### PR TITLE
feat: double-authorized adoption engine on transaction core (cathedral C1)

### DIFF
--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -1,0 +1,402 @@
+"""Double-authorized catalog adoption through the transaction core only."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import posixpath
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.lifecycle.catalog import CatalogError, load_catalog
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import HEX_SHA256, ITEM_ID, ReleaseCatalog
+from core.lifecycle.plan import (
+    PLAN_VERSION,
+    AdoptionPlan,
+    PlannedAction,
+    isolate_item_evidence,
+    plan_catalog_item,
+)
+from core.lifecycle.preview import (
+    AdoptionPreview,
+    AdoptionPreviewError,
+    PayloadLoader,
+    build_adoption_preview,
+    canonical_adoption_preview_bytes,
+)
+from core.transaction.engine import PlanEntry, PlanRejected, Transaction, TransactionError
+
+RECEIPT_VERSION = 1
+CATALOG_RELATIVE = "System/.release-catalog.json"
+TRANSACTION_ID = re.compile(r"^[0-9]{8}T[0-9]{6}-[0-9a-f]{8}$")
+
+
+class AdoptionExecutionError(RuntimeError):
+    """Adoption refused or failed without a partial lifecycle result."""
+
+
+def _refuse(message: str) -> AdoptionExecutionError:
+    return AdoptionExecutionError(f"adoption refused: {message}")
+
+
+def _mapping(value: object, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise _refuse(f"{context} must be an object with string field names")
+    return value
+
+
+def _closed_fields(value: Mapping[str, Any], *, required: set[str], context: str) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise _refuse(f"{context} is missing required fields: {', '.join(sorted(missing))}")
+    if unknown:
+        raise _refuse(f"{context} has unknown fields: {', '.join(sorted(unknown))}")
+
+
+def _string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise _refuse(f"{context} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, context: str) -> str:
+    digest = _string(value, context)
+    if HEX_SHA256.fullmatch(digest) is None:
+        raise _refuse(f"{context} must be a lowercase sha256 digest")
+    return digest
+
+
+def _relative_path(value: object, context: str) -> str:
+    path = _string(value, context)
+    if "\\" in path or path.startswith("/") or any(ord(char) < 32 for char in path):
+        raise _refuse(f"{context} must be a relative POSIX path")
+    normalized = posixpath.normpath(path)
+    if normalized != path or normalized in ("", ".", "..") or normalized.startswith("../"):
+        raise _refuse(f"{context} is not a canonical relative path")
+    return path
+
+
+@dataclass(frozen=True)
+class ReceiptFile:
+    item_id: str
+    path: str
+    sha256: str
+    byte_size: int
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ReceiptFile":
+        value = _mapping(raw, "adoption receipt file")
+        _closed_fields(
+            value,
+            required={"item_id", "path", "sha256", "byte_size"},
+            context="adoption receipt file",
+        )
+        item_id = _string(value["item_id"], "adoption receipt file item_id")
+        if ITEM_ID.fullmatch(item_id) is None:
+            raise _refuse("adoption receipt file item_id is not canonical")
+        byte_size = value["byte_size"]
+        if type(byte_size) is not int or byte_size < 0:
+            raise _refuse("adoption receipt file byte_size must be a non-negative integer")
+        return cls(
+            item_id,
+            _relative_path(value["path"], "adoption receipt file path"),
+            _sha256(value["sha256"], "adoption receipt file sha256"),
+            byte_size,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "path": self.path,
+            "sha256": self.sha256,
+            "byte_size": self.byte_size,
+        }
+
+
+@dataclass(frozen=True)
+class AdoptionReceipt:
+    """Evidence of one committed adoption, with a short-lived rewind reference.
+
+    The transaction core keeps only the newest three committed snapshots via
+    ``_prune_committed(keep=3)``. ``snapshot_ref`` is therefore not durable:
+    after three further committed transactions, its snapshot has been deleted.
+    The future C3 rewind implementation must detect a missing/pruned snapshot
+    and fail safe rather than attempting a partial rewind.
+    """
+
+    receipt_version: int
+    items_adopted: tuple[str, ...]
+    files_written: tuple[ReceiptFile, ...]
+    transaction_id: str
+    snapshot_ref: str
+    catalog_sha256: str
+    inventory_sha256: str
+    preview_sha256: str
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "AdoptionReceipt":
+        value = _mapping(raw, "adoption receipt")
+        _closed_fields(
+            value,
+            required={
+                "receipt_version",
+                "items_adopted",
+                "files_written",
+                "transaction_id",
+                "snapshot_ref",
+                "catalog_sha256",
+                "inventory_sha256",
+                "preview_sha256",
+            },
+            context="adoption receipt",
+        )
+        if type(value["receipt_version"]) is not int or value["receipt_version"] != RECEIPT_VERSION:
+            raise _refuse(f"receipt_version must be exactly {RECEIPT_VERSION}")
+        if not isinstance(value["items_adopted"], list) or not value["items_adopted"]:
+            raise _refuse("adoption receipt needs at least one adopted item")
+        items = tuple(
+            _string(item, "adoption receipt item") for item in value["items_adopted"]
+        )
+        if any(ITEM_ID.fullmatch(item) is None for item in items):
+            raise _refuse("adoption receipt contains a non-canonical item id")
+        if items != tuple(sorted(set(items))):
+            raise _refuse("adoption receipt items must be sorted and unique")
+        if not isinstance(value["files_written"], list) or not value["files_written"]:
+            raise _refuse("adoption receipt needs at least one written file")
+        files = tuple(ReceiptFile.from_dict(entry) for entry in value["files_written"])
+        if files != tuple(sorted(files, key=lambda entry: (entry.path, entry.item_id))):
+            raise _refuse("adoption receipt files must be sorted by path")
+        if len({entry.path for entry in files}) != len(files):
+            raise _refuse("adoption receipt repeats a written path")
+        if {entry.item_id for entry in files} - set(items):
+            raise _refuse("adoption receipt file names an item that was not adopted")
+        transaction_id = _string(value["transaction_id"], "adoption receipt transaction_id")
+        if TRANSACTION_ID.fullmatch(transaction_id) is None:
+            raise _refuse("adoption receipt transaction_id is not canonical")
+        # This validates the reference shape, not its lifetime. The transaction
+        # core prunes all but the newest three committed snapshots, so C3 rewind
+        # must treat a missing snapshot_ref as a safe refusal.
+        snapshot_ref = _relative_path(value["snapshot_ref"], "adoption receipt snapshot_ref")
+        expected_snapshot = f"System/.dex/tx/{transaction_id}/snapshot"
+        if snapshot_ref != expected_snapshot:
+            raise _refuse("adoption receipt snapshot_ref does not match its transaction_id")
+        return cls(
+            RECEIPT_VERSION,
+            items,
+            files,
+            transaction_id,
+            snapshot_ref,
+            _sha256(value["catalog_sha256"], "adoption receipt catalog_sha256"),
+            _sha256(value["inventory_sha256"], "adoption receipt inventory_sha256"),
+            _sha256(value["preview_sha256"], "adoption receipt preview_sha256"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "receipt_version": self.receipt_version,
+            "items_adopted": list(self.items_adopted),
+            "files_written": [entry.to_dict() for entry in self.files_written],
+            "transaction_id": self.transaction_id,
+            "snapshot_ref": self.snapshot_ref,
+            "catalog_sha256": self.catalog_sha256,
+            "inventory_sha256": self.inventory_sha256,
+            "preview_sha256": self.preview_sha256,
+        }
+
+
+def canonical_adoption_receipt_bytes(receipt: AdoptionReceipt) -> bytes:
+    if not isinstance(receipt, AdoptionReceipt):
+        raise _refuse("receipt must be an AdoptionReceipt")
+    try:
+        return (
+            json.dumps(
+                receipt.to_dict(),
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise _refuse(f"receipt cannot be serialized canonically: {error}") from error
+
+
+def _rebuild_requested_plan(catalog, inventory, requested: tuple[str, ...]) -> AdoptionPlan:
+    by_id = {item.id: item for item in catalog.items}
+    rebuilt_items = []
+    for item_id in requested:
+        item = by_id.get(item_id)
+        if item is None:
+            raise _refuse(f"requested item {item_id} is no longer in the catalog")
+        planned = plan_catalog_item(
+            item,
+            isolate_item_evidence(item, inventory, inventory.customizations),
+        )
+        if planned.action is not PlannedAction.ADOPT:
+            raise _refuse(
+                f"item {item_id} planned action changed from adopt to "
+                f"{planned.action.value} since preview; review the current plan"
+            )
+        rebuilt_items.append(planned)
+    return AdoptionPlan(
+        PLAN_VERSION,
+        catalog.release.version,
+        catalog.integrity.catalog_sha256,
+        tuple(rebuilt_items),
+    )
+
+
+def _catalog_inventory_scope(
+    catalog: ReleaseCatalog, requested: tuple[str, ...]
+) -> ReleaseCatalog:
+    """Keep full identity while inventory hashes payloads for requested items only."""
+    by_id = {item.id: item for item in catalog.items}
+    missing = set(requested) - set(by_id)
+    if missing:
+        raise _refuse(f"requested item is no longer in the catalog: {', '.join(sorted(missing))}")
+    return ReleaseCatalog(
+        catalog.catalog_version,
+        catalog.release,
+        tuple(by_id[item_id] for item_id in requested),
+        catalog.integrity,
+    )
+
+
+def execute_adoption(
+    vault_root: Path,
+    preview: AdoptionPreview,
+    approved_token: str,
+    payload_loader: PayloadLoader,
+) -> AdoptionReceipt:
+    """Re-prove an approved preview, then execute all writes in one transaction."""
+    if not isinstance(preview, AdoptionPreview):
+        raise _refuse("preview must be an AdoptionPreview")
+    if not isinstance(approved_token, str) or not hmac.compare_digest(
+        approved_token, preview.sha256
+    ):
+        raise _refuse("approval token does not match the exact canonical preview")
+    if not callable(payload_loader):
+        raise _refuse("payload_loader must be callable")
+
+    root = Path(vault_root)
+    try:
+        current_catalog = load_catalog(root / CATALOG_RELATIVE, release_root=root)
+    except CatalogError as error:
+        raise _refuse(f"current catalog could not be verified: {error}") from error
+    if current_catalog.integrity.catalog_sha256 != preview.catalog_sha256:
+        raise _refuse("catalog changed since preview; build and approve a fresh preview")
+
+    requested = tuple(item.item_id for item in preview.items)
+    current_inventory = build_inventory(
+        root,
+        catalog=_catalog_inventory_scope(current_catalog, requested),
+    )
+    current_plan = _rebuild_requested_plan(current_catalog, current_inventory, requested)
+    payload_cache: dict[str, bytes] = {}
+
+    def cached_loader(path: str) -> bytes:
+        if path not in payload_cache:
+            payload_cache[path] = payload_loader(path)
+        return payload_cache[path]
+
+    try:
+        rebuilt = build_adoption_preview(
+            current_catalog,
+            current_inventory,
+            current_plan,
+            requested,
+            cached_loader,
+        )
+    except AdoptionPreviewError as error:
+        raise _refuse(f"current preview could not be rebuilt: {error}") from error
+    if canonical_adoption_preview_bytes(rebuilt) != canonical_adoption_preview_bytes(preview):
+        if rebuilt.inventory_sha256 != preview.inventory_sha256:
+            raise _refuse(
+                "requested file inventory changed since preview; build and approve a fresh preview"
+            )
+        raise _refuse("rebuilt preview differs from the approved preview; approve a fresh preview")
+
+    entries = [
+        PlanEntry(write.path, payload_cache[write.path])
+        for item in rebuilt.items
+        for write in item.writes
+    ]
+
+    try:
+        transaction = Transaction.begin(root, entries)
+
+        def verify_approval_binding() -> None:
+            """Catch pre-snapshot drift, with one inherited residual window.
+
+            If a target changes after the final preview rebuild but before
+            snapshot capture, the snapshot records those newer bytes; comparing
+            it with the approved catalog bytes catches the drift and rollback
+            restores the newer bytes. A non-transaction writer that changes a
+            target after snapshot capture but before ``_apply_one`` is not
+            caught: apply overwrites the edit with the approved stock bytes,
+            this comparison still sees snapshot(stock) == catalog, and the
+            adoption commits. That sub-millisecond window is inherited from the
+            trusted transaction core because write PlanEntry objects cannot set
+            ``expected_current_sha256``.
+            """
+            if not hmac.compare_digest(approved_token, rebuilt.sha256):
+                raise _refuse("approval binding changed before commit")
+            snapshot_by_path = {
+                entry.relative: entry for entry in transaction.snapshot.read_manifest()
+            }
+            for item in rebuilt.items:
+                for write in item.writes:
+                    captured = snapshot_by_path.get(write.path)
+                    if (
+                        captured is None
+                        or not captured.existed
+                        or captured.sha256 != write.new_sha256
+                        or captured.size != write.byte_size
+                    ):
+                        raise _refuse(
+                            f"requested file {write.path} changed after final preview rebuild; "
+                            "the transaction will restore the newer bytes"
+                        )
+
+        result = transaction.run(before_commit=verify_approval_binding)
+    except PlanRejected as error:
+        raise _refuse(f"the ownership contract rejected the complete adoption: {error}") from error
+    except TransactionError as error:
+        raise _refuse(f"the transaction could not complete safely: {error}") from error
+
+    files = tuple(
+        sorted(
+            (
+                ReceiptFile(item.item_id, write.path, write.new_sha256, write.byte_size)
+                for item in rebuilt.items
+                for write in item.writes
+            ),
+            key=lambda entry: (entry.path, entry.item_id),
+        )
+    )
+    transaction_id = result["tx_id"]
+    return AdoptionReceipt(
+        RECEIPT_VERSION,
+        requested,
+        files,
+        transaction_id,
+        f"System/.dex/tx/{transaction_id}/snapshot",
+        rebuilt.catalog_sha256,
+        rebuilt.inventory_sha256,
+        rebuilt.sha256,
+    )
+
+
+__all__ = [
+    "AdoptionExecutionError",
+    "AdoptionReceipt",
+    "ReceiptFile",
+    "canonical_adoption_receipt_bytes",
+    "execute_adoption",
+]

--- a/core/lifecycle/preview.py
+++ b/core/lifecycle/preview.py
@@ -1,0 +1,372 @@
+"""Canonical, read-only previews for explicitly requested catalog adoption."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from core.lifecycle.inventory import InventoryReport
+from core.lifecycle.model import HEX_SHA256, ITEM_ID, SEMVER, ReleaseCatalog
+from core.lifecycle.plan import AdoptionPlan, PlannedAction
+
+PREVIEW_VERSION = 1
+PayloadLoader = Callable[[str], bytes]
+
+
+class AdoptionPreviewError(ValueError):
+    """An adoption preview cannot be proved exactly and safely."""
+
+
+def _refuse(message: str) -> AdoptionPreviewError:
+    return AdoptionPreviewError(f"adoption preview refused: {message}")
+
+
+def _mapping(value: object, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise _refuse(f"{context} must be an object with string field names")
+    return value
+
+
+def _closed_fields(value: Mapping[str, Any], *, required: set[str], context: str) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise _refuse(f"{context} is missing required fields: {', '.join(sorted(missing))}")
+    if unknown:
+        raise _refuse(f"{context} has unknown fields: {', '.join(sorted(unknown))}")
+
+
+def _string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise _refuse(f"{context} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, context: str) -> str:
+    digest = _string(value, context)
+    if HEX_SHA256.fullmatch(digest) is None:
+        raise _refuse(f"{context} must be a lowercase sha256 digest")
+    return digest
+
+
+def _item_id(value: object, context: str) -> str:
+    item_id = _string(value, context)
+    if ITEM_ID.fullmatch(item_id) is None:
+        raise _refuse(f"{context} is not a canonical item id")
+    return item_id
+
+
+def _version(value: object, context: str) -> str:
+    version = _string(value, context)
+    if SEMVER.fullmatch(version) is None:
+        raise _refuse(f"{context} is not strict SemVer")
+    return version
+
+
+def _relative_path(value: object, context: str) -> str:
+    path = _string(value, context)
+    if "\\" in path or path.startswith("/") or any(ord(char) < 32 for char in path):
+        raise _refuse(f"{context} must be a release-relative POSIX path")
+    normalized = posixpath.normpath(path)
+    if normalized != path or normalized in ("", ".", "..") or normalized.startswith("../"):
+        raise _refuse(f"{context} is not a canonical release-relative path")
+    return path
+
+
+def _canonical_bytes(value: object, context: str) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise _refuse(f"{context} cannot be serialized canonically: {error}") from error
+
+
+@dataclass(frozen=True)
+class PreviewWrite:
+    """Approved content bytes for one adoption write, intentionally without mode.
+
+    The catalog carries no file mode, so the preview and approval token do not
+    encode one. Adoption always writes with the transaction default ``0o644``;
+    normalizing a stock-content file from a user-restricted mode such as
+    ``0o600`` to ``0o644`` is an intentional fixed side effect.
+    """
+
+    path: str
+    new_sha256: str
+    byte_size: int
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "PreviewWrite":
+        value = _mapping(raw, "preview write")
+        _closed_fields(
+            value,
+            required={"path", "new_sha256", "byte_size"},
+            context="preview write",
+        )
+        byte_size = value["byte_size"]
+        if type(byte_size) is not int or byte_size < 0:
+            raise _refuse("preview write byte_size must be a non-negative integer")
+        return cls(
+            _relative_path(value["path"], "preview write path"),
+            _sha256(value["new_sha256"], "preview write new_sha256"),
+            byte_size,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "new_sha256": self.new_sha256,
+            "byte_size": self.byte_size,
+        }
+
+
+@dataclass(frozen=True)
+class PreviewItem:
+    item_id: str
+    item_version: str
+    action: str
+    writes: tuple[PreviewWrite, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "PreviewItem":
+        value = _mapping(raw, "preview item")
+        _closed_fields(
+            value,
+            required={"item_id", "item_version", "action", "writes"},
+            context="preview item",
+        )
+        item_id = _item_id(value["item_id"], "preview item_id")
+        action = _string(value["action"], f"preview item {item_id} action")
+        if action != PlannedAction.ADOPT.value:
+            raise _refuse(f"preview item {item_id} action must be adopt")
+        if not isinstance(value["writes"], list) or not value["writes"]:
+            raise _refuse(f"preview item {item_id} needs at least one write")
+        writes = tuple(PreviewWrite.from_dict(write) for write in value["writes"])
+        if writes != tuple(sorted(writes, key=lambda write: write.path)):
+            raise _refuse(f"preview item {item_id} writes must be sorted by path")
+        if len({write.path for write in writes}) != len(writes):
+            raise _refuse(f"preview item {item_id} repeats a write path")
+        return cls(
+            item_id,
+            _version(value["item_version"], f"preview item {item_id} version"),
+            action,
+            writes,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "item_version": self.item_version,
+            "action": self.action,
+            "writes": [write.to_dict() for write in self.writes],
+        }
+
+
+@dataclass(frozen=True)
+class AdoptionPreview:
+    preview_version: int
+    catalog_sha256: str
+    inventory_sha256: str
+    items: tuple[PreviewItem, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "AdoptionPreview":
+        value = _mapping(raw, "adoption preview")
+        _closed_fields(
+            value,
+            required={"preview_version", "catalog_sha256", "inventory_sha256", "items"},
+            context="adoption preview",
+        )
+        if type(value["preview_version"]) is not int or value["preview_version"] != PREVIEW_VERSION:
+            raise _refuse(f"preview_version must be exactly {PREVIEW_VERSION}")
+        if not isinstance(value["items"], list) or not value["items"]:
+            raise _refuse("adoption preview needs at least one item")
+        items = tuple(PreviewItem.from_dict(item) for item in value["items"])
+        if items != tuple(sorted(items, key=lambda item: item.item_id)):
+            raise _refuse("adoption preview items must be sorted by item_id")
+        if len({item.item_id for item in items}) != len(items):
+            raise _refuse("adoption preview repeats an item_id")
+        all_paths = [write.path for item in items for write in item.writes]
+        if len(set(all_paths)) != len(all_paths):
+            raise _refuse("adoption preview assigns one path to multiple items")
+        return cls(
+            PREVIEW_VERSION,
+            _sha256(value["catalog_sha256"], "adoption preview catalog_sha256"),
+            _sha256(value["inventory_sha256"], "adoption preview inventory_sha256"),
+            items,
+        )
+
+    @property
+    def sha256(self) -> str:
+        """The approval token for these exact canonical preview bytes."""
+        return hashlib.sha256(canonical_adoption_preview_bytes(self)).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "preview_version": self.preview_version,
+            "catalog_sha256": self.catalog_sha256,
+            "inventory_sha256": self.inventory_sha256,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+def _requested_inventory_sha256(
+    inventory: InventoryReport,
+    item_paths: Mapping[str, frozenset[str]],
+) -> str:
+    """Hash only requested-item evidence, preserving B5/E6 isolation."""
+    evidence_items = []
+    for item_id, paths in sorted(item_paths.items()):
+        entries = []
+        for entry in inventory.entries:
+            if entry.canonical_path not in paths:
+                continue
+            entries.append(
+                {
+                    "actual_path": entry.actual_path,
+                    "canonical_path": entry.canonical_path,
+                    "kind": entry.kind,
+                    "release_state": entry.release_state,
+                    "size": entry.size,
+                    "sha256": entry.sha256,
+                    "redacted": entry.redacted,
+                }
+            )
+        entries.sort(
+            key=lambda entry: (
+                str(entry["canonical_path"]),
+                str(entry["actual_path"]),
+                str(entry["kind"]),
+            )
+        )
+        divergences = [
+            divergence.to_dict()
+            for divergence in inventory.customizations.divergences
+            if divergence.canonical_path in paths
+        ]
+        divergences.sort(
+            key=lambda entry: (
+                entry["canonical_path"],
+                entry["path"],
+                entry["state"],
+            )
+        )
+        evidence_items.append(
+            {"item_id": item_id, "entries": entries, "divergences": divergences}
+        )
+    evidence = {"inventory_evidence_version": 1, "items": evidence_items}
+    return hashlib.sha256(_canonical_bytes(evidence, "requested inventory evidence")).hexdigest()
+
+
+def build_adoption_preview(
+    catalog: ReleaseCatalog,
+    inventory: InventoryReport,
+    plan: AdoptionPlan,
+    requested_item_ids: Sequence[str],
+    payload_loader: PayloadLoader,
+) -> AdoptionPreview:
+    """Build the exact, payload-verified writes a user may approve."""
+    if not isinstance(catalog, ReleaseCatalog):
+        raise _refuse("catalog must be a loaded ReleaseCatalog")
+    if not isinstance(inventory, InventoryReport):
+        raise _refuse("inventory must be an InventoryReport")
+    if not isinstance(plan, AdoptionPlan):
+        raise _refuse("plan must be an AdoptionPlan")
+    if plan.catalog_sha256 != catalog.integrity.catalog_sha256:
+        raise _refuse("plan catalog identity does not match the supplied catalog")
+    if plan.release_version != catalog.release.version:
+        raise _refuse("plan release version does not match the supplied catalog")
+    if isinstance(requested_item_ids, (str, bytes)) or not isinstance(
+        requested_item_ids, Sequence
+    ):
+        raise _refuse("requested item ids must be a sequence")
+    if not requested_item_ids or not all(isinstance(item_id, str) for item_id in requested_item_ids):
+        raise _refuse("at least one canonical requested item id is required")
+    if not callable(payload_loader):
+        raise _refuse("payload_loader must be callable")
+    requested = tuple(sorted(requested_item_ids))
+    if len(set(requested)) != len(requested):
+        raise _refuse("requested item ids must be unique")
+
+    catalog_by_id = {item.id: item for item in catalog.items}
+    plan_by_id = {item.item_id: item for item in plan.items}
+    unknown = set(requested) - set(catalog_by_id)
+    if unknown:
+        raise _refuse(f"unknown requested item: {', '.join(sorted(unknown))}")
+
+    items: list[PreviewItem] = []
+    item_paths: dict[str, frozenset[str]] = {}
+    for item_id in requested:
+        catalog_item = catalog_by_id[item_id]
+        planned = plan_by_id.get(item_id)
+        if planned is None:
+            raise _refuse(f"requested item {item_id} is absent from the adoption plan")
+        if planned.item_version != catalog_item.version:
+            raise _refuse(f"requested item {item_id} version disagrees with the catalog")
+        if planned.action is not PlannedAction.ADOPT:
+            raise _refuse(
+                f"requested item {item_id} has planned action {planned.action.value}; "
+                "only adopt may be approved"
+            )
+        writes = []
+        for catalog_file in sorted(catalog_item.files, key=lambda entry: entry.path):
+            try:
+                payload = payload_loader(catalog_file.path)
+            except Exception as error:
+                raise _refuse(
+                    f"item {item_id} payload {catalog_file.path} could not be loaded: {error}"
+                ) from error
+            if not isinstance(payload, bytes):
+                raise _refuse(
+                    f"item {item_id} payload {catalog_file.path} loader must return bytes"
+                )
+            digest = hashlib.sha256(payload).hexdigest()
+            if digest != catalog_file.sha256:
+                raise _refuse(
+                    f"item {item_id} payload {catalog_file.path} sha256 does not match the catalog"
+                )
+            writes.append(PreviewWrite(catalog_file.path, digest, len(payload)))
+        item_paths[item_id] = frozenset(write.path for write in writes)
+        items.append(
+            PreviewItem(
+                item_id,
+                catalog_item.version,
+                PlannedAction.ADOPT.value,
+                tuple(writes),
+            )
+        )
+    return AdoptionPreview(
+        PREVIEW_VERSION,
+        catalog.integrity.catalog_sha256,
+        _requested_inventory_sha256(inventory, item_paths),
+        tuple(items),
+    )
+
+
+def canonical_adoption_preview_bytes(preview: AdoptionPreview) -> bytes:
+    if not isinstance(preview, AdoptionPreview):
+        raise _refuse("preview must be an AdoptionPreview")
+    return _canonical_bytes(preview.to_dict(), "adoption preview")
+
+
+__all__ = [
+    "AdoptionPreview",
+    "AdoptionPreviewError",
+    "PayloadLoader",
+    "PreviewItem",
+    "PreviewWrite",
+    "build_adoption_preview",
+    "canonical_adoption_preview_bytes",
+]

--- a/core/tests/test_adoption_transaction.py
+++ b/core/tests/test_adoption_transaction.py
@@ -1,0 +1,580 @@
+"""C1 catalog adoption: approved previews, one transaction, exact recovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle.catalog import canonical_catalog_bytes, with_catalog_identity
+from core.lifecycle.engine import (
+    AdoptionExecutionError,
+    AdoptionReceipt,
+    canonical_adoption_receipt_bytes,
+    execute_adoption,
+)
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import ReleaseCatalog
+from core.lifecycle.plan import build_adoption_plan
+from core.lifecycle.preview import (
+    AdoptionPreview,
+    AdoptionPreviewError,
+    build_adoption_preview,
+    canonical_adoption_preview_bytes,
+)
+from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
+from core.transaction.engine import Transaction
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = "System/.release-catalog.json"
+
+
+def _document(manifest: bytes, payloads: dict[str, dict[str, bytes]]) -> dict[str, object]:
+    items = []
+    for item_id, files in sorted(payloads.items()):
+        items.append(
+            {
+                "id": item_id,
+                "kind": "skill",
+                "version": "1.0.0",
+                "files": [
+                    {
+                        "path": path,
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "ownership_class": "brain",
+                    }
+                    for path, content in sorted(files.items())
+                ],
+                "dependencies": [],
+                "capabilities": [],
+                "rewind": {
+                    "acknowledgement_required": True,
+                    "token": f"rewind:{item_id}@1.0.0",
+                },
+            }
+        )
+    return with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.64.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.64.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": items,
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+
+
+def _setup(tmp_path: Path, item_ids: tuple[str, ...] = ("alpha", "beta")):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    payloads = {
+        item_id: {
+            f".claude/skills/{item_id}/SKILL.md": f"# {item_id}\n".encode()
+        }
+        for item_id in item_ids
+    }
+    paths = [path for files in payloads.values() for path in files]
+    manifest = write_manifest(vault, paths)
+    document = _document(manifest, payloads)
+    catalog = ReleaseCatalog.from_dict(document)
+    write_file(vault, CATALOG_PATH, canonical_catalog_bytes(document))
+    flat_payloads = {
+        path: content for files in payloads.values() for path, content in files.items()
+    }
+    for path, content in flat_payloads.items():
+        write_file(vault, path, content)
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+
+    def loader(path: str) -> bytes:
+        return flat_payloads[path]
+
+    return vault, document, catalog, inventory, plan, loader
+
+
+def _preview(tmp_path: Path, requested: tuple[str, ...] = ("alpha",)):
+    vault, document, catalog, inventory, plan, loader = _setup(tmp_path)
+    preview = build_adoption_preview(
+        catalog,
+        inventory,
+        plan,
+        requested,
+        loader,
+    )
+    return vault, document, preview, loader
+
+
+def _tx_directories(vault: Path) -> list[Path]:
+    tx_root = vault / "System/.dex/tx"
+    return sorted(path for path in tx_root.iterdir() if path.is_dir()) if tx_root.exists() else []
+
+
+def test_preview_is_canonical_payload_bound_and_requested_order_independent(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    calls: list[str] = []
+
+    def recording_loader(path: str) -> bytes:
+        calls.append(path)
+        return loader(path)
+
+    reversed_preview = build_adoption_preview(
+        catalog, inventory, plan, ("beta", "alpha"), recording_loader
+    )
+    ordered_preview = build_adoption_preview(
+        catalog, inventory, plan, ("alpha", "beta"), loader
+    )
+
+    assert reversed_preview == ordered_preview
+    assert canonical_adoption_preview_bytes(reversed_preview) == (
+        canonical_adoption_preview_bytes(ordered_preview)
+    )
+    assert reversed_preview.sha256 == hashlib.sha256(
+        canonical_adoption_preview_bytes(reversed_preview)
+    ).hexdigest()
+    assert calls == [
+        ".claude/skills/alpha/SKILL.md",
+        ".claude/skills/beta/SKILL.md",
+    ]
+    assert AdoptionPreview.from_dict(reversed_preview.to_dict()) == reversed_preview
+    assert vault.is_dir()
+
+
+def test_preview_rejects_non_adopt_item_and_names_its_action(tmp_path: Path) -> None:
+    vault, _document_value, catalog, _inventory, _plan, loader = _setup(tmp_path)
+    write_file(vault, ".claude/skills/beta/SKILL.md", b"user changed this\n")
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+
+    with pytest.raises(AdoptionPreviewError, match=r"beta.*conflict"):
+        build_adoption_preview(catalog, inventory, plan, ("beta",), loader)
+
+
+def test_preview_refuses_payload_bytes_that_do_not_match_catalog(tmp_path: Path) -> None:
+    _vault, _document_value, catalog, inventory, plan, _loader = _setup(tmp_path)
+
+    with pytest.raises(AdoptionPreviewError, match=r"alpha.*payload.*sha256"):
+        build_adoption_preview(
+            catalog,
+            inventory,
+            plan,
+            ("alpha",),
+            lambda _path: b"substituted bytes\n",
+        )
+
+
+def test_single_item_happy_path_returns_exact_rewind_receipt(tmp_path: Path) -> None:
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    target = vault / ".claude/skills/alpha/SKILL.md"
+    os.chmod(target, 0o600)
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert receipt.items_adopted == ("alpha",)
+    assert [(entry.path, entry.sha256, entry.byte_size) for entry in receipt.files_written] == [
+        (
+            ".claude/skills/alpha/SKILL.md",
+            hashlib.sha256(b"# alpha\n").hexdigest(),
+            len(b"# alpha\n"),
+        )
+    ]
+    assert receipt.catalog_sha256 == preview.catalog_sha256
+    assert receipt.inventory_sha256 == preview.inventory_sha256
+    assert receipt.preview_sha256 == preview.sha256
+    assert receipt.transaction_id
+    assert receipt.snapshot_ref == (
+        f"System/.dex/tx/{receipt.transaction_id}/snapshot"
+    )
+    snapshot = vault / receipt.snapshot_ref
+    assert snapshot.is_dir()
+    manifest = json.loads((snapshot / "manifest.json").read_text(encoding="utf-8"))
+    assert [entry["relative"] for entry in manifest["entries"]] == [
+        ".claude/skills/alpha/SKILL.md"
+    ]
+    # PreviewWrite documents this fixed, intentionally token-independent side effect.
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_multi_item_happy_path_uses_one_transaction_and_sorted_writes(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    preview = build_adoption_preview(
+        catalog, inventory, plan, ("beta", "alpha"), loader
+    )
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert receipt.items_adopted == ("alpha", "beta")
+    assert [entry.path for entry in receipt.files_written] == [
+        ".claude/skills/alpha/SKILL.md",
+        ".claude/skills/beta/SKILL.md",
+    ]
+    assert len(_tx_directories(vault)) == 1
+
+
+def test_wrong_approval_token_refuses_before_payload_or_transaction_write(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, preview, _loader = _preview(tmp_path)
+    calls: list[str] = []
+
+    with pytest.raises(AdoptionExecutionError, match="approval token"):
+        execute_adoption(
+            vault,
+            preview,
+            "0" * 64,
+            lambda path: calls.append(path) or b"never",
+        )
+
+    assert calls == []
+    assert _tx_directories(vault) == []
+
+
+def test_self_consistent_but_stale_preview_refuses_on_inventory_rebuild(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    forged_raw = preview.to_dict()
+    forged_raw["inventory_sha256"] = "f" * 64
+    forged = AdoptionPreview.from_dict(forged_raw)
+
+    with pytest.raises(AdoptionExecutionError, match="inventory changed since preview"):
+        execute_adoption(vault, forged, forged.sha256, loader)
+
+    assert _tx_directories(vault) == []
+
+
+def test_requested_file_drift_changes_plan_and_refuses_without_transaction_write(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    write_file(vault, ".claude/skills/alpha/SKILL.md", b"changed after approval\n")
+
+    with pytest.raises(
+        AdoptionExecutionError,
+        match=r"alpha.*action changed.*conflict",
+    ):
+        execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert _tx_directories(vault) == []
+    assert (vault / ".claude/skills/alpha/SKILL.md").read_bytes() == (
+        b"changed after approval\n"
+    )
+
+
+def test_drift_after_rebuild_is_detected_from_snapshot_and_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import engine as adoption_engine
+
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    target = vault / ".claude/skills/alpha/SKILL.md"
+    real_begin = Transaction.begin
+
+    def begin_then_race(vault_root: Path, entries):
+        transaction = real_begin(vault_root, entries)
+        target.write_bytes(b"external writer won the race\n")
+        return transaction
+
+    monkeypatch.setattr(adoption_engine.Transaction, "begin", begin_then_race)
+
+    with pytest.raises(AdoptionExecutionError, match="changed after final preview rebuild"):
+        execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert target.read_bytes() == b"external writer won the race\n"
+    transaction_dir = _tx_directories(vault)[0]
+    events = (transaction_dir / "journal.jsonl").read_text(encoding="utf-8")
+    assert '"event":"ROLLED-BACK"' in events
+
+
+def test_post_snapshot_writer_is_currently_overwritten_and_adoption_commits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the residual window documented by verify_approval_binding.
+
+    Together with the pre-snapshot drift test above, this makes moving either
+    boundary require an explicit test and documentation update.
+    """
+    from core.transaction import engine as transaction_engine
+
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    target = vault / ".claude/skills/alpha/SKILL.md"
+    race_was_injected = False
+
+    def inject_writer_at_test_seam(seam: str) -> None:
+        nonlocal race_was_injected
+        if seam == "after-snapshot":
+            target.write_bytes(b"saved after snapshot capture\n")
+            race_was_injected = True
+
+    monkeypatch.setattr(transaction_engine, "_stop_seam", inject_writer_at_test_seam)
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert race_was_injected is True
+    assert target.read_bytes() == b"# alpha\n"
+    transaction_dir = vault / receipt.snapshot_ref
+    assert transaction_dir.is_dir()
+    events = (transaction_dir.parent / "journal.jsonl").read_text(encoding="utf-8")
+    assert '"event":"COMMITTED"' in events
+    assert '"event":"ROLLED-BACK"' not in events
+
+
+def test_catalog_identity_drift_refuses_without_transaction_write(tmp_path: Path) -> None:
+    vault, document, preview, loader = _preview(tmp_path)
+    changed = json.loads(json.dumps(document))
+    changed["release"]["version"] = "1.64.1"
+    changed["release"]["immutable_distribution_tag"] = "dist/release/v1.64.1-0123456"
+    changed = with_catalog_identity(changed)
+    write_file(vault, CATALOG_PATH, canonical_catalog_bytes(changed))
+
+    with pytest.raises(AdoptionExecutionError, match="catalog changed since preview"):
+        execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert _tx_directories(vault) == []
+
+
+def test_e6_non_requested_item_state_does_not_change_preview_or_execution(
+    tmp_path: Path,
+) -> None:
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    before = build_adoption_preview(catalog, inventory, plan, ("alpha",), loader)
+    write_file(vault, ".claude/skills/beta/SKILL.md", b"beta held back elsewhere\n")
+    after_inventory = build_inventory(vault, catalog=catalog)
+    after_plan = build_adoption_plan(catalog, after_inventory, held_back={"beta"})
+    after = build_adoption_preview(
+        catalog, after_inventory, after_plan, ("alpha",), loader
+    )
+
+    assert canonical_adoption_preview_bytes(after) == canonical_adoption_preview_bytes(before)
+    receipt = execute_adoption(vault, before, before.sha256, loader)
+    assert receipt.items_adopted == ("alpha",)
+    assert (vault / ".claude/skills/beta/SKILL.md").read_bytes() == (
+        b"beta held back elsewhere\n"
+    )
+
+
+def test_e6_execution_does_not_hash_non_requested_item_payloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import inventory as inventory_module
+
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    preview = build_adoption_preview(catalog, inventory, plan, ("alpha",), loader)
+    original_sha256_file = inventory_module.sha256_file
+
+    def requested_only(root: Path, relative: str, *, max_bytes: int) -> str:
+        if relative == ".claude/skills/beta/SKILL.md":
+            raise AssertionError("execution read a non-requested item payload")
+        return original_sha256_file(root, relative, max_bytes=max_bytes)
+
+    monkeypatch.setattr(inventory_module, "sha256_file", requested_only)
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert receipt.items_adopted == ("alpha",)
+
+
+def test_contract_refusal_aborts_the_whole_adoption_without_skipping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    preview = build_adoption_preview(
+        catalog, inventory, plan, ("alpha", "beta"), loader
+    )
+    original = portable_contract.update_write_verdict
+
+    def refuse_alpha(path: str, *, exists: bool):
+        if path == ".claude/skills/alpha/SKILL.md":
+            return portable_contract.WriteVerdict(
+                path, False, "deny", "brain", "adversarial-test"
+            )
+        return original(path, exists=exists)
+
+    monkeypatch.setattr(portable_contract, "update_write_verdict", refuse_alpha)
+
+    with pytest.raises(AdoptionExecutionError, match=r"ownership contract.*alpha"):
+        execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert _tx_directories(vault) == []
+    assert (vault / ".claude/skills/alpha/SKILL.md").read_bytes() == b"# alpha\n"
+    assert (vault / ".claude/skills/beta/SKILL.md").read_bytes() == b"# beta\n"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda raw: raw.update({"surprise": True}),
+        lambda raw: raw.update({"preview_version": True}),
+        lambda raw: raw["items"][0].update({"action": "conflict"}),
+        lambda raw: raw["items"][0]["writes"][0].update({"path": "../escape"}),
+        lambda raw: raw["items"][0]["writes"][0].update({"byte_size": -1}),
+        lambda raw: raw["items"].append(dict(raw["items"][0])),
+    ],
+)
+def test_preview_parser_fails_closed_on_ambiguous_documents(
+    tmp_path: Path, mutation
+) -> None:
+    _vault, _document_value, preview, _loader = _preview(tmp_path)
+    raw = json.loads(json.dumps(preview.to_dict()))
+    mutation(raw)
+
+    with pytest.raises(AdoptionPreviewError, match="refused"):
+        AdoptionPreview.from_dict(raw)
+
+
+def test_receipt_serialization_is_strict_and_deterministic(tmp_path: Path) -> None:
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    canonical = canonical_adoption_receipt_bytes(receipt)
+
+    assert canonical_adoption_receipt_bytes(receipt) == canonical
+    assert AdoptionReceipt.from_dict(receipt.to_dict()) == receipt
+    unknown = receipt.to_dict()
+    unknown["surprise"] = True
+    with pytest.raises(AdoptionExecutionError, match="unknown fields"):
+        AdoptionReceipt.from_dict(unknown)
+    nested_transaction = receipt.to_dict()
+    nested_transaction["transaction_id"] = "nested/id"
+    nested_transaction["snapshot_ref"] = "System/.dex/tx/nested/id/snapshot"
+    with pytest.raises(AdoptionExecutionError, match="transaction_id"):
+        AdoptionReceipt.from_dict(nested_transaction)
+
+
+def test_receipt_snapshot_ref_expires_after_three_further_commits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.transaction import engine as transaction_engine
+
+    vault, _document_value, preview, loader = _preview(tmp_path)
+    timestamps = iter(
+        (
+            "20260721T000001-",
+            "20260721T000002-",
+            "20260721T000003-",
+            "20260721T000004-",
+        )
+    )
+    monkeypatch.setattr(
+        transaction_engine.time,
+        "strftime",
+        lambda _format: next(timestamps),
+    )
+
+    receipts = [
+        execute_adoption(vault, preview, preview.sha256, loader) for _ in range(4)
+    ]
+
+    assert not (vault / receipts[0].snapshot_ref).exists()
+    assert all((vault / receipt.snapshot_ref).is_dir() for receipt in receipts[1:])
+
+
+_FAULT_WORKER = r"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[3])
+
+from core.lifecycle.engine import execute_adoption
+from core.lifecycle.preview import AdoptionPreview
+
+vault = Path(sys.argv[1])
+preview = AdoptionPreview.from_dict(json.loads(Path(sys.argv[2]).read_text()))
+payloads = {
+    ".claude/skills/alpha/SKILL.md": b"# alpha\n",
+    ".claude/skills/beta/SKILL.md": b"# beta\n",
+}
+execute_adoption(vault, preview, preview.sha256, payloads.__getitem__)
+"""
+
+
+@pytest.mark.parametrize(
+    "seam",
+    [
+        "after-begin",
+        "after-snapshot",
+        "mid-apply:0",
+        "mid-apply:1",
+        "after-apply",
+        "after-verify",
+        "before-finalize",
+        "after-commit-record",
+    ],
+)
+def test_e9_adoption_crash_at_every_transaction_seam_converges(
+    seam: str, tmp_path: Path
+) -> None:
+    vault, _document_value, catalog, inventory, plan, loader = _setup(tmp_path)
+    preview = build_adoption_preview(
+        catalog, inventory, plan, ("alpha", "beta"), loader
+    )
+    relatives = [
+        ".claude/skills/alpha/SKILL.md",
+        ".claude/skills/beta/SKILL.md",
+    ]
+    os.chmod(vault / relatives[0], 0o600)
+    os.chmod(vault / relatives[1], 0o640)
+    before = {
+        relative: (
+            (vault / relative).read_bytes(),
+            stat.S_IMODE((vault / relative).stat().st_mode),
+        )
+        for relative in relatives
+    }
+    preview_path = tmp_path / "approved-preview.json"
+    preview_path.write_bytes(canonical_adoption_preview_bytes(preview))
+    env = dict(os.environ, DEX_TX_TEST_STOP_AFTER=seam)
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _FAULT_WORKER,
+            str(vault),
+            str(preview_path),
+            str(REPO_ROOT),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert process.returncode == 137, (seam, process.stderr[-500:])
+    outcomes = Transaction.resume(vault)
+    after = {
+        relative: (
+            (vault / relative).read_bytes(),
+            stat.S_IMODE((vault / relative).stat().st_mode),
+        )
+        for relative in relatives
+    }
+    if seam == "after-commit-record":
+        assert after == {
+            ".claude/skills/alpha/SKILL.md": (b"# alpha\n", 0o644),
+            ".claude/skills/beta/SKILL.md": (b"# beta\n", 0o644),
+        }
+        assert outcomes == []
+    else:
+        assert after == before, seam
+        assert len(outcomes) == 1
+        assert outcomes[0]["resumed"] is True


### PR DESCRIPTION
Chunk C1 of the lifecycle catalog program (spec §5). Opens Phase C.

## What
- **core/lifecycle/preview.py** (new): canonical adoption preview; its sha256 is the approval token the user approves.
- **core/lifecycle/engine.py** (new): `execute_adoption` = double authorization (token check + full rebuild from current disk immediately before writing; any drift → refuse, write nothing), then ONE transaction through `core.transaction` for all writes. Receipts bind tx id + snapshot ref + catalog/inventory/preview hashes.

## Gates
- **E9 (interruption/resume):** 8-seam crash matrix — every interruption converges to fully-adopted or byte-identical untouched.
- **E10 (rewind entry):** receipt carries snapshot location; retention interaction (keep-last-3) documented and tested for the C3 rewind builder.
- **E6 preserved:** non-requested items never read or hashed during execution.

## Review trail
- Fable diff review, then independent adversarial review (Opus): **SHIP-WITH-FIXES**, no data-loss or path-escape break found; token discipline, payload substitution, path traversal, and crash matrix all attacked and held.
- All 3 mandatory fixes applied and pinned by red-when-removed tests (post-snapshot race characterization, snapshot-retention durability, 0o644 mode normalization docs).

## Verification
- 30 adoption-transaction tests + 17 plan tests green (47 total re-run by orchestrator)
- ruff clean; portable-contract gate green (1056 paths); founder-content gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42