### PR TITLE
'Off' and 'broken' now mean different things — everywhere (v1.33.0)

### DIFF
--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -359,6 +359,16 @@ This ensures every task gets a unique, sortable ID that's stable across files.
 
 If interrupted, calling `start_onboarding_session()` resumes from the last completed step.
 
+### How servers report feature status
+
+Dex servers use five shared states so skills and diagnostics describe each feature consistently:
+
+- `ok` — Enabled and working.
+- `off` — Deliberately not enabled or configured by the user. Skills render `off` as healthy, never use an error tone, and never nag.
+- `not_installed` — A required app, binary, or dependency is absent.
+- `broken` — Configured and expected to work, but failing.
+- `unknown` — Dex could not determine the state because the check itself failed.
+
 ### External MCP Integrations
 
 #### Pendo (Optional for Pendo Customers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.33.0] - 'Off' and 'broken' now mean different things — everywhere (2026-07-11)
+
+Dex could describe an optional feature as broken in one place and merely disconnected in another; this release gives those responses one shared meaning.
+
+**What this fixes for you:**
+
+* **Optional features stay peacefully off.** If you deliberately did not enable or configure something, Dex treats it as healthy, never uses an error tone, and never nags you to fix it.
+* **Real failures stand out.** “Broken” is reserved for a feature that is configured and expected to work but is failing, so genuine problems no longer look like personal setup choices.
+* **Missing software has its own answer.** When a required app, binary, or dependency is absent, Dex says that directly instead of calling the feature broken.
+* **Uncertain checks admit uncertainty.** If a check itself fails, Dex reports that it could not determine the state instead of inventing a diagnosis.
+
+---
+
 ## [1.32.0] - Dex can no longer tell you to use tools that don't exist (2026-07-11)
 
 Some instructions could send you looking for a tool or runnable helper that was never included, leaving you stuck at the moment Dex was supposed to help.

--- a/core/mcp/analytics_server.py
+++ b/core/mcp/analytics_server.py
@@ -46,6 +46,8 @@ from analytics_helper import (
     load_user_profile,
 )
 
+from core.utils.feature_status import feature_status
+
 try:
     import requests
     HAS_REQUESTS = True
@@ -227,10 +229,14 @@ async def _call_tool_inner(name: str, arguments: dict) -> list[TextContent]:
 
     elif name == "test_connection":
         if not HAS_REQUESTS:
-            return [TextContent(type="text", text=json.dumps({
-                "success": False,
-                "error": "requests library not installed. Run: pip install requests"
-            }))]
+            error = "requests library not installed. Run: pip install requests"
+            payload = feature_status(
+                "Usage analytics",
+                "not_installed",
+                error,
+                error=error,
+            )
+            return [TextContent(type="text", text=json.dumps(payload))]
 
         transport = get_analytics_transport()
         if not transport.get("configured"):
@@ -267,18 +273,26 @@ async def _call_tool_inner(name: str, arguments: dict) -> list[TextContent]:
                     "transport_endpoint": transport.get("endpoint"),
                 }))]
             else:
-                return [TextContent(type="text", text=json.dumps({
-                    "success": False,
-                    "status": response.status_code,
-                    "transport_mode": transport.get("mode"),
-                    "transport_endpoint": transport.get("endpoint"),
-                    "body": response.text[:200]
-                }))]
+                message = f"Analytics connection failed (HTTP {response.status_code})."
+                payload = feature_status(
+                    "Usage analytics",
+                    "broken",
+                    message,
+                    status=response.status_code,
+                    transport_mode=transport.get("mode"),
+                    transport_endpoint=transport.get("endpoint"),
+                    body=response.text[:200],
+                )
+                return [TextContent(type="text", text=json.dumps(payload))]
         except Exception as e:
-            return [TextContent(type="text", text=json.dumps({
-                "success": False,
-                "error": str(e)
-            }))]
+            error = str(e)
+            payload = feature_status(
+                "Usage analytics",
+                "broken",
+                error,
+                error=error,
+            )
+            return [TextContent(type="text", text=json.dumps(payload))]
 
     else:
         return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]

--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -46,6 +46,7 @@ if _repo_root not in sys.path:
     sys.path.append(_repo_root)
 from core.paths import PEOPLE_DIR
 from core.paths import VAULT_ROOT as VAULT_PATH
+from core.utils.feature_status import feature_status
 
 # Health system — error queue and health reporting
 try:
@@ -75,6 +76,8 @@ logger = logging.getLogger(__name__)
 
 # Scripts directory
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
+CALENDAR_FEATURE = "Calendar access"
+REMINDERS_FEATURE = "Reminders access"
 
 # User profile path
 USER_PROFILE_PATH = VAULT_PATH / "System" / "user-profile.yaml"
@@ -169,12 +172,17 @@ def run_shell_script(script_name: str, *args) -> tuple[bool, str]:
         return False, str(e)
 
 
+def _broken_feature_payload(feature: str, error: str) -> dict:
+    """Preserve a legacy Calendar/Reminders error while adding status fields."""
+    return feature_status(feature, "broken", error, error=error)
+
+
 def _get_calendar_list_result() -> dict:
     """Return the same calendar-list payload exposed by the MCP tool."""
     success, output = run_shell_script("calendar_eventkit.py", "list")
 
     if not success:
-        return {"success": False, "error": output}
+        return _broken_feature_payload(CALENDAR_FEATURE, output)
 
     try:
         calendars = json.loads(output)
@@ -186,7 +194,7 @@ def _get_calendar_list_result() -> dict:
             "details": calendars,
         }
     except json.JSONDecodeError as e:
-        return {"success": False, "error": f"JSON parse error: {e}"}
+        return _broken_feature_payload(CALENDAR_FEATURE, f"JSON parse error: {e}")
 
 
 @cache
@@ -696,9 +704,9 @@ async def _handle_call_tool_inner(
                     "count": len(filtered_events)
                 }
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(CALENDAR_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
 
         result = _add_missing_calendar_warning(
             result,
@@ -755,7 +763,7 @@ async def _handle_call_tool_inner(
                 }
             }
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
         
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     
@@ -786,9 +794,9 @@ async def _handle_call_tool_inner(
                     "count": len(events)
                 }
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(CALENDAR_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
 
         result = _add_missing_calendar_warning(
             result,
@@ -827,7 +835,7 @@ async def _handle_call_tool_inner(
                 "message": output
             }
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     
     elif name == "calendar_get_next_event":
@@ -853,9 +861,9 @@ async def _handle_call_tool_inner(
                         "next_event": event_data
                     }
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(CALENDAR_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
 
         result = _add_missing_calendar_warning(
             result,
@@ -909,9 +917,9 @@ async def _handle_call_tool_inner(
                     "count": len(events)
                 }
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(CALENDAR_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(CALENDAR_FEATURE, output)
 
         result = _add_missing_calendar_warning(
             result,
@@ -929,9 +937,9 @@ async def _handle_call_tool_inner(
                 items = json.loads(output)
                 result = {"success": True, "list": list_name, "items": items, "count": len(items)}
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(REMINDERS_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_complete_item":
@@ -943,7 +951,7 @@ async def _handle_call_tool_inner(
             except json.JSONDecodeError:
                 result = {"success": True, "message": output}
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_create_item":
@@ -958,7 +966,7 @@ async def _handle_call_tool_inner(
             except json.JSONDecodeError:
                 result = {"success": True, "message": output}
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_ensure_lists":
@@ -969,7 +977,7 @@ async def _handle_call_tool_inner(
             except json.JSONDecodeError:
                 result = {"success": True, "message": output}
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_list_completed":
@@ -980,9 +988,9 @@ async def _handle_call_tool_inner(
                 items = json.loads(output)
                 result = {"success": True, "list": list_name, "items": items, "count": len(items)}
             except json.JSONDecodeError as e:
-                result = {"success": False, "error": f"JSON parse error: {e}"}
+                result = _broken_feature_payload(REMINDERS_FEATURE, f"JSON parse error: {e}")
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_find_and_complete":
@@ -995,7 +1003,7 @@ async def _handle_call_tool_inner(
             except json.JSONDecodeError:
                 result = {"success": True, "message": output}
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "reminders_clear_completed":
@@ -1007,7 +1015,7 @@ async def _handle_call_tool_inner(
             except json.JSONDecodeError:
                 result = {"success": True, "message": output}
         else:
-            result = {"success": False, "error": output}
+            result = _broken_feature_payload(REMINDERS_FEATURE, output)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     else:

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -88,8 +88,11 @@ from core.paths import (
 from core.paths import (
     VAULT_ROOT as BASE_DIR,
 )
+from core.utils.feature_status import feature_status
 
 LADDER_FILE = CAREER_DIR / 'Career_Ladder.md'
+CAREER_EVIDENCE_FEATURE = "Career evidence"
+CAREER_LADDER_FEATURE = "Career ladder"
 
 # Initialize the MCP server
 app = Server("dex-career-mcp")
@@ -286,6 +289,17 @@ async def handle_list_tools() -> list[types.Tool]:
 # TOOL HANDLERS
 # ============================================================================
 
+
+def _feature_response(
+    feature: str,
+    state: str,
+    user_message: str,
+    **extra,
+) -> list[types.TextContent]:
+    payload = feature_status(feature, state, user_message, **extra)
+    return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+
 @app.call_tool()
 async def handle_call_tool(
     name: str, arguments: dict | None
@@ -348,14 +362,14 @@ async def handle_scan_evidence(arguments: dict) -> list[types.TextContent]:
     """Scan and aggregate evidence files"""
     
     if not EVIDENCE_DIR.exists():
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": f"Evidence directory not found: {EVIDENCE_DIR}",
-                "note": "Run /career-setup to initialize your career system"
-            }, indent=2)
-        )]
+        error = f"Evidence directory not found: {EVIDENCE_DIR}"
+        return _feature_response(
+            CAREER_EVIDENCE_FEATURE,
+            "off",
+            error,
+            error=error,
+            note="Run /career-setup to initialize your career system",
+        )
     
     # Parse date range if provided
     date_range_arg = arguments.get('date_range')
@@ -426,26 +440,25 @@ async def handle_parse_ladder(arguments: dict) -> list[types.TextContent]:
     """Parse career ladder file"""
     
     if not LADDER_FILE.exists():
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": f"Career ladder file not found: {LADDER_FILE}",
-                "note": "Run /career-setup to create your career ladder"
-            }, indent=2)
-        )]
+        error = f"Career ladder file not found: {LADDER_FILE}"
+        return _feature_response(
+            CAREER_LADDER_FEATURE,
+            "off",
+            error,
+            error=error,
+            note="Run /career-setup to create your career ladder",
+        )
     
     # Parse the ladder
     ladder_data = parse_ladder_file(LADDER_FILE)
     
     if "error" in ladder_data:
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                **ladder_data
-            }, indent=2)
-        )]
+        return _feature_response(
+            CAREER_LADDER_FEATURE,
+            "broken",
+            str(ladder_data["error"]),
+            **ladder_data,
+        )
     
     # Add success flag
     ladder_data["success"] = True
@@ -461,36 +474,36 @@ async def handle_analyze_coverage(arguments: dict) -> list[types.TextContent]:
     
     # Check prerequisites
     if not EVIDENCE_DIR.exists():
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": "Evidence directory not found",
-                "note": "Run /career-setup to initialize your career system"
-            }, indent=2)
-        )]
+        error = "Evidence directory not found"
+        return _feature_response(
+            CAREER_EVIDENCE_FEATURE,
+            "off",
+            error,
+            error=error,
+            note="Run /career-setup to initialize your career system",
+        )
     
     if not LADDER_FILE.exists():
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": "Career ladder file not found",
-                "note": "Run /career-setup to create your career ladder"
-            }, indent=2)
-        )]
+        error = "Career ladder file not found"
+        return _feature_response(
+            CAREER_LADDER_FEATURE,
+            "off",
+            error,
+            error=error,
+            note="Run /career-setup to create your career ladder",
+        )
     
     # Parse ladder
     ladder_data = parse_ladder_file(LADDER_FILE)
     if "error" in ladder_data or not ladder_data.get('competencies'):
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": "Failed to parse career ladder or no competencies found",
-                "ladder_data": ladder_data
-            }, indent=2)
-        )]
+        error = "Failed to parse career ladder or no competencies found"
+        return _feature_response(
+            CAREER_LADDER_FEATURE,
+            "broken",
+            error,
+            error=error,
+            ladder_data=ladder_data,
+        )
     
     # Scan evidence (with optional date range filter)
     date_range_arg = arguments.get('date_range')
@@ -560,14 +573,14 @@ async def handle_timeline_analysis(arguments: dict) -> list[types.TextContent]:
     """Analyze evidence timeline and trends"""
     
     if not EVIDENCE_DIR.exists():
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "success": False,
-                "error": "Evidence directory not found",
-                "note": "Run /career-setup to initialize your career system"
-            }, indent=2)
-        )]
+        error = "Evidence directory not found"
+        return _feature_response(
+            CAREER_EVIDENCE_FEATURE,
+            "off",
+            error,
+            error=error,
+            note="Run /career-setup to initialize your career system",
+        )
     
     # Parse arguments
     period_arg = arguments.get('period', 'last-12-months')

--- a/core/mcp/granola_server.py
+++ b/core/mcp/granola_server.py
@@ -27,6 +27,7 @@ Tools (interface unchanged):
 import json
 import logging
 import os
+import sys
 import time
 import urllib.error
 import urllib.parse
@@ -40,11 +41,17 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
+_repo_root = str(Path(__file__).parent.parent.parent)
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+from core.utils.feature_status import feature_status
+
 # ============================================================================
 # CONFIGURATION
 # ============================================================================
 
 API_BASE_URL = "https://public-api.granola.ai"
+FEATURE_NAME = "Granola meeting sync"
 
 # Vault paths
 VAULT_PATH = Path(os.environ.get("VAULT_PATH", Path.cwd()))
@@ -610,20 +617,27 @@ async def handle_list_tools() -> list[types.Tool]:
 
 def _not_connected_response() -> list[types.TextContent]:
     """Standard payload returned by every tool when no API key is configured."""
-    return [types.TextContent(type="text", text=json.dumps({
-        "success": False,
-        "connected": False,
-        "message": NOT_CONNECTED_MESSAGE
-    }, indent=2))]
+    payload = feature_status(
+        FEATURE_NAME,
+        "off",
+        NOT_CONNECTED_MESSAGE,
+        connected=False,
+        message=NOT_CONNECTED_MESSAGE,
+    )
+    return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
 
 
 def _api_error_response(error: GranolaAPIError) -> list[types.TextContent]:
     """Return a visible tool failure instead of an ambiguous empty result."""
-    return [types.TextContent(type="text", text=json.dumps({
-        "success": False,
-        "error": error.user_message,
-        "data_source": "official_api",
-    }, indent=2))]
+    message = error.user_message
+    payload = feature_status(
+        FEATURE_NAME,
+        "broken",
+        message,
+        error=message,
+        data_source="official_api",
+    )
+    return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
 
 
 @app.call_tool()
@@ -681,7 +695,15 @@ async def handle_call_tool(
             )
         }
         if api_error is not None:
-            result["error"] = api_error.user_message
+            message = result["message"]
+            result["error"] = message
+            result.update(
+                feature_status(
+                    FEATURE_NAME,
+                    "broken",
+                    message,
+                )
+            )
 
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 

--- a/core/mcp/resume_server.py
+++ b/core/mcp/resume_server.py
@@ -108,6 +108,7 @@ from core.paths import (
 from core.paths import (
     VAULT_ROOT as BASE_DIR,
 )
+from core.utils.feature_status import feature_status
 
 # Ensure directories exist
 SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
@@ -820,13 +821,19 @@ async def handle_pull_career_evidence(arguments: dict) -> list[types.TextContent
     
     # Check if Career Evidence exists
     if not EVIDENCE_DIR.exists():
+        error = "Career Evidence directory not found"
         return [types.TextContent(
             type="text",
-            text=json.dumps({
-                "success": False,
-                "error": "Career Evidence directory not found",
-                "note": "Run /career-setup to initialize career system"
-            }, indent=2)
+            text=json.dumps(
+                feature_status(
+                    "Career evidence",
+                    "off",
+                    error,
+                    error=error,
+                    note="Run /career-setup to initialize career system",
+                ),
+                indent=2,
+            )
         )]
     
     # Find relevant evidence

--- a/core/tests/test_feature_status.py
+++ b/core/tests/test_feature_status.py
@@ -1,0 +1,372 @@
+"""Contract tests for feature availability responses."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from core.mcp import (
+    analytics_server,
+    calendar_server,
+    career_server,
+    granola_server,
+    resume_server,
+)
+from core.utils import feature_status as feature_status_module
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_success"),
+    [
+        ("ok", True),
+        ("off", False),
+        ("not_installed", False),
+        ("broken", False),
+        ("unknown", False),
+    ],
+)
+def test_feature_status_derives_success_from_state(state, expected_success):
+    result = feature_status_module.feature_status(
+        "Example feature",
+        state,
+        "Example status",
+    )
+
+    assert result["success"] is expected_success
+    assert result["feature"] == "Example feature"
+    assert result["feature_status"] == state
+    assert result["user_message"] == "Example status"
+
+
+def test_feature_status_rejects_invalid_state():
+    with pytest.raises(ValueError):
+        feature_status_module.feature_status(
+            "Example feature",
+            "disabled",
+            "Example status",
+        )
+
+
+def test_feature_status_passes_through_extra_keys():
+    result = feature_status_module.feature_status(
+        "Example feature",
+        "off",
+        "Example status",
+        connected=False,
+        message="Legacy message",
+    )
+
+    assert result["connected"] is False
+    assert result["message"] == "Legacy message"
+
+
+def test_feature_status_includes_detail_only_when_given():
+    without_detail = feature_status_module.feature_status(
+        "Example feature",
+        "off",
+        "Example status",
+    )
+    with_detail = feature_status_module.feature_status(
+        "Example feature",
+        "broken",
+        "Example status",
+        detail="Diagnostic detail",
+    )
+
+    assert "detail" not in without_detail
+    assert with_detail["detail"] == "Diagnostic detail"
+
+
+def _decode_tool_result(result):
+    return json.loads(result[0].text)
+
+
+def test_granola_without_api_key_reports_off_and_preserves_legacy_keys(monkeypatch):
+    monkeypatch.setattr(granola_server, "get_api_key", lambda: None)
+
+    payload = _decode_tool_result(
+        asyncio.run(granola_server.handle_call_tool("granola_check_available", {}))
+    )
+
+    assert payload["feature"] == "Granola meeting sync"
+    assert payload["feature_status"] == "off"
+    assert payload["user_message"] == granola_server.NOT_CONNECTED_MESSAGE
+    assert payload["success"] is False
+    assert payload["connected"] is False
+    assert payload["message"] == granola_server.NOT_CONNECTED_MESSAGE
+
+
+def test_calendar_eventkit_permission_failure_reports_broken_and_preserves_error(
+    monkeypatch,
+):
+    error = "Calendar permission denied"
+
+    def deny_calendar(script_name, operation, *args):
+        assert script_name == "calendar_eventkit.py"
+        assert operation == "list"
+        return False, error
+
+    monkeypatch.setattr(calendar_server, "run_shell_script", deny_calendar)
+
+    payload = _decode_tool_result(
+        asyncio.run(
+            calendar_server._handle_call_tool_inner("calendar_list_calendars", {})
+        )
+    )
+
+    assert payload["feature"] == "Calendar access"
+    assert payload["feature_status"] == "broken"
+    assert payload["user_message"] == error
+    assert payload["success"] is False
+    assert payload["error"] == error
+
+
+@pytest.mark.parametrize(
+    ("success", "output", "expected_message"),
+    [
+        (False, "Reminders permission denied", "Reminders permission denied"),
+        (True, "not valid JSON", "JSON parse error:"),
+    ],
+)
+def test_reminders_failures_report_broken_and_preserve_error(
+    monkeypatch,
+    success,
+    output,
+    expected_message,
+):
+    monkeypatch.setattr(
+        calendar_server,
+        "run_shell_script",
+        lambda *_args: (success, output),
+    )
+
+    payload = _decode_tool_result(
+        asyncio.run(
+            calendar_server._handle_call_tool_inner("reminders_list_items", {})
+        )
+    )
+
+    assert payload["feature"] == "Reminders access"
+    assert payload["feature_status"] == "broken"
+    assert expected_message in payload["user_message"]
+    assert payload["success"] is False
+    assert payload["error"] == payload["user_message"]
+
+
+def test_missing_career_folder_reports_off_and_preserves_setup_guidance(
+    monkeypatch,
+    tmp_path,
+):
+    career_dir = tmp_path / "vault" / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    monkeypatch.setattr(career_server, "CAREER_DIR", career_dir)
+    monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
+    monkeypatch.setattr(career_server, "LADDER_FILE", career_dir / "Career_Ladder.md")
+
+    payload = _decode_tool_result(
+        asyncio.run(career_server.handle_call_tool("scan_evidence", {}))
+    )
+
+    assert payload["feature"] == "Career evidence"
+    assert payload["feature_status"] == "off"
+    assert payload["user_message"] == payload["error"]
+    assert payload["success"] is False
+    assert payload["error"] == f"Evidence directory not found: {evidence_dir}"
+    assert payload["note"] == "Run /career-setup to initialize your career system"
+    assert not career_dir.exists()
+
+
+def test_missing_career_ladder_reports_off_and_preserves_setup_guidance(
+    monkeypatch,
+    tmp_path,
+):
+    evidence_dir = tmp_path / "Career" / "Evidence"
+    evidence_dir.mkdir(parents=True)
+    ladder_file = tmp_path / "Career" / "Career_Ladder.md"
+    monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
+    monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
+
+    payload = _decode_tool_result(
+        asyncio.run(career_server.handle_call_tool("analyze_coverage", {}))
+    )
+
+    assert payload["feature"] == "Career ladder"
+    assert payload["feature_status"] == "off"
+    assert payload["user_message"] == payload["error"]
+    assert payload["success"] is False
+    assert payload["error"] == "Career ladder file not found"
+    assert payload["note"] == "Run /career-setup to create your career ladder"
+
+
+def test_existing_unreadable_career_ladder_reports_broken(monkeypatch, tmp_path):
+    ladder_file = tmp_path / "Career_Ladder.md"
+    ladder_file.write_text("not a valid ladder")
+    monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
+    monkeypatch.setattr(
+        career_server,
+        "parse_ladder_file",
+        lambda _path: {"error": "Could not parse career ladder"},
+    )
+
+    payload = _decode_tool_result(
+        asyncio.run(career_server.handle_call_tool("parse_ladder", {}))
+    )
+
+    assert payload["feature"] == "Career ladder"
+    assert payload["feature_status"] == "broken"
+    assert payload["user_message"] == "Could not parse career ladder"
+    assert payload["success"] is False
+    assert payload["error"] == "Could not parse career ladder"
+
+
+def test_career_ladder_without_competencies_reports_broken(monkeypatch, tmp_path):
+    evidence_dir = tmp_path / "Career" / "Evidence"
+    evidence_dir.mkdir(parents=True)
+    ladder_file = tmp_path / "Career" / "Career_Ladder.md"
+    ladder_file.write_text("# Career ladder")
+    ladder_data = {"competencies": [], "competency_count": 0}
+    monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
+    monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
+    monkeypatch.setattr(career_server, "parse_ladder_file", lambda _path: ladder_data)
+
+    payload = _decode_tool_result(
+        asyncio.run(career_server.handle_call_tool("analyze_coverage", {}))
+    )
+
+    assert payload["feature"] == "Career ladder"
+    assert payload["feature_status"] == "broken"
+    assert payload["user_message"] == payload["error"]
+    assert payload["success"] is False
+    assert payload["error"] == "Failed to parse career ladder or no competencies found"
+    assert payload["ladder_data"] == ladder_data
+
+
+def test_resume_missing_career_evidence_reports_off_and_preserves_keys(
+    monkeypatch,
+    tmp_path,
+):
+    role = resume_server.Role(
+        role_id="role-1",
+        title="Product lead",
+        company="Dex",
+        start_date="2025-01",
+        end_date="present",
+        responsibilities="Lead product work",
+    )
+    session = resume_server.ResumeSession(
+        session_id="session-1",
+        created_at="2026-07-11T00:00:00",
+        last_modified="2026-07-11T00:00:00",
+        phase=resume_server.PhaseEnum.ROLES,
+        approach="from_scratch",
+        roles=[role],
+    )
+    monkeypatch.setattr(resume_server, "sessions", {session.session_id: session})
+    monkeypatch.setattr(resume_server, "EVIDENCE_DIR", tmp_path / "Career" / "Evidence")
+
+    payload = _decode_tool_result(
+        asyncio.run(
+            resume_server.handle_pull_career_evidence(
+                {"session_id": session.session_id, "role_id": role.role_id}
+            )
+        )
+    )
+
+    assert payload["feature"] == "Career evidence"
+    assert payload["feature_status"] == "off"
+    assert payload["user_message"] == payload["error"]
+    assert payload["success"] is False
+    assert payload["error"] == "Career Evidence directory not found"
+    assert payload["note"] == "Run /career-setup to initialize career system"
+
+
+def test_analytics_missing_requests_reports_not_installed_and_preserves_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", False)
+
+    payload = _decode_tool_result(
+        asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
+    )
+
+    assert payload["feature"] == "Usage analytics"
+    assert payload["feature_status"] == "not_installed"
+    assert payload["user_message"] == payload["error"]
+    assert payload["success"] is False
+    assert payload["error"] == "requests library not installed. Run: pip install requests"
+
+
+def test_analytics_http_failure_reports_broken_and_preserves_transport_keys(
+    monkeypatch,
+):
+    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", True)
+    monkeypatch.setattr(
+        analytics_server,
+        "get_analytics_transport",
+        lambda: {
+            "configured": True,
+            "mode": "proxy",
+            "endpoint": "https://analytics.example.test",
+            "headers": {},
+        },
+    )
+    monkeypatch.setattr(
+        analytics_server,
+        "get_visitor_info",
+        lambda: {"visitor_id": "visitor-123", "account_id": "account-123"},
+    )
+    monkeypatch.setattr(
+        analytics_server.requests,
+        "post",
+        lambda *args, **kwargs: SimpleNamespace(status_code=503, text="unavailable"),
+    )
+
+    payload = _decode_tool_result(
+        asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
+    )
+
+    assert payload["feature"] == "Usage analytics"
+    assert payload["feature_status"] == "broken"
+    assert payload["user_message"] == "Analytics connection failed (HTTP 503)."
+    assert payload["success"] is False
+    assert payload["status"] == 503
+    assert payload["transport_mode"] == "proxy"
+    assert payload["transport_endpoint"] == "https://analytics.example.test"
+    assert payload["body"] == "unavailable"
+
+
+def test_analytics_request_exception_reports_broken_and_preserves_error(monkeypatch):
+    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", True)
+    monkeypatch.setattr(
+        analytics_server,
+        "get_analytics_transport",
+        lambda: {
+            "configured": True,
+            "mode": "proxy",
+            "endpoint": "https://analytics.example.test",
+            "headers": {},
+        },
+    )
+    monkeypatch.setattr(
+        analytics_server,
+        "get_visitor_info",
+        lambda: {"visitor_id": "visitor-123", "account_id": "account-123"},
+    )
+
+    def raise_network_error(*_args, **_kwargs):
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(analytics_server.requests, "post", raise_network_error)
+
+    payload = _decode_tool_result(
+        asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
+    )
+
+    assert payload["feature"] == "Usage analytics"
+    assert payload["feature_status"] == "broken"
+    assert payload["user_message"] == "network unavailable"
+    assert payload["success"] is False
+    assert payload["error"] == "network unavailable"

--- a/core/tests/test_granola_server.py
+++ b/core/tests/test_granola_server.py
@@ -96,6 +96,10 @@ def test_recent_meetings_surfaces_filtered_http_400(monkeypatch):
     assert "HTTP 400" in result["error"]
     assert "connector may need updating" in result["error"]
     assert "invalid created_after" in result["error"]
+    assert result["feature"] == "Granola meeting sync"
+    assert result["feature_status"] == "broken"
+    assert result["user_message"] == result["error"]
+    assert result["data_source"] == "official_api"
 
 
 def test_recent_meetings_surfaces_url_errors(monkeypatch):
@@ -156,6 +160,10 @@ def test_check_available_uses_filtered_probe_and_surfaces_http_400(monkeypatch):
     assert result["available"] is False
     assert result["api"]["status"] == "unavailable"
     assert "HTTP 400" in result["error"]
+    assert result["success"] is False
+    assert result["feature"] == "Granola meeting sync"
+    assert result["feature_status"] == "broken"
+    assert result["user_message"] == result["message"]
 
 
 @pytest.mark.parametrize(

--- a/core/utils/feature_status.py
+++ b/core/utils/feature_status.py
@@ -1,0 +1,35 @@
+"""Shared feature-status response contract for Dex MCP servers.
+
+Vocabulary:
+- ``ok``: the feature is enabled and working.
+- ``off``: the user deliberately did not enable or configure the feature. This
+  is healthy, must never use an error tone, and must never nag the user.
+- ``not_installed``: a required app, binary, or dependency is absent.
+- ``broken``: the feature is configured and expected to work, but is failing.
+- ``unknown``: the state could not be determined because the check itself failed.
+"""
+
+STATES = ("ok", "off", "not_installed", "broken", "unknown")
+
+
+def feature_status(
+    feature: str,
+    state: str,
+    user_message: str,
+    detail: str | None = None,
+    **extra,
+) -> dict:
+    """Build a feature-status payload while preserving caller-supplied fields."""
+    if state not in STATES:
+        raise ValueError(f"Invalid feature state: {state}")
+
+    result = {
+        "success": state == "ok",
+        "feature": feature,
+        "feature_status": state,
+        "user_message": user_message,
+    }
+    if detail is not None:
+        result["detail"] = detail
+    result.update(extra)
+    return result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Audit Build item 4 — the root theme of every user complaint was Dex describing "off", "not installed", and "broken" with the same words. This gives every MCP server one status vocabulary.

- `core/utils/feature_status.py` (new): `ok / off / not_installed / broken / unknown` + a `user_message`, with the contract documented (off is healthy, never an error tone).
- Adopted **additively** in granola (no key → off; API failures → broken), calendar + reminders (EventKit failures → broken), career (Evidence/Ladder not set up → off; parse failure → broken), resume (missing evidence → off), analytics (missing dependency → not_installed; HTTP failures → broken). Every legacy key and message text preserved; no success-path shapes touched.
- Deliberately untouched: work-server task/file errors (domain states, not feature availability), onboarding dependency probes, analytics consent states — reasoning in the code review.
- Granola server tests consolidated into `core/tests/` (all 11 preserved) + new contract and per-server off/broken tests.
- Vocabulary documented in the Technical Guide; CHANGELOG v1.33.0; package.json synced.

## Test plan

- [x] 51 tests pass (contract unit tests, per-server off/broken tests, existing server suites)
- [x] ruff clean
- [x] Instructed-tool gate, path-contract, doc-drift, test-delta all green locally against origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG