### PR TITLE
feat: Apple Reminders integration for mobile task capture

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -164,7 +164,50 @@ Match tasks to available time based on effort classification:
 > 
 > ⚠️ **Heads up:** You have 2 deep work tasks but today's too fragmented. Consider protecting tomorrow morning."
 
-### 5.6 Standard Context Gathering
+### 5.6 Reminders Completion Sync (Dex Today → Dex)
+
+Check if any tasks were completed on phone since the last plan:
+
+```
+Use: reminders_list_completed(list_name="Dex Today")
+```
+
+For each completed item:
+- Match to a Dex task by title
+- Update task status via Work MCP: `update_task_status(task_title="...", status="d")`
+- Surface what was synced:
+
+> "📱 **Synced from phone:**
+> - ✅ "Follow up with Hero Coders" — marked done in Dex"
+
+**If nothing to sync:** Skip silently.
+
+### 5.7 Mobile Capture Check (Dex Inbox)
+
+```
+Use: reminders_list_items(list_name="Dex Inbox")
+```
+
+If items found, surface:
+
+> 📱 **Captured on phone** (3 items in Dex Inbox):
+>
+> 1. "Follow up with Peter about roadmap" — captured yesterday 4:32pm
+> 2. "Look into Rovo for in-app guides" — captured today 2:15pm
+> 3. "Send Anastasia the productized offering doc" — captured today 11:45am
+>
+> **Triage these now?** I'll help assign pillars and priorities.
+
+**Triage flow:**
+- Present each item
+- Infer pillar (using existing smart pillar inference)
+- Confirm with user
+- Create task via Work MCP `process_inbox_with_dedup`
+- Mark Reminder as complete via `reminders_complete_item`
+
+**If Dex Inbox is empty:** Skip silently (no "0 items captured" noise).
+
+### 5.8 Standard Context Gathering
 
 Also gather:
 - **Calendar**: Today's meetings with times and attendees
@@ -325,6 +368,33 @@ integrations_used: [calendar, tasks, people, work-intelligence]
 
 ---
 
+## Step 7.5: Push Focus Tasks to Reminders (Dex → iPhone)
+
+After generating the plan, push today's P0 and P1 focus tasks to Apple Reminders for native iOS notifications:
+
+1. **Clear yesterday's items:**
+   ```
+   Use: reminders_clear_completed(list_name="Dex Today")
+   ```
+
+2. **Push today's focus items:**
+   For each P0/P1 task in today's focus:
+   ```
+   Use: reminders_create_item(
+       list_name="Dex Today",
+       title="Task title",
+       notes="From Dex daily plan",
+       due_date="YYYY-MM-DD"
+   )
+   ```
+
+3. **Confirm silently:**
+   > "📱 Pushed 3 focus tasks to iPhone Reminders (Dex Today)"
+
+**If Reminders MCP unavailable:** Skip silently.
+
+---
+
 ## Step 8: Track Usage (Silent)
 
 Update `System/usage_log.md` to mark daily planning as used.
@@ -361,5 +431,6 @@ The plan works at multiple levels:
 | Integration | MCP Server | Tools Used |
 |-------------|------------|------------|
 | Calendar | dex-calendar-mcp | `calendar_get_today`, `calendar_get_events_with_attendees` |
+| Reminders | dex-calendar-mcp | `reminders_list_items`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed` |
 | Granola | dex-granola-mcp | `get_recent_meetings` |
 | Work | dex-work-mcp | `list_tasks`, `get_week_progress`, `get_meeting_context`, `get_commitments_due`, `analyze_calendar_capacity`, `suggest_task_scheduling` |

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -156,6 +156,38 @@ Use: process_commitment(commitment_id="comm-XXXXXX-XXX", action="dismiss")
 
 ---
 
+## Step 2.5: Reminders Completion Sync (Dex Today → Dex)
+
+Check if tasks were completed on phone since the morning plan:
+
+```
+Use: reminders_list_completed(list_name="Dex Today")
+```
+
+For each completed item:
+- Match to a Dex task by title
+- Update task status via Work MCP: `update_task_status(task_title="...", status="d")`
+- Surface what was synced:
+
+> "📱 **Synced from phone:**
+> - ✅ "Follow up with Hero Coders" — marked done in Dex"
+
+Also check for tasks completed in Dex today that still have active Reminders:
+
+```
+# For each task completed today in Dex, check if a matching Reminder exists
+Use: reminders_find_and_complete(list_name="Dex Today", title_query="task title")
+```
+
+Clean up completed items:
+```
+Use: reminders_clear_completed(list_name="Dex Today")
+```
+
+**If nothing to sync:** Skip silently.
+
+---
+
 ## Step 3: Daily Plan Completion Tracking (NEW)
 
 **Compare what you planned vs. what you did.**
@@ -453,6 +485,7 @@ Based on weekly priorities and today's carryover:
 |-------------|------------|------------|
 | Work | dex-work-mcp | `list_tasks`, `get_week_progress`, `get_commitments_due`, `analyze_calendar_capacity` |
 | Calendar | dex-calendar-mcp | `calendar_get_today` |
+| Reminders | dex-calendar-mcp | `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed` |
 | Screen Activity | screenpipe-mcp | `screenpipe_time_audit`, `screenpipe_summarize`, `screenpipe_query` |
 
 ### ScreenPipe Integration Notes

--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -14,6 +14,13 @@ Tools:
 - calendar_delete_event: Delete an event
 - calendar_get_next_event: Get the next upcoming event
 - calendar_get_events_with_attendees: Get events with full attendee details
+- reminders_list_items: Get incomplete items from a Reminders list
+- reminders_complete_item: Mark a Reminder as complete
+- reminders_create_item: Create a new Reminder
+- reminders_ensure_lists: Create Dex Inbox/Today lists if missing
+- reminders_list_completed: Get recently completed Reminders for sync
+- reminders_find_and_complete: Find and complete a Reminder by title match
+- reminders_clear_completed: Remove completed Reminders from a list
 """
 
 import os
@@ -439,7 +446,117 @@ async def handle_list_tools() -> list[types.Tool]:
                 },
                 "required": []
             }
-        )
+        ),
+        # --- Apple Reminders tools ---
+        types.Tool(
+            name="reminders_list_items",
+            description="Get incomplete items from an Apple Reminders list. Use with 'Dex Inbox' to check for mobile-captured tasks.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "list_name": {
+                        "type": "string",
+                        "description": "Name of the Reminders list (default: 'Dex Inbox')"
+                    }
+                },
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="reminders_complete_item",
+            description="Mark a Reminder as complete (e.g., after triaging into Dex tasks)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "reminder_id": {
+                        "type": "string",
+                        "description": "The calendarItemIdentifier of the reminder to complete"
+                    }
+                },
+                "required": ["reminder_id"]
+            }
+        ),
+        types.Tool(
+            name="reminders_create_item",
+            description="Create a new Reminder in a specific list (e.g., push P0 tasks to 'Dex Today' for iOS notifications)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "list_name": {
+                        "type": "string",
+                        "description": "Name of the Reminders list (default: 'Dex Today')"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Reminder title"
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Optional notes/description"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "description": "Optional due date in YYYY-MM-DD format"
+                    }
+                },
+                "required": ["title"]
+            }
+        ),
+        types.Tool(
+            name="reminders_ensure_lists",
+            description="Create 'Dex Inbox' and 'Dex Today' Reminders lists if they don't exist. Idempotent — safe to call every time.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="reminders_list_completed",
+            description="Get recently completed items from a Reminders list (last 2 days). Use with 'Dex Today' to detect tasks completed on phone for sync back to Dex.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "list_name": {
+                        "type": "string",
+                        "description": "Name of the Reminders list (default: 'Dex Today')"
+                    }
+                },
+                "required": []
+            }
+        ),
+        types.Tool(
+            name="reminders_find_and_complete",
+            description="Find a Reminder by title match and mark it complete. Use for Dex → Reminders sync when a task is done in Dex.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "list_name": {
+                        "type": "string",
+                        "description": "Name of the Reminders list (default: 'Dex Today')"
+                    },
+                    "title_query": {
+                        "type": "string",
+                        "description": "Title text to match against (fuzzy substring match)"
+                    }
+                },
+                "required": ["title_query"]
+            }
+        ),
+        types.Tool(
+            name="reminders_clear_completed",
+            description="Remove all completed Reminders from a list. Use to clean up 'Dex Today' at start of day.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "list_name": {
+                        "type": "string",
+                        "description": "Name of the Reminders list (default: 'Dex Today')"
+                    }
+                },
+                "required": []
+            }
+        ),
     ]
 
 
@@ -731,6 +848,96 @@ async def handle_call_tool(
         
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     
+    # --- Apple Reminders handlers ---
+    elif name == "reminders_list_items":
+        list_name = arguments.get("list_name", "Dex Inbox")
+        success, output = run_shell_script("reminders_eventkit.py", "list_items", list_name)
+        if success:
+            try:
+                items = json.loads(output)
+                result = {"success": True, "list": list_name, "items": items, "count": len(items)}
+            except json.JSONDecodeError as e:
+                result = {"success": False, "error": f"JSON parse error: {e}"}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_complete_item":
+        reminder_id = arguments["reminder_id"]
+        success, output = run_shell_script("reminders_eventkit.py", "complete", reminder_id)
+        if success:
+            try:
+                result = json.loads(output)
+            except json.JSONDecodeError:
+                result = {"success": True, "message": output}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_create_item":
+        list_name = arguments.get("list_name", "Dex Today")
+        title = arguments["title"]
+        notes = arguments.get("notes", "")
+        due_date = arguments.get("due_date", "")
+        success, output = run_shell_script("reminders_eventkit.py", "create", list_name, title, notes, due_date)
+        if success:
+            try:
+                result = json.loads(output)
+            except json.JSONDecodeError:
+                result = {"success": True, "message": output}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_ensure_lists":
+        success, output = run_shell_script("reminders_eventkit.py", "ensure_lists")
+        if success:
+            try:
+                result = json.loads(output)
+            except json.JSONDecodeError:
+                result = {"success": True, "message": output}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_list_completed":
+        list_name = arguments.get("list_name", "Dex Today")
+        success, output = run_shell_script("reminders_eventkit.py", "list_completed", list_name)
+        if success:
+            try:
+                items = json.loads(output)
+                result = {"success": True, "list": list_name, "items": items, "count": len(items)}
+            except json.JSONDecodeError as e:
+                result = {"success": False, "error": f"JSON parse error: {e}"}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_find_and_complete":
+        list_name = arguments.get("list_name", "Dex Today")
+        title_query = arguments["title_query"]
+        success, output = run_shell_script("reminders_eventkit.py", "find_and_complete", list_name, title_query)
+        if success:
+            try:
+                result = json.loads(output)
+            except json.JSONDecodeError:
+                result = {"success": True, "message": output}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == "reminders_clear_completed":
+        list_name = arguments.get("list_name", "Dex Today")
+        success, output = run_shell_script("reminders_eventkit.py", "clear_completed", list_name)
+        if success:
+            try:
+                result = json.loads(output)
+            except json.JSONDecodeError:
+                result = {"success": True, "message": output}
+        else:
+            result = {"success": False, "error": output}
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
     else:
         return [types.TextContent(type="text", text=json.dumps({
             "error": f"Unknown tool: {name}"

--- a/core/mcp/scripts/check_reminders_permission.py
+++ b/core/mcp/scripts/check_reminders_permission.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Check and request Reminders permissions for Dex.
+
+Mirrors check_calendar_permission.py but for EKEntityTypeReminder.
+Reminders uses a separate TCC permission from Calendar even though
+both use EventKit.
+"""
+
+import sys
+import time
+try:
+    import EventKit
+except ImportError:
+    print("❌ EventKit not installed. Run: pip3 install pyobjc-framework-EventKit")
+    sys.exit(1)
+
+
+def main():
+    store = EventKit.EKEventStore.alloc().init()
+    status = EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeReminder)
+
+    status_names = {
+        0: "NotDetermined",
+        1: "Restricted",
+        2: "Denied",
+        3: "Authorized",
+        4: "FullAccess",      # macOS 14+
+        5: "WriteOnly",       # macOS 14+ (not applicable for Reminders)
+    }
+
+    print(f"Current Reminders access: {status_names.get(status, f'Unknown ({status})')}")
+
+    if status in (3, 4):  # Authorized or FullAccess
+        print("✅ Reminders access already granted!")
+        print("   EventKit can read and write Reminders.")
+        return 0
+
+    elif status == 2:  # Denied
+        print()
+        print("❌ Reminders access was previously denied.")
+        print()
+        print("To enable Reminders integration:")
+        print("1. Open System Settings")
+        print("2. Go to Privacy & Security > Reminders")
+        print("3. Find 'Python' or 'python3' in the list")
+        print("4. Enable the checkbox")
+        print()
+        print("Then run this script again to verify.")
+        return 1
+
+    elif status == 1:  # Restricted
+        print()
+        print("❌ Reminders access is restricted by system policies.")
+        print("   This may be due to parental controls or enterprise MDM.")
+        return 1
+
+    else:  # NotDetermined (0)
+        print()
+        print("📋 Reminders access not yet requested.")
+        print("   A permission dialog will appear...")
+        print()
+
+        access_granted = [None]
+
+        def completion_handler(granted, error):
+            access_granted[0] = granted
+
+        store.requestAccessToEntityType_completion_(
+            EventKit.EKEntityTypeReminder, completion_handler
+        )
+
+        # Wait for user response (max 30 seconds)
+        for i in range(300):
+            if access_granted[0] is not None:
+                break
+            time.sleep(0.1)
+            if i % 10 == 0:
+                print(".", end="", flush=True)
+
+        print()
+
+        if access_granted[0]:
+            print("✅ Reminders access granted!")
+            print("   EventKit can now read and write Reminders.")
+            return 0
+        else:
+            print("❌ Reminders access was not granted.")
+            print("   Run this script again to retry, or grant access in System Settings.")
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/mcp/scripts/reminders_eventkit.py
+++ b/core/mcp/scripts/reminders_eventkit.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""
+Apple Reminders access using native EventKit framework.
+Companion to calendar_eventkit.py — same framework, different entity type.
+
+Usage:
+    reminders_eventkit.py list_lists
+    reminders_eventkit.py list_items <list_name>
+    reminders_eventkit.py list_completed <list_name>
+    reminders_eventkit.py complete <reminder_id>
+    reminders_eventkit.py create <list_name> <title> [notes] [due_date]
+    reminders_eventkit.py find_and_complete <list_name> <title_query>
+    reminders_eventkit.py clear_completed <list_name>
+    reminders_eventkit.py ensure_lists
+"""
+
+import sys
+import json
+import time
+from datetime import datetime, timedelta
+import EventKit
+from Foundation import NSDate, NSRunLoop
+
+
+def get_store():
+    """Get an authorized EKEventStore for Reminders."""
+    store = EventKit.EKEventStore.alloc().init()
+    return store
+
+
+def find_reminder_list(store, list_name: str):
+    """Find a Reminders list (calendar) by name."""
+    calendars = store.calendarsForEntityType_(EventKit.EKEntityTypeReminder)
+    for cal in calendars:
+        if cal.title() == list_name:
+            return cal
+    return None
+
+
+def list_lists():
+    """List all Reminders lists."""
+    store = get_store()
+    calendars = store.calendarsForEntityType_(EventKit.EKEntityTypeReminder)
+
+    result = []
+    for cal in calendars:
+        result.append({
+            "title": cal.title(),
+            "identifier": cal.calendarIdentifier(),
+            "color": str(cal.color()) if cal.color() else None,
+        })
+
+    print(json.dumps(result, indent=2))
+
+
+def fetch_reminders_sync(store, predicate):
+    """Fetch reminders synchronously using a run loop.
+
+    EventKit's fetchRemindersMatchingPredicate is async — we spin the
+    run loop until the completion handler fires.
+    """
+    results = [None]
+    done = [False]
+
+    def completion(reminders):
+        results[0] = reminders
+        done[0] = True
+
+    store.fetchRemindersMatchingPredicate_completion_(predicate, completion)
+
+    # Spin run loop until callback fires (max 10 seconds)
+    deadline = time.time() + 10
+    while not done[0] and time.time() < deadline:
+        NSRunLoop.currentRunLoop().runUntilDate_(
+            NSDate.dateWithTimeIntervalSinceNow_(0.05)
+        )
+
+    return results[0] or []
+
+
+def list_items(list_name: str):
+    """Get incomplete reminders from a specific list."""
+    store = get_store()
+    target = find_reminder_list(store, list_name)
+
+    if not target:
+        print(json.dumps({"error": f"Reminders list not found: {list_name}"}))
+        sys.exit(1)
+
+    # Predicate for incomplete reminders in this list
+    predicate = store.predicateForIncompleteRemindersWithDueDateStarting_ending_calendars_(
+        None,  # no start date filter
+        None,  # no end date filter
+        [target],
+    )
+
+    reminders = fetch_reminders_sync(store, predicate)
+
+    result = []
+    for rem in reminders:
+        item = {
+            "title": rem.title() or "",
+            "notes": rem.notes() or "",
+            "reminder_id": rem.calendarItemIdentifier() or "",
+            "creation_date": rem.creationDate().description() if rem.creationDate() else "",
+            "completed": bool(rem.isCompleted()),
+        }
+        if rem.dueDateComponents():
+            dc = rem.dueDateComponents()
+            try:
+                item["due_date"] = f"{dc.year():04d}-{dc.month():02d}-{dc.day():02d}"
+            except Exception:
+                item["due_date"] = ""
+        else:
+            item["due_date"] = ""
+        result.append(item)
+
+    # Sort by creation date (newest first)
+    result.sort(key=lambda x: x.get("creation_date", ""), reverse=True)
+
+    print(json.dumps(result, indent=2))
+
+
+def complete_item(reminder_id: str):
+    """Mark a reminder as complete by its calendarItemIdentifier."""
+    store = get_store()
+
+    # Fetch all incomplete reminders across all lists to find the one
+    predicate = store.predicateForRemindersInCalendars_(None)
+    reminders = fetch_reminders_sync(store, predicate)
+
+    target_reminder = None
+    for rem in reminders:
+        if rem.calendarItemIdentifier() == reminder_id:
+            target_reminder = rem
+            break
+
+    if not target_reminder:
+        print(json.dumps({"error": f"Reminder not found: {reminder_id}"}))
+        sys.exit(1)
+
+    target_reminder.setCompleted_(True)
+    target_reminder.setCompletionDate_(NSDate.date())
+
+    error = None
+    success = store.saveReminder_commit_error_(target_reminder, True, error)
+
+    if success:
+        print(json.dumps({"success": True, "reminder_id": reminder_id, "status": "completed"}))
+    else:
+        print(json.dumps({"error": f"Failed to save reminder: {error}"}))
+        sys.exit(1)
+
+
+def create_item(list_name: str, title: str, notes: str = "", due_date: str = ""):
+    """Create a new reminder in the specified list."""
+    store = get_store()
+    target = find_reminder_list(store, list_name)
+
+    if not target:
+        print(json.dumps({"error": f"Reminders list not found: {list_name}. Run 'ensure_lists' first."}))
+        sys.exit(1)
+
+    reminder = EventKit.EKReminder.reminderWithEventStore_(store)
+    reminder.setTitle_(title)
+    reminder.setCalendar_(target)
+
+    if notes:
+        reminder.setNotes_(notes)
+
+    if due_date:
+        try:
+            dt = datetime.strptime(due_date, "%Y-%m-%d")
+            components = EventKit.NSDateComponents.alloc().init()
+            components.setYear_(dt.year)
+            components.setMonth_(dt.month)
+            components.setDay_(dt.day)
+            components.setHour_(9)  # Default 9am
+            components.setMinute_(0)
+            reminder.setDueDateComponents_(components)
+        except ValueError:
+            pass  # Skip invalid date, create without due date
+
+    error = None
+    success = store.saveReminder_commit_error_(reminder, True, error)
+
+    if success:
+        print(json.dumps({
+            "success": True,
+            "reminder_id": reminder.calendarItemIdentifier(),
+            "title": title,
+            "list": list_name,
+        }))
+    else:
+        print(json.dumps({"error": f"Failed to create reminder: {error}"}))
+        sys.exit(1)
+
+
+def list_completed_items(list_name: str):
+    """Get completed reminders from a specific list (for sync checking).
+
+    Used to detect items the user marked done on their phone so Dex can
+    sync the completion back to Tasks.md.
+    """
+    store = get_store()
+    target = find_reminder_list(store, list_name)
+
+    if not target:
+        print(json.dumps({"error": f"Reminders list not found: {list_name}"}))
+        sys.exit(1)
+
+    predicate = store.predicateForCompletedRemindersWithCompletionDateStarting_ending_calendars_(
+        NSDate.dateWithTimeIntervalSinceNow_(-86400 * 2),  # last 2 days
+        NSDate.date(),
+        [target],
+    )
+
+    reminders = fetch_reminders_sync(store, predicate)
+
+    result = []
+    for rem in reminders:
+        item = {
+            "title": rem.title() or "",
+            "notes": rem.notes() or "",
+            "reminder_id": rem.calendarItemIdentifier() or "",
+            "completed": True,
+            "completion_date": rem.completionDate().description() if rem.completionDate() else "",
+        }
+        result.append(item)
+
+    print(json.dumps(result, indent=2))
+
+
+def find_and_complete(list_name: str, title_query: str):
+    """Find a reminder by title match and mark it complete.
+
+    Used for Dex → Reminders sync: when a task is marked done in Dex,
+    clear the matching Reminder in 'Dex Today' to prevent stale notifications.
+    """
+    store = get_store()
+    target = find_reminder_list(store, list_name)
+
+    if not target:
+        print(json.dumps({"error": f"Reminders list not found: {list_name}"}))
+        sys.exit(1)
+
+    predicate = store.predicateForIncompleteRemindersWithDueDateStarting_ending_calendars_(
+        None, None, [target],
+    )
+    reminders = fetch_reminders_sync(store, predicate)
+
+    query_lower = title_query.lower()
+    matched = None
+    for rem in reminders:
+        rem_title = (rem.title() or "").lower()
+        if query_lower in rem_title or rem_title in query_lower:
+            matched = rem
+            break
+
+    if not matched:
+        print(json.dumps({"found": False, "message": f"No matching reminder for: {title_query}"}))
+        return
+
+    matched.setCompleted_(True)
+    matched.setCompletionDate_(NSDate.date())
+
+    error = None
+    success = store.saveReminder_commit_error_(matched, True, error)
+
+    if success:
+        print(json.dumps({
+            "found": True,
+            "completed": True,
+            "reminder_id": matched.calendarItemIdentifier(),
+            "title": matched.title(),
+        }))
+    else:
+        print(json.dumps({"error": f"Failed to save: {error}"}))
+        sys.exit(1)
+
+
+def clear_completed(list_name: str):
+    """Remove all completed reminders from a list.
+
+    Used to clean up 'Dex Today' at the start of a new day so yesterday's
+    completed items don't clutter the list.
+    """
+    store = get_store()
+    target = find_reminder_list(store, list_name)
+
+    if not target:
+        print(json.dumps({"error": f"Reminders list not found: {list_name}"}))
+        sys.exit(1)
+
+    predicate = store.predicateForCompletedRemindersWithCompletionDateStarting_ending_calendars_(
+        NSDate.dateWithTimeIntervalSinceNow_(-86400 * 7),  # last 7 days
+        NSDate.date(),
+        [target],
+    )
+    reminders = fetch_reminders_sync(store, predicate)
+
+    removed = 0
+    for rem in reminders:
+        error = None
+        success = store.removeReminder_commit_error_(rem, True, error)
+        if success:
+            removed += 1
+
+    print(json.dumps({"success": True, "removed": removed, "list": list_name}))
+
+
+def ensure_lists():
+    """Create 'Dex Inbox' and 'Dex Today' lists if they don't exist."""
+    store = get_store()
+    created = []
+    existing = []
+
+    for list_name in ["Dex Inbox", "Dex Today"]:
+        if find_reminder_list(store, list_name):
+            existing.append(list_name)
+            continue
+
+        # Create new Reminders list
+        source = store.defaultCalendarForNewReminders().source()
+        new_cal = EventKit.EKCalendar.calendarForEntityType_eventStore_(
+            EventKit.EKEntityTypeReminder, store
+        )
+        new_cal.setTitle_(list_name)
+        new_cal.setSource_(source)
+
+        error = None
+        success = store.saveCalendar_commit_error_(new_cal, True, error)
+
+        if success:
+            created.append(list_name)
+        else:
+            print(json.dumps({"error": f"Failed to create list '{list_name}': {error}"}))
+            sys.exit(1)
+
+    print(json.dumps({
+        "success": True,
+        "created": created,
+        "existing": existing,
+        "message": f"Created {len(created)}, already existed {len(existing)}",
+    }))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage:")
+        print("  reminders_eventkit.py list_lists")
+        print("  reminders_eventkit.py list_items <list_name>")
+        print("  reminders_eventkit.py complete <reminder_id>")
+        print("  reminders_eventkit.py create <list_name> <title> [notes] [due_date]")
+        print("  reminders_eventkit.py ensure_lists")
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    if command == "list_lists":
+        list_lists()
+
+    elif command == "list_items":
+        if len(sys.argv) != 3:
+            print("Usage: reminders_eventkit.py list_items <list_name>")
+            sys.exit(1)
+        list_items(sys.argv[2])
+
+    elif command == "complete":
+        if len(sys.argv) != 3:
+            print("Usage: reminders_eventkit.py complete <reminder_id>")
+            sys.exit(1)
+        complete_item(sys.argv[2])
+
+    elif command == "create":
+        if len(sys.argv) < 4:
+            print("Usage: reminders_eventkit.py create <list_name> <title> [notes] [due_date]")
+            sys.exit(1)
+        list_name = sys.argv[2]
+        title = sys.argv[3]
+        notes = sys.argv[4] if len(sys.argv) > 4 else ""
+        due_date = sys.argv[5] if len(sys.argv) > 5 else ""
+        create_item(list_name, title, notes, due_date)
+
+    elif command == "ensure_lists":
+        ensure_lists()
+
+    elif command == "list_completed":
+        if len(sys.argv) != 3:
+            print("Usage: reminders_eventkit.py list_completed <list_name>")
+            sys.exit(1)
+        list_completed_items(sys.argv[2])
+
+    elif command == "find_and_complete":
+        if len(sys.argv) != 4:
+            print("Usage: reminders_eventkit.py find_and_complete <list_name> <title_query>")
+            sys.exit(1)
+        find_and_complete(sys.argv[2], sys.argv[3])
+
+    elif command == "clear_completed":
+        if len(sys.argv) != 3:
+            print("Usage: reminders_eventkit.py clear_completed <list_name>")
+            sys.exit(1)
+        clear_completed(sys.argv[2])
+
+    else:
+        print(f"Unknown command: {command}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds 7 new MCP tools to the calendar server for Apple Reminders read/write via EventKit
- Enables "Hey Siri, remind me to..." → appears in Dex triage during `/daily-plan`
- Pushes P0/P1 focus tasks to iOS Reminders for native notifications
- Bidirectional completion sync: done on phone → syncs to Dex (and vice versa)

## How It Works

**Two dedicated Reminders lists:**
- **"Dex Inbox"** — Capture list. Siri/phone → here. Dex reads and triages during `/daily-plan`
- **"Dex Today"** — Push list. Dex writes focus tasks here. iOS notifies you

**Mode 1 (Reminders → Dex):**
1. User captures tasks via Siri or Reminders app to "Dex Inbox"
2. During `/daily-plan`, items are surfaced for triage
3. User assigns pillar/priority, task is created via Work MCP
4. Reminder is marked complete to prevent re-import

**Mode 2 (Dex → Reminders):**
1. After daily plan is generated, P0/P1 tasks push to "Dex Today"
2. iOS sends native notifications for these tasks
3. Completing on either side syncs to the other

## New MCP Tools

| Tool | Purpose |
|------|---------|
| `reminders_list_items` | Read incomplete items from a list |
| `reminders_complete_item` | Mark a Reminder complete (post-triage) |
| `reminders_create_item` | Create a Reminder (push to iOS) |
| `reminders_ensure_lists` | Create Dex Inbox/Today lists idempotently |
| `reminders_list_completed` | Get recently completed items (sync check) |
| `reminders_find_and_complete` | Find by title and complete (Dex → Reminders sync) |
| `reminders_clear_completed` | Clean up completed items |

## Files Changed

| File | Change |
|------|--------|
| `core/mcp/calendar_server.py` | 7 new tool definitions + handlers |
| `core/mcp/scripts/reminders_eventkit.py` | New EventKit Python script for Reminders |
| `core/mcp/scripts/check_reminders_permission.py` | Permission checker for Reminders access |
| `.claude/skills/daily-plan/SKILL.md` | Steps 5.6-5.7 (sync + triage) and Step 7.5 (push) |
| `.claude/skills/daily-review/SKILL.md` | Step 2.5 (completion sync) |

## Setup Requirements

- macOS with Reminders.app
- Python access to Reminders in System Settings → Privacy & Security → Reminders
- PyObjC (same dependency as existing calendar integration)

## Test plan

- [ ] `reminders_ensure_lists` creates "Dex Inbox" and "Dex Today" lists
- [ ] Adding a Reminder via Siri to "Dex Inbox" is picked up by `reminders_list_items`
- [ ] Triage flow creates task and marks Reminder complete
- [ ] `reminders_create_item` pushes task to "Dex Today" with due date
- [ ] Completing on phone detected by `reminders_list_completed`
- [ ] `reminders_find_and_complete` matches and completes by title
- [ ] Graceful degradation when Reminders permission not granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)