### PR TITLE
Dex's release checks no longer break contributor setups (v1.34.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.34.1] - Dex's release checks no longer break contributor setups (2026-07-12)
+
+Release checks now preserve your local Git history and explain when they cannot compare it.
+
+**What this fixes for you:**
+
+* **Checks no longer quietly truncate your local Git history.** They now fetch safely when you run them on your machine.
+* **A failed history comparison now explains how to fix it.** Instead of stopping with no output, Dex tells you to unshallow the repository and retry.
+
 ## [1.35.0] - Tasks now remember what you told them (2026-07-11)
 
 When you created a task and confirmed its pillar and priority, Dex wrote them down — and then never read them back, re-guessing both from the task's wording every time it listed your tasks. A P0 could show up as P2 unless its title happened to sound urgent. This release makes task details stick, and adds the fields tasks always needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/check-coverage-threshold.py
+++ b/scripts/check-coverage-threshold.py
@@ -68,12 +68,24 @@ def main() -> int:
         print(f"Total coverage {total:.2f}% is below required {min_total:.2f}%.", file=sys.stderr)
         return 1
 
+    fetch_cmd = ["git", "fetch", "origin", base_ref]
+    if os.environ.get("GITHUB_ACTIONS"):
+        fetch_cmd.append("--depth=1")
     try:
-        run(["git", "fetch", "origin", base_ref, "--depth=1"])
+        run(fetch_cmd)
     except subprocess.CalledProcessError:
         pass
 
-    merge_base = run(["git", "merge-base", "HEAD", f"origin/{base_ref}"])
+    try:
+        merge_base = run(["git", "merge-base", "HEAD", f"origin/{base_ref}"])
+    except subprocess.CalledProcessError:
+        print(
+            "❌ check-coverage-threshold.py: cannot find a common ancestor between HEAD and "
+            f"origin/{base_ref}. Your local history may be shallow — run: "
+            "git fetch --unshallow origin — then retry.",
+            file=sys.stderr,
+        )
+        return 1
     # --diff-filter=ACMR drops deleted (D) files: a deleted module is absent from
     # coverage.json and would otherwise score 0% and fail the gate. Removing code
     # must never fail a coverage gate.

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
+else
+  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
+fi
+if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
+  echo "❌ check-doc-drift.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
+  exit 1
+fi
 # --diff-filter=ACMR drops deleted (D) files: removing code should not require
 # a doc change.
 CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"

--- a/scripts/check-path-contract-usage.sh
+++ b/scripts/check-path-contract-usage.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
+else
+  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
+fi
+if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
+  echo "❌ check-path-contract-usage.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
+  exit 1
+fi
 # --diff-filter=ACMR drops deleted (D) files so we never grep a path that no
 # longer exists, and never punish a PR for removing code.
 CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"

--- a/scripts/check-test-delta.sh
+++ b/scripts/check-test-delta.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
+else
+  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
+fi
+if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
+  echo "❌ check-test-delta.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
+  exit 1
+fi
 # --diff-filter=ACMR drops deleted (D) files: removing dead code should not
 # require adding a test.
 CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE...HEAD")"


### PR DESCRIPTION
## Summary

The four diff-gate scripts (`check-test-delta.sh`, `check-doc-drift.sh`, `check-path-contract-usage.sh`, `check-coverage-threshold.py`) had two defects that surfaced repeatedly during yesterday's five-PR run:

1. **They truncated local git history.** `git fetch origin main --depth=1` shallows a working clone at the fetched tip, severing `origin/main` from local branches — every subsequent rebase then fails with "unrelated histories" until `git fetch --unshallow origin`. The `--depth=1` is only a speed win for CI's fresh clones, so it's now applied only when `GITHUB_ACTIONS` is set; local runs do a normal fetch.
2. **They died silently.** Under `set -euo pipefail`, a merge-base failure killed the script inside the command substitution with exit 1 and zero output. All four now print an actionable message (naming the script and the `--unshallow` fix) to stderr and exit 1.

Normal-path behavior is byte-identical. CI is unaffected (still shallow-fetches for speed).

## Test plan

- [x] `bash -n` on all three shell scripts; ruff clean on the Python one
- [x] All four gates pass in this worktree, and running them locally no longer creates `.git/shallow`
- [x] Functional demo: unrelated-history repo → each script prints the new ❌ message and exits 1
- [x] CHANGELOG v1.34.1 + package.json synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG