### PR TITLE
Instruction layer tells the truth: fix 10 audited wrong-instruction defects

### DIFF
--- a/.agents/skills/getting-started/SKILL.md
+++ b/.agents/skills/getting-started/SKILL.md
@@ -47,8 +47,8 @@ else:
 Say: "Hold on... analyzing your calendar and meetings. 🔍"
 
 **Execute analysis:**
-1. Call calendar MCP: `get_events_for_week()` 
-2. Call granola MCP: `get_recent_meetings(days=7)`
+1. Call calendar MCP: `calendar_get_events` for the next 7 days 
+2. Call granola MCP: `granola_get_recent_meetings(days_back=7)`
 3. Analyze the data
 
 **Then reveal what you found:**
@@ -854,12 +854,7 @@ After completing the main pathway flow (A, B, or C) but before showing the compl
 
 ### How to Run
 
-Execute the integration concierge:
-```bash
-node .Codex/hooks/integration-concierge.cjs
-```
-
-Parse the JSON output for `high_value` and `moderate_value` recommendations.
+Derive the recommendations inline — the standalone concierge script is not shipped. Review which integrations are connected (calendar, Granola, task manager) against what the user's setup suggests they would value, and classify the gaps as high-value or moderate-value yourself.
 
 ### Presenting Recommendations
 

--- a/.agents/skills/process-meetings/SKILL.md
+++ b/.agents/skills/process-meetings/SKILL.md
@@ -7,10 +7,10 @@ hooks:
   PostToolUse:
     - matcher: Write
       type: command
-      command: "node .Codex/hooks/post-meeting-person-update.cjs"
+      command: "node .claude/hooks/post-meeting-person-update.cjs"
   Stop:
     - type: command
-      command: "node .Codex/hooks/meeting-summary-generator.cjs"
+      command: "node .claude/hooks/meeting-summary-generator.cjs"
 ---
 
 # Process Meetings

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -47,6 +47,8 @@ Check for tasks captured from phone that haven't been triaged:
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
 
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
+
 If items found, triage them before building the plan so task counts are accurate. See Step 5.10a for the full triage flow.
 
 **If empty:** Skip silently.
@@ -62,7 +64,7 @@ Run these silently without user-facing output:
 3. **Search index refresh**: Run `qmd update && qmd embed` to refresh vault search index with any overnight changes (meetings processed, files edited, etc.). If `qmd` is not installed, skip silently.
 4. **People index refresh**: Call `build_people_index` from Work MCP. This keeps the People Directory current so person lookups throughout the day are fast. Takes <2 seconds.
 5. **Innovation synthesis** (silent): Call `synthesize_changelog()` and `synthesize_learnings()` from Improvements MCP. These run in background and populate the backlog — results are surfaced in Step 1.5 below.
-6. **Granola check** (silent): Granola meeting sync uses the desktop app's stored credentials automatically. No migration check needed.
+6. **Granola check** (silent): Granola sync uses the official API via `GRANOLA_API_KEY` (environment or vault-root `.env`). If no key is configured, skip all Granola steps silently — an unconnected optional integration is not an error.
 
 ---
 
@@ -212,23 +214,23 @@ Match tasks to available time based on effort classification:
 
 **This step runs automatically when QMD is installed via `/enable-semantic-search`.** It adds a semantic search layer on top of the standard context gathering to surface connections that keyword search misses.
 
-Check if QMD MCP tools are available by calling `qmd_status`. **If available:**
+Check if QMD MCP tools are available by calling the `status` tool (QMD MCP). **If available:**
 
 1. **For each meeting today**, run:
    ```
-   qmd_search(query="[meeting topic] [attendee names]", limit=3)
+   query(query="[meeting topic] [attendee names]", limit=3)
    ```
    Surface: past discussions, related decisions, relevant commitments that share **meaning** but not keywords with this meeting. Example: a meeting about "customer onboarding" finds notes about "activation rates" and "time to value".
 
 2. **For each weekly priority that's lagging**, run:
    ```
-   qmd_search(query="[priority description]", limit=3)
+   query(query="[priority description]", limit=3)
    ```
    Surface: vault content that advances or relates to this priority but wouldn't appear in a keyword search. Especially useful for finding forgotten context about stalled work.
 
 3. **Cross-topic connection scan:**
    ```
-   qmd_search(query="[today's key themes combined]", limit=5)
+   query(query="[today's key themes combined]", limit=5)
    ```
    Surface: unexpected connections between today's meetings, tasks, and priorities. This is where semantic search shines — finding that a 2pm customer call relates to a PRD you wrote last month using completely different terminology.
 
@@ -302,6 +304,8 @@ If unhealthy: skip silently (graceful degradation -- no error to user).
 ```
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
+
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
 
 If items found, surface:
 
@@ -549,10 +553,10 @@ The plan works at multiple levels:
 
 | Integration | MCP Server | Tools Used |
 |-------------|------------|------------|
-| Calendar | dex-calendar-mcp | `calendar_get_today`, `calendar_get_events_with_attendees` |
-| Reminders | dex-calendar-mcp | `reminders_list_items`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed` |
-| Granola | dex-granola-mcp | `get_recent_meetings` |
-| Work | dex-work-mcp | `list_tasks`, `get_week_progress`, `get_meeting_context`, `get_commitments_due`, `analyze_calendar_capacity`, `suggest_task_scheduling` |
+| Calendar | calendar-mcp | `calendar_get_today`, `calendar_get_events_with_attendees` |
+| Reminders | calendar-mcp | `reminders_list_items`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed` |
+| Granola | granola-mcp | `granola_get_recent_meetings` |
+| Work | work-mcp | `list_tasks`, `get_week_progress`, `get_meeting_context`, `get_commitments_due`, `analyze_calendar_capacity`, `suggest_task_scheduling` |
 | Improvements | dex-improvements-mcp | `synthesize_changelog`, `synthesize_learnings`, `list_ideas` |
 | Google Workspace | google-workspace-mcp | Gmail query, email search (if enabled) |
 | Teams | teams-mcp | `teams_list_chats`, `teams_search_messages`, `teams_health_check` (if enabled) |

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -97,6 +97,8 @@ Check for tasks added from phone during the day that weren't triaged in the morn
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
 
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
+
 If items found:
 - Surface them: "📱 **Phone captures not yet triaged** (X items in Dex Inbox)"
 - Run the same triage flow as daily-plan Step 5.10a: infer pillar, confirm with user, create task, mark Reminder complete
@@ -462,6 +464,6 @@ Add one line at the end of the review output:
 | Integration | MCP Server | Tools Used |
 |-------------|------------|------------|
 | Meetings | Meeting source MCP (via `/process-meetings today`) | Fetches and processes unprocessed meetings |
-| Work | dex-work-mcp | `list_tasks`, `get_week_progress`, `get_commitments_due`, `analyze_calendar_capacity` |
-| Calendar | dex-calendar-mcp | `calendar_get_today` |
-| Reminders | dex-calendar-mcp | `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed`, `reminders_list_items` |
+| Work | work-mcp | `list_tasks`, `get_week_progress`, `get_commitments_due`, `analyze_calendar_capacity` |
+| Calendar | calendar-mcp | `calendar_get_today` |
+| Reminders | calendar-mcp | `reminders_list_completed`, `reminders_find_and_complete`, `reminders_clear_completed`, `reminders_list_items` |

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -390,7 +390,7 @@ git reset --hard backup-before-v1.3.0
 If breaking_changes was true, check for migration script:
 
 ```bash
-ls core/migrations/v*-to-v*.sh
+ls core/migrations/v*-to-v*.sh 2>/dev/null | grep -v -- '-example'   # templates ending in -example.sh are not migrations
 ```
 
 If found:
@@ -403,7 +403,7 @@ This is safe and automatic.
 
 Run:
 ```bash
-./core/migrations/v1-to-v2.sh --auto
+./core/migrations/<script-found-by-the-check-above>.sh --auto
 ```
 
 Show migration output.
@@ -693,7 +693,7 @@ Nothing was changed. Your Dex is exactly as it was.
 If migration script supports `--auto` flag, run non-interactively:
 
 ```bash
-./core/migrations/v1-to-v2.sh --auto
+./core/migrations/<script-found-by-the-check-above>.sh --auto
 ```
 
 **Migration script must:**
@@ -715,7 +715,7 @@ Don't worry - it's one command and takes 30 seconds.
 
 **In Cursor's terminal (bottom panel), run:**
 
-./core/migrations/v1-to-v2.sh
+./core/migrations/<script-found-by-the-check-above>.sh
 
 **Then come back here when it's done.**
 

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -46,8 +46,8 @@ else:
 Say: "Hold on... analyzing your calendar and meetings. 🔍"
 
 **Execute analysis:**
-1. Call calendar MCP: `get_events_for_week()` 
-2. Call granola MCP: `get_recent_meetings(days=7)`
+1. Call calendar MCP: `calendar_get_events` for the next 7 days 
+2. Call granola MCP: `granola_get_recent_meetings(days_back=7)`
 3. Analyze the data
 
 **Then reveal what you found:**

--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -231,7 +231,7 @@ For each issue, show the full technical context (this is the one time you show t
 Issue #1: Granola MCP — missing package
 
   Technical error: ModuleNotFoundError: No module named 'granola_server'
-  Server config: dex-granola-mcp in .mcp.json
+  Server config: granola-mcp in .mcp.json
   Last working: 2 days ago
 
   Fix: pip install -e dex-core
@@ -376,7 +376,7 @@ Don't go into fix mode unless asked.
 
 ### Granola Check
 
-Granola meeting sync uses the desktop app's stored credentials automatically. As part of the health check, verify that Granola's credentials file exists (supabase.json in Granola's app data directory). If missing, note that Granola isn't installed or the user isn't signed in.
+Granola sync uses the official Granola API with an API key — there is no local-file fallback. Verify a key is configured: `GRANOLA_API_KEY` in the environment or in the vault-root `.env`. If no key is set, report that Granola isn't connected and point to `/granola-setup`. Do NOT check for `supabase.json` or any Granola desktop-app file — the shipping connector never reads them, so their absence says nothing about whether Granola works.
 
 ---
 

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -97,17 +97,17 @@ Search `00-Inbox/Meetings/` for recent meetings with these attendees:
 
 **This step runs automatically when QMD is installed.** It enriches meeting prep with semantically related vault content that keyword search would miss.
 
-Check if QMD MCP tools are available by calling `qmd_status`. **If available:**
+Check if QMD MCP tools are available by calling the `status` tool (QMD MCP). **If available:**
 
 1. **Semantic search for meeting topic:**
    ```
-   qmd_search(query="$MEETING", limit=5)
+   query(query="$MEETING", limit=5)
    ```
    Look for: related past discussions, relevant decisions, thematic connections — content that shares meaning with the meeting topic but uses different words.
 
 2. **Semantic search for each attendee (beyond their person page):**
    ```
-   qmd_search(query="$ATTENDEE_NAME context discussions decisions", limit=3)
+   query(query="$ATTENDEE_NAME context discussions decisions", limit=3)
    ```
    Look for: contextual references where this person is mentioned by role/title/team (e.g., "the VP of Sales asked about..."), not just by name.
 

--- a/.claude/skills/quarter-review/SKILL.md
+++ b/.claude/skills/quarter-review/SKILL.md
@@ -66,6 +66,8 @@ Before reviewing, check for tasks captured from phone that haven't been triaged:
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
 
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
+
 If items found:
 - Surface them: "📱 **Phone captures not yet triaged** (X items in Dex Inbox)"
 - Run triage flow: infer pillar, confirm with user, create task, mark Reminder complete

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -81,25 +81,25 @@ Parse `System/pillars.yaml`:
 
 **This step activates automatically when QMD is installed.** It dramatically improves routing accuracy by matching inbox items to goals, projects, and people by **meaning**, not just keywords.
 
-Check if QMD MCP tools are available by calling `qmd_status`. **If available:**
+Check if QMD MCP tools are available by calling the `status` tool (QMD MCP). **If available:**
 
 After loading strategic context (Step 0), enhance matching with semantic search:
 
 1. **For each inbox item**, run:
    ```
-   qmd_search(query="[item title + first 100 words of content]", limit=5)
+   query(query="[item title + first 100 words of content]", limit=5)
    ```
    This finds vault content related by meaning. "Email about onboarding flow" matches "Q1 goal: improve activation rate" even though they share no keywords.
 
 2. **For task deduplication**, use semantic similarity instead of keyword overlap:
    ```
-   qmd_search(query="[task description]", limit=3)
+   query(query="[task description]", limit=3)
    ```
    Catches semantic duplicates: "Review Q1 metrics" detected as duplicate of "Check quarterly pipeline numbers".
 
 3. **For goal alignment scoring**, run:
    ```
-   qmd_search(query="[item content]", limit=3)
+   query(query="[item content]", limit=3)
    ```
    against quarterly goals and weekly priorities. Items semantically related to active goals get a +25 confidence boost.
 

--- a/.claude/skills/week-plan/SKILL.md
+++ b/.claude/skills/week-plan/SKILL.md
@@ -396,6 +396,6 @@ After generating the file, provide a summary:
 
 | Integration | MCP Server | Tools Used |
 |-------------|------------|------------|
-| Calendar | dex-calendar-mcp | `calendar_get_events_with_attendees` |
-| Work | dex-work-mcp | `list_tasks`, `get_quarterly_goals`, `get_goal_status`, `create_weekly_priority`, `analyze_calendar_capacity`, `classify_task_effort`, `suggest_task_scheduling`, `get_commitments_due` |
-| Granola | dex-granola-mcp | `get_upcoming_meetings` (optional) |
+| Calendar | calendar-mcp | `calendar_get_events_with_attendees` |
+| Work | work-mcp | `list_tasks`, `get_quarterly_goals`, `get_goal_status`, `create_weekly_priority`, `analyze_calendar_capacity`, `classify_task_effort`, `suggest_task_scheduling`, `get_commitments_due` |
+| Granola | granola-mcp | `granola_get_today_meetings` (optional) |

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -28,6 +28,8 @@ After processing meetings, check for tasks captured from phone that haven't been
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
 
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
+
 If items found:
 - Surface them: "📱 **Phone captures not yet triaged** (X items in Dex Inbox)"
 - Run triage flow: infer pillar, confirm with user, create task, mark Reminder complete
@@ -470,8 +472,8 @@ After synthesis:
 
 | Integration | MCP Server | Tools Used |
 |-------------|------------|------------|
-| Work | dex-work-mcp | `list_tasks`, `get_week_progress`, `get_quarterly_goals`, `get_goal_status` |
-| Calendar | dex-calendar-mcp | `calendar_get_events_with_attendees` |
+| Work | work-mcp | `list_tasks`, `get_week_progress`, `get_quarterly_goals`, `get_goal_status` |
+| Calendar | calendar-mcp | `calendar_get_events_with_attendees` |
 | Improvements | dex-improvements-mcp | `list_ideas` |
 | Analytics | dex-analytics | `track_event` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ When the user requests task creation without specifying a pillar:
    - User confirms (yes/sounds good/correct) → Create task with inferred pillar
    - User specifies different pillar → Use their choice
    - Unclear task → Ask which pillar makes most sense
-5. **Call Work MCP**: `work_mcp_create_task` with confirmed pillar
+5. **Call Work MCP**: `create_task` with confirmed pillar
 
 **Inference examples** (match against the user's actual pillars in `System/pillars.yaml` — names below are illustrative only):
 - "Prep demo for Acme Corp" → the pillar whose keywords cover sales/customer/demo work
@@ -503,7 +503,7 @@ Domain matching is configured during onboarding or can be updated manually in `S
 **MCP Server:** `scrapling` (runs via `scrapling mcp`)
 **No API key required.** Local, free, stealth-capable.
 
-**When a user asks to scrape/fetch/extract from a URL, prefer Scrapling MCP tools over WebFetch.**
+**If the `scrapling` MCP server is connected, prefer its tools over WebFetch when a user asks to scrape/fetch/extract from a URL.** Scrapling is not part of the default install — if the server is not connected, use WebFetch (or offer to set Scrapling up, see Setup below) instead of calling tools that are not there.
 
 | Tool | When to Use |
 |------|-------------|


### PR DESCRIPTION
Batch B from the [2026-07-10 audit](https://github.com/davekilleen/Dex) — every finding was adversarially verified before making this list. Each item is a shipped instruction that names a wrong tool, a wrong path, or a wrong model of how a feature works, so Claude either silently no-ops or tells the user a working feature is broken.

| fix | files |
|---|---|
| QMD tools are `status`/`query`, not `qmd_status`/`qmd_search` | daily-plan, triage, meeting-prep |
| `work_mcp_create_task` → `create_task` | CLAUDE.md |
| Tour called `get_events_for_week()` / `get_recent_meetings(days=7)` — neither exists | getting-started (both copies) |
| Granola health diagnosed via `supabase.json`, which the API-key-only connector never reads → working setups reported broken | health-check, daily-plan |
| Apple Reminders phone-capture invoked ungated at 5 sites → opaque error for never-enabled users | daily-plan, daily-review, week-review, quarter-review |
| Migration glob matched `v1-to-v2-example.sh`; 3 refs to a script that ships nowhere | dex-update |
| Scrapling hard-instructed but not in the default install → made conditional | CLAUDE.md |
| `.Codex/hooks/` → `.claude/hooks/`; unshipped concierge invocation removed (fixes #74's path half) | .agents adapters |
| Dependency tables: wrong server keys + nonexistent tools | 5 skills |

Markdown only — no runtime code. Gates: verify-distribution 0 errors · path-consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG