### PR TITLE
Dex asks which calendar is yours instead of guessing (v1.31.0)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -144,89 +144,48 @@ Ask: "What's your company email domain? This helps me automatically:
 
 ---
 
-## Step 4b: Calendar Optimization (Auto-detected)
+## Step 4b: Calendar Selection
 
-**This step is AUTOMATIC - no user input needed unless multiple calendars detected.**
+**Purpose:** Optimize calendar queries for performance (45s → 0.3s) by identifying the user's actual work calendar instead of guessing its name.
 
-**Purpose:** Optimize calendar queries for performance (45s → 0.3s) by identifying the user's work calendar.
+Call `calendar_list_calendars` from the Calendar MCP to get the calendar names Calendar.app can see.
 
-**How to check calendar count:**
+**If the listing succeeds:**
 
-Run this AppleScript to count calendars (launch first to ensure it's queryable):
-```bash
-osascript -e 'launch application "Calendar"' && sleep 1 && osascript -e 'tell application "Calendar" to return count of calendars'
+Say: "Which calendar should I use for your work schedule?"
+
+Present every returned calendar name as a numbered list:
+```
+1. [exact calendar name]
+2. [exact calendar name]
+3. [exact calendar name]
 ```
 
-**If the command fails** (Calendar not installed, permissions denied, etc.):
+The user can reply with a number or type the calendar name. Resolve a number to the exact returned name, then call `save_calendar_selection` from the Onboarding MCP with:
+- `work_calendar`: the exact selected calendar name
+- `calendar_count`: the `count` returned by `calendar_list_calendars`
+- `work_email`: the selected name only when that calendar name is an email address; otherwise omit it
 
-First, check if it's a permissions issue (common on macOS with Cursor/Claude Desktop):
-
-Say: "Your calendar app is installed but your editor doesn't have permission to access it yet. This is a one-time macOS setup:
-
-1. Open **System Settings** → **Privacy & Security** → **Calendars**
-2. Find **Cursor** (or **Claude Desktop**) in the list and turn it **on**
-3. If it's not in the list yet, run this in your terminal inside Cursor: `osascript -e 'tell application \"Calendar\" to get name of calendars'` — macOS will prompt you to allow access
-4. After granting access, come back here and we'll continue
-
-**Can't do this right now?** No problem — calendar features will work once you grant permission later. Moving on!"
-
-- Do NOT skip silently — always explain the permission step
-- Don't block onboarding — let the user continue if they prefer to do it later
-- Store `calendar.permissions_pending: true` in user-profile.yaml if they skip
-
-**If 1-2 calendars:**
-- Skip this step silently
-- Store `calendar.calendar_count: 1` in user-profile.yaml
-- The system will query all calendars (fast enough with just 1-2)
-
-**If 3+ calendars:**
-
-Say: "I noticed you have [X] calendars connected to Apple Calendar. To keep things fast, I'll focus on your work calendar.
-
-**What's your work email address?** (e.g., dave@company.com)
-
-This helps me:
-- Query only your work calendar (much faster)
-- Skip personal calendars, holidays, etc."
-
-**After receiving work email:**
-
-1. Verify the calendar exists:
-```bash
-osascript -e 'tell application "Calendar" to return name of calendars' | grep -i "[work_email]"
+Example:
+```
+save_calendar_selection(
+  work_calendar="user@company.com",
+  work_email="user@company.com",
+  calendar_count=4
+)
 ```
 
-2. If found, store in `System/user-profile.yaml`:
-```yaml
-work_email: "user@company.com"
-calendar:
-  work_calendar: "user@company.com"
-  calendar_count: [X]
-  lazy_load: true
-```
+If the save returns `success: false`, show the available names from its error response and ask the user to choose again. If it succeeds, say: "✓ Got it — I'll use [calendar name] for your work schedule."
 
-3. Say: "✓ Found your work calendar. Calendar queries will be much faster now."
+**If the listing fails or calendar permission is denied:**
 
-**If calendar not found:**
+Say: "macOS hasn't let this terminal app read your calendars yet — open **System Settings** → **Privacy & Security** → **Calendars** and enable the terminal app you're using."
 
-Say: "I couldn't find a calendar matching that email. Your calendars are:
-[list calendar names]
+Offer two choices:
+1. Try again after granting access — call `calendar_list_calendars` again
+2. Skip for now — call `save_calendar_selection(skipped=true)`
 
-Which one is your primary work calendar?"
-
-**If user doesn't want to specify:**
-
-Say: "No problem! I'll query all calendars. Note: This may take 15-45 seconds when you ask about your schedule."
-
-Store:
-```yaml
-calendar:
-  work_calendar: ""
-  calendar_count: [X]
-  lazy_load: true
-```
-
-**Note:** This step doesn't use validate_and_save_step() - it's handled inline. Move directly to Step 5.
+Do not block onboarding when they skip. `/dex-doctor` will confirm the calendar setup later.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.31.0] - Dex asks which calendar is yours instead of guessing (2026-07-11)
+
+Empty calendar results were traced back to onboarding guessing a work calendar name that did not match the names Apple Calendar actually exposes.
+
+**What this fixes for you:**
+
+* **You choose from calendars Dex can actually see.** Onboarding shows the exact Calendar.app names and saves your selection instead of constructing one from your email address.
+* **Wrong calendar names are caught during setup.** If a typed name does not match, Dex shows the available calendars and asks again before an empty schedule can surprise you later.
+* **Calendar permissions no longer block onboarding.** Dex explains the one-time macOS setting, lets you try again, or records that you skipped so `/dex-doctor` can confirm the setup later.
+
+---
+
 ## [1.30.0] - Dex now tells you when its background sync has quietly stopped (2026-07-11)
 
 A beta user's meeting sync was dead from February to July with no signal, so Dex now surfaces that silent failure at the start of your next session.

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -392,6 +392,10 @@ def create_user_profile(session_data: Dict) -> bool:
         profile['company'] = data.get('company', '')
         profile['company_size'] = data.get('company_size', '')
         profile['email_domain'] = data.get('email_domain', '')
+
+        if 'calendar' in data:
+            profile['work_email'] = data.get('work_email', '')
+            profile['calendar'] = data['calendar']
         
         # Update Obsidian mode (defaults to false)
         profile['obsidian_mode'] = data.get('obsidian_mode', False)
@@ -837,6 +841,36 @@ async def handle_list_tools() -> list[types.Tool]:
             }
         ),
         types.Tool(
+            name="save_calendar_selection",
+            description="Save the work calendar selected during onboarding, or defer calendar permission setup.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "work_calendar": {
+                        "type": "string",
+                        "description": "Exact work calendar name returned by Calendar.app",
+                        "default": ""
+                    },
+                    "work_email": {
+                        "type": "string",
+                        "description": "Work email when the selected calendar name is an email address",
+                        "default": ""
+                    },
+                    "calendar_count": {
+                        "type": "integer",
+                        "description": "Number of calendars returned by Calendar.app",
+                        "minimum": 0,
+                        "default": 0
+                    },
+                    "skipped": {
+                        "type": "boolean",
+                        "description": "Defer calendar setup until permissions can be checked later",
+                        "default": False
+                    }
+                }
+            }
+        ),
+        types.Tool(
             name="get_onboarding_status",
             description="Get current onboarding progress and completion status",
             inputSchema={
@@ -1116,6 +1150,83 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 result = create_error_response(f"Invalid step number: {step_number}", suggestion="Step must be 1-6")
             
             return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
+
+        elif name == "save_calendar_selection":
+            skipped = arguments.get('skipped', False)
+            work_calendar = (arguments.get('work_calendar') or '').strip()
+            work_email = (arguments.get('work_email') or '').strip()
+            calendar_count = arguments.get('calendar_count', 0)
+
+            session = load_session()
+            if not session:
+                result = create_error_response(
+                    "No active session",
+                    suggestion="Call start_onboarding_session first"
+                )
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            if skipped:
+                calendar = {"permissions_pending": True}
+                session['data'].pop('work_email', None)
+                session['data']['calendar'] = calendar
+                save_session(session)
+                result = create_success_response(
+                    {"calendar": calendar},
+                    "Calendar setup skipped for now. /dex-doctor will pick this up later."
+                )
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            if not work_calendar:
+                result = create_error_response(
+                    "work_calendar is required unless calendar setup is skipped",
+                    field="work_calendar",
+                    suggestion="Choose a calendar name or set skipped=true"
+                )
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            verification_note = ""
+            try:
+                from core.mcp.calendar_server import _get_calendar_list_result
+
+                calendar_list = _get_calendar_list_result()
+                if calendar_list.get("success"):
+                    available_calendars = calendar_list["calendars"]
+                    if work_calendar not in available_calendars:
+                        result = create_error_response(
+                            f"Calendar '{work_calendar}' was not found. Available calendars: "
+                            f"{', '.join(available_calendars)}",
+                            field="work_calendar",
+                            suggestion="Choose one of the available calendar names"
+                        )
+                        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+                else:
+                    verification_note = (
+                        " Couldn't verify against your live calendars — "
+                        "/dex-doctor will confirm later."
+                    )
+            except Exception:
+                verification_note = (
+                    " Couldn't verify against your live calendars — "
+                    "/dex-doctor will confirm later."
+                )
+
+            calendar = {
+                "work_calendar": work_calendar,
+                "calendar_count": calendar_count,
+                "lazy_load": True,
+            }
+            if work_email:
+                session['data']['work_email'] = work_email
+            else:
+                session['data'].pop('work_email', None)
+            session['data']['calendar'] = calendar
+            save_session(session)
+
+            result = create_success_response(
+                {"work_email": work_email, "calendar": calendar},
+                f"Work calendar saved.{verification_note}"
+            )
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
         
         elif name == "get_onboarding_status":
             session = load_session()
@@ -1260,6 +1371,9 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                     'obsidian_mode': data.get('obsidian_mode', False),
                     'communication': data.get('communication', {})
                 }
+                if 'calendar' in data:
+                    profile_preview['work_email'] = data.get('work_email', '')
+                    profile_preview['calendar'] = data['calendar']
 
                 # Build preview of pillars.yaml content
                 pillars_preview = []

--- a/core/tests/test_onboarding_calendar.py
+++ b/core/tests/test_onboarding_calendar.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.mcp import calendar_server, onboarding_server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _decode_tool_result(result):
+    return json.loads(result[0].text)
+
+
+def _call_tool(name: str, arguments: dict | None = None) -> dict:
+    return _decode_tool_result(
+        asyncio.run(onboarding_server.handle_call_tool(name, arguments or {}))
+    )
+
+
+@pytest.fixture
+def onboarding_vault(tmp_path, monkeypatch) -> Path:
+    vault = tmp_path / "vault"
+    system_dir = vault / "System"
+    system_dir.mkdir(parents=True)
+
+    profile_template = system_dir / "user-profile-template.yaml"
+    shutil.copy2(REPO_ROOT / "System" / "user-profile-template.yaml", profile_template)
+
+    monkeypatch.setattr(onboarding_server, "BASE_DIR", vault)
+    monkeypatch.setattr(
+        onboarding_server,
+        "SESSION_FILE",
+        system_dir / ".onboarding-session.json",
+    )
+    monkeypatch.setattr(
+        onboarding_server,
+        "USER_PROFILE_FILE",
+        system_dir / "user-profile.yaml",
+    )
+    monkeypatch.setattr(onboarding_server, "USER_PROFILE_TEMPLATE", profile_template)
+    return vault
+
+
+def _start_session() -> None:
+    result = _call_tool("start_onboarding_session", {"force_new": True})
+    assert result["success"] is True
+
+
+def test_save_calendar_selection_stores_valid_live_calendar(
+    onboarding_vault,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_calendar_list_result",
+        lambda: {
+            "success": True,
+            "calendars": ["Home", "dave@dex.ai"],
+            "count": 2,
+        },
+    )
+    _start_session()
+
+    result = _call_tool(
+        "save_calendar_selection",
+        {
+            "work_calendar": "dave@dex.ai",
+            "work_email": "dave@dex.ai",
+            "calendar_count": 2,
+        },
+    )
+
+    assert result["success"] is True
+    session = onboarding_server.load_session()
+    assert session["data"]["work_email"] == "dave@dex.ai"
+    assert session["data"]["calendar"] == {
+        "work_calendar": "dave@dex.ai",
+        "calendar_count": 2,
+        "lazy_load": True,
+    }
+
+
+def test_save_calendar_selection_rejects_name_missing_from_live_calendars(
+    onboarding_vault,
+    monkeypatch,
+):
+    available = ["Home", "Team Calendar"]
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_calendar_list_result",
+        lambda: {"success": True, "calendars": available, "count": len(available)},
+    )
+    _start_session()
+
+    result = _call_tool(
+        "save_calendar_selection",
+        {"work_calendar": "Guessed Work", "calendar_count": 2},
+    )
+
+    assert result["success"] is False
+    assert all(name in result["error"] for name in available)
+    assert "calendar" not in onboarding_server.load_session()["data"]
+
+
+@pytest.mark.parametrize("failure_mode", ["raises", "returns_failure"])
+def test_save_calendar_selection_accepts_value_when_live_list_is_unavailable(
+    onboarding_vault,
+    monkeypatch,
+    failure_mode,
+):
+    if failure_mode == "raises":
+        def unavailable_calendar_list():
+            raise RuntimeError("Calendar permission denied")
+    else:
+        def unavailable_calendar_list():
+            return {"success": False, "error": "Calendar permission denied"}
+
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_calendar_list_result",
+        unavailable_calendar_list,
+    )
+    _start_session()
+
+    result = _call_tool(
+        "save_calendar_selection",
+        {"work_calendar": "Team Calendar", "calendar_count": 3},
+    )
+
+    assert result["success"] is True
+    assert "couldn't verify against your live calendars" in result["message"].lower()
+    assert onboarding_server.load_session()["data"]["calendar"] == {
+        "work_calendar": "Team Calendar",
+        "calendar_count": 3,
+        "lazy_load": True,
+    }
+
+
+def test_save_calendar_selection_marks_permissions_pending_when_skipped(
+    onboarding_vault,
+    monkeypatch,
+):
+    def fail_if_called():
+        raise AssertionError("skip should not list calendars")
+
+    monkeypatch.setattr(calendar_server, "_get_calendar_list_result", fail_if_called)
+    _start_session()
+
+    result = _call_tool("save_calendar_selection", {"skipped": True})
+
+    assert result["success"] is True
+    assert "/dex-doctor" in result["message"]
+    assert onboarding_server.load_session()["data"]["calendar"] == {
+        "permissions_pending": True,
+    }
+
+
+def test_save_calendar_selection_clears_old_email_for_non_email_calendar(
+    onboarding_vault,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_calendar_list_result",
+        lambda: {
+            "success": True,
+            "calendars": ["dave@dex.ai", "Team Calendar"],
+            "count": 2,
+        },
+    )
+    _start_session()
+    first_result = _call_tool(
+        "save_calendar_selection",
+        {
+            "work_calendar": "dave@dex.ai",
+            "work_email": "dave@dex.ai",
+            "calendar_count": 2,
+        },
+    )
+    assert first_result["success"] is True
+
+    second_result = _call_tool(
+        "save_calendar_selection",
+        {"work_calendar": "Team Calendar", "calendar_count": 2},
+    )
+
+    assert second_result["success"] is True
+    assert "work_email" not in onboarding_server.load_session()["data"]
+
+
+def test_save_calendar_selection_clears_old_email_when_skipped(
+    onboarding_vault,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        calendar_server,
+        "_get_calendar_list_result",
+        lambda: {
+            "success": True,
+            "calendars": ["dave@dex.ai"],
+            "count": 1,
+        },
+    )
+    _start_session()
+    first_result = _call_tool(
+        "save_calendar_selection",
+        {
+            "work_calendar": "dave@dex.ai",
+            "work_email": "dave@dex.ai",
+            "calendar_count": 1,
+        },
+    )
+    assert first_result["success"] is True
+
+    skipped_result = _call_tool("save_calendar_selection", {"skipped": True})
+
+    assert skipped_result["success"] is True
+    assert "work_email" not in onboarding_server.load_session()["data"]
+
+
+def test_save_calendar_selection_requires_calendar_name(onboarding_vault):
+    _start_session()
+
+    result = _call_tool("save_calendar_selection")
+
+    assert result["success"] is False
+    assert "work_calendar" in result["error"]
+
+
+def test_save_calendar_selection_is_registered():
+    tools = asyncio.run(onboarding_server.handle_list_tools())
+
+    assert "save_calendar_selection" in {tool.name for tool in tools}
+
+
+def test_create_user_profile_writes_calendar_selection(onboarding_vault):
+    session = onboarding_server.create_new_session()
+    session["data"] = {
+        "work_email": "dave@dex.ai",
+        "calendar": {
+            "work_calendar": "dave@dex.ai",
+            "calendar_count": 4,
+            "lazy_load": True,
+        },
+    }
+
+    assert onboarding_server.create_user_profile(session) is True
+
+    profile = yaml.safe_load(
+        (onboarding_vault / "System" / "user-profile.yaml").read_text()
+    )
+    assert profile["work_email"] == "dave@dex.ai"
+    assert profile["calendar"] == {
+        "work_calendar": "dave@dex.ai",
+        "calendar_count": 4,
+        "lazy_load": True,
+    }
+
+
+def test_create_user_profile_writes_pending_calendar_permissions(onboarding_vault):
+    session = onboarding_server.create_new_session()
+    session["data"] = {"calendar": {"permissions_pending": True}}
+
+    assert onboarding_server.create_user_profile(session) is True
+
+    profile = yaml.safe_load(
+        (onboarding_vault / "System" / "user-profile.yaml").read_text()
+    )
+    assert profile["calendar"] == {"permissions_pending": True}
+
+
+def test_finalize_dry_run_previews_calendar_selection(onboarding_vault):
+    session = onboarding_server.create_new_session()
+    session["completed_steps"] = [1, 2, 3, 4, 5, 6]
+    session["data"] = {
+        "name": "Dave",
+        "role": "Founder",
+        "email_domain": "dex.ai",
+        "pillars": ["Product", "Customers"],
+        "work_email": "dave@dex.ai",
+        "calendar": {
+            "work_calendar": "dave@dex.ai",
+            "calendar_count": 2,
+            "lazy_load": True,
+        },
+    }
+    assert onboarding_server.save_session(session) is True
+
+    result = _call_tool("finalize_onboarding", {"dry_run": True})
+
+    assert result["success"] is True
+    assert result["data"]["preview_user_profile"]["work_email"] == "dave@dex.ai"
+    assert result["data"]["preview_user_profile"]["calendar"] == {
+        "work_calendar": "dave@dex.ai",
+        "calendar_count": 2,
+        "lazy_load": True,
+    }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.28.0",
+  "version": "1.31.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

The proper fix for the audit's D3 lane (v1.24.0 shipped the interim warning). Onboarding no longer constructs a work-calendar name from the email address.

- `core/mcp/onboarding_server.py`: new `save_calendar_selection` tool — validates the pick against the live calendar list when possible (in-process import of the calendar server's list helper), degrades gracefully when permission isn't granted yet ("couldn't verify — /dex-doctor will confirm later"), and stores a skip as `calendar.permissions_pending`. `create_user_profile()` now writes `work_email` + the `calendar:` block at finalize; the dry-run preview shows it too.
- `.claude/flows/onboarding.md` Step 4b rewritten: list real calendar names via `calendar_list_calendars`, numbered pick, save through the MCP like every other step. Permission-denied path explains the one-time macOS setting and offers retry-or-skip.
- `core/tests/test_onboarding_calendar.py`: 12 tests, all calendar access stubbed — valid pick, wrong-name re-ask, listing-failure acceptance, skip path, and finalize writing the profile keys.
- CHANGELOG v1.31.0 (house style); package.json synced to 1.31.0 (was lagging at 1.28.0).

## Test plan

- [x] 12 new onboarding-calendar tests + server import tests pass
- [x] ruff clean
- [x] path-contract / doc-drift / test-delta gates green locally against origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG