### PR TITLE
fix(work-mcp): harden pillar keyword loading and repair QMD import flag

### DIFF
--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -33,12 +33,9 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
-# QMD semantic search (optional - gracefully degrade if not available)
-try:
-    from utils.qmd_query import is_qmd_available, vault_search
-    HAS_QMD = True
-except ImportError:
-    HAS_QMD = False
+# QMD semantic search (optional). The real import is deferred until after
+# sys.path is set up for 'core.*' below; assume unavailable until then.
+HAS_QMD = False
 
 # Analytics helper (optional - gracefully degrade if not available)
 try:
@@ -57,6 +54,14 @@ logger = logging.getLogger(__name__)
 # The script is at core/mcp/work_server.py, so we need to add the vault root
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+# QMD semantic search (optional - gracefully degrade if not available).
+# Must come after the sys.path.insert above so 'core.*' resolves.
+try:
+    from core.utils.qmd_query import is_qmd_available, vault_search
+    HAS_QMD = True
+except ImportError:
+    HAS_QMD = False
+
 # Import reference formatter for Obsidian wiki link support
 try:
     from core.utils.reference_formatter import (
@@ -73,11 +78,10 @@ except ImportError:
     HAS_REFERENCE_FORMATTER = False
 
 # Import QMD search index refresh (optional - silently skips if QMD not installed)
+# Note: does not touch HAS_QMD — that flag tracks the qmd_query import above.
 try:
     from core.utils.qmd_indexer import refresh_search_index
-    HAS_QMD = True
 except ImportError:
-    HAS_QMD = False
     def refresh_search_index(): pass
 
 # Health system — error queue and health reporting
@@ -226,7 +230,9 @@ def load_pillars_from_yaml() -> Dict[str, Dict]:
             pillars[pillar_id] = {
                 'name': pillar.get('name', pillar_id),
                 'description': pillar.get('description', ''),
-                'keywords': pillar.get('keywords', [])
+                # Coerce to str: YAML parses unquoted tokens like 1:1 as ints
+                # (base-60), which would crash guess_pillar's `keyword in text`.
+                'keywords': [str(k) for k in pillar.get('keywords', [])]
             }
         
         if not pillars:


### PR DESCRIPTION
## Linked Issue
- N/A — community contribution. Full bug analysis is in this description; happy to open a tracking issue if you'd prefer one.

## What Changed
Two root-cause fixes in `core/mcp/work_server.py`:

1. **Pillar keyword crash.** An unquoted YAML token like `1:1` in a user's `System/pillars.yaml` parses as a base-60 int (`61`), so `guess_pillar()`'s `keyword in item_lower` (`work_server.py:313`) raises `'in <string>' requires string as left operand, not int`. That takes down **every** pillar-inferring tool — `list_tasks`, `create_task`, `get_work_summary`, `get_week_progress`. Fix: coerce keywords to `str` at load (`load_pillars_from_yaml`), so the loader is robust to any non-string value regardless of how a user's pillars file was written.

2. **`create_task` NameError.** Two `HAS_QMD` assignments guard different imports:
   - The `qmd_query` import (`is_qmd_available`, `vault_search`) used the wrong path (`utils.qmd_query` rather than `core.utils.qmd_query`) **and** ran before `sys.path.insert(..., <vault root>)`, so it always failed → `is_qmd_available` never defined.
   - The later `qmd_indexer` import succeeds (it runs after the `sys.path` insert) and set `HAS_QMD = True`, clobbering the earlier `False`.

   Result: `HAS_QMD` is `True` while `is_qmd_available` is undefined, so `find_similar_tasks` (`:2140`) and the meeting-context path (`:2613`) raise `NameError: name 'is_qmd_available' is not defined`. (Side note: because the `qmd_query` import never resolved, QMD semantic de-duplication has effectively been dead code.) Fix: move the `qmd_query` import to after the `sys.path` insert with the correct path, and stop the `qmd_indexer` block from touching `HAS_QMD` (it has a no-op fallback and one unguarded call site, so it never needed the flag).

## Test Plan
- Verified in a clean Python process (independent of any long-running MCP server):
  - All pillar keywords load as `str`; `guess_pillar` returns the right pillar for `1:1`, `121`, and multi-word titles with no crash.
  - `is_qmd_available`, `vault_search`, `refresh_search_index` all resolve; `HAS_QMD == True`.
  - With QMD not indexed, `is_qmd_available()` returns `False` → `find_similar_tasks` falls back to keyword matching (the existing `try/except`), so there's no behavior change beyond removing the crash.
- Negative path: confirmed graceful degradation when QMD isn't installed (import guarded; no-op `refresh_search_index` intact).
- Regression test: not included yet. Suggested unit tests: (a) `load_pillars_from_yaml` returns all-`str` keywords given an unquoted `1:1`; (b) `guess_pillar('1:1 sync')` does not raise. Glad to add before merge if you'd like.

## Risk & Rollback
- Risk: **low.** No public API or tool-signature changes. The keyword coercion is a pure boundary normalization; the QMD path stays guarded by `is_qmd_available()` plus a `try/except` keyword fallback, so it can't crash task creation. The one behavioral change: on machines where QMD *is* installed, semantic de-dup now actually runs (its intended, previously-dead behavior).
- Rollback: revert this commit (four small hunks in one file).

## Docs Impact
- None required. Suggest a `CHANGELOG.md` entry (e.g. v1.20.2): task tools crashed on certain pillar keywords, and `create_task` hit a hidden semantic-search error — both fixed.

---
*Found while using Dex; fix written with Claude Code's help and verified before submitting, per CONTRIBUTING.md.*
