### PR TITLE
fix(install): silence upstream Node deprecation warnings during setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+# Quiet Node's noisy upstream deprecation warnings (e.g. DEP0040 "punycode is
+# deprecated") so first-run install output stays clean. These originate from
+# transitive dependencies / npm internals on newer Node versions, not from Dex,
+# and are harmless. Preserves any NODE_OPTIONS the user already set.
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
+
 echo "🚀 Setting up Dex..."
 echo ""
 


### PR DESCRIPTION
## What
Sets `NODE_OPTIONS=--no-deprecation` at the top of `install.sh` so Node's upstream deprecation warnings (e.g. `[DEP0040]` punycode) don't clutter first-run install output.

## Why
On newer Node versions `install.sh` prints:

    (node:xxxxx) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.

The warning comes from transitive dependencies / npm internals, **not** Dex code, and the install completes fine — but it reads like an error and alarms new users. Reported in #51.

## Change
One line, right after `set -e`:

    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"

Preserves any `NODE_OPTIONS` the user already set. Purely cosmetic — no behavioural change to the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)