### PR TITLE
fix: remove placeholder MCP servers from onboarding template

### DIFF
--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -427,8 +427,10 @@ Check if new MCP servers were added in the update by comparing `.mcp.json.exampl
 For each entry in `.mcp.json.example` that is NOT in the user's `.mcp.json`:
 1. Read the entry from `.mcp.json.example`
 2. Replace `{{VAULT_PATH}}` with the actual vault path
-3. Add to the user's `.mcp.json`
-4. Log: "✓ Added new MCP server: [name]"
+3. **Skip** entries whose env values still contain `{{...}}` placeholder patterns after substitution
+4. **Skip** entries whose key starts with `_` (comment keys)
+5. Add to the user's `.mcp.json`
+6. Log: "✓ Added new MCP server: [name]"
 
 **Never remove or modify existing user MCP entries.** Only add missing ones.
 

--- a/System/.mcp.json.example
+++ b/System/.mcp.json.example
@@ -107,61 +107,6 @@
       "command": "npx",
       "args": ["-y", "slack-mcp"],
       "env": {}
-    },
-
-    "_comment_integrations": "--- Optional Integrations (add via /[tool]-setup) ---",
-
-    "google-workspace-mcp": {
-      "command": "npx",
-      "args": ["-y", "google-workspace-mcp"],
-      "env": {
-        "GOOGLE_CLIENT_ID": "{{GOOGLE_CLIENT_ID}}",
-        "GOOGLE_CLIENT_SECRET": "{{GOOGLE_CLIENT_SECRET}}"
-      }
-    },
-    "teams-mcp": {
-      "command": "npx",
-      "args": ["-y", "teams-mcp"],
-      "env": {
-        "TEAMS_TENANT_ID": "{{TEAMS_TENANT_ID}}",
-        "TEAMS_CLIENT_ID": "{{TEAMS_CLIENT_ID}}"
-      }
-    },
-    "todoist-mcp": {
-      "command": "npx",
-      "args": ["-y", "todoist-mcp-server"],
-      "env": {
-        "TODOIST_API_KEY": "{{TODOIST_API_KEY}}"
-      }
-    },
-    "things3-mcp": {
-      "command": "npx",
-      "args": ["-y", "things3-mcp"],
-      "env": {}
-    },
-    "trello-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-trello"],
-      "env": {
-        "TRELLO_API_KEY": "{{TRELLO_API_KEY}}",
-        "TRELLO_TOKEN": "{{TRELLO_TOKEN}}"
-      }
-    },
-    "zoom-mcp": {
-      "command": "npx",
-      "args": ["-y", "zoom-mcp"],
-      "env": {
-        "ZOOM_CLIENT_ID": "{{ZOOM_CLIENT_ID}}",
-        "ZOOM_CLIENT_SECRET": "{{ZOOM_CLIENT_SECRET}}"
-      }
-    },
-    "atlassian-mcp": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/atlassian-remote-mcp"],
-      "env": {
-        "ATLASSIAN_SITE": "{{ATLASSIAN_SITE}}",
-        "ATLASSIAN_TOKEN": "{{ATLASSIAN_TOKEN}}"
-      }
     }
   }
 }

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -482,15 +482,28 @@ def setup_mcp_config(vault_path: Path) -> tuple[bool, Optional[str]]:
         # Replace {{VAULT_PATH}} with actual path
         config_content = config_content.replace('{{VAULT_PATH}}', str(vault_path))
         
-        # Validate JSON
+        # Validate JSON and filter placeholder servers
         try:
-            json.loads(config_content)
+            config = json.loads(config_content)
         except json.JSONDecodeError as e:
             return False, f"Invalid JSON after substitution: {e}"
-        
+
+        # Remove servers with unresolved placeholder credentials
+        if 'mcpServers' in config:
+            placeholder_re = re.compile(r'\{\{.*?\}\}')
+            to_remove = [
+                name for name, cfg in config['mcpServers'].items()
+                if name.startswith('_') or any(
+                    placeholder_re.search(str(v))
+                    for v in cfg.get('env', {}).values()
+                )
+            ]
+            for name in to_remove:
+                del config['mcpServers'][name]
+
         # Write to target
         with open(MCP_CONFIG_TARGET, 'w') as f:
-            f.write(config_content)
+            json.dump(config, f, indent=2)
         
         return True, None
     except Exception as e:


### PR DESCRIPTION
## Summary

- Placeholder integration servers (google-workspace, teams, todoist, things3, trello, zoom, atlassian) ship in `.mcp.json.example` with template credentials like `{{GOOGLE_CLIENT_ID}}`
- These get copied into the user's live `.mcp.json` during onboarding and load every session, registering tool schemas into Claude's context even though they can't authenticate
- This wastes ~30K-50K context tokens per session for tools that will never work until explicitly configured

## Changes

- **`System/.mcp.json.example`** — Remove 7 placeholder integration entries (55 lines). Only the 11 core servers that work out of the box remain.
- **`core/mcp/onboarding_server.py`** — Add a safety filter in `setup_mcp_config()` that strips any server entries with unresolved `{{...}}` placeholder patterns in their env values. Defense-in-depth so future template additions with placeholders won't leak into live configs.
- **`.claude/skills/dex-update/SKILL.md`** — Update the MCP sync logic to skip entries with unresolved placeholder patterns, preventing the update flow from re-adding placeholder servers.

## Why this is safe

- Setup skills (`/todoist-setup`, `/gmail-setup`, `/atlassian-setup`, etc.) already handle adding servers with real credentials when users configure integrations — this just stops pre-loading unused ones
- The placeholder filter only catches `{{...}}` patterns, so any user who has already replaced placeholders with real credentials is unaffected
- `{{VAULT_PATH}}` is replaced *before* the filter runs, so core servers are never filtered out

## Test plan

- [ ] Run `setup_mcp_config()` on a fresh vault — verify output contains only 11 core servers
- [ ] Verify no `{{...}}` patterns in generated `.mcp.json` (except none should remain)
- [ ] Run a setup skill (e.g. `/todoist-setup`) — verify it still adds the server entry correctly
- [ ] Run `/dex-update` — verify placeholder entries are not re-added