### PR TITLE
Every task promise is one the code keeps: honest integrations, canonical paths, first-class capture

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -318,10 +318,11 @@ If items found, surface:
 > **Triage these now?** I'll help assign pillars and priorities.
 
 **Triage flow:**
-- Present each item
-- Infer pillar (using existing smart pillar inference)
-- Confirm with user
-- Create task via Work MCP `process_inbox_with_dedup`
+- Run Work MCP `process_inbox_with_dedup` to classify the captured items — it flags
+  duplicates and ambiguous items and suggests a pillar; it does NOT create tasks
+- Present each item, confirm pillar with user (smart pillar inference)
+- Create each confirmed task via Work MCP `create_task` (pass `due`, `people`, or
+  `account` when the captured item mentions them)
 - Mark Reminder as complete via `reminders_complete_item`
 
 **If Dex Inbox is empty:** Skip silently (no "0 items captured" noise).

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -210,10 +210,15 @@ Then prompt:
 
 ### 4.3 Create Follow-Up Tasks
 
-For any follow-ups mentioned:
-- Add to Tasks.md with appropriate priority
-- Link to the person page
-- Add due date if mentioned
+For any follow-ups mentioned, create each one via Work MCP `create_task` — never by
+writing checkboxes into Tasks.md directly (hand-written tasks get no task ID, so
+completion sync, dedup, and goal rollups can't track them). Pass:
+- `pillar` (inferred per the Task Creation flow, confirmed with the user) and `priority`
+- `people`: the page path(s) of who you met (e.g. `05-Areas/People/External/Sarah_Chen.md`)
+  — this keeps the person page's Related Tasks table in sync automatically
+- `account` if the meeting was with a company you track
+- `due` (YYYY-MM-DD) if a date was mentioned
+- `weekly_priority_id` / `goal` if the follow-up clearly serves one
 
 ---
 

--- a/.claude/skills/things-setup/SKILL.md
+++ b/.claude/skills/things-setup/SKILL.md
@@ -1,31 +1,32 @@
 ---
 name: things-setup
-description: Connect Things 3 to Dex for bi-directional task sync
+description: Connect Things 3 so Dex can read and update your Things tasks on request
 manifest:
   id: things
   auth: none
-  category: task_sync
+  category: task_access
   platform: macos
   mcp_server: things3-mcp
 ---
 
 # Things 3 Setup
 
-Connect Things 3 to Dex for bi-directional task sync. No account needed. Everything stays on your Mac. Works offline.
+Connect Things 3 so Dex can work with your Things tasks whenever you ask. No account needed. Everything stays on your Mac. Works offline.
+
+**What this is not (honesty first):** there is no automatic background sync. Creating a task in Dex does not create it in Things, and completing one in Things does not automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Things automatically" gets it captured on the improvement backlog.
 
 ## What This Enables
 
-Once connected, Dex can:
-- **Task Sync:** Create tasks in Things 3 when you add them in Dex, and vice versa
-- **Daily Plan:** Pull in tasks you created in Things and merge them into your plan
-- **Completion Sync:** Complete a task in either place — it syncs to the other
-- **Priority Mapping:** P0/P1 tasks go to your Today list, P2/P3 to Anytime
-- **Pillar Mapping:** Dex pillars map to Things Areas for organized task views
+Once connected, you can ask Dex to:
+- **See your Things lists:** "What's in my Things Today list?" — including alongside your daily plan
+- **Create there instead:** "Put that in Things, not Dex" in any conversation
+- **Complete from chat:** "Mark the deck task done in Things"
+- **Cross-check:** "Anything in Things that isn't tracked in Dex?"
 
 ## Privacy
 
 - Everything is local. Things 3 uses AppleScript — no cloud API, no tokens, no accounts
-- Tasks sync between two apps on YOUR Mac. Nothing leaves your machine
+- Dex reads and writes Things only when you ask. Nothing leaves your machine
 - No credentials to store. No tokens to expire. No OAuth flows
 - Works completely offline
 
@@ -33,7 +34,7 @@ Once connected, Dex can:
 
 - User types `/things-setup`
 - User asks about connecting Things 3
-- User wants task sync with a Mac-native app
+- User wants Dex working with a Mac-native task app
 - During `/integrate-mcp` if Things is mentioned
 - During onboarding if user mentions Things 3
 
@@ -50,7 +51,7 @@ Things 3 is macOS only. Verify:
    ```
    Things 3 is a macOS-only app. It won't work on this platform.
 
-   For cross-platform task sync, consider:
+   For a cross-platform task app connection, consider:
    - /todoist-setup (works everywhere)
    - /trello-setup (web-based)
    ```
@@ -193,20 +194,9 @@ If areas don't exist, offer to create them (run once per missing pillar):
 osascript -e 'tell application "Things3" to make new area with properties {name:"[pillar name]"}'
 ```
 
-Then ask about sync behavior:
-
-```
-One more question: How should task sync work?
-
-1. **Auto-sync** — Tasks sync automatically between Dex and Things
-2. **Ask each time** — I'll confirm before syncing each task
-
-Most people prefer auto-sync. Which do you want?
-```
-
 ### Step 7: Save Configuration
 
-Write to `System/integrations/config.yaml` — update the things section. Build `area_mapping` dynamically from the user's pillars: use each pillar's `id` as the key and the confirmed Things Area name as the value.
+Write to `System/integrations/config.yaml` — update the things section. Build `area_mapping` dynamically from the user's pillars: use each pillar's `id` as the key and the confirmed Things Area name as the value (used when the user asks Dex to file something in Things under the right Area).
 
 ```yaml
 things:
@@ -214,13 +204,8 @@ things:
   configured_at: YYYY-MM-DD
   mcp_server: things3-mcp
   auth_type: none
-  task_sync: true
-  sync_mode: auto
   area_mapping:
     [pillar_id]: [Things Area name]   # one entry per pillar
-  features:
-    task_sync: true
-    external_task_merge: true
 ```
 
 If the file already exists, only update the `things:` section. Preserve other integration configs.
@@ -232,16 +217,20 @@ Now that Things is connected, highlight what changes:
 ```
 Things 3 is connected.
 
-Here's what changes now:
+Here's what you can do now:
 
-- **/daily-plan** syncs tasks from Things into your morning plan
-- **Task creation** in Dex mirrors to Things (P0/P1 → Today, P2/P3 → Anytime)
-- **Task completion** syncs both ways — finish in either app
-- **Pillars → Areas** keep your Things organized by Dex structure
+- **Ask about Things anytime** — "What's in my Today list?", "Put that in
+  Things", "Mark the deck task done in Things"
+- **Bring it into planning** — during /daily-plan, ask me to include your
+  Things tasks and I will
+- **Right Area, automatically** — when I file something in Things for you,
+  your pillars map to your Things Areas
 
 No accounts. No tokens. No expiration. Works offline.
 
-Tip: Tasks you create directly in Things will appear in your next /daily-plan.
+One honest note: there's no automatic background sync — I work with Things
+when you ask, not on my own. Want automatic two-way sync? Say so and I'll
+capture it on the improvement backlog.
 ```
 
 ---
@@ -275,14 +264,6 @@ If no Areas appear during setup:
 3. Make sure Areas are enabled
 4. Create at least one Area, then retry
 
-### Sync Conflicts
-
-If a task is edited in both Dex and Things between syncs:
-
-- Dex is the source of truth for task status
-- Things is the source of truth for task title edits
-- Notes merge (Dex context is appended, not overwritten)
-
 ---
 
 ## Reconfiguration
@@ -292,7 +273,6 @@ If the user runs `/things-setup` when already configured:
 1. Show current config from `System/integrations/config.yaml`
 2. Offer options:
    - Update pillar-to-area mapping
-   - Change sync mode (auto vs. ask)
    - Re-test the connection
    - Disconnect Things
 

--- a/.claude/skills/todoist-setup/SKILL.md
+++ b/.claude/skills/todoist-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: todoist-setup
-description: Connect Todoist to Dex for two-way task sync
+description: Connect Todoist so Dex can read and update your Todoist tasks on request
 integration:
   id: todoist
   name: Todoist
@@ -8,48 +8,33 @@ integration:
   auth: api_key
   enhances:
     - skill: daily-plan
-      capability: "Merges Todoist tasks due today alongside Dex tasks"
+      capability: "Can pull in your Todoist tasks due today when you ask"
     - skill: triage
-      capability: "Routes items to Dex, Todoist, or both"
-    - skill: process-inbox
-      capability: "Creates tasks in both systems when processing captured items"
-    - skill: week-review
-      capability: "Shows cross-system completion stats (Dex + Todoist)"
+      capability: "Can route an item to Todoist instead of Dex when you ask"
   new_capabilities:
-    - name: Bidirectional task sync
-      trigger: "Automatic at daily plan and task creation touchpoints"
-  sync:
-    direction: bidirectional
-    entities: tasks
+    - name: On-request Todoist access
+      trigger: "Ask Dex to check, create, or complete Todoist tasks in any conversation"
 ---
 
 # Todoist Setup
 
-Connect your Todoist account to Dex so tasks stay in sync across both systems. Create a task in Dex and it appears in Todoist. Complete one in Todoist and Dex knows about it.
+Connect your Todoist account so Dex can work with your Todoist tasks whenever you ask — check what's due, create a task there instead of in Dex, or mark something done.
+
+**What this is not (honesty first):** there is no automatic background sync. Dex tasks don't push themselves to Todoist, and completing a task in Todoist doesn't automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Todoist automatically" gets it captured on the improvement backlog.
 
 ## What This Enables
 
-Once connected, Dex can:
-- **Daily Plan** (`/daily-plan`): Merge Todoist tasks due today alongside your Dex tasks
-- **Triage** (`/triage`): Route new items to Dex, Todoist, or both
-- **Process Inbox** (`/process-inbox`): Same routing options when processing captured items
-- **Week Review** (`/week-review`): See completion stats across both Dex and Todoist
-
-## How Sync Works (Plain English)
-
-- When you create a task in Dex, it gets pushed to Todoist automatically
-- When you complete a task in Todoist, Dex picks it up during your next daily plan
-- Task titles, priorities, and completion status travel between both systems
-- Each system keeps its own copy — if one goes offline, the other still works
-- Sync happens at natural touchpoints (daily plan, triage) — not constantly in the background
-- Tasks created by Dex carry a `[dex:task-ID]` marker in the description so the systems never duplicate
+Once connected, you can ask Dex to:
+- **See what's due**: "What's due in Todoist today?" — including alongside your daily plan
+- **Create there instead**: "Add that to Todoist, not Dex" during triage or any conversation
+- **Complete from chat**: "Mark the invoice task done in Todoist"
+- **Cross-check**: "Anything in Todoist that isn't tracked in Dex?"
 
 ## Privacy
 
-- Task titles and status sync between Dex and Todoist. No task content or notes are stored beyond what you already have in both systems.
+- Dex reads and writes your Todoist tasks only when you ask it to
 - Your API key stays local on your machine in `System/integrations/config.yaml` (gitignored)
 - Dex never shares your Todoist data with third parties
-- Tasks created in Todoist are only pulled into Dex if they were NOT originally pushed from Dex (loop prevention via `[dex:...]` marker)
 
 ## When to Run
 
@@ -76,7 +61,8 @@ Say:
 ```
 **Let's connect Todoist to Dex.**
 
-Two-way task sync. Create in Dex — appears in Todoist. Complete in Todoist — done in Dex.
+Once connected, you can ask me to check, create, or complete Todoist tasks
+right from our conversations.
 
 **What you'll need:**
 - Your Todoist API token (I'll show you where to find it)
@@ -192,26 +178,12 @@ Which works for you?
 
 Save their choices for the config file.
 
-### Step 7: Trust Level
+### Step 7: Save Configuration
 
-Ask about sync autonomy — **never use the word "tier"** (per integration-patterns.md):
-
-```
-**How hands-on do you want to be with task sync?**
-
-1. **"Show me first"** — I'll preview changes before syncing (recommended to start)
-2. **"Keep them in sync"** — Tasks auto-sync both ways, silently
-3. **"Only pull in"** — Import tasks from Todoist but don't push back
-```
-
-Map their choice to config values:
-- **Show me first** → `trust_level: confirm_each`
-- **Keep them in sync** → `trust_level: autonomous`
-- **Only pull in** → `trust_level: read_only`
-
-### Step 8: Save Configuration
-
-Write to `System/integrations/config.yaml` — update the todoist section:
+Write to `System/integrations/config.yaml` — update the todoist section. Build
+`pillar_map` dynamically from the user's actual pillars in `System/pillars.yaml`
+(one entry per pillar id — never assume fixed pillar names); it's used when the
+user asks Dex to file a task in the matching Todoist project.
 
 ```yaml
 todoist:
@@ -220,51 +192,28 @@ todoist:
   mcp_server: todoist-mcp
   auth_type: api_key
   api_key: <user's API key>
-  task_sync: true
-  trust_level: <confirm_each | autonomous | read_only>
   project: <default project name>
   pillar_map:
-    deal_support: <project name or omit>
-    thought_leadership: <project name or omit>
-    product_feedback: <project name or omit>
-  sync_labels: []
-  auto_sync: true
-  features:
-    task_sync: true
-    external_task_merge: true
+    [pillar_id]: <Todoist project name>   # one entry per pillar, from pillars.yaml
 ```
 
 If the file already exists, only update the `todoist:` section. Preserve other integration configs.
 
-### Step 9: Capability Cascade
+### Step 8: Capability Cascade
 
 Read the integration manifest from this skill's frontmatter. Present:
 
 ```
-**Todoist is connected!** Here's what just changed:
+**Todoist is connected!** Here's what you can do now:
 
-### Enhanced (existing skills that got smarter)
+- **Ask about Todoist anytime** — "What's due in Todoist today?", "Add that to
+  Todoist", "Mark the invoice task done in Todoist".
+- **Bring it into your planning** — during `/daily-plan` or `/triage`, ask Dex to
+  include or route to Todoist and it will.
 
-- **`/daily-plan`** → Merges Todoist tasks due today alongside your Dex tasks.
-  Externally-created tasks show a [Todoist] label so you know where they came from.
-
-- **`/triage`** → Now offers routing to Dex, Todoist, or both when processing items.
-
-- **`/process-inbox`** → Same routing — "This looks like a task. Add to Dex, Todoist, or both?"
-
-- **`/week-review`** → Shows completion stats across both systems so you see the full picture.
-
-### New Superpowers
-
-- Bidirectional task sync — automatic at daily plan and task creation touchpoints.
-
-### How It Works
-
-- **Reading:** Todoist tasks appear in your daily plan automatically
-- **Writing:** [trust level description based on user's choice above]
-- **Privacy:** Task titles and status sync. Your API key stays local. No data shared with third parties.
-
-These work automatically starting now. Run `/dex-level-up` anytime to see what else you can do.
+One honest note: there's no automatic background sync — Dex works with Todoist
+when you ask, not on its own. If you'd like automatic two-way sync, say so and
+I'll capture it on the improvement backlog.
 ```
 
 ---
@@ -279,29 +228,16 @@ Todoist API keys don't expire unless you regenerate them. If you see auth errors
 2. Copy the current API token (or regenerate if needed)
 3. Update the key by running `/todoist-setup` again
 
-### Tasks Not Syncing
+### "Dex doesn't see my Todoist tasks"
 
-A few possibilities:
-- **Sync only happens at touchpoints** — during `/daily-plan`, task creation, or `/triage`. There's no background sync.
-- **Check the project mapping** — if your Dex pillar maps to a project that was renamed or deleted in Todoist, tasks may go to the Inbox instead.
-- **Rate limits** — Todoist allows 450 requests per minute. The adapter handles 429 responses with automatic retry, so this is almost never an issue.
-
-### Wrong Project
-
-If tasks are landing in the wrong Todoist project:
-1. Run `/todoist-setup` again
-2. Update the pillar-to-project mapping
-3. Existing tasks won't move — only new tasks use the updated mapping
-
-### Duplicate Tasks
-
-If you see duplicates, check:
-- **Dex-originated tasks** should have `[dex:task-...]` in their Todoist description. The adapter skips these during pull-in to prevent loops.
-- **Todoist-originated tasks** that you manually add to Dex won't have a mapping in `.sync-state.json` and may get pulled again. Mark them in Dex to create the mapping.
+Dex only reads Todoist when you ask it to — there is no background sync. Ask
+directly ("what's in Todoist?") and if that errors, re-run `/todoist-setup` to
+check the connection.
 
 ### "Todoist MCP not found"
 
-The Todoist adapter uses direct API calls (not MCP) for the sync bridge. The MCP server is optional but enhances other skills. Re-run `/todoist-setup` to detect and fix configuration.
+The connection runs through the Todoist MCP server. Re-run `/todoist-setup` to
+detect and fix configuration.
 
 ---
 
@@ -311,10 +247,9 @@ If the user runs `/todoist-setup` when already configured:
 
 1. Check current config from `System/integrations/config.yaml`
 2. Test the existing API key with a project list call
-3. Show current mapping and trust level
+3. Show the current pillar-to-project mapping
 4. Offer options:
    - Update project mapping
-   - Change sync behavior (trust level)
    - Update API key
    - Disconnect Todoist
 

--- a/.claude/skills/trello-setup/SKILL.md
+++ b/.claude/skills/trello-setup/SKILL.md
@@ -1,31 +1,33 @@
 ---
 name: trello-setup
-description: Connect Trello to Dex for visual Kanban task sync
+description: Connect Trello so Dex can read your boards and manage cards on request
 manifest:
   id: trello
   auth: api_key_token
-  category: task_sync
+  category: task_access
   mcp_server: mcp-server-trello
   runtime: bun
 ---
 
 # Trello Setup
 
-Connect your Trello boards to Dex so your tasks, projects, and daily plans stay in sync with your Trello Kanban boards.
+Connect your Trello boards so Dex can work with them whenever you ask — check board status, create cards, or move them.
+
+**What this is not (honesty first):** there is no automatic background sync. Dex tasks don't become Trello cards by themselves, and moving a card to Done doesn't automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Trello automatically" gets it captured on the improvement backlog.
 
 ## What This Enables
 
-Once connected, Dex can:
-- **Task Sync:** Cards created in Dex appear on your Trello board; cards moved to Done in Trello mark tasks complete in Dex
-- **Project Health:** See live board status -- cards by list, blocked items, stale cards
-- **Daily Plan:** Surface Trello cards assigned to you, including overdue items
-- **Meeting Prep:** Know which board has blocked cards to discuss with attendees
+Once connected, you can ask Dex to:
+- **See board status:** cards by list, blocked items, stale cards — "how's the launch board looking?"
+- **Create cards:** "Add a card for the pricing review to the backlog list"
+- **Update from chat:** "Move the onboarding card to Done" (and, if you ask, mark the matching Dex task complete)
+- **Prep with context:** "Which cards are blocked before my 2pm?"
 
 ## Privacy
 
-- Card titles and status sync. No attachments or comments are read unless you ask.
+- Dex reads and writes your boards only when you ask it to
 - Your API key and token stay local on your machine and are gitignored
-- Sync is on-demand (during daily plan or task creation) -- no background polling
+- No attachments or comments are read unless you ask
 - Only boards you explicitly configure are accessed
 
 ## When to Run
@@ -52,8 +54,8 @@ Say:
 ```
 **Let's connect Trello to Dex.**
 
-This links your Trello boards so tasks sync between Dex and Trello.
-Cards move between lists = status updates in Dex. Simple Kanban sync.
+This links your Trello boards so you can ask Dex to check board status,
+create cards, and move them — right from our conversations.
 
 **What you'll need:**
 - A Trello account with at least one board
@@ -181,60 +183,44 @@ Let the user confirm or customize the mapping. Default status list names:
 - Blocked / On Hold / Waiting -> status `b`
 - Done / Complete / Finished -> status `d`
 
-### Step 7: Trust Level
+### Step 7: Save Configuration
 
-Ask about sync behavior:
-
-```
-**How should Dex handle Trello sync?**
-
-1. **Auto-sync** — Cards sync automatically during daily plan and task creation
-2. **Ask each time** — Dex shows you what changed and asks before syncing
-
-Which do you prefer? (Most people choose auto-sync)
-```
-
-### Step 8: Save Configuration
-
-Write to `System/integrations/config.yaml` -- update the trello section:
+Write to `System/integrations/config.yaml` -- update the trello section (the list
+mapping is used when the user asks Dex to file or move cards):
 
 ```yaml
 trello:
   enabled: true
-  task_sync: true
   configured_at: YYYY-MM-DD
   api_key: <user's api key>
   token: <user's token>
   default_board: <board id>
   board_name: <board name>
-  trust_level: auto | ask
   list_mapping:
     backlog: <list id for Backlog>
     in_progress: <list id for In Progress>
     blocked: <list id for Blocked>
     done: <list id for Done>
-  features:
-    task_sync: true
-    project_health: true
-    daily_plan: true
-    meeting_prep: true
 ```
 
 If the file already exists, only update the `trello:` section. Preserve other integration configs.
 
-### Step 9: Confirm
+### Step 8: Confirm
 
 ```
 **Trello is connected!**
 
-Here's what changes now:
+Here's what you can do now:
 
-- **Task Sync** — New Dex tasks appear on your [Board Name] board. Cards completed in Trello mark tasks done in Dex.
-- **Project Health** (`/project-health`) shows live board status -- cards by list, blocked items
-- **Daily Plan** (`/daily-plan`) includes your assigned Trello cards and overdue items
-- **Meeting Prep** (`/meeting-prep`) surfaces blocked cards relevant to attendees
+- **Ask about your board anytime** — "How's the [Board Name] board looking?",
+  "Add a card to the backlog", "Move the onboarding card to Done"
+- **Bring it into planning** — during /daily-plan or /project-health, ask me
+  to include your Trello cards and I will
+- **Meeting prep with context** — ask which cards are blocked before a meeting
 
-**Capability cascade:** These skills now have Trello awareness built in.
+One honest note: there's no automatic background sync — I work with Trello
+when you ask, not on my own. Want automatic two-way sync? Say so and I'll
+capture it on the improvement backlog.
 
 You can adjust settings anytime by running `/trello-setup` again.
 ```
@@ -262,7 +248,7 @@ If the configured board was deleted or renamed:
 
 ### Rate Limiting
 
-Trello allows 100 requests per 10 seconds. This is generous -- you'd only hit it during bulk sync. If you see rate limit errors, wait 10 seconds and retry.
+Trello allows 100 requests per 10 seconds. This is generous -- you'd only hit it when asking Dex to make many changes at once. If you see rate limit errors, wait 10 seconds and retry.
 
 ### Cards Not Syncing
 
@@ -279,9 +265,8 @@ If the user runs `/trello-setup` when already configured:
 
 1. Show current config from `System/integrations/config.yaml`
 2. Offer options:
-   - Change synced board
+   - Change the connected board
    - Update list mapping
-   - Change trust level (auto/ask)
    - Re-authenticate (new API key/token)
    - Add additional boards
    - Disconnect Trello

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -36,12 +36,12 @@ Before processing inbox items, load strategic context and build an index of exis
 
 Read these files to understand current priorities:
 
-1. **Week Priorities**: `00-Inbox/Week_Priorities.md`
+1. **Week Priorities**: `02-Week_Priorities/Week_Priorities.md`
    - Extract this week's Top 3 focus items
    - Note any specific projects/people mentioned
    - Capture keywords and themes
 
-2. **Quarterly Goals**: `03-Tasks/Quarterly_Goals.md`
+2. **Quarterly Goals**: `01-Quarter_Goals/Quarter_Goals.md`
    - Extract current quarter's goals
    - Note associated projects and outcomes
    - Capture keywords and themes
@@ -210,11 +210,10 @@ Extract uncompleted tasks from notes and route them appropriately.
 
 4. **Deduplication Check**
 
-   For each task, check against:
-   - `00-Inbox/Weekly_Plans.md`
-   - `03-Tasks/Tasks.md`
-
-   Flag items with >60% similarity to existing tasks.
+   For each task, check against `03-Tasks/Tasks.md`. Flag items with >60% similarity
+   to existing tasks. (The Work MCP `create_task` tool runs its own similarity gate at
+   creation time — this pre-check is so you can show duplicates to the user before
+   proposing a route, not a replacement for the tool's gate.)
 
 5. **Ambiguity Detection**
 
@@ -241,9 +240,16 @@ Extract uncompleted tasks from notes and route them appropriately.
    - Wait for user input
 
 7. **Route with Confirmation**
-   - To Week Priorities: Add to `00-Inbox/Weekly_Plans.md`
-   - To Project: Add to relevant project file
-   - To Person: Add to person page's action items
+   - **Actionable task → Work MCP `create_task`.** Never append task checkboxes to
+     files by hand — hand-written tasks get no task ID, so completion sync, dedup,
+     and goal rollups can't see them. Pass what triage learned: `pillar` (confirmed
+     with the user), `priority`, `due` if a date was mentioned, `weekly_priority_id`
+     if it supports a weekly priority, `people`/`account` page paths for anyone
+     involved, and `project`/`goal` when the item clearly belongs to one. If the
+     tool flags a duplicate the user already reviewed in step 6 and chose "Keep
+     Both", retry with `on_duplicate: "force"`.
+   - To Project: Add non-task context to the relevant project file
+   - To Person: Add non-task context to the person page
    - Skip: Don't process
    - Defer: Leave for later
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.36.0] - Every promise about tasks is now one Dex keeps (2026-07-12)
+
+A few task features described things that didn't actually happen: the Todoist, Things, and Trello setups promised automatic two-way sync that was never built, the inbox triage helper read planning files from locations that no longer exist, and some flows quietly wrote tasks in a way the rest of the system couldn't track. This release makes every promise honest and every capture path first-class.
+
+**What this fixes for you:**
+
+* **Todoist, Things, and Trello setups now tell the truth.** They connect Dex so you can check, create, and complete tasks in those apps *on request, in conversation* — and they say plainly that there's no automatic background sync. Before, setup walked you through configuring "auto-sync" choices that did nothing.
+* **Inbox triage reads your real plans again.** `/triage` was reading your weekly priorities and quarterly goals from folders that were reorganized long ago, so its routing suggestions ignored your actual priorities.
+* **Every captured task is now a real task.** Triage and end-of-day follow-ups used to write plain checkboxes into files; those never got a task ID, so completion tracking, duplicate detection, and goal progress couldn't see them. Both now create tasks properly, carrying the person, company, due date, and goal details they learned along the way.
+* **Phone-captured items are handled honestly.** The morning-plan flow claimed one tool both checked and created your captured tasks; it only checked. The instructions now match reality, and the misleading option was removed from the tool itself.
+
 ## [1.34.1] - Dex's release checks no longer break contributor setups (2026-07-12)
 
 Release checks now preserve your local Git history and explain when they cannot compare it.

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3167,11 +3167,6 @@ async def handle_list_tools() -> list[types.Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "List of items to process"
-                    },
-                    "auto_create": {
-                        "type": "boolean",
-                        "description": "Automatically create non-duplicate, non-ambiguous tasks",
-                        "default": False
                     }
                 },
                 "required": ["items"]
@@ -4053,7 +4048,6 @@ async def _handle_call_tool_inner(
     
     elif name == "process_inbox_with_dedup":
         items = arguments.get('items', [])
-        auto_create = arguments.get('auto_create', False)
         
         if not items:
             return [types.TextContent(type="text", text=json.dumps({
@@ -4066,7 +4060,6 @@ async def _handle_call_tool_inner(
             "new_tasks": [],
             "potential_duplicates": [],
             "needs_clarification": [],
-            "auto_created": [],
             "summary": {}
         }
         

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -312,6 +312,50 @@ def test_create_task_schema_adds_owned_fields_without_source():
     assert properties["on_duplicate"]["default"] == "fail"
 
 
+def test_process_inbox_with_dedup_classifies_without_creating_tasks(task_vault):
+    tools = asyncio.run(work_server.handle_list_tools())
+    inbox_tool = next(tool for tool in tools if tool.name == "process_inbox_with_dedup")
+    assert "auto_create" not in inbox_tool.inputSchema["properties"]
+
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Prepare quarterly customer renewal brief ^task-20260711-070\n",
+        encoding="utf-8",
+    )
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "process_inbox_with_dedup",
+        {
+            "items": [
+                "Prepare quarterly customer renewal brief",
+                "Fix bug",
+                "Draft customer onboarding plan for this week",
+            ],
+            "auto_create": True,
+        },
+    )
+
+    assert [entry["item"] for entry in result["potential_duplicates"]] == [
+        "Prepare quarterly customer renewal brief"
+    ]
+    assert [entry["item"] for entry in result["needs_clarification"]] == ["Fix bug"]
+    assert result["new_tasks"] == [
+        {
+            "item": "Draft customer onboarding plan for this week",
+            "suggested_pillar": "pillar_2",
+            "suggested_priority": "P1",
+            "ready_to_create": True,
+        }
+    ]
+    assert result["summary"]["total_items"] == 3
+    assert result["summary"]["new_tasks"] == 1
+    assert result["summary"]["duplicates_found"] == 1
+    assert result["summary"]["needs_clarification"] == 1
+    assert "auto_created" not in result
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
 def test_create_task_writes_and_parses_due_project_and_goal(task_vault):
     project = task_vault["root"] / "04-Projects" / "Customer_Renewal.md"
     project.parent.mkdir(parents=True)


### PR DESCRIPTION
## What

Phase 3 of the task-engine repair (follows #100, #106). The instruction layer promised task machinery that doesn't exist; this PR makes every promise honest and routes every capture path through the real task API.

**External integrations tell the truth** — the Todoist/Things/Trello setup skills promised automatic two-way sync backed by a bridge that was never written (the adapters exist only untracked on the author's machine; nothing ships them). Rewritten to describe the real capability: on-request access through each connected MCP ("what's due in Todoist?", "move the card to Done"), with the limitation stated plainly and an improvement-backlog hook for users who want real sync. The auto-sync/trust-level setup steps that configured nothing are gone, along with the Todoist `pillar_map` that hardcoded the demo persona's pillars.

**Capture paths become first-class** — `/triage` was reading weekly priorities and quarterly goals from three pre-restructure paths that don't exist in current vaults, and both `/triage` and `/daily-review` follow-ups appended raw checkboxes that completion sync, dedup, and rollups could never see. Both now route through `create_task`, carrying the pillar/people/account/due/goal context they learned.

**The classify-only tool stops claiming otherwise** — `/daily-plan` said `process_inbox_with_dedup` creates tasks; it only classifies (its `auto_create` parameter was parsed and never used). The parameter and the always-empty `auto_created` response key are removed, with regression tests asserting classification without creation and that legacy `auto_create: true` is inert. The skill flow now classifies, confirms, then creates per item.

## Verification

- Full suite **408 passed, 1 skipped** (outside any sandbox), **45/45** hook tests, ruff clean
- All four gates locally: test-delta ✅ path-contract ✅ doc-drift ✅ instructed-tools ✅
- CHANGELOG 1.36.0 included

Remaining decision for Dave (logged to Dispatch): build the real sync bridge as a feature, or leave external tools as on-request. Nothing in this PR blocks either path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WZCmEDi4qiNLDTwsSJXL