### PR TITLE
Phase 3 (health page): a public, honest per-release proof — plus a changelog repair (v1.54.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate paths.json
         run: python core/paths.py
       - name: Test suites + coverage
-        run: pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -v --cov=core --cov-report=term --cov-report=json:coverage.json --cov-fail-under="${COVERAGE_MIN_TOTAL}"
+        run: pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -v --junitxml=.logs/pytest-report.xml --cov=core --cov-report=term --cov-report=json:coverage.json --cov-fail-under="${COVERAGE_MIN_TOTAL}"
       - name: Touched-file coverage gate
         if: github.event_name == 'pull_request'
         run: python scripts/check-coverage-threshold.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
         run: bash scripts/verify-distribution.sh
       - name: Path consistency check
         run: bash scripts/check-path-consistency.sh
+      - name: Upload release health inputs
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-health-inputs
+          path: |
+            .logs/pytest-report.xml
+            coverage.json
+          if-no-files-found: error
+          retention-days: 1
 
   build-release:
     needs: quality
@@ -68,6 +78,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    outputs:
+      release_sha: ${{ steps.release_build.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,7 +93,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Build release branch
-        run: bash scripts/build-release.sh
+        id: release_build
+        run: |
+          bash scripts/build-release.sh
+          echo "release_sha=$(git rev-parse release)" >> "$GITHUB_OUTPUT"
       - name: Push release branch
         run: git push origin release --force
       - name: Build self-contained vault bundle
@@ -104,3 +119,53 @@ jobs:
             "dist/dex-vault-bundle-v$VERSION.tar.gz" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
             --clobber
+
+  deploy-health:
+    needs: [quality, build-release]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.quality.result == 'success' && needs['build-release'].result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Download release health inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: release-health-inputs
+          path: .
+      - name: Build release health page
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          RELEASE_SHA: ${{ needs['build-release'].outputs.release_sha }}
+        run: |
+          python scripts/build-health-json.py \
+            --source-sha "$SOURCE_SHA" \
+            --release-sha "$RELEASE_SHA" \
+            --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --quality-conclusion success \
+            --output health.json
+          python scripts/render-health-page.py --input health.json --output public/health.html
+      - name: Configure GitHub Pages
+        id: pages
+        continue-on-error: true
+        uses: actions/configure-pages@v5
+      - name: Explain Pages setup skip
+        if: steps.pages.outcome != 'success'
+        run: echo "::notice::Health page not deployed because GitHub Pages is not enabled. Enable Settings → Pages → GitHub Actions."
+      - name: Upload GitHub Pages artifact
+        if: steps.pages.outcome == 'success'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - name: Deploy health page
+        if: steps.pages.outcome == 'success'
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1063,6 +1063,8 @@ files. Its optional deep scan also runs `core/utils/smoke.py`, which exercises c
 loading, a real task lifecycle, MCP startup, skills, and hook structure in isolated
 subprocesses.
 
+The public proof for the latest successful release build is on the repository's GitHub Pages site at `/health.html`.
+
 The smoke runner copies the minimum vault data into a temporary directory before product
 code is imported. It uses a temporary home, disables analytics, never reads credential or
 `.env` files, redacts secret-like config values before child journeys, never contacts the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.53.0] - See exactly what Dex checked before a release reached you — a public, honest per-release health page (2026-07-13)
+
+Dex's release checks were rigorous but invisible once a release reached you. Each successful
+release build now publishes a small public page showing the evidence for that exact version,
+without turning checks that did not run into reassuring green ticks.
+
+* **The proof is tied to one release.** The page names the package version, source commit,
+  generated release commit, verification time, and workflow run.
+* **Every gate tells the truth.** Checks run by the successful main build are marked passed;
+  pull-request-only checks are explicitly marked not applicable and not run on the release
+  build. Missing evidence stays unknown.
+* **A failed later build cannot rewrite history.** The published page remains labelled as the
+  last successful release build, so it never claims to describe a newer failing `HEAD`.
+
+---
+
 ## [1.52.0] - Your own tools can now be health-checked for real — only when you say so (2026-07-13)
 
 Custom MCP servers used to stay permanently "unknown" because Dex would not execute user code during a check. You can now ask `/create-mcp` for a one-off startup proof and, as a separate default-no choice, trust one exact local Python file for nightly and deep checks.

--- a/core/tests/test_health_page_scripts.py
+++ b/core/tests/test_health_page_scripts.py
@@ -1,0 +1,96 @@
+"""Tests for the release health-data and page generators."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build-health-json.py"
+
+
+def _load_script(path: Path, module_name: str):
+    assert path.is_file(), f"missing script: {path}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_health_json_parses_pytest_counts(tmp_path):
+    build_health = _load_script(BUILD_SCRIPT, "build_health_json")
+    report = tmp_path / "pytest-report.xml"
+    report.write_text(
+        '<testsuites tests="9" failures="2" errors="1" skipped="2" time="1.0" />',
+        encoding="utf-8",
+    )
+
+    counts = build_health.parse_pytest_report(report)
+
+    assert counts == {"passed": 4, "skipped": 2, "failed": 3, "total": 9}
+
+
+def test_build_health_json_marks_pr_only_gates_not_run(tmp_path):
+    build_health = _load_script(BUILD_SCRIPT, "build_health_json")
+    package = tmp_path / "package.json"
+    package.write_text(json.dumps({"version": "1.53.0"}), encoding="utf-8")
+
+    data = build_health.build_health_data(
+        package_path=package,
+        junit_path=tmp_path / "missing-report.xml",
+        coverage_path=tmp_path / "missing-coverage.json",
+        changelog_path=tmp_path / "missing-changelog.md",
+        source_sha="a" * 40,
+        release_sha="b" * 40,
+        generated_at="2026-07-13T10:20:30Z",
+        workflow_run_url="https://github.com/example/dex/actions/runs/123",
+        quality_conclusion="success",
+    )
+
+    gates = {gate["name"]: gate for gate in data["gates"]}
+    for name in (
+        "Diff-aware test gate",
+        "Path-contract usage gate",
+        "Documentation drift gate",
+        "Touched-file coverage gate",
+    ):
+        assert gates[name] == {
+            "name": name,
+            "status": "not-applicable",
+            "detail": "not run on release build (PR-only)",
+        }
+
+
+def test_build_health_json_marks_missing_inputs_unknown(tmp_path):
+    build_health = _load_script(BUILD_SCRIPT, "build_health_json")
+    data = build_health.build_health_data(
+        package_path=tmp_path / "missing-package.json",
+        junit_path=tmp_path / "missing-report.xml",
+        coverage_path=tmp_path / "missing-coverage.json",
+        changelog_path=tmp_path / "missing-changelog.md",
+        source_sha=None,
+        release_sha=None,
+        generated_at="2026-07-13T10:20:30Z",
+        workflow_run_url=None,
+        quality_conclusion=None,
+    )
+
+    assert data["release"]["version"] == "unknown"
+    assert data["release"]["source_sha"] == "unknown"
+    assert data["release"]["release_sha"] == "unknown"
+    assert data["release"]["workflow_run_url"] == "unknown"
+    assert data["automated_checks"] == {
+        "passed": "unknown",
+        "skipped": "unknown",
+        "failed": "unknown",
+        "total": "unknown",
+    }
+    assert data["coverage"]["total_percent"] == "unknown"
+    assert data["changelog_headline"] == "unknown"
+    assert all(
+        gate["status"] != "passed"
+        for gate in data["gates"]
+        if gate["status"] != "not-applicable"
+    )

--- a/core/tests/test_health_page_scripts.py
+++ b/core/tests/test_health_page_scripts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BUILD_SCRIPT = REPO_ROOT / "scripts" / "build-health-json.py"
+RENDER_SCRIPT = REPO_ROOT / "scripts" / "render-health-page.py"
 
 
 def _load_script(path: Path, module_name: str):
@@ -94,3 +95,50 @@ def test_build_health_json_marks_missing_inputs_unknown(tmp_path):
         for gate in data["gates"]
         if gate["status"] != "not-applicable"
     )
+
+
+def test_render_health_page_contains_release_truth_and_provenance():
+    render_health = _load_script(RENDER_SCRIPT, "render_health_page")
+    data = {
+        "schema_version": 1,
+        "label": "Last successful release build",
+        "release": {
+            "version": "1.53.0",
+            "source_sha": "a" * 40,
+            "release_sha": "b" * 40,
+            "generated_at": "2026-07-13T10:20:30Z",
+            "workflow_run_url": "https://github.com/example/dex/actions/runs/123",
+        },
+        "automated_checks": {"passed": 412, "skipped": 3, "failed": 0, "total": 415},
+        "coverage": {"total_percent": 82.5},
+        "changelog_headline": "See exactly what Dex checked before a release reached you",
+        "gates": [
+            {
+                "name": "Test suites + coverage",
+                "status": "passed",
+                "detail": "completed on the successful main release build",
+            },
+            {
+                "name": "Diff-aware test gate",
+                "status": "not-applicable",
+                "detail": "not run on release build (PR-only)",
+            },
+        ],
+    }
+
+    html = render_health.render_health_html(data)
+
+    assert "Dex v1.53.0 passed 412 automated checks before this release reached you." in html
+    assert "See exactly what Dex checked before a release reached you" in html
+    assert "Test suites + coverage" in html
+    assert "Passed" in html
+    assert "Not applicable — not run (PR-only)" in html
+    assert "not run on release build (PR-only)" in html
+    assert "Last successful release build" in html
+    assert "Source commit" in html and "a" * 40 in html
+    assert "Generated release commit" in html and "b" * 40 in html
+    assert "Verified at (UTC)" in html and "2026-07-13T10:20:30Z" in html
+    assert "Workflow run" in html and data["release"]["workflow_run_url"] in html
+    assert "<style>" in html
+    assert "<link" not in html
+    assert "<script" not in html

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -29,6 +29,25 @@ Current coverage thresholds (ratchet baseline):
 - Total coverage >= 15%
 - Touched source files >= 10%
 
+## Public Release Health Page
+
+After the main-branch release build and release-branch push both succeed, CI publishes
+`health.html` through the repository's GitHub Pages site. It is labelled **Last successful
+release build** and follows these honesty rules:
+
+- The page describes one exact package version, source commit, and generated release commit.
+- Its gate matrix distinguishes `passed`, `skipped`, `not-applicable`, and `unknown` evidence.
+- Gates that run only on pull requests are labelled `not run on release build (PR-only)`;
+  they are never presented as passed by a main-push release.
+- Missing JUnit, coverage, provenance, or changelog input stays `unknown` rather than becoming
+  an inferred pass.
+- Publication happens only after the release branch is built and pushed successfully. If a
+  later build fails, the previous page remains available and still describes only its own
+  last green release, not current `HEAD`.
+
+Repository maintainers can enable publication once under **Settings → Pages → GitHub
+Actions**. Until then, the health deployment steps skip cleanly after the release build.
+
 ## Golden User Journeys
 These journeys are release-critical and cannot regress:
 - onboarding -> profile/pillars creation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.47.0",
+  "version": "1.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.47.0",
+      "version": "1.53.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/build-health-json.py
+++ b/scripts/build-health-json.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Build truthful, release-specific health data from CI artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+UNKNOWN = "unknown"
+PR_ONLY_DETAIL = "not run on release build (PR-only)"
+
+MAIN_PUSH_GATES = (
+    "Governance docs present",
+    "Hook harness tests",
+    "Script library tests",
+    "Instructed-tool existence gate",
+    "Test suites + coverage",
+    "Large-vault performance budget",
+    "Security gate",
+    "Ruff linting",
+    "Distribution safety check",
+    "Path consistency check",
+)
+
+PR_ONLY_GATES = (
+    "Diff-aware test gate",
+    "Path-contract usage gate",
+    "Documentation drift gate",
+    "Touched-file coverage gate",
+)
+
+
+def _unknown_counts() -> dict[str, str]:
+    return {"passed": UNKNOWN, "skipped": UNKNOWN, "failed": UNKNOWN, "total": UNKNOWN}
+
+
+def parse_pytest_report(path: Path) -> dict[str, int | str]:
+    """Return aggregate pytest counts from JUnit XML, or explicit unknowns."""
+    if not path.is_file():
+        return _unknown_counts()
+
+    try:
+        root = ET.parse(path).getroot()
+        totals = root.attrib
+        if "tests" not in totals and root.tag == "testsuites":
+            suites = root.findall("testsuite")
+            totals = {
+                key: sum(int(suite.attrib.get(key, 0)) for suite in suites)
+                for key in ("tests", "failures", "errors", "skipped")
+            }
+
+        total = int(totals["tests"])
+        skipped = int(totals.get("skipped", 0))
+        failed = int(totals.get("failures", 0)) + int(totals.get("errors", 0))
+        passed = total - skipped - failed
+        if min(total, skipped, failed, passed) < 0:
+            raise ValueError("invalid negative JUnit count")
+    except (ET.ParseError, KeyError, TypeError, ValueError):
+        return _unknown_counts()
+
+    return {"passed": passed, "skipped": skipped, "failed": failed, "total": total}
+
+
+def parse_coverage(path: Path) -> dict[str, float | str]:
+    """Return coverage.py's total percentage, or an explicit unknown."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        percent = float(data["totals"]["percent_covered"])
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return {"total_percent": UNKNOWN}
+    return {"total_percent": round(percent, 2)}
+
+
+def read_version(path: Path) -> str:
+    try:
+        version = json.loads(path.read_text(encoding="utf-8"))["version"]
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError):
+        return UNKNOWN
+    return version if isinstance(version, str) and version else UNKNOWN
+
+
+def read_changelog_headline(path: Path, version: str) -> str:
+    if version == UNKNOWN:
+        return UNKNOWN
+    try:
+        changelog = path.read_text(encoding="utf-8")
+    except OSError:
+        return UNKNOWN
+
+    match = re.search(
+        rf"^## \[{re.escape(version)}\]\s+-\s+(.+?)(?:\s+\(\d{{4}}-\d{{2}}-\d{{2}}\))?$",
+        changelog,
+        flags=re.MULTILINE,
+    )
+    return match.group(1).strip() if match else UNKNOWN
+
+
+def build_gate_matrix(quality_conclusion: str | None) -> list[dict[str, str]]:
+    if quality_conclusion == "success":
+        main_status = "passed"
+        main_detail = "completed on the successful main release build"
+    elif quality_conclusion == "skipped":
+        main_status = "skipped"
+        main_detail = "quality job was skipped"
+    else:
+        main_status = UNKNOWN
+        main_detail = "quality-job result was not available"
+
+    gates = [
+        {"name": name, "status": main_status, "detail": main_detail}
+        for name in MAIN_PUSH_GATES
+    ]
+    gates.extend(
+        {"name": name, "status": "not-applicable", "detail": PR_ONLY_DETAIL}
+        for name in PR_ONLY_GATES
+    )
+    return gates
+
+
+def build_health_data(
+    *,
+    package_path: Path,
+    junit_path: Path,
+    coverage_path: Path,
+    changelog_path: Path,
+    source_sha: str | None,
+    release_sha: str | None,
+    generated_at: str,
+    workflow_run_url: str | None,
+    quality_conclusion: str | None,
+) -> dict[str, Any]:
+    version = read_version(package_path)
+    return {
+        "schema_version": 1,
+        "label": "Last successful release build",
+        "release": {
+            "version": version,
+            "source_sha": source_sha or UNKNOWN,
+            "release_sha": release_sha or UNKNOWN,
+            "generated_at": generated_at,
+            "workflow_run_url": workflow_run_url or UNKNOWN,
+        },
+        "automated_checks": parse_pytest_report(junit_path),
+        "coverage": parse_coverage(coverage_path),
+        "gates": build_gate_matrix(quality_conclusion),
+        "changelog_headline": read_changelog_headline(changelog_path, version),
+    }
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", type=Path, default=Path("package.json"))
+    parser.add_argument("--junit", type=Path, default=Path(".logs/pytest-report.xml"))
+    parser.add_argument("--coverage", type=Path, default=Path("coverage.json"))
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument("--source-sha")
+    parser.add_argument("--release-sha")
+    parser.add_argument("--generated-at", default=None)
+    parser.add_argument("--workflow-run-url")
+    parser.add_argument("--quality-conclusion")
+    parser.add_argument("--output", type=Path, default=Path("health.json"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    data = build_health_data(
+        package_path=args.package,
+        junit_path=args.junit,
+        coverage_path=args.coverage,
+        changelog_path=args.changelog,
+        source_sha=args.source_sha,
+        release_sha=args.release_sha,
+        generated_at=args.generated_at or _utc_now(),
+        workflow_run_url=args.workflow_run_url,
+        quality_conclusion=args.quality_conclusion,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render-health-page.py
+++ b/scripts/render-health-page.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Render health.json as one self-contained, truthful HTML page."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+UNKNOWN = "unknown"
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _safe_workflow_link(value: Any) -> str:
+    url = str(value)
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return f"<code>{_escape(value)}</code>"
+    escaped = _escape(url)
+    return f'<a href="{escaped}" rel="noreferrer">Open workflow run</a>'
+
+
+def _summary(data: dict[str, Any]) -> str:
+    version = _escape(data.get("release", {}).get("version", UNKNOWN))
+    passed = data.get("automated_checks", {}).get("passed", UNKNOWN)
+    if isinstance(passed, int):
+        return f"Dex v{version} passed {passed} automated checks before this release reached you."
+    return f"Automated check counts are unavailable for Dex v{version}; no count is being claimed."
+
+
+def _status_label(status: Any) -> str:
+    labels = {
+        "passed": "Passed",
+        "skipped": "Skipped",
+        "not-applicable": "Not applicable — not run (PR-only)",
+        UNKNOWN: "Unknown",
+    }
+    return labels.get(str(status), str(status).replace("-", " ").title())
+
+
+def _render_gate_rows(gates: Any) -> str:
+    if not isinstance(gates, list):
+        gates = []
+    rows = []
+    for gate in gates:
+        if not isinstance(gate, dict):
+            continue
+        status = str(gate.get("status", UNKNOWN))
+        css_status = status if status in {"passed", "skipped", "not-applicable", UNKNOWN} else UNKNOWN
+        rows.append(
+            "<tr>"
+            f'<th scope="row">{_escape(gate.get("name", UNKNOWN))}</th>'
+            f'<td><span class="status status-{css_status}">{_escape(_status_label(status))}</span></td>'
+            f'<td>{_escape(gate.get("detail", UNKNOWN))}</td>'
+            "</tr>"
+        )
+    return "\n".join(rows) or '<tr><td colspan="3">Gate data is unknown.</td></tr>'
+
+
+def render_health_html(data: dict[str, Any]) -> str:
+    release = data.get("release", {})
+    checks = data.get("automated_checks", {})
+    coverage = data.get("coverage", {})
+    version = release.get("version", UNKNOWN)
+    source_sha = release.get("source_sha", UNKNOWN)
+    release_sha = release.get("release_sha", UNKNOWN)
+    generated_at = release.get("generated_at", UNKNOWN)
+    workflow_url = release.get("workflow_run_url", UNKNOWN)
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>Dex v{_escape(version)} release health</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      --bg: #f5f3ee;
+      --surface: #fffdf8;
+      --text: #18201d;
+      --muted: #5e6a65;
+      --border: #d8ddd8;
+      --accent: #176b52;
+      --pass-bg: #dff4e9;
+      --pass-text: #155b45;
+      --neutral-bg: #ecefe9;
+      --neutral-text: #4b5550;
+      --unknown-bg: #fff0c7;
+      --unknown-text: #6f5011;
+    }}
+    @media (prefers-color-scheme: dark) {{
+      :root {{
+        --bg: #121715;
+        --surface: #1a211e;
+        --text: #eef3ef;
+        --muted: #aeb9b3;
+        --border: #35413b;
+        --accent: #7ed2b3;
+        --pass-bg: #173f32;
+        --pass-text: #9be0c5;
+        --neutral-bg: #303833;
+        --neutral-text: #d0d8d3;
+        --unknown-bg: #4c3c18;
+        --unknown-text: #f4d681;
+      }}
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    main {{ width: min(72rem, calc(100% - 2rem)); margin: 0 auto; padding: 4rem 0; }}
+    header, section {{
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      padding: clamp(1.25rem, 3vw, 2.25rem);
+      margin-bottom: 1rem;
+    }}
+    .eyebrow {{ color: var(--accent); font-size: .8rem; font-weight: 750; letter-spacing: .08em; text-transform: uppercase; }}
+    h1 {{ max-width: 22ch; margin: .35rem 0 .75rem; font-size: clamp(2rem, 6vw, 4.5rem); line-height: 1.02; letter-spacing: -.04em; }}
+    h2 {{ margin-top: 0; font-size: 1.35rem; }}
+    .lede {{ max-width: 68ch; margin: 0; color: var(--muted); font-size: clamp(1.05rem, 2vw, 1.3rem); }}
+    .headline {{ margin-top: 1.5rem; font-weight: 650; }}
+    .metrics, .provenance {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: .75rem; margin: 1rem 0 0; }}
+    .metric, .provenance div {{ padding: 1rem; border: 1px solid var(--border); border-radius: .75rem; min-width: 0; }}
+    dt {{ color: var(--muted); font-size: .82rem; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; }}
+    dd {{ margin: .35rem 0 0; font-weight: 650; overflow-wrap: anywhere; }}
+    .table-wrap {{ overflow-x: auto; }}
+    table {{ width: 100%; border-collapse: collapse; min-width: 42rem; }}
+    th, td {{ padding: .85rem .7rem; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }}
+    thead th {{ color: var(--muted); font-size: .8rem; letter-spacing: .04em; text-transform: uppercase; }}
+    tbody th {{ font-weight: 650; }}
+    .status {{ display: inline-block; border-radius: 999px; padding: .2rem .6rem; font-size: .84rem; font-weight: 750; white-space: nowrap; }}
+    .status-passed {{ background: var(--pass-bg); color: var(--pass-text); }}
+    .status-skipped, .status-not-applicable {{ background: var(--neutral-bg); color: var(--neutral-text); }}
+    .status-unknown {{ background: var(--unknown-bg); color: var(--unknown-text); }}
+    a {{ color: var(--accent); }}
+    code {{ font-size: .85em; }}
+    footer {{ color: var(--muted); padding: .5rem .25rem; font-size: .9rem; }}
+    @media (max-width: 40rem) {{ main {{ padding: 1rem 0; }} header, section {{ border-radius: .75rem; }} }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="eyebrow">{_escape(data.get("label", "Last successful release build"))}</div>
+      <h1>Release health for Dex v{_escape(version)}</h1>
+      <p class="lede">{_summary(data)}</p>
+      <p class="headline">{_escape(data.get("changelog_headline", UNKNOWN))}</p>
+      <dl class="metrics">
+        <div class="metric"><dt>Passed checks</dt><dd>{_escape(checks.get("passed", UNKNOWN))}</dd></div>
+        <div class="metric"><dt>Skipped checks</dt><dd>{_escape(checks.get("skipped", UNKNOWN))}</dd></div>
+        <div class="metric"><dt>Failed checks</dt><dd>{_escape(checks.get("failed", UNKNOWN))}</dd></div>
+        <div class="metric"><dt>Total coverage</dt><dd>{_escape(coverage.get("total_percent", UNKNOWN))}%</dd></div>
+      </dl>
+    </header>
+
+    <section aria-labelledby="gate-heading">
+      <h2 id="gate-heading">What this release build ran</h2>
+      <p>Each row reports this exact release build. Pull-request-only checks are shown as not run, never passed.</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th scope="col">Gate</th><th scope="col">Status</th><th scope="col">What happened</th></tr></thead>
+          <tbody>
+            {_render_gate_rows(data.get("gates"))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section aria-labelledby="provenance-heading">
+      <h2 id="provenance-heading">Build provenance</h2>
+      <dl class="provenance">
+        <div><dt>Source commit</dt><dd><code>{_escape(source_sha)}</code></dd></div>
+        <div><dt>Generated release commit</dt><dd><code>{_escape(release_sha)}</code></dd></div>
+        <div><dt>Verified at (UTC)</dt><dd>{_escape(generated_at)}</dd></div>
+        <div><dt>Workflow run</dt><dd>{_safe_workflow_link(workflow_url)}</dd></div>
+      </dl>
+    </section>
+
+    <footer>This page remains the record of the last successful release build. A later failed build does not rewrite it or make it a claim about current HEAD.</footer>
+  </main>
+</body>
+</html>
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=Path("health.json"))
+    parser.add_argument("--output", type=Path, default=Path("health.html"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    data = json.loads(args.input.read_text(encoding="utf-8"))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_health_html(data), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

The visible half of the trust engine: after each successful release build, Dex publishes a small self-contained page showing exactly what was verified for that exact version — turning invisible rigour into proof anyone can see. Two scripts + a Pages workflow + docs. No runtime code, no external credentials.

**Honesty is the whole point** (a plan-check enforced this):
- The page is tied to one version + source SHA + generated release SHA + timestamp + workflow link.
- Per-gate matrix with explicit status: gates the main build actually ran → passed; PR-only gates → **"not applicable — not run (PR-only)"** (never a green tick); missing evidence → **unknown**, never silently "passed".
- Published only after the release build+push succeeds, labelled "last successful release build" so a later failing HEAD can't be misrepresented.

Verified: `build-health-json.py` marks main-push gates passed only when the real quality-job conclusion is success, defaults missing counts/coverage to explicit "unknown", and always marks PR-only gates not-applicable. Render output confirmed to show the honest statuses.

## Also: repairs a broken CHANGELOG on main

While rebasing, I found main's CHANGELOG had lost the `## [1.52.0]` header and duplicated its body — an auto-merge from #127 that produced a semantic mess without a git conflict. Since this PR touches CHANGELOG, it restores a clean, single, properly-headed 1.52.0 entry. (Cosmetic, but the changelog is what users read to decide whether to update, so worth fixing.)

## Verification
Health-page script tests 4/4; ruff clean; all three PR diff gates pass; workflows parse. Pages must be enabled once: Settings → Pages → GitHub Actions (deploy skips cleanly until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY