### PR TITLE
feat: the split-aware updater on the crash-safe engine (PR-3)

### DIFF
--- a/.claude/hooks/tests/vault-autocommit.test.cjs
+++ b/.claude/hooks/tests/vault-autocommit.test.cjs
@@ -1,0 +1,166 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const HOOK_PATH = path.join(REPO_ROOT, '.claude', 'hooks', 'vault-autocommit.cjs');
+const CONTRACT_PATH = path.join(
+  REPO_ROOT,
+  'packages',
+  'dex-contracts',
+  'dist',
+  'portable-vault.contract.json',
+);
+
+function git(root, ...args) {
+  const result = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+  assert.equal(result.status, 0, `${args.join(' ')}\n${result.stdout}\n${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function fixture(t, enabled = false) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-vault-autocommit-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  git(root, 'init', '--quiet');
+  fs.writeFileSync(path.join(root, '.git', 'dex-vault-v2'), '{"role":"vault"}\n');
+  fs.mkdirSync(path.join(root, 'System'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'System', 'user-profile.yaml'),
+    `name: Test User\nvault:\n  auto_commit: ${enabled ? 'true' : 'false'}\n`,
+  );
+  const contract = path.join(root, 'packages', 'dex-contracts', 'dist');
+  fs.mkdirSync(contract, { recursive: true });
+  fs.copyFileSync(CONTRACT_PATH, path.join(contract, 'portable-vault.contract.json'));
+  return root;
+}
+
+test('vault auto-commit is off unless the nested profile switch is exactly true', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, false);
+  fs.writeFileSync(path.join(root, 'note.md'), 'private note\n');
+
+  const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'off');
+  assert.equal(result.success, false);
+  assert.match(result.user_message, /off by default/i);
+  assert.equal(git(root, 'for-each-ref', '--format=%(refname)'), '');
+  fs.writeFileSync(
+    path.join(root, 'System', 'user-profile.yaml'),
+    'vault:\n  nested:\n    auto_commit: true\n',
+  );
+  assert.equal(hook.run({ root }).feature_status, 'off');
+});
+
+test('enabled hook commits only contract-owned vault and seed changes locally', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.writeFileSync(path.join(root, 'note.md'), 'unclassified stays out\n');
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'private.md'), 'private note\n');
+  fs.mkdirSync(path.join(root, '03-Tasks'), { recursive: true });
+  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), '# edited seed\n');
+  fs.mkdirSync(path.join(root, 'core'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'core', 'brain.py'), 'BRAIN = true\n');
+  fs.mkdirSync(path.join(root, 'System', '.dex'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'System', '.dex', 'runtime.json'), '{}\n');
+
+  const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(result.success, true);
+  assert.equal(git(root, 'log', '-1', '--format=%s'), 'Dex vault 2026-07-13');
+  assert.equal(git(root, 'show', 'HEAD:04-Projects/private.md'), 'private note');
+  assert.equal(git(root, 'show', 'HEAD:03-Tasks/Tasks.md'), '# edited seed');
+  for (const relative of ['note.md', 'core/brain.py', 'System/.dex/runtime.json']) {
+    assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
+  }
+});
+
+test('enabled hook holds back contract-denied paths and staged content secrets', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'safe.md'), 'safe note\n');
+  fs.writeFileSync(
+    path.join(root, '04-Projects', 'session.md'),
+    '{"access_token":"scanner-positive-fixture-value"}\n',
+  );
+  fs.writeFileSync(path.join(root, '.env'), 'API_KEY=fixture-secret-value\n');
+  git(root, 'add', '--', '04-Projects/session.md');
+
+  const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.match(result.user_message, /held back|protected/i);
+  assert.equal(git(root, 'show', 'HEAD:04-Projects/safe.md'), 'safe note');
+  for (const relative of ['04-Projects/session.md', '.env']) {
+    assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
+  }
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
+test('enabled hook disables commit hooks and never pushes', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  const hooks = path.join(root, 'hostile-hooks');
+  const marker = path.join(root, 'post-commit-ran');
+  fs.mkdirSync(hooks);
+  fs.writeFileSync(path.join(hooks, 'post-commit'), `#!/bin/sh\nprintf ran > "${marker}"\n`, {
+    mode: 0o755,
+  });
+  git(root, 'config', 'core.hooksPath', hooks);
+  const remote = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-vault-autocommit-remote-'));
+  t.after(() => fs.rmSync(remote, { recursive: true, force: true }));
+  git(remote, 'init', '--bare', '--quiet');
+  git(root, 'remote', 'add', 'backup', remote);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'local-only.md'), 'never pushed\n');
+
+  const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(fs.existsSync(marker), false);
+  assert.equal(git(remote, 'for-each-ref', '--format=%(refname)'), '');
+  assert.doesNotMatch(fs.readFileSync(HOOK_PATH, 'utf8'), /\bgit\s+push\b|['"]push['"]/);
+});
+
+test('the shared transaction lock pauses auto-commit and is held while Git runs', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, 'System', '.dex'), { recursive: true });
+  const lock = path.join(root, 'System', '.dex', 'mutation.lock');
+  fs.writeFileSync(lock, `${JSON.stringify({ pid: process.pid, kind: 'update' })}\n`);
+  assert.equal(hook.run({ root }).feature_status, 'off');
+  fs.unlinkSync(lock);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'note.md'), 'serialized snapshot\n');
+  let observed = false;
+
+  const result = hook.run({
+    root,
+    onLockAcquired() {
+      observed = true;
+      assert.equal(fs.existsSync(lock), true);
+      assert.throws(() => fs.openSync(lock, 'wx'), { code: 'EEXIST' });
+    },
+  });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(observed, true);
+  assert.equal(fs.existsSync(lock), false);
+});
+
+test('settings wires the opt-in hook after session-end and the shipped profile defaults off', () => {
+  const settings = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, '.claude', 'settings.json'), 'utf8'));
+  const commands = settings.hooks.SessionEnd[0].hooks.map((entry) => entry.command);
+  assert.match(commands[0], /session-end\.sh/);
+  assert.match(commands[1], /vault-autocommit\.cjs/);
+  const profile = fs.readFileSync(path.join(REPO_ROOT, 'System', 'user-profile-template.yaml'), 'utf8');
+  assert.match(profile, /^vault:\n  auto_commit: false$/m);
+});

--- a/.claude/hooks/tests/vault-autocommit.test.cjs
+++ b/.claude/hooks/tests/vault-autocommit.test.cjs
@@ -105,6 +105,23 @@ test('enabled hook holds back contract-denied paths and staged content secrets',
   assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
 });
 
+test('enabled hook scans NUL-containing buffers for secret content', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '04-Projects', 'binary-note.bin'),
+    Buffer.from('safe-prefix\0{"access_token":"scanner-positive-fixture-value"}\n'),
+  );
+
+  const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.match(result.user_message, /held back|protected/i);
+  assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', '04-Projects/binary-note.bin'), '');
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
 test('enabled hook disables commit hooks and never pushes', (t) => {
   const hook = require(HOOK_PATH);
   const root = fixture(t, true);

--- a/.claude/hooks/vault-autocommit.cjs
+++ b/.claude/hooks/vault-autocommit.cjs
@@ -239,7 +239,7 @@ function operationInProgress(gitDirectory) {
 }
 
 function ensureLocalIdentity(root) {
-  for (const [key, value] of [['user.name', 'Dex Vault'], ['user.email', 'vault@dex.local']]) {
+  for (const [key, value] of [['user.name', 'Dex Vault'], ['user.email', 'vault@example.com']]) {
     const current = git(root, ['config', '--local', '--get', key]);
     if (current.status === 0 && current.stdout.trim()) continue;
     if (git(root, ['config', '--local', key, value]).status !== 0) return false;

--- a/.claude/hooks/vault-autocommit.cjs
+++ b/.claude/hooks/vault-autocommit.cjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
+// Fail-safe lock policy: any existing mutation.lock, including a stale lock
+// left by a crashed updater, pauses auto-commit until recovery removes it.
+// This hook never takes over a stale lock and never risks racing a vault mutation.
+
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -144,7 +148,6 @@ function classify(contract, input) {
 
 function containsSecretContent(content) {
   const source = Buffer.isBuffer(content) ? content : Buffer.from(String(content));
-  if (source.includes(0)) return false;
   const text = source.toString('utf8');
   return SECRET_CONTENT_PATTERNS.some((expression) => expression.test(text));
 }

--- a/.claude/hooks/vault-autocommit.cjs
+++ b/.claude/hooks/vault-autocommit.cjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const FEATURE = 'Vault auto-commit';
+const CONTRACT_RELATIVE = path.join(
+  'packages',
+  'dex-contracts',
+  'dist',
+  'portable-vault.contract.json',
+);
+const SECRET_CONTENT_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/,
+  /\bAKIA[A-Z0-9]{16}\b/,
+  /"(?:access[_-]?token|refresh[_-]?token|client[_-]?secret|api[_-]?key|private[_-]?key)"\s*:\s*"[^"\s]{8,}"/i,
+  /^\s*[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*\s*=\s*\S+/m,
+];
+
+function status(state, userMessage) {
+  return {
+    success: state === 'ok',
+    feature: FEATURE,
+    feature_status: state,
+    user_message: userMessage,
+  };
+}
+
+function exists(candidate) {
+  try {
+    fs.lstatSync(candidate);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function regularFileWithoutSymlinkedParents(root, relative) {
+  try {
+    let current = path.resolve(root);
+    for (const part of relative.split('/')) {
+      current = path.join(current, part);
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) return null;
+    }
+    return fs.lstatSync(current).isFile() ? current : null;
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function parseVaultAutoCommit(source) {
+  const lines = String(source).split(/\r?\n/);
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!/^vault:\s*(?:#.*)?$/.test(line)) continue;
+    const vaultIndent = line.match(/^\s*/)[0].length;
+    const block = [];
+    for (index += 1; index < lines.length; index += 1) {
+      const child = lines[index];
+      if (!child.trim() || child.trimStart().startsWith('#')) continue;
+      const indent = child.match(/^\s*/)[0].length;
+      if (indent <= vaultIndent) {
+        index -= 1;
+        break;
+      }
+      block.push({ line: child, indent });
+    }
+    blocks.push(block);
+  }
+  if (blocks.length !== 1 || blocks[0].length === 0) return false;
+  const directIndent = Math.min(...blocks[0].map((entry) => entry.indent));
+  const values = blocks[0]
+    .filter((entry) => entry.indent === directIndent)
+    .flatMap((entry) => {
+      const match = /^\s*auto_commit:\s*([^#\s]+)\s*(?:#.*)?$/.exec(entry.line);
+      return match ? [match[1].replace(/^['"]|['"]$/g, '').toLowerCase()] : [];
+    });
+  return values.length === 1 && values[0] === 'true';
+}
+
+function loadContract(root) {
+  const contractPath = regularFileWithoutSymlinkedParents(root, CONTRACT_RELATIVE.replaceAll(path.sep, '/'));
+  if (!contractPath) throw new Error('portable ownership contract is unavailable');
+  const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+  if (
+    !contract
+    || contract.source !== 'core/portable_contract.py'
+    || !Array.isArray(contract.rules)
+    || !Array.isArray(contract.hard_deny)
+  ) {
+    throw new Error('portable ownership contract is invalid');
+  }
+  return contract;
+}
+
+function normalizeRelative(input) {
+  const candidate = String(input).replaceAll('\\', '/').replace(/^\.\//, '');
+  const parts = candidate.split('/');
+  if (
+    !candidate
+    || candidate.startsWith('/')
+    || /^[A-Za-z]:\//.test(candidate)
+    || parts.some((part) => !part || part === '.' || part === '..')
+  ) return null;
+  return candidate;
+}
+
+function globMatches(candidate, pattern) {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replaceAll('*', '[^/]*')
+    .replaceAll('?', '[^/]');
+  const expression = new RegExp(`^${escaped}$`, 'i');
+  if (expression.test(candidate)) return true;
+  return !pattern.includes('/') && candidate.split('/').some((part) => expression.test(part));
+}
+
+function classify(contract, input) {
+  const candidate = normalizeRelative(input);
+  if (!candidate) return { ownership: null, denied: true };
+  if (contract.hard_deny.some((pattern) => globMatches(candidate, pattern))) {
+    return { ownership: 'vault', denied: true };
+  }
+  const exact = contract.rules.find((rule) => rule.kind === 'file' && rule.path === candidate);
+  if (exact) return { ownership: exact.ownership, denied: false };
+  const matches = contract.rules.filter(
+    (rule) => rule.kind === 'dir' && (candidate === rule.path || candidate.startsWith(`${rule.path}/`)),
+  );
+  if (matches.length === 0) return { ownership: null, denied: false };
+  const longest = Math.max(...matches.map((rule) => rule.path.length));
+  const mostSpecific = matches.filter((rule) => rule.path.length === longest);
+  const classes = new Set(mostSpecific.map((rule) => rule.ownership));
+  return { ownership: classes.size === 1 ? mostSpecific[0].ownership : null, denied: false };
+}
+
+function containsSecretContent(content) {
+  const source = Buffer.isBuffer(content) ? content : Buffer.from(String(content));
+  if (source.includes(0)) return false;
+  const text = source.toString('utf8');
+  return SECRET_CONTENT_PATTERNS.some((expression) => expression.test(text));
+}
+
+function eligiblePath(contract, relative) {
+  const verdict = classify(contract, relative);
+  return !verdict.denied && ['vault', 'seed'].includes(verdict.ownership);
+}
+
+function acquireSharedLock(root) {
+  const stateDirectory = path.join(root, 'System', '.dex');
+  if (
+    exists(stateDirectory)
+    && (fs.lstatSync(stateDirectory).isSymbolicLink() || !fs.lstatSync(stateDirectory).isDirectory())
+  ) return null;
+  fs.mkdirSync(stateDirectory, { recursive: true });
+  const lock = path.join(stateDirectory, 'mutation.lock');
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let descriptor;
+  try {
+    descriptor = fs.openSync(lock, 'wx', 0o600);
+    fs.writeFileSync(
+      descriptor,
+      `${JSON.stringify({ pid: process.pid, kind: 'vault-auto-commit', token, at: new Date().toISOString() })}\n`,
+    );
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    return () => {
+      try {
+        const current = JSON.parse(fs.readFileSync(lock, 'utf8'));
+        if (current.token === token) fs.unlinkSync(lock);
+      } catch {
+        // A vanished lock or a new owner is left alone.
+      }
+    };
+  } catch (error) {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    if (error.code === 'EEXIST') return null;
+    throw error;
+  }
+}
+
+function trustedGit(root) {
+  for (const candidate of ['/usr/bin/git', '/bin/git', '/usr/local/bin/git', '/opt/homebrew/bin/git']) {
+    try {
+      const resolved = fs.realpathSync(candidate);
+      const stat = fs.statSync(resolved);
+      if (!stat.isFile() || !(stat.mode & 0o111)) continue;
+      if (resolved === path.resolve(root) || resolved.startsWith(`${path.resolve(root)}${path.sep}`)) continue;
+      return resolved;
+    } catch {
+      // Try the next fixed system location.
+    }
+  }
+  return null;
+}
+
+function git(root, args, options = {}) {
+  const executable = trustedGit(root);
+  if (!executable) return { status: 127, stdout: '', stderr: 'trusted system Git unavailable' };
+  return spawnSync(executable, [
+    '-c', 'commit.gpgsign=false',
+    '-c', 'core.excludesFile=/dev/null',
+    '-c', 'core.hooksPath=/dev/null',
+    '-c', 'credential.helper=',
+    '-C', root,
+    ...args,
+  ], {
+    encoding: options.encoding === undefined ? 'utf8' : options.encoding,
+    env: {
+      PATH: `${path.dirname(executable)}:/usr/bin:/bin`,
+      HOME: fs.existsSync('/var/empty') ? '/var/empty' : os.tmpdir(),
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_OPTIONAL_LOCKS: '0',
+    },
+  });
+}
+
+function localDate(now) {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function operationInProgress(gitDirectory) {
+  return ['MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'rebase-merge', 'rebase-apply']
+    .some((name) => exists(path.join(gitDirectory, name)));
+}
+
+function ensureLocalIdentity(root) {
+  for (const [key, value] of [['user.name', 'Dex Vault'], ['user.email', 'vault@dex.local']]) {
+    const current = git(root, ['config', '--local', '--get', key]);
+    if (current.status === 0 && current.stdout.trim()) continue;
+    if (git(root, ['config', '--local', key, value]).status !== 0) return false;
+  }
+  return true;
+}
+
+function nulPaths(result) {
+  if (result.status !== 0) return null;
+  return result.stdout.toString('utf8').split('\0').filter(Boolean);
+}
+
+function candidateWorktreePaths(root) {
+  const commands = [
+    ['diff', '--name-only', '-z'],
+    ['diff', '--cached', '--name-only', '-z'],
+    ['ls-files', '--others', '--exclude-standard', '-z'],
+  ];
+  const paths = [];
+  for (const command of commands) {
+    const result = nulPaths(git(root, command, { encoding: null }));
+    if (result === null) return null;
+    paths.push(...result);
+  }
+  return [...new Set(paths)].sort();
+}
+
+function stagedRejectedPaths(root, contract) {
+  const staged = nulPaths(
+    git(root, ['diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'], { encoding: null }),
+  );
+  if (staged === null) return null;
+  const rejected = [];
+  for (const relative of staged) {
+    if (!eligiblePath(contract, relative)) {
+      rejected.push(relative);
+      continue;
+    }
+    const blob = git(root, ['show', `:${relative}`], { encoding: null });
+    if (blob.status !== 0 || containsSecretContent(blob.stdout)) rejected.push(relative);
+  }
+  return rejected;
+}
+
+function unstagePaths(root, paths) {
+  if (paths.length === 0) return true;
+  const hasHead = git(root, ['rev-parse', '--verify', 'HEAD']).status === 0;
+  const result = hasHead
+    ? git(root, ['restore', '--staged', '--', ...paths])
+    : git(root, ['rm', '--cached', '-r', '--ignore-unmatch', '--', ...paths]);
+  return result.status === 0;
+}
+
+function run(options = {}) {
+  let releaseLock = null;
+  try {
+    const root = path.resolve(options.root || process.env.CLAUDE_PROJECT_DIR || process.cwd());
+    const profile = regularFileWithoutSymlinkedParents(root, 'System/user-profile.yaml');
+    if (!profile || !parseVaultAutoCommit(fs.readFileSync(profile, 'utf8'))) {
+      return status(
+        'off',
+        'Vault auto-commit is off by default. Set vault.auto_commit to true for local snapshots.',
+      );
+    }
+    const gitDirectory = path.join(root, '.git');
+    if (!exists(gitDirectory) || fs.lstatSync(gitDirectory).isSymbolicLink() || !fs.lstatSync(gitDirectory).isDirectory()) {
+      return status('broken', 'Vault auto-commit is enabled, but the local vault Git repository is unavailable.');
+    }
+    const marker = regularFileWithoutSymlinkedParents(root, '.git/dex-vault-v2');
+    let markerValue = null;
+    try {
+      markerValue = marker ? JSON.parse(fs.readFileSync(marker, 'utf8')) : null;
+    } catch {
+      markerValue = null;
+    }
+    if (markerValue?.role !== 'vault') {
+      return status('off', 'Vault auto-commit waits until the brain/vault split is complete.');
+    }
+    const contract = loadContract(root);
+    releaseLock = acquireSharedLock(root);
+    if (!releaseLock) {
+      return status('off', 'Vault auto-commit paused because a migration or update is running.');
+    }
+    if (typeof options.onLockAcquired === 'function') options.onLockAcquired();
+    if (operationInProgress(gitDirectory)) {
+      return status('off', 'Vault auto-commit paused because a Git operation is in progress.');
+    }
+    if (!ensureLocalIdentity(root)) {
+      return status('broken', 'Vault auto-commit could not set a local-only commit identity.');
+    }
+    const candidates = candidateWorktreePaths(root);
+    if (candidates === null) {
+      return status('unknown', 'Vault auto-commit could not determine eligible local files.');
+    }
+    const eligible = candidates.filter((relative) => eligiblePath(contract, relative));
+    if (eligible.length > 0 && git(root, ['add', '-A', '--', ...eligible]).status !== 0) {
+      return status('broken', 'Vault auto-commit could not prepare the local snapshot. Files are unchanged.');
+    }
+    const rejected = stagedRejectedPaths(root, contract);
+    if (rejected === null || !unstagePaths(root, rejected)) {
+      return status('broken', 'Vault auto-commit found protected files but could not unstage them safely.');
+    }
+    const staged = git(root, ['diff', '--cached', '--quiet']);
+    if (staged.status === 0) {
+      return status(
+        'ok',
+        rejected.length > 0
+          ? `Dex held back ${rejected.length} protected ${rejected.length === 1 ? 'file' : 'files'}; there were no other changes to save.`
+          : 'Your vault was already saved; there were no new changes to commit.',
+      );
+    }
+    if (staged.status !== 1) {
+      return status('unknown', 'Vault auto-commit could not determine whether a snapshot was needed.');
+    }
+    const now = options.now instanceof Date ? options.now : new Date();
+    const committed = git(root, ['commit', '-m', `Dex vault ${localDate(now)}`]);
+    if (committed.status !== 0) {
+      return status('broken', 'Vault auto-commit could not create the local snapshot. Files remain in the vault.');
+    }
+    return status(
+      'ok',
+      rejected.length > 0
+        ? `Dex saved eligible changes locally and held back ${rejected.length} protected ${rejected.length === 1 ? 'file' : 'files'}. It did not run a push.`
+        : 'Dex saved this session to local vault history. It did not run a push.',
+    );
+  } catch {
+    return status('unknown', 'Vault auto-commit could not check this session, so it left the vault alone.');
+  } finally {
+    if (releaseLock) releaseLock();
+  }
+}
+
+module.exports = { classify, parseVaultAutoCommit, run };
+
+if (require.main === module) {
+  run();
+  process.exitCode = 0;
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,6 +78,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh \"$transcript_path\""
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/vault-autocommit.cjs"
           }
         ]
       }

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -60,6 +60,67 @@ If user skips, exit gracefully.
 
 **B. Check current setup**
 
+Detect the installed topology before inspecting or renaming remotes. This is a
+closed structural check: a declared split with incomplete markers stops rather
+than falling through to the combined Git workflow.
+
+```bash
+DEX_UPDATE_TOPOLOGY=$(python3 - <<'PY'
+import json
+from pathlib import Path
+
+root = Path.cwd()
+def regular_json(relative):
+    candidate = root / relative
+    try:
+        if candidate.is_symlink() or not candidate.is_file():
+            return None
+        value = json.loads(candidate.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+topology = regular_json("System/.dex/topology.json")
+vault_marker = regular_json(".git/dex-vault-v2")
+brain_marker = regular_json(".dex/brain.git/dex-brain-v2")
+if topology and topology.get("topology") == "brain-vault-split":
+    environment = topology.get("environment")
+    valid = (
+        topology.get("vaultGitDir") == ".git"
+        and topology.get("brainGitDir") == ".dex/brain.git"
+        and (root / ".git").is_dir()
+        and not (root / ".git").is_symlink()
+        and (root / ".dex/brain.git").is_dir()
+        and not (root / ".dex/brain.git").is_symlink()
+        and vault_marker and vault_marker.get("role") == "vault"
+        and brain_marker and brain_marker.get("role") == "brain"
+        and isinstance(environment, dict)
+        and isinstance(environment.get("DEX_VAULT"), str)
+        and environment["DEX_VAULT"]
+        and Path(environment["DEX_VAULT"]).resolve() == root.resolve()
+    )
+    print("split" if valid else "invalid-split")
+elif (root / ".git").exists():
+    print("combined")
+else:
+    print("manual")
+PY
+) || exit 1
+
+case "$DEX_UPDATE_TOPOLOGY" in
+  split|combined|manual) ;;
+  invalid-split)
+    echo "Update stopped: the brain/vault topology markers disagree. Run /dex-doctor and use updater/migrator recovery; do not use raw Git recovery."
+    exit 1
+    ;;
+  *) echo "Update stopped: Dex could not classify this installation topology"; exit 1 ;;
+esac
+```
+
+If this prints `split`, do not rename the vault repository's remotes. Continue
+to Step 2, then use the split route below. `combined` keeps the existing remote
+setup and merge workflow. `manual` uses Scenario 1.
+
 Run: `git remote -v`
 
 **Scenario 1: Downloaded as ZIP (no Git)**
@@ -159,6 +220,86 @@ Run /dex-doctor to review this evidence and update guidance. Dex will not update
 
 Never say `update available`, `verified`, `safe`, `current`, or `up to date` for this result. Continue only after the
 user separately chooses the existing manual update workflow.
+
+---
+
+### Split-topology route
+
+When `DEX_UPDATE_TOPOLOGY` is `split`, the vault and Dex brain have separate
+histories. Do not run the backup-tag or merge workflow in Steps 3-6. Preserve
+the exact evidence fields returned by Step 2 (`tag`, `tag_object`, `commit`,
+and `tree`), validate their closed shapes, fetch only that immutable tag plus
+the configured channel branch into `.dex/brain.git`, and let the Python
+transaction updater replace only contract-authorized brain/generated files
+and absent seeds.
+
+```bash
+# Set these from the exact structured Step 2 response; never infer or shorten them.
+DEX_RELEASE_TAG='<exact dist/release/v tag>'
+DEX_RELEASE_TAG_OBJECT='<exact full tag object>'
+DEX_RELEASE_COMMIT='<exact full commit>'
+DEX_RELEASE_TREE='<exact full tree>'
+
+case "$DEX_RELEASE_TAG" in
+  dist/release/v[0-9]*.[0-9]*.[0-9]*-[0-9a-f]*) ;;
+  *) echo "Update stopped: immutable release tag shape is invalid"; exit 1 ;;
+esac
+for DEX_RELEASE_IDENTITY in \
+  "$DEX_RELEASE_TAG_OBJECT" "$DEX_RELEASE_COMMIT" "$DEX_RELEASE_TREE"; do
+  case "$DEX_RELEASE_IDENTITY" in
+    *[!0-9a-f]*|'') echo "Update stopped: immutable release identity is invalid"; exit 1 ;;
+  esac
+  [ "${#DEX_RELEASE_IDENTITY}" -ge 40 ] && [ "${#DEX_RELEASE_IDENTITY}" -le 64 ] || {
+    echo "Update stopped: immutable release identity length is invalid"
+    exit 1
+  }
+done
+
+if ! python3 -m core.utils.credential_workflow migrate; then
+  echo "Credential migration was refused. Run /dex-doctor --credential-status for redacted guidance."
+  exit 1
+fi
+
+DEX_UPDATE_CHANNEL=$(python3 - <<'PY'
+from core.utils.release_channel import read_channel
+print(read_channel('.'))
+PY
+) || exit 1
+case "$DEX_UPDATE_CHANNEL" in
+  stable) DEX_RELEASE_BRANCH=release ;;
+  beta) DEX_RELEASE_BRANCH=release-beta ;;
+  *) echo "Update stopped: the configured update channel is invalid"; exit 1 ;;
+esac
+
+DEX_BRAIN_ORIGIN=$(git --git-dir=.dex/brain.git config --get remote.origin.url) || exit 1
+DEX_BRAIN_EFFECTIVE=$(git --git-dir=.dex/brain.git remote get-url origin) || exit 1
+case "$DEX_BRAIN_ORIGIN|$DEX_BRAIN_EFFECTIVE" in
+  https://github.com/davekilleen/Dex.git\|https://github.com/davekilleen/Dex.git|\
+  https://github.com/davekilleen/Dex\|https://github.com/davekilleen/Dex) ;;
+  *) echo "Update stopped: the Dex brain origin is not the effective official repository"; exit 1 ;;
+esac
+
+git --git-dir=.dex/brain.git fetch --no-tags origin \
+  "+refs/heads/$DEX_RELEASE_BRANCH:refs/remotes/origin/$DEX_RELEASE_BRANCH" \
+  "refs/tags/$DEX_RELEASE_TAG:refs/tags/$DEX_RELEASE_TAG" || exit 1
+
+python3 -m core.update.apply_update \
+  --vault "$PWD" \
+  --tag "$DEX_RELEASE_TAG" \
+  --tag-object "$DEX_RELEASE_TAG_OBJECT" \
+  --commit "$DEX_RELEASE_COMMIT" \
+  --tree "$DEX_RELEASE_TREE" || exit 1
+```
+
+The service re-checks the immutable annotated tag, full commit/tree, selected
+stable or beta channel, official brain origin, topology markers, and
+`System/.dex/mutation.lock` before it commits. Its transaction snapshot is the
+exact undo record for replaced and pruned brain files. Vault/runtime paths and
+existing seeds are not in the mutation plan.
+
+After a successful split update, continue at Step 7 for dependencies and
+outcome verification. Combined topology continues to Step 3 and uses today's
+merge flow unchanged.
 
 ---
 

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -23,6 +23,10 @@ timezone: ""
 updates:
   channel: stable
 
+# Optional local Git snapshots after the brain/vault split. This never pushes.
+vault:
+  auto_commit: false
+
 # Role Intelligence
 # This section is populated during onboarding based on the role definition
 role_context:

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from core.update import apply_update
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -74,9 +77,7 @@ def split_release_fixture(tmp_path: Path) -> dict[str, object]:
     _write(release, "04-Projects/private.md", b"release tried to replace user notes\n")
     _write(release, "System/.dex/release-runtime.json", b'{"new":true}\n')
     (release / "core/obsolete.py").unlink()
-    target_tag, target_tag_object, target_commit, target_tree = _commit_release(
-        release, "1.64.0"
-    )
+    target_tag, target_tag_object, target_commit, target_tree = _commit_release(release, "1.64.0")
 
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -198,12 +199,15 @@ def test_apply_update_replaces_brain_prunes_unchanged_and_preserves_user_owned_p
     marker = json.loads((vault / ".dex/brain.git/dex-brain-v2").read_text())
     assert topology["installedRelease"] == target_commit
     assert marker["installed"] == target_commit
-    assert subprocess.run(
-        ["git", f"--git-dir={split_release_fixture['brain']}", "rev-parse", "refs/dex/installed"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip() == target_commit
+    assert (
+        subprocess.run(
+            ["git", f"--git-dir={split_release_fixture['brain']}", "rev-parse", "refs/dex/installed"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        == target_commit
+    )
 
 
 def test_apply_update_verification_failure_restores_every_release_file(
@@ -239,15 +243,17 @@ def test_apply_update_verification_failure_restores_every_release_file(
     assert json.loads((vault / "System/.dex/topology.json").read_text())["installedRelease"] == old_commit
 
 
-def test_release_pinning_failure_rolls_back_the_committed_file_transaction(
+def test_release_pinning_failure_rolls_back_file_transaction_under_lock(
     monkeypatch: pytest.MonkeyPatch,
     split_release_fixture: dict[str, object],
 ) -> None:
     vault = split_release_fixture["vault"]
     before_readme = (vault / "README.md").read_bytes()
     before_obsolete = (vault / "core/obsolete.py").read_bytes()
+    lock = vault / "System/.dex/mutation.lock"
 
     def fail_release_pin(*_args: object, **_kwargs: object) -> None:
+        assert lock.is_file(), "release identity finalization must run under the transaction lock"
         raise RuntimeError("simulated release pin failure")
 
     monkeypatch.setattr(apply_update, "_finalize_release_metadata", fail_release_pin)
@@ -258,3 +264,96 @@ def test_release_pinning_failure_rolls_back_the_committed_file_transaction(
     assert (vault / "README.md").read_bytes() == before_readme
     assert (vault / "core/obsolete.py").read_bytes() == before_obsolete
     assert not (vault / "core/new.py").exists()
+
+
+def test_crash_between_apply_and_release_identity_finalize_converges(
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    tag, tag_object, target_commit, tree = split_release_fixture["target"]
+    _, _, old_commit, _ = split_release_fixture["old"]
+    before = {relative: (vault / relative).read_bytes() for relative in ("README.md", "core/obsolete.py")}
+    worker = """
+import sys
+from pathlib import Path
+from core.update.apply_update import apply_verified_release, verify_release_ref
+vault = Path(sys.argv[1])
+release = verify_release_ref(
+    vault,
+    tag=sys.argv[2],
+    tag_object=sys.argv[3],
+    commit=sys.argv[4],
+    tree=sys.argv[5],
+)
+apply_verified_release(vault, release)
+"""
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            worker,
+            str(vault),
+            tag,
+            tag_object,
+            target_commit,
+            tree,
+        ],
+        cwd=REPO_ROOT,
+        env=dict(os.environ, DEX_TX_TEST_STOP_AFTER="before-finalize"),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert process.returncode == 137, process.stderr[-500:]
+    outcomes = apply_update.Transaction.resume(vault)
+
+    assert len(outcomes) == 1 and outcomes[0]["resumed"] is True
+    assert (vault / "README.md").read_bytes() == before["README.md"]
+    assert (vault / "core/obsolete.py").read_bytes() == before["core/obsolete.py"]
+    assert not (vault / "core/new.py").exists()
+    assert json.loads((vault / "System/.dex/topology.json").read_text())["installedRelease"] == old_commit
+    assert json.loads((vault / ".dex/brain.git/dex-brain-v2").read_text())["installed"] == old_commit
+    assert _git(vault / ".dex/brain.git", "rev-parse", "refs/dex/installed") == old_commit
+
+
+def test_update_plan_skips_release_entries_that_already_match_bytes_and_mode(
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    release = _verified(split_release_fixture)
+    (vault / "README.md").write_bytes(b"new brain\n")
+    (vault / "README.md").chmod(0o644)
+
+    plan = apply_update.build_update_plan(vault, release)
+
+    assert "README.md" not in {entry.relative for entry in plan.entries}
+    assert "README.md" not in plan.replaced
+
+
+def test_apply_update_can_finalize_when_every_release_mutation_already_matches(
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    release = _verified(split_release_fixture)
+    for entry in release.entries:
+        target = vault / entry.path
+        verdict = apply_update.portable_contract.update_write_verdict(
+            entry.path,
+            exists=target.exists(),
+        )
+        if not verdict.allowed:
+            continue
+        content = subprocess.run(
+            ["git", f"--git-dir={release.brain_git}", "show", f"{release.commit}:{entry.path}"],
+            check=True,
+            capture_output=True,
+        ).stdout
+        _write(vault, entry.path, content, entry.mode)
+    (vault / "core/obsolete.py").unlink()
+
+    result = apply_update.apply_verified_release(vault, release)
+
+    assert result["committed"] is True
+    assert result["targets"] == []
+    assert _git(vault / ".dex/brain.git", "rev-parse", "refs/dex/installed") == release.commit

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -60,7 +60,7 @@ def split_release_fixture(tmp_path: Path) -> dict[str, object]:
     release.mkdir()
     _git(release, "init", "--quiet")
     _git(release, "config", "user.name", "Dex Update Tests")
-    _git(release, "config", "user.email", "update@example.test")
+    _git(release, "config", "user.email", "update@example.com")
     _write(release, "README.md", b"old brain\n")
     _write(release, "core/obsolete.py", b"OLD = True\n", 0o755)
     _write(release, "03-Tasks/Tasks.md", b"# shipped seed\n")

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1,0 +1,260 @@
+"""Contract tests for the split-topology no-merge updater."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.update import apply_update
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _write(root: Path, relative: str, content: bytes, mode: int = 0o644) -> None:
+    target = root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    target.chmod(mode)
+
+
+def _refresh_manifest(release: Path) -> None:
+    manifest = release / "System/.installed-files.manifest"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_bytes(b"")
+    paths = sorted(
+        candidate.relative_to(release).as_posix()
+        for candidate in release.rglob("*")
+        if candidate.is_file() and ".git" not in candidate.relative_to(release).parts
+    )
+    manifest.write_text("".join(f"{relative}\n" for relative in paths), encoding="utf-8")
+
+
+def _commit_release(release: Path, version: str) -> tuple[str, str, str, str]:
+    package = release / "package.json"
+    package.write_text(json.dumps({"name": "dex-test", "version": version}) + "\n")
+    _refresh_manifest(release)
+    _git(release, "add", "-A")
+    _git(release, "commit", "--quiet", "-m", f"release {version}")
+    commit = _git(release, "rev-parse", "HEAD")
+    tree = _git(release, "rev-parse", "HEAD^{tree}")
+    tag = f"dist/release/v{version}-{commit[:7]}"
+    _git(release, "tag", "-a", tag, "-m", f"Dex {version}")
+    tag_object = _git(release, "rev-parse", f"refs/tags/{tag}")
+    return tag, tag_object, commit, tree
+
+
+@pytest.fixture
+def split_release_fixture(tmp_path: Path) -> dict[str, object]:
+    release = tmp_path / "release"
+    release.mkdir()
+    _git(release, "init", "--quiet")
+    _git(release, "config", "user.name", "Dex Update Tests")
+    _git(release, "config", "user.email", "update@example.test")
+    _write(release, "README.md", b"old brain\n")
+    _write(release, "core/obsolete.py", b"OLD = True\n", 0o755)
+    _write(release, "03-Tasks/Tasks.md", b"# shipped seed\n")
+    _write(release, "04-Projects/private.md", b"release placeholder\n")
+    _write(release, "System/.dex/release-runtime.json", b"{}\n")
+    old_tag, old_tag_object, old_commit, old_tree = _commit_release(release, "1.63.0")
+
+    _write(release, "README.md", b"new brain\n")
+    _write(release, "core/new.py", b"NEW = True\n")
+    _write(release, "03-Tasks/Tasks.md", b"# changed shipped seed\n")
+    _write(release, "04-Projects/private.md", b"release tried to replace user notes\n")
+    _write(release, "System/.dex/release-runtime.json", b'{"new":true}\n')
+    (release / "core/obsolete.py").unlink()
+    target_tag, target_tag_object, target_commit, target_tree = _commit_release(
+        release, "1.64.0"
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for relative in (
+        "README.md",
+        "core/obsolete.py",
+        "03-Tasks/Tasks.md",
+        "04-Projects/private.md",
+        "System/.dex/release-runtime.json",
+    ):
+        raw = subprocess.run(
+            ["git", "-C", str(release), "show", f"{old_commit}:{relative}"],
+            check=True,
+            capture_output=True,
+        ).stdout
+        _write(vault, relative, raw, 0o755 if relative == "core/obsolete.py" else 0o644)
+    _write(vault, "03-Tasks/Tasks.md", b"# user's edited tasks\n")
+    _write(vault, "04-Projects/private.md", b"private user bytes\n")
+    _write(vault, "System/.dex/release-runtime.json", b'{"local":true}\n')
+    _write(vault, "System/user-profile.yaml", b"updates:\n  channel: stable\n")
+
+    brain = vault / ".dex/brain.git"
+    brain.parent.mkdir(parents=True)
+    _git(vault, "init", "--bare", "--quiet", str(brain))
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={brain}",
+            "fetch",
+            "--quiet",
+            "--tags",
+            str(release),
+            f"+{old_commit}:refs/dex/installed",
+            f"+{target_commit}:refs/remotes/upstream/release",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
+        check=True,
+    )
+    _write(vault, ".git/dex-vault-v2", b'{"role":"vault"}\n')
+    _write(
+        vault,
+        ".dex/brain.git/dex-brain-v2",
+        (json.dumps({"role": "brain", "installed": old_commit}) + "\n").encode(),
+    )
+    _write(
+        vault,
+        "System/.dex/topology.json",
+        (
+            json.dumps(
+                {
+                    "topology": "brain-vault-split",
+                    "vaultGitDir": ".git",
+                    "brainGitDir": ".dex/brain.git",
+                    "installedRelease": old_commit,
+                    "environment": {"DEX_VAULT": str(vault.resolve())},
+                }
+            )
+            + "\n"
+        ).encode(),
+    )
+    return {
+        "vault": vault,
+        "brain": brain,
+        "old": (old_tag, old_tag_object, old_commit, old_tree),
+        "target": (target_tag, target_tag_object, target_commit, target_tree),
+    }
+
+
+def _verified(fixture: dict[str, object]) -> apply_update.VerifiedReleaseRef:
+    tag, tag_object, commit, tree = fixture["target"]
+    return apply_update.verify_release_ref(
+        fixture["vault"],
+        tag=tag,
+        tag_object=tag_object,
+        commit=commit,
+        tree=tree,
+    )
+
+
+def test_verified_release_is_pinned_to_immutable_tag_and_channel(
+    split_release_fixture: dict[str, object],
+) -> None:
+    release = _verified(split_release_fixture)
+
+    assert release.tag.startswith("dist/release/v1.64.0-")
+    assert release.channel == "stable"
+
+    tag, tag_object, commit, tree = split_release_fixture["target"]
+    with pytest.raises(apply_update.ReleaseVerificationError, match="tag object"):
+        apply_update.verify_release_ref(
+            split_release_fixture["vault"],
+            tag=tag,
+            tag_object="0" * len(tag_object),
+            commit=commit,
+            tree=tree,
+        )
+
+
+def test_apply_update_replaces_brain_prunes_unchanged_and_preserves_user_owned_paths(
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    release = _verified(split_release_fixture)
+
+    result = apply_update.apply_verified_release(vault, release)
+
+    assert result["committed"] is True
+    assert (vault / "README.md").read_bytes() == b"new brain\n"
+    assert (vault / "core/new.py").read_bytes() == b"NEW = True\n"
+    assert not (vault / "core/obsolete.py").exists()
+    assert (vault / "03-Tasks/Tasks.md").read_bytes() == b"# user's edited tasks\n"
+    assert (vault / "04-Projects/private.md").read_bytes() == b"private user bytes\n"
+    assert (vault / "System/.dex/release-runtime.json").read_bytes() == b'{"local":true}\n'
+    _, _, target_commit, _ = split_release_fixture["target"]
+    topology = json.loads((vault / "System/.dex/topology.json").read_text())
+    marker = json.loads((vault / ".dex/brain.git/dex-brain-v2").read_text())
+    assert topology["installedRelease"] == target_commit
+    assert marker["installed"] == target_commit
+    assert subprocess.run(
+        ["git", f"--git-dir={split_release_fixture['brain']}", "rev-parse", "refs/dex/installed"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == target_commit
+
+
+def test_apply_update_verification_failure_restores_every_release_file(
+    monkeypatch: pytest.MonkeyPatch,
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    before = {
+        relative: (vault / relative).read_bytes()
+        for relative in (
+            "README.md",
+            "core/obsolete.py",
+            "03-Tasks/Tasks.md",
+            "04-Projects/private.md",
+            "System/.dex/release-runtime.json",
+        )
+    }
+    original_verify = apply_update.Transaction._verify_phase
+
+    def fail_after_verify(transaction: apply_update.Transaction) -> None:
+        original_verify(transaction)
+        raise RuntimeError("simulated final verification failure")
+
+    monkeypatch.setattr(apply_update.Transaction, "_verify_phase", fail_after_verify)
+
+    with pytest.raises(RuntimeError, match="simulated final verification"):
+        apply_update.apply_verified_release(vault, _verified(split_release_fixture))
+
+    for relative, content in before.items():
+        assert (vault / relative).read_bytes() == content
+    assert not (vault / "core/new.py").exists()
+    _, _, old_commit, _ = split_release_fixture["old"]
+    assert json.loads((vault / "System/.dex/topology.json").read_text())["installedRelease"] == old_commit
+
+
+def test_release_pinning_failure_rolls_back_the_committed_file_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault = split_release_fixture["vault"]
+    before_readme = (vault / "README.md").read_bytes()
+    before_obsolete = (vault / "core/obsolete.py").read_bytes()
+
+    def fail_release_pin(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("simulated release pin failure")
+
+    monkeypatch.setattr(apply_update, "_finalize_release_metadata", fail_release_pin)
+
+    with pytest.raises(RuntimeError, match="simulated release pin failure"):
+        apply_update.apply_verified_release(vault, _verified(split_release_fixture))
+
+    assert (vault / "README.md").read_bytes() == before_readme
+    assert (vault / "core/obsolete.py").read_bytes() == before_obsolete
+    assert not (vault / "core/new.py").exists()

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -20,6 +20,10 @@ NOW = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
 QUICK_IDS = [
     "vault.structure",
     "vault.configs",
+    "vault.git",
+    "brain.git",
+    "vault.auto-commit",
+    "topology.migration-pending",
     "smoke.history",
     "mcp.registered",
     "mcp.orphans",
@@ -301,6 +305,76 @@ def test_registry_ids_match_the_approved_spec():
     assert doctor.VERDICTS == frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 
 
+def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
+    _git(context.vault_root, "init", "--quiet")
+    (context.vault_root / ".git/dex-vault-v2").write_text('{"role":"vault"}\n')
+    brain = context.vault_root / ".dex/brain.git"
+    brain.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "--quiet", str(brain)], check=True)
+    _git(context.vault_root, "config", "user.name", "Doctor Test")
+    _git(context.vault_root, "config", "user.email", "doctor@example.test")
+    (context.vault_root / "README.md").write_text("brain\n")
+    _git(context.vault_root, "add", "README.md")
+    _git(context.vault_root, "commit", "--quiet", "-m", "brain")
+    commit = _git(context.vault_root, "rev-parse", "HEAD").stdout.strip()
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "fetch", "--quiet", str(context.vault_root), f"+{commit}:refs/dex/installed"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
+        check=True,
+    )
+    (brain / "dex-brain-v2").write_text(
+        json.dumps({"role": "brain", "installed": commit}) + "\n"
+    )
+    topology = context.vault_root / "System/.dex/topology.json"
+    topology.parent.mkdir(parents=True, exist_ok=True)
+    topology.write_text(
+        json.dumps(
+            {
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "installedRelease": commit,
+                "environment": {"DEX_VAULT": str(context.vault_root.resolve())},
+            }
+        )
+        + "\n"
+    )
+    return brain
+
+
+def test_topology_probe_distinguishes_combined_split_and_invalid(context):
+    (context.vault_root / ".git").mkdir()
+    assert doctor._topology_state(context) == "combined"
+    assert doctor._probe_migration_pending(context).verdict == "OFF"
+
+    shutil.rmtree(context.vault_root / ".git")
+    _write_split_topology(context)
+    assert doctor._topology_state(context) == "post-split"
+    assert doctor._probe_migration_pending(context).verdict == "OK"
+
+    (context.vault_root / ".dex/brain.git/dex-brain-v2").unlink()
+    assert doctor._topology_state(context) == "invalid-split"
+    assert doctor._probe_migration_pending(context).verdict == "BROKEN"
+
+
+def test_split_brain_install_probe_checks_ref_markers_origin_and_integrity(context):
+    brain = _write_split_topology(context)
+
+    healthy = doctor._probe_brain_git(context)
+
+    assert healthy.verdict == "OK"
+    assert "brain history is healthy" in healthy.detail
+    marker = json.loads((brain / "dex-brain-v2").read_text())
+    marker["installed"] = "0" * 40
+    (brain / "dex-brain-v2").write_text(json.dumps(marker) + "\n")
+    broken = doctor._probe_brain_git(context)
+    assert broken.verdict == "BROKEN"
+    assert "disagrees" in broken.detail
+
+
 def _smoke_entry(timestamp, *, broken=0, version="1.47.0"):
     verdict = "BROKEN" if broken else "OK"
     return {
@@ -446,7 +520,12 @@ def test_summary_counts_each_exact_verdict(monkeypatch, context):
 
     report = doctor.collect(context=context)
 
-    assert report["summary"] == {"ok": 12, "off": 1, "broken": 1, "unknown": 1}
+    assert report["summary"] == {
+        "ok": len(doctor.QUICK_CHECKS) - 3,
+        "off": 1,
+        "broken": 1,
+        "unknown": 1,
+    }
     assert report["instruments"]["completed"] == len(QUICK_IDS)
 
 

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -181,7 +181,7 @@ def _drift_context(tmp_path, *, release_ref=True, channel=None):
     vault = tmp_path / "drift-vault"
     vault.mkdir()
     _git(vault, "init")
-    _git(vault, "config", "user.email", "doctor@example.test")
+    _git(vault, "config", "user.email", "doctor@example.com")
     _git(vault, "config", "user.name", "Doctor Test")
 
     (vault / "core").mkdir()
@@ -312,7 +312,7 @@ def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
     brain.parent.mkdir(parents=True)
     subprocess.run(["git", "init", "--bare", "--quiet", str(brain)], check=True)
     _git(context.vault_root, "config", "user.name", "Doctor Test")
-    _git(context.vault_root, "config", "user.email", "doctor@example.test")
+    _git(context.vault_root, "config", "user.email", "doctor@example.com")
     (context.vault_root / "README.md").write_text("brain\n")
     _git(context.vault_root, "add", "README.md")
     _git(context.vault_root, "commit", "--quiet", "-m", "brain")

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -93,6 +93,57 @@ def _remote_release_ref(channel: str) -> str:
     return f"refs/remotes/{release_channel.release_ref_candidates(channel)[0]}"
 
 
+def test_topology_journey_checks_combined_split_and_vault_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    combined = tmp_path / "combined"
+    (combined / ".git").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(combined))
+    monkeypatch.setenv("VAULT_ROOT", str(combined))
+    monkeypatch.setenv("DEX_VAULT", str(combined))
+    result = smoke._journey_topology(combined, tmp_path)
+    assert result["verdict"] == "OK"
+    assert "combined topology" in result["detail"]
+
+    split = tmp_path / "split"
+    (split / ".git").mkdir(parents=True)
+    (split / ".dex/brain.git").mkdir(parents=True)
+    (split / "System/.dex").mkdir(parents=True)
+    (split / ".git/dex-vault-v2").write_text('{"role":"vault"}\n')
+    (split / ".dex/brain.git/dex-brain-v2").write_text(
+        '{"role":"brain","installed":"abc"}\n'
+    )
+    (split / "System/.dex/topology.json").write_text(
+        '{"topology":"brain-vault-split","vaultGitDir":".git",'
+        '"brainGitDir":".dex/brain.git","installedRelease":"abc",'
+        f'"environment":{{"DEX_VAULT":{json.dumps(str(split.resolve()))}}}}}\n'
+    )
+    monkeypatch.setenv("VAULT_PATH", str(split))
+    monkeypatch.setenv("VAULT_ROOT", str(split))
+    monkeypatch.setenv("DEX_VAULT", str(split))
+    result = smoke._journey_topology(split, tmp_path)
+    assert result["verdict"] == "OK"
+    assert "split topology" in result["detail"]
+
+    monkeypatch.setenv("VAULT_ROOT", str(combined))
+    result = smoke._journey_topology(split, tmp_path)
+    assert result["verdict"] == "BROKEN"
+    assert "VAULT_ROOT" in result["detail"]
+
+    monkeypatch.setenv("VAULT_ROOT", str(split))
+    monkeypatch.setenv("DEX_VAULT", str(combined))
+    result = smoke._journey_topology(split, tmp_path)
+    assert result["verdict"] == "BROKEN"
+    assert "DEX_VAULT" in result["detail"]
+
+
+def test_smoke_registry_adds_topology_without_losing_shipped_journeys() -> None:
+    ids = {definition.id for definition in smoke.JOURNEYS}
+    assert {"configs", "task_lifecycle", "mcp_startup", "skills", "hooks"} <= ids
+    assert "topology" in ids
+
+
 def test_mcp_handshake_timeout_env_override_changes_effective_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -291,6 +342,7 @@ def test_report_schema_exit_zero_and_no_live_write(tmp_path: Path) -> None:
     assert run.report["schema_version"] == 1
     assert run.report["generated_at"].endswith("+00:00")
     assert [journey["id"] for journey in run.report["journeys"]] == [
+        "topology",
         "configs",
         "task_lifecycle",
         "mcp_startup",
@@ -298,6 +350,7 @@ def test_report_schema_exit_zero_and_no_live_write(tmp_path: Path) -> None:
         "hooks",
     ]
     verdicts = {journey["id"]: journey["verdict"] for journey in run.report["journeys"]}
+    assert verdicts["topology"] == "OFF"
     assert verdicts["configs"] == "OK"
     assert verdicts["mcp_startup"] == "OK"  # empty .mcp.json → OK regardless of the execution gate
     assert verdicts["skills"] == "OFF"
@@ -313,7 +366,7 @@ def test_report_schema_exit_zero_and_no_live_write(tmp_path: Path) -> None:
         "ok": 3 if executed else 2,
         "broken": 0,
         "unknown": 0 if executed else 1,
-        "off": 2,
+        "off": 3,
     }
     for journey in run.report["journeys"]:
         assert set(journey) == {"id", "verdict", "detail", "duration_ms"}

--- a/core/tests/test_split_probe_regression.py
+++ b/core/tests/test_split_probe_regression.py
@@ -1,0 +1,42 @@
+"""Poison-pill guard: split probes must never replace shipped safety probes."""
+
+from pathlib import Path
+
+from core.utils import doctor, smoke
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_doctor_split_registry_retains_trust_channel_and_credential_surfaces() -> None:
+    ids = {definition.id for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)}
+    source = (ROOT / "core/utils/doctor.py").read_text(encoding="utf-8")
+
+    assert {
+        "customizations.mcp",
+        "core.drift",
+        "integrations.enabled",
+        "mcp.registered",
+    } <= ids
+    for symbol in (
+        "release_channel.read_channel",
+        "load_trusted_mcp_registry",
+        "snapshot_trusted_mcp",
+        "--credential-scan",
+        "run_credential_workflow",
+    ):
+        assert symbol in source
+
+
+def test_smoke_split_registry_retains_trust_channel_and_credential_surfaces() -> None:
+    ids = {definition.id for definition in smoke.JOURNEYS}
+    source = (ROOT / "core/utils/smoke.py").read_text(encoding="utf-8")
+
+    assert {"configs", "task_lifecycle", "mcp_startup", "skills", "hooks"} <= ids
+    for symbol in (
+        "release_channel.read_channel",
+        "load_trusted_mcp_registry",
+        "snapshot_trusted_mcp",
+        "credential_migration_exceptions.json",
+        "integration_credentials.py",
+    ):
+        assert symbol in source

--- a/core/tests/test_split_probe_regression.py
+++ b/core/tests/test_split_probe_regression.py
@@ -1,42 +1,100 @@
-"""Poison-pill guard: split probes must never replace shipped safety probes."""
+"""Behavioral poison pills for trust, channel, and credential safety probes."""
 
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
 from pathlib import Path
+
+import pytest
 
 from core.utils import doctor, smoke
 
-ROOT = Path(__file__).resolve().parents[2]
+
+def _known_bad_doctor_results(tmp_path: Path) -> dict[str, doctor.ProbeResult]:
+    vault = tmp_path / "vault"
+    (vault / "System/integrations").mkdir(parents=True)
+    (vault / "core").mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    (vault / "System/user-profile.yaml").write_text(
+        "updates:\n  channel: nightly\n",
+        encoding="utf-8",
+    )
+    (vault / "System/integrations/config.yaml").write_text(
+        "teams:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    external = tmp_path / "external-mcp.json"
+    external.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    (vault / ".mcp.json").symlink_to(external)
+    context = doctor.DoctorContext(
+        vault_root=vault,
+        repo_root=vault,
+        home=home,
+        now=datetime(2026, 7, 21, tzinfo=timezone.utc),
+    )
+    return {
+        "channel": doctor._probe_core_drift(context),
+        "trust": doctor._probe_customization_mcp(context),
+        "credential": doctor._probe_integrations_enabled(context),
+    }
 
 
-def test_doctor_split_registry_retains_trust_channel_and_credential_surfaces() -> None:
-    ids = {definition.id for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)}
-    source = (ROOT / "core/utils/doctor.py").read_text(encoding="utf-8")
-
-    assert {
-        "customizations.mcp",
-        "core.drift",
-        "integrations.enabled",
-        "mcp.registered",
-    } <= ids
-    for symbol in (
-        "release_channel.read_channel",
-        "load_trusted_mcp_registry",
-        "snapshot_trusted_mcp",
-        "--credential-scan",
-        "run_credential_workflow",
-    ):
-        assert symbol in source
+def _assert_known_bad_doctor_probes_fail_closed(tmp_path: Path) -> None:
+    results = _known_bad_doctor_results(tmp_path)
+    assert results["channel"].verdict in {"BROKEN", "UNKNOWN"}
+    assert results["trust"].verdict in {"BROKEN", "UNKNOWN"}
+    assert results["credential"].verdict in {"BROKEN", "UNKNOWN"}
 
 
-def test_smoke_split_registry_retains_trust_channel_and_credential_surfaces() -> None:
-    ids = {definition.id for definition in smoke.JOURNEYS}
-    source = (ROOT / "core/utils/smoke.py").read_text(encoding="utf-8")
+def test_doctor_split_safety_probes_fail_closed_on_known_bad_fixtures(
+    tmp_path: Path,
+) -> None:
+    _assert_known_bad_doctor_probes_fail_closed(tmp_path)
 
-    assert {"configs", "task_lifecycle", "mcp_startup", "skills", "hooks"} <= ids
-    for symbol in (
-        "release_channel.read_channel",
-        "load_trusted_mcp_registry",
-        "snapshot_trusted_mcp",
-        "credential_migration_exceptions.json",
-        "integration_credentials.py",
-    ):
-        assert symbol in source
+
+def test_doctor_behavior_guard_turns_red_when_core_drift_is_gutted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "_probe_core_drift",
+        lambda _context: doctor.ProbeResult("OK", "gutted probe"),
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_known_bad_doctor_probes_fail_closed(tmp_path)
+
+
+def test_smoke_trust_and_credentials_fail_closed_on_known_bad_mcp(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    (source / "System").mkdir(parents=True)
+    (source / "System/.onboarding-complete").write_text("{}\n", encoding="utf-8")
+    secret = "scanner-positive-fixture-value"
+    (source / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "custom-untrusted": {
+                        "command": "python3",
+                        "args": ["custom-mcp/server.py"],
+                        "env": {"API_TOKEN": secret},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+
+    smoke._prepare_mcp_vault(source, source, isolated, None, None)
+    result = smoke._journey_mcp_startup(isolated, tmp_path)
+
+    assert result["verdict"] in {"BROKEN", "UNKNOWN"}
+    assert secret not in result["detail"]
+    assert secret.encode() not in (isolated / smoke.MCP_PLAN).read_bytes()

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -10,8 +10,10 @@ gate carries a red-when-removed proof.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -242,6 +244,54 @@ def test_engine_verify_failure_rolls_back_byte_exact(tmp_path: Path) -> None:
     with pytest.raises(Exception):
         tx.run()
     assert target.read_bytes() == b"old manifest\n"
+
+
+def test_engine_delete_entry_commits_and_rolls_back_byte_exact(tmp_path: Path) -> None:
+    """Updater removals use the same snapshot/apply/verify/undo path as writes."""
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"old shipped bytes\r\nwith\x00data")
+    os.chmod(target, 0o640)
+
+    deleted = Transaction.begin(vault, [PlanEntry("README.md", None)]).run()
+
+    assert deleted["committed"] is True
+    assert not target.exists()
+
+    target.write_bytes(b"restorable shipped bytes\n")
+    os.chmod(target, 0o600)
+    tx = Transaction.begin(vault, [PlanEntry("README.md", None)])
+    original_verify = tx._verify_phase
+
+    def verify_then_fail() -> None:
+        original_verify()
+        raise RuntimeError("simulated updater verification failure")
+
+    tx._verify_phase = verify_then_fail
+    with pytest.raises(RuntimeError, match="simulated updater"):
+        tx.run()
+
+    assert target.read_bytes() == b"restorable shipped bytes\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_engine_delete_precondition_preserves_a_file_changed_after_planning(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"unchanged shipped bytes\n")
+    expected = hashlib.sha256(target.read_bytes()).hexdigest()
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", None, 0o644, expected_current_sha256=expected)],
+    )
+    target.write_bytes(b"user changed this after planning\n")
+
+    with pytest.raises(PlanRejected, match="changed after the mutation plan"):
+        tx.run()
+
+    assert target.read_bytes() == b"user changed this after planning\n"
 
 
 def test_engine_holds_the_single_mutator_lock(tmp_path: Path) -> None:

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -38,17 +38,14 @@ def _tree_state(vault: Path, relatives: list[str]) -> dict:
     state = {}
     for relative in relatives:
         path = vault / relative
-        state[relative] = (
-            (path.read_bytes(), path.stat().st_mode & 0o7777)
-            if path.exists()
-            else None
-        )
+        state[relative] = (path.read_bytes(), path.stat().st_mode & 0o7777) if path.exists() else None
     return state
 
 
 # ---------------------------------------------------------------------------
 # Lock
 # ---------------------------------------------------------------------------
+
 
 def test_lock_busy_refusal_release_and_stale_takeover(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
@@ -81,6 +78,7 @@ def test_lock_release_after_takeover_is_a_noop(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Journal
 # ---------------------------------------------------------------------------
+
 
 def test_journal_round_trip_and_sequence(tmp_path: Path) -> None:
     journal = Journal(tmp_path / "j.jsonl")
@@ -125,6 +123,7 @@ def test_journal_interior_tamper_fails_closed(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Snapshot
 # ---------------------------------------------------------------------------
+
 
 def test_snapshot_restore_is_byte_and_mode_exact_and_deletes_created(
     tmp_path: Path,
@@ -173,6 +172,7 @@ def test_snapshot_refuses_symlinks_and_directories(tmp_path: Path) -> None:
 # Engine semantics
 # ---------------------------------------------------------------------------
 
+
 def test_engine_happy_path_commits_and_reports(tmp_path: Path) -> None:
     vault = _vault(tmp_path)
     result = Transaction.begin(
@@ -212,9 +212,7 @@ def test_engine_rejects_seed_overwrite_vault_deny_and_unclassified(
     assert not (vault / "System/.installed-files.manifest").exists()
 
 
-def test_engine_authorization_gate_is_load_bearing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_engine_authorization_gate_is_load_bearing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Red-when-removed: neuter the contract verdict and the engine happily
     writes into user content — proving the gate is what stands between an
     update and the user's files."""
@@ -253,14 +251,22 @@ def test_engine_delete_entry_commits_and_rolls_back_byte_exact(tmp_path: Path) -
     target.write_bytes(b"old shipped bytes\r\nwith\x00data")
     os.chmod(target, 0o640)
 
-    deleted = Transaction.begin(vault, [PlanEntry("README.md", None)]).run()
+    original_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    deleted = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", None, 0o640, expected_current_sha256=original_sha)],
+    ).run()
 
     assert deleted["committed"] is True
     assert not target.exists()
 
     target.write_bytes(b"restorable shipped bytes\n")
     os.chmod(target, 0o600)
-    tx = Transaction.begin(vault, [PlanEntry("README.md", None)])
+    restorable_sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", None, 0o600, expected_current_sha256=restorable_sha)],
+    )
     original_verify = tx._verify_phase
 
     def verify_then_fail() -> None:
@@ -273,6 +279,19 @@ def test_engine_delete_entry_commits_and_rolls_back_byte_exact(tmp_path: Path) -
 
     assert target.read_bytes() == b"restorable shipped bytes\n"
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_engine_rejects_deletion_without_current_content_precondition(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"shipped bytes\n")
+
+    with pytest.raises(PlanRejected, match="deletions require"):
+        Transaction.begin(vault, [PlanEntry("README.md", None)])
+
+    assert target.read_bytes() == b"shipped bytes\n"
 
 
 def test_engine_delete_precondition_preserves_a_file_changed_after_planning(
@@ -292,6 +311,34 @@ def test_engine_delete_precondition_preserves_a_file_changed_after_planning(
         tx.run()
 
     assert target.read_bytes() == b"user changed this after planning\n"
+
+
+def test_engine_rechecks_deletion_content_immediately_before_unlink(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"shipped bytes\n")
+    expected = hashlib.sha256(target.read_bytes()).hexdigest()
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", None, 0o644, expected_current_sha256=expected)],
+    )
+    tx._snapshot_phase()
+    original_append = tx.journal.append
+
+    def change_after_apply_intent(event: str, payload=None) -> None:
+        original_append(event, payload)
+        if event == "APPLYING":
+            target.write_bytes(b"changed immediately before unlink\n")
+
+    tx.journal.append = change_after_apply_intent
+
+    with pytest.raises(PlanRejected, match="changed after the mutation snapshot"):
+        tx._apply_phase()
+    tx.rollback()
+
+    assert target.read_bytes() == b"changed immediately before unlink\n"
 
 
 def test_engine_holds_the_single_mutator_lock(tmp_path: Path) -> None:
@@ -362,9 +409,7 @@ def test_crash_at_every_seam_converges(seam: str, tmp_path: Path) -> None:
         assert len(outcomes) == 1 and outcomes[0]["resumed"] is True
 
     # Either way the vault must be immediately usable again.
-    Transaction.begin(
-        vault, [PlanEntry("System/.installed-files.manifest", b"post-recovery\n")]
-    ).run()
+    Transaction.begin(vault, [PlanEntry("System/.installed-files.manifest", b"post-recovery\n")]).run()
 
 
 def test_resume_is_idempotent(tmp_path: Path) -> None:
@@ -385,6 +430,7 @@ def test_resume_is_idempotent(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Adversarial-review fixes (F1-F5, F9), each pinned
 # ---------------------------------------------------------------------------
+
 
 def test_seed_created_mid_window_wins_and_aborts_transaction(tmp_path: Path) -> None:
     """F1: a seed file appearing AFTER authorization (user, Obsidian, background
@@ -441,9 +487,7 @@ def test_resume_quarantines_a_corrupt_journal_and_recovers_the_rest(
 def test_rollback_removes_directories_the_transaction_created(tmp_path: Path) -> None:
     """F3: rollback removes empty directories the apply created."""
     vault = _vault(tmp_path)
-    tx = Transaction.begin(
-        vault, [PlanEntry("System/Templates/New/Deep/t.md", b"x\n")]
-    )
+    tx = Transaction.begin(vault, [PlanEntry("System/Templates/New/Deep/t.md", b"x\n")])
     tx._snapshot_phase()
     tx._apply_phase()
     tx.rollback()
@@ -472,17 +516,13 @@ def test_special_mode_bits_are_rejected(tmp_path: Path) -> None:
     """F5: no setuid/setgid/sticky or non-permission bits."""
     vault = _vault(tmp_path)
     with pytest.raises(PlanRejected):
-        Transaction.begin(
-            vault, [PlanEntry("System/.installed-files.manifest", b"x", mode=0o4777)]
-        )
+        Transaction.begin(vault, [PlanEntry("System/.installed-files.manifest", b"x", mode=0o4777)])
 
 
 def test_verify_checks_mode_as_well_as_bytes(tmp_path: Path) -> None:
     """F9: a mode mismatch after apply fails verification and rolls back."""
     vault = _vault(tmp_path)
-    tx = Transaction.begin(
-        vault, [PlanEntry("System/.installed-files.manifest", b"x\n", mode=0o600)]
-    )
+    tx = Transaction.begin(vault, [PlanEntry("System/.installed-files.manifest", b"x\n", mode=0o600)])
     original_verify = tx._verify_phase
 
     def sabotage_then_verify() -> None:

--- a/core/tests/test_update_rollback_journey.py
+++ b/core/tests/test_update_rollback_journey.py
@@ -41,6 +41,23 @@ def test_update_runs_credential_migration_before_status_and_safe_autosave():
     assert migration < status < autosave
 
 
+def test_update_skill_routes_split_topology_to_transaction_updater_without_merge() -> None:
+    update = UPDATE_SKILL.read_text(encoding="utf-8")
+    start = update.index("### Split-topology route")
+    end = update.index("### Step 3: Pre-Update Safety Check")
+    split = update[start:end]
+
+    assert "core.update.apply_update" in split
+    assert "dist/release/v" in split
+    assert "--tag-object" in split
+    assert "--commit" in split
+    assert "--tree" in split
+    assert "release-beta" in split
+    assert "System/.dex/mutation.lock" in split
+    assert "git merge" not in split
+    assert "Combined topology continues to Step 3" in split
+
+
 def test_update_and_duplicated_rollback_flows_recognize_both_baselines() -> None:
     update = UPDATE_SKILL.read_text(encoding="utf-8")
     rollback = ROLLBACK_SKILL.read_text(encoding="utf-8")

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -17,8 +17,9 @@ repair) to mutate a vault. Its guarantees, each fault-injection tested:
 
 Test seams: setting ``DEX_TX_TEST_STOP_AFTER`` to one of
 ``after-begin | after-snapshot | mid-apply:<index> | after-apply |
-after-verify | after-commit-record`` makes the engine ``os._exit(137)`` at
-that exact point, so tests can assert recovery from every crash window.
+after-verify | before-finalize | after-commit-record`` makes the engine
+``os._exit(137)`` at that exact point, so tests can assert recovery from every
+crash window.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ import re
 import shutil
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -91,9 +93,15 @@ class Transaction:
     # -- lifecycle -----------------------------------------------------------
 
     @classmethod
-    def begin(cls, vault_root: Path, plan: list[PlanEntry]) -> "Transaction":
+    def begin(
+        cls,
+        vault_root: Path,
+        plan: list[PlanEntry],
+        *,
+        allow_empty: bool = False,
+    ) -> "Transaction":
         """Authorize the whole plan, take the lock, journal BEGIN."""
-        if not plan:
+        if not plan and not allow_empty:
             raise TransactionError("a transaction needs at least one plan entry")
 
         # Target modes are bounded: no setuid/setgid/sticky, no bits beyond
@@ -105,13 +113,14 @@ class Transaction:
                     "bits; only permission bits up to 0o777 are allowed"
                 )
             if entry.expected_current_sha256 is not None and (
-                entry.content is not None
-                or not re.fullmatch(r"[0-9a-f]{64}", entry.expected_current_sha256)
+                entry.content is not None or not re.fullmatch(r"[0-9a-f]{64}", entry.expected_current_sha256)
             ):
                 raise PlanRejected(
                     f"{entry.relative}: current-content preconditions are valid only for "
                     "deletions and must be a lowercase sha256"
                 )
+            if entry.content is None and entry.expected_current_sha256 is None:
+                raise PlanRejected(f"{entry.relative}: deletions require expected_current_sha256")
 
         # All-or-nothing authorization BEFORE the lock: one disallowed entry
         # rejects the plan with nothing acquired and nothing written. For
@@ -122,15 +131,11 @@ class Transaction:
         rejections = []
         for entry in plan:
             target = Path(vault_root) / entry.relative
-            verdict = portable_contract.update_write_verdict(
-                entry.relative, exists=target.exists()
-            )
+            verdict = portable_contract.update_write_verdict(entry.relative, exists=target.exists())
             if not verdict.allowed:
                 rejections.append(f"{entry.relative} [{verdict.action}]")
         if rejections:
-            raise PlanRejected(
-                "the ownership contract forbids writing: " + ", ".join(rejections)
-            )
+            raise PlanRejected("the ownership contract forbids writing: " + ", ".join(rejections))
 
         tx = cls(vault_root, time.strftime("%Y%m%dT%H%M%S-") + uuid.uuid4().hex[:8])
         tx._plan = list(plan)
@@ -171,8 +176,13 @@ class Transaction:
         _stop_seam("after-begin")
         return tx
 
-    def run(self) -> dict:
-        """snapshot → apply → verify → commit. Rolls back on any failure."""
+    def run(self, *, before_commit: Callable[[], None] | None = None) -> dict:
+        """snapshot → apply → verify → finalize → commit.
+
+        ``before_commit`` runs while the mutation lock is still held and before
+        COMMITTED is journaled. Any failure therefore uses the normal locked
+        rollback path instead of compensating after transaction success.
+        """
         try:
             self._snapshot_phase()
             _stop_seam("after-snapshot")
@@ -180,6 +190,9 @@ class Transaction:
             _stop_seam("after-apply")
             self._verify_phase()
             _stop_seam("after-verify")
+            if before_commit is not None:
+                _stop_seam("before-finalize")
+                before_commit()
             return self._commit_phase()
         except BaseException:
             self.rollback()
@@ -199,17 +212,14 @@ class Transaction:
             if (
                 target.is_symlink()
                 or not target.is_file()
-                or hashlib.sha256(target.read_bytes()).hexdigest()
-                != entry.expected_current_sha256
+                or hashlib.sha256(target.read_bytes()).hexdigest() != entry.expected_current_sha256
                 or target.stat().st_mode & 0o777 != entry.mode
             ):
                 raise PlanRejected(
                     f"{entry.relative} changed after the mutation plan was built; "
                     "the existing file wins and the transaction aborts"
                 )
-        self.snapshot.capture(
-            self.vault_root, [entry.relative for entry in self._plan]
-        )
+        self.snapshot.capture(self.vault_root, [entry.relative for entry in self._plan])
         self.journal.append("SNAPSHOT-DONE")
 
     def _apply_phase(self) -> None:
@@ -230,10 +240,42 @@ class Transaction:
                     f"[{verdict.action}]; the existing file wins and the "
                     "transaction aborts"
                 )
-            self._apply_one(index, entry)
+            if entry.content is None:
+                self._verify_deletion_precondition(
+                    entry,
+                    changed_when="after the mutation snapshot",
+                )
+            self.journal.append("APPLYING", {"index": index, "relative": entry.relative})
+            try:
+                self._apply_one(index, entry)
+            except PlanRejected:
+                self.journal.append(
+                    "NOT-APPLIED",
+                    {"index": index, "relative": entry.relative},
+                )
+                raise
             self.journal.append("APPLIED", {"index": index, "relative": entry.relative})
             _stop_seam(f"mid-apply:{index}")
         self.journal.append("APPLY-DONE")
+
+    def _verify_deletion_precondition(
+        self,
+        entry: PlanEntry,
+        *,
+        changed_when: str,
+    ) -> None:
+        target = self.vault_root / entry.relative
+        if not target.exists():
+            return
+        if (
+            target.is_symlink()
+            or not target.is_file()
+            or hashlib.sha256(target.read_bytes()).hexdigest() != entry.expected_current_sha256
+            or target.stat().st_mode & 0o777 != entry.mode
+        ):
+            raise PlanRejected(
+                f"{entry.relative} changed {changed_when}; the existing file wins and the transaction aborts"
+            )
 
     def _apply_one(self, index: int, entry: PlanEntry) -> None:
         relative = entry.relative
@@ -241,6 +283,10 @@ class Transaction:
         if entry.content is None:
             if target.is_symlink() or target.is_dir():
                 raise TransactionError(f"refusing to delete a non-file target: {relative}")
+            self._verify_deletion_precondition(
+                entry,
+                changed_when="after the mutation snapshot",
+            )
             try:
                 target.unlink()
             except FileNotFoundError:
@@ -277,16 +323,11 @@ class Transaction:
             target = self.vault_root / entry.relative
             if entry.content is None:
                 if target.is_symlink() or target.exists():
-                    raise TransactionError(
-                        f"verification failed for {entry.relative}: deleted target still exists"
-                    )
+                    raise TransactionError(f"verification failed for {entry.relative}: deleted target still exists")
                 continue
             digest = hashlib.sha256(target.read_bytes()).hexdigest()
             if digest != entry.sha256():
-                raise TransactionError(
-                    f"verification failed for {entry.relative}: applied bytes do "
-                    "not match the plan"
-                )
+                raise TransactionError(f"verification failed for {entry.relative}: applied bytes do not match the plan")
             actual_mode = target.stat().st_mode & 0o777
             if actual_mode != entry.mode:
                 raise TransactionError(
@@ -321,10 +362,7 @@ class Transaction:
             if not candidate.is_dir():
                 continue
             try:
-                events = {
-                    entry.event
-                    for entry in Journal(candidate / "journal.jsonl").read()
-                }
+                events = {entry.event for entry in Journal(candidate / "journal.jsonl").read()}
             except JournalCorruptError:
                 continue
             if "COMMITTED" in events:
@@ -335,11 +373,16 @@ class Transaction:
     # -- recovery / undo -------------------------------------------------------
 
     def _applied_relatives(self, entries) -> set[str]:
-        return {
-            entry.payload.get("relative")
-            for entry in entries
-            if entry.event == "APPLIED" and entry.payload.get("relative")
-        }
+        applied: set[str] = set()
+        for entry in entries:
+            relative = entry.payload.get("relative")
+            if not relative:
+                continue
+            if entry.event in {"APPLYING", "APPLIED"}:
+                applied.add(relative)
+            elif entry.event == "NOT-APPLIED":
+                applied.discard(relative)
+        return applied
 
     def rollback(self) -> dict:
         """Byte-exact restore from the snapshot; journaled; releases the lock.
@@ -363,7 +406,9 @@ class Transaction:
             if journal_ok:
                 if "SNAPSHOT-DONE" in events:
                     restored = self.snapshot.restore(
-                        self.vault_root, created_deletions=applied
+                        self.vault_root,
+                        created_deletions=applied,
+                        restore_relatives=applied,
                     )
                 # Before SNAPSHOT-DONE nothing was mutated: nothing to restore.
             else:
@@ -373,9 +418,7 @@ class Transaction:
                 # alone: with no journal we cannot know who created them, and
                 # deleting a user's file is the one unforgivable outcome.
                 try:
-                    restored = self.snapshot.restore(
-                        self.vault_root, created_deletions=set()
-                    )
+                    restored = self.snapshot.restore(self.vault_root, created_deletions=set())
                 except Exception:
                     restored = []
             if journal_ok:

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import time
 import uuid
@@ -49,14 +50,24 @@ class PlanRejected(TransactionError):
 
 @dataclass(frozen=True)
 class PlanEntry:
-    """One intended write: put ``content`` at vault-relative ``relative``."""
+    """One intended mutation at vault-relative ``relative``.
+
+    ``content=None`` is an authorized deletion. Deletions use the same
+    snapshot/apply/verify/rollback lifecycle as replacements, so an updater
+    can prune a retired brain file without opening a second mutation path.
+    """
 
     relative: str
-    content: bytes
+    content: bytes | None
     mode: int = 0o644
+    expected_current_sha256: str | None = None
 
-    def sha256(self) -> str:
-        return hashlib.sha256(self.content).hexdigest()
+    def sha256(self) -> str | None:
+        return hashlib.sha256(self.content).hexdigest() if self.content is not None else None
+
+    @property
+    def operation(self) -> str:
+        return "delete" if self.content is None else "write"
 
 
 def _stop_seam(seam: str) -> None:
@@ -93,6 +104,14 @@ class Transaction:
                     f"{entry.relative}: mode {oct(entry.mode)} carries special "
                     "bits; only permission bits up to 0o777 are allowed"
                 )
+            if entry.expected_current_sha256 is not None and (
+                entry.content is not None
+                or not re.fullmatch(r"[0-9a-f]{64}", entry.expected_current_sha256)
+            ):
+                raise PlanRejected(
+                    f"{entry.relative}: current-content preconditions are valid only for "
+                    "deletions and must be a lowercase sha256"
+                )
 
         # All-or-nothing authorization BEFORE the lock: one disallowed entry
         # rejects the plan with nothing acquired and nothing written. For
@@ -125,9 +144,11 @@ class Transaction:
                     "plan": [
                         {
                             "relative": entry.relative,
+                            "operation": entry.operation,
                             "sha256": entry.sha256(),
                             "mode": entry.mode,
-                            "size": len(entry.content),
+                            "size": len(entry.content) if entry.content is not None else None,
+                            "expected_current_sha256": entry.expected_current_sha256,
                         }
                         for entry in plan
                     ],
@@ -138,6 +159,8 @@ class Transaction:
             staged = tx.tx_dir / "staged"
             staged.mkdir(mode=0o700, exist_ok=True)
             for index, entry in enumerate(plan):
+                if entry.content is None:
+                    continue
                 blob = staged / f"{index:06d}.bin"
                 blob.write_bytes(entry.content)
                 os.chmod(blob, 0o600)
@@ -167,6 +190,23 @@ class Transaction:
     def _snapshot_phase(self) -> None:
         assert self._plan is not None
         self.journal.append("SNAPSHOT-START")
+        for entry in self._plan:
+            if entry.expected_current_sha256 is None:
+                continue
+            target = self.vault_root / entry.relative
+            if not target.exists():
+                continue
+            if (
+                target.is_symlink()
+                or not target.is_file()
+                or hashlib.sha256(target.read_bytes()).hexdigest()
+                != entry.expected_current_sha256
+                or target.stat().st_mode & 0o777 != entry.mode
+            ):
+                raise PlanRejected(
+                    f"{entry.relative} changed after the mutation plan was built; "
+                    "the existing file wins and the transaction aborts"
+                )
         self.snapshot.capture(
             self.vault_root, [entry.relative for entry in self._plan]
         )
@@ -190,18 +230,34 @@ class Transaction:
                     f"[{verdict.action}]; the existing file wins and the "
                     "transaction aborts"
                 )
-            self._apply_one(index, entry.relative, entry.mode)
+            self._apply_one(index, entry)
             self.journal.append("APPLIED", {"index": index, "relative": entry.relative})
             _stop_seam(f"mid-apply:{index}")
         self.journal.append("APPLY-DONE")
 
-    def _apply_one(self, index: int, relative: str, mode: int) -> None:
-        staged = self.tx_dir / "staged" / f"{index:06d}.bin"
+    def _apply_one(self, index: int, entry: PlanEntry) -> None:
+        relative = entry.relative
         target = self.vault_root / relative
+        if entry.content is None:
+            if target.is_symlink() or target.is_dir():
+                raise TransactionError(f"refusing to delete a non-file target: {relative}")
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                pass
+            else:
+                directory = os.open(target.parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            return
+
+        staged = self.tx_dir / "staged" / f"{index:06d}.bin"
         target.parent.mkdir(parents=True, exist_ok=True)
         temporary = target.parent / f".{target.name}.tx-{self.tx_id}"
         shutil.copyfile(staged, temporary)
-        os.chmod(temporary, mode)
+        os.chmod(temporary, entry.mode)
         descriptor = os.open(temporary, os.O_RDONLY)
         try:
             os.fsync(descriptor)
@@ -219,6 +275,12 @@ class Transaction:
         self.journal.append("VERIFY-START")
         for entry in self._plan:
             target = self.vault_root / entry.relative
+            if entry.content is None:
+                if target.is_symlink() or target.exists():
+                    raise TransactionError(
+                        f"verification failed for {entry.relative}: deleted target still exists"
+                    )
+                continue
             digest = hashlib.sha256(target.read_bytes()).hexdigest()
             if digest != entry.sha256():
                 raise TransactionError(

--- a/core/transaction/snapshot.py
+++ b/core/transaction/snapshot.py
@@ -84,9 +84,7 @@ class Snapshot:
             if target.is_symlink():
                 raise SnapshotError(f"refusing to snapshot a symlink: {relative}")
             if target.is_dir():
-                raise SnapshotError(
-                    f"plans operate on files, not directories: {relative}"
-                )
+                raise SnapshotError(f"plans operate on files, not directories: {relative}")
             if target.exists():
                 store = self.root / _store_name(index)
                 shutil.copyfile(target, store)
@@ -97,9 +95,7 @@ class Snapshot:
                 # and we must not proceed on a torn snapshot.
                 source_digest, _ = _sha256(target)
                 if digest != source_digest:
-                    raise SnapshotError(
-                        f"target changed while being snapshotted: {relative}"
-                    )
+                    raise SnapshotError(f"target changed while being snapshotted: {relative}")
                 descriptor = os.open(store, os.O_RDONLY)
                 try:
                     os.fsync(descriptor)
@@ -144,9 +140,7 @@ class Snapshot:
             raise SnapshotError("snapshot manifest is missing") from error
         except (json.JSONDecodeError, UnicodeDecodeError) as error:
             raise SnapshotError("snapshot manifest is unreadable") from error
-        if payload.get("schema_version") != 1 or not isinstance(
-            payload.get("entries"), list
-        ):
+        if payload.get("schema_version") != 1 or not isinstance(payload.get("entries"), list):
             raise SnapshotError("snapshot manifest has an unsupported shape")
         entries = []
         for raw in payload["entries"]:
@@ -162,30 +156,37 @@ class Snapshot:
         return entries
 
     def restore(
-        self, vault_root: Path, *, created_deletions: set[str] | None = None
+        self,
+        vault_root: Path,
+        *,
+        created_deletions: set[str] | None = None,
+        restore_relatives: set[str] | None = None,
     ) -> list[str]:
         """Byte-exact restore of every captured target; returns restored paths.
 
         Files absent at capture time are removed ONLY when the caller confirms
         the transaction actually wrote them (``created_deletions``): the vault
         is live, and a file the USER created in the window must never be
-        deleted by someone else's rollback. ``None`` means "the caller applied
-        everything" (legacy behavior). Every stored blob is verified against
-        its manifest sha before it is copied back — a damaged snapshot store
-        fails closed.
+        deleted by someone else's rollback. ``restore_relatives`` can narrow
+        restoration to entries the journal says the transaction attempted;
+        this preserves a live file that changed after snapshot but before its
+        apply. ``None`` means "restore everything" (legacy behavior). Every
+        stored blob is verified against its manifest sha before it is copied
+        back — a damaged snapshot store fails closed.
         """
         vault = Path(vault_root)
         entries = self.read_manifest()
         restored: list[str] = []
         for index, entry in enumerate(entries):
+            if restore_relatives is not None and entry.relative not in restore_relatives:
+                continue
             target = vault / entry.relative
             if entry.existed:
                 store = self.root / _store_name(index)
                 digest, size = _sha256(store)
                 if digest != entry.sha256 or size != entry.size:
                     raise SnapshotError(
-                        f"snapshot store is damaged for {entry.relative}; "
-                        "refusing to restore wrong bytes"
+                        f"snapshot store is damaged for {entry.relative}; refusing to restore wrong bytes"
                     )
                 target.parent.mkdir(parents=True, exist_ok=True)
                 temporary = target.parent / f".{target.name}.tx-restore"
@@ -200,9 +201,7 @@ class Snapshot:
                 os.replace(temporary, target)
                 _fsync_directory(target.parent)
             else:
-                transaction_wrote_it = (
-                    created_deletions is None or entry.relative in created_deletions
-                )
+                transaction_wrote_it = created_deletions is None or entry.relative in created_deletions
                 if transaction_wrote_it and (target.is_symlink() or target.exists()):
                     target.unlink()
                     _fsync_directory(target.parent)

--- a/core/update/__init__.py
+++ b/core/update/__init__.py
@@ -1,0 +1,2 @@
+"""Split-topology update services."""
+

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Apply one immutable Dex release without merging Git histories.
+
+The release identity is supplied by the existing bounded release-evidence
+flow. This module re-verifies that exact annotated ``dist/release/v*`` tag
+against the selected stable/beta channel in the split brain Git store, builds
+an ownership-authorized file plan, then delegates every release-tree mutation
+to :class:`core.transaction.engine.Transaction`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core import portable_contract
+from core.transaction.engine import PlanEntry, Transaction
+from core.utils import release_channel
+from core.utils.local_git import git_output
+
+MANIFEST_RELATIVE = "System/.installed-files.manifest"
+TOPOLOGY_RELATIVE = Path("System/.dex/topology.json")
+BRAIN_RELATIVE = Path(".dex/brain.git")
+VAULT_MARKER_RELATIVE = Path(".git/dex-vault-v2")
+BRAIN_MARKER_NAME = "dex-brain-v2"
+OFFICIAL_REMOTE = re.compile(
+    r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)"
+    r"davekilleen/Dex(?:\.git)?/?$",
+    re.IGNORECASE,
+)
+RELEASE_TAG = re.compile(
+    r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,64})$"
+)
+
+
+class UpdateError(RuntimeError):
+    """The update could not safely proceed."""
+
+
+class ReleaseVerificationError(UpdateError):
+    """The supplied immutable release identity failed closed verification."""
+
+
+@dataclass(frozen=True)
+class TreeEntry:
+    path: str
+    mode: int
+    object_id: str
+
+
+@dataclass(frozen=True)
+class VerifiedReleaseRef:
+    tag: str
+    tag_object: str
+    commit: str
+    tree: str
+    version: str
+    channel: str
+    brain_git: Path
+    entries: tuple[TreeEntry, ...]
+
+
+@dataclass(frozen=True)
+class UpdatePlan:
+    entries: tuple[PlanEntry, ...]
+    replaced: tuple[str, ...]
+    seeded: tuple[str, ...]
+    regenerated: tuple[str, ...]
+    pruned: tuple[str, ...]
+    kept: tuple[str, ...]
+    untouched: tuple[str, ...]
+
+
+def _read_regular_json(path: Path, description: str) -> dict[str, Any]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise UpdateError(f"{description} is not a regular file")
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise UpdateError(f"{description} is unreadable") from error
+    if not isinstance(value, dict):
+        raise UpdateError(f"{description} is not an object")
+    return value
+
+
+def _brain_output(vault_root: Path, brain_git: Path, *arguments: str) -> bytes:
+    return git_output(
+        vault_root,
+        f"--git-dir={brain_git}",
+        *arguments,
+        profile="read-only",
+    )
+
+
+def _brain_text(vault_root: Path, brain_git: Path, *arguments: str) -> str:
+    try:
+        return _brain_output(vault_root, brain_git, *arguments).decode("utf-8").strip()
+    except UnicodeDecodeError as error:
+        raise ReleaseVerificationError("Git release metadata is not UTF-8") from error
+
+
+def _tree_entries(vault_root: Path, brain_git: Path, commit: str) -> tuple[TreeEntry, ...]:
+    raw = _brain_output(
+        vault_root,
+        brain_git,
+        "ls-tree",
+        "-r",
+        "-z",
+        "--full-tree",
+        commit,
+    )
+    entries: list[TreeEntry] = []
+    seen: set[str] = set()
+    for record in raw.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            raw_mode, object_type, object_id = metadata.decode("ascii").split(" ")
+            relative = raw_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ReleaseVerificationError("release tree contains a malformed entry") from error
+        if relative in seen or object_type != "blob" or raw_mode not in {"100644", "100755"}:
+            raise ReleaseVerificationError(
+                "release tree is ambiguous or contains a symlink/unsupported entry"
+            )
+        seen.add(relative)
+        entries.append(TreeEntry(relative, 0o755 if raw_mode == "100755" else 0o644, object_id))
+    return tuple(sorted(entries, key=lambda entry: entry.path))
+
+
+def _blob(vault_root: Path, brain_git: Path, object_id: str) -> bytes:
+    return _brain_output(vault_root, brain_git, "cat-file", "blob", object_id)
+
+
+def _entry_map(entries: tuple[TreeEntry, ...]) -> dict[str, TreeEntry]:
+    return {entry.path: entry for entry in entries}
+
+
+def _verify_manifest(
+    vault_root: Path,
+    brain_git: Path,
+    entries: tuple[TreeEntry, ...],
+) -> None:
+    by_path = _entry_map(entries)
+    manifest = by_path.get(MANIFEST_RELATIVE)
+    if manifest is None:
+        raise ReleaseVerificationError("release is missing its installed-files manifest")
+    try:
+        source = _blob(vault_root, brain_git, manifest.object_id).decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ReleaseVerificationError("release manifest is not UTF-8") from error
+    paths = source.splitlines()
+    if (
+        not source.endswith("\n")
+        or "\r" in source
+        or paths != sorted(set(paths))
+        or set(paths) != set(by_path)
+    ):
+        raise ReleaseVerificationError("release manifest contradicts the exact release tree")
+
+
+def _topology(vault_root: Path) -> tuple[Path, dict[str, Any], dict[str, Any]]:
+    root = Path(vault_root).resolve()
+    for relative in (Path(".git"), Path(".dex"), BRAIN_RELATIVE, Path("System"), Path("System/.dex")):
+        candidate = root / relative
+        if candidate.is_symlink():
+            raise UpdateError(f"split update refuses a symlinked {relative.as_posix()}")
+    topology = _read_regular_json(root / TOPOLOGY_RELATIVE, "split topology marker")
+    vault_marker = _read_regular_json(root / VAULT_MARKER_RELATIVE, "vault Git marker")
+    brain_git = root / BRAIN_RELATIVE
+    brain_marker = _read_regular_json(brain_git / BRAIN_MARKER_NAME, "brain Git marker")
+    environment = topology.get("environment")
+    wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
+    try:
+        vault_wiring_matches = isinstance(wired_vault, str) and Path(wired_vault).resolve() == root
+    except (OSError, RuntimeError):
+        vault_wiring_matches = False
+    if (
+        topology.get("topology") != "brain-vault-split"
+        or topology.get("vaultGitDir") != ".git"
+        or topology.get("brainGitDir") != ".dex/brain.git"
+        or not vault_wiring_matches
+        or vault_marker.get("role") != "vault"
+        or brain_marker.get("role") != "brain"
+        or not brain_git.is_dir()
+    ):
+        raise UpdateError("the brain/vault split topology is incomplete or inconsistent")
+    return brain_git, topology, brain_marker
+
+
+def _verify_official_origin(vault_root: Path, brain_git: Path) -> None:
+    configured = _brain_text(vault_root, brain_git, "config", "--get", "remote.origin.url")
+    effective = _brain_text(vault_root, brain_git, "remote", "get-url", "origin")
+    if not OFFICIAL_REMOTE.fullmatch(configured) or not OFFICIAL_REMOTE.fullmatch(effective):
+        raise ReleaseVerificationError("brain origin is not the effective official Dex repository")
+
+
+def verify_release_ref(
+    vault_root: Path,
+    *,
+    tag: str,
+    tag_object: str,
+    commit: str,
+    tree: str,
+) -> VerifiedReleaseRef:
+    """Re-verify one evidence-pinned tag against the selected release channel."""
+    root = Path(vault_root).resolve()
+    brain_git, _topology_value, _brain_marker = _topology(root)
+    _verify_official_origin(root, brain_git)
+    match = RELEASE_TAG.fullmatch(tag)
+    if match is None:
+        raise ReleaseVerificationError("release ref is not an immutable dist/release/v* tag")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", tag_object):
+        raise ReleaseVerificationError("release tag object identity is malformed")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", commit) or not re.fullmatch(
+        r"[0-9a-f]{40,64}", tree
+    ):
+        raise ReleaseVerificationError("release commit/tree identity is malformed")
+
+    actual_tag_object = _brain_text(root, brain_git, "rev-parse", "--verify", f"refs/tags/{tag}")
+    if actual_tag_object != tag_object:
+        raise ReleaseVerificationError("immutable release tag object does not match the evidence pin")
+    if _brain_text(root, brain_git, "cat-file", "-t", tag_object) != "tag":
+        raise ReleaseVerificationError("immutable release tag is not annotated")
+    tag_payload = _brain_text(root, brain_git, "cat-file", "tag", tag_object)
+    headers: dict[str, str] = {}
+    for line in tag_payload.split("\n\n", 1)[0].splitlines():
+        if " " not in line:
+            continue
+        key, value = line.split(" ", 1)
+        if key in headers:
+            raise ReleaseVerificationError("annotated release tag headers are ambiguous")
+        headers[key] = value
+    if headers.get("type") != "commit" or headers.get("tag") != tag or headers.get("object") != commit:
+        raise ReleaseVerificationError("annotated release tag identity contradicts the evidence pin")
+    if not commit.startswith(match.group("short")):
+        raise ReleaseVerificationError("immutable tag suffix does not pin the full release commit")
+    if _brain_text(root, brain_git, "rev-parse", "--verify", f"{commit}^{{tree}}") != tree:
+        raise ReleaseVerificationError("release tree does not match the evidence pin")
+
+    channel = release_channel.read_channel(root)
+    if channel not in release_channel.VALID_CHANNELS:
+        raise ReleaseVerificationError("the configured update channel is invalid")
+    channel_commits = []
+    for candidate in release_channel.release_ref_candidates(channel):
+        try:
+            channel_commits.append(
+                _brain_text(
+                    root,
+                    brain_git,
+                    "rev-parse",
+                    "--verify",
+                    f"refs/remotes/{candidate}^{{commit}}",
+                )
+            )
+        except RuntimeError:
+            continue
+    if not channel_commits or commit not in channel_commits:
+        raise ReleaseVerificationError(
+            f"immutable release is not the pinned target of the {channel} channel"
+        )
+
+    entries = _tree_entries(root, brain_git, commit)
+    _verify_manifest(root, brain_git, entries)
+    package_entry = _entry_map(entries).get("package.json")
+    if package_entry is None:
+        raise ReleaseVerificationError("release is missing package.json")
+    try:
+        package = json.loads(_blob(root, brain_git, package_entry.object_id).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseVerificationError("release package metadata is unreadable") from error
+    if not isinstance(package, dict) or package.get("version") != match.group("version"):
+        raise ReleaseVerificationError("release package version contradicts the immutable tag")
+    return VerifiedReleaseRef(
+        tag,
+        tag_object,
+        commit,
+        tree,
+        match.group("version"),
+        channel,
+        brain_git,
+        entries,
+    )
+
+
+def _matches_entry(vault_root: Path, entry: TreeEntry, brain_git: Path) -> bool:
+    target = vault_root / entry.path
+    try:
+        return (
+            not target.is_symlink()
+            and target.is_file()
+            and target.read_bytes() == _blob(vault_root, brain_git, entry.object_id)
+            and (target.stat().st_mode & 0o777) == entry.mode
+        )
+    except OSError:
+        return False
+
+
+def build_update_plan(vault_root: Path, release: VerifiedReleaseRef) -> UpdatePlan:
+    """Build a fail-closed release mutation plan from contract verdicts."""
+    root = Path(vault_root).resolve()
+    installed = _brain_text(root, release.brain_git, "rev-parse", "--verify", "refs/dex/installed^{commit}")
+    previous_entries = _tree_entries(root, release.brain_git, installed)
+    _verify_manifest(root, release.brain_git, previous_entries)
+    target_brain: set[str] = set()
+    planned: list[PlanEntry] = []
+    replaced: list[str] = []
+    seeded: list[str] = []
+    regenerated: list[str] = []
+    untouched: list[str] = []
+
+    for entry in release.entries:
+        target = root / entry.path
+        verdict = portable_contract.update_write_verdict(entry.path, exists=target.exists())
+        if verdict.action in {"deny", "unclassified-never-write"}:
+            raise UpdateError(
+                f"release contains a path the ownership contract refuses: {entry.path} [{verdict.action}]"
+            )
+        if verdict.ownership == "brain":
+            target_brain.add(entry.path)
+        if not verdict.allowed:
+            untouched.append(entry.path)
+            continue
+        content = _blob(root, release.brain_git, entry.object_id)
+        planned.append(PlanEntry(entry.path, content, entry.mode))
+        if verdict.ownership == "brain":
+            replaced.append(entry.path)
+        elif verdict.ownership == "seed":
+            seeded.append(entry.path)
+        elif verdict.ownership == "generated":
+            regenerated.append(entry.path)
+
+    pruned: list[str] = []
+    kept: list[str] = []
+    for previous in previous_entries:
+        resolution = portable_contract.resolve(previous.path)
+        if resolution.ownership != "brain" or previous.path in target_brain:
+            continue
+        target = root / previous.path
+        if not target.exists():
+            continue
+        if _matches_entry(root, previous, release.brain_git):
+            verdict = portable_contract.update_write_verdict(previous.path, exists=True)
+            if not verdict.allowed or verdict.ownership != "brain":
+                raise UpdateError(f"ownership contract refuses pruning {previous.path}")
+            planned.append(
+                PlanEntry(
+                    previous.path,
+                    None,
+                    previous.mode,
+                    expected_current_sha256=hashlib.sha256(
+                        _blob(root, release.brain_git, previous.object_id)
+                    ).hexdigest(),
+                )
+            )
+            pruned.append(previous.path)
+        else:
+            kept.append(previous.path)
+
+    return UpdatePlan(
+        tuple(planned),
+        tuple(replaced),
+        tuple(seeded),
+        tuple(regenerated),
+        tuple(pruned),
+        tuple(kept),
+        tuple(untouched),
+    )
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    data = (json.dumps(value, sort_keys=True, indent=2) + "\n").encode("utf-8")
+    temporary = path.parent / f".{path.name}.update-{os.getpid()}"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(descriptor, data)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.replace(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def _finalize_release_metadata(
+    vault_root: Path,
+    release: VerifiedReleaseRef,
+    previous_commit: str,
+) -> None:
+    topology_path = vault_root / TOPOLOGY_RELATIVE
+    marker_path = release.brain_git / BRAIN_MARKER_NAME
+    topology = _read_regular_json(topology_path, "split topology marker")
+    marker = _read_regular_json(marker_path, "brain Git marker")
+    previous_topology = dict(topology)
+    previous_marker = dict(marker)
+    topology["installedRelease"] = release.commit
+    marker["installed"] = release.commit
+    try:
+        _atomic_json(topology_path, topology)
+        _atomic_json(marker_path, marker)
+        git_output(
+            vault_root,
+            f"--git-dir={release.brain_git}",
+            "update-ref",
+            "refs/dex/installed",
+            release.commit,
+            previous_commit,
+            profile="mutation",
+        )
+    except BaseException:
+        _atomic_json(topology_path, previous_topology)
+        _atomic_json(marker_path, previous_marker)
+        raise
+
+
+def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dict[str, Any]:
+    """Apply a verified immutable release through the shared transaction core."""
+    root = Path(vault_root).resolve()
+    Transaction.resume(root)
+    brain_git, topology, marker = _topology(root)
+    if brain_git != release.brain_git:
+        raise UpdateError("verified release belongs to a different split brain store")
+    previous_commit = _brain_text(root, brain_git, "rev-parse", "--verify", "refs/dex/installed^{commit}")
+    if topology.get("installedRelease") != previous_commit or marker.get("installed") != previous_commit:
+        raise UpdateError("installed release identity disagrees across the split topology markers")
+    if previous_commit == release.commit:
+        raise UpdateError("that immutable release is already installed")
+    plan = build_update_plan(root, release)
+    if not plan.entries:
+        raise UpdateError("verified release produced no authorized file changes")
+    transaction = Transaction.begin(root, list(plan.entries))
+    transaction_result = transaction.run()
+    try:
+        _finalize_release_metadata(root, release, previous_commit)
+    except BaseException:
+        # COMMITTED retains the exact snapshot for undo. Release identity is
+        # part of the updater's success boundary, so a failed pin must not
+        # leave target bytes installed under the previous release identity.
+        transaction.rollback()
+        raise
+    return {
+        **transaction_result,
+        "tag": release.tag,
+        "commit": release.commit,
+        "version": release.version,
+        "channel": release.channel,
+        "replaced": list(plan.replaced),
+        "seeded": list(plan.seeded),
+        "regenerated": list(plan.regenerated),
+        "pruned": list(plan.pruned),
+        "kept": list(plan.kept),
+        "untouched": list(plan.untouched),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, default=Path.cwd())
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--tag-object", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--tree", required=True)
+    args = parser.parse_args(argv)
+    try:
+        release = verify_release_ref(
+            args.vault,
+            tag=args.tag,
+            tag_object=args.tag_object,
+            commit=args.commit,
+            tree=args.tree,
+        )
+        result = apply_verified_release(args.vault, release)
+    except (OSError, RuntimeError) as error:
+        print(json.dumps({"ok": False, "error": str(error)}, sort_keys=True))
+        return 1
+    print(json.dumps({"ok": True, **result}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -128,9 +128,7 @@ def _tree_entries(vault_root: Path, brain_git: Path, commit: str) -> tuple[TreeE
         except (ValueError, UnicodeDecodeError) as error:
             raise ReleaseVerificationError("release tree contains a malformed entry") from error
         if relative in seen or object_type != "blob" or raw_mode not in {"100644", "100755"}:
-            raise ReleaseVerificationError(
-                "release tree is ambiguous or contains a symlink/unsupported entry"
-            )
+            raise ReleaseVerificationError("release tree is ambiguous or contains a symlink/unsupported entry")
         seen.add(relative)
         entries.append(TreeEntry(relative, 0o755 if raw_mode == "100755" else 0o644, object_id))
     return tuple(sorted(entries, key=lambda entry: entry.path))
@@ -158,12 +156,7 @@ def _verify_manifest(
     except UnicodeDecodeError as error:
         raise ReleaseVerificationError("release manifest is not UTF-8") from error
     paths = source.splitlines()
-    if (
-        not source.endswith("\n")
-        or "\r" in source
-        or paths != sorted(set(paths))
-        or set(paths) != set(by_path)
-    ):
+    if not source.endswith("\n") or "\r" in source or paths != sorted(set(paths)) or set(paths) != set(by_path):
         raise ReleaseVerificationError("release manifest contradicts the exact release tree")
 
 
@@ -220,9 +213,7 @@ def verify_release_ref(
         raise ReleaseVerificationError("release ref is not an immutable dist/release/v* tag")
     if not re.fullmatch(r"[0-9a-f]{40,64}", tag_object):
         raise ReleaseVerificationError("release tag object identity is malformed")
-    if not re.fullmatch(r"[0-9a-f]{40,64}", commit) or not re.fullmatch(
-        r"[0-9a-f]{40,64}", tree
-    ):
+    if not re.fullmatch(r"[0-9a-f]{40,64}", commit) or not re.fullmatch(r"[0-9a-f]{40,64}", tree):
         raise ReleaseVerificationError("release commit/tree identity is malformed")
 
     actual_tag_object = _brain_text(root, brain_git, "rev-parse", "--verify", f"refs/tags/{tag}")
@@ -264,9 +255,7 @@ def verify_release_ref(
         except RuntimeError:
             continue
     if not channel_commits or commit not in channel_commits:
-        raise ReleaseVerificationError(
-            f"immutable release is not the pinned target of the {channel} channel"
-        )
+        raise ReleaseVerificationError(f"immutable release is not the pinned target of the {channel} channel")
 
     entries = _tree_entries(root, brain_git, commit)
     _verify_manifest(root, brain_git, entries)
@@ -327,6 +316,9 @@ def build_update_plan(vault_root: Path, release: VerifiedReleaseRef) -> UpdatePl
         if verdict.ownership == "brain":
             target_brain.add(entry.path)
         if not verdict.allowed:
+            untouched.append(entry.path)
+            continue
+        if _matches_entry(root, entry, release.brain_git):
             untouched.append(entry.path)
             continue
         content = _blob(root, release.brain_git, entry.object_id)
@@ -437,18 +429,14 @@ def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dic
     if previous_commit == release.commit:
         raise UpdateError("that immutable release is already installed")
     plan = build_update_plan(root, release)
-    if not plan.entries:
-        raise UpdateError("verified release produced no authorized file changes")
-    transaction = Transaction.begin(root, list(plan.entries))
-    transaction_result = transaction.run()
-    try:
-        _finalize_release_metadata(root, release, previous_commit)
-    except BaseException:
-        # COMMITTED retains the exact snapshot for undo. Release identity is
-        # part of the updater's success boundary, so a failed pin must not
-        # leave target bytes installed under the previous release identity.
-        transaction.rollback()
-        raise
+    transaction = Transaction.begin(root, list(plan.entries), allow_empty=True)
+    transaction_result = transaction.run(
+        before_commit=lambda: _finalize_release_metadata(
+            root,
+            release,
+            previous_commit,
+        )
+    )
     return {
         **transaction_result,
         "tag": release.tag,

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -26,7 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from core import paths
+from core import paths, portable_contract
 from core.utils import preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
@@ -160,6 +160,14 @@ SHIPPED_LAUNCH_AGENT_LABELS = frozenset(
 QUICK_CHECKS = (
     CheckDefinition("vault.structure", "Vault structure", "_probe_vault_structure"),
     CheckDefinition("vault.configs", "Vault configuration", "_probe_vault_configs"),
+    CheckDefinition("vault.git", "Vault history", "_probe_vault_git"),
+    CheckDefinition("brain.git", "Dex brain history", "_probe_brain_git"),
+    CheckDefinition("vault.auto-commit", "Vault auto-commit", "_probe_vault_auto_commit"),
+    CheckDefinition(
+        "topology.migration-pending",
+        "Brain/vault topology",
+        "_probe_migration_pending",
+    ),
     CheckDefinition("smoke.history", "Nightly smoke results", "_probe_smoke_history"),
     CheckDefinition("mcp.registered", "MCP registration", "_probe_mcp_registered"),
     CheckDefinition("mcp.orphans", "MCP server registration", "_probe_mcp_orphans"),
@@ -843,7 +851,7 @@ def _plist_owned_by_vault(plist: Path, data: dict[str, Any], context: DoctorCont
             continue
         try:
             resolved = candidate.resolve()
-        except OSError:
+        except (OSError, RuntimeError):
             continue
         if resolved.is_relative_to(vault_root):
             return True
@@ -1374,7 +1382,11 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
     )
 
 
-def _git_result(context: DoctorContext, *arguments: str) -> subprocess.CompletedProcess[str]:
+def _git_result(
+    context: DoctorContext,
+    *arguments: str,
+    git_directory: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     executable = next(
         (
             str(candidate)
@@ -1400,6 +1412,7 @@ def _git_result(context: DoctorContext, *arguments: str) -> subprocess.Completed
             "submodule.recurse=false",
             "-C",
             str(context.repo_root),
+            *([f"--git-dir={git_directory}"] if git_directory is not None else []),
             *arguments,
         ],
         capture_output=True,
@@ -1416,6 +1429,244 @@ def _git_result(context: DoctorContext, *arguments: str) -> subprocess.Completed
         text=True,
         timeout=10,
         check=False,
+    )
+
+
+def _regular_json(path: Path) -> dict[str, Any] | None:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+
+def _topology_state(context: DoctorContext) -> str:
+    vault_git = context.vault_root / ".git"
+    brain_git = context.vault_root / ".dex/brain.git"
+    topology = _regular_json(context.vault_root / "System/.dex/topology.json")
+    vault_marker = _regular_json(vault_git / "dex-vault-v2")
+    brain_marker = _regular_json(brain_git / "dex-brain-v2")
+    if topology and topology.get("topology") == "brain-vault-split":
+        environment = topology.get("environment")
+        wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
+        try:
+            vault_wiring_matches = (
+                isinstance(wired_vault, str)
+                and Path(wired_vault).resolve() == context.vault_root.resolve()
+            )
+        except OSError:
+            vault_wiring_matches = False
+        if (
+            topology.get("vaultGitDir") == ".git"
+            and topology.get("brainGitDir") == ".dex/brain.git"
+            and vault_wiring_matches
+            and vault_git.is_dir()
+            and not vault_git.is_symlink()
+            and brain_git.is_dir()
+            and not brain_git.is_symlink()
+            and vault_marker
+            and vault_marker.get("role") == "vault"
+            and brain_marker
+            and brain_marker.get("role") == "brain"
+        ):
+            return "post-split"
+        return "invalid-split"
+    migration_state = _regular_json(
+        context.vault_root / "System/.dex/migration-v2-state.json"
+    )
+    if migration_state and migration_state.get("status") != "complete":
+        return "migration-in-progress"
+    if any(
+        candidate.exists()
+        for candidate in (
+            context.vault_root / ".dex/pre-split-archive.git",
+            context.vault_root / ".dex/vault-staging.git",
+        )
+    ):
+        return "migration-in-progress"
+    migrator = context.vault_root / "core/migrations/v1-to-v2-brain-vault-split.cjs"
+    if vault_git.exists() and migrator.is_file() and not migrator.is_symlink():
+        return "migration-pending"
+    if not vault_git.exists():
+        return "zip-or-manual"
+    return "combined"
+
+
+def _probe_vault_git(context: DoctorContext) -> ProbeResult:
+    topology = _topology_state(context)
+    if topology != "post-split":
+        if topology == "invalid-split":
+            return ProbeResult(
+                "BROKEN",
+                "The split topology marker exists, but the vault Git marker is missing or invalid — use /dex-update recovery",
+            )
+        return ProbeResult(
+            "OFF",
+            "The separate vault history is not active; the topology check reports the current layout",
+        )
+    git_directory = context.vault_root / ".git"
+    healthy = _git_result(
+        context, "rev-parse", "--git-dir", git_directory=git_directory
+    )
+    if healthy.returncode != 0:
+        return ProbeResult(
+            "BROKEN",
+            "The vault Git repository cannot be opened — your files remain on disk, but history needs repair",
+        )
+    integrity = _git_result(
+        context, "fsck", "--no-progress", git_directory=git_directory
+    )
+    if integrity.returncode != 0:
+        return ProbeResult(
+            "BROKEN",
+            "The vault Git repository failed its integrity check — do not push it; repair the local history",
+        )
+    remotes = _git_result(context, "remote", git_directory=git_directory)
+    remote_count = (
+        len([line for line in remotes.stdout.splitlines() if line.strip()])
+        if remotes.returncode == 0
+        else 0
+    )
+    suffix = (
+        "no private backup remote configured"
+        if remote_count == 0
+        else f"{remote_count} private backup remote(s) configured"
+    )
+    return ProbeResult("OK", f"The local vault history is healthy; {suffix}")
+
+
+def _probe_brain_git(context: DoctorContext) -> ProbeResult:
+    topology_state = _topology_state(context)
+    if topology_state != "post-split":
+        if topology_state == "invalid-split":
+            return ProbeResult(
+                "BROKEN",
+                "The split topology marker exists, but the brain Git marker is missing or invalid — use the updater recovery path",
+            )
+        return ProbeResult("OFF", "The separate Dex brain history is not active")
+    brain = context.vault_root / ".dex/brain.git"
+    installed = _git_result(
+        context,
+        "rev-parse",
+        "--verify",
+        "refs/dex/installed^{commit}",
+        git_directory=brain,
+    )
+    if installed.returncode != 0:
+        return ProbeResult(
+            "BROKEN",
+            "The Dex brain history cannot resolve its installed release — rerun /dex-update",
+        )
+    installed_oid = installed.stdout.strip().lower()
+    brain_marker = _regular_json(brain / "dex-brain-v2")
+    topology = _regular_json(context.vault_root / "System/.dex/topology.json")
+    marker_oid = str(brain_marker.get("installed", "")).lower() if brain_marker else ""
+    topology_oid = str(topology.get("installedRelease", "")).lower() if topology else ""
+    if not installed_oid or marker_oid != installed_oid or topology_oid != installed_oid:
+        return ProbeResult(
+            "BROKEN",
+            "The Dex brain release identity disagrees across its installed ref and topology markers — rerun /dex-update",
+        )
+    configured = _git_result(
+        context, "config", "--get", "remote.origin.url", git_directory=brain
+    )
+    effective = _git_result(
+        context, "remote", "get-url", "origin", git_directory=brain
+    )
+    official = re.compile(
+        r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)"
+        r"davekilleen/Dex(?:\.git)?/?$",
+        re.IGNORECASE,
+    )
+    if (
+        configured.returncode != 0
+        or effective.returncode != 0
+        or not official.fullmatch(configured.stdout.strip())
+        or not official.fullmatch(effective.stdout.strip())
+    ):
+        return ProbeResult(
+            "BROKEN",
+            "The Dex brain origin is not the effective official repository — repair it before updating",
+        )
+    integrity = _git_result(context, "fsck", "--no-progress", git_directory=brain)
+    if integrity.returncode != 0:
+        return ProbeResult(
+            "BROKEN",
+            "The Dex brain Git store failed its integrity check — stop updating and repair it",
+        )
+    archive = context.vault_root / ".dex/pre-split-archive.git"
+    archive_note = (
+        " The pre-split restore archive is still present."
+        if archive.is_dir() and not archive.is_symlink()
+        else ""
+    )
+    return ProbeResult(
+        "OK",
+        f"The Dex brain history is healthy at {installed_oid[:12]}.{archive_note}",
+    )
+
+
+def _probe_vault_auto_commit(context: DoctorContext) -> ProbeResult:
+    profile_path = context.vault_root / "System/user-profile.yaml"
+    if profile_path.is_symlink():
+        return ProbeResult(
+            "UNKNOWN",
+            "The doctor will not follow a symlinked profile to inspect vault auto-commit",
+        )
+    try:
+        profile = _load_yaml(profile_path)
+    except FileNotFoundError:
+        profile = {}
+    if not isinstance(profile, dict):
+        return ProbeResult(
+            "BROKEN", "Vault auto-commit cannot read user-profile.yaml as a mapping"
+        )
+    vault_settings = profile.get("vault")
+    enabled = (
+        isinstance(vault_settings, dict)
+        and vault_settings.get("auto_commit") is True
+    )
+    if not enabled:
+        return ProbeResult(
+            "OFF", "Vault auto-commit is off by default; local files remain untouched"
+        )
+    if _topology_state(context) != "post-split":
+        return ProbeResult(
+            "BROKEN",
+            "Vault auto-commit is enabled before the split topology is ready — run /dex-update",
+        )
+    return ProbeResult(
+        "OK", "Vault auto-commit is enabled for local snapshots and never pushes"
+    )
+
+
+def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
+    topology = _topology_state(context)
+    if topology == "post-split":
+        return ProbeResult("OK", "The brain/vault split is complete")
+    if topology == "migration-pending":
+        return ProbeResult(
+            "BROKEN",
+            "Dex needs its one-time brain/vault upgrade — run /dex-update; notes stay in place",
+        )
+    if topology == "migration-in-progress":
+        return ProbeResult(
+            "BROKEN",
+            "The one-time upgrade is incomplete — run /dex-update so recovery can resume",
+        )
+    if topology == "invalid-split":
+        return ProbeResult(
+            "BROKEN",
+            "The split topology markers or DEX_VAULT wiring disagree — use updater or migrator recovery, never raw Git",
+        )
+    if topology == "zip-or-manual":
+        return ProbeResult(
+            "OFF", "This ZIP/manual install has no Git topology; use the manual update path"
+        )
+    return ProbeResult(
+        "OFF", "This is the older combined topology; updates keep using the merge path"
     )
 
 
@@ -1453,8 +1704,19 @@ def _sanctioned_customization_path(relative: str) -> bool:
     )
 
 
-def _git_file(context: DoctorContext, treeish: str, relative: str) -> str | None:
-    result = _git_result(context, "show", f"{treeish}:{relative}")
+def _git_file(
+    context: DoctorContext,
+    treeish: str,
+    relative: str,
+    *,
+    git_directory: Path | None = None,
+) -> str | None:
+    result = _git_result(
+        context,
+        "show",
+        f"{treeish}:{relative}",
+        git_directory=git_directory,
+    )
     return result.stdout if result.returncode == 0 else None
 
 
@@ -1538,9 +1800,21 @@ def _only_sanctioned_file_changes(
     return False
 
 
-def _release_tree_entries(context: DoctorContext, baseline: str) -> dict[str, tuple[str, str]]:
+def _release_tree_entries(
+    context: DoctorContext,
+    baseline: str,
+    *,
+    git_directory: Path | None = None,
+) -> dict[str, tuple[str, str]]:
     output = _git_output_or_raise(
-        _git_result(context, "ls-tree", "-r", "-z", baseline),
+        _git_result(
+            context,
+            "ls-tree",
+            "-r",
+            "-z",
+            baseline,
+            git_directory=git_directory,
+        ),
         "list release files",
     )
     entries = {}
@@ -1605,7 +1879,72 @@ def _worktree_matches_release_blob(
     return digest.hexdigest() == object_id
 
 
+def _brain_paths_from_installed_release(
+    context: DoctorContext,
+    baseline: str,
+    brain: Path,
+) -> set[str]:
+    manifest = _git_file(
+        context,
+        baseline,
+        "System/.installed-files.manifest",
+        git_directory=brain,
+    )
+    if manifest is None:
+        raise RuntimeError("installed brain release is missing its manifest")
+    paths: set[str] = set()
+    for relative in manifest.splitlines():
+        try:
+            resolution = portable_contract.resolve(relative)
+        except portable_contract.ContractViolation as error:
+            raise RuntimeError(
+                f"installed brain release has an unclassified path: {relative}"
+            ) from error
+        if resolution.ownership == "brain":
+            paths.add(relative)
+    return paths
+
+
 def _probe_core_drift(context: DoctorContext) -> ProbeResult:
+    if _topology_state(context) == "post-split":
+        brain = context.vault_root / ".dex/brain.git"
+        baseline = "refs/dex/installed"
+        installed = _git_result(
+            context,
+            "rev-parse",
+            "--verify",
+            f"{baseline}^{{commit}}",
+            git_directory=brain,
+        )
+        if installed.returncode != 0:
+            return ProbeResult(
+                "UNKNOWN",
+                "the brain Git store cannot resolve refs/dex/installed — rerun /dex-update",
+            )
+        release_entries = _release_tree_entries(
+            context, baseline, git_directory=brain
+        )
+        brain_paths = _brain_paths_from_installed_release(context, baseline, brain)
+        drifted = sorted(
+            relative
+            for relative in brain_paths
+            if relative in release_entries
+            and not _worktree_matches_release_blob(
+                context,
+                relative,
+                *release_entries[relative],
+            )
+        )
+        if not drifted:
+            return ProbeResult(
+                "OK", "No shipped brain files differ from refs/dex/installed"
+            )
+        return ProbeResult(
+            "UNKNOWN",
+            "Modified shipped brain files: "
+            f"{', '.join(drifted)}; the updater snapshots them before replacement",
+        )
+
     channel = release_channel.read_channel(context.vault_root)
     release_ref = _upstream_release_ref(context, channel)
     if release_ref is None:

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -182,6 +182,7 @@ class SmokeRun:
 
 
 JOURNEYS = (
+    JourneyDefinition("topology", 5.0),
     JourneyDefinition("configs", 5.0),
     JourneyDefinition("task_lifecycle", 8.0),
     JourneyDefinition("mcp_startup", MCP_STARTUP_JOURNEY_TIMEOUT_SECONDS),
@@ -587,6 +588,80 @@ def _prepare_hooks_vault(source: Path, vault: Path) -> None:
         shutil.copytree(hooks, vault / ".claude" / "hooks", symlinks=True)
 
 
+def _topology_json(path: Path) -> dict[str, Any] | None:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+
+def _topology_state(vault: Path) -> str:
+    topology = _topology_json(vault / "System/.dex/topology.json")
+    vault_marker = _topology_json(vault / ".git/dex-vault-v2")
+    brain_marker = _topology_json(vault / ".dex/brain.git/dex-brain-v2")
+    if topology and topology.get("topology") == "brain-vault-split":
+        installed = topology.get("installedRelease")
+        environment = topology.get("environment")
+        wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
+        try:
+            vault_wiring_matches = (
+                isinstance(wired_vault, str) and Path(wired_vault).resolve() == vault.resolve()
+            )
+        except (OSError, RuntimeError):
+            vault_wiring_matches = False
+        if (
+            topology.get("vaultGitDir") == ".git"
+            and topology.get("brainGitDir") == ".dex/brain.git"
+            and vault_wiring_matches
+            and (vault / ".git").is_dir()
+            and not (vault / ".git").is_symlink()
+            and (vault / ".dex/brain.git").is_dir()
+            and not (vault / ".dex/brain.git").is_symlink()
+            and vault_marker
+            and vault_marker.get("role") == "vault"
+            and brain_marker
+            and brain_marker.get("role") == "brain"
+            and isinstance(installed, str)
+            and installed
+            and brain_marker.get("installed") == installed
+        ):
+            return "split"
+        return "invalid"
+    return "combined" if (vault / ".git").exists() else "manual"
+
+
+def _prepare_topology_vault(source: Path, vault: Path) -> None:
+    state = _topology_state(source)
+    if state == "split":
+        topology = _topology_json(source / "System/.dex/topology.json")
+        vault_marker = _topology_json(source / ".git/dex-vault-v2")
+        brain_marker = _topology_json(source / ".dex/brain.git/dex-brain-v2")
+        assert topology is not None and vault_marker is not None and brain_marker is not None
+        topology = {
+            **topology,
+            "environment": {"DEX_VAULT": str(vault.resolve())},
+        }
+        for relative, value in (
+            ("System/.dex/topology.json", topology),
+            (".git/dex-vault-v2", vault_marker),
+            (".dex/brain.git/dex-brain-v2", brain_marker),
+        ):
+            destination = vault / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(json.dumps(value) + "\n", encoding="utf-8")
+    elif state == "invalid":
+        topology = _topology_json(source / "System/.dex/topology.json")
+        if topology is not None:
+            destination = vault / "System/.dex/topology.json"
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(json.dumps(topology) + "\n", encoding="utf-8")
+    elif state == "combined":
+        (vault / ".git").mkdir()
+
+
 def _prepare_vault(
     journey_id: str,
     source: Path,
@@ -597,7 +672,9 @@ def _prepare_vault(
 ) -> None:
     vault.mkdir(parents=True)
     try:
-        if journey_id == "configs":
+        if journey_id == "topology":
+            _prepare_topology_vault(source, vault)
+        elif journey_id == "configs":
             _copy_configs(source, vault)
         elif journey_id == "task_lifecycle":
             _prepare_task_vault(source, repo_root, vault, release_root, release_ref)
@@ -1052,6 +1129,8 @@ def _clean_environment(
         "PYTHONUNBUFFERED": "1",
         "TMPDIR": str(temporary_root),
         "VAULT_PATH": str(vault),
+        "VAULT_ROOT": str(vault),
+        "DEX_VAULT": str(vault),
         "DEX_SMOKE_RUN_TOKEN": run_token,
         "DEX_SMOKE_SERVER_BOOTSTRAP": str(guard / "server_bootstrap.py"),
         **({"DEX_SMOKE_NODE": node} if (node := _trusted_node()) is not None else {}),
@@ -2404,7 +2483,38 @@ def _journey_hooks(vault: Path, _repo_root: Path) -> dict[str, str]:
     return {"verdict": verdict, "detail": f"structurally validated {len(commands)} hook commands"}
 
 
+def _journey_topology(vault: Path, _repo_root: Path) -> dict[str, str]:
+    for variable in ("VAULT_PATH", "VAULT_ROOT", "DEX_VAULT"):
+        configured = os.environ.get(variable)
+        if configured is None or Path(configured).resolve() != vault.resolve():
+            return {
+                "verdict": "BROKEN",
+                "detail": f"{variable} is not wired to the isolated vault",
+            }
+    state = _topology_state(vault)
+    if state == "split":
+        return {
+            "verdict": "OK",
+            "detail": "split topology markers and vault environment wiring agree",
+        }
+    if state == "combined":
+        return {
+            "verdict": "OK",
+            "detail": "combined topology is intact and remains on the merge updater path",
+        }
+    if state == "manual":
+        return {
+            "verdict": "OFF",
+            "detail": "ZIP/manual topology has no Git layout to validate",
+        }
+    return {
+        "verdict": "BROKEN",
+        "detail": "split topology markers disagree; use updater or migrator recovery",
+    }
+
+
 INTERNAL_JOURNEYS: dict[str, Callable[[Path, Path], dict[str, str]]] = {
+    "topology": _journey_topology,
     "configs": _journey_configs,
     "task_lifecycle": _journey_task_lifecycle,
     "mcp_startup": _journey_mcp_startup,


### PR DESCRIPTION
Updates for split installations now flow through the transaction core: verified release in, snapshot, apply, verify, one-click undo — never a git merge over user content. Health checks gain split awareness additively, with a regression guard that fails if they ever lose their shipped trust/channel/credential probes (the #141 poison-pill, permanently fenced). Combined installs keep today's flow untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)