### PR TITLE
Daily plan review surface: what your meetings turned into, plus one-tap goal-link confirmation

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -339,6 +339,38 @@ Also gather:
 - **People**: Context for meeting attendees
 - **Self-Learning Alerts**: Changelog updates, pending learnings
 
+### 5.11 Meeting-Task Review (NEW)
+
+Give the user one place to review what their meetings turned into. Work from the
+`list_tasks` output already gathered (open tasks include `metadata_source` — the
+meeting note each task came from — and `goal_tentative`).
+
+1. **Recent meeting tasks.** Collect open tasks whose `metadata_source` is set and
+   whose task ID date (`^task-YYYYMMDD-…`) is within the last 3 days. If any,
+   present them compactly under the plan's context:
+
+   > **From your meetings** (3 tasks)
+   > - Send Acme the revised pricing — from *Acme Quarterly Review* (due Jul 15)
+   > - …
+
+2. **Tentative goal links.** Collect open tasks where `goal_tentative` is true.
+   If any, review them in one pass:
+
+   > **2 tasks have a likely goal link marked (?)** — want to confirm them?
+   > 1. "Draft churn playbook" → *Q3-2026-goal-2: Reduce churn to 4%* — keep this link?
+
+   For each answer, call Work MCP `confirm_goal_link(task_id, "confirm")` to keep
+   the link or `confirm_goal_link(task_id, "clear")` to remove it. Never edit the
+   task file by hand for this.
+
+3. **Unprocessed meetings.** If `00-Inbox/Meetings/` has notes with unchecked
+   `### For Me` items and no `tasks-extracted` marker, add one line:
+   "N meetings have unextracted action items — run `/process-meetings` to turn
+   them into tasks."
+
+Skip this entire step silently when nothing qualifies — no "0 tasks from meetings"
+noise.
+
 ---
 
 ## Step 6: Synthesis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.48.0] - Your morning plan now shows what your meetings turned into (2026-07-13)
+
+Tasks extracted from meetings used to land in your backlog without a moment to review them, and tasks that guessed at a goal link had no way to be confirmed. The daily plan now closes both loops.
+
+**What this fixes for you:**
+
+* **One glance at what your meetings produced.** The daily plan lists tasks created from recent meetings, each with the meeting it came from and its due date — so nothing your meetings generated slips past you.
+* **Likely goal links get a yes or no.** When Dex links a task to a quarterly goal with a "(?)" (meaning "probably, but confirm"), the daily plan walks you through them in one pass — keep the link or clear it, one word each. A new under-the-hood tool makes the answer stick properly, so you never have to edit task files by hand.
+* **Unextracted meetings get a nudge.** If meetings are sitting with action items nobody turned into tasks, the plan says so and points at `/process-meetings`.
+* **Quiet when there's nothing to review.** No "0 tasks from meetings" noise on quiet days.
+
 ## [1.47.0] - Release checks stop failing themselves on a technicality (2026-07-12)
 
 The automated checks that run on every proposed change could fail with a confusing "cannot find a common ancestor" error that had nothing to do with the change itself — a self-inflicted glitch in how the checks fetched the project's main line.

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -400,7 +400,9 @@ def _indent_width(line: str) -> int:
     match = re.match(r'^[ \t]*', line)
     return len(match.group(0).expandtabs(4)) if match else 0
 
-def _task_child_lines(lines: List[str], task_index: int) -> List[str]:
+def _task_child_lines(
+    lines: List[str], task_index: int, *, include_indices: bool = False
+) -> List[str] | List[tuple[int, str]]:
     """Return direct child bullets without borrowing a sibling task's metadata."""
     task_indent = _indent_width(lines[task_index])
     descendants = []
@@ -409,12 +411,19 @@ def _task_child_lines(lines: List[str], task_index: int) -> List[str]:
         indent = _indent_width(lines[index])
         if indent <= task_indent:
             break
-        descendants.append((indent, lines[index]))
+        descendants.append((index, indent, lines[index]))
         index += 1
     if not descendants:
         return []
-    direct_indent = min(indent for indent, _line in descendants)
-    return [line for indent, line in descendants if indent == direct_indent]
+    direct_indent = min(indent for _index, indent, _line in descendants)
+    child_lines = [
+        (index, line)
+        for index, indent, line in descendants
+        if indent == direct_indent
+    ]
+    if include_indices:
+        return child_lines
+    return [line for _index, line in child_lines]
 
 def _parse_task_metadata(child_lines: List[str], title: str) -> Dict[str, Any]:
     """Parse additive task metadata, silently ignoring malformed values."""
@@ -3785,6 +3794,26 @@ async def handle_list_tools() -> list[types.Tool]:
             }
         ),
         types.Tool(
+            name="confirm_goal_link",
+            description="Confirm or clear a tentative quarterly-goal link on a canonical task.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "pattern": r"^task-\d{8}-\d{3}$",
+                        "description": "Task ID without the leading caret (e.g., task-20260128-001)",
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["confirm", "clear"],
+                        "description": "Confirm the tentative goal link or clear it",
+                    },
+                },
+                "required": ["task_id", "action"],
+            },
+        ),
+        types.Tool(
             name="get_system_status",
             description="Get comprehensive system status: task counts, priority distribution, pillar balance, blocked items",
             inputSchema={"type": "object", "properties": {}}
@@ -4181,7 +4210,7 @@ async def handle_list_tools() -> list[types.Tool]:
 
 # Tools that write to vault files and should trigger search index refresh
 WRITE_TOOLS = {
-    "create_task", "update_task_status", "create_company", "refresh_company",
+    "create_task", "update_task_status", "confirm_goal_link", "create_company", "refresh_company",
     "sync_task_refs", "create_quarterly_goal", "update_goal_progress",
     "create_weekly_priority", "complete_weekly_priority",
     "process_inbox_with_dedup", "migrate_quarterly_goals", "migrate_weekly_priorities",
@@ -4646,6 +4675,120 @@ async def _handle_call_tool_inner(
         if priority_warning:
             result["priority_warning"] = priority_warning
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
+
+    elif name == "confirm_goal_link":
+        task_id = arguments["task_id"]
+        action = arguments["action"]
+        tasks_file = get_tasks_file()
+
+        if not tasks_file.exists():
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": "task not found",
+            }))]
+
+        lines = tasks_file.read_text().split("\n")
+        task_anchor = re.compile(rf"\^{re.escape(task_id)}(?![A-Za-z0-9_-])")
+        task_index = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if line.strip().startswith(("- [ ]", "- [x]")) and task_anchor.search(line)
+            ),
+            None,
+        )
+        if task_index is None:
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": "task not found",
+            }))]
+
+        indexed_child_lines = _task_child_lines(lines, task_index, include_indices=True)
+        child_lines = [line for _index, line in indexed_child_lines]
+        metadata = _parse_task_metadata(
+            child_lines,
+            _task_title_from_line(lines[task_index]),
+        )
+        goal_id = metadata["goal"]
+        if not goal_id:
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": "no goal link on this task",
+            }))]
+
+        if not metadata["goal_tentative"]:
+            error = (
+                "goal link is already confirmed"
+                if action == "confirm"
+                else "goal link is confirmed; edit explicitly if you want to remove it"
+            )
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": error,
+            }))]
+
+        goal_field = re.compile(
+            rf"\s*Goal\s*:\s*{re.escape(goal_id)}\s+\(\?\)\s*",
+            re.IGNORECASE,
+        )
+        metadata_line_index = None
+        metadata_parts = None
+        goal_part_index = None
+        for child_index, child_line in indexed_child_lines:
+            bullet_match = re.match(r"^([ \t]+-\s*)(.*)$", child_line)
+            if not bullet_match:
+                continue
+            parts = bullet_match.group(2).split("|")
+            for part_index, part in enumerate(parts):
+                if goal_field.fullmatch(part):
+                    metadata_line_index = child_index
+                    metadata_parts = parts
+                    goal_part_index = part_index
+                    break
+            if metadata_line_index is not None:
+                break
+
+        if metadata_line_index is None or metadata_parts is None or goal_part_index is None:
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": "no goal link on this task",
+            }))]
+
+        if action == "confirm":
+            metadata_parts[goal_part_index] = re.sub(
+                r"\s+\(\?\)(?=\s*$)",
+                "",
+                metadata_parts[goal_part_index],
+            )
+            prefix = re.match(r"^([ \t]+-\s*)", lines[metadata_line_index]).group(1)
+            lines[metadata_line_index] = prefix + "|".join(metadata_parts)
+            result = {
+                "success": True,
+                "task_id": task_id,
+                "action": action,
+                "goal_id": goal_id,
+                "goal_tentative": False,
+            }
+        else:
+            remaining_parts = [
+                part.strip()
+                for part_index, part in enumerate(metadata_parts)
+                if part_index != goal_part_index and part.strip()
+            ]
+            if remaining_parts:
+                prefix = re.match(r"^([ \t]+-\s*)", lines[metadata_line_index]).group(1)
+                lines[metadata_line_index] = prefix + " | ".join(remaining_parts)
+            else:
+                del lines[metadata_line_index]
+            result = {
+                "success": True,
+                "task_id": task_id,
+                "action": action,
+                "goal_id": goal_id,
+            }
+
+        tasks_file.write_text("\n".join(lines))
+        return [types.TextContent(type="text", text=json.dumps(result))]
 
     elif name == "update_task_status":
         task_id = arguments.get('task_id')

--- a/core/tests/test_confirm_goal_link.py
+++ b/core/tests/test_confirm_goal_link.py
@@ -1,0 +1,203 @@
+"""Regression coverage for confirming or clearing tentative task-goal links."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+TASK_ID = "task-20260712-001"
+GOAL_ID = "Q3-2026-goal-2"
+
+TEST_PILLARS = {
+    "pillar_1": {
+        "name": "Test Pillar",
+        "description": "Neutral test work",
+        "keywords": ["test"],
+    }
+}
+
+
+def _call_tool(name: str, arguments: dict) -> dict:
+    result = asyncio.run(work_server.handle_call_tool(name, arguments))
+    return json.loads(result[0].text)
+
+
+def _write_task(tasks_file: Path, metadata: str) -> None:
+    tasks_file.write_text(
+        "# Tasks\n\n"
+        "## Next Week\n"
+        f"- [ ] Prepare review surface ^{TASK_ID}\n"
+        f"\t- {metadata}\n",
+        encoding="utf-8",
+    )
+
+
+def _parsed_task(tasks_file: Path) -> dict:
+    return next(
+        task
+        for task in work_server.parse_tasks_file(tasks_file)
+        if task["task_id"] == TASK_ID
+    )
+
+
+@pytest.fixture
+def tasks_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "03-Tasks" / "Tasks.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# Tasks\n", encoding="utf-8")
+
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: path)
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    monkeypatch.setattr(work_server, "refresh_search_index", lambda: None)
+
+    return path
+
+
+def test_confirm_goal_link_schema_requires_task_id_and_action():
+    tools = asyncio.run(work_server.handle_list_tools())
+    confirm_goal_link = next(tool for tool in tools if tool.name == "confirm_goal_link")
+
+    assert confirm_goal_link.inputSchema["required"] == ["task_id", "action"]
+    assert confirm_goal_link.inputSchema["properties"]["task_id"]["pattern"] == r"^task-\d{8}-\d{3}$"
+    assert confirm_goal_link.inputSchema["properties"]["action"]["enum"] == ["confirm", "clear"]
+
+
+def test_confirm_goal_link_confirms_tentative_goal_and_round_trips(tasks_file: Path):
+    _write_task(
+        tasks_file,
+        f"Pillar: Test Pillar | Priority: P1 | Goal: {GOAL_ID} (?)",
+    )
+
+    result = _call_tool("confirm_goal_link", {"task_id": TASK_ID, "action": "confirm"})
+
+    assert result == {
+        "success": True,
+        "task_id": TASK_ID,
+        "action": "confirm",
+        "goal_id": GOAL_ID,
+        "goal_tentative": False,
+    }
+    assert f"Goal: {GOAL_ID} (?)" not in tasks_file.read_text(encoding="utf-8")
+
+    task = _parsed_task(tasks_file)
+    assert task["goal"] == GOAL_ID
+    assert task["goal_tentative"] is False
+
+
+def test_confirm_goal_link_clears_tentative_goal_and_round_trips(tasks_file: Path):
+    _write_task(
+        tasks_file,
+        f"Pillar: Test Pillar | Priority: P1 | Goal: {GOAL_ID} (?)",
+    )
+
+    result = _call_tool("confirm_goal_link", {"task_id": TASK_ID, "action": "clear"})
+
+    assert result == {
+        "success": True,
+        "task_id": TASK_ID,
+        "action": "clear",
+        "goal_id": GOAL_ID,
+    }
+    assert "Goal:" not in tasks_file.read_text(encoding="utf-8")
+
+    task = _parsed_task(tasks_file)
+    assert task["goal"] is None
+    assert task["goal_tentative"] is False
+
+
+def test_confirm_goal_link_rejects_unknown_task_without_writing(tasks_file: Path):
+    _write_task(
+        tasks_file,
+        f"Pillar: Test Pillar | Priority: P1 | Goal: {GOAL_ID} (?)",
+    )
+    before = tasks_file.read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "confirm_goal_link",
+        {"task_id": "task-20260712-999", "action": "confirm"},
+    )
+
+    assert result == {"success": False, "error": "task not found"}
+    assert tasks_file.read_text(encoding="utf-8") == before
+
+
+def test_confirm_goal_link_rejects_task_without_goal_without_writing(tasks_file: Path):
+    _write_task(tasks_file, "Pillar: Test Pillar | Priority: P1 | Due: 2026-07-18")
+    before = tasks_file.read_text(encoding="utf-8")
+
+    result = _call_tool("confirm_goal_link", {"task_id": TASK_ID, "action": "confirm"})
+
+    assert result == {"success": False, "error": "no goal link on this task"}
+    assert tasks_file.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize(
+    ("action", "error"),
+    [
+        ("confirm", "goal link is already confirmed"),
+        ("clear", "goal link is confirmed; edit explicitly if you want to remove it"),
+    ],
+)
+def test_confirm_goal_link_rejects_confirmed_goal_without_writing(
+    tasks_file: Path,
+    action: str,
+    error: str,
+):
+    _write_task(
+        tasks_file,
+        f"Pillar: Test Pillar | Priority: P1 | Goal: {GOAL_ID}",
+    )
+    before = tasks_file.read_text(encoding="utf-8")
+
+    result = _call_tool("confirm_goal_link", {"task_id": TASK_ID, "action": action})
+
+    assert result == {"success": False, "error": error}
+    assert tasks_file.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_metadata", "expected_goal"),
+    [
+        (
+            "confirm",
+            f"Pillar: Test Pillar | Priority: P1 | Due: 2026-07-18 | Goal: {GOAL_ID} | "
+            "Project: 04-Projects/Review.md",
+            GOAL_ID,
+        ),
+        (
+            "clear",
+            "Pillar: Test Pillar | Priority: P1 | Due: 2026-07-18 | Project: 04-Projects/Review.md",
+            None,
+        ),
+    ],
+)
+def test_confirm_goal_link_keeps_midline_metadata_separators_valid(
+    tasks_file: Path,
+    action: str,
+    expected_metadata: str,
+    expected_goal: str | None,
+):
+    _write_task(
+        tasks_file,
+        f"Pillar: Test Pillar | Priority: P1 | Due: 2026-07-18 | Goal: {GOAL_ID} (?) | "
+        "Project: 04-Projects/Review.md",
+    )
+
+    result = _call_tool("confirm_goal_link", {"task_id": TASK_ID, "action": action})
+
+    assert result["success"] is True
+    assert result["goal_id"] == GOAL_ID
+    assert f"\t- {expected_metadata}\n" in tasks_file.read_text(encoding="utf-8")
+    assert "||" not in tasks_file.read_text(encoding="utf-8")
+    assert " | \n" not in tasks_file.read_text(encoding="utf-8")
+
+    task = _parsed_task(tasks_file)
+    assert task["due"] == "2026-07-18"
+    assert task["project"] == "04-Projects/Review.md"
+    assert task["goal"] == expected_goal
+    assert task["goal_tentative"] is False


### PR DESCRIPTION
## What

The review surface from the task assessment (approved by Dave alongside the sync-bridge build).

**Daily plan step 5.11 — Meeting-Task Review.** The morning plan now shows tasks created from recent meetings (each with its source meeting and due date, via the `metadata_source` provenance that v1.38.0 introduced), walks tentative goal links marked `(?)` in one confirmation pass, and nudges when meetings have unextracted action items. Completely silent when nothing qualifies.

**New Work MCP tool `confirm_goal_link(task_id, confirm|clear)`** — resolves tentative goal links properly instead of hand-editing task files: `confirm` strips exactly the `(?)` marker; `clear` removes the goal segment with separator-safe rewriting (no dangling pipes). Only tentative links are actionable; already-confirmed links return a clear error. Registered as a write tool so the search index refreshes.

## Verification

- 9 focused tests: confirm, clear, not-found, no-goal, already-confirmed, separator integrity mid-line (both actions), parse round-trips after edit
- Ruff clean, hook tests green, all four gates locally: test-delta ✅ path-contract ✅ doc-drift ✅ instructed-tools ✅
- Honest note: 3 tests in the recently-added `test_smoke.py` (release-snapshot class) flaked in some local full-suite runs but pass solo and pass on a clean tree in identical order — evidence points at order/load-dependent flakiness in those tests rather than this diff; flagging for visibility and letting CI arbitrate
- CHANGELOG 1.48.0 included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WZCmEDi4qiNLDTwsSJXL