### PR TITLE
Tasks remember what you told them: metadata round-trips, validated links, due/project/goal fields

### DIFF
--- a/.claude/hooks/meeting-cache-builder.cjs
+++ b/.claude/hooks/meeting-cache-builder.cjs
@@ -8,7 +8,7 @@
  * Usage: node meeting-cache-builder.cjs [--rebuild]
  *   --rebuild: Reprocess all meetings (not just recent ones)
  *
- * Reads: 00-Inbox/Meetings/*.md
+ * Reads: Markdown files recursively under 00-Inbox/Meetings/ (excluding queue/ subtrees)
  * Writes: System/Memory/meeting-cache.json
  */
 
@@ -101,8 +101,9 @@ function extractSection(content, heading) {
       let item = trimmed.slice(2).trim();
       // Strip checkbox markers: [ ] or [x]
       item = item.replace(/^\[[ x]\]\s*/, "");
-      // Strip task IDs: ^task-XXXXXXXX-XXX
-      item = item.replace(/\s*\^task-\d{8}-\d{3}\s*$/, "");
+      // Strip completion timestamps and task IDs in either stored layout.
+      item = item.replace(/\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}/, "");
+      item = item.replace(/\s*\^task-\d{8}-\d{3}\b/, "");
       // Strip WikiLink wrappers: [[path|display]] -> display
       item = item.replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, "$1");
       item = item.replace(/\[\[([^\]]*)\]\]/g, "$1");
@@ -356,6 +357,20 @@ function pruneOldEntries(cache) {
 // Main
 // ---------------------------------------------------------------------------
 
+function findMeetingFiles(directory) {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "queue") continue;
+      files.push(...findMeetingFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md") {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
 function main() {
   // Guard: meetings directory must exist
   if (!fs.existsSync(MEETINGS_DIR)) {
@@ -363,10 +378,8 @@ function main() {
     process.exit(0);
   }
 
-  // List meeting markdown files (skip README)
-  const files = fs.readdirSync(MEETINGS_DIR).filter((f) => {
-    return f.endsWith(".md") && f !== "README.md";
-  });
+  // List meeting markdown files recursively (skip README and queue subtrees).
+  const files = findMeetingFiles(MEETINGS_DIR);
 
   if (files.length === 0) {
     process.stderr.write("[meeting-cache] No meeting files found\n");
@@ -388,8 +401,8 @@ function main() {
   let processed = 0;
   let skipped = 0;
 
-  for (const fileName of files) {
-    const filePath = path.join(MEETINGS_DIR, fileName);
+  for (const filePath of files) {
+    const fileName = path.basename(filePath);
     const relativePath = path.relative(VAULT_ROOT, filePath);
 
     // Get file modification time

--- a/.claude/hooks/tests/hook-harness.test.cjs
+++ b/.claude/hooks/tests/hook-harness.test.cjs
@@ -105,3 +105,55 @@ test('safety guard uses its documented exit 2 contract for blocked commands', (t
   assert.equal(result.status, 2);
   assert.match(result.stdout, /Blocked/);
 });
+
+test('meeting cache builder reads dated folders and skips queue', (t) => {
+  const sandbox = createSandbox(t);
+  const day = new Date().toISOString().slice(0, 10);
+  const meetingsDir = path.join(sandbox.vault, '00-Inbox', 'Meetings');
+  const datedDir = path.join(meetingsDir, day);
+  const queueDir = path.join(datedDir, 'queue');
+  fs.mkdirSync(datedDir, { recursive: true });
+  fs.mkdirSync(queueDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(datedDir, 'customer-sync.md'),
+    [
+      '---',
+      `date: ${day}`,
+      'participants: [Jane Doe]',
+      '---',
+      '# Nested Customer Sync',
+      '',
+      '## Action Items',
+      '',
+      '- [x] Close old loop ^task-20260711-061 ✅ 2026-07-10 08:30',
+      '- [x] Close new loop ✅ 2026-07-10 08:30 ^task-20260711-062',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(queueDir, 'must-not-cache.md'),
+    `---\ndate: ${day}\n---\n# Must Not Cache\n`,
+  );
+
+  const hookPath = path.join(HOOKS_DIR, 'meeting-cache-builder.cjs');
+  const result = spawnSync(process.execPath, [hookPath, '--rebuild'], {
+    cwd: sandbox.vault,
+    encoding: 'utf-8',
+    env: minimalEnv(sandbox),
+    timeout: 10_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `meeting-cache-builder.cjs exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  const cachePath = path.join(sandbox.vault, 'System', 'Memory', 'meeting-cache.json');
+  const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+  assert.deepEqual(cache.meetings.map((meeting) => meeting.title), ['Nested Customer Sync']);
+  assert.equal(
+    cache.meetings[0].source_file,
+    path.join('00-Inbox', 'Meetings', day, 'customer-sync.md'),
+  );
+  assert.deepEqual(cache.meetings[0].action_items, ['Close old loop', 'Close new loop']);
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.35.0] - Tasks now remember what you told them (2026-07-11)
+
+When you created a task and confirmed its pillar and priority, Dex wrote them down — and then never read them back, re-guessing both from the task's wording every time it listed your tasks. A P0 could show up as P2 unless its title happened to sound urgent. This release makes task details stick, and adds the fields tasks always needed.
+
+**What this fixes for you:**
+
+* **The priority and pillar you confirm are the ones you see.** Lists, focus suggestions, and limits now read the stored values instead of guessing from the title.
+* **Tasks linked to a weekly priority finally count.** Goal and week progress now include tasks you created through Dex — before, those links were written where nothing could read them, so rollups showed zero.
+* **Tasks can carry a due date, a project, and a quarterly goal.** All optional, all checked when set — an unknown goal or missing project file gets a helpful error listing what's available instead of a silent dead link.
+* **Duplicate detection stops teaching the wrong habit.** When Dex flags a similar task, you can now say "create it anyway" — before, the suggested workaround was to reword the title, which defeated the duplicate check entirely.
+* **A rare data-loss bug is gone.** Adding a task to a section whose heading appeared twice in your task file could silently delete everything after the second heading. Inserts are now safe no matter what your file looks like.
+* **Completed tasks stay clickable in Obsidian.** The completion timestamp used to be written where it broke Obsidian's link-to-this-line feature; it now goes before the link anchor.
+* **Meeting prep sees all your meetings again.** Synced meetings are stored in dated folders that the meeting memory never looked inside — daily plans and meeting prep were blind to them. Both now scan the full folder tree.
+
 ## [1.34.0] - People in your notes now link themselves — safely (2026-07-11)
 
 People auto-linking was promised but never shipped (issue #46); this release finally delivers it with safeguards that keep links accurate.

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -376,6 +376,98 @@ def extract_task_id(line: str) -> Optional[str]:
     match = re.search(r'\^(task-\d{8}-\d{3})', line)
     return match.group(1) if match else None
 
+def _is_indented_bullet(line: str) -> bool:
+    """Return whether a line is an indented child bullet of a task."""
+    return bool(re.match(r'^[ \t]+-\s+', line))
+
+def _indent_width(line: str) -> int:
+    """Return indentation width with tabs normalized for hierarchy checks."""
+    match = re.match(r'^[ \t]*', line)
+    return len(match.group(0).expandtabs(4)) if match else 0
+
+def _task_child_lines(lines: List[str], task_index: int) -> List[str]:
+    """Return direct child bullets without borrowing a sibling task's metadata."""
+    task_indent = _indent_width(lines[task_index])
+    descendants = []
+    index = task_index + 1
+    while index < len(lines) and _is_indented_bullet(lines[index]):
+        indent = _indent_width(lines[index])
+        if indent <= task_indent:
+            break
+        descendants.append((indent, lines[index]))
+        index += 1
+    if not descendants:
+        return []
+    direct_indent = min(indent for indent, _line in descendants)
+    return [line for indent, line in descendants if indent == direct_indent]
+
+def _parse_task_metadata(child_lines: List[str], title: str) -> Dict[str, Any]:
+    """Parse additive task metadata, silently ignoring malformed values."""
+    fields: Dict[str, str] = {}
+    for child_line in child_lines:
+        bullet = re.sub(r'^[ \t]+-\s*', '', child_line, count=1)
+        for part in bullet.split('|'):
+            match = re.match(
+                r'^\s*(Pillar|Priority|Weekly priority|Due|Source|Project|Goal)\s*:\s*(.*?)\s*$',
+                part,
+                re.IGNORECASE,
+            )
+            if match:
+                fields[match.group(1).lower()] = match.group(2)
+
+    pillar = guess_pillar(title)
+    stored_pillar = fields.get('pillar')
+    if stored_pillar:
+        stored_pillar_lower = stored_pillar.casefold()
+        pillar = next(
+            (
+                pillar_key
+                for pillar_key, pillar_info in PILLARS.items()
+                if str(pillar_info.get('name', '')).casefold() == stored_pillar_lower
+            ),
+            pillar,
+        )
+
+    priority = fields.get('priority')
+    if priority not in PRIORITIES:
+        priority = None
+
+    weekly_priority_id = None
+    weekly_match = re.fullmatch(
+        r'\[(week-\d{4}-W\d{2}-p\d+)\]', fields.get('weekly priority', '')
+    )
+    if weekly_match:
+        weekly_priority_id = weekly_match.group(1)
+
+    due = fields.get('due')
+    if due and not re.fullmatch(r'\d{4}-\d{2}-\d{2}', due):
+        due = None
+
+    goal = fields.get('goal')
+    if goal and not re.fullmatch(r'Q\d+-\d{4}-goal-\d+', goal):
+        goal = None
+
+    return {
+        'pillar': pillar,
+        'priority': priority,
+        'weekly_priority_id': weekly_priority_id,
+        'due': due,
+        'source': fields.get('source') or None,
+        'project': fields.get('project') or None,
+        'goal': goal,
+    }
+
+def _task_title_from_line(line: str) -> str:
+    """Extract task text while accepting both completion timestamp layouts."""
+    title = re.sub(r'^\s*-\s*\[[x ]\]\s*', '', line, count=1)
+    title = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', title)
+    title = re.sub(r'\s*\^task-\d{8}-\d{3}\b', '', title)
+    title = title.strip()
+    bold_match = re.match(r'^\*\*(.+?)\*\*(.*)$', title)
+    if bold_match:
+        title = (bold_match.group(1) + bold_match.group(2)).strip()
+    return title
+
 def find_task_by_id(task_id: str) -> List[Dict[str, Any]]:
     """Find all instances of a task ID across all markdown files"""
     instances = []
@@ -388,8 +480,7 @@ def find_task_by_id(task_id: str) -> List[Dict[str, Any]]:
             for i, line in enumerate(lines):
                 if f'^{task_id}' in line and ('- [ ]' in line or '- [x]' in line):
                     # Extract task title
-                    title_match = re.match(r'-\s*\[[x ]\]\s*\*?\*?(.+?)\*?\*?\s*\^', line.strip())
-                    title = title_match.group(1).strip() if title_match else line.strip()
+                    title = _task_title_from_line(line).split('|', 1)[0].strip()
                     
                     instances.append({
                         'file': str(md_file),
@@ -427,23 +518,26 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
             line_idx = instance['line_number'] - 1
             old_line = lines[line_idx]
             
-            # Update checkbox and add/remove completion timestamp
+            # Update checkbox and normalize completion metadata around the anchor.
             if completed:
                 new_line = old_line.replace('- [ ]', '- [x]')
-                
-                # Add completion timestamp after task ID if not already present
-                # Remove any existing timestamp first
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
-                
-                # Find position after task ID to insert timestamp
                 task_id_match = re.search(r'\^' + re.escape(task_id), new_line)
                 if task_id_match:
-                    insert_pos = task_id_match.end()
-                    new_line = new_line[:insert_pos] + f' ✅ {completion_timestamp}' + new_line[insert_pos:]
+                    without_anchor = (
+                        new_line[:task_id_match.start()] + new_line[task_id_match.end():]
+                    ).rstrip()
+                    new_line = f'{without_anchor} ✅ {completion_timestamp} ^{task_id}'
             else:
                 # Uncompleting: change checkbox and remove timestamp
                 new_line = old_line.replace('- [x]', '- [ ]')
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
+                task_id_match = re.search(r'\^' + re.escape(task_id), new_line)
+                if task_id_match:
+                    without_anchor = (
+                        new_line[:task_id_match.start()] + new_line[task_id_match.end():]
+                    ).rstrip()
+                    new_line = f'{without_anchor} ^{task_id}'
             
             if new_line != old_line:
                 lines[line_idx] = new_line
@@ -578,6 +672,7 @@ def find_tasks_for_page(page_path: str) -> List[Dict[str, Any]]:
     
     matching_tasks = []
     current_section = None
+    current_section_priority = None
     
     i = 0
     while i < len(lines):
@@ -586,6 +681,7 @@ def find_tasks_for_page(page_path: str) -> List[Dict[str, Any]]:
         # Track section headers
         if line.startswith('# ') or line.startswith('## '):
             current_section = line.lstrip('#').strip()
+            current_section_priority = priority_from_section(current_section)
             i += 1
             continue
         
@@ -606,28 +702,25 @@ def find_tasks_for_page(page_path: str) -> List[Dict[str, Any]]:
             
             if task_mentions_page:
                 # Extract title
-                title_match = re.match(r'-\s*\[[x ]\]\s*\*?\*?(.+?)\*?\*?(?:\s*\|.*)?$', line.strip())
-                title = title_match.group(1).strip() if title_match else line.strip()[6:]
+                title = _task_title_from_line(line)
                 
                 # Clean title of file references for display
                 clean_title = re.sub(r'\s*\|\s*(?:People|Active)/[^\s]+', '', title)
                 clean_title = re.sub(r'\s+\.md\b', '', clean_title)
                 clean_title = re.sub(r'\s*\|.*$', '', clean_title)  # Remove trailing | refs
                 
-                # Look for context/priority in following lines
-                priority = 'P2'
-                j = i + 1
-                while j < len(lines) and lines[j].strip().startswith('\t-'):
-                    if 'Priority:' in lines[j]:
-                        priority_match = re.search(r'Priority:\s*(P[0-3])', lines[j])
-                        if priority_match:
-                            priority = priority_match.group(1)
-                    j += 1
+                metadata = _parse_task_metadata(_task_child_lines(lines, i), clean_title)
+                priority = (
+                    metadata['priority']
+                    or current_section_priority
+                    or guess_priority(clean_title)
+                )
                 
                 matching_tasks.append({
                     'title': clean_title,
                     'completed': completed,
                     'priority': priority,
+                    'pillar': metadata['pillar'],
                     'section': current_section,
                     'line_number': i + 1
                 })
@@ -1021,7 +1114,19 @@ def rebuild_meeting_cache_data() -> Dict[str, Any]:
     if not meetings_dir.exists():
         return {'success': False, 'error': 'No meetings directory found'}
 
-    files = [f for f in meetings_dir.glob('*.md') if f.name != 'README.md']
+    meetings_root = meetings_dir.resolve()
+    files = []
+    for filepath in meetings_dir.rglob('*.md'):
+        relative_path = filepath.relative_to(meetings_dir)
+        if filepath.name == 'README.md' or 'queue' in relative_path.parts[:-1]:
+            continue
+        try:
+            if filepath.is_symlink():
+                continue
+            filepath.resolve().relative_to(meetings_root)
+        except (OSError, ValueError):
+            continue
+        files.append(filepath)
     if not files:
         return {'success': False, 'error': 'No meeting files found'}
 
@@ -1144,7 +1249,8 @@ def _parse_meeting_file_python(content: str, filename: str, rel_path: str) -> Di
             if stripped.startswith('- '):
                 item = stripped[2:].strip()
                 item = re.sub(r'^\[[ x]\]\s*', '', item)
-                item = re.sub(r'\s*\^task-\d{8}-\d{3}\s*$', '', item)
+                item = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', item)
+                item = re.sub(r'\s*\^task-\d{8}-\d{3}\b', '', item)
                 item = re.sub(r'\[\[[^\]|]*\|([^\]]*)\]\]', r'\1', item)
                 item = re.sub(r'\[\[([^\]]*)\]\]', r'\1', item)
                 item = re.sub(r'\*\*([^*]+)\*\*', r'\1', item)
@@ -1892,21 +1998,22 @@ def find_linked_tasks(priority_id: str) -> List[Dict[str, Any]]:
     
     linked_tasks = []
     for i, line in enumerate(lines):
-        # Look for tasks that mention the priority_id
-        if priority_id in line and ('- [ ]' in line or '- [x]' in line):
-            completed = '- [x]' in line
-            task_id = extract_task_id(line)
-            
-            # Extract title
-            title_match = re.match(r'-\s*\[[x ]\]\s*\*?\*?(.+?)\*?\*?(?:\s*\^task-|\s*\|)', line.strip())
-            title = title_match.group(1).strip() if title_match else line.strip()
-            
-            linked_tasks.append({
-                'task_id': task_id,
-                'title': title,
-                'completed': completed,
-                'line_number': i + 1
-            })
+        if not (line.strip().startswith('- [ ]') or line.strip().startswith('- [x]')):
+            continue
+
+        linked_text = '\n'.join([line, *_task_child_lines(lines, i)])
+        priority_pattern = (
+            rf'(?<![A-Za-z0-9_-]){re.escape(priority_id)}(?![A-Za-z0-9_-])'
+        )
+        if not re.search(priority_pattern, linked_text):
+            continue
+
+        linked_tasks.append({
+            'task_id': extract_task_id(line),
+            'title': _task_title_from_line(line).split('|', 1)[0].strip(),
+            'completed': '- [x]' in line,
+            'line_number': i + 1
+        })
     
     return linked_tasks
 
@@ -2060,9 +2167,8 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
             # Extract task ID if present
             task_id = extract_task_id(line)
             
-            # Extract task title (remove the checkbox and task ID)
-            title_match = re.match(r'-\s*\[[x ]\]\s*\*?\*?(.+?)\*?\*?(?:\s*\^task-\d{8}-\d{3})?\s*$', line.strip())
-            title = title_match.group(1).strip() if title_match else line.strip()[6:]
+            # Extract task title (remove checkbox, completion mark, and task ID)
+            title = _task_title_from_line(line)
             
             # Clean title - remove file path references for display
             clean_title = re.sub(r'\s*\|\s*(?:People|Active)/[^\s]+', '', title)
@@ -2072,6 +2178,8 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
             # Determine status
             status = 'd' if completed else 'n'
             
+            metadata = _parse_task_metadata(_task_child_lines(lines, i), clean_title)
+
             tasks.append({
                 'id': task_id or f'temp-{task_counter}',
                 'task_id': task_id,  # The actual ^task-YYYYMMDD-XXX ID
@@ -2082,8 +2190,17 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
                 'status': status,
                 'line_number': i + 1,
                 'source_file': str(filepath),
-                'pillar': guess_pillar(clean_title),
-                'priority': current_section_priority or guess_priority(clean_title),
+                'pillar': metadata['pillar'],
+                'priority': (
+                    metadata['priority']
+                    or current_section_priority
+                    or guess_priority(clean_title)
+                ),
+                'weekly_priority_id': metadata['weekly_priority_id'],
+                'due': metadata['due'],
+                'source': metadata['source'],
+                'project': metadata['project'],
+                'goal': metadata['goal'],
             })
     
     return tasks
@@ -2096,6 +2213,9 @@ def get_all_tasks() -> List[Dict[str, Any]]:
     if get_tasks_file().exists():
         tasks = parse_tasks_file(get_tasks_file())
         for t in tasks:
+            metadata_source = t.pop('source', None)
+            if metadata_source:
+                t['metadata_source'] = metadata_source
             t['source'] = 'tasks'
         all_tasks.extend(tasks)
     
@@ -2103,6 +2223,9 @@ def get_all_tasks() -> List[Dict[str, Any]]:
     if get_week_priorities_file().exists():
         tasks = parse_tasks_file(get_week_priorities_file())
         for t in tasks:
+            metadata_source = t.pop('source', None)
+            if metadata_source:
+                t['metadata_source'] = metadata_source
             t['source'] = 'week_priorities'
         all_tasks.extend(tasks)
     
@@ -3000,6 +3123,10 @@ async def handle_list_tools() -> list[types.Tool]:
                     "context": {"type": "string", "description": "Additional context or sub-tasks"},
                     "section": {"type": "string", "description": "Which section in 03-Tasks/Tasks.md to add to", "default": "Next Week"},
                     "weekly_priority_id": {"type": "string", "description": "Link to weekly priority (e.g., 'week-2026-W05-p1') - task contributes to this priority"},
+                    "due": {"type": "string", "description": "Optional due date in YYYY-MM-DD format"},
+                    "project": {"type": "string", "description": "Optional existing vault-relative project path under 04-Projects/"},
+                    "goal": {"type": "string", "description": "Optional quarterly goal ID (e.g., Q3-2026-goal-2)"},
+                    "on_duplicate": {"type": "string", "enum": ["fail", "force"], "default": "fail", "description": "Fail on similar tasks, or force creation past only the similarity check"},
                     "account": {"type": "string", "description": "Path to account page to link"},
                     "people": {"type": "array", "items": {"type": "string"}, "description": "List of paths to people pages to link"}
                 },
@@ -3498,6 +3625,10 @@ async def _handle_call_tool_inner(
         context = arguments.get('context', '')
         section = arguments.get('section', 'Next Week')
         weekly_priority_id = arguments.get('weekly_priority_id', '')
+        due = arguments.get('due', '')
+        project = arguments.get('project', '')
+        goal = arguments.get('goal', '')
+        on_duplicate = arguments.get('on_duplicate', 'fail')
         account = arguments.get('account', '')
         people = arguments.get('people', [])
         
@@ -3514,6 +3645,85 @@ async def _handle_call_tool_inner(
                 "success": False,
                 "error": f"Invalid priority '{priority}'. Must be one of: {PRIORITIES}"
             }, indent=2))]
+
+        if on_duplicate not in ('fail', 'force'):
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": "Invalid on_duplicate value. Must be one of: ['fail', 'force']"
+            }, indent=2))]
+
+        if weekly_priority_id:
+            weekly_priorities = parse_weekly_priorities(get_week_priorities_file())
+            available_weekly_ids = [
+                weekly.get('priority_id')
+                for weekly in weekly_priorities
+                if weekly.get('priority_id')
+            ]
+            if weekly_priority_id not in available_weekly_ids:
+                available_text = ', '.join(available_weekly_ids) or 'none'
+                return [types.TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Unknown weekly priority '{weekly_priority_id}'. "
+                        f"Available weekly priority ids: {available_text}"
+                    ),
+                    "available_weekly_priority_ids": available_weekly_ids,
+                }, indent=2))]
+
+        if due and not re.fullmatch(r'\d{4}-\d{2}-\d{2}', due):
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": f"Invalid due date '{due}'. Use YYYY-MM-DD format."
+            }, indent=2))]
+
+        if project:
+            projects_dir = (BASE_DIR / '04-Projects').resolve()
+            supplied_project = Path(project)
+            project_path = (BASE_DIR / supplied_project).resolve()
+            project_is_contained = (
+                not supplied_project.is_absolute()
+                and (project_path == projects_dir or projects_dir in project_path.parents)
+            )
+            if not project_is_contained:
+                return [types.TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": "Project must be a vault-relative file under 04-Projects/."
+                }, indent=2))]
+            if not project_path.is_file():
+                requested_stem = supplied_project.stem.casefold()
+                close_matches = []
+                if projects_dir.exists():
+                    close_matches = sorted(
+                        str(candidate.relative_to(BASE_DIR))
+                        for candidate in projects_dir.rglob('*.md')
+                        if (
+                            requested_stem in candidate.stem.casefold()
+                            or candidate.stem.casefold() in requested_stem
+                        )
+                    )
+                return [types.TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": f"Project file does not exist: {project}",
+                    "close_matches": close_matches,
+                }, indent=2))]
+
+        if goal:
+            quarterly_goals = parse_quarterly_goals(QUARTER_GOALS_FILE)
+            available_goal_ids = [
+                quarterly_goal.get('goal_id')
+                for quarterly_goal in quarterly_goals
+                if quarterly_goal.get('goal_id')
+            ]
+            if goal not in available_goal_ids:
+                available_text = ', '.join(available_goal_ids) or 'none'
+                return [types.TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Unknown quarterly goal '{goal}'. "
+                        f"Available goal ids: {available_text}"
+                    ),
+                    "available_goal_ids": available_goal_ids,
+                }, indent=2))]
         
         # Check ambiguity
         if is_ambiguous(title):
@@ -3528,14 +3738,14 @@ async def _handle_call_tool_inner(
         
         # Check for duplicates
         existing_tasks = get_all_tasks()
-        similar = find_similar_tasks(title, existing_tasks)
+        similar = find_similar_tasks(title, existing_tasks) if on_duplicate == 'fail' else []
         if similar:
             return [types.TextContent(type="text", text=json.dumps({
                 "success": False,
                 "error": "Potential duplicate detected",
                 "title": title,
                 "similar_tasks": similar,
-                "suggestion": "Review these similar tasks. If still unique, rephrase the title to be more distinct."
+                "suggestion": "Review these similar tasks. If this is intentionally separate, retry with on_duplicate=force."
             }, indent=2))]
         
         # Check priority limits against the canonical backlog only.
@@ -3543,11 +3753,27 @@ async def _handle_call_tool_inner(
         priority_counts = Counter(t.get('priority', 'P2') for t in active_tasks)
         
         if priority in PRIORITY_LIMITS and priority_counts.get(priority, 0) >= PRIORITY_LIMITS[priority]:
+            occupying_tasks = [
+                {
+                    "title": task.get('title', ''),
+                    "task_id": task.get('task_id') or task.get('id'),
+                }
+                for task in active_tasks
+                if task.get('priority', 'P2') == priority
+            ]
+            occupying_text = ', '.join(
+                f"{task['title']} ({task['task_id']})" for task in occupying_tasks
+            )
             return [types.TextContent(type="text", text=json.dumps({
                 "success": False,
-                "error": f"Priority limit exceeded for {priority}",
+                "error": (
+                    f"Priority limit exceeded for {priority}. Currently occupying "
+                    f"this priority: {occupying_text}. Limits may be newly enforced "
+                    "now that stored priorities are read correctly."
+                ),
                 "current_count": priority_counts.get(priority, 0),
                 "limit": PRIORITY_LIMITS[priority],
+                "occupying_tasks": occupying_tasks,
                 "suggestion": f"You have too many {priority} tasks. Complete or deprioritize some before adding more."
             }, indent=2))]
         
@@ -3575,6 +3801,12 @@ async def _handle_call_tool_inner(
         task_entry += f"\n\t- Pillar: {pillar_name} | Priority: {priority}"
         if weekly_priority_id:
             task_entry += f" | Weekly priority: [{weekly_priority_id}]"
+        if due:
+            task_entry += f" | Due: {due}"
+        if project:
+            task_entry += f" | Project: {project}"
+        if goal:
+            task_entry += f" | Goal: {goal}"
         
         # Add to 03-Tasks/Tasks.md under the appropriate section
         if get_tasks_file().exists():
@@ -3584,10 +3816,19 @@ async def _handle_call_tool_inner(
         
         # Find the section and add the task
         section_header = f"## {section}"
-        if section_header in content:
-            # Add after section header
-            parts = content.split(section_header)
-            new_content = parts[0] + section_header + "\n" + task_entry + "\n" + parts[1]
+        section_match = re.search(
+            rf'(?m)^{re.escape(section_header)}(?=\r?$)', content
+        )
+        if section_match:
+            # Insert after the first exact heading without reconstructing user data.
+            insert_at = section_match.end()
+            new_content = (
+                content[:insert_at]
+                + "\n"
+                + task_entry
+                + "\n"
+                + content[insert_at:]
+            )
         else:
             # Create new section at the top
             lines = content.split('\n')
@@ -3630,6 +3871,9 @@ async def _handle_call_tool_inner(
                 "priority": priority,
                 "section": section,
                 "weekly_priority_id": weekly_priority_id if weekly_priority_id else None,
+                "due": due if due else None,
+                "project": project if project else None,
+                "goal": goal if goal else None,
                 "account": account if account else None,
                 "people": people if people else None
             },

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -116,6 +116,7 @@ from core.paths import (
     PEOPLE_DIR,
     PEOPLE_INDEX_FILE,
     PILLARS_FILE,
+    PROJECTS_DIR,
     QUARTER_GOALS_FILE,
     SKILL_RATINGS_FILE,
     TASKS_FILE,
@@ -3124,7 +3125,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     "section": {"type": "string", "description": "Which section in 03-Tasks/Tasks.md to add to", "default": "Next Week"},
                     "weekly_priority_id": {"type": "string", "description": "Link to weekly priority (e.g., 'week-2026-W05-p1') - task contributes to this priority"},
                     "due": {"type": "string", "description": "Optional due date in YYYY-MM-DD format"},
-                    "project": {"type": "string", "description": "Optional existing vault-relative project path under 04-Projects/"},
+                    "project": {"type": "string", "description": f"Optional existing vault-relative project path under {PROJECTS_DIR.name}/"},
                     "goal": {"type": "string", "description": "Optional quarterly goal ID (e.g., Q3-2026-goal-2)"},
                     "on_duplicate": {"type": "string", "enum": ["fail", "force"], "default": "fail", "description": "Fail on similar tasks, or force creation past only the similarity check"},
                     "account": {"type": "string", "description": "Path to account page to link"},
@@ -3677,7 +3678,7 @@ async def _handle_call_tool_inner(
             }, indent=2))]
 
         if project:
-            projects_dir = (BASE_DIR / '04-Projects').resolve()
+            projects_dir = (BASE_DIR / PROJECTS_DIR.name).resolve()
             supplied_project = Path(project)
             project_path = (BASE_DIR / supplied_project).resolve()
             project_is_contained = (
@@ -3687,7 +3688,7 @@ async def _handle_call_tool_inner(
             if not project_is_contained:
                 return [types.TextContent(type="text", text=json.dumps({
                     "success": False,
-                    "error": "Project must be a vault-relative file under 04-Projects/."
+                    "error": f"Project must be a vault-relative file under {PROJECTS_DIR.name}/."
                 }, indent=2))]
             if not project_path.is_file():
                 requested_stem = supplied_project.stem.casefold()

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -248,7 +248,7 @@ def test_golden_task_lifecycle_propagates_and_rolls_up(fixture_vault: Path, tmp_
         line for line in journey["tasks_after_complete"].splitlines() if f"^{task_id}" in line
     )
     assert completed_line.startswith("- [x]")
-    assert completed_line.index(updated["completed_at"]) > completed_line.index(f"^{task_id}")
+    assert completed_line.index(updated["completed_at"]) < completed_line.index(f"^{task_id}")
     assert f"| ✅ | {title} | P2 |" in journey["person_after_complete"]
 
     initial_active = journey["initial_summary"]["daily_summary"]["total_tasks"]

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -1,0 +1,646 @@
+"""Regression coverage for honest task metadata and user-data-safe writes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+TEST_PILLARS = {
+    "pillar_1": {
+        "name": "Test Pillar",
+        "description": "Neutral test work",
+        "keywords": ["test"],
+    },
+    "pillar_2": {
+        "name": "Customer Growth",
+        "description": "Customer work",
+        "keywords": ["customer"],
+    },
+}
+
+
+def _decode_tool_result(result) -> dict:
+    return json.loads(result[0].text)
+
+
+def _call_tool(name: str, arguments: dict | None = None) -> dict:
+    return _decode_tool_result(
+        asyncio.run(work_server.handle_call_tool(name, arguments or {}))
+    )
+
+
+@pytest.fixture
+def task_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    tasks_file = tmp_path / "03-Tasks" / "Tasks.md"
+    priorities_file = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
+    goals_file = tmp_path / "01-Quarter_Goals" / "Quarter_Goals.md"
+    cache_file = tmp_path / "System" / "Memory" / "meeting-cache.json"
+    tasks_file.parent.mkdir(parents=True)
+    priorities_file.parent.mkdir(parents=True)
+    goals_file.parent.mkdir(parents=True)
+    tasks_file.write_text("# Tasks\n\n## Next Week\n", encoding="utf-8")
+
+    monkeypatch.setattr(work_server, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: tasks_file)
+    monkeypatch.setattr(work_server, "get_week_priorities_file", lambda: priorities_file)
+    monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals_file)
+    monkeypatch.setattr(work_server, "MEETING_CACHE_FILE", cache_file)
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    monkeypatch.setattr(
+        work_server,
+        "PRIORITY_LIMITS",
+        {"P0": 20, "P1": 20, "P2": 20},
+    )
+    monkeypatch.setattr(work_server, "_fire_analytics_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(work_server, "refresh_search_index", lambda: None)
+
+    next_id = 40
+
+    def generate_task_id() -> str:
+        nonlocal next_id
+        next_id += 1
+        return f"task-20260711-{next_id:03d}"
+
+    monkeypatch.setattr(work_server, "generate_task_id", generate_task_id)
+
+    return {
+        "root": tmp_path,
+        "tasks": tasks_file,
+        "priorities": priorities_file,
+        "goals": goals_file,
+        "cache": cache_file,
+    }
+
+
+def test_created_task_lists_exact_pillar_key_and_explicit_p0(task_vault):
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Draft neutral launch briefing document",
+            "pillar": "pillar_1",
+            "priority": "P0",
+        },
+    )
+
+    assert created["success"] is True
+    listed = _call_tool("list_tasks")
+    task = next(
+        item
+        for item in listed["tasks"]
+        if item["task_id"] == created["task"]["task_id"]
+    )
+    assert task["pillar"] == "pillar_1"
+    assert task["priority"] == "P0"
+    assert "urgent" not in task["title"].lower()
+
+
+def test_parse_tasks_reads_all_metadata_fields_and_reverse_maps_pillar_case_insensitively(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    tasks_file = tmp_path / "Tasks.md"
+    tasks_file.write_text(
+        "# Tasks\n\n"
+        "## P2 - Normal\n"
+        "- [ ] Prepare quarterly account brief ^task-20260711-042\n"
+        "\t- Pillar: test pillar | Priority: P1 | Weekly priority: "
+        "[week-2026-W28-p1] | Due: 2026-07-18 | Source: "
+        "00-Inbox/Meetings/2026-07-11/customer.md | Project: "
+        "04-Projects/Customer_Renewal.md | Goal: Q3-2026-goal-2\n",
+        encoding="utf-8",
+    )
+
+    [task] = work_server.parse_tasks_file(tasks_file)
+
+    assert task["pillar"] == "pillar_1"
+    assert task["priority"] == "P1"
+    assert task["weekly_priority_id"] == "week-2026-W28-p1"
+    assert task["due"] == "2026-07-18"
+    assert task["source"] == "00-Inbox/Meetings/2026-07-11/customer.md"
+    assert task["project"] == "04-Projects/Customer_Renewal.md"
+    assert task["goal"] == "Q3-2026-goal-2"
+
+
+def test_task_listing_preserves_provenance_and_exposes_future_source_metadata(task_vault):
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Prepare meeting follow-up ^task-20260711-049\n"
+        "\t- Pillar: Test Pillar | Priority: P2 | Source: "
+        "00-Inbox/Meetings/2026-07-11/customer.md\n",
+        encoding="utf-8",
+    )
+
+    task = next(
+        item
+        for item in work_server.get_all_tasks()
+        if item["task_id"] == "task-20260711-049"
+    )
+
+    assert task["source"] == "tasks"
+    assert task["metadata_source"] == "00-Inbox/Meetings/2026-07-11/customer.md"
+
+
+def test_legacy_task_without_metadata_keeps_keyword_guesses(tmp_path, monkeypatch):
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    tasks_file = tmp_path / "Tasks.md"
+    tasks_file.write_text(
+        "# Tasks\n\n## Later\n"
+        "- [ ] Urgent customer renewal response ^task-20260711-043\n",
+        encoding="utf-8",
+    )
+
+    [task] = work_server.parse_tasks_file(tasks_file)
+
+    assert task["pillar"] == "pillar_2"
+    assert task["priority"] == "P0"
+    assert task.get("weekly_priority_id") is None
+
+
+def test_malformed_metadata_falls_back_silently_with_section_before_keyword(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    tasks_file = tmp_path / "Tasks.md"
+    tasks_file.write_text(
+        "# Tasks\n\n## P1 - Important\n"
+        "- [ ] Urgent customer renewal response ^task-20260711-044\n"
+        "\t- Pillar: Unknown Pillar | Priority: PX | Weekly priority: nope | "
+        "Due: next Friday | Goal: quarterly-two\n",
+        encoding="utf-8",
+    )
+
+    [task] = work_server.parse_tasks_file(tasks_file)
+
+    assert task["pillar"] == "pillar_2"
+    assert task["priority"] == "P1"
+    assert task.get("weekly_priority_id") is None
+    assert task.get("due") is None
+    assert task.get("goal") is None
+
+
+def test_valid_weekly_priority_link_round_trips_into_week_progress(task_vault):
+    priority_id = "week-2026-W28-p1"
+    task_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        f"1. Ship customer launch — **Test Pillar** ^{priority_id}\n",
+        encoding="utf-8",
+    )
+
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare launch evidence package",
+            "pillar": "pillar_1",
+            "priority": "P1",
+            "weekly_priority_id": priority_id,
+        },
+    )
+
+    assert created["success"] is True
+    progress = work_server.get_week_progress_data()
+    linked = next(item for item in progress["priorities"] if item["priority_id"] == priority_id)
+    assert linked["tasks_total"] == 1
+    assert linked["tasks_done"] == 0
+
+
+def test_invalid_weekly_priority_lists_available_ids_without_writing(task_vault):
+    available_id = "week-2026-W28-p1"
+    task_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        f"1. Ship customer launch — **Test Pillar** ^{available_id}\n",
+        encoding="utf-8",
+    )
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare launch proof bundle",
+            "pillar": "pillar_1",
+            "weekly_priority_id": "week-2026-W28-p999",
+        },
+    )
+
+    assert result["success"] is False
+    assert "week-2026-W28-p999" in result["error"]
+    assert available_id in result["error"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_find_linked_tasks_keeps_old_same_line_links(task_vault):
+    priority_id = "week-2026-W28-p1"
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        f"- [ ] Legacy linked task [{priority_id}] ^task-20260711-045\n",
+        encoding="utf-8",
+    )
+
+    [task] = work_server.find_linked_tasks(priority_id)
+
+    assert task["task_id"] == "task-20260711-045"
+    assert "Legacy linked task" in task["title"]
+
+
+def test_find_linked_tasks_does_not_match_priority_id_prefix(task_vault):
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Linked only to priority ten ^task-20260711-063\n"
+        "\t- Pillar: Test Pillar | Priority: P1 | Weekly priority: "
+        "[week-2026-W28-p10]\n",
+        encoding="utf-8",
+    )
+
+    assert work_server.find_linked_tasks("week-2026-W28-p1") == []
+    assert len(work_server.find_linked_tasks("week-2026-W28-p10")) == 1
+
+
+def test_nested_task_does_not_inherit_parent_metadata(task_vault):
+    priority_id = "week-2026-W28-p1"
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Parent launch task ^task-20260711-064\n"
+        "    - [ ] Nested checklist task ^task-20260711-065\n"
+        f"    - Pillar: Test Pillar | Priority: P1 | Weekly priority: [{priority_id}]\n",
+        encoding="utf-8",
+    )
+
+    linked = work_server.find_linked_tasks(priority_id)
+
+    assert [task["task_id"] for task in linked] == ["task-20260711-064"]
+    tasks = work_server.parse_tasks_file(task_vault["tasks"])
+    assert next(task for task in tasks if task["task_id"] == "task-20260711-065")[
+        "priority"
+    ] == "P2"
+
+
+def test_related_tasks_table_uses_metadata_priority_and_pillar_key(task_vault):
+    person_path = "05-Areas/People/External/Jane_Doe.md"
+    person_file = task_vault["root"] / person_path
+    person_file.parent.mkdir(parents=True)
+    person_file.write_text("# Jane Doe\n", encoding="utf-8")
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] **Prepare renewal evidence for Jane** | "
+        f"{person_path} ^task-20260711-046\n"
+        "\t- Pillar: Test Pillar | Priority: P1\n",
+        encoding="utf-8",
+    )
+
+    tasks = work_server.find_tasks_for_page(person_path)
+    sync_result = work_server.sync_task_refs_for_page(person_path)
+
+    assert tasks[0]["priority"] == "P1"
+    assert tasks[0]["pillar"] == "pillar_1"
+    assert sync_result["success"] is True
+    assert "| P1 |" in person_file.read_text(encoding="utf-8")
+
+
+def test_create_task_schema_adds_owned_fields_without_source():
+    tools = asyncio.run(work_server.handle_list_tools())
+    create_tool = next(tool for tool in tools if tool.name == "create_task")
+    properties = create_tool.inputSchema["properties"]
+
+    assert {"due", "project", "goal", "on_duplicate"} <= properties.keys()
+    assert "source" not in properties
+    assert properties["on_duplicate"]["enum"] == ["fail", "force"]
+    assert properties["on_duplicate"]["default"] == "fail"
+
+
+def test_create_task_writes_and_parses_due_project_and_goal(task_vault):
+    project = task_vault["root"] / "04-Projects" / "Customer_Renewal.md"
+    project.parent.mkdir(parents=True)
+    project.write_text("# Customer Renewal\n", encoding="utf-8")
+    goal_id = "Q3-2026-goal-2"
+    task_vault["goals"].write_text(
+        "# Quarterly Goals\n\n"
+        f"### 1. Retain strategic accounts — **Test Pillar** ^{goal_id}\n",
+        encoding="utf-8",
+    )
+
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Assemble strategic account evidence",
+            "pillar": "pillar_1",
+            "priority": "P1",
+            "due": "2026-07-18",
+            "project": "04-Projects/Customer_Renewal.md",
+            "goal": goal_id,
+        },
+    )
+
+    assert created["success"] is True
+    text = task_vault["tasks"].read_text(encoding="utf-8")
+    assert (
+        "\t- Pillar: Test Pillar | Priority: P1 | Due: 2026-07-18 | "
+        "Project: 04-Projects/Customer_Renewal.md | Goal: Q3-2026-goal-2"
+    ) in text
+    task = next(
+        item
+        for item in work_server.parse_tasks_file(task_vault["tasks"])
+        if item["task_id"] == created["task"]["task_id"]
+    )
+    assert (task["due"], task["project"], task["goal"]) == (
+        "2026-07-18",
+        "04-Projects/Customer_Renewal.md",
+        goal_id,
+    )
+
+
+@pytest.mark.parametrize("due", ["18-07-2026", "2026/07/18", "2026-7-18"])
+def test_create_task_rejects_non_iso_due_without_writing(task_vault, due):
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare dated evidence package",
+            "pillar": "pillar_1",
+            "due": due,
+        },
+    )
+
+    assert result["success"] is False
+    assert "YYYY-MM-DD" in result["error"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_create_task_rejects_missing_project_with_substring_matches(task_vault):
+    projects_dir = task_vault["root"] / "04-Projects"
+    projects_dir.mkdir()
+    (projects_dir / "Customer_Renewal_2026.md").write_text("# Renewal\n", encoding="utf-8")
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare customer renewal materials",
+            "pillar": "pillar_1",
+            "project": "04-Projects/Customer_Renewal.md",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["close_matches"] == ["04-Projects/Customer_Renewal_2026.md"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_create_task_rejects_existing_file_outside_projects(task_vault):
+    outside = task_vault["root"] / "00-Inbox" / "Not_A_Project.md"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("# No\n", encoding="utf-8")
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare bounded project reference",
+            "pillar": "pillar_1",
+            "project": "00-Inbox/Not_A_Project.md",
+        },
+    )
+
+    assert result["success"] is False
+    assert "04-Projects/" in result["error"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_create_task_rejects_unknown_goal_and_lists_available_ids(task_vault):
+    available_id = "Q3-2026-goal-2"
+    task_vault["goals"].write_text(
+        "# Quarterly Goals\n\n"
+        f"### 1. Retain strategic accounts — **Test Pillar** ^{available_id}\n",
+        encoding="utf-8",
+    )
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare aligned evidence package",
+            "pillar": "pillar_1",
+            "goal": "Q3-2026-goal-999",
+        },
+    )
+
+    assert result["success"] is False
+    assert "Q3-2026-goal-999" in result["error"]
+    assert available_id in result["error"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_optional_metadata_omission_keeps_existing_metadata_line(task_vault):
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare byte stable metadata example",
+            "pillar": "pillar_1",
+            "priority": "P2",
+        },
+    )
+
+    assert created["success"] is True
+    lines = task_vault["tasks"].read_text(encoding="utf-8").splitlines()
+    assert "\t- Pillar: Test Pillar | Priority: P2" in lines
+    assert not any("Due:" in line or "Project:" in line or "Goal:" in line for line in lines)
+
+
+def test_duplicate_defaults_to_fail_and_force_skips_only_similarity_gate(task_vault):
+    arguments = {
+        "title": "Prepare unique renewal decision record",
+        "pillar": "pillar_1",
+    }
+    first = _call_tool("create_task", arguments)
+    duplicate = _call_tool("create_task", arguments)
+    forced = _call_tool("create_task", {**arguments, "on_duplicate": "force"})
+
+    assert first["success"] is True
+    assert duplicate["success"] is False
+    assert "on_duplicate=force" in duplicate["suggestion"]
+    assert forced["success"] is True
+
+
+def test_duplicate_force_does_not_bypass_ambiguity(task_vault):
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Fix bug",
+            "pillar": "pillar_1",
+            "on_duplicate": "force",
+        },
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "Task is too vague"
+
+
+def test_first_duplicate_section_insert_preserves_every_original_byte(task_vault):
+    before = (
+        "# Tasks\n\n"
+        "## Next Week\n"
+        "- [ ] First existing task ^task-20260711-001\n\n"
+        "## Archive\n"
+        "Archive body\n\n"
+        "## Next Week\n"
+        "- [ ] Second existing task ^task-20260711-002\n"
+        "TRAILING-SENTINEL\n"
+    )
+    task_vault["tasks"].write_text(before, encoding="utf-8")
+
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Insert without losing user data",
+            "pillar": "pillar_1",
+            "section": "Next Week",
+        },
+    )
+
+    assert created["success"] is True
+    task_id = created["task"]["task_id"]
+    task_entry = (
+        f"- [ ] **Insert without losing user data** ^{task_id}\n"
+        "\t- Pillar: Test Pillar | Priority: P2"
+    )
+    after = task_vault["tasks"].read_text(encoding="utf-8")
+    expected = before.replace(
+        "## Next Week",
+        f"## Next Week\n{task_entry}\n",
+        1,
+    )
+    assert after == expected
+    assert after.count("## Next Week") == 2
+    assert after.endswith("TRAILING-SENTINEL\n")
+
+
+@pytest.mark.parametrize(
+    "task_line",
+    [
+        "- [x] **Finish launch report** ^task-20260711-047 ✅ 2026-07-10 08:30",
+        "- [x] **Finish launch report** ✅ 2026-07-10 08:30 ^task-20260711-047",
+    ],
+    ids=["old-layout", "block-ref-safe-layout"],
+)
+def test_completion_normalizes_old_and_new_layouts_with_anchor_last(
+    task_vault, monkeypatch, task_line
+):
+    task_vault["tasks"].write_text(f"# Tasks\n\n## Done\n{task_line}\n", encoding="utf-8")
+    monkeypatch.setattr(work_server, "_tz_now", lambda: datetime(2026, 7, 11, 21, 15))
+
+    result = work_server.update_task_status_everywhere(
+        "task-20260711-047", completed=True
+    )
+
+    assert result["success"] is True
+    assert result["title"] == "Finish launch report"
+    completed_line = next(
+        line
+        for line in task_vault["tasks"].read_text(encoding="utf-8").splitlines()
+        if "task-20260711-047" in line
+    )
+    assert completed_line == (
+        "- [x] **Finish launch report** ✅ 2026-07-11 21:15 "
+        "^task-20260711-047"
+    )
+    assert completed_line.count("✅") == 1
+    [parsed] = work_server.parse_tasks_file(task_vault["tasks"])
+    assert parsed["title"] == "Finish launch report"
+
+
+@pytest.mark.parametrize(
+    "task_line",
+    [
+        "- [x] Finish launch report ^task-20260711-048 ✅ 2026-07-10 08:30",
+        "- [x] Finish launch report ✅ 2026-07-10 08:30 ^task-20260711-048",
+    ],
+)
+def test_uncompletion_accepts_both_stored_completion_layouts(task_vault, task_line):
+    task_vault["tasks"].write_text(f"# Tasks\n\n## Done\n{task_line}\n", encoding="utf-8")
+
+    result = work_server.update_task_status_everywhere(
+        "task-20260711-048", completed=False
+    )
+
+    assert result["success"] is True
+    assert task_vault["tasks"].read_text(encoding="utf-8").splitlines()[-1] == (
+        "- [ ] Finish launch report ^task-20260711-048"
+    )
+
+
+def test_priority_limit_error_names_occupying_tasks_and_new_enforcement(task_vault, monkeypatch):
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Existing launch brief ^task-20260711-051\n"
+        "\t- Pillar: Test Pillar | Priority: P1\n"
+        "- [ ] Existing evidence review ^task-20260711-052\n"
+        "\t- Pillar: Test Pillar | Priority: P1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "PRIORITY_LIMITS", {"P0": 3, "P1": 2, "P2": 10})
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare another planning record",
+            "pillar": "pillar_1",
+            "priority": "P1",
+        },
+    )
+
+    assert result["success"] is False
+    assert "Existing launch brief" in result["error"]
+    assert "task-20260711-051" in result["error"]
+    assert "Existing evidence review" in result["error"]
+    assert "task-20260711-052" in result["error"]
+    assert "newly enforced" in result["error"].lower()
+    assert result["occupying_tasks"] == [
+        {"title": "Existing launch brief", "task_id": "task-20260711-051"},
+        {"title": "Existing evidence review", "task_id": "task-20260711-052"},
+    ]
+
+
+def test_python_meeting_cache_recurses_dated_folders_and_skips_queue(
+    task_vault, monkeypatch
+):
+    day = date.today().isoformat()
+    meetings_dir = task_vault["root"] / "00-Inbox" / "Meetings"
+    dated_dir = meetings_dir / day
+    dated_dir.mkdir(parents=True)
+    (dated_dir / "customer-sync.md").write_text(
+        f"---\ndate: {day}\nparticipants: [Jane Doe]\n---\n"
+        "# Customer Sync\n\n## Decisions\n\n- Ship it\n\n"
+        "## Action Items\n\n"
+        "- [x] Close old loop ^task-20260711-061 ✅ 2026-07-10 08:30\n"
+        "- [x] Close new loop ✅ 2026-07-10 08:30 ^task-20260711-062\n",
+        encoding="utf-8",
+    )
+    external_file = task_vault["root"].parent / "external-secret-meeting.md"
+    external_file.write_text(
+        f"---\ndate: {day}\n---\n# External Secret Must Not Cache\n",
+        encoding="utf-8",
+    )
+    (dated_dir / "external-secret-link.md").symlink_to(external_file)
+    queue_dir = dated_dir / "queue"
+    queue_dir.mkdir()
+    (queue_dir / "must-not-cache.md").write_text(
+        f"---\ndate: {day}\n---\n# Must Not Cache\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "get_meetings_dir", lambda: meetings_dir)
+
+    result = work_server.rebuild_meeting_cache_data()
+
+    assert result["success"] is True
+    assert result["processed"] == 1
+    cache = json.loads(task_vault["cache"].read_text(encoding="utf-8"))
+    assert [meeting["title"] for meeting in cache["meetings"]] == ["Customer Sync"]
+    assert cache["meetings"][0]["source_file"] == (
+        f"00-Inbox/Meetings/{day}/customer-sync.md"
+    )
+    assert cache["meetings"][0]["action_items"] == ["Close old loop", "Close new loop"]


### PR DESCRIPTION
## What

Phase 2 of the task-engine repair (follows #100). The engine wrote metadata it could never read back, and its links were written where no reader looked.

**Round-trips** — `parse_tasks_file` (and every task reader) now parses the metadata sub-bullet `create_task` writes: pillar (display name reverse-mapped to key — filters compare keys), priority, weekly priority, and the new fields. Precedence: explicit metadata > section header > keyword guess, with full legacy fallbacks — old vaults and hand-written tasks parse exactly as before.

**Links that count** — `weekly_priority_id` is validated at creation (unknown id → error listing available ids); rollup readers now match links on the task line *or* its child bullets with boundary guards (`p1` no longer matches `p10`). Week/goal progress finally counts MCP-created tasks.

**Additive schema** — optional `due` (ISO date), `project` (must exist under the projects dir, containment-checked, close-matches suggested on miss), `goal` (validated against quarterly goals). No `source` param — that's owned by the parallel entity-engine lane; the parser is forward-compatible with it.

**Safety + UX** — `on_duplicate: fail|force` (force skips only the similarity gate; the error now suggests it instead of "rephrase the title", which defeated dedup); section insertion is anchored to the first exact heading and can no longer silently delete content after a duplicated heading; completion timestamps move *before* `^task-id` so Obsidian block refs keep working (both layouts accepted on read); priority-cap errors list the occupying tasks.

**Meeting cache** — both the Python and Node builders now recurse the dated subfolders the Granola sync actually writes (skipping `queue/`, guarding symlinks), so meeting-prep and daily-plan stop being blind to synced meetings.

## Verification

- **Red-first, run on clean c92fafd** (not reconstructed): 20 failed / 6 passed before implementation — including the data-loss and both timestamp-layout cases
- After: full suite **407 passed, 1 skipped** (outside any sandbox), **45/45** hook tests, ruff clean
- All four gates locally: test-delta ✅ path-contract ✅ doc-drift ✅ instructed-tools ✅
- CHANGELOG 1.35.0 included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WZCmEDi4qiNLDTwsSJXL