### PR TITLE
Fix: run calendar EventKit helper under the venv Python (not system python3)

### DIFF
--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -184,9 +184,14 @@ def run_shell_script(script_name: str, *args) -> tuple[bool, str]:
             err_path = err_file.name
         
         try:
-            # Build command with quoted args
+            # Build command with quoted args.
+            # Run the helper under THIS interpreter (the venv python, which has
+            # pyobjc EventKit) and put the repo root on PYTHONPATH so the
+            # helper's `from core.paths import ...` resolves. Relying on the
+            # script's `#!/usr/bin/env python3` shebang picks up system python3,
+            # which lacks EventKit and the `core` package.
             cmd_args = ' '.join(f'"{arg}"' for arg in args)
-            cmd = f'"{script_path}" {cmd_args} > "{out_path}" 2> "{err_path}"'
+            cmd = f'PYTHONPATH="{VAULT_PATH}" "{sys.executable}" "{script_path}" {cmd_args} > "{out_path}" 2> "{err_path}"'
             exit_code = os.system(cmd)
             
             with open(out_path, 'r') as f:


### PR DESCRIPTION
## Problem

The calendar MCP server fails with an EventKit import error even when `pyobjc-framework-EventKit` is correctly installed in the project venv.

`run_shell_script()` in `core/mcp/calendar_server.py` executes `scripts/calendar_eventkit.py` via its `#!/usr/bin/env python3` shebang. When the server is launched from the venv — as `System/.mcp.json.example` specifies (`command: {{VAULT_PATH}}/.venv/bin/python`) — the helper is instead run by the **system** `python3`, which:

- lacks `pyobjc-framework-EventKit` → `ModuleNotFoundError: No module named 'EventKit'`
- runs without the repo root on `PYTHONPATH` → `from core.paths import ...` → `ModuleNotFoundError: No module named 'core'`

So every calendar tool (`calendar_list_calendars`, `calendar_get_today`, …) returns an import traceback.

## Fix

Invoke the helper with `sys.executable` — the same interpreter running the server (the venv Python that has EventKit) — and pass the repo root via `PYTHONPATH` so `core.paths` resolves.

```python
cmd = f'PYTHONPATH="{VAULT_PATH}" "{sys.executable}" "{script_path}" {cmd_args} > "{out_path}" 2> "{err_path}"'
```

## Testing

- **Before:** `calendar_list_calendars` → `ModuleNotFoundError: No module named 'EventKit'`
- **After:** the helper runs under the venv Python and returns calendar data, or the expected `"Calendar access denied…"` message when macOS Calendar permission hasn't been granted — i.e. it reaches the real EventKit code path.

Repro: configure the calendar MCP from `System/.mcp.json.example` (uses `.venv/bin/python`), `pip install -r core/mcp/requirements.txt` into `.venv`, then call any calendar tool.