### PR TITLE
feat: automatic session-learning capture (learning-heartbeat Stop hook)

### DIFF
--- a/.claude/hooks/learning-heartbeat.cjs
+++ b/.claude/hooks/learning-heartbeat.cjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Stop hook: automatic session-learning capture (see Memory_Ownership.md "learning-heartbeat").
+ *
+ * Session_Learnings/YYYY-MM-DD.md only ever gets populated today via /review or
+ * /daily-review, which the user has to remember to run. This hook closes that gap: a
+ * hook can't reason about the conversation itself (it's a dumb script), so when a
+ * session looks substantive enough to be worth reflecting on, it blocks the Stop once
+ * and asks the live Claude session to do the actual extraction, using the canonical
+ * template in System/Session_Learnings/README.md.
+ *
+ * Fires at most once per (session, calendar day) — debounced via a state file, not
+ * just stop_hook_active, since Stop fires on every turn and stop_hook_active only
+ * guards the single forced continuation, not the rest of the session.
+ *
+ * Opt-out: System/user-profile.yaml -> learning_heartbeat.enabled: false
+ *
+ * v1 heuristic: "substantive" = >=3 user turns OR >=8 tool calls in the transcript.
+ * This is a cheap proxy, not a precise measure — tune later if it over/under-fires.
+ *
+ * Verified empirically (in a fork with an additional local Stop hook also using
+ * decision:block): when two Stop hooks in the same array both want to block, Claude
+ * Code surfaces BOTH reasons rather than dropping one — safe to run alongside other
+ * Stop hooks that also use decision:block.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MIN_USER_TURNS = 3;
+const MIN_TOOL_CALLS = 8;
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function todayStr() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function isHeartbeatEnabled(vaultRoot) {
+  const profilePath = path.join(vaultRoot, 'System', 'user-profile.yaml');
+  try {
+    const content = fs.readFileSync(profilePath, 'utf8');
+    const m = content.match(/learning_heartbeat:\s*\n(?:[ \t]+.*\n?)*/);
+    if (!m) return true; // field absent -> default on
+    const block = m[0];
+    const enabledMatch = block.match(/enabled:\s*(true|false)/);
+    if (!enabledMatch) return true;
+    return enabledMatch[1] !== 'false';
+  } catch {
+    return true; // no profile / unreadable -> default on
+  }
+}
+
+function countSignals(transcriptPath) {
+  let lines;
+  try {
+    lines = fs.readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return { userTurns: 0, toolCalls: 0 };
+  }
+
+  let userTurns = 0;
+  let toolCalls = 0;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const msg = parsed?.message;
+    if (!msg) continue;
+    if (msg.role === 'user') {
+      const c = msg.content;
+      const isHumanText =
+        typeof c === 'string' ||
+        (Array.isArray(c) && c.some((b) => b?.type === 'text'));
+      if (isHumanText) userTurns++;
+    }
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block?.type === 'tool_use') toolCalls++;
+      }
+    }
+  }
+  return { userTurns, toolCalls };
+}
+
+function loadState(statePath) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    if (raw && raw.date === todayStr() && Array.isArray(raw.sessionsExtractedToday)) {
+      return raw;
+    }
+  } catch {
+    // missing/corrupt -> fresh state
+  }
+  return { date: todayStr(), sessionsExtractedToday: [] };
+}
+
+function saveStateAtomic(statePath, state) {
+  const dir = path.dirname(statePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmpPath = `${statePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(state), 'utf8');
+  fs.renameSync(tmpPath, statePath);
+}
+
+function main() {
+  let input = {};
+  try {
+    input = JSON.parse(readStdin() || '{}');
+  } catch {
+    process.exit(0); // malformed input -> never block
+  }
+
+  // Avoid infinite loops: if we're already in a stop-hook-induced continuation, pass.
+  if (input.stop_hook_active) process.exit(0);
+
+  const vaultRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  try {
+    if (!isHeartbeatEnabled(vaultRoot)) process.exit(0);
+  } catch {
+    // fail open
+  }
+
+  const transcriptPath = input.transcript_path || process.env.transcript_path;
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) process.exit(0);
+
+  const sessionId = input.session_id || 'unknown-session';
+  const statePath = path.join(vaultRoot, 'System', 'Session_Learnings', '.heartbeat-state.json');
+
+  let state;
+  try {
+    state = loadState(statePath);
+  } catch {
+    process.exit(0); // fail open on any state-file trouble
+  }
+
+  if (state.sessionsExtractedToday.includes(sessionId)) process.exit(0);
+
+  const { userTurns, toolCalls } = countSignals(transcriptPath);
+  if (userTurns < MIN_USER_TURNS && toolCalls < MIN_TOOL_CALLS) process.exit(0);
+
+  // Mark this session as extracted for today BEFORE blocking, so a failed or
+  // interrupted forced-turn can never cause a re-block loop for the rest of the day.
+  state.sessionsExtractedToday.push(sessionId);
+  try {
+    saveStateAtomic(statePath, state);
+  } catch {
+    process.exit(0); // if we can't record the debounce, don't risk blocking repeatedly
+  }
+
+  const reason =
+    'Learning heartbeat (Memory_Ownership.md): this looks like a substantive session. ' +
+    'Before finishing, reflect on it and extract any learnings worth keeping — mistakes ' +
+    'or corrections, preferences mentioned, documentation gaps, workflow inefficiencies. ' +
+    'Follow the exact template in System/Session_Learnings/README.md and write conforming ' +
+    'entries to System/Session_Learnings/YYYY-MM-DD.md. If nothing meets the bar, say so ' +
+    "in one short line and stop — don't fabricate entries. Keep this brief either way.";
+
+  process.stdout.write(JSON.stringify({ decision: 'block', reason }));
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -13,7 +13,10 @@
 
 CLAUDE_DIR="$CLAUDE_PROJECT_DIR"
 SESSION_LEARNINGS_DIR="$CLAUDE_DIR/System/Session_Learnings"
-TRANSCRIPT_PATH="$1"  # Passed as argument by Claude Code
+
+# Claude Code delivers hook data as JSON on stdin, not as $1 or an env var.
+HOOK_INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 
 # Ensure session learnings directory exists
 mkdir -p "$SESSION_LEARNINGS_DIR"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,11 @@
           {
             "type": "command",
             "command": "afplay /System/Library/Sounds/Ping.aiff"
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/learning-heartbeat.cjs",
+            "statusMessage": "Checking for session learnings worth capturing..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh \"$transcript_path\""
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh"
           }
         ]
       }

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -260,7 +260,9 @@ Scan today's conversation for learnings:
 3. **Documentation gaps** — Were there questions about how the system works?
 4. **Workflow inefficiencies** — Did any task take longer than it should?
 
-Write to `System/Session_Learnings/YYYY-MM-DD.md`.
+Write to `System/Session_Learnings/YYYY-MM-DD.md`, following the exact template in
+`System/Session_Learnings/README.md` (the format matters — other tools, like
+`synthesize_learnings`, parse these entries by their exact markdown shape).
 
 Then ask: "I captured [N] learnings from today's session. Anything else you'd like to add?"
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -105,18 +105,9 @@ Before asking the user anything, reflect on today's session and automatically ex
    - Were there repetitive manual steps?
    - Opportunities for automation?
 
-**For each learning identified, write to `00-Inbox/Session_Learnings/YYYY-MM-DD.md`:**
-
-```markdown
-## HH:MM - [Short title]
-
-**What happened:** [Specific situation from today's session]
-**Why it matters:** [Impact on workflows/system]
-**Suggested fix:** [Specific action with file paths if applicable]
-**Status:** pending
-
----
-```
+**For each learning identified, write to `System/Session_Learnings/YYYY-MM-DD.md`, following the
+exact template in `System/Session_Learnings/README.md`** (the format matters — other tools parse
+these entries by their exact markdown shape).
 
 **Then ask the user:** "I captured [N] learnings from today's session. Anything else you'd like to add?"
 

--- a/06-Resources/Dex_System/Memory_Ownership.md
+++ b/06-Resources/Dex_System/Memory_Ownership.md
@@ -15,7 +15,12 @@
 ## Dex Session Memory (learning-heartbeat)
 **Owns:** Operational decisions, commitments, work patterns, system learnings
 **Examples:** "Agreed to deliver DACH deck by Friday", "Meeting-prep skill needs more account context"
-**How it works:** Captured at session Stop, stored in System/Session_Learnings/
+**How it works today:** Not yet automatic. `SessionEnd` only logs a timestamp/transcript
+pointer to `System/Session_Learnings/`; actual extraction (mistakes, preferences, doc gaps)
+runs as an LLM-reasoning step inside `/review` and `/daily-review`, and only fires when one
+of those is run to completion. A hook alone can't do the judgment call — see
+`Background_Processing_Guide.md` for the planned Stop-hook automation that would close this
+gap and make "learning-heartbeat" live up to its name.
 **Dex action:** Filter for operational only (WP-2.1).
 
 ## Dex Vault Search (QMD)

--- a/06-Resources/Dex_System/Memory_Ownership.md
+++ b/06-Resources/Dex_System/Memory_Ownership.md
@@ -15,12 +15,17 @@
 ## Dex Session Memory (learning-heartbeat)
 **Owns:** Operational decisions, commitments, work patterns, system learnings
 **Examples:** "Agreed to deliver DACH deck by Friday", "Meeting-prep skill needs more account context"
-**How it works today:** Not yet automatic. `SessionEnd` only logs a timestamp/transcript
-pointer to `System/Session_Learnings/`; actual extraction (mistakes, preferences, doc gaps)
-runs as an LLM-reasoning step inside `/review` and `/daily-review`, and only fires when one
-of those is run to completion. A hook alone can't do the judgment call — see
-`Background_Processing_Guide.md` for the planned Stop-hook automation that would close this
-gap and make "learning-heartbeat" live up to its name.
+**How it works:** `.claude/hooks/learning-heartbeat.cjs` (a `Stop` hook) blocks once per
+session per day, when the session looks substantive (>=3 user turns or >=8 tool calls),
+forcing one extra turn where Claude reflects on the session and writes conforming entries
+to `System/Session_Learnings/YYYY-MM-DD.md` using the template in that folder's `README.md`.
+A hook script can't do the judgment call itself — it forces the live session to do it.
+Confirmed safe to run alongside other `Stop` hooks that also use `decision:block` (Claude
+Code surfaces every hook's reason rather than dropping one when multiple fire on the same
+event). Opt-out:
+`System/user-profile.yaml` -> `learning_heartbeat.enabled: false`. `/review` and
+`/daily-review` still work as manual triggers too — the hook just removes the dependency on
+remembering to run them.
 **Dex action:** Filter for operational only (WP-2.1).
 
 ## Dex Vault Search (QMD)

--- a/System/Session_Learnings/README.md
+++ b/System/Session_Learnings/README.md
@@ -8,7 +8,7 @@ System improvements discovered during work sessions.
 
 ## What Goes Here
 
-Meta-feedback about Dex itself, captured during `/review` or `/daily-review`:
+Meta-feedback about Dex itself, captured automatically or during `/review`/`/daily-review`:
 
 - **Mistakes or corrections** — Things that went wrong and how to fix them
 - **Preferences mentioned** — Workflow preferences you shared
@@ -39,9 +39,10 @@ tool — so match it precisely:
 
 ## Workflow
 
-1. **Capture** — Currently requires running `/review` or `/daily-review` to completion; the
-   `SessionEnd` hook alone only logs a timestamp, it doesn't extract learnings (that step
-   needs LLM judgment a hook script can't do on its own).
+1. **Capture** — Automatic: `.claude/hooks/learning-heartbeat.cjs` (a `Stop` hook) briefly
+   pauses substantive sessions, once per session per day, and has Claude reflect and write
+   conforming entries. Opt-out: `System/user-profile.yaml` -> `learning_heartbeat.enabled:
+   false`. `/review` and `/daily-review` still work as manual triggers too.
 2. **Review** — Periodically check pending learnings via `/dex-whats-new`
 3. **Implement** — Fix documentation gaps or system issues
 4. **Update status** — Mark as implemented when done

--- a/System/Session_Learnings/README.md
+++ b/System/Session_Learnings/README.md
@@ -1,23 +1,37 @@
 # Session Learnings
 
+> Note: this directory is gitignored (see `.gitignore`) except for this README — it's
+> grandfathered in from before that rule was added, and intentionally kept as the canonical
+> schema reference below. Don't delete it as part of a gitignore cleanup.
+
 System improvements discovered during work sessions.
 
 ## What Goes Here
 
-Meta-feedback about Dex itself, captured during `/review`:
+Meta-feedback about Dex itself, captured during `/review` or `/daily-review`:
 
 - **Mistakes or corrections** — Things that went wrong and how to fix them
 - **Preferences mentioned** — Workflow preferences you shared
 - **Documentation gaps** — Places where docs were unclear or missing
 - **Workflow inefficiencies** — Friction points discovered
 
-## Format
+## Format (exact — other tools parse this)
 
-Each learning includes:
-- **What happened** — Specific situation
-- **Why it matters** — Impact on system/workflow
-- **Suggested fix** — Specific action with file paths
-- **Status** — pending, implemented, or won't-fix
+`mcp__dex-improvements-mcp__synthesize_learnings` parses entries by this literal markdown
+shape (`## HH:MM - Title`, `**Field:**` labels, a `**Status:** pending` value, blocks
+separated by `\n---\n`). Entries that don't match this exactly are silently skipped by that
+tool — so match it precisely:
+
+```markdown
+## HH:MM - [Short title]
+
+**What happened:** [Specific situation]
+**Why it matters:** [Impact on system/workflow]
+**Suggested fix:** [Specific action, with file paths if applicable]
+**Status:** pending
+
+---
+```
 
 ## Naming Convention
 
@@ -25,7 +39,9 @@ Each learning includes:
 
 ## Workflow
 
-1. **Capture** — Happens automatically during `/review` (daily review)
+1. **Capture** — Currently requires running `/review` or `/daily-review` to completion; the
+   `SessionEnd` hook alone only logs a timestamp, it doesn't extract learnings (that step
+   needs LLM judgment a hook script can't do on its own).
 2. **Review** — Periodically check pending learnings via `/dex-whats-new`
 3. **Implement** — Fix documentation gaps or system issues
 4. **Update status** — Mark as implemented when done

--- a/System/user-profile.example.yaml
+++ b/System/user-profile.example.yaml
@@ -107,6 +107,13 @@ journaling:
   # Weekly journal: patterns and synthesis
   weekly: false
 
+# Learning Heartbeat
+# When a session looks substantive, Dex briefly pauses at the end to capture
+# learnings automatically (System/Session_Learnings/) instead of requiring you to
+# run /review or /daily-review yourself. At most once per session per day.
+learning_heartbeat:
+  enabled: true
+
 # Quarterly Planning Configuration
 # Controls whether you use quarterly goal setting
 quarterly_planning:


### PR DESCRIPTION
## What Changed

`Session_Learnings/YYYY-MM-DD.md` (fixed in #145 to actually write correctly) still only ever gets populated by explicitly running `/review` or `/daily-review` to completion — easy to forget, and `Memory_Ownership.md` already documented capture as happening "at session Stop" (automatic) even though nothing was actually wired up to do that.

Adds `.claude/hooks/learning-heartbeat.cjs`: a `Stop` hook that, once per session per day, when a session looks substantive (`>=3` user turns or `>=8` tool calls in the transcript), blocks once and asks the live Claude session to reflect and write conforming entries using the canonical template in `Session_Learnings/README.md`. A hook script can't do that reasoning itself (no LLM call inside it) — it forces the live session to do it once, which is also how I confirmed multiple Stop hooks returning `decision:block` on the same event compose safely (Claude Code surfaces every reason, doesn't drop any) — tested with an additional local Stop hook in my own fork.

Debounce is state-file based (`System/Session_Learnings/.heartbeat-state.json`, already gitignored), not just `stop_hook_active`, since `Stop` fires on every turn and `stop_hook_active` only guards the single forced continuation, not the rest of the session.

**Trade-off worth being upfront about:** this isn't literally silent. `Stop` fires at the end of every turn, not just "true" end-of-session, so the forced extra turn can land mid-task rather than at a natural closing point — there's no reliable static signal from inside a hook for "this is really the end." Opt-out via `System/user-profile.yaml` → `learning_heartbeat.enabled: false`.

**Depends on #145** — this hook's block reason points at the README template that PR fixes.

## Test Plan

- `node --check` syntax check
- Simulated via stdin exactly as Claude Code invokes it:
  - blocks on a substantive synthetic transcript
  - stays silent below the turn/tool-call threshold
  - stays silent on a debounced repeat call for the same session/day
  - stays silent when disabled via profile (before touching the transcript)
  - handles a brand-new vault with no `Session_Learnings/` directory yet (creates it)
- Live end-to-end in real Claude Code sessions: confirmed the forced turn fires once, writes entries that parse correctly against `synthesize_learnings`' regex parser, and doesn't refire for the same session/day
- Commands run locally: see above; no automated test suite covers Stop hooks, tested by direct invocation and live sessions

## Risk & Rollback

- Risk level: low-medium — no data risk (opt-out available, fails open on any error), but it does introduce a new forced-turn interruption pattern; flagging the mid-task-timing trade-off above for reviewer judgment
- Rollback: revert the commit; the debounce state file is gitignored and self-contained, no migration needed

## Docs Impact

- Files updated: `06-Resources/Dex_System/Memory_Ownership.md` (now describes the real mechanism), `System/Session_Learnings/README.md` (Capture step now says automatic + opt-out), `System/user-profile.example.yaml` (new toggle documented)