### PR TITLE
Dex can no longer tell you to use tools that don't exist (v1.32.0)

### DIFF
--- a/.claude/plugins/compound-engineering/skills/compound-docs/SKILL.md
+++ b/.claude/plugins/compound-engineering/skills/compound-docs/SKILL.md
@@ -326,7 +326,7 @@ User selects this when the solution represents the start of a new learning domai
 
 Action:
 1. Prompt: "What should the new skill be called? (e.g., stripe-billing, email-processing)"
-2. Run `python3 .claude/skills/skill-creator/scripts/init_skill.py [skill-name]`
+2. Run `python3 .claude/skills/anthropic-skill-creator/scripts/init_skill.py [skill-name]`
 3. Create initial reference files with this solution as first example
 4. Confirm: "✓ Created new [skill-name] skill with this solution as first example"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Documentation drift gate
         if: github.event_name == 'pull_request'
         run: bash scripts/check-doc-drift.sh
+      - name: Instructed-tool existence gate
+        run: python scripts/check-instructed-tools.py
       - name: Create vault directories
         run: python -c "from core import paths; from pathlib import Path; [getattr(paths, n).mkdir(parents=True, exist_ok=True) for n in dir(paths) if n.endswith('_DIR') and isinstance(getattr(paths, n), Path)]"
       - name: Generate paths.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.32.0] - Dex can no longer tell you to use tools that don't exist (2026-07-11)
+
+Some instructions could send you looking for a tool or runnable helper that was never included, leaving you stuck at the moment Dex was supposed to help.
+
+**What this fixes for you:**
+
+* **Tool instructions now match what Dex can actually use.** Every release checks each named tool against what Dex ships or deliberately supports through an installed connection, so stale or mistyped names stop the release.
+* **Broken run commands now block a release.** If instructions point to a missing required helper, the release fails instead of passing with a warning; truly optional helpers remain clearly identified.
+* **Skill-creation guidance no longer points to a missing file.** The shipped guidance now points to the skill creator that actually exists.
+
+---
+
 ## [1.31.0] - Dex asks which calendar is yours instead of guessing (2026-07-11)
 
 Empty calendar results were traced back to onboarding guessing a work calendar name that did not match the names Apple Calendar actually exposes.

--- a/core/tests/test_instructed_tools_gate.py
+++ b/core/tests/test_instructed_tools_gate.py
@@ -1,0 +1,135 @@
+"""Tests for the instructed MCP tool existence gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-instructed-tools.py"
+
+
+def _load_checker():
+    assert SCRIPT.exists(), f"missing instructed-tool checker: {SCRIPT}"
+    spec = importlib.util.spec_from_file_location("check_instructed_tools", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _find_unknown(
+    source: str,
+    *,
+    defined: set[str] | None = None,
+    allowlisted: set[str] | None = None,
+):
+    checker = _load_checker()
+    return checker.find_unknown_references(
+        source,
+        Path("fixture/SKILL.md"),
+        defined or set(),
+        allowlisted or set(),
+    )
+
+
+def test_defined_tool_extraction_handles_multiline_and_inline_declarations() -> None:
+    checker = _load_checker()
+    source = """
+tools = [
+    types.Tool(
+        name="multiline_tool",
+        description="Example",
+    ),
+    Tool(name='inline_tool', description="Example"),
+]
+"""
+
+    assert checker.extract_defined_tool_names(source) == {
+        "inline_tool",
+        "multiline_tool",
+    }
+
+
+def test_defined_tool_extraction_handles_fastmcp_decorated_functions() -> None:
+    checker = _load_checker()
+    source = """
+@mcp.tool()
+def sync_tool(value: str) -> str:
+    return value
+
+@mcp.tool ( description="Example" )
+async def async_tool() -> dict:
+    return {}
+
+def plain_helper() -> None:
+    pass
+"""
+
+    assert checker.extract_defined_tool_names(source) == {
+        "async_tool",
+        "sync_tool",
+    }
+
+
+def test_unknown_call_reference_is_detected() -> None:
+    findings = _find_unknown("First line.\nCall `missing_tool()` now.\n")
+
+    assert [(finding.name, finding.line) for finding in findings] == [
+        ("missing_tool", 2)
+    ]
+
+
+def test_known_call_reference_passes() -> None:
+    findings = _find_unknown(
+        "Call `known_tool(arg=\"value\")` now.\n",
+        defined={"known_tool"},
+    )
+
+    assert findings == []
+
+
+def test_allowlisted_call_reference_passes() -> None:
+    checker = _load_checker()
+    allowlisted = checker.parse_allowlist(
+        "# Provided by an external MCP.\nexternal_tool  # inline comments work\n"
+    )
+
+    findings = checker.find_unknown_references(
+        "Call `external_tool()` now.\n",
+        Path("fixture/SKILL.md"),
+        set(),
+        allowlisted,
+    )
+
+    assert findings == []
+
+
+def test_mcp_line_snake_case_reference_is_detected() -> None:
+    findings = _find_unknown("Use the MCP tool `missing_tool` for this step.\n")
+
+    assert [(finding.name, finding.line) for finding in findings] == [
+        ("missing_tool", 1)
+    ]
+
+
+def test_unknown_reference_report_includes_closest_defined_tool() -> None:
+    checker = _load_checker()
+    findings = _find_unknown(
+        "Call `create_taks()` now.\n",
+        defined={"create_task"},
+    )
+
+    report = checker.format_findings(findings, {"create_task"})
+
+    assert "Did you mean 'create_task'?" in report
+
+
+def test_plugin_skill_path_is_not_an_instruction_surface() -> None:
+    checker = _load_checker()
+
+    assert not checker.is_instruction_surface(
+        Path(".claude/plugins/example/skills/example/SKILL.md")
+    )
+    assert checker.is_instruction_surface(Path(".claude/skills/example/SKILL.md"))

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -19,6 +19,8 @@ RUNNABLE_REFERENCE = re.compile(
     r"(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_./-]+\.(?:cjs|js|mjs|sh|py))"
 )
 
+# Keep in sync with Check 15's MISSING_RUNNABLE_ALLOWLIST in
+# scripts/verify-distribution.sh.
 # These are intentionally not distribution-owned implementations:
 # - prompt-improver checks for the optional script and documents two fallbacks.
 # - dex-add-mcp shows a user-managed Gmail MCP command as an example.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/check-instructed-tools.py
+++ b/scripts/check-instructed-tools.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Fail when Dex instructions name an MCP tool that is not available."""
+
+from __future__ import annotations
+
+import difflib
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "instructed-tools-allowlist.txt"
+
+TOOL_NAME_PATTERN = r"[a-z][a-z0-9_]+"
+TOOL_DECLARATION = re.compile(
+    rf"\b(?:types\.)?Tool\s*\(\s*name\s*=\s*['\"]({TOOL_NAME_PATTERN})['\"]",
+    re.MULTILINE,
+)
+FASTMCP_TOOL_DECLARATION = re.compile(
+    rf"^[ \t]*@mcp\.tool[ \t]*\([^\r\n]*\)[ \t]*\r?\n"
+    rf"[ \t]*(?:async[ \t]+)?def[ \t]+({TOOL_NAME_PATTERN})[ \t]*\(",
+    re.MULTILINE,
+)
+CALL_REFERENCE = re.compile(rf"`(?P<name>{TOOL_NAME_PATTERN})\([^`\r\n]*\)`")
+MCP_NAME_REFERENCE = re.compile(rf"`(?P<name>{TOOL_NAME_PATTERN})`")
+SNAKE_CASE_NAME = re.compile(r"[a-z][a-z0-9]*_[a-z0-9_]+")
+
+
+class ToolReference(NamedTuple):
+    """An instructed tool name and its source location."""
+
+    name: str
+    path: Path
+    line: int
+
+
+def extract_defined_tool_names(source: str) -> set[str]:
+    """Extract names from static Tool declarations and FastMCP decorators."""
+    return set(TOOL_DECLARATION.findall(source)) | set(
+        FASTMCP_TOOL_DECLARATION.findall(source)
+    )
+
+
+def parse_allowlist(source: str) -> set[str]:
+    """Parse one tool name per line, ignoring comments and blank lines."""
+    names: set[str] = set()
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        name = line.split("#", 1)[0].strip()
+        if not name:
+            continue
+        if re.fullmatch(TOOL_NAME_PATTERN, name) is None:
+            raise ValueError(f"invalid allowlist entry on line {line_number}: {name!r}")
+        names.add(name)
+    return names
+
+
+def extract_instructed_references(source: str, path: Path) -> list[ToolReference]:
+    """Extract precise MCP-like references from an instruction surface."""
+    references: list[ToolReference] = []
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        references.extend(
+            ToolReference(match.group("name"), path, line_number)
+            for match in CALL_REFERENCE.finditer(line)
+        )
+        if "mcp" not in line.casefold():
+            continue
+        references.extend(
+            ToolReference(name, path, line_number)
+            for match in MCP_NAME_REFERENCE.finditer(line)
+            if SNAKE_CASE_NAME.fullmatch(name := match.group("name"))
+        )
+    return references
+
+
+def find_unknown_references(
+    source: str,
+    path: Path,
+    defined_tools: set[str],
+    allowlisted_tools: set[str],
+) -> list[ToolReference]:
+    """Return instructed references absent from local and external tool sets."""
+    known_tools = defined_tools | allowlisted_tools
+    return [
+        reference
+        for reference in extract_instructed_references(source, path)
+        if reference.name not in known_tools
+    ]
+
+
+def _relative_path(path: Path, repo_root: Path) -> Path:
+    if path.is_absolute():
+        try:
+            return path.relative_to(repo_root)
+        except ValueError:
+            return path
+    return path
+
+
+def is_instruction_surface(path: Path, repo_root: Path = REPO_ROOT) -> bool:
+    """Return whether a path belongs to the Dex-owned instruction surfaces."""
+    relative_path = _relative_path(path, repo_root)
+    parts = relative_path.parts
+    if parts[:2] == (".claude", "plugins"):
+        return False
+    if parts == ("CLAUDE.md",):
+        return True
+    if len(parts) >= 3 and parts[:2] == (".claude", "skills"):
+        return relative_path.name == "SKILL.md"
+    if len(parts) == 3 and parts[:2] == (".claude", "flows"):
+        return relative_path.suffix == ".md"
+    if len(parts) >= 3 and parts[:2] == (".agents", "skills"):
+        return relative_path.name == "SKILL.md"
+    return False
+
+
+def collect_defined_tools(repo_root: Path = REPO_ROOT) -> set[str]:
+    """Collect every statically declared top-level MCP tool."""
+    defined_tools: set[str] = set()
+    for path in sorted((repo_root / "core" / "mcp").glob("*.py")):
+        defined_tools.update(extract_defined_tool_names(path.read_text(encoding="utf-8")))
+    return defined_tools
+
+
+def collect_instruction_files(repo_root: Path = REPO_ROOT) -> list[Path]:
+    """Collect Dex-owned instruction files, excluding bundled plugins."""
+    candidates = [repo_root / "CLAUDE.md"]
+    candidates.extend((repo_root / ".claude" / "skills").rglob("SKILL.md"))
+    candidates.extend((repo_root / ".claude" / "flows").glob("*.md"))
+    candidates.extend((repo_root / ".agents" / "skills").rglob("SKILL.md"))
+    return sorted(
+        path for path in set(candidates) if path.is_file() and is_instruction_surface(path, repo_root)
+    )
+
+
+def format_findings(findings: list[ToolReference], defined_tools: set[str]) -> str:
+    """Format missing tools with the closest locally defined suggestion."""
+    lines: list[str] = []
+    candidates = sorted(defined_tools)
+    for finding in findings:
+        suggestion = difflib.get_close_matches(
+            finding.name,
+            candidates,
+            n=1,
+            cutoff=0.0,
+        )
+        suggestion_text = (
+            f" Did you mean '{suggestion[0]}'?" if suggestion else " No defined tools found."
+        )
+        lines.append(
+            f"{finding.path}:{finding.line}: unknown instructed MCP tool "
+            f"'{finding.name}'.{suggestion_text}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Run the instructed-tool existence gate for this repository."""
+    try:
+        allowlisted_tools = parse_allowlist(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        print(f"❌ Instructed-tool existence gate could not read its allowlist: {error}")
+        return 1
+
+    defined_tools = collect_defined_tools()
+    instruction_files = collect_instruction_files()
+    findings: list[ToolReference] = []
+    for path in instruction_files:
+        findings.extend(
+            find_unknown_references(
+                path.read_text(encoding="utf-8"),
+                path.relative_to(REPO_ROOT),
+                defined_tools,
+                allowlisted_tools,
+            )
+        )
+
+    if findings:
+        print("❌ Instructed-tool existence gate failed:")
+        print(format_findings(findings, defined_tools))
+        return 1
+
+    print(
+        "✅ Instructed-tool existence gate passed: "
+        f"{len(defined_tools)} defined tools, "
+        f"{len(allowlisted_tools)} allowlisted tools, "
+        f"{len(instruction_files)} instruction files checked"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/instructed-tools-allowlist.txt
+++ b/scripts/instructed-tools-allowlist.txt
@@ -1,0 +1,47 @@
+# qmd semantic-search MCP tools are installed separately from Dex core.
+query
+status
+get
+multi_get
+
+# Scrapling MCP tools are supplied by the separately installed scraper service.
+scrapling_get
+scrapling_fetch
+scrapling_stealthy_fetch
+scrapling_bulk_get
+
+# html2pptx is a bundled presentation-library helper, not an MCP tool.
+html2pptx
+
+# interpolate is a local animation helper function, not an MCP tool.
+interpolate
+
+# sync_playwright is the Playwright Python API used by the web-testing skill.
+sync_playwright
+
+# load_workbook is the openpyxl API used by the spreadsheet skill.
+load_workbook
+
+# mcp_created is an analytics event name, not a tool reference.
+mcp_created
+
+# mcp_added is an analytics event name, not a tool reference.
+mcp_added
+
+# mcp_integrated is an analytics event name, not a tool reference.
+mcp_integrated
+
+# teams_health_check belongs to the separately installed Microsoft Teams MCP.
+teams_health_check
+
+# teams_authenticate belongs to the separately installed Microsoft Teams MCP.
+teams_authenticate
+
+# teams_list_channels belongs to the separately installed Microsoft Teams MCP.
+teams_list_channels
+
+# teams_list_chats belongs to the separately installed Microsoft Teams MCP.
+teams_list_chats
+
+# teams_search_messages belongs to the separately installed Microsoft Teams MCP.
+teams_search_messages

--- a/scripts/verify-distribution.sh
+++ b/scripts/verify-distribution.sh
@@ -226,16 +226,40 @@ fi
 # dirs (.scripts/.claude/core) — prose mentions of a filename are ignored.
 echo ""
 echo "✓ Checking referenced runnable scripts exist..."
+# Keep in sync with core/tests/test_skill_integrity.py MISSING_RUNNABLE_ALLOWLIST.
+MISSING_RUNNABLE_ALLOWLIST=(
+    ".scripts/improve-prompt.cjs"
+    ".scripts/mcp/gmail-mcp.js"
+)
 MISSING_RUN=$(git grep -hoE '(node|bash|sh|python3?)[[:space:]]+(\./)?(\.scripts|\.claude|core)/[A-Za-z0-9_./-]+\.(cjs|js|sh|py)' -- '*.md' 2>/dev/null \
     | grep -oE '(\.scripts|\.claude|core)/[A-Za-z0-9_./-]+\.(cjs|js|sh|py)' \
     | sort -u | while read -r p; do if [ ! -e "$p" ]; then echo "$p"; fi; done || true)
+MISSING_REQUIRED_RUN=""
 if [ -n "$MISSING_RUN" ]; then
-    echo "  ⚠️  WARNING: Docs tell Dex to run scripts that don't exist:"
-    echo "$MISSING_RUN" | sed 's/^/     /'
+    while IFS= read -r p; do
+        ALLOWLISTED=false
+        for allowed in "${MISSING_RUNNABLE_ALLOWLIST[@]}"; do
+            if [ "$p" = "$allowed" ]; then
+                ALLOWLISTED=true
+                break
+            fi
+        done
+        if [ "$ALLOWLISTED" = true ]; then
+            echo "  ℹ️  INFO: Optional referenced script is not shipped: $p"
+        elif [ -z "$MISSING_REQUIRED_RUN" ]; then
+            MISSING_REQUIRED_RUN="$p"
+        else
+            MISSING_REQUIRED_RUN="${MISSING_REQUIRED_RUN}"$'\n'"$p"
+        fi
+    done <<< "$MISSING_RUN"
+fi
+if [ -n "$MISSING_REQUIRED_RUN" ]; then
+    echo "  ❌ ERROR: Docs tell Dex to run scripts that don't exist:"
+    echo "$MISSING_REQUIRED_RUN" | sed 's/^/     /'
     echo "     Either ship the script or remove the instruction."
-    WARNINGS=$((WARNINGS + 1))
+    ERRORS=$((ERRORS + 1))
 else
-    echo "  ✅ All referenced runnable scripts exist"
+    echo "  ✅ All required referenced runnable scripts exist"
 fi
 
 # Check 16: A real release build contains no test suites.


### PR DESCRIPTION
## Summary

Two CI honesty gates from the audit Build list (items 2+3). Together they permanently close the "instruction shipped, implementation didn't" class.

**Gate 1 — instructed tool names must exist** (`scripts/check-instructed-tools.py`, new CI step, push+PR):
- Discovers every defined tool from `core/mcp/*.py` — both `types.Tool(name=...)` declarations and FastMCP `@mcp.tool()` decorators (sync and async).
- Scans the instruction surfaces (CLAUDE.md, `.claude/skills/**/SKILL.md`, `.claude/flows/*.md`, `.agents/skills/**/SKILL.md`; bundled plugins excluded) for backticked `tool_name(...)` calls plus snake_case names on MCP-mentioning lines.
- Unknown name → error with file:line and a did-you-mean suggestion. External tools (qmd, scrapling, Teams MCP) live in an annotated allowlist (`scripts/instructed-tools-allowlist.txt`).
- Current tree: 114 defined tools, 20 allowlisted, 104 files checked, 0 violations.

**Gate 2 — referenced scripts must ship** (`scripts/verify-distribution.sh` check 15):
- "Docs tell Dex to run scripts that don't exist" is now an **error**, not a warning.
- The two intentionally-optional scripts (improve-prompt, gmail example) are allowlisted, kept in sync with `test_skill_integrity.py`'s allowlist via cross-referencing comments.
- Fixed the one real violation: a bundled doc pointed at `skill-creator/scripts/init_skill.py`; the real path is `anthropic-skill-creator/scripts/init_skill.py`.

Also: package.json synced to 1.32.0; CHANGELOG in house style.

## Test plan

- [x] `python3 scripts/check-instructed-tools.py` exits 0 (would exit 1 with file:line + suggestion on any violation)
- [x] `bash scripts/verify-distribution.sh` — 0 errors
- [x] 88 tests pass (new gate tests incl. FastMCP extraction + existing skill-integrity)
- [x] ruff clean; path-contract/doc-drift/test-delta gates green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG