### PR TITLE
The gardener: person pages get smarter, not just longer (v1.38.0)

### DIFF
--- a/.claude/hooks/paths.cjs
+++ b/.claude/hooks/paths.cjs
@@ -58,6 +58,7 @@ function loadPaths() {
     COMPANY_INDEX_FILE: path.join(VAULT_ROOT, 'System', 'Company_Index.json'),
     DEX_RUNTIME_DIR: path.join(VAULT_ROOT, 'System', '.dex'),
     CONTACTS_STATE_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'contacts.json'),
+    GARDENER_STATE_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'gardener.json'),
     ENTITY_SUGGESTIONS_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'entity-suggestions.json'),
     ENTITY_VERIFICATION_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'entity-verification.json'),
   };

--- a/.scripts/lib/entity-pages.cjs
+++ b/.scripts/lib/entity-pages.cjs
@@ -207,6 +207,7 @@ function replaceMachineRegionInFile(filePath, slug, newContent) {
 }
 
 module.exports = {
+  atomicWrite,
   parseEntityPage, upsertFrontmatter, renderPersonPage, renderCompanyPage,
   replaceMachineRegion, replaceMachineRegionInFile,
 };

--- a/.scripts/meeting-intel/__tests__/gardener.test.cjs
+++ b/.scripts/meeting-intel/__tests__/gardener.test.cjs
@@ -1,0 +1,173 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const { renderPersonPage, replaceMachineRegion } = require('../../lib/entity-pages.cjs');
+const { gardenEntities } = require('../lib/gardener.cjs');
+
+const NOW = new Date('2026-07-12T12:00:00.000Z');
+const BULLETS = '- Product leader at Acme.\n- Discussing the launch plan.';
+
+async function withVault(fn) {
+  const oldVault = process.env.VAULT_PATH;
+  const oldProject = process.env.CLAUDE_PROJECT_DIR;
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-gardener-'));
+  process.env.VAULT_PATH = vault;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  try {
+    return await fn(vault);
+  } finally {
+    if (oldVault === undefined) delete process.env.VAULT_PATH; else process.env.VAULT_PATH = oldVault;
+    if (oldProject === undefined) delete process.env.CLAUDE_PROJECT_DIR; else process.env.CLAUDE_PROJECT_DIR = oldProject;
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+function writePerson(vault, name = 'Jane Doe', options = {}) {
+  const directory = path.join(vault, '05-Areas', 'People', options.location || 'External');
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, `${name.replace(/ /g, '_')}.md`);
+  let text = renderPersonPage(name, options.role || 'Product Lead', 'Acme', [`${name.split(' ')[0].toLowerCase()}@acme.com`]);
+  if (options.noHeading) text = text.replace(/\n## Key Context\n/, '\n');
+  if (options.summary !== undefined) {
+    if (!text.includes('dex:auto:context-summary')) {
+      text = text.replace('## Key Context\n', '## Key Context\n\n<!-- dex:auto:context-summary -->\n<!-- /dex:auto -->\n');
+    }
+    text = replaceMachineRegion(text, 'context-summary', options.summary);
+  }
+  if (options.relatedTasks) text += `\n## Related Tasks\n\n${options.relatedTasks}\n`;
+  fs.writeFileSync(filePath, text);
+  return filePath;
+}
+
+function writeMeeting(vault, { date = '2026-07-10', email = 'jane@acme.com', body = 'Launch planning notes.' } = {}) {
+  const directory = path.join(vault, '00-Inbox', 'Meetings', date);
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'launch.md'), `---\n${yaml.dump({
+    title: 'Launch review', date, attendees: [{ name: 'Jane Doe', email, location: 'external' }],
+  })}---\n# Launch review\n\n${body}\n\n## Transcript\n\nDo not include this transcript.\n`);
+}
+
+function statePath(vault) {
+  return path.join(vault, 'System', '.dex', 'gardener.json');
+}
+
+function readState(vault) {
+  return JSON.parse(fs.readFileSync(statePath(vault), 'utf8'));
+}
+
+test('creates the summary region under Key Context and uses meeting signal', () => withVault(async vault => {
+  const page = writePerson(vault);
+  writeMeeting(vault);
+  let prompt;
+  const result = await gardenEntities({ generate: async value => { prompt = value; return BULLETS; }, now: NOW });
+  const text = fs.readFileSync(page, 'utf8');
+  assert.match(text, /## Key Context\n\n<!-- dex:auto:context-summary -->\n- Product leader at Acme\./);
+  assert.match(prompt, /Launch review/);
+  assert.doesNotMatch(prompt, /Do not include this transcript/);
+  assert.equal(result.gardened.length, 1);
+}));
+
+test('appends Key Context when the heading is missing', () => withVault(async vault => {
+  const page = writePerson(vault, 'Jane Doe', { noHeading: true });
+  await gardenEntities({ generate: async () => BULLETS, now: NOW });
+  assert.match(fs.readFileSync(page, 'utf8'), /## Key Context\n\n<!-- dex:auto:context-summary -->/);
+}));
+
+test('respects seven-day cadence and unchanged input hash', () => withVault(async vault => {
+  writePerson(vault);
+  let calls = 0;
+  const generate = async () => { calls += 1; return BULLETS; };
+  await gardenEntities({ generate, now: NOW });
+  await gardenEntities({ generate, now: new Date('2026-07-18T12:00:00Z') });
+  await gardenEntities({ generate, now: new Date('2026-07-20T12:00:00Z') });
+  assert.equal(calls, 1);
+}));
+
+test('user edit inside the region locks the page and it is never rewritten', () => withVault(async vault => {
+  const page = writePerson(vault);
+  await gardenEntities({ generate: async () => BULLETS, now: NOW });
+  fs.writeFileSync(page, replaceMachineRegion(fs.readFileSync(page, 'utf8'), 'context-summary', '- Human edit'));
+  let calls = 0;
+  const run = () => gardenEntities({
+    generate: async () => { calls += 1; return '- Replacement'; },
+    now: new Date('2026-07-25T12:00:00Z'),
+  });
+  const first = await run();
+  await run();
+  assert.equal(calls, 0);
+  assert.equal(first.locked, 1);
+  assert.match(fs.readFileSync(page, 'utf8'), /- Human edit/);
+  const entry = Object.values(readState(vault).pages)[0];
+  assert.equal(entry.locked_reason, 'user-edited');
+}));
+
+test('limit is honored in never-gardened then oldest ordering', () => withVault(async vault => {
+  writePerson(vault, 'Alpha Person');
+  writePerson(vault, 'Beta Person');
+  writePerson(vault, 'Gamma Person');
+  const pages = {
+    '05-Areas/People/External/Alpha_Person.md': { last_gardened: '2026-06-20T00:00:00Z' },
+    '05-Areas/People/External/Beta_Person.md': { last_gardened: '2026-06-01T00:00:00Z' },
+  };
+  fs.mkdirSync(path.dirname(statePath(vault)), { recursive: true });
+  fs.writeFileSync(statePath(vault), JSON.stringify({ version: 1, pages }));
+  const result = await gardenEntities({ generate: async () => BULLETS, now: NOW, limit: 2 });
+  assert.deepEqual(result.gardened, [
+    '05-Areas/People/External/Gamma_Person.md',
+    '05-Areas/People/External/Beta_Person.md',
+  ]);
+}));
+
+test('empty or garbage LLM output skips without changing the page', () => withVault(async vault => {
+  const page = writePerson(vault);
+  const before = fs.readFileSync(page, 'utf8');
+  const result = await gardenEntities({ generate: async () => 'Summary without bullets', now: NOW });
+  assert.equal(result.gardened.length, 0);
+  assert.equal(fs.readFileSync(page, 'utf8'), before);
+  assert.equal(fs.existsSync(statePath(vault)), false);
+}));
+
+test('quarantined pages are skipped', () => withVault(async vault => {
+  const page = writePerson(vault);
+  fs.writeFileSync(page, '---\nname: [broken\n---\n# Broken\n');
+  let called = false;
+  const result = await gardenEntities({ generate: async () => { called = true; return BULLETS; }, now: NOW });
+  assert.equal(called, false);
+  assert.equal(result.skipped, 1);
+}));
+
+test('dry-run reports candidates but writes neither page nor state', () => withVault(async vault => {
+  const page = writePerson(vault);
+  const before = fs.readFileSync(page, 'utf8');
+  const result = await gardenEntities({ generate: async () => BULLETS, now: NOW, dryRun: true });
+  assert.equal(result.gardened.length, 1);
+  assert.equal(fs.readFileSync(page, 'utf8'), before);
+  assert.equal(fs.existsSync(statePath(vault)), false);
+}));
+
+test('signal is capped at 6000 characters', () => withVault(async vault => {
+  const page = writePerson(vault, 'Jane Doe', { relatedTasks: Array(10).fill(`- ${'x'.repeat(900)}`).join('\n') });
+  const recent = `${'y'.repeat(8000)}`;
+  fs.writeFileSync(page, replaceMachineRegion(fs.readFileSync(page, 'utf8'), 'recent-interactions', recent));
+  let prompt;
+  await gardenEntities({ generate: async value => { prompt = value; return BULLETS; }, now: NOW });
+  const signal = prompt.split('\nSIGNAL:\n')[1];
+  assert.equal(signal.length, 6000);
+}));
+
+test('post-processing keeps six bullets and caps each line', () => withVault(async vault => {
+  const page = writePerson(vault);
+  const output = Array(8).fill(`- ${'z'.repeat(250)}`).join('\n');
+  await gardenEntities({ generate: async () => output, now: NOW });
+  const region = fs.readFileSync(page, 'utf8').match(/dex:auto:context-summary -->\n([\s\S]*?)\n<!-- \/dex:auto/)[1];
+  assert.equal(region.split('\n').length, 6);
+  assert.ok(region.split('\n').every(line => line.length === 200));
+  assert.equal(readState(vault).pages['05-Areas/People/External/Jane_Doe.md'].output_hash,
+    crypto.createHash('sha1').update(region).digest('hex'));
+}));

--- a/.scripts/meeting-intel/garden-entities.cjs
+++ b/.scripts/meeting-intel/garden-entities.cjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+const { generateContent, isConfigured } = require('../lib/llm-client.cjs');
+const { gardenEntities } = require('./lib/gardener.cjs');
+const { runtimePaths } = require('./lib/contacts-state.cjs');
+
+function loadProfile() {
+  const profilePath = runtimePaths().USER_PROFILE_FILE;
+  try {
+    const profile = yaml.load(fs.readFileSync(profilePath, 'utf8'));
+    return profile && typeof profile === 'object' ? profile : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function parseLimit(args) {
+  const index = args.indexOf('--limit');
+  if (index < 0) return 5;
+  const value = Number(args[index + 1]);
+  return Number.isInteger(value) && value >= 0 ? value : 5;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (!isConfigured()) {
+    console.log('Gardener skipped: no LLM key configured.');
+    return;
+  }
+  if (loadProfile().entity_gardener?.enabled === false) {
+    console.log('Gardener skipped: disabled in user profile.');
+    return;
+  }
+  const result = await gardenEntities({
+    generate: generateContent,
+    dryRun: args.includes('--dry-run'),
+    limit: parseLimit(args),
+    log: console.log,
+  });
+  for (const page of result.gardened) console.log(`Gardened: ${page}`);
+  for (const failure of result.errors) {
+    console.log(`Gardener error${failure.page ? ` (${failure.page})` : ''}: ${failure.error}`);
+  }
+  console.log(
+    `Gardener summary: ${result.gardened.length} gardened, ${result.skipped} skipped, `
+    + `${result.locked} locked, ${result.errors.length} errors.`,
+  );
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(`Gardener error: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { main };

--- a/.scripts/meeting-intel/lib/gardener.cjs
+++ b/.scripts/meeting-intel/lib/gardener.cjs
@@ -1,0 +1,296 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const {
+  atomicWrite: atomicWritePage,
+  parseEntityPage,
+  replaceMachineRegion,
+} = require('../../lib/entity-pages.cjs');
+const {
+  atomicWrite,
+  runtimePaths,
+  withLock,
+} = require('./contacts-state.cjs');
+
+const REGION_SLUG = 'context-summary';
+const REGION_START = `<!-- dex:auto:${REGION_SLUG} -->`;
+const REGION_END = '<!-- /dex:auto -->';
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const SIGNAL_LIMIT = 6000;
+
+function sha1(value) {
+  return crypto.createHash('sha1').update(value).digest('hex');
+}
+
+function emptyState() {
+  return { version: 1, pages: {} };
+}
+
+function loadGardenerState(filePath) {
+  try {
+    const candidate = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return {
+      version: 1,
+      pages: candidate && typeof candidate.pages === 'object' && candidate.pages ? candidate.pages : {},
+    };
+  } catch (error) {
+    if (error.code === 'ENOENT' || error instanceof SyntaxError) return emptyState();
+    throw error;
+  }
+}
+
+function savePageState(filePath, relativePath, pageState) {
+  withLock(filePath, () => {
+    const state = loadGardenerState(filePath);
+    state.pages[relativePath] = pageState;
+    atomicWrite(filePath, state);
+  });
+}
+
+function machineRegion(text, slug) {
+  const start = `<!-- dex:auto:${slug} -->`;
+  const startIndex = text.indexOf(start);
+  if (startIndex < 0) return null;
+  const contentStart = startIndex + start.length;
+  const endIndex = text.indexOf(REGION_END, contentStart);
+  if (endIndex < 0) return null;
+  return text.slice(contentStart, endIndex).replace(/^[\r\n]+|[\r\n]+$/g, '');
+}
+
+function ensureSummaryRegion(text) {
+  if (machineRegion(text, REGION_SLUG) !== null) return text;
+  const region = `${REGION_START}\n${REGION_END}`;
+  const heading = /^## Key Context[ \t]*$/m.exec(text);
+  if (heading) {
+    const lineEnd = text.indexOf('\n', heading.index + heading[0].length);
+    const insertionPoint = lineEnd < 0 ? text.length : lineEnd + 1;
+    return `${text.slice(0, insertionPoint)}\n${region}\n${text.slice(insertionPoint)}`;
+  }
+  return `${text.replace(/\s*$/, '')}\n\n## Key Context\n\n${region}\n`;
+}
+
+function sectionLines(text, heading, maximum) {
+  const match = new RegExp(`^## ${heading}[ \\t]*$`, 'mi').exec(text);
+  if (!match) return [];
+  const after = text.slice(match.index + match[0].length).replace(/^\r?\n/, '');
+  const end = /^##\s+/m.exec(after);
+  return (end ? after.slice(0, end.index) : after)
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .slice(0, maximum);
+}
+
+function splitMarkdown(text) {
+  if (!text.startsWith('---')) return { frontmatter: {}, body: text };
+  const match = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*\r?$(?:\r?\n)?/m.exec(text);
+  if (!match || match.index !== 0) return { frontmatter: {}, body: text };
+  try {
+    const frontmatter = yaml.load(match[1]);
+    return {
+      frontmatter: frontmatter && typeof frontmatter === 'object' ? frontmatter : {},
+      body: text.slice(match[0].length),
+    };
+  } catch (_) {
+    return { frontmatter: {}, body: text.slice(match[0].length) };
+  }
+}
+
+function markdownFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  const results = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) results.push(...markdownFiles(fullPath));
+    else if (entry.isFile() && entry.name.endsWith('.md')) results.push(fullPath);
+  }
+  return results;
+}
+
+function meetingSignals(meetingsDir) {
+  const meetings = [];
+  for (const filePath of markdownFiles(meetingsDir)) {
+    try {
+      const { frontmatter, body } = splitMarkdown(fs.readFileSync(filePath, 'utf8'));
+      const attendees = Array.isArray(frontmatter.attendees) ? frontmatter.attendees : [];
+      const emails = new Set(attendees
+        .map(attendee => attendee && typeof attendee.email === 'string' ? attendee.email.toLowerCase() : null)
+        .filter(Boolean));
+      if (emails.size === 0) continue;
+      const withoutTranscript = body.split(/^##\s+Transcript\b.*$/im, 1)[0];
+      const titleMatch = /^#\s+(.+?)\s*$/m.exec(body);
+      const pathDate = filePath.match(/(?:^|[\\/])(\d{4}-\d{2}-\d{2})(?:[\\/]|$)/);
+      const rawDate = frontmatter.date || pathDate?.[1] || '';
+      const date = rawDate instanceof Date && !Number.isNaN(rawDate.getTime())
+        ? rawDate.toISOString().slice(0, 10)
+        : String(rawDate).slice(0, 10);
+      meetings.push({
+        date,
+        title: String(frontmatter.title || titleMatch?.[1] || path.basename(filePath, '.md')),
+        excerpt: withoutTranscript.trim().slice(0, 600),
+        emails,
+      });
+    } catch (_) {
+      // One malformed or unreadable meeting must not stop other signals.
+    }
+  }
+  return meetings.sort((a, b) => b.date.localeCompare(a.date));
+}
+
+function buildSignal(entity, pageText, meetings) {
+  const fields = ['name', 'role', 'company', 'emails', 'location', 'last_interaction'];
+  const lines = ['PERSON:'];
+  for (const field of fields) {
+    const value = entity[field];
+    if (Array.isArray(value)) lines.push(`${field}: ${value.join(', ')}`);
+    else if (value !== null && value !== undefined && value !== '') lines.push(`${field}: ${value}`);
+  }
+
+  const recent = machineRegion(pageText, 'recent-interactions');
+  if (recent) lines.push('', 'RECENT INTERACTIONS:', ...recent.split(/\r?\n/).filter(Boolean));
+
+  const emails = new Set((entity.emails || []).map(email => email.toLowerCase()));
+  const matchingMeetings = meetings
+    .filter(meeting => [...meeting.emails].some(email => emails.has(email)))
+    .slice(0, 5);
+  if (matchingMeetings.length) {
+    lines.push('', 'MEETINGS:');
+    for (const meeting of matchingMeetings) {
+      lines.push(`${meeting.date} — ${meeting.title}`);
+      if (meeting.excerpt) lines.push(meeting.excerpt);
+    }
+  }
+
+  const tasks = sectionLines(pageText, 'Related Tasks', 10);
+  if (tasks.length) lines.push('', 'RELATED TASKS:', ...tasks);
+  return lines.join('\n').slice(0, SIGNAL_LIMIT);
+}
+
+function promptFor(signal) {
+  return `You maintain a short factual summary on a person page in a personal knowledge vault.
+Write 3-6 plain bullet points ("- ") capturing who this person is to the vault owner and what currently matters: role and company, what you've been meeting about, open threads or commitments, and anything that changed recently.
+Rules: only state facts present in the signal below — never speculate or embellish. Most recent information wins. No dates older than 90 days unless still clearly relevant. No pleasantries, no headers, no bold, just bullets. Maximum 6 bullets, each under 25 words.
+
+SIGNAL:
+${signal}`;
+}
+
+function cleanOutput(response) {
+  return String(response || '')
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('- '))
+    .slice(0, 6)
+    .map(line => line.slice(0, 200).trimEnd())
+    .join('\n');
+}
+
+function personPages(peopleDir) {
+  return ['Internal', 'External', 'CPO_Network']
+    .flatMap(folder => markdownFiles(path.join(peopleDir, folder)))
+    .filter(filePath => path.basename(filePath) !== 'README.md');
+}
+
+async function gardenEntities({
+  generate,
+  now = new Date(),
+  limit = 5,
+  dryRun = false,
+  log = () => {},
+} = {}) {
+  const result = { gardened: [], skipped: 0, locked: 0, errors: [] };
+  try {
+    if (typeof generate !== 'function') throw new Error('generate must be a function');
+    const paths = runtimePaths();
+    const nowDate = now instanceof Date ? now : new Date(now);
+    if (Number.isNaN(nowDate.getTime())) throw new Error('now must be a valid date');
+    const maximum = Number.isInteger(Number(limit)) && Number(limit) >= 0 ? Number(limit) : 5;
+    const state = withLock(paths.GARDENER_STATE_FILE, () => loadGardenerState(paths.GARDENER_STATE_FILE));
+    const meetings = meetingSignals(paths.MEETINGS_DIR);
+    const candidates = [];
+
+    for (const filePath of personPages(paths.PEOPLE_DIR)) {
+      try {
+        const entity = parseEntityPage(filePath);
+        if (entity.quarantined) { result.skipped += 1; continue; }
+        const relativePath = path.relative(paths.VAULT_ROOT, filePath).split(path.sep).join('/');
+        const saved = state.pages[relativePath] || {};
+        if (saved.locked) { result.locked += 1; result.skipped += 1; continue; }
+        const pageText = fs.readFileSync(filePath, 'utf8');
+        const currentOutput = machineRegion(pageText, REGION_SLUG);
+        if (currentOutput?.trim() && sha1(currentOutput) !== saved.output_hash) {
+          saved.locked = true;
+          saved.locked_reason = 'user-edited';
+          state.pages[relativePath] = saved;
+          if (!dryRun) savePageState(paths.GARDENER_STATE_FILE, relativePath, saved);
+          result.locked += 1;
+          result.skipped += 1;
+          log(`Gardener locked ${relativePath}: user-edited`);
+          continue;
+        }
+        const signal = buildSignal(entity, pageText, meetings);
+        const inputHash = sha1(signal);
+        const lastGardened = saved.last_gardened ? new Date(saved.last_gardened) : null;
+        if (lastGardened && !Number.isNaN(lastGardened.getTime()) && nowDate - lastGardened < WEEK_MS) {
+          result.skipped += 1;
+          continue;
+        }
+        if (saved.input_hash === inputHash) { result.skipped += 1; continue; }
+        candidates.push({ filePath, relativePath, pageText, signal, inputHash, saved });
+      } catch (error) {
+        result.errors.push({ page: filePath, error: error.message });
+      }
+    }
+
+    candidates.sort((a, b) => {
+      const parsedA = a.saved.last_gardened ? new Date(a.saved.last_gardened).getTime() : NaN;
+      const parsedB = b.saved.last_gardened ? new Date(b.saved.last_gardened).getTime() : NaN;
+      const aTime = Number.isNaN(parsedA) ? -Infinity : parsedA;
+      const bTime = Number.isNaN(parsedB) ? -Infinity : parsedB;
+      return aTime - bTime || a.relativePath.localeCompare(b.relativePath);
+    });
+
+    const selected = candidates.slice(0, maximum);
+    result.skipped += candidates.length - selected.length;
+    for (const candidate of selected) {
+      try {
+        const output = cleanOutput(await generate(promptFor(candidate.signal)));
+        if (!output) { result.skipped += 1; continue; }
+        if (!dryRun) {
+          const latestText = fs.readFileSync(candidate.filePath, 'utf8');
+          const latestOutput = machineRegion(latestText, REGION_SLUG);
+          if (latestOutput?.trim() && sha1(latestOutput) !== candidate.saved.output_hash) {
+            candidate.saved.locked = true;
+            candidate.saved.locked_reason = 'user-edited';
+            savePageState(paths.GARDENER_STATE_FILE, candidate.relativePath, candidate.saved);
+            result.locked += 1;
+            result.skipped += 1;
+            log(`Gardener locked ${candidate.relativePath}: user-edited`);
+            continue;
+          }
+          const withRegion = ensureSummaryRegion(latestText);
+          atomicWritePage(candidate.filePath, replaceMachineRegion(withRegion, REGION_SLUG, output));
+          const nextState = {
+            ...candidate.saved,
+            last_gardened: nowDate.toISOString(),
+            input_hash: candidate.inputHash,
+            output_hash: sha1(output),
+            locked: false,
+            locked_reason: null,
+          };
+          savePageState(paths.GARDENER_STATE_FILE, candidate.relativePath, nextState);
+        }
+        result.gardened.push(candidate.relativePath);
+      } catch (error) {
+        result.errors.push({ page: candidate.relativePath, error: error.message });
+      }
+    }
+  } catch (error) {
+    result.errors.push({ page: null, error: error.message });
+  }
+  return result;
+}
+
+module.exports = { gardenEntities };

--- a/.scripts/meeting-intel/sync-from-granola.cjs
+++ b/.scripts/meeting-intel/sync-from-granola.cjs
@@ -47,7 +47,9 @@ const {
   filterOwner,
 } = require('./lib/attendees.cjs');
 const { processEntityCreation } = require('./lib/entity-creation.cjs');
+const { gardenEntities } = require('./lib/gardener.cjs');
 const { verifyEntities } = require('./verify-entities.cjs');
+const { generateContent, isConfigured } = require('../lib/llm-client.cjs');
 
 // ============================================================================
 // CONFIGURATION
@@ -962,6 +964,18 @@ function runEntityVerification() {
   }
 }
 
+async function runEntityGardener(profile) {
+  if (!isConfigured()
+      || profile.entity_gardener?.enabled === false
+      || profile.meeting_processing?.mode !== 'automatic') return;
+  try {
+    const result = await gardenEntities({ generate: generateContent, limit: 5, log });
+    log(`Gardener: ${result.gardened.length} maintained, ${result.locked} locked, ${result.errors.length} errors`);
+  } catch (error) {
+    log(`Entity gardener skipped after error: ${error.message}`);
+  }
+}
+
 // ============================================================================
 // MAIN
 // ============================================================================
@@ -1004,7 +1018,10 @@ async function main() {
   if (newMeetings === null) {
     // Auth rejected or network failure — already logged a friendly reason.
     log('Could not reach the Granola API this run. Exiting cleanly.');
-    if (!dryRun) runEntityVerification();
+    if (!dryRun) {
+      runEntityVerification();
+      await runEntityGardener(profile);
+    }
     return;
   }
 
@@ -1013,7 +1030,10 @@ async function main() {
   if (newMeetings.length === 0) {
     log('Nothing to process. Exiting.');
     saveState(state);
-    if (!dryRun) runEntityVerification();
+    if (!dryRun) {
+      runEntityVerification();
+      await runEntityGardener(profile);
+    }
     return;
   }
 
@@ -1131,6 +1151,7 @@ async function main() {
   }
 
   runEntityVerification();
+  await runEntityGardener(profile);
 
   // Summary
   log('\n' + '='.repeat(60));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.44.0] - Person pages now get smarter, not just longer (2026-07-12)
+
+The entity engine made pages accumulate facts automatically — meetings, tasks, dates. But accumulation isn't understanding: a page that only grows becomes a log file. The gardener fixes that.
+
+**What this fixes for you:**
+
+* **Every active person page keeps a living summary.** A short "who this person is to you right now" section — role, what you've been meeting about, open threads — distilled from their recent meetings and tasks, refreshed as things change.
+* **It never touches your own writing.** The summary lives in its own clearly marked block. If you ever edit inside that block, Dex takes the hint and permanently stops maintaining that page's summary (and the doctor checkup tells you it did).
+* **Costs stay small and predictable.** At most five pages per sync, each page at most weekly, and only when something new actually happened for that person. It runs only if you already use an AI key for meeting processing, and one settings line (`entity_gardener: enabled: false`) turns it off.
+* **Nothing is written on a bad day.** If the AI returns nothing useful, the page is left exactly as it was — and failures now print the actual reason instead of just an error count.
+
+---
+
+## [1.43.0] - Adding a task never fails just because a priority is busy (2026-07-12)
+
+When a priority level was already full, Dex used to refuse to create the task at all — and that refusal was easy to miss in a wall of terminal text, so the task either vanished or landed at the wrong priority.
+
+**What this fixes for you:**
+
+* **Your task always gets created.** If a priority level is over its guideline, Dex still adds the task there and simply notes that the level is getting crowded — it never silently drops the task or quietly downgrades it.
+* **The nudge is gentle, not a wall.** You see a one-line heads-up with the current count, so you can rebalance when you choose to — not mid-thought.
+* **A pillar keyword like `1:1` no longer breaks task filing.** Certain shorthand written in your pillar settings could crash the step that guesses which pillar a task belongs to; it's now handled safely. Thanks to stevegranshaw for reporting.
+
+---
+
 ## [1.42.0] - Dex now tells the truth about what your setup can do (2026-07-12)
 
 Some setup and recovery guidance could promise features that never reached your active Dex, point you to commands that did not exist, or treat an optional choice as a failure.
@@ -34,20 +59,6 @@ A fresh install could mistake other Dex products or optional features for failur
 * **Checkup totals add up.** Status summaries now use the numbers from the checkup that just ran instead of copying contradictory example totals.
 * **Career features stay quietly optional.** If career tracking is not set up, Dex offers the setup command calmly without an error, a missing-file warning, or a private path from your Mac.
 * **New installs start genuinely clean.** Slack and every related meeting or planning hook begin off, so a new vault no longer inherits someone else's connected-tool state or gets noisy connection warnings.
----
-
-## [1.37.0] - Your people and company pages now build themselves (2026-07-12)
-
-## [1.43.0] - Adding a task never fails just because a priority is busy (2026-07-12)
-
-When a priority level was already full, Dex used to refuse to create the task at all — and that refusal was easy to miss in a wall of terminal text, so the task either vanished or landed at the wrong priority.
-
-**What this fixes for you:**
-
-* **Your task always gets created.** If a priority level is over its guideline, Dex still adds the task there and simply notes that the level is getting crowded — it never silently drops the task or quietly downgrades it.
-* **The nudge is gentle, not a wall.** You see a one-line heads-up with the current count, so you can rebalance when you choose to — not mid-thought.
-* **A pillar keyword like `1:1` no longer breaks task filing.** Certain shorthand written in your pillar settings could crash the step that guesses which pillar a task belongs to; it's now handled safely. Thanks to stevegranshaw for reporting.
-
 ---
 
 ## [1.40.0] - Granola setup now tells you the truth (2026-07-12)
@@ -82,25 +93,6 @@ Two long-standing gaps closed at once: tasks extracted from meetings finally get
 
 ## [1.37.0] - Your people and company pages now build themselves (2026-07-12)
 
-Dex now protects your current plans and notes through rollbacks, manual moves, meeting sync, and Obsidian file events, while also building reliable pages for the people and companies in your work life.
-
-**What this fixes for you:**
-
-* **Rolling back Dex no longer rolls back your life.** Tasks, quarterly goals, weekly priorities, notes, projects, resources, and learnings are snapshotted before Dex changes version and restored afterward. If two versions cannot be combined cleanly, rollback stops, keeps both copies in a dated rescue folder, and tells you instead of claiming everything is fine.
-* **Manual updates bring every learning with you.** The ZIP instructions now include your resources, meeting intelligence, quarterly reviews, and session learnings — and tell you to verify the copies before deleting the old folder.
-* **Two meetings with the same name both survive.** If Granola records two “Weekly Sync” meetings on the same day, Dex keeps the familiar clean filename for the first and adds a short meeting identifier only to the collision. Reprocessing either meeting updates its own note instead of creating another copy or overwriting the other one.
-* **A file touch can no longer undo a completed task.** Obsidian sync now reacts only to a checkbox that actually changed and disagrees with the main task list. Repeated sync failures appear at session start after the third attempt instead of living only in a log file.
-* **People you actually work with get pages automatically.** Once someone shows up in two real meetings across two different weeks (or one with a transcript), Dex creates their page — filed under Internal or External based on their email address, never guessed. One-off intro calls don't clutter your vault, and re-running a sync can never create duplicates.
-* **You choose how hands-off to be.** New setups get fully automatic creation. Existing vaults start in suggest mode: your daily plan says "Dex suggests a page for Jane (2 meetings)" and you say yes, no, or never — "never" is remembered forever. One line in your settings switches modes anytime.
-* **Companies appear from the people you meet.** Meet two people from acme.co.uk and an "Acme" company page exists, with the domain recorded so future contacts attach to it. Personal email services never become companies, and an existing company page always wins over creating a duplicate.
-* **Meeting emails aren't thrown away anymore.** Dex used to fetch each attendee's email address and immediately discard it — which is why colleagues were misfiled as external contacts. Attendee details are now kept with each meeting note, and the everyone-gets-filed-as-External bug is gone.
-* **Pages update themselves after every processed meeting.** The behind-the-scenes step that adds meeting references to person pages had been broken since the day it shipped (it listened on a channel that doesn't exist). It works now: recent meetings, freshness dates, capped and deduplicated — and it only ever touches its own marked sections, never your notes.
-* **Auto-linked names now go somewhere.** The recent auto-linking feature created links that looked right but pointed at pages that didn't exist (clicking made an empty duplicate). Links now open the person's real page, and linking politely stays off unless your vault uses Obsidian-style links.
-* **One page format, four readers reconciled.** Different parts of Dex wrote person pages in four incompatible layouts, so pages created by one feature were invisible to another. There's now a single machine-readable format, every old layout is still understood, and a damaged page is quarantined and reported instead of being overwritten.
-* **You can see it working.** After every sync, a verification pass confirms each attendee ended up somewhere deliberate — page, suggestion, or tracked-for-later — and `/dex-doctor` now has an entity-engine checkup covering all of it, including anything unresolved.
-
----
-
 ## [1.36.0] - Every promise about tasks is now one Dex keeps (2026-07-12)
 
 A few task features described things that didn't actually happen: the Todoist, Things, and Trello setups promised automatic two-way sync that was never built, the inbox triage helper read planning files from locations that no longer exist, and some flows quietly wrote tasks in a way the rest of the system couldn't track. This release makes every promise honest and every capture path first-class.
@@ -111,15 +103,6 @@ A few task features described things that didn't actually happen: the Todoist, T
 * **Inbox triage reads your real plans again.** `/triage` was reading your weekly priorities and quarterly goals from folders that were reorganized long ago, so its routing suggestions ignored your actual priorities.
 * **Every captured task is now a real task.** Triage and end-of-day follow-ups used to write plain checkboxes into files; those never got a task ID, so completion tracking, duplicate detection, and goal progress couldn't see them. Both now create tasks properly, carrying the person, company, due date, and goal details they learned along the way.
 * **Phone-captured items are handled honestly.** The morning-plan flow claimed one tool both checked and created your captured tasks; it only checked. The instructions now match reality, and the misleading option was removed from the tool itself.
-
-## [1.34.1] - Dex's release checks no longer break contributor setups (2026-07-12)
-
-Release checks now preserve your local Git history and explain when they cannot compare it.
-
-**What this fixes for you:**
-
-* **Checks no longer quietly truncate your local Git history.** They now fetch safely when you run them on your machine.
-* **A failed history comparison now explains how to fix it.** Instead of stopping with no output, Dex tells you to unshallow the repository and retry.
 
 ## [1.35.0] - Tasks now remember what you told them (2026-07-11)
 
@@ -134,6 +117,15 @@ When you created a task and confirmed its pillar and priority, Dex wrote them do
 * **A rare data-loss bug is gone.** Adding a task to a section whose heading appeared twice in your task file could silently delete everything after the second heading. Inserts are now safe no matter what your file looks like.
 * **Completed tasks stay clickable in Obsidian.** The completion timestamp used to be written where it broke Obsidian's link-to-this-line feature; it now goes before the link anchor.
 * **Meeting prep sees all your meetings again.** Synced meetings are stored in dated folders that the meeting memory never looked inside — daily plans and meeting prep were blind to them. Both now scan the full folder tree.
+
+## [1.34.1] - Dex's release checks no longer break contributor setups (2026-07-12)
+
+Release checks now preserve your local Git history and explain when they cannot compare it.
+
+**What this fixes for you:**
+
+* **Checks no longer quietly truncate your local Git history.** They now fetch safely when you run them on your machine.
+* **A failed history comparison now explains how to fix it.** Instead of stopping with no output, Dex tells you to unshallow the repository and retry.
 
 ## [1.34.0] - People in your notes now link themselves — safely (2026-07-11)
 

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -71,6 +71,10 @@ meeting_processing:
 entity_creation:
   mode: auto
 
+# Background person-summary maintenance; missing key is enabled, explicit false disables.
+entity_gardener:
+  enabled: true
+
 # Meeting Intelligence Configuration
 # Controls what gets extracted from your meetings (set during onboarding based on role)
 meeting_intelligence:

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -55,6 +55,10 @@ meeting_processing:
 entity_creation:
   mode: auto
 
+# Background person-summary maintenance; missing key is enabled, explicit false disables.
+entity_gardener:
+  enabled: true
+
 # Meeting Intelligence Configuration
 # Controls what gets extracted from your meetings (set during onboarding based on role)
 meeting_intelligence:

--- a/core/paths.py
+++ b/core/paths.py
@@ -91,6 +91,7 @@ MCP_CONFIG_TARGET = VAULT_ROOT / '.mcp.json'
 OBSIDIAN_SYNC_LOG = SYSTEM_DIR / 'obsidian-sync.log'
 RITUAL_INTELLIGENCE_DB_FILE = DEX_RUNTIME_DIR / 'ritual-intelligence.db'
 CONTACTS_STATE_FILE = DEX_RUNTIME_DIR / 'contacts.json'
+GARDENER_STATE_FILE = DEX_RUNTIME_DIR / 'gardener.json'
 ENTITY_SUGGESTIONS_FILE = DEX_RUNTIME_DIR / 'entity-suggestions.json'
 ENTITY_VERIFICATION_FILE = DEX_RUNTIME_DIR / 'entity-verification.json'
 

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -183,6 +183,28 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     assert "stale >48h" in result.detail
 
 
+def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    _write_entity_probe_files(context)
+    result = doctor._probe_entity_engine(context)
+    assert "gardener off (no LLM key)" in result.detail
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    gardener = context.core_path("GARDENER_STATE_FILE")
+    gardener.write_text(json.dumps({"pages": {
+        "one.md": {"output_hash": "one", "locked": False},
+        "two.md": {"output_hash": "two", "locked": True},
+    }}))
+    result = doctor._probe_entity_engine(context)
+    assert "gardener on (2 pages maintained), 1 locked" in result.detail
+
+    profile = context.core_path("USER_PROFILE_FILE")
+    profile.write_text("entity_creation:\n  mode: auto\nentity_gardener:\n  enabled: false\n")
+    result = doctor._probe_entity_engine(context)
+    assert "gardener off (disabled), 1 locked" in result.detail
+
+
 def test_registry_ids_match_the_approved_spec():
     assert [definition.id for definition in doctor.QUICK_CHECKS] == QUICK_IDS
     assert [definition.id for definition in doctor.DEEP_CHECKS] == DEEP_IDS

--- a/core/tests/test_paths.py
+++ b/core/tests/test_paths.py
@@ -96,6 +96,9 @@ class TestDerivedPaths:
     def test_ritual_intelligence_db_parent_is_runtime_dir(self):
         assert paths.RITUAL_INTELLIGENCE_DB_FILE.parent == paths.DEX_RUNTIME_DIR
 
+    def test_gardener_state_file_parent_is_runtime_dir(self):
+        assert paths.GARDENER_STATE_FILE.parent == paths.DEX_RUNTIME_DIR
+
     def test_mcp_config_target_is_at_vault_root(self):
         assert paths.MCP_CONFIG_TARGET == paths.VAULT_ROOT / ".mcp.json"
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -1067,6 +1067,7 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         contacts_path = context.core_path("CONTACTS_STATE_FILE")
         suggestions_path = context.core_path("ENTITY_SUGGESTIONS_FILE")
         verification_path = context.core_path("ENTITY_VERIFICATION_FILE")
+        gardener_path = context.core_path("GARDENER_STATE_FILE")
         profile_path = context.core_path("USER_PROFILE_FILE")
         people_dir = context.core_path("PEOPLE_DIR")
         companies_dir = context.core_path("COMPANIES_DIR")
@@ -1075,6 +1076,7 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         contacts = json.loads(contacts_path.read_text()) if contacts_path.exists() else {}
         suggestions = json.loads(suggestions_path.read_text()) if suggestions_path.exists() else {}
         verification = json.loads(verification_path.read_text()) if verification_path.exists() else {}
+        gardener = json.loads(gardener_path.read_text()) if gardener_path.exists() else {}
         profile = _load_yaml(profile_path) if profile_path.exists() else {}
         if profile is None:
             profile = {}
@@ -1090,6 +1092,17 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         observations = len(contacts.get("observations", {}))
         suggestion_items = suggestions if isinstance(suggestions, list) else suggestions.get("suggestions", [])
         pending = sum(item.get("status") == "suggested" for item in suggestion_items)
+        gardener_pages = gardener.get("pages", {}) if isinstance(gardener, dict) else {}
+        gardener_locked = sum(bool(item.get("locked")) for item in gardener_pages.values())
+        if profile.get("entity_gardener", {}).get("enabled") is False:
+            gardener_label = "off (disabled)"
+        elif not any(os.environ.get(key) for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")):
+            gardener_label = "off (no LLM key)"
+        else:
+            maintained = sum(bool(item.get("output_hash")) for item in gardener_pages.values())
+            gardener_label = f"on ({maintained} pages maintained)"
+        if gardener_locked:
+            gardener_label += f", {gardener_locked} locked"
 
         unresolved = len(verification.get("unresolved", []))
         generated_at = verification.get("generated_at")
@@ -1128,6 +1141,7 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
             f"Entity engine tracks {tracked} contacts and {observations} observations; "
             f"creation is {mode_label}; {pending} suggestions pending; last verification "
             f"{verification_label}; {quarantine_label} quarantined pages; people index {index_freshness}"
+            f"; gardener {gardener_label}"
         )
         if unresolved or quarantined_paths:
             return ProbeResult("BROKEN", detail)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/packages/dex-contracts/dist/paths.contract.json
+++ b/packages/dex-contracts/dist/paths.contract.json
@@ -19,6 +19,7 @@
     "ENTITY_SUGGESTIONS_FILE": "System/.dex/entity-suggestions.json",
     "ENTITY_VERIFICATION_FILE": "System/.dex/entity-verification.json",
     "EVIDENCE_DIR": "05-Areas/Career/Evidence",
+    "GARDENER_STATE_FILE": "System/.dex/gardener.json",
     "GOALS_FILE": "GOALS.md",
     "IDEAS_DIR": "00-Inbox/Ideas",
     "INBOX_DIR": "00-Inbox",


### PR DESCRIPTION
Completes the entity engine's promise arc (#109): the engine made pages accumulate facts automatically; the gardener makes them improve. A budgeted background LLM pass maintains a compact "who this person is to you right now" summary on active person pages.

## Safety rails (the design center)
- Summary lives ONLY inside a `dex:auto:context-summary` region under `## Key Context`; human prose is never read as ours or written over.
- A user edit inside the region **permanently locks** the page — checked at selection and re-checked after the LLM call returns (closes the mid-flight-edit race). Locked pages surface in `/dex-doctor`.
- Empty/malformed LLM output writes nothing; output is post-processed (bullets only, max 6 × 200 chars); quarantined pages skipped.

## Budget
Max 5 pages per sync run, weekly per page, input-hash skip when nothing new happened. Runs only when an LLM key is configured AND `meeting_processing.mode: automatic` (users who already accepted background LLM use); `entity_gardener.enabled: false` disables. Manual CLI: `garden-entities.cjs [--dry-run] [--limit N]` with real error messages.

## Verification
44 script tests + 58 hook tests + 435 pytest green; ruff/path-contract/consistency/instructed-tools/distribution clean; fixture vault pristine. Live provider failure ladder exercised for real (over-quota key → per-page error and no write; invalid key → same; no key → clean skip). Caveat noted honestly: live model output quality not yet observed (no working LLM key available in the build session); bounded by post-processing + the lock rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyDgkbZc3PmRicaBvJDnzp