### PR TITLE
fix: correct path references in Python MCP servers

### DIFF
--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -41,7 +41,7 @@ import mcp.types as types
 
 # Vault paths
 VAULT_PATH = Path(os.environ.get('VAULT_PATH', Path.cwd()))
-PEOPLE_DIR = VAULT_PATH / "People"
+PEOPLE_DIR = VAULT_PATH / "05-Areas" / "People"
 
 # Health system — error queue and health reporting
 try:

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -75,8 +75,8 @@ class DateTimeEncoder(json.JSONEncoder):
 
 # Configuration - Vault paths
 BASE_DIR = Path(os.environ.get('VAULT_PATH', Path.cwd()))
-CAREER_DIR = BASE_DIR / 'Active' / 'Career'
-EVIDENCE_DIR = BASE_DIR / 'Resources' / 'Career_Evidence'
+CAREER_DIR = BASE_DIR / '05-Areas' / 'Career'
+EVIDENCE_DIR = BASE_DIR / '05-Areas' / 'Career' / 'Evidence'
 LADDER_FILE = CAREER_DIR / 'Career_Ladder.md'
 
 # Initialize the MCP server

--- a/core/mcp/demo_mode_server.py
+++ b/core/mcp/demo_mode_server.py
@@ -314,13 +314,13 @@ def scan_planning_and_career_files() -> Set[str]:
     files_to_scan = [
         BASE_DIR / '01-Quarter_Goals' / 'Quarter_Goals.md',
         BASE_DIR / '02-Week_Priorities' / 'Week_Priorities.md',
-        BASE_DIR / 'Active' / 'Career' / 'Growth_Goals.md',
-        BASE_DIR / 'Active' / 'Career' / 'Current_Role.md',
-        BASE_DIR / 'Active' / 'Career' / 'Career_Ladder.md',
+        BASE_DIR / '05-Areas' / 'Career' / 'Growth_Goals.md',
+        BASE_DIR / '05-Areas' / 'Career' / 'Current_Role.md',
+        BASE_DIR / '05-Areas' / 'Career' / 'Career_Ladder.md',
     ]
 
     evidence_dirs = [
-        BASE_DIR / 'Resources' / 'Career_Evidence',
+        BASE_DIR / '05-Areas' / 'Career' / 'Evidence',
         BASE_DIR / '05-Areas' / 'Career' / 'Evidence',
     ]
     for edir in evidence_dirs:

--- a/core/mcp/resume_server.py
+++ b/core/mcp/resume_server.py
@@ -94,10 +94,10 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 # Configuration - Vault paths
 BASE_DIR = Path(os.environ.get('VAULT_PATH', Path.cwd()))
-CAREER_DIR = BASE_DIR / 'Active' / 'Career'
+CAREER_DIR = BASE_DIR / '05-Areas' / 'Career'
 RESUME_DIR = CAREER_DIR / 'Resume'
 SESSIONS_DIR = RESUME_DIR / 'Sessions'
-EVIDENCE_DIR = BASE_DIR / 'Resources' / 'Career_Evidence'
+EVIDENCE_DIR = BASE_DIR / '05-Areas' / 'Career' / 'Evidence'
 
 # Ensure directories exist
 SESSIONS_DIR.mkdir(parents=True, exist_ok=True)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -109,15 +109,15 @@ if not _vault_path:
     logging.warning("VAULT_PATH not set — falling back to cwd(). Task ID generation may produce duplicates.")
 BASE_DIR = Path(_vault_path) if _vault_path else Path.cwd()
 TASKS_FILE = BASE_DIR / '03-Tasks/Tasks.md'
-WEEK_PRIORITIES_FILE = BASE_DIR / 'Inbox' / 'Week Priorities.md'
+WEEK_PRIORITIES_FILE = BASE_DIR / '02-Week_Priorities' / 'Week_Priorities.md'
 QUARTER_GOALS_FILE = BASE_DIR / '01-Quarter_Goals/Quarter_Goals.md'
 GOALS_FILE = BASE_DIR / 'GOALS.md'  # Legacy, kept for compatibility
-INBOX_DIR = BASE_DIR / 'Inbox'
+INBOX_DIR = BASE_DIR / '00-Inbox'
 PILLARS_FILE = BASE_DIR / 'System' / 'pillars.yaml'
 SKILL_RATINGS_FILE = BASE_DIR / 'System' / 'Skill_Ratings' / 'ratings.jsonl'
-COMPANIES_DIR = BASE_DIR / 'Active' / 'Relationships' / 'Companies'
-PEOPLE_DIR = BASE_DIR / 'People'
-MEETINGS_DIR = BASE_DIR / 'Inbox' / 'Meetings'
+COMPANIES_DIR = BASE_DIR / '05-Areas' / 'Companies'
+PEOPLE_DIR = BASE_DIR / '05-Areas' / 'People'
+MEETINGS_DIR = BASE_DIR / '00-Inbox' / 'Meetings'
 PEOPLE_INDEX_FILE = BASE_DIR / 'System' / 'People_Index.json'
 MEETING_CACHE_FILE = BASE_DIR / 'System' / 'Memory' / 'meeting-cache.json'
 
@@ -155,19 +155,19 @@ def get_pillars_file() -> Path:
 def get_week_priorities_file() -> Path:
     """Get the appropriate Week Priorities file based on demo mode"""
     if is_demo_mode():
-        return DEMO_DIR / 'Inbox' / 'Week Priorities.md'
+        return DEMO_DIR / '02-Week_Priorities' / 'Week_Priorities.md'
     return WEEK_PRIORITIES_FILE
 
 def get_people_dir() -> Path:
     """Get the appropriate People directory based on demo mode"""
     if is_demo_mode():
-        return DEMO_DIR / 'People'
+        return DEMO_DIR / '05-Areas' / 'People'
     return PEOPLE_DIR
 
 def get_meetings_dir() -> Path:
     """Get the appropriate Meetings directory based on demo mode"""
     if is_demo_mode():
-        return DEMO_DIR / 'Inbox' / 'Meetings'
+        return DEMO_DIR / '00-Inbox' / 'Meetings'
     return MEETINGS_DIR
 
 
@@ -796,14 +796,8 @@ def get_company_domains(company_filepath: Path) -> List[str]:
 # ============================================================================
 
 def _resolve_people_dir() -> Path:
-    """Resolve the actual People directory, checking both possible locations."""
-    standard = get_people_dir()
-    if standard.exists() and any(standard.iterdir()):
-        return standard
-    para = BASE_DIR / '05-Areas' / 'People'
-    if para.exists():
-        return para
-    return standard
+    """Resolve the actual People directory."""
+    return get_people_dir()
 
 
 def build_people_index_data() -> Dict[str, Any]:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.0.0",
+  "version": "1.18.1",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Fixed pre-PARA path references in 5 Python MCP servers (`work_server.py`, `career_server.py`, `resume_server.py`, `demo_mode_server.py`, `calendar_server.py`)
- Updated `Inbox` → `00-Inbox`, `Active` → `05-Areas`, `People` → `05-Areas/People`, `Resources/Career_Evidence` → `05-Areas/Career/Evidence`
- Simplified `_resolve_people_dir()` in work_server.py to just delegate to `get_people_dir()`
- Fixed `package.json` version from `1.0.0` to `1.18.1`
- Also applied same fixes to `/Users/dave/Vault/` instance

Closes https://github.com/davekilleen/dex-backlog/issues/6

## Test plan
- [x] All 5 Python files parse successfully (`ast.parse`)
- [x] Zero grep hits for bare `Inbox`, `Active`, `People`, `Resources` paths in `core/mcp/`
- [x] `package.json` version reads `1.18.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)