### PR TITLE
Adding a task never fails just because a priority is busy (closes #80, v1.43.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ A fresh install could mistake other Dex products or optional features for failur
 
 ## [1.37.0] - Your people and company pages now build themselves (2026-07-12)
 
+## [1.43.0] - Adding a task never fails just because a priority is busy (2026-07-12)
+
+When a priority level was already full, Dex used to refuse to create the task at all — and that refusal was easy to miss in a wall of terminal text, so the task either vanished or landed at the wrong priority.
+
+**What this fixes for you:**
+
+* **Your task always gets created.** If a priority level is over its guideline, Dex still adds the task there and simply notes that the level is getting crowded — it never silently drops the task or quietly downgrades it.
+* **The nudge is gentle, not a wall.** You see a one-line heads-up with the current count, so you can rebalance when you choose to — not mid-thought.
+* **A pillar keyword like `1:1` no longer breaks task filing.** Certain shorthand written in your pillar settings could crash the step that guesses which pillar a task belongs to; it's now handled safely. Thanks to stevegranshaw for reporting.
+
+---
+
 ## [1.40.0] - Granola setup now tells you the truth (2026-07-12)
 
 Granola could be fully connected while Dex said it was missing, look ready without the key it needed, or ignore your choice to process meetings manually.

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -208,7 +208,9 @@ def load_pillars_from_yaml() -> Dict[str, Dict]:
             pillars[pillar_id] = {
                 'name': pillar.get('name', pillar_id),
                 'description': pillar.get('description', ''),
-                'keywords': pillar.get('keywords', [])
+                # Coerce to str: YAML parses unquoted tokens like 1:1 as ints
+                # (base-60), which would crash guess_pillar's `keyword in text`.
+                'keywords': [str(k) for k in pillar.get('keywords', [])]
             }
         
         if not pillars:
@@ -4437,34 +4439,29 @@ async def _handle_call_tool_inner(
                 "suggestion": "Review these similar tasks. If this is intentionally separate, retry with on_duplicate=force."
             }, indent=2))]
         
-        # Check priority limits against the canonical backlog only.
+        # Priority limits are a guideline, not a wall. Creating the task always
+        # succeeds; when a bucket is over its limit we attach a warning to the
+        # success payload rather than refusing (issue #80 — a mid-workflow
+        # refusal gets missed in the terminal scroll, silently losing the task
+        # or filing it at the wrong priority). The count reflects state BEFORE
+        # this task is added.
+        priority_warning = None
         active_tasks = active_tasks_for_priority_limits(existing_tasks)
         priority_counts = Counter(t.get('priority', 'P2') for t in active_tasks)
-        
+
         if priority in PRIORITY_LIMITS and priority_counts.get(priority, 0) >= PRIORITY_LIMITS[priority]:
-            occupying_tasks = [
-                {
-                    "title": task.get('title', ''),
-                    "task_id": task.get('task_id') or task.get('id'),
-                }
-                for task in active_tasks
-                if task.get('priority', 'P2') == priority
-            ]
-            occupying_text = ', '.join(
-                f"{task['title']} ({task['task_id']})" for task in occupying_tasks
-            )
-            return [types.TextContent(type="text", text=json.dumps({
-                "success": False,
-                "error": (
-                    f"Priority limit exceeded for {priority}. Currently occupying "
-                    f"this priority: {occupying_text}. Limits may be newly enforced "
-                    "now that stored priorities are read correctly."
+            new_count = priority_counts.get(priority, 0) + 1
+            priority_warning = {
+                "warning": (
+                    f"{priority} now holds {new_count} tasks "
+                    f"(guideline is {PRIORITY_LIMITS[priority]}) — consider "
+                    "completing or demoting one to keep this priority focused."
                 ),
-                "current_count": priority_counts.get(priority, 0),
+                "priority": priority,
+                "current_count": new_count,
                 "limit": PRIORITY_LIMITS[priority],
-                "occupying_tasks": occupying_tasks,
-                "suggestion": f"You have too many {priority} tasks. Complete or deprioritize some before adding more."
-            }, indent=2))]
+                "priority_counts": dict(priority_counts),
+            }
 
         if not goal:
             quarterly_goals = (
@@ -4643,8 +4640,10 @@ async def _handle_call_tool_inner(
             "synced_pages": synced_pages,
             "message": f"Task '{title}' created successfully under {section} with ID: {task_id}"
         }
+        if priority_warning:
+            result["priority_warning"] = priority_warning
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
-    
+
     elif name == "update_task_status":
         task_id = arguments.get('task_id')
         task_title = arguments.get('task_title')

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -619,7 +619,8 @@ def test_uncompletion_accepts_both_stored_completion_layouts(task_vault, task_li
     )
 
 
-def test_priority_limit_error_names_occupying_tasks_and_new_enforcement(task_vault, monkeypatch):
+def test_over_limit_priority_creates_task_with_warning_not_refusal(task_vault, monkeypatch):
+    """Issue #80: an over-limit priority warns but still creates the task."""
     task_vault["tasks"].write_text(
         "# Tasks\n\n## Next Week\n"
         "- [ ] Existing launch brief ^task-20260711-051\n"
@@ -639,16 +640,33 @@ def test_priority_limit_error_names_occupying_tasks_and_new_enforcement(task_vau
         },
     )
 
-    assert result["success"] is False
-    assert "Existing launch brief" in result["error"]
-    assert "task-20260711-051" in result["error"]
-    assert "Existing evidence review" in result["error"]
-    assert "task-20260711-052" in result["error"]
-    assert "newly enforced" in result["error"].lower()
-    assert result["occupying_tasks"] == [
-        {"title": "Existing launch brief", "task_id": "task-20260711-051"},
-        {"title": "Existing evidence review", "task_id": "task-20260711-052"},
-    ]
+    # The task is created, not refused.
+    assert result["success"] is True
+    assert "Prepare another planning record" in task_vault["tasks"].read_text(encoding="utf-8")
+    # ...but a warning surfaces the over-limit state.
+    warning = result["priority_warning"]
+    assert warning["priority"] == "P1"
+    assert warning["current_count"] == 3
+    assert warning["limit"] == 2
+    assert "guideline is 2" in warning["warning"]
+
+
+def test_within_limit_priority_has_no_warning(task_vault, monkeypatch):
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Existing launch brief ^task-20260711-051\n"
+        "\t- Pillar: Test Pillar | Priority: P1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "PRIORITY_LIMITS", {"P0": 3, "P1": 5, "P2": 10})
+
+    result = _call_tool(
+        "create_task",
+        {"title": "One more planning record", "pillar": "pillar_1", "priority": "P1"},
+    )
+
+    assert result["success"] is True
+    assert "priority_warning" not in result
 
 
 def test_python_meeting_cache_recurses_dated_folders_and_skips_queue(

--- a/core/tests/test_work_server_task_priorities.py
+++ b/core/tests/test_work_server_task_priorities.py
@@ -315,3 +315,26 @@ def test_update_task_status_tool_surfaces_title_match_write_failure(monkeypatch)
     )
 
     assert payload == failure
+
+
+def test_load_pillars_coerces_non_string_keywords(tmp_path, monkeypatch):
+    """A YAML keyword like `1:1` parses as an int (base-60); guess_pillar must not crash."""
+    pillars_file = tmp_path / "pillars.yaml"
+    pillars_file.write_text(
+        "pillars:\n"
+        "  - id: sales\n"
+        "    name: Sales\n"
+        "    keywords:\n"
+        "      - 1:1\n"
+        "      - pipeline\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "get_pillars_file", lambda: pillars_file)
+
+    pillars = work_server.load_pillars_from_yaml()
+
+    assert pillars["sales"]["keywords"] == ["61", "pipeline"]
+    # guess_pillar iterates `keyword in text` over module-level PILLARS — the
+    # int-coerced keyword must not raise a TypeError on `61 in "..."`.
+    monkeypatch.setattr(work_server, "PILLARS", pillars)
+    assert work_server.guess_pillar("let's sync on the pipeline") == "sales"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Round-2 audit **work-server** batch. Closes #80; lands community PR #77's crash fix with credit.

- **Priority limits warn instead of blocking (#80).** When a bucket was full, `create_task` returned `success: false` and refused — and that refusal was easy to miss in the terminal scroll, so the task was silently lost or re-filed at the wrong priority. It now always creates the task at the requested priority and, when over the guideline, attaches a `priority_warning` (with the current count and limit) to the success payload.
- **Pillar keywords never crash (#77, @stevegranshaw).** An unquoted YAML token like `1:1` parses as an int (base-60); `guess_pillar`'s `keyword in text` then raised. Keywords are coerced to strings on load.

## Test plan
- [x] 39 work-server tests pass, incl. new `test_over_limit_priority_creates_task_with_warning_not_refusal`, `test_within_limit_priority_has_no_warning`, and `test_load_pillars_coerces_non_string_keywords`
- [x] doc-drift / test-delta / instructed-tools / ruff green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG