### PR TITLE
fix: MCP handshake timeout was 1.5s — false-BROKENs slow machines (v1.59.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.59.0] - Dex stops calling a working feature "broken" just because your machine was slow to start it (2026-07-13)
+
+Dex's health check gave built-in services just 1.5 seconds to wake up. On a slower or busy machine, a service could still be starting normally when Dex labelled it broken. Those services now get a fair eight-second window, with enough room in the overall check for the slower start to finish without changing the usual quick path.
+
+**What this fixes for you:**
+
+* **Slow starts no longer look like failures.** `/dex-doctor` and nightly health checks wait long enough for working built-in services to answer, even when your machine is under load.
+* **Unusually slow setups can choose a longer window.** Set `DEX_MCP_HANDSHAKE_TIMEOUT` to a positive number of seconds when your services genuinely need more than the standard eight seconds; missing or invalid values safely keep the default.
+
+---
+
 ## [1.58.0] - Your tasks and priorities are handled more carefully (2026-07-13)
 
 A coverage review of the code that edits your task and priority files turned up eight ways Dex could quietly mishandle them. All eight are now fixed, each locked in by a test so they can't come back.

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -89,6 +89,99 @@ def _definition(journey_id: str, timeout: float = 5.0) -> smoke.JourneyDefinitio
     return smoke.JourneyDefinition(journey_id, timeout)
 
 
+def test_mcp_handshake_timeout_env_override_changes_effective_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEX_MCP_HANDSHAKE_TIMEOUT", "3.25")
+
+    assert smoke._mcp_handshake_timeout_seconds() == 3.25
+
+
+@pytest.mark.parametrize("value", [None, "", "invalid", "0", "-1", "nan", "inf"])
+def test_mcp_handshake_timeout_invalid_env_falls_back_without_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("DEX_MCP_HANDSHAKE_TIMEOUT", raising=False)
+    else:
+        monkeypatch.setenv("DEX_MCP_HANDSHAKE_TIMEOUT", value)
+
+    assert smoke._mcp_handshake_timeout_seconds() == 8.0
+
+
+def test_mcp_startup_allows_server_taking_three_seconds_to_handshake(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from core.utils import mcp_handshake
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / smoke.MCP_PLAN).write_text(
+        json.dumps(
+            {
+                "state": "OK",
+                "entries": [
+                    {
+                        "name": "work-mcp",
+                        "verdict": "EXECUTE",
+                        "kind": "builtin",
+                        "script": "core/mcp/work_server.py",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    bootstrap = smoke._install_network_guard(tmp_path) / "server_bootstrap.py"
+    monkeypatch.setenv("DEX_SMOKE_SERVER_BOOTSTRAP", str(bootstrap))
+    observed_timeouts: list[float] = []
+
+    def simulated_slow_handshake(*_args: object, timeout: float, **_kwargs: object):
+        observed_timeouts.append(timeout)
+        simulated_startup_seconds = 3.23
+        if timeout < simulated_startup_seconds:
+            return mcp_handshake.MCPHandshakeResult(
+                ok=False,
+                response=None,
+                error=f"initialize response timed out after {timeout:g}s",
+                stderr="",
+                returncode=None,
+            )
+        return mcp_handshake.MCPHandshakeResult(
+            ok=True,
+            response={"jsonrpc": "2.0", "id": 1, "result": {}},
+            error=None,
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(mcp_handshake, "mcp_stdio_handshake", simulated_slow_handshake)
+
+    result = smoke._journey_mcp_startup(vault, tmp_path / "release")
+
+    assert result == {"verdict": "OK", "detail": "work-mcp: OK"}
+    assert observed_timeouts == [smoke.HANDSHAKE_TIMEOUT_SECONDS]
+
+
+def test_mcp_timeout_budget_ordering_invariant() -> None:
+    mcp_startup = next(journey for journey in smoke.JOURNEYS if journey.id == "mcp_startup")
+
+    assert (
+        smoke.GLOBAL_TIMEOUT_SECONDS,
+        mcp_startup.timeout_seconds,
+        smoke.MCP_STARTUP_HANDSHAKE_BUDGET_SECONDS,
+        smoke.HANDSHAKE_TIMEOUT_SECONDS,
+    ) == (60.0, 45.0, 40.0, 8.0)
+    assert (
+        smoke.GLOBAL_TIMEOUT_SECONDS
+        > mcp_startup.timeout_seconds
+        > smoke.MCP_STARTUP_HANDSHAKE_BUDGET_SECONDS
+        > smoke.HANDSHAKE_TIMEOUT_SECONDS
+    )
+
+
 def _release_repo(tmp_path: Path, *, release_validators: str | None = None) -> Path:
     repo = tmp_path / "release-repo"
     repo.mkdir()

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -33,7 +33,24 @@ sys.path.insert(0, str(RUNNER_ROOT))
 
 SCHEMA_VERSION = 1
 HISTORY_LIMIT = 120
-GLOBAL_TIMEOUT_SECONDS = 30.0
+DEFAULT_MCP_HANDSHAKE_TIMEOUT_SECONDS = 8.0
+
+
+def _mcp_handshake_timeout_seconds() -> float:
+    raw_value = os.environ.get("DEX_MCP_HANDSHAKE_TIMEOUT")
+    try:
+        value = float(raw_value) if raw_value is not None else DEFAULT_MCP_HANDSHAKE_TIMEOUT_SECONDS
+    except (TypeError, ValueError):
+        return DEFAULT_MCP_HANDSHAKE_TIMEOUT_SECONDS
+    if not 0 < value < float("inf"):
+        return DEFAULT_MCP_HANDSHAKE_TIMEOUT_SECONDS
+    return value
+
+
+HANDSHAKE_TIMEOUT_SECONDS = _mcp_handshake_timeout_seconds()
+MCP_STARTUP_HANDSHAKE_BUDGET_SECONDS = 40.0
+MCP_STARTUP_JOURNEY_TIMEOUT_SECONDS = 45.0
+GLOBAL_TIMEOUT_SECONDS = 60.0
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 VERDICT_PRIORITY = {"OFF": 0, "OK": 1, "UNKNOWN": 2, "BROKEN": 3}
 NOT_SET_UP_DETAIL = "not set up yet — complete onboarding first"
@@ -155,7 +172,7 @@ class SmokeRun:
 JOURNEYS = (
     JourneyDefinition("configs", 5.0),
     JourneyDefinition("task_lifecycle", 8.0),
-    JourneyDefinition("mcp_startup", 20.0),
+    JourneyDefinition("mcp_startup", MCP_STARTUP_JOURNEY_TIMEOUT_SECONDS),
     JourneyDefinition("skills", 5.0),
     JourneyDefinition("hooks", 8.0),
 )
@@ -1614,7 +1631,7 @@ def check_custom_mcp_once(
                 ],
                 cwd=isolated_vault,
                 env=env,
-                timeout=1.5,
+                timeout=HANDSHAKE_TIMEOUT_SECONDS,
             )
     except (OSError, TrustRegistryError) as exc:
         return {"verdict": "UNKNOWN", "detail": _one_line(exc)}
@@ -1990,7 +2007,7 @@ def _journey_mcp_startup(vault: Path, _release_root: Path) -> dict[str, str]:
 
     statuses = []
     details = []
-    handshake_deadline = time.monotonic() + 15.0
+    handshake_deadline = time.monotonic() + MCP_STARTUP_HANDSHAKE_BUDGET_SECONDS
     handshake = None
     if any(isinstance(entry, Mapping) and entry.get("verdict") == "EXECUTE" for entry in plan["entries"]):
         expected_handshake = RUNNER_ROOT / "core" / "utils" / "mcp_handshake.py"
@@ -2085,7 +2102,7 @@ def _journey_mcp_startup(vault: Path, _release_root: Path) -> dict[str, str]:
             command,
             cwd=RUNNER_ROOT,
             env=os.environ,
-            timeout=min(1.5, handshake_budget),
+            timeout=min(HANDSHAKE_TIMEOUT_SECONDS, handshake_budget),
         )
         if result.ok:
             statuses.append("OK")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this fixes for users

`/dex-doctor` and the nightly self-check gave each built-in service only **1.5 seconds** to complete its startup handshake before declaring it **broken**. That's too aggressive: measured cold-start on a *fast* machine already spiked to 3.23s, and slower consumer hardware projects to ~10s. So a perfectly working feature could be reported "broken" purely because the machine was slow to start it — quietly eroding the exact trust the health check exists to build.

(The `10.0` default in `mcp_handshake.py` was dead code — both real call sites overrode it to 1.5s. Tell: the doctor's cheaper *import-only* check already gets 30s, while the handshake, which does strictly more work, got 1.5s.)

## The fix

- **Per-handshake timeout 1.5s → 8s**, as a named constant resolved from `DEX_MCP_HANDSHAKE_TIMEOUT` (safe fallback on missing/invalid/≤0/inf) so unusually slow setups can widen it without a code change. Applied at both call sites (the on-demand doctor probe and the smoke `mcp_startup` journey).
- **Budget hierarchy widened in lockstep** — the crucial part: raising per-server alone would just hit the 15s journey ceiling and trade one false-BROKEN for another. Now: per-server `8` < internal deadline `40` < journey cap `45` < global `60`, invariant asserted by test. Normal runs stay ~5-6s; the wider caps only bite when a server is genuinely slow.
- Left alone (already safe): the doctor import-only check (30s) and preflight (find_spec only).

## Verification

New tests prove: a server taking ~3s now returns **OK** (not BROKEN); the env override works and every invalid value (`None`, `""`, `"invalid"`, `"0"`, `"-1"`, `"nan"`, `"inf"`) falls back to 8.0 without crashing; and the budget-ordering invariant holds with exact values (60 > 45 > 40 > 8). Full suite 723 passed; ruff + all four PR gates clean.

## How this was found

A flaky *test* was the thread; pulling it revealed a real *product* bug that would have told slower-machine users their working Dex was broken — the trust engine's own diagnostics held to the honesty standard they enforce everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY