### PR TITLE
Fix notification hooks for Linux (afplay → pw-play)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Ping.aiff"
+            "command": "pw-play /usr/share/sounds/freedesktop/stereo/complete.oga"
           }
         ]
       }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Ping.aiff"
+            "command": "pw-play /usr/share/sounds/freedesktop/stereo/complete.oga"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Replaces macOS `afplay` with `pw-play` (PipeWire) in Stop and Notification hooks
- Uses freedesktop `complete.oga` sound as the notification tone
- Fixes hooks silently failing on Linux since `afplay` doesn't exist

## Test plan
- [ ] Verify notification sound plays on Stop events
- [ ] Verify notification sound plays on permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)