### PR TITLE
People in your notes now link themselves — safely (v1.34.0)

### DIFF
--- a/.claude/hooks/tests/auto-link-people.test.cjs
+++ b/.claude/hooks/tests/auto-link-people.test.cjs
@@ -1,0 +1,373 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT_PATH = path.resolve(__dirname, '../../../.scripts/auto-link-people.cjs');
+
+function loadScript() {
+  delete require.cache[SCRIPT_PATH];
+  return require(SCRIPT_PATH);
+}
+
+function makeRegistry({
+  fullNames = [],
+  firstNames = [],
+  aliases = [],
+  ownerName = '',
+} = {}) {
+  return {
+    fullNames: new Set(fullNames),
+    firstNameToFull: new Map(firstNames),
+    aliases: new Map(aliases),
+    ownerName,
+  };
+}
+
+function createVault(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-auto-link-'));
+  const vault = path.join(root, 'vault');
+  const peopleDir = path.join(vault, '05-Areas', 'People');
+  const meetingsDir = path.join(vault, '00-Inbox', 'Meetings');
+  const systemDir = path.join(vault, 'System');
+  const userProfileFile = path.join(systemDir, 'user-profile.yaml');
+
+  fs.mkdirSync(peopleDir, { recursive: true });
+  fs.mkdirSync(meetingsDir, { recursive: true });
+  fs.mkdirSync(systemDir, { recursive: true });
+  fs.writeFileSync(userProfileFile, 'name: Test User\n');
+
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { vault, peopleDir, meetingsDir, userProfileFile };
+}
+
+function writePerson(peopleDir, subdirectory, fileName, content = '') {
+  const directory = path.join(peopleDir, subdirectory);
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, fileName);
+  fs.writeFileSync(filePath, content || `# ${path.basename(fileName, '.md')}\n`);
+  return filePath;
+}
+
+function cliEnv(vault) {
+  return {
+    CLAUDE_PROJECT_DIR: vault,
+    HOME: path.dirname(vault),
+    PATH: '/usr/bin:/bin',
+    VAULT_PATH: vault,
+  };
+}
+
+function runCli(vault, args) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    cwd: vault,
+    encoding: 'utf-8',
+    env: cliEnv(vault),
+    timeout: 10_000,
+  });
+}
+
+function localDateString(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+test('exports the auto-link module contract', () => {
+  assert.ok(fs.existsSync(SCRIPT_PATH), `${SCRIPT_PATH} must exist`);
+  const module = loadScript();
+  assert.equal(typeof module.autoLinkContent, 'function');
+  assert.equal(typeof module.buildRegistry, 'function');
+});
+
+test('uses the shared path contract without raw vault paths', () => {
+  const source = fs.readFileSync(SCRIPT_PATH, 'utf-8');
+  assert.match(
+    source,
+    /const \{ loadPaths \} = require\('\.\.\/\.claude\/hooks\/paths\.cjs'\);/,
+  );
+  assert.doesNotMatch(
+    source,
+    /00-Inbox|01-Quarter_Goals|02-Week_Priorities|03-Tasks|04-Projects|05-Areas|06-Resources|07-Archives/,
+  );
+});
+
+test('links a full name to its person page', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+
+  assert.equal(
+    autoLinkContent('Met Sarah Chen today.', registry),
+    'Met [[Sarah Chen]] today.',
+  );
+});
+
+test('links an unambiguous alias with its visible text preserved', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Grace Brown'],
+    firstNames: [['Grace', 'Grace Brown']],
+    aliases: [['Alex', 'Grace Brown']],
+  });
+
+  assert.equal(
+    autoLinkContent('Alex raised the risk.', registry),
+    '[[Grace Brown|Alex]] raised the risk.',
+  );
+});
+
+test('does not link an ambiguous standalone first name', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen', 'Sarah Jones'],
+    firstNames: [['Sarah', null]],
+  });
+
+  assert.equal(autoLinkContent('Sarah raised the risk.', registry), 'Sarah raised the risk.');
+});
+
+test('poisons a known first name when an unknown full name uses it', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+  const input = 'Met Sarah Connor. Later Sarah spoke. Sarah Chen replied.';
+
+  assert.equal(
+    autoLinkContent(input, registry),
+    'Met Sarah Connor. Later Sarah spoke. [[Sarah Chen]] replied.',
+  );
+});
+
+test('does not poison a first name from a known multi-part full name', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Jane Chen'],
+    firstNames: [['Sarah', 'Sarah Jane Chen']],
+  });
+
+  assert.equal(
+    autoLinkContent('Sarah spoke. Later Sarah Jane Chen joined.', registry),
+    '[[Sarah Jane Chen|Sarah]] spoke. Later Sarah Jane Chen joined.',
+  );
+});
+
+test('does not link a stoplisted word standalone but still links its full name', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Mark Lee'],
+    firstNames: [['Mark', 'Mark Lee']],
+  });
+
+  assert.equal(
+    autoLinkContent('Mark this. Mark Lee agreed.', registry),
+    'Mark this. [[Mark Lee]] agreed.',
+  );
+});
+
+test('applies the complete stoplist case-sensitively', () => {
+  const { autoLinkContent } = loadScript();
+  const stoplisted = [
+    'Will', 'May', 'Mark', 'Grace', 'Art', 'Rose', 'Dawn', 'Bill', 'Penny', 'Summer',
+    'June', 'April', 'Jay', 'Ray', 'Miles', 'Drew', 'Chase', 'Hope', 'Faith', 'Joy',
+  ];
+
+  for (const firstName of stoplisted) {
+    const fullName = `${firstName} Person`;
+    const registry = makeRegistry({
+      fullNames: [fullName],
+      firstNames: [[firstName, fullName]],
+    });
+    assert.equal(
+      autoLinkContent(`${firstName} spoke. ${fullName} replied.`, registry),
+      `${firstName} spoke. [[${fullName}]] replied.`,
+      `${firstName} must remain plain when standalone`,
+    );
+  }
+
+  const lowercaseRegistry = makeRegistry({
+    fullNames: ['mark Person'],
+    firstNames: [['mark', 'mark Person']],
+  });
+  assert.equal(
+    autoLinkContent('mark spoke.', lowercaseRegistry),
+    '[[mark Person|mark]] spoke.',
+  );
+});
+
+test('leaves protected Markdown untouched and links the first prose occurrence', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+  const input = [
+    '---',
+    'attendee: Sarah Chen',
+    '---',
+    '```js',
+    'const person = "Sarah Chen";',
+    '```',
+    'Inline `Sarah Chen` stays code.',
+    '[Sarah Chen](https://example.test/Sarah-Chen)',
+    '[Notes about Sarah Chen]',
+    '[Notes about Sarah Chen]: https://example.test/people/Sarah',
+    'Bare URL: https://example.test/people/Sarah',
+    'Obsidian URL: obsidian://open?person=Sarah',
+    'Sarah Chen spoke in prose.',
+  ].join('\n');
+  const expected = input.replace(
+    'Sarah Chen spoke in prose.',
+    '[[Sarah Chen]] spoke in prose.',
+  );
+
+  assert.equal(autoLinkContent(input, registry), expected);
+});
+
+test('an existing wiki-link is untouched and consumes the person link for the file', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+  const input = 'Already [[Sarah Chen|Sarah]]. Later Sarah Chen spoke.';
+
+  assert.equal(autoLinkContent(input, registry), input);
+});
+
+test('never links the owner by full name, first name, or alias', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Dave Killeen', 'Dave Smith'],
+    firstNames: [['Dave', 'Dave Smith']],
+    aliases: [['Davy', 'Dave Killeen']],
+    ownerName: 'Dave Killeen',
+  });
+
+  assert.equal(
+    autoLinkContent('Dave Killeen, Dave, and Davy met Dave Smith.', registry),
+    'Dave Killeen, Dave, and Davy met [[Dave Smith]].',
+  );
+});
+
+test('links only the earliest eligible occurrence for a person', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+
+  assert.equal(
+    autoLinkContent('Sarah spoke before Sarah Chen replied.', registry),
+    '[[Sarah Chen|Sarah]] spoke before Sarah Chen replied.',
+  );
+});
+
+test('is idempotent and preserves CRLF bytes outside the inserted link', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+  const input = 'Sarah Chen spoke.\r\nSarah followed up.\r\n';
+  const once = autoLinkContent(input, registry);
+
+  assert.equal(once, '[[Sarah Chen]] spoke.\r\nSarah followed up.\r\n');
+  assert.equal(autoLinkContent(once, registry), once);
+});
+
+test('does not match names inside longer words or compound identifiers', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Sarah Chen'],
+    firstNames: [['Sarah', 'Sarah Chen']],
+  });
+
+  assert.equal(
+    autoLinkContent('preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane Sarah', registry),
+    'preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane [[Sarah Chen|Sarah]]',
+  );
+});
+
+test('buildRegistry scans every nested People directory and rejects ambiguous aliases', (t) => {
+  const { buildRegistry } = loadScript();
+  const fixture = createVault(t);
+  writePerson(
+    fixture.peopleDir,
+    'Community/Founders',
+    'Sarah_Chen.md',
+    '# Sarah Chen\n\n- Goes by "Saz"\n',
+  );
+  writePerson(
+    fixture.peopleDir,
+    'Partners',
+    'Alex_Smith.md',
+    '# Alex Smith\n\nGoes by "Lex"\n',
+  );
+  writePerson(
+    fixture.peopleDir,
+    'Advisors',
+    'Samuel_Jones.md',
+    '# Samuel Jones\n\nGoes by "Saz"\n',
+  );
+  fs.writeFileSync(fixture.userProfileFile, 'name: "Test User"\n');
+
+  const registry = buildRegistry({
+    PEOPLE_DIR: fixture.peopleDir,
+    USER_PROFILE_FILE: fixture.userProfileFile,
+  });
+
+  assert.deepEqual(
+    [...registry.fullNames].sort(),
+    ['Alex Smith', 'Samuel Jones', 'Sarah Chen'],
+  );
+  assert.equal(registry.firstNameToFull.get('Sarah'), 'Sarah Chen');
+  assert.equal(registry.aliases.get('Lex'), 'Alex Smith');
+  assert.equal(registry.aliases.has('Saz'), false);
+  assert.equal(registry.ownerName, 'Test User');
+});
+
+test('dry-run prints proposed links and writes nothing', (t) => {
+  const fixture = createVault(t);
+  writePerson(fixture.peopleDir, 'Community', 'Sarah_Chen.md', '# Sarah Chen\n');
+  const notePath = path.join(fixture.vault, 'note.md');
+  const original = 'Sarah Chen joined. Sarah followed up.\n';
+  fs.writeFileSync(notePath, original);
+
+  const result = runCli(fixture.vault, ['--dry-run', notePath]);
+
+  assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.equal(fs.readFileSync(notePath, 'utf-8'), original);
+  assert.match(result.stdout, /\[dry-run\]/);
+  assert.match(result.stdout, /\[\[Sarah Chen\]\]/);
+});
+
+test('--today processes only notes in today\'s nested meeting folder', (t) => {
+  const fixture = createVault(t);
+  writePerson(fixture.peopleDir, 'Community', 'Sarah_Chen.md', '# Sarah Chen\n');
+  const today = localDateString();
+  const todayDir = path.join(fixture.meetingsDir, today);
+  const otherDir = path.join(fixture.meetingsDir, '1900-01-01');
+  fs.mkdirSync(todayDir, { recursive: true });
+  fs.mkdirSync(otherDir, { recursive: true });
+  const todayNote = path.join(todayDir, 'standup.md');
+  const otherNote = path.join(otherDir, 'old.md');
+  const prefixedButNotToday = path.join(fixture.meetingsDir, `${today}0-old.md`);
+  fs.writeFileSync(todayNote, 'Sarah Chen joined.\n');
+  fs.writeFileSync(otherNote, 'Sarah Chen joined.\n');
+  fs.writeFileSync(prefixedButNotToday, 'Sarah Chen joined.\n');
+
+  const result = runCli(fixture.vault, ['--today']);
+
+  assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.equal(fs.readFileSync(todayNote, 'utf-8'), '[[Sarah Chen]] joined.\n');
+  assert.equal(fs.readFileSync(otherNote, 'utf-8'), 'Sarah Chen joined.\n');
+  assert.equal(fs.readFileSync(prefixedButNotToday, 'utf-8'), 'Sarah Chen joined.\n');
+});

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -239,7 +239,16 @@ For each meeting with unextracted tasks:
    <!-- tasks-extracted: 2026-02-03T10:30:00Z -->
    ```
 
-### Step 6: Summary Report
+### Step 6: Auto-link People in Processed Notes
+
+After finishing edits to each processed meeting note, run this once for every processed note:
+```bash
+node .scripts/auto-link-people.cjs "<note-file>"
+```
+
+Use `node .scripts/auto-link-people.cjs --dry-run "<note-file>"` to preview what would be linked without changing the file.
+
+### Step 7: Summary Report
 
 ```
 ## Meeting Processing Complete ✅

--- a/.scripts/auto-link-people.cjs
+++ b/.scripts/auto-link-people.cjs
@@ -1,0 +1,700 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { loadPaths } = require('../.claude/hooks/paths.cjs');
+
+const STOPLIST = new Set([
+  'Will',
+  'May',
+  'Mark',
+  'Grace',
+  'Art',
+  'Rose',
+  'Dawn',
+  'Bill',
+  'Penny',
+  'Summer',
+  'June',
+  'April',
+  'Jay',
+  'Ray',
+  'Miles',
+  'Drew',
+  'Chase',
+  'Hope',
+  'Faith',
+  'Joy',
+]);
+
+const WORD_CONTINUATION = /[\p{L}\p{M}\p{N}\p{Pc}\p{Pd}'’\\/|[\]]/u;
+
+function addTarget(targetsByLabel, label, target) {
+  if (!label) return;
+  if (!targetsByLabel.has(label)) targetsByLabel.set(label, new Set());
+  targetsByLabel.get(label).add(target);
+}
+
+function collectTargets(label, fullNames, firstTargets, aliasTargets) {
+  const targets = new Set();
+  if (fullNames.has(label)) targets.add(label);
+  for (const target of firstTargets.get(label) || []) targets.add(target);
+  for (const target of aliasTargets.get(label) || []) targets.add(target);
+  return targets;
+}
+
+function onlyValue(values) {
+  return values.size === 1 ? values.values().next().value : null;
+}
+
+function listMarkdownFiles(rootDirectory) {
+  const files = [];
+
+  function visit(directory) {
+    let entries;
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      return;
+    }
+
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (
+        entry.isFile()
+        && path.extname(entry.name).toLowerCase() === '.md'
+        && entry.name.toLowerCase() !== 'readme.md'
+      ) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  if (rootDirectory && fs.existsSync(rootDirectory)) visit(rootDirectory);
+  return files;
+}
+
+function displayNameFromFile(filePath) {
+  return path.basename(filePath, path.extname(filePath)).replace(/_/g, ' ').trim();
+}
+
+function readOwnerName(profileFile) {
+  if (!profileFile || !fs.existsSync(profileFile)) return '';
+
+  try {
+    const profile = fs.readFileSync(profileFile, 'utf-8');
+    const match = profile.match(/^name\s*:\s*(.*?)\s*$/m);
+    if (!match) return '';
+
+    let value = match[1].trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+      value = value.slice(1, -1);
+    } else {
+      value = value.replace(/\s+#.*$/, '').trim();
+    }
+    return value.trim();
+  } catch (error) {
+    return '';
+  }
+}
+
+function aliasesFromPage(content) {
+  const aliases = [];
+  const pattern = /\bGoes\s+by\s+["“]([^"”\r\n]+)["”]/giu;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    const alias = match[1].trim();
+    if (alias) aliases.push(alias);
+  }
+  return aliases;
+}
+
+function buildRegistry(pathConfig = loadPaths()) {
+  const personFiles = listMarkdownFiles(pathConfig.PEOPLE_DIR);
+  const fullNames = new Set();
+  const firstTargets = new Map();
+  const aliasTargets = new Map();
+
+  for (const filePath of personFiles) {
+    const fullName = displayNameFromFile(filePath);
+    if (!fullName) continue;
+
+    fullNames.add(fullName);
+    const firstName = fullName.split(/\s+/u)[0];
+    addTarget(firstTargets, firstName, fullName);
+
+    try {
+      const page = fs.readFileSync(filePath, 'utf-8');
+      for (const alias of aliasesFromPage(page)) {
+        addTarget(aliasTargets, alias, fullName);
+      }
+    } catch (error) {
+      // An unreadable person page should not prevent other pages being indexed.
+    }
+  }
+
+  const firstNameToFull = new Map();
+  for (const firstName of firstTargets.keys()) {
+    const targets = collectTargets(firstName, fullNames, firstTargets, aliasTargets);
+    firstNameToFull.set(firstName, onlyValue(targets));
+  }
+
+  const aliases = new Map();
+  for (const alias of aliasTargets.keys()) {
+    const targets = collectTargets(alias, fullNames, firstTargets, aliasTargets);
+    const target = onlyValue(targets);
+    if (target) aliases.set(alias, target);
+  }
+
+  return {
+    fullNames,
+    firstNameToFull,
+    ownerName: readOwnerName(pathConfig.USER_PROFILE_FILE),
+    aliases,
+  };
+}
+
+function linesWithOffsets(text) {
+  const lines = [];
+  let start = 0;
+
+  while (start < text.length) {
+    let contentEnd = start;
+    while (contentEnd < text.length && text[contentEnd] !== '\n' && text[contentEnd] !== '\r') {
+      contentEnd += 1;
+    }
+
+    let end = contentEnd;
+    if (text[end] === '\r' && text[end + 1] === '\n') end += 2;
+    else if (text[end] === '\r' || text[end] === '\n') end += 1;
+
+    lines.push({ start, contentEnd, end, body: text.slice(start, contentEnd) });
+    start = end;
+  }
+
+  return lines;
+}
+
+function findBlockRanges(text) {
+  const lines = linesWithOffsets(text);
+  const ranges = [];
+  let frontmatterEnd = 0;
+
+  if (lines.length > 0 && lines[0].body.replace(/^\uFEFF/u, '') === '---') {
+    let closingLine = null;
+    for (let index = 1; index < lines.length; index += 1) {
+      if (lines[index].body === '---' || lines[index].body === '...') {
+        closingLine = lines[index];
+        break;
+      }
+    }
+    frontmatterEnd = closingLine ? closingLine.end : text.length;
+    ranges.push({ start: 0, end: frontmatterEnd, type: 'frontmatter' });
+  }
+
+  let openFence = null;
+  for (const line of lines) {
+    if (line.start < frontmatterEnd) continue;
+
+    if (!openFence) {
+      const opener = line.body.match(/^ {0,3}(`{3,}|~{3,})/u);
+      if (opener) {
+        openFence = {
+          start: line.start,
+          character: opener[1][0],
+          length: opener[1].length,
+        };
+      }
+      continue;
+    }
+
+    const closingPattern = new RegExp(
+      `^ {0,3}${openFence.character}{${openFence.length},}\\s*$`,
+      'u',
+    );
+    if (closingPattern.test(line.body)) {
+      ranges.push({ start: openFence.start, end: line.end, type: 'fence' });
+      openFence = null;
+    }
+  }
+
+  if (openFence) ranges.push({ start: openFence.start, end: text.length, type: 'fence' });
+  return ranges.sort((left, right) => left.start - right.start);
+}
+
+function containingRange(index, ranges) {
+  for (const range of ranges) {
+    if (range.start > index) return null;
+    if (range.start <= index && index < range.end) return range;
+  }
+  return null;
+}
+
+function findClosingBracket(text, openIndex) {
+  let depth = 1;
+  for (let index = openIndex + 1; index < text.length; index += 1) {
+    if (text[index] === '\\') {
+      index += 1;
+      continue;
+    }
+    if (text[index] === '[') depth += 1;
+    if (text[index] === ']') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+    if (text[index] === '\n' || text[index] === '\r') return -1;
+  }
+  return -1;
+}
+
+function findClosingDestination(text, openIndex) {
+  let depth = 1;
+  for (let index = openIndex + 1; index < text.length; index += 1) {
+    if (text[index] === '\\') {
+      index += 1;
+      continue;
+    }
+    if (text[index] === '(') depth += 1;
+    if (text[index] === ')') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+    if (text[index] === '\n' || text[index] === '\r') return -1;
+  }
+  return -1;
+}
+
+function normalizeReferenceLabel(label) {
+  return label.trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+function findReferenceLabels(text, blockRanges) {
+  const labels = new Set();
+  const definitionPattern = /^ {0,3}\[([^\]\r\n]+)\]:/gmu;
+  let match;
+  while ((match = definitionPattern.exec(text)) !== null) {
+    if (!rangesOverlap(match.index, match.index + match[0].length, blockRanges)) {
+      labels.add(normalizeReferenceLabel(match[1]));
+    }
+  }
+  return labels;
+}
+
+function findMarkdownLinkEnd(text, labelOpen, labelClose, referenceLabels) {
+  const next = labelClose + 1;
+  if (text[next] === '(') {
+    const destinationClose = findClosingDestination(text, next);
+    return destinationClose === -1 ? -1 : destinationClose + 1;
+  }
+
+  if (text[next] === '[') {
+    const referenceClose = findClosingBracket(text, next);
+    return referenceClose === -1 ? -1 : referenceClose + 1;
+  }
+
+  if (text[next] === ':') {
+    let lineEnd = next + 1;
+    while (lineEnd < text.length && text[lineEnd] !== '\n' && text[lineEnd] !== '\r') {
+      lineEnd += 1;
+    }
+    return lineEnd;
+  }
+
+  const label = normalizeReferenceLabel(text.slice(labelOpen + 1, labelClose));
+  if (referenceLabels.has(label)) return labelClose + 1;
+
+  return -1;
+}
+
+function findInlineRanges(text, blockRanges) {
+  const ranges = [];
+  const wikiRanges = [];
+  const referenceLabels = findReferenceLabels(text, blockRanges);
+  let index = 0;
+
+  while (index < text.length) {
+    const blockRange = containingRange(index, blockRanges);
+    if (blockRange) {
+      index = blockRange.end;
+      continue;
+    }
+
+    if (text.startsWith('[[', index)) {
+      const close = text.indexOf(']]', index + 2);
+      if (close !== -1) {
+        const range = { start: index, end: close + 2, type: 'wiki' };
+        ranges.push(range);
+        wikiRanges.push(range);
+        index = range.end;
+        continue;
+      }
+    }
+
+    if (text.startsWith('\\[\\[', index)) {
+      const escapedClose = text.indexOf('\\]\\]', index + 4);
+      const plainClose = text.indexOf(']]', index + 4);
+      const closes = [
+        escapedClose === -1 ? -1 : escapedClose + 4,
+        plainClose === -1 ? -1 : plainClose + 2,
+      ].filter((value) => value !== -1);
+      if (closes.length > 0) {
+        const end = Math.min(...closes);
+        ranges.push({ start: index, end, type: 'escaped-wiki' });
+        index = end;
+        continue;
+      }
+    }
+
+    if (text[index] === '`') {
+      let runEnd = index + 1;
+      while (text[runEnd] === '`') runEnd += 1;
+      const marker = text.slice(index, runEnd);
+      let close = text.indexOf(marker, runEnd);
+      while (close !== -1 && (text[close - 1] === '`' || text[close + marker.length] === '`')) {
+        close = text.indexOf(marker, close + marker.length);
+      }
+      if (close !== -1) {
+        const end = close + marker.length;
+        ranges.push({ start: index, end, type: 'inline-code' });
+        index = end;
+        continue;
+      }
+    }
+
+    const isImage = text[index] === '!' && text[index + 1] === '[';
+    const labelOpen = isImage ? index + 1 : index;
+    if (text[labelOpen] === '[') {
+      const labelClose = findClosingBracket(text, labelOpen);
+      if (labelClose !== -1) {
+        const linkEnd = findMarkdownLinkEnd(text, labelOpen, labelClose, referenceLabels);
+        if (linkEnd !== -1) {
+          ranges.push({ start: index, end: linkEnd, type: 'markdown-link' });
+          index = linkEnd;
+          continue;
+        }
+      }
+    }
+
+    const urlMatch = text.slice(index).match(
+      /^[A-Za-z][A-Za-z0-9+.-]*:(?:\/\/)?[^\s<>\[\]]+/u,
+    );
+    if (urlMatch) {
+      const end = index + urlMatch[0].length;
+      ranges.push({ start: index, end, type: 'url' });
+      index = end;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return { ranges, wikiRanges };
+}
+
+function mergeRanges(ranges) {
+  const sorted = [...ranges].sort((left, right) => left.start - right.start || left.end - right.end);
+  const merged = [];
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ start: range.start, end: range.end });
+    }
+  }
+  return merged;
+}
+
+function rangesOverlap(start, end, ranges) {
+  for (const range of ranges) {
+    if (range.start >= end) return false;
+    if (range.end > start && range.start < end) return true;
+  }
+  return false;
+}
+
+function codePointBefore(text, index) {
+  if (index <= 0) return '';
+  const finalUnit = text.charCodeAt(index - 1);
+  if (finalUnit >= 0xDC00 && finalUnit <= 0xDFFF && index >= 2) {
+    const firstUnit = text.charCodeAt(index - 2);
+    if (firstUnit >= 0xD800 && firstUnit <= 0xDBFF) return text.slice(index - 2, index);
+  }
+  return text[index - 1];
+}
+
+function codePointAt(text, index) {
+  if (index >= text.length) return '';
+  return String.fromCodePoint(text.codePointAt(index));
+}
+
+function boundaryIsSafe(text, start, length) {
+  const previous = codePointBefore(text, start);
+  const next = codePointAt(text, start + length);
+  return (!previous || !WORD_CONTINUATION.test(previous))
+    && (!next || !WORD_CONTINUATION.test(next));
+}
+
+function canonicalWikiTarget(text, range) {
+  let target = text.slice(range.start + 2, range.end - 2).split('|', 1)[0].trim();
+  target = target.split('#', 1)[0].trim();
+  target = target.replace(/\\/g, '/');
+  target = path.posix.basename(target);
+  if (target.toLowerCase().endsWith('.md')) target = target.slice(0, -3);
+  return target.replace(/_/g, ' ');
+}
+
+function findPoisonedFirstNames(text, registry, protectedRanges) {
+  const poisoned = new Set();
+  const pattern = /[\p{Lu}][\p{L}\p{M}'’\p{Pd}]*/gu;
+  let match;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const tail = text.slice(match.index + match[0].length).match(
+      /^[ \t]+([\p{Lu}][\p{L}\p{M}'’\p{Pd}]*)/u,
+    );
+    if (!tail) continue;
+
+    const start = match.index;
+    const phraseLength = match[0].length + tail[0].length;
+    const end = start + phraseLength;
+    if (rangesOverlap(start, end, protectedRanges)) continue;
+    if (!boundaryIsSafe(text, start, phraseLength)) continue;
+
+    const startsKnownFullName = [...registry.fullNames].some((knownFullName) => (
+      text.startsWith(knownFullName, start)
+      && boundaryIsSafe(text, start, knownFullName.length)
+      && !rangesOverlap(start, start + knownFullName.length, protectedRanges)
+    ));
+    if (startsKnownFullName) continue;
+
+    const fullName = `${match[0]} ${tail[1]}`;
+    if (!registry.fullNames.has(fullName) && registry.firstNameToFull.has(match[0])) {
+      poisoned.add(match[0]);
+    }
+  }
+
+  return poisoned;
+}
+
+function autoLinkContent(text, registry = buildRegistry()) {
+  const blockRanges = findBlockRanges(text);
+  const inline = findInlineRanges(text, blockRanges);
+  const protectedRanges = mergeRanges([...blockRanges, ...inline.ranges]);
+  const linkedPeople = new Set();
+
+  for (const wikiRange of inline.wikiRanges) {
+    const target = canonicalWikiTarget(text, wikiRange);
+    if (registry.fullNames.has(target)) linkedPeople.add(target);
+  }
+
+  const poisoned = findPoisonedFirstNames(text, registry, protectedRanges);
+  const ownerName = registry.ownerName || '';
+  const ownerFirstName = ownerName ? ownerName.split(/\s+/u)[0] : '';
+  const candidates = [];
+
+  for (const fullName of registry.fullNames) {
+    if (fullName === ownerName) continue;
+    candidates.push({ text: fullName, target: fullName, kind: 'full', priority: 0 });
+  }
+
+  for (const [alias, fullName] of registry.aliases || []) {
+    if (!fullName || fullName === ownerName || alias === ownerName || alias === ownerFirstName) continue;
+    candidates.push({ text: alias, target: fullName, kind: 'alias', priority: 1 });
+  }
+
+  for (const [firstName, fullName] of registry.firstNameToFull) {
+    if (
+      !fullName
+      || fullName === ownerName
+      || firstName === ownerName
+      || firstName === ownerFirstName
+      || STOPLIST.has(firstName)
+      || poisoned.has(firstName)
+    ) {
+      continue;
+    }
+    candidates.push({ text: firstName, target: fullName, kind: 'first', priority: 2 });
+  }
+
+  const occurrences = [];
+  for (const candidate of candidates) {
+    if (!candidate.text) continue;
+    let fromIndex = 0;
+    while (fromIndex < text.length) {
+      const start = text.indexOf(candidate.text, fromIndex);
+      if (start === -1) break;
+      const end = start + candidate.text.length;
+      if (
+        boundaryIsSafe(text, start, candidate.text.length)
+        && !rangesOverlap(start, end, protectedRanges)
+      ) {
+        occurrences.push({ ...candidate, start, end });
+      }
+      fromIndex = start + Math.max(1, candidate.text.length);
+    }
+  }
+
+  occurrences.sort((left, right) => (
+    left.start - right.start
+    || (right.end - right.start) - (left.end - left.start)
+    || left.priority - right.priority
+    || left.target.localeCompare(right.target)
+  ));
+
+  const replacements = [];
+  for (const occurrence of occurrences) {
+    if (linkedPeople.has(occurrence.target)) continue;
+    if (rangesOverlap(occurrence.start, occurrence.end, replacements)) continue;
+
+    const replacement = occurrence.kind === 'full'
+      ? `[[${occurrence.target}]]`
+      : `[[${occurrence.target}|${occurrence.text}]]`;
+    replacements.push({
+      start: occurrence.start,
+      end: occurrence.end,
+      replacement,
+    });
+    linkedPeople.add(occurrence.target);
+  }
+
+  let linkedText = text;
+  replacements.sort((left, right) => right.start - left.start);
+  for (const replacement of replacements) {
+    linkedText = linkedText.slice(0, replacement.start)
+      + replacement.replacement
+      + linkedText.slice(replacement.end);
+  }
+  return linkedText;
+}
+
+function addedWikiLinks(original, linked) {
+  const existingCounts = new Map();
+  for (const match of original.matchAll(/\[\[[^\]\r\n]+\]\]/gu)) {
+    existingCounts.set(match[0], (existingCounts.get(match[0]) || 0) + 1);
+  }
+
+  const added = [];
+  for (const match of linked.matchAll(/\[\[[^\]\r\n]+\]\]/gu)) {
+    const remaining = existingCounts.get(match[0]) || 0;
+    if (remaining > 0) existingCounts.set(match[0], remaining - 1);
+    else added.push(match[0]);
+  }
+  return added;
+}
+
+function displayPath(filePath, vaultRoot) {
+  const relative = vaultRoot ? path.relative(vaultRoot, filePath) : '';
+  return relative && !relative.startsWith('..') ? relative : filePath;
+}
+
+function processFile(filePath, options) {
+  const absolutePath = path.resolve(filePath);
+  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    throw new Error(`File not found: ${absolutePath}`);
+  }
+
+  const original = fs.readFileSync(absolutePath, 'utf-8');
+  const linked = autoLinkContent(original, options.registry);
+  const added = addedWikiLinks(original, linked);
+  if (linked !== original && !options.dryRun) {
+    fs.writeFileSync(absolutePath, linked, 'utf-8');
+  }
+  return { filePath: absolutePath, changed: linked !== original, added };
+}
+
+function reportResult(result, options) {
+  const fileName = displayPath(result.filePath, options.vaultRoot);
+  if (!result.changed) {
+    console.log(`${fileName}: no changes`);
+    return;
+  }
+
+  const noun = result.added.length === 1 ? 'link' : 'links';
+  if (options.dryRun) {
+    console.log(`[dry-run] ${fileName}: would add ${result.added.length} person ${noun}`);
+  } else {
+    console.log(`${fileName}: added ${result.added.length} person ${noun}`);
+  }
+  for (const wikiLink of result.added) console.log(`  ${wikiLink}`);
+}
+
+function localDateString(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function isTodaysMeeting(filePath, meetingsDirectory, today) {
+  const relative = path.relative(meetingsDirectory, filePath);
+  if (relative.split(path.sep).includes(today)) return true;
+
+  const stem = path.basename(filePath, path.extname(filePath));
+  return stem === today
+    || stem.startsWith(`${today}-`)
+    || stem.startsWith(`${today}_`)
+    || stem.startsWith(`${today} `);
+}
+
+function printUsage() {
+  console.error('Usage: node .scripts/auto-link-people.cjs <file>');
+  console.error('       node .scripts/auto-link-people.cjs --dry-run <file>');
+  console.error('       node .scripts/auto-link-people.cjs [--dry-run] --today');
+}
+
+function runCli() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const remaining = args.filter((argument) => argument !== '--dry-run');
+  const todayMode = remaining.includes('--today');
+  const paths = loadPaths();
+  const registry = buildRegistry(paths);
+  const options = { dryRun, registry, vaultRoot: paths.VAULT_ROOT };
+
+  if (todayMode) {
+    if (remaining.length !== 1) {
+      printUsage();
+      process.exitCode = 1;
+      return;
+    }
+
+    const today = localDateString();
+    const meetingFiles = listMarkdownFiles(paths.MEETINGS_DIR)
+      .filter((filePath) => isTodaysMeeting(filePath, paths.MEETINGS_DIR, today));
+    if (meetingFiles.length === 0) {
+      console.log(`No meeting notes found for ${today}.`);
+      return;
+    }
+
+    for (const filePath of meetingFiles) {
+      const result = processFile(filePath, options);
+      reportResult(result, options);
+    }
+    return;
+  }
+
+  if (remaining.length !== 1 || remaining[0].startsWith('--')) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = processFile(remaining[0], options);
+  reportResult(result, options);
+}
+
+if (require.main === module) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { autoLinkContent, buildRegistry };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.34.0] - People in your notes now link themselves — safely (2026-07-11)
+
+People auto-linking was promised but never shipped (issue #46); this release finally delivers it with safeguards that keep links accurate.
+
+**What this fixes for you:**
+
+* **People become connected on their first useful mention.** Full names, unique aliases, and safe unique first names now create backlinks to the right person page without cluttering every mention.
+* **Dex never guesses on ambiguous names.** Shared first names, common English words, and names that could refer to someone unknown stay as plain text.
+* **Your identity and carefully formatted text stay untouched.** Your own name, existing links, note metadata, code, and Markdown links are preserved, and running the feature again adds nothing extra.
+
+---
+
 ## [1.33.0] - 'Off' and 'broken' now mean different things — everywhere (2026-07-11)
 
 Dex could describe an optional feature as broken in one place and merely disconnected in another; this release gives those responses one shared meaning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ When the user shares meeting notes or says they had a meeting:
 4. Suggest follow-ups. Use the `query` tool to search for implicit commitments — soft language like "we should revisit" or "let me think about" that regex might not catch as action items.
 5. If meeting with manager and Career folder exists, extract career development context
 
-**Automation:** When meetings are processed via `/process-meetings`, skill-scoped hooks automatically update person pages with meeting references and extracted context. Manual person page updates are still applied for ad-hoc meeting notes shared outside the skill.
+**Automation:** When meetings are processed via `/process-meetings`, skill-scoped hooks automatically update person pages with meeting references and extracted context. Manual person page updates are still applied for ad-hoc meeting notes shared outside the skill. Person names in processed meeting notes are auto-linked to their person pages by `.scripts/auto-link-people.cjs`; it runs during `/process-meetings` and can also be run manually on any file.
 
 ### Task Creation (Smart Pillar Inference)
 When the user requests task creation without specifying a pillar:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

The feature CLAUDE.md promised for two months, built for real. Closes #46.

- `.scripts/auto-link-people.cjs` (new): converts known people's names to `[[wiki-links]]` in vault markdown.
  - Registry from **all** People subdirectories via `loadPaths()` (no hardcoded folder names); aliases from `Goes by "X"` lines; owner excluded.
  - Safety-first linking: full names always; first names only when unambiguous, not poisoned by an unknown "First Last" in the same file, and not on a common-English-word stoplist (Will, May, Grace…).
  - Never touches frontmatter, code blocks, inline code, existing wiki-links, markdown links, or URLs. Unicode-safe word boundaries. First occurrence per person per file. Idempotent — second run is a no-op.
  - CLI: `<file>`, `--dry-run <file>`, `--today`. Module exports for reuse.
- Wired into `/process-meetings` as an explicit step; CLAUDE.md gets one accurate sentence (no "mandatory" over-promise — that's what v1.26.0 removed).
- 18 new hook tests (44 total pass).
- Nice closure: the v1.32.0 referenced-scripts gate — which would have caught #46 the day it happened — now verifies this very file ships.

## Test plan

- [x] `node --test .claude/hooks/tests/*.test.cjs` — 44/44
- [x] Live demo: dry-run predicts, real run links first prose occurrence only (inline code untouched), second run reports "no changes"
- [x] Instructed-tool gate, path-contract, doc-drift, test-delta, verify-distribution (0 errors) all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG