### PR TITLE
test: deflake load-sensitive timing assertions (stop CI crying wolf)

### DIFF
--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -163,7 +163,10 @@ def test_release_branch_strips_dev_files_and_keeps_user_runtime(tmp_path: Path) 
         check=False,
         capture_output=True,
         text=True,
-        timeout=30,
+        # Generous sanity ceiling, not a perf assertion: the smoke run spawns several
+        # subprocess journeys, which can exceed a tight 30s budget on a loaded CI runner
+        # and flake this test even though the run succeeds.
+        timeout=90,
     )
     assert smoke_result.returncode == 0, smoke_result.stderr or smoke_result.stdout
     assert json.loads(smoke_result.stdout)["schema_version"] == 1

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -728,7 +728,10 @@ def test_hanging_journey_is_killed_and_returns_exit_two(monkeypatch, tmp_path: P
         journey_definitions=(_definition("configs", 0.5),),
     )
 
-    assert time.monotonic() - started < 2
+    # Generous ceiling: the journey sleeps 60s, so completing well under that proves
+    # the timeout+kill fired. Kept loose (not ~1s) so heavy CI load can't flake it;
+    # the exit_code/verdict assertions below are what actually verify the behavior.
+    assert time.monotonic() - started < 30
     assert run.exit_code == 2
     assert run.harness_failed is True
     assert run.report["journeys"][0]["verdict"] == "UNKNOWN"
@@ -784,7 +787,10 @@ def test_hanging_preparation_is_killed_within_the_journey_budget(monkeypatch, tm
         journey_definitions=(_definition("configs", 0.5),),
     )
 
-    assert time.monotonic() - started < 2
+    # Generous ceiling (see test_hanging_journey_is_killed_and_returns_exit_two):
+    # the preparation sleeps 60s, so finishing well under that proves the kill fired;
+    # the exit_code/detail assertions below verify the actual behavior.
+    assert time.monotonic() - started < 30
     assert run.exit_code == 2
     assert run.harness_failed is True
     assert "preparation timed out" in run.report["journeys"][0]["detail"]


### PR DESCRIPTION
## What this is

Three timing-sensitive tests intermittently failed on CI under heavy load with no real defect — the exact "green checkmark you can't trust" problem that undercuts a testing-rigor effort. This widens their load-fragile margins without weakening what they verify.

- **`test_hanging_journey_is_killed_and_returns_exit_two`** and **`test_hanging_preparation_is_killed_within_the_journey_budget`**: both sleep a journey 60s with a 0.5s timeout, then asserted the whole thing completed in `< 2s`. That ceiling is too tight for a loaded runner. Widened to `< 30s` — still far under the 60s sleep, so it definitively proves the timeout+kill fired, while being immune to load. The `exit_code == 2` / verdict / "timed out" assertions (unchanged) are what actually verify the behavior.
- **`test_release_branch_strips_dev_files_and_keeps_user_runtime`**: gave its smoke subprocess (several child journeys) only 30s; widened to 90s (a sanity ceiling, not a perf assertion).

## Deliberately not changed

The `test_mcp_launch...` flake traces to the **production** MCP handshake timeout (~10s vs ~10s server init), not a test margin. Changing a production timeout to quiet a test could mask a real "slow user machine → false BROKEN in /dex-doctor" issue — that deserves a separate, careful look, flagged rather than papered over here.

## Verification

Hammered the fixed tests locally: **hanging tests 10/10**, distribution test 3/3. Full smoke suite 41 passed. Ruff clean, all three PR diff gates pass. Test-only change — no production code, no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY