### PR TITLE
fix: Session_Learnings capture pipeline was silently a no-op

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -13,7 +13,10 @@
 
 CLAUDE_DIR="$CLAUDE_PROJECT_DIR"
 SESSION_LEARNINGS_DIR="$CLAUDE_DIR/System/Session_Learnings"
-TRANSCRIPT_PATH="$1"  # Passed as argument by Claude Code
+
+# Claude Code delivers hook data as JSON on stdin, not as $1 or an env var.
+HOOK_INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 
 # Ensure session learnings directory exists
 mkdir -p "$SESSION_LEARNINGS_DIR"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh \"$transcript_path\""
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh"
           }
         ]
       }

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -260,7 +260,9 @@ Scan today's conversation for learnings:
 3. **Documentation gaps** — Were there questions about how the system works?
 4. **Workflow inefficiencies** — Did any task take longer than it should?
 
-Write to `System/Session_Learnings/YYYY-MM-DD.md`.
+Write to `System/Session_Learnings/YYYY-MM-DD.md`, following the exact template in
+`System/Session_Learnings/README.md` (the format matters — other tools, like
+`synthesize_learnings`, parse these entries by their exact markdown shape).
 
 Then ask: "I captured [N] learnings from today's session. Anything else you'd like to add?"
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -105,18 +105,9 @@ Before asking the user anything, reflect on today's session and automatically ex
    - Were there repetitive manual steps?
    - Opportunities for automation?
 
-**For each learning identified, write to `00-Inbox/Session_Learnings/YYYY-MM-DD.md`:**
-
-```markdown
-## HH:MM - [Short title]
-
-**What happened:** [Specific situation from today's session]
-**Why it matters:** [Impact on workflows/system]
-**Suggested fix:** [Specific action with file paths if applicable]
-**Status:** pending
-
----
-```
+**For each learning identified, write to `System/Session_Learnings/YYYY-MM-DD.md`, following the
+exact template in `System/Session_Learnings/README.md`** (the format matters — other tools parse
+these entries by their exact markdown shape).
 
 **Then ask the user:** "I captured [N] learnings from today's session. Anything else you'd like to add?"
 

--- a/06-Resources/Dex_System/Memory_Ownership.md
+++ b/06-Resources/Dex_System/Memory_Ownership.md
@@ -15,7 +15,12 @@
 ## Dex Session Memory (learning-heartbeat)
 **Owns:** Operational decisions, commitments, work patterns, system learnings
 **Examples:** "Agreed to deliver DACH deck by Friday", "Meeting-prep skill needs more account context"
-**How it works:** Captured at session Stop, stored in System/Session_Learnings/
+**How it works today:** Not yet automatic. `SessionEnd` only logs a timestamp/transcript
+pointer to `System/Session_Learnings/`; actual extraction (mistakes, preferences, doc gaps)
+runs as an LLM-reasoning step inside `/review` and `/daily-review`, and only fires when one
+of those is run to completion. A hook alone can't do the judgment call — see
+`Background_Processing_Guide.md` for the planned Stop-hook automation that would close this
+gap and make "learning-heartbeat" live up to its name.
 **Dex action:** Filter for operational only (WP-2.1).
 
 ## Dex Vault Search (QMD)

--- a/System/Session_Learnings/README.md
+++ b/System/Session_Learnings/README.md
@@ -1,23 +1,37 @@
 # Session Learnings
 
+> Note: this directory is gitignored (see `.gitignore`) except for this README — it's
+> grandfathered in from before that rule was added, and intentionally kept as the canonical
+> schema reference below. Don't delete it as part of a gitignore cleanup.
+
 System improvements discovered during work sessions.
 
 ## What Goes Here
 
-Meta-feedback about Dex itself, captured during `/review`:
+Meta-feedback about Dex itself, captured during `/review` or `/daily-review`:
 
 - **Mistakes or corrections** — Things that went wrong and how to fix them
 - **Preferences mentioned** — Workflow preferences you shared
 - **Documentation gaps** — Places where docs were unclear or missing
 - **Workflow inefficiencies** — Friction points discovered
 
-## Format
+## Format (exact — other tools parse this)
 
-Each learning includes:
-- **What happened** — Specific situation
-- **Why it matters** — Impact on system/workflow
-- **Suggested fix** — Specific action with file paths
-- **Status** — pending, implemented, or won't-fix
+`mcp__dex-improvements-mcp__synthesize_learnings` parses entries by this literal markdown
+shape (`## HH:MM - Title`, `**Field:**` labels, a `**Status:** pending` value, blocks
+separated by `\n---\n`). Entries that don't match this exactly are silently skipped by that
+tool — so match it precisely:
+
+```markdown
+## HH:MM - [Short title]
+
+**What happened:** [Specific situation]
+**Why it matters:** [Impact on system/workflow]
+**Suggested fix:** [Specific action, with file paths if applicable]
+**Status:** pending
+
+---
+```
 
 ## Naming Convention
 
@@ -25,7 +39,9 @@ Each learning includes:
 
 ## Workflow
 
-1. **Capture** — Happens automatically during `/review` (daily review)
+1. **Capture** — Currently requires running `/review` or `/daily-review` to completion; the
+   `SessionEnd` hook alone only logs a timestamp, it doesn't extract learnings (that step
+   needs LLM judgment a hook script can't do on its own).
 2. **Review** — Periodically check pending learnings via `/dex-whats-new`
 3. **Implement** — Fix documentation gaps or system issues
 4. **Update status** — Mark as implemented when done


### PR DESCRIPTION
## What Changed

Session_Learnings files (`System/Session_Learnings/YYYY-MM-DD.md`) were always empty. Two stacked bugs:

1. `SessionEnd` passed `transcript_path` to `session-end.sh` as a shell variable (`"$transcript_path"` in `settings.json`), but Claude Code delivers hook data as JSON on **stdin**, not an env var. The variable was always empty, so the hook's logging block never ran — you'd get the file header and nothing else, forever.
2. `/review`'s learning-capture step wrote to `00-Inbox/Session_Learnings/` — a folder nothing reads and that never gets created — while `/daily-review`, `Memory_Ownership.md`, and every consumer (`dex-whats-new`, `synthesize_learnings`, `week-review`) expect `System/Session_Learnings/`.

While fixing this I found a third, related gap: `/daily-review`'s own learning-capture step has no template at all, so even a successful run could produce entries that `synthesize_learnings`' strict regex parser (`## HH:MM - Title` / `**Field:**` labels / `**Status:** pending` / `\n---\n` separators) would silently drop.

**Fixes:**
- `session-end.sh` now reads `transcript_path` from stdin JSON via `jq`, matching the pattern already used by `check-project-readme.cjs` and `dex-safety-guard.sh`
- `/review` now writes to the same folder as `/daily-review`
- `/review` and `/daily-review` both point at one canonical schema in `System/Session_Learnings/README.md` instead of one skill having its own copy and the other having none
- `README.md`'s format section is now the exact literal template the regex parser requires
- `Memory_Ownership.md` no longer claims capture is automatic ("at session Stop") — today it requires running `/review` or `/daily-review` to completion. (A follow-up PR will build the automation to make that claim true again.)

## Test Plan

- `bash -n` / `python3 -m json.tool` syntax checks on the changed hook/settings files
- Simulated the hook exactly as Claude Code invokes it — piped `{"transcript_path": "...", "session_id": "..."}` via stdin, confirmed the log block now appears; also tested with `{}` (no transcript_path) to confirm it still creates the header without erroring
- Built a test file using the README's exact template and ran it directly through `parse_session_learnings` (`core/mcp/dex_improvements_server.py`) to confirm it parses — this is what `synthesize_learnings` depends on
- Commands run locally: see above; no automated test suite covers this hook, tested by direct invocation

## Risk & Rollback

- Risk level: low — no new behavior, just fixes a pipeline that was already documented/intended but never worked
- Rollback: revert the commit; no data migrations or schema changes involved

## Docs Impact

- Files updated: `System/Session_Learnings/README.md`, `06-Resources/Dex_System/Memory_Ownership.md` (both now describe actual current behavior)