### PR TITLE
ci: make diff-aware gates enforce on new code, not pre-existing debt

### DIFF
--- a/scripts/check-coverage-threshold.py
+++ b/scripts/check-coverage-threshold.py
@@ -47,7 +47,12 @@ def main() -> int:
         pass
 
     merge_base = run(["git", "merge-base", "HEAD", f"origin/{base_ref}"])
-    changed = run(["git", "diff", "--name-only", f"{merge_base}...HEAD"]).splitlines()
+    # --diff-filter=ACMR drops deleted (D) files: a deleted module is absent from
+    # coverage.json and would otherwise score 0% and fail the gate. Removing code
+    # must never fail a coverage gate.
+    changed = run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{merge_base}...HEAD"]
+    ).splitlines()
     touched = [
         f
         for f in changed
@@ -55,6 +60,8 @@ def main() -> int:
         and f.endswith(".py")
         and not f.startswith("core/tests/")
         and not f.startswith("core/mcp/tests/")
+        # Guard against any rename/edge-case path that no longer exists on disk.
+        and Path(f).is_file()
     ]
 
     if not touched:

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 BASE_REF="${GITHUB_BASE_REF:-main}"
 git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
 MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
-CHANGED_FILES="$(git diff --name-only "$MERGE_BASE...HEAD")"
+# --diff-filter=ACMR drops deleted (D) files: removing code should not require
+# a doc change.
+CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"
 
 if [ ! -f "docs/testing-governance.md" ]; then
   echo "Missing required governance document: docs/testing-governance.md"

--- a/scripts/check-path-contract-usage.sh
+++ b/scripts/check-path-contract-usage.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 BASE_REF="${GITHUB_BASE_REF:-main}"
 git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
 MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
-CHANGED_FILES="$(git diff --name-only "$MERGE_BASE...HEAD")"
+# --diff-filter=ACMR drops deleted (D) files so we never grep a path that no
+# longer exists, and never punish a PR for removing code.
+CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changed files detected."
@@ -18,7 +20,10 @@ if [ -z "$CODE_FILES" ]; then
 fi
 
 PATTERN="00-Inbox|01-Quarter_Goals|02-Week_Priorities|03-Tasks|04-Projects|05-Areas|06-Resources|07-Archives"
-ALLOWLIST='^(core/paths\.py|\.claude/hooks/paths\.cjs|\.claude/hooks/(company-context-injector|person-context-injector)\.cjs|scripts/check-path-consistency\.sh|scripts/verify-distribution\.sh|scripts/check-path-contract-usage\.sh|core/migrations/)'
+# Bash hooks (*.sh) cannot import core.paths (Python) or paths.cjs (CJS), so the
+# path-contract is enforced only on Python/CJS/TS/JS code. Shell scripts are
+# allowlisted alongside the contract-source files and migrations.
+ALLOWLIST='^(core/paths\.py|\.claude/hooks/paths\.cjs|\.claude/hooks/(company-context-injector|person-context-injector)\.cjs|scripts/check-path-consistency\.sh|scripts/verify-distribution\.sh|scripts/check-path-contract-usage\.sh|core/migrations/|.*\.sh$)'
 
 VIOLATIONS=0
 for file in $CODE_FILES; do
@@ -26,10 +31,20 @@ for file in $CODE_FILES; do
     continue
   fi
 
-  matches="$(grep -nE "['\"][^'\"]*($PATTERN)[^'\"]*['\"]" "$file" || true)"
-  if [ -n "$matches" ]; then
-    echo "Path-contract violation in $file:"
-    echo "$matches" | sed 's/^/  /'
+  # Defensive guard in case a rename/edge-case slips a non-existent path through.
+  [ -f "$file" ] || continue
+
+  # Diff-aware: only inspect lines this PR ADDS (the '+' side of the unified
+  # diff, excluding the '+++' file header). This stops the gate punishing
+  # pre-existing PARA literals that already lived in a file the PR merely
+  # touched, while still catching any new raw PARA literal the PR introduces.
+  added="$(git diff "$MERGE_BASE...HEAD" -- "$file" \
+    | grep -E '^\+' | grep -Ev '^\+\+\+' \
+    | sed -E 's/^\+//' \
+    | grep -nE "['\"][^'\"]*($PATTERN)[^'\"]*['\"]" || true)"
+  if [ -n "$added" ]; then
+    echo "Path-contract violation in $file (newly added lines):"
+    echo "$added" | sed 's/^/  +/'
     VIOLATIONS=$((VIOLATIONS + 1))
   fi
 done

--- a/scripts/check-test-delta.sh
+++ b/scripts/check-test-delta.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 BASE_REF="${GITHUB_BASE_REF:-main}"
 git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
 MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
-CHANGED_FILES="$(git diff --name-only "$MERGE_BASE...HEAD")"
+# --diff-filter=ACMR drops deleted (D) files: removing dead code should not
+# require adding a test.
+CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changed files detected."


### PR DESCRIPTION
## Summary

Makes the four `pull_request`-only CI gates enforce standards on NEW code without punishing pre-existing debt in touched files. This is why the repo's PR CI had been hostile: any PR editing an existing file inherited its old violations.

- All four diff-aware gates (path-contract, test-delta, doc-drift, touched-file coverage) now use `git diff --diff-filter=ACMR`, so deletions no longer demand a test/doc and a deleted file is never scored 0% coverage.
- `check-path-contract-usage.sh` flags PARA path literals only on lines the PR ADDS, skips deleted files (no more `No such file` grep noise), and allowlists bash hooks that cannot use the Python/CJS path contract.

Main-push (release-gating) gates are unaffected and stay green. Verified with synthetic-PR harnesses plus the full main-push gate set.

Deferred maintainer-calibration decisions (not in this PR): patch-vs-whole-file coverage, raising the 15% floor, moving the governance-doc check out of doc-drift, advisory-vs-blocking for test/doc gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)