### PR TITLE
Things 3 + Trello two-way sync on the shipped engine (v1.51.0)

### DIFF
--- a/.claude/hooks/adapters/things.cjs
+++ b/.claude/hooks/adapters/things.cjs
@@ -19,6 +19,8 @@
  * Rate limit: n/a (local process calls)
  */
 
+const childProcess = require('node:child_process');
+
 // ---------------------------------------------------------------------------
 // Status mapping — Dex status codes -> Things 3 status
 // Things has no in-progress or blocked concept; everything is open or done.
@@ -50,12 +52,12 @@ function pillarToArea(pillar, adapterConfig) {
   const mapping = (adapterConfig && adapterConfig.area_mapping) || {};
   if (mapping[pillar]) return mapping[pillar];
 
-  const defaults = {
-    deal_support: 'Deal Support',
-    thought_leadership: 'Thought Leadership',
-    product_feedback: 'Product Feedback',
-  };
-  return defaults[pillar] || pillar || 'Inbox';
+  if (!pillar) return 'Inbox';
+  return String(pillar)
+    .split('_')
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ') || 'Inbox';
 }
 
 function areaToPillar(areaName) {
@@ -63,7 +65,7 @@ function areaToPillar(areaName) {
   if (name.includes('deal') || name.includes('sales') || name.includes('revenue')) return 'deal_support';
   if (name.includes('thought') || name.includes('leadership') || name.includes('content')) return 'thought_leadership';
   if (name.includes('product') || name.includes('feedback')) return 'product_feedback';
-  return 'deal_support'; // Default pillar
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -83,10 +85,10 @@ function tagsToPriority(tags) {
 // Transform: Dex task -> Things 3 task format
 // ---------------------------------------------------------------------------
 
-function toExternal(dexTask) {
+function toExternal(dexTask, adapterConfig = {}) {
   return {
     title: dexTask.title,
-    area: pillarToArea(dexTask.pillar),
+    area: pillarToArea(dexTask.pillar, adapterConfig),
     project: dexTask.week_priority || null,
     list: thingsListForPriority(dexTask.priority),
     notes: formatNotes(dexTask),
@@ -114,8 +116,6 @@ function toDex(thingsTask) {
 // ---------------------------------------------------------------------------
 
 async function create(externalTask, adapterConfig) {
-  const { execSync } = require('child_process');
-
   const params = {
     title: externalTask.title,
     notes: externalTask.notes || '',
@@ -126,10 +126,7 @@ async function create(externalTask, adapterConfig) {
 
   try {
     const script = buildCreateScript(params);
-    const result = execSync(`osascript -e '${script}'`, {
-      encoding: 'utf-8',
-      timeout: 10000,
-    }).trim();
+    const result = runAppleScript(script, 10000);
     // Things returns the task ID on creation
     return result || `things-${Date.now()}`;
   } catch (err) {
@@ -142,13 +139,9 @@ async function create(externalTask, adapterConfig) {
 // ---------------------------------------------------------------------------
 
 async function complete(externalId, adapterConfig) {
-  const { execSync } = require('child_process');
   try {
     const script = `tell application "Things3" to complete to do id "${escapeAS(externalId)}"`;
-    execSync(`osascript -e '${script}'`, {
-      encoding: 'utf-8',
-      timeout: 10000,
-    });
+    runAppleScript(script, 10000);
   } catch (err) {
     throw new Error(`Things 3 complete failed: ${err.message}`);
   }
@@ -160,30 +153,48 @@ async function complete(externalId, adapterConfig) {
 // ---------------------------------------------------------------------------
 
 async function getChanges(since, adapterConfig) {
-  const { execSync } = require('child_process');
   const changes = [];
+  const sinceDate = new Date(since);
+  const sinceTime = sinceDate.getTime();
+  const hasValidSince = Number.isFinite(sinceTime);
+  const sinceDateSetup = hasValidSince ? buildAppleScriptDate('sinceDate', sinceDate) : '';
+  const completionDateCondition = hasValidSince
+    ? 'completedAt is greater than or equal to sinceDate'
+    : 'true';
 
   // 1. Recently completed tasks from Logbook
   try {
     const logbookScript = `
 tell application "Things3"
   set output to ""
+${sinceDateSetup}
   repeat with t in to dos of list "Logbook"
-    set taskId to id of t
-    set taskName to name of t
-    set output to output & taskId & "|||" & taskName & "\\n"
+    if status of t is completed then
+      set completedAt to completion date of t
+      if ${completionDateCondition} then
+        set taskId to id of t
+        set taskName to name of t
+        set completedAtText to (completion date of t as string)
+        set output to output & taskId & "|||" & taskName & "|||" & completedAtText & "\\n"
+      end if
+    end if
   end repeat
   return output
 end tell`;
-    const logbookResult = execSync(`osascript -e '${logbookScript.replace(/'/g, "'\\''")}'`, {
-      encoding: 'utf-8',
-      timeout: 15000,
-    }).trim();
+    const logbookResult = runAppleScript(logbookScript, 15000);
 
     if (logbookResult) {
       for (const line of logbookResult.split('\n')) {
-        const [id, title] = line.split('|||');
+        const [id, title, completedAt] = line.split('|||');
         if (id && title) {
+          const completedTime = Date.parse(completedAt);
+          if (
+            Number.isFinite(sinceTime) &&
+            Number.isFinite(completedTime) &&
+            completedTime < sinceTime
+          ) {
+            continue;
+          }
           changes.push({
             id: id.trim(),
             action: 'completed',
@@ -209,10 +220,7 @@ tell application "Things3"
   end repeat
   return output
 end tell`;
-    const inboxResult = execSync(`osascript -e '${inboxScript.replace(/'/g, "'\\''")}'`, {
-      encoding: 'utf-8',
-      timeout: 15000,
-    }).trim();
+    const inboxResult = runAppleScript(inboxScript, 15000);
 
     if (inboxResult) {
       for (const line of inboxResult.split('\n')) {
@@ -249,23 +257,62 @@ function formatNotes(dexTask) {
   return parts.join('\n');
 }
 
+function buildAppleScriptDate(variableName, date) {
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const secondsSinceMidnight =
+    date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
+  return `  set ${variableName} to current date
+  set day of ${variableName} to 1
+  set year of ${variableName} to ${date.getFullYear()}
+  set month of ${variableName} to ${monthNames[date.getMonth()]}
+  set day of ${variableName} to ${date.getDate()}
+  set time of ${variableName} to ${secondsSinceMidnight}`;
+}
+
+function runAppleScript(script, timeout) {
+  const result = childProcess.spawnSync('osascript', ['-e', script], {
+    encoding: 'utf-8',
+    timeout,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = String(result.stderr || '').trim();
+    throw new Error(detail || 'osascript failed');
+  }
+  return String(result.stdout || '').trim();
+}
+
 function buildCreateScript(params) {
   let props = `name:"${escapeAS(params.title)}"`;
   if (params.notes) props += `, notes:"${escapeAS(params.notes)}"`;
+  const moveToToday = params.list === 'today' ? '\n  move newTask to list "Today"' : '';
 
   if (params.area) {
     return `tell application "Things3"
-  set newTask to make new to do with properties {${props}} in area "${escapeAS(params.area)}"
+  set newTask to make new to do with properties {${props}} in area "${escapeAS(params.area)}"${moveToToday}
   return id of newTask
 end tell`;
   } else if (params.project) {
     return `tell application "Things3"
-  set newTask to make new to do with properties {${props}} in project "${escapeAS(params.project)}"
+  set newTask to make new to do with properties {${props}} in project "${escapeAS(params.project)}"${moveToToday}
   return id of newTask
 end tell`;
   } else {
     return `tell application "Things3"
-  set newTask to make new to do with properties {${props}}
+  set newTask to make new to do with properties {${props}}${moveToToday}
   return id of newTask
 end tell`;
   }

--- a/.claude/hooks/adapters/trello.cjs
+++ b/.claude/hooks/adapters/trello.cjs
@@ -95,6 +95,16 @@ async function trelloFetch(endpoint, adapterConfig, options = {}) {
 // ---------------------------------------------------------------------------
 
 async function getListIdForStatus(boardId, status, adapterConfig) {
+  const listMapping = adapterConfig.list_mapping || {};
+  const dexStatusToMapKey = {
+    n: 'backlog',
+    s: 'in_progress',
+    b: 'blocked',
+    d: 'done',
+  };
+  const mapKey = dexStatusToMapKey[status];
+  if (mapKey && listMapping[mapKey]) return listMapping[mapKey];
+
   const lists = await trelloFetch(`/boards/${boardId}/lists`, adapterConfig, {
     params: { filter: 'open' },
   });
@@ -113,7 +123,7 @@ async function getListIdForStatus(boardId, status, adapterConfig) {
 // Transform: Dex task -> Trello card format
 // ---------------------------------------------------------------------------
 
-function toExternal(dexTask) {
+function toExternal(dexTask, adapterConfig = {}) {
   return {
     name: dexTask.title,
     desc: dexTask.context || '',
@@ -150,20 +160,9 @@ function toDex(trelloCard) {
     }
   }
 
-  // Infer pillar from board name or labels
-  let pillar = 'deal_support';
-  if (trelloCard.board?.name) {
-    const boardLower = trelloCard.board.name.toLowerCase();
-    if (boardLower.includes('thought') || boardLower.includes('content') || boardLower.includes('leadership')) {
-      pillar = 'thought_leadership';
-    } else if (boardLower.includes('product') || boardLower.includes('feedback')) {
-      pillar = 'product_feedback';
-    }
-  }
-
   return {
     title: trelloCard.name || 'Untitled card',
-    pillar,
+    pillar: null,
     priority,
     status,
     context: trelloCard.desc || '',
@@ -190,7 +189,9 @@ async function create(externalTask, adapterConfig) {
 
   const params = {
     name: externalTask.name,
-    desc: externalTask.desc || '',
+    desc: `${externalTask.desc || ''}${
+      externalTask._dexTaskId ? `\n\n[dex:${externalTask._dexTaskId}]` : ''
+    }`,
     idList: listId,
     pos: 'top',
   };
@@ -268,12 +269,15 @@ async function getChanges(since, adapterConfig) {
 
     for (const action of actions) {
       if (action.type === 'createCard') {
+        const description = action.data.card?.desc || '';
+        if (description.includes('[dex:')) continue;
+
         changes.push({
           id: action.data.card?.id,
           action: 'created',
           task: {
             name: action.data.card?.name || '',
-            desc: '',
+            desc: description,
             listName: action.data.list?.name || '',
             labels: [],
           },
@@ -281,7 +285,14 @@ async function getChanges(since, adapterConfig) {
       } else if (action.type === 'updateCard' && action.data.listAfter) {
         // Card moved between lists — check if moved to Done
         const listName = (action.data.listAfter.name || '').toLowerCase();
-        if (listName.includes('done') || listName.includes('complete')) {
+        const configuredDoneListId = adapterConfig.list_mapping?.done;
+        const movedToConfiguredDone =
+          configuredDoneListId && action.data.listAfter.id === configuredDoneListId;
+        if (
+          movedToConfiguredDone ||
+          listName.includes('done') ||
+          listName.includes('complete')
+        ) {
           changes.push({
             id: action.data.card?.id,
             action: 'completed',

--- a/.claude/hooks/tests/things-adapter.test.cjs
+++ b/.claude/hooks/tests/things-adapter.test.cjs
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+
+const ADAPTER_PATH = require.resolve('../adapters/things.cjs');
+
+function loadAdapter() {
+  delete require.cache[ADAPTER_PATH];
+  return require(ADAPTER_PATH);
+}
+
+function stubAppleScript(t, responder) {
+  const originalExecSync = childProcess.execSync;
+  const originalSpawnSync = childProcess.spawnSync;
+  const calls = [];
+
+  childProcess.execSync = () => {
+    throw new Error('execSync must not be used for AppleScript');
+  };
+  childProcess.spawnSync = (command, args, options) => {
+    calls.push({ command, args, options });
+    return responder(command, args, options, calls.length - 1);
+  };
+  t.after(() => {
+    childProcess.execSync = originalExecSync;
+    childProcess.spawnSync = originalSpawnSync;
+  });
+
+  return calls;
+}
+
+test('toExternal honors area_mapping and formats an unmapped pillar as an area', () => {
+  const adapter = loadAdapter();
+
+  const mapped = adapter.toExternal(
+    { title: 'Map me', pillar: 'pillar_1', priority: 'P1' },
+    { area_mapping: { pillar_1: 'Product Delivery' } },
+  );
+  const fallback = adapter.toExternal(
+    { title: 'Format me', pillar: 'customer_success', priority: 'P2' },
+    {},
+  );
+
+  assert.equal(mapped.area, 'Product Delivery');
+  assert.equal(mapped.list, 'today');
+  assert.equal(fallback.area, 'Customer Success');
+  assert.equal(fallback.list, 'anytime');
+});
+
+test('toDex leaves an unknown Things area unresolved', () => {
+  const adapter = loadAdapter();
+
+  const converted = adapter.toDex({
+    id: 'things-opaque-A',
+    name: 'External task',
+    area: 'Operations',
+    tags: ['P1'],
+  });
+
+  assert.equal(converted.pillar, null);
+  assert.equal(converted.priority, 'P1');
+});
+
+test('create passes AppleScript as argv and schedules Today without shell quoting', async (t) => {
+  const calls = stubAppleScript(t, () => ({
+    status: 0,
+    stdout: 'things-opaque-B\n',
+    stderr: '',
+  }));
+  const adapter = loadAdapter();
+
+  const id = await adapter.create({
+    title: "Dave's follow-up",
+    notes: "Don't lose the context",
+    area: 'Customers',
+    list: 'today',
+  }, {});
+
+  assert.equal(id, 'things-opaque-B');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'osascript');
+  assert.equal(calls[0].args[0], '-e');
+  assert.equal(calls[0].args.length, 2);
+  assert.match(calls[0].args[1], /name:"Dave's follow-up"/);
+  assert.match(calls[0].args[1], /move newTask to list "Today"/);
+  assert.doesNotMatch(calls[0].args[1], /scheduled date/);
+  assert.match(calls[0].args[1], /in area "Customers"/);
+  assert.equal(calls[0].options.timeout, 10_000);
+});
+
+test('complete passes an opaque ID to osascript without a shell', async (t) => {
+  const calls = stubAppleScript(t, () => ({ status: 0, stdout: '', stderr: '' }));
+  const adapter = loadAdapter();
+
+  await adapter.complete("things-id-with-'apostrophe", {});
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'osascript');
+  assert.deepEqual(calls[0].args.slice(0, 1), ['-e']);
+  assert.match(calls[0].args[1], /things-id-with-'apostrophe/);
+  assert.equal(calls[0].options.timeout, 10_000);
+});
+
+test('create reports the specified fallback when osascript exits without stderr', async (t) => {
+  stubAppleScript(t, () => ({ status: 1, stdout: '', stderr: '' }));
+  const adapter = loadAdapter();
+
+  await assert.rejects(
+    adapter.create({ title: 'Fail safely', list: 'anytime' }, {}),
+    /Things 3 create failed: osascript failed/,
+  );
+});
+
+test('getChanges filters Logbook by since and preserves the Inbox Dex-marker skip', async (t) => {
+  const calls = stubAppleScript(t, (_command, args) => {
+    const script = args[1];
+    if (script.includes('Logbook')) {
+      return {
+        status: 0,
+        stdout: [
+          'things-old|||Old completion|||2026-07-13T08:59:59.000Z',
+          'things-new|||New completion|||2026-07-13T09:00:00.000Z',
+          'things-unknown|||Unknown completion|||not-a-date',
+        ].join('\n'),
+        stderr: '',
+      };
+    }
+    if (script.includes('Inbox')) {
+      return {
+        status: 0,
+        stdout: [
+          'things-dex|||Dex-created|||dex-task-id: task-20260713-001',
+          'things-inbound|||Inbox-created|||Captured on phone',
+        ].join('\n'),
+        stderr: '',
+      };
+    }
+    throw new Error(`unexpected AppleScript: ${script}`);
+  });
+  const adapter = loadAdapter();
+
+  const changes = await adapter.getChanges('2026-07-13T09:00:00.000Z', {});
+
+  assert.equal(calls.length, 2);
+  assert.ok(calls.every((call) => call.command === 'osascript'));
+  assert.ok(calls.every((call) => call.args[0] === '-e' && call.args.length === 2));
+  assert.match(calls[0].args[1], /if status of t is completed then/);
+  assert.match(calls[0].args[1], /completedAt is greater than or equal to sinceDate/);
+  assert.match(calls[0].args[1], /\(completion date of t as string\)/);
+  assert.deepEqual(
+    changes.map(({ id, action }) => ({ id, action })),
+    [
+      { id: 'things-new', action: 'completed' },
+      { id: 'things-unknown', action: 'completed' },
+      { id: 'things-inbound', action: 'created' },
+    ],
+  );
+});

--- a/.claude/hooks/tests/trello-adapter.test.cjs
+++ b/.claude/hooks/tests/trello-adapter.test.cjs
@@ -1,0 +1,193 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ADAPTER_PATH = require.resolve('../adapters/trello.cjs');
+
+function loadAdapter() {
+  delete require.cache[ADAPTER_PATH];
+  return require(ADAPTER_PATH);
+}
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function stubFetch(t, implementation) {
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (requestUrl, options) => {
+    calls.push({ url: new URL(requestUrl), options });
+    return implementation(calls.at(-1), calls.length - 1);
+  };
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+  return calls;
+}
+
+test('create uses configured list_mapping and embeds the Dex marker', async (t) => {
+  const calls = stubFetch(t, ({ url, options }) => {
+    if (url.pathname === '/1/cards' && options.method === 'POST') {
+      return jsonResponse({ id: 'trello-card-opaque' });
+    }
+    if (url.pathname === '/1/boards/board-1/labels') return jsonResponse([]);
+    throw new Error(`unexpected request: ${options.method} ${url.pathname}`);
+  });
+  const adapter = loadAdapter();
+  const config = {
+    api_key: 'key',
+    token: 'token',
+    default_board: 'board-1',
+    list_mapping: { backlog: 'list-backlog-opaque' },
+  };
+  const external = adapter.toExternal({
+    title: 'Prepare launch',
+    context: 'Customer-facing release',
+    task_id: 'task-20260713-002',
+    status: 'n',
+    priority: 'P1',
+  }, config);
+
+  const id = await adapter.create(external, config);
+
+  assert.equal(id, 'trello-card-opaque');
+  assert.equal(calls.some(({ url }) => url.pathname.endsWith('/lists')), false);
+  const createCall = calls.find(({ url }) => url.pathname === '/1/cards');
+  assert.equal(createCall.url.searchParams.get('idList'), 'list-backlog-opaque');
+  assert.equal(
+    createCall.url.searchParams.get('desc'),
+    'Customer-facing release\n\n[dex:task-20260713-002]',
+  );
+});
+
+test('an unknown status falls back to list discovery instead of configured backlog', async (t) => {
+  const calls = stubFetch(t, ({ url, options }) => {
+    if (url.pathname === '/1/boards/board-1/lists') {
+      return jsonResponse([{ id: 'discovered-backlog', name: 'Backlog' }]);
+    }
+    if (url.pathname === '/1/cards' && options.method === 'POST') {
+      return jsonResponse({ id: 'trello-card-unknown-status' });
+    }
+    throw new Error(`unexpected request: ${options.method} ${url.pathname}`);
+  });
+  const adapter = loadAdapter();
+
+  await adapter.create(
+    {
+      name: 'Unknown status',
+      desc: '',
+      _dexStatus: 'unknown',
+      _dexPriority: '',
+      _dexTaskId: '',
+    },
+    {
+      api_key: 'key',
+      token: 'token',
+      default_board: 'board-1',
+      list_mapping: { backlog: 'configured-backlog' },
+    },
+  );
+
+  assert.ok(calls.some(({ url }) => url.pathname.endsWith('/lists')));
+  const createCall = calls.find(({ url }) => url.pathname === '/1/cards');
+  assert.equal(createCall.url.searchParams.get('idList'), 'discovered-backlog');
+});
+
+test('getChanges skips createCard actions whose description has a Dex marker', async (t) => {
+  stubFetch(t, ({ url }) => {
+    assert.equal(url.pathname, '/1/boards/board-1/actions');
+    return jsonResponse([
+      {
+        type: 'createCard',
+        data: {
+          card: { id: 'dex-card', name: 'Dex card', desc: '[dex:task-20260713-003]' },
+          list: { name: 'Backlog' },
+        },
+      },
+      {
+        type: 'createCard',
+        data: {
+          card: { id: 'external-card', name: 'External card', desc: 'From Trello' },
+          list: { name: 'Backlog' },
+        },
+      },
+    ]);
+  });
+  const adapter = loadAdapter();
+
+  const changes = await adapter.getChanges('2026-07-13T09:00:00.000Z', {
+    api_key: 'key',
+    token: 'token',
+    default_board: 'board-1',
+  });
+
+  assert.deepEqual(changes, [
+    {
+      id: 'external-card',
+      action: 'created',
+      task: {
+        name: 'External card',
+        desc: 'From Trello',
+        listName: 'Backlog',
+        labels: [],
+      },
+    },
+  ]);
+});
+
+test('getChanges recognizes a configured Done list whose name is custom', async (t) => {
+  stubFetch(t, ({ url }) => {
+    assert.equal(url.pathname, '/1/boards/board-1/actions');
+    return jsonResponse([
+      {
+        type: 'updateCard',
+        data: {
+          card: { id: 'shipped-card', name: 'Shipped externally' },
+          listAfter: { id: 'list-shipped', name: 'Shipped' },
+        },
+      },
+    ]);
+  });
+  const adapter = loadAdapter();
+
+  const changes = await adapter.getChanges('2026-07-13T09:00:00.000Z', {
+    api_key: 'key',
+    token: 'token',
+    default_board: 'board-1',
+    list_mapping: { done: 'list-shipped' },
+  });
+
+  assert.deepEqual(changes, [
+    {
+      id: 'shipped-card',
+      action: 'completed',
+      task: { name: 'Shipped externally' },
+    },
+  ]);
+});
+
+test('toDex leaves pillar resolution to the orchestrator', () => {
+  const adapter = loadAdapter();
+
+  const converted = adapter.toDex({
+    id: 'external-card',
+    name: 'External card',
+    desc: 'Created in Trello',
+    board: { name: 'Thought Leadership' },
+    listName: 'In Progress',
+    labels: [{ color: 'orange' }],
+  });
+
+  assert.deepEqual(converted, {
+    title: 'External card',
+    pillar: null,
+    priority: 'P1',
+    status: 's',
+    context: 'Created in Trello',
+    source: 'trello',
+    external_id: 'external-card',
+  });
+});

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -373,6 +373,37 @@ meeting note each task came from — and `goal_tentative`).
 Skip this entire step silently when nothing qualifies — no "0 tasks from meetings"
 noise.
 
+### 5.12 Inbound External Tasks Review (NEW)
+
+Give the user one place to review tasks that arrived from a connected task app
+(Todoist / Things / Trello) since the last sync. Check
+`System/integrations/inbound-tasks.json`. If it exists and is non-empty:
+
+1. Read each item: `{service, external_id, title, raw}`. The `raw` object contains the
+   service payload and may include notes/description, priority, and an inferred `pillar`.
+2. For each, offer a one-line summary and ask whether to bring it into Dex:
+   ```
+   📥 From [service]: "[title]"
+   Import as a Dex task? (yes / skip / [pillar] [priority])
+   ```
+3. On confirmation (or pillar/priority provided), call `create_task` with:
+   - `title`: from the item
+   - `on_duplicate: "fail"` (skip if already exists)
+   - `pillar`: user-specified, otherwise `raw.pillar` (the sync step fills this in
+     from an automatic pillar guess when inference succeeds). If it is absent, ask the
+     user to choose a valid pillar before calling `create_task`
+   - `priority`: user-specified, otherwise a valid P0-P3 value from `raw` when present
+   - `context`: notes/description/context from `raw` when present
+   - Do not pass the integration name as `source`; `source` is reserved for a
+     vault-relative source page, while the external mapping records provenance
+4. On "skip": leave the item in the queue so it can be reviewed later
+5. Immediately after each successful create, call `record_external_task_mapping` with
+   the returned `task.task_id`, the item's `service`, and its `external_id`. This records
+   the link and removes that item from the inbound queue.
+
+**Silent when empty:** if `inbound-tasks.json` doesn't exist or is empty/`[]`, skip this
+step entirely. Never say "no inbound tasks" — just proceed.
+
 ---
 
 ## Step 6: Synthesis

--- a/.claude/skills/things-setup/SKILL.md
+++ b/.claude/skills/things-setup/SKILL.md
@@ -13,7 +13,10 @@ manifest:
 
 Connect Things 3 so Dex can work with your Things tasks whenever you ask. No account needed. Everything stays on your Mac. Works offline.
 
-**What this is not (honesty first):** there is no automatic background sync. Creating a task in Dex does not create it in Things, and completing one in Things does not automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Things automatically" gets it captured on the improvement backlog.
+**What this enables (on request):** Once connected, say "sync with Things" — Dex pushes new
+tasks to the right Things Area (mapped from your pillars), marks completions via AppleScript,
+and pulls tasks you completed or added to Things Inbox. Everything stays local — no network
+calls, no accounts. Sync runs on demand when you ask.
 
 ## What This Enables
 
@@ -225,12 +228,12 @@ Here's what you can do now:
   Things tasks and I will
 - **Right Area, automatically** — when I file something in Things for you,
   your pillars map to your Things Areas
+- **Sync on demand** — say "sync Dex with Things" and Dex pushes pending tasks, marks
+  completions, and reviews anything new in your Things Inbox
 
 No accounts. No tokens. No expiration. Works offline.
 
-One honest note: there's no automatic background sync — I work with Things
-when you ask, not on my own. Want automatic two-way sync? Say so and I'll
-capture it on the improvement backlog.
+**Sync is on demand** — say "sync with Things" anytime. No background polling.
 ```
 
 ---

--- a/.claude/skills/todoist-setup/SKILL.md
+++ b/.claude/skills/todoist-setup/SKILL.md
@@ -20,7 +20,10 @@ integration:
 
 Connect your Todoist account so Dex can work with your Todoist tasks whenever you ask — check what's due, create a task there instead of in Dex, or mark something done.
 
-**What this is not (honesty first):** there is no automatic background sync. Dex tasks don't push themselves to Todoist, and completing a task in Todoist doesn't automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Todoist automatically" gets it captured on the improvement backlog.
+**What this enables (on request):** Once connected, say "sync with Todoist" — Dex pushes
+new tasks to the right Todoist project, marks completions, and pulls back tasks you completed
+or created in Todoist directly. Sync runs on demand; Dex does not poll Todoist in the
+background without you asking.
 
 ## What This Enables
 
@@ -210,10 +213,10 @@ Read the integration manifest from this skill's frontmatter. Present:
   Todoist", "Mark the invoice task done in Todoist".
 - **Bring it into your planning** — during `/daily-plan` or `/triage`, ask Dex to
   include or route to Todoist and it will.
+- **Sync on demand** — say "sync Dex with Todoist" and new tasks push, completions flow
+  both directions, and tasks you added in Todoist come in for review
 
-One honest note: there's no automatic background sync — Dex works with Todoist
-when you ask, not on its own. If you'd like automatic two-way sync, say so and
-I'll capture it on the improvement backlog.
+**Sync is on demand** — say "sync with Todoist" anytime. Dex doesn't poll in the background.
 ```
 
 ---

--- a/.claude/skills/trello-setup/SKILL.md
+++ b/.claude/skills/trello-setup/SKILL.md
@@ -13,7 +13,9 @@ manifest:
 
 Connect your Trello boards so Dex can work with them whenever you ask — check board status, create cards, or move them.
 
-**What this is not (honesty first):** there is no automatic background sync. Dex tasks don't become Trello cards by themselves, and moving a card to Done doesn't automatically update Dex. Everything happens on request, in conversation. If automatic two-way sync matters to you, tell Dex — "I wish Dex synced with Trello automatically" gets it captured on the improvement backlog.
+**What this enables (on request):** Once connected, say "sync with Trello" — Dex pushes new
+tasks as cards in the right list (Backlog/In Progress/Blocked/Done), marks completions by
+moving cards to Done, and pulls cards you moved or created in Trello. Sync runs on demand.
 
 ## What This Enables
 
@@ -217,10 +219,10 @@ Here's what you can do now:
 - **Bring it into planning** — during /daily-plan or /project-health, ask me
   to include your Trello cards and I will
 - **Meeting prep with context** — ask which cards are blocked before a meeting
+- **Sync on demand** — say "sync Dex with Trello" and Dex pushes pending tasks, moves
+  completions to Done, and reviews cards you created in Trello
 
-One honest note: there's no automatic background sync — I work with Trello
-when you ask, not on my own. Want automatic two-way sync? Say so and I'll
-capture it on the improvement backlog.
+**Sync is on demand** — say "sync with Trello" anytime. Dex doesn't poll in the background.
 
 You can adjust settings anytime by running `/trello-setup` again.
 ```
@@ -255,7 +257,8 @@ Trello allows 100 requests per 10 seconds. This is generous -- you'd only hit it
 Check:
 - Is the board ID correct in config.yaml?
 - Does the token have write access?
-- Are the list names matching? (List mapping is case-insensitive but names must partially match)
+- Are the list IDs under `list_mapping` still current? Re-run `/trello-setup` if the
+  board's lists were recreated or changed.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.51.0] - Things 3 and Trello sync join the party (2026-07-13)
+
+Real two-way sync landed for Todoist in the last release. This one brings your Mac's Things 3 and your Trello boards onto the same engine — so whichever task app you actually live in, Dex keeps step with it.
+
+**What this fixes for you:**
+
+* **Things 3, fully local, now syncs.** Ask Dex to sync and your pending tasks appear in the right Things Area (mapped from your pillars), the urgent ones land in Today, completions flow both ways, and anything you drop into your Things Inbox comes back for review in your morning plan. No accounts, no network — it all happens on your Mac through Things' own scripting.
+* **Trello boards stay in step.** New Dex tasks become cards in the right list, finishing a task moves its card to Done, and cards you add or move on the board come back to you for review — matched to the exact lists you picked during setup, not guessed from their names.
+* **Tasks from either tool arrive through your review, never behind your back.** Whatever you created in Things or Trello queues up in your daily plan, where you decide what becomes a Dex task — with duplicate checks and pillar linking — instead of it silently appearing in your backlog.
+* **A task title with an apostrophe can't break things anymore.** The Things connection was rebuilt to hand your task text to macOS safely, so quotes, apostrophes, and punctuation in a task name just work instead of causing a failure.
+* **Your pillars, not someone else's.** Both connections now read the Areas and lists from your own setup rather than falling back to a hardcoded set of categories that only fit one person's vault.
+* **Honest setup guides, again.** The Things, Trello, and Todoist setup walkthroughs now describe the sync that genuinely exists — the "coming later" note is gone because it's here.
+
 ## [1.50.0] - Real Todoist sync — the promise, finally built (2026-07-13)
 
 Earlier setups promised automatic two-way Todoist sync that never existed (we removed that promise in 1.36.0). This release builds the real thing, carefully.

--- a/core/tests/test_task_sync.py
+++ b/core/tests/test_task_sync.py
@@ -98,6 +98,36 @@ def _enable(sync_vault: dict[str, Path], *services: str) -> None:
     sync_vault["config"].write_text("\n".join(blocks) + "\n", encoding="utf-8")
 
 
+def _install_fake_runner(monkeypatch: pytest.MonkeyPatch, responses: dict) -> list[dict]:
+    calls = []
+    monkeypatch.setattr(task_sync, "_find_node", lambda: "/fake/node")
+
+    def run(command, **kwargs):
+        service, operation = command[-2:]
+        request = json.loads(kwargs["input"])
+        calls.append(
+            {
+                "command": command,
+                "service": service,
+                "operation": operation,
+                "request": request,
+            }
+        )
+        key = (service, operation)
+        if key not in responses:
+            raise AssertionError(f"unexpected adapter call: {service} {operation}")
+        result = responses[key]
+        return task_sync.subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=json.dumps({"ok": True, "result": result}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(task_sync.subprocess, "run", run)
+    return calls
+
+
 def test_first_service_run_creates_baseline_without_adapter_calls(sync_vault, monkeypatch):
     _enable(sync_vault, "todoist")
 
@@ -327,6 +357,263 @@ def test_one_service_error_does_not_block_another(sync_vault, monkeypatch):
     assert task_sync._load_state()["good"]["map"] == {
         "task-20260712-006": "good-external-id"
     }
+
+
+class TestThingsSync:
+    def test_push_create_via_runner_records_mapping(self, sync_vault, monkeypatch):
+        _enable(sync_vault, "things")
+        _write_tasks(
+            sync_vault["tasks"],
+            "- [ ] Launch Things product notes ^task-20260713-101",
+            "\t- Pillar: Product | Priority: P1",
+        )
+        task_sync._write_state(_state(things=_service_state()))
+        monkeypatch.setattr(task_sync.platform, "system", lambda: "Darwin")
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("things", "create"): "things-opaque-id",
+                ("things", "get_changes"): [],
+            },
+        )
+
+        result = task_sync.sync_external_tasks(services=["things"])
+
+        assert result["things"]["pushed_creates"] == 1
+        assert task_sync._load_state()["things"]["map"] == {
+            "task-20260713-101": "things-opaque-id"
+        }
+        assert [(call["service"], call["operation"]) for call in calls] == [
+            ("things", "create"),
+            ("things", "get_changes"),
+        ]
+        assert calls[0]["request"]["config"]["enabled"] is True
+        assert calls[0]["request"]["args"]["task_id"] == "task-20260713-101"
+        assert calls[1]["request"]["args"] == "2026-07-12T08:00:00+00:00"
+
+    def test_non_darwin_guard_never_calls_runner(self, sync_vault, monkeypatch):
+        _enable(sync_vault, "things")
+        task_sync._write_state(_state(things=_service_state()))
+        before = sync_vault["state"].read_bytes()
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("Things runner must not be called off macOS")
+
+        monkeypatch.setattr(task_sync.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(task_sync, "_find_node", fail_if_called)
+        monkeypatch.setattr(task_sync.subprocess, "run", fail_if_called)
+
+        result = task_sync.sync_external_tasks(services=["things"])
+
+        assert result["things"]["pushed_creates"] == 0
+        assert result["things"]["pulled_completes"] == 0
+        assert result["things"]["errors"] == [
+            "things task sync is only available on macOS"
+        ]
+        assert sync_vault["state"].read_bytes() == before
+
+    def test_completed_change_via_runner_updates_linked_dex_task(
+        self, sync_vault, monkeypatch
+    ):
+        _enable(sync_vault, "things")
+        task_id = "task-20260713-102"
+        _write_tasks(sync_vault["tasks"], f"- [ ] Finish Things follow-up ^{task_id}")
+        service_state = _service_state()
+        service_state["map"][task_id] = "things-completed-id"
+        task_sync._write_state(_state(things=service_state))
+        monkeypatch.setattr(task_sync.platform, "system", lambda: "Darwin")
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("things", "get_changes"): [
+                    {
+                        "id": "things-completed-id",
+                        "action": "completed",
+                        "task": {"title": "Finish Things follow-up"},
+                    }
+                ]
+            },
+        )
+
+        result = task_sync.sync_external_tasks(services=["things"])
+
+        assert result["things"]["pulled_completes"] == 1
+        assert "- [x] Finish Things follow-up" in sync_vault["tasks"].read_text(
+            encoding="utf-8"
+        )
+        assert task_id in task_sync._load_state()["things"]["completed_pushed"]
+        assert [call["operation"] for call in calls] == ["get_changes"]
+
+    def test_created_change_via_runner_queues_once_across_reruns(
+        self, sync_vault, monkeypatch
+    ):
+        _enable(sync_vault, "things")
+        task_sync._write_state(_state(things=_service_state()))
+        monkeypatch.setattr(task_sync.platform, "system", lambda: "Darwin")
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("things", "get_changes"): [
+                    {
+                        "id": "things-created-id",
+                        "action": "created",
+                        "task": {
+                            "title": "Prepare product demo",
+                            "notes": "Captured in Things Inbox",
+                        },
+                    }
+                ]
+            },
+        )
+
+        first = task_sync.sync_external_tasks(services=["things"])
+        second = task_sync.sync_external_tasks(services=["things"])
+
+        assert first["things"]["inbound_queued"] == 1
+        assert second["things"]["inbound_queued"] == 0
+        assert json.loads(sync_vault["inbound"].read_text(encoding="utf-8")) == [
+            {
+                "service": "things",
+                "external_id": "things-created-id",
+                "title": "Prepare product demo",
+                "raw": {
+                    "title": "Prepare product demo",
+                    "notes": "Captured in Things Inbox",
+                    "pillar": "pillar_1",
+                },
+            }
+        ]
+        assert [call["operation"] for call in calls] == [
+            "get_changes",
+            "get_changes",
+        ]
+
+
+class TestTrelloSync:
+    def test_push_create_via_runner_records_mapping(self, sync_vault, monkeypatch):
+        _enable(sync_vault, "trello")
+        _write_tasks(
+            sync_vault["tasks"],
+            "- [ ] Launch Trello product card ^task-20260713-201",
+            "\t- Pillar: Product | Priority: P1",
+        )
+        task_sync._write_state(_state(trello=_service_state()))
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("trello", "create"): "trello-opaque-id",
+                ("trello", "get_changes"): [],
+            },
+        )
+
+        result = task_sync.sync_external_tasks(services=["trello"])
+
+        assert result["trello"]["pushed_creates"] == 1
+        assert task_sync._load_state()["trello"]["map"] == {
+            "task-20260713-201": "trello-opaque-id"
+        }
+        assert [(call["service"], call["operation"]) for call in calls] == [
+            ("trello", "create"),
+            ("trello", "get_changes"),
+        ]
+        assert calls[0]["request"]["config"]["api_key"] == "test-token"
+        assert calls[0]["request"]["args"]["task_id"] == "task-20260713-201"
+
+    def test_created_change_via_runner_queues_inbound(self, sync_vault, monkeypatch):
+        _enable(sync_vault, "trello")
+        task_sync._write_state(_state(trello=_service_state()))
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("trello", "get_changes"): [
+                    {
+                        "id": "trello-created-id",
+                        "action": "created",
+                        "task": {
+                            "name": "Review product launch board",
+                            "listName": "Backlog",
+                            "labels": [],
+                        },
+                    }
+                ]
+            },
+        )
+
+        result = task_sync.sync_external_tasks(services=["trello"])
+
+        assert result["trello"]["inbound_queued"] == 1
+        assert json.loads(sync_vault["inbound"].read_text(encoding="utf-8")) == [
+            {
+                "service": "trello",
+                "external_id": "trello-created-id",
+                "title": "Review product launch board",
+                "raw": {
+                    "name": "Review product launch board",
+                    "listName": "Backlog",
+                    "labels": [],
+                    "pillar": "pillar_1",
+                },
+            }
+        ]
+        assert [call["operation"] for call in calls] == ["get_changes"]
+
+    def test_completed_change_via_runner_updates_linked_dex_task(
+        self, sync_vault, monkeypatch
+    ):
+        _enable(sync_vault, "trello")
+        task_id = "task-20260713-202"
+        _write_tasks(sync_vault["tasks"], f"- [ ] Finish Trello follow-up ^{task_id}")
+        service_state = _service_state()
+        service_state["map"][task_id] = "trello-completed-id"
+        task_sync._write_state(_state(trello=service_state))
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("trello", "get_changes"): [
+                    {
+                        "id": "trello-completed-id",
+                        "action": "completed",
+                        "task": {"name": "Finish Trello follow-up"},
+                    }
+                ]
+            },
+        )
+
+        result = task_sync.sync_external_tasks(services=["trello"])
+
+        assert result["trello"]["pulled_completes"] == 1
+        assert "- [x] Finish Trello follow-up" in sync_vault["tasks"].read_text(
+            encoding="utf-8"
+        )
+        assert task_id in task_sync._load_state()["trello"]["completed_pushed"]
+        assert [call["operation"] for call in calls] == ["get_changes"]
+
+    def test_push_complete_via_runner_uses_mapped_id_once(
+        self, sync_vault, monkeypatch
+    ):
+        _enable(sync_vault, "trello")
+        task_id = "task-20260713-203"
+        _write_tasks(sync_vault["tasks"], f"- [x] Archive Trello card ^{task_id}")
+        service_state = _service_state()
+        service_state["map"][task_id] = "trello-mapped-complete-id"
+        task_sync._write_state(_state(trello=service_state))
+        calls = _install_fake_runner(
+            monkeypatch,
+            {
+                ("trello", "complete"): None,
+                ("trello", "get_changes"): [],
+            },
+        )
+
+        first = task_sync.sync_external_tasks(services=["trello"])
+        second = task_sync.sync_external_tasks(services=["trello"])
+
+        assert first["trello"]["pushed_completes"] == 1
+        assert second["trello"]["pushed_completes"] == 0
+        complete_calls = [call for call in calls if call["operation"] == "complete"]
+        assert len(complete_calls) == 1
+        assert complete_calls[0]["request"]["args"] == "trello-mapped-complete-id"
+        assert task_id in task_sync._load_state()["trello"]["completed_pushed"]
 
 
 def test_record_mapping_validates_task_updates_state_and_removes_queue_item(sync_vault):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.49.0",
+  "version": "1.51.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this does

Completes Lane 2 of external task sync. Todoist landed the engine in #123; this brings **Things 3** (local, AppleScript) and **Trello** (REST API) onto the same two-layer bridge — Python orchestrator (`task_sync.py`) + JSON-stdio adapter runner (`run.cjs`).

## Adapter fixes

**`things.cjs`**
- **Shell injection fixed** — `execSync('osascript -e '<script>'')` replaced with `spawnSync('osascript', ['-e', script])` (no shell). Task titles with apostrophes/quotes no longer break out of quoting or fail.
- `toExternal(dexTask, adapterConfig)` now applies the user's `area_mapping`.
- Hardcoded demo-persona pillar defaults removed → generic title-cased fallback; `areaToPillar` returns `null` (orchestrator owns pillar inference).
- Today placement wired via Things' documented `move to list "Today"`.
- `getChanges` bounds the Logbook scan by since-date (AppleScript-side filter + JS double-check), with correct AppleScript date construction (day-set-to-1 before month to avoid month-overflow).

**`trello.cjs`**
- `getListIdForStatus` prefers config `list_mapping` list IDs over English name matching.
- `[dex:task-id]` marker embedded on create; marked cards skipped in `getChanges`.
- Configured Done list recognized by ID, not just name heuristics.
- `toDex` returns `pillar: null` (orchestrator owns inference); `toExternal` gets `adapterConfig` for contract parity.

Loop prevention rests on the orchestrator's ID map (a Dex-created card is a mapped value → in `reverse_mapping` → never re-imported); the marker is a second line of defense.

## Tests
- 8 new Python fake-runner tests in `test_task_sync.py` (Things darwin-guard/push/complete-inbound, Trello push/created-inbound/completed-inbound).
- 11 new JS adapter unit tests (`.claude/hooks/tests/`).

## Skills
- Honest sync descriptions restored to `todoist-setup`, `things-setup`, `trello-setup` — the "no sync exists, add to backlog" note is gone because sync exists now.
- `daily-plan` gains **step 5.12**: walks inbound external tasks through review-and-create (`create_task` with `on_duplicate: fail`, then `record_external_task_mapping` to dequeue).

## Verification (local, clean env)
- ✅ 21 Python task-sync tests, 11 JS adapter tests
- ✅ ruff clean, `node -c` clean on adapters
- ✅ All CI diff gates: test-delta, path-contract, doc-drift, instructed-tools, security, verify-distribution, path-consistency, `paths.py`
- Diff changes **zero production Python** (only `test_task_sync.py`), so the rest of the suite is unaffected; full-suite run left to CI on a clean runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)