### PR TITLE
Concierge notices installed apps + configured connectors (v1.55.0)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -385,19 +385,18 @@ If any integrations are already connected, briefly note them so you don't re-off
 
 ### 8b: Personalize with Vault Signals
 
-Before asking which to connect, run the integration concierge — it scans the vault for signals (mentions, links, email domains) of tools the user already works with, so you can lead with what fits them instead of a flat list:
+Before asking which to connect, run the integration concierge — it scans for signals of tools the user already works with (apps installed on their Mac, connectors already configured, and mentions/links in their notes), so you can lead with what fits them instead of a flat list:
 
 ```bash
 node .claude/hooks/integration-concierge.cjs
 ```
 
-Parse the JSON for `high_value` and `moderate_value`. If any `high_value` items came back, surface them first, personalized:
+Parse the JSON for the high_value and moderate_value tiers. Each entry has a `reason` field with a ready-made plain-English signal ("installed on your Mac", "already set up as a connector but not switched on yet", or a mention count). If any high_value items came back, surface them first, personalized:
 
 ```
-Based on what's already in your vault, these look most useful:
+Based on what's already on your machine and in your vault, these look most useful:
 
-- **[shortName]** — I noticed [mentions] references (e.g. [first example file]).
-  [value proposition]. Setup: [setupTime].
+- **[shortName]** — [reason]. [value proposition]. Setup: [setupTime].
 ```
 
 Then present the rest of the categorized list from 8a for anything not already surfaced. If the concierge returns no high_value signals (common for a brand-new vault), just use the 8a list as-is — don't mention the scan.

--- a/.claude/hooks/integration-concierge.cjs
+++ b/.claude/hooks/integration-concierge.cjs
@@ -18,9 +18,12 @@
  * - Calendar signatures: "Teams meeting", "Zoom Meeting" in event titles
  * - Email patterns: @gmail.com, @outlook.com in person pages
  * - File patterns: .ics attachments, Jira ticket IDs (PROJ-123)
+ * - Installed macOS app bundles
+ * - Configured MCP servers
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const { loadPaths } = require('./paths.cjs');
@@ -40,6 +43,7 @@ const INTEGRATIONS = {
     name: 'Google Workspace (Gmail + Calendar + Docs)',
     shortName: 'Gmail',
     setup: '/google-workspace-setup',
+    mcpServers: ['google-workspace-mcp'],
     signals: {
       keywords: ['gmail', 'google docs', 'google sheets', 'google drive', 'google calendar', 'google meet'],
       urls: [/gmail\.com/i, /docs\.google\.com/i, /drive\.google\.com/i, /meet\.google\.com/i, /calendar\.google\.com/i],
@@ -55,6 +59,8 @@ const INTEGRATIONS = {
     name: 'Microsoft Teams',
     shortName: 'Teams',
     setup: '/ms-teams-setup',
+    apps: ['Microsoft Teams.app'],
+    mcpServers: ['teams-mcp'],
     signals: {
       keywords: ['microsoft teams', 'teams meeting', 'teams call', 'ms teams'],
       urls: [/teams\.microsoft\.com/i, /teams\.live\.com/i],
@@ -70,6 +76,8 @@ const INTEGRATIONS = {
     name: 'Todoist',
     shortName: 'Todoist',
     setup: '/todoist-setup',
+    apps: ['Todoist.app'],
+    mcpServers: ['todoist-mcp'],
     signals: {
       keywords: ['todoist', 'todoist task', 'todoist project'],
       urls: [/todoist\.com/i, /app\.todoist\.com/i],
@@ -83,6 +91,8 @@ const INTEGRATIONS = {
     name: 'Things 3',
     shortName: 'Things 3',
     setup: '/things-setup',
+    apps: ['Things3.app'],
+    mcpServers: ['things3-mcp'],
     signals: {
       keywords: ['things 3', 'things app', 'things today', 'things inbox'],
       urls: [/things:\/\//i, /culturedcode\.com/i],
@@ -96,6 +106,8 @@ const INTEGRATIONS = {
     name: 'Trello',
     shortName: 'Trello',
     setup: '/trello-setup',
+    apps: ['Trello.app'],
+    mcpServers: ['mcp-server-trello'],
     signals: {
       keywords: ['trello', 'trello board', 'trello card'],
       urls: [/trello\.com/i],
@@ -109,6 +121,8 @@ const INTEGRATIONS = {
     name: 'Zoom',
     shortName: 'Zoom',
     setup: '/zoom-setup',
+    apps: ['zoom.us.app'],
+    mcpServers: ['zoom-mcp'],
     signals: {
       keywords: ['zoom call', 'zoom meeting', 'zoom recording', 'zoom link'],
       urls: [/zoom\.us/i, /zoom\.com/i],
@@ -124,6 +138,7 @@ const INTEGRATIONS = {
     name: 'Atlassian (Jira + Confluence)',
     shortName: 'Jira/Confluence',
     setup: '/atlassian-setup',
+    mcpServers: ['atlassian-mcp'],
     signals: {
       keywords: ['jira', 'confluence', 'atlassian', 'sprint', 'epic', 'jira ticket'],
       urls: [/atlassian\.net/i, /jira\./i, /confluence\./i],
@@ -134,6 +149,102 @@ const INTEGRATIONS = {
     auth: 'OAuth (Atlassian Cloud)',
   },
 };
+
+// ---------------------------------------------------------------------------
+// Environment scanning
+// ---------------------------------------------------------------------------
+
+function scanInstalledApps() {
+  const hasAppDirOverride = process.env.DEX_APP_DIRS !== undefined;
+  if (process.platform !== 'darwin' && !hasAppDirOverride) return {};
+
+  try {
+    const appDirs = hasAppDirOverride
+      ? process.env.DEX_APP_DIRS.split(path.delimiter).filter(Boolean)
+      : ['/Applications', path.join(os.homedir(), 'Applications')];
+    const installedApps = [];
+
+    for (const appDir of appDirs) {
+      try {
+        if (!fs.existsSync(appDir)) continue;
+        for (const basename of fs.readdirSync(appDir)) {
+          if (fs.existsSync(path.join(appDir, basename))) {
+            installedApps.push(basename);
+          }
+        }
+      } catch {
+        // Missing or unreadable app directories are expected — skip silently.
+      }
+    }
+
+    const matches = {};
+    for (const [key, integration] of Object.entries(INTEGRATIONS)) {
+      if (!integration.apps) continue;
+
+      const matchedApps = integration.apps
+        .map(app => installedApps.find(installed => installed.toLowerCase() === app.toLowerCase()))
+        .filter(Boolean);
+      if (matchedApps.length > 0) {
+        matches[key] = [...new Set(matchedApps)];
+      }
+    }
+    return matches;
+  } catch {
+    return {};
+  }
+}
+
+function scanMcpConfig() {
+  try {
+    const configPaths = [
+      path.join(VAULT_ROOT, '.mcp.json'),
+      path.join(VAULT_ROOT, 'System', '.mcp.json'),
+      path.join(VAULT_ROOT, '.claude', 'mcp-servers.json'),
+    ];
+    const configuredServers = [];
+
+    for (const configPath of configPaths) {
+      try {
+        if (!fs.existsSync(configPath)) continue;
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        if (!config || typeof config !== 'object' || Array.isArray(config)) continue;
+
+        const servers = config.mcpServers
+          && typeof config.mcpServers === 'object'
+          && !Array.isArray(config.mcpServers)
+          ? config.mcpServers
+          : config;
+        for (const serverName of Object.keys(servers)) {
+          if (!configuredServers.some(name => name.toLowerCase() === serverName.toLowerCase())) {
+            configuredServers.push(serverName);
+          }
+        }
+      } catch {
+        // Missing or malformed MCP configs are expected — skip silently.
+      }
+    }
+
+    const matches = {};
+    for (const [key, integration] of Object.entries(INTEGRATIONS)) {
+      if (!integration.mcpServers) continue;
+
+      const matchedServers = configuredServers.filter((configured) => {
+        const configuredName = configured.toLowerCase();
+        return integration.mcpServers.some((server) => {
+          const expectedName = server.toLowerCase();
+          return configuredName === expectedName
+            || configuredName.includes(expectedName);
+        });
+      });
+      if (matchedServers.length > 0) {
+        matches[key] = matchedServers;
+      }
+    }
+    return matches;
+  } catch {
+    return {};
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Vault scanning
@@ -165,13 +276,19 @@ function scanDirectory(dir, extensions, maxDepth = 3, depth = 0) {
 
 function scanForSignals() {
   const results = {};
+  const installedApps = scanInstalledApps();
+  const configuredMcp = scanMcpConfig();
 
   for (const [key, integration] of Object.entries(INTEGRATIONS)) {
+    const matchedApps = installedApps[key] || [];
+    const matchedMcp = configuredMcp[key] || [];
     results[key] = {
       ...integration,
-      score: 0,
+      score: (matchedApps.length > 0 ? 6 : 0) + (matchedMcp.length > 0 ? 4 : 0),
       mentions: 0,
       examples: [],
+      installedApps: matchedApps,
+      configuredMcp: matchedMcp,
     };
   }
 
@@ -381,6 +498,15 @@ function generateRecommendations(signals) {
       score: data.score,
       mentions: data.mentions,
       examples: data.examples,
+      installedApps: data.installedApps,
+      configuredMcp: data.configuredMcp,
+      reason: data.installedApps.length > 0
+        ? 'installed on your Mac'
+        : data.configuredMcp.length > 0
+          ? 'already set up but not switched on yet'
+          : data.mentions > 0
+            ? `${data.mentions} mention${data.mentions === 1 ? '' : 's'} in your notes${data.examples.length > 0 ? ` (e.g. ${data.examples[0]})` : ''}`
+            : 'available to connect',
     };
 
     // Add Granola note to Zoom

--- a/.claude/hooks/tests/integration-concierge.test.cjs
+++ b/.claude/hooks/tests/integration-concierge.test.cjs
@@ -1,0 +1,243 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadPaths } = require('../paths.cjs');
+
+const CONCIERGE_PATH = path.resolve(__dirname, '../integration-concierge.cjs');
+const SOURCE_PATHS = loadPaths();
+
+function remapVaultPath(vault, sourcePath) {
+  return path.join(vault, path.relative(SOURCE_PATHS.VAULT_ROOT, sourcePath));
+}
+
+function createFixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-integration-concierge-'));
+  const vault = path.join(root, 'vault');
+  const appDir = path.join(root, 'Applications');
+  const inboxDir = remapVaultPath(vault, SOURCE_PATHS.INBOX_DIR);
+  const projectsDir = remapVaultPath(vault, SOURCE_PATHS.PROJECTS_DIR);
+  const peopleDir = remapVaultPath(vault, SOURCE_PATHS.PEOPLE_DIR);
+  const systemDir = remapVaultPath(vault, SOURCE_PATHS.SYSTEM_DIR);
+  const integrationsDir = path.join(systemDir, 'integrations');
+
+  for (const dir of [
+    inboxDir,
+    projectsDir,
+    path.join(peopleDir, 'Internal'),
+    integrationsDir,
+    appDir,
+  ]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  return {
+    root,
+    vault,
+    appDir,
+    inboxDir,
+    systemDir,
+    configFile: path.join(integrationsDir, 'config.yaml'),
+    env: {
+      CLAUDE_PROJECT_DIR: vault,
+      DEX_APP_DIRS: appDir,
+      VAULT_PATH: vault,
+    },
+  };
+}
+
+function runConcierge(env) {
+  const result = spawnSync(process.execPath, [CONCIERGE_PATH], {
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+    timeout: 5_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `integration-concierge.cjs exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return JSON.parse(result.stdout);
+}
+
+function recommendationFor(output, id) {
+  return [
+    ...output.high_value,
+    ...output.moderate_value,
+    ...output.available,
+  ].find((entry) => entry.id === id);
+}
+
+function assertFourTiers(output) {
+  assert.deepEqual(Object.keys(output), [
+    'high_value',
+    'moderate_value',
+    'available',
+    'already_connected',
+  ]);
+}
+
+test('installed Things app promotes the integration to high value', (t) => {
+  const fixture = createFixture(t);
+  fs.mkdirSync(path.join(fixture.appDir, 'Things3.app'));
+
+  const output = runConcierge(fixture.env);
+  const things = output.high_value.find((entry) => entry.id === 'things');
+
+  assert.ok(things, JSON.stringify(output, null, 2));
+  assert.equal(things.reason, 'installed on your Mac');
+  assert.ok(things.score >= 6);
+  assert.deepEqual(things.installedApps, ['Things3.app']);
+  assert.deepEqual(things.configuredMcp, []);
+});
+
+test('installed app matching is case insensitive across configured app directories', (t) => {
+  const fixture = createFixture(t);
+  const secondAppDir = path.join(fixture.root, 'User Applications');
+  fs.mkdirSync(path.join(secondAppDir, 'things3.app'), { recursive: true });
+
+  const output = runConcierge({
+    ...fixture.env,
+    DEX_APP_DIRS: [fixture.appDir, secondAppDir].join(path.delimiter),
+  });
+  const things = output.high_value.find((entry) => entry.id === 'things');
+
+  assert.ok(things, JSON.stringify(output, null, 2));
+  assert.equal(things.reason, 'installed on your Mac');
+  assert.deepEqual(things.installedApps, ['things3.app']);
+});
+
+test('integration with no detected signals stays available', (t) => {
+  const fixture = createFixture(t);
+
+  const output = runConcierge(fixture.env);
+  const things = output.available.find((entry) => entry.id === 'things');
+
+  assert.ok(things, JSON.stringify(output, null, 2));
+  assert.equal(things.reason, 'available to connect');
+  assert.deepEqual(things.installedApps, []);
+  assert.deepEqual(things.configuredMcp, []);
+});
+
+test('configured Trello MCP server boosts an integration that is not enabled', (t) => {
+  const fixture = createFixture(t);
+  fs.writeFileSync(
+    path.join(fixture.vault, '.mcp.json'),
+    JSON.stringify({ mcpServers: { 'mcp-server-trello': {} } }),
+  );
+
+  const output = runConcierge(fixture.env);
+  const trello = recommendationFor(output, 'trello');
+
+  assert.ok(trello, JSON.stringify(output, null, 2));
+  assert.equal(trello.reason, 'already set up but not switched on yet');
+  assert.ok(trello.score >= 4);
+  assert.deepEqual(trello.configuredMcp, ['mcp-server-trello']);
+  assert.equal(output.already_connected.some((entry) => entry.id === 'trello'), false);
+});
+
+test('configured MCP server matching allows a longer server-name substring', (t) => {
+  const fixture = createFixture(t);
+  fs.writeFileSync(
+    path.join(fixture.vault, '.mcp.json'),
+    JSON.stringify({ mcpServers: { 'todoist-mcp-server': {} } }),
+  );
+
+  const output = runConcierge(fixture.env);
+  const todoist = recommendationFor(output, 'todoist');
+
+  assert.ok(todoist, JSON.stringify(output, null, 2));
+  assert.equal(todoist.reason, 'already set up but not switched on yet');
+  assert.deepEqual(todoist.configuredMcp, ['todoist-mcp-server']);
+});
+
+test('configured MCP substring matching does not accept a shorter generic key', (t) => {
+  const fixture = createFixture(t);
+  fs.writeFileSync(
+    path.join(fixture.vault, '.mcp.json'),
+    JSON.stringify({ mcpServers: { mcp: {} } }),
+  );
+
+  const output = runConcierge(fixture.env);
+
+  for (const id of ['google-workspace', 'teams', 'todoist', 'things', 'trello', 'zoom', 'atlassian']) {
+    assert.deepEqual(recommendationFor(output, id).configuredMcp, []);
+  }
+});
+
+test('enabled integration stays already connected even when its app is installed', (t) => {
+  const fixture = createFixture(t);
+  fs.mkdirSync(path.join(fixture.appDir, 'Trello.app'));
+  fs.writeFileSync(fixture.configFile, 'trello:\n  enabled: true\n');
+
+  const output = runConcierge(fixture.env);
+
+  assert.deepEqual(
+    output.already_connected.find((entry) => entry.id === 'trello'),
+    { id: 'trello', name: 'Trello' },
+  );
+  assert.equal(recommendationFor(output, 'trello'), undefined);
+});
+
+test('malformed MCP config is ignored without changing the output tiers', (t) => {
+  const fixture = createFixture(t);
+  fs.writeFileSync(path.join(fixture.vault, '.mcp.json'), '{not valid JSON');
+
+  const output = runConcierge(fixture.env);
+  const trello = output.available.find((entry) => entry.id === 'trello');
+
+  assertFourTiers(output);
+  assert.ok(trello, JSON.stringify(output, null, 2));
+  assert.equal(trello.reason, 'available to connect');
+  assert.deepEqual(trello.configuredMcp, []);
+});
+
+test('vault text signals still produce a mentions-based reason', (t) => {
+  const fixture = createFixture(t);
+  fs.writeFileSync(
+    path.join(fixture.inboxDir, 'trello-note.md'),
+    '# Planning\n\nWe should review the Trello board before the meeting.\n',
+  );
+
+  const output = runConcierge(fixture.env);
+  const trello = recommendationFor(output, 'trello');
+
+  assert.ok(trello, JSON.stringify(output, null, 2));
+  assert.ok(trello.mentions > 0);
+  assert.ok(trello.examples.length > 0);
+  assert.equal(
+    trello.reason,
+    `${trello.mentions} mention${trello.mentions === 1 ? '' : 's'} in your notes (e.g. ${trello.examples[0]})`,
+  );
+  assert.deepEqual(trello.installedApps, []);
+  assert.deepEqual(trello.configuredMcp, []);
+});
+
+test('MCP configs are unioned across candidate files and support top-level server keys', (t) => {
+  const fixture = createFixture(t);
+  const claudeDir = path.join(fixture.vault, '.claude');
+  fs.mkdirSync(claudeDir);
+  fs.writeFileSync(
+    path.join(fixture.systemDir, '.mcp.json'),
+    JSON.stringify({ 'zoom-mcp': {} }),
+  );
+  fs.writeFileSync(
+    path.join(claudeDir, 'mcp-servers.json'),
+    JSON.stringify({ mcpServers: { 'teams-mcp': {} } }),
+  );
+
+  const output = runConcierge(fixture.env);
+  const zoom = recommendationFor(output, 'zoom');
+  const teams = recommendationFor(output, 'teams');
+
+  assert.deepEqual(zoom.configuredMcp, ['zoom-mcp']);
+  assert.deepEqual(teams.configuredMcp, ['teams-mcp']);
+  assert.equal(zoom.reason, 'already set up but not switched on yet');
+  assert.equal(teams.reason, 'already set up but not switched on yet');
+});

--- a/.claude/skills/dex-level-up/SKILL.md
+++ b/.claude/skills/dex-level-up/SKILL.md
@@ -188,13 +188,12 @@ Run the integration concierge to find tools the user already works with but hasn
 node .claude/hooks/integration-concierge.cjs
 ```
 
-Parse the JSON output — the high_value tier holds items scoring 5 or higher, moderate_value holds the rest with any signal. Surface up to two, named specifically, with the concrete signal you found:
+Parse the JSON output — the high_value tier holds items scoring 5 or higher, moderate_value holds the rest with any signal. Each entry carries a `reason` field naming the strongest evidence ("installed on your Mac", "already set up as an MCP server but not connected yet", or a mention count). Surface up to two, named specifically, using that reason:
 
 ```markdown
 ## Tools You Could Connect
 
-- **[shortName]** — you reference it [mentions] times (e.g. [first example file]).
-  [value proposition]. Connect with `[setup]` ([setupTime]).
+- **[shortName]** — [reason]. [value proposition]. Connect with `[setup]` ([setupTime]).
 ```
 
 Lead with the high_value items; fall back to a single role-fit moderate_value suggestion only if there are no high_value hits. If nothing scores, don't force it — a generic "run `/integrate-mcp` to connect calendar, email, task apps (Todoist/Things/Trello), and more" line is enough. Keep it to high-signal suggestions only — don't overwhelm.

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -859,7 +859,7 @@ Execute the integration concierge — it scans the vault for signals (mentions, 
 node .claude/hooks/integration-concierge.cjs
 ```
 
-Parse the JSON output for `high_value` and `moderate_value` recommendations. Each entry includes `shortName`, `mentions`, `examples` (files where signals appeared), `value`, `setupTime`, and `setup` (the setup skill to run).
+Parse the JSON output for the high_value and moderate_value tiers. Each entry includes `shortName`, `reason` (a ready-to-use plain-English signal — "installed on your Mac", "3 mentions in your notes", "already set up as a connector but not switched on yet"), `value`, `setupTime`, and `setup` (the setup skill to run). Prefer `reason` verbatim — it already names the strongest evidence (an installed app or configured connector outranks a passing mention).
 
 ### Presenting Recommendations
 
@@ -868,8 +868,7 @@ Parse the JSON output for `high_value` and `moderate_value` recommendations. Eac
 For each high_value integration found:
 
 ```
-By the way, I noticed you mention **[shortName]** in a few places
-([mentions] references across files like [first example file]).
+By the way — **[shortName]** ([reason]).
 
 Connecting it would give you: [value proposition]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.56.0] - Dex notices the apps you actually have installed (2026-07-13)
+
+When Dex suggests connecting a tool, it now leans on real evidence — is the app sitting in your Applications folder? Is the connector already half set up? — instead of just scanning your notes for mentions. A tool you actually have installed is a far better signal than a passing reference to one.
+
+**What this fixes for you:**
+
+* **"Installed on your Mac" beats a guess.** When Dex offers to connect Things, Trello, Todoist, Zoom, or Teams, it now checks whether the app is actually installed and leads with that — so its suggestions feel observant, not random. An installed app is strong enough to surface on its own.
+* **Half-finished setups get noticed.** If a tool's connector is already configured but sync was never switched on, Dex spots the loose end and offers to finish it, rather than treating it as brand new.
+* **Suggestions say why.** Each recommendation now comes with its reason in plain words — "installed on your Mac", "already set up but not switched on yet", or how many times you mentioned it — so you understand where the nudge came from.
+* **Nothing leaves your machine.** The check is a local look at your Applications folder and your own config files — no network calls, and it quietly does nothing on non-Mac systems where those apps don't apply.
+
+---
+
 ## [1.55.0] - Contributing to Dex is now safer (2026-07-13)
 
 Contributing to Dex is now safer — CI catches personal data before it's shared, and tells contributors in plain English what their change touches.
@@ -17,8 +30,6 @@ Contributing to Dex is now safer — CI catches personal data before it's shared
 * **Every contribution gets a product map.** A sticky report translates changed paths into recognizable Dex areas, the user journeys they feed, and the quality gates that apply. Fork contributors still get the identical report in the job summary when GitHub withholds comment permission.
 * **Messy real-world content gets exercised.** Disposable vault fixtures now include unicode and spaced filenames, half-written notes, duplicate task headings, and recoverable malformed YAML, backed by fast property tests and larger nightly fuzz cases.
 * **A loaded machine no longer makes one smoke test look broken.** The release-snapshot MCP assertion gets a generous test budget and one timeout-only retry while Dex's production 1.5-second server-start guarantee stays unchanged.
-
----
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Why

Follow-up to #129 (discovery wiring). Dave's ask: an installed app is a far stronger signal than a text mention — if Things 3 is in `/Applications`, they use it; a passing note might be someone else's tool. Presence beats mention. This extends the concierge's signal model to notice the tools the user demonstrably has.

## What changed (`integration-concierge.cjs`)

- **Installed macOS apps** — scans `/Applications` + `~/Applications` for `Things3.app`, `Trello.app`, `Todoist.app`, `Microsoft Teams.app`, `zoom.us.app`. Darwin-gated for production; a `DEX_APP_DIRS` env override makes the logic testable on Linux CI. Case-insensitive bundle match. Score **+6** — reaches the high_value tier on its own.
- **Configured-but-not-enabled MCP servers** — scans `.mcp.json` (root + `System/`) and `.claude/mcp-servers.json`, matching each integration's declared `mcp_server`. Score **+4** — the "started but didn't finish" nudge.
- **Plain-English `reason` per recommendation** — "installed on your Mac" / "already set up but not switched on yet" / "N mentions in your notes" / "available to connect", in that priority order. The skill prose now presents this verbatim so the strongest evidence leads.
- Enabled integrations still route to `already_connected` (enabled wins). All detection is **local filesystem only**, fail-safe — never throws on missing/malformed files, returns `{}` off-Mac.

Skill prose updated to use `reason`: getting-started, dex-level-up, onboarding Step 8b.

## Tests (`integration-concierge.test.cjs`, new)
10 subprocess tests — fake `.app` bundles via `DEX_APP_DIRS`, fixture `.mcp.json`. Cover: installed-app promotion to high_value, case-insensitive match, MCP match/substring/multi-file union, enabled-integration precedence over an installed app, malformed-config resilience, and a vault-text regression.

## Verification
- ✅ 10/10 tests, `node -c` clean, all diff gates (instructed-tools, path-contract, doc-drift, path-consistency, verify-distribution) green
- ✅ **Real-Mac run**: detects Teams, Todoist, Zoom as installed → high_value with "installed on your Mac"
- No Python touched; pytest/coverage/ruff/security unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)