### PR TITLE
Release checks stop failing themselves on a technicality (v1.47.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.47.0] - Release checks stop failing themselves on a technicality (2026-07-12)
+
+The automated checks that run on every proposed change could fail with a confusing "cannot find a common ancestor" error that had nothing to do with the change itself — a self-inflicted glitch in how the checks fetched the project's main line.
+
+**What this fixes for you:**
+
+* **Contributor and update checks stop flaking.** The checks now fetch the main line in full instead of a truncated snapshot, so they can always compare your change against it. The earlier partial-fetch was the actual cause of the spurious "no common ancestor" failures — not, as first suspected, anything rewriting the project history.
+* **A guard keeps it from coming back.** A new test fails the build if any check reintroduces the truncated fetch.
+
+---
+
 ## [1.46.0] - Hardening two recent fixes (2026-07-12)
 
 An independent review of this week's safety fixes caught two cases where a fix didn't fully deliver what it promised. Both are now closed.

--- a/core/tests/test_diff_gate_fetch.py
+++ b/core/tests/test_diff_gate_fetch.py
@@ -1,0 +1,43 @@
+"""Guard the diff-gate scripts against re-shallowing the base ref.
+
+The PR diff gates (path-contract, doc-drift, test-delta, coverage) compute
+`git merge-base HEAD origin/<base>`. Fetching the base ref with `--depth=1`
+grafts it with no parents, so merge-base can't find the common ancestor and the
+gate fails with a spurious "no common ancestor" error — which is exactly what
+happened in CI (a `--depth=1`-in-CI fetch from an earlier fix). These tests pin
+the base-ref fetch to a plain fetch so that regression can't return.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+
+SHELL_GATES = [
+    "check-path-contract-usage.sh",
+    "check-doc-drift.sh",
+    "check-test-delta.sh",
+]
+PY_GATE = "check-coverage-threshold.py"
+
+
+def test_shell_gates_do_not_shallow_fetch_the_base_ref():
+    for name in SHELL_GATES:
+        text = (SCRIPTS / name).read_text(encoding="utf-8")
+        assert 'git fetch origin "$BASE_REF"' in text, f"{name} must fetch the base ref"
+        offenders = [
+            line.strip()
+            for line in text.splitlines()
+            if "git fetch" in line and "$BASE_REF" in line and "--depth" in line
+        ]
+        assert offenders == [], f"{name} must not --depth-fetch the base ref: {offenders}"
+
+
+def test_coverage_gate_does_not_shallow_fetch_the_base_ref():
+    text = (SCRIPTS / PY_GATE).read_text(encoding="utf-8")
+    # The base-ref fetch must not append --depth (which grafts away ancestry).
+    assert not re.search(r'"--depth', text), f"{PY_GATE} must not --depth-fetch the base ref"
+    assert '"fetch", "origin", base_ref' in text, f"{PY_GATE} must fetch the base ref"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/check-coverage-threshold.py
+++ b/scripts/check-coverage-threshold.py
@@ -68,11 +68,12 @@ def main() -> int:
         print(f"Total coverage {total:.2f}% is below required {min_total:.2f}%.", file=sys.stderr)
         return 1
 
-    fetch_cmd = ["git", "fetch", "origin", base_ref]
-    if os.environ.get("GITHUB_ACTIONS"):
-        fetch_cmd.append("--depth=1")
+    # Plain fetch, never --depth=1: the base ref must carry enough ancestry for
+    # the git merge-base below. A --depth=1 fetch grafts the ref with no parents,
+    # so merge-base fails with "no common ancestor". CI checks out at
+    # fetch-depth:0, so a full fetch of one ref is cheap.
     try:
-        run(fetch_cmd)
+        run(["git", "fetch", "origin", base_ref])
     except subprocess.CalledProcessError:
         pass
 

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-if [ -n "${GITHUB_ACTIONS:-}" ]; then
-  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-else
-  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
-fi
+# Plain fetch, never --depth=1: the base ref must carry enough ancestry for the
+# `git merge-base` below. A --depth=1 fetch grafts the ref with no parents, so
+# merge-base can't find the common ancestor and this gate fails with the exact
+# "no common ancestor" error it prints. CI checks out at fetch-depth:0, so a
+# full fetch of one ref is cheap.
+git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
 if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
   echo "❌ check-doc-drift.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
   exit 1

--- a/scripts/check-path-contract-usage.sh
+++ b/scripts/check-path-contract-usage.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-if [ -n "${GITHUB_ACTIONS:-}" ]; then
-  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-else
-  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
-fi
+# Plain fetch, never --depth=1: the base ref must carry enough ancestry for the
+# `git merge-base` below. A --depth=1 fetch grafts the ref with no parents, so
+# merge-base can't find the common ancestor and this gate fails with the exact
+# "no common ancestor" error it prints. CI checks out at fetch-depth:0, so a
+# full fetch of one ref is cheap.
+git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
 if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
   echo "❌ check-path-contract-usage.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
   exit 1

--- a/scripts/check-test-delta.sh
+++ b/scripts/check-test-delta.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
-if [ -n "${GITHUB_ACTIONS:-}" ]; then
-  git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 || true
-else
-  git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
-fi
+# Plain fetch, never --depth=1: the base ref must carry enough ancestry for the
+# `git merge-base` below. A --depth=1 fetch grafts the ref with no parents, so
+# merge-base can't find the common ancestor and this gate fails with the exact
+# "no common ancestor" error it prints. CI checks out at fetch-depth:0, so a
+# full fetch of one ref is cheap.
+git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
 if ! MERGE_BASE="$(git merge-base HEAD "origin/$BASE_REF")"; then
   echo "❌ check-test-delta.sh: cannot find a common ancestor between HEAD and origin/$BASE_REF. Your local history may be shallow — run: git fetch --unshallow origin — then retry." >&2
   exit 1


### PR DESCRIPTION
## What this actually was (correcting an earlier diagnosis)

The recurring CI failures during the round-2 work — `cannot find a common ancestor between HEAD and origin/main`, and git reporting `main -> origin/main (forced update)` — looked like something force-pushing `main` while PRs were open. **It wasn't.** I verified `main`'s history is a clean fast-forward chain end to end (`git merge-base --is-ancestor` holds for every consecutive pair to the tip); nothing rewrote it. The `(forced update)` messages that *were* real belonged to `origin/release` — a release branch that's rebuilt/force-pushed by design and is irrelevant to PRs targeting `main`.

The true cause is self-inflicted: the four diff gates fetched the base ref with `git fetch origin main --depth=1` under `GITHUB_ACTIONS`. `--depth=1` grafts the ref with **no ancestry**, so the `git merge-base HEAD origin/main` these gates run next can't find the common ancestor and the gate aborts with the exact error it prints. CI checks out at `fetch-depth: 0` (full history), so a plain fetch is both correct and cheap. This corrects **v1.34.1** (mine), which made the `--depth=1` fetch CI-only — precisely where it does the damage.

## The fix

- `scripts/check-path-contract-usage.sh`, `check-doc-drift.sh`, `check-test-delta.sh`, and `check-coverage-threshold.py` now plain-fetch the base ref (no `--depth=1`), in CI and locally alike.
- New `core/tests/test_diff_gate_fetch.py` fails the build if any gate reintroduces a `--depth`-fetch of the base ref.

## Test plan
- [x] `bash -n` clean on all three shell gates; ruff clean on the Python gate
- [x] All four gates run cleanly locally against the real commit (merge-base resolves)
- [x] New guard test passes and would fail on the old `--depth=1` form

## Note
`origin/release` genuinely is force-pushed (by the release pipeline). That's expected for a release branch and doesn't affect PRs — no action needed there. (Supersedes the "diagnose the force-push" flag from the round-2 wrap-up; there was no force-push of `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azij97SEksTxraikqVWiaG