### PR TITLE
chore(release): v1.20.1 — session-start, task priorities, budget model fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.20.1] - Fixes: a false startup alarm, blocked tasks, and the budget model (2026-06-02)
+
+A round of fixes for small things that were quietly getting in the way.
+
+**What this fixes for you:**
+
+* **No more false "your install is broken" alarm.** On startup, Dex sometimes warned that "0/8 MCP servers ready" and that it "may need reinstalling" — even when everything was working perfectly. It was looking in the wrong folder. Fixed.
+* **Tasks won't get wrongly rejected.** Adding a task could fail with "priority limit exceeded" even when you only had a couple of tasks at that level, because Dex was miscounting and reading the priority from the wrong place. It now reads your real backlog correctly.
+* **The budget AI model works again.** The low-cost option still pointed at a Google model that has since been retired, so it could fail. It now uses the current Gemini 2.5 Flash (still around 90% cheaper than Claude).
+* **Behind the scenes:** the automated checks that run on every release no longer fail spuriously, so Dex's own update pipeline is healthy again.
+
+Nothing to do on your end — just update.
+
+---
+
 ## [1.20.0] - Granola Meetings Now Sync Through the Official API (2026-06-01)
 
 For a while, Dex pulled your Granola meetings by reading Granola's local files on your machine. That worked until Granola encrypted those files in v7.162.6, and the local route quietly stopped being viable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Linked Issue
- Release packaging fixes already on `main`: #45 (closed), #41 (via #54), and the clean re-dos #49→#70 and #11→#71.
- Tracking: DEX-1201

## What Changed
- Bump `package.json` to **1.20.1**.
- Add the **1.20.1** CHANGELOG entry (user-facing notes for the four fixes).

No functional code — version + changelog only. Tagging `v1.20.1` after merge triggers the GitHub Release (notes are extracted from the CHANGELOG) so existing users get the update notification.

## Test Plan
- Ran `bash scripts/verify-distribution.sh` → **0 errors** (10 pre-existing warnings, unrelated to this change); `package.json` 1.20.1 now matches the CHANGELOG top version.
- No code paths changed.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert the version/changelog bump; no functional code to roll back.

## Docs Impact
- Files updated: `CHANGELOG.md` (release notes), `package.json` (version)
- If none, reason: n/a
