### PR TITLE
ci: calibrate gates (patch coverage, 25% floor, advisory test/doc gates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: macos-latest
     env:
       VAULT_PATH: core/tests/fixtures/vault
-      COVERAGE_MIN_TOTAL: "15"
+      COVERAGE_MIN_TOTAL: "25"
       COVERAGE_MIN_TOUCHED: "10"
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,9 @@ jobs:
       - run: npm ci
       - name: Ensure policy scripts are executable
         run: chmod +x scripts/check-*.sh scripts/check-coverage-threshold.py scripts/check-path-contract-usage.sh scripts/security-gate.sh scripts/benchmark_large_vault.py
+      - name: Governance docs present
+        run: |
+          test -f docs/testing-governance.md || { echo "Missing required governance document docs/testing-governance.md"; exit 1; }
       - name: Hook harness tests
         run: npm run test:hooks
       - name: Diff-aware test gate

--- a/scripts/check-coverage-threshold.py
+++ b/scripts/check-coverage-threshold.py
@@ -24,6 +24,33 @@ def normalize_path(path: str, root: Path) -> str:
     return p.as_posix()
 
 
+def added_line_numbers(merge_base: str, file_path: str) -> set[int]:
+    """Return the new-file line numbers ADDED by this PR for file_path."""
+    try:
+        diff = run(["git", "diff", "--unified=0", f"{merge_base}...HEAD", "--", file_path])
+    except subprocess.CalledProcessError:
+        return set()
+    added: set[int] = set()
+    new_lineno = 0
+    for line in diff.splitlines():
+        if line.startswith("@@"):
+            # @@ -old,cnt +new,cnt @@
+            seg = line.split("+", 1)
+            if len(seg) < 2:
+                continue
+            try:
+                new_lineno = int(seg[1].split(" ", 1)[0].split(",", 1)[0])
+            except ValueError:
+                continue
+        elif line.startswith(("+++", "---")):
+            continue
+        elif line.startswith("+"):
+            added.add(new_lineno)
+            new_lineno += 1
+        # '-' (old-file) and '\' (no-newline) lines do not advance the new-file counter
+    return added
+
+
 def main() -> int:
     coverage_path = Path(os.environ.get("COVERAGE_JSON", "coverage.json"))
     min_total = float(os.environ.get("COVERAGE_MIN_TOTAL", "15"))
@@ -68,17 +95,31 @@ def main() -> int:
         print(f"Coverage gate passed. Total coverage: {total:.2f}% (no touched source files).")
         return 0
 
-    file_coverage: dict[str, float] = {}
+    # Patch coverage: judge each touched file on the lines it CHANGED, not its
+    # whole-file coverage. Editing a line in a historically-untested file no
+    # longer inherits that file's pre-existing debt.
+    line_coverage: dict[str, tuple[set[int], set[int]]] = {}
     for raw_path, payload in data.get("files", {}).items():
         key = normalize_path(raw_path, cwd)
-        pct = float(payload.get("summary", {}).get("percent_covered", 0.0))
-        file_coverage[key] = pct
+        executed = set(payload.get("executed_lines", []) or [])
+        missing = set(payload.get("missing_lines", []) or [])
+        line_coverage[key] = (executed, missing)
 
     failures: list[str] = []
     for file_path in touched:
-        pct = file_coverage.get(file_path, 0.0)
+        added = added_line_numbers(merge_base, file_path)
+        executed, missing = line_coverage.get(file_path, (set(), set()))
+        coverable = added & (executed | missing)
+        if not coverable:
+            # No new executable lines (comments, blanks, docstrings) — nothing to score.
+            continue
+        covered = added & executed
+        pct = len(covered) / len(coverable) * 100.0
         if pct < min_touched:
-            failures.append(f"{file_path}: {pct:.2f}% (required {min_touched:.2f}%)")
+            failures.append(
+                f"{file_path}: {pct:.2f}% of changed lines covered "
+                f"({len(covered)}/{len(coverable)}, required {min_touched:.2f}%)"
+            )
 
     if failures:
         print("Touched-file coverage gate failed:", file=sys.stderr)

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -8,11 +8,6 @@ MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
 # a doc change.
 CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"
 
-if [ ! -f "docs/testing-governance.md" ]; then
-  echo "Missing required governance document: docs/testing-governance.md"
-  exit 1
-fi
-
 if [ -z "$CHANGED_FILES" ]; then
   echo "No changed files detected."
   exit 0
@@ -35,29 +30,8 @@ if [ -n "$DOC_CHANGED" ]; then
   exit 0
 fi
 
-LABEL_APPROVED=$(python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-
-event_path = os.environ.get("GITHUB_EVENT_PATH")
-if not event_path or not Path(event_path).is_file():
-    print("0")
-    raise SystemExit
-event = json.loads(Path(event_path).read_text(encoding="utf-8"))
-labels = {(label.get("name") or "").strip() for label in (event.get("pull_request") or {}).get("labels", [])}
-print("1" if "docs-exception-approved" in labels else "0")
-PY
-)
-
-if [ "$LABEL_APPROVED" = "1" ]; then
-  echo "docs-exception-approved label found; bypassing docs drift gate."
-  exit 0
-fi
-
-echo "Source files changed without documentation updates."
+# Advisory only: warn, never block. Quality relies on reviewer judgment.
+echo "::warning::Source changed without doc updates (advisory). Consider updating docs/, System/PRDs/, README, CHANGELOG, or CONTRIBUTING."
 echo "Changed source files:"
 printf "%s\n" "$SOURCE_CHANGED"
-echo ""
-echo "Update docs/System/PRDs or apply 'docs-exception-approved' label with rationale."
-exit 1
+exit 0

--- a/scripts/check-test-delta.sh
+++ b/scripts/check-test-delta.sh
@@ -30,29 +30,8 @@ if [ -n "$TEST_CHANGED" ]; then
   exit 0
 fi
 
-LABEL_APPROVED=$(python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-
-event_path = os.environ.get("GITHUB_EVENT_PATH")
-if not event_path or not Path(event_path).is_file():
-    print("0")
-    raise SystemExit
-event = json.loads(Path(event_path).read_text(encoding="utf-8"))
-labels = {(label.get("name") or "").strip() for label in (event.get("pull_request") or {}).get("labels", [])}
-print("1" if "test-exception-approved" in labels else "0")
-PY
-)
-
-if [ "$LABEL_APPROVED" = "1" ]; then
-  echo "test-exception-approved label found; bypassing test delta gate."
-  exit 0
-fi
-
-echo "Source files changed without test updates."
+# Advisory only: warn, never block. Quality relies on reviewer judgment.
+echo "::warning::Source changed without test updates (advisory). Consider adding or updating tests."
 echo "Changed source files:"
 printf "%s\n" "$SOURCE_CHANGED"
-echo ""
-echo "Add tests or apply 'test-exception-approved' label with rationale."
-exit 1
+exit 0


### PR DESCRIPTION
Implements the four maintainer-decision items deferred from #66.

1. **Patch coverage** — touched-file coverage now judges each file on the lines the PR *changed* (added lines vs `coverage.json` executed/missing), not whole-file %. Editing a line in a historically-untested file no longer inherits its debt.
2. **Coverage floor 15% → 25%** — actual is ~30%, leaving ~5 points headroom.
3. **`test-delta` + `doc-drift` are now advisory** — they emit a `::warning::` but never block. Removed the now-moot label hatches.
4. **Governance-doc check moved** out of the (now advisory) doc-drift gate into its own always-on, blocking step, so a missing `docs/testing-governance.md` can't masquerade as a contributor doc-drift failure.

Verified with synthetic-PR harnesses (covered vs uncovered changed lines both behave correctly; source-without-test/doc now exits 0 advisory) plus the full main-push gate set (pytest+coverage at the new 25% floor, ruff, security, distribution, path-consistency, perf, hook tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)