### PR TITLE
feat: SQLite snapshot adapter + sync-folder gate (cathedral C2)

### DIFF
--- a/core/lifecycle/sqlite_snapshot.py
+++ b/core/lifecycle/sqlite_snapshot.py
@@ -1,0 +1,535 @@
+"""Consistent, manifest-backed snapshots for externally owned SQLite databases.
+
+Raw file copies are not SQLite snapshots: committed pages may still live in a
+WAL sidecar, and copying a database while its owner writes can capture torn
+state. This adapter therefore uses SQLite's online backup API for both capture
+and restoration, verifies each resulting database with ``PRAGMA quick_check``,
+and publishes restores with one atomic replace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MANIFEST_NAME = "manifest.json"
+BACKUP_NAME = "database.sqlite3"
+SCHEMA_VERSION = 1
+_KIND = "sqlite-online-backup"
+_HEX = frozenset("0123456789abcdef")
+_DEFAULT_BACKUP_TIMEOUT_SECONDS = 5.0
+_BACKUP_PAGES = 256
+_BACKUP_SLEEP_SECONDS = 0.01
+
+
+class SQLiteSnapshotError(RuntimeError):
+    """A SQLite snapshot or restore could not complete without risking data."""
+
+
+class _BackupDeadlineExpired(Exception):
+    """The online backup did not finish within its bounded retry budget."""
+
+
+def _refuse(message: str) -> SQLiteSnapshotError:
+    return SQLiteSnapshotError(f"SQLite snapshot refused: {message}")
+
+
+@dataclass(frozen=True)
+class SQLiteSnapshotResult:
+    """Capture result; data-file owner activity is informational, not a failure."""
+
+    snapshot_dir: Path
+    sha256: str
+    size: int
+    owner_activity: bool
+    database_changed: bool
+    wal_changed: bool
+    shm_changed: bool
+
+
+@dataclass(frozen=True)
+class _StoredEntry:
+    relative: str
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class _SyncMarker:
+    provider: str
+    kind: str
+    values: tuple[str, ...]
+
+
+# The table is deliberately declarative so later providers can be added without
+# changing snapshot policy. Specific OneDrive signals precede the generic
+# CloudStorage provider directory.
+SYNC_MARKERS = (
+    _SyncMarker("OneDrive", "path-segment", ("onedrive", "onedrive - ")),
+    _SyncMarker(
+        "OneDrive",
+        "paired-children",
+        ("desktop.ini", ".849C9593-D756-4E56-8D6E-42412F2A707B"),
+    ),
+    _SyncMarker("Dropbox", "child", (".dropbox", ".dropbox.cache")),
+    _SyncMarker("a cloud-synced folder", "cloudstorage-provider", ("library", "cloudstorage")),
+    _SyncMarker("iCloud Drive", "icloud-materialization", (".icloud",)),
+)
+
+_CLOUDSTORAGE_PROVIDER_PREFIXES = (
+    ("dropbox", "Dropbox"),
+    ("googledrive", "GoogleDrive"),
+    ("onedrive", "OneDrive"),
+    ("box", "Box"),
+)
+
+
+def _ancestors(path: Path) -> tuple[Path, ...]:
+    current = path.absolute()
+    return (current, *current.parents)
+
+
+def _child_names(directory: Path) -> frozenset[str]:
+    try:
+        return frozenset(child.name.casefold() for child in directory.iterdir())
+    except OSError:
+        return frozenset()
+
+
+def _cloudstorage_provider(folded_parts: tuple[str, ...], sequence: tuple[str, ...]) -> str | None:
+    width = len(sequence)
+    for index in range(len(folded_parts)):
+        if folded_parts[index : index + width] != sequence:
+            continue
+        provider_index = index + width
+        if provider_index >= len(folded_parts):
+            return "a cloud-synced folder"
+        provider_directory = folded_parts[provider_index]
+        for prefix, provider in _CLOUDSTORAGE_PROVIDER_PREFIXES:
+            if provider_directory.startswith(prefix):
+                return provider
+        return "a cloud-synced folder"
+    return None
+
+
+def detect_sync_folder(path: Path) -> str | None:
+    """Return a known sync provider for ``path`` or an ancestor, else ``None``.
+
+    Signals intentionally cover only documented, high-confidence markers:
+    Dropbox marker entries, Apple's CloudStorage/materialization convention,
+    and OneDrive path or paired folder identifiers. Unknown provider folders
+    under CloudStorage receive a generic cloud-synced label instead of a guess;
+    paths without a documented signal remain unknown.
+    """
+
+    ancestors = _ancestors(Path(path))
+    folded_parts = tuple(part.casefold() for part in Path(path).absolute().parts)
+    names_by_directory: dict[Path, frozenset[str]] = {}
+
+    for marker in SYNC_MARKERS:
+        if marker.kind == "path-segment":
+            exact, tenant_prefix = marker.values
+            if any(part == exact or part.startswith(tenant_prefix) for part in folded_parts):
+                return marker.provider
+            continue
+        if marker.kind == "cloudstorage-provider":
+            provider = _cloudstorage_provider(folded_parts, marker.values)
+            if provider is not None:
+                return provider
+            continue
+
+        for directory in ancestors:
+            names = names_by_directory.setdefault(directory, _child_names(directory))
+            if marker.kind == "child" and any(value.casefold() in names for value in marker.values):
+                return marker.provider
+            if marker.kind == "paired-children" and all(value.casefold() in names for value in marker.values):
+                return marker.provider
+            if marker.kind == "icloud-materialization" and any(
+                name == ".icloud" or name.endswith(".icloud") for name in names
+            ):
+                return marker.provider
+    return None
+
+
+def _sha256(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as handle:
+        while chunk := handle.read(1 << 20):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _optional_sha256(path: Path) -> str | None:
+    try:
+        return _sha256(path)[0]
+    except FileNotFoundError:
+        return None
+
+
+def _fsync_file(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    offset = 0
+    while offset < len(data):
+        written = os.write(descriptor, data[offset:])
+        if written <= 0:
+            raise OSError("manifest write made no progress")
+        offset += written
+
+
+def _write_manifest(root: Path, result: SQLiteSnapshotResult) -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": _KIND,
+        "entries": [
+            {
+                "relative": BACKUP_NAME,
+                "sha256": result.sha256,
+                "size": result.size,
+            }
+        ],
+        "owner_activity": result.owner_activity,
+        "source_changes": {
+            "database": result.database_changed,
+            "shm": result.shm_changed,
+            "wal": result.wal_changed,
+        },
+    }
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    path = root / MANIFEST_NAME
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _readonly_uri(path: Path, *, immutable: bool = False) -> str:
+    query = "mode=ro&immutable=1" if immutable else "mode=ro"
+    return f"{path.resolve(strict=True).as_uri()}?{query}"
+
+
+def _quick_check(connection: sqlite3.Connection, context: str) -> None:
+    try:
+        rows = connection.execute("PRAGMA quick_check").fetchall()
+    except sqlite3.Error as error:
+        raise _refuse(f"{context} quick_check could not run: {error}") from error
+    details = []
+    for row in rows:
+        if len(row) != 1:
+            details.append(repr(row))
+        elif row[0] != "ok":
+            details.append(str(row[0]))
+    if not rows or details:
+        reported = "; ".join(details) if details else "no result"
+        raise _refuse(f"{context} quick_check failed: {reported}")
+
+
+def _cleanup_partial_snapshot(root: Path, *, remove_root: bool) -> None:
+    for name in (MANIFEST_NAME, BACKUP_NAME, f"{BACKUP_NAME}-journal", f"{BACKUP_NAME}-wal", f"{BACKUP_NAME}-shm"):
+        path = root / name
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+    if remove_root:
+        try:
+            root.rmdir()
+        except OSError:
+            pass
+
+
+def snapshot_sqlite(
+    source_db: Path,
+    dest_dir: Path,
+    *,
+    acknowledged_sync_risk: bool = False,
+    backup_timeout_seconds: float = _DEFAULT_BACKUP_TIMEOUT_SECONDS,
+) -> SQLiteSnapshotResult:
+    """Capture one consistent SQLite database using the online backup API.
+
+    The source is opened with SQLite URI ``mode=ro`` and the online backup is
+    refused after ``backup_timeout_seconds`` rather than retrying a busy source
+    forever. A hot WAL database must either still have its owner running or live
+    in a directory where SQLite can create a missing ``-shm`` file; ``mode=ro``
+    does not make that directory operation read-only.
+
+    Changes to database, WAL, and SHM bytes are observed before/after. Database
+    and WAL changes are reported as owner activity without invalidating the
+    transactionally consistent backup. Creating or updating SHM is benign lock
+    coordination that the snapshot connection itself may cause, so it is
+    reported separately as ``shm_changed`` rather than as an owner data write.
+    """
+
+    source = Path(source_db)
+    destination = Path(dest_dir)
+    if type(acknowledged_sync_risk) is not bool:
+        raise _refuse("acknowledged_sync_risk must be a boolean")
+    if source.is_symlink() or not source.is_file():
+        raise _refuse(f"source is not a regular database file: {source}")
+    # Resolve ancestor symlinks before provider detection so a vault cannot
+    # accidentally hide that it physically lives inside a sync root.
+    source = source.resolve(strict=True)
+    provider = detect_sync_folder(source.parent)
+    if provider is not None and not acknowledged_sync_risk:
+        raise _refuse(
+            f"{provider} sync-folder risk was not acknowledged; "
+            "sync services can corrupt SQLite databases mid-write"
+        )
+    if destination.is_symlink() or destination.exists():
+        raise _refuse(f"destination snapshot directory already exists: {destination}")
+
+    sidecars = (source, Path(f"{source}-wal"), Path(f"{source}-shm"))
+    before = tuple(_optional_sha256(path) for path in sidecars)
+    destination.mkdir(mode=0o700)
+    backup = destination / BACKUP_NAME
+    source_connection: sqlite3.Connection | None = None
+    backup_connection: sqlite3.Connection | None = None
+    try:
+        try:
+            source_connection = sqlite3.connect(_readonly_uri(source), uri=True)
+            source_connection.execute("PRAGMA query_only=ON")
+            busy_timeout_ms = max(1, int(backup_timeout_seconds * 1000))
+            source_connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+            backup_connection = sqlite3.connect(backup)
+            deadline = time.monotonic() + backup_timeout_seconds
+
+            def refuse_after_deadline(_status: int, _remaining: int, _total: int) -> None:
+                if time.monotonic() >= deadline:
+                    raise _BackupDeadlineExpired
+
+            try:
+                source_connection.backup(
+                    backup_connection,
+                    pages=_BACKUP_PAGES,
+                    progress=refuse_after_deadline,
+                    sleep=min(_BACKUP_SLEEP_SECONDS, backup_timeout_seconds),
+                )
+            except _BackupDeadlineExpired as error:
+                raise _refuse(
+                    "source database is busy; try again when the owning app is idle"
+                ) from error
+            _quick_check(backup_connection, "backup")
+            backup_connection.close()
+            backup_connection = None
+            os.chmod(backup, 0o600)
+            _fsync_file(backup)
+            digest, size = _sha256(backup)
+
+            source_connection.close()
+            source_connection = None
+            after = tuple(_optional_sha256(path) for path in sidecars)
+            changes = tuple(first != last for first, last in zip(before, after, strict=True))
+            result = SQLiteSnapshotResult(
+                destination,
+                digest,
+                size,
+                changes[0] or changes[1],
+                changes[0],
+                changes[1],
+                changes[2],
+            )
+            _write_manifest(destination, result)
+            _fsync_directory(destination)
+            return result
+        finally:
+            if backup_connection is not None:
+                backup_connection.close()
+            if source_connection is not None:
+                source_connection.close()
+    except SQLiteSnapshotError:
+        _cleanup_partial_snapshot(destination, remove_root=True)
+        raise
+    except (OSError, sqlite3.Error) as error:
+        _cleanup_partial_snapshot(destination, remove_root=True)
+        raise _refuse(f"capture failed: {error}") from error
+
+
+def _require_mapping(value: object, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise _refuse(f"{context} must be an object with string fields")
+    return value
+
+
+def _require_fields(value: dict[str, Any], required: set[str], context: str) -> None:
+    if set(value) != required:
+        raise _refuse(f"{context} has an unsupported shape")
+
+
+def _read_manifest(root: Path) -> _StoredEntry:
+    if root.is_symlink() or not root.is_dir():
+        raise _refuse("snapshot directory is missing or not a regular directory")
+    manifest = root / MANIFEST_NAME
+    if manifest.is_symlink():
+        raise _refuse("snapshot manifest must not be a symlink")
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise _refuse("snapshot manifest is missing") from error
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _refuse(f"snapshot manifest is unreadable: {error}") from error
+    value = _require_mapping(payload, "snapshot manifest")
+    _require_fields(
+        value,
+        {"schema_version", "kind", "entries", "owner_activity", "source_changes"},
+        "snapshot manifest",
+    )
+    if type(value["schema_version"]) is not int or value["schema_version"] != SCHEMA_VERSION:
+        raise _refuse("snapshot manifest version or kind is unsupported")
+    if not isinstance(value["kind"], str) or value["kind"] != _KIND:
+        raise _refuse("snapshot manifest version or kind is unsupported")
+    if type(value["owner_activity"]) is not bool:
+        raise _refuse("snapshot manifest owner_activity must be a boolean")
+    changes = _require_mapping(value["source_changes"], "snapshot source_changes")
+    _require_fields(changes, {"database", "shm", "wal"}, "snapshot source_changes")
+    if any(type(changes[name]) is not bool for name in ("database", "shm", "wal")):
+        raise _refuse("snapshot source_changes values must be booleans")
+    if value["owner_activity"] is not (changes["database"] or changes["wal"]):
+        raise _refuse("snapshot owner_activity disagrees with source_changes")
+
+    entries = value["entries"]
+    if not isinstance(entries, list) or len(entries) != 1:
+        raise _refuse("snapshot manifest must contain exactly one database entry")
+    entry = _require_mapping(entries[0], "snapshot entry")
+    _require_fields(entry, {"relative", "sha256", "size"}, "snapshot entry")
+    digest = entry["sha256"]
+    size = entry["size"]
+    if entry["relative"] != BACKUP_NAME:
+        raise _refuse("snapshot entry does not name the fixed database backup")
+    if not isinstance(digest, str) or len(digest) != 64 or any(character not in _HEX for character in digest):
+        raise _refuse("snapshot entry sha256 is not a lowercase digest")
+    if type(size) is not int or size < 0:
+        raise _refuse("snapshot entry size must be a non-negative integer")
+    return _StoredEntry(BACKUP_NAME, digest, size)
+
+
+def _reserve_restore_temp(destination: Path) -> Path:
+    for attempt in range(100):
+        temporary = destination.parent / f".{destination.name}.sqlite-restore-{os.getpid()}-{attempt}"
+        try:
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            continue
+        os.close(descriptor)
+        return temporary
+    raise _refuse("could not reserve a unique restore temporary file")
+
+
+def restore_sqlite(snapshot_dir: Path, dest_db: Path) -> None:
+    """Verify and atomically restore a SQLite snapshot to ``dest_db``.
+
+    Existing ``-wal`` and ``-shm`` files belong to the pre-restore database
+    generation. They are removed and that directory change is synced before the
+    checked temporary database atomically replaces the destination. Therefore,
+    whenever the new main database is durably visible, old-generation sidecars
+    cannot be durably paired with it.
+
+    This ordering deliberately does not preserve WAL-only commits if the atomic
+    replace then fails: an existing old main database remains without its
+    sidecars, and the caller receives a detectable failure. That state is
+    degraded but consistent and retryable instead of silently replaying a stale
+    WAL against the restored main database.
+    """
+
+    root = Path(snapshot_dir)
+    destination = Path(dest_db)
+    if not destination.parent.is_dir():
+        raise _refuse(f"restore destination directory does not exist: {destination.parent}")
+    if destination.is_dir():
+        raise _refuse(f"restore destination is a directory: {destination}")
+    entry = _read_manifest(root)
+    stored = root / entry.relative
+    if stored.is_symlink() or not stored.is_file():
+        raise _refuse("stored database backup is missing or not a regular file")
+    digest, size = _sha256(stored)
+    if digest != entry.sha256 or size != entry.size:
+        raise _refuse("stored database bytes do not match the manifest; refusing restore")
+
+    stale_sidecars = (Path(f"{destination}-wal"), Path(f"{destination}-shm"))
+    if any(path.exists() and not (path.is_file() or path.is_symlink()) for path in stale_sidecars):
+        raise _refuse("a stale destination sidecar is not a removable file")
+
+    temporary = _reserve_restore_temp(destination)
+    source_connection: sqlite3.Connection | None = None
+    temporary_connection: sqlite3.Connection | None = None
+    replaced = False
+    try:
+        # The stored backup has already been closed and verified byte-for-byte,
+        # so immutable mode is truthful and prevents SQLite from creating WAL/
+        # SHM coordination files inside the read-only snapshot store.
+        source_connection = sqlite3.connect(_readonly_uri(stored, immutable=True), uri=True)
+        source_connection.execute("PRAGMA query_only=ON")
+        temporary_connection = sqlite3.connect(temporary)
+        source_connection.backup(temporary_connection)
+        _quick_check(temporary_connection, "restore temporary")
+        temporary_connection.close()
+        temporary_connection = None
+        source_connection.close()
+        source_connection = None
+        final_digest, final_size = _sha256(stored)
+        if final_digest != entry.sha256 or final_size != entry.size:
+            raise _refuse("stored database changed during restore; refusing atomic replace")
+        os.chmod(temporary, 0o600)
+        _fsync_file(temporary)
+        # These files contain state and coordination for the old inode. Keeping
+        # either beside the restored main file could replay the wrong generation.
+        for sidecar in stale_sidecars:
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+        _fsync_directory(destination.parent)
+        os.replace(temporary, destination)
+        replaced = True
+        _fsync_directory(destination.parent)
+    except SQLiteSnapshotError:
+        raise
+    except (OSError, sqlite3.Error) as error:
+        state = "after atomic replace" if replaced else "before atomic replace"
+        raise _refuse(f"restore failed {state}: {error}") from error
+    finally:
+        if temporary_connection is not None:
+            temporary_connection.close()
+        if source_connection is not None:
+            source_connection.close()
+        suffixes = ("-journal", "-wal", "-shm") if replaced else ("", "-journal", "-wal", "-shm")
+        for suffix in suffixes:
+            try:
+                Path(f"{temporary}{suffix}").unlink()
+            except FileNotFoundError:
+                pass
+
+
+__all__ = [
+    "BACKUP_NAME",
+    "MANIFEST_NAME",
+    "SYNC_MARKERS",
+    "SQLiteSnapshotError",
+    "SQLiteSnapshotResult",
+    "detect_sync_folder",
+    "restore_sqlite",
+    "snapshot_sqlite",
+]

--- a/core/tests/test_adoption_sqlite_snapshot.py
+++ b/core/tests/test_adoption_sqlite_snapshot.py
@@ -1,0 +1,552 @@
+"""Adversarial contract tests for lifecycle SQLite snapshots (Gate E8)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle.sqlite_snapshot import (
+    BACKUP_NAME,
+    MANIFEST_NAME,
+    SQLiteSnapshotError,
+    detect_sync_folder,
+    restore_sqlite,
+    snapshot_sqlite,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _rows(database: Path) -> list[tuple[int, str]]:
+    connection = sqlite3.connect(database)
+    try:
+        return connection.execute("SELECT id, value FROM entries ORDER BY id").fetchall()
+    finally:
+        connection.close()
+
+
+def _create_database(path: Path, rows: int = 3) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE entries(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        connection.executemany(
+            "INSERT INTO entries(value) VALUES (?)",
+            [(f"row-{index}",) for index in range(rows)],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_wal_snapshot_restores_all_committed_rows_without_touching_source_database_or_wal(
+    tmp_path: Path,
+) -> None:
+    """E8: online backup includes committed WAL pages and is read-only to its source."""
+    source = tmp_path / "source.sqlite3"
+    owner = sqlite3.connect(source)
+    try:
+        assert owner.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        owner.execute("PRAGMA wal_autocheckpoint=0")
+        owner.execute("CREATE TABLE entries(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        owner.executemany(
+            "INSERT INTO entries(value) VALUES (?)",
+            [("main",), ("wal-only-1",), ("wal-only-2",)],
+        )
+        owner.commit()
+
+        source_wal = Path(f"{source}-wal")
+        source_shm = Path(f"{source}-shm")
+        assert source_wal.stat().st_size > 0
+        assert source_shm.is_file()
+        # SQLite's WAL locking protocol may update read-mark bytes in an
+        # already-live SHM file. The externally meaningful persistent bytes we
+        # promise to leave invariant are the database and WAL themselves.
+        before = {path: path.read_bytes() for path in (source, source_wal)}
+
+        snapshot_dir = tmp_path / "snapshot"
+        result = snapshot_sqlite(source, snapshot_dir)
+
+        assert {path: path.read_bytes() for path in before} == before
+        assert result.owner_activity is False
+        manifest = json.loads((snapshot_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+        entry = manifest["entries"][0]
+        backup = snapshot_dir / BACKUP_NAME
+        assert entry == {
+            "relative": BACKUP_NAME,
+            "sha256": _sha256(backup),
+            "size": backup.stat().st_size,
+        }
+        stored_before_restore = {
+            path.name: path.read_bytes() for path in snapshot_dir.iterdir()
+        }
+
+        restored = tmp_path / "restored.sqlite3"
+        restore_sqlite(snapshot_dir, restored)
+        assert _rows(restored) == [(1, "main"), (2, "wal-only-1"), (3, "wal-only-2")]
+        assert {path.name: path.read_bytes() for path in snapshot_dir.iterdir()} == stored_before_restore
+    finally:
+        owner.close()
+
+
+def test_quiescent_source_open_creates_or_changes_no_sqlite_sidecars(tmp_path: Path) -> None:
+    source = tmp_path / "quiescent.sqlite3"
+    _create_database(source)
+    before = source.read_bytes()
+    assert not Path(f"{source}-wal").exists()
+    assert not Path(f"{source}-shm").exists()
+
+    result = snapshot_sqlite(source, tmp_path / "snapshot")
+
+    assert source.read_bytes() == before
+    assert not Path(f"{source}-wal").exists()
+    assert not Path(f"{source}-shm").exists()
+    assert result.owner_activity is False
+
+
+@pytest.mark.parametrize(
+    ("layout", "provider"),
+    [
+        ("dropbox", "Dropbox"),
+        ("dropbox-cache", "Dropbox"),
+        ("cloud-storage-dropbox", "Dropbox"),
+        ("cloud-storage-google-drive", "GoogleDrive"),
+        ("cloud-storage-onedrive", "OneDrive"),
+        ("cloud-storage-box", "Box"),
+        ("cloud-storage-unknown", "a cloud-synced folder"),
+        ("icloud-materialization", "iCloud Drive"),
+        ("onedrive-segment", "OneDrive"),
+        ("onedrive-markers", "OneDrive"),
+    ],
+)
+def test_sync_folder_detection_uses_only_documented_markers(
+    tmp_path: Path,
+    layout: str,
+    provider: str,
+) -> None:
+    root = tmp_path / "sync-root"
+    vault = root / "Vault"
+    if layout == "dropbox":
+        (root / ".dropbox").mkdir(parents=True)
+    elif layout == "dropbox-cache":
+        (root / ".dropbox.cache").mkdir(parents=True)
+    elif layout.startswith("cloud-storage-"):
+        provider_directory = {
+            "cloud-storage-dropbox": "Dropbox",
+            "cloud-storage-google-drive": "GoogleDrive-example.com",
+            "cloud-storage-onedrive": "OneDrive-ExampleOrg",
+            "cloud-storage-box": "Box-Box",
+            "cloud-storage-unknown": "AcmeSync-example.com",
+        }[layout]
+        vault = tmp_path / "Library" / "CloudStorage" / provider_directory / "Vault"
+    elif layout == "icloud-materialization":
+        root.mkdir(parents=True)
+        (root / "pending-note.md.icloud").write_bytes(b"")
+    elif layout == "onedrive-segment":
+        vault = tmp_path / "OneDrive - Example Org" / "Vault"
+    elif layout == "onedrive-markers":
+        root.mkdir(parents=True)
+        (root / "desktop.ini").write_bytes(b"")
+        (root / ".849C9593-D756-4E56-8D6E-42412F2A707B").write_bytes(b"")
+    vault.mkdir(parents=True, exist_ok=True)
+
+    assert detect_sync_folder(vault) == provider
+
+
+def test_unknown_folder_is_not_guessed_to_be_synced(tmp_path: Path) -> None:
+    vault = tmp_path / "ordinary" / "Vault"
+    vault.mkdir(parents=True)
+    (vault.parent / "desktop.ini").write_bytes(b"not enough for OneDrive")
+
+    assert detect_sync_folder(vault) is None
+
+
+def test_onedrive_detection_requires_a_full_provider_path_segment(tmp_path: Path) -> None:
+    ordinary = tmp_path / "not-onedrive-backup" / "Vault"
+    onedrive = tmp_path / "OneDrive" / "Vault"
+    tenant = tmp_path / "OneDrive - Example Org" / "Vault"
+    ordinary.mkdir(parents=True)
+    onedrive.mkdir(parents=True)
+    tenant.mkdir(parents=True)
+
+    assert detect_sync_folder(ordinary) is None
+    assert detect_sync_folder(onedrive) == "OneDrive"
+    assert detect_sync_folder(tenant) == "OneDrive"
+
+
+def test_sync_folder_snapshot_requires_named_explicit_acknowledgement(tmp_path: Path) -> None:
+    sync_root = tmp_path / "team-files"
+    (sync_root / ".dropbox").mkdir(parents=True)
+    vault = sync_root / "Vault"
+    vault.mkdir()
+    source = vault / "external.sqlite3"
+    _create_database(source)
+    snapshot_dir = tmp_path / "snapshot"
+
+    with pytest.raises(SQLiteSnapshotError, match="Dropbox.*sync services can corrupt SQLite databases mid-write"):
+        snapshot_sqlite(source, snapshot_dir)
+    assert not snapshot_dir.exists()
+
+    snapshot_sqlite(source, snapshot_dir, acknowledged_sync_risk=True)
+    assert (snapshot_dir / MANIFEST_NAME).is_file()
+
+
+def test_concurrent_owner_write_is_reported_instead_of_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "owner.sqlite3"
+    owner = sqlite3.connect(source)
+    snapshot_dir = tmp_path / "snapshot"
+    writer_finished = threading.Event()
+    try:
+        owner.execute("PRAGMA journal_mode=WAL")
+        owner.execute("PRAGMA wal_autocheckpoint=0")
+        owner.execute("CREATE TABLE entries(id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+        owner.execute("CREATE TABLE ballast(content BLOB NOT NULL)")
+        owner.execute("INSERT INTO entries(value) VALUES ('before')")
+        owner.execute("INSERT INTO ballast(content) VALUES (zeroblob(33554432))")
+        owner.commit()
+
+        def owner_write() -> None:
+            while not (snapshot_dir / BACKUP_NAME).exists():
+                writer_finished.wait(0.001)
+            connection = sqlite3.connect(source)
+            try:
+                connection.execute("INSERT INTO entries(value) VALUES ('during')")
+                connection.commit()
+            finally:
+                connection.close()
+                writer_finished.set()
+
+        writer = threading.Thread(target=owner_write)
+        writer.start()
+        result = snapshot_sqlite(source, snapshot_dir)
+        writer.join(timeout=5)
+
+        assert writer_finished.is_set()
+        assert result.owner_activity is True
+        assert result.wal_changed is True
+        manifest = json.loads((snapshot_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+        assert manifest["owner_activity"] is True
+        assert manifest["source_changes"]["wal"] is True
+        restored = tmp_path / "restored.sqlite3"
+        restore_sqlite(snapshot_dir, restored)
+        connection = sqlite3.connect(restored)
+        try:
+            assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
+            assert connection.execute("SELECT value FROM entries ORDER BY id").fetchall() in (
+                [("before",)],
+                [("before",), ("during",)],
+            )
+        finally:
+            connection.close()
+    finally:
+        owner.close()
+
+
+def test_locked_rollback_journal_source_refuses_within_backup_deadline(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "locked.sqlite3"
+    _create_database(source)
+    owner = sqlite3.connect(source)
+    snapshot_dir = tmp_path / "snapshot"
+    finished = threading.Event()
+    outcomes: list[Exception] = []
+
+    def capture() -> None:
+        try:
+            snapshot_sqlite(source, snapshot_dir, backup_timeout_seconds=0.05)
+        except Exception as error:
+            outcomes.append(error)
+        finally:
+            finished.set()
+
+    worker = threading.Thread(target=capture, daemon=True)
+    try:
+        assert owner.execute("PRAGMA journal_mode=DELETE").fetchone() == ("delete",)
+        owner.execute("BEGIN EXCLUSIVE")
+        owner.execute("INSERT INTO entries(value) VALUES ('uncommitted')")
+
+        started = time.monotonic()
+        worker.start()
+        finished_within_bound = finished.wait(0.75)
+        elapsed = time.monotonic() - started
+    finally:
+        owner.rollback()
+        owner.close()
+        worker.join(timeout=2)
+
+    assert finished_within_bound, "snapshot_sqlite hung on an exclusively locked source"
+    assert elapsed < 0.75
+    assert len(outcomes) == 1
+    assert isinstance(outcomes[0], SQLiteSnapshotError)
+    assert "source database is busy; try again when the owning app is idle" in str(outcomes[0])
+    assert not snapshot_dir.exists()
+
+
+def test_hot_wal_without_shm_reports_benign_snapshot_created_shm(tmp_path: Path) -> None:
+    source = tmp_path / "hot-wal.sqlite3"
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                (
+                    "import os, sqlite3, sys",
+                    "connection = sqlite3.connect(sys.argv[1])",
+                    "connection.execute('PRAGMA journal_mode=WAL')",
+                    "connection.execute('PRAGMA wal_autocheckpoint=0')",
+                    "connection.execute('CREATE TABLE entries(id INTEGER PRIMARY KEY, value TEXT NOT NULL)')",
+                    "connection.execute(\"INSERT INTO entries(value) VALUES ('wal-only')\")",
+                    "connection.commit()",
+                    "os._exit(0)",
+                )
+            ),
+            str(source),
+        ],
+        check=True,
+    )
+
+    wal = Path(f"{source}-wal")
+    shm = Path(f"{source}-shm")
+    assert wal.stat().st_size > 0
+    assert shm.is_file()
+    shm.unlink()
+    assert not shm.exists()
+
+    snapshot_dir = tmp_path / "snapshot"
+    result = snapshot_sqlite(source, snapshot_dir)
+
+    assert shm.is_file()
+    assert result.shm_changed is True
+    assert result.owner_activity is False
+    manifest = json.loads((snapshot_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert manifest["source_changes"] == {
+        "database": False,
+        "shm": True,
+        "wal": False,
+    }
+
+
+def test_corrupt_manifest_refuses_without_touching_destination_or_sidecars(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+    manifest_path = snapshot_dir / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["entries"][0]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    before = destination.read_bytes()
+    wal = Path(f"{destination}-wal")
+    shm = Path(f"{destination}-shm")
+    wal.write_bytes(b"old-wal")
+    shm.write_bytes(b"old-shm")
+
+    with pytest.raises(SQLiteSnapshotError, match="do not match the manifest"):
+        restore_sqlite(snapshot_dir, destination)
+    assert destination.read_bytes() == before
+    assert wal.read_bytes() == b"old-wal"
+    assert shm.read_bytes() == b"old-shm"
+
+
+def test_corrupt_backup_refuses_without_touching_destination(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+    backup = snapshot_dir / BACKUP_NAME
+    damaged = bytearray(backup.read_bytes())
+    damaged[len(damaged) // 2] ^= 0xFF
+    backup.write_bytes(damaged)
+
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    before = destination.read_bytes()
+    with pytest.raises(SQLiteSnapshotError, match="do not match the manifest"):
+        restore_sqlite(snapshot_dir, destination)
+    assert destination.read_bytes() == before
+
+
+def test_restore_quick_check_rejects_malformed_backup_even_with_matching_manifest(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+    backup = snapshot_dir / BACKUP_NAME
+    connection = sqlite3.connect(backup)
+    try:
+        connection.execute("PRAGMA writable_schema=ON")
+        connection.execute("UPDATE sqlite_schema SET rootpage=999999 WHERE name='entries'")
+        connection.commit()
+    finally:
+        connection.close()
+    manifest_path = snapshot_dir / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["entries"][0]["sha256"] = _sha256(backup)
+    manifest["entries"][0]["size"] = backup.stat().st_size
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    before = destination.read_bytes()
+    with pytest.raises(SQLiteSnapshotError, match="restore temporary quick_check"):
+        restore_sqlite(snapshot_dir, destination)
+    assert destination.read_bytes() == before
+    assert not list(tmp_path.glob(f".{destination.name}.sqlite-restore-*"))
+
+
+def test_snapshot_quick_check_failure_deletes_partial_output(tmp_path: Path) -> None:
+    source = tmp_path / "malformed.sqlite3"
+    _create_database(source)
+    connection = sqlite3.connect(source)
+    try:
+        connection.execute("PRAGMA writable_schema=ON")
+        connection.execute("UPDATE sqlite_schema SET rootpage=999999 WHERE name='entries'")
+        connection.commit()
+    finally:
+        connection.close()
+
+    snapshot_dir = tmp_path / "snapshot"
+    with pytest.raises(SQLiteSnapshotError, match="quick_check"):
+        snapshot_sqlite(source, snapshot_dir)
+    assert not snapshot_dir.exists()
+
+
+def test_successful_restore_removes_only_old_generation_sidecars(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source, rows=4)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    wal = Path(f"{destination}-wal")
+    shm = Path(f"{destination}-shm")
+    wal.write_bytes(b"pre-restore generation")
+    shm.write_bytes(b"pre-restore generation")
+
+    restore_sqlite(snapshot_dir, destination)
+
+    assert _rows(destination) == [
+        (1, "row-0"),
+        (2, "row-1"),
+        (3, "row-2"),
+        (4, "row-3"),
+    ]
+    assert not wal.exists()
+    assert not shm.exists()
+
+
+def test_existing_snapshot_destination_is_refused_without_reusing_its_contents(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    sentinel = snapshot_dir / "belongs-to-someone-else"
+    sentinel.write_bytes(b"preserve")
+
+    with pytest.raises(SQLiteSnapshotError, match="already exists"):
+        snapshot_sqlite(source, snapshot_dir)
+    assert {path.name: path.read_bytes() for path in snapshot_dir.iterdir()} == {
+        sentinel.name: b"preserve"
+    }
+
+
+def test_sync_acknowledgement_must_be_an_actual_boolean(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source)
+
+    with pytest.raises(SQLiteSnapshotError, match="acknowledged_sync_risk must be a boolean"):
+        snapshot_sqlite(source, tmp_path / "snapshot", acknowledged_sync_risk="yes")  # type: ignore[arg-type]
+
+
+def test_failed_atomic_replace_preserves_destination_but_removes_old_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source, rows=4)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    before = destination.read_bytes()
+    wal = Path(f"{destination}-wal")
+    shm = Path(f"{destination}-shm")
+    wal.write_bytes(b"old-wal")
+    shm.write_bytes(b"old-shm")
+
+    from core.lifecycle import sqlite_snapshot as sqlite_snapshot_module
+
+    def fail_replace(source_path: Path, destination_path: Path) -> None:
+        raise OSError(f"synthetic replace failure: {source_path} -> {destination_path}")
+
+    monkeypatch.setattr(sqlite_snapshot_module.os, "replace", fail_replace)
+    with pytest.raises(SQLiteSnapshotError, match="before atomic replace"):
+        restore_sqlite(snapshot_dir, destination)
+
+    assert destination.read_bytes() == before
+    assert not wal.exists()
+    assert not shm.exists()
+    assert not list(tmp_path.glob(f".{destination.name}.sqlite-restore-*"))
+
+
+def test_restore_fsyncs_removed_sidecars_before_atomic_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    _create_database(source, rows=4)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_sqlite(source, snapshot_dir)
+    destination = tmp_path / "destination.sqlite3"
+    _create_database(destination, rows=1)
+    wal = Path(f"{destination}-wal")
+    shm = Path(f"{destination}-shm")
+    wal.write_bytes(b"old-wal")
+    shm.write_bytes(b"old-shm")
+
+    from core.lifecycle import sqlite_snapshot as sqlite_snapshot_module
+
+    real_fsync_directory = sqlite_snapshot_module._fsync_directory
+    real_replace = sqlite_snapshot_module.os.replace
+    fsynced_directories: list[Path] = []
+
+    def observe_fsync(directory: Path) -> None:
+        real_fsync_directory(directory)
+        fsynced_directories.append(directory)
+
+    def assert_ordering(source_path: Path, destination_path: Path) -> None:
+        assert not wal.exists()
+        assert not shm.exists()
+        assert fsynced_directories == [destination.parent]
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(sqlite_snapshot_module, "_fsync_directory", observe_fsync)
+    monkeypatch.setattr(sqlite_snapshot_module.os, "replace", assert_ordering)
+
+    restore_sqlite(snapshot_dir, destination)
+
+    assert _rows(destination) == [
+        (1, "row-0"),
+        (2, "row-1"),
+        (3, "row-2"),
+        (4, "row-3"),
+    ]
+    assert fsynced_directories == [destination.parent, destination.parent]


### PR DESCRIPTION
Chunk C2 of the lifecycle catalog program (spec §5). With #170, completes Phase C code.

## What
- Safe snapshots of SQLite databases (including ones owned by other apps) using SQLite's online backup API — never raw file copies. Integrity-checked, manifest-backed, fail-closed.
- Restore is crash-ordering-safe: stale WAL/SHM sidecars are removed and fsynced BEFORE the atomic replace, eliminating a silent stale-WAL replay corruption window the adversarial reviewer proved empirically.
- Backups have a deadline and refuse busy sources instead of hanging the update flow.
- Sync-folder gate: snapshotting a database inside Dropbox/iCloud/OneDrive/CloudStorage requires explicit risk acknowledgement, with honest provider labeling.

## Review trail
- Fable diff review; independent adversarial review (Opus): **SHIP-WITH-FIXES** (1 HIGH, 1 MEDIUM, 2 LOW) — all four applied and pinned by red-when-removed tests, verified by orchestrator re-run.

## Verification
- 27 tests green (orchestrator re-run); ruff clean; portable-contract gate green.

Note: branch contains C1's pre-squash commit; diff vs main shows only C2 files after #169's squash — will update-branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42