### PR TITLE
Make career evidence capture real across all promised channels

### DIFF
--- a/.claude/skills/career-setup/SKILL.md
+++ b/.claude/skills/career-setup/SKILL.md
@@ -76,16 +76,30 @@ Please share:
 2. Your job description (copy/paste from your company's JD, or just describe it in your own words)
 3. Your team/department
 4. Key responsibilities
+5. Your manager's name and work email (optional)
 
 You can be as detailed or brief as you like — whatever helps paint the picture.
 ```
 
-After they respond, **acknowledge and summarize**:
+**Why the manager's email?** It's how Dex recognises your 1:1s during `/process-meetings`
+and pulls manager feedback into your career evidence automatically. It's optional — the
+other capture channels work without it — but without it, manager-1:1 feedback extraction
+stays off.
+
+After they respond, **acknowledge and summarize**. If they gave a manager name/email,
+write it to `System/user-profile.yaml` under the `career:` block (create the block if it's
+missing — see `System/user-profile.example.yaml` for the shape):
+
+```yaml
+career:
+  manager_name: "[NAME]"
+  manager_email: "[EMAIL]"
+```
 
 ```markdown
 Got it. So you're a [ROLE] on the [TEAM], focused on [SUMMARY OF RESPONSIBILITIES].
 
-✓ Role captured.
+✓ Role captured.[ Manager saved — I'll watch for your 1:1s.]
 
 Next up: your career ladder.
 ```
@@ -470,7 +484,8 @@ This folder captures evidence of your professional growth — achievements, feed
 
 ## How This Works
 
-As you work, Dex automatically captures evidence that supports your career progression:
+Dex surfaces evidence as you work and asks before saving it — so this folder fills up
+without you having to remember to document things:
 
 - **Achievements/**: Major wins, successful projects, measurable impact
 - **Feedback_Received/**: Praise from colleagues, stakeholders, manager feedback
@@ -478,12 +493,16 @@ As you work, Dex automatically captures evidence that supports your career progr
 
 ---
 
-## When Evidence Gets Captured
+## When Evidence Gets Surfaced
 
-1. **During `/review`**: End-of-day reflections prompt for notable achievements
-2. **From Granola meetings**: Feedback and discussions with your manager are extracted
-3. **Project completions**: When you finish projects, you'll be asked if there's career evidence worth noting
-4. **Ad-hoc**: Just tell me "capture this for my career evidence" and I'll add it
+1. **During `/daily-review`**: End-of-day reflections prompt for notable achievements
+2. **During `/week-review`**: Completed goals and projects are scanned and offered as evidence
+3. **From manager 1:1s** (via Granola): When a 1:1 with your configured manager is
+   processed, feedback in the notes is offered for capture
+4. **During `/career-coach`**: Achievements with metrics are detected as you talk
+5. **Ad-hoc**: Just tell me "capture this for my career evidence" and I'll add it
+
+Each of these *prompts* you — nothing is written to this folder without your say-so.
 
 ---
 
@@ -503,7 +522,7 @@ As you work, Dex automatically captures evidence that supports your career progr
 
 ---
 
-**This system is most powerful when it captures evidence passively as you work. Don't worry about manual updates — Dex handles it.**
+**This system is most powerful when you let Dex surface evidence as you work — it spots the moments worth keeping and offers them, so you approve rather than author.**
 ```
 
 ---
@@ -540,12 +559,12 @@ Run `/career-coach` anytime you want to:
 3. **Prepare for reviews** — Build self-assessment from accumulated evidence
 4. **Assess promotion readiness** — Gap analysis against career ladder
 
-### Automatic Capture
+### Evidence Capture (Prompted)
 
-As you use Dex:
-- **Meetings with your manager** (via Granola) → Feedback automatically extracted
-- **Daily reviews** (`/review`) → Achievements captured as career evidence
-- **Project completions** → Impact and skills demonstrated are saved
+As you use Dex, it surfaces evidence and asks before saving:
+- **Manager 1:1s** (via Granola, if you set a manager email) → feedback in the notes is offered for capture
+- **`/daily-review`** → prompts you for achievements worth keeping
+- **`/week-review`** → scans completed goals and archived projects, offers them as evidence
 
 ### Quarterly Career Check-ins
 
@@ -612,10 +631,10 @@ For now, I'll create the folder structure and you can update files when you're r
 
 After running `/career-setup` once:
 
-1. **Career folder exists** → Dex knows to capture career evidence during daily work
-2. **Granola integration** → Manager 1:1s are flagged for feedback extraction
-3. **Review prompts** → End-of-day reviews ask about achievements worth capturing
-4. **Project completions** → Prompt to add impact to career evidence
+1. **Career folder exists** → `/daily-review` and `/week-review` start surfacing career evidence
+2. **Manager email set** → `/process-meetings` recognises your 1:1s and offers to capture feedback
+3. **Review prompts** → `/daily-review` asks about achievements; `/week-review` scans completed work
+4. **Project completions** → when a project is archived, `/week-review` offers to capture its impact
 
 ---
 

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -276,6 +276,30 @@ Get user confirmation before adding.
 
 ---
 
+## Step 8.5: Career Evidence Prompt (If Career System Enabled)
+
+**Only run this if `05-Areas/Career/` exists.** If it doesn't, skip this step silently —
+the user hasn't set up the Career system (`/career-setup`).
+
+Look at today's accomplishments (from Step 5) and learnings for anything that would matter
+at review or promotion time — a shipped project, measurable impact, a hard problem solved,
+positive feedback received, a skill demonstrably stretched. If nothing today clears that
+bar, skip silently — don't manufacture a prompt.
+
+If something does, offer it (don't auto-save):
+
+> "One for your career evidence: today you [specific achievement — e.g. 'shipped the
+> pricing migration two weeks early']. Want me to save it to `05-Areas/Career/Evidence/`?
+> (I'll note the impact and skills it demonstrates.)"
+
+- If yes: write an evidence file to `05-Areas/Career/Evidence/Achievements/` using the
+  `System/Templates/Career_Evidence_Achievement.md` format (date, what you did, impact,
+  skills demonstrated).
+- If no or no response: drop it, don't re-ask.
+- Surface at most one per review — pick the single strongest item.
+
+---
+
 ## Step 9: Tomorrow's Setup
 
 Based on:

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -152,6 +152,39 @@ For each participant in synced meetings:
    - Keep max 20 entries (remove oldest if needed)
    - Update "Last Interaction" in frontmatter
 
+### Step 3.5: Manager 1:1 Feedback Capture (If Career System Enabled)
+
+**Only run this if `05-Areas/Career/` exists AND `System/user-profile.yaml` has a
+`career.manager_email` (or `career.manager_name`) set.** If either is missing, skip
+silently — this channel is opt-in via `/career-setup` and is off by default.
+
+For each synced meeting, decide if it's a manager 1:1:
+1. Read `career.manager_email` / `career.manager_name` from `System/user-profile.yaml`.
+2. A meeting qualifies as a 1:1 only if it has **exactly two attendees** and the other
+   attendee's email matches `career.manager_email` (fall back to a name match against
+   `career.manager_name` only when no attendee emails are present).
+
+> **Known limitation:** this heuristic can misfire on a genuine 2-person sync that happens
+> to be with your manager, and misses 1:1s folded into a larger recurring meeting. That's
+> acceptable — it only ever *offers* to save evidence, never writes silently.
+
+For a qualifying 1:1, scan the meeting notes/transcript for feedback-shaped content —
+praise, constructive criticism, development suggestions, or recognition of impact. Use the
+same marker approach as the `/career-coach` capture hook (percentages, "delivered/achieved/
+improved/led", "feedback", "great work", "area to develop"); **if QMD is available**, also
+run `qmd query "feedback on my work / areas to improve"` against the note to catch feedback
+that doesn't use obvious markers. If QMD is unavailable, the marker scan alone is fine.
+
+If feedback is found, offer to capture it (don't auto-save):
+
+> "Your 1:1 with [Manager] had some feedback worth keeping: *'[short quote]'*. Save it to
+> your career evidence?"
+
+- If yes: write to `05-Areas/Career/Evidence/Feedback_Received/` using the
+  `System/Templates/Career_Evidence_Feedback.md` format (date, source meeting, the
+  feedback, and what it implies for development).
+- If no feedback is found, or the user declines: skip silently, don't re-ask.
+
 ### Step 4: Update Company Pages
 
 For each unique external company domain:

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -47,6 +47,7 @@ If items found:
 
 ### 2. Project Activity
 - `04-Projects/**/*.md` — Modified this week
+- `07-Archives/Projects/` — Folders that arrived here this week (a project moving here is Dex's "project finished" signal — used for career evidence)
 
 ### 3. Meetings & People
 - `00-Inbox/Meetings/*.md` — Meeting notes from this week
@@ -399,6 +400,40 @@ Based on this week's progress:
 *Weekly completion: X of 3 priorities*
 *Task completion: X%*
 ```
+
+---
+
+## Career Evidence Scan (If Career System Enabled)
+
+**Only run this if `05-Areas/Career/` exists.** If it doesn't, skip silently — the user
+hasn't set up the Career system (`/career-setup`). This populates the "🏆 Career Evidence"
+section of the output above.
+
+Find work from this week worth keeping for reviews and promotions:
+
+1. **Completed goals & priorities:** Call `scan_work_for_evidence(impact_level: "high")`
+   from Career MCP. It returns completed quarterly goals and priorities (≥80% done, or
+   tagged with career metadata) as high-impact candidates for evidence. Focus on ones that
+   were finished or moved substantially *this week*.
+2. **Finished projects:** List `07-Archives/Projects/` for folders with an mtime in the
+   last 7 days (a project archived this week = a completed project). Read each one's
+   `README.md` for objective, outcome, and stakeholders.
+3. **Merge and rank** the candidates; surface at most the top 3–4 (don't dump everything).
+
+Feed the results into the "🏆 Career Evidence" output section, then offer to save:
+
+> "A few things from this week look worth keeping for your career evidence:
+> - **Shipped the pricing migration** — demonstrates delivery under deadline
+> - **Closed out Project Juno** (archived Tuesday) — cross-team migration, stakeholder mgmt
+>
+> Want me to save any of these to `05-Areas/Career/Evidence/`?"
+
+- For a goal/priority the user picks: call `generate_evidence_from_work(work_id, work_type)`
+  from Career MCP (it writes the evidence file from the work item's metadata).
+- For an archived project the user picks: write an evidence file to
+  `05-Areas/Career/Evidence/Achievements/` using the
+  `System/Templates/Career_Evidence_Achievement.md` format, drawing from the project README.
+- If nothing clears the bar, or the user declines: skip silently, don't re-ask.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.63.0] - Your career wins actually get captured now (2026-07-20)
+
+Dex has always promised to quietly build up a record of your best work — achievements, feedback from your manager, projects you finished — so that when review or promotion time comes, you're not scrambling to remember what you did. It turns out most of that was only ever a promise: the setup created the folder and told you evidence would be captured, but four of the five ways it was supposed to happen did nothing at all. Only evidence you captured *during* a career-coaching session was ever saved. This release makes the rest real.
+
+**What this fixes for you:**
+
+* **Your daily review now asks about wins worth keeping.** At the end of the day, if you shipped something, hit a number, or solved a hard problem, Dex offers to save it to your career evidence — one prompt, only when something genuinely clears the bar, never nagging.
+* **Your weekly review looks back for evidence you'd forget.** It scans the goals and priorities you completed and the projects you finished that week, and offers the strongest few for your record — so a big win in a busy week doesn't just evaporate.
+* **Feedback from your manager 1:1s gets captured.** Tell Dex your manager's email once (during `/career-setup`), and when it processes a 1:1 with them, it reads the notes for feedback and offers to save it. If you don't set a manager, this stays off — no guessing about who your boss is.
+* **Nothing is saved behind your back.** Every one of these *asks first*. Evidence lands in your folder because you said yes, not because Dex decided for you. The old setup text that claimed "don't worry about manual updates — Dex handles it" was rewritten to match what actually happens.
+* **`/dex-doctor` can now tell you if this is broken.** A new check flags the case where your career system is set up but has silently captured nothing — the exact failure this release fixes — so it can't quietly rot again.
+
+---
+
 ## [1.62.0] - Your integration keys stay private, and Dex never updates itself behind your back (2026-07-20)
 
 This release is a safety floor: a set of fixes that protect your private information and put you back in control of when Dex changes. Before this, a few things could happen quietly in the background that you'd never have chosen — this closes them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,15 +283,17 @@ When the user says they completed a task (any phrasing):
 - Don't require exact task title - use fuzzy matching on keywords
 
 ### Career Evidence Capture
-If `05-Areas/Career/` folder exists, the system automatically captures career development evidence:
-- **During `/daily-review`**: Prompt for achievements worth capturing for career growth
-- **During `/career-coach`**: Achievements with quantifiable metrics are auto-detected and captured as evidence without manual prompting
-- **From Granola meetings**: Extract feedback and development discussions from manager 1:1s
-- **Project completions**: Suggest capturing impact and skills demonstrated
+If `05-Areas/Career/` folder exists, Dex surfaces career development evidence as you work
+and **prompts before saving** — nothing is written to the Evidence folder without the
+user's say-so:
+- **During `/daily-review`**: Prompt for the day's achievements worth capturing (only if something clears the bar)
+- **During `/week-review`**: Scan completed goals/priorities (via Career MCP `scan_work_for_evidence`) and projects archived to `07-Archives/Projects/` this week, offer the strongest as evidence
+- **From manager 1:1s** (via `/process-meetings`): If `career.manager_email` is set in `System/user-profile.yaml` and a synced meeting is a 1:1 with that manager, scan the notes for feedback and offer to capture it. Off unless a manager is configured (set via `/career-setup`).
+- **During `/career-coach`**: Achievements with quantifiable metrics are auto-detected during coaching sessions
 - **Skill tracking**: Tag tasks/goals with `# Career: [skill]` to track skill development over time. **If QMD is available**, the Career MCP also detects skill demonstration *without* explicit tags — semantically matching achievements to competencies (e.g., a task about "designing the API migration strategy" matches the "System Design" competency even without a `# Career: System Design` tag).
-- **Weekly reviews**: Scan for completed work tagged with career skills, prompt evidence capture
 - **Ad-hoc**: When user says "capture this for career evidence", save to appropriate folder
 - Evidence accumulates in `05-Areas/Career/Evidence/` for reviews and promotion discussions
+- `/dex-doctor` includes a `career.evidence` check that flags if the capture hook is missing or setup is stale with no evidence ever captured
 
 ### Person Pages
 Maintain pages for people the user interacts with:

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Eight jobs that happen reliably every day:
 | **Start Each Day Focused** | One command gives you three priorities. Heavy meeting day? Drops to two. Won't let you overcommit. |
 | **Never Miss a Commitment** | Promises made in meetings extracted automatically. Three days old? Flagged. You can't forget. |
 | **Track Relationships** | Before any call: what you discussed last time, open items, what they care about. Never walk in cold. |
-| **Accelerate Career Growth** | Captures evidence automatically. Feedback from 1:1s, achievements, skills growth. Review-ready when you need it. |
+| **Accelerate Career Growth** | Surfaces evidence as you work and saves what you approve. Feedback from 1:1s, achievements, skills growth. Review-ready when you need it. |
 | **Manage Tasks Reliably** | Work MCP syncs tasks with unique IDs across all files. Check off once, updates everywhere. Deduplication prevents doubles. Priority limits stop overcommit. Strategic alignment required. |
 | **Reflect & Improve** | Captures mistakes → rules. Learns preferences. Each session makes the next better. |
 | **Keep Projects Moving** | Auto-detects stalls (12+ days no update). Surfaces blockers. You know what needs attention. |
@@ -522,7 +522,7 @@ Out of the box, working immediately:
 - **Role-based setup** - 31 roles from CEO to IC, scaffolds appropriate folder structure and workflows. Onboarding MCP enforces validation (email domain required for Internal/External person routing) with session resume capability
 - **Meeting intelligence** - Process transcripts into structured notes with action items auto-synced. Works with Granola MCP (included), or paste transcripts from any source - system recognizes and processes them
 - **Task management with unique IDs (Work MCP)** - Tasks sync everywhere automatically (meeting notes, person pages, project files). Check off once, updates everywhere. Deduplication prevents doubles. Priority limits stop overcommit.
-- **Career development coach** - Captures evidence automatically, prepares reviews, assesses promotion readiness
+- **Career development coach** - Surfaces evidence as you work (you approve what's saved), prepares reviews, assesses promotion readiness
 - **Person & company pages** - Relationship context for individuals + organization-level rollups (contacts, meetings, tasks)
 - **Compound learning** - Captures preferences and mistakes. Every session makes the next one better.
 - **Self-upgrading system** - Checks for new Claude Code features daily. When detected, explains what they mean for YOUR system and suggests implementations. Like having a concierge who reads release notes you'll never read.
@@ -574,14 +574,16 @@ One decision instead of many. Immediate filing.
 
 Great work happens daily, but evidence disappears. Review time becomes a scramble to remember what you accomplished.
 
-Run `/career-setup` once (job description, career ladder, recent review, growth goals). From that point forward, Dex automatically captures career evidence:
+Run `/career-setup` once (job description, career ladder, recent review, growth goals — and optionally your manager's email). From that point forward, Dex surfaces career evidence as you work and asks before saving it:
 
-| When | What Gets Captured |
+| When | What Dex Surfaces |
 |------|-------------------|
-| Daily reviews | Achievements worth saving for promotion discussions |
-| Manager 1:1s (via Granola) | Feedback and development context |
-| Project completions | Impact and skills demonstrated |
-| Weekly reviews | Work tagged with career skills |
+| Daily reviews | The day's achievements worth saving for promotion discussions |
+| Weekly reviews | Completed goals and projects finished this week |
+| Manager 1:1s (via Granola) | Feedback from 1:1s — if you set your manager's email |
+| Career coaching | Metric-backed achievements, detected as you talk |
+
+Every one of these *prompts* you — evidence lands in your folder because you approved it, not behind your back.
 
 ### Your Personal Career Coach
 

--- a/System/user-profile.example.yaml
+++ b/System/user-profile.example.yaml
@@ -58,6 +58,16 @@ communication:
   # Coaching style preference (for career coaching)
   coaching_style: "collaborative"  # options: encouraging, collaborative, challenging
 
+# Career Configuration
+# Optional. Populated by /career-setup. Powers automatic career evidence capture
+# (see CLAUDE.md → "Career Evidence Capture"). Leave blank to skip manager-1:1
+# feedback extraction — the other capture channels still work without it.
+career:
+  # Who your manager is. Used to recognise 1:1s in /process-meetings and pull
+  # feedback into your career evidence. Email is the reliable match; name is a fallback.
+  manager_name: ""
+  manager_email: ""
+
 # Strategic Pillars
 # Defined during onboarding, sync'd with System/pillars.yaml
 pillars: []

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -29,6 +29,7 @@ QUICK_IDS = [
     "jobs.fresh",
     "preflight.queue",
     "entity.engine",
+    "career.evidence",
     "customizations.skills",
     "customizations.mcp",
     "core.drift",
@@ -295,6 +296,73 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     assert "gardener off (disabled), 1 locked" in result.detail
 
 
+def _write_career_probe_files(context, *, hook=True, setup_age_days=1, evidence=1):
+    career = context.core_path("CAREER_DIR")
+    evidence_dir = career / "Evidence"
+    if evidence_dir.exists():
+        shutil.rmtree(evidence_dir)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(evidence):
+        (evidence_dir / f"achievement-{index}.md").write_text("# win\n")
+    (evidence_dir / "README.md").write_text("# Career Evidence\n")
+
+    ladder = career / "Career_Ladder.md"
+    ladder.write_text("# Ladder\n")
+    setup_time = (NOW - timedelta(days=setup_age_days)).timestamp()
+    os.utime(ladder, (setup_time, setup_time))
+
+    profile = context.core_path("USER_PROFILE_FILE")
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    profile.write_text("name: Test\n")
+    os.utime(profile, (setup_time, setup_time))
+
+    hook_path = context.vault_root / doctor.CAREER_EVIDENCE_HOOK
+    if hook:
+        hook_path.parent.mkdir(parents=True, exist_ok=True)
+        hook_path.write_text("// hook\n")
+    elif hook_path.exists():
+        hook_path.unlink()
+
+
+def test_career_evidence_probe_reports_working_off_broken_and_could_not_check(context):
+    # OFF — no Career folder at all.
+    assert doctor._probe_career_evidence(context).verdict == "OFF"
+
+    # OK — set up recently, hook present, evidence exists.
+    _write_career_probe_files(context)
+    working = doctor._probe_career_evidence(context)
+    assert working.verdict == "OK"
+    assert "1 evidence files" in working.detail
+
+    # BROKEN — the one real capture hook is missing.
+    _write_career_probe_files(context, hook=False)
+    missing_hook = doctor._probe_career_evidence(context)
+    assert missing_hook.verdict == "BROKEN"
+    assert "hook is missing" in missing_hook.detail
+
+    # BROKEN — old setup that has never produced any evidence.
+    _write_career_probe_files(context, setup_age_days=90, evidence=0)
+    stale = doctor._probe_career_evidence(context)
+    assert stale.verdict == "BROKEN"
+    assert "no evidence has ever been captured" in stale.detail
+
+    # OK — old setup but evidence exists is fine.
+    _write_career_probe_files(context, setup_age_days=90, evidence=2)
+    assert doctor._probe_career_evidence(context).verdict == "OK"
+
+
+def test_career_evidence_probe_reports_could_not_check(monkeypatch, context):
+    _write_career_probe_files(context)
+
+    def boom(_self, _name):
+        raise OSError("simulated filesystem failure")
+
+    monkeypatch.setattr(doctor.DoctorContext, "core_path", boom)
+    result = doctor._probe_career_evidence(context)
+    assert result.verdict == "UNKNOWN"
+    assert "could not be checked" in result.detail
+
+
 def test_registry_ids_match_the_approved_spec():
     assert [definition.id for definition in doctor.QUICK_CHECKS] == QUICK_IDS
     assert [definition.id for definition in doctor.DEEP_CHECKS] == DEEP_IDS
@@ -446,7 +514,7 @@ def test_summary_counts_each_exact_verdict(monkeypatch, context):
 
     report = doctor.collect(context=context)
 
-    assert report["summary"] == {"ok": 12, "off": 1, "broken": 1, "unknown": 1}
+    assert report["summary"] == {"ok": 13, "off": 1, "broken": 1, "unknown": 1}
     assert report["instruments"]["completed"] == len(QUICK_IDS)
 
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -169,6 +169,7 @@ QUICK_CHECKS = (
     CheckDefinition("jobs.fresh", "Background job freshness", "_probe_jobs_fresh"),
     CheckDefinition("preflight.queue", "Preflight health", "_probe_preflight_queue"),
     CheckDefinition("entity.engine", "Entity engine", "_probe_entity_engine"),
+    CheckDefinition("career.evidence", "Career evidence capture", "_probe_career_evidence"),
     CheckDefinition(
         "customizations.skills",
         "Skill customizations",
@@ -1732,6 +1733,70 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         return ProbeResult("OK", detail)
     except (ImportError, OSError, ValueError, TypeError, json.JSONDecodeError) as error:
         return ProbeResult("UNKNOWN", f"Entity engine files could not be checked: {_one_line(error)}")
+
+
+CAREER_EVIDENCE_HOOK = Path(".claude/hooks/career-evidence-capture.cjs")
+CAREER_SETUP_STALE_AFTER = timedelta(days=60)
+
+
+def _probe_career_evidence(context: DoctorContext) -> ProbeResult:
+    """Report whether career evidence capture is set up and actually producing evidence.
+
+    Filesystem-only by design: it verifies the one real capture mechanism (the
+    /career-coach PostToolUse hook) exists, and flags long-term total inactivity —
+    a Career folder that was set up long ago but has never accumulated any evidence.
+    It deliberately does not judge whether evidence *should* exist for specific
+    completed work; that is /career-coach's job, not a smoke check.
+    """
+    try:
+        career_dir = context.core_path("CAREER_DIR")
+        if not career_dir.exists():
+            return ProbeResult("OFF", "Career system not set up (no 05-Areas/Career/ folder)")
+
+        evidence_dir = context.core_path("EVIDENCE_DIR")
+        evidence_count = 0
+        if evidence_dir.exists():
+            evidence_count = sum(
+                1
+                for path in evidence_dir.rglob("*.md")
+                if path.name != "README.md"
+            )
+
+        hook_path = context.vault_root / CAREER_EVIDENCE_HOOK
+        if not hook_path.is_file():
+            return ProbeResult(
+                "BROKEN",
+                "The /career-coach evidence-capture hook is missing "
+                f"({CAREER_EVIDENCE_HOOK}) — no capture channel can fire; "
+                f"{evidence_count} evidence files present",
+            )
+
+        ladder_path = career_dir / "Career_Ladder.md"
+        profile_path = context.core_path("USER_PROFILE_FILE")
+        setup_mtimes = [
+            path.stat().st_mtime
+            for path in (ladder_path, profile_path)
+            if path.exists()
+        ]
+        setup_age_known = bool(setup_mtimes)
+        stale_setup = False
+        if setup_age_known:
+            newest_setup = datetime.fromtimestamp(max(setup_mtimes), tz=timezone.utc)
+            stale_setup = context.now - newest_setup > CAREER_SETUP_STALE_AFTER
+
+        detail = (
+            f"Career system set up; capture hook present; {evidence_count} evidence files"
+        )
+        if stale_setup and evidence_count == 0:
+            return ProbeResult(
+                "BROKEN",
+                f"{detail}; setup is over {CAREER_SETUP_STALE_AFTER.days} days old but no "
+                "evidence has ever been captured — capture may be silently failing "
+                "(run /career-coach or /week-review to confirm)",
+            )
+        return ProbeResult("OK", detail)
+    except (OSError, ValueError, TypeError) as error:
+        return ProbeResult("UNKNOWN", f"Career evidence files could not be checked: {_one_line(error)}")
 
 
 def _probe_doctor_self(_context: DoctorContext) -> ProbeResult:


### PR DESCRIPTION
## What this fixes

CLAUDE.md and README.md promise that once the Career system is set up, Dex "automatically captures career evidence" through five channels. Auditing the actual implementation, **only one of the five is real** — the `/career-coach` `PostToolUse` hook (`.claude/hooks/career-evidence-capture.cjs`). The other four were documentation with no corresponding instructions or code:

- `daily-review/SKILL.md` — zero mentions of career
- `process-meetings/SKILL.md` — zero mentions of career; also no mechanism to identify the user's manager
- Project completions — no step anywhere
- `week-review/SKILL.md` — had a "🏆 Career Evidence" heading, but only inside the sample *output template*; no instructional step ever populated it

This is the same class of bug as the Session Learnings fix (v1.21.1): a feature that reads as built but silently does nothing, with no `/dex-doctor` check to catch it.

## Changes

**Wire up the four missing capture channels** (all *prompt before saving* — nothing written without consent):
- **`/daily-review`** — new gated step prompts for the day's achievements worth keeping
- **`/week-review`** — new instructional step calls Career MCP `scan_work_for_evidence` for completed goals/priorities and scans `07-Archives/Projects/` for projects archived this week (the codebase's actual "project finished" signal — there is no `status: complete` field), mirroring the existing Innovation Concierge pattern
- **`/process-meetings`** — new step detects a 1:1 with a configured manager (exactly 2 attendees + `career.manager_email` match) and offers to capture feedback from the notes

**Manager identification**
- Add optional `career.manager_name` / `career.manager_email` to `System/user-profile.example.yaml`, collected during `/career-setup`

**`/dex-doctor` regression guard**
- Add a filesystem-only `career.evidence` probe to `core/utils/doctor.py` (OFF / OK / BROKEN / UNKNOWN), modeled on `_probe_entity_engine`. BROKEN when the capture hook is missing, or when setup is >60 days old with zero evidence ever captured. Full OK/OFF/BROKEN/UNKNOWN test coverage added to `core/tests/test_doctor.py`.

**Docs honesty pass**
- Rewrite over-promising "don't worry about manual updates — Dex handles it" language in career-setup's generated Evidence README, CLAUDE.md, and README.md to match the prompt-before-save reality.

## Design notes

- **Project completions** are folded into the weekly scan rather than a real-time Stop hook — trades immediacy for simplicity/robustness and matches how other "silent" capture in this codebase works (batched into reviews).
- The doctor check is deliberately a **smoke check, not a completeness audit** — it does not import `career_server.py` (whose handlers are async and bind paths at import time); it verifies the hook exists and flags long-term total inactivity via filesystem only.
- The manager-1:1 heuristic can misfire on 2-person non-1:1 syncs; acceptable because it only ever *prompts*, never auto-writes.

## Testing

- `pytest core/tests/test_doctor.py` — 109 passed (includes new career.evidence coverage)
- `pytest core/tests/test_feature_status.py` — 23 passed
- `ruff check` clean on changed Python
- New `career.evidence` probe run against a real vault returns a correct non-crashing verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)