### PR TITLE
Phase 3a: Dex checks itself overnight and says what changed when something breaks (v1.48.0)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -289,6 +289,30 @@ if errors:
     fi
 fi
 
+# 19. Overnight smoke result — surface only actionable broken journeys.
+SMOKE_LAST_RUN="$CLAUDE_DIR/System/.smoke-last-run.json"
+if [[ -f "$ONBOARDING_MARKER" && -f "$SMOKE_LAST_RUN" ]]; then
+    SMOKE_ALERT=$(python3 -c "
+import json
+try:
+    with open('$SMOKE_LAST_RUN') as handle:
+        report = json.load(handle)
+    if report.get('summary', {}).get('broken', 0) > 0:
+        print('--- 🚨 Overnight check found a problem ---')
+        for journey in report.get('journeys', []):
+            if journey.get('verdict') == 'BROKEN':
+                detail = ' '.join(str(journey.get('detail', 'Unknown problem')).split())[:140]
+                print(f\"{journey.get('id', '?')} — {detail}\")
+        print('Run /dex-doctor for diagnosis and the fix.')
+except Exception:
+    pass
+" 2>/dev/null)
+    if [[ -n "$SMOKE_ALERT" ]]; then
+        echo "$SMOKE_ALERT"
+        echo ""
+    fi
+fi
+
 # Background job staleness — keep in sync with core/utils/doctor.py's JOB_FRESHNESS table.
 {
     DEX_LAUNCH_AGENTS_DIR="${DEX_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -322,6 +322,7 @@ fi
             echo "⏰ $JOB_LABEL last ran $JOB_AGE $JOB_AGE_UNIT ago (expected every $JOB_EXPECTED_CADENCE) — run /dex-doctor to investigate."
         fi
     done <<'EOF'
+com.dex.smoke-nightly|.scripts/logs/smoke-nightly.log|93600|26 hours|Nightly smoke
 com.dex.meeting-intel|.scripts/logs/meeting-intel.log|172800|2 days|Meeting sync
 com.dex.changelog-checker|.scripts/logs/changelog-checker.log|604800|7 days|Claude update watcher
 com.dex.learning-review|.scripts/logs/learning-review.log|604800|7 days|Learning review

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -35,6 +35,33 @@ function writeMeetingIntelLog(sandbox) {
   return logPath;
 }
 
+function completeOnboarding(sandbox) {
+  const marker = path.join(sandbox.vault, 'System', '.onboarding-complete');
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  fs.writeFileSync(marker, '{}\n');
+}
+
+function writeSmokeResult(sandbox, broken) {
+  const resultPath = path.join(sandbox.vault, 'System', '.smoke-last-run.json');
+  fs.mkdirSync(path.dirname(resultPath), { recursive: true });
+  fs.writeFileSync(
+    resultPath,
+    JSON.stringify({
+      schema_version: 1,
+      generated_at: '2026-07-12T03:15:00+00:00',
+      journeys: [
+        {
+          id: 'task_lifecycle',
+          verdict: broken ? 'BROKEN' : 'OK',
+          detail: broken ? 'task creation failed after the config changed' : 'task lifecycle passed',
+          duration_ms: 10,
+        },
+      ],
+      summary: { ok: broken ? 0 : 1, off: 0, broken: broken ? 1 : 0, unknown: 0 },
+    }),
+  );
+}
+
 function runSessionStart(sandbox) {
   const result = spawnSync('/bin/bash', [HOOK_PATH], {
     cwd: sandbox.vault,
@@ -107,4 +134,35 @@ test('session start warns when an installed meeting sync has never run', (t) => 
     stdout,
     /⏰ Meeting sync is installed but has never run — run \/dex-doctor to investigate\./,
   );
+});
+
+test('overnight smoke block is silent when the result file is missing', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /Overnight check found a problem/);
+});
+
+test('overnight smoke block is silent for a healthy result', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  writeSmokeResult(sandbox, false);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /Overnight check found a problem/);
+});
+
+test('overnight smoke block emits broken journey details', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  writeSmokeResult(sandbox, true);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.match(stdout, /--- 🚨 Overnight check found a problem ---/);
+  assert.match(stdout, /task_lifecycle — task creation failed after the config changed/);
+  assert.match(stdout, /Run \/dex-doctor for diagnosis and the fix\./);
 });

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -65,6 +65,7 @@ Run these silently without user-facing output:
 4. **People index refresh**: Call `build_people_index` from Work MCP. This keeps the People Directory current so person lookups throughout the day are fast. Takes <2 seconds.
 5. **Innovation synthesis** (silent): Call `synthesize_changelog()` and `synthesize_learnings()` from Improvements MCP. These run in background and populate the backlog — results are surfaced in Step 1.5 below.
 6. **Granola check** (silent): Granola sync uses the official API via `GRANOLA_API_KEY` (environment or vault-root `.env`). If no key is configured, skip all Granola steps silently — an unconnected optional integration is not an error.
+7. **System health** (silent): Read `System/.smoke-last-run.json` when present and retain any broken-journey context for Step 5.10b.
 
 ---
 
@@ -338,6 +339,7 @@ Also gather:
 - **Work Summary**: Quarterly goals context (if enabled)
 - **People**: Context for meeting attendees
 - **Self-Learning Alerts**: Changelog updates, pending learnings
+- **System health**: Only when the overnight smoke report has `summary.broken > 0`, note that a self-check found a problem and point to `/dex-doctor` for diagnosis
 
 ---
 

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -624,6 +624,16 @@ cd .scripts/meeting-intel && ./install-automation.sh 2>/dev/null
 
 Add to summary if installed: "✓ Enabled automatic meeting sync (runs every 30 min)"
 
+**Nightly smoke (reinstall if already installed):**
+
+```bash
+if launchctl list | grep -q com.dex.smoke-nightly; then
+  .scripts/install-smoke-automation.sh 2>/dev/null
+fi
+```
+
+Add to summary if reinstalled: "✓ Updated nightly self-check automation"
+
 **Future automations:** This pattern extends to other background services. Check for the prerequisite (e.g., app installed, API key present), then run the installer silently.
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ System/user-profile.yaml
 System/pillars.yaml
 System/.last-update-check
 System/.update-available
+System/.smoke-last-run.json
+System/.dex/smoke-history.jsonl
 
 # Custom extensions (user-created, never in upstream)
 CLAUDE-custom.md

--- a/.scripts/com.dex.smoke-nightly.plist.template
+++ b/.scripts/com.dex.smoke-nightly.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dex.smoke-nightly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__VAULT_PATH__/.scripts/nightly-smoke.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__VAULT_PATH__</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__VAULT_PATH__/.scripts/logs/smoke-nightly.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__VAULT_PATH__/.scripts/logs/smoke-nightly.stderr.log</string>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
+    <key>Nice</key>
+    <integer>10</integer>
+    <key>TimeOut</key>
+    <integer>300</integer>
+</dict>
+</plist>

--- a/.scripts/install-smoke-automation.sh
+++ b/.scripts/install-smoke-automation.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VAULT_PATH="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLIST_NAME="com.dex.smoke-nightly"
+PLIST_TEMPLATE="$SCRIPT_DIR/$PLIST_NAME.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
+
+launchctl_list() { launchctl list; }
+launchctl_load() { launchctl load "$1"; }
+launchctl_unload() { launchctl unload "$1"; }
+is_loaded() { launchctl_list 2>/dev/null | grep -q "$PLIST_NAME"; }
+
+if [ "${1:-}" = "--status" ]; then
+    if [ -f "$PLIST_DEST" ]; then
+        echo "Nightly smoke automation is installed."
+    else
+        echo "Nightly smoke automation is not installed."
+    fi
+    if is_loaded; then
+        echo "Launch Agent is loaded."
+    else
+        echo "Launch Agent is not loaded."
+    fi
+    exit 0
+fi
+
+if [ "${1:-}" = "--uninstall" ]; then
+    if is_loaded; then
+        launchctl_unload "$PLIST_DEST" 2>/dev/null || true
+    fi
+    if [ -f "$PLIST_DEST" ]; then
+        rm "$PLIST_DEST"
+    fi
+    echo "Nightly smoke automation uninstalled."
+    exit 0
+fi
+
+if [ "${1:-}" != "" ]; then
+    echo "Usage: $0 [--status|--uninstall]" >&2
+    exit 2
+fi
+
+mkdir -p "$HOME/.config/dex" "$HOME/Library/LaunchAgents" "$VAULT_PATH/.scripts/logs"
+echo "$VAULT_PATH" > "$HOME/.config/dex/vault-path"
+chmod +x "$VAULT_PATH/.scripts/nightly-smoke.sh"
+sed "s|__VAULT_PATH__|$VAULT_PATH|g" "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+if is_loaded; then
+    launchctl_unload "$PLIST_DEST" 2>/dev/null || true
+fi
+launchctl_load "$PLIST_DEST"
+echo "Nightly smoke automation installed."

--- a/.scripts/nightly-smoke.sh
+++ b/.scripts/nightly-smoke.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+VAULT_PATH=""
+BREADCRUMB="$HOME/.config/dex/vault-path"
+if [ -f "$BREADCRUMB" ]; then
+    VAULT_PATH="$(tr -d '[:space:]' < "$BREADCRUMB")"
+fi
+
+if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    VAULT_PATH="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+if [ -x "$VAULT_PATH/.venv/bin/python" ]; then
+    PYTHON="$VAULT_PATH/.venv/bin/python"
+else
+    PYTHON="python3"
+fi
+
+cd "$VAULT_PATH"
+VAULT_PATH="$VAULT_PATH" "$PYTHON" core/utils/smoke.py --json --ledger
+mkdir -p .scripts/logs
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] nightly smoke completed" >> .scripts/logs/smoke-nightly.log

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1075,6 +1075,19 @@ executed.
 Customization failures name the exact user-owned file to fix. Dex only suggests an
 update or rollback for failures in unmodified Dex-owned code.
 
+### Nightly self-checks
+
+Run `.scripts/install-smoke-automation.sh` once to install the macOS nightly check. At
+03:15 it exercises Dex's five isolated smoke journeys and records the latest result in
+`System/.smoke-last-run.json`, with up to 120 versioned runs in
+`System/.dex/smoke-history.jsonl`.
+
+When a journey breaks, the next session start names it and points to `/dex-doctor`.
+The daily plan also includes a system-health line only while a broken result is present.
+The doctor's quick `smoke.history` check narrows the change window and reports only
+matching configuration/custom-skill modification times or a Dex version change. The
+automation heartbeat lives at `.scripts/logs/smoke-nightly.log`.
+
 ---
 
 ## Design Constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.48.0] - Dex now checks itself overnight — and tells you what changed when something breaks (2026-07-12)
+
+Dex's safe release checks used to run only when someone asked for a deep diagnosis or
+prepared a release. A problem that appeared between updates could therefore sit quietly
+until the next manual check.
+
+**What this fixes for you:**
+
+* **Dex checks its core journeys every night.** At 03:15 it safely tests configuration,
+  task creation, built-in services, skills, and hooks in temporary copies without writing
+  into your live vault.
+* **The next session tells you when something broke.** You see the affected journey and
+  its concrete failure, while healthy nights stay silent.
+* **`/dex-doctor` narrows down what changed.** It compares the last passing night with the
+  first broken one and reports only matching configuration edits, custom-skill edits, or
+  a Dex update—without inventing a cause when the evidence is not there.
+* **The evidence stays inspectable.** The latest result and a capped history live as plain
+  JSON files in your vault, with safe atomic writes so half-written reports never surface.
+
 ## [1.47.0] - Release checks stop failing themselves on a technicality (2026-07-12)
 
 The automated checks that run on every proposed change could fail with a confusing "cannot find a common ancestor" error that had nothing to do with the change itself — a self-inflicted glitch in how the checks fetched the project's main line.

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -20,6 +20,7 @@ NOW = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
 QUICK_IDS = [
     "vault.structure",
     "vault.configs",
+    "smoke.history",
     "mcp.registered",
     "mcp.orphans",
     "python.env",
@@ -292,6 +293,114 @@ def test_registry_ids_match_the_approved_spec():
     assert doctor.VERDICTS == frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 
 
+def _smoke_entry(timestamp, *, broken=0, version="1.47.0"):
+    verdict = "BROKEN" if broken else "OK"
+    return {
+        "schema_version": 1,
+        "generated_at": timestamp.isoformat(),
+        "dex_version": version,
+        "journeys": [
+            {
+                "id": "task_lifecycle",
+                "verdict": verdict,
+                "detail": "task lifecycle failed" if broken else "task lifecycle passed",
+                "duration_ms": 1,
+            }
+        ],
+        "summary": {"ok": 0 if broken else 1, "off": 0, "broken": broken, "unknown": 0},
+    }
+
+
+def _write_smoke_history(context, *entries, corrupt_prefix=False):
+    path = context.vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = (["{not json"] if corrupt_prefix else []) + [json.dumps(entry) for entry in entries]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_smoke_history_is_off_without_a_ledger(context):
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "OFF"
+    assert result.detail == "nightly checks not installed — run .scripts/install-smoke-automation.sh"
+
+
+def test_smoke_history_reports_latest_healthy_run(context):
+    _write_smoke_history(context, _smoke_entry(NOW - timedelta(hours=1)))
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == f"last verified {(NOW - timedelta(hours=1)).isoformat()} (1 journeys OK)"
+
+
+def test_smoke_history_attributes_config_mtime(context):
+    good_at = NOW - timedelta(hours=2)
+    broken_at = NOW - timedelta(hours=1)
+    _write_smoke_history(context, _smoke_entry(good_at), _smoke_entry(broken_at, broken=1))
+    pillars = context.vault_root / "System" / "pillars.yaml"
+    pillars.write_text("pillars: []\n")
+    modified = NOW - timedelta(minutes=90)
+    os.utime(pillars, (modified.timestamp(), modified.timestamp()))
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "BROKEN"
+    assert f"task_lifecycle broke between {good_at.isoformat()} and {broken_at.isoformat()}" in result.detail
+    assert f"pillars.yaml modified {modified.isoformat()}" in result.detail
+
+
+def test_smoke_history_attributes_dex_version_change(context):
+    good_at = NOW - timedelta(hours=2)
+    broken_at = NOW - timedelta(hours=1)
+    _write_smoke_history(
+        context,
+        _smoke_entry(good_at, version="1.46.0"),
+        _smoke_entry(broken_at, broken=1, version="1.47.0"),
+    )
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "BROKEN"
+    assert "Dex updated from 1.46.0 to 1.47.0 in this window" in result.detail
+
+
+def test_smoke_history_skips_corrupt_lines(context):
+    _write_smoke_history(
+        context,
+        _smoke_entry(NOW - timedelta(hours=1)),
+        corrupt_prefix=True,
+    )
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "OK"
+
+
+def test_smoke_history_falls_back_to_valid_last_run_when_all_lines_are_corrupt(context):
+    history = context.vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    history.parent.mkdir(parents=True)
+    history.write_text("{not json\n")
+    last_run = context.vault_root / "System" / ".smoke-last-run.json"
+    last_run.write_text(json.dumps(_smoke_entry(NOW - timedelta(hours=1))))
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "OK"
+
+
+def test_smoke_history_is_unknown_when_whole_ledger_is_unreadable(context):
+    path = context.vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json\n")
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert "ledger is unreadable" in result.detail
+
+
 @pytest.mark.parametrize("deep,expected_ids", [(False, QUICK_IDS), (True, QUICK_IDS + DEEP_IDS)])
 def test_json_contract_shape_and_last_run_file(monkeypatch, context, deep, expected_ids):
     _stub_probes(monkeypatch)
@@ -329,7 +438,7 @@ def test_summary_counts_each_exact_verdict(monkeypatch, context):
 
     report = doctor.collect(context=context)
 
-    assert report["summary"] == {"ok": 11, "off": 1, "broken": 1, "unknown": 1}
+    assert report["summary"] == {"ok": 12, "off": 1, "broken": 1, "unknown": 1}
     assert report["instruments"]["completed"] == len(QUICK_IDS)
 
 

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1080,6 +1080,7 @@ def test_jobs_loaded_degrades_to_unknown_off_macos(monkeypatch, context):
 @pytest.mark.parametrize(
     ("label", "expected_max_age"),
     [
+        ("com.dex.smoke-nightly", timedelta(hours=26)),
         ("com.dex.meeting-intel", timedelta(hours=48)),
         ("com.dex.changelog-checker", timedelta(days=7)),
         ("com.dex.learning-review", timedelta(days=7)),

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -12,6 +12,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 from core.utils import smoke
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -262,6 +264,86 @@ def test_main_exit_one_for_a_broken_journey(tmp_path: Path, capsys) -> None:
 
     assert exit_code == 1
     assert report["summary"] == {"ok": 0, "broken": 1, "unknown": 0, "off": 0}
+
+
+def test_ledger_writes_latest_and_versioned_history(tmp_path: Path, capsys) -> None:
+    vault = _write_valid_vault(tmp_path)
+
+    exit_code = smoke.main(
+        ["--json", "--ledger"],
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+    emitted = json.loads(capsys.readouterr().out)
+    latest = json.loads((vault / "System" / ".smoke-last-run.json").read_text())
+    history = [
+        json.loads(line)
+        for line in (vault / "System" / ".dex" / "smoke-history.jsonl").read_text().splitlines()
+    ]
+
+    assert exit_code == 0
+    assert latest == emitted
+    expected_version = json.loads((REPO_ROOT / "package.json").read_text())["version"]
+    assert history[0] == {**emitted, "dex_version": expected_version}
+
+
+def test_ledger_history_rotates_at_cap(tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    history_path = vault / "System" / ".dex" / "smoke-history.jsonl"
+    history_path.parent.mkdir(parents=True)
+    old_entries = [
+        json.dumps({"schema_version": 1, "generated_at": f"old-{index}"})
+        for index in range(smoke.HISTORY_LIMIT)
+    ]
+    history_path.write_text("\n".join(old_entries) + "\n")
+    report = {
+        "schema_version": 1,
+        "generated_at": "new",
+        "journeys": [],
+        "summary": {"ok": 0, "broken": 0, "unknown": 0, "off": 0},
+    }
+
+    smoke._write_ledger(report, vault, REPO_ROOT)
+
+    entries = [json.loads(line) for line in history_path.read_text().splitlines()]
+    assert len(entries) == smoke.HISTORY_LIMIT
+    assert entries[0]["generated_at"] == "old-1"
+    assert entries[-1]["generated_at"] == "new"
+
+
+def test_atomic_ledger_failure_preserves_target_and_removes_temp(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "ledger.json"
+    target.write_text("original\n")
+
+    def fail_replace(_source, _target):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(smoke.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="simulated replace failure"):
+        smoke._atomic_write(target, "replacement\n")
+
+    assert target.read_text() == "original\n"
+    assert list(tmp_path.glob(".ledger.json.*.tmp")) == []
+
+
+def test_json_without_ledger_writes_nothing(tmp_path: Path, capsys) -> None:
+    vault = _write_valid_vault(tmp_path)
+
+    exit_code = smoke.main(
+        ["--json"],
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["summary"]["ok"] == 1
+    assert not (vault / "System" / ".smoke-last-run.json").exists()
+    assert not (vault / "System" / ".dex" / "smoke-history.jsonl").exists()
 
 
 def test_head_runner_generation_stays_coherent_when_release_is_older(tmp_path: Path) -> None:

--- a/core/tests/test_smoke_automation.py
+++ b/core/tests/test_smoke_automation.py
@@ -1,0 +1,73 @@
+"""Contract tests for the nightly smoke Launch Agent surfaces."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKER = REPO_ROOT / ".scripts" / "nightly-smoke.sh"
+INSTALLER = REPO_ROOT / ".scripts" / "install-smoke-automation.sh"
+TEMPLATE = REPO_ROOT / ".scripts" / "com.dex.smoke-nightly.plist.template"
+
+
+def test_shell_scripts_parse() -> None:
+    for script in (WORKER, INSTALLER):
+        subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_rendered_plist_is_valid(tmp_path: Path) -> None:
+    rendered = tmp_path / "com.dex.smoke-nightly.plist"
+    rendered.write_text(TEMPLATE.read_text().replace("__VAULT_PATH__", str(REPO_ROOT)))
+    with rendered.open("rb") as handle:
+        data = plistlib.load(handle)
+
+    assert data["ProgramArguments"] == ["/bin/bash", str(WORKER)]
+    assert data["StartCalendarInterval"] == {"Hour": 3, "Minute": 15}
+    assert data["RunAtLoad"] is False
+    if shutil.which("plutil"):
+        subprocess.run(["plutil", "-lint", str(rendered)], check=True)
+
+
+def test_installer_status_and_uninstall_use_stubbed_launchctl(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    agents = home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    plist = agents / "com.dex.smoke-nightly.plist"
+    plist.write_text("installed")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    launchctl = bin_dir / "launchctl"
+    launchctl.write_text(
+        "#!/bin/bash\n"
+        "case \"$1\" in\n"
+        "list) echo '1 0 com.dex.smoke-nightly' ;;\n"
+        "unload) echo \"$2\" >> \"$LAUNCHCTL_CALLS\" ;;\n"
+        "*) exit 2 ;;\n"
+        "esac\n"
+    )
+    launchctl.chmod(0o755)
+    calls = tmp_path / "launchctl-calls"
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "LAUNCHCTL_CALLS": str(calls),
+    }
+
+    status = subprocess.run(
+        ["bash", str(INSTALLER), "--status"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "is installed" in status.stdout
+    assert "is loaded" in status.stdout
+
+    subprocess.run(["bash", str(INSTALLER), "--uninstall"], env=env, check=True)
+    assert not plist.exists()
+    assert str(plist) in calls.read_text()

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -160,6 +160,7 @@ SHIPPED_LAUNCH_AGENT_LABELS = frozenset(
 QUICK_CHECKS = (
     CheckDefinition("vault.structure", "Vault structure", "_probe_vault_structure"),
     CheckDefinition("vault.configs", "Vault configuration", "_probe_vault_configs"),
+    CheckDefinition("smoke.history", "Nightly smoke results", "_probe_smoke_history"),
     CheckDefinition("mcp.registered", "MCP registration", "_probe_mcp_registered"),
     CheckDefinition("mcp.orphans", "MCP server registration", "_probe_mcp_orphans"),
     CheckDefinition("python.env", "Python environment", "_probe_python_env"),
@@ -2088,6 +2089,172 @@ def _probe_mcp_importable(context: DoctorContext) -> ProbeResult:
             Heal(tier=2, action="Reinstall the missing MCP dependencies into the vault .venv.", applied=False),
         )
     return ProbeResult("OK", f"All {len(registered)} registered core MCP servers import in a subprocess")
+
+
+def _smoke_timestamp(entry: dict[str, Any]) -> datetime | None:
+    value = entry.get("generated_at")
+    if not isinstance(value, str):
+        return None
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def _valid_smoke_entry(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or _smoke_timestamp(value) is None:
+        return None
+    journeys = value.get("journeys")
+    summary = value.get("summary")
+    if not isinstance(journeys, list) or not isinstance(summary, dict):
+        return None
+    if not all(
+        isinstance(journey, dict)
+        and isinstance(journey.get("id"), str)
+        and journey.get("verdict") in VERDICTS
+        and isinstance(journey.get("detail"), str)
+        for journey in journeys
+    ):
+        return None
+    if not isinstance(summary.get("broken"), int):
+        return None
+    return value
+
+
+def _read_smoke_history(context: DoctorContext) -> list[dict[str, Any]]:
+    history_path = context.vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    last_run_path = context.vault_root / "System" / ".smoke-last-run.json"
+    history_unreadable = False
+    if history_path.exists():
+        lines = history_path.read_text(encoding="utf-8").splitlines()
+        entries = []
+        for line in lines:
+            try:
+                entry = _valid_smoke_entry(json.loads(line))
+            except (json.JSONDecodeError, TypeError):
+                entry = None
+            if entry is not None:
+                entries.append(entry)
+        if entries:
+            return sorted(entries, key=lambda entry: _smoke_timestamp(entry) or datetime.min)
+        history_unreadable = True
+    if last_run_path.exists():
+        entry = _valid_smoke_entry(json.loads(last_run_path.read_text(encoding="utf-8")))
+        if entry is None:
+            raise ValueError("smoke last-run file is unreadable")
+        return [entry]
+    if history_unreadable:
+        raise ValueError("smoke history contains no readable ledger entries")
+    return []
+
+
+def _smoke_attribution_paths(context: DoctorContext) -> list[Path]:
+    system = context.vault_root / "System"
+    paths_to_check = [
+        system / "user-profile.yaml",
+        system / "pillars.yaml",
+        context.vault_root / ".mcp.json",
+    ]
+    paths_to_check.extend(sorted((system / "integrations").glob("*.yaml")))
+    custom_skills = context.vault_root / ".claude" / "skills"
+    paths_to_check.extend(
+        path
+        for root in sorted(custom_skills.glob("*-custom"))
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    )
+    return paths_to_check
+
+
+def _smoke_attribution_name(path: Path, context: DoctorContext) -> str:
+    system = context.vault_root / "System"
+    try:
+        return path.relative_to(system).as_posix()
+    except ValueError:
+        return path.relative_to(context.vault_root).as_posix()
+
+
+def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
+    history_path = context.vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    last_run_path = context.vault_root / "System" / ".smoke-last-run.json"
+    if not history_path.exists() and not last_run_path.exists():
+        return ProbeResult(
+            "OFF",
+            "nightly checks not installed — run .scripts/install-smoke-automation.sh",
+        )
+    try:
+        entries = _read_smoke_history(context)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        return ProbeResult("UNKNOWN", f"nightly smoke ledger is unreadable: {_one_line(error)}")
+
+    latest = entries[-1]
+    latest_timestamp = _smoke_timestamp(latest)
+    journeys = latest["journeys"]
+    broken = [journey for journey in journeys if journey["verdict"] == "BROKEN"]
+    unknown = [journey for journey in journeys if journey["verdict"] == "UNKNOWN"]
+    if not broken and not unknown:
+        ok_count = sum(journey["verdict"] == "OK" for journey in journeys)
+        return ProbeResult(
+            "OK",
+            f"last verified {latest_timestamp.isoformat()} ({ok_count} journeys OK)",
+        )
+    if not broken:
+        return ProbeResult(
+            "UNKNOWN",
+            f"last nightly check at {latest_timestamp.isoformat()} was inconclusive",
+        )
+
+    prior_good_index = next(
+        (
+            index
+            for index in range(len(entries) - 2, -1, -1)
+            if entries[index]["summary"].get("broken") == 0
+        ),
+        None,
+    )
+    broken_ids = ", ".join(journey["id"] for journey in broken)
+    if prior_good_index is None:
+        return ProbeResult(
+            "BROKEN",
+            f"{broken_ids} is broken as of {latest_timestamp.isoformat()}; no prior passing nightly run is available for attribution",
+        )
+
+    good_entry = entries[prior_good_index]
+    first_broken = next(
+        entry
+        for entry in entries[prior_good_index + 1 :]
+        if entry["summary"].get("broken", 0) > 0
+    )
+    window_start = _smoke_timestamp(good_entry)
+    window_end = _smoke_timestamp(first_broken)
+    facts = []
+    for path in _smoke_attribution_paths(context):
+        try:
+            modified = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if window_start < modified <= window_end:
+            facts.append(
+                f"{_smoke_attribution_name(path, context)} modified {modified.isoformat()}"
+            )
+    old_version = good_entry.get("dex_version")
+    new_version = first_broken.get("dex_version")
+    if isinstance(old_version, str) and isinstance(new_version, str) and old_version != new_version:
+        facts.append(f"Dex updated from {old_version} to {new_version} in this window")
+
+    detail = (
+        f"{broken_ids} broke between {window_start.isoformat()} and {window_end.isoformat()}. "
+        f"In that window: {'; '.join(facts)}"
+        if facts
+        else (
+            f"{broken_ids} broke between {window_start.isoformat()} and {window_end.isoformat()}; "
+            "nothing obvious changed — run /dex-doctor --deep for the full picture"
+        )
+    )
+    return ProbeResult("BROKEN", detail)
 
 
 def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -127,6 +127,10 @@ PARA_PATH_NAMES = (
 
 # Keep in sync with .claude/hooks/session-start.sh's background-job staleness table.
 JOB_FRESHNESS = {
+    "com.dex.smoke-nightly": JobFreshness(
+        Path(".scripts/logs/smoke-nightly.log"),
+        timedelta(hours=26),
+    ),
     "com.dex.meeting-intel": JobFreshness(
         Path(".scripts/logs/meeting-intel.log"),
         timedelta(hours=48),
@@ -148,6 +152,7 @@ SHIPPED_LAUNCH_AGENT_LABELS = frozenset(
         "com.dex.learning-review",
         "com.dex.meeting-intel",
         "com.dex.obsidian-sync",
+        "com.dex.smoke-nightly",
     }
 )
 

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -32,6 +32,7 @@ if str(RUNNER_ROOT) in sys.path:
 sys.path.insert(0, str(RUNNER_ROOT))
 
 SCHEMA_VERSION = 1
+HISTORY_LIMIT = 120
 GLOBAL_TIMEOUT_SECONDS = 30.0
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 VERDICT_PRIORITY = {"OFF": 0, "OK": 1, "UNKNOWN": 2, "BROKEN": 3}
@@ -1976,6 +1977,56 @@ def _print_human(report: Mapping[str, object]) -> None:
         )
 
 
+def _atomic_write(path: Path, content: str) -> None:
+    """Durably replace one ledger file without exposing partial JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _dex_version(repo_root: Path) -> str:
+    package = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("package.json has no Dex version")
+    return version
+
+
+def _write_ledger(report: Mapping[str, object], vault_root: Path, repo_root: Path) -> None:
+    """Persist the latest report and capped, versioned smoke history."""
+    last_run_path = vault_root / "System" / ".smoke-last-run.json"
+    history_path = vault_root / "System" / ".dex" / "smoke-history.jsonl"
+    entry = dict(report)
+    entry["dex_version"] = _dex_version(repo_root)
+
+    history: list[str] = []
+    try:
+        history = [line for line in history_path.read_text(encoding="utf-8").splitlines() if line]
+    except FileNotFoundError:
+        pass
+    history.append(json.dumps(entry, separators=(",", ":")))
+    history = history[-HISTORY_LIMIT:]
+
+    _atomic_write(last_run_path, json.dumps(report, indent=2) + "\n")
+    _atomic_write(history_path, "\n".join(history) + "\n")
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -1985,6 +2036,7 @@ def main(
 ) -> int:
     parser = argparse.ArgumentParser(description="Run Dex's safe, isolated smoke journeys.")
     parser.add_argument("--json", action="store_true", help="emit the versioned JSON report")
+    parser.add_argument("--ledger", action="store_true", help="record the latest run and history")
     parser.add_argument("--_journey", choices=tuple(INTERNAL_JOURNEYS), help=argparse.SUPPRESS)
     parser.add_argument("--_prepare", choices=tuple(INTERNAL_JOURNEYS), help=argparse.SUPPRESS)
     parser.add_argument("--source-root", type=Path, help=argparse.SUPPRESS)
@@ -2048,6 +2100,14 @@ def main(
         repo_root=repo_root,
         journey_definitions=journey_definitions,
     )
+    if args.ledger:
+        source = (vault_root or Path(os.environ.get("VAULT_PATH", Path.cwd()))).resolve()
+        repository = (repo_root or Path(__file__).resolve().parents[2]).resolve()
+        try:
+            _write_ledger(run.report, source, repository)
+        except Exception as exc:
+            print(f"smoke ledger write failed: {_one_line(exc)}", file=sys.stderr)
+            return 2
     if args.json:
         print(json.dumps(run.report, separators=(",", ":")))
     else:

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -55,6 +55,25 @@ values before child journeys; executable task and MCP code is loaded only from a
 snapshot of the installed release. If that release cannot be verified, the affected
 journey is `UNKNOWN` instead of falling back to live code.
 
+### Nightly smoke ledger and attribution
+
+The macOS Launch Agent installed by `.scripts/install-smoke-automation.sh` runs the five
+smoke journeys every night at 03:15. Successful worker completion updates the heartbeat
+at `.scripts/logs/smoke-nightly.log`; `/dex-doctor` treats a heartbeat older than 26 hours
+as stale.
+
+Passing `--ledger` leaves the complete latest report at
+`System/.smoke-last-run.json` and appends a versioned entry to
+`System/.dex/smoke-history.jsonl`. History is capped at 120 runs and both files are
+replaced atomically, so readers never observe partial JSON. Plain `--json` runs remain
+read-only.
+
+The quick doctor's `smoke.history` check compares the last passing entry with the first
+broken entry after it. Attribution reports only facts inside that window: modification
+times for profile, pillar, integration, MCP, and custom-skill files, plus a Dex version
+change. When no listed fact changed, the doctor says so and points to the deep check; it
+does not guess at a cause.
+
 ## Testing Doctor Inventory
 
 The quick doctor adds three always-visible checks:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this is

Phase 3 of the trust engine, part one (plan-checked; follows #98/#99). Dex stops waiting to be asked.

- **Nightly self-check**: a launchd job runs the smoke journeys at 03:15 and keeps a result ledger (`System/.smoke-last-run.json` + capped `System/.dex/smoke-history.jsonl`, both gitignored, atomic writes). Installer follows the meeting-intel pattern (`.scripts/install-smoke-automation.sh`, `--status`/`--uninstall`), wired into all four keep-in-sync points (doctor JOB_FRESHNESS, SHIPPED_LAUNCH_AGENT_LABELS, session-start job table, dex-update Step 7.5).
- **Blame attribution**: new quick doctor check `smoke.history` — on a broken night, it reports the exact window and what factually changed in it (sanctioned config mtimes, -custom skill mtimes, Dex version delta). Proven output: `task_lifecycle broke between 21:48:07 and 21:48:33. In that window: pillars.yaml modified 21:48:08`. Never speculates; "nothing obvious changed" when nothing did.
- **Morning surfacing**: session-start emits an alert block only when the last overnight run found breakage; daily-plan gains a silent check + single health line.

## Verification

- 575 passed outside any sandbox (2 unrelated flakes under heavy host load passed on rerun — this box runs several worker fleets; CI's clean runner arbitrates; the nightly flaky detector monitors this class).
- Ruff clean, hooks 69/69, all three PR diff gates pass locally.
- Functional proof: two real ledger runs + induced breakage → attribution line above. Mutation proofs: no ledger → OFF with install hint; session-start silent on healthy, emits on broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY