### PR TITLE
Coverage session → 8 real bugs found and fixed in task/priority file handling (v1.58.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.58.0] - Your tasks and priorities are handled more carefully (2026-07-13)
+
+A coverage review of the code that edits your task and priority files turned up eight ways Dex could quietly mishandle them. All eight are now fixed, each locked in by a test so they can't come back.
+
+**What this fixes for you:**
+
+* **Completing a task marks the *right* one.** If two tasks had similar wording (one a substring of the other) and no ID, saying "done" could flip the wrong task. Dex now matches the exact task, and refuses to guess when it's genuinely ambiguous rather than picking wrong.
+* **"Done" actually completes an open task.** If an already-completed copy of a task sat above an open one, Dex could report success without ticking the open one. It now finds the open task and completes it.
+* **Your file's line endings are left alone.** Completing a task in a file edited on Windows no longer rewrites every line ending — only the one task line changes.
+* **Checkbox text inside a task title is safe.** A task whose title happened to contain checkbox characters is no longer mangled when completed.
+* **Weekly priorities stay in order.** New "Top 3" priorities are added at the bottom, numbered in sequence — no more entries landing out of order or two items sharing a number.
+* **A fourth priority is handled gracefully.** Adding beyond three no longer corrupts the list; the item is numbered correctly and Dex gently notes that "Top 3" is meant to keep your focus tight.
+* **Backlog ideas rank correctly.** A captured idea now sorts into the right spot by score instead of jumping ahead of higher-scored ones, and marking an idea implemented no longer alters its title.
+
+---
+
 ## [1.57.0] - Catch bad releases across vaults without sharing your content (2026-07-13)
 
 Opt in to help catch bad releases across all vaults — anonymous nightly health counts, no content ever.

--- a/core/mcp/dex_improvements_server.py
+++ b/core/mcp/dex_improvements_server.py
@@ -847,7 +847,10 @@ def mark_idea_implemented(idea_id: str, implementation_date: Optional[str] = Non
     
     # Create archive entry
     impl_date = implementation_date or datetime.now().strftime('%Y-%m-%d')
-    archive_entry = f"- **[{idea_id}]** {idea['title']} - *Implemented: {impl_date}*\n"
+    archive_entry = (
+        f"- **[{idea_id}]** {idea['title']}\n"
+        f"  - **Implemented:** {impl_date}\n"
+    )
     
     # Add to archive section
     archive_pattern = r'(## Archive \(Implemented\)\s*\n(?:\s*\*.*?\*\s*\n)?)'

--- a/core/mcp/dex_improvements_server.py
+++ b/core/mcp/dex_improvements_server.py
@@ -457,7 +457,37 @@ def insert_idea_into_priority_queue(idea_id: str, title: str, description: str, 
     match = re.search(section_pattern, content)
     if match:
         insert_pos = match.end()
-        new_content = content[:insert_pos] + "\n" + idea_entry + content[insert_pos:]
+        next_section = re.search(r'\n(?:### |---)', content[insert_pos:])
+        section_end = (
+            insert_pos + next_section.start()
+            if next_section
+            else len(content)
+        )
+        section_content = content[insert_pos:section_end]
+        existing_ideas = list(re.finditer(
+            r'^-\s*\*\*\[[^\]]+\]\*\*.*?(?=^-\s*\*\*\[[^\]]+\]\*\*|\Z)',
+            section_content,
+            re.MULTILINE | re.DOTALL,
+        ))
+        for existing_idea in existing_ideas:
+            existing_score = re.search(
+                r'\*\*Score:\*\*\s*(\d+)',
+                existing_idea.group(0),
+            )
+            if existing_score and int(existing_score.group(1)) < score:
+                insert_pos += existing_idea.start()
+                break
+        else:
+            if existing_ideas:
+                insert_pos = section_end
+
+        leading_newline = '\n' if not existing_ideas else ''
+        new_content = (
+            content[:insert_pos]
+            + leading_newline
+            + idea_entry
+            + content[insert_pos:]
+        )
     else:
         fallback = re.search(r'(## Archive|## Summary|---\s*$)', content)
         if fallback:

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -4917,9 +4917,9 @@ async def _handle_call_tool_inner(
                 
                 # Update checkbox based on status
                 if new_status == 'd':
-                    new_line = old_line.replace('- [ ]', '- [x]')
+                    new_line = re.sub(r'^(\s*)- \[ \]', r'\1- [x]', old_line, count=1)
                 else:
-                    new_line = old_line.replace('- [x]', '- [ ]')
+                    new_line = re.sub(r'^(\s*)- \[x\]', r'\1- [ ]', old_line, count=1)
                 
                 lines[line_idx] = new_line
                 with filepath.open('w', encoding='utf-8', newline='') as file:

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -4908,7 +4908,8 @@ async def _handle_call_tool_inner(
             # Legacy support: task without ID, update only in source file
             else:
                 filepath = Path(task['source_file'])
-                content = filepath.read_text()
+                with filepath.open('r', encoding='utf-8', newline='') as file:
+                    content = file.read()
                 lines = content.split('\n')
                 
                 line_idx = task['line_number'] - 1
@@ -4921,7 +4922,8 @@ async def _handle_call_tool_inner(
                     new_line = old_line.replace('- [x]', '- [ ]')
                 
                 lines[line_idx] = new_line
-                filepath.write_text('\n'.join(lines))
+                with filepath.open('w', encoding='utf-8', newline='') as file:
+                    file.write('\n'.join(lines))
                 
                 # Propagate status change to referenced pages
                 synced_pages = propagate_task_status_to_refs(task['title'], completed)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -4864,6 +4864,18 @@ async def _handle_call_tool_inner(
                     "success": False,
                     "error": f"No task found matching '{task_title}'"
                 }, indent=2))]
+
+            exact_matching = [
+                task for task in matching
+                if task['title'].lower() == task_title.lower()
+            ]
+            if exact_matching:
+                matching = exact_matching
+            elif len(matching) > 1:
+                return [types.TextContent(type="text", text=json.dumps({
+                    "success": False,
+                    "error": f"Multiple tasks found matching '{task_title}'"
+                }, indent=2))]
             
             task = matching[0]
             

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -5440,9 +5440,10 @@ async def _handle_call_tool_inner(
         priority_id = generate_priority_id(week_date, existing_priorities)
         
         # Build priority entry
-        priority_num = len([p for p in existing_priorities if p.get('priority_num', 0) <= 3]) + 1
-        if priority_num > 3:
-            priority_num = 3  # Cap at 3 for Top 3
+        priority_num = max(
+            (priority.get('priority_num', 0) for priority in existing_priorities),
+            default=0,
+        ) + 1
         
         pillar_name = PILLARS[pillar]['name']
         priority_line = f"{priority_num}. {title} — **{pillar_name}** ^{priority_id}"
@@ -5491,6 +5492,11 @@ async def _handle_call_tool_inner(
             "goal_inference": goal_inference,
             "message": f"Created weekly priority: {title}"
         }
+        if len(existing_priorities) + 1 > 3:
+            result["note"] = (
+                f"You now have {len(existing_priorities) + 1} priorities this week — "
+                "'Top 3' is meant to keep focus tight; consider clearing one."
+            )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     
     elif name == "get_week_priorities":

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -4876,6 +4876,13 @@ async def _handle_call_tool_inner(
                     "success": False,
                     "error": f"Multiple tasks found matching '{task_title}'"
                 }, indent=2))]
+
+            if completed:
+                open_matching = [
+                    task for task in matching if not task.get('completed', False)
+                ]
+                if open_matching:
+                    matching = open_matching
             
             task = matching[0]
             

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -5464,8 +5464,17 @@ async def _handle_call_tool_inner(
         # Insert after "## 🎯 Top 3 This Week" section
         top3_marker = "## 🎯 Top 3 This Week"
         if top3_marker in content:
-            parts = content.split(top3_marker)
-            new_content = parts[0] + top3_marker + "\n\n" + priority_entry + "\n" + parts[1]
+            before_top3, after_top3 = content.split(top3_marker, 1)
+            next_section = re.search(r'\n##\s', after_top3)
+            section_end = next_section.start() if next_section else len(after_top3)
+            section_content = after_top3[:section_end]
+            section_tail = after_top3[section_end:]
+            if section_content.strip():
+                separator = '' if section_content.endswith('\n') else '\n'
+                section_content += separator + priority_entry + '\n'
+            else:
+                section_content = '\n\n' + priority_entry + '\n\n'
+            new_content = before_top3 + top3_marker + section_content + section_tail
         else:
             content += "\n" + priority_entry + "\n"
             new_content = content

--- a/core/tests/test_dex_improvements_server.py
+++ b/core/tests/test_dex_improvements_server.py
@@ -1,0 +1,233 @@
+"""Regression coverage for the data-mutating Dex improvements backlog."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from core.mcp import dex_improvements_server as improvements
+
+
+class _FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 7, 13, 9, 30, tzinfo=tz)
+
+
+def _call_tool(name: str, arguments: dict) -> dict:
+    result = asyncio.run(improvements.handle_call_tool(name, arguments))
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def backlog_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    system_dir = tmp_path / "System"
+    path = system_dir / "Dex_Backlog.md"
+
+    monkeypatch.setattr(improvements, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(improvements, "SYSTEM_DIR", system_dir)
+    monkeypatch.setattr(improvements, "BACKLOG_FILE", path)
+    monkeypatch.setattr(improvements, "datetime", _FixedDateTime)
+    monkeypatch.setattr(improvements, "HAS_QMD", False)
+    monkeypatch.setattr(improvements, "_fire_analytics_event", lambda *_args: None)
+    return path
+
+
+def test_capture_idea_persists_fields_and_parser_round_trips_them(
+    backlog_file: Path,
+):
+    result = _call_tool(
+        "capture_idea",
+        {
+            "title": "Surface stale meeting follow-ups",
+            "description": (
+                "Show unresolved meeting commitments before the weekly review."
+            ),
+            "category": "automation",
+        },
+    )
+
+    assert result == {
+        "success": True,
+        "idea_id": "idea-001",
+        "title": "Surface stale meeting follow-ups",
+        "category": "automation",
+        "message": (
+            "Idea captured successfully! Run `/dex-backlog` to see it ranked "
+            "against other ideas."
+        ),
+        "next_steps": [
+            "Run `/dex-backlog` to see AI-powered ranking",
+            'Run `/dex-improve "{title}"` to workshop this idea',
+            "Check `System/Dex_Backlog.md` to see all your ideas",
+        ],
+    }
+    content = backlog_file.read_text(encoding="utf-8")
+    assert "### 💡 Low Priority (Score: <60)" in content
+    assert content.count("- **[idea-001]** Surface stale meeting follow-ups") == 1
+    assert "  - **Score:** 0 (not yet ranked" in content
+    assert "  - **Category:** automation" in content
+    assert "  - **Captured:** 2026-07-13" in content
+    assert (
+        "  - **Description:** Show unresolved meeting commitments before the "
+        "weekly review."
+    ) in content
+
+    assert improvements.parse_backlog_file() == [
+        {
+            "id": "idea-001",
+            "title": "Surface stale meeting follow-ups",
+            "score": 0,
+            "category": "automation",
+            "captured": "2026-07-13",
+            "description": (
+                "Show unresolved meeting commitments before the weekly review."
+            ),
+            "status": "active",
+        }
+    ]
+
+
+def test_find_similar_ideas_detects_near_duplicate_but_not_different_idea(
+    backlog_file: Path,
+):
+    _call_tool(
+        "capture_idea",
+        {
+            "title": "Surface stale meeting follow-ups",
+            "description": (
+                "Show unresolved meeting commitments before the weekly review."
+            ),
+            "category": "automation",
+        },
+    )
+
+    near_duplicate = improvements.find_similar_ideas(
+        "Surface stale meeting followup",
+        "Show unresolved meeting commitments ahead of the weekly review.",
+    )
+    clearly_different = improvements.find_similar_ideas(
+        "Add company logo colour themes",
+        "Let users customise exported PDF colours for each company brand.",
+    )
+
+    assert near_duplicate
+    assert near_duplicate[0]["id"] == "idea-001"
+    assert near_duplicate[0]["similarity"] >= 0.5
+    assert clearly_different == []
+    assert backlog_file.exists()
+
+
+@pytest.mark.parametrize(
+    ("score", "expected_heading"),
+    [
+        (91, "### 🔥 High Priority (Score: 85+)"),
+        (72, "### ⚡ Medium Priority (Score: 60-84)"),
+        (40, "### 💡 Low Priority (Score: <60)"),
+    ],
+)
+def test_queue_insertion_routes_idea_to_score_band(
+    backlog_file: Path,
+    score: int,
+    expected_heading: str,
+):
+    improvements.initialize_backlog_file()
+
+    assert improvements.insert_idea_into_priority_queue(
+        f"idea-{score:03d}",
+        f"Scored idea {score}",
+        "A scored queue entry.",
+        "system",
+        score=score,
+    )
+
+    content = backlog_file.read_text(encoding="utf-8")
+    heading_pos = content.index(expected_heading)
+    idea_pos = content.index(f"- **[idea-{score:03d}]** Scored idea {score}")
+    next_heading_pos = content.find("\n### ", heading_pos + 1)
+    if next_heading_pos == -1:
+        next_heading_pos = content.index("\n---", heading_pos)
+    assert heading_pos < idea_pos < next_heading_pos
+    [parsed] = improvements.parse_backlog_file()
+    assert parsed["score"] == score
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: insert_idea_into_priority_queue always prepends within a score band, "
+        "so a score-65 idea is placed ahead of an existing score-80 idea"
+    ),
+    strict=False,
+)
+def test_queue_insertion_keeps_descending_score_order_within_band(
+    backlog_file: Path,
+):
+    improvements.initialize_backlog_file()
+    improvements.insert_idea_into_priority_queue(
+        "idea-080",
+        "Higher medium idea",
+        "Higher-ranked existing idea.",
+        "system",
+        score=80,
+    )
+
+    improvements.insert_idea_into_priority_queue(
+        "idea-065",
+        "Lower medium idea",
+        "Lower-ranked new idea.",
+        "system",
+        score=65,
+    )
+
+    medium_ideas = [
+        idea
+        for idea in improvements.parse_backlog_file()
+        if 60 <= idea["score"] < 85
+    ]
+    assert [idea["id"] for idea in medium_ideas] == ["idea-080", "idea-065"]
+    assert backlog_file.read_text(encoding="utf-8").index("idea-080") < (
+        backlog_file.read_text(encoding="utf-8").index("idea-065")
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: mark_idea_implemented appends the implementation suffix to the "
+        "stored title, so parsing the archive no longer round-trips the title"
+    ),
+    strict=False,
+)
+def test_mark_implemented_moves_idea_to_archive_without_changing_title(
+    backlog_file: Path,
+):
+    _call_tool(
+        "capture_idea",
+        {
+            "title": "Surface stale meeting follow-ups",
+            "description": "Show unresolved meeting commitments.",
+            "category": "automation",
+        },
+    )
+
+    result = _call_tool(
+        "mark_implemented",
+        {"idea_id": "idea-001", "implementation_date": "2026-07-13"},
+    )
+
+    assert result["success"] is True
+    [archived] = improvements.parse_backlog_file()
+    assert archived == {
+        "id": "idea-001",
+        "title": "Surface stale meeting follow-ups",
+        "score": 0,
+        "category": "system",
+        "captured": "2026-07-13",
+        "description": "",
+        "status": "implemented",
+    }
+    content = backlog_file.read_text(encoding="utf-8")
+    assert content.index("## Archive (Implemented)") < content.index("idea-001")

--- a/core/tests/test_dex_improvements_server.py
+++ b/core/tests/test_dex_improvements_server.py
@@ -156,13 +156,6 @@ def test_queue_insertion_routes_idea_to_score_band(
     assert parsed["score"] == score
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: insert_idea_into_priority_queue always prepends within a score band, "
-        "so a score-65 idea is placed ahead of an existing score-80 idea"
-    ),
-    strict=False,
-)
 def test_queue_insertion_keeps_descending_score_order_within_band(
     backlog_file: Path,
 ):

--- a/core/tests/test_dex_improvements_server.py
+++ b/core/tests/test_dex_improvements_server.py
@@ -187,13 +187,6 @@ def test_queue_insertion_keeps_descending_score_order_within_band(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: mark_idea_implemented appends the implementation suffix to the "
-        "stored title, so parsing the archive no longer round-trips the title"
-    ),
-    strict=False,
-)
 def test_mark_implemented_moves_idea_to_archive_without_changing_title(
     backlog_file: Path,
 ):

--- a/core/tests/test_qmd_query_grep_fallback.py
+++ b/core/tests/test_qmd_query_grep_fallback.py
@@ -1,0 +1,108 @@
+"""Regression coverage for vault search when QMD is unavailable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.utils import qmd_query
+
+
+@pytest.fixture
+def fallback_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    monkeypatch.setattr(qmd_query, "is_qmd_available", lambda: False)
+    return tmp_path
+
+
+def _write(vault: Path, relative_path: str, content: str) -> Path:
+    path = vault / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_grep_fallback_returns_matching_file_with_usable_snippet(
+    fallback_vault: Path,
+):
+    matching = _write(
+        fallback_vault,
+        "06-Resources/Accounts/Acme.md",
+        "# Acme\n\n"
+        "Renewal context before the key sentence.\n"
+        "The customer retention plan needs an executive owner this week.\n"
+        "Follow-up context after the key sentence.\n",
+    )
+    _write(
+        fallback_vault,
+        "06-Resources/Accounts/Other.md",
+        "# Other\n\nA procurement timeline with no related content.\n",
+    )
+
+    results = qmd_query.vault_search("retention", limit=10)
+
+    assert len(results) == 1
+    assert results[0]["path"] == str(matching)
+    assert results[0]["source"] == "grep"
+    assert results[0]["score"] > 0
+    assert "customer retention plan" in results[0]["snippet"]
+    assert len(results[0]["snippet"]) <= 264
+
+
+def test_grep_fallback_returns_empty_list_for_no_match(fallback_vault: Path):
+    _write(
+        fallback_vault,
+        "Projects/Roadmap.md",
+        "# Roadmap\n\nShip the onboarding improvements.\n",
+    )
+
+    assert qmd_query.vault_search("nonexistent-zebra-phrase") == []
+
+
+def test_grep_fallback_is_case_insensitive_and_uses_any_meaningful_query_term(
+    fallback_vault: Path,
+):
+    customer_file = _write(
+        fallback_vault,
+        "Notes/CUSTOMER.md",
+        "A CUSTOMER interview is scheduled tomorrow.\n",
+    )
+    retention_file = _write(
+        fallback_vault,
+        "Notes/retention.md",
+        "Retention metrics improved this month.\n",
+    )
+    _write(
+        fallback_vault,
+        "Notes/unrelated.md",
+        "Engineering deployment notes.\n",
+    )
+
+    results = qmd_query.vault_search("customer retention")
+
+    assert {result["path"] for result in results} == {
+        str(customer_file),
+        str(retention_file),
+    }
+    assert all(result["source"] == "grep" for result in results)
+
+
+def test_grep_fallback_handles_unicode_and_odd_markdown_filenames(
+    fallback_vault: Path,
+):
+    matching = _write(
+        fallback_vault,
+        "06-Résources/Café notes (Q3) ✨.md",
+        "# Résumé\n\nThe café launch includes a résumé review.\n",
+    )
+    _write(
+        fallback_vault,
+        "06-Résources/会議 notes [draft].md",
+        "# 会議\n\nUnrelated international meeting notes.\n",
+    )
+
+    results = qmd_query.vault_search("RÉSUMÉ")
+
+    assert [result["path"] for result in results] == [str(matching)]
+    assert "résumé review" in results[0]["snippet"].lower()

--- a/core/tests/test_work_server_legacy_task_completion.py
+++ b/core/tests/test_work_server_legacy_task_completion.py
@@ -151,13 +151,6 @@ def test_legacy_completion_preserves_crlf_bytes_outside_target_line(tasks_file: 
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: legacy completion replaces every '- [ ]' token on the target line, "
-        "including checkbox syntax quoted in the task title"
-    ),
-    strict=False,
-)
 def test_legacy_completion_does_not_rewrite_checkbox_syntax_inside_title(
     tasks_file: Path,
 ):

--- a/core/tests/test_work_server_legacy_task_completion.py
+++ b/core/tests/test_work_server_legacy_task_completion.py
@@ -84,13 +84,6 @@ def test_legacy_completion_changes_only_the_exact_task_line(tasks_file: Path):
     ).encode()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: legacy title lookup uses substring matching and completes an earlier "
-        "longer task instead of the later exact-title task"
-    ),
-    strict=False,
-)
 def test_legacy_completion_prefers_exact_title_over_earlier_substring_match(
     tasks_file: Path,
 ):

--- a/core/tests/test_work_server_legacy_task_completion.py
+++ b/core/tests/test_work_server_legacy_task_completion.py
@@ -131,13 +131,6 @@ def test_legacy_completion_skips_completed_duplicate_and_completes_open_copy(
     ).encode()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: legacy completion normalizes a CRLF Tasks.md to LF, changing every "
-        "line ending instead of only the intended task line"
-    ),
-    strict=False,
-)
 def test_legacy_completion_preserves_crlf_bytes_outside_target_line(tasks_file: Path):
     before = (
         b"# Tasks\r\n\r\n"

--- a/core/tests/test_work_server_legacy_task_completion.py
+++ b/core/tests/test_work_server_legacy_task_completion.py
@@ -105,13 +105,6 @@ def test_legacy_completion_prefers_exact_title_over_earlier_substring_match(
     ).encode()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: when an already-completed ID-less duplicate precedes an open one, "
-        "legacy completion reports success without completing the open task"
-    ),
-    strict=False,
-)
 def test_legacy_completion_skips_completed_duplicate_and_completes_open_copy(
     tasks_file: Path,
 ):

--- a/core/tests/test_work_server_legacy_task_completion.py
+++ b/core/tests/test_work_server_legacy_task_completion.py
@@ -1,0 +1,201 @@
+"""Regression coverage for completing ID-less tasks without corrupting Tasks.md."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+
+def _complete_legacy_task(task_title: str) -> dict:
+    result = asyncio.run(
+        work_server.handle_call_tool(
+            "update_task_status",
+            {"task_title": task_title, "status": "d"},
+        )
+    )
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def tasks_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "03-Tasks" / "Tasks.md"
+    path.parent.mkdir(parents=True)
+
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: path)
+    monkeypatch.setattr(
+        work_server,
+        "get_week_priorities_file",
+        lambda: tmp_path / "02-Week_Priorities" / "Week_Priorities.md",
+    )
+    monkeypatch.setattr(
+        work_server,
+        "PILLARS",
+        {
+            "operations": {
+                "name": "Operations",
+                "description": "Operational work",
+                "keywords": ["operations"],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        work_server, "propagate_task_status_to_refs", lambda *_args: []
+    )
+    monkeypatch.setattr(work_server, "_fire_analytics_event", lambda *_args: None)
+    return path
+
+
+def test_legacy_completion_changes_only_the_exact_task_line(tasks_file: Path):
+    before = (
+        "# Tasks\n\n"
+        "## P1 - Important\n"
+        "- [ ] Prepare renewal review\n"
+        "  - Pillar: Operations | Priority: P1\n"
+        "- [ ] Prepare renewal review notes\n\n"
+        "## P2 - Normal\n"
+        "- [ ] Follow up after prepare renewal review\n"
+        "- [x] Already completed item\n\n"
+        "## Notes\n"
+        "The phrase Prepare renewal review appears here too.\n"
+    )
+    tasks_file.write_text(before, encoding="utf-8")
+
+    result = _complete_legacy_task("Prepare renewal review notes")
+
+    assert result["success"] is True
+    assert result["task"] == "Prepare renewal review notes"
+    assert result["new_status"] == "done"
+    assert tasks_file.read_bytes() == (
+        "# Tasks\n\n"
+        "## P1 - Important\n"
+        "- [ ] Prepare renewal review\n"
+        "  - Pillar: Operations | Priority: P1\n"
+        "- [x] Prepare renewal review notes\n\n"
+        "## P2 - Normal\n"
+        "- [ ] Follow up after prepare renewal review\n"
+        "- [x] Already completed item\n\n"
+        "## Notes\n"
+        "The phrase Prepare renewal review appears here too.\n"
+    ).encode()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: legacy title lookup uses substring matching and completes an earlier "
+        "longer task instead of the later exact-title task"
+    ),
+    strict=False,
+)
+def test_legacy_completion_prefers_exact_title_over_earlier_substring_match(
+    tasks_file: Path,
+):
+    before = (
+        "# Tasks\n\n"
+        "## P1 - Important\n"
+        "- [ ] Prepare launch notes for the board\n"
+        "- [ ] Prepare launch notes\n"
+        "- [ ] Prepare launch note\n"
+    )
+    tasks_file.write_text(before, encoding="utf-8")
+
+    result = _complete_legacy_task("Prepare launch notes")
+
+    assert result["task"] == "Prepare launch notes"
+    assert tasks_file.read_bytes() == before.replace(
+        "- [ ] Prepare launch notes\n",
+        "- [x] Prepare launch notes\n",
+    ).encode()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: when an already-completed ID-less duplicate precedes an open one, "
+        "legacy completion reports success without completing the open task"
+    ),
+    strict=False,
+)
+def test_legacy_completion_skips_completed_duplicate_and_completes_open_copy(
+    tasks_file: Path,
+):
+    before = (
+        "# Tasks\n\n"
+        "## Completed\n"
+        "- [x] Send customer update\n\n"
+        "## Next\n"
+        "- [ ] Send customer update\n"
+        "- [ ] Send customer update summary\n"
+    )
+    tasks_file.write_text(before, encoding="utf-8")
+
+    result = _complete_legacy_task("Send customer update")
+
+    assert result["success"] is True
+    assert tasks_file.read_bytes() == (
+        "# Tasks\n\n"
+        "## Completed\n"
+        "- [x] Send customer update\n\n"
+        "## Next\n"
+        "- [x] Send customer update\n"
+        "- [ ] Send customer update summary\n"
+    ).encode()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: legacy completion normalizes a CRLF Tasks.md to LF, changing every "
+        "line ending instead of only the intended task line"
+    ),
+    strict=False,
+)
+def test_legacy_completion_preserves_crlf_bytes_outside_target_line(tasks_file: Path):
+    before = (
+        b"# Tasks\r\n\r\n"
+        b"## Next\r\n"
+        b"- [ ] Complete migration checklist\r\n"
+        b"- [ ] Leave this task untouched\r\n"
+        b"\r\n## Notes\r\n"
+        b"Do not rewrite these line endings.\r\n"
+    )
+    tasks_file.write_bytes(before)
+
+    result = _complete_legacy_task("Complete migration checklist")
+
+    assert result["success"] is True
+    assert tasks_file.read_bytes() == before.replace(
+        b"- [ ] Complete migration checklist\r\n",
+        b"- [x] Complete migration checklist\r\n",
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: legacy completion replaces every '- [ ]' token on the target line, "
+        "including checkbox syntax quoted in the task title"
+    ),
+    strict=False,
+)
+def test_legacy_completion_does_not_rewrite_checkbox_syntax_inside_title(
+    tasks_file: Path,
+):
+    before = (
+        "# Tasks\n\n"
+        "## Next\n"
+        "- [ ] Document the literal - [ ] checkbox syntax\n"
+        "- [ ] Other task\n"
+    )
+    tasks_file.write_text(before, encoding="utf-8")
+
+    result = _complete_legacy_task("Document the literal - [ ] checkbox syntax")
+
+    assert result["success"] is True
+    assert tasks_file.read_bytes() == (
+        "# Tasks\n\n"
+        "## Next\n"
+        "- [x] Document the literal - [ ] checkbox syntax\n"
+        "- [ ] Other task\n"
+    ).encode()

--- a/core/tests/test_work_server_weekly_priority_creation.py
+++ b/core/tests/test_work_server_weekly_priority_creation.py
@@ -1,0 +1,177 @@
+"""Regression coverage for weekly-priority file writes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+WEEK_DATE = "2026-07-13"
+TOP_3 = "## 🎯 Top 3 This Week"
+PILLARS = {
+    "customer": {
+        "name": "Customer Growth",
+        "description": "Customer outcomes",
+        "keywords": ["customer"],
+    }
+}
+
+
+def _call_create_priority(**overrides) -> dict:
+    arguments = {
+        "title": "Publish customer renewal playbook",
+        "pillar": "customer",
+        "week_date": WEEK_DATE,
+        **overrides,
+    }
+    result = asyncio.run(
+        work_server.handle_call_tool("create_weekly_priority", arguments)
+    )
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def priority_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
+    path.parent.mkdir(parents=True)
+    goals = tmp_path / "01-Quarter_Goals" / "Quarter_Goals.md"
+
+    monkeypatch.setattr(work_server, "get_week_priorities_file", lambda: path)
+    monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals)
+    monkeypatch.setattr(work_server, "PILLARS", PILLARS)
+    return path
+
+
+def test_create_weekly_priority_fills_empty_section_without_losing_following_content(
+    priority_file: Path,
+):
+    before = (
+        "# Week Priorities\n\n"
+        "**Week of:** 2026-07-13\n\n"
+        "---\n\n"
+        f"{TOP_3}\n\n"
+        "## 📋 Supporting Tasks\n\n"
+        "- [ ] Preserve this task exactly\n\n"
+        "## 📝 Notes\n\n"
+        "This text must survive the splice.\n"
+    )
+    priority_file.write_text(before, encoding="utf-8")
+
+    result = _call_create_priority(success_criteria="Playbook is shared with Sales")
+
+    assert result["success"] is True
+    assert result["linked_goal"] is None
+    assert priority_file.read_text(encoding="utf-8") == (
+        "# Week Priorities\n\n"
+        "**Week of:** 2026-07-13\n\n"
+        "---\n\n"
+        f"{TOP_3}\n\n"
+        "1. Publish customer renewal playbook — **Customer Growth** "
+        "^week-2026-W29-p1\n"
+        "   - Success criteria: Playbook is shared with Sales\n\n\n"
+        "## 📋 Supporting Tasks\n\n"
+        "- [ ] Preserve this task exactly\n\n"
+        "## 📝 Notes\n\n"
+        "This text must survive the splice.\n"
+    )
+
+
+def test_create_weekly_priority_writes_explicit_goal_link_without_mangling_headings(
+    priority_file: Path,
+):
+    priority_file.write_text(
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        "## 📊 Review\n\n"
+        "Review notes stay here.\n",
+        encoding="utf-8",
+    )
+
+    result = _call_create_priority(quarterly_goal_id="Q3-2026-goal-2")
+
+    assert result["linked_goal"] == "Q3-2026-goal-2"
+    content = priority_file.read_text(encoding="utf-8")
+    assert content == (
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        "1. Publish customer renewal playbook — **Customer Growth** "
+        "^week-2026-W29-p1\n"
+        "   - Quarterly goal: [Q3-2026-goal-2]\n\n\n"
+        "## 📊 Review\n\n"
+        "Review notes stay here.\n"
+    )
+    assert content.count(TOP_3) == 1
+    assert content.count("## 📊 Review") == 1
+
+
+@pytest.mark.parametrize("existing_count", [1, 2])
+@pytest.mark.xfail(
+    reason=(
+        "BUG: create_weekly_priority inserts a newly numbered priority before "
+        "existing priorities, leaving Top 3 out of numeric order"
+    ),
+    strict=False,
+)
+def test_create_weekly_priority_appends_after_existing_priorities_in_number_order(
+    priority_file: Path,
+    existing_count: int,
+):
+    existing = "".join(
+        f"{number}. Existing priority {number} — **Customer Growth** "
+        f"^week-2026-W29-p{number}\n"
+        for number in range(1, existing_count + 1)
+    )
+    priority_file.write_text(
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        f"{existing}\n"
+        "## 📊 Review\n\n"
+        "Tail sentinel.\n",
+        encoding="utf-8",
+    )
+
+    result = _call_create_priority()
+
+    assert result["success"] is True
+    new_number = existing_count + 1
+    assert priority_file.read_text(encoding="utf-8") == (
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        f"{existing}"
+        f"{new_number}. Publish customer renewal playbook — **Customer Growth** "
+        f"^week-2026-W29-p{new_number}\n\n"
+        "## 📊 Review\n\n"
+        "Tail sentinel.\n"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BUG: create_weekly_priority accepts a fourth Top-3 item and writes a "
+        "second priority numbered 3"
+    ),
+    strict=False,
+)
+def test_create_weekly_priority_rejects_fourth_item_without_changing_file(
+    priority_file: Path,
+):
+    before = (
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        "1. First priority — **Customer Growth** ^week-2026-W29-p1\n"
+        "2. Second priority — **Customer Growth** ^week-2026-W29-p2\n"
+        "3. Third priority — **Customer Growth** ^week-2026-W29-p3\n\n"
+        "## 📊 Review\n\n"
+        "Tail sentinel.\n"
+    )
+    priority_file.write_text(before, encoding="utf-8")
+
+    result = _call_create_priority()
+
+    assert result["success"] is False
+    assert "top 3" in result["error"].lower()
+    assert priority_file.read_text(encoding="utf-8") == before

--- a/core/tests/test_work_server_weekly_priority_creation.py
+++ b/core/tests/test_work_server_weekly_priority_creation.py
@@ -142,14 +142,7 @@ def test_create_weekly_priority_appends_after_existing_priorities_in_number_orde
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "BUG: create_weekly_priority accepts a fourth Top-3 item and writes a "
-        "second priority numbered 3"
-    ),
-    strict=False,
-)
-def test_create_weekly_priority_rejects_fourth_item_without_changing_file(
+def test_create_weekly_priority_numbers_a_fourth_item_and_warns(
     priority_file: Path,
 ):
     before = (
@@ -165,6 +158,19 @@ def test_create_weekly_priority_rejects_fourth_item_without_changing_file(
 
     result = _call_create_priority()
 
-    assert result["success"] is False
-    assert "top 3" in result["error"].lower()
-    assert priority_file.read_text(encoding="utf-8") == before
+    assert result["success"] is True
+    assert result["note"] == (
+        "You now have 4 priorities this week — 'Top 3' is meant to keep focus "
+        "tight; consider clearing one."
+    )
+    assert priority_file.read_text(encoding="utf-8") == (
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        "1. First priority — **Customer Growth** ^week-2026-W29-p1\n"
+        "2. Second priority — **Customer Growth** ^week-2026-W29-p2\n"
+        "3. Third priority — **Customer Growth** ^week-2026-W29-p3\n"
+        "4. Publish customer renewal playbook — **Customer Growth** "
+        "^week-2026-W29-p4\n\n"
+        "## 📊 Review\n\n"
+        "Tail sentinel.\n"
+    )

--- a/core/tests/test_work_server_weekly_priority_creation.py
+++ b/core/tests/test_work_server_weekly_priority_creation.py
@@ -109,13 +109,6 @@ def test_create_weekly_priority_writes_explicit_goal_link_without_mangling_headi
 
 
 @pytest.mark.parametrize("existing_count", [1, 2])
-@pytest.mark.xfail(
-    reason=(
-        "BUG: create_weekly_priority inserts a newly numbered priority before "
-        "existing priorities, leaving Top 3 out of numeric order"
-    ),
-    strict=False,
-)
 def test_create_weekly_priority_appends_after_existing_priorities_in_number_order(
     priority_file: Path,
     existing_count: int,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this is

The follow-up coverage session turned into a bug hunt. Adding regression tests to the four highest-risk *untested, file-mutating* code paths surfaced **8 genuine bugs** — each first written as a failing (xfail) test proving the defect, then fixed so the test passes for real. Every fix is guarded by that test so it can't regress.

## The bugs, fixed

**Task completion (touches your Tasks.md — highest risk):**
1. Substring matching could complete the *wrong* task → now exact-title match, refuses ambiguity rather than guessing.
2. An already-completed duplicate above an open task → "done" reported success without completing the open one → now selects the open task.
3. Completing a task rewrote *all* line endings on a CRLF (Windows-edited) file → now preserves newlines, changes only the target line.
4. `.replace('- [ ]', ...)` mangled checkbox text quoted in a title → now anchored to the leading checkbox only.

**Weekly priorities (per Dave's product calls):**
5. New priorities could land out of numeric order → now appended at the bottom, in sequence.
6. A 4th "Top 3" item was silently accepted and duplicated the number "3" → now numbered uniquely, with a gentle focus note (not a hard block, per Dave).

**Idea backlog:**
7. Queue insertion mis-ordered within a score band (65 ahead of 80) → now correct descending order.
8. Marking an idea implemented mutated its stored title → now preserved, status stored separately.

## Verification

21 new tests pass (0 xfail remaining). The existing 40 ID-based task tests still pass (no regression). Full suite 716 passed. Ruff clean, all four PR diff gates pass (incl. PII). Coverage up on all four target modules.

Each fix is a minimal, surgical production change — no refactors, no scope creep. Reviewed line by line; the four Tasks.md-touching fixes got the closest read since a wrong fix there is the corruption we set out to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY