### PR TITLE
fix(ci): vault-bundle release upload was silently failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          gh release create "v$VERSION" --notes-from-tag || true
+          # Create the release (and its git tag, at this commit) only if absent.
+          # --notes-from-tag needs a pre-existing annotated tag, which the release
+          # process never makes; let gh create the tag and generate notes instead.
+          if ! gh release view "v$VERSION" >/dev/null 2>&1; then
+            gh release create "v$VERSION" \
+              --target "$GITHUB_SHA" \
+              --title "v$VERSION" \
+              --generate-notes
+          fi
           gh release upload "v$VERSION" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \


### PR DESCRIPTION
Follow-up to Lane P (#124). The vault-bundle CI step **built** the tarball but the **upload silently no-op'd** on every main push — confirmed broken on its first real run (main at v1.49.0, no `dex-vault-bundle` asset published).

**Root cause:** `gh release create "v$VERSION" --notes-from-tag` requires a pre-existing *annotated tag*; the release flow pushes a `release` branch and never creates version tags. So create failed, `|| true` swallowed it, and `gh release upload` then had no release to attach to.

**Fix:** create the release (and its git tag, at the merge commit) with `--generate-notes` only when it doesn't already exist (idempotent on re-run), then upload with `--clobber`. This is the exact fragility flagged as a follow-up in #124.

Impact: the bundle Desktop will pin now actually publishes. Nothing consumes it yet, so no user-facing effect — this unbreaks the shipping path ahead of the Desktop lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RStjVtoPYHzhfDxSgv4EaA