### PR TITLE
Phase 3 (fleet verdicts): opt-in anonymous release-health signal (v1.57.0)

### DIFF
--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -49,6 +49,17 @@ ran completely.
 error, and continue with whatever manual checks you can do — do not present a partial
 picture as a full one.
 
+### Step 1a: Offer anonymous health telemetry once
+
+Read `System/usage_log.md`. Make this offer only when `**Health telemetry:** pending` or the line is missing:
+
+> "Want to help catch bad releases early? Dex can send anonymous nightly health counts — no names, notes, or file contents, ever. Share them? (y/N)"
+
+If the user explicitly says yes, replace the line with `**Health telemetry:** opted-in` (or add it under a
+`## Health Telemetry Consent` heading when missing). If the user says no, skips, or accepts the default,
+record `**Health telemetry:** opted-out`. Once either decision is recorded, do not offer again.
+Never read or change the separate analytics consent while handling this choice.
+
 ### Step 2: Offer the deep scan
 
 Quick mode checks configuration, wiring, and background-job freshness. Deep mode

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ System/.last-update-check
 System/.update-available
 System/.smoke-last-run.json
 System/.dex/smoke-history.jsonl
+System/.dex/health-telemetry-log.jsonl
+System/.dex/telemetry-id
 
 # Custom extensions (user-created, never in upstream)
 CLAUDE-custom.md

--- a/.scripts/nightly-smoke.sh
+++ b/.scripts/nightly-smoke.sh
@@ -20,6 +20,22 @@ else
 fi
 
 cd "$VAULT_PATH"
+set +e
 VAULT_PATH="$VAULT_PATH" "$PYTHON" core/utils/smoke.py --json --ledger
+SMOKE_STATUS=$?
+set -e
+
+if [ -f "System/.smoke-last-run.json" ]; then
+    "$PYTHON" core/utils/health_telemetry.py \
+        --report "System/.smoke-last-run.json" \
+        --vault "$VAULT_PATH" \
+        --repo "$VAULT_PATH" \
+        --channel "stable" >/dev/null 2>&1 || true
+fi
+
+if [ "$SMOKE_STATUS" -ne 0 ]; then
+    exit "$SMOKE_STATUS"
+fi
+
 mkdir -p .scripts/logs
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] nightly smoke completed" >> .scripts/logs/smoke-nightly.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.56.0] - Catch bad releases across vaults without sharing your content (2026-07-13)
+
+Opt in to help catch bad releases across all vaults — anonymous nightly health counts, no content ever.
+
+**What this fixes for you:**
+
+* **Bad releases can show up within hours.** If you explicitly opt in, Dex shares one tiny verdict after its nightly self-check so maintainers can see when the same update starts breaking across installations.
+* **Your work never joins the report.** The verdict contains only outcome counts, one fixed check identifier when something is wrong, the Dex version and release channel, and a random installation ID. It never includes names, notes, filenames, paths, or file contents.
+* **This choice is separate and defaults to no.** Existing analytics consent does not enable health sharing. Missing, pending, or malformed consent sends nothing, and you can turn health telemetry on or off in plain language anytime.
+* **You can inspect every attempt locally.** Dex keeps an ignored local line-by-line audit of exactly what it would send, including attempts skipped by consent and requests dropped after a network failure.
+
+---
+
 ## [1.55.0] - Contributing to Dex is now safer (2026-07-13)
 
 Contributing to Dex is now safer — CI catches personal data before it's shared, and tells contributors in plain English what their change touches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,31 @@ When user says anything like:
 2. Update `System/usage_log.md` → `Consent decision: opted-in`
 3. Say: "Done! Analytics is back on. Thanks for helping improve Dex!"
 
+### Health Telemetry Opt-In/Out (Anytime)
+
+Health telemetry is a separate, default-off choice. It sends only anonymous nightly smoke counts and never
+uses analytics consent, analytics identity, profile metadata, names, notes, filenames, or file contents.
+
+When user says anything like:
+- "Share anonymous nightly health counts"
+- "Turn on health telemetry"
+- "Opt in to health telemetry"
+
+**Your response:**
+1. Update `System/usage_log.md` → `**Health telemetry:** opted-in`
+2. Do not change analytics consent or `System/user-profile.yaml`
+3. Say: "Done! Anonymous nightly health counts are on. You can inspect every attempt in `System/.dex/health-telemetry-log.jsonl` or turn them off anytime."
+
+When user says anything like:
+- "Turn off health telemetry"
+- "Stop sharing health counts"
+- "Opt out of health telemetry"
+
+**Your response:**
+1. Update `System/usage_log.md` → `**Health telemetry:** opted-out`
+2. Do not change analytics consent or `System/user-profile.yaml`
+3. Say: "Done! Nightly health telemetry is off. Local smoke checks and their local audit log still run."
+
 ### Skill Rating
 After `/daily-plan`, `/week-plan`, `/meeting-prep`, `/process-meetings`, `/week-review`, `/daily-review` complete, ask "Quick rating (1-5)?" If user responds with a number, call `capture_skill_rating`. If they ignore or move on, don't ask again.
 

--- a/System/usage_log.md
+++ b/System/usage_log.md
@@ -113,6 +113,19 @@ Tracks anonymous feature usage tracking to help improve Dex.
 
 ---
 
+## Health Telemetry Consent
+
+Separate, optional nightly fleet-health counts. This setting is independent of analytics.
+
+**Health telemetry:** pending
+
+**Values:**
+- `Health telemetry: opted-in` → Send the counts-only nightly smoke verdict
+- `Health telemetry: opted-out` → Do not send nightly health telemetry
+- `Health telemetry: pending` → Not yet decided; missing or pending means nothing is sent
+
+---
+
 ## Journey Metadata
 
 Auto-calculated metrics (if analytics opted in). Updated when features are used.

--- a/core/tests/test_health_telemetry.py
+++ b/core/tests/test_health_telemetry.py
@@ -1,0 +1,154 @@
+"""Contract tests for Dex's dedicated fleet-health telemetry sender."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from core.utils import health_telemetry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _report(*, broken: int = 0, unknown: int = 0) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-07-13T03:15:00+00:00",
+        "summary": {"ok": 5 - broken - unknown, "broken": broken, "unknown": unknown, "off": 0},
+        "journeys": [
+            {
+                "id": "task_lifecycle",
+                "verdict": "BROKEN" if broken else "OK",
+                "detail": "private/path/that/must/not/leave.md",
+                "duration_ms": 12,
+            },
+            {
+                "id": "mcp_startup",
+                "verdict": "UNKNOWN" if unknown else "OK",
+                "detail": "another private detail",
+                "duration_ms": 8,
+            },
+        ],
+    }
+
+
+def _vault(tmp_path: Path, decision: str = "opted-in") -> Path:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    (vault / "System" / "usage_log.md").write_text(
+        f"# Usage\n\n**Health telemetry:** {decision}\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text('{"version":"1.56.0"}\n', encoding="utf-8")
+    return repo
+
+
+def test_opted_in_posts_only_the_counts_only_contract_and_logs_it(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    repo = _repo(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    class Response:
+        status_code = 200
+
+    def post(endpoint, *, json, headers, timeout):
+        calls.append({"endpoint": endpoint, "json": json, "headers": headers, "timeout": timeout})
+        return Response()
+
+    result = health_telemetry.send_smoke_verdict(
+        _report(broken=1),
+        vault_root=vault,
+        repo_root=repo,
+        channel="canary",
+        transport_getter=lambda: {
+            "configured": True,
+            "endpoint": "https://telemetry.invalid/verdict",
+            "headers": {"Authorization": "Bearer test"},
+        },
+        post=post,
+    )
+
+    assert result == {"sent": True, "reason": "sent"}
+    assert len(calls) == 1
+    payload = calls[0]["json"]
+    assert payload == {
+        "schema_version": 1,
+        "event": "smoke_verdict",
+        "counts": {"ok": 4, "broken": 1, "unknown": 0, "off": 0},
+        "worst_journey_id": "task_lifecycle",
+        "dex_version": "1.56.0",
+        "channel": "canary",
+        "telemetry_id": payload["telemetry_id"],
+    }
+    uuid.UUID(payload["telemetry_id"])
+    assert calls[0]["timeout"] == health_telemetry.POST_TIMEOUT_SECONDS
+
+    records = [
+        json.loads(line)
+        for line in (vault / "System" / ".dex" / "health-telemetry-log.jsonl").read_text().splitlines()
+    ]
+    assert records[0]["sent"] is True
+    assert records[0]["payload"] == payload
+
+
+def test_transport_failure_is_logged_and_never_retried(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    repo = _repo(tmp_path)
+    calls = 0
+
+    def failing_post(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise OSError("offline")
+
+    result = health_telemetry.send_smoke_verdict(
+        _report(unknown=1),
+        vault_root=vault,
+        repo_root=repo,
+        transport_getter=lambda: {
+            "configured": True,
+            "endpoint": "https://telemetry.invalid/verdict",
+            "headers": {},
+        },
+        post=failing_post,
+    )
+
+    assert calls == 1
+    assert result == {"sent": False, "reason": "post_failed"}
+    record = json.loads((vault / "System" / ".dex" / "health-telemetry-log.jsonl").read_text())
+    assert record["sent"] is False
+    assert record["reason"] == "post_failed"
+    assert record["payload"]["worst_journey_id"] == "mcp_startup"
+
+
+def test_telemetry_id_is_created_only_for_opt_in_and_stable(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+
+    first = health_telemetry.get_or_create_telemetry_id(vault)
+    second = health_telemetry.get_or_create_telemetry_id(vault)
+
+    assert first == second
+    assert (vault / "System" / ".dex" / "telemetry-id").read_text().strip() == first
+    uuid.UUID(first)
+
+
+def test_sender_cli_can_run_from_the_nightly_worker_path() -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "core" / "utils" / "health_telemetry.py"), "--help"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--report" in result.stdout

--- a/core/tests/test_health_telemetry_consent_ux.py
+++ b/core/tests/test_health_telemetry_consent_ux.py
@@ -1,0 +1,37 @@
+"""Instruction contracts for the separate health-telemetry consent UX."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROMPT = (
+    "Want to help catch bad releases early? Dex can send anonymous nightly health counts — "
+    "no names, notes, or file contents, ever. Share them? (y/N)"
+)
+
+
+def test_usage_log_defaults_health_telemetry_to_pending() -> None:
+    usage_log = (REPO_ROOT / "System" / "usage_log.md").read_text(encoding="utf-8")
+
+    assert "## Health Telemetry Consent" in usage_log
+    assert "**Health telemetry:** pending" in usage_log
+    assert "missing or pending means nothing is sent" in usage_log
+
+
+def test_dex_doctor_offers_health_telemetry_once_with_default_no() -> None:
+    doctor_skill = (REPO_ROOT / ".claude" / "skills" / "dex-doctor" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert PROMPT in doctor_skill
+    assert "only when `**Health telemetry:** pending` or the line is missing" in doctor_skill
+    assert "record `**Health telemetry:** opted-out`" in doctor_skill
+    assert "Never read or change the separate analytics consent" in doctor_skill
+
+
+def test_claude_instructions_wire_independent_natural_language_choices() -> None:
+    instructions = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    health_block = instructions.split("### Health Telemetry Opt-In/Out (Anytime)", 1)[1].split("### Skill Rating", 1)[0]
+
+    assert '"Share anonymous nightly health counts"' in health_block
+    assert '"Turn off health telemetry"' in health_block
+    assert "`**Health telemetry:** opted-in`" in health_block
+    assert "`**Health telemetry:** opted-out`" in health_block
+    assert "Do not change analytics consent" in health_block

--- a/core/tests/test_health_telemetry_privacy.py
+++ b/core/tests/test_health_telemetry_privacy.py
@@ -1,0 +1,200 @@
+"""Hard privacy acceptance tests for anonymous fleet-health verdicts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import analytics_helper
+from core.utils import health_telemetry
+
+EXPECTED_FIELDS = {
+    "schema_version",
+    "event",
+    "counts",
+    "worst_journey_id",
+    "dex_version",
+    "channel",
+    "telemetry_id",
+}
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    (repo / "package.json").write_text('{"version":"1.56.0"}\n', encoding="utf-8")
+    return repo
+
+
+def _report() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "summary": {"ok": 2, "broken": 1, "unknown": 1, "off": 1},
+        "journeys": [
+            {
+                "id": "task_lifecycle",
+                "verdict": "BROKEN",
+                "detail": "/vault/03-Tasks/Secret Client.md failed",
+                "duration_ms": 1,
+            },
+            {
+                "id": "mcp_startup",
+                "verdict": "UNKNOWN",
+                "detail": "private integration name",
+                "duration_ms": 1,
+            },
+        ],
+    }
+
+
+def _write_usage(vault: Path, content: str | None) -> None:
+    system = vault / "System"
+    system.mkdir(parents=True)
+    if content is not None:
+        (system / "usage_log.md").write_text(content, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "usage_content",
+    [
+        "**Health telemetry:** opted-out\n",
+        "**Health telemetry:** pending\n",
+        None,
+    ],
+    ids=["opted-out", "pending", "missing"],
+)
+def test_without_explicit_opt_in_post_is_never_called_but_attempt_is_logged(
+    tmp_path: Path,
+    usage_content: str | None,
+) -> None:
+    vault = tmp_path / "vault"
+    _write_usage(vault, usage_content)
+    post_calls = 0
+
+    def forbidden_post(*_args, **_kwargs):
+        nonlocal post_calls
+        post_calls += 1
+        pytest.fail("POST must not be called without explicit health-telemetry opt-in")
+
+    result = health_telemetry.send_smoke_verdict(
+        _report(),
+        vault_root=vault,
+        repo_root=_repo(tmp_path),
+        transport_getter=lambda: pytest.fail("transport must not be resolved without opt-in"),
+        post=forbidden_post,
+    )
+
+    assert post_calls == 0
+    assert result == {"sent": False, "reason": "health_telemetry_not_opted_in"}
+    record = json.loads((vault / "System/.dex/health-telemetry-log.jsonl").read_text())
+    assert record["sent"] is False
+    assert record["payload"]["telemetry_id"] is None
+    assert not (vault / "System/.dex/telemetry-id").exists()
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        "**Health telemetry:** yes\n",
+        "**Health telemetry:** OPTED-IN\n",
+        "**Health telemetry:** opted-in trailing-text\n",
+        "**Health telemetry:** opted-in\n**Health telemetry:** opted-out\n",
+        b"\xff\xfe",
+    ],
+)
+def test_malformed_usage_log_fails_closed_and_never_posts(tmp_path: Path, malformed: str | bytes) -> None:
+    vault = tmp_path / "vault"
+    _write_usage(vault, "")
+    usage_log = vault / "System/usage_log.md"
+    if isinstance(malformed, bytes):
+        usage_log.write_bytes(malformed)
+    else:
+        usage_log.write_text(malformed, encoding="utf-8")
+
+    result = health_telemetry.send_smoke_verdict(
+        _report(),
+        vault_root=vault,
+        repo_root=_repo(tmp_path),
+        transport_getter=lambda: pytest.fail("malformed consent must fail closed before transport"),
+        post=lambda *_args, **_kwargs: pytest.fail("malformed consent must never POST"),
+    )
+
+    assert result["sent"] is False
+    assert health_telemetry.read_health_consent(vault) == "pending"
+    assert (vault / "System/.dex/health-telemetry-log.jsonl").is_file()
+
+
+def test_opted_in_wire_dict_is_exactly_counts_only_and_uses_separate_stable_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    _write_usage(vault, "**Health telemetry:** opted-in\n")
+    (vault / "System/user-profile.yaml").write_text(
+        "analytics:\n  visitor_id: analytics-visitor-123\n  account_id: analytics-account-456\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posted: list[dict[str, object]] = []
+
+    class Response:
+        status_code = 200
+
+    def capture_post(_endpoint, *, json, headers, timeout):
+        posted.append(json)
+        return Response()
+
+    kwargs = {
+        "vault_root": vault,
+        "repo_root": _repo(tmp_path),
+        "transport_getter": lambda: {
+            "configured": True,
+            "endpoint": "https://telemetry.invalid/verdict",
+            "headers": {"Content-Type": "application/json"},
+        },
+        "post": capture_post,
+    }
+    health_telemetry.send_smoke_verdict(_report(), **kwargs)
+    health_telemetry.send_smoke_verdict(_report(), **kwargs)
+
+    assert len(posted) == 2
+    payload = posted[0]
+    assert set(payload) == EXPECTED_FIELDS
+    assert payload == {
+        "schema_version": 1,
+        "event": "smoke_verdict",
+        "counts": {"ok": 2, "broken": 1, "unknown": 1, "off": 1},
+        "worst_journey_id": "task_lifecycle",
+        "dex_version": "1.56.0",
+        "channel": "stable",
+        "telemetry_id": payload["telemetry_id"],
+    }
+    assert posted[1]["telemetry_id"] == payload["telemetry_id"]
+    visitor = analytics_helper.get_visitor_info()
+    assert payload["telemetry_id"] != visitor["visitor_id"]
+    assert payload["telemetry_id"] != visitor["account_id"]
+
+    encoded = json.dumps(payload)
+    for forbidden in (
+        "role",
+        "company_size",
+        "journey_stage",
+        "visitorId",
+        "accountId",
+        "analytics-visitor-123",
+        "analytics-account-456",
+        "Secret Client.md",
+        "/vault/03-Tasks",
+        "private integration name",
+    ):
+        assert forbidden not in encoded
+
+
+def test_dedicated_sender_never_references_analytics_event_enrichment() -> None:
+    source = Path(health_telemetry.__file__).read_text(encoding="utf-8")
+
+    assert "fire_event" not in source
+    assert "calculate_journey_metadata" not in source
+    assert "get_visitor_info" not in source

--- a/core/tests/test_smoke_automation.py
+++ b/core/tests/test_smoke_automation.py
@@ -6,6 +6,7 @@ import os
 import plistlib
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -71,3 +72,71 @@ def test_installer_status_and_uninstall_use_stubbed_launchctl(tmp_path: Path) ->
     subprocess.run(["bash", str(INSTALLER), "--uninstall"], env=env, check=True)
     assert not plist.exists()
     assert str(plist) in calls.read_text()
+
+
+def _nightly_worker_fixture(tmp_path: Path, *, smoke_exit: int) -> tuple[Path, dict[str, str]]:
+    vault = tmp_path / "vault"
+    (vault / "core" / "utils").mkdir(parents=True)
+    (vault / ".scripts").mkdir()
+    (vault / "core" / "utils" / "smoke.py").write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            from pathlib import Path
+
+            report = {{
+                "schema_version": 1,
+                "summary": {{"ok": 4, "broken": {smoke_exit}, "unknown": 0, "off": 0}},
+                "journeys": [],
+            }}
+            target = Path("System/.smoke-last-run.json")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(report))
+            raise SystemExit({smoke_exit})
+            """
+        ),
+        encoding="utf-8",
+    )
+    (vault / "core" / "utils" / "health_telemetry.py").write_text(
+        textwrap.dedent(
+            """
+            import json
+            import sys
+            from pathlib import Path
+
+            args = sys.argv[1:]
+            report_path = Path(args[args.index("--report") + 1])
+            assert json.loads(report_path.read_text())["summary"]["ok"] == 4
+            Path("telemetry-called").write_text(" ".join(args))
+            """
+        ),
+        encoding="utf-8",
+    )
+    home = tmp_path / "home"
+    breadcrumb = home / ".config" / "dex" / "vault-path"
+    breadcrumb.parent.mkdir(parents=True)
+    breadcrumb.write_text(str(vault), encoding="utf-8")
+    return vault, {**os.environ, "HOME": str(home)}
+
+
+def test_nightly_worker_sends_latest_ledger_before_success_heartbeat(tmp_path: Path) -> None:
+    vault, env = _nightly_worker_fixture(tmp_path, smoke_exit=0)
+
+    subprocess.run(["bash", str(WORKER)], env=env, check=True)
+
+    call = (vault / "telemetry-called").read_text()
+    assert "--report System/.smoke-last-run.json" in call
+    assert f"--vault {vault}" in call
+    assert f"--repo {vault}" in call
+    assert "--channel stable" in call
+    assert "nightly smoke completed" in (vault / ".scripts" / "logs" / "smoke-nightly.log").read_text()
+
+
+def test_nightly_worker_records_broken_verdict_without_success_heartbeat(tmp_path: Path) -> None:
+    vault, env = _nightly_worker_fixture(tmp_path, smoke_exit=1)
+
+    result = subprocess.run(["bash", str(WORKER)], env=env, check=False)
+
+    assert result.returncode == 1
+    assert (vault / "telemetry-called").exists()
+    assert not (vault / ".scripts" / "logs" / "smoke-nightly.log").exists()

--- a/core/utils/health_telemetry.py
+++ b/core/utils/health_telemetry.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Send an explicitly opted-in, counts-only nightly smoke verdict."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+RUNNER_ROOT = Path(__file__).resolve().parents[2]
+if str(RUNNER_ROOT) in sys.path:
+    sys.path.remove(str(RUNNER_ROOT))
+sys.path.insert(0, str(RUNNER_ROOT))
+
+from core.mcp.analytics_helper import get_analytics_transport
+
+SCHEMA_VERSION = 1
+EVENT_NAME = "smoke_verdict"
+DEFAULT_CHANNEL = "stable"
+POST_TIMEOUT_SECONDS = 5
+COUNT_KEYS = ("ok", "broken", "unknown", "off")
+KNOWN_JOURNEY_IDS = frozenset({"configs", "task_lifecycle", "mcp_startup", "skills", "hooks"})
+HEALTH_CONSENT_PATTERN = re.compile(
+    r"^\*\*Health telemetry:\*\* (opted-in|opted-out|pending)$",
+    re.MULTILINE,
+)
+
+TransportGetter = Callable[[], Mapping[str, Any]]
+PostFunction = Callable[..., Any]
+
+
+def read_health_consent(vault_root: Path) -> str:
+    """Read the separate health-telemetry decision, failing closed to pending."""
+    try:
+        content = (vault_root / "System" / "usage_log.md").read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return "pending"
+
+    decisions = HEALTH_CONSENT_PATTERN.findall(content)
+    if len(decisions) != 1:
+        return "pending"
+    return decisions[0]
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def get_or_create_telemetry_id(vault_root: Path) -> str:
+    """Return the install-scoped anonymous UUID, creating it after opt-in."""
+    telemetry_path = vault_root / "System" / ".dex" / "telemetry-id"
+    try:
+        existing = telemetry_path.read_text(encoding="utf-8").strip()
+        return str(uuid.UUID(existing))
+    except (FileNotFoundError, ValueError, UnicodeError):
+        telemetry_id = str(uuid.uuid4())
+        _atomic_write(telemetry_path, telemetry_id + "\n")
+        return telemetry_id
+
+
+def _read_dex_version(repo_root: Path) -> str:
+    package = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("package.json has no Dex version")
+    return version
+
+
+def _counts(report: Mapping[str, Any]) -> dict[str, int]:
+    summary = report.get("summary")
+    if not isinstance(summary, Mapping):
+        raise ValueError("smoke report has no summary")
+
+    counts: dict[str, int] = {}
+    for key in COUNT_KEYS:
+        value = summary.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"smoke report has invalid {key} count")
+        counts[key] = value
+    return counts
+
+
+def _worst_journey_id(report: Mapping[str, Any]) -> str | None:
+    journeys = report.get("journeys")
+    if not isinstance(journeys, list):
+        return None
+    for verdict in ("BROKEN", "UNKNOWN"):
+        for journey in journeys:
+            if not isinstance(journey, Mapping) or journey.get("verdict") != verdict:
+                continue
+            journey_id = journey.get("id")
+            if isinstance(journey_id, str) and journey_id in KNOWN_JOURNEY_IDS:
+                return journey_id
+    return None
+
+
+def build_payload(
+    report: Mapping[str, Any],
+    *,
+    telemetry_id: str | None,
+    dex_version: str,
+    channel: str = DEFAULT_CHANNEL,
+) -> dict[str, Any]:
+    """Build the complete, unenriched wire payload."""
+    if not isinstance(channel, str) or not channel.strip():
+        raise ValueError("channel must be a non-empty string")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event": EVENT_NAME,
+        "counts": _counts(report),
+        "worst_journey_id": _worst_journey_id(report),
+        "dex_version": dex_version,
+        "channel": channel,
+        "telemetry_id": telemetry_id,
+    }
+
+
+def _append_local_record(
+    vault_root: Path,
+    *,
+    payload: Mapping[str, Any],
+    sent: bool,
+    reason: str,
+) -> None:
+    log_path = vault_root / "System" / ".dex" / "health-telemetry-log.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "attempted_at": datetime.now(timezone.utc).isoformat(),
+        "sent": sent,
+        "reason": reason,
+        "payload": dict(payload),
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def send_smoke_verdict(
+    report: Mapping[str, Any],
+    *,
+    vault_root: Path,
+    repo_root: Path,
+    channel: str = DEFAULT_CHANNEL,
+    transport_getter: TransportGetter = get_analytics_transport,
+    post: PostFunction = requests.post,
+) -> dict[str, object]:
+    """Record one attempt and POST it once only when health telemetry is opted in."""
+    consent = read_health_consent(vault_root)
+    telemetry_id = get_or_create_telemetry_id(vault_root) if consent == "opted-in" else None
+    payload = build_payload(
+        report,
+        telemetry_id=telemetry_id,
+        dex_version=_read_dex_version(repo_root),
+        channel=channel,
+    )
+
+    if consent != "opted-in":
+        reason = "health_telemetry_not_opted_in"
+        _append_local_record(vault_root, payload=payload, sent=False, reason=reason)
+        return {"sent": False, "reason": reason}
+
+    transport = transport_getter()
+    if not transport.get("configured"):
+        reason = "transport_not_configured"
+        _append_local_record(vault_root, payload=payload, sent=False, reason=reason)
+        return {"sent": False, "reason": reason}
+
+    try:
+        response = post(
+            transport["endpoint"],
+            json=payload,
+            headers=transport["headers"],
+            timeout=POST_TIMEOUT_SECONDS,
+        )
+        sent = 200 <= response.status_code < 300
+        reason = "sent" if sent else "http_error"
+    except Exception:
+        sent = False
+        reason = "post_failed"
+
+    _append_local_record(vault_root, payload=payload, sent=sent, reason=reason)
+    return {"sent": sent, "reason": reason}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Record and optionally send a nightly health verdict.")
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--vault", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--channel", default=DEFAULT_CHANNEL)
+    args = parser.parse_args(argv)
+
+    report = json.loads(args.report.read_text(encoding="utf-8"))
+    result = send_smoke_verdict(
+        report,
+        vault_root=args.vault,
+        repo_root=args.repo,
+        channel=args.channel,
+    )
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/health-telemetry.md
+++ b/docs/health-telemetry.md
@@ -1,0 +1,55 @@
+# Anonymous Nightly Health Telemetry
+
+Dex can share one counts-only verdict after its nightly smoke check so maintainers can spot a bad release
+across installed vaults quickly. This is off unless the user makes a separate, explicit choice to opt in.
+It is independent of Dex analytics consent.
+
+## Exact payload
+
+The dedicated sender posts exactly these fields:
+
+```json
+{
+  "schema_version": 1,
+  "event": "smoke_verdict",
+  "counts": {"ok": 2, "broken": 1, "unknown": 1, "off": 1},
+  "worst_journey_id": "task_lifecycle",
+  "dex_version": "1.56.0",
+  "channel": "stable",
+  "telemetry_id": "a random per-install UUID"
+}
+```
+
+`worst_journey_id` is either one of the fixed shipped smoke journey IDs or `null`. It can never contain a
+filename, path, diagnostic detail, note, or other free text. The `channel` is a plain string that currently
+defaults to `stable`; the sender does not assume that it is the only possible channel.
+
+The payload never contains names, notes, file contents, filenames, paths, role, company size, feature
+adoption, journey stage, analytics visitor ID, analytics account ID, or any other profile metadata. The sender
+does not call the analytics event helper and does not enrich the payload.
+
+## Separate opt-in
+
+The decision lives in `System/usage_log.md`:
+
+```markdown
+**Health telemetry:** opted-in|opted-out|pending
+```
+
+Only the exact `opted-in` value permits a network request. Missing, pending, duplicated, unreadable, or
+malformed values fail closed and do not send. Analytics may be on or off independently; changing either
+choice must never change the other.
+
+The first opted-in nightly attempt creates a random UUID at `System/.dex/telemetry-id`. It is stable for that
+installation but distinct from analytics visitor/account identity. The file is local and gitignored.
+
+## Local audit and transport
+
+Every nightly attempt appends a JSON line to `System/.dex/health-telemetry-log.jsonl`, including the exact
+candidate payload, whether it was sent, and the outcome reason. This happens even when consent is pending or
+opted out and even when transport fails. The audit file is local and gitignored.
+
+Network access occurs only in `.scripts/nightly-smoke.sh` after `System/.smoke-last-run.json` has been written.
+The sender reuses `get_analytics_transport()` only to resolve the configured endpoint and headers. It builds
+the body itself, performs one synchronous POST with a five-second timeout, and drops failures. There is no
+retry, background retry queue, or later replay.

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -116,6 +116,14 @@ Passing `--ledger` leaves the complete latest report at
 replaced atomically, so readers never observe partial JSON. Plain `--json` runs remain
 read-only.
 
+After the ledger is written, the nightly worker records one health-telemetry attempt locally. A network POST
+is permitted only by the separate exact `**Health telemetry:** opted-in` decision; analytics consent has no
+effect. Privacy tests assert that pending, missing, opted-out, duplicated, unreadable, and malformed decisions
+never reach the POST seam; that the opted-in wire dictionary has only the documented counts-only fields; that
+its install UUID is stable and distinct from analytics identity; and that the dedicated sender never references
+the enriching analytics event helper. Transport gets one synchronous attempt with a short timeout and has no
+retry queue. See `docs/health-telemetry.md` for the complete contract.
+
 The quick doctor's `smoke.history` check compares the last passing entry with the first
 broken entry after it. Attribution reports only facts inside that window: modification
 times for profile, pillar, integration, MCP, and custom-skill files, plus a Dex version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this is

The last piece of the trust engine, and the one with the most privacy weight. Each vault's nightly self-check can — **only if the user explicitly opts in** — send home one anonymous line so a bad release is caught across the fleet within hours instead of weeks of support pain. Counts only, never content.

## Privacy posture (verified by inspection + tests)

- **Dedicated counts-only sender** (`core/utils/health_telemetry.py`) — NOT `analytics_helper.fire_event` (which auto-attaches role, company size, visitor/account identity). The entire wire payload is: `{schema_version, event:"smoke_verdict", counts{ok,broken,unknown,off}, worst_journey_id (a fixed journey id or null — never a path/detail), dex_version, channel, telemetry_id}`. Nothing else.
- **Separate, independent opt-in** — a `**Health telemetry:** opted-in|opted-out|pending` line in `usage_log.md`, read by its own pattern, wholly separate from the existing analytics consent. **Fails closed:** anything but exactly `opted-in` (missing, malformed, opted-out, pending) → not sent.
- **Distinct telemetry_id** — a random per-install UUID, created only on opt-in, separate from the analytics visitor id. No personal identity.
- **Always-inspectable local record** — every attempt (sent or not, with reason) is appended to `System/.dex/health-telemetry-log.jsonl` so the user can see exactly what would be/was sent.
- **Transport reused for endpoint/headers only** — single POST, short timeout, drop-on-failure, no retry queue. Network happens only in the nightly worker's post-step, never in smoke/doctor probes.
- **Channel-ready, no beta machinery** (per Dave's decision): the payload carries a `channel` field defaulting to `"stable"`; nothing hard-codes a single-channel assumption, so a future beta channel is additive — but no beta channel is built here.

## Verification

Privacy tests 4/4 (opted-out/pending never send but still log locally; opted-in payload is counts-only with no identity asserted field-by-field; telemetry_id ≠ analytics id; fire_event never called). Full suite 707 passed. Ruff clean, hooks 90/90, all four PR diff gates pass (incl. the new PII gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY