### PR TITLE
Testing rigor: real e2e journeys, server startup checks, and three verified distribution bugs fixed (v1.28.0)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -376,7 +376,7 @@ Call `finalize_onboarding()` from onboarding-mcp. This single call handles:
 4. Write System/user-profile.yaml from session data
 5. Write System/pillars.yaml from pillars
 6. Update CLAUDE.md User Profile section
-7. Setup System/.mcp.json (replace {{VAULT_PATH}} automatically)
+7. Setup root .mcp.json (replace {{VAULT_PATH}} automatically)
 8. Delete session file on success
 
 The MCP returns a summary of what was created (folders, files, configs).

--- a/.claude/hooks/integration-concierge.cjs
+++ b/.claude/hooks/integration-concierge.cjs
@@ -330,12 +330,19 @@ function isGranolaConfigured() {
     return /granola:[\s\S]*?enabled:\s*true/.test(config);
   } catch {
     // Also check if Granola MCP is in the server list
-    try {
-      const mcpConfig = fs.readFileSync(path.join(VAULT_ROOT, 'System', '.mcp.json'), 'utf-8');
-      return mcpConfig.includes('granola');
-    } catch {
-      return false;
+    const mcpConfigPaths = [
+      path.join(VAULT_ROOT, '.mcp.json'),
+      path.join(VAULT_ROOT, 'System', '.mcp.json'),
+    ];
+    for (const mcpConfigPath of mcpConfigPaths) {
+      try {
+        const mcpConfig = fs.readFileSync(mcpConfigPath, 'utf-8');
+        return mcpConfig.includes('granola');
+      } catch {
+        // Root config is canonical; System/.mcp.json is a legacy fallback.
+      }
     }
+    return false;
   }
 }
 

--- a/.claude/hooks/tests/context-injectors.test.cjs
+++ b/.claude/hooks/tests/context-injectors.test.cjs
@@ -1,37 +1,98 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
-function runHook(scriptName, stdin) {
+const FIXTURE_VAULT = path.resolve(__dirname, '../../../core/tests/fixtures/vault');
+
+function createSandbox(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-context-hook-'));
+  const vault = path.join(root, 'vault');
+  const home = path.join(root, 'home');
+  fs.cpSync(FIXTURE_VAULT, vault, { recursive: true });
+  fs.mkdirSync(home);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { vault, home };
+}
+
+function runHook(scriptName, stdin, sandbox) {
   const scriptPath = path.join(__dirname, '..', scriptName);
-  return spawnSync('node', [scriptPath], {
+  return spawnSync(process.execPath, [scriptPath], {
     input: stdin,
     encoding: 'utf-8',
-    env: { ...process.env, DEX_HOOK_DEBUG: '1' },
+    env: {
+      CLAUDE_HOOK_CONTEXT: '{}',
+      CLAUDE_PROJECT_DIR: sandbox.vault,
+      DEX_HOOK_DEBUG: '1',
+      HOME: sandbox.home,
+      PATH: '/usr/bin:/bin',
+      VAULT_PATH: sandbox.vault,
+    },
   });
 }
 
-test('person context injector emits skip reason on invalid JSON', () => {
-  const result = runHook('person-context-injector.cjs', 'not-json');
+test('person context injector emits skip reason on invalid JSON', (t) => {
+  const sandbox = createSandbox(t);
+  const result = runHook('person-context-injector.cjs', 'not-json', sandbox);
   assert.equal(result.status, 0);
   assert.match(result.stderr, /\[dex-hook-skip] invalid-json-input/);
 });
 
-test('person context injector emits skip reason when file path missing', () => {
-  const result = runHook('person-context-injector.cjs', JSON.stringify({ tool_input: {} }));
+test('person context injector emits skip reason when file path missing', (t) => {
+  const sandbox = createSandbox(t);
+  const result = runHook('person-context-injector.cjs', JSON.stringify({ tool_input: {} }), sandbox);
   assert.equal(result.status, 0);
   assert.match(result.stderr, /\[dex-hook-skip] missing-file-path-or-recursive-person-file/);
 });
 
-test('company context injector emits skip reason on invalid JSON', () => {
-  const result = runHook('company-context-injector.cjs', '{oops');
+test('company context injector emits skip reason on invalid JSON', (t) => {
+  const sandbox = createSandbox(t);
+  const result = runHook('company-context-injector.cjs', '{oops', sandbox);
   assert.equal(result.status, 0);
   assert.match(result.stderr, /\[dex-hook-skip] invalid-json-input/);
 });
 
-test('company context injector emits skip reason when file path missing', () => {
-  const result = runHook('company-context-injector.cjs', JSON.stringify({ tool_input: {} }));
+test('company context injector emits skip reason when file path missing', (t) => {
+  const sandbox = createSandbox(t);
+  const result = runHook('company-context-injector.cjs', JSON.stringify({ tool_input: {} }), sandbox);
   assert.equal(result.status, 0);
   assert.match(result.stderr, /\[dex-hook-skip] missing-file-path-or-recursive-company-file/);
+});
+
+test('person context injector emits fixture person context', (t) => {
+  const sandbox = createSandbox(t);
+  const note = path.join(sandbox.vault, '00-Inbox', 'Meetings', 'person-context.md');
+  fs.writeFileSync(note, '# Meeting\n\nMeeting with Alice Smith about the launch.\n');
+
+  const result = runHook(
+    'person-context-injector.cjs',
+    JSON.stringify({ tool_input: { file_path: note } }),
+    sandbox,
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /<person_context>/);
+  assert.match(result.stdout, /Alice Smith/);
+  assert.match(result.stdout, /<\/person_context>/);
+});
+
+test('company context injector emits fixture company context', (t) => {
+  const sandbox = createSandbox(t);
+  const company = path.join(sandbox.vault, '05-Areas', 'Companies', 'Acme_Corp.md');
+  fs.writeFileSync(company, '---\nname: Acme Corp\nstatus: Active\n---\n\nRenewal account.\n');
+  const note = path.join(sandbox.vault, '00-Inbox', 'Meetings', 'company-context.md');
+  fs.writeFileSync(note, '# Meeting\n\nMeeting with Acme Corp about the renewal.\n');
+
+  const result = runHook(
+    'company-context-injector.cjs',
+    JSON.stringify({ tool_input: { path: note } }),
+    sandbox,
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /<company_context>/);
+  assert.match(result.stdout, /Acme Corp/);
+  assert.match(result.stdout, /<\/company_context>/);
 });

--- a/.claude/hooks/tests/hook-harness.test.cjs
+++ b/.claude/hooks/tests/hook-harness.test.cjs
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOKS_DIR = path.resolve(__dirname, '..');
+const FIXTURE_VAULT = path.resolve(__dirname, '../../../core/tests/fixtures/vault');
+const HOOK_PROGRAMS = fs.readdirSync(HOOKS_DIR)
+  .filter((name) => name.endsWith('.cjs') || name.endsWith('.sh'))
+  .sort();
+
+assert.ok(HOOK_PROGRAMS.length > 0, 'no root hook programs discovered');
+
+function createSandbox(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-hook-harness-'));
+  const vault = path.join(root, 'vault');
+  const home = path.join(root, 'home');
+  fs.cpSync(FIXTURE_VAULT, vault, { recursive: true });
+  fs.mkdirSync(home);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { vault, home };
+}
+
+function minimalEnv(sandbox) {
+  return {
+    CLAUDE_HOOK_CONTEXT: '{}',
+    CLAUDE_PROJECT_DIR: sandbox.vault,
+    DEX_HOOK_DEBUG: '1',
+    HOME: sandbox.home,
+    PATH: '/usr/bin:/bin',
+    VAULT_PATH: sandbox.vault,
+  };
+}
+
+for (const hookName of HOOK_PROGRAMS) {
+  test(`benign stdin exits cleanly: ${hookName}`, (t) => {
+    const sandbox = createSandbox(t);
+    const hookPath = path.join(HOOKS_DIR, hookName);
+    const command = hookName.endsWith('.sh') ? '/bin/bash' : process.execPath;
+    const result = spawnSync(command, [hookPath], {
+      cwd: sandbox.vault,
+      encoding: 'utf-8',
+      env: minimalEnv(sandbox),
+      input: '{}\n',
+      timeout: 10_000,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `${hookName} exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  });
+}
+
+test('safety guard uses its documented exit 2 contract for blocked commands', (t) => {
+  const sandbox = createSandbox(t);
+  const result = spawnSync('/bin/bash', [path.join(HOOKS_DIR, 'dex-safety-guard.sh')], {
+    cwd: sandbox.vault,
+    encoding: 'utf-8',
+    env: minimalEnv(sandbox),
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }),
+    timeout: 10_000,
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stdout, /Blocked/);
+});

--- a/.claude/hooks/tests/hook-harness.test.cjs
+++ b/.claude/hooks/tests/hook-harness.test.cjs
@@ -10,6 +10,7 @@ const FIXTURE_VAULT = path.resolve(__dirname, '../../../core/tests/fixtures/vaul
 const HOOK_PROGRAMS = fs.readdirSync(HOOKS_DIR)
   .filter((name) => name.endsWith('.cjs') || name.endsWith('.sh'))
   .sort();
+const DIRECT_SHELL_HOOKS = new Set(['session-end.sh']);
 
 assert.ok(HOOK_PROGRAMS.length > 0, 'no root hook programs discovered');
 
@@ -38,8 +39,18 @@ for (const hookName of HOOK_PROGRAMS) {
   test(`benign stdin exits cleanly: ${hookName}`, (t) => {
     const sandbox = createSandbox(t);
     const hookPath = path.join(HOOKS_DIR, hookName);
-    const command = hookName.endsWith('.sh') ? '/bin/bash' : process.execPath;
-    const result = spawnSync(command, [hookPath], {
+    const isShellHook = hookName.endsWith('.sh');
+    if (isShellHook) {
+      assert.notEqual(
+        fs.statSync(hookPath).mode & 0o111,
+        0,
+        `${hookName} must retain an executable mode`,
+      );
+    }
+    const directInvocation = DIRECT_SHELL_HOOKS.has(hookName);
+    const command = directInvocation ? hookPath : isShellHook ? '/bin/bash' : process.execPath;
+    const args = directInvocation ? [] : [hookPath];
+    const result = spawnSync(command, args, {
       cwd: sandbox.vault,
       encoding: 'utf-8',
       env: minimalEnv(sandbox),
@@ -54,6 +65,32 @@ for (const hookName of HOOK_PROGRAMS) {
     );
   });
 }
+
+test('session end runs directly and records its transcript', (t) => {
+  const sandbox = createSandbox(t);
+  const hookPath = path.join(HOOKS_DIR, 'session-end.sh');
+  const transcriptPath = path.join(sandbox.vault, 'session-transcript.jsonl');
+  fs.writeFileSync(transcriptPath, '{"type":"test"}\n');
+
+  const result = spawnSync(hookPath, [transcriptPath], {
+    cwd: sandbox.vault,
+    encoding: 'utf-8',
+    env: minimalEnv(sandbox),
+    timeout: 10_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `session-end.sh exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  const learningsDir = path.join(sandbox.vault, 'System', 'Session_Learnings');
+  const learningFiles = fs.readdirSync(learningsDir).filter((name) => name.endsWith('.md'));
+  assert.equal(learningFiles.length, 1);
+  const learning = fs.readFileSync(path.join(learningsDir, learningFiles[0]), 'utf-8');
+  assert.match(learning, /Session completed/);
+  assert.ok(learning.includes(transcriptPath));
+});
 
 test('safety guard uses its documented exit 2 contract for blocked commands', (t) => {
   const sandbox = createSandbox(t);

--- a/.claude/skills/career-coach/SKILL.md
+++ b/.claude/skills/career-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: career-coach
-description: Personal career coach with 4 modes: weekly reports, monthly reflections, self-reviews, promotion assessments
+description: "Personal career coach with 4 modes: weekly reports, monthly reflections, self-reviews, promotion assessments"
 context: fork
 hooks:
   PostToolUse:

--- a/.claude/skills/diff-generate/SKILL.md
+++ b/.claude/skills/diff-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diff-generate
-description: Generate a DexDiff methodology document from your vault customisations: package how you use Dex so others can replicate it
+description: "Generate a DexDiff methodology document from your vault customisations: package how you use Dex so others can replicate it"
 ---
 
 ## What This Command Does

--- a/.distignore
+++ b/.distignore
@@ -6,12 +6,15 @@
 
 # Dev tooling configs
 pyproject.toml
+requirements-dev.txt
 vitest.config.mjs
 .husky/
 
 # Test suites
 core/tests/
-.claude/hooks/__tests__/
+core/mcp/tests/
+core/migrations/tests/
+.claude/hooks/tests/
 .scripts/meeting-intel/__tests__/
 
 # Dev scripts and docs

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,13 @@
 
 .github/               export-ignore
 pyproject.toml          export-ignore
+requirements-dev.txt    export-ignore
 vitest.config.mjs       export-ignore
 .husky/                 export-ignore
 core/tests/             export-ignore
-.claude/hooks/__tests__/ export-ignore
+core/mcp/tests/         export-ignore
+core/migrations/tests/  export-ignore
+.claude/hooks/tests/    export-ignore
 .scripts/meeting-intel/__tests__/ export-ignore
 CONTRIBUTING.md         export-ignore
 DISTRIBUTION_READY.md   export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@ core/tests/             export-ignore
 .scripts/meeting-intel/__tests__/ export-ignore
 CONTRIBUTING.md         export-ignore
 DISTRIBUTION_READY.md   export-ignore
-scripts/                export-ignore
+/scripts/               export-ignore
 .ao-issue.md            export-ignore
 .distignore             export-ignore
 .gitattributes          export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '20'
       - name: Install Python dependencies
         run: |
-          pip install pytest pytest-cov ruff
+          pip install -r requirements-dev.txt
           pip install mcp pyyaml python-dateutil requests
       - run: npm ci
       - name: Ensure policy scripts are executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.28.0] - Installs now contain the Dex features they promise (2026-07-11)
+
+Some install and update paths looked successful while quietly leaving out working parts of Dex, carrying developer-only test files, or writing MCP settings somewhere Claude Code never reads. This release fixes those distribution gaps and makes the release checks exercise the same paths you do.
+
+**What this fixes for you:**
+
+* **GitHub ZIP installs keep every skill's working parts.** ZIP downloads were stripping the implementation scripts nested inside skills, so document, presentation, PDF, and other scripted skills could arrive as instructions with no code behind them. Those nested scripts now ship; only Dex's top-level release tooling stays out.
+* **Updates no longer bring 58 internal test files into your vault.** The release builder now removes every Python and hook test surface reliably, including filenames with spaces, and no longer leaves behind developer dependencies or a broken `test:hooks` command pointing at files you do not have.
+* **Onboarding and Claude Code now agree on MCP settings.** Onboarding wrote `System/.mcp.json`, while Claude Code and Dex's health checks read the root `.mcp.json`. New setup now writes the root file consistently. Existing vaults with only the old System file are still read safely and are told when that fallback is in use.
+* **Release checks now use Dex the way you do.** CI completes real onboarding and task journeys, verifies meeting writeback, starts every built-in MCP server over its real stdio protocol, validates every shipped skill, and runs every hook in an isolated vault. Packaging and startup failures should be caught before an update reaches you.
+
+*Version note: package metadata moves from 1.26.0 to 1.28.0 to catch up with the already-published 1.27.0 changelog entry.*
+
+---
+
 ## [1.27.0] - /dex-doctor: a real system checkup that tells the truth (2026-07-11)
 
 Replaces `/health-check` with a rigorous whole-system diagnostic that knows the difference between "off", "broken", "couldn't check", and "fine" — built against the exact failure modes the July 2026 audit uncovered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ All notable changes to Dex will be documented in this file.
 
 ## [1.28.0] - Installs now contain the Dex features they promise (2026-07-11)
 
-Some install and update paths looked successful while quietly leaving out working parts of Dex, carrying developer-only test files, or writing MCP settings somewhere Claude Code never reads. This release fixes those distribution gaps and makes the release checks exercise the same paths you do.
+Some install and update paths looked successful while quietly leaving out working parts of Dex, carrying developer-only files, or saving connection settings somewhere Claude Code never reads. This release makes installs complete and checks them through the same journeys you use.
 
 **What this fixes for you:**
 
-* **GitHub ZIP installs keep every skill's working parts.** ZIP downloads were stripping the implementation scripts nested inside skills, so document, presentation, PDF, and other scripted skills could arrive as instructions with no code behind them. Those nested scripts now ship; only Dex's top-level release tooling stays out.
-* **Updates no longer bring 58 internal test files into your vault.** The release builder now removes every Python and hook test surface reliably, including filenames with spaces, and no longer leaves behind developer dependencies or a broken `test:hooks` command pointing at files you do not have.
-* **Onboarding and Claude Code now agree on MCP settings.** Onboarding wrote `System/.mcp.json`, while Claude Code and Dex's health checks read the root `.mcp.json`. New setup now writes the root file consistently. Existing vaults with only the old System file are still read safely and are told when that fallback is in use.
-* **Release checks now use Dex the way you do.** CI completes real onboarding and task journeys, verifies meeting writeback, starts every built-in MCP server over its real stdio protocol, validates every shipped skill, and runs every hook in an isolated vault. Packaging and startup failures should be caught before an update reaches you.
+* **GitHub ZIP installs keep every skill's working parts.** Document, presentation, PDF, and other scripted skills could arrive as instructions with no working code behind them. ZIP downloads now include everything those skills need to run.
+* **Updates no longer bring 58 internal test files into your vault.** Releases now leave out test suites and developer setup files reliably, even when filenames contain spaces, and no longer include commands that point at files you do not have.
+* **Onboarding and Claude Code now use the same connection settings.** New setup, Claude Code, and Dex's health checks all look in one place. Existing vaults that use the old location still work, and Dex tells you when it is relying on that fallback.
+* **Release checks now use Dex the way you do.** They complete real onboarding and task journeys, confirm meeting updates are written back, start every built-in service, validate every shipped skill, and run every hook in an isolated vault. Packaging and startup failures should be caught before an update reaches you.
 
 *Version note: package metadata moves from 1.26.0 to 1.28.0 to catch up with the already-published 1.27.0 changelog entry.*
 

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -500,6 +500,28 @@ def setup_mcp_config(vault_path: Path) -> tuple[bool, Optional[str]]:
             ]
             for name in to_remove:
                 del config['mcpServers'][name]
+
+        # Preserve user-added MCPs when onboarding writes the canonical root
+        # config. Existing entries win, including entries with shipped names.
+        if MCP_CONFIG_TARGET.exists():
+            try:
+                existing_config = json.loads(MCP_CONFIG_TARGET.read_text())
+            except json.JSONDecodeError as e:
+                return False, f"Existing .mcp.json is invalid JSON: {e}"
+
+            if not isinstance(existing_config, dict):
+                return False, "Existing .mcp.json must contain a JSON object"
+
+            existing_servers = existing_config.get('mcpServers')
+            if existing_servers is None:
+                existing_servers = {}
+                existing_config['mcpServers'] = existing_servers
+            elif not isinstance(existing_servers, dict):
+                return False, "Existing .mcp.json mcpServers must contain a JSON object"
+
+            for server_name, server_config in config.get('mcpServers', {}).items():
+                existing_servers.setdefault(server_name, server_config)
+            config = existing_config
         
         # Write to target
         with open(MCP_CONFIG_TARGET, 'w') as f:

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -1224,7 +1224,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 # Configs that would be updated
                 would_update_configs = ['CLAUDE.md (User Profile section)']
                 if MCP_CONFIG_EXAMPLE.exists():
-                    would_update_configs.append('System/.mcp.json')
+                    would_update_configs.append('.mcp.json')
 
                 # Build preview of user-profile.yaml content
                 data = session['data']
@@ -1322,7 +1322,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 logger.info("Setting up .mcp.json")
                 success, error = setup_mcp_config(BASE_DIR)
                 if success:
-                    summary['configs_updated'].append('System/.mcp.json')
+                    summary['configs_updated'].append('.mcp.json')
                 else:
                     summary['errors'].append(f"MCP config error: {error}")
 

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -104,6 +104,74 @@ class TestSetupMcpConfig:
         assert "Invalid JSON after substitution" in err
         assert not target.exists()
 
+    def test_preserves_existing_servers_and_adds_only_missing_defaults(
+        self, tmp_path, monkeypatch
+    ):
+        example = _write_example(
+            tmp_path,
+            {
+                "work-mcp": {
+                    "command": "{{VAULT_PATH}}/.venv/bin/python",
+                    "args": ["{{VAULT_PATH}}/core/mcp/work_server.py"],
+                },
+                "calendar-mcp": {
+                    "command": "{{VAULT_PATH}}/.venv/bin/python",
+                    "args": ["{{VAULT_PATH}}/core/mcp/calendar_server.py"],
+                },
+            },
+        )
+        target = tmp_path / ".mcp.json"
+        existing_work = {
+            "command": "custom-python",
+            "args": ["custom-work-server.py"],
+            "env": {"CUSTOM": "preserve-me"},
+        }
+        custom_server = {
+            "command": "npx",
+            "args": ["-y", "custom-mcp"],
+        }
+        target.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "work-mcp": existing_work,
+                        "custom-mcp": custom_server,
+                    },
+                    "customTopLevel": {"preserve": True},
+                },
+                indent=2,
+            )
+        )
+        _redirect_config(monkeypatch, example, target)
+
+        ok, err = onboarding_server.setup_mcp_config(tmp_path)
+
+        assert ok is True
+        assert err is None
+        config = json.loads(target.read_text())
+        assert config["mcpServers"]["work-mcp"] == existing_work
+        assert config["mcpServers"]["custom-mcp"] == custom_server
+        assert config["customTopLevel"] == {"preserve": True}
+        assert config["mcpServers"]["calendar-mcp"]["command"] == str(tmp_path / ".venv/bin/python")
+
+    def test_invalid_existing_config_returns_error_without_overwriting(
+        self, tmp_path, monkeypatch
+    ):
+        example = _write_example(
+            tmp_path,
+            {"work-mcp": {"command": "python", "args": ["work_server.py"]}},
+        )
+        target = tmp_path / ".mcp.json"
+        invalid_content = '{ "mcpServers": { not valid json }'
+        target.write_text(invalid_content)
+        _redirect_config(monkeypatch, example, target)
+
+        ok, err = onboarding_server.setup_mcp_config(tmp_path)
+
+        assert ok is False
+        assert "Existing .mcp.json is invalid JSON" in err
+        assert target.read_text() == invalid_content
+
     def test_onboarding_output_is_the_config_preflight_and_doctor_read(
         self, tmp_path, monkeypatch
     ):

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -9,6 +9,7 @@ Run with: pytest core/mcp/tests/test_onboarding_server.py -v
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # core/mcp/tests -> repo root (for `core.paths`) and core/mcp (for the module).
@@ -17,6 +18,8 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "core" / "mcp"))
 
 import onboarding_server  # noqa: E402
+
+from core.utils import doctor, preflight  # noqa: E402
 
 
 def _write_example(tmp_path: Path, servers: dict) -> Path:
@@ -32,6 +35,9 @@ def _redirect_config(monkeypatch, example: Path, target: Path) -> None:
 
 class TestSetupMcpConfig:
     """setup_mcp_config substitution, validation, and filtering."""
+
+    def test_production_target_is_root_mcp_config(self):
+        assert onboarding_server.MCP_CONFIG_TARGET == onboarding_server.BASE_DIR / ".mcp.json"
 
     def test_resolves_vault_path_and_strips_placeholder_and_comment_servers(
         self, tmp_path, monkeypatch
@@ -97,3 +103,28 @@ class TestSetupMcpConfig:
         assert ok is False
         assert "Invalid JSON after substitution" in err
         assert not target.exists()
+
+    def test_onboarding_output_is_the_config_preflight_and_doctor_read(
+        self, tmp_path, monkeypatch
+    ):
+        example = _write_example(
+            tmp_path,
+            {"work-mcp": {"command": "python", "args": ["{{VAULT_PATH}}/core/mcp/work_server.py"]}},
+        )
+        target = tmp_path / ".mcp.json"
+        _redirect_config(monkeypatch, example, target)
+        monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+
+        ok, err = onboarding_server.setup_mcp_config(tmp_path)
+
+        assert ok is True
+        assert err is None
+        assert preflight.get_mcp_config_path() == target
+        context = doctor.DoctorContext(
+            vault_root=tmp_path,
+            repo_root=tmp_path,
+            home=tmp_path,
+            now=datetime.now(timezone.utc),
+        )
+        assert doctor._mcp_config_path(context) == target
+        assert doctor._load_mcp_config(context) == json.loads(target.read_text())

--- a/core/paths.py
+++ b/core/paths.py
@@ -86,7 +86,7 @@ MARKER_FILE = SYSTEM_DIR / '.onboarding-complete'
 USER_PROFILE_TEMPLATE = SYSTEM_DIR / 'user-profile-template.yaml'
 CLAUDE_MD = VAULT_ROOT / 'CLAUDE.md'
 MCP_CONFIG_EXAMPLE = SYSTEM_DIR / '.mcp.json.example'
-MCP_CONFIG_TARGET = SYSTEM_DIR / '.mcp.json'
+MCP_CONFIG_TARGET = VAULT_ROOT / '.mcp.json'
 OBSIDIAN_SYNC_LOG = SYSTEM_DIR / 'obsidian-sync.log'
 RITUAL_INTELLIGENCE_DB_FILE = DEX_RUNTIME_DIR / 'ritual-intelligence.db'
 

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,12 +1,22 @@
 """Pytest bootstrap for deterministic vault-path tests."""
 
 import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
 
-FIXTURE_VAULT = Path(__file__).resolve().parent / "fixtures" / "vault"
-os.environ.setdefault("VAULT_PATH", str(FIXTURE_VAULT))
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_FIXTURE_VAULT = Path(__file__).resolve().parent / "fixtures" / "vault"
+_RUNTIME_DIRECTORY = tempfile.TemporaryDirectory(prefix="dex-pytest-vault-")
+RUNTIME_FIXTURE_VAULT = Path(_RUNTIME_DIRECTORY.name) / "vault"
+shutil.copytree(SOURCE_FIXTURE_VAULT, RUNTIME_FIXTURE_VAULT)
+
+# core.paths binds VAULT_PATH when test modules import it, so force the
+# disposable copy here before collection imports any product modules.
+os.environ["VAULT_PATH"] = str(RUNTIME_FIXTURE_VAULT)
 
 for relative in (
     "05-Areas/Meetings",
@@ -16,10 +26,34 @@ for relative in (
     "04-Projects/DexDiff/beta/profile",
     "04-Projects/DexDiff/design",
 ):
-    (FIXTURE_VAULT / relative).mkdir(parents=True, exist_ok=True)
+    (RUNTIME_FIXTURE_VAULT / relative).mkdir(parents=True, exist_ok=True)
 
 
 @pytest.fixture
 def fixture_vault() -> Path:
-    """Return the path to the minimal PARA fixture vault."""
-    return FIXTURE_VAULT
+    """Return the pristine tracked fixture for read-only checks and per-test copies."""
+    return SOURCE_FIXTURE_VAULT
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Fail the suite if any test touched the tracked fixture vault."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--", "core/tests/fixtures/vault"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if not result.stdout:
+        return
+
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_sep("=", "tracked fixture vault was mutated")
+        reporter.write_line(result.stdout.rstrip())
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Remove the disposable session vault after all plugins finish."""
+    _RUNTIME_DIRECTORY.cleanup()

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import io
+import json
+import shutil
 import subprocess
 import tarfile
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RELEASE_BUILD_INPUTS = (
+    ".distignore",
+    ".gitattributes",
+    ".github/workflows/ci.yml",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "scripts/build-release.sh",
+    "scripts/verify-distribution.sh",
+)
 
 
 def _archive_members() -> set[str]:
@@ -28,3 +39,99 @@ def test_git_archive_keeps_skill_scripts_but_strips_top_level_scripts() -> None:
 
     assert ".claude/skills/anthropic-docx/scripts/document.py" in members
     assert not any(path == "scripts" or path.startswith("scripts/") for path in members)
+
+
+def _build_release_in_clone(tmp_path: Path) -> tuple[Path, set[str]]:
+    """Build from the current checkout without ever switching its branches."""
+    clone = tmp_path / "release-build"
+    subprocess.run(
+        ["git", "clone", "--local", "--no-hardlinks", "--quiet", str(REPO_ROOT), str(clone)],
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=clone, check=True)
+    subprocess.run(["git", "config", "user.email", "tests@example.com"], cwd=clone, check=True)
+    subprocess.run(["git", "checkout", "-B", "main", "HEAD"], cwd=clone, check=True, capture_output=True)
+
+    # Let this test prove uncommitted changes while developing; once committed,
+    # these copies are identical to the clone's files.
+    for relative_path in RELEASE_BUILD_INPUTS:
+        source = REPO_ROOT / relative_path
+        destination = clone / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    spaced_fixture = clone / "core/tests/fixtures/vault/has space.md"
+    spaced_fixture.write_text("release stripping regression\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "--", *RELEASE_BUILD_INPUTS, str(spaced_fixture.relative_to(clone))],
+        cwd=clone,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "test: prepare release build fixture"],
+        cwd=clone,
+        check=True,
+    )
+
+    subprocess.run(
+        ["bash", "scripts/build-release.sh"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "release"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return clone, set(result.stdout.splitlines())
+
+
+def test_release_branch_strips_dev_files_and_keeps_user_runtime(tmp_path: Path) -> None:
+    clone, members = _build_release_in_clone(tmp_path)
+
+    stripped_prefixes = (
+        "core/tests/",
+        "core/mcp/tests/",
+        "core/migrations/tests/",
+        ".claude/hooks/tests/",
+        "scripts/",
+    )
+    for prefix in stripped_prefixes:
+        assert not any(path.startswith(prefix) for path in members), prefix
+    assert "pyproject.toml" not in members
+    assert "requirements-dev.txt" not in members
+    assert "core/tests/fixtures/vault/has space.md" not in members
+
+    assert "core/utils/doctor.py" in members
+    assert ".claude/skills/dex-update/SKILL.md" in members
+    assert ".claude/skills/anthropic-docx/scripts/document.py" in members
+
+    source_servers = {
+        path
+        for path in subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "main", "--", "core/mcp"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        if path.endswith("_server.py") and "/tests/" not in path
+    }
+    assert source_servers
+    assert source_servers <= members
+
+    package_json = json.loads(
+        subprocess.run(
+            ["git", "show", "release:package.json"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+    assert "test:hooks" not in package_json.get("scripts", {})

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -1,0 +1,30 @@
+"""Regression tests for artifacts produced from the public repository."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _archive_members() -> set[str]:
+    """Return paths from the archive users receive from the current checkout."""
+    result = subprocess.run(
+        ["git", "archive", "--worktree-attributes", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    with tarfile.open(fileobj=io.BytesIO(result.stdout), mode="r:") as archive:
+        return set(archive.getnames())
+
+
+def test_git_archive_keeps_skill_scripts_but_strips_top_level_scripts() -> None:
+    members = _archive_members()
+
+    assert ".claude/skills/anthropic-docx/scripts/document.py" in members
+    assert not any(path == "scripts" or path.startswith("scripts/") for path in members)

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -503,6 +503,30 @@ def test_mcp_orphans_compares_server_targets_not_registry_names(context):
     assert "beta_server.py" in result.detail
 
 
+def test_mcp_probes_read_legacy_config_without_moving_it(context):
+    mcp_dir = context.vault_root / "core" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    server = mcp_dir / "alpha_server.py"
+    server.touch()
+    legacy = context.vault_root / "System" / ".mcp.json"
+    legacy.write_text(
+        json.dumps(
+            {"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}
+        )
+    )
+
+    before = _tree_snapshot(context.vault_root)
+    registered = doctor._probe_mcp_registered(context)
+    orphans = doctor._probe_mcp_orphans(context)
+
+    assert registered.verdict == "OK"
+    assert orphans.verdict == "OK"
+    assert "legacy System/.mcp.json" in registered.detail
+    assert "legacy System/.mcp.json" in orphans.detail
+    assert _tree_snapshot(context.vault_root) == before
+    assert not (context.vault_root / ".mcp.json").exists()
+
+
 def test_mcp_orphans_invalid_registry_becomes_unknown_in_the_runner(monkeypatch, context):
     mcp_dir = context.vault_root / "core" / "mcp"
     mcp_dir.mkdir(parents=True)

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -1,87 +1,259 @@
-"""Golden user-journey continuity tests."""
+"""Golden journeys through the real onboarding and work MCP handlers."""
 
 from __future__ import annotations
 
+import json
+import os
+import re
 import shutil
-from datetime import date
+import subprocess
+import sys
 from pathlib import Path
 
 import yaml
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
-def _copy_fixture_vault(fixture_vault: Path, tmp_path: Path) -> Path:
-    target = tmp_path / "vault"
-    shutil.copytree(fixture_vault, target)
-    return target
+ONBOARDING_JOURNEY = r"""
+import asyncio
+import json
+
+from core.mcp import onboarding_server as onboarding
 
 
-def test_golden_journey_onboarding_to_week_review(fixture_vault: Path, tmp_path: Path):
+def decode(contents):
+    return json.loads(contents[0].text)
+
+
+async def call(name, arguments=None):
+    return decode(await onboarding.handle_call_tool(name, arguments or {}))
+
+
+async def main():
+    results = {}
+    results["start"] = await call("start_onboarding_session", {"force_new": True})
+    results["resume"] = await call("start_onboarding_session")
+
+    onboarding.check_python_packages = lambda: {
+        "mcp": {"installed": True},
+        "yaml": {"installed": True},
+        "aiohttp": {"installed": True},
+    }
+    onboarding.check_calendar_app = lambda: {"available": True}
+    onboarding.check_granola = lambda: {"available": True}
+    results["dependencies"] = await call("verify_dependencies")
+
+    step_data = {
+        1: {"name": "Golden User"},
+        2: {"role_number": 1},
+        3: {"company": "Golden Co", "company_size": "startup"},
+        4: {"email_domain": "golden.example"},
+        5: {"pillars": ["Customer", "Product"]},
+        6: {
+            "communication": {
+                "formality": "professional_casual",
+                "directness": "balanced",
+                "career_level": "leadership",
+            },
+            "obsidian_mode": False,
+        },
+    }
+    results["steps"] = [
+        await call("validate_and_save_step", {"step_number": number, "step_data": data})
+        for number, data in step_data.items()
+    ]
+    results["status"] = await call("get_onboarding_status")
+    results["finalize"] = await call("finalize_onboarding")
+    print(json.dumps(results))
+
+
+asyncio.run(main())
+"""
+
+TASK_JOURNEY = r"""
+import asyncio
+import json
+from pathlib import Path
+
+from core.mcp import work_server as work
+
+
+def decode(contents):
+    return json.loads(contents[0].text)
+
+
+async def call(name, arguments=None):
+    return decode(await work.handle_call_tool(name, arguments or {}))
+
+
+async def main():
+    work.HAS_QMD = False
+    work.is_qmd_available = lambda: False
+    work.refresh_search_index = lambda: None
+    work._fire_analytics_event = lambda *_args, **_kwargs: {"fired": False}
+
+    title = "Prepare golden customer renewal brief"
+    person_path = "05-Areas/People/Internal/Alice_Smith"
+    person_file = work.BASE_DIR / f"{person_path}.md"
+    tasks_file = work.BASE_DIR / "03-Tasks" / "Tasks.md"
+
+    initial_summary = await call("get_work_summary")
+    created = await call(
+        "create_task",
+        {
+            "title": title,
+            "pillar": "pillar_1",
+            "priority": "P2",
+            "section": "Next Week",
+            "context": "Use the latest customer evidence.",
+            "people": [person_path],
+        },
+    )
+    created_summary = await call("get_work_summary")
+    person_after_create = person_file.read_text(encoding="utf-8")
+    tasks_after_create = tasks_file.read_text(encoding="utf-8")
+
+    updated = await call(
+        "update_task_status",
+        {"task_id": created["task"]["task_id"], "status": "d"},
+    )
+    completed_summary = await call("get_work_summary")
+    week_progress = await call("get_week_progress")
+
+    print(
+        json.dumps(
+            {
+                "title": title,
+                "person_path": person_path,
+                "initial_summary": initial_summary,
+                "created": created,
+                "created_summary": created_summary,
+                "person_after_create": person_after_create,
+                "tasks_after_create": tasks_after_create,
+                "updated": updated,
+                "completed_summary": completed_summary,
+                "week_progress": week_progress,
+                "person_after_complete": person_file.read_text(encoding="utf-8"),
+                "tasks_after_complete": tasks_file.read_text(encoding="utf-8"),
+            }
+        )
+    )
+
+
+asyncio.run(main())
+"""
+
+
+def _copy_fixture_vault(fixture_vault: Path, tmp_path: Path, *, onboarding: bool = False) -> Path:
+    vault = tmp_path / "vault"
+    shutil.copytree(fixture_vault, vault)
+    if onboarding:
+        shutil.copy2(REPO_ROOT / "CLAUDE.md", vault / "CLAUDE.md")
+        shutil.copy2(REPO_ROOT / "System" / ".mcp.json.example", vault / "System" / ".mcp.json.example")
+    return vault
+
+
+def _run_journey(vault: Path, source: str) -> dict:
+    env = os.environ.copy()
+    env["VAULT_PATH"] = str(vault)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return json.loads(result.stdout)
+
+
+def test_golden_onboarding_drives_state_machine_to_real_vault(fixture_vault: Path, tmp_path: Path):
+    vault = _copy_fixture_vault(fixture_vault, tmp_path, onboarding=True)
+
+    journey = _run_journey(vault, ONBOARDING_JOURNEY)
+
+    assert journey["start"]["success"] is True
+    assert journey["resume"]["success"] is True
+    assert journey["start"]["data"]["started_at"] == journey["resume"]["data"]["started_at"]
+    assert journey["resume"]["data"]["completed_steps"] == []
+    assert "Resuming onboarding session" in journey["resume"]["message"]
+    assert journey["dependencies"]["data"]["all_required_installed"] is True
+    assert all(step["success"] for step in journey["steps"])
+    assert journey["status"]["data"]["progress_percent"] == 100.0
+    assert journey["status"]["data"]["ready_to_finalize"] is True
+    assert journey["finalize"]["success"] is True
+    assert journey["finalize"]["data"]["errors"] == []
+
+    for directory in (
+        "00-Inbox",
+        "01-Quarter_Goals",
+        "02-Week_Priorities",
+        "03-Tasks",
+        "04-Projects",
+        "05-Areas",
+        "06-Resources",
+        "07-Archives",
+        "System",
+    ):
+        assert (vault / directory).is_dir(), directory
+    assert (vault / "03-Tasks/Tasks.md").is_file()
+    assert (vault / "02-Week_Priorities/Week_Priorities.md").is_file()
+
+    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
+    assert profile["name"] == "Golden User"
+    assert profile["role"] == "Product Manager"
+    assert profile["company"] == "Golden Co"
+    assert profile["company_size"] == "startup"
+    assert profile["email_domain"] == "golden.example"
+    assert profile["communication"]["career_level"] == "leadership"
+
+    pillars = yaml.safe_load((vault / "System/pillars.yaml").read_text(encoding="utf-8"))
+    assert [pillar["name"] for pillar in pillars["pillars"]] == ["Customer", "Product"]
+
+    root_config = vault / ".mcp.json"
+    config_text = root_config.read_text(encoding="utf-8")
+    config = json.loads(config_text)
+    assert "{{" not in config_text
+    assert config["mcpServers"]["work-mcp"]["command"] == f"{vault}/.venv/bin/python"
+    assert config["mcpServers"]["work-mcp"]["args"] == [f"{vault}/core/mcp/work_server.py"]
+    assert config["mcpServers"]["work-mcp"]["env"]["VAULT_PATH"] == str(vault)
+    assert not (vault / "System/.mcp.json").exists()
+    assert (vault / "System/.onboarding-complete").is_file()
+    assert not (vault / "System/.onboarding-session.json").exists()
+
+
+def test_golden_task_lifecycle_propagates_and_rolls_up(fixture_vault: Path, tmp_path: Path):
     vault = _copy_fixture_vault(fixture_vault, tmp_path)
 
-    # 1) Onboarding baseline
-    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
-    pillars = yaml.safe_load((vault / "System/pillars.yaml").read_text(encoding="utf-8"))
-    assert profile["name"] == "Test User"
-    assert "pillars" in pillars
+    journey = _run_journey(vault, TASK_JOURNEY)
 
-    # 2) Task creation
-    task_id = "task-golden-001"
-    tasks_file = vault / "03-Tasks/Tasks.md"
-    task_line = f"- [ ] Prepare partner sync ({task_id}) #P1\\n"
-    tasks_file.write_text(tasks_file.read_text(encoding="utf-8") + task_line, encoding="utf-8")
+    created = journey["created"]
+    updated = journey["updated"]
+    title = journey["title"]
+    task_id = created["task"]["task_id"]
+    assert created["success"] is True
+    assert re.fullmatch(r"task-\d{8}-\d{3}", task_id)
+    assert journey["person_path"] in created["synced_pages"]
+    assert f"^{task_id}" in journey["tasks_after_create"]
+    assert f"| ⏳ | {title} | P2 |" in journey["person_after_create"]
 
-    # 3) Meeting sync
-    today = date.today().isoformat()
-    meeting_file = vault / "00-Inbox/Meetings" / f"{today}-partner-sync.md"
-    meeting_file.write_text(
-        "\\n".join(
-            [
-                f"# Partner Sync — {today}",
-                "",
-                f"- Follow-up task: {task_id}",
-                "- Attendee: Alice Smith",
-            ]
-        ),
-        encoding="utf-8",
+    assert updated["success"] is True
+    assert updated["status"] == "completed"
+    assert updated["instances_found"] == 1
+    assert f"{journey['person_path']}.md" in updated["related_tasks_synced"]
+    assert len(updated["updated_files"]) == 1
+    completed_line = next(
+        line for line in journey["tasks_after_complete"].splitlines() if f"^{task_id}" in line
     )
+    assert completed_line.startswith("- [x]")
+    assert completed_line.index(updated["completed_at"]) > completed_line.index(f"^{task_id}")
+    assert f"| ✅ | {title} | P2 |" in journey["person_after_complete"]
 
-    # 4) Daily plan
-    daily_plan = vault / "00-Inbox/Daily_Plans" / f"{today}.md"
-    daily_plan.write_text(
-        "\\n".join(
-            [
-                f"# Daily Plan — {today}",
-                "",
-                "## Must-do",
-                f"- Finish: {task_id}",
-                f"- Review notes: [[Meetings/{today}-partner-sync]]",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    # 5) Week review
-    week_review = vault / "02-Week_Priorities" / "Week_Review.md"
-    week_review.write_text(
-        "\\n".join(
-            [
-                "# Week Review",
-                "",
-                f"- Closed loop from meeting to execution: {task_id}",
-                f"- Source meeting: {meeting_file.name}",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    # Continuity assertions
-    tasks_content = tasks_file.read_text(encoding="utf-8")
-    meeting_content = meeting_file.read_text(encoding="utf-8")
-    daily_content = daily_plan.read_text(encoding="utf-8")
-    review_content = week_review.read_text(encoding="utf-8")
-
-    assert task_id in tasks_content
-    assert task_id in meeting_content
-    assert task_id in daily_content
-    assert task_id in review_content
-    assert meeting_file.name in review_content
+    initial_active = journey["initial_summary"]["daily_summary"]["total_tasks"]
+    created_active = journey["created_summary"]["daily_summary"]["total_tasks"]
+    completed_active = journey["completed_summary"]["daily_summary"]["total_tasks"]
+    assert created_active == initial_active + 1
+    assert completed_active == initial_active
+    assert journey["week_progress"]["tasks_completed_this_week"] == 1

--- a/core/tests/test_mcp_stdio_startup.py
+++ b/core/tests/test_mcp_stdio_startup.py
@@ -1,0 +1,84 @@
+"""Start every shipped Dex MCP server and perform a real stdio initialize."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.utils.mcp_handshake import mcp_stdio_handshake
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MCP_TEMPLATE = REPO_ROOT / "System" / ".mcp.json.example"
+
+
+def _dex_owned_servers() -> list[tuple[str, Path, dict[str, str]]]:
+    config = json.loads(MCP_TEMPLATE.read_text(encoding="utf-8"))
+    servers = []
+    prefix = "{{VAULT_PATH}}/"
+    for name, entry in config["mcpServers"].items():
+        command = entry.get("command")
+        args = entry.get("args", [])
+        script_args = [
+            argument
+            for argument in args
+            if isinstance(argument, str) and argument.startswith(f"{prefix}core/mcp/")
+        ]
+        if not isinstance(command, str) or not command.endswith("/.venv/bin/python") or len(script_args) != 1:
+            continue
+        script = REPO_ROOT / script_args[0].removeprefix(prefix)
+        servers.append((name, script, entry.get("env", {})))
+    return servers
+
+
+DEX_OWNED_SERVERS = _dex_owned_servers()
+assert DEX_OWNED_SERVERS, "System/.mcp.json.example contains no Dex-owned Python servers"
+
+
+@pytest.mark.parametrize(
+    ("server_name", "script", "configured_env"),
+    DEX_OWNED_SERVERS,
+    ids=[name for name, _script, _env in DEX_OWNED_SERVERS],
+)
+def test_dex_owned_server_completes_stdio_initialize(
+    server_name: str,
+    script: Path,
+    configured_env: dict[str, str],
+    fixture_vault: Path,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    shutil.copytree(fixture_vault, vault)
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {
+        "HOME": str(home),
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "PYTHONPATH": str(REPO_ROOT),
+        "PYTHONUNBUFFERED": "1",
+        "VAULT_PATH": str(vault),
+    }
+    env.update(
+        {
+            key: value.replace("{{VAULT_PATH}}", str(vault))
+            for key, value in configured_env.items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+    )
+
+    result = mcp_stdio_handshake(
+        [sys.executable, str(script)],
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=10,
+    )
+
+    assert result.ok, f"{server_name}: {result.error}\nstderr:\n{result.stderr}"
+    assert result.response is not None
+    assert result.response["jsonrpc"] == "2.0"
+    assert result.response["id"] == 1
+    assert isinstance(result.response["result"]["capabilities"], dict)
+    assert isinstance(result.response["result"]["serverInfo"], dict)

--- a/core/tests/test_mcp_stdio_startup.py
+++ b/core/tests/test_mcp_stdio_startup.py
@@ -13,24 +13,55 @@ from core.utils.mcp_handshake import mcp_stdio_handshake
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MCP_TEMPLATE = REPO_ROOT / "System" / ".mcp.json.example"
+VAULT_PLACEHOLDER = "{{VAULT_PATH}}"
+CONFIGURED_PYTHON = f"{VAULT_PLACEHOLDER}/.venv/bin/python"
+DEX_SCRIPT_PREFIX = f"{VAULT_PLACEHOLDER}/core/mcp/"
 
 
-def _dex_owned_servers() -> list[tuple[str, Path, dict[str, str]]]:
-    config = json.loads(MCP_TEMPLATE.read_text(encoding="utf-8"))
+def _dex_owned_servers(
+    config: object | None = None,
+) -> list[tuple[str, str, tuple[str, ...], dict[str, str]]]:
+    if config is None:
+        config = json.loads(MCP_TEMPLATE.read_text(encoding="utf-8"))
+    if not isinstance(config, dict) or not isinstance(config.get("mcpServers"), dict):
+        raise AssertionError("System/.mcp.json.example must contain an mcpServers object")
+
     servers = []
-    prefix = "{{VAULT_PATH}}/"
     for name, entry in config["mcpServers"].items():
+        if not isinstance(entry, dict):
+            continue
         command = entry.get("command")
         args = entry.get("args", [])
+        is_candidate = command == CONFIGURED_PYTHON or "core/mcp/" in json.dumps(args)
+        if not is_candidate:
+            continue
+        if command != CONFIGURED_PYTHON:
+            raise AssertionError(
+                f"{name}: Dex-owned server command must be {CONFIGURED_PYTHON!r}"
+            )
+        if not isinstance(args, list) or not all(isinstance(argument, str) for argument in args):
+            raise AssertionError(f"{name}: Dex-owned server args must be a list of strings")
+
         script_args = [
             argument
             for argument in args
-            if isinstance(argument, str) and argument.startswith(f"{prefix}core/mcp/")
+            if argument.startswith(DEX_SCRIPT_PREFIX)
         ]
-        if not isinstance(command, str) or not command.endswith("/.venv/bin/python") or len(script_args) != 1:
-            continue
-        script = REPO_ROOT / script_args[0].removeprefix(prefix)
-        servers.append((name, script, entry.get("env", {})))
+        if len(script_args) != 1:
+            raise AssertionError(
+                f"{name}: Dex-owned server must have exactly one {DEX_SCRIPT_PREFIX} argument"
+            )
+        script = REPO_ROOT / script_args[0].removeprefix(f"{VAULT_PLACEHOLDER}/")
+        if not script.is_file():
+            raise AssertionError(f"{name}: configured server script does not exist: {script}")
+
+        configured_env = entry.get("env", {})
+        if not isinstance(configured_env, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in configured_env.items()
+        ):
+            raise AssertionError(f"{name}: Dex-owned server env must contain string values")
+        servers.append((name, command, tuple(args), configured_env))
     return servers
 
 
@@ -39,13 +70,14 @@ assert DEX_OWNED_SERVERS, "System/.mcp.json.example contains no Dex-owned Python
 
 
 @pytest.mark.parametrize(
-    ("server_name", "script", "configured_env"),
+    ("server_name", "configured_command", "configured_args", "configured_env"),
     DEX_OWNED_SERVERS,
-    ids=[name for name, _script, _env in DEX_OWNED_SERVERS],
+    ids=[name for name, _command, _args, _env in DEX_OWNED_SERVERS],
 )
 def test_dex_owned_server_completes_stdio_initialize(
     server_name: str,
-    script: Path,
+    configured_command: str,
+    configured_args: tuple[str, ...],
     configured_env: dict[str, str],
     fixture_vault: Path,
     tmp_path: Path,
@@ -69,8 +101,15 @@ def test_dex_owned_server_completes_stdio_initialize(
         }
     )
 
+    resolved_command = configured_command.replace(VAULT_PLACEHOLDER, str(REPO_ROOT))
+    assert resolved_command == str(REPO_ROOT / ".venv/bin/python")
+    resolved_args = [
+        argument.replace(VAULT_PLACEHOLDER, str(REPO_ROOT))
+        for argument in configured_args
+    ]
+
     result = mcp_stdio_handshake(
-        [sys.executable, str(script)],
+        [sys.executable, *resolved_args],
         cwd=REPO_ROOT,
         env=env,
         timeout=10,
@@ -82,3 +121,27 @@ def test_dex_owned_server_completes_stdio_initialize(
     assert result.response["id"] == 1
     assert isinstance(result.response["result"]["capabilities"], dict)
     assert isinstance(result.response["result"]["serverInfo"], dict)
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected_error"),
+    [
+        (
+            {"command": "python", "args": [f"{DEX_SCRIPT_PREFIX}work_server.py"]},
+            "command must be",
+        ),
+        (
+            {"command": CONFIGURED_PYTHON, "args": f"{DEX_SCRIPT_PREFIX}work_server.py"},
+            "args must be a list of strings",
+        ),
+        (
+            {"command": CONFIGURED_PYTHON, "args": []},
+            "must have exactly one",
+        ),
+    ],
+)
+def test_dex_owned_server_discovery_rejects_malformed_candidates(
+    entry: dict[str, object], expected_error: str
+) -> None:
+    with pytest.raises(AssertionError, match=expected_error):
+        _dex_owned_servers({"mcpServers": {"broken": entry}})

--- a/core/tests/test_paths.py
+++ b/core/tests/test_paths.py
@@ -96,6 +96,9 @@ class TestDerivedPaths:
     def test_ritual_intelligence_db_parent_is_runtime_dir(self):
         assert paths.RITUAL_INTELLIGENCE_DB_FILE.parent == paths.DEX_RUNTIME_DIR
 
+    def test_mcp_config_target_is_at_vault_root(self):
+        assert paths.MCP_CONFIG_TARGET == paths.VAULT_ROOT / ".mcp.json"
+
 
 # ---------------------------------------------------------------------------
 # TestNoBarePaths

--- a/core/tests/test_preflight_paths.py
+++ b/core/tests/test_preflight_paths.py
@@ -8,6 +8,8 @@ actually live at ``<vault>/core/mcp``. These tests pin the corrected path so the
 ``dex-core`` segment can never creep back in.
 """
 
+import json
+
 from core.utils import preflight
 
 
@@ -51,3 +53,26 @@ def test_check_server_ignores_stale_dexcore_path(tmp_path, monkeypatch):
 
     assert result["status"] == "error"
     assert result["error"] == f"Server file not found: {module_file}"
+
+
+def test_mcp_config_path_prefers_root_when_both_configs_exist(tmp_path, monkeypatch):
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    root = tmp_path / ".mcp.json"
+    legacy = tmp_path / "System" / ".mcp.json"
+    legacy.parent.mkdir()
+    root.write_text(json.dumps({"mcpServers": {"root": {}}}))
+    legacy.write_text(json.dumps({"mcpServers": {"legacy": {}}}))
+
+    assert preflight.get_mcp_config_path() == root
+    assert preflight.get_configured_servers() == ["root"]
+
+
+def test_mcp_config_path_falls_back_to_legacy_when_root_is_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    legacy = tmp_path / "System" / ".mcp.json"
+    legacy.parent.mkdir()
+    legacy.write_text(json.dumps({"mcpServers": {"legacy": {}}}))
+
+    assert preflight.get_mcp_config_path() == legacy
+    assert preflight.get_configured_servers() == ["legacy"]
+    assert not (tmp_path / ".mcp.json").exists()

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -1,0 +1,87 @@
+"""Validate shipped skill metadata and executable references."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core.utils.validators import validate_mcp_config, validate_skill_frontmatter
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
+SKILL_FILES = sorted(SKILLS_ROOT.glob("*/SKILL.md"))
+
+RUNNABLE_REFERENCE = re.compile(
+    r"\b(?:node|bash|sh|python3?)\s+(?:\./)?"
+    r"(?P<path>(?:\.scripts|\.claude|core)/[A-Za-z0-9_./-]+\.(?:cjs|js|sh|py))"
+)
+
+# These are intentionally not distribution-owned implementations:
+# - prompt-improver checks for the optional script and documents two fallbacks.
+# - dex-add-mcp shows a user-managed Gmail MCP command as an example.
+MISSING_RUNNABLE_ALLOWLIST = {
+    ".scripts/improve-prompt.cjs",
+    ".scripts/mcp/gmail-mcp.js",
+}
+
+
+@pytest.mark.parametrize("skill_path", SKILL_FILES, ids=[path.parent.name for path in SKILL_FILES])
+def test_skill_frontmatter_is_valid(skill_path: Path) -> None:
+    assert validate_skill_frontmatter(skill_path) == []
+
+
+def test_skill_runnable_references_exist_or_are_documented_dynamic_paths() -> None:
+    missing: dict[str, list[str]] = {}
+    for skill_path in SKILL_FILES:
+        text = skill_path.read_text(encoding="utf-8")
+        body = text.split("---", 2)[-1]
+        for match in RUNNABLE_REFERENCE.finditer(body):
+            relative_path = match.group("path")
+            if not (REPO_ROOT / relative_path).exists():
+                missing.setdefault(relative_path, []).append(skill_path.parent.name)
+
+    assert set(missing) == MISSING_RUNNABLE_ALLOWLIST, missing
+
+
+def test_validate_mcp_config_accepts_resolved_stdio_entries() -> None:
+    config = {
+        "mcpServers": {
+            "work-mcp": {
+                "command": "/vault/.venv/bin/python",
+                "args": ["/vault/core/mcp/work_server.py"],
+                "env": {"VAULT_PATH": "/vault"},
+            }
+        }
+    }
+
+    assert validate_mcp_config(config) == []
+    assert validate_mcp_config('{"mcpServers":{"server":{"command":"python","args":[]}}}') == []
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_error"),
+    [
+        ({}, "mcpServers"),
+        ({"mcpServers": []}, "object"),
+        ({"mcpServers": {"bad": []}}, "entry must be an object"),
+        ({"mcpServers": {"bad": {"command": "", "args": []}}}, "command"),
+        ({"mcpServers": {"bad": {"command": "python", "args": "server.py"}}}, "args"),
+        (
+            {
+                "mcpServers": {
+                    "bad": {
+                        "command": "python",
+                        "args": ["{{VAULT_PATH}}/server.py"],
+                    }
+                }
+            },
+            "unresolved placeholder",
+        ),
+    ],
+)
+def test_validate_mcp_config_reports_structural_errors(config: object, expected_error: str) -> None:
+    errors = validate_mcp_config(config)
+
+    assert any(expected_error in error for error in errors), errors

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -14,8 +14,9 @@ SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
 SKILL_FILES = sorted(SKILLS_ROOT.glob("*/SKILL.md"))
 
 RUNNABLE_REFERENCE = re.compile(
-    r"\b(?:node|bash|sh|python3?)\s+(?:\./)?"
-    r"(?P<path>(?:\.scripts|\.claude|core)/[A-Za-z0-9_./-]+\.(?:cjs|js|sh|py))"
+    r"\b(?:node|bash|sh|python3?)[ \t]+[\"']?(?:\./)?"
+    r"(?P<prefix>\$(?:\{VAULT_PATH\}|VAULT_PATH)/|<skill-dir>/)?"
+    r"(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_./-]+\.(?:cjs|js|mjs|sh|py))"
 )
 
 # These are intentionally not distribution-owned implementations:
@@ -27,6 +28,34 @@ MISSING_RUNNABLE_ALLOWLIST = {
 }
 
 
+def _runnable_target(match: re.Match[str], skill_path: Path, repo_root: Path) -> Path:
+    """Resolve a referenced implementation from the root or its owning skill."""
+    relative_path = Path(match.group("path"))
+    prefix = match.group("prefix")
+    if prefix == "<skill-dir>/":
+        return skill_path.parent / relative_path
+    if prefix is not None:
+        return repo_root / relative_path
+
+    # Bundled skills conventionally invoke their own scripts as `scripts/...`
+    # or `ooxml/...`. A same-named directory beside SKILL.md makes that intent
+    # explicit; otherwise the invocation is rooted at the vault/repository.
+    if (skill_path.parent / relative_path.parts[0]).is_dir():
+        return skill_path.parent / relative_path
+    return repo_root / relative_path
+
+
+def _missing_runnable_references(skill_path: Path, repo_root: Path = REPO_ROOT) -> set[str]:
+    """Return canonical repo-relative paths for missing runnable references."""
+    body = skill_path.read_text(encoding="utf-8").split("---", 2)[-1]
+    missing = set()
+    for match in RUNNABLE_REFERENCE.finditer(body):
+        target = _runnable_target(match, skill_path, repo_root)
+        if not target.exists():
+            missing.add(target.relative_to(repo_root).as_posix())
+    return missing
+
+
 @pytest.mark.parametrize("skill_path", SKILL_FILES, ids=[path.parent.name for path in SKILL_FILES])
 def test_skill_frontmatter_is_valid(skill_path: Path) -> None:
     assert validate_skill_frontmatter(skill_path) == []
@@ -35,14 +64,24 @@ def test_skill_frontmatter_is_valid(skill_path: Path) -> None:
 def test_skill_runnable_references_exist_or_are_documented_dynamic_paths() -> None:
     missing: dict[str, list[str]] = {}
     for skill_path in SKILL_FILES:
-        text = skill_path.read_text(encoding="utf-8")
-        body = text.split("---", 2)[-1]
-        for match in RUNNABLE_REFERENCE.finditer(body):
-            relative_path = match.group("path")
-            if not (REPO_ROOT / relative_path).exists():
-                missing.setdefault(relative_path, []).append(skill_path.parent.name)
+        for relative_path in _missing_runnable_references(skill_path):
+            missing.setdefault(relative_path, []).append(skill_path.parent.name)
 
     assert set(missing) == MISSING_RUNNABLE_ALLOWLIST, missing
+
+
+def test_missing_skill_relative_runnable_is_reported(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".claude" / "skills" / "example" / "SKILL.md"
+    (skill_path.parent / "scripts").mkdir(parents=True)
+    skill_path.write_text(
+        "---\nname: example\ndescription: Example skill\n---\n"
+        "Run `python scripts/missing.py` to perform the work.\n",
+        encoding="utf-8",
+    )
+
+    assert _missing_runnable_references(skill_path, tmp_path) == {
+        ".claude/skills/example/scripts/missing.py"
+    }
 
 
 def test_validate_mcp_config_accepts_resolved_stdio_entries() -> None:

--- a/core/tests/test_transcript_reconcile.py
+++ b/core/tests/test_transcript_reconcile.py
@@ -180,7 +180,15 @@ def test_confirmed_ritual_brief_uses_previous_transcript_summary():
 
     suggestions = list_ritual_suggestions()
     result = confirm_ritual(suggestions[0]["series_id"], now=upcoming.replace(hour=8))
-    upcoming_note = Path([item["note_path"] for item in result["generated"] if upcoming_str in item["note_path"]][0])
-    rendered = upcoming_note.read_text(encoding="utf-8")
+    raw_path = MEETING_INTEL_DIR / "raw" / "trn-granola-d-Weekly 11.md"
+    summary_path = MEETING_INTEL_DIR / "summaries" / "trn-granola-d-Weekly 11.md"
+    assert raw_path.read_text(encoding="utf-8") == "Decision: ship the update\nAction: share launch notes\n"
+    assert "Decision: ship the update" in summary_path.read_text(encoding="utf-8")
 
-    assert "Transcript continuity: Decision: ship the update" in rendered
+    generated = next(item for item in result["generated"] if upcoming_str in item["note_path"])
+    note_path = Path(generated["note_path"])
+    daily_log_path = Path(generated["daily_log_path"])
+    assert note_path.exists()
+    assert "Transcript continuity: Decision: ship the update" in note_path.read_text(encoding="utf-8")
+    assert daily_log_path.exists()
+    assert f"[[{note_path.name}]]" in daily_log_path.read_text(encoding="utf-8")

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -478,6 +478,13 @@ def _load_mcp_config(context: DoctorContext) -> dict[str, Any]:
     return loaded
 
 
+def _with_mcp_config_note(context: DoctorContext, detail: str) -> str:
+    legacy_path = context.vault_root / "System" / ".mcp.json"
+    if _mcp_config_path(context) == legacy_path:
+        return f"{detail} (using legacy System/.mcp.json because root .mcp.json is absent)"
+    return detail
+
+
 def _expand_path_token(token: str, context: DoctorContext) -> str:
     expanded = token.replace("{{VAULT_PATH}}", str(context.vault_root))
     expanded = expanded.replace("__VAULT_PATH__", str(context.vault_root))
@@ -574,16 +581,22 @@ def _probe_mcp_registered(context: DoctorContext) -> ProbeResult:
     except (OSError, ValueError, json.JSONDecodeError) as error:
         return ProbeResult(
             "BROKEN",
-            f".mcp.json is invalid: {_one_line(error)}",
+            _with_mcp_config_note(context, f".mcp.json is invalid: {_one_line(error)}"),
             Heal(tier=3, action="Repair .mcp.json by hand while preserving user-added servers.", applied=False),
         )
     if missing:
         return ProbeResult(
             "BROKEN",
-            f"Registered MCP targets are missing: {', '.join(missing)}",
+            _with_mcp_config_note(context, f"Registered MCP targets are missing: {', '.join(missing)}"),
             Heal(tier=2, action="Repair the missing MCP target paths in .mcp.json.", applied=False),
         )
-    return ProbeResult("OK", f"All {len(config['mcpServers'])} registered MCP entries have valid targets")
+    return ProbeResult(
+        "OK",
+        _with_mcp_config_note(
+            context,
+            f"All {len(config['mcpServers'])} registered MCP entries have valid targets",
+        ),
+    )
 
 
 def _probe_mcp_orphans(context: DoctorContext) -> ProbeResult:
@@ -602,10 +615,16 @@ def _probe_mcp_orphans(context: DoctorContext) -> ProbeResult:
     if orphans:
         return ProbeResult(
             "BROKEN",
-            f"Core MCP servers are not registered: {', '.join(sorted(orphans))}",
+            _with_mcp_config_note(
+                context,
+                f"Core MCP servers are not registered: {', '.join(sorted(orphans))}",
+            ),
             Heal(tier=2, action="Add the orphaned core MCP servers to .mcp.json.", applied=False),
         )
-    return ProbeResult("OK", f"All {len(shipped)} core MCP server files are registered")
+    return ProbeResult(
+        "OK",
+        _with_mcp_config_note(context, f"All {len(shipped)} core MCP server files are registered"),
+    )
 
 
 def _python_import_check(python: Path) -> tuple[bool, list[str]]:

--- a/core/utils/mcp_handshake.py
+++ b/core/utils/mcp_handshake.py
@@ -1,0 +1,169 @@
+"""Minimal stdio JSON-RPC handshake for Dex MCP smoke checks."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Empty, Queue
+from threading import Thread
+from typing import Any, Mapping, Sequence
+
+INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "dex-mcp-handshake", "version": "1.0"},
+    },
+}
+
+
+@dataclass(frozen=True)
+class MCPHandshakeResult:
+    """Outcome from one initialize request."""
+
+    ok: bool
+    response: dict[str, Any] | None
+    error: str | None
+    stderr: str
+    returncode: int | None
+
+
+def _response_error(response: object) -> str | None:
+    if not isinstance(response, dict):
+        return "initialize response is not a JSON object"
+    if response.get("jsonrpc") != "2.0":
+        return "initialize response has an invalid jsonrpc version"
+    if response.get("id") != INITIALIZE_REQUEST["id"]:
+        return "initialize response id does not match the request"
+    if "error" in response:
+        return f"initialize returned a JSON-RPC error: {response['error']}"
+    if not isinstance(response.get("result"), dict):
+        return "initialize response has no result object"
+    return None
+
+
+def _terminate_process_group(process: subprocess.Popen[str]) -> None:
+    """Stop the server and any children, escalating when it ignores SIGTERM."""
+    if process.stdin is not None:
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+    if process.poll() is not None:
+        return
+
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        return
+
+    try:
+        process.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except ProcessLookupError:
+        return
+    process.wait(timeout=1)
+
+
+def mcp_stdio_handshake(
+    command: Sequence[str | os.PathLike[str]],
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float = 10.0,
+) -> MCPHandshakeResult:
+    """Launch ``command``, send initialize, and return its first JSON-RPC response.
+
+    The child runs in a separate process group and is always terminated. The
+    timeout covers waiting for the newline-delimited initialize response.
+    """
+    if not command:
+        raise ValueError("command must not be empty")
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than zero")
+
+    process: subprocess.Popen[str] | None = None
+    response: dict[str, Any] | None = None
+    error: str | None = None
+    stderr = ""
+    returncode: int | None = None
+
+    with tempfile.TemporaryFile(mode="w+b") as stderr_file:
+        try:
+            process = subprocess.Popen(
+                [os.fspath(part) for part in command],
+                cwd=Path(cwd) if cwd is not None else None,
+                env=dict(env) if env is not None else None,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr_file,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                start_new_session=True,
+            )
+            if process.stdin is None or process.stdout is None:
+                error = "could not open server stdio pipes"
+            else:
+                request = json.dumps(INITIALIZE_REQUEST, separators=(",", ":")) + "\n"
+                process.stdin.write(request)
+                process.stdin.flush()
+
+                lines: Queue[str] = Queue(maxsize=1)
+                reader = Thread(target=lambda: lines.put(process.stdout.readline()), daemon=True)
+                reader.start()
+                try:
+                    line = lines.get(timeout=timeout)
+                except Empty:
+                    if process.poll() is None:
+                        error = f"initialize response timed out after {timeout:g}s"
+                    else:
+                        error = f"server exited before initialize response (exit {process.returncode})"
+                else:
+                    if not line:
+                        error = f"server closed stdout before initialize response (exit {process.poll()})"
+                    else:
+                        try:
+                            decoded = json.loads(line)
+                        except json.JSONDecodeError as exc:
+                            error = f"initialize response is not valid JSON: {exc}"
+                        else:
+                            if isinstance(decoded, dict):
+                                response = decoded
+                            error = _response_error(decoded)
+        except (BrokenPipeError, OSError) as exc:
+            error = f"could not complete initialize handshake: {exc}"
+        finally:
+            if process is not None:
+                _terminate_process_group(process)
+                returncode = process.returncode
+            stderr_file.flush()
+            stderr_file.seek(0)
+            stderr = stderr_file.read().decode("utf-8", errors="replace")
+
+    return MCPHandshakeResult(
+        ok=error is None,
+        response=response,
+        error=error,
+        stderr=stderr,
+        returncode=returncode,
+    )

--- a/core/utils/preflight.py
+++ b/core/utils/preflight.py
@@ -27,7 +27,12 @@ def get_vault_path() -> str:
 
 
 def get_mcp_config_path() -> Path:
-    return Path(get_vault_path()) / ".mcp.json"
+    vault_root = Path(get_vault_path())
+    root_config = vault_root / ".mcp.json"
+    legacy_config = vault_root / "System" / ".mcp.json"
+    if root_config.exists() or not legacy_config.exists():
+        return root_config
+    return legacy_config
 
 
 def get_health_path() -> Path:

--- a/core/utils/validators.py
+++ b/core/utils/validators.py
@@ -1,0 +1,102 @@
+"""Reusable validators for shipped Dex skills and MCP configuration."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PLACEHOLDER_PATTERN = re.compile(r"\{\{[^{}]+\}\}")
+
+
+def validate_skill_frontmatter(path: str | Path) -> list[str]:
+    """Return validation errors for one skill's YAML frontmatter."""
+    skill_path = Path(path)
+    try:
+        lines = skill_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return [f"could not read {skill_path}: {exc}"]
+
+    if not lines or lines[0].strip() != "---":
+        return ["frontmatter must start with ---"]
+    try:
+        closing_index = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return ["frontmatter is missing its closing ---"]
+
+    try:
+        frontmatter = yaml.safe_load("\n".join(lines[1:closing_index]))
+    except yaml.YAMLError as exc:
+        return [f"frontmatter is not valid YAML: {exc}"]
+    if not isinstance(frontmatter, Mapping):
+        return ["frontmatter must be a YAML object"]
+
+    errors = []
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+    if not isinstance(name, str) or not name.strip():
+        errors.append("frontmatter name must be a non-empty string")
+    elif name != skill_path.parent.name:
+        errors.append(f"frontmatter name {name!r} must match folder {skill_path.parent.name!r}")
+    if not isinstance(description, str) or not description.strip():
+        errors.append("frontmatter description must be a non-empty string")
+    return errors
+
+
+def _placeholder_errors(value: object, location: str = "$") -> list[str]:
+    errors = []
+    if isinstance(value, str):
+        if PLACEHOLDER_PATTERN.search(value):
+            errors.append(f"{location} contains an unresolved placeholder")
+    elif isinstance(value, Mapping):
+        for key, child in value.items():
+            errors.extend(_placeholder_errors(key, f"{location}.<key>"))
+            errors.extend(_placeholder_errors(child, f"{location}.{key}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            errors.extend(_placeholder_errors(child, f"{location}[{index}]"))
+    return errors
+
+
+def validate_mcp_config(config: object) -> list[str]:
+    """Return structural and unresolved-placeholder errors for an MCP config."""
+    parsed: Any = config
+    if isinstance(config, str):
+        try:
+            parsed = json.loads(config)
+        except json.JSONDecodeError as exc:
+            return [f"config is not valid JSON: {exc}"]
+
+    if not isinstance(parsed, Mapping):
+        return ["config must be an object"]
+    servers = parsed.get("mcpServers")
+    if not isinstance(servers, Mapping):
+        return ["mcpServers must be an object"]
+
+    errors = []
+    for name, entry in servers.items():
+        label = str(name)
+        if not isinstance(name, str) or not name.strip():
+            errors.append("MCP server names must be non-empty strings")
+        if not isinstance(entry, Mapping):
+            errors.append(f"{label}: entry must be an object")
+            continue
+
+        command = entry.get("command")
+        if not isinstance(command, str) or not command.strip():
+            errors.append(f"{label}: command must be a non-empty string")
+        args = entry.get("args", [])
+        if not isinstance(args, list) or not all(isinstance(argument, str) for argument in args):
+            errors.append(f"{label}: args must be a list of strings")
+        env = entry.get("env", {})
+        if not isinstance(env, Mapping) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in env.items()
+        ):
+            errors.append(f"{label}: env must be an object of string values")
+
+    errors.extend(_placeholder_errors(parsed))
+    return errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.21.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.21.0",
+      "version": "1.28.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.26.0",
+  "version": "1.28.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/packages/dex-contracts/dist/paths.contract.json
+++ b/packages/dex-contracts/dist/paths.contract.json
@@ -23,7 +23,7 @@
     "LEGACY_MEETINGS_DIR": "00-Inbox/Meetings",
     "MARKER_FILE": "System/.onboarding-complete",
     "MCP_CONFIG_EXAMPLE": "System/.mcp.json.example",
-    "MCP_CONFIG_TARGET": "System/.mcp.json",
+    "MCP_CONFIG_TARGET": ".mcp.json",
     "MEETINGS_DIR": "00-Inbox/Meetings",
     "MEETING_CACHE_FILE": "System/Memory/meeting-cache.json",
     "MEETING_DAILY_LOGS_DIR": "05-Areas/Meetings/Daily_Log",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Dex development and CI requirements
+pytest
+pytest-cov
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,6 @@ python-dateutil>=2.8.0
 # Web scraping (no API key required)
 scrapling[ai]>=0.4.1
 
-# Testing
-pytest
-ruff
-
 # Optional integrations (uncomment if needed)
 # google-auth>=2.16.0
 # google-auth-oauthlib>=1.0.0

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -65,11 +65,10 @@ if [ "$DRY_RUN" = true ]; then
     echo "Dry run — files that would be removed from release branch:"
     echo ""
     for pattern in "${PATTERNS[@]}"; do
-        # Use git ls-files to match tracked files
-        matches=$(git ls-files -- "$pattern" 2>/dev/null || true)
-        if [ -n "$matches" ]; then
-            echo "$matches" | sed 's/^/  /'
-        fi
+        # Keep path boundaries intact for spaces and other special characters.
+        while IFS= read -r -d '' match; do
+            printf '  %s\n' "$match"
+        done < <(git ls-files -z -- "$pattern")
     done
     echo ""
     echo "Source: $SOURCE_BRANCH ($(git rev-parse --short $SOURCE_BRANCH))"
@@ -92,34 +91,37 @@ git checkout -B "$RELEASE_BRANCH" "$SOURCE_BRANCH" --quiet
 
 # Remove dev-only files
 REMOVED=0
+MATCHES_FILE=$(mktemp)
+trap 'rm -f "$MATCHES_FILE"' EXIT
 for pattern in "${PATTERNS[@]}"; do
-    matches=$(git ls-files -- "$pattern" 2>/dev/null || true)
-    if [ -n "$matches" ]; then
-        echo "$matches" | xargs git rm -rf --quiet 2>/dev/null || true
-        count=$(echo "$matches" | wc -l | tr -d ' ')
+    git ls-files -z -- "$pattern" > "$MATCHES_FILE"
+    if [ -s "$MATCHES_FILE" ]; then
+        count=0
+        while IFS= read -r -d '' _match; do
+            count=$((count + 1))
+        done < "$MATCHES_FILE"
+        xargs -0 git rm -rf --quiet -- < "$MATCHES_FILE"
         REMOVED=$((REMOVED + count))
     fi
 done
 
-if [ $REMOVED -eq 0 ]; then
+# Remove development-only package metadata that points at stripped files.
+node -e "
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    delete pkg.devDependencies;
+    if (pkg.scripts) delete pkg.scripts['test:hooks'];
+    fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+git add -- package.json
+
+if git diff --cached --quiet; then
     echo "Nothing to remove — release branch matches main."
     git checkout - --quiet
     exit 0
 fi
 
-# Remove devDependencies from package.json if present
-if grep -q '"devDependencies"' package.json 2>/dev/null; then
-    # Use node to strip devDependencies cleanly
-    node -e "
-        const pkg = require('./package.json');
-        delete pkg.devDependencies;
-        require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-    "
-    git add package.json
-fi
-
 # Commit the clean state
-git add -A
 git commit -m "$(cat <<EOF
 release: v$PKG_VERSION
 

--- a/scripts/verify-distribution.sh
+++ b/scripts/verify-distribution.sh
@@ -238,6 +238,31 @@ else
     echo "  ✅ All referenced runnable scripts exist"
 fi
 
+# Check 16: A real release build contains no test suites.
+echo ""
+echo "✓ Verifying release branch strips all test suites..."
+RELEASE_CHECK_DIR=$(mktemp -d)
+RELEASE_CHECK_REPO="$RELEASE_CHECK_DIR/repo"
+if git clone --local --no-hardlinks --quiet "$PWD" "$RELEASE_CHECK_REPO" \
+    && git -C "$RELEASE_CHECK_REPO" config user.name "Dex Distribution Check" \
+    && git -C "$RELEASE_CHECK_REPO" config user.email "distribution@example.com" \
+    && git -C "$RELEASE_CHECK_REPO" checkout -B main HEAD --quiet \
+    && bash "$RELEASE_CHECK_REPO/scripts/build-release.sh" >/dev/null; then
+    RELEASE_TEST_FILES=$(git -C "$RELEASE_CHECK_REPO" ls-tree -r --name-only release -- \
+        core/tests core/mcp/tests core/migrations/tests .claude/hooks/tests)
+    if [ -n "$RELEASE_TEST_FILES" ]; then
+        echo "  ❌ ERROR: Test files found in generated release branch:"
+        echo "$RELEASE_TEST_FILES" | sed 's/^/     /'
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  ✅ Generated release branch contains no test suites"
+    fi
+else
+    echo "  ❌ ERROR: Could not build a temporary release branch"
+    ERRORS=$((ERRORS + 1))
+fi
+rm -rf "$RELEASE_CHECK_DIR"
+
 # Summary
 echo ""
 echo "================================="


### PR DESCRIPTION
## What this is

Part one of the testing-rigor effort: make CI exercise Dex the way users actually use it, and fix three verified bugs in what ships to users.

## Verified bugs fixed

1. **ZIP installs shipped skills without their implementations.** The unanchored `scripts/` export-ignore rule stripped every `.claude/skills/*/scripts/` directory from `git archive` output. Anchored to `/scripts/`; regression test archives HEAD and checks both directions.
2. **The release branch shipped 58 internal test files.** `build-release.sh` piped newline paths through xargs under `|| true`, so filenames with spaces broke stripping silently. Now null-delimited and fail-loud; distribution tests build a release in a temp clone and assert what must be absent (all test dirs, dev deps, `test:hooks`) and what must survive (doctor, servers, skills incl. nested scripts).
3. **MCP config split-brain.** `core/paths.py` targeted `System/.mcp.json` while preflight and Claude Code read the vault root. Root is now canonical everywhere (onboarding, preflight, doctor, concierge) with a tolerant legacy fallback; onboarding merges into an existing config (user entries win) and refuses to overwrite invalid JSON.

## New rigor

- **Real golden journeys** replace the fake string-writing test: the onboarding state machine driven end-to-end (including the mandatory email-domain step), task lifecycle via real `create_task`/`update_task_status`, transcript reconcile through file writeback.
- **MCP stdio startup matrix**: every Dex-owned server must complete a real JSON-RPC initialize handshake (new shipped helper `core/utils/mcp_handshake.py`). A server that imports fine but crashes on startup now fails CI.
- **Skill integrity**: all shipped `SKILL.md` frontmatter validated (new shipped `core/utils/validators.py`); runnable references must exist. Two frontmatter fixes: `career-coach`, `diff-generate`.
- **Hook harness**: every shipped hook is executed (dynamic enumeration — new hooks auto-covered), plus happy-path context-injection assertions.
- **Fixture isolation**: the suite ran against the tracked fixture vault and mutated it; tests now run against a disposable session copy, with a suite-failing guard if the tracked fixture is ever dirtied.
- Dev/runtime dependency split (`requirements-dev.txt`), release `package.json` no longer references stripped files.

## Verification

- Full suite: 336 passed, 1 skipped (was 232) — run outside any sandbox.
- `npm run test:hooks`: 22 passed. Ruff clean. `verify-distribution.sh`, `check-path-consistency.sh` pass.
- Mutation proofs (each verified failing, then reverted): unanchored scripts rule → archive test fails; corrupted frontmatter → skill integrity fails naming the skill; server crashing on startup → handshake test fails.

Part two (next PR): `/dex-doctor` learns to run shipped smoke journeys and report which user customization broke what; `/dex-update`/`/dex-rollback` get real post-update verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY