### PR TITLE
Fix: task creation works again — repair the create_task import crash + production-path regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.29.0] - Creating tasks works again (2026-07-11)
+
+Since mid-February, asking Dex to create a task quietly failed with a technical error — every time, for everyone. A code mix-up made the task tool trip over an optional search feature even when that feature wasn't installed, and the existing tests happened to sidestep the exact switch that was broken, so nothing caught it.
+
+**What this fixes for you:**
+
+* **"Create a task to…" actually creates the task.** The error that blocked every task creation — and also broke meeting-context lookups and inbox processing — is gone.
+* **This can't silently break again.** Dex now tests task creation the exact way your vault runs it: starting the real task service and creating, listing, and completing a task end to end. If a future change breaks task creation, the release checks catch it before an update reaches you.
+
 ## [1.28.0] - Installs now contain the Dex features they promise (2026-07-11)
 
 Some install and update paths looked successful while quietly leaving out working parts of Dex, carrying developer-only files, or saving connection settings somewhere Claude Code never reads. This release makes installs complete and checks them through the same journeys you use.

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -33,13 +33,6 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
-# QMD semantic search (optional - gracefully degrade if not available)
-try:
-    from utils.qmd_query import is_qmd_available, vault_search
-    HAS_QMD = True
-except ImportError:
-    HAS_QMD = False
-
 # Analytics helper (optional - gracefully degrade if not available)
 try:
     from analytics_helper import fire_event as _fire_analytics_event
@@ -56,6 +49,13 @@ logger = logging.getLogger(__name__)
 # Add grandparent directory to path for 'core.utils' imports
 # The script is at core/mcp/work_server.py, so we need to add the vault root
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# QMD semantic search (optional - gracefully degrade if not available)
+try:
+    from core.utils.qmd_query import is_qmd_available, vault_search
+    HAS_QMD = True
+except ImportError:
+    HAS_QMD = False
 
 # Import reference formatter for Obsidian wiki link support
 try:
@@ -75,9 +75,7 @@ except ImportError:
 # Import QMD search index refresh (optional - silently skips if QMD not installed)
 try:
     from core.utils.qmd_indexer import refresh_search_index
-    HAS_QMD = True
 except ImportError:
-    HAS_QMD = False
     def refresh_search_index(): pass
 
 # Health system — error queue and health reporting

--- a/core/tests/test_work_server_production_paths.py
+++ b/core/tests/test_work_server_production_paths.py
@@ -15,7 +15,6 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 
 from core.mcp import work_server
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TASK_TITLE = "Draft production path regression note"
 

--- a/core/tests/test_work_server_production_paths.py
+++ b/core/tests/test_work_server_production_paths.py
@@ -1,0 +1,145 @@
+"""Regression tests for production task-server execution paths."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import shutil
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from core.mcp import work_server
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TASK_TITLE = "Draft production path regression note"
+
+
+def _copy_fixture_vault(fixture_vault: Path, tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    shutil.copytree(fixture_vault, vault)
+    (vault / "System" / "pillars.yaml").write_text(
+        "pillars:\n"
+        "  - id: pillar_1\n"
+        "    name: Test Pillar\n"
+        "    description: For production-path tests\n"
+        "    keywords: [test]\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+async def _create_task_over_production_stdio(vault: Path):
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=["core/mcp/work_server.py"],
+        env={"VAULT_PATH": str(vault)},
+        cwd=REPO_ROOT,
+    )
+
+    async with asyncio.timeout(30):
+        async with stdio_client(server) as (read_stream, write_stream):
+            async with ClientSession(
+                read_stream,
+                write_stream,
+                read_timeout_seconds=timedelta(seconds=30),
+            ) as session:
+                await session.initialize()
+                return await session.call_tool(
+                    "create_task",
+                    {
+                        "title": TASK_TITLE,
+                        "pillar": "pillar_1",
+                        "priority": "P2",
+                    },
+                )
+
+
+def _decode_handler_result(result) -> dict:
+    return json.loads(result[0].text)
+
+
+def test_create_task_succeeds_over_production_stdio(fixture_vault: Path, tmp_path: Path):
+    vault = _copy_fixture_vault(fixture_vault, tmp_path)
+
+    result = asyncio.run(_create_task_over_production_stdio(vault))
+
+    assert result.isError is False, result.content
+    payload = json.loads(result.content[0].text)
+    assert payload["success"] is True
+
+    tasks_text = (vault / "03-Tasks" / "Tasks.md").read_text(encoding="utf-8")
+    assert TASK_TITLE in tasks_text
+    assert re.search(r"\^task-\d{8}-\d{3}", tasks_text)
+
+
+def test_task_lifecycle_succeeds_in_process_without_qmd_patching(tmp_path: Path, monkeypatch):
+    tasks_file = tmp_path / "03-Tasks" / "Tasks.md"
+    week_priorities_file = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
+    tasks_file.parent.mkdir(parents=True)
+    tasks_file.write_text("# Tasks\n", encoding="utf-8")
+
+    monkeypatch.setattr(work_server, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: tasks_file)
+    monkeypatch.setattr(
+        work_server,
+        "get_week_priorities_file",
+        lambda: week_priorities_file,
+    )
+    monkeypatch.setattr(
+        work_server,
+        "PILLARS",
+        {
+            "pillar_1": {
+                "name": "Test Pillar",
+                "description": "For production-path tests",
+                "keywords": ["test"],
+            }
+        },
+    )
+
+    created = _decode_handler_result(
+        asyncio.run(
+            work_server.handle_call_tool(
+                "create_task",
+                {
+                    "title": TASK_TITLE,
+                    "pillar": "pillar_1",
+                    "priority": "P2",
+                },
+            )
+        )
+    )
+    assert created["success"] is True
+    task_id = created["task"]["task_id"]
+
+    listed = _decode_handler_result(
+        asyncio.run(work_server.handle_call_tool("list_tasks", {}))
+    )
+    assert any(
+        task["task_id"] == task_id and task["title"] == TASK_TITLE
+        for task in listed["tasks"]
+    )
+
+    updated = _decode_handler_result(
+        asyncio.run(
+            work_server.handle_call_tool(
+                "update_task_status",
+                {"task_id": task_id, "status": "d"},
+            )
+        )
+    )
+    assert updated["success"] is True
+
+    task_line = next(
+        line
+        for line in tasks_file.read_text(encoding="utf-8").splitlines()
+        if f"^{task_id}" in line
+    )
+    assert task_line.startswith("- [x]")
+    assert f"^{task_id}" in task_line


### PR DESCRIPTION
## What

Every `create_task` call (plus `process_inbox_with_dedup` and titled `get_meeting_context`) has failed with a `NameError` since ~2026-02-16.

`work_server.py:38` imported the QMD helpers from `utils.qmd_query` — a path that never resolves when the server runs as a script, because the vault-root `sys.path` insert happens 20 lines later. The import silently failed (`HAS_QMD=False`), then a second, stdlib-only import (`core.utils.qmd_indexer`) re-set `HAS_QMD=True` with `is_qmd_available`/`vault_search` still unbound. First call into `find_similar_tasks` → `NameError`, surfaced as an MCP tool error.

## Why tests never caught it

`test_work_server_task_priorities.py` calls `create_task` but monkeypatches `HAS_QMD=False` — patching away the exact flag that's broken in production.

## The fix

- Move the QMD query import below the `sys.path` insert; import from `core.utils.qmd_query`; only that import owns `HAS_QMD`. The indexer import keeps its no-op fallback and no longer touches the flag. 7 insertions, 9 deletions, no refactor.

## The regression guard

New `core/tests/test_work_server_production_paths.py`:
- **stdio subprocess test** — launches the server exactly as the shipped `.mcp.json` does (`python core/mcp/work_server.py`, env containing only `VAULT_PATH`, no inherited `PYTHONPATH` which would mask the bug) and asserts on the tool payload and resulting `Tasks.md` content.
- **in-process journey** — create → list → complete with zero QMD flag patching.

Both verified **red before the fix** (failing with the production `NameError`), green after.

## Verification

- Full suite outside any sandbox: **338 passed, 1 skipped**
- PR gates run locally: test-delta ✅ path-contract ✅ doc-drift ✅
- CHANGELOG 1.29.0 included

Part 1 of the task-engine repair mapped in the 2026-07-11 task-creation assessment (heydex.ai/explainers). Next: metadata round-trip fixes (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WZCmEDi4qiNLDTwsSJXL