### PR TITLE
fix(ai): upgrade budget model to google/gemini-2.5-flash — clean re-do of #11

### DIFF
--- a/.claude/skills/ai-setup/SKILL.md
+++ b/.claude/skills/ai-setup/SKILL.md
@@ -164,7 +164,7 @@ These are AI models from other companies that cost much less:
 |-------|-----------------|---------|----------|
 | **Kimi K2.5** | ~80% cheaper | ⭐⭐⭐⭐ Great | General tasks, thinking |
 | **DeepSeek V3** | ~95% cheaper | ⭐⭐⭐⭐ Great | Coding, analysis |
-| **Gemini Flash** | ~97% cheaper | ⭐⭐⭐ Good | Long documents |
+| **Gemini 2.5 Flash** | ~90% cheaper | ⭐⭐⭐⭐ Great | Long documents, reasoning |
 
 **My recommendation:** Start with **Kimi K2.5** — it's the closest to Claude in quality.
 
@@ -251,12 +251,12 @@ Generate `~/.pi/agent/models.json`:
           "cost": { "input": 0.14, "output": 0.28, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "google/gemini-2.0-flash-exp:free",
-          "name": "Gemini Flash (Free tier)",
+          "id": "google/gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash (Budget)",
           "input": ["text", "image"],
           "contextWindow": 1048576,
           "maxTokens": 8192,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          "cost": { "input": 0.3, "output": 2.5, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
     }
@@ -272,7 +272,7 @@ Say:
 I've added three models you can switch to anytime:
 - **Kimi K2.5** — Best quality budget option
 - **DeepSeek V3** — Super cheap, great for coding
-- **Gemini Flash** — Google's free tier (with limits)
+- **Gemini 2.5 Flash** — Google's budget option, great for reasoning
 
 **How to use them:**
 
@@ -739,7 +739,7 @@ Want me to help you switch to a smaller model?
 
 Some alternatives:
 
-1. **Gemini Flash Free Tier** — Google offers free usage (with limits)
+1. **Gemini 2.5 Flash** — Google's budget model, very affordable
    I can set that up instead
 
 2. **Offline Only** — Skip budget cloud, just use local models

--- a/.scripts/lib/llm-client.cjs
+++ b/.scripts/lib/llm-client.cjs
@@ -76,7 +76,7 @@ async function generateWithGemini(prompt, options = {}) {
   const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
   
   const model = genAI.getGenerativeModel({
-    model: options.model || 'gemini-2.0-flash-thinking-exp-1219',
+    model: options.model || 'gemini-2.5-flash',
     generationConfig: {
       maxOutputTokens: options.maxOutputTokens || 4096,
       temperature: options.temperature || 1.0,

--- a/06-Resources/Dex_System/AI_Model_Options.md
+++ b/06-Resources/Dex_System/AI_Model_Options.md
@@ -23,7 +23,7 @@ Dex can use different AI models depending on your needs:
 Other companies make AI models that cost much less than Claude:
 - **Kimi K2.5** (Moonshot AI) — 80% cheaper, similar quality
 - **DeepSeek V3** — 95% cheaper, great for coding
-- **Gemini Flash** (Google) — 97% cheaper, handles long documents
+- **Gemini 2.5 Flash** (Google) — 90% cheaper, handles long documents
 
 ### Why Use Them?
 
@@ -168,7 +168,7 @@ Run `/ai-status` to see:
 | Claude Sonnet | `claude-sonnet-4-20250514` |
 | Kimi K2.5 | `moonshotai/kimi-k2.5` |
 | DeepSeek V3 | `deepseek/deepseek-chat` |
-| Gemini Flash | `google/gemini-2.0-flash-exp:free` |
+| Gemini 2.5 Flash | `google/gemini-2.5-flash` |
 | Qwen (Offline) | `qwen2.5:14b` |
 
 ---

--- a/System/scripts/configure-ai-models.sh
+++ b/System/scripts/configure-ai-models.sh
@@ -54,12 +54,12 @@ if [[ -n "$OPENROUTER_KEY" ]]; then
           "cost": { "input": 0.14, "output": 0.28, "cacheRead": 0, "cacheWrite": 0 }
         },
         {
-          "id": "google/gemini-2.0-flash-exp:free",
-          "name": "Gemini Flash (Free)",
+          "id": "google/gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash (Budget)",
           "input": ["text", "image"],
           "contextWindow": 1048576,
           "maxTokens": 8192,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          "cost": { "input": 0.3, "output": 2.5, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
     }
@@ -130,7 +130,7 @@ if [[ -n "$OPENROUTER_KEY" ]]; then
     echo "☁️  Budget Cloud (OpenRouter):"
     echo "   - Kimi K2.5"
     echo "   - DeepSeek V3"
-    echo "   - Gemini Flash (free tier)"
+    echo "   - Gemini 2.5 Flash (budget)"
 fi
 
 if command -v ollama &> /dev/null && ollama list 2>/dev/null | grep -q "$OLLAMA_MODEL"; then

--- a/core/tests/test_no_deprecated_models.py
+++ b/core/tests/test_no_deprecated_models.py
@@ -1,0 +1,35 @@
+"""Regression: the budget AI model must not point at a deprecated Gemini model.
+
+PR #11 originally upgraded ``google/gemini-2.0-flash-exp:free`` (deprecated)
+to ``google/gemini-2.5-flash`` but also bundled a macOS-breaking sound change
+and personal config, so it was reworked. These tests pin the model upgrade so
+the deprecated id can't creep back into the config the budget path reads.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Files that configure the budget / cloud model.
+CONFIG_FILES = [
+    ".claude/skills/ai-setup/SKILL.md",
+    "System/scripts/configure-ai-models.sh",
+    "06-Resources/Dex_System/AI_Model_Options.md",
+    ".scripts/lib/llm-client.cjs",
+]
+
+
+def test_no_deprecated_gemini_2_0_flash_in_config():
+    """No config file may reference any deprecated gemini-2.0-flash model."""
+    offenders = [
+        rel
+        for rel in CONFIG_FILES
+        if "gemini-2.0-flash" in (REPO / rel).read_text(encoding="utf-8")
+    ]
+    assert not offenders, f"Deprecated gemini-2.0-flash model still referenced in: {offenders}"
+
+
+def test_budget_model_is_gemini_2_5_flash():
+    """The ai-setup budget model is the current google/gemini-2.5-flash."""
+    text = (REPO / ".claude/skills/ai-setup/SKILL.md").read_text(encoding="utf-8")
+    assert "google/gemini-2.5-flash" in text


### PR DESCRIPTION
## Linked Issue
- Supersedes #11 (to be closed). Re-applies only the model upgrade from that PR; the original also swapped `afplay` → `pw-play` (breaks notification sound on macOS) and committed a personal `ai_models` block into `System/user-profile.yaml`, so it was reworked cleanly here.
- Tracking: DEX-11

## What Changed
- Replace the deprecated budget model `google/gemini-2.0-flash-exp:free` with `google/gemini-2.5-flash` in `.claude/skills/ai-setup/SKILL.md` and `System/scripts/configure-ai-models.sh` (id, display name, and cost — now `input 0.3 / output 2.5`, a paid budget model rather than the retired free tier).
- Update the `06-Resources/Dex_System/AI_Model_Options.md` table + summary and the `.scripts/lib/llm-client.cjs` default (was the stale `gemini-2.0-flash-thinking-exp-1219`).
- Relabel "~97% cheaper / free tier" → "~90% cheaper / budget" so the docs no longer claim a free tier that no longer exists.
- Add `core/tests/test_no_deprecated_models.py` to guard against the deprecated id returning.

## Test Plan
- Added `core/tests/test_no_deprecated_models.py` (2 tests): one asserts no budget-model config file references any `gemini-2.0-flash` model; the other asserts the ai-setup model is `google/gemini-2.5-flash`. The first **fails against the pre-fix config**, so it genuinely guards the regression.
- Ran locally: `pytest core/tests/test_no_deprecated_models.py -v` → **2 passed**.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert this PR's commit; changes are config/doc string swaps plus an additive test file.

## Docs Impact
- Files updated: `06-Resources/Dex_System/AI_Model_Options.md`, `.claude/skills/ai-setup/SKILL.md` (budget-model id, cost, and "free tier" → "budget" labels)
- If none, reason: n/a

---
Original contribution by @markalexwatson (PR #11), preserved via `Co-authored-by`. The Linux notification-sound change from that PR was intentionally **not** included because `pw-play` is Linux/PipeWire-only and would break sound on macOS; a cross-platform version can be a separate PR.
