### PR TITLE
Upgrade Gemini Flash 2.5 and fix Linux notification hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Ping.aiff"
+            "command": "pw-play /usr/share/sounds/freedesktop/stereo/complete.oga"
           }
         ]
       }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay /System/Library/Sounds/Ping.aiff"
+            "command": "pw-play /usr/share/sounds/freedesktop/stereo/complete.oga"
           }
         ]
       }

--- a/.claude/skills/ai-setup/SKILL.md
+++ b/.claude/skills/ai-setup/SKILL.md
@@ -164,7 +164,7 @@ These are AI models from other companies that cost much less:
 |-------|-----------------|---------|----------|
 | **Kimi K2.5** | ~80% cheaper | ⭐⭐⭐⭐ Great | General tasks, thinking |
 | **DeepSeek V3** | ~95% cheaper | ⭐⭐⭐⭐ Great | Coding, analysis |
-| **Gemini Flash** | ~97% cheaper | ⭐⭐⭐ Good | Long documents |
+| **Gemini 2.5 Flash** | ~90% cheaper | ⭐⭐⭐⭐ Great | Long documents, reasoning |
 
 **My recommendation:** Start with **Kimi K2.5** — it's the closest to Claude in quality.
 
@@ -251,12 +251,12 @@ Generate `~/.pi/agent/models.json`:
           "cost": { "input": 0.14, "output": 0.28, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "google/gemini-2.0-flash-exp:free",
-          "name": "Gemini Flash (Free tier)",
+          "id": "google/gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash (Budget)",
           "input": ["text", "image"],
           "contextWindow": 1048576,
           "maxTokens": 8192,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          "cost": { "input": 0.3, "output": 2.5, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
     }
@@ -272,7 +272,7 @@ Say:
 I've added three models you can switch to anytime:
 - **Kimi K2.5** — Best quality budget option
 - **DeepSeek V3** — Super cheap, great for coding
-- **Gemini Flash** — Google's free tier (with limits)
+- **Gemini 2.5 Flash** — Google's budget option, great for reasoning
 
 **How to use them:**
 
@@ -739,7 +739,7 @@ Want me to help you switch to a smaller model?
 
 Some alternatives:
 
-1. **Gemini Flash Free Tier** — Google offers free usage (with limits)
+1. **Gemini 2.5 Flash** — Google's budget model, very affordable
    I can set that up instead
 
 2. **Offline Only** — Skip budget cloud, just use local models

--- a/.scripts/lib/llm-client.cjs
+++ b/.scripts/lib/llm-client.cjs
@@ -76,7 +76,7 @@ async function generateWithGemini(prompt, options = {}) {
   const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
   
   const model = genAI.getGenerativeModel({
-    model: options.model || 'gemini-2.0-flash-thinking-exp-1219',
+    model: options.model || 'gemini-2.5-flash',
     generationConfig: {
       maxOutputTokens: options.maxOutputTokens || 4096,
       temperature: options.temperature || 1.0,

--- a/06-Resources/Dex_System/AI_Model_Options.md
+++ b/06-Resources/Dex_System/AI_Model_Options.md
@@ -23,7 +23,7 @@ Dex can use different AI models depending on your needs:
 Other companies make AI models that cost much less than Claude:
 - **Kimi K2.5** (Moonshot AI) — 80% cheaper, similar quality
 - **DeepSeek V3** — 95% cheaper, great for coding
-- **Gemini Flash** (Google) — 97% cheaper, handles long documents
+- **Gemini 2.5 Flash** (Google) — 90% cheaper, handles long documents
 
 ### Why Use Them?
 
@@ -168,7 +168,7 @@ Run `/ai-status` to see:
 | Claude Sonnet | `claude-sonnet-4-20250514` |
 | Kimi K2.5 | `moonshotai/kimi-k2.5` |
 | DeepSeek V3 | `deepseek/deepseek-chat` |
-| Gemini Flash | `google/gemini-2.0-flash-exp:free` |
+| Gemini 2.5 Flash | `google/gemini-2.5-flash` |
 | Qwen (Offline) | `qwen2.5:14b` |
 
 ---

--- a/System/scripts/configure-ai-models.sh
+++ b/System/scripts/configure-ai-models.sh
@@ -54,12 +54,12 @@ if [[ -n "$OPENROUTER_KEY" ]]; then
           "cost": { "input": 0.14, "output": 0.28, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "google/gemini-2.0-flash-exp:free",
-          "name": "Gemini Flash (Free)",
+          "id": "google/gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash (Budget)",
           "input": ["text", "image"],
           "contextWindow": 1048576,
           "maxTokens": 8192,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          "cost": { "input": 0.3, "output": 2.5, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
     }
@@ -130,7 +130,7 @@ if [[ -n "$OPENROUTER_KEY" ]]; then
     echo "☁️  Budget Cloud (OpenRouter):"
     echo "   - Kimi K2.5"
     echo "   - DeepSeek V3"
-    echo "   - Gemini Flash (free tier)"
+    echo "   - Gemini 2.5 Flash"
 fi
 
 if command -v ollama &> /dev/null && ollama list 2>/dev/null | grep -q "$OLLAMA_MODEL"; then

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -110,3 +110,25 @@ quarterly_planning:
   # Current quarter dates (auto-calculated)
   quarter_start_date: "2026-01-01"
   quarter_end_date: "2026-03-31"
+
+# AI Model Configuration
+ai_models:
+  budget_cloud:
+    enabled: true
+    provider: openrouter
+    primary_model: google/gemini-2.5-flash
+    configured_date: 2026-02-21
+  offline:
+    enabled: true
+    runner: ollama
+    model: llama3.3:latest
+    configured_date: 2026-02-21
+  smart_routing:
+    enabled: true
+    rules:
+      complex_tasks:
+        model: claude-sonnet
+      routine_tasks:
+        model: google/gemini-2.5-flash
+      offline:
+        model: llama3.3:latest


### PR DESCRIPTION
## Summary
- **Gemini 2.5 Flash:** Replaces deprecated `google/gemini-2.0-flash-exp:free` with `google/gemini-2.5-flash` across all model configs ($0.30/M input, $2.50/M output, ~90% cheaper than Claude)
- **Linux hooks fix:** Replaces macOS `afplay` with `pw-play` (PipeWire) in Stop and Notification hooks, using freedesktop `complete.oga` sound

## Test plan
- [ ] Run `/ai-setup` and verify Gemini 2.5 Flash appears in budget model list
- [ ] Run `configure-ai-models.sh` and verify generated `models.json` has correct model ID
- [ ] Verify notification sound plays on Stop and permission prompt events (Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)