### PR TITLE
fix: correct path references in CJS hooks

### DIFF
--- a/.claude/hooks/company-context-injector.cjs
+++ b/.claude/hooks/company-context-injector.cjs
@@ -42,9 +42,9 @@ if (skipExts.includes(ext)) {
 
 const VAULT_ROOT = process.env.CLAUDE_PROJECT_DIR || process.env.VAULT_PATH || process.cwd();
 // Primary location for company pages (new universal pattern)
-const COMPANIES_DIR = path.join(VAULT_ROOT, '02-Areas', 'Companies');
+const COMPANIES_DIR = path.join(VAULT_ROOT, '05-Areas', 'Companies');
 // Legacy location for backwards compatibility
-const ACCOUNTS_DIR = path.join(VAULT_ROOT, '02-Areas', 'Accounts');
+const ACCOUNTS_DIR = path.join(VAULT_ROOT, '05-Areas', 'Accounts');
 
 // Helper function to recursively scan a directory for company files
 function scanDir(dirPath, index) {
@@ -113,7 +113,7 @@ try {
   const foundCompanies = new Set();
   
   // Method 1: File path references (05-Areas/Companies/ or 05-Areas/Accounts/)
-  const fileRefPattern = /02-Areas\/(?:Companies|Accounts)\/[^\s]*?([A-Za-z0-9_-]+)(?:\.md)?/g;
+  const fileRefPattern = /05-Areas\/(?:Companies|Accounts)\/[^\s]*?([A-Za-z0-9_-]+)(?:\.md)?/g;
   let match;
   while ((match = fileRefPattern.exec(content)) !== null) {
     const name = match[1].toLowerCase();

--- a/.claude/hooks/person-context-injector.cjs
+++ b/.claude/hooks/person-context-injector.cjs
@@ -41,7 +41,7 @@ if (skipExts.includes(ext)) {
 }
 
 const VAULT_ROOT = process.env.CLAUDE_PROJECT_DIR || process.env.VAULT_PATH || process.cwd();
-const PEOPLE_DIR = path.join(VAULT_ROOT, 'People');
+const PEOPLE_DIR = path.join(VAULT_ROOT, '05-Areas', 'People');
 
 // Build an index of all person names to their files
 function buildPersonIndex() {


### PR DESCRIPTION
## Summary
- Fix pre-PARA path in `person-context-injector.cjs`: `People` → `05-Areas/People`
- Fix pre-PARA paths in `company-context-injector.cjs`: `02-Areas/Companies|Accounts` → `05-Areas/Companies|Accounts` (including regex pattern on line 116)
- Also applied same fixes to `/Users/dave/Vault/` instance

Closes https://github.com/davekilleen/dex-backlog/issues/7

## Test plan
- [x] `grep -n "People'" person-context-injector.cjs | grep -v '05-Areas'` returns nothing
- [x] `grep -n "02-Areas" company-context-injector.cjs` returns nothing
- [x] Both files load without crash via `node -e "require(...)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)