### PR TITLE
Dex now tells you when its background sync has quietly stopped (v1.30.0)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,7 +4,7 @@
 # For Dex personal knowledge system
 
 # Prevent duplicate injection (symlinked working directories)
-DEDUP_FILE="/tmp/dex-session-context-dedup"
+DEDUP_FILE="${DEX_SESSION_CONTEXT_DEDUP_FILE:-/tmp/dex-session-context-dedup}"
 NOW=$(date +%s)
 if [[ -f "$DEDUP_FILE" ]]; then
     LAST=$(cat "$DEDUP_FILE" 2>/dev/null || echo "0")
@@ -288,5 +288,44 @@ if errors:
         fi
     fi
 fi
+
+# Background job staleness — keep in sync with core/utils/doctor.py's JOB_FRESHNESS table.
+{
+    DEX_LAUNCH_AGENTS_DIR="${DEX_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+    while IFS='|' read -r JOB_NAME JOB_LOG_RELATIVE_PATH JOB_MAX_AGE_SECONDS JOB_EXPECTED_CADENCE JOB_LABEL; do
+        [[ -f "$DEX_LAUNCH_AGENTS_DIR/$JOB_NAME.plist" ]] || continue
+
+        JOB_LOG="$CLAUDE_DIR/$JOB_LOG_RELATIVE_PATH"
+        if [[ ! -f "$JOB_LOG" ]]; then
+            echo "⏰ $JOB_LABEL is installed but has never run — run /dex-doctor to investigate."
+            continue
+        fi
+
+        JOB_MTIME=$(stat -f %m "$JOB_LOG" 2>/dev/null || true)
+        if [[ ! "$JOB_MTIME" =~ ^[0-9]+$ ]]; then
+            JOB_MTIME=$(stat -c %Y "$JOB_LOG" 2>/dev/null || true)
+        fi
+        [[ "$JOB_MTIME" =~ ^[0-9]+$ && "$NOW" =~ ^[0-9]+$ ]] || continue
+
+        JOB_AGE_SECONDS=$(( NOW - JOB_MTIME ))
+        if (( JOB_AGE_SECONDS > JOB_MAX_AGE_SECONDS )); then
+            if (( JOB_AGE_SECONDS < 86400 )); then
+                JOB_AGE=$(( JOB_AGE_SECONDS / 3600 ))
+                JOB_AGE_UNIT="hours"
+            else
+                JOB_AGE=$(( JOB_AGE_SECONDS / 86400 ))
+                JOB_AGE_UNIT="days"
+            fi
+            if (( JOB_AGE == 1 )); then
+                JOB_AGE_UNIT="${JOB_AGE_UNIT%s}"
+            fi
+            echo "⏰ $JOB_LABEL last ran $JOB_AGE $JOB_AGE_UNIT ago (expected every $JOB_EXPECTED_CADENCE) — run /dex-doctor to investigate."
+        fi
+    done <<'EOF'
+com.dex.meeting-intel|.scripts/logs/meeting-intel.log|172800|2 days|Meeting sync
+com.dex.changelog-checker|.scripts/logs/changelog-checker.log|604800|7 days|Claude update watcher
+com.dex.learning-review|.scripts/logs/learning-review.log|604800|7 days|Learning review
+EOF
+} || true
 
 echo "=== End Session Context ==="

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOK_PATH = path.resolve(__dirname, '..', 'session-start.sh');
+const MEETING_INTEL_PLIST = 'com.dex.meeting-intel.plist';
+const MEETING_INTEL_LOG = '.scripts/logs/meeting-intel.log';
+
+function createSandbox(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-session-staleness-'));
+  const vault = path.join(root, 'vault');
+  const home = path.join(root, 'home');
+  const launchAgents = path.join(root, 'LaunchAgents');
+  const dedupFile = path.join(root, 'session-context-dedup');
+  fs.mkdirSync(vault, { recursive: true });
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(launchAgents, { recursive: true });
+  t.after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  return { vault, home, launchAgents, dedupFile };
+}
+
+function installMeetingIntel(sandbox) {
+  fs.writeFileSync(path.join(sandbox.launchAgents, MEETING_INTEL_PLIST), '<plist/>\n');
+}
+
+function writeMeetingIntelLog(sandbox) {
+  const logPath = path.join(sandbox.vault, MEETING_INTEL_LOG);
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.writeFileSync(logPath, 'meeting sync ran\n');
+  return logPath;
+}
+
+function runSessionStart(sandbox) {
+  const result = spawnSync('/bin/bash', [HOOK_PATH], {
+    cwd: sandbox.vault,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: sandbox.vault,
+      DEX_LAUNCH_AGENTS_DIR: sandbox.launchAgents,
+      DEX_SESSION_CONTEXT_DEDUP_FILE: sandbox.dedupFile,
+      HOME: sandbox.home,
+      PATH: process.env.PATH || '/usr/bin:/bin',
+      VAULT_PATH: sandbox.vault,
+    },
+    timeout: 10_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `session-start.sh exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.equal(result.stderr, '', `session-start.sh wrote to stderr:\n${result.stderr}`);
+  assert.ok(fs.existsSync(sandbox.dedupFile), 'session-start.sh must use the sandbox dedup file');
+  return result.stdout;
+}
+
+test('session start warns when an installed meeting sync log is stale', (t) => {
+  const sandbox = createSandbox(t);
+  installMeetingIntel(sandbox);
+  const logPath = writeMeetingIntelLog(sandbox);
+  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(logPath, threeDaysAgo, threeDaysAgo);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.match(
+    stdout,
+    /⏰ Meeting sync last ran 3 days ago \(expected every 2 days\) — run \/dex-doctor to investigate\./,
+  );
+});
+
+test('session start stays silent for a fresh installed meeting sync log', (t) => {
+  const sandbox = createSandbox(t);
+  installMeetingIntel(sandbox);
+  writeMeetingIntelLog(sandbox);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /⏰ Meeting sync/);
+});
+
+test('session start ignores stale logs for launch agents that are not installed', (t) => {
+  const sandbox = createSandbox(t);
+  const logPath = writeMeetingIntelLog(sandbox);
+  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(logPath, threeDaysAgo, threeDaysAgo);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /⏰ Meeting sync/);
+});
+
+test('session start warns when an installed meeting sync has never run', (t) => {
+  const sandbox = createSandbox(t);
+  installMeetingIntel(sandbox);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.match(
+    stdout,
+    /⏰ Meeting sync is installed but has never run — run \/dex-doctor to investigate\./,
+  );
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.30.0] - Dex now tells you when its background sync has quietly stopped (2026-07-11)
+
+A beta user's meeting sync was dead from February to July with no signal, so Dex now surfaces that silent failure at the start of your next session.
+
+**What this fixes for you:**
+
+* **You will know when meeting sync has stopped.** If its background service is installed but has not run recently, Dex tells you at session start and points you to `/dex-doctor`.
+* **A never-started service no longer looks fine.** Dex calls out a configured background sync that has no record of ever running.
+* **Normal sessions stay quiet.** Fresh services, and optional services you have never installed, do not create an alert.
+
+---
+
 ## [1.29.0] - Creating tasks works again (2026-07-11)
 
 Since mid-February, asking Dex to create a task quietly failed with a technical error — every time, for everyone. A code mix-up made the task tool trip over an optional search feature even when that feature wasn't installed, and the existing tests happened to sidestep the exact switch that was broken, so nothing caught it.
@@ -15,6 +27,8 @@ Since mid-February, asking Dex to create a task quietly failed with a technical 
 
 * **"Create a task to…" actually creates the task.** The error that blocked every task creation — and also broke meeting-context lookups and inbox processing — is gone.
 * **This can't silently break again.** Dex now tests task creation the exact way your vault runs it: starting the real task service and creating, listing, and completing a task end to end. If a future change breaks task creation, the release checks catch it before an update reaches you.
+
+---
 
 ## [1.28.0] - Installs now contain the Dex features they promise (2026-07-11)
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -117,6 +117,7 @@ PARA_PATH_NAMES = (
     "ARCHIVES_DIR",
 )
 
+# Keep in sync with .claude/hooks/session-start.sh's background-job staleness table.
 JOB_FRESHNESS = {
     "com.dex.meeting-intel": JobFreshness(
         Path(".scripts/logs/meeting-intel.log"),


### PR DESCRIPTION
## Summary

Session start now surfaces stale background jobs — the audit Build-list item 6 ("Michelle's morning question, answered proactively").

- `.claude/hooks/session-start.sh`: new staleness section after preflight. For each installed `com.dex.*` launch agent, compares its log mtime against the cadence from `core/utils/doctor.py`'s `JOB_FRESHNESS` (meeting-intel 48h; changelog-checker and learning-review 7d). Stale → one line pointing at `/dex-doctor`. Installed-but-never-ran → says so. Not installed or fresh → silent. The block is failure-isolated (`{ … } || true`) and pure bash/stat — no launchctl, no network, no python.
- Testable: `DEX_LAUNCH_AGENTS_DIR` override + the dedup file made overridable.
- `.claude/hooks/tests/session-staleness.test.cjs`: 4 cases (stale → line; fresh → silent; plist absent → silent; log absent → "never run").
- Sync comments added in both the hook and `doctor.py` so the two tables stay aligned.
- CHANGELOG v1.30.0 in house style.

## Test plan

- [x] `node --test .claude/hooks/tests/*.test.cjs` — 26/26 pass
- [x] `bash -n .claude/hooks/session-start.sh`
- [x] path-contract, doc-drift, test-delta gates green locally against origin/main
- [x] Manual demo: 3-day-old log → "⏰ Meeting sync last ran 3 days ago (expected every 2 days)…"; fresh log → silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG