### PR TITLE
Fix hardcoded paths in Pi extensions and session-start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -222,7 +222,7 @@ fi
 
 # 11. QMD Index Refresh (if stale > 12 hours)
 QMD_TIMESTAMP="$CLAUDE_DIR/System/.last-qmd-update"
-QMD_BIN="/Users/dave/.bun/bin/qmd"
+QMD_BIN="${QMD_BIN:-$(which qmd 2>/dev/null || echo '')}"
 if [[ -x "$QMD_BIN" && -f "$ONBOARDING_MARKER" ]]; then
     NEEDS_UPDATE=false
     if [[ ! -f "$QMD_TIMESTAMP" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ System/my-customizations.md
 
 # Pi integration (created when user activates Pi beta)
 .pi/
+# Symlink to pi-extensions/dex (tracked via pi-extensions/)
+!.pi/agent/extensions/dex
 
 # Beta documentation (created on feature activation)
 System/Beta/

--- a/pi-extensions/dex/data-layer.ts
+++ b/pi-extensions/dex/data-layer.ts
@@ -7,10 +7,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const VAULT_PATH = process.env.VAULT_PATH || "/Users/dave/Claudesidian";
+const VAULT_PATH = process.env.VAULT_PATH || process.cwd();
 const TASKS_PATH = path.join(VAULT_PATH, "03-Tasks/Tasks.md");
 const WEEK_PRIORITIES_PATH = path.join(VAULT_PATH, "02-Week_Priorities");
-const DAILY_PLAN_PATH = path.join(VAULT_PATH, "01-Daily_Plan");
+const DAILY_PLAN_PATH = path.join(VAULT_PATH, "00-Inbox", "Daily_Plans");
 const CAREER_EVIDENCE_PATH = path.join(VAULT_PATH, "05-Areas/Career/Evidence");
 
 // Type definitions

--- a/pi-extensions/dex/index.ts
+++ b/pi-extensions/dex/index.ts
@@ -31,7 +31,7 @@ const execAsync = promisify(exec);
 // CONFIGURATION
 // ============================================================================
 
-const VAULT_PATH = process.env.VAULT_PATH || "/Users/dave/Claudesidian";
+const VAULT_PATH = process.env.VAULT_PATH || process.cwd();
 const PEOPLE_PATH = path.join(VAULT_PATH, "05-Areas/People");
 const COMPANIES_PATH = path.join(VAULT_PATH, "05-Areas/Companies");
 const TASKS_PATH = path.join(VAULT_PATH, "03-Tasks/Tasks.md");

--- a/pi-extensions/dex/orchestrator.ts
+++ b/pi-extensions/dex/orchestrator.ts
@@ -14,7 +14,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { Text, Container } from "@mariozechner/pi-tui";
 
-const VAULT_PATH = process.env.VAULT_PATH || "/Users/dave/Claudesidian";
+const VAULT_PATH = process.env.VAULT_PATH || process.cwd();
 
 // ============================================================================
 // TYPES

--- a/pi-extensions/dex/ritual-command-bar.ts
+++ b/pi-extensions/dex/ritual-command-bar.ts
@@ -12,7 +12,7 @@ import { Container, type SelectItem, SelectList, Text, truncateToWidth } from "@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const VAULT_PATH = process.env.VAULT_PATH || "/Users/dave/Claudesidian";
+const VAULT_PATH = process.env.VAULT_PATH || process.cwd();
 
 // ============================================================================
 // RITUAL STATE DETECTION
@@ -122,7 +122,7 @@ function getRitualStates(): RitualState[] {
   }
 
   // Daily Plan (for today)
-  const todayPlan = path.join(VAULT_PATH, `00-Inbox/Daily_Prep/Daily_Prep_${today}.md`);
+  const todayPlan = path.join(VAULT_PATH, `00-Inbox/Daily_Plans/${today}.md`);
   if (!checkFileExists(todayPlan)) {
     rituals.push({
       id: "daily-plan",


### PR DESCRIPTION
## Summary
- Replace all `/Users/dave/Claudesidian` hardcoded paths with `process.cwd()` fallback in 4 Pi extension files
- Fix daily plan path from `01-Daily_Plan` to `00-Inbox/Daily_Plans` in data-layer.ts and ritual-command-bar.ts
- Fix QMD binary path in session-start.sh to use `which qmd` lookup instead of hardcoded `/Users/dave/.bun/bin/qmd`
- Symlink `.pi/agent/extensions/dex` → `pi-extensions/dex` with .gitignore entry

Closes davekilleen/dex-backlog#8

## Test plan
- [ ] `grep -rn "/Users/dave" pi-extensions/` returns nothing
- [ ] `grep -rn "/Users/dave" .claude/hooks/session-start.sh` returns nothing
- [ ] `grep -rn "01-Daily_Plan" pi-extensions/` returns nothing
- [ ] `ls -la .pi/agent/extensions/dex` shows symlink to `../../../../pi-extensions/dex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)