### PR TITLE
Your work stays safe: rollback no longer eats tasks, meetings stop overwriting (v1.39.0)

### DIFF
--- a/.claude/hooks/tests/data-safety-instructions.test.cjs
+++ b/.claude/hooks/tests/data-safety-instructions.test.cjs
@@ -1,0 +1,321 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const ROLLBACK_SKILL = fs.readFileSync(
+  path.join(REPO_ROOT, '.claude', 'skills', 'dex-rollback', 'SKILL.md'),
+  'utf-8',
+);
+const UPDATE_SKILL = fs.readFileSync(
+  path.join(REPO_ROOT, '.claude', 'skills', 'dex-update', 'SKILL.md'),
+  'utf-8',
+);
+
+const USER_DATA_PATHS = [
+  '00-Inbox/',
+  '01-Quarter_Goals/',
+  '02-Week_Priorities/',
+  '03-Tasks/',
+  '04-Projects/',
+  '05-Areas/',
+  '06-Resources/',
+  '07-Archives/',
+];
+
+const MANUAL_RESOURCE_COPY = '06-Resources/ (copy the entire folder, including root-level files)';
+const MANUAL_RESOURCE_RESTORE = 'replace 06-Resources/Dex_System/ with the copy from the downloaded Dex';
+
+function executableResetMatches(document) {
+  return [...document.matchAll(/^(?:if ! )?git reset --hard\s+.+$/gm)];
+}
+
+function assertEveryHardResetProtectsUserData(document, label) {
+  const resets = executableResetMatches(document);
+  assert.ok(resets.length > 0, `${label} must contain at least one hard reset`);
+
+  for (const [index, reset] of resets.entries()) {
+    const previousResetIndex = index === 0 ? 0 : resets[index - 1].index;
+    const nextResetIndex = index + 1 < resets.length ? resets[index + 1].index : document.length;
+    const stashIndex = document.lastIndexOf('git stash push --include-untracked', reset.index);
+    const popIndex = document.indexOf('git stash pop', reset.index);
+
+    assert.ok(
+      stashIndex > previousResetIndex,
+      `${label} reset ${reset[0]} must create its own user-data stash first`,
+    );
+    assert.ok(
+      popIndex > reset.index && popIndex < nextResetIndex,
+      `${label} reset ${reset[0]} must restore its own user-data stash afterward`,
+    );
+
+    const protectedBlock = document.slice(previousResetIndex, popIndex);
+    for (const userPath of USER_DATA_PATHS) {
+      assert.ok(
+        protectedBlock.includes(userPath),
+        `${label} reset ${reset[0]} does not protect ${userPath}`,
+      );
+    }
+
+    const recoveryBlock = document.slice(stashIndex, nextResetIndex);
+    assert.match(
+      recoveryBlock,
+      /System\/rollback-rescue\//,
+      `${label} reset ${reset[0]} needs a timestamped conflict-rescue branch`,
+    );
+  }
+}
+
+function sectionBetween(document, start, end) {
+  const startIndex = document.indexOf(start);
+  const endIndex = document.indexOf(end, startIndex + start.length);
+  assert.notEqual(startIndex, -1, `missing manual-copy section start: ${start}`);
+  assert.notEqual(endIndex, -1, `missing manual-copy section end: ${end}`);
+  return document.slice(startIndex, endIndex);
+}
+
+function bashBlocks(document) {
+  return [...document.matchAll(/```bash\n([\s\S]*?)```/g)].map((match) => match[1]);
+}
+
+function bashBlockContaining(document, needle) {
+  const block = bashBlocks(document).find((candidate) => candidate.includes(needle));
+  assert.ok(block, `missing bash block containing ${needle}`);
+  return block;
+}
+
+function runGit(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  assert.equal(result.status, 0, `git ${args.join(' ')} failed:\n${result.stderr}`);
+  return result.stdout.trim();
+}
+
+test('every hard reset snapshots and restores all user data with conflict rescue', () => {
+  assertEveryHardResetProtectsUserData(ROLLBACK_SKILL, 'dex-rollback');
+  assertEveryHardResetProtectsUserData(UPDATE_SKILL, 'dex-update');
+});
+
+test('rollback and update explain that tracked planning files require protection', () => {
+  for (const [label, document] of [
+    ['dex-rollback', ROLLBACK_SKILL],
+    ['dex-update', UPDATE_SKILL],
+  ]) {
+    assert.match(document, /some files in 00-07 are tracked/i, `${label} must state the tracked-data truth`);
+    assert.doesNotMatch(document, /they(?:'|’)re gitignored \(not tracked\)/i);
+    assert.doesNotMatch(document, /data folders \(00-07\) are not affected/i);
+    assert.doesNotMatch(document, /user data never at risk \(gitignored\)/i);
+  }
+
+  assert.doesNotMatch(ROLLBACK_SKILL, /notes, tasks, projects stay as they are/i);
+  assert.doesNotMatch(ROLLBACK_SKILL, /no data loss ever/i);
+  assert.doesNotMatch(UPDATE_SKILL, /never touches your notes, tasks, projects/i);
+  assert.doesNotMatch(UPDATE_SKILL, /exactly as it was/i);
+});
+
+test('every manual copy list includes the full resources tree and session learnings', () => {
+  const manualLists = [
+    sectionBetween(UPDATE_SKILL, '3. Copy these folders', '[Show detailed guide]'),
+    sectionBetween(UPDATE_SKILL, 'From OLD Dex folder', "3. **DON'T copy:**"),
+    sectionBetween(ROLLBACK_SKILL, 'From CURRENT Dex', '3. **Replace folders:**'),
+  ];
+
+  for (const manualList of manualLists) {
+    assert.ok(manualList.includes(MANUAL_RESOURCE_COPY), 'manual copy list omits the full 06-Resources tree');
+    assert.ok(
+      manualList.includes(MANUAL_RESOURCE_RESTORE),
+      'manual copy list does not restore the downloaded Dex_System docs',
+    );
+    assert.ok(manualList.includes('System/Session_Learnings/'));
+  }
+});
+
+test('documented shell blocks parse as bash and recovery never cleans untracked work', () => {
+  for (const [label, document] of [
+    ['dex-rollback', ROLLBACK_SKILL],
+    ['dex-update', UPDATE_SKILL],
+  ]) {
+    const destructiveBlocks = bashBlocks(document).filter((block) => block.includes('git reset --hard'));
+    for (const [index, block] of destructiveBlocks.entries()) {
+      const parsed = spawnSync('/bin/bash', ['-n'], { input: block, encoding: 'utf-8' });
+      assert.equal(
+        parsed.status,
+        0,
+        `${label} protected-reset bash block ${index + 1} is invalid:\n${parsed.stderr}`,
+      );
+      assert.doesNotMatch(
+        block,
+        /^git (?:reset --hard|restore --source=)/gm,
+        `${label} protected-reset bash block ${index + 1} has an unchecked reset/restore`,
+      );
+      assert.doesNotMatch(
+        block,
+        /^\s*git archive/gm,
+        `${label} protected-reset bash block ${index + 1} has an unchecked rescue export`,
+      );
+      assert.match(
+        block,
+        /Automatic rescue export failed/,
+        `${label} protected-reset bash block ${index + 1} needs an honest rescue failure branch`,
+      );
+    }
+    assert.doesNotMatch(document, /^git clean\s+-[^\n]*f[^\n]*d/gm);
+  }
+});
+
+test('rollback manifest cleanup removes newer core files but never user data', (t) => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-manifest-cleanup-'));
+  t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+
+  const protectedFiles = [
+    '03-Tasks/new-task-data.md',
+    '06-Resources/root-reference.md',
+    'System/Session_Learnings/new-learning.md',
+  ];
+  const newerCoreFile = 'core/new-feature.py';
+  for (const relativePath of [...protectedFiles, newerCoreFile]) {
+    const filepath = path.join(repo, relativePath);
+    fs.mkdirSync(path.dirname(filepath), { recursive: true });
+    fs.writeFileSync(filepath, `${relativePath}\n`);
+  }
+
+  const newManifest = path.join(repo, 'new-manifest.txt');
+  fs.writeFileSync(
+    newManifest,
+    [...protectedFiles, newerCoreFile].map((relativePath) => `hash  ${relativePath}`).join('\n') + '\n',
+  );
+  const restoredManifest = path.join(repo, 'System', '.installed-files.manifest');
+  fs.writeFileSync(restoredManifest, '# restored version\n');
+
+  const cleanupBlock = bashBlockContaining(ROLLBACK_SKILL, 'comm -23')
+    .replaceAll('/tmp/dex-new-manifest.txt', newManifest);
+  const result = spawnSync('/bin/bash', ['-c', cleanupBlock], {
+    cwd: repo,
+    encoding: 'utf-8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(repo, newerCoreFile)), false);
+  for (const relativePath of protectedFiles) {
+    assert.equal(fs.existsSync(path.join(repo, relativePath)), true, relativePath);
+  }
+});
+
+function setupProtectedResetRepo(t) {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-protected-reset-'));
+  t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+
+  const protectedFiles = [
+    ['00-Inbox/', 'data.md'],
+    ['01-Quarter_Goals/', 'Quarter_Goals.md'],
+    ['02-Week_Priorities/', 'Week_Priorities.md'],
+    ['03-Tasks/', 'Tasks.md'],
+    ['04-Projects/', 'data.md'],
+    ['05-Areas/', 'data.md'],
+    ['06-Resources/', 'data.md'],
+    ['07-Archives/', 'data.md'],
+    ['System/', 'user-profile.yaml'],
+    ['System/', 'pillars.yaml'],
+    ['System/Session_Learnings/', 'learning.md'],
+  ].map(([directory, filename]) => path.join(repo, directory, filename));
+
+  for (const filepath of protectedFiles) {
+    fs.mkdirSync(path.dirname(filepath), { recursive: true });
+    fs.writeFileSync(filepath, 'backup version\n');
+  }
+  fs.writeFileSync(path.join(repo, 'core.txt'), 'backup core\n');
+  fs.writeFileSync(
+    path.join(repo, '.gitignore'),
+    ['00-Inbox/', '01-Quarter_Goals/', '02-Week_Priorities/', '03-Tasks/',
+      '04-Projects/', '05-Areas/', '07-Archives/'].join('\n') + '\n',
+  );
+
+  runGit(repo, ['init', '-q']);
+  runGit(repo, ['config', 'user.email', 'test@example.com']);
+  runGit(repo, ['config', 'user.name', 'Dex Test']);
+  runGit(repo, ['add', '-f', '.']);
+  runGit(repo, ['commit', '-qm', 'backup release']);
+  runGit(repo, ['tag', 'backup-before-v1.3.0']);
+
+  for (const filepath of protectedFiles) fs.writeFileSync(filepath, 'committed current version\n');
+  fs.writeFileSync(path.join(repo, 'core.txt'), 'newer core\n');
+  runGit(repo, ['add', '-f', '.']);
+  runGit(repo, ['commit', '-qm', 'current release']);
+
+  return { repo, protectedFiles };
+}
+
+test('the primary rollback block preserves committed, uncommitted, and untracked user data', (t) => {
+  const { repo, protectedFiles } = setupProtectedResetRepo(t);
+
+  for (const filepath of protectedFiles) fs.writeFileSync(filepath, 'latest user version\n');
+  const untrackedResource = path.join(repo, '06-Resources', 'private.md');
+  const ignoredProject = path.join(repo, '04-Projects', 'private.md');
+  fs.writeFileSync(untrackedResource, 'private resource\n');
+  fs.writeFileSync(ignoredProject, 'private project\n');
+
+  const rollbackBlock = bashBlockContaining(
+    ROLLBACK_SKILL,
+    'DEX_ROLLBACK_TARGET="backup-before-v1.3.0"',
+  );
+  const result = spawnSync('/bin/bash', ['-c', rollbackBlock], {
+    cwd: repo,
+    encoding: 'utf-8',
+  });
+  assert.equal(
+    result.status,
+    0,
+    `protected rollback failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+
+  assert.equal(fs.readFileSync(path.join(repo, 'core.txt'), 'utf-8'), 'backup core\n');
+  for (const filepath of protectedFiles) {
+    assert.equal(fs.readFileSync(filepath, 'utf-8'), 'latest user version\n', filepath);
+  }
+  assert.equal(fs.readFileSync(untrackedResource, 'utf-8'), 'private resource\n');
+  assert.equal(fs.readFileSync(ignoredProject, 'utf-8'), 'private project\n');
+  assert.equal(runGit(repo, ['stash', 'list']), '');
+});
+
+test('a restore conflict exports both tracked and untracked snapshots and retains the stash', (t) => {
+  const { repo, protectedFiles } = setupProtectedResetRepo(t);
+
+  for (const filepath of protectedFiles) fs.writeFileSync(filepath, 'latest user version\n');
+  const untrackedResource = path.join(repo, '06-Resources', 'private.md');
+  fs.writeFileSync(untrackedResource, 'private resource\n');
+
+  const popNeedle = 'if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then';
+  const rollbackBlock = bashBlockContaining(
+    ROLLBACK_SKILL,
+    'DEX_ROLLBACK_TARGET="backup-before-v1.3.0"',
+  ).replace(
+    popNeedle,
+    `printf 'concurrent edit\\n' > 03-Tasks/Tasks.md\n${popNeedle}`,
+  );
+  const result = spawnSync('/bin/bash', ['-c', rollbackBlock], {
+    cwd: repo,
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 2, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  const rescueRoot = path.join(repo, 'System', 'rollback-rescue');
+  const rescueDirs = fs.readdirSync(rescueRoot);
+  assert.equal(rescueDirs.length, 1);
+  const rescueDir = path.join(rescueRoot, rescueDirs[0]);
+  assert.equal(
+    fs.readFileSync(path.join(rescueDir, 'committed-before-reset', '03-Tasks', 'Tasks.md'), 'utf-8'),
+    'committed current version\n',
+  );
+  assert.equal(
+    fs.readFileSync(path.join(rescueDir, 'stashed-tracked', '03-Tasks', 'Tasks.md'), 'utf-8'),
+    'latest user version\n',
+  );
+  assert.equal(
+    fs.readFileSync(path.join(rescueDir, 'stashed-untracked', '06-Resources', 'private.md'), 'utf-8'),
+    'private resource\n',
+  );
+  assert.match(runGit(repo, ['stash', 'list']), /dex-user-data-before-rollback/);
+});

--- a/.claude/skills/dex-rollback/SKILL.md
+++ b/.claude/skills/dex-rollback/SKILL.md
@@ -13,7 +13,7 @@ description: Undo the last Dex update if something went wrong
 - System feels unstable
 - Want to go back for any reason
 
-**Safe to use:** Your notes, tasks, and projects are never at risk.
+**Safe to use:** Rollback explicitly snapshots and restores your user-owned files before changing Dex. Some files in 00-07 are tracked by Git, so this protection is required rather than assumed.
 
 ---
 
@@ -75,12 +75,13 @@ Will restore to: v1.2.0 (last backup)
 
 **What happens:**
 ✓ Dex features restored to v1.2.0
-✓ Your notes, tasks, projects stay as they are
+✓ Your latest notes, tasks, projects are snapshotted and restored
 ✓ Any new skills from v1.3.0 will be removed
 
 **This is safe:**
-• Your data folders (00-07) are not affected
-• Your configuration (user-profile, pillars) stays
+• Some files in 00-07 are tracked, so every hard reset protects all eight data folders first
+• Your configuration (user-profile, pillars) is protected in the same snapshot
+• If restoration conflicts, rollback stops and keeps both versions in a timestamped rescue folder
 • You can update again later if you want
 
 [Confirm rollback]
@@ -89,29 +90,15 @@ Will restore to: v1.2.0 (last backup)
 
 ---
 
-### Step 3: Save Current State
+### Step 3: Save and Protect Current State
 
-Before rolling back, save any uncommitted changes:
+Before rolling back, protect all user-owned content. This includes every folder from `00-Inbox/` through `07-Archives/`, because tracked planning files such as tasks, quarterly goals, and weekly priorities would otherwise be replaced by a hard reset.
 
 ```
 💾 Saving current state...
 ```
 
-Run:
-```bash
-git add .
-git commit -m "Auto-save before rollback to v1.2.0" || true
-```
-
-Create a "before rollback" tag in case they want to undo the rollback:
-
-```bash
-git tag before-rollback-$(date +%Y%m%d-%H%M%S)
-```
-
-```
-✓ Current state saved
-```
+Run Step 4's single protected shell block. It stashes user data before the auto-save, creates the undo tag only after the save succeeds, performs the reset, restores the tracked snapshot, then reapplies uncommitted and untracked user files.
 
 ---
 
@@ -121,16 +108,134 @@ git tag before-rollback-$(date +%Y%m%d-%H%M%S)
 🔄 Rolling back to v1.2.0...
 ```
 
-Run:
+Run this entire block in one shell invocation so the snapshot references cannot be lost between commands:
 ```bash
-git reset --hard backup-before-v1.3.0
+DEX_ROLLBACK_TARGET="backup-before-v1.3.0"
+DEX_USER_DATA_PATHS=(
+  "00-Inbox/" "01-Quarter_Goals/" "02-Week_Priorities/" "03-Tasks/"
+  "04-Projects/" "05-Areas/" "06-Resources/" "07-Archives/"
+  "System/user-profile.yaml" "System/pillars.yaml" "System/Session_Learnings/"
+)
+DEX_USER_DATA_STASH_PATHS=(
+  ":(top,glob)00-Inbox/**" ":(top,glob)01-Quarter_Goals/**"
+  ":(top,glob)02-Week_Priorities/**" ":(top,glob)03-Tasks/**"
+  ":(top,glob)04-Projects/**" ":(top,glob)05-Areas/**"
+  ":(top,glob)06-Resources/**" ":(top,glob)07-Archives/**"
+  ":(top)System/user-profile.yaml" ":(top)System/pillars.yaml"
+  ":(top,glob)System/Session_Learnings/**"
+)
+DEX_USER_DATA_SOURCE=$(git rev-parse HEAD)
+DEX_DATA_STASH_BEFORE=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+
+git stash push --include-untracked \
+  -m "dex-user-data-before-rollback-$(date +%Y%m%d-%H%M%S)" \
+  -- "${DEX_USER_DATA_STASH_PATHS[@]}" || true
+
+DEX_DATA_STASH_AFTER=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+if [ -n "$DEX_DATA_STASH_AFTER" ] && [ "$DEX_DATA_STASH_AFTER" != "$DEX_DATA_STASH_BEFORE" ]; then
+  DEX_DATA_STASH_REF='stash@{0}'
+  DEX_DATA_STASH_OID="$DEX_DATA_STASH_AFTER"
+else
+  DEX_DATA_STASH_REF=""
+  DEX_DATA_STASH_OID=""
+  if ! git diff --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! git diff --cached --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     [ -n "$(git ls-files --others --exclude-standard -- "${DEX_USER_DATA_PATHS[@]}")" ]; then
+    echo "Rollback stopped: changed user data remains outside the snapshot, so no reset ran"
+    exit 1
+  fi
+fi
+
+if ! git add .; then
+  [ -z "$DEX_DATA_STASH_REF" ] || git stash pop "$DEX_DATA_STASH_REF"
+  echo "Rollback stopped: Git could not prepare the current state, so no reset ran"
+  exit 1
+fi
+if ! git diff --cached --quiet && ! git commit -m "Auto-save before rollback to v1.2.0"; then
+  git reset
+  [ -z "$DEX_DATA_STASH_REF" ] || git stash pop "$DEX_DATA_STASH_REF"
+  echo "Rollback stopped: Git could not save the current state, so no reset ran"
+  exit 1
+fi
+
+DEX_BEFORE_ROLLBACK_TAG="before-rollback-$(date +%Y%m%d-%H%M%S)"
+if ! git tag "$DEX_BEFORE_ROLLBACK_TAG"; then
+  [ -z "$DEX_DATA_STASH_REF" ] || git stash pop "$DEX_DATA_STASH_REF"
+  echo "Rollback stopped: the undo tag could not be created, so no reset ran"
+  exit 1
+fi
+cp System/.installed-files.manifest /tmp/dex-new-manifest.txt 2>/dev/null || true
+
+dex_export_user_data_rescue() {
+  DEX_RESCUE_DIR="System/rollback-rescue/$(date +%Y%m%d-%H%M%S)-$$"
+  if ! mkdir -p "$DEX_RESCUE_DIR/committed-before-reset" \
+      "$DEX_RESCUE_DIR/stashed-tracked" "$DEX_RESCUE_DIR/stashed-untracked"; then
+    echo "Automatic rescue export failed: could not create $DEX_RESCUE_DIR"
+    return 1
+  fi
+
+  DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.committed.tar"
+  if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+      "$DEX_USER_DATA_SOURCE" -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/committed-before-reset"; then
+    echo "Automatic rescue export failed. The committed snapshot remains at $DEX_USER_DATA_SOURCE"
+    return 1
+  fi
+  rm -f "$DEX_RESCUE_ARCHIVE"
+
+  if [ -n "$DEX_DATA_STASH_OID" ]; then
+    DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.stashed.tar"
+    if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+        "$DEX_DATA_STASH_OID" -- "${DEX_USER_DATA_PATHS[@]}" || \
+       ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-tracked"; then
+      echo "Automatic rescue export failed. The latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+      return 1
+    fi
+    rm -f "$DEX_RESCUE_ARCHIVE"
+
+    DEX_UNTRACKED_STASH=$(git rev-parse -q --verify "$DEX_DATA_STASH_OID^3" 2>/dev/null || true)
+    if [ -n "$DEX_UNTRACKED_STASH" ]; then
+      DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.untracked.tar"
+      if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" "$DEX_UNTRACKED_STASH" || \
+         ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-untracked"; then
+        echo "Automatic rescue export failed. Untracked data remains in $DEX_DATA_STASH_REF ($DEX_UNTRACKED_STASH)"
+        return 1
+      fi
+      rm -f "$DEX_RESCUE_ARCHIVE"
+    fi
+  fi
+}
+
+if ! git reset --hard "$DEX_ROLLBACK_TARGET"; then
+  echo "Rollback stopped: the reset failed. User data remains at $DEX_USER_DATA_SOURCE and in $DEX_DATA_STASH_REF"
+  exit 1
+fi
+if ! git restore --source="$DEX_USER_DATA_SOURCE" --staged --worktree -- "${DEX_USER_DATA_PATHS[@]}"; then
+  if dex_export_user_data_rescue; then
+    echo "Rollback stopped: the committed snapshot was exported to $DEX_RESCUE_DIR"
+  else
+    echo "Do not continue: use commit $DEX_USER_DATA_SOURCE and $DEX_DATA_STASH_REF to recover user data"
+  fi
+  exit 2
+fi
+if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then
+  if dex_export_user_data_rescue; then
+    echo "Rollback stopped for review: both user-data versions are preserved in $DEX_RESCUE_DIR"
+    echo "The latest snapshot also remains in $DEX_DATA_STASH_REF"
+  else
+    echo "Do not continue: the latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+  fi
+  exit 2
+fi
+if ! git reset -- "${DEX_USER_DATA_PATHS[@]}"; then
+  echo "User data was restored, but Git could not clear its staged state; review git status before continuing"
+  exit 2
+fi
 ```
 
-This restores all Dex files to the state before update.
+This restores Dex files to the state before the update, then restores the user's latest tracked, uncommitted, and untracked content.
 
-**Note:** User data folders (00-07) remain untouched because:
-1. They're gitignored (not tracked)
-2. `git reset` only affects tracked files
+**Why the restore is explicit:** Some files in 00-07 are tracked even when their folders also appear in `.gitignore`. A hard reset does affect those files, so safety comes from the snapshot-and-restore sequence above, not from ignore rules.
 
 ---
 
@@ -138,15 +243,7 @@ This restores all Dex files to the state before update.
 
 **A. Remove files added by the newer version (manifest-based)**
 
-If `System/.installed-files.manifest` exists for the **current** (newer) version,
-use it to detect files that were added by the update and should be removed:
-
-```bash
-# Save manifests before reset
-cp System/.installed-files.manifest /tmp/dex-new-manifest.txt 2>/dev/null || true
-```
-
-After `git reset --hard` in Step 4, compare:
+The protected Step 4 block already saved the newer manifest before its reset. Compare it with the restored manifest:
 
 ```bash
 if [ -f /tmp/dex-new-manifest.txt ] && [ -f System/.installed-files.manifest ]; then
@@ -155,6 +252,14 @@ if [ -f /tmp/dex-new-manifest.txt ] && [ -f System/.installed-files.manifest ]; 
     <(awk '{print $NF}' /tmp/dex-new-manifest.txt | sort) \
     <(awk '{print $NF}' System/.installed-files.manifest | sort) \
   | while read -r f; do
+      case "$f" in
+        00-Inbox/*|01-Quarter_Goals/*|02-Week_Priorities/*|03-Tasks/*|\
+        04-Projects/*|05-Areas/*|06-Resources/*|07-Archives/*|\
+        System/user-profile.yaml|System/pillars.yaml|System/Session_Learnings/*)
+          echo "  Kept user data: $f"
+          continue
+          ;;
+      esac
       [ -f "$f" ] && rm "$f" && echo "  Removed: $f"
     done
   echo "✓ Cleaned up files added by the update"
@@ -227,7 +332,7 @@ rm -f .migration-version
 
 [Details]
 
-Your data is safe. You may want to:
+The protected reset keeps a recoverable copy of your user data. You may want to:
 [Report this issue]
 [Try rolling back again]
 [Continue anyway]
@@ -243,7 +348,7 @@ Your data is safe. You may want to:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Dex restored to: v1.2.0
-Your data: All preserved (notes, tasks, projects)
+Your data: Pre-rollback snapshot restored (notes, tasks, projects)
 
 You're back to the version from before your last update.
 
@@ -275,7 +380,102 @@ If user chooses restore:
 
 ```bash
 RESTORE_TAG=$(git tag | grep before-rollback | tail -1)
-git reset --hard $RESTORE_TAG
+DEX_ROLLBACK_TARGET="$RESTORE_TAG"
+DEX_USER_DATA_PATHS=(
+  "00-Inbox/" "01-Quarter_Goals/" "02-Week_Priorities/" "03-Tasks/"
+  "04-Projects/" "05-Areas/" "06-Resources/" "07-Archives/"
+  "System/user-profile.yaml" "System/pillars.yaml" "System/Session_Learnings/"
+)
+DEX_USER_DATA_SOURCE=$(git rev-parse HEAD)
+DEX_DATA_STASH_BEFORE=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+DEX_USER_DATA_STASH_PATHS=(
+  ":(top,glob)00-Inbox/**" ":(top,glob)01-Quarter_Goals/**"
+  ":(top,glob)02-Week_Priorities/**" ":(top,glob)03-Tasks/**"
+  ":(top,glob)04-Projects/**" ":(top,glob)05-Areas/**"
+  ":(top,glob)06-Resources/**" ":(top,glob)07-Archives/**"
+  ":(top)System/user-profile.yaml" ":(top)System/pillars.yaml"
+  ":(top,glob)System/Session_Learnings/**"
+)
+git stash push --include-untracked \
+  -m "dex-user-data-before-undo-rollback-$(date +%Y%m%d-%H%M%S)" \
+  -- "${DEX_USER_DATA_STASH_PATHS[@]}" || true
+DEX_DATA_STASH_AFTER=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+if [ -n "$DEX_DATA_STASH_AFTER" ] && [ "$DEX_DATA_STASH_AFTER" != "$DEX_DATA_STASH_BEFORE" ]; then
+  DEX_DATA_STASH_REF='stash@{0}'
+  DEX_DATA_STASH_OID="$DEX_DATA_STASH_AFTER"
+else
+  DEX_DATA_STASH_REF=""
+  DEX_DATA_STASH_OID=""
+  if ! git diff --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! git diff --cached --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     [ -n "$(git ls-files --others --exclude-standard -- "${DEX_USER_DATA_PATHS[@]}")" ]; then
+    echo "Undo stopped: changed user data remains outside the snapshot, so no reset ran"
+    exit 1
+  fi
+fi
+
+dex_export_user_data_rescue() {
+  DEX_RESCUE_DIR="System/rollback-rescue/$(date +%Y%m%d-%H%M%S)-$$"
+  if ! mkdir -p "$DEX_RESCUE_DIR/committed-before-reset" \
+      "$DEX_RESCUE_DIR/stashed-tracked" "$DEX_RESCUE_DIR/stashed-untracked"; then
+    echo "Automatic rescue export failed: could not create $DEX_RESCUE_DIR"
+    return 1
+  fi
+  DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.committed.tar"
+  if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+      "$DEX_USER_DATA_SOURCE" -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/committed-before-reset"; then
+    echo "Automatic rescue export failed. The committed snapshot remains at $DEX_USER_DATA_SOURCE"
+    return 1
+  fi
+  rm -f "$DEX_RESCUE_ARCHIVE"
+  if [ -n "$DEX_DATA_STASH_OID" ]; then
+    DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.stashed.tar"
+    if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+        "$DEX_DATA_STASH_OID" -- "${DEX_USER_DATA_PATHS[@]}" || \
+       ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-tracked"; then
+      echo "Automatic rescue export failed. The latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+      return 1
+    fi
+    rm -f "$DEX_RESCUE_ARCHIVE"
+    DEX_UNTRACKED_STASH=$(git rev-parse -q --verify "$DEX_DATA_STASH_OID^3" 2>/dev/null || true)
+    if [ -n "$DEX_UNTRACKED_STASH" ]; then
+      DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.untracked.tar"
+      if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" "$DEX_UNTRACKED_STASH" || \
+         ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-untracked"; then
+        echo "Automatic rescue export failed. Untracked data remains in $DEX_DATA_STASH_REF ($DEX_UNTRACKED_STASH)"
+        return 1
+      fi
+      rm -f "$DEX_RESCUE_ARCHIVE"
+    fi
+  fi
+}
+
+if ! git reset --hard "$DEX_ROLLBACK_TARGET"; then
+  echo "Undo stopped: the reset failed. User data remains at $DEX_USER_DATA_SOURCE and in $DEX_DATA_STASH_REF"
+  exit 1
+fi
+if ! git restore --source="$DEX_USER_DATA_SOURCE" --staged --worktree -- "${DEX_USER_DATA_PATHS[@]}"; then
+  if dex_export_user_data_rescue; then
+    echo "Undo stopped: the committed snapshot was exported to $DEX_RESCUE_DIR"
+  else
+    echo "Do not continue: use commit $DEX_USER_DATA_SOURCE and $DEX_DATA_STASH_REF to recover user data"
+  fi
+  exit 2
+fi
+if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then
+  if dex_export_user_data_rescue; then
+    echo "Undo stopped for review: both user-data versions are preserved in $DEX_RESCUE_DIR"
+    echo "The latest snapshot also remains in $DEX_DATA_STASH_REF"
+  else
+    echo "Do not continue: the latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+  fi
+  exit 2
+fi
+if ! git reset -- "${DEX_USER_DATA_PATHS[@]}"; then
+  echo "User data was restored, but Git could not clear its staged state; review git status before continuing"
+  exit 2
+fi
 ```
 
 ---
@@ -308,7 +508,10 @@ To restore an older version without Git:
    ✓ 03-Tasks/
    ✓ 04-Projects/
    ✓ 05-Areas/
+   ✓ 06-Resources/ (copy the entire folder, including root-level files)
+   ✓ Then replace 06-Resources/Dex_System/ with the copy from the downloaded Dex so shipped documentation stays current
    ✓ 07-Archives/
+   ✓ System/Session_Learnings/
    ✓ .env (if exists)
 
 3. **Replace folders:**
@@ -335,9 +538,11 @@ To restore an older version without Git:
 - ✓ Core features
 - ✓ Documentation
 
-**What rollback preserves (doesn't touch):**
+**What rollback snapshots and restores:**
 - ✓ Your notes (00-Inbox, 04-Projects, 05-Areas)
 - ✓ Your tasks (03-Tasks/)
+- ✓ Your goals and weekly priorities (01-Quarter_Goals/, 02-Week_Priorities/)
+- ✓ Your resources, learnings, and reviews (06-Resources/)
 - ✓ Your configuration (user-profile, pillars)
 - ✓ Your API keys (.env)
 
@@ -360,11 +565,11 @@ Likely MCP servers need restart:
 
 ### "My tasks look different after rollback"
 
-Your task data is unchanged. What might look different:
+The protected reset restores the task snapshot taken immediately before rollback. What might look different:
 - Task display format (if update changed rendering)
 - Task sorting (if update changed logic)
 
-**Your actual tasks are safe.** Check `03-Tasks/Tasks.md` directly - everything is there.
+**Verify the restored task snapshot:** Check `03-Tasks/Tasks.md` directly. If rollback reported a restore conflict, also check the timestamped `System/rollback-rescue/` folder before continuing.
 
 ### "Can I rollback multiple versions?"
 
@@ -383,7 +588,102 @@ backup-before-v1.3.0
 
 To rollback to specific version:
 ```bash
-git reset --hard backup-before-v1.1.0
+DEX_ROLLBACK_TARGET="backup-before-v1.1.0"
+DEX_USER_DATA_PATHS=(
+  "00-Inbox/" "01-Quarter_Goals/" "02-Week_Priorities/" "03-Tasks/"
+  "04-Projects/" "05-Areas/" "06-Resources/" "07-Archives/"
+  "System/user-profile.yaml" "System/pillars.yaml" "System/Session_Learnings/"
+)
+DEX_USER_DATA_SOURCE=$(git rev-parse HEAD)
+DEX_DATA_STASH_BEFORE=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+DEX_USER_DATA_STASH_PATHS=(
+  ":(top,glob)00-Inbox/**" ":(top,glob)01-Quarter_Goals/**"
+  ":(top,glob)02-Week_Priorities/**" ":(top,glob)03-Tasks/**"
+  ":(top,glob)04-Projects/**" ":(top,glob)05-Areas/**"
+  ":(top,glob)06-Resources/**" ":(top,glob)07-Archives/**"
+  ":(top)System/user-profile.yaml" ":(top)System/pillars.yaml"
+  ":(top,glob)System/Session_Learnings/**"
+)
+git stash push --include-untracked \
+  -m "dex-user-data-before-version-rollback-$(date +%Y%m%d-%H%M%S)" \
+  -- "${DEX_USER_DATA_STASH_PATHS[@]}" || true
+DEX_DATA_STASH_AFTER=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+if [ -n "$DEX_DATA_STASH_AFTER" ] && [ "$DEX_DATA_STASH_AFTER" != "$DEX_DATA_STASH_BEFORE" ]; then
+  DEX_DATA_STASH_REF='stash@{0}'
+  DEX_DATA_STASH_OID="$DEX_DATA_STASH_AFTER"
+else
+  DEX_DATA_STASH_REF=""
+  DEX_DATA_STASH_OID=""
+  if ! git diff --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! git diff --cached --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     [ -n "$(git ls-files --others --exclude-standard -- "${DEX_USER_DATA_PATHS[@]}")" ]; then
+    echo "Rollback stopped: changed user data remains outside the snapshot, so no reset ran"
+    exit 1
+  fi
+fi
+
+dex_export_user_data_rescue() {
+  DEX_RESCUE_DIR="System/rollback-rescue/$(date +%Y%m%d-%H%M%S)-$$"
+  if ! mkdir -p "$DEX_RESCUE_DIR/committed-before-reset" \
+      "$DEX_RESCUE_DIR/stashed-tracked" "$DEX_RESCUE_DIR/stashed-untracked"; then
+    echo "Automatic rescue export failed: could not create $DEX_RESCUE_DIR"
+    return 1
+  fi
+  DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.committed.tar"
+  if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+      "$DEX_USER_DATA_SOURCE" -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/committed-before-reset"; then
+    echo "Automatic rescue export failed. The committed snapshot remains at $DEX_USER_DATA_SOURCE"
+    return 1
+  fi
+  rm -f "$DEX_RESCUE_ARCHIVE"
+  if [ -n "$DEX_DATA_STASH_OID" ]; then
+    DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.stashed.tar"
+    if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+        "$DEX_DATA_STASH_OID" -- "${DEX_USER_DATA_PATHS[@]}" || \
+       ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-tracked"; then
+      echo "Automatic rescue export failed. The latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+      return 1
+    fi
+    rm -f "$DEX_RESCUE_ARCHIVE"
+    DEX_UNTRACKED_STASH=$(git rev-parse -q --verify "$DEX_DATA_STASH_OID^3" 2>/dev/null || true)
+    if [ -n "$DEX_UNTRACKED_STASH" ]; then
+      DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.untracked.tar"
+      if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" "$DEX_UNTRACKED_STASH" || \
+         ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-untracked"; then
+        echo "Automatic rescue export failed. Untracked data remains in $DEX_DATA_STASH_REF ($DEX_UNTRACKED_STASH)"
+        return 1
+      fi
+      rm -f "$DEX_RESCUE_ARCHIVE"
+    fi
+  fi
+}
+
+if ! git reset --hard "$DEX_ROLLBACK_TARGET"; then
+  echo "Rollback stopped: the reset failed. User data remains at $DEX_USER_DATA_SOURCE and in $DEX_DATA_STASH_REF"
+  exit 1
+fi
+if ! git restore --source="$DEX_USER_DATA_SOURCE" --staged --worktree -- "${DEX_USER_DATA_PATHS[@]}"; then
+  if dex_export_user_data_rescue; then
+    echo "Rollback stopped: the committed snapshot was exported to $DEX_RESCUE_DIR"
+  else
+    echo "Do not continue: use commit $DEX_USER_DATA_SOURCE and $DEX_DATA_STASH_REF to recover user data"
+  fi
+  exit 2
+fi
+if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then
+  if dex_export_user_data_rescue; then
+    echo "Rollback stopped for review: both user-data versions are preserved in $DEX_RESCUE_DIR"
+    echo "The latest snapshot also remains in $DEX_DATA_STASH_REF"
+  else
+    echo "Do not continue: the latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+  fi
+  exit 2
+fi
+if ! git reset -- "${DEX_USER_DATA_PATHS[@]}"; then
+  echo "User data was restored, but Git could not clear its staged state; review git status before continuing"
+  exit 2
+fi
 ```
 
 But easier: tell `/dex-rollback` which version you want, and it handles it.
@@ -428,8 +728,8 @@ But easier: tell `/dex-rollback` which version you want, and it handles it.
 **Rollback should be:**
 - One command away
 - Always available
-- Completely safe
-- No data loss ever
+- Explicit about tracked user data
+- Able to stop safely and keep both versions when restoration conflicts
 
 **User confidence:**
 "I can try updates knowing I can undo them instantly"

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -13,7 +13,7 @@ description: Safely update Dex with one command (handles everything automaticall
 
 **What it handles:**
 - Downloads updates automatically
-- Protects your data (never touches your notes, tasks, projects)
+- Protects and restores user data before any hard-reset recovery; some files in 00-07 are tracked, so Dex never relies on `.gitignore` for safety
 - Preserves protected user blocks and user-owned MCP entries
 - Resolves conflicts with a guided choice (no manual merge editor)
 - Shows clear progress and confirmation
@@ -80,10 +80,15 @@ Looks like you downloaded Dex as a ZIP file instead of cloning it.
    • 03-Tasks/
    • 04-Projects/
    • 05-Areas/
+   • 06-Resources/ (copy the entire folder, including root-level files)
+   • Then replace 06-Resources/Dex_System/ with the copy from the downloaded Dex so shipped documentation stays current
    • 07-Archives/
-4. Delete old Dex folder
-5. Rename new folder to 'dex'
-6. Open in Cursor
+   • System/Session_Learnings/
+   • .env (if it exists)
+4. Verify those copies exist in the new folder
+5. Delete old Dex folder
+6. Rename new folder to 'dex'
+7. Open in Cursor
 
 [Show detailed guide] — Open step-by-step instructions
 [Cancel] — I'll do this later
@@ -334,7 +339,7 @@ Options:
 **If AskUserQuestion is not available (non-Claude Code):**
 - Use a simple CLI prompt with the same 4 options.
 - Add one-line tradeoffs to each option (what you keep vs lose).
-- If user types an invalid choice, re-prompt once and default to "Use Dex version".
+- If user types an invalid choice, re-prompt once and default to "Keep my version" so an input mistake cannot discard user work.
 
 **If user chooses "Keep both":**
 - MCP: `name` → `name-custom`
@@ -378,8 +383,105 @@ This is rare, but sometimes updates need manual review.
 If restore:
 ```bash
 git merge --abort
-git reset --hard backup-before-v1.3.0
+DEX_UPDATE_RESET_TARGET="backup-before-v1.3.0"
+DEX_USER_DATA_PATHS=(
+  "00-Inbox/" "01-Quarter_Goals/" "02-Week_Priorities/" "03-Tasks/"
+  "04-Projects/" "05-Areas/" "06-Resources/" "07-Archives/"
+  "System/user-profile.yaml" "System/pillars.yaml" "System/Session_Learnings/"
+)
+DEX_USER_DATA_SOURCE=$(git rev-parse HEAD)
+DEX_DATA_STASH_BEFORE=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+DEX_USER_DATA_STASH_PATHS=(
+  ":(top,glob)00-Inbox/**" ":(top,glob)01-Quarter_Goals/**"
+  ":(top,glob)02-Week_Priorities/**" ":(top,glob)03-Tasks/**"
+  ":(top,glob)04-Projects/**" ":(top,glob)05-Areas/**"
+  ":(top,glob)06-Resources/**" ":(top,glob)07-Archives/**"
+  ":(top)System/user-profile.yaml" ":(top)System/pillars.yaml"
+  ":(top,glob)System/Session_Learnings/**"
+)
+git stash push --include-untracked \
+  -m "dex-user-data-before-update-recovery-$(date +%Y%m%d-%H%M%S)" \
+  -- "${DEX_USER_DATA_STASH_PATHS[@]}" || true
+DEX_DATA_STASH_AFTER=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+if [ -n "$DEX_DATA_STASH_AFTER" ] && [ "$DEX_DATA_STASH_AFTER" != "$DEX_DATA_STASH_BEFORE" ]; then
+  DEX_DATA_STASH_REF='stash@{0}'
+  DEX_DATA_STASH_OID="$DEX_DATA_STASH_AFTER"
+else
+  DEX_DATA_STASH_REF=""
+  DEX_DATA_STASH_OID=""
+  if ! git diff --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! git diff --cached --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     [ -n "$(git ls-files --others --exclude-standard -- "${DEX_USER_DATA_PATHS[@]}")" ]; then
+    echo "Update recovery stopped: changed user data remains outside the snapshot, so no reset ran"
+    exit 1
+  fi
+fi
+
+dex_export_user_data_rescue() {
+  DEX_RESCUE_DIR="System/rollback-rescue/$(date +%Y%m%d-%H%M%S)-$$"
+  if ! mkdir -p "$DEX_RESCUE_DIR/committed-before-reset" \
+      "$DEX_RESCUE_DIR/stashed-tracked" "$DEX_RESCUE_DIR/stashed-untracked"; then
+    echo "Automatic rescue export failed: could not create $DEX_RESCUE_DIR"
+    return 1
+  fi
+  DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.committed.tar"
+  if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+      "$DEX_USER_DATA_SOURCE" -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/committed-before-reset"; then
+    echo "Automatic rescue export failed. The committed snapshot remains at $DEX_USER_DATA_SOURCE"
+    return 1
+  fi
+  rm -f "$DEX_RESCUE_ARCHIVE"
+  if [ -n "$DEX_DATA_STASH_OID" ]; then
+    DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.stashed.tar"
+    if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+        "$DEX_DATA_STASH_OID" -- "${DEX_USER_DATA_PATHS[@]}" || \
+       ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-tracked"; then
+      echo "Automatic rescue export failed. The latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+      return 1
+    fi
+    rm -f "$DEX_RESCUE_ARCHIVE"
+    DEX_UNTRACKED_STASH=$(git rev-parse -q --verify "$DEX_DATA_STASH_OID^3" 2>/dev/null || true)
+    if [ -n "$DEX_UNTRACKED_STASH" ]; then
+      DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.untracked.tar"
+      if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" "$DEX_UNTRACKED_STASH" || \
+         ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-untracked"; then
+        echo "Automatic rescue export failed. Untracked data remains in $DEX_DATA_STASH_REF ($DEX_UNTRACKED_STASH)"
+        return 1
+      fi
+      rm -f "$DEX_RESCUE_ARCHIVE"
+    fi
+  fi
+}
+
+if ! git reset --hard "$DEX_UPDATE_RESET_TARGET"; then
+  echo "Update recovery stopped: the reset failed. User data remains at $DEX_USER_DATA_SOURCE and in $DEX_DATA_STASH_REF"
+  exit 1
+fi
+if ! git restore --source="$DEX_USER_DATA_SOURCE" --staged --worktree -- "${DEX_USER_DATA_PATHS[@]}"; then
+  if dex_export_user_data_rescue; then
+    echo "Update recovery stopped: the committed snapshot was exported to $DEX_RESCUE_DIR"
+  else
+    echo "Do not continue: use commit $DEX_USER_DATA_SOURCE and $DEX_DATA_STASH_REF to recover user data"
+  fi
+  exit 2
+fi
+if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then
+  if dex_export_user_data_rescue; then
+    echo "Update recovery stopped for review: both user-data versions are preserved in $DEX_RESCUE_DIR"
+    echo "The latest snapshot also remains in $DEX_DATA_STASH_REF"
+  else
+    echo "Do not continue: the latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+  fi
+  exit 2
+fi
+if ! git reset -- "${DEX_USER_DATA_PATHS[@]}"; then
+  echo "User data was restored, but Git could not clear its staged state; review git status before continuing"
+  exit 2
+fi
 ```
+
+Some files in 00-07 are tracked. The recovery therefore restores their pre-reset snapshot explicitly; it does not assume ignore rules make them safe.
 
 ---
 
@@ -539,7 +641,7 @@ Add to summary if installed: "✓ Enabled automatic meeting sync (runs every 30 
 
 [Details of what failed]
 
-Your data is safe, but you may want to:
+The pre-update backup and protected user-data snapshot remain available. You may want to:
 [Restore to previous version]
 [Report this issue]
 [Continue anyway]
@@ -560,9 +662,9 @@ What's new:
 • Meeting intelligence enhancement
 
 Your data:
-✓ All notes preserved
-✓ All tasks preserved
-✓ All customizations preserved
+✓ Note files present after update
+✓ Task files present after update
+✓ Protected customization markers and entries present
 
 [View full changelog]
 [Start using new features]
@@ -579,7 +681,7 @@ Your data:
 🔍 Changes applied:
 • Updated 12 core files
 • Kept 5 of your customized files
-• Protected all your data folders
+• Kept your version of every user-data conflict
 
 [See detailed change list]
 ```
@@ -670,14 +772,111 @@ User always has escape hatch:
 Run:
 ```bash
 git merge --abort 2>/dev/null || true
-git reset --hard backup-before-v1.3.0
-git clean -fd
+DEX_UPDATE_RESET_TARGET="backup-before-v1.3.0"
+DEX_USER_DATA_PATHS=(
+  "00-Inbox/" "01-Quarter_Goals/" "02-Week_Priorities/" "03-Tasks/"
+  "04-Projects/" "05-Areas/" "06-Resources/" "07-Archives/"
+  "System/user-profile.yaml" "System/pillars.yaml" "System/Session_Learnings/"
+)
+DEX_USER_DATA_SOURCE=$(git rev-parse HEAD)
+DEX_DATA_STASH_BEFORE=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+DEX_USER_DATA_STASH_PATHS=(
+  ":(top,glob)00-Inbox/**" ":(top,glob)01-Quarter_Goals/**"
+  ":(top,glob)02-Week_Priorities/**" ":(top,glob)03-Tasks/**"
+  ":(top,glob)04-Projects/**" ":(top,glob)05-Areas/**"
+  ":(top,glob)06-Resources/**" ":(top,glob)07-Archives/**"
+  ":(top)System/user-profile.yaml" ":(top)System/pillars.yaml"
+  ":(top,glob)System/Session_Learnings/**"
+)
+git stash push --include-untracked \
+  -m "dex-user-data-before-update-error-recovery-$(date +%Y%m%d-%H%M%S)" \
+  -- "${DEX_USER_DATA_STASH_PATHS[@]}" || true
+DEX_DATA_STASH_AFTER=$(git rev-parse -q --verify refs/stash 2>/dev/null || true)
+if [ -n "$DEX_DATA_STASH_AFTER" ] && [ "$DEX_DATA_STASH_AFTER" != "$DEX_DATA_STASH_BEFORE" ]; then
+  DEX_DATA_STASH_REF='stash@{0}'
+  DEX_DATA_STASH_OID="$DEX_DATA_STASH_AFTER"
+else
+  DEX_DATA_STASH_REF=""
+  DEX_DATA_STASH_OID=""
+  if ! git diff --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! git diff --cached --quiet -- "${DEX_USER_DATA_PATHS[@]}" || \
+     [ -n "$(git ls-files --others --exclude-standard -- "${DEX_USER_DATA_PATHS[@]}")" ]; then
+    echo "Update recovery stopped: changed user data remains outside the snapshot, so no reset ran"
+    exit 1
+  fi
+fi
+
+dex_export_user_data_rescue() {
+  DEX_RESCUE_DIR="System/rollback-rescue/$(date +%Y%m%d-%H%M%S)-$$"
+  if ! mkdir -p "$DEX_RESCUE_DIR/committed-before-reset" \
+      "$DEX_RESCUE_DIR/stashed-tracked" "$DEX_RESCUE_DIR/stashed-untracked"; then
+    echo "Automatic rescue export failed: could not create $DEX_RESCUE_DIR"
+    return 1
+  fi
+  DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.committed.tar"
+  if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+      "$DEX_USER_DATA_SOURCE" -- "${DEX_USER_DATA_PATHS[@]}" || \
+     ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/committed-before-reset"; then
+    echo "Automatic rescue export failed. The committed snapshot remains at $DEX_USER_DATA_SOURCE"
+    return 1
+  fi
+  rm -f "$DEX_RESCUE_ARCHIVE"
+  if [ -n "$DEX_DATA_STASH_OID" ]; then
+    DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.stashed.tar"
+    if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" \
+        "$DEX_DATA_STASH_OID" -- "${DEX_USER_DATA_PATHS[@]}" || \
+       ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-tracked"; then
+      echo "Automatic rescue export failed. The latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+      return 1
+    fi
+    rm -f "$DEX_RESCUE_ARCHIVE"
+    DEX_UNTRACKED_STASH=$(git rev-parse -q --verify "$DEX_DATA_STASH_OID^3" 2>/dev/null || true)
+    if [ -n "$DEX_UNTRACKED_STASH" ]; then
+      DEX_RESCUE_ARCHIVE="$DEX_RESCUE_DIR/.untracked.tar"
+      if ! git archive --format=tar -o "$DEX_RESCUE_ARCHIVE" "$DEX_UNTRACKED_STASH" || \
+         ! tar -xf "$DEX_RESCUE_ARCHIVE" -C "$DEX_RESCUE_DIR/stashed-untracked"; then
+        echo "Automatic rescue export failed. Untracked data remains in $DEX_DATA_STASH_REF ($DEX_UNTRACKED_STASH)"
+        return 1
+      fi
+      rm -f "$DEX_RESCUE_ARCHIVE"
+    fi
+  fi
+}
+
+if ! git reset --hard "$DEX_UPDATE_RESET_TARGET"; then
+  echo "Update recovery stopped: the reset failed. User data remains at $DEX_USER_DATA_SOURCE and in $DEX_DATA_STASH_REF"
+  exit 1
+fi
+if ! git restore --source="$DEX_USER_DATA_SOURCE" --staged --worktree -- "${DEX_USER_DATA_PATHS[@]}"; then
+  if dex_export_user_data_rescue; then
+    echo "Update recovery stopped: the committed snapshot was exported to $DEX_RESCUE_DIR"
+  else
+    echo "Do not continue: use commit $DEX_USER_DATA_SOURCE and $DEX_DATA_STASH_REF to recover user data"
+  fi
+  exit 2
+fi
+if [ -n "$DEX_DATA_STASH_REF" ] && ! git stash pop "$DEX_DATA_STASH_REF"; then
+  if dex_export_user_data_rescue; then
+    echo "Update recovery stopped for review: both user-data versions are preserved in $DEX_RESCUE_DIR"
+    echo "The latest snapshot also remains in $DEX_DATA_STASH_REF"
+  else
+    echo "Do not continue: the latest snapshot remains in $DEX_DATA_STASH_REF ($DEX_DATA_STASH_OID)"
+  fi
+  exit 2
+fi
+if ! git reset -- "${DEX_USER_DATA_PATHS[@]}"; then
+  echo "User data was restored, but Git could not clear its staged state; review git status before continuing"
+  exit 2
+fi
+git status --short
 ```
+
+Do not run `git clean` during recovery: untracked files may be the user's unsaved work. Any stray files created by the failed update are left in place and listed by `git status` for review.
 
 ```
 ✓ Restored to v1.2.0
 
-Nothing was changed. Your Dex is exactly as it was.
+Tracked Dex files are back to their pre-update state. User data was restored from the protected snapshot, and untracked files were left in place. If the restore needed manual review, the command stopped and printed the timestamped rescue folder instead of showing this success message.
 
 [Try update again]
 [Report issue]
@@ -749,7 +948,10 @@ If automatic updates don't work, you can update manually:
    ✓ 03-Tasks/ (entire folder)
    ✓ 04-Projects/ (entire folder)
    ✓ 05-Areas/ (entire folder)
+   ✓ 06-Resources/ (copy the entire folder, including root-level files)
+   ✓ Then replace 06-Resources/Dex_System/ with the copy from the downloaded Dex so shipped documentation stays current
    ✓ 07-Archives/ (entire folder)
+   ✓ System/Session_Learnings/
    ✓ .env (if it exists)
    ✓ Your `USER_EXTENSIONS` block from `CLAUDE.md`
    ✓ Any custom MCP entries named `custom-*` from `.mcp.json`
@@ -834,7 +1036,8 @@ updates:
 
 **Safe always:**
 - Backup created before any changes
-- User data never at risk (gitignored)
+- Some files in 00-07 are tracked, so hard-reset recovery snapshots and restores all eight data folders explicitly
+- Restore conflicts stop the recovery and keep both versions in a timestamped rescue folder
 - One-command rollback if issues
 - Clear status at every step
 

--- a/.scripts/meeting-intel/__tests__/meeting-note-filenames.test.cjs
+++ b/.scripts/meeting-intel/__tests__/meeting-note-filenames.test.cjs
@@ -1,0 +1,94 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  createBasicMeetingNote,
+  createMeetingNote,
+  resolveMeetingNoteTarget,
+} = require('../sync-from-granola.cjs');
+
+const PROFILE = { name: 'Owner', obsidian_mode: false };
+const PILLARS = ['General'];
+const ANALYSIS = '## Summary\n\nUseful discussion.\n\n## Pillar Assignment\n\nGeneral\n';
+
+function meeting(id) {
+  return {
+    id,
+    title: 'Weekly Sync',
+    createdAt: '2026-07-12T10:00:00Z',
+    notes: 'Detailed notes for a real meeting.',
+    transcript: '',
+    participants: [],
+    attendees: [],
+    owner: null,
+    company: '',
+    duration: null,
+    source: 'api',
+  };
+}
+
+function assertCollisionSafety(t, label, writer) {
+  const meetingsDir = fs.mkdtempSync(path.join(os.tmpdir(), `dex-${label}-notes-`));
+  t.after(() => fs.rmSync(meetingsDir, { recursive: true, force: true }));
+  const options = { meetingsDir, logger: () => {} };
+
+  const first = writer(meeting('11111111-alpha'), options);
+  const second = writer(meeting('22222222-beta'), options);
+  const rerun = writer(meeting('22222222-beta'), options);
+
+  const datedDir = path.join(meetingsDir, '2026-07-12');
+  const files = fs.readdirSync(datedDir).sort();
+  assert.equal(files.length, 2, `${label} must keep both distinct meetings`);
+  assert.equal(path.basename(first.filepath), 'weekly-sync.md');
+  assert.equal(path.basename(second.filepath), 'weekly-sync-22222222.md');
+  assert.equal(rerun.filepath, second.filepath, `${label} rerun must reuse its suffixed note`);
+  assert.match(fs.readFileSync(first.filepath, 'utf-8'), /granola_id: "11111111-alpha"/);
+  assert.match(fs.readFileSync(second.filepath, 'utf-8'), /granola_id: "22222222-beta"/);
+}
+
+test('AI meeting notes suffix only a different same-title meeting and rerun idempotently', (t) => {
+  assertCollisionSafety(t, 'ai', (item, options) => (
+    createMeetingNote(item, ANALYSIS, PROFILE, PILLARS, options)
+  ));
+});
+
+test('basic meeting notes suffix only a different same-title meeting and rerun idempotently', (t) => {
+  assertCollisionSafety(t, 'basic', (item, options) => (
+    createBasicMeetingNote(item, PROFILE, options)
+  ));
+});
+
+test('quoted Granola id in YAML frontmatter still owns the clean filename', (t) => {
+  const meetingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-frontmatter-owner-'));
+  t.after(() => fs.rmSync(meetingsDir, { recursive: true, force: true }));
+
+  const datedDir = path.join(meetingsDir, '2026-07-12');
+  const cleanPath = path.join(datedDir, 'weekly-sync.md');
+  fs.mkdirSync(datedDir, { recursive: true });
+  fs.writeFileSync(
+    cleanPath,
+    '---\ngranola_id: "same-id" # valid YAML comment\n---\n\n# Weekly Sync\n',
+  );
+
+  const target = resolveMeetingNoteTarget(meeting('same-id'), meetingsDir);
+
+  assert.equal(target.filepath, cleanPath);
+});
+
+test('Granola id text outside frontmatter cannot claim the clean filename', (t) => {
+  const meetingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-body-id-lookalike-'));
+  t.after(() => fs.rmSync(meetingsDir, { recursive: true, force: true }));
+
+  const datedDir = path.join(meetingsDir, '2026-07-12');
+  const cleanPath = path.join(datedDir, 'weekly-sync.md');
+  fs.mkdirSync(datedDir, { recursive: true });
+  fs.writeFileSync(cleanPath, '# Manual note\n\ngranola_id: same-id\n');
+
+  const target = resolveMeetingNoteTarget(meeting('same-id'), meetingsDir);
+
+  assert.equal(path.basename(target.filepath), 'weekly-sync-same-id.md');
+});

--- a/.scripts/meeting-intel/sync-from-granola.cjs
+++ b/.scripts/meeting-intel/sync-from-granola.cjs
@@ -640,6 +640,65 @@ function slugify(text) {
     .slice(0, 60);
 }
 
+function readGranolaId(filepath) {
+  try {
+    const content = fs.readFileSync(filepath, 'utf-8');
+    const frontmatterMatch = content.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+    if (!frontmatterMatch) return null;
+
+    const frontmatter = yaml.load(frontmatterMatch[1]);
+    if (!frontmatter || typeof frontmatter !== 'object' || Array.isArray(frontmatter)) {
+      return null;
+    }
+
+    const granolaId = frontmatter.granola_id;
+    return granolaId === undefined || granolaId === null
+      ? null
+      : String(granolaId).trim();
+  } catch (error) {
+    return null;
+  }
+}
+
+function granolaIdFragment(meetingId, length = 8) {
+  const safeId = String(meetingId || '')
+    .replace(/[^a-z0-9_-]+/gi, '')
+    .slice(0, length);
+  return safeId || 'unknown';
+}
+
+function resolveMeetingNoteTarget(meeting, meetingsDir = MEETINGS_DIR) {
+  const date = meeting.createdAt.split('T')[0];
+  const outputDir = path.join(meetingsDir, date);
+  const slug = slugify(meeting.title);
+  const meetingId = String(meeting.id);
+  const baseFilename = `${slug}.md`;
+  const baseFilepath = path.join(outputDir, baseFilename);
+
+  if (!fs.existsSync(baseFilepath) || readGranolaId(baseFilepath) === meetingId) {
+    return { filename: baseFilename, filepath: baseFilepath };
+  }
+
+  const shortFragment = granolaIdFragment(meetingId);
+  const shortFilename = `${slug}-${shortFragment}.md`;
+  const shortFilepath = path.join(outputDir, shortFilename);
+  if (!fs.existsSync(shortFilepath) || readGranolaId(shortFilepath) === meetingId) {
+    return { filename: shortFilename, filepath: shortFilepath };
+  }
+
+  const fullFragment = granolaIdFragment(meetingId, 64);
+  let counter = 1;
+  while (true) {
+    const suffix = counter === 1 ? fullFragment : `${fullFragment}-${counter}`;
+    const filename = `${slug}-${suffix}.md`;
+    const filepath = path.join(outputDir, filename);
+    if (!fs.existsSync(filepath) || readGranolaId(filepath) === meetingId) {
+      return { filename, filepath };
+    }
+    counter += 1;
+  }
+}
+
 function getOwnerFilteredAttendees(meeting, profile) {
   const attendees = Array.isArray(meeting.attendees)
     ? meeting.attendees
@@ -667,18 +726,18 @@ function renderParticipants(attendees, profile) {
   }).join(', ');
 }
 
-function createMeetingNote(meeting, analysis, profile, pillars) {
+function createMeetingNote(meeting, analysis, profile, pillars, options = {}) {
   const date = meeting.createdAt.split('T')[0];
   const time = meeting.createdAt.split('T')[1]?.slice(0, 5) || '00:00';
 
-  const outputDir = path.join(MEETINGS_DIR, date);
+  const meetingsDir = options.meetingsDir || MEETINGS_DIR;
+  const noteLogger = options.logger || log;
+  const outputDir = path.join(meetingsDir, date);
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
 
-  const slug = slugify(meeting.title);
-  const filename = `${slug}.md`;
-  const filepath = path.join(outputDir, filename);
+  const { filename, filepath } = resolveMeetingNoteTarget(meeting, meetingsDir);
 
   // Extract pillar from analysis
   const pillarMatch = analysis.match(/## Pillar Assignment\n\n([^\n]+)/i);
@@ -701,7 +760,7 @@ ${renderAttendeesYamlBlock(filteredAttendees)}
 company: "${meeting.company}"
 pillar: "${pillar}"
 duration: ${meeting.duration || 'unknown'}
-granola_id: ${meeting.id}
+granola_id: ${JSON.stringify(String(meeting.id))}
 processed: ${new Date().toISOString()}
 ---
 
@@ -740,11 +799,11 @@ ${meeting.transcript.slice(0, 5000)}${meeting.transcript.length > 5000 ? '\n\n[T
 `;
 
   fs.writeFileSync(filepath, content);
-  log(`Created meeting note: ${filepath}`);
+  noteLogger(`Created meeting note: ${filepath}`);
 
   return {
     filepath,
-    wikilink: `00-Inbox/Meetings/${date}/${slug}.md`
+    wikilink: `00-Inbox/Meetings/${date}/${filename}`
   };
 }
 
@@ -752,18 +811,18 @@ ${meeting.transcript.slice(0, 5000)}${meeting.transcript.length > 5000 ? '\n\n[T
 // BASIC NOTE (no LLM — fallback for automatic mode when API key not configured)
 // ============================================================================
 
-function createBasicMeetingNote(meeting, profile) {
+function createBasicMeetingNote(meeting, profile, options = {}) {
   const date = meeting.createdAt.split('T')[0];
   const time = meeting.createdAt.split('T')[1]?.slice(0, 5) || '00:00';
 
-  const outputDir = path.join(MEETINGS_DIR, date);
+  const meetingsDir = options.meetingsDir || MEETINGS_DIR;
+  const noteLogger = options.logger || log;
+  const outputDir = path.join(meetingsDir, date);
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
 
-  const slug = slugify(meeting.title);
-  const filename = `${slug}.md`;
-  const filepath = path.join(outputDir, filename);
+  const { filename, filepath } = resolveMeetingNoteTarget(meeting, meetingsDir);
 
   const filteredAttendees = getOwnerFilteredAttendees(meeting, profile);
   const filteredParticipants = filteredAttendees.map(attendee => attendee.name);
@@ -785,7 +844,7 @@ title: "${meeting.title.replace(/"/g, '\\"')}"
 participants: [${filteredParticipants.map(p => `"${p}"`).join(', ')}]
 ${renderAttendeesYamlBlock(filteredAttendees)}
 company: "${meeting.company || ''}"
-granola_id: ${meeting.id}
+granola_id: ${JSON.stringify(String(meeting.id))}
 processed: ${new Date().toISOString()}
 ai_analyzed: false
 ---
@@ -806,11 +865,11 @@ ${transcriptSection}
 `;
 
   fs.writeFileSync(filepath, content);
-  log(`  Created basic note (no LLM): ${filepath}`);
+  noteLogger(`  Created basic note (no LLM): ${filepath}`);
 
   return {
     filepath,
-    wikilink: `00-Inbox/Meetings/${date}/${slug}.md`
+    wikilink: `00-Inbox/Meetings/${date}/${filename}`
   };
 }
 
@@ -1120,6 +1179,9 @@ module.exports = {
   getGranolaApiKey,
   getNewMeetingsFromApi,
   fetchMeetingDetail,
+  createBasicMeetingNote,
+  createMeetingNote,
+  resolveMeetingNoteTarget,
   renderAttendeesYamlBlock,
   renderParticipants,
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+
+## [1.39.0] - Your work stays safe and organizes itself (2026-07-12)
+
+---
+
 ## [1.38.0] - Tasks now connect themselves to your people, companies, and goals (2026-07-12)
 
 Two long-standing gaps closed at once: tasks extracted from meetings finally get real, trackable IDs, and every task you create now links itself to the right person page, company, and quarterly goal — carefully, never by guessing.
@@ -22,10 +27,14 @@ Two long-standing gaps closed at once: tasks extracted from meetings finally get
 
 ## [1.37.0] - Your people and company pages now build themselves (2026-07-12)
 
-Dex always promised that the people and companies in your work life would organize themselves into pages — but behind the scenes, most of that depended on the AI remembering to do it, and it often quietly didn't. This release replaces hope with machinery.
+Dex now protects your current plans and notes through rollbacks, manual moves, meeting sync, and Obsidian file events, while also building reliable pages for the people and companies in your work life.
 
 **What this fixes for you:**
 
+* **Rolling back Dex no longer rolls back your life.** Tasks, quarterly goals, weekly priorities, notes, projects, resources, and learnings are snapshotted before Dex changes version and restored afterward. If two versions cannot be combined cleanly, rollback stops, keeps both copies in a dated rescue folder, and tells you instead of claiming everything is fine.
+* **Manual updates bring every learning with you.** The ZIP instructions now include your resources, meeting intelligence, quarterly reviews, and session learnings — and tell you to verify the copies before deleting the old folder.
+* **Two meetings with the same name both survive.** If Granola records two “Weekly Sync” meetings on the same day, Dex keeps the familiar clean filename for the first and adds a short meeting identifier only to the collision. Reprocessing either meeting updates its own note instead of creating another copy or overwriting the other one.
+* **A file touch can no longer undo a completed task.** Obsidian sync now reacts only to a checkbox that actually changed and disagrees with the main task list. Repeated sync failures appear at session start after the third attempt instead of living only in a log file.
 * **People you actually work with get pages automatically.** Once someone shows up in two real meetings across two different weeks (or one with a transcript), Dex creates their page — filed under Internal or External based on their email address, never guessed. One-off intro calls don't clutter your vault, and re-running a sync can never create duplicates.
 * **You choose how hands-off to be.** New setups get fully automatic creation. Existing vaults start in suggest mode: your daily plan says "Dex suggests a page for Jane (2 meetings)" and you say yes, no, or never — "never" is remembered forever. One line in your settings switches modes anytime.
 * **Companies appear from the people you meet.** Meet two people from acme.co.uk and an "Acme" company page exists, with the domain recorded so future contacts attach to it. Personal email services never become companies, and an existing company page always wins over creating a duplicate.

--- a/core/obsidian/sync_daemon.py
+++ b/core/obsidian/sync_daemon.py
@@ -4,6 +4,7 @@ Bidirectional sync daemon for Obsidian ↔ Dex
 Monitors file changes and syncs task states using Work MCP
 """
 import logging
+import re
 import sys
 import time
 from pathlib import Path
@@ -17,6 +18,7 @@ if _repo_root not in sys.path:
     sys.path.append(_repo_root)
 from core.paths import OBSIDIAN_SYNC_LOG as LOG_FILE
 from core.paths import VAULT_ROOT as BASE_DIR
+from core.utils.dex_logger import log_error
 
 logging.basicConfig(
     level=logging.INFO,
@@ -28,13 +30,39 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+TASK_PATTERN = re.compile(r'- \[([ xX])\].*?\^(task-\d{8}-\d{3})')
+
+
 class DexSyncHandler(FileSystemEventHandler):
     """Handle file changes and sync task states"""
-    
-    def __init__(self):
+
+    def __init__(self, vault_root: Path = BASE_DIR):
         self.debounce_time = 1.0  # seconds
         self.pending_files: Set[Path] = set()
         self.last_process_time = time.time()
+        self.last_seen_states = {}
+        self.failure_counts = {}
+        self._prime_last_seen_states(Path(vault_root))
+
+    @staticmethod
+    def _read_task_states(file_path: Path):
+        content = file_path.read_text()
+        return [
+            (task_id, checkbox_state.lower() == 'x')
+            for checkbox_state, task_id in TASK_PATTERN.findall(content)
+        ]
+
+    def _prime_last_seen_states(self, vault_root: Path):
+        """Capture checkbox baselines before file events begin."""
+        if not vault_root.exists():
+            return
+
+        for file_path in vault_root.rglob('*.md'):
+            try:
+                for task_id, completed in self._read_task_states(file_path):
+                    self.last_seen_states[(file_path, task_id)] = completed
+            except (OSError, UnicodeError) as error:
+                logger.warning(f"Could not baseline task states in {file_path}: {error}")
     
     def on_modified(self, event):
         if event.is_directory or not event.src_path.endswith('.md'):
@@ -55,44 +83,98 @@ class DexSyncHandler(FileSystemEventHandler):
         
         logger.info(f"Processing {len(self.pending_files)} changed files")
         
+        canonical_states = None
         for file_path in self.pending_files:
             try:
-                self.sync_file_tasks(file_path)
+                canonical_states = self.sync_file_tasks(file_path, canonical_states)
             except Exception as e:
                 logger.error(f"Error syncing {file_path}: {e}")
         
         self.pending_files.clear()
         self.last_process_time = time.time()
     
-    def sync_file_tasks(self, file_path: Path):
+    def sync_file_tasks(self, file_path: Path, canonical_states=None):
         """Sync task states from a modified file"""
-        content = file_path.read_text()
+        task_states = self._read_task_states(file_path)
         
-        # Find all task checkboxes with IDs
-        import re
-        pattern = r'- \[([ xX])\].*?\^(task-\d{8}-\d{3})'
-        matches = re.findall(pattern, content)
+        if not task_states:
+            return canonical_states
         
-        if not matches:
-            return
+        logger.info(f"Found {len(task_states)} tasks in {file_path.name}")
         
-        logger.info(f"Found {len(matches)} tasks in {file_path.name}")
-        
-        # Call Work MCP to sync each task
-        for checkbox_state, task_id in matches:
-            status = 'd' if checkbox_state.lower() == 'x' else 'n'
-            
+        changed_states = []
+        for task_id, completed in task_states:
+            state_key = (file_path, task_id)
+            previous_state = self.last_seen_states.get(state_key)
+
+            if previous_state is None:
+                self.last_seen_states[state_key] = completed
+                continue
+            if previous_state == completed:
+                continue
+            changed_states.append((state_key, task_id, completed))
+
+        if not changed_states:
+            return canonical_states
+
+        from core.mcp import work_server
+
+        if canonical_states is None:
+            canonical_states = {
+                task['task_id']: task['completed']
+                for task in work_server.parse_tasks_file(work_server.get_tasks_file())
+                if task.get('task_id')
+            }
+
+        # Call Work MCP only for a newly observed transition that differs
+        # from the canonical backlog.
+        for state_key, task_id, completed in changed_states:
+            if task_id not in canonical_states:
+                logger.warning(f"Skipped {task_id}: not found in canonical Tasks.md")
+                self.last_seen_states[state_key] = completed
+                self._clear_sync_failure(task_id)
+                continue
+            if canonical_states[task_id] == completed:
+                self.last_seen_states[state_key] = completed
+                self._clear_sync_failure(task_id)
+                continue
+
+            status = 'd' if completed else 'n'
             # Call Work MCP update_task_status
             # This updates the task everywhere (Tasks.md, person pages, etc.)
             try:
-                from core.mcp.work_server import update_task_status_everywhere
-                result = update_task_status_everywhere(task_id, status == 'd')
+                result = work_server.update_task_status_everywhere(task_id, completed)
                 if result['success']:
+                    self.last_seen_states[state_key] = completed
+                    canonical_states[task_id] = completed
+                    self._clear_sync_failure(task_id)
                     logger.info(f"Synced {task_id} → {status}")
                 else:
-                    logger.error(f"Failed to sync {task_id}: {result['error']}")
+                    error = result.get('error', 'unknown error')
+                    logger.error(f"Failed to sync {task_id}: {error}")
+                    self._record_sync_failure(task_id, error)
             except Exception as e:
                 logger.error(f"Failed to sync {task_id}: {e}")
+                self._record_sync_failure(task_id, str(e))
+
+        return canonical_states
+
+    def _clear_sync_failure(self, task_id: str):
+        self.failure_counts.pop(task_id, None)
+
+    def _record_sync_failure(self, task_id: str, error: str):
+        """Surface one session-start error after a task fails repeatedly."""
+        failures = self.failure_counts.get(task_id, 0) + 1
+        self.failure_counts[task_id] = failures
+        if failures != 3:
+            return
+
+        log_error(
+            source="obsidian-sync",
+            message=f"Obsidian task sync repeatedly failed for {task_id}: {error}",
+            human_message=f"Obsidian changes for {task_id} could not be synced after 3 attempts",
+            context={"task_id": task_id, "failures": 3},
+        )
 
 def start_daemon():
     """Start the sync daemon"""

--- a/core/tests/test_sync_daemon.py
+++ b/core/tests/test_sync_daemon.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
+import json
 import logging
 import sys
 from types import ModuleType
 
+import pytest
+
 from core import paths
 
 
-def test_sync_file_tasks_logs_update_success_and_failure(tmp_path, monkeypatch, caplog):
+@pytest.fixture
+def sync_daemon(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "OBSIDIAN_SYNC_LOG", tmp_path / "obsidian-sync.log")
 
     watchdog = ModuleType("watchdog")
@@ -19,25 +24,199 @@ def test_sync_file_tasks_logs_update_success_and_failure(tmp_path, monkeypatch, 
     monkeypatch.setitem(sys.modules, "watchdog.events", watchdog_events)
     monkeypatch.setitem(sys.modules, "watchdog.observers", watchdog_observers)
 
+    sys.modules.pop("core.obsidian.sync_daemon", None)
+    return importlib.import_module("core.obsidian.sync_daemon")
+
+
+def write_task(path, task_id, completed):
+    checkbox = "x" if completed else " "
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"- [{checkbox}] Ship coverage fix ^{task_id}\n")
+
+
+def test_unchanged_stale_note_never_overrides_canonical_state(
+    tmp_path, monkeypatch, sync_daemon
+):
     from core.mcp import work_server
-    from core.obsidian.sync_daemon import DexSyncHandler
 
     task_id = "task-20260711-001"
-    task_file = tmp_path / "tasks.md"
-    task_file.write_text(f"- [x] Ship coverage fix ^{task_id}\n")
-    handler = DexSyncHandler()
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    note_file = tmp_path / "meeting.md"
+    write_task(canonical_file, task_id, completed=True)
+    write_task(note_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
 
+    updates = []
     monkeypatch.setattr(
         work_server,
         "update_task_status_everywhere",
-        lambda _task_id, _completed: {"success": True, "task_id": task_id},
+        lambda changed_id, completed: updates.append((changed_id, completed))
+        or {"success": True, "task_id": changed_id},
     )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    handler.sync_file_tasks(note_file)
+    handler.sync_file_tasks(note_file)
+
+    assert updates == []
+
+
+def test_first_changed_note_after_startup_propagates_when_it_differs_from_canonical(
+    tmp_path, monkeypatch, sync_daemon
+):
+    from core.mcp import work_server
+
+    task_id = "task-20260711-002"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    note_file = tmp_path / "meeting.md"
+    write_task(canonical_file, task_id, completed=False)
+    write_task(note_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
+
+    updates = []
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda changed_id, completed: updates.append((changed_id, completed))
+        or {"success": True, "task_id": changed_id},
+    )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    write_task(note_file, task_id, completed=True)
+    handler.sync_file_tasks(note_file)
+    handler.sync_file_tasks(note_file)  # An mtime-only event is ignored.
+
+    assert updates == [(task_id, True)]
+
+
+def test_changed_note_matching_canonical_does_not_push(
+    tmp_path, monkeypatch, sync_daemon
+):
+    from core.mcp import work_server
+
+    task_id = "task-20260711-003"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    note_file = tmp_path / "meeting.md"
+    write_task(canonical_file, task_id, completed=True)
+    write_task(note_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
+
+    updates = []
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda changed_id, completed: updates.append((changed_id, completed))
+        or {"success": True, "task_id": changed_id},
+    )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    write_task(note_file, task_id, completed=True)
+    handler.sync_file_tasks(note_file)
+
+    assert updates == []
+
+
+def test_pending_batch_parses_the_canonical_task_list_once(
+    tmp_path, monkeypatch, sync_daemon
+):
+    from core.mcp import work_server
+
+    first_id = "task-20260711-007"
+    second_id = "task-20260711-008"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    first_note = tmp_path / "first.md"
+    second_note = tmp_path / "second.md"
+    canonical_file.parent.mkdir(parents=True, exist_ok=True)
+    canonical_file.write_text(
+        f"- [ ] First task ^{first_id}\n- [ ] Second task ^{second_id}\n"
+    )
+    write_task(first_note, first_id, completed=False)
+    write_task(second_note, second_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
+
+    parse_calls = []
+    real_parse_tasks_file = work_server.parse_tasks_file
+
+    def count_parse_calls(filepath):
+        parse_calls.append(filepath)
+        return real_parse_tasks_file(filepath)
+
+    monkeypatch.setattr(work_server, "parse_tasks_file", count_parse_calls)
+    updates = []
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda task_id, completed: updates.append((task_id, completed))
+        or {"success": True, "task_id": task_id},
+    )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    write_task(first_note, first_id, completed=True)
+    write_task(second_note, second_id, completed=True)
+    handler.pending_files.update({first_note, second_note})
+    handler.process_pending_files()
+
+    assert parse_calls == [canonical_file]
+    assert sorted(updates) == sorted([(first_id, True), (second_id, True)])
+
+
+def test_third_failure_is_queued_once_for_session_start(
+    tmp_path, monkeypatch, sync_daemon, caplog
+):
+    from core.mcp import work_server
+
+    task_id = "task-20260711-004"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    note_file = tmp_path / "meeting.md"
+    write_task(canonical_file, task_id, completed=False)
+    write_task(note_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
+    attempts = []
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda changed_id, completed: attempts.append((changed_id, completed))
+        or {
+            "success": False,
+            "error": "boom",
+            "task_id": task_id,
+        },
+    )
+    queued = []
+    monkeypatch.setattr(
+        sync_daemon,
+        "log_error",
+        lambda source, message, human_message=None, context=None: queued.append(
+            (source, message, human_message, context)
+        ),
+    )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    write_task(note_file, task_id, completed=True)
     with caplog.at_level(logging.INFO, logger="core.obsidian.sync_daemon"):
-        handler.sync_file_tasks(task_file)
+        for attempt in range(4):
+            handler.sync_file_tasks(note_file)
+            if attempt < 2:
+                assert queued == []
 
-    assert f"Synced {task_id} → d" in caplog.messages
+    assert f"Failed to sync {task_id}: boom" in caplog.messages
+    assert attempts == [(task_id, True)] * 4
+    assert len(queued) == 1
+    assert queued[0][0] == "obsidian-sync"
+    assert queued[0][3] == {"task_id": task_id, "failures": 3}
 
-    caplog.clear()
+
+def test_canonical_reconciliation_resets_the_failure_episode(
+    tmp_path, monkeypatch, sync_daemon
+):
+    from core.mcp import work_server
+
+    task_id = "task-20260711-006"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    note_file = tmp_path / "meeting.md"
+    write_task(canonical_file, task_id, completed=False)
+    write_task(note_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
     monkeypatch.setattr(
         work_server,
         "update_task_status_everywhere",
@@ -47,7 +226,49 @@ def test_sync_file_tasks_logs_update_success_and_failure(tmp_path, monkeypatch, 
             "task_id": task_id,
         },
     )
-    with caplog.at_level(logging.INFO, logger="core.obsidian.sync_daemon"):
-        handler.sync_file_tasks(task_file)
+    queued = []
+    monkeypatch.setattr(
+        sync_daemon,
+        "log_error",
+        lambda source, message, human_message=None, context=None: queued.append(
+            (source, message, human_message, context)
+        ),
+    )
 
-    assert f"Failed to sync {task_id}: boom" in caplog.messages
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    write_task(note_file, task_id, completed=True)
+    handler.sync_file_tasks(note_file)
+    handler.sync_file_tasks(note_file)
+    assert handler.failure_counts[task_id] == 2
+
+    write_task(canonical_file, task_id, completed=True)
+    handler.sync_file_tasks(note_file)
+    assert task_id not in handler.failure_counts
+
+    write_task(note_file, task_id, completed=False)
+    handler.sync_file_tasks(note_file)
+    handler.sync_file_tasks(note_file)
+    assert queued == []
+
+    handler.sync_file_tasks(note_file)
+    assert len(queued) == 1
+
+
+def test_repeated_failure_uses_the_session_start_error_queue(
+    tmp_path, monkeypatch, sync_daemon
+):
+    from core.utils import preflight
+
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    task_id = "task-20260711-005"
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+
+    for _ in range(4):
+        handler._record_sync_failure(task_id, "boom")
+
+    queue_path = preflight.get_error_queue_path()
+    queue = json.loads(queue_path.read_text())
+    assert len(queue) == 1
+    assert queue[0]["source"] == "obsidian-sync"
+    assert queue[0]["context"] == {"task_id": task_id, "failures": 3}
+    assert task_id in preflight.format_errors()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.37.0",
+  "version": "1.39.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Round-2 audit **data-safety** batch — four adversarially-verified findings, most-severe first.

- **P1 — /dex-rollback silently reverted user task data.** Rollback (and update) run `git reset --hard`, and `03-Tasks/`, `01-Quarter_Goals/`, `02-Week_Priorities/` are *tracked* — so a rollback threw away every task/goal/priority edit since the last update, while the skill claimed "they're gitignored, your data stays as it is." Now every hard reset stashes all of 00-07 first, restores after, and on conflict rescues both versions into `System/rollback-rescue/`. The false claim is corrected.
- **P2 — same-title meetings overwrote each other.** Two Granola meetings with the same title on one day (a recurring "1:1", "Standup") slugged to the same filename; the second silently overwrote the first and the loss was never re-synced. Collisions now suffix a short meeting-id; re-running the same meeting stays idempotent.
- **P2 — Obsidian sync pushed unchanged state on every file event.** The daemon called the task-status writer on any file-modify regardless of whether the checkbox changed. Now it only propagates a real change, and queues repeated failures to the session-start surface.
- **P3 — manual ZIP update/rollback lost content.** The copy lists omitted `06-Resources/` and `System/Session_Learnings/` while claiming "all notes preserved." Added.

## Test plan
- [x] 105 tests pass (65 hook + 33 meeting-filename + 7 sync-daemon), incl. new collision-safety and instruction-safety suites
- [x] path-contract / doc-drift / test-delta / instructed-tools / ruff / verify-distribution all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG