### PR TITLE
Honest task completion, opt-in qmd registration, calendar guidance, live safety guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash .claude/hooks/dex-safety-guard.sh"
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/ensure-mcp-user-scope.cjs"
           }
         ]

--- a/.claude/skills/enable-semantic-search/SKILL.md
+++ b/.claude/skills/enable-semantic-search/SKILL.md
@@ -166,6 +166,26 @@ echo ""
 cd "$VAULT_PATH" && qmd embed --help 2>/dev/null || true
 ```
 
+## Step 4.5: Register the QMD MCP Server
+
+qmd is intentionally NOT pre-registered in `.mcp.json` — a registered server whose binary
+is missing shows the user a failing MCP server every session. Now that qmd is installed,
+add the registration to the vault's `.mcp.json`:
+
+```bash
+python3 - <<'EOF'
+import json, pathlib
+p = pathlib.Path(".mcp.json")
+cfg = json.loads(p.read_text()) if p.exists() else {"mcpServers": {}}
+cfg.setdefault("mcpServers", {})["qmd"] = {"command": "qmd", "args": ["mcp"]}
+p.write_text(json.dumps(cfg, indent=2) + "\n")
+print("qmd registered in .mcp.json")
+EOF
+```
+
+Tell the user to restart their coding harness (Claude Code/Cursor) after setup completes
+so the new MCP server is picked up.
+
 ## Step 5: Smart Collection Discovery (THE CONCIERGE)
 
 This is what makes Dex's semantic search better than generic indexing. Instead of dumping everything into one blob, we analyze the vault and create purpose-built collections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.24.0] - Honest task completion, opt-in search registration, calendar guidance (2026-07-11)
+
+Final code batch from the dex-core audit.
+
+**What this fixes for you:**
+
+* **"Task marked done" now means it.** If updating a completed task failed in some of its locations, Dex used to report success anyway. It now tells you exactly which locations updated and which failed.
+* **No more phantom "failing server" for search you never enabled.** Semantic search (qmd) is no longer pre-registered for everyone; it registers when you actually enable it (`/enable-semantic-search`), or automatically at install if it's already on your machine.
+* **Empty calendar results now explain themselves.** If your configured work calendar doesn't match any real calendar, Dex says so and lists the calendars it can see — instead of silently returning nothing.
+* **The safety guard actually guards.** A shipped protection hook (blocks destructive commands) was never registered, so it never ran. It's now wired in.
+
+---
+
 ## [1.23.0] - The health system tells the truth (2026-07-11)
 
 Fixes from the full dex-core audit (every finding independently verified before fixing).

--- a/System/.mcp.json.example
+++ b/System/.mcp.json.example
@@ -107,10 +107,6 @@
       "command": "npx",
       "args": ["-y", "slack-mcp"],
       "env": {}
-    },
-    "qmd": {
-      "command": "qmd",
-      "args": ["mcp"]
     }
   }
 }

--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -32,6 +32,7 @@ import re
 import subprocess
 import sys
 from datetime import date, datetime, timedelta
+from functools import cache
 from pathlib import Path
 from typing import Optional
 
@@ -117,7 +118,6 @@ def get_default_work_calendar() -> str:
 DEFAULT_WORK_CALENDAR = get_default_work_calendar()
 logger.info(f"Default work calendar: {DEFAULT_WORK_CALENDAR}")
 
-
 # Custom JSON encoder for handling date/datetime objects
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -167,6 +167,65 @@ def run_shell_script(script_name: str, *args) -> tuple[bool, str]:
         return False, f"Script '{script_name}' timed out after 120 seconds"
     except Exception as e:
         return False, str(e)
+
+
+def _get_calendar_list_result() -> dict:
+    """Return the same calendar-list payload exposed by the MCP tool."""
+    success, output = run_shell_script("calendar_eventkit.py", "list")
+
+    if not success:
+        return {"success": False, "error": output}
+
+    try:
+        calendars = json.loads(output)
+        calendar_names = [calendar["title"] for calendar in calendars]
+        return {
+            "success": True,
+            "calendars": calendar_names,
+            "count": len(calendar_names),
+            "details": calendars,
+        }
+    except json.JSONDecodeError as e:
+        return {"success": False, "error": f"JSON parse error: {e}"}
+
+
+@cache
+def _get_available_calendar_names() -> Optional[list[str]]:
+    """List calendar names once per process for empty-query validation."""
+    try:
+        result = _get_calendar_list_result()
+    except Exception:
+        return None
+
+    if not result.get("success"):
+        return None
+
+    return result["calendars"]
+
+
+def _add_missing_calendar_warning(
+    result: dict,
+    calendar_name: str,
+    *,
+    event_count: int,
+) -> dict:
+    """Warn when an empty query targeted a calendar that does not exist."""
+    if not result.get("success") or event_count != 0:
+        return result
+
+    try:
+        calendar_names = _get_available_calendar_names()
+    except Exception:
+        return result
+
+    if calendar_names is not None and calendar_name not in calendar_names:
+        result["warning"] = (
+            f"Calendar '{calendar_name}' was not found. Available calendars: "
+            f"{calendar_names}. Set calendar.work_calendar in "
+            "System/user-profile.yaml."
+        )
+
+    return result
 
 
 def parse_applescript_list(output: str) -> list[str]:
@@ -581,25 +640,7 @@ async def _handle_call_tool_inner(
     arguments = arguments or {}
 
     if name == "calendar_list_calendars":
-        # Use fast EventKit
-        success, output = run_shell_script("calendar_eventkit.py", "list")
-        
-        if success:
-            try:
-                calendars = json.loads(output)
-                # Extract just the titles for backward compatibility
-                calendar_names = [cal["title"] for cal in calendars]
-                result = {
-                    "success": True,
-                    "calendars": calendar_names,
-                    "count": len(calendar_names),
-                    "details": calendars  # Full details for advanced use
-                }
-            except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
-        else:
-            result = {"success": False, "error": output}
-        
+        result = _get_calendar_list_result()
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     
     elif name == "calendar_get_events":
@@ -658,7 +699,12 @@ async def _handle_call_tool_inner(
                 result = {"success": False, "error": f"JSON parse error: {e}"}
         else:
             result = {"success": False, "error": output}
-        
+
+        result = _add_missing_calendar_warning(
+            result,
+            calendar_name,
+            event_count=result.get("count", -1),
+        )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     
     elif name == "calendar_get_today":
@@ -743,7 +789,12 @@ async def _handle_call_tool_inner(
                 result = {"success": False, "error": f"JSON parse error: {e}"}
         else:
             result = {"success": False, "error": output}
-        
+
+        result = _add_missing_calendar_warning(
+            result,
+            calendar_name,
+            event_count=result.get("count", -1),
+        )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     
     elif name == "calendar_delete_event":
@@ -777,7 +828,6 @@ async def _handle_call_tool_inner(
             }
         else:
             result = {"success": False, "error": output}
-        
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     
     elif name == "calendar_get_next_event":
@@ -806,7 +856,12 @@ async def _handle_call_tool_inner(
                 result = {"success": False, "error": f"JSON parse error: {e}"}
         else:
             result = {"success": False, "error": output}
-        
+
+        result = _add_missing_calendar_warning(
+            result,
+            calendar_name,
+            event_count=0 if result.get("next_event") is None else 1,
+        )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     
     elif name == "calendar_get_events_with_attendees":
@@ -857,7 +912,12 @@ async def _handle_call_tool_inner(
                 result = {"success": False, "error": f"JSON parse error: {e}"}
         else:
             result = {"success": False, "error": output}
-        
+
+        result = _add_missing_calendar_warning(
+            result,
+            calendar_name,
+            event_count=result.get("count", -1),
+        )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     
     # --- Apple Reminders handlers ---

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -417,6 +417,7 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
         }
     
     updated_files = []
+    failed_files = []
     completion_timestamp = _tz_now().strftime('%Y-%m-%d %H:%M')
     
     for instance in instances:
@@ -455,10 +456,14 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
                 })
         except Exception as e:
             logger.error(f"Error updating {instance['file']}: {e}")
+            failed_files.append({
+                'file': instance['file'],
+                'error': str(e)
+            })
             continue
-    
-    return {
-        'success': True,
+
+    result = {
+        'success': len(failed_files) == 0,
         'task_id': task_id,
         'title': instances[0]['title'] if instances else '',
         'status': 'completed' if completed else 'not_completed',
@@ -466,6 +471,19 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
         'updated_files': updated_files,
         'instances_found': len(instances)
     }
+
+    if failed_files:
+        failures = '; '.join(
+            f"{failure['file']}: {failure['error']}"
+            for failure in failed_files
+        )
+        result['failed_files'] = failed_files
+        result['error'] = (
+            f"task updated in {len(updated_files)} of {len(instances)} locations; "
+            f"failures: {failures}"
+        )
+
+    return result
 
 def get_pillar_ids() -> List[str]:
     """Get list of valid pillar IDs"""
@@ -3662,6 +3680,9 @@ async def _handle_call_tool_inner(
             # If task has an ID, use the sync function
             if task.get('task_id'):
                 result = update_task_status_everywhere(task['task_id'], completed)
+
+                if not result['success']:
+                    return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
                 
                 # Also sync Related Tasks sections
                 synced_pages = propagate_task_status_to_refs(task['title'], completed)

--- a/core/obsidian/sync_daemon.py
+++ b/core/obsidian/sync_daemon.py
@@ -87,7 +87,10 @@ class DexSyncHandler(FileSystemEventHandler):
             try:
                 from core.mcp.work_server import update_task_status_everywhere
                 result = update_task_status_everywhere(task_id, status == 'd')
-                logger.info(f"Synced {task_id} → {status}")
+                if result['success']:
+                    logger.info(f"Synced {task_id} → {status}")
+                else:
+                    logger.error(f"Failed to sync {task_id}: {result['error']}")
             except Exception as e:
                 logger.error(f"Failed to sync {task_id}: {e}")
 

--- a/core/tests/fixtures/vault/05-Areas/Meetings/Daily_Log/2026-07-12.md
+++ b/core/tests/fixtures/vault/05-Areas/Meetings/Daily_Log/2026-07-12.md
@@ -1,2 +1,2 @@
 ## 2026-07-12
-- 15:51 Weekly Ritual -> [[2026-07-12 - Weekly Ritual.md]]
+- 23:49 Weekly Ritual -> [[2026-07-12 - Weekly Ritual.md]]

--- a/core/tests/test_calendar_server.py
+++ b/core/tests/test_calendar_server.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from core.mcp import calendar_server
+
+
+def _decode_tool_result(result):
+    return json.loads(result[0].text)
+
+
+def test_add_missing_calendar_warning_reports_available_calendars(monkeypatch):
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_available_calendar_names",
+        lambda: ["Home", "Team Calendar"],
+    )
+    result = {
+        "success": True,
+        "calendar": "Guessed Work",
+        "events": [],
+        "count": 0,
+    }
+
+    warned = calendar_server._add_missing_calendar_warning(
+        result,
+        "Guessed Work",
+        event_count=0,
+    )
+
+    assert warned["warning"] == (
+        "Calendar 'Guessed Work' was not found. Available calendars: "
+        "['Home', 'Team Calendar']. Set calendar.work_calendar in "
+        "System/user-profile.yaml."
+    )
+
+
+def test_add_missing_calendar_warning_skips_calendar_list_for_nonempty_results(
+    monkeypatch,
+):
+    def fail_if_called():
+        raise AssertionError("calendar list should only be fetched for empty results")
+
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_available_calendar_names",
+        fail_if_called,
+    )
+    result = {"success": True, "events": [{"title": "Standup"}], "count": 1}
+
+    unchanged = calendar_server._add_missing_calendar_warning(
+        result,
+        "Work",
+        event_count=1,
+    )
+
+    assert unchanged == result
+    assert "warning" not in unchanged
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("calendar_get_events", {}),
+        ("calendar_get_today", {}),
+        ("calendar_search_events", {"query": "planning"}),
+        ("calendar_get_next_event", {}),
+        ("calendar_get_events_with_attendees", {}),
+    ],
+)
+def test_empty_calendar_queries_warn_when_default_calendar_is_missing(
+    monkeypatch,
+    tool_name,
+    arguments,
+):
+    def fake_run_shell_script(script_name, operation, *args):
+        assert script_name == "calendar_eventkit.py"
+        if operation == "list":
+            return True, json.dumps([{"title": "Home"}])
+        if operation == "next":
+            return True, json.dumps({"message": "No upcoming events"})
+        return True, "[]"
+
+    monkeypatch.setattr(calendar_server, "run_shell_script", fake_run_shell_script)
+    monkeypatch.setattr(calendar_server, "DEFAULT_WORK_CALENDAR", "Guessed Work")
+    calendar_server._get_available_calendar_names.cache_clear()
+
+    payload = _decode_tool_result(
+        asyncio.run(calendar_server._handle_call_tool_inner(tool_name, arguments))
+    )
+
+    assert payload["warning"] == (
+        "Calendar 'Guessed Work' was not found. Available calendars: ['Home']. "
+        "Set calendar.work_calendar in System/user-profile.yaml."
+    )

--- a/core/tests/test_sync_daemon.py
+++ b/core/tests/test_sync_daemon.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType
+
+from core import paths
+
+
+def test_sync_file_tasks_logs_update_success_and_failure(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(paths, "OBSIDIAN_SYNC_LOG", tmp_path / "obsidian-sync.log")
+
+    watchdog = ModuleType("watchdog")
+    watchdog_events = ModuleType("watchdog.events")
+    watchdog_observers = ModuleType("watchdog.observers")
+    watchdog_events.FileSystemEventHandler = object
+    watchdog_observers.Observer = object
+    monkeypatch.setitem(sys.modules, "watchdog", watchdog)
+    monkeypatch.setitem(sys.modules, "watchdog.events", watchdog_events)
+    monkeypatch.setitem(sys.modules, "watchdog.observers", watchdog_observers)
+
+    from core.mcp import work_server
+    from core.obsidian.sync_daemon import DexSyncHandler
+
+    task_id = "task-20260711-001"
+    task_file = tmp_path / "tasks.md"
+    task_file.write_text(f"- [x] Ship coverage fix ^{task_id}\n")
+    handler = DexSyncHandler()
+
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda _task_id, _completed: {"success": True, "task_id": task_id},
+    )
+    with caplog.at_level(logging.INFO, logger="core.obsidian.sync_daemon"):
+        handler.sync_file_tasks(task_file)
+
+    assert f"Synced {task_id} → d" in caplog.messages
+
+    caplog.clear()
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda _task_id, _completed: {
+            "success": False,
+            "error": "boom",
+            "task_id": task_id,
+        },
+    )
+    with caplog.at_level(logging.INFO, logger="core.obsidian.sync_daemon"):
+        handler.sync_file_tasks(task_file)
+
+    assert f"Failed to sync {task_id}: boom" in caplog.messages

--- a/core/tests/test_work_server_task_priorities.py
+++ b/core/tests/test_work_server_task_priorities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 
 from core.mcp import work_server
 
@@ -132,3 +133,112 @@ def test_check_priority_limits_uses_canonical_backlog_counts(tmp_path, monkeypat
     assert payload["priority_counts"] == {"P2": 1}
     assert payload["alerts"] == []
     assert payload["balanced"] is True
+
+
+def test_update_task_status_everywhere_reports_partial_write_failure(tmp_path, monkeypatch):
+    task_id = "task-20260711-001"
+    first_successful_file = tmp_path / "Tasks.md"
+    failed_file = tmp_path / "Meeting.md"
+    second_successful_file = tmp_path / "Person.md"
+    task_line = f"- [ ] Ship audited fixes ^{task_id}"
+    first_successful_file.write_text(task_line)
+    failed_file.write_text(task_line)
+    second_successful_file.write_text(task_line)
+
+    monkeypatch.setattr(
+        work_server,
+        "find_task_by_id",
+        lambda _task_id: [
+            {
+                "file": str(first_successful_file),
+                "line_number": 1,
+                "title": "Ship audited fixes",
+            },
+            {
+                "file": str(failed_file),
+                "line_number": 1,
+                "title": "Ship audited fixes",
+            },
+            {
+                "file": str(second_successful_file),
+                "line_number": 1,
+                "title": "Ship audited fixes",
+            },
+        ],
+    )
+
+    original_write_text = Path.write_text
+
+    def fail_one_write(path, content, *args, **kwargs):
+        if path == failed_file:
+            raise OSError("disk full")
+        return original_write_text(path, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_one_write)
+
+    result = work_server.update_task_status_everywhere(task_id, completed=True)
+
+    assert result["success"] is False
+    assert result["failed_files"] == [
+        {"file": str(failed_file), "error": "disk full"}
+    ]
+    assert result["updated_files"] == [
+        {"file": str(first_successful_file), "line": 1},
+        {"file": str(second_successful_file), "line": 1},
+    ]
+    assert result["instances_found"] == 3
+    assert result["error"] == (
+        f"task updated in 2 of 3 locations; failures: {failed_file}: disk full"
+    )
+
+
+def test_update_task_status_tool_surfaces_title_match_write_failure(monkeypatch):
+    failure = {
+        "success": False,
+        "task_id": "task-20260711-001",
+        "title": "Ship audited fixes",
+        "status": "completed",
+        "completed_at": "2026-07-11 12:00",
+        "updated_files": [{"file": "/vault/Tasks.md", "line": 1}],
+        "instances_found": 2,
+        "failed_files": [{"file": "/vault/Meeting.md", "error": "disk full"}],
+        "error": (
+            "task updated in 1 of 2 locations; failures: "
+            "/vault/Meeting.md: disk full"
+        ),
+    }
+    monkeypatch.setattr(
+        work_server,
+        "get_all_tasks",
+        lambda: [
+            {
+                "title": "Ship audited fixes",
+                "task_id": "task-20260711-001",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda _task_id, _completed: failure.copy(),
+    )
+
+    def fail_if_propagated(*_args, **_kwargs):
+        raise AssertionError("related task sync must not run after a failed write")
+
+    monkeypatch.setattr(
+        work_server,
+        "propagate_task_status_to_refs",
+        fail_if_propagated,
+    )
+
+    payload = _decode_tool_result(
+        asyncio.run(
+            work_server.handle_call_tool(
+                "update_task_status",
+                {"task_title": "audited fixes", "status": "d"},
+            )
+        )
+    )
+
+    assert payload == failure

--- a/install.sh
+++ b/install.sh
@@ -177,6 +177,25 @@ if [ ! -f .mcp.json ]; then
     else
         sed "s|{{VAULT_PATH}}|$CURRENT_PATH|g" System/.mcp.json.example > .mcp.json
     fi
+
+    if command -v qmd &> /dev/null; then
+        "$PYTHON_CMD" - <<'PY'
+import json
+from pathlib import Path
+
+mcp_path = Path(".mcp.json")
+config = json.loads(mcp_path.read_text(encoding="utf-8"))
+config.setdefault("mcpServers", {})["qmd"] = {
+    "command": "qmd",
+    "args": ["mcp"],
+}
+mcp_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+PY
+        echo "   qmd MCP server added"
+    else
+        echo "   semantic search not installed — run /enable-semantic-search to add it later"
+    fi
+
     echo "   MCP servers configured for: $CURRENT_PATH"
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Batch D — the final code batch from the 2026-07-10 audit (all findings adversarially verified).

1. **Task completion no longer lies.** `update_task_status_everywhere` swallowed every per-file write failure and returned `success: true`. Now: `success: false` + `failed_files` + aggregate error; both MCP tool paths early-return it; the Obsidian sync daemon logs it. Regression test included.
2. **qmd unregistered by default.** It was pre-registered for everyone, so installs without the binary showed a failing MCP server every session (the "error for a feature I never enabled" class). `install.sh` now adds it only when qmd is present; `/enable-semantic-search` registers it on opt-in.
3. **Empty calendar results explain themselves.** When the configured work calendar matches no real calendar, responses carry a warning listing available calendars and how to set `calendar.work_calendar`. Lazy + cached; degrades silently if listing fails.
4. **The safety guard now runs.** `dex-safety-guard.sh` shipped but was wired into nothing. Registered first under PreToolUse→Bash (exit-2 block contract verified).

Gates: 154 pytest pass (3 new) · ruff · hooks 4/4 · verify-distribution 0 errors · path-consistency. CHANGELOG **1.24.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG