### PR TITLE
Surface task-app integrations so users actually find them (v1.53.0)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -383,6 +383,27 @@ Say: "Now the fun part — let's connect the tools you use day to day."
 
 If any integrations are already connected, briefly note them so you don't re-offer.
 
+### 8b: Personalize with Vault Signals
+
+Before asking which to connect, run the integration concierge — it scans the vault for signals (mentions, links, email domains) of tools the user already works with, so you can lead with what fits them instead of a flat list:
+
+```bash
+node .claude/hooks/integration-concierge.cjs
+```
+
+Parse the JSON for `high_value` and `moderate_value`. If any `high_value` items came back, surface them first, personalized:
+
+```
+Based on what's already in your vault, these look most useful:
+
+- **[shortName]** — I noticed [mentions] references (e.g. [first example file]).
+  [value proposition]. Setup: [setupTime].
+```
+
+Then present the rest of the categorized list from 8a for anything not already surfaced. If the concierge returns no high_value signals (common for a brand-new vault), just use the 8a list as-is — don't mention the scan.
+
+After presenting, set an `integrations_offered` flag in the `.onboarding-complete` marker so `/getting-started` doesn't re-run this discovery.
+
 **Then ask:**
 
 "Which ones would you like to connect? You can always add more later with `/integrate-mcp` or individual setup commands."

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -213,6 +213,18 @@ Built specifically for personal knowledge management and productivity workflows 
 - `/meeting-prep` - Prepare for meetings *(v1.11: isolated context)*
 - `/process-meetings` - Process Granola meetings *(v1.11: isolated context, auto-updates person pages, background execution)*
 
+**Integrations (Connect Your Tools):**
+- `/todoist-setup` - Connect Todoist for two-way task sync (any platform)
+- `/things-setup` - Connect Things 3 for two-way task sync (macOS, no account, offline)
+- `/trello-setup` - Connect Trello so cards and Dex tasks stay in step
+- `/google-workspace-setup` - Gmail + Calendar + Docs (email digest, follow-up detection)
+- `/ms-teams-setup` - Microsoft Teams chat digest alongside Slack
+- `/zoom-setup` - Zoom recording access and scheduling
+- `/atlassian-setup` - Jira tickets and Confluence docs in daily plans
+- `/granola-setup` - Connect Granola for automatic meeting capture
+- `/calendar-setup` - Connect your calendar
+- `/integrate-mcp` - Browse and connect more tools via the MCP marketplace
+
 **Career Development:**
 - `/career-setup` - Initialize career system
 - `/career-coach` - Career reflections and assessments *(v1.11: isolated context, auto-captures career evidence)*

--- a/.claude/skills/dex-level-up/SKILL.md
+++ b/.claude/skills/dex-level-up/SKILL.md
@@ -182,7 +182,22 @@ If all features of all connected integrations are active, skip this section.
 
 ### Missing Integrations (Not Connected)
 
-If the user has few integrations connected, suggest one or two that fit their role and point them to `/integrate-mcp` to connect tools (calendar, email, Slack, task managers, and more) whenever they're ready. Keep it to high-signal suggestions only — don't overwhelm.
+Run the integration concierge to find tools the user already works with but hasn't connected — it scans the vault for signals (mentions, links, email domains) and ranks them:
+
+```bash
+node .claude/hooks/integration-concierge.cjs
+```
+
+Parse the JSON output — the high_value tier holds items scoring 5 or higher, moderate_value holds the rest with any signal. Surface up to two, named specifically, with the concrete signal you found:
+
+```markdown
+## Tools You Could Connect
+
+- **[shortName]** — you reference it [mentions] times (e.g. [first example file]).
+  [value proposition]. Connect with `[setup]` ([setupTime]).
+```
+
+Lead with the high_value items; fall back to a single role-fit moderate_value suggestion only if there are no high_value hits. If nothing scores, don't force it — a generic "run `/integrate-mcp` to connect calendar, email, task apps (Todoist/Things/Trello), and more" line is enough. Keep it to high-signal suggestions only — don't overwhelm.
 
 ---
 

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -841,11 +841,54 @@ Only show if:
 
 ## Integration Discovery (Contextual)
 
-If the vault is < 7 days old and few or no integrations are connected, you can
-nudge the user once: mention that `/integrate-mcp` connects tools (calendar,
-email, Slack, task managers, and more) whenever they're ready. Keep it light —
-one suggestion, no pressure — and skip it entirely if they already set up
-integrations during onboarding.
+**Trigger:** Run this check if the vault is < 7 days old AND few or no integrations are connected.
+
+### When to Check
+
+After completing the main pathway flow (A, B, or C) but before showing the completion message:
+
+1. Read `System/integrations/config.yaml` (if it exists)
+2. Count how many integrations have `enabled: true` (exclude `slack` since it's a default)
+3. If connected integrations <= 1 AND vault age < 7 days, run the concierge
+
+### How to Run
+
+Execute the integration concierge — it scans the vault for signals (mentions, links, email domains) of tools the user already works with and ranks them:
+
+```bash
+node .claude/hooks/integration-concierge.cjs
+```
+
+Parse the JSON output for `high_value` and `moderate_value` recommendations. Each entry includes `shortName`, `mentions`, `examples` (files where signals appeared), `value`, `setupTime`, and `setup` (the setup skill to run).
+
+### Presenting Recommendations
+
+**Only surface high_value items** (keep it light — this isn't onboarding, it's a nudge).
+
+For each high_value integration found:
+
+```
+By the way, I noticed you mention **[shortName]** in a few places
+([mentions] references across files like [first example file]).
+
+Connecting it would give you: [value proposition]
+
+Setup takes [setupTime]. Want to connect it now?
+```
+
+**If multiple high_value items:**
+
+```
+I also spotted signals for **[shortName2]** and **[shortName3]** in your notes.
+Want to connect any of these? Or run `/integrate-mcp` anytime later.
+```
+
+**Rules:**
+- Maximum 2 integration suggestions (don't overwhelm)
+- Only mention high_value items (score >= 5) — skip moderate and available
+- If the user says yes, run the setup skill (its `setup` field, e.g. `/trello-setup`) inline, then return to the getting-started completion
+- If the user says no/skip/later, move on without pressure
+- Don't show this section if the user already went through integration setup during onboarding Step 8 — check the `.onboarding-complete` marker for an `integrations_offered` flag and skip if present
 
 ---
 

--- a/.claude/skills/integrate-mcp/SKILL.md
+++ b/.claude/skills/integrate-mcp/SKILL.md
@@ -21,7 +21,13 @@ Say:
 ```
 **Want to connect more tools to Dex?**
 
-There's a marketplace of 100+ pre-built MCP servers at:
+Some tools have a built-in, guided setup — no marketplace hunting needed:
+• **Task apps:** Todoist (`/todoist-setup`), Things 3 (`/things-setup`), Trello (`/trello-setup`) — two-way task sync
+• **Email & calendar:** Google Workspace (`/google-workspace-setup`), Microsoft Teams (`/ms-teams-setup`)
+• **Meetings:** Granola (`/granola-setup`), Zoom (`/zoom-setup`)
+• **Work tracking:** Jira + Confluence (`/atlassian-setup`)
+
+For anything else, there's a marketplace of 100+ pre-built MCP servers at:
 **[Smithery.ai](https://smithery.ai/servers)**
 
 These are production-ready integrations for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.52.0] - Your own tools can now be health-checked for real — only when you say so (2026-07-13)
+## [1.53.0] - Dex now tells you it can connect to your task apps (2026-07-13)
+
+Dex quietly gained two-way sync with Todoist, Things 3, and Trello — but you'd only have found out during first-run setup, or by already knowing to ask. That's a shame for a feature this useful. Now Dex surfaces it the moment it's relevant.
+
+**What this fixes for you:**
+
+* **Mention your task app and Dex offers to connect it.** Say "I keep my tasks in Trello" or "that's on my Todoist" — or just paste a board link — and Dex offers to set up sync right there, in one light line. Say no and it drops it; no nagging.
+* **Dex notices the tools you already use.** During the getting-started tour and when you run `/dex-level-up`, Dex now scans your notes for signs of the tools you work with (mentions, links) and leads with the ones that actually fit you — "I noticed you mention Things in a few places" — instead of a generic list.
+* **First-time setup leads with what fits you.** Onboarding still offers every integration, but now puts the ones your vault already hints at up top.
+* **They're in the catalog now.** The skills list (`/dex-level-up`, `.claude/skills/README.md`) finally names every connect command — Todoist, Things, Trello, Gmail, Teams, Zoom, Jira, Granola, calendar — so browsing "what can Dex do?" actually shows them.
+* **`/integrate-mcp` points you the right way.** The "connect more tools" command now names the task apps and their built-in setup commands first, instead of sending you to hunt through a marketplace for something Dex already supports natively.
 
 Custom MCP servers used to stay permanently "unknown" because Dex would not execute user code during a check. You can now ask `/create-mcp` for a one-off startup proof and, as a separate default-no choice, trust one exact local Python file for nightly and deep checks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,22 @@ When the user mentions any of these:
 2. If a key is configured: Granola sync uses the official Granola public API, so desktop and mobile recordings come through the same way — there's nothing phone-specific to set up. Offer to run a sync (`/process-meetings`) and confirm background sync is installed (`cd .scripts/meeting-intel && ./install-automation.sh`).
 3. If no key is configured: tell the user "Granola isn't connected yet — run `/granola-setup` to add your Granola API key (requires a Granola Business plan)." Offer to walk them through it.
 
+### Task App Connections (Natural Language Triggers)
+
+Dex can sync tasks two ways with Todoist, Things 3, and Trello — but most users don't know that unless told. When the user mentions their task app in passing, offer to connect it. Watch for phrases like:
+- "I use Todoist / Things / Trello", "I keep my tasks in [app]", "my [app] board / list"
+- "I track that in Todoist", "that's on my Trello board", "it's in my Things inbox"
+- "can Dex sync with [app]", "does Dex work with [app]", "I wish this synced to [app]"
+- pasted links: `todoist.com`, `trello.com`, `things://`
+
+**Action:**
+1. Check `System/integrations/config.yaml` — if that app is already `enabled: true`, don't re-offer; instead offer to sync ("Want me to sync with [app] now?").
+2. If not connected, offer setup in one light line — no pressure, don't derail what they were doing:
+   > "By the way — I can sync two ways with [app]: new Dex tasks show up there, completions flow both directions, and tasks you make in [app] come back through your daily plan for review. Takes [30 sec–2 min] to connect. Want to? (Run `/[app]-setup` anytime.)"
+3. If yes, run the matching setup skill (`/todoist-setup`, `/things-setup`, `/trello-setup`). If no, drop it — capture nothing, don't nag again this session.
+
+Route by app: Todoist → `/todoist-setup` (any platform), Things 3 → `/things-setup` (macOS only), Trello → `/trello-setup`.
+
 ### Meeting Capture
 When the user shares meeting notes or says they had a meeting:
 1. Extract key points, decisions, and action items

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Why

We shipped real two-way sync with Todoist (#123), Things 3 + Trello (#126) — but a user would only discover it during first-run onboarding, or by already knowing to type `/things-setup`. An investigation confirmed the gaps: the skills catalog omitted all three setup skills, `/integrate-mcp` never named them, there was no mid-conversation trigger, and the one proactive detector (`integration-concierge.cjs`) was committed but **never wired into the active `.claude` runtime** — only the `.agents` mirror called it.

This closes the loop end-to-end. **No code changes** — it wires the existing scanner into the runtime and adds discovery prose.

## Changes

- **`CLAUDE.md`** — new "Task App Connections" natural-language trigger block (mirrors the existing Granola trigger). Mentioning an app or pasting a `todoist.com`/`trello.com`/`things://` link offers setup in one light line; a "no" drops it with no nagging.
- **`getting-started`** — replaced the watered-down "just mention `/integrate-mcp`" stub with the real `integration-concierge.cjs` run + ranked `high_value` presentation (ported from the `.agents` version that actually worked).
- **`onboarding` Step 8b** — runs the concierge to lead with vault-signal matches before the flat categorized list; sets the `integrations_offered` marker so `/getting-started` doesn't double-nudge.
- **`dex-level-up`** — "Missing Integrations" now runs the concierge and names specific apps with the concrete signal found, instead of a generic "task managers" line.
- **`skills/README.md`** — new Integrations section listing every connect command (task apps + Gmail/Teams/Zoom/Jira/Granola/calendar); the catalog previously named none of them.
- **`integrate-mcp`** — names the built-in task-app setup commands first, before pointing at the Smithery marketplace.

## Verification
- ✅ Diff gates: instructed-tools, doc-drift, path-contract, test-delta, path-consistency, verify-distribution (0 errors)
- ✅ `integration-concierge.cjs` runs clean and already covers todoist/things/trello
- Zero code files changed (docs/skill-prose + version bump only), so pytest/coverage/ruff/security are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)