### PR TITLE
fix(preflight): correct MCP server path (core/mcp) — clean re-do of #49

### DIFF
--- a/core/tests/test_preflight_paths.py
+++ b/core/tests/test_preflight_paths.py
@@ -1,0 +1,53 @@
+"""Regression tests for the pre-flight MCP server path.
+
+Bug (originally surfaced in #49): ``check_server()`` looked for MCP server
+modules under ``<vault>/dex-core/core/mcp`` — a directory that does not exist —
+so every session start falsely reported ``0/8 MCP servers ready`` and
+``dex-core may need reinstalling`` even when the servers were fine. The servers
+actually live at ``<vault>/core/mcp``. These tests pin the corrected path so the
+``dex-core`` segment can never creep back in.
+"""
+
+from core.utils import preflight
+
+
+def _known_server():
+    """Return any registered core server name and its module filename."""
+    return next(iter(preflight.SERVER_MODULES.items()))
+
+
+def test_check_server_finds_module_under_core_mcp(tmp_path, monkeypatch):
+    """A server file at ``<vault>/core/mcp`` passes the existence check."""
+    server_name, module_file = _known_server()
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+
+    mcp_dir = tmp_path / "core" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    (mcp_dir / module_file).write_text("# stub module\n")
+
+    result = preflight.check_server(server_name)
+
+    # Check 1 (file existence) must pass — the file is NOT reported missing.
+    # (Later checks may still flag a missing 'mcp' package; that's unrelated.)
+    assert result.get("error") != f"Server file not found: {module_file}"
+    assert "may need reinstalling" not in result.get("humanError", "")
+
+
+def test_check_server_ignores_stale_dexcore_path(tmp_path, monkeypatch):
+    """A server file ONLY under the old ``dex-core/core/mcp`` path is NOT found.
+
+    This is the actual regression guard: against the pre-fix code (which looked
+    under ``dex-core/core/mcp``) this test would FAIL, because it would locate
+    the stub there and not report it missing.
+    """
+    server_name, module_file = _known_server()
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+
+    stale_dir = tmp_path / "dex-core" / "core" / "mcp"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / module_file).write_text("# stub module\n")
+
+    result = preflight.check_server(server_name)
+
+    assert result["status"] == "error"
+    assert result["error"] == f"Server file not found: {module_file}"

--- a/core/utils/preflight.py
+++ b/core/utils/preflight.py
@@ -40,7 +40,7 @@ def get_error_queue_path() -> Path:
     return Path(get_vault_path()) / ".logs" / "error-queue.json"
 
 
-# Map of MCP server names → their Python module files (relative to dex-core/core/mcp/)
+# Map of MCP server names → their Python module files (relative to core/mcp/)
 SERVER_MODULES = {
     "work-mcp": "work_server.py",
     "calendar-mcp": "calendar_server.py",
@@ -128,7 +128,7 @@ def needs_recheck(health: dict) -> bool:
 
 def check_server(server_name: str) -> dict:
     """Run fast health check for a single MCP server."""
-    mcp_dir = Path(get_vault_path()) / "dex-core" / "core" / "mcp"
+    mcp_dir = Path(get_vault_path()) / "core" / "mcp"
     module_file = SERVER_MODULES.get(server_name)
 
     if not module_file:


### PR DESCRIPTION
## Linked Issue
- Supersedes #49 (closed). Re-creates only the code fix from that PR; the original inadvertently committed personal vault config, so it was closed and the fix re-done cleanly here.
- Tracking: DEX-49

## What Changed
- `core/utils/preflight.py`: drop the bogus `dex-core/` segment so the pre-flight checker resolves MCP servers at the real `core/mcp/` location instead of the non-existent `dex-core/core/mcp/`. This removes the false "0/8 MCP servers ready" / "dex-core may need reinstalling" alarm shown at every session start.
- Fixed a now-stale code comment that still referenced the old path.
- Added `core/tests/test_preflight_paths.py` — regression tests pinning the corrected path.

## Test Plan
- Added `core/tests/test_preflight_paths.py` (2 tests): one asserts a server file at `<vault>/core/mcp` passes the existence check; the other asserts a file present **only** under the old `dex-core/core/mcp` path is reported missing — this second test **fails against the pre-fix code**, so it genuinely guards the regression.
- Ran locally: `pytest core/tests/test_preflight_paths.py -v` → **2 passed**.
- Tests are dependency-free (Check 1 runs before the `mcp` import check), so they pass regardless of whether the `mcp` package is installed.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert this PR's commit; the change is a one-line path constant (plus a stale-comment tidy and an additive test file).

## Docs Impact
- Files updated: none
- If none, reason: the pre-flight checker is internal tooling with no user-facing surface; behavior is now correct rather than changed.
