### PR TITLE
Harden two round-2 fixes flagged by independent review (v1.46.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.46.0] - Hardening two recent fixes (2026-07-12)
+
+An independent review of this week's safety fixes caught two cases where a fix didn't fully deliver what it promised. Both are now closed.
+
+**What this fixes for you:**
+
+* **Checking a task off directly in your task list now updates everywhere.** A recent change meant that ticking a box straight in `Tasks.md` (rather than through chat or a person page) quietly stopped updating the linked person and meeting pages. Those edits propagate again.
+* **An empty pillar keyword list no longer wipes your pillars.** Leaving a pillar's keywords blank in your settings could quietly reset *all* your pillars to the defaults. A blank list is now handled safely.
+
+---
+
 ## [1.45.0] - Dex can prove your setup still works (2026-07-12)
 
 Dex can now tell you when YOUR customizations break it — and updates prove themselves

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -210,7 +210,10 @@ def load_pillars_from_yaml() -> Dict[str, Dict]:
                 'description': pillar.get('description', ''),
                 # Coerce to str: YAML parses unquoted tokens like 1:1 as ints
                 # (base-60), which would crash guess_pillar's `keyword in text`.
-                'keywords': [str(k) for k in pillar.get('keywords', [])]
+                # `or []` guards a present-but-empty `keywords:` (parses as None),
+                # which would otherwise raise here and discard ALL pillars via the
+                # outer except.
+                'keywords': [str(k) for k in (pillar.get('keywords') or [])]
             }
         
         if not pillars:

--- a/core/obsidian/sync_daemon.py
+++ b/core/obsidian/sync_daemon.py
@@ -126,6 +126,19 @@ class DexSyncHandler(FileSystemEventHandler):
                 if task.get('task_id')
             }
 
+        # When the edit happened in Tasks.md itself, the canonical snapshot was
+        # read from that same just-saved file, so it trivially matches — the
+        # equality guard below would wrongly skip it. A direct Tasks.md edit is
+        # exactly the case that must still propagate to the mirror pages, so we
+        # bypass the equality guard for it (the last_seen guard above already
+        # prevents the write-back it triggers from looping).
+        try:
+            edit_is_canonical_tasks_file = (
+                file_path.resolve() == work_server.get_tasks_file().resolve()
+            )
+        except OSError:
+            edit_is_canonical_tasks_file = False
+
         # Call Work MCP only for a newly observed transition that differs
         # from the canonical backlog.
         for state_key, task_id, completed in changed_states:
@@ -134,7 +147,7 @@ class DexSyncHandler(FileSystemEventHandler):
                 self.last_seen_states[state_key] = completed
                 self._clear_sync_failure(task_id)
                 continue
-            if canonical_states[task_id] == completed:
+            if not edit_is_canonical_tasks_file and canonical_states[task_id] == completed:
                 self.last_seen_states[state_key] = completed
                 self._clear_sync_failure(task_id)
                 continue

--- a/core/tests/test_sync_daemon.py
+++ b/core/tests/test_sync_daemon.py
@@ -272,3 +272,37 @@ def test_repeated_failure_uses_the_session_start_error_queue(
     assert queue[0]["source"] == "obsidian-sync"
     assert queue[0]["context"] == {"task_id": task_id, "failures": 3}
     assert task_id in preflight.format_errors()
+
+
+def test_direct_edit_to_canonical_tasks_file_propagates(
+    tmp_path, monkeypatch, sync_daemon
+):
+    """A checkbox toggled directly in Tasks.md must still sync to the mirror
+    pages — the canonical-equality guard would otherwise skip it because the
+    canonical snapshot is read from that same just-saved file."""
+    from core.mcp import work_server
+
+    task_id = "task-20260712-010"
+    canonical_file = tmp_path / "03-Tasks" / "Tasks.md"
+    write_task(canonical_file, task_id, completed=False)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: canonical_file)
+
+    updates = []
+    monkeypatch.setattr(
+        work_server,
+        "update_task_status_everywhere",
+        lambda changed_id, completed: updates.append((changed_id, completed))
+        or {"success": True, "task_id": changed_id},
+    )
+
+    handler = sync_daemon.DexSyncHandler(tmp_path)
+    handler.sync_file_tasks(canonical_file)  # startup prime, no propagation
+    assert updates == []
+
+    write_task(canonical_file, task_id, completed=True)  # user checks the box in Tasks.md
+    handler.sync_file_tasks(canonical_file)
+
+    assert updates == [(task_id, True)]
+    # The write-back this triggers is caught by the last-seen guard, not re-pushed.
+    handler.sync_file_tasks(canonical_file)
+    assert updates == [(task_id, True)]

--- a/core/tests/test_work_server_task_priorities.py
+++ b/core/tests/test_work_server_task_priorities.py
@@ -338,3 +338,28 @@ def test_load_pillars_coerces_non_string_keywords(tmp_path, monkeypatch):
     # int-coerced keyword must not raise a TypeError on `61 in "..."`.
     monkeypatch.setattr(work_server, "PILLARS", pillars)
     assert work_server.guess_pillar("let's sync on the pipeline") == "sales"
+
+
+def test_empty_keywords_does_not_discard_all_pillars(tmp_path, monkeypatch):
+    """A present-but-empty `keywords:` parses as None; it must load that pillar
+    with no keywords, not raise and fall back to DEFAULT_PILLARS (wiping the
+    user's real pillars)."""
+    pillars_file = tmp_path / "pillars.yaml"
+    pillars_file.write_text(
+        "pillars:\n"
+        "  - id: sales\n"
+        "    name: Sales\n"
+        "    keywords:\n"
+        "  - id: product\n"
+        "    name: Product\n"
+        "    keywords:\n"
+        "      - roadmap\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "get_pillars_file", lambda: pillars_file)
+
+    pillars = work_server.load_pillars_from_yaml()
+
+    assert set(pillars) == {"sales", "product"}
+    assert pillars["sales"]["keywords"] == []
+    assert pillars["product"]["keywords"] == ["roadmap"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

An independent adversarial review of this week's round-2 fixes (v1.39–v1.43) found three cases where a fix didn't fully deliver its guarantee. This PR ships the two that are cleanly fixable; the third is filed separately (see below).

- **sync_daemon — direct `Tasks.md` edits stopped propagating (P3).** The v1.39.0 diff-guard rebuilt "canonical" state from the same `Tasks.md` that just changed, so a checkbox ticked *directly in Tasks.md* always equalled canonical and was skipped — no update to the linked person/meeting pages. Now the equality guard is bypassed when the edited file *is* the canonical tasks file; the existing last-seen guard still prevents the write-back it triggers from looping.
- **work_server — an empty `keywords:` wiped all pillars (P3/P4).** The v1.43.0 coercion `[str(k) for k in pillar.get('keywords', [])]` raised on a present-but-empty `keywords:` (which parses as `None`), and the outer `except` swallowed it by returning DEFAULT_PILLARS — discarding *all* the user's pillars. Guarded with `or []`.

Regression tests added for both.

## The third finding (filed separately, not in this PR)

The review also found that `/dex-rollback`'s `git restore` is all-or-nothing: one user-data path with no tracked content at the source aborts the whole restore. My per-path fix removes that abort, **but** main's rollback blocks were rewritten this week (v1.44 update-verify work) and now hit a *separate* stash-pop conflict for the same untracked-at-source paths — so the scenario needs a coordinated fix in that freshly-rewritten code, not an isolated change I can't validate end-to-end. Filed as an issue for the rollback owners with full repro. Shipping a half-fix into another session's fresh rewrite would be worse than flagging it clearly.

## Test plan
- [x] 17 tests pass (sync_daemon + work_server priorities), incl. new `test_direct_edit_to_canonical_tasks_file_propagates` and `test_empty_keywords_does_not_discard_all_pillars`
- [x] ruff / doc-drift / test-delta / path-contract green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG