### PR TITLE
Release-channel foundation: channel-aware trust engine, beta not yet selectable (v1.60.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.60.0] - Groundwork for opt-in beta updates, with no user-visible change yet (2026-07-13)
+
+Dex now has the internal release-channel plumbing needed for a future opt-in beta. The health check understands which release line an installation belongs to, so future beta users will not get false "couldn't verify" warnings from being compared with stable code.
+
+**What this changes for you today:**
+
+* **Stable updates work exactly as before.** Existing installations still use the stable release path, including profiles that do not yet contain the new internal setting.
+* **Unverifiable channels fail safely.** Health checks report that they could not verify a missing beta release or invalid channel instead of treating it as broken or silently trusting stable code.
+* **Beta is not selectable yet.** This release adds only the safety foundation; update, rollback, and channel-switching controls will arrive separately.
+
+---
+
 ## [1.59.0] - Dex stops calling a working feature "broken" just because your machine was slow to start it (2026-07-13)
 
 Dex's health check gave built-in services just 1.5 seconds to wake up. On a slower or busy machine, a service could still be starting normally when Dex labelled it broken. Those services now get a fair eight-second window, with enough room in the overall check for the slower start to finish without changing the usual quick path.

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -18,6 +18,11 @@ email_domain: ""
 # Auto-detected from system if not set. Used for time-of-day greetings and focus time calculations.
 timezone: ""
 
+# Update Channel
+# Additional channels are reserved for a future release.
+updates:
+  channel: stable
+
 # Role Intelligence
 # This section is populated during onboarding based on the role definition
 role_context:

--- a/System/user-profile.example.yaml
+++ b/System/user-profile.example.yaml
@@ -18,6 +18,11 @@ email_domain: ""
 # Auto-detected from system if not set. Used for time-of-day greetings and focus time calculations.
 timezone: ""
 
+# Update Channel
+# Additional channels are reserved for a future release.
+updates:
+  channel: stable
+
 # Role Intelligence
 # This section is populated during onboarding based on the role definition
 role_context:

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -23,6 +23,11 @@ company_size: ""  # options: startup (1-100), scaling (100-1000), enterprise (10
 # Multiple domains: "pendo.io, pendo.com"
 email_domain: ""
 
+# Update Channel
+# Additional channels are reserved for a future release.
+updates:
+  channel: stable
+
 # Communication Preferences
 # How the AI adapts its tone and language when working with you
 communication:

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -23,11 +23,6 @@ company_size: ""  # options: startup (1-100), scaling (100-1000), enterprise (10
 # Multiple domains: "pendo.io, pendo.com"
 email_domain: ""
 
-# Update Channel
-# Additional channels are reserved for a future release.
-updates:
-  channel: stable
-
 # Communication Preferences
 # How the AI adapts its tone and language when working with you
 communication:

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from core.utils import doctor
+from core.utils import doctor, release_channel
 
 DOCTOR_PATH = Path(__file__).resolve().parents[1] / "utils" / "doctor.py"
 NOW = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
@@ -169,7 +169,11 @@ def _git(repo, *args, check=True):
     return result
 
 
-def _drift_context(tmp_path, *, release_ref=True):
+def _remote_release_ref(channel):
+    return f"refs/remotes/{release_channel.release_ref_candidates(channel)[0]}"
+
+
+def _drift_context(tmp_path, *, release_ref=True, channel=None):
     vault = tmp_path / "drift-vault"
     vault.mkdir()
     _git(vault, "init")
@@ -201,7 +205,10 @@ def _drift_context(tmp_path, *, release_ref=True):
     )
     integrations = vault / "System" / "integrations"
     integrations.mkdir(parents=True)
-    (vault / "System" / "user-profile.yaml").write_text("name: Original\n")
+    profile = "name: Original\n"
+    if channel is not None:
+        profile += f"updates:\n  channel: {channel}\n"
+    (vault / "System" / "user-profile.yaml").write_text(profile)
     (vault / "System" / "pillars.yaml").write_text("pillars: []\n")
     (integrations / "calendar.yaml").write_text("enabled: false\n")
     _git(
@@ -217,7 +224,8 @@ def _drift_context(tmp_path, *, release_ref=True):
     )
     _git(vault, "commit", "-m", "release fixture")
     if release_ref:
-        _git(vault, "update-ref", "refs/remotes/upstream/release", "HEAD")
+        available_channel = channel if channel in {"stable", "beta"} else "stable"
+        _git(vault, "update-ref", _remote_release_ref(available_channel), "HEAD")
 
     home = tmp_path / "drift-home"
     home.mkdir()
@@ -1463,6 +1471,41 @@ def test_core_drift_is_ok_for_a_clean_release_checkout(tmp_path):
     assert doctor._probe_core_drift(drift_context).verdict == "OK"
 
 
+def test_core_drift_missing_channel_keeps_stable_release_ref_behavior(tmp_path):
+    drift_context = _drift_context(tmp_path)
+
+    assert doctor._upstream_release_ref(drift_context) == _remote_release_ref("stable")
+    assert doctor._probe_core_drift(drift_context).verdict == "OK"
+
+
+def test_core_drift_is_ok_for_clean_beta_head_against_beta_release(tmp_path):
+    drift_context = _drift_context(tmp_path, channel="beta")
+
+    result = doctor._probe_core_drift(drift_context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "No tracked shipped files differ from the installed release"
+
+
+def test_core_drift_beta_without_beta_ref_is_unknown_and_does_not_use_stable(tmp_path):
+    drift_context = _drift_context(tmp_path, release_ref=False, channel="beta")
+    _git(drift_context.repo_root, "update-ref", _remote_release_ref("stable"), "HEAD")
+
+    result = doctor._probe_core_drift(drift_context)
+
+    assert result.verdict == "UNKNOWN"
+    assert result.detail == "beta channel selected but no beta release found — staying on stable is safe"
+
+
+def test_core_drift_invalid_channel_is_unknown_and_does_not_use_stable(tmp_path):
+    drift_context = _drift_context(tmp_path, channel="nightly")
+
+    result = doctor._probe_core_drift(drift_context)
+
+    assert result.verdict == "UNKNOWN"
+    assert result.detail == "couldn't verify your update channel"
+
+
 def test_core_drift_never_executes_repo_fsmonitor_or_ambient_git(
     monkeypatch,
     tmp_path,
@@ -1514,7 +1557,7 @@ def test_core_drift_reports_modified_installed_file_deleted_by_latest_release(tm
     (vault / "core" / "shipped.py").unlink()
     _git(vault, "add", "-u", "--", "core/shipped.py")
     _git(vault, "commit", "-m", "delete shipped file")
-    _git(vault, "update-ref", "refs/remotes/upstream/release", "HEAD")
+    _git(vault, "update-ref", _remote_release_ref("stable"), "HEAD")
     _git(vault, "checkout", "--detach", installed)
     (vault / "core" / "shipped.py").write_text("SHIPPED = 2\n")
 

--- a/core/tests/test_release_channel.py
+++ b/core/tests/test_release_channel.py
@@ -1,0 +1,86 @@
+"""Contract tests for the per-machine release-channel resolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.utils.release_channel import read_channel, release_branch, release_ref_candidates
+
+
+def _write_profile(vault_root: Path, content: str) -> None:
+    profile = vault_root / "System" / "user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    profile.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("name: Test User\n", "stable"),
+        ("updates: {}\n", "stable"),
+        ("updates:\n  channel: stable\n", "stable"),
+        ("updates:\n  channel: beta\n", "beta"),
+        ("updates:\n  channel: Stable\n", "invalid"),
+        ("updates:\n  channel: nightly\n", "invalid"),
+        ("updates:\n  channel: null\n", "invalid"),
+        ("updates:\n  channel: 1\n", "invalid"),
+    ],
+)
+def test_read_channel_resolves_present_and_absent_values(
+    tmp_path: Path,
+    content: str,
+    expected: str,
+) -> None:
+    _write_profile(tmp_path, content)
+
+    assert read_channel(tmp_path) == expected
+
+
+def test_read_channel_defaults_to_stable_when_profile_is_missing(tmp_path: Path) -> None:
+    assert read_channel(tmp_path) == "stable"
+
+
+def test_read_channel_returns_invalid_when_profile_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_profile(tmp_path, "updates:\n  channel: beta\n")
+
+    def refuse_read(_path: Path, *_args: object, **_kwargs: object) -> str:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", refuse_read)
+
+    assert read_channel(tmp_path) == "invalid"
+
+
+def test_read_channel_returns_invalid_when_profile_yaml_cannot_be_parsed(tmp_path: Path) -> None:
+    _write_profile(tmp_path, "updates:\n  channel: [beta\n")
+
+    assert read_channel(tmp_path) == "invalid"
+
+
+@pytest.mark.parametrize(
+    ("channel", "expected"),
+    [
+        ("stable", ("upstream/release", "origin/release")),
+        ("beta", ("upstream/release-beta", "origin/release-beta")),
+        ("invalid", ()),
+        ("nightly", ()),
+    ],
+)
+def test_release_ref_candidates_are_channel_specific(
+    channel: str,
+    expected: tuple[str, ...],
+) -> None:
+    assert release_ref_candidates(channel) == expected
+
+
+@pytest.mark.parametrize(
+    ("channel", "expected"),
+    [("stable", "release"), ("beta", "release-beta"), ("invalid", None), ("nightly", None)],
+)
+def test_release_branch_is_channel_specific(channel: str, expected: str | None) -> None:
+    assert release_branch(channel) == expected

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from core.utils.validators import validate_mcp_config, validate_skill_frontmatter
+from core.utils.validators import (
+    validate_mcp_config,
+    validate_skill_frontmatter,
+    validate_user_profile_config,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
@@ -99,6 +103,44 @@ def test_validate_mcp_config_accepts_resolved_stdio_entries() -> None:
 
     assert validate_mcp_config(config) == []
     assert validate_mcp_config('{"mcpServers":{"server":{"command":"python","args":[]}}}') == []
+
+
+@pytest.mark.parametrize(
+    "config",
+    [{}, {"updates": {}}, {"updates": {"channel": "stable"}}, {"updates": {"channel": "beta"}}],
+)
+def test_validate_user_profile_accepts_supported_or_absent_update_channel(
+    config: object,
+) -> None:
+    assert validate_user_profile_config(config) == []
+
+
+@pytest.mark.parametrize("channel", ["nightly", "Stable", "", None, 1, True])
+def test_validate_user_profile_warns_for_invalid_update_channel(channel: object) -> None:
+    errors = validate_user_profile_config({"updates": {"channel": channel}})
+
+    assert errors == ["updates.channel must be stable or beta"]
+
+
+def test_validate_user_profile_requires_updates_to_be_an_object() -> None:
+    assert validate_user_profile_config({"updates": "stable"}) == ["updates must be an object"]
+
+
+@pytest.mark.parametrize(
+    "profile_path",
+    [
+        REPO_ROOT / "System" / "user-profile.yaml",
+        REPO_ROOT / "System" / "user-profile-template.yaml",
+        REPO_ROOT / "System" / "user-profile.example.yaml",
+    ],
+    ids=lambda path: path.name,
+)
+def test_shipped_user_profiles_explicitly_default_to_stable(profile_path: Path) -> None:
+    import yaml
+
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+
+    assert profile["updates"] == {"channel": "stable"}
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -135,7 +135,28 @@ def test_validate_user_profile_requires_updates_to_be_an_object() -> None:
     ],
     ids=lambda path: path.name,
 )
-def test_shipped_user_profiles_explicitly_default_to_stable(profile_path: Path) -> None:
+def test_shipped_user_profiles_never_default_to_non_stable(profile_path: Path) -> None:
+    # The resolver treats a missing channel as stable, so a shipped profile may omit
+    # the block entirely (the placeholder does — leaving it byte-clean for the PII gate).
+    # What must never happen is a shipped profile silently defaulting to beta/invalid.
+    import yaml
+
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    channel = (profile.get("updates") or {}).get("channel", "stable")
+    assert channel == "stable"
+
+
+@pytest.mark.parametrize(
+    "profile_path",
+    [
+        REPO_ROOT / "System" / "user-profile-template.yaml",
+        REPO_ROOT / "System" / "user-profile.example.yaml",
+    ],
+    ids=lambda path: path.name,
+)
+def test_profile_templates_document_the_stable_default(profile_path: Path) -> None:
+    # New profiles are seeded from the template/example, so those must carry the
+    # explicit default. The shipped placeholder is exempt (see the test above).
     import yaml
 
     profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from core.utils import smoke
+from core.utils import release_channel, smoke
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -87,6 +87,10 @@ def _tree_hash(root: Path) -> str:
 
 def _definition(journey_id: str, timeout: float = 5.0) -> smoke.JourneyDefinition:
     return smoke.JourneyDefinition(journey_id, timeout)
+
+
+def _remote_release_ref(channel: str) -> str:
+    return f"refs/remotes/{release_channel.release_ref_candidates(channel)[0]}"
 
 
 def test_mcp_handshake_timeout_env_override_changes_effective_timeout(
@@ -216,7 +220,7 @@ def _release_repo(tmp_path: Path, *, release_validators: str | None = None) -> P
     subprocess.run(["git", "add", "--", "core"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "--quiet", "-m", "release fixture"], cwd=repo, check=True)
     subprocess.run(
-        ["git", "update-ref", "refs/remotes/upstream/release", "HEAD"],
+        ["git", "update-ref", _remote_release_ref("stable"), "HEAD"],
         cwd=repo,
         check=True,
     )
@@ -236,6 +240,12 @@ def _release_repo(tmp_path: Path, *, release_validators: str | None = None) -> P
             check=True,
         )
     return repo
+
+
+def _write_release_channel(repo: Path, channel: str) -> None:
+    profile = repo / "System" / "user-profile.yaml"
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    profile.write_text(f"updates:\n  channel: {channel}\n", encoding="utf-8")
 
 
 def test_release_repo_fixture_copies_only_git_tracked_source_files(
@@ -586,6 +596,19 @@ def test_release_gate_ignores_untracked_runtime_artifacts(monkeypatch, tmp_path:
     monkeypatch.setattr(smoke, "RUNNER_ROOT", repo)
 
     assert smoke._release_execution_reason(repo, release_root, reference) is None
+
+
+def test_missing_channel_keeps_stable_release_gate_behavior(tmp_path: Path) -> None:
+    repo = _release_repo(tmp_path)
+
+    reference, detail = smoke._materialize_release_core(
+        repo,
+        tmp_path / "stable-release",
+        timeout_seconds=3.0,
+    )
+
+    assert reference is not None
+    assert detail == "verified installed release snapshot"
 
 
 def test_runtime_artifacts_and_untracked_code_do_not_enter_verified_journeys(
@@ -1211,6 +1234,69 @@ def test_task_lifecycle_without_release_ref_never_imports_live_work_server(tmp_p
     assert run.report["journeys"][0]["verdict"] == "UNKNOWN"
     assert "not executed for safety" in run.report["journeys"][0]["detail"]
     assert not sentinel.exists()
+
+
+def test_task_lifecycle_beta_head_matching_beta_release_is_clean(tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    repo = _release_repo(tmp_path)
+    _write_release_channel(repo, "beta")
+    subprocess.run(
+        ["git", "update-ref", _remote_release_ref("beta"), "HEAD"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "-d", _remote_release_ref("stable")],
+        cwd=repo,
+        check=True,
+    )
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=repo,
+        journey_definitions=(_definition("task_lifecycle", 8.0),),
+    )
+
+    assert run.exit_code == 0
+    assert run.report["journeys"][0]["verdict"] == "OK"
+
+
+def test_task_lifecycle_beta_without_beta_ref_is_unknown_and_refuses_execution(
+    tmp_path: Path,
+) -> None:
+    vault = _write_valid_vault(tmp_path)
+    repo = _release_repo(tmp_path)
+    _write_release_channel(repo, "beta")
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=repo,
+        journey_definitions=(_definition("task_lifecycle"),),
+    )
+
+    result = run.report["journeys"][0]
+    assert run.exit_code == 0
+    assert result["verdict"] == "UNKNOWN"
+    assert "beta channel selected but no beta release found — staying on stable is safe" in result["detail"]
+    assert "not executed for safety" in result["detail"]
+
+
+def test_task_lifecycle_invalid_channel_is_unknown_and_refuses_execution(tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    repo = _release_repo(tmp_path)
+    _write_release_channel(repo, "nightly")
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=repo,
+        journey_definitions=(_definition("task_lifecycle"),),
+    )
+
+    result = run.report["journeys"][0]
+    assert run.exit_code == 0
+    assert result["verdict"] == "UNKNOWN"
+    assert "couldn't verify your update channel" in result["detail"]
+    assert "not executed for safety" in result["detail"]
 
 
 def test_task_lifecycle_runs_verified_release_and_refuses_dependency_drift(tmp_path: Path) -> None:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -27,7 +27,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from core import paths
-from core.utils import preflight
+from core.utils import preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_SAFE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
@@ -1419,11 +1419,13 @@ def _git_result(context: DoctorContext, *arguments: str) -> subprocess.Completed
     )
 
 
-def _upstream_release_ref(context: DoctorContext) -> str | None:
-    for candidate in ("refs/remotes/upstream/release", "refs/remotes/origin/release"):
-        result = _git_result(context, "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}")
+def _upstream_release_ref(context: DoctorContext, channel: str | None = None) -> str | None:
+    resolved_channel = channel or release_channel.read_channel(context.vault_root)
+    for candidate in release_channel.release_ref_candidates(resolved_channel):
+        remote_ref = f"refs/remotes/{candidate}"
+        result = _git_result(context, "rev-parse", "--verify", "--quiet", f"{remote_ref}^{{commit}}")
         if result.returncode == 0:
-            return candidate
+            return remote_ref
     return None
 
 
@@ -1604,8 +1606,16 @@ def _worktree_matches_release_blob(
 
 
 def _probe_core_drift(context: DoctorContext) -> ProbeResult:
-    release_ref = _upstream_release_ref(context)
+    channel = release_channel.read_channel(context.vault_root)
+    release_ref = _upstream_release_ref(context, channel)
     if release_ref is None:
+        if channel == "beta":
+            return ProbeResult(
+                "UNKNOWN",
+                "beta channel selected but no beta release found — staying on stable is safe",
+            )
+        if channel == "invalid":
+            return ProbeResult("UNKNOWN", "couldn't verify your update channel")
         return ProbeResult("UNKNOWN", "no upstream remote — can't compare")
 
     merge_base = _git_result(context, "merge-base", "HEAD", release_ref)

--- a/core/utils/release_channel.py
+++ b/core/utils/release_channel.py
@@ -1,0 +1,50 @@
+"""Resolve the installed Dex release channel and its trusted Git refs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+VALID_CHANNELS = frozenset({"stable", "beta"})
+
+
+def read_channel(vault_root: str | Path) -> str:
+    """Return the configured channel, the stable default, or ``invalid``."""
+    profile_path = Path(vault_root) / "System" / "user-profile.yaml"
+    try:
+        content = profile_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "stable"
+    except OSError:
+        return "invalid"
+
+    try:
+        profile = yaml.safe_load(content)
+    except Exception:
+        return "invalid"
+    if not isinstance(profile, Mapping) or "updates" not in profile:
+        return "stable"
+    updates = profile["updates"]
+    if not isinstance(updates, Mapping) or "channel" not in updates:
+        return "stable"
+    channel = updates["channel"]
+    return channel if isinstance(channel, str) and channel in VALID_CHANNELS else "invalid"
+
+
+def release_ref_candidates(channel: str) -> tuple[str, ...]:
+    """Return trusted remote refs for ``channel`` in precedence order."""
+    branch = release_branch(channel)
+    if branch is None:
+        return ()
+    return (f"upstream/{branch}", f"origin/{branch}")
+
+
+def release_branch(channel: str) -> str | None:
+    """Return the release branch for ``channel``, if it is valid."""
+    if channel == "stable":
+        return "release"
+    if channel == "beta":
+        return "release-beta"
+    return None

--- a/core/utils/release_channel.py
+++ b/core/utils/release_channel.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from pathlib import Path
 
-import yaml
-
 VALID_CHANNELS = frozenset({"stable", "beta"})
 
 
@@ -21,6 +19,8 @@ def read_channel(vault_root: str | Path) -> str:
         return "invalid"
 
     try:
+        import yaml
+
         profile = yaml.safe_load(content)
     except Exception:
         return "invalid"

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -31,6 +31,8 @@ if str(RUNNER_ROOT) in sys.path:
     sys.path.remove(str(RUNNER_ROOT))
 sys.path.insert(0, str(RUNNER_ROOT))
 
+from core.utils import release_channel
+
 SCHEMA_VERSION = 1
 HISTORY_LIMIT = 120
 DEFAULT_MCP_HANDSHAKE_TIMEOUT_SECONDS = 8.0
@@ -859,9 +861,10 @@ def _materialize_release_core(
     timeout_seconds: float,
 ) -> tuple[str | None, str]:
     """Extract regular ``core`` files from the installed release Git tree."""
-    reference = _git_release_ref(repo_root)
+    channel = release_channel.read_channel(repo_root)
+    reference = _git_release_ref(repo_root, channel)
     if reference is None:
-        return None, "no upstream/release or origin/release ref is available"
+        return None, _missing_release_ref_reason(channel)
     command = _git_command(repo_root, "archive", "--format=tar", reference, "--", "core")
     if command is None:
         return None, "trusted system git is unavailable"
@@ -1814,8 +1817,9 @@ def _journey_task_lifecycle(vault: Path, _release_root: Path) -> dict[str, str]:
     return {"verdict": "OK", "detail": "create_task and update_task_status preserved Tasks.md integrity"}
 
 
-def _git_release_ref(repo_root: Path) -> str | None:
-    for ref in ("upstream/release", "origin/release"):
+def _git_release_ref(repo_root: Path, channel: str | None = None) -> str | None:
+    resolved_channel = channel or release_channel.read_channel(repo_root)
+    for ref in release_channel.release_ref_candidates(resolved_channel):
         verify_command = _git_command(repo_root, "rev-parse", "--verify", f"{ref}^{{commit}}")
         if verify_command is None:
             return None
@@ -1843,6 +1847,15 @@ def _git_release_ref(repo_root: Path) -> str | None:
     return None
 
 
+def _missing_release_ref_reason(channel: str, *, server: bool = False) -> str:
+    if channel == "beta":
+        return "beta channel selected but no beta release found — staying on stable is safe"
+    if channel == "invalid":
+        return "couldn't verify your update channel"
+    suffix = " to verify the server" if server else ""
+    return f"no upstream/release or origin/release ref is available{suffix}"
+
+
 def _git_tree_paths(repo_root: Path, treeish: str) -> set[str] | None:
     command = _git_command(repo_root, "ls-tree", "-r", "-z", "--name-only", treeish, "--", "core")
     if command is None:
@@ -1868,7 +1881,7 @@ def _release_execution_reason(
     reference: str | None,
 ) -> str | None:
     if reference is None or release_root is None:
-        return "no upstream/release or origin/release ref is available"
+        return _missing_release_ref_reason(release_channel.read_channel(repo_root))
     if release_root.is_symlink() or not (release_root / "core").is_dir():
         return "the verified release snapshot is unavailable"
     reference_paths = _git_tree_paths(repo_root, reference)
@@ -1934,9 +1947,10 @@ def _script_is_unmodified(
     if current.is_symlink() or not current.is_file():
         return False, "server target is missing or symlinked"
 
-    reference = reference or _git_release_ref(repo_root)
+    channel = release_channel.read_channel(repo_root)
+    reference = reference or _git_release_ref(repo_root, channel)
     if reference is None:
-        return False, "no upstream/release or origin/release ref is available to verify the server"
+        return False, _missing_release_ref_reason(channel, server=True)
     repo_relative = current.relative_to(repository).as_posix()
     command = _git_command(repo_root, "cat-file", "blob", f"{reference}:{repo_relative}")
     if command is None:

--- a/core/utils/validators.py
+++ b/core/utils/validators.py
@@ -31,10 +31,16 @@ def validate_user_profile_config(config: object) -> list[str]:
         "quarterly_planning",
         "analytics",
         "calendar",
+        "updates",
     )
     for field in object_fields:
         if field in config and not isinstance(config[field], Mapping):
             errors.append(f"{field} must be an object")
+    updates = config.get("updates")
+    if isinstance(updates, Mapping) and "channel" in updates:
+        channel = updates["channel"]
+        if not isinstance(channel, str) or channel not in {"stable", "beta"}:
+            errors.append("updates.channel must be stable or beta")
     return errors
 
 

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -99,6 +99,19 @@ content-addressed filename, and executed from the verified bytes. If any identit
 release verification fails, the affected journey is `UNKNOWN` instead of falling back to
 live code.
 
+### Release-channel trust foundation
+
+`core/utils/release_channel.py` is the single source of truth for mapping the per-machine
+`updates.channel` profile value to trusted release refs. A missing channel keeps the
+existing stable behavior (`upstream/release`, then `origin/release`). Internally, beta maps
+only to `upstream/release-beta` or `origin/release-beta`; invalid or unreadable channel
+configuration maps to no ref at all. Doctor and smoke therefore report `UNKNOWN` and refuse
+trusted execution when the selected channel cannot be verified, rather than comparing or
+materializing code from another channel.
+
+This is foundation-only. Beta is not user-selectable yet, no beta release branch is
+published, and update, rollback, and channel-switching workflows remain unchanged.
+
 The one-off token prevents the automatic/recurring health checks from ever launching a
 one-off custom server and makes each explicit approval single-use. It is not protection
 against another program running as you, which could run your code directly regardless.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this is

PR-1 of the two-channel (stable + beta) release system — the **safe internal foundation only**. Beta is NOT user-selectable yet (no `release-beta` branch exists, no skill invites it). Stable behavior is semantically unchanged. This exists so the trust engine won't false-alarm future beta users.

## The hazard it designs out

The trust engine diffs your installed code against the `release` (stable) branch in two trust-root spots — doctor's `core.drift` and smoke's release-verification/execution gate. A future beta user (HEAD from `release-beta`) would be reported as drifted/"couldn't verify." This teaches both to honor the configured channel.

## What's in it

- **`core/utils/release_channel.py`** — one resolver: `read_channel` (missing→stable, unreadable/unparseable/typo→`invalid`, never silently stable for a corrupt value), `release_ref_candidates`, `release_branch`. Replaces the hard-coded two-ref list that was copy-pasted around.
- **doctor + smoke** now resolve their release refs through it. Stable → the exact same refs and error strings as today (existing assertions preserved). Beta-selected-but-no-beta-ref-yet → **UNKNOWN** with "beta channel selected but no beta release found — staying on stable is safe". Invalid channel → **UNKNOWN** "couldn't verify your update channel". Never a false BROKEN, never a silent stable diff.
- **Schema:** `updates.channel: stable` default documented in the *template* + *example* (not the shipped placeholder — see below); `validators.py` constrains it to stable|beta.

## Two notes for reviewers

1. **The shipped `System/user-profile.yaml` is intentionally left untouched.** The resolver defaults a missing channel to stable, so the live placeholder needs no edit — and editing it trips the PII gate. The default lives in the template (which onboarding uses for new profiles).
2. **Found while doing this (separate follow-up):** the PII gate's `user-profile.yaml`-vs-template *byte-identical* check assumes those two files are identical, but they're legitimately different in the repo — so it would block any genuine future edit to the shipped placeholder. Not blocking here (PR-1 doesn't touch the profile), but the check should compare "identity values are empty" rather than byte-identity. Flagged for a small follow-up.

## Verification

180 channel/doctor/smoke tests pass (incl. the H2-fix: beta HEAD vs release-beta = clean; and invalid-channel refuses execution). Ruff clean, all four PR diff gates pass (PII included, after the fix above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyQh6E5BNVyrMzwkKZZHNY