### PR TITLE
Adopt community PRs #38, #55, #56, #63

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -366,6 +366,8 @@ Flag potential issues:
 
 ## Step 7: Generate Daily Plan
 
+**ALWAYS generate and save a new plan file.** Never skip generation because a plan from a previous day exists in the conversation or vault. Even if context from a prior plan is visible, today is a new day and requires its own plan. If a plan for today's date already exists, overwrite it (the user is requesting a refresh).
+
 Create `07-Archives/Plans/YYYY-MM-DD.md`:
 
 ```markdown

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -432,8 +432,10 @@ Check if new MCP servers were added in the update by comparing `.mcp.json.exampl
 For each entry in `.mcp.json.example` that is NOT in the user's `.mcp.json`:
 1. Read the entry from `.mcp.json.example`
 2. Replace `{{VAULT_PATH}}` with the actual vault path
-3. Add to the user's `.mcp.json`
-4. Log: "✓ Added new MCP server: [name]"
+3. **Skip** entries whose env values still contain `{{...}}` placeholder patterns after substitution
+4. **Skip** entries whose key starts with `_` (comment keys)
+5. Add to the user's `.mcp.json`
+6. Log: "✓ Added new MCP server: [name]"
 
 **Never remove or modify existing user MCP entries.** Only add missing ones.
 

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -27,7 +27,8 @@ Create a synthesis of the week reviewing activity, progress, and what was accomp
 - `06-Resources/Learnings/**/*.md` — Explicit learnings
 - `System/Session_Learnings/*.md` — Auto-captured session learnings
 
-### 5. Daily Reviews
+### 5. Daily Plans & Reviews
+- `07-Archives/Plans/YYYY-MM-DD.md` — This week's daily plans (primary record of planning ritual)
 - `07-Archives/Reviews/Daily_Review_YYYY-MM-DD.md` — This week's reviews
 
 ### 6. Journals (If Enabled)
@@ -139,9 +140,10 @@ For each goal:
 > **Goal 1** advanced because you completed Priority 1.
 > **Goal 2** needs attention — no linked work completed this week."
 
-### 4. Daily Completion Rate Trend (NEW)
+### 4. Daily Completion Rate Trend
 
-If daily reviews exist, calculate completion trends:
+**First check `07-Archives/Plans/` for this week's daily plans.** Count how many days had a `/daily-plan` generated. If daily reviews also exist, cross-reference plan focus items against review completion. If only plans exist (no corresponding review), still count the plan as evidence of the planning ritual and note which focus items were checked off in the plan file itself.
+Calculate completion trends:
 
 > "**Daily plan completion this week:**
 > 

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ ENV/
 # pytest
 .pytest_cache/
 .coverage
+coverage.json
 htmlcov/
 
 # ============================================

--- a/System/.mcp.json.example
+++ b/System/.mcp.json.example
@@ -111,57 +111,6 @@
     "qmd": {
       "command": "qmd",
       "args": ["mcp"]
-    },
-
-    "_comment_integrations": "--- Optional Integrations (add via /[tool]-setup) ---",
-
-    "google-workspace-mcp": {
-      "command": "npx",
-      "args": ["-y", "google-workspace-mcp"],
-      "env": {
-        "GOOGLE_CLIENT_ID": "{{GOOGLE_CLIENT_ID}}",
-        "GOOGLE_CLIENT_SECRET": "{{GOOGLE_CLIENT_SECRET}}"
-      }
-    },
-    "teams-mcp": {
-      "command": "npx",
-      "args": ["-y", "teams-mcp"],
-      "env": {
-        "TEAMS_TENANT_ID": "{{TEAMS_TENANT_ID}}",
-        "TEAMS_CLIENT_ID": "{{TEAMS_CLIENT_ID}}"
-      }
-    },
-    "todoist-mcp": {
-      "command": "npx",
-      "args": ["-y", "todoist-mcp-server"],
-      "env": {
-        "TODOIST_API_KEY": "{{TODOIST_API_KEY}}"
-      }
-    },
-    "things3-mcp": {
-      "command": "npx",
-      "args": ["-y", "things3-mcp"],
-      "env": {}
-    },
-    "trello-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-server-trello"],
-      "env": {
-        "TRELLO_API_KEY": "{{TRELLO_API_KEY}}",
-        "TRELLO_TOKEN": "{{TRELLO_TOKEN}}"
-      }
-    },
-    "zoom-mcp": {
-      "command": "npx",
-      "args": ["-y", "zoom-mcp"],
-      "env": {
-        "ZOOM_CLIENT_ID": "{{ZOOM_CLIENT_ID}}",
-        "ZOOM_CLIENT_SECRET": "{{ZOOM_CLIENT_SECRET}}"
-      }
-    },
-    "atlassian-mcp": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://mcp.atlassian.com/v1/sse"]
     }
   }
 }

--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -25,6 +25,7 @@ Tools:
 
 import json
 import logging
+import os
 import re
 
 # Vault paths (centralized in core.paths)
@@ -148,9 +149,14 @@ def run_shell_script(script_name: str, *args) -> tuple[bool, str]:
         return False, f"Script not found: {script_name}"
 
     try:
+        # Run the helper under THIS interpreter (the venv python, which has
+        # pyobjc EventKit) with the repo root on PYTHONPATH so its
+        # `from core.paths import ...` resolves. The script's shebang would
+        # otherwise pick up system python3, which lacks EventKit. (adapted from #63)
+        env = {**os.environ, "PYTHONPATH": str(VAULT_PATH)}
         result = subprocess.run(
-            [str(script_path), *args],
-            capture_output=True, text=True, timeout=120
+            [sys.executable, str(script_path), *args],
+            capture_output=True, text=True, timeout=120, env=env
         )
 
         if result.returncode == 0:

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -482,15 +482,28 @@ def setup_mcp_config(vault_path: Path) -> tuple[bool, Optional[str]]:
         # Replace {{VAULT_PATH}} with actual path
         config_content = config_content.replace('{{VAULT_PATH}}', str(vault_path))
         
-        # Validate JSON
+        # Validate JSON and filter placeholder servers
         try:
-            json.loads(config_content)
+            config = json.loads(config_content)
         except json.JSONDecodeError as e:
             return False, f"Invalid JSON after substitution: {e}"
+
+        # Remove servers with unresolved placeholder credentials or comment keys
+        if 'mcpServers' in config:
+            placeholder_re = re.compile(r'\{\{.*?\}\}')
+            to_remove = [
+                name for name, cfg in config['mcpServers'].items()
+                if name.startswith('_') or any(
+                    placeholder_re.search(str(v))
+                    for v in cfg.get('env', {}).values()
+                )
+            ]
+            for name in to_remove:
+                del config['mcpServers'][name]
         
         # Write to target
         with open(MCP_CONFIG_TARGET, 'w') as f:
-            f.write(config_content)
+            json.dump(config, f, indent=2)
         
         return True, None
     except Exception as e:

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -1,0 +1,99 @@
+"""
+Tests for the onboarding MCP server's .mcp.json setup.
+
+Covers setup_mcp_config: {{VAULT_PATH}} substitution, JSON validation, and the
+placeholder/comment-key server filtering adopted from community PR #38.
+
+Run with: pytest core/mcp/tests/test_onboarding_server.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# core/mcp/tests -> repo root (for `core.paths`) and core/mcp (for the module).
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "core" / "mcp"))
+
+import onboarding_server  # noqa: E402
+
+
+def _write_example(tmp_path: Path, servers: dict) -> Path:
+    example = tmp_path / ".mcp.json.example"
+    example.write_text(json.dumps({"mcpServers": servers}, indent=2))
+    return example
+
+
+def _redirect_config(monkeypatch, example: Path, target: Path) -> None:
+    monkeypatch.setattr(onboarding_server, "MCP_CONFIG_EXAMPLE", example)
+    monkeypatch.setattr(onboarding_server, "MCP_CONFIG_TARGET", target)
+
+
+class TestSetupMcpConfig:
+    """setup_mcp_config substitution, validation, and filtering."""
+
+    def test_resolves_vault_path_and_strips_placeholder_and_comment_servers(
+        self, tmp_path, monkeypatch
+    ):
+        example = _write_example(
+            tmp_path,
+            {
+                "clean": {
+                    "command": "{{VAULT_PATH}}/.venv/bin/python",
+                    "args": ["{{VAULT_PATH}}/core/mcp/work_server.py"],
+                    "env": {"VAULT_PATH": "{{VAULT_PATH}}"},
+                },
+                "needs_api_key": {
+                    "command": "npx",
+                    "args": ["-y", "some-mcp"],
+                    "env": {"API_KEY": "{{API_KEY}}"},
+                },
+                "_comment_integrations": {
+                    "note": "optional integrations a user can enable later"
+                },
+            },
+        )
+        target = tmp_path / ".mcp.json"
+        _redirect_config(monkeypatch, example, target)
+
+        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+
+        assert ok is True
+        assert err is None
+
+        servers = json.loads(target.read_text())["mcpServers"]
+        # Clean server survives with the real path substituted in.
+        assert "clean" in servers
+        assert servers["clean"]["env"]["VAULT_PATH"] == "/Users/me/Vault"
+        assert "{{VAULT_PATH}}" not in json.dumps(servers["clean"])
+        # Server with an unresolved credential placeholder is dropped.
+        assert "needs_api_key" not in servers
+        # Comment-key block is dropped.
+        assert "_comment_integrations" not in servers
+
+    def test_missing_example_returns_error(self, tmp_path, monkeypatch):
+        _redirect_config(
+            monkeypatch,
+            tmp_path / "does-not-exist.json",
+            tmp_path / ".mcp.json",
+        )
+
+        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+
+        assert ok is False
+        assert ".mcp.json.example not found" in err
+
+    def test_invalid_json_after_substitution_returns_error(
+        self, tmp_path, monkeypatch
+    ):
+        example = tmp_path / ".mcp.json.example"
+        example.write_text('{ "mcpServers": { not valid json }')
+        target = tmp_path / ".mcp.json"
+        _redirect_config(monkeypatch, example, target)
+
+        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+
+        assert ok is False
+        assert "Invalid JSON after substitution" in err
+        assert not target.exists()

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -57,7 +57,7 @@ class TestSetupMcpConfig:
         target = tmp_path / ".mcp.json"
         _redirect_config(monkeypatch, example, target)
 
-        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+        ok, err = onboarding_server.setup_mcp_config(Path("/tmp/test-vault"))
 
         assert ok is True
         assert err is None
@@ -65,7 +65,7 @@ class TestSetupMcpConfig:
         servers = json.loads(target.read_text())["mcpServers"]
         # Clean server survives with the real path substituted in.
         assert "clean" in servers
-        assert servers["clean"]["env"]["VAULT_PATH"] == "/Users/me/Vault"
+        assert servers["clean"]["env"]["VAULT_PATH"] == "/tmp/test-vault"
         assert "{{VAULT_PATH}}" not in json.dumps(servers["clean"])
         # Server with an unresolved credential placeholder is dropped.
         assert "needs_api_key" not in servers
@@ -79,7 +79,7 @@ class TestSetupMcpConfig:
             tmp_path / ".mcp.json",
         )
 
-        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+        ok, err = onboarding_server.setup_mcp_config(Path("/tmp/test-vault"))
 
         assert ok is False
         assert ".mcp.json.example not found" in err
@@ -92,7 +92,7 @@ class TestSetupMcpConfig:
         target = tmp_path / ".mcp.json"
         _redirect_config(monkeypatch, example, target)
 
-        ok, err = onboarding_server.setup_mcp_config(Path("/Users/me/Vault"))
+        ok, err = onboarding_server.setup_mcp_config(Path("/tmp/test-vault"))
 
         assert ok is False
         assert "Invalid JSON after substitution" in err


### PR DESCRIPTION
Adopts four community contributions that couldn't be merged as-is (fork branches, a stale `release` base, or conflicts with changes already on `main` this cycle). Each is re-applied on top of current `main` and adapted where needed. Original authors are credited via `Co-authored-by` on the commit.

## What's included

**#38 (@caleb-love) — onboarding template cleanup**
Strips the placeholder "Optional Integrations" servers from `System/.mcp.json.example`, and filters out any server with an unresolved `{{...}}` credential or a `_`-prefixed comment key during onboarding and `dex-update`. Prevents a fresh install from writing a broken `.mcp.json` full of placeholder servers that fail to start. Adds `core/mcp/tests/test_onboarding_server.py` covering the filter (happy path + both error branches).

**#55 (@rhadiaris) — daily-plan always generates**
`daily-plan` now always generates and saves a current-day plan instead of skipping when a prior day's plan is visible in context. (The PR's personal triathlon-training block was left out, as it's specific to the author rather than the public skill.)

**#56 (@rhadiaris) — week-review reads archived plans**
`week-review` now reads daily plans from `07-Archives/Plans/`.

**#63 (@linusnikander) — calendar helper runs under the venv python**
Runs the EventKit helper under `sys.executable` with the repo root on `PYTHONPATH`, so it picks up the venv's pyobjc instead of system python3 (which lacks EventKit). Adapted to the `subprocess.run()` that landed in #37.

## Housekeeping
- `.gitignore`: ignore the CI-generated `coverage.json`.

Closes #38
Closes #55
Closes #56
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)