### PR TITLE
feat: adoption plan + Doctor read-only probes (cathedral B5)

### DIFF
--- a/core/lifecycle/__init__.py
+++ b/core/lifecycle/__init__.py
@@ -5,5 +5,14 @@ plans. Mutation remains owned by :mod:`core.transaction` in later chunks.
 """
 
 from core.lifecycle.model import AdoptionState, CatalogItem, ReleaseCatalog
+from core.lifecycle.plan import AdoptionPlan, AdoptionPlanItem, PlannedAction, build_adoption_plan
 
-__all__ = ["AdoptionState", "CatalogItem", "ReleaseCatalog"]
+__all__ = [
+    "AdoptionPlan",
+    "AdoptionPlanItem",
+    "AdoptionState",
+    "CatalogItem",
+    "PlannedAction",
+    "ReleaseCatalog",
+    "build_adoption_plan",
+]

--- a/core/lifecycle/plan.py
+++ b/core/lifecycle/plan.py
@@ -1,0 +1,495 @@
+"""Pure, deterministic adoption planning over read-only lifecycle evidence."""
+
+from __future__ import annotations
+
+import json
+import posixpath
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from core.lifecycle.customizations import CustomizationReport, Divergence
+from core.lifecycle.inventory import InventoryEntry, InventoryReport
+from core.lifecycle.model import (
+    HEX_SHA256,
+    ITEM_ID,
+    SEMVER,
+    AdoptionState,
+    CatalogItem,
+    ReleaseCatalog,
+)
+
+PLAN_VERSION = 1
+
+
+class AdoptionPlanError(ValueError):
+    """The requested or serialized plan cannot be interpreted safely."""
+
+
+def _unknown(message: str) -> AdoptionPlanError:
+    return AdoptionPlanError(f"adoption plan is UNKNOWN: {message}")
+
+
+def _mapping(value: object, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _unknown(f"{context} must be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise _unknown(f"{context} has a non-string field name")
+    return value
+
+
+def _closed_fields(value: Mapping[str, Any], *, required: set[str], context: str) -> None:
+    fields = set(value)
+    missing = required - fields
+    extra = fields - required
+    if missing:
+        raise _unknown(f"{context} is missing required fields: {', '.join(sorted(missing))}")
+    if extra:
+        raise _unknown(f"{context} has unknown fields: {', '.join(sorted(extra))}")
+
+
+def _string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise _unknown(f"{context} must be a non-empty string")
+    return value
+
+
+def _item_id(value: object, context: str) -> str:
+    candidate = _string(value, context)
+    if ITEM_ID.fullmatch(candidate) is None:
+        raise _unknown(f"{context} is not a canonical item id")
+    return candidate
+
+
+def _version(value: object, context: str) -> str:
+    candidate = _string(value, context)
+    if SEMVER.fullmatch(candidate) is None:
+        raise _unknown(f"{context} is not strict SemVer")
+    return candidate
+
+
+def _sha256(value: object, context: str) -> str:
+    candidate = _string(value, context)
+    if HEX_SHA256.fullmatch(candidate) is None:
+        raise _unknown(f"{context} must be a lowercase sha256 digest")
+    return candidate
+
+
+def _relative_path(value: object, context: str) -> str:
+    candidate = _string(value, context)
+    if "\\" in candidate or candidate.startswith("/") or any(ord(char) < 32 for char in candidate):
+        raise _unknown(f"{context} must be a release-relative POSIX path")
+    normalized = posixpath.normpath(candidate)
+    if normalized != candidate or normalized in ("", ".", "..") or normalized.startswith("../"):
+        raise _unknown(f"{context} is not a canonical release-relative path")
+    return candidate
+
+
+class PlannedAction(str, Enum):
+    ADOPT = "adopt"
+    ALREADY_ADOPTED = "already-adopted"
+    SKIP_HELD_BACK = "skip-held-back"
+    CONFLICT = "conflict"
+    UNKNOWN = "unknown"
+
+
+class ReasonCode(str, Enum):
+    HELD_BACK_BY_USER = "held-back-by-user"
+    ADOPTION_RECEIPT_ADOPTED = "adoption-receipt-adopted"
+    ADOPTION_RECEIPT_INCOMPLETE = "adoption-receipt-incomplete"
+    ADOPTION_RECEIPT_CONFLICT = "adoption-receipt-conflict"
+    ADOPTION_RECEIPT_NOT_ADOPTED = "adoption-receipt-not-adopted"
+    RELEASE_FILES_MODIFIED = "release-files-modified"
+    RELEASE_FILES_MISSING = "release-files-missing"
+    RELEASE_FILES_UNKNOWN = "release-files-unknown"
+    RELEASE_FILES_READY = "release-files-ready"
+
+
+@dataclass(frozen=True)
+class PlanReason:
+    code: ReasonCode
+    paths: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "PlanReason":
+        value = _mapping(raw, "adoption plan reason")
+        _closed_fields(value, required={"code", "paths"}, context="adoption plan reason")
+        try:
+            code = ReasonCode(_string(value["code"], "adoption plan reason code"))
+        except ValueError as error:
+            raise _unknown("adoption plan reason has an unknown code") from error
+        if not isinstance(value["paths"], list):
+            raise _unknown("adoption plan reason paths must be an array")
+        paths = tuple(
+            _relative_path(path, "adoption plan reason path") for path in value["paths"]
+        )
+        if paths != tuple(sorted(set(paths))):
+            raise _unknown("adoption plan reason paths must be sorted and unique")
+        path_reason_codes = {
+            ReasonCode.RELEASE_FILES_MODIFIED,
+            ReasonCode.RELEASE_FILES_MISSING,
+            ReasonCode.RELEASE_FILES_UNKNOWN,
+            ReasonCode.RELEASE_FILES_READY,
+        }
+        if (code in path_reason_codes) != bool(paths):
+            raise _unknown("adoption plan reason path shape disagrees with its code")
+        return cls(code, paths)
+
+    def to_dict(self) -> dict[str, object]:
+        return {"code": self.code.value, "paths": list(self.paths)}
+
+
+@dataclass(frozen=True)
+class ItemEvidence:
+    """Evidence already isolated to one catalog item."""
+
+    inventory_entries: tuple[InventoryEntry, ...]
+    divergences: tuple[Divergence, ...]
+
+
+@dataclass(frozen=True)
+class AdoptionPlanItem:
+    item_id: str
+    item_version: str
+    action: PlannedAction
+    reasons: tuple[PlanReason, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "AdoptionPlanItem":
+        value = _mapping(raw, "adoption plan item")
+        _closed_fields(
+            value,
+            required={"item_id", "item_version", "action", "reasons"},
+            context="adoption plan item",
+        )
+        item_id = _item_id(value["item_id"], "adoption plan item_id")
+        item_version = _version(value["item_version"], f"adoption plan item {item_id} version")
+        try:
+            action = PlannedAction(_string(value["action"], f"adoption plan item {item_id} action"))
+        except ValueError as error:
+            raise _unknown(f"adoption plan item {item_id} has an unknown action") from error
+        if not isinstance(value["reasons"], list) or not value["reasons"]:
+            raise _unknown(f"adoption plan item {item_id} needs at least one reason")
+        reasons = tuple(PlanReason.from_dict(reason) for reason in value["reasons"])
+        if reasons != tuple(sorted(set(reasons), key=lambda reason: (reason.code.value, reason.paths))):
+            raise _unknown(f"adoption plan item {item_id} reasons must be sorted and unique")
+        reason_codes = {reason.code for reason in reasons}
+        required_codes = {
+            PlannedAction.ADOPT: {ReasonCode.RELEASE_FILES_READY},
+            PlannedAction.ALREADY_ADOPTED: {ReasonCode.ADOPTION_RECEIPT_ADOPTED},
+            PlannedAction.SKIP_HELD_BACK: {ReasonCode.HELD_BACK_BY_USER},
+            PlannedAction.CONFLICT: {
+                ReasonCode.ADOPTION_RECEIPT_CONFLICT,
+                ReasonCode.RELEASE_FILES_MODIFIED,
+                ReasonCode.RELEASE_FILES_MISSING,
+            },
+            PlannedAction.UNKNOWN: {
+                ReasonCode.ADOPTION_RECEIPT_INCOMPLETE,
+                ReasonCode.RELEASE_FILES_UNKNOWN,
+            },
+        }
+        allowed_codes = {
+            PlannedAction.ADOPT: {
+                ReasonCode.ADOPTION_RECEIPT_NOT_ADOPTED,
+                ReasonCode.RELEASE_FILES_READY,
+            },
+            PlannedAction.ALREADY_ADOPTED: {ReasonCode.ADOPTION_RECEIPT_ADOPTED},
+            PlannedAction.SKIP_HELD_BACK: {ReasonCode.HELD_BACK_BY_USER},
+            PlannedAction.CONFLICT: {
+                ReasonCode.ADOPTION_RECEIPT_CONFLICT,
+                ReasonCode.ADOPTION_RECEIPT_NOT_ADOPTED,
+                ReasonCode.RELEASE_FILES_MODIFIED,
+                ReasonCode.RELEASE_FILES_MISSING,
+                ReasonCode.RELEASE_FILES_UNKNOWN,
+            },
+            PlannedAction.UNKNOWN: {
+                ReasonCode.ADOPTION_RECEIPT_INCOMPLETE,
+                ReasonCode.ADOPTION_RECEIPT_NOT_ADOPTED,
+                ReasonCode.RELEASE_FILES_UNKNOWN,
+            },
+        }
+        if not reason_codes.intersection(required_codes[action]) or not reason_codes.issubset(
+            allowed_codes[action]
+        ):
+            raise _unknown(f"adoption plan item {item_id} reasons disagree with its action")
+        return cls(item_id, item_version, action, reasons)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "item_version": self.item_version,
+            "action": self.action.value,
+            "reasons": [reason.to_dict() for reason in self.reasons],
+        }
+
+
+@dataclass(frozen=True)
+class AdoptionPlan:
+    plan_version: int
+    release_version: str
+    catalog_sha256: str
+    items: tuple[AdoptionPlanItem, ...]
+
+    @property
+    def counts(self) -> dict[str, int]:
+        observed = Counter(item.action.value for item in self.items)
+        return {action.value: observed[action.value] for action in PlannedAction}
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "AdoptionPlan":
+        value = _mapping(raw, "adoption plan")
+        _closed_fields(
+            value,
+            required={"plan_version", "release_version", "catalog_sha256", "items", "counts"},
+            context="adoption plan",
+        )
+        if type(value["plan_version"]) is not int or value["plan_version"] != PLAN_VERSION:
+            raise _unknown(f"plan_version must be exactly {PLAN_VERSION}")
+        if not isinstance(value["items"], list):
+            raise _unknown("adoption plan items must be an array")
+        items = tuple(AdoptionPlanItem.from_dict(item) for item in value["items"])
+        if items != tuple(sorted(items, key=lambda item: item.item_id)):
+            raise _unknown("adoption plan items must be sorted by item_id")
+        if len({item.item_id for item in items}) != len(items):
+            raise _unknown("adoption plan repeats an item_id")
+        plan = cls(
+            PLAN_VERSION,
+            _version(value["release_version"], "adoption plan release_version"),
+            _sha256(value["catalog_sha256"], "adoption plan catalog_sha256"),
+            items,
+        )
+        counts = _mapping(value["counts"], "adoption plan counts")
+        expected_fields = {action.value for action in PlannedAction}
+        _closed_fields(counts, required=expected_fields, context="adoption plan counts")
+        if any(type(counts[action]) is not int or counts[action] < 0 for action in expected_fields):
+            raise _unknown("adoption plan counts must be non-negative integers")
+        if dict(counts) != plan.counts:
+            raise _unknown("adoption plan counts disagree with its items")
+        return plan
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "plan_version": self.plan_version,
+            "release_version": self.release_version,
+            "catalog_sha256": self.catalog_sha256,
+            "items": [item.to_dict() for item in self.items],
+            "counts": self.counts,
+        }
+
+
+def isolate_item_evidence(
+    item: CatalogItem,
+    inventory: InventoryReport,
+    customizations: CustomizationReport,
+) -> ItemEvidence:
+    """Partition shared reports before planning so later items cannot influence this one."""
+    paths = {catalog_file.path for catalog_file in item.files}
+    entries = tuple(
+        sorted(
+            (entry for entry in inventory.entries if entry.canonical_path in paths),
+            key=lambda entry: (entry.canonical_path, entry.actual_path, entry.kind),
+        )
+    )
+    divergences = tuple(
+        sorted(
+            (entry for entry in customizations.divergences if entry.canonical_path in paths),
+            key=lambda entry: (entry.canonical_path, entry.path, entry.state),
+        )
+    )
+    return ItemEvidence(entries, divergences)
+
+
+def _reason(code: ReasonCode, paths: set[str] | tuple[str, ...] = ()) -> PlanReason:
+    return PlanReason(code, tuple(sorted(set(paths))))
+
+
+def _ordered_reasons(reasons: list[PlanReason]) -> tuple[PlanReason, ...]:
+    return tuple(sorted(set(reasons), key=lambda reason: (reason.code.value, reason.paths)))
+
+
+def plan_catalog_item(
+    item: CatalogItem,
+    evidence: ItemEvidence,
+    *,
+    adoption_state: AdoptionState | None = None,
+    held_back: bool = False,
+) -> AdoptionPlanItem:
+    """Plan exactly one item; no other item's state or action is an input."""
+    if adoption_state is not None and not isinstance(adoption_state, AdoptionState):
+        raise _unknown(f"adoption state for {item.id} must be an AdoptionState")
+    if type(held_back) is not bool:
+        raise _unknown(f"held_back for {item.id} must be a boolean")
+    if held_back:
+        return AdoptionPlanItem(
+            item.id,
+            item.version,
+            PlannedAction.SKIP_HELD_BACK,
+            (_reason(ReasonCode.HELD_BACK_BY_USER),),
+        )
+    if adoption_state is AdoptionState.ADOPTED:
+        return AdoptionPlanItem(
+            item.id,
+            item.version,
+            PlannedAction.ALREADY_ADOPTED,
+            (_reason(ReasonCode.ADOPTION_RECEIPT_ADOPTED),),
+        )
+    if adoption_state in {
+        AdoptionState.HELD_FOR_REVIEW,
+        AdoptionState.CUSTOMIZATION_REVIEW_REQUIRED,
+    }:
+        return AdoptionPlanItem(
+            item.id,
+            item.version,
+            PlannedAction.CONFLICT,
+            (_reason(ReasonCode.ADOPTION_RECEIPT_CONFLICT),),
+        )
+    if adoption_state in {
+        AdoptionState.APPLIED,
+        AdoptionState.EXTERNAL_RECONCILIATION_PENDING,
+        AdoptionState.NEEDS_RECHECK,
+    }:
+        return AdoptionPlanItem(
+            item.id,
+            item.version,
+            PlannedAction.UNKNOWN,
+            (_reason(ReasonCode.ADOPTION_RECEIPT_INCOMPLETE),),
+        )
+
+    item_paths = {catalog_file.path for catalog_file in item.files}
+    by_path: dict[str, list[InventoryEntry]] = {path: [] for path in item_paths}
+    for entry in evidence.inventory_entries:
+        if entry.canonical_path not in item_paths:
+            raise _unknown(f"item evidence for {item.id} includes another item's inventory path")
+        by_path[entry.canonical_path].append(entry)
+    conflict_paths: dict[ReasonCode, set[str]] = {
+        ReasonCode.RELEASE_FILES_MODIFIED: set(),
+        ReasonCode.RELEASE_FILES_MISSING: set(),
+    }
+    unknown_paths: set[str] = set()
+    for path, entries in by_path.items():
+        if len(entries) != 1:
+            unknown_paths.add(path)
+            continue
+        state = entries[0].release_state
+        if state == "stock-modified":
+            conflict_paths[ReasonCode.RELEASE_FILES_MODIFIED].add(path)
+        elif state == "stock-missing":
+            conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(path)
+        elif state != "stock-unmodified":
+            unknown_paths.add(path)
+    for divergence in evidence.divergences:
+        if divergence.canonical_path not in item_paths:
+            raise _unknown(f"item evidence for {item.id} includes another item's divergence")
+        if divergence.state == "stock-modified":
+            conflict_paths[ReasonCode.RELEASE_FILES_MODIFIED].add(divergence.canonical_path)
+        elif divergence.state == "stock-missing":
+            conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(divergence.canonical_path)
+        else:
+            unknown_paths.add(divergence.canonical_path)
+
+    reasons: list[PlanReason] = []
+    if adoption_state in {
+        AdoptionState.REWOUND,
+        AdoptionState.SKIPPED_BY_USER,
+        AdoptionState.FAILED_ROLLED_BACK,
+    }:
+        reasons.append(_reason(ReasonCode.ADOPTION_RECEIPT_NOT_ADOPTED))
+    reasons.extend(
+        _reason(code, paths)
+        for code, paths in conflict_paths.items()
+        if paths
+    )
+    if unknown_paths:
+        reasons.append(_reason(ReasonCode.RELEASE_FILES_UNKNOWN, unknown_paths))
+    if any(conflict_paths.values()):
+        action = PlannedAction.CONFLICT
+    elif unknown_paths:
+        action = PlannedAction.UNKNOWN
+    else:
+        action = PlannedAction.ADOPT
+        reasons.append(_reason(ReasonCode.RELEASE_FILES_READY, item_paths))
+    return AdoptionPlanItem(item.id, item.version, action, _ordered_reasons(reasons))
+
+
+def build_adoption_plan(
+    catalog: ReleaseCatalog,
+    inventory: InventoryReport,
+    *,
+    customizations: CustomizationReport | None = None,
+    adoption_states: Mapping[str, AdoptionState] | None = None,
+    held_back: set[str] | frozenset[str] = frozenset(),
+) -> AdoptionPlan:
+    """Build a read-only plan by invoking the pure per-item planner independently."""
+    if not isinstance(catalog, ReleaseCatalog):
+        raise _unknown("catalog must be a loaded ReleaseCatalog")
+    if not isinstance(inventory, InventoryReport):
+        raise _unknown("inventory must be an InventoryReport")
+    customizations = inventory.customizations if customizations is None else customizations
+    if not isinstance(customizations, CustomizationReport):
+        raise _unknown("customizations must be a CustomizationReport")
+    if not isinstance(held_back, (set, frozenset)) or not all(
+        isinstance(item_id, str) for item_id in held_back
+    ):
+        raise _unknown("held_back must be a set of item ids")
+    states = {} if adoption_states is None else adoption_states
+    if not isinstance(states, Mapping) or not all(isinstance(item_id, str) for item_id in states):
+        raise _unknown("adoption_states must map item ids to AdoptionState values")
+    catalog_ids = {item.id for item in catalog.items}
+    unknown_holdbacks = set(held_back) - catalog_ids
+    if unknown_holdbacks:
+        raise _unknown(f"unknown held-back item: {', '.join(sorted(unknown_holdbacks))}")
+    unknown_states = set(states) - catalog_ids
+    if unknown_states:
+        raise _unknown(f"unknown adoption-state item: {', '.join(sorted(unknown_states))}")
+    for item_id, state in states.items():
+        if not isinstance(state, AdoptionState):
+            raise _unknown(f"adoption state for {item_id} must be an AdoptionState")
+
+    items = tuple(
+        plan_catalog_item(
+            item,
+            isolate_item_evidence(item, inventory, customizations),
+            adoption_state=states.get(item.id),
+            held_back=item.id in held_back,
+        )
+        for item in sorted(catalog.items, key=lambda candidate: candidate.id)
+    )
+    return AdoptionPlan(
+        PLAN_VERSION,
+        catalog.release.version,
+        catalog.integrity.catalog_sha256,
+        items,
+    )
+
+
+def canonical_adoption_plan_bytes(plan: AdoptionPlan) -> bytes:
+    """Stable JSON bytes for receipts and equality checks; contains no clock fields."""
+    try:
+        return (
+            json.dumps(
+                plan.to_dict(),
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise _unknown(f"plan cannot be serialized canonically: {error}") from error
+
+
+__all__ = [
+    "AdoptionPlan",
+    "AdoptionPlanError",
+    "AdoptionPlanItem",
+    "ItemEvidence",
+    "PlanReason",
+    "PlannedAction",
+    "ReasonCode",
+    "build_adoption_plan",
+    "canonical_adoption_plan_bytes",
+    "isolate_item_evidence",
+    "plan_catalog_item",
+]

--- a/core/tests/test_adoption_plan.py
+++ b/core/tests/test_adoption_plan.py
@@ -1,0 +1,221 @@
+"""B5 adoption planning semantics and E6 holdback isolation."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import random
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import AdoptionState, ReleaseCatalog
+from core.lifecycle.plan import (
+    AdoptionPlan,
+    AdoptionPlanError,
+    build_adoption_plan,
+    canonical_adoption_plan_bytes,
+)
+from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
+
+
+def _catalog(manifest: bytes, expected: dict[str, bytes]) -> ReleaseCatalog:
+    items = []
+    for item_id, content in sorted(expected.items()):
+        path = f".claude/skills/{item_id}/SKILL.md"
+        items.append(
+            {
+                "id": item_id,
+                "kind": "skill",
+                "version": "1.0.0",
+                "files": [
+                    {
+                        "path": path,
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "ownership_class": "brain",
+                    }
+                ],
+                "dependencies": [],
+                "capabilities": [],
+                "rewind": {
+                    "acknowledgement_required": True,
+                    "token": f"rewind:{item_id}@1.0.0",
+                },
+            }
+        )
+    return ReleaseCatalog.from_dict(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.64.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.64.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": items,
+            "integrity": {"catalog_sha256": "a" * 64, "signatures": []},
+        }
+    )
+
+
+def _scenario(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    expected = {
+        "adopted": b"adopted release\n",
+        "conflict": b"conflict release\n",
+        "held": b"held release\n",
+        "missing": b"missing release\n",
+        "ready": b"ready release\n",
+        "unknown": b"unknown release\n",
+    }
+    paths = [f".claude/skills/{item_id}/SKILL.md" for item_id in expected]
+    manifest = write_manifest(vault, paths)
+    catalog = _catalog(manifest, expected)
+    for item_id, content in expected.items():
+        if item_id == "missing":
+            continue
+        actual = b"user changed this\n" if item_id == "conflict" else content
+        write_file(vault, f".claude/skills/{item_id}/SKILL.md", actual)
+    unknown = vault / ".claude/skills/unknown/SKILL.md"
+    unknown.unlink()
+    unknown.symlink_to(vault / ".claude/skills/ready/SKILL.md")
+    inventory = build_inventory(vault, catalog=catalog)
+    return catalog, inventory
+
+
+def _items_by_id(plan: AdoptionPlan):
+    return {item.item_id: item for item in plan.items}
+
+
+def test_plan_classifies_each_catalog_item_from_its_own_evidence(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+
+    plan = build_adoption_plan(
+        catalog,
+        inventory,
+        customizations=inventory.customizations,
+        adoption_states={"adopted": AdoptionState.ADOPTED},
+        held_back={"held"},
+    )
+
+    by_id = _items_by_id(plan)
+    assert by_id["ready"].action == "adopt"
+    assert by_id["ready"].reasons[0].code == "release-files-ready"
+    assert by_id["adopted"].action == "already-adopted"
+    assert by_id["held"].action == "skip-held-back"
+    assert by_id["conflict"].action == "conflict"
+    assert by_id["conflict"].reasons[0].paths == (
+        ".claude/skills/conflict/SKILL.md",
+    )
+    assert by_id["missing"].action == "conflict"
+    assert by_id["unknown"].action == "unknown"
+    assert plan.counts == {
+        "adopt": 1,
+        "already-adopted": 1,
+        "skip-held-back": 1,
+        "conflict": 2,
+        "unknown": 1,
+    }
+
+
+def test_no_recorded_adoption_state_means_nothing_is_already_adopted(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+
+    plan = build_adoption_plan(catalog, inventory)
+
+    assert _items_by_id(plan)["adopted"].action == "adopt"
+    assert plan.counts["already-adopted"] == 0
+
+
+def test_e6_random_holdbacks_never_change_non_held_item_plans(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+    states = {"adopted": AdoptionState.ADOPTED}
+    baseline = _items_by_id(
+        build_adoption_plan(catalog, inventory, adoption_states=states)
+    )
+    item_ids = sorted(baseline)
+    random_source = random.Random(20260721)
+
+    for _ in range(100):
+        held_back = {
+            item_id for item_id in item_ids if random_source.choice((False, True))
+        }
+        candidate = _items_by_id(
+            build_adoption_plan(
+                catalog,
+                inventory,
+                adoption_states=states,
+                held_back=held_back,
+            )
+        )
+        for item_id in set(item_ids) - held_back:
+            assert candidate[item_id] == baseline[item_id]
+
+
+def test_conflict_and_unknown_items_do_not_block_ready_items(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+
+    plan = _items_by_id(build_adoption_plan(catalog, inventory))
+
+    assert plan["conflict"].action == "conflict"
+    assert plan["unknown"].action == "unknown"
+    assert plan["ready"].action == "adopt"
+
+
+def test_plan_round_trip_and_canonical_bytes_are_deterministic(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+    plan = build_adoption_plan(catalog, inventory, held_back={"held"})
+
+    reparsed = AdoptionPlan.from_dict(plan.to_dict())
+
+    assert reparsed == plan
+    assert canonical_adoption_plan_bytes(reparsed) == canonical_adoption_plan_bytes(plan)
+    assert [item.item_id for item in plan.items] == sorted(item.id for item in catalog.items)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda raw: raw.update({"surprise": True}),
+        lambda raw: raw.pop("catalog_sha256"),
+        lambda raw: raw.update({"plan_version": True}),
+        lambda raw: raw["items"][0].update({"action": "maybe"}),
+        lambda raw: raw["items"][0].update({"action": "already-adopted"}),
+        lambda raw: raw["items"][0]["reasons"][0].update({"code": "guess"}),
+        lambda raw: raw["items"][0]["reasons"][0].update({"paths": "not-an-array"}),
+        lambda raw: raw["items"][0]["reasons"][0].update({"paths": []}),
+        lambda raw: raw["items"][0]["reasons"][0].update({"paths": ["../escape"]}),
+        lambda raw: raw.update({"counts": {"adopt": 999}}),
+        lambda raw: raw["items"].append(copy.deepcopy(raw["items"][0])),
+    ],
+)
+def test_plan_parser_fails_closed_on_ambiguous_documents(
+    tmp_path: Path, mutation
+) -> None:
+    catalog, inventory = _scenario(tmp_path)
+    raw = build_adoption_plan(catalog, inventory).to_dict()
+    mutation(raw)
+
+    with pytest.raises(AdoptionPlanError, match="UNKNOWN"):
+        AdoptionPlan.from_dict(raw)
+
+
+def test_planner_rejects_unknown_ids_and_untyped_receipt_states(tmp_path: Path) -> None:
+    catalog, inventory = _scenario(tmp_path)
+
+    with pytest.raises(AdoptionPlanError, match="unknown held-back item"):
+        build_adoption_plan(catalog, inventory, held_back={"not-in-catalog"})
+    with pytest.raises(AdoptionPlanError, match="unknown adoption-state item"):
+        build_adoption_plan(
+            catalog,
+            inventory,
+            adoption_states={"not-in-catalog": AdoptionState.ADOPTED},
+        )
+    with pytest.raises(AdoptionPlanError, match="must be an AdoptionState"):
+        build_adoption_plan(catalog, inventory, adoption_states={"ready": "adopted"})

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,5 +1,6 @@
 """Contract tests for the /dex-doctor collector."""
 
+import hashlib
 import json
 import os
 import plistlib
@@ -12,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from core.lifecycle.catalog import with_catalog_identity
+from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
 from core.utils import doctor, release_channel
 
 DOCTOR_PATH = Path(__file__).resolve().parents[1] / "utils" / "doctor.py"
@@ -24,6 +27,8 @@ QUICK_IDS = [
     "brain.git",
     "vault.auto-commit",
     "topology.migration-pending",
+    "release.catalog",
+    "adoption.plan",
     "smoke.history",
     "mcp.registered",
     "mcp.orphans",
@@ -140,6 +145,51 @@ def _write_entity_probe_files(context, *, mode="auto", unresolved=None):
     (context.vault_root / "System" / "People_Index.json").write_text(json.dumps({
         "built_at": NOW.isoformat(),
     }))
+
+
+def _write_release_catalog(context, *, content=b"release skill\n"):
+    item_path = ".claude/skills/fixture-item/SKILL.md"
+    manifest = write_manifest(context.vault_root, [item_path])
+    write_file(context.vault_root, item_path, content)
+    document = with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.64.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.64.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": [
+                {
+                    "id": "fixture-item",
+                    "kind": "skill",
+                    "version": "1.0.0",
+                    "files": [
+                        {
+                            "path": item_path,
+                            "sha256": hashlib.sha256(content).hexdigest(),
+                            "ownership_class": "brain",
+                        }
+                    ],
+                    "dependencies": [],
+                    "capabilities": [],
+                    "rewind": {
+                        "acknowledgement_required": True,
+                        "token": "rewind:fixture-item@1.0.0",
+                    },
+                }
+            ],
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+    path = context.vault_root / "System/.release-catalog.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
 
 
 def _tree_snapshot(root):
@@ -303,6 +353,88 @@ def test_registry_ids_match_the_approved_spec():
     assert [definition.id for definition in doctor.QUICK_CHECKS] == QUICK_IDS
     assert [definition.id for definition in doctor.DEEP_CHECKS] == DEEP_IDS
     assert doctor.VERDICTS == frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
+
+
+def test_release_catalog_probe_is_calmly_off_for_older_installs(context):
+    result = doctor._probe_release_catalog(context)
+
+    assert result.verdict == "OFF"
+    assert "normal for older Dex releases" in result.detail
+
+
+def test_release_catalog_probe_reports_valid_version_without_writing(context):
+    _write_release_catalog(context)
+    before = _tree_snapshot(context.vault_root)
+
+    result = doctor._probe_release_catalog(context)
+
+    assert result.verdict == "OK"
+    assert "1.64.0" in result.detail
+    assert _tree_snapshot(context.vault_root) == before
+
+
+def test_release_catalog_probe_reports_corruption_as_broken(context):
+    path = context.vault_root / "System/.release-catalog.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    result = doctor._probe_release_catalog(context)
+
+    assert result.verdict == "BROKEN"
+    assert "cannot be parsed" in result.detail
+
+
+def test_release_catalog_probe_reports_non_utf8_corruption_as_broken(context):
+    path = context.vault_root / "System/.release-catalog.json"
+    path.write_bytes(b"\xff")
+
+    result = doctor._probe_release_catalog(context)
+
+    assert result.verdict == "BROKEN"
+    assert "codec can't decode" in result.detail
+
+
+def test_adoption_plan_probe_summarizes_valid_catalog_in_memory(context):
+    _write_release_catalog(context)
+    before = _tree_snapshot(context.vault_root)
+
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "1 adoptable / 0 adopted / 0 conflicts"
+    assert _tree_snapshot(context.vault_root) == before
+
+
+def test_adoption_plan_probe_is_off_without_a_release_catalog(context):
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "OFF"
+    assert "older Dex release" in result.detail
+
+
+def test_adoption_plan_probe_maps_internal_failures_to_unknown(monkeypatch, context):
+    _write_release_catalog(context)
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("inventory exploded")
+
+    monkeypatch.setattr(doctor, "build_inventory", explode)
+
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert "inventory exploded" in result.detail
+
+
+def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
+    (context.vault_root / "System/.release-catalog.json").write_text(
+        "{not json", encoding="utf-8"
+    )
+    _stub_probes(monkeypatch, exclude={"release.catalog", "adoption.plan"})
+
+    report = doctor.collect(context=context)
+
+    assert _check(report, "release.catalog")["verdict"] == "BROKEN"
+    assert _check(report, "adoption.plan")["verdict"] == "UNKNOWN"
 
 
 def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -27,6 +27,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from core import paths, portable_contract
+from core.lifecycle.catalog import CatalogError, load_catalog
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.plan import build_adoption_plan
 from core.utils import preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
@@ -36,6 +39,7 @@ MISSING_PACKAGES_DETAIL = (
     "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
     "then re-run /dex-doctor"
 )
+RELEASE_CATALOG_PATH = "System/.release-catalog.json"
 
 
 @dataclass(frozen=True)
@@ -168,6 +172,8 @@ QUICK_CHECKS = (
         "Brain/vault topology",
         "_probe_migration_pending",
     ),
+    CheckDefinition("release.catalog", "Release catalog", "_probe_release_catalog"),
+    CheckDefinition("adoption.plan", "Adoption plan", "_probe_adoption_plan"),
     CheckDefinition("smoke.history", "Nightly smoke results", "_probe_smoke_history"),
     CheckDefinition("mcp.registered", "MCP registration", "_probe_mcp_registered"),
     CheckDefinition("mcp.orphans", "MCP server registration", "_probe_mcp_orphans"),
@@ -524,6 +530,50 @@ def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
             Heal(tier=3, action="Repair the named configuration file by hand.", applied=False),
         )
     return ProbeResult("OK", "user-profile.yaml, pillars.yaml, and .claude/settings.json all parse")
+
+
+def _release_catalog_path(context: DoctorContext) -> Path:
+    return context.vault_root / RELEASE_CATALOG_PATH
+
+
+def _probe_release_catalog(context: DoctorContext) -> ProbeResult:
+    """Validate the installed release catalog without changing the vault."""
+    catalog_path = _release_catalog_path(context)
+    if not os.path.lexists(catalog_path):
+        return ProbeResult(
+            "OFF",
+            "No release catalog is installed; this is normal for older Dex releases",
+        )
+    try:
+        catalog = load_catalog(catalog_path, release_root=context.vault_root)
+    except (CatalogError, UnicodeError) as error:
+        return ProbeResult("BROKEN", f"The installed release catalog is invalid: {_one_line(error)}")
+    return ProbeResult(
+        "OK",
+        f"Release catalog {catalog.release.version} is valid ({len(catalog.items)} items)",
+    )
+
+
+def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
+    """Build and summarize the adoption plan entirely in memory."""
+    catalog_path = _release_catalog_path(context)
+    if not os.path.lexists(catalog_path):
+        return ProbeResult(
+            "OFF",
+            "Adoption planning is unavailable on this older Dex release because no release catalog is installed",
+        )
+    try:
+        catalog = load_catalog(catalog_path, release_root=context.vault_root)
+        inventory = build_inventory(context.vault_root, catalog=catalog)
+        plan = build_adoption_plan(catalog, inventory)
+        counts = plan.counts
+        return ProbeResult(
+            "OK",
+            f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / "
+            f"{counts['conflict']} conflicts",
+        )
+    except Exception as error:
+        return ProbeResult("UNKNOWN", f"The adoption plan could not be built: {_one_line(error)}")
 
 
 def _mcp_config_path(context: DoctorContext) -> Path:


### PR DESCRIPTION
Chunk B5 of the lifecycle catalog program (spec §5). Completes Phase B.

## What
- **core/lifecycle/plan.py** (new): pure, read-only adoption planning. Per catalog item: adopt / already-adopted / skip-held-back / conflict / unknown, with machine-readable reasons and canonical serialization.
- **Holdback isolation (gate E6, binding):** each item is planned by a pure per-item function; holding back any subset of items cannot change any other item's plan. Proven structurally and by randomized property tests.
- **core/utils/doctor.py**: two new read-only probes (release-catalog validity; in-memory adoption-plan summary). Existing OK/OFF/BROKEN/UNKNOWN vocabulary unchanged; probes never raise and never write.

## Verification
- 163 targeted tests green (test_adoption_plan, test_doctor, test_adoption_diff, test_release_catalog)
- ruff clean; portable-contract gate green (1054 paths); founder-content gate green
- E6 red-when-removed proof: isolation test fails under a deliberate cross-item mutation, passes when restored

Built by Codex (gpt-5.6-sol); diff reviewed by Fable against merged B1/B4 APIs (AdoptionState members, release_state vocabulary, build_inventory signature all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42