### PR TITLE
feat: rewind-by-receipt + retention report (cathedral C3)

### DIFF
--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import json
+import os
 import posixpath
 import re
+import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,9 +32,13 @@ from core.lifecycle.preview import (
     canonical_adoption_preview_bytes,
 )
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction, TransactionError
+from core.transaction.journal import Journal, JournalCorruptError
+from core.transaction.snapshot import Snapshot, SnapshotEntry, SnapshotError
 
 RECEIPT_VERSION = 1
+REWIND_RECEIPT_VERSION = 1
 CATALOG_RELATIVE = "System/.release-catalog.json"
+ADOPTION_RECEIPTS_RELATIVE = Path("System") / ".dex" / "adoptions"
 TRANSACTION_ID = re.compile(r"^[0-9]{8}T[0-9]{6}-[0-9a-f]{8}$")
 
 
@@ -39,8 +46,20 @@ class AdoptionExecutionError(RuntimeError):
     """Adoption refused or failed without a partial lifecycle result."""
 
 
+class AdoptionReceiptPersistenceError(RuntimeError):
+    """The adoption committed, but its convenience receipt was not persisted."""
+
+
+class AdoptionRewindError(RuntimeError):
+    """An adoption rewind was refused or failed without a partial result."""
+
+
 def _refuse(message: str) -> AdoptionExecutionError:
     return AdoptionExecutionError(f"adoption refused: {message}")
+
+
+def _rewind_refuse(message: str) -> AdoptionRewindError:
+    return AdoptionRewindError(f"rewind refused: {message}")
 
 
 def _mapping(value: object, context: str) -> Mapping[str, Any]:
@@ -227,6 +246,576 @@ def canonical_adoption_receipt_bytes(receipt: AdoptionReceipt) -> bytes:
         raise _refuse(f"receipt cannot be serialized canonically: {error}") from error
 
 
+@dataclass(frozen=True)
+class RewindReceiptFile:
+    """The exact pre-adoption state restored for one adopted path."""
+
+    item_id: str
+    path: str
+    existed_before_adoption: bool
+    restored_sha256: str | None
+    byte_size: int | None
+    mode: int | None
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "RewindReceiptFile":
+        value = _mapping(raw, "rewind receipt file")
+        _closed_fields(
+            value,
+            required={
+                "item_id",
+                "path",
+                "existed_before_adoption",
+                "restored_sha256",
+                "byte_size",
+                "mode",
+            },
+            context="rewind receipt file",
+        )
+        item_id = _string(value["item_id"], "rewind receipt file item_id")
+        if ITEM_ID.fullmatch(item_id) is None:
+            raise _refuse("rewind receipt file item_id is not canonical")
+        existed = value["existed_before_adoption"]
+        if type(existed) is not bool:
+            raise _refuse("rewind receipt file existed_before_adoption must be a boolean")
+        if existed:
+            digest = _sha256(
+                value["restored_sha256"], "rewind receipt file restored_sha256"
+            )
+            byte_size = value["byte_size"]
+            mode = value["mode"]
+            if type(byte_size) is not int or byte_size < 0:
+                raise _refuse(
+                    "rewind receipt file byte_size must be a non-negative integer"
+                )
+            if type(mode) is not int or mode < 0 or mode > 0o777:
+                raise _refuse("rewind receipt file mode must be permission bits up to 0o777")
+        else:
+            if any(
+                value[field] is not None
+                for field in ("restored_sha256", "byte_size", "mode")
+            ):
+                raise _refuse(
+                    "rewind receipt file absent state needs null hash, size, and mode"
+                )
+            digest = None
+            byte_size = None
+            mode = None
+        return cls(
+            item_id,
+            _relative_path(value["path"], "rewind receipt file path"),
+            existed,
+            digest,
+            byte_size,
+            mode,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "path": self.path,
+            "existed_before_adoption": self.existed_before_adoption,
+            "restored_sha256": self.restored_sha256,
+            "byte_size": self.byte_size,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True)
+class RewindReceipt:
+    """Strict evidence that one adoption was rewound in a new transaction."""
+
+    rewind_receipt_version: int
+    adoption_transaction_id: str
+    rewind_transaction_id: str
+    snapshot_ref: str
+    source_receipt_sha256: str
+    files_restored: tuple[RewindReceiptFile, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "RewindReceipt":
+        value = _mapping(raw, "rewind receipt")
+        _closed_fields(
+            value,
+            required={
+                "rewind_receipt_version",
+                "adoption_transaction_id",
+                "rewind_transaction_id",
+                "snapshot_ref",
+                "source_receipt_sha256",
+                "files_restored",
+            },
+            context="rewind receipt",
+        )
+        if (
+            type(value["rewind_receipt_version"]) is not int
+            or value["rewind_receipt_version"] != REWIND_RECEIPT_VERSION
+        ):
+            raise _refuse(
+                f"rewind_receipt_version must be exactly {REWIND_RECEIPT_VERSION}"
+            )
+        adoption_id = _string(
+            value["adoption_transaction_id"],
+            "rewind receipt adoption_transaction_id",
+        )
+        rewind_id = _string(
+            value["rewind_transaction_id"], "rewind receipt rewind_transaction_id"
+        )
+        if TRANSACTION_ID.fullmatch(adoption_id) is None:
+            raise _refuse("rewind receipt adoption_transaction_id is not canonical")
+        if TRANSACTION_ID.fullmatch(rewind_id) is None:
+            raise _refuse("rewind receipt rewind_transaction_id is not canonical")
+        if adoption_id == rewind_id:
+            raise _refuse("rewind receipt transaction ids must be distinct")
+        snapshot_ref = _relative_path(
+            value["snapshot_ref"], "rewind receipt snapshot_ref"
+        )
+        if snapshot_ref != f"System/.dex/tx/{rewind_id}/snapshot":
+            raise _refuse(
+                "rewind receipt snapshot_ref does not match its rewind_transaction_id"
+            )
+        raw_files = value["files_restored"]
+        if not isinstance(raw_files, list) or not raw_files:
+            raise _refuse("rewind receipt needs at least one restored file")
+        files = tuple(RewindReceiptFile.from_dict(entry) for entry in raw_files)
+        if files != tuple(sorted(files, key=lambda entry: (entry.path, entry.item_id))):
+            raise _refuse("rewind receipt files must be sorted by path")
+        if len({entry.path for entry in files}) != len(files):
+            raise _refuse("rewind receipt repeats a restored path")
+        return cls(
+            REWIND_RECEIPT_VERSION,
+            adoption_id,
+            rewind_id,
+            snapshot_ref,
+            _sha256(
+                value["source_receipt_sha256"],
+                "rewind receipt source_receipt_sha256",
+            ),
+            files,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rewind_receipt_version": self.rewind_receipt_version,
+            "adoption_transaction_id": self.adoption_transaction_id,
+            "rewind_transaction_id": self.rewind_transaction_id,
+            "snapshot_ref": self.snapshot_ref,
+            "source_receipt_sha256": self.source_receipt_sha256,
+            "files_restored": [entry.to_dict() for entry in self.files_restored],
+        }
+
+
+def canonical_rewind_receipt_bytes(receipt: RewindReceipt) -> bytes:
+    if not isinstance(receipt, RewindReceipt):
+        raise _rewind_refuse("rewind receipt must be a RewindReceipt")
+    try:
+        validated = RewindReceipt.from_dict(receipt.to_dict())
+        return (
+            json.dumps(
+                validated.to_dict(),
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except AdoptionExecutionError as error:
+        raise _rewind_refuse(str(error).removeprefix("adoption refused: ")) from error
+    except (TypeError, ValueError) as error:
+        raise _rewind_refuse(
+            f"rewind receipt cannot be serialized canonically: {error}"
+        ) from error
+
+
+def _validated_adoption_receipt(raw: object) -> AdoptionReceipt:
+    try:
+        document = raw.to_dict() if isinstance(raw, AdoptionReceipt) else raw
+        return AdoptionReceipt.from_dict(document)
+    except AdoptionExecutionError as error:
+        raise _rewind_refuse(
+            f"receipt is invalid: {str(error).removeprefix('adoption refused: ')}"
+        ) from error
+    except (AttributeError, TypeError, ValueError) as error:
+        raise _rewind_refuse(f"receipt is invalid: {error}") from error
+
+
+def rewind_acknowledgement_token(receipt: object) -> str:
+    """Bind rewind acknowledgement to the exact adoption id and sorted paths."""
+    validated = _validated_adoption_receipt(receipt)
+    payload = {
+        "rewind": validated.transaction_id,
+        "files": sorted(entry.path for entry in validated.files_written),
+    }
+    canonical = (
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _receipt_path(vault_root: Path, transaction_id: str) -> Path:
+    if TRANSACTION_ID.fullmatch(transaction_id) is None:
+        raise _rewind_refuse("receipt transaction_id is not canonical")
+    return (
+        Path(vault_root)
+        / ADOPTION_RECEIPTS_RELATIVE
+        / f"{transaction_id}.receipt.json"
+    )
+
+
+def _persist_adoption_receipt(vault_root: Path, receipt: AdoptionReceipt) -> None:
+    """Atomically persist post-commit runtime evidence.
+
+    This deliberately happens after the adoption transaction commits because
+    the receipt describes that outcome. A process crash between COMMITTED and
+    this write leaves a committed-but-unreceipted adoption; the fsynced
+    transaction journal remains the authority for what happened.
+    """
+    target = _receipt_path(vault_root, receipt.transaction_id)
+    root = Path(vault_root)
+    directory = target.parent
+    for component in (root / "System", root / "System/.dex", directory):
+        if component.is_symlink() or (component.exists() and not component.is_dir()):
+            raise AdoptionReceiptPersistenceError(
+                f"adoption {receipt.transaction_id} committed, but its receipt path "
+                f"is unsafe: {component}"
+            )
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(directory, 0o700)
+    temporary = directory / (
+        f".{target.name}.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    )
+    data = canonical_adoption_receipt_bytes(receipt)
+    descriptor = None
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        view = memoryview(data)
+        while view:
+            written = os.write(descriptor, view)
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary, target)
+        os.chmod(target, 0o600)
+        _fsync_directory(directory)
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def load_adoption_receipt(vault_root: Path, transaction_id: str) -> AdoptionReceipt:
+    """Load one canonical persisted receipt through the strict receipt parser."""
+    path = _receipt_path(vault_root, transaction_id)
+    if path.is_symlink() or not path.is_file():
+        raise _rewind_refuse(f"receipt file is missing or unsafe: {path}")
+    try:
+        raw = path.read_bytes()
+        document = json.loads(raw.decode("utf-8"))
+        receipt = AdoptionReceipt.from_dict(document)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _rewind_refuse(f"receipt file is unreadable: {error}") from error
+    except AdoptionExecutionError as error:
+        raise _rewind_refuse(
+            f"receipt file is invalid: {str(error).removeprefix('adoption refused: ')}"
+        ) from error
+    if receipt.transaction_id != transaction_id:
+        raise _rewind_refuse("receipt file transaction_id does not match its filename")
+    if not hmac.compare_digest(raw, canonical_adoption_receipt_bytes(receipt)):
+        raise _rewind_refuse("receipt file is valid JSON but not canonical")
+    return receipt
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _current_adopted_modes(
+    root: Path, receipt: AdoptionReceipt
+) -> tuple[dict[str, int], tuple[str, ...]]:
+    modes: dict[str, int] = {}
+    drifted: list[str] = []
+    for entry in receipt.files_written:
+        target = root / entry.path
+        if target.is_symlink() or not target.is_file():
+            drifted.append(entry.path)
+            continue
+        digest, size = _sha256_file(target)
+        if digest != entry.sha256 or size != entry.byte_size:
+            drifted.append(entry.path)
+            continue
+        modes[entry.path] = target.stat().st_mode & 0o777
+    return modes, tuple(sorted(drifted))
+
+
+def _drift_refusal(drifted: tuple[str, ...]) -> AdoptionRewindError:
+    return _rewind_refuse(
+        "files changed after adoption and were left untouched: "
+        f"{', '.join(drifted)}. Keep those edits or restore the adopted bytes, "
+        "then request a new rewind."
+    )
+
+
+def _verify_adoption_commit(root: Path, receipt: AdoptionReceipt) -> None:
+    journal = (root / receipt.snapshot_ref).parent / "journal.jsonl"
+    try:
+        entries = Journal(journal).read()
+    except JournalCorruptError as error:
+        raise _rewind_refuse(
+            "the adoption transaction journal is damaged; no files were changed"
+        ) from error
+    events = [entry.event for entry in entries]
+    begins = [entry for entry in entries if entry.event == "BEGIN"]
+    if (
+        events.count("COMMITTED") != 1
+        or "ROLLED-BACK" in events
+        or len(begins) != 1
+        or begins[0].payload.get("tx_id") != receipt.transaction_id
+    ):
+        raise _rewind_refuse(
+            "the receipt does not point to a verifiably committed adoption; "
+            "no files were changed"
+        )
+
+
+def _snapshot_rewind_plan(
+    root: Path,
+    receipt: AdoptionReceipt,
+    current_modes: dict[str, int],
+) -> tuple[list[PlanEntry], tuple[RewindReceiptFile, ...]]:
+    snapshot_root = root / receipt.snapshot_ref
+    manifest_path = snapshot_root / "manifest.json"
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise _rewind_refuse(
+            "the adoption snapshot manifest is damaged; no files were changed"
+        )
+    snapshot = Snapshot(snapshot_root)
+    try:
+        manifest = snapshot.read_manifest()
+    except (SnapshotError, KeyError, TypeError, ValueError) as error:
+        raise _rewind_refuse(
+            f"the adoption snapshot manifest is damaged; no files were changed ({error})"
+        ) from error
+
+    receipt_by_path = {entry.path: entry for entry in receipt.files_written}
+    try:
+        manifest_paths = [
+            _relative_path(entry.relative, "adoption snapshot path")
+            for entry in manifest
+        ]
+    except (AdoptionExecutionError, AttributeError, TypeError, ValueError) as error:
+        raise _rewind_refuse(
+            f"the adoption snapshot manifest is damaged; no files were changed ({error})"
+        ) from error
+    if (
+        len(manifest_paths) != len(set(manifest_paths))
+        or set(manifest_paths) != set(receipt_by_path)
+    ):
+        raise _rewind_refuse(
+            "the adoption snapshot does not exactly match the receipt; no files were changed"
+        )
+
+    plan: list[PlanEntry] = []
+    restored: list[RewindReceiptFile] = []
+    for index, snapshot_entry in enumerate(manifest):
+        receipt_file = receipt_by_path[snapshot_entry.relative]
+        if type(snapshot_entry.existed) is not bool:
+            raise _rewind_refuse(
+                f"the adoption snapshot is damaged for {snapshot_entry.relative}; "
+                "no files were changed"
+            )
+        if snapshot_entry.existed:
+            if not _valid_existing_snapshot_entry(snapshot_entry):
+                raise _rewind_refuse(
+                    f"the adoption snapshot is damaged for {snapshot_entry.relative}; "
+                    "no files were changed"
+                )
+            blob = snapshot_root / f"{index:06d}.bin"
+            if blob.is_symlink() or not blob.is_file():
+                raise _rewind_refuse(
+                    f"the adoption snapshot is damaged for {snapshot_entry.relative}; "
+                    "no files were changed"
+                )
+            content = blob.read_bytes()
+            if (
+                len(content) != snapshot_entry.size
+                or hashlib.sha256(content).hexdigest() != snapshot_entry.sha256
+            ):
+                raise _rewind_refuse(
+                    f"the adoption snapshot is damaged for {snapshot_entry.relative}; "
+                    "no files were changed"
+                )
+            plan.append(
+                PlanEntry(snapshot_entry.relative, content, mode=snapshot_entry.mode)
+            )
+            restored.append(
+                RewindReceiptFile(
+                    receipt_file.item_id,
+                    snapshot_entry.relative,
+                    True,
+                    snapshot_entry.sha256,
+                    snapshot_entry.size,
+                    snapshot_entry.mode,
+                )
+            )
+        else:
+            if any(
+                value is not None
+                for value in (
+                    snapshot_entry.mode,
+                    snapshot_entry.sha256,
+                    snapshot_entry.size,
+                )
+            ):
+                raise _rewind_refuse(
+                    f"the adoption snapshot is damaged for {snapshot_entry.relative}; "
+                    "no files were changed"
+                )
+            plan.append(
+                PlanEntry(
+                    snapshot_entry.relative,
+                    None,
+                    mode=current_modes[snapshot_entry.relative],
+                    expected_current_sha256=receipt_file.sha256,
+                )
+            )
+            restored.append(
+                RewindReceiptFile(
+                    receipt_file.item_id,
+                    snapshot_entry.relative,
+                    False,
+                    None,
+                    None,
+                    None,
+                )
+            )
+    return plan, tuple(sorted(restored, key=lambda entry: (entry.path, entry.item_id)))
+
+
+def _valid_existing_snapshot_entry(entry: SnapshotEntry) -> bool:
+    return bool(
+        type(entry.relative) is str
+        and entry.relative
+        and type(entry.mode) is int
+        and 0 <= entry.mode <= 0o777
+        and type(entry.sha256) is str
+        and HEX_SHA256.fullmatch(entry.sha256)
+        and type(entry.size) is int
+        and entry.size >= 0
+    )
+
+
+def rewind_adoption(
+    vault_root: Path,
+    receipt: object,
+    acknowledgement_token: str | None = None,
+) -> RewindReceipt:
+    """Restore one adoption's pre-state through a new crash-safe transaction."""
+    validated = _validated_adoption_receipt(receipt)
+    root = Path(vault_root)
+
+    current_modes, drifted = _current_adopted_modes(root, validated)
+    if drifted:
+        raise _drift_refusal(drifted)
+
+    expected_token = rewind_acknowledgement_token(validated)
+    if not isinstance(acknowledgement_token, str) or not hmac.compare_digest(
+        acknowledgement_token, expected_token
+    ):
+        raise _rewind_refuse(
+            "acknowledgement token does not match the exact adoption id and file list; "
+            "show the rewind preview again and retry"
+        )
+
+    snapshot_root = root / validated.snapshot_ref
+    if snapshot_root.is_symlink() or not snapshot_root.is_dir():
+        raise _rewind_refuse(
+            "the adoption snapshot is no longer available under keep-last-3 retention; "
+            "this adoption can no longer be rewound"
+        )
+    _verify_adoption_commit(root, validated)
+    plan, restored = _snapshot_rewind_plan(root, validated, current_modes)
+
+    try:
+        transaction = Transaction.begin(root, plan)
+
+        def verify_no_late_drift() -> None:
+            """Bind the rewind to the state captured by its transaction.
+
+            This closes drift between the initial hash pass and snapshot
+            capture: rollback restores those later user bytes. As in C1, the
+            trusted transaction core cannot detect a non-transaction writer
+            that ignores the mutation lock after snapshot capture and races a
+            write PlanEntry's atomic replace; that inherited residual window
+            remains documented rather than hidden.
+            """
+            captured = {
+                entry.relative: entry for entry in transaction.snapshot.read_manifest()
+            }
+            late_drift = tuple(
+                sorted(
+                    entry.path
+                    for entry in validated.files_written
+                    if entry.path not in captured
+                    or not captured[entry.path].existed
+                    or captured[entry.path].sha256 != entry.sha256
+                    or captured[entry.path].size != entry.byte_size
+                )
+            )
+            if late_drift:
+                raise _drift_refusal(late_drift)
+
+        result = transaction.run(before_commit=verify_no_late_drift)
+    except PlanRejected as error:
+        raise _rewind_refuse(
+            f"the ownership contract rejected the complete rewind: {error}"
+        ) from error
+    except (SnapshotError, TransactionError) as error:
+        raise _rewind_refuse(
+            f"the rewind transaction could not complete safely: {error}"
+        ) from error
+
+    rewind_transaction_id = result["tx_id"]
+    return RewindReceipt.from_dict(
+        {
+            "rewind_receipt_version": REWIND_RECEIPT_VERSION,
+            "adoption_transaction_id": validated.transaction_id,
+            "rewind_transaction_id": rewind_transaction_id,
+            "snapshot_ref": (
+                f"System/.dex/tx/{rewind_transaction_id}/snapshot"
+            ),
+            "source_receipt_sha256": hashlib.sha256(
+                canonical_adoption_receipt_bytes(validated)
+            ).hexdigest(),
+            "files_restored": [entry.to_dict() for entry in restored],
+        }
+    )
+
+
 def _rebuild_requested_plan(catalog, inventory, requested: tuple[str, ...]) -> AdoptionPlan:
     by_id = {item.id: item for item in catalog.items}
     rebuilt_items = []
@@ -274,7 +863,13 @@ def execute_adoption(
     approved_token: str,
     payload_loader: PayloadLoader,
 ) -> AdoptionReceipt:
-    """Re-prove an approved preview, then execute all writes in one transaction."""
+    """Re-prove an approved preview, execute it, then persist its receipt.
+
+    Receipt persistence is intentionally after COMMITTED because the receipt
+    records the transaction outcome. A crash in that narrow window leaves a
+    committed-but-unreceipted adoption; the transaction journal remains the
+    durable source of truth and no adoption bytes are rolled back or guessed.
+    """
     if not isinstance(preview, AdoptionPreview):
         raise _refuse("preview must be an AdoptionPreview")
     if not isinstance(approved_token, str) or not hmac.compare_digest(
@@ -381,7 +976,7 @@ def execute_adoption(
         )
     )
     transaction_id = result["tx_id"]
-    return AdoptionReceipt(
+    receipt = AdoptionReceipt(
         RECEIPT_VERSION,
         requested,
         files,
@@ -391,12 +986,30 @@ def execute_adoption(
         rebuilt.inventory_sha256,
         rebuilt.sha256,
     )
+    try:
+        _persist_adoption_receipt(root, receipt)
+    except AdoptionReceiptPersistenceError:
+        raise
+    except (OSError, AdoptionExecutionError) as error:
+        raise AdoptionReceiptPersistenceError(
+            f"adoption {transaction_id} committed, but its receipt could not be "
+            f"persisted; the transaction journal is authoritative: {error}"
+        ) from error
+    return receipt
 
 
 __all__ = [
     "AdoptionExecutionError",
     "AdoptionReceipt",
+    "AdoptionReceiptPersistenceError",
+    "AdoptionRewindError",
     "ReceiptFile",
+    "RewindReceipt",
+    "RewindReceiptFile",
     "canonical_adoption_receipt_bytes",
+    "canonical_rewind_receipt_bytes",
     "execute_adoption",
+    "load_adoption_receipt",
+    "rewind_acknowledgement_token",
+    "rewind_adoption",
 ]

--- a/core/lifecycle/retention.py
+++ b/core/lifecycle/retention.py
@@ -1,0 +1,74 @@
+"""Read-only reporting for Dex's lean transaction-snapshot retention."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.transaction.journal import Journal, JournalCorruptError
+
+RETENTION_WARNING_BYTES = 2 * 1024**3
+TX_RELATIVE = Path("System") / ".dex" / "tx"
+
+
+@dataclass(frozen=True)
+class RetentionReport:
+    """Current transaction-store footprint; warning is advisory only."""
+
+    total_bytes: int
+    committed_snapshot_count: int
+    warning: bool
+    warning_threshold_bytes: int
+
+
+def _total_file_bytes(root: Path) -> int:
+    total = 0
+    for directory, _subdirectories, filenames in os.walk(root, followlinks=False):
+        parent = Path(directory)
+        for filename in filenames:
+            candidate = parent / filename
+            try:
+                if not candidate.is_symlink() and candidate.is_file():
+                    total += candidate.stat().st_size
+            except FileNotFoundError:
+                continue
+    return total
+
+
+def _committed_snapshots(tx_root: Path) -> int:
+    count = 0
+    for candidate in tx_root.iterdir():
+        snapshot = candidate / "snapshot"
+        if not candidate.is_dir() or snapshot.is_symlink() or not snapshot.is_dir():
+            continue
+        try:
+            events = [
+                entry.event for entry in Journal(candidate / "journal.jsonl").read()
+            ]
+        except JournalCorruptError:
+            continue
+        if events.count("COMMITTED") == 1 and "ROLLED-BACK" not in events:
+            count += 1
+    return count
+
+
+def compute_retention_report(vault_root: Path) -> RetentionReport:
+    """Measure retained transaction state and warn above 2 GiB without blocking."""
+    tx_root = Path(vault_root) / TX_RELATIVE
+    if tx_root.is_symlink() or not tx_root.is_dir():
+        return RetentionReport(0, 0, False, RETENTION_WARNING_BYTES)
+    total_bytes = _total_file_bytes(tx_root)
+    return RetentionReport(
+        total_bytes,
+        _committed_snapshots(tx_root),
+        total_bytes > RETENTION_WARNING_BYTES,
+        RETENTION_WARNING_BYTES,
+    )
+
+
+__all__ = [
+    "RETENTION_WARNING_BYTES",
+    "RetentionReport",
+    "compute_retention_report",
+]

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -263,6 +263,8 @@ RULES: tuple[Rule, ...] = (
        "legacy-tracked runtime state"),
     _r("runtime-last-learning-check", "System/.last-learning-check", "file", "runtime",
        "legacy-tracked runtime marker"),
+    _r("runtime-adoption-receipts", "System/.dex/adoptions", "dir", "runtime",
+       "post-commit lifecycle receipts; local runtime evidence, never shipped"),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),

--- a/core/tests/test_adoption_retention.py
+++ b/core/tests/test_adoption_retention.py
@@ -1,0 +1,71 @@
+"""C3 read-only reporting for the transaction snapshot retention budget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.lifecycle import retention
+from core.transaction.engine import PlanEntry, Transaction
+
+
+def _disk_bytes(root: Path) -> int:
+    if not root.exists():
+        return 0
+    return sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
+
+
+def test_retention_report_counts_bytes_and_only_committed_snapshots(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for index in range(2):
+        Transaction.begin(
+            vault,
+            [
+                PlanEntry(
+                    "System/.installed-files.manifest",
+                    f"manifest {index}\n".encode(),
+                )
+            ],
+        ).run()
+    unfinished = vault / "System/.dex/tx/99999999T999999-deadbeef/snapshot"
+    unfinished.mkdir(parents=True)
+    (unfinished / "orphan.bin").write_bytes(b"orphan bytes")
+    tx_root = vault / "System/.dex/tx"
+
+    report = retention.compute_retention_report(vault)
+
+    assert report.total_bytes == _disk_bytes(tx_root)
+    assert report.committed_snapshot_count == 2
+    assert report.warning is False
+
+
+def test_retention_warning_uses_patchable_two_gib_threshold_and_never_blocks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    vault = tmp_path / "vault"
+    payload = vault / "System/.dex/tx/uncommitted/small.bin"
+    payload.parent.mkdir(parents=True)
+    payload.write_bytes(b"1234567")
+    monkeypatch.setattr(retention, "RETENTION_WARNING_BYTES", 6)
+
+    report = retention.compute_retention_report(vault)
+
+    assert report.total_bytes == 7
+    assert report.warning is True
+    assert report.warning_threshold_bytes == 6
+
+    monkeypatch.setattr(retention, "RETENTION_WARNING_BYTES", 7)
+    assert retention.compute_retention_report(vault).warning is False
+
+
+def test_retention_report_is_zero_for_vault_without_transaction_state(
+    tmp_path: Path,
+) -> None:
+    report = retention.compute_retention_report(tmp_path / "vault")
+
+    assert report.total_bytes == 0
+    assert report.committed_snapshot_count == 0
+    assert report.warning is False
+    assert report.warning_threshold_bytes == 2 * 1024**3

--- a/core/tests/test_adoption_rewind.py
+++ b/core/tests/test_adoption_rewind.py
@@ -1,0 +1,361 @@
+"""C3 adoption rewind: exact acknowledgement, drift refusal, and recovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle.engine import (
+    AdoptionReceipt,
+    AdoptionRewindError,
+    RewindReceipt,
+    canonical_adoption_receipt_bytes,
+    canonical_rewind_receipt_bytes,
+    execute_adoption,
+    load_adoption_receipt,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.tests.test_adoption_transaction import _preview
+from core.transaction.engine import PlanEntry, Transaction
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OLD = b"before adoption\r\nwith exact bytes\x00"
+NEW = b"after adoption\n"
+CREATED = b"created by adoption\n"
+EXISTING_PATH = "README.md"
+CREATED_PATH = ".claude/skills/created/SKILL.md"
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _tx_directories(vault: Path) -> list[Path]:
+    tx_root = vault / "System/.dex/tx"
+    return sorted(path for path in tx_root.iterdir() if path.is_dir())
+
+
+def _committed_adoption(tmp_path: Path) -> tuple[Path, AdoptionReceipt]:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    existing = vault / EXISTING_PATH
+    existing.write_bytes(OLD)
+    os.chmod(existing, 0o640)
+    transaction = Transaction.begin(
+        vault,
+        [
+            PlanEntry(EXISTING_PATH, NEW, mode=0o644),
+            PlanEntry(CREATED_PATH, CREATED, mode=0o600),
+        ],
+    )
+    result = transaction.run()
+    receipt = AdoptionReceipt.from_dict(
+        {
+            "receipt_version": 1,
+            "items_adopted": ["alpha"],
+            "files_written": [
+                {
+                    "item_id": "alpha",
+                    "path": CREATED_PATH,
+                    "sha256": _sha256(CREATED),
+                    "byte_size": len(CREATED),
+                },
+                {
+                    "item_id": "alpha",
+                    "path": EXISTING_PATH,
+                    "sha256": _sha256(NEW),
+                    "byte_size": len(NEW),
+                },
+            ],
+            "transaction_id": result["tx_id"],
+            "snapshot_ref": f"System/.dex/tx/{result['tx_id']}/snapshot",
+            "catalog_sha256": "a" * 64,
+            "inventory_sha256": "b" * 64,
+            "preview_sha256": "c" * 64,
+        }
+    )
+    return vault, receipt
+
+
+def test_happy_rewind_restores_exact_bytes_and_mode_and_deletes_created_file(
+    tmp_path: Path,
+) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+
+    rewind_receipt = rewind_adoption(
+        vault,
+        receipt,
+        rewind_acknowledgement_token(receipt),
+    )
+
+    assert (vault / EXISTING_PATH).read_bytes() == OLD
+    assert stat.S_IMODE((vault / EXISTING_PATH).stat().st_mode) == 0o640
+    assert not (vault / CREATED_PATH).exists()
+    assert rewind_receipt.adoption_transaction_id == receipt.transaction_id
+    assert rewind_receipt.rewind_transaction_id != receipt.transaction_id
+    assert rewind_receipt.snapshot_ref == (
+        f"System/.dex/tx/{rewind_receipt.rewind_transaction_id}/snapshot"
+    )
+    assert rewind_receipt.source_receipt_sha256 == hashlib.sha256(
+        canonical_adoption_receipt_bytes(receipt)
+    ).hexdigest()
+    assert [entry.to_dict() for entry in rewind_receipt.files_restored] == [
+        {
+            "item_id": "alpha",
+            "path": CREATED_PATH,
+            "existed_before_adoption": False,
+            "restored_sha256": None,
+            "byte_size": None,
+            "mode": None,
+        },
+        {
+            "item_id": "alpha",
+            "path": EXISTING_PATH,
+            "existed_before_adoption": True,
+            "restored_sha256": _sha256(OLD),
+            "byte_size": len(OLD),
+            "mode": 0o640,
+        },
+    ]
+    assert RewindReceipt.from_dict(rewind_receipt.to_dict()) == rewind_receipt
+    assert canonical_rewind_receipt_bytes(rewind_receipt).endswith(b"\n")
+
+
+def test_rewind_refuses_all_drift_and_names_exact_paths(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    (vault / EXISTING_PATH).write_bytes(b"user edit\n")
+    (vault / CREATED_PATH).write_bytes(b"another user edit\n")
+
+    with pytest.raises(AdoptionRewindError) as raised:
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert str(raised.value) == (
+        "rewind refused: files changed after adoption and were left untouched: "
+        f"{CREATED_PATH}, {EXISTING_PATH}. Keep those edits or restore the adopted "
+        "bytes, then request a new rewind."
+    )
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == b"user edit\n"
+    assert (vault / CREATED_PATH).read_bytes() == b"another user edit\n"
+
+
+def test_rewind_catches_drift_immediately_before_snapshot_and_restores_the_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import engine as rewind_engine
+
+    vault, receipt = _committed_adoption(tmp_path)
+    target = vault / EXISTING_PATH
+    real_begin = Transaction.begin
+
+    def begin_then_race(vault_root: Path, plan: list[PlanEntry]):
+        transaction = real_begin(vault_root, plan)
+        target.write_bytes(b"edit won immediately before rewind snapshot\n")
+        return transaction
+
+    monkeypatch.setattr(rewind_engine.Transaction, "begin", begin_then_race)
+
+    with pytest.raises(AdoptionRewindError, match=EXISTING_PATH):
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert target.read_bytes() == b"edit won immediately before rewind snapshot\n"
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+
+
+@pytest.mark.parametrize("token", [None, "0" * 64])
+def test_rewind_refuses_missing_or_wrong_acknowledgement_token(
+    tmp_path: Path, token: str | None
+) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+
+    with pytest.raises(AdoptionRewindError, match="acknowledgement token"):
+        rewind_adoption(vault, receipt, token)
+
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+
+
+def test_acknowledgement_token_is_bound_to_exact_id_and_sorted_paths(
+    tmp_path: Path,
+) -> None:
+    _vault, receipt = _committed_adoption(tmp_path)
+    expected_payload = {
+        "rewind": receipt.transaction_id,
+        "files": sorted([CREATED_PATH, EXISTING_PATH]),
+    }
+    expected = hashlib.sha256(
+        (
+            json.dumps(expected_payload, sort_keys=True, separators=(",", ":"))
+            + "\n"
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert rewind_acknowledgement_token(receipt) == expected
+    changed = receipt.to_dict()
+    changed["transaction_id"] = "20260721T235959-deadbeef"
+    changed["snapshot_ref"] = "System/.dex/tx/20260721T235959-deadbeef/snapshot"
+    assert rewind_acknowledgement_token(AdoptionReceipt.from_dict(changed)) != expected
+
+
+def test_rewind_refuses_when_adoption_snapshot_was_pruned(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    snapshot = vault / receipt.snapshot_ref
+    for path in sorted(snapshot.rglob("*"), reverse=True):
+        if path.is_file():
+            path.unlink()
+        else:
+            path.rmdir()
+    snapshot.rmdir()
+
+    with pytest.raises(
+        AdoptionRewindError,
+        match=r"keep-last-3 retention.*can no longer be rewound",
+    ):
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+
+
+def test_rewind_verifies_snapshot_blob_before_starting_transaction(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    snapshot_blob = vault / receipt.snapshot_ref / "000000.bin"
+    snapshot_blob.write_bytes(b"tampered snapshot bytes")
+
+    with pytest.raises(AdoptionRewindError, match=r"snapshot.*damaged"):
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+
+
+def test_rewind_fails_closed_on_malformed_snapshot_manifest(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    manifest_path = vault / receipt.snapshot_ref / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["entries"][0]["relative"] = [EXISTING_PATH]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(AdoptionRewindError, match=r"snapshot manifest is damaged"):
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+
+
+def test_rewind_strictly_revalidates_receipt_input(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    malformed = receipt.to_dict()
+    malformed["unexpected"] = True
+
+    with pytest.raises(AdoptionRewindError, match=r"receipt is invalid.*unknown fields"):
+        rewind_adoption(vault, malformed, "0" * 64)
+
+    assert len(_tx_directories(vault)) == 1
+
+
+def test_ownership_contract_refusal_aborts_the_whole_rewind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    original = portable_contract.update_write_verdict
+
+    def refuse_existing(path: str, *, exists: bool):
+        if path == EXISTING_PATH:
+            return portable_contract.WriteVerdict(
+                path, False, "deny", "brain", "adversarial-test"
+            )
+        return original(path, exists=exists)
+
+    monkeypatch.setattr(portable_contract, "update_write_verdict", refuse_existing)
+
+    with pytest.raises(AdoptionRewindError, match=r"ownership contract.*README"):
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert len(_tx_directories(vault)) == 1
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+
+
+def test_successful_adoption_persists_canonical_loadable_receipt(tmp_path: Path) -> None:
+    vault, _document, preview, loader = _preview(tmp_path)
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+
+    receipt_path = (
+        vault
+        / "System/.dex/adoptions"
+        / f"{receipt.transaction_id}.receipt.json"
+    )
+    assert receipt_path.read_bytes() == canonical_adoption_receipt_bytes(receipt)
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o600
+    assert load_adoption_receipt(vault, receipt.transaction_id) == receipt
+    assert portable_contract.resolve(str(receipt_path.relative_to(vault))).ownership == (
+        "runtime"
+    )
+
+    receipt_path.write_bytes(receipt_path.read_bytes().replace(b"\n", b" \n", 1))
+    with pytest.raises(AdoptionRewindError, match="not canonical"):
+        load_adoption_receipt(vault, receipt.transaction_id)
+
+
+_REWIND_FAULT_WORKER = r"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[3])
+
+from core.lifecycle.engine import (
+    AdoptionReceipt,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+
+vault = Path(sys.argv[1])
+receipt = AdoptionReceipt.from_dict(json.loads(Path(sys.argv[2]).read_text()))
+rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+"""
+
+
+def test_crash_during_rewind_converges_via_transaction_resume(tmp_path: Path) -> None:
+    vault, receipt = _committed_adoption(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_bytes(canonical_adoption_receipt_bytes(receipt))
+    env = dict(os.environ, DEX_TX_TEST_STOP_AFTER="mid-apply:0")
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _REWIND_FAULT_WORKER,
+            str(vault),
+            str(receipt_path),
+            str(REPO_ROOT),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert process.returncode == 137, process.stderr[-500:]
+    outcomes = Transaction.resume(vault)
+    assert len(outcomes) == 1
+    assert outcomes[0]["resumed"] is True
+    assert (vault / EXISTING_PATH).read_bytes() == NEW
+    assert stat.S_IMODE((vault / EXISTING_PATH).stat().st_mode) == 0o644
+    assert (vault / CREATED_PATH).read_bytes() == CREATED
+    assert stat.S_IMODE((vault / CREATED_PATH).stat().st_mode) == 0o600

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -465,6 +465,13 @@
       "ownership": "runtime"
     },
     {
+      "id": "runtime-adoption-receipts",
+      "path": "System/.dex/adoptions",
+      "kind": "dir",
+      "ownership": "runtime",
+      "note": "post-commit lifecycle receipts; local runtime evidence, never shipped"
+    },
+    {
       "id": "generated-manifest",
       "path": "System/.installed-files.manifest",
       "kind": "file",


### PR DESCRIPTION
Chunk C3 of the lifecycle catalog program (spec §5).

## What
- Receipt persistence: adoptions now leave a durable, canonical receipt under `System/.dex/adoptions/` (atomic write, fail-closed load).
- `rewind_adoption`: restores an adoption to exact pre-state through the transaction core. Drift of any kind (edit, delete, symlink/dir swap) refuses and names the files; snapshot bytes are verified before they can enter a plan; acknowledgement token binds tx id + exact paths; pruned snapshots fail safe with a retention explanation.
- `retention.py`: read-only usage report, 2 GiB warn-never-block (decision C-3).
- Ownership contract: receipts dir explicitly classified runtime (no ownership change — parent rule already covered it).

## Review trail
- Fable diff review; independent adversarial review (Opus): **SHIP, no mandatory fixes.** Crash convergence proven at all 8 transaction seams; consistent-tamper, cross-receipt binding, rolled-back-tx binding, double-rewind, and symlink-swap attacks all failed closed.
- Non-blocking reviewer notes (parametrized seam sweep in shipped tests, stale receipt housekeeping, mode-only drift asymmetry) logged for the D-GATE pass.

## Verification
- 63 adoption-suite tests green in orchestrator re-run; ruff clean; portable-contract (1059 paths, dist in sync) and founder-content gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42