### PR TITLE
feat: tamper-evident lifecycle ledger + CLI (cathedral D1)

### DIFF
--- a/core/lifecycle/cli.py
+++ b/core/lifecycle/cli.py
@@ -1,0 +1,98 @@
+"""Inspect and verify Dex's local lifecycle ledger."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from core.lifecycle.ledger import (
+    LedgerError,
+    project_state,
+    read_events,
+    repair_state,
+)
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _non_negative(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a non-negative sequence number") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative sequence number")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m core.lifecycle.cli",
+        description="Inspect or repair Dex lifecycle history.",
+    )
+    parser.add_argument(
+        "--vault-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Dex vault root (default: current directory)",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("status", help="print the current lifecycle state as JSON")
+    events = commands.add_parser("events", help="print verified lifecycle events as JSON")
+    events.add_argument(
+        "--since",
+        type=_non_negative,
+        default=1,
+        metavar="SEQ",
+        help="include events at or after this sequence (default: 1)",
+    )
+    commands.add_parser("verify", help="verify the complete immutable event chain")
+    commands.add_parser(
+        "rebuild-state",
+        help="repair an interrupted terminal publication and rebuild the state cache",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    vault_root: Path = args.vault_root
+    try:
+        if args.command == "status":
+            print(_canonical_json(project_state(vault_root)))
+            return 0
+        if args.command == "events":
+            print(_canonical_json(read_events(vault_root, since=args.since)))
+            return 0
+        if args.command == "verify":
+            state = project_state(vault_root)
+            count = int(state["last_seq"])
+            noun = "event" if count == 1 else "events"
+            verb = "forms" if count == 1 else "form"
+            print(f"Ledger verified: {count} immutable {noun} {verb} a valid chain.")
+            return 0
+        state, repairs = repair_state(vault_root)
+        print(_canonical_json(state))
+        count = int(state["last_seq"])
+        noun = "event" if count == 1 else "events"
+        actions = [*repairs, f"rebuilt state cache from {count} {noun}"]
+        print(f"Ledger rebuild-state completed: {'; '.join(actions)}.", file=sys.stderr)
+        return 0
+    except (LedgerError, OSError) as error:
+        action = "verification" if args.command == "verify" else args.command
+        print(f"Ledger {action} failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -54,6 +54,14 @@ class AdoptionRewindError(RuntimeError):
     """An adoption rewind was refused or failed without a partial result."""
 
 
+class LifecycleLedgerPersistenceError(RuntimeError):
+    """A committed lifecycle transaction was not recorded in the ledger.
+
+    Callers must not blanket-catch this error: the filesystem transaction has
+    already committed and the user must be told how to repair its ledger.
+    """
+
+
 def _refuse(message: str) -> AdoptionExecutionError:
     return AdoptionExecutionError(f"adoption refused: {message}")
 
@@ -800,7 +808,7 @@ def rewind_adoption(
         ) from error
 
     rewind_transaction_id = result["tx_id"]
-    return RewindReceipt.from_dict(
+    rewind_receipt = RewindReceipt.from_dict(
         {
             "rewind_receipt_version": REWIND_RECEIPT_VERSION,
             "adoption_transaction_id": validated.transaction_id,
@@ -814,6 +822,21 @@ def rewind_adoption(
             "files_restored": [entry.to_dict() for entry in restored],
         }
     )
+    # Boundary: the rewind transaction is already COMMITTED.  The transaction
+    # journal is authoritative, so a later ledger failure is reported loudly
+    # but must never trigger an attempted rollback of the committed rewind.
+    try:
+        from core.lifecycle.ledger import LedgerError, record_rewind
+
+        record_rewind(root, rewind_receipt)
+    except (LedgerError, OSError) as error:
+        raise LifecycleLedgerPersistenceError(
+            f"rewind {rewind_transaction_id} committed, but its lifecycle ledger refresh "
+            f"did not complete; its event may already be durable and the transaction journal "
+            f"is authoritative: {error}. Run 'python3 -m core.lifecycle.cli --vault-root "
+            f"{root} rebuild-state' to repair the lifecycle ledger"
+        ) from error
+    return rewind_receipt
 
 
 def _rebuild_requested_plan(catalog, inventory, requested: tuple[str, ...]) -> AdoptionPlan:
@@ -995,6 +1018,24 @@ def execute_adoption(
             f"adoption {transaction_id} committed, but its receipt could not be "
             f"persisted; the transaction journal is authoritative: {error}"
         ) from error
+    # Boundary: adoption and receipt persistence are already durable.  Ledger
+    # projection is post-commit evidence; failure is loud and never rolls back
+    # the transaction whose fsynced journal remains authoritative.
+    try:
+        from core.lifecycle.ledger import LedgerError, record_adoption
+
+        record_adoption(
+            root,
+            receipt,
+            {item.item_id: item.item_version for item in rebuilt.items},
+        )
+    except (LedgerError, OSError) as error:
+        raise LifecycleLedgerPersistenceError(
+            f"adoption {transaction_id} committed, but its lifecycle ledger refresh did not "
+            f"complete; its event may already be durable and the transaction journal is "
+            f"authoritative: {error}. Run 'python3 -m core.lifecycle.cli --vault-root "
+            f"{root} rebuild-state' to repair the lifecycle ledger"
+        ) from error
     return receipt
 
 
@@ -1003,6 +1044,7 @@ __all__ = [
     "AdoptionReceipt",
     "AdoptionReceiptPersistenceError",
     "AdoptionRewindError",
+    "LifecycleLedgerPersistenceError",
     "ReceiptFile",
     "RewindReceipt",
     "RewindReceiptFile",

--- a/core/lifecycle/ledger.py
+++ b/core/lifecycle/ledger.py
@@ -1,0 +1,974 @@
+"""Immutable lifecycle events with a rebuildable local state projection.
+
+The transaction journal remains the authority for filesystem commits.  This
+ledger records lifecycle meaning after those commits: event publication never
+rewrites an existing sequence file, and a cache-write failure never alters an
+already published event.  An append-only ``commitments/<seq>.sha256`` witness
+marks publication complete, while the state cache is also a high-water mark
+against joint tail loss.  An interrupted publication is repaired only while
+holding the exclusive write lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import UUID, uuid4
+
+from core.lifecycle.engine import (
+    AdoptionExecutionError,
+    AdoptionReceipt,
+    RewindReceipt,
+)
+from core.lifecycle.model import HEX_SHA256, ITEM_ID, SEMVER
+
+LEDGER_VERSION = 1
+GENESIS_SHA256 = "0" * 64
+MAX_SEQUENCE = 99_999_999
+LEDGER_RELATIVE = Path("System") / ".dex" / "ledger"
+EVENT_TYPES = frozenset(
+    {
+        "install-registered",
+        "adoption-recorded",
+        "rewind-recorded",
+        "holdback-recorded",
+        "holdback-cleared",
+    }
+)
+EVENT_FILENAME = re.compile(
+    r"^(?P<seq>[0-9]{8})-(?P<event_type>"
+    + "|".join(sorted(EVENT_TYPES))
+    + r")\.json$"
+)
+COMMITMENT_FILENAME = re.compile(r"^(?P<seq>[0-9]{8})\.sha256$")
+EVENT_FIELDS = {
+    "ledger_version",
+    "seq",
+    "event_type",
+    "prev_event_sha256",
+    "payload",
+    "event_sha256",
+}
+STATE_FIELDS = {
+    "ledger_version",
+    "install_id",
+    "adopted",
+    "held_back",
+    "last_seq",
+    "last_event_sha256",
+}
+
+
+class LedgerError(RuntimeError):
+    """The lifecycle ledger is unsafe, invalid, or could not be updated."""
+
+
+class _UnreadableEvent(LedgerError):
+    """A byte-level parse failure that may be a torn final publication."""
+
+
+def _canonical_bytes(value: object, context: str) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise LedgerError(f"{context} cannot be serialized canonically: {error}") from error
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _ledger_paths(vault_root: Path) -> tuple[Path, Path, Path]:
+    ledger_root = Path(vault_root) / LEDGER_RELATIVE
+    return ledger_root, ledger_root / "events", ledger_root / "state.json"
+
+
+def _check_existing_directory(path: Path, context: str) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_dir()):
+        raise LedgerError(f"ledger path is unsafe at {context}: {path}")
+
+
+def _ensure_directories(vault_root: Path) -> tuple[Path, Path, Path]:
+    root = Path(vault_root)
+    _check_existing_directory(root, "vault root")
+    if not root.is_dir():
+        raise LedgerError(f"vault root does not exist: {root}")
+    ledger_root, events_dir, state_path = _ledger_paths(root)
+    parents = (root / "System", root / "System/.dex")
+    for component in parents:
+        _check_existing_directory(component, str(component.relative_to(root)))
+        component.mkdir(exist_ok=True, mode=0o700)
+    for component in (ledger_root, events_dir, ledger_root / "commitments"):
+        _check_existing_directory(component, str(component.relative_to(root)))
+        component.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(component, 0o700)
+    return ledger_root, events_dir, state_path
+
+
+def _strict_json(raw: bytes, context: str) -> object:
+    def reject_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise LedgerError(f"{context} repeats field {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(raw.decode("utf-8"), object_pairs_hook=reject_duplicates)
+    except LedgerError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _UnreadableEvent(f"{context} is unreadable or torn") from error
+
+
+def _closed_mapping(
+    raw: object,
+    *,
+    fields: set[str],
+    context: str,
+) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping) or not all(isinstance(key, str) for key in raw):
+        raise LedgerError(f"{context} must be an object with string field names")
+    missing = fields - set(raw)
+    unknown = set(raw) - fields
+    if missing:
+        raise LedgerError(f"{context} is missing fields: {', '.join(sorted(missing))}")
+    if unknown:
+        raise LedgerError(f"{context} has unknown fields: {', '.join(sorted(unknown))}")
+    return raw
+
+
+def _item_id(raw: object, context: str = "ledger item id") -> str:
+    if not isinstance(raw, str) or ITEM_ID.fullmatch(raw) is None:
+        raise LedgerError(f"{context} is not a canonical item id")
+    return raw
+
+
+def _semver(raw: object, context: str) -> str:
+    if not isinstance(raw, str) or SEMVER.fullmatch(raw) is None:
+        raise LedgerError(f"{context} is not strict SemVer")
+    return raw
+
+
+def _uuid4(raw: object) -> str:
+    text = str(raw) if isinstance(raw, UUID) else raw
+    if not isinstance(text, str):
+        raise LedgerError("install_id must be a canonical UUID4 string")
+    try:
+        value = UUID(text)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise LedgerError("install_id must be a canonical UUID4 string") from error
+    if str(value) != text or value.version != 4:
+        raise LedgerError("install_id must be a canonical UUID4 string")
+    return text
+
+
+def _validated_adoption(raw: object) -> AdoptionReceipt:
+    try:
+        document = raw.to_dict() if isinstance(raw, AdoptionReceipt) else raw
+        return AdoptionReceipt.from_dict(document)
+    except (AdoptionExecutionError, AttributeError, TypeError, ValueError) as error:
+        raise LedgerError(f"adoption receipt is invalid: {error}") from error
+
+
+def _validated_rewind(raw: object) -> RewindReceipt:
+    try:
+        document = raw.to_dict() if isinstance(raw, RewindReceipt) else raw
+        return RewindReceipt.from_dict(document)
+    except (AdoptionExecutionError, AttributeError, TypeError, ValueError) as error:
+        raise LedgerError(f"rewind receipt is invalid: {error}") from error
+
+
+def _validated_versions(
+    raw: object,
+    receipt: AdoptionReceipt,
+) -> dict[str, str]:
+    if not isinstance(raw, Mapping) or not all(isinstance(key, str) for key in raw):
+        raise LedgerError("adoption item versions must be an object")
+    if set(raw) != set(receipt.items_adopted):
+        raise LedgerError("adoption item versions must exactly match the receipt items")
+    return {
+        item_id: _semver(raw[item_id], f"adoption item {item_id} version")
+        for item_id in sorted(raw)
+    }
+
+
+def _validated_payload(event_type: str, raw: object) -> dict[str, object]:
+    if event_type == "install-registered":
+        payload = _closed_mapping(raw, fields={"install_id"}, context="install event payload")
+        return {"install_id": _uuid4(payload["install_id"])}
+    if event_type == "adoption-recorded":
+        payload = _closed_mapping(
+            raw,
+            fields={"receipt", "item_versions"},
+            context="adoption event payload",
+        )
+        receipt = _validated_adoption(payload["receipt"])
+        versions = _validated_versions(payload["item_versions"], receipt)
+        return {"receipt": receipt.to_dict(), "item_versions": versions}
+    if event_type == "rewind-recorded":
+        payload = _closed_mapping(raw, fields={"receipt"}, context="rewind event payload")
+        return {"receipt": _validated_rewind(payload["receipt"]).to_dict()}
+    if event_type in {"holdback-recorded", "holdback-cleared"}:
+        payload = _closed_mapping(raw, fields={"item_id"}, context="holdback event payload")
+        return {"item_id": _item_id(payload["item_id"])}
+    raise LedgerError(f"unknown lifecycle event type: {event_type}")
+
+
+def _event_sha256(without_sha: Mapping[str, object]) -> str:
+    return hashlib.sha256(_canonical_bytes(without_sha, "lifecycle event")).hexdigest()
+
+
+def _validate_event(path: Path, raw: bytes, expected_seq: int, expected_prev: str) -> dict[str, object]:
+    context = f"event {expected_seq} ({path.name})"
+    document = _closed_mapping(
+        _strict_json(raw, context),
+        fields=EVENT_FIELDS,
+        context=context,
+    )
+    if type(document["ledger_version"]) is not int or document["ledger_version"] != LEDGER_VERSION:
+        raise LedgerError(f"event {expected_seq} has unsupported ledger version")
+    if type(document["seq"]) is not int or document["seq"] != expected_seq:
+        raise LedgerError(f"event {expected_seq} sequence does not match its filename")
+    event_type = document["event_type"]
+    if not isinstance(event_type, str) or event_type not in EVENT_TYPES:
+        raise LedgerError(f"event {expected_seq} has an unknown event type")
+    expected_name = f"{expected_seq:08d}-{event_type}.json"
+    if path.name != expected_name:
+        raise LedgerError(f"event {expected_seq} type does not match its filename")
+    previous = document["prev_event_sha256"]
+    if not isinstance(previous, str) or HEX_SHA256.fullmatch(previous) is None:
+        raise LedgerError(f"event {expected_seq} has an invalid previous-event hash")
+    own_hash = document["event_sha256"]
+    if not isinstance(own_hash, str) or HEX_SHA256.fullmatch(own_hash) is None:
+        raise LedgerError(f"event {expected_seq} has an invalid integrity hash")
+    without_sha = {key: value for key, value in document.items() if key != "event_sha256"}
+    if own_hash != _event_sha256(without_sha):
+        raise LedgerError(f"event {expected_seq} fails its integrity hash")
+    if raw != _canonical_bytes(document, context):
+        raise LedgerError(f"event {expected_seq} is valid JSON but not canonical")
+    if previous != expected_prev:
+        raise LedgerError(
+            f"event {expected_seq} breaks the hash chain: expected {expected_prev}, found {previous}"
+        )
+    payload = _validated_payload(event_type, document["payload"])
+    if payload != document["payload"]:
+        raise LedgerError(f"event {expected_seq} payload is not canonical")
+    return dict(document)
+
+
+def _event_candidates(events_dir: Path) -> list[tuple[int, Path]]:
+    if events_dir.is_symlink():
+        raise LedgerError(f"ledger events path is unsafe: {events_dir}")
+    if not events_dir.exists():
+        return []
+    _check_existing_directory(events_dir, "events")
+    candidates: list[tuple[int, Path]] = []
+    seen: dict[int, Path] = {}
+    for path in events_dir.iterdir():
+        match = EVENT_FILENAME.fullmatch(path.name)
+        if match is None:
+            raise LedgerError(f"events directory contains an unexpected entry: {path.name}")
+        sequence = int(match.group("seq"))
+        if sequence in seen:
+            raise LedgerError(
+                f"ledger fork at sequence {sequence}: {seen[sequence].name}, {path.name}"
+            )
+        if path.is_symlink() or not path.is_file():
+            raise LedgerError(f"event {sequence} is missing or unsafe: {path}")
+        seen[sequence] = path
+        candidates.append((sequence, path))
+    candidates.sort(key=lambda candidate: candidate[0])
+    for expected, (sequence, _path) in enumerate(candidates, start=1):
+        if sequence != expected:
+            raise LedgerError(
+                f"ledger sequence gap: expected {expected}, found {sequence}; history is missing"
+            )
+    return candidates
+
+
+def _repair_command(vault_root: Path) -> str:
+    return f"python3 -m core.lifecycle.cli --vault-root {Path(vault_root)} rebuild-state"
+
+
+def _quarantine_torn_event(vault_root: Path, path: Path) -> Path:
+    ledger_root, _events_dir, _state_path = _ensure_directories(vault_root)
+    quarantine = ledger_root / "quarantine"
+    _check_existing_directory(quarantine, "quarantine")
+    quarantine.mkdir(exist_ok=True, mode=0o700)
+    os.chmod(quarantine, 0o700)
+    target = quarantine / f"{path.name}.torn"
+    suffix = 1
+    while target.exists():
+        target = quarantine / f"{path.name}.torn-{suffix}"
+        suffix += 1
+    os.rename(path, target)
+    _fsync_directory(path.parent)
+    _fsync_directory(quarantine)
+    return target
+
+
+def _complete_commitment(vault_root: Path, sequence: int, digest: str) -> None:
+    ledger_root, _events_dir, _state_path = _ensure_directories(vault_root)
+    commitment_directory = ledger_root / "commitments"
+    target = commitment_directory / f"{sequence:08d}.sha256"
+    data = f"{digest}\n".encode("ascii")
+    if target.exists():
+        if target.is_symlink() or not target.is_file() or target.read_bytes() != data:
+            raise LedgerError(
+                f"existing lifecycle commitment sequence {sequence} disagrees with event"
+            )
+        return
+    temporary = ledger_root / f".commitment.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        view = memoryview(data)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        try:
+            os.link(temporary, target)
+        except FileExistsError:
+            if target.is_symlink() or not target.is_file() or target.read_bytes() != data:
+                raise LedgerError(
+                    f"existing lifecycle commitment sequence {sequence} disagrees with event"
+                )
+        _fsync_directory(commitment_directory)
+        temporary.unlink()
+        _fsync_directory(ledger_root)
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _commitments(vault_root: Path) -> list[tuple[int, str]]:
+    ledger_root, _events_dir, _state_path = _ledger_paths(vault_root)
+    directory = ledger_root / "commitments"
+    if directory.is_symlink():
+        raise LedgerError(f"ledger commitments path is unsafe: {directory}")
+    if not directory.exists():
+        return []
+    _check_existing_directory(directory, "commitments")
+    commitments: list[tuple[int, str]] = []
+    for path in directory.iterdir():
+        match = COMMITMENT_FILENAME.fullmatch(path.name)
+        if match is None:
+            raise LedgerError(f"commitments directory contains an unexpected entry: {path.name}")
+        sequence = int(match.group("seq"))
+        if path.is_symlink() or not path.is_file():
+            raise LedgerError(f"commitment {sequence} is missing or unsafe: {path}")
+        try:
+            raw = path.read_bytes()
+        except OSError as error:
+            raise LedgerError(f"commitment {sequence} could not be read: {error}") from error
+        try:
+            digest = raw.decode("ascii").removesuffix("\n")
+        except UnicodeDecodeError as error:
+            raise LedgerError(f"commitment {sequence} is unreadable") from error
+        if raw != f"{digest}\n".encode("ascii") or HEX_SHA256.fullmatch(digest) is None:
+            raise LedgerError(f"commitment {sequence} is not a canonical sha256 record")
+        commitments.append((sequence, digest))
+    commitments.sort(key=lambda entry: entry[0])
+    for expected, (sequence, _digest) in enumerate(commitments, start=1):
+        if sequence != expected:
+            raise LedgerError(
+                f"ledger commitment gap: expected {expected}, found {sequence}; history is missing"
+            )
+    return commitments
+
+
+def _existing_state_floor(vault_root: Path) -> dict[str, object] | None:
+    _ledger_root, _events_dir, state_path = _ledger_paths(vault_root)
+    if not state_path.exists():
+        return None
+    if state_path.is_symlink() or not state_path.is_file():
+        raise LedgerError(f"ledger state path is unsafe: {state_path}")
+    try:
+        raw = state_path.read_bytes()
+        state = _validate_state_document(_strict_json(raw, "ledger state"))
+        if raw != canonical_state_bytes(state):
+            return None
+        return state
+    except LedgerError:
+        return None
+    except OSError as error:
+        raise LedgerError(f"ledger state could not be read: {error}") from error
+
+
+def _enforce_state_floor(vault_root: Path, events: list[dict[str, object]]) -> None:
+    floor = _existing_state_floor(vault_root)
+    if floor is None:
+        return
+    floor_seq = int(floor["last_seq"])
+    if len(events) < floor_seq:
+        raise LedgerError(
+            f"possible ledger tail loss: verified history ends at sequence {len(events)}, but "
+            f"valid state.json reached sequence {floor_seq}; backup/sync may have dropped the "
+            "newest event and commitment files. Restore the missing files from backup/sync "
+            f"before retrying {_repair_command(vault_root)!r}"
+        )
+    actual_hash = GENESIS_SHA256 if floor_seq == 0 else str(events[floor_seq - 1]["event_sha256"])
+    if actual_hash != floor["last_event_sha256"]:
+        raise LedgerError(
+            f"possible ledger tail loss or history replacement at state.json sequence {floor_seq}: "
+            "the verified event hash differs from the surviving high-water mark. Restore the "
+            f"ledger from backup/sync before retrying {_repair_command(vault_root)!r}"
+        )
+
+
+def _load_events(
+    vault_root: Path,
+    *,
+    repair_terminal_publication: bool,
+    quarantine_unreadable: bool = False,
+    repair_actions: list[str] | None = None,
+) -> list[dict[str, object]]:
+    _ledger_root, events_dir, _state_path = _ledger_paths(vault_root)
+    candidates = _event_candidates(events_dir)
+    commitments = _commitments(vault_root)
+    if len(candidates) < len(commitments):
+        raise LedgerError(
+            f"ledger is missing event file for committed sequence {len(candidates) + 1}"
+        )
+    uncommitted: tuple[int, Path] | None = None
+    if len(candidates) > len(commitments):
+        uncommitted = candidates[len(commitments)]
+        if len(candidates) != len(commitments) + 1:
+            raise LedgerError(
+                f"ledger has multiple uncommitted event files beginning at sequence "
+                f"{uncommitted[0]}"
+            )
+        candidates = candidates[: len(commitments)]
+    events: list[dict[str, object]] = []
+    previous = GENESIS_SHA256
+    for (sequence, path), (committed_sequence, committed_hash) in zip(
+        candidates, commitments, strict=True
+    ):
+        if sequence != committed_sequence:
+            raise LedgerError(
+                f"event and commitment sequences disagree at {sequence} and {committed_sequence}"
+            )
+        try:
+            event = _validate_event(path, path.read_bytes(), sequence, previous)
+        except OSError as error:
+            raise LedgerError(f"event {sequence} could not be read: {error}") from error
+        if event["event_sha256"] != committed_hash:
+            raise LedgerError(f"event {sequence} disagrees with its immutable commitment")
+        events.append(event)
+        previous = str(event["event_sha256"])
+    if uncommitted is not None:
+        sequence, path = uncommitted
+        try:
+            raw = path.read_bytes()
+            event = _validate_event(path, raw, sequence, previous)
+        except _UnreadableEvent as error:
+            if not quarantine_unreadable:
+                raise LedgerError(
+                    f"event {sequence} publication is incomplete and its event file is unreadable "
+                    f"or torn; run {_repair_command(vault_root)!r} to quarantine it and rebuild state"
+                ) from error
+            _enforce_state_floor(vault_root, events)
+            _quarantine_torn_event(vault_root, path)
+            if repair_actions is not None:
+                repair_actions.append(f"quarantined unreadable torn event {sequence}")
+        except OSError as error:
+            raise LedgerError(f"event {sequence} could not be read: {error}") from error
+        else:
+            if not repair_terminal_publication:
+                raise LedgerError(
+                    f"event {sequence} publication is incomplete: the valid event has no "
+                    f"commitment; run {_repair_command(vault_root)!r} to complete publication"
+                )
+            _enforce_state_floor(vault_root, [*events, event])
+            _complete_commitment(vault_root, sequence, str(event["event_sha256"]))
+            events.append(event)
+            if repair_actions is not None:
+                repair_actions.append(
+                    f"completed publication commitment for valid event {sequence}"
+                )
+    _enforce_state_floor(vault_root, events)
+    return events
+
+
+def _empty_state() -> dict[str, object]:
+    return {
+        "ledger_version": LEDGER_VERSION,
+        "install_id": None,
+        "adopted": {},
+        "held_back": [],
+        "last_seq": 0,
+        "last_event_sha256": GENESIS_SHA256,
+    }
+
+
+def _project(events: list[dict[str, object]]) -> dict[str, object]:
+    state = _empty_state()
+    adopted: dict[str, dict[str, str]] = {}
+    held_back: set[str] = set()
+    for event in events:
+        event_type = str(event["event_type"])
+        payload = event["payload"]
+        assert isinstance(payload, dict)
+        if event_type == "install-registered":
+            if state["install_id"] is not None:
+                raise LedgerError(f"event {event['seq']} attempts to re-register the install")
+            state["install_id"] = payload["install_id"]
+        elif event_type == "adoption-recorded":
+            receipt = _validated_adoption(payload["receipt"])
+            versions = _validated_versions(payload["item_versions"], receipt)
+            for item_id in receipt.items_adopted:
+                adopted[item_id] = {
+                    "version": versions[item_id],
+                    "tx_id": receipt.transaction_id,
+                    "receipt_path": (
+                        f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json"
+                    ),
+                }
+        elif event_type == "rewind-recorded":
+            receipt = _validated_rewind(payload["receipt"])
+            item_ids = {entry.item_id for entry in receipt.files_restored}
+            for item_id in sorted(item_ids):
+                current = adopted.get(item_id)
+                if current is None:
+                    continue
+                if current["tx_id"] != receipt.adoption_transaction_id:
+                    raise LedgerError(
+                        f"event {event['seq']} rewinds item {item_id} without its matching current adoption"
+                    )
+                del adopted[item_id]
+        elif event_type == "holdback-recorded":
+            held_back.add(str(payload["item_id"]))
+        elif event_type == "holdback-cleared":
+            item_id = str(payload["item_id"])
+            if item_id not in held_back:
+                raise LedgerError(
+                    f"event {event['seq']} clears item {item_id}, but it is not held back"
+                )
+            held_back.remove(item_id)
+        state["last_seq"] = event["seq"]
+        state["last_event_sha256"] = event["event_sha256"]
+    state["adopted"] = {key: adopted[key] for key in sorted(adopted)}
+    state["held_back"] = sorted(held_back)
+    return state
+
+
+def _validate_state_document(raw: object) -> dict[str, object]:
+    state = _closed_mapping(raw, fields=STATE_FIELDS, context="ledger state")
+    if type(state["ledger_version"]) is not int or state["ledger_version"] != LEDGER_VERSION:
+        raise LedgerError("ledger state has unsupported version")
+    install_id = state["install_id"]
+    if install_id is not None:
+        install_id = _uuid4(install_id)
+    last_seq = state["last_seq"]
+    if type(last_seq) is not int or last_seq < 0:
+        raise LedgerError("ledger state last_seq must be a non-negative integer")
+    last_hash = state["last_event_sha256"]
+    if not isinstance(last_hash, str) or HEX_SHA256.fullmatch(last_hash) is None:
+        raise LedgerError("ledger state last_event_sha256 is invalid")
+    adopted_raw = state["adopted"]
+    if not isinstance(adopted_raw, Mapping) or not all(isinstance(key, str) for key in adopted_raw):
+        raise LedgerError("ledger state adopted must be an object")
+    adopted: dict[str, dict[str, str]] = {}
+    for item_id in sorted(adopted_raw):
+        _item_id(item_id, "ledger state adopted item id")
+        entry = _closed_mapping(
+            adopted_raw[item_id],
+            fields={"version", "tx_id", "receipt_path"},
+            context=f"ledger state adopted item {item_id}",
+        )
+        version = _semver(entry["version"], f"ledger state adopted item {item_id} version")
+        tx_id = entry["tx_id"]
+        receipt_path = entry["receipt_path"]
+        if not isinstance(tx_id, str) or not isinstance(receipt_path, str):
+            raise LedgerError(f"ledger state adopted item {item_id} has invalid receipt fields")
+        if receipt_path != f"System/.dex/adoptions/{tx_id}.receipt.json":
+            raise LedgerError(f"ledger state adopted item {item_id} has a mismatched receipt path")
+        adopted[item_id] = {"version": version, "tx_id": tx_id, "receipt_path": receipt_path}
+    held_raw = state["held_back"]
+    if not isinstance(held_raw, list):
+        raise LedgerError("ledger state held_back must be an array")
+    held = [_item_id(item_id, "ledger state held-back item id") for item_id in held_raw]
+    if held != sorted(set(held)):
+        raise LedgerError("ledger state held_back must be sorted and unique")
+    if last_seq == 0 and last_hash != GENESIS_SHA256:
+        raise LedgerError("empty ledger state must use the genesis hash")
+    return {
+        "ledger_version": LEDGER_VERSION,
+        "install_id": install_id,
+        "adopted": adopted,
+        "held_back": held,
+        "last_seq": last_seq,
+        "last_event_sha256": last_hash,
+    }
+
+
+def canonical_state_bytes(state: object) -> bytes:
+    """Canonical bytes for the rebuildable state cache."""
+    return _canonical_bytes(_validate_state_document(state), "ledger state")
+
+
+def _project_state_unlocked(vault_root: Path) -> dict[str, object]:
+    return _project(_load_events(vault_root, repair_terminal_publication=False))
+
+
+def project_state(vault_root: Path) -> dict[str, object]:
+    """Verify and replay a shared-lock-consistent snapshot without writes."""
+    with _read_lock(vault_root):
+        return _project_state_unlocked(vault_root)
+
+
+def _write_state(vault_root: Path, state: dict[str, object]) -> None:
+    ledger_root, _events_dir, state_path = _ensure_directories(vault_root)
+    data = canonical_state_bytes(state)
+    temporary = ledger_root / f".state.json.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        view = memoryview(data)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary, state_path)
+        os.chmod(state_path, 0o600)
+        _fsync_directory(ledger_root)
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _rebuild_state_unlocked(
+    vault_root: Path, repair_actions: list[str] | None = None
+) -> dict[str, object]:
+    projected = _project(
+        _load_events(
+            vault_root,
+            repair_terminal_publication=True,
+            quarantine_unreadable=True,
+            repair_actions=repair_actions,
+        )
+    )
+    _write_state(vault_root, projected)
+    return projected
+
+
+def rebuild_state(vault_root: Path) -> dict[str, object]:
+    """Serialize with writers, verify history, and regenerate the state cache."""
+    with _write_lock(vault_root):
+        return _rebuild_state_unlocked(vault_root)
+
+
+def repair_state(vault_root: Path) -> tuple[dict[str, object], tuple[str, ...]]:
+    """Repair an interrupted tail and rebuild state under the exclusive lock."""
+    with _write_lock(vault_root):
+        actions: list[str] = []
+        state = _rebuild_state_unlocked(vault_root, actions)
+        return state, tuple(actions)
+
+
+def rebuild_state_cache(vault_root: Path) -> dict[str, object]:
+    """Regenerate only state.json; never quarantine or otherwise alter events."""
+    with _write_lock(vault_root):
+        projected = _project_state_unlocked(vault_root)
+        _write_state(vault_root, projected)
+        return projected
+
+
+def read_events(vault_root: Path, *, since: int = 1) -> list[dict[str, object]]:
+    """Return verified immutable events at or after ``since`` without writes."""
+    if type(since) is not int or since < 0:
+        raise LedgerError("event --since sequence must be a non-negative integer")
+    with _read_lock(vault_root):
+        events = _load_events(vault_root, repair_terminal_publication=False)
+        _project(events)
+        return [event for event in events if int(event["seq"]) >= since]
+
+
+def _open_lock(path: Path, *, create: bool) -> int:
+    if path.is_symlink():
+        raise LedgerError(f"ledger lock path is unsafe: {path}")
+    flags = os.O_RDONLY
+    if create:
+        flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise LedgerError(f"ledger lock path is unsafe or unavailable: {path}: {error}") from error
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        os.close(descriptor)
+        raise LedgerError(f"ledger lock path is unsafe: {path}")
+    return descriptor
+
+
+@contextmanager
+def _read_lock(vault_root: Path) -> Iterator[None]:
+    ledger_root, _events_dir, _state_path = _ledger_paths(vault_root)
+    if ledger_root.is_symlink():
+        raise LedgerError(f"ledger path is unsafe: {ledger_root}")
+    if not ledger_root.exists():
+        yield
+        return
+    _check_existing_directory(ledger_root, "ledger")
+    lock_path = ledger_root / ".write.lock"
+    if lock_path.is_symlink():
+        raise LedgerError(f"ledger lock path is unsafe: {lock_path}")
+    if not lock_path.exists():
+        events_exist = (ledger_root / "events").exists()
+        commitments_exist = (ledger_root / "commitments").exists()
+        if events_exist or commitments_exist:
+            raise LedgerError(f"ledger lock file is missing: {lock_path}")
+        yield
+        return
+    descriptor = _open_lock(lock_path, create=False)
+    try:
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_SH)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+@contextmanager
+def _write_lock(vault_root: Path) -> Iterator[None]:
+    import fcntl
+
+    ledger_root, _events_dir, _state_path = _ensure_directories(vault_root)
+    lock_path = ledger_root / ".write.lock"
+    descriptor = _open_lock(lock_path, create=True)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _publish_event(vault_root: Path, event_type: str, payload: dict[str, object]) -> None:
+    ledger_root, events_dir, _state_path = _ensure_directories(vault_root)
+    events = _load_events(vault_root, repair_terminal_publication=True)
+    _project(events)
+    last_sequence = int(events[-1]["seq"]) if events else 0
+    if last_sequence >= MAX_SEQUENCE:
+        raise LedgerError(
+            f"lifecycle ledger sequence maximum {MAX_SEQUENCE:,} reached; refusing to append"
+        )
+    sequence = last_sequence + 1
+    previous = str(events[-1]["event_sha256"]) if events else GENESIS_SHA256
+    without_sha: dict[str, object] = {
+        "ledger_version": LEDGER_VERSION,
+        "seq": sequence,
+        "event_type": event_type,
+        "prev_event_sha256": previous,
+        "payload": payload,
+    }
+    event = {**without_sha, "event_sha256": _event_sha256(without_sha)}
+    data = _canonical_bytes(event, f"event {sequence}")
+    target = events_dir / f"{sequence:08d}-{event_type}.json"
+    temporary = ledger_root / f".event.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        view = memoryview(data)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        try:
+            os.link(temporary, target)
+        except FileExistsError as error:
+            raise LedgerError(
+                f"refusing to rewrite existing lifecycle event sequence {sequence}: {target.name}"
+            ) from error
+        _fsync_directory(events_dir)
+        temporary.unlink()
+        _fsync_directory(ledger_root)
+        commitment_directory = ledger_root / "commitments"
+        commitment_target = commitment_directory / f"{sequence:08d}.sha256"
+        commitment_temporary = (
+            ledger_root / f".commitment.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+        )
+        commitment_data = f"{event['event_sha256']}\n".encode("ascii")
+        commitment_descriptor: int | None = None
+        try:
+            commitment_descriptor = os.open(
+                commitment_temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            view = memoryview(commitment_data)
+            while view:
+                view = view[os.write(commitment_descriptor, view) :]
+            os.fsync(commitment_descriptor)
+            os.close(commitment_descriptor)
+            commitment_descriptor = None
+            try:
+                os.link(commitment_temporary, commitment_target)
+            except FileExistsError as error:
+                raise LedgerError(
+                    f"refusing to rewrite existing lifecycle commitment sequence {sequence}"
+                ) from error
+            _fsync_directory(commitment_directory)
+            commitment_temporary.unlink()
+            _fsync_directory(ledger_root)
+        except BaseException:
+            if commitment_descriptor is not None:
+                os.close(commitment_descriptor)
+            try:
+                commitment_temporary.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _record(vault_root: Path, event_type: str, payload: dict[str, object]) -> dict[str, object]:
+    validated_payload = _validated_payload(event_type, payload)
+    with _write_lock(vault_root):
+        events = _load_events(vault_root, repair_terminal_publication=True)
+        current = _project(events)
+        if event_type != "install-registered" and current["install_id"] is None:
+            _publish_event(
+                vault_root,
+                "install-registered",
+                {"install_id": str(uuid4())},
+            )
+            events = _load_events(vault_root, repair_terminal_publication=True)
+            current = _project(events)
+        if event_type == "install-registered" and current["install_id"] is not None:
+            raise LedgerError(f"install is already registered as {current['install_id']}")
+        if event_type == "holdback-cleared" and validated_payload["item_id"] not in current["held_back"]:
+            raise LedgerError(f"item {validated_payload['item_id']} is not currently held back")
+        if event_type == "rewind-recorded":
+            rewind = _validated_rewind(validated_payload["receipt"])
+            item_ids = {entry.item_id for entry in rewind.files_restored}
+            adopted = current["adopted"]
+            assert isinstance(adopted, dict)
+            if any(
+                item_id in adopted
+                and adopted[item_id]["tx_id"] != rewind.adoption_transaction_id
+                for item_id in item_ids
+            ):
+                raise LedgerError("rewind receipt conflicts with a newer currently adopted item")
+        transaction_id: str | None = None
+        if event_type == "adoption-recorded":
+            transaction_id = _validated_adoption(validated_payload["receipt"]).transaction_id
+            id_field = "transaction_id"
+        elif event_type == "rewind-recorded":
+            transaction_id = _validated_rewind(validated_payload["receipt"]).rewind_transaction_id
+            id_field = "rewind_transaction_id"
+        if transaction_id is not None:
+            for event in events:
+                if event["event_type"] != event_type:
+                    continue
+                receipt = event["payload"]["receipt"]
+                assert isinstance(receipt, dict)
+                if receipt[id_field] != transaction_id:
+                    continue
+                if event["payload"] != validated_payload:
+                    raise LedgerError(
+                        f"lifecycle transaction id {transaction_id} is already recorded "
+                        "with different evidence"
+                    )
+                _write_state(vault_root, current)
+                return current
+        _publish_event(vault_root, event_type, validated_payload)
+        return _rebuild_state_unlocked(vault_root)
+
+
+def register_install(vault_root: Path, install_id: UUID | str) -> dict[str, object]:
+    return _record(vault_root, "install-registered", {"install_id": _uuid4(install_id)})
+
+
+def record_adoption(
+    vault_root: Path,
+    receipt: AdoptionReceipt | object,
+    item_versions: Mapping[str, str] | object,
+) -> dict[str, object]:
+    validated = _validated_adoption(receipt)
+    versions = _validated_versions(item_versions, validated)
+    return _record(
+        vault_root,
+        "adoption-recorded",
+        {"receipt": validated.to_dict(), "item_versions": versions},
+    )
+
+
+def record_rewind(vault_root: Path, receipt: RewindReceipt | object) -> dict[str, object]:
+    validated = _validated_rewind(receipt)
+    return _record(vault_root, "rewind-recorded", {"receipt": validated.to_dict()})
+
+
+def record_holdback(vault_root: Path, item_id: str) -> dict[str, object]:
+    return _record(vault_root, "holdback-recorded", {"item_id": _item_id(item_id)})
+
+
+def clear_holdback(vault_root: Path, item_id: str) -> dict[str, object]:
+    return _record(vault_root, "holdback-cleared", {"item_id": _item_id(item_id)})
+
+
+__all__ = [
+    "EVENT_TYPES",
+    "GENESIS_SHA256",
+    "LEDGER_VERSION",
+    "MAX_SEQUENCE",
+    "LedgerError",
+    "canonical_state_bytes",
+    "clear_holdback",
+    "project_state",
+    "read_events",
+    "rebuild_state",
+    "rebuild_state_cache",
+    "repair_state",
+    "record_adoption",
+    "record_holdback",
+    "record_rewind",
+    "register_install",
+]

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -265,6 +265,8 @@ RULES: tuple[Rule, ...] = (
        "legacy-tracked runtime marker"),
     _r("runtime-adoption-receipts", "System/.dex/adoptions", "dir", "runtime",
        "post-commit lifecycle receipts; local runtime evidence, never shipped"),
+    _r("runtime-lifecycle-ledger", "System/.dex/ledger", "dir", "runtime",
+       "immutable local lifecycle events and rebuildable state; never shipped or updated"),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),

--- a/core/tests/test_adoption_cli.py
+++ b/core/tests/test_adoption_cli.py
@@ -1,0 +1,174 @@
+"""D1 lifecycle-ledger command-line behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from core.lifecycle.cli import main
+from core.lifecycle.ledger import record_holdback, register_install
+
+
+def _new_vault(path: Path) -> Path:
+    path.mkdir()
+    return path
+
+
+def test_status_prints_canonical_state_json_without_writing_cache(
+    tmp_path: Path, capsys
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_path.unlink()
+
+    assert main(["--vault-root", str(vault), "status"]) == 0
+
+    output = capsys.readouterr()
+    document = json.loads(output.out)
+    assert document == {
+        "adopted": {},
+        "held_back": [],
+        "install_id": "12345678-1234-4678-9234-567812345678",
+        "last_event_sha256": document["last_event_sha256"],
+        "last_seq": 1,
+        "ledger_version": 1,
+    }
+    assert output.out == json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n"
+    assert output.err == ""
+    assert not state_path.exists()
+
+
+def test_events_lists_canonical_json_since_sequence(tmp_path: Path, capsys) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+
+    assert main(["--vault-root", str(vault), "events", "--since", "2"]) == 0
+
+    output = capsys.readouterr()
+    events = json.loads(output.out)
+    assert len(events) == 1
+    assert events[0]["seq"] == 2
+    assert events[0]["event_type"] == "holdback-recorded"
+    assert output.out == json.dumps(events, sort_keys=True, separators=(",", ":")) + "\n"
+    assert output.err == ""
+
+
+def test_verify_is_read_only_and_reports_plain_success(tmp_path: Path, capsys) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_path.unlink()
+
+    assert main(["--vault-root", str(vault), "verify"]) == 0
+
+    output = capsys.readouterr()
+    assert output.out == "Ledger verified: 1 immutable event forms a valid chain.\n"
+    assert output.err == ""
+    assert not state_path.exists()
+
+
+def test_verify_returns_one_and_precise_message_for_tampering(tmp_path: Path, capsys) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event = next((vault / "System/.dex/ledger/events").glob("*.json"))
+    event.write_bytes(event.read_bytes().replace(b'"ledger_version":1', b'"ledger_version":2'))
+
+    assert main(["--vault-root", str(vault), "verify"]) == 1
+
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert output.err.startswith("Ledger verification failed: event 1 ")
+
+
+def test_rebuild_state_regenerates_the_cache_and_reports_action(tmp_path: Path, capsys) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event = next((vault / "System/.dex/ledger/events").glob("*.json"))
+    event_before = event.read_bytes()
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_path.unlink()
+
+    assert main(["--vault-root", str(vault), "rebuild-state"]) == 0
+
+    output = capsys.readouterr()
+    state = json.loads(output.out)
+    assert state_path.read_bytes() == output.out.encode()
+    assert state["last_seq"] == 1
+    assert event.read_bytes() == event_before
+    assert output.err == "Ledger rebuild-state completed: rebuilt state cache from 1 event.\n"
+
+
+def test_rebuild_state_quarantines_torn_tail_and_reports_repair(tmp_path: Path, capsys) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    torn = vault / "System/.dex/ledger/events/00000002-holdback-recorded.json"
+    torn.write_bytes(b"{")
+
+    assert main(["--vault-root", str(vault), "rebuild-state"]) == 0
+
+    output = capsys.readouterr()
+    assert json.loads(output.out)["last_seq"] == 1
+    assert "quarantined unreadable torn event 2" in output.err
+    assert not torn.exists()
+    quarantined = list((vault / "System/.dex/ledger/quarantine").iterdir())
+    assert len(quarantined) == 1
+    assert quarantined[0].name.startswith(torn.name + ".torn")
+
+
+def test_rebuild_state_completes_valid_terminal_commitment_and_reports_repair(
+    tmp_path: Path, capsys
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event = next((vault / "System/.dex/ledger/events").glob("*.json"))
+    event_before = event.read_bytes()
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.unlink()
+
+    assert main(["--vault-root", str(vault), "rebuild-state"]) == 0
+
+    output = capsys.readouterr()
+    assert json.loads(output.out)["last_seq"] == 1
+    assert "completed publication commitment for valid event 1" in output.err
+    assert event.read_bytes() == event_before
+    assert commitment.read_text(encoding="ascii") == json.loads(event_before)["event_sha256"] + "\n"
+
+
+@pytest.mark.parametrize("command", ["status", "verify", "events"])
+def test_read_only_commands_report_incomplete_publication_without_mutating(
+    tmp_path: Path, capsys, command: str
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event = next((vault / "System/.dex/ledger/events").glob("*.json"))
+    event_before = event.read_bytes()
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_before = state_path.read_bytes()
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.unlink()
+
+    assert main(["--vault-root", str(vault), command]) == 1
+
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert "publication is incomplete" in output.err
+    assert f"python3 -m core.lifecycle.cli --vault-root {vault} rebuild-state" in output.err
+    assert event.read_bytes() == event_before
+    assert state_path.read_bytes() == state_before
+    assert not commitment.exists()
+
+
+def test_cli_rejects_negative_since_with_argparse_exit_two(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+
+    try:
+        main(["--vault-root", str(vault), "events", "--since", "-1"])
+    except SystemExit as error:
+        assert error.code == 2
+    else:
+        raise AssertionError("negative --since must be rejected")

--- a/core/tests/test_adoption_ledger.py
+++ b/core/tests/test_adoption_ledger.py
@@ -1,0 +1,644 @@
+"""D1 lifecycle ledger: immutable history and rebuildable state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import threading
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle import ledger as ledger_module
+from core.lifecycle.engine import (
+    AdoptionReceipt,
+    LifecycleLedgerPersistenceError,
+    RewindReceipt,
+    RewindReceiptFile,
+    execute_adoption,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.ledger import (
+    GENESIS_SHA256,
+    LedgerError,
+    canonical_state_bytes,
+    clear_holdback,
+    project_state,
+    read_events,
+    rebuild_state,
+    record_adoption,
+    record_holdback,
+    record_rewind,
+    register_install,
+)
+from core.tests.test_adoption_rewind import CREATED_PATH, EXISTING_PATH, OLD, _committed_adoption
+from core.tests.test_adoption_transaction import _preview
+
+
+def _adoption_receipt(
+    *,
+    tx_id: str = "20260721T120000-00000001",
+    items: tuple[str, ...] = ("alpha",),
+) -> AdoptionReceipt:
+    return AdoptionReceipt.from_dict(
+        {
+            "receipt_version": 1,
+            "items_adopted": list(items),
+            "files_written": [
+                {
+                    "item_id": item_id,
+                    "path": f".claude/skills/{item_id}/SKILL.md",
+                    "sha256": hashlib.sha256(item_id.encode()).hexdigest(),
+                    "byte_size": len(item_id),
+                }
+                for item_id in items
+            ],
+            "transaction_id": tx_id,
+            "snapshot_ref": f"System/.dex/tx/{tx_id}/snapshot",
+            "catalog_sha256": "a" * 64,
+            "inventory_sha256": "b" * 64,
+            "preview_sha256": "c" * 64,
+        }
+    )
+
+
+def _rewind_receipt(receipt: AdoptionReceipt) -> RewindReceipt:
+    rewind_tx = "20260721T120001-00000002"
+    return RewindReceipt(
+        1,
+        receipt.transaction_id,
+        rewind_tx,
+        f"System/.dex/tx/{rewind_tx}/snapshot",
+        hashlib.sha256(
+            (json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")) + "\n").encode()
+        ).hexdigest(),
+        tuple(
+            RewindReceiptFile(item_id, f".claude/skills/{item_id}/SKILL.md", False, None, None, None)
+            for item_id in receipt.items_adopted
+        ),
+    )
+
+
+def _event_files(vault: Path) -> list[Path]:
+    return sorted((vault / "System/.dex/ledger/events").glob("*.json"))
+
+
+def _new_vault(path: Path) -> Path:
+    path.mkdir()
+    return path
+
+
+def test_events_are_canonical_self_hashed_and_hash_chained(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    install_id = UUID("12345678-1234-4678-9234-567812345678")
+
+    register_install(vault, install_id)
+    record_holdback(vault, "alpha")
+    clear_holdback(vault, "alpha")
+
+    events = read_events(vault)
+    assert [event["seq"] for event in events] == [1, 2, 3]
+    assert [event["event_type"] for event in events] == [
+        "install-registered",
+        "holdback-recorded",
+        "holdback-cleared",
+    ]
+    assert events[0]["prev_event_sha256"] == GENESIS_SHA256
+    assert events[1]["prev_event_sha256"] == events[0]["event_sha256"]
+    assert events[2]["prev_event_sha256"] == events[1]["event_sha256"]
+    for path, event in zip(_event_files(vault), events, strict=True):
+        assert path.name == f"{event['seq']:08d}-{event['event_type']}.json"
+        assert path.read_bytes().endswith(b"\n")
+        assert json.loads(path.read_bytes()) == event
+
+
+def test_ledger_setup_does_not_change_parent_directory_permissions(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    system = vault / "System"
+    dex = system / ".dex"
+    dex.mkdir(parents=True)
+    os.chmod(system, 0o755)
+    os.chmod(dex, 0o750)
+
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+
+    assert stat.S_IMODE(system.stat().st_mode) == 0o755
+    assert stat.S_IMODE(dex.stat().st_mode) == 0o750
+
+
+@pytest.mark.parametrize("event_index", [0, 1, 2])
+def test_mutating_any_historical_event_fails_closed(tmp_path: Path, event_index: int) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+    clear_holdback(vault, "alpha")
+    target = _event_files(vault)[event_index]
+    raw = target.read_bytes()
+    target.write_bytes(raw.replace(b'"ledger_version":1', b'"ledger_version":9', 1))
+
+    with pytest.raises(LedgerError, match=r"event .*integrity hash|unsupported ledger version"):
+        rebuild_state(vault)
+
+
+@pytest.mark.parametrize("event_index", [0, 1, 2])
+def test_deleting_any_historical_event_fails_closed(tmp_path: Path, event_index: int) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+    clear_holdback(vault, "alpha")
+    _event_files(vault)[event_index].unlink()
+
+    with pytest.raises(LedgerError, match=r"gap|rollback|missing"):
+        rebuild_state(vault)
+
+
+def test_terminal_event_deletion_is_detected_without_state_cache(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+    (vault / "System/.dex/ledger/state.json").unlink()
+    _event_files(vault)[-1].unlink()
+
+    with pytest.raises(LedgerError, match=r"missing.*event.*sequence 2"):
+        rebuild_state(vault)
+
+
+def test_terminal_event_truncation_is_not_quarantined_without_state_cache(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_path.unlink()
+    event = _event_files(vault)[0]
+    event.write_bytes(b"{")
+
+    with pytest.raises(LedgerError, match=r"event 1.*unreadable"):
+        rebuild_state(vault)
+
+    assert event.exists()
+
+
+def test_next_record_completes_missing_terminal_commitment(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event = _event_files(vault)[0]
+    event_before = event.read_bytes()
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.unlink()
+
+    state = record_holdback(vault, "alpha")
+
+    assert state["last_seq"] == 2
+    assert event.read_bytes() == event_before
+    assert commitment.read_text(encoding="ascii") == json.loads(event_before)["event_sha256"] + "\n"
+    assert [entry["event_type"] for entry in read_events(vault)] == [
+        "install-registered",
+        "holdback-recorded",
+    ]
+    assert not (vault / "System/.dex/ledger/quarantine").exists()
+
+
+def test_chain_invalid_uncommitted_tail_is_never_completed_or_quarantined(
+    tmp_path: Path,
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event_path = _event_files(vault)[0]
+    event = json.loads(event_path.read_bytes())
+    event["prev_event_sha256"] = "f" * 64
+    without_sha = {key: value for key, value in event.items() if key != "event_sha256"}
+    event["event_sha256"] = ledger_module._event_sha256(without_sha)
+    event_path.write_bytes(
+        (json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    )
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.unlink()
+
+    with pytest.raises(LedgerError, match=r"event 1.*breaks the hash chain"):
+        rebuild_state(vault)
+
+    assert event_path.exists()
+    assert not commitment.exists()
+    assert not (vault / "System/.dex/ledger/quarantine").exists()
+
+
+def test_state_floor_mismatch_prevents_completing_uncommitted_tail(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event_path = _event_files(vault)[0]
+    event = json.loads(event_path.read_bytes())
+    event["payload"] = {"install_id": "87654321-4321-4765-8765-432187654321"}
+    without_sha = {key: value for key, value in event.items() if key != "event_sha256"}
+    event["event_sha256"] = ledger_module._event_sha256(without_sha)
+    event_path.write_bytes(
+        (json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    )
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.unlink()
+
+    with pytest.raises(LedgerError, match=r"possible.*history replacement"):
+        rebuild_state(vault)
+
+    assert event_path.exists()
+    assert not commitment.exists()
+    assert not (vault / "System/.dex/ledger/quarantine").exists()
+
+
+def test_rebuild_state_serializes_with_event_publication(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    started = threading.Event()
+    finished = threading.Event()
+    errors: list[BaseException] = []
+
+    def rebuild() -> None:
+        started.set()
+        try:
+            rebuild_state(vault)
+        except BaseException as error:
+            errors.append(error)
+        finally:
+            finished.set()
+
+    with ledger_module._write_lock(vault):
+        worker = threading.Thread(target=rebuild)
+        worker.start()
+        assert started.wait(timeout=1)
+        assert not finished.wait(timeout=0.05)
+
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+    assert errors == []
+
+
+def test_read_only_projection_serializes_with_event_publication(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    started = threading.Event()
+    finished = threading.Event()
+
+    def project() -> None:
+        started.set()
+        try:
+            ledger_module.project_state(vault)
+        finally:
+            finished.set()
+
+    with ledger_module._write_lock(vault):
+        worker = threading.Thread(target=project)
+        worker.start()
+        assert started.wait(timeout=1)
+        assert not finished.wait(timeout=0.05)
+
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+
+
+def test_boolean_schema_versions_fail_closed_even_with_matching_hashes(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    event_path = _event_files(vault)[0]
+    event = json.loads(event_path.read_bytes())
+    event["ledger_version"] = True
+    without_sha = {key: value for key, value in event.items() if key != "event_sha256"}
+    event["event_sha256"] = ledger_module._event_sha256(without_sha)
+    event_path.write_bytes(
+        (json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    )
+    commitment = vault / "System/.dex/ledger/commitments/00000001.sha256"
+    commitment.write_text(event["event_sha256"] + "\n", encoding="ascii")
+
+    with pytest.raises(LedgerError, match="unsupported ledger version"):
+        rebuild_state(vault)
+
+    empty = {
+        "ledger_version": True,
+        "install_id": None,
+        "adopted": {},
+        "held_back": [],
+        "last_seq": 0,
+        "last_event_sha256": GENESIS_SHA256,
+    }
+    with pytest.raises(LedgerError, match="unsupported version"):
+        canonical_state_bytes(empty)
+
+
+def test_retry_after_state_cache_failure_does_not_duplicate_transaction_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    receipt = _adoption_receipt()
+    real_write_state = ledger_module._write_state
+    calls = 0
+
+    def fail_once(vault_root: Path, state: dict[str, object]) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("injected cache failure")
+        real_write_state(vault_root, state)
+
+    monkeypatch.setattr(ledger_module, "_write_state", fail_once)
+
+    with pytest.raises(OSError, match="injected cache failure"):
+        record_adoption(vault, receipt, {"alpha": "1.0.0"})
+    state = record_adoption(vault, receipt, {"alpha": "1.0.0"})
+
+    assert state["last_seq"] == 2
+    assert len(read_events(vault)) == 2
+
+
+def test_write_lock_refuses_symlink_without_touching_target(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    ledger_root = vault / "System/.dex/ledger"
+    ledger_root.mkdir(parents=True)
+    outside = tmp_path / "outside-lock"
+    outside.write_bytes(b"outside\n")
+    (ledger_root / ".write.lock").symlink_to(outside)
+
+    with pytest.raises(LedgerError, match=r"lock.*unsafe"):
+        register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+
+    assert outside.read_bytes() == b"outside\n"
+
+
+def test_gap_and_fork_are_detected_precisely(tmp_path: Path) -> None:
+    gap_vault = _new_vault(tmp_path / "gap")
+    register_install(gap_vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(gap_vault, "alpha")
+    second = _event_files(gap_vault)[1]
+    second.rename(second.with_name(second.name.replace("00000002", "00000003")))
+    with pytest.raises(LedgerError, match=r"sequence gap.*expected 2.*found 3"):
+        rebuild_state(gap_vault)
+
+    fork_vault = _new_vault(tmp_path / "fork")
+    register_install(fork_vault, UUID("87654321-4321-4765-8765-432187654321"))
+    record_holdback(fork_vault, "alpha")
+    second = _event_files(fork_vault)[1]
+    second.with_name("00000002-holdback-cleared.json").write_bytes(second.read_bytes())
+    with pytest.raises(LedgerError, match=r"fork.*sequence 2"):
+        rebuild_state(fork_vault)
+
+
+def test_torn_last_event_is_quarantined_but_interior_damage_fails(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    events_dir = vault / "System/.dex/ledger/events"
+    torn = events_dir / "00000002-holdback-recorded.json"
+    torn.write_bytes(b'{"event_type":"holdback-recorded"')
+
+    state = rebuild_state(vault)
+
+    assert state["last_seq"] == 1
+    assert not torn.exists()
+    quarantined = list((vault / "System/.dex/ledger/quarantine").iterdir())
+    assert len(quarantined) == 1
+    assert quarantined[0].name.startswith(torn.name + ".torn")
+
+    record_holdback(vault, "alpha")
+    first = _event_files(vault)[0]
+    first.write_bytes(b"{")
+    with pytest.raises(LedgerError, match="unreadable"):
+        rebuild_state(vault)
+
+
+def test_state_rebuild_is_byte_identical_after_cache_deletion(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    receipt = _adoption_receipt(items=("alpha", "beta"))
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_adoption(vault, receipt, {"alpha": "1.0.0", "beta": "2.0.0"})
+    record_holdback(vault, "beta")
+    state_path = vault / "System/.dex/ledger/state.json"
+    first = state_path.read_bytes()
+
+    state_path.unlink()
+    rebuilt = rebuild_state(vault)
+
+    assert state_path.read_bytes() == first == canonical_state_bytes(rebuilt)
+    assert rebuilt["adopted"] == {
+        "alpha": {
+            "receipt_path": f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json",
+            "tx_id": receipt.transaction_id,
+            "version": "1.0.0",
+        },
+        "beta": {
+            "receipt_path": f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json",
+            "tx_id": receipt.transaction_id,
+            "version": "2.0.0",
+        },
+    }
+    assert rebuilt["held_back"] == ["beta"]
+
+
+def test_state_floor_detects_joint_terminal_event_and_commitment_deletion(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+    state_path = vault / "System/.dex/ledger/state.json"
+    state_before = state_path.read_bytes()
+    _event_files(vault)[-1].unlink()
+    (vault / "System/.dex/ledger/commitments/00000002.sha256").unlink()
+
+    with pytest.raises(LedgerError, match=r"possible.*tail loss.*backup|sync.*newest files"):
+        rebuild_state(vault)
+
+    assert state_path.read_bytes() == state_before
+
+
+def test_state_floor_detects_replaced_terminal_event_at_same_sequence(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "alpha")
+    event_path = _event_files(vault)[-1]
+    event = json.loads(event_path.read_bytes())
+    event["payload"] = {"item_id": "beta"}
+    without_sha = {key: value for key, value in event.items() if key != "event_sha256"}
+    event["event_sha256"] = ledger_module._event_sha256(without_sha)
+    event_path.write_bytes(
+        (json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    )
+    (vault / "System/.dex/ledger/commitments/00000002.sha256").write_text(
+        event["event_sha256"] + "\n", encoding="ascii"
+    )
+
+    with pytest.raises(LedgerError, match=r"possible.*tail loss|history replacement"):
+        project_state(vault)
+
+
+def test_first_state_build_without_existing_cache_is_unaffected(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+
+    state = rebuild_state(vault)
+
+    assert state["last_seq"] == 0
+    assert (vault / "System/.dex/ledger/state.json").read_bytes() == canonical_state_bytes(state)
+
+
+def test_install_id_is_stable_and_reregistration_refuses_without_append(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    install_id = UUID("12345678-1234-4678-9234-567812345678")
+    register_install(vault, install_id)
+    before = _event_files(vault)[0].read_bytes()
+
+    with pytest.raises(LedgerError, match="already registered"):
+        register_install(vault, install_id)
+    with pytest.raises(LedgerError, match="already registered"):
+        register_install(vault, UUID("87654321-4321-4765-8765-432187654321"))
+
+    assert len(_event_files(vault)) == 1
+    assert _event_files(vault)[0].read_bytes() == before
+
+
+def test_first_lifecycle_record_automatically_registers_install(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+
+    state = record_holdback(vault, "alpha")
+
+    install_id = UUID(str(state["install_id"]))
+    assert install_id.version == 4
+    assert [event["event_type"] for event in read_events(vault)] == [
+        "install-registered",
+        "holdback-recorded",
+    ]
+
+
+def test_record_helpers_strictly_validate_receipts_versions_and_ids(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    receipt = _adoption_receipt()
+    malformed = receipt.to_dict()
+    malformed["surprise"] = True
+
+    with pytest.raises(LedgerError, match="receipt"):
+        record_adoption(vault, malformed, {"alpha": "1.0.0"})
+    with pytest.raises(LedgerError, match="versions"):
+        record_adoption(vault, receipt, {"other": "1.0.0"})
+    with pytest.raises(LedgerError, match="item id"):
+        record_holdback(vault, "../alpha")
+    assert _event_files(vault) == []
+
+
+def test_rewind_event_durably_embeds_receipt_and_removes_matching_adoption(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    adoption = _adoption_receipt()
+    rewind = _rewind_receipt(adoption)
+    record_adoption(vault, adoption, {"alpha": "1.0.0"})
+
+    state = record_rewind(vault, rewind)
+
+    assert state["adopted"] == {}
+    assert read_events(vault)[2]["payload"]["receipt"] == rewind.to_dict()
+
+
+def test_append_refuses_sequence_beyond_filename_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    fake_tail = {
+        "seq": 99_999_999,
+        "event_type": "holdback-recorded",
+        "payload": {"item_id": "alpha"},
+        "event_sha256": "a" * 64,
+    }
+    monkeypatch.setattr(ledger_module, "_load_events", lambda *_args, **_kwargs: [fake_tail])
+
+    with pytest.raises(LedgerError, match=r"99,999,999|99999999.*maximum"):
+        ledger_module._publish_event(vault, "holdback-recorded", {"item_id": "beta"})
+
+    assert _event_files(vault) == []
+
+
+def test_record_never_rewrites_an_existing_sequence_file(tmp_path: Path) -> None:
+    vault = _new_vault(tmp_path / "vault")
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    first = _event_files(vault)[0]
+    original = first.read_bytes()
+    occupied = first.with_name("00000002-holdback-recorded.json")
+    occupied.write_bytes(b"do not overwrite\n")
+
+    with pytest.raises(LedgerError):
+        record_holdback(vault, "alpha")
+
+    assert first.read_bytes() == original
+    assert occupied.read_bytes() == b"do not overwrite\n"
+
+
+def test_execute_adoption_records_real_receipt_and_item_version(tmp_path: Path) -> None:
+    vault, _document, preview, loader = _preview(tmp_path)
+
+    receipt = execute_adoption(vault, preview, preview.sha256, loader)
+    state = rebuild_state(vault)
+
+    assert state["adopted"] == {
+        "alpha": {
+            "receipt_path": f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json",
+            "tx_id": receipt.transaction_id,
+            "version": "1.0.0",
+        }
+    }
+    event = read_events(vault)[1]
+    assert event["event_type"] == "adoption-recorded"
+    assert event["payload"]["receipt"] == receipt.to_dict()
+    assert portable_contract.resolve("System/.dex/ledger/events/00000001-adoption-recorded.json").rule_id == (
+        "runtime-lifecycle-ledger"
+    )
+
+
+def test_ledger_failure_after_adoption_reports_without_rolling_back_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import ledger
+
+    vault, _document, preview, loader = _preview(tmp_path)
+    target = vault / ".claude/skills/alpha/SKILL.md"
+
+    def fail_record(*_args, **_kwargs):
+        raise LedgerError("injected ledger failure")
+
+    monkeypatch.setattr(ledger, "record_adoption", fail_record)
+
+    with pytest.raises(
+        LifecycleLedgerPersistenceError,
+        match=r"committed.*journal is authoritative.*python3 -m core.lifecycle.cli.*rebuild-state",
+    ):
+        execute_adoption(vault, preview, preview.sha256, loader)
+
+    assert target.read_bytes() == b"# alpha\n"
+    receipts = list((vault / "System/.dex/adoptions").glob("*.receipt.json"))
+    assert len(receipts) == 1
+
+
+def test_rewind_flow_durably_records_preledger_adoption_receipt(tmp_path: Path) -> None:
+    vault, adoption = _committed_adoption(tmp_path)
+
+    rewind = rewind_adoption(vault, adoption, rewind_acknowledgement_token(adoption))
+
+    events = read_events(vault)
+    assert len(events) == 2
+    assert events[1]["event_type"] == "rewind-recorded"
+    assert events[1]["payload"]["receipt"] == rewind.to_dict()
+
+
+def test_ledger_failure_after_rewind_reports_without_rolling_back_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import ledger
+
+    vault, adoption = _committed_adoption(tmp_path)
+
+    def fail_record(*_args, **_kwargs):
+        raise LedgerError("injected ledger failure")
+
+    monkeypatch.setattr(ledger, "record_rewind", fail_record)
+
+    with pytest.raises(
+        LifecycleLedgerPersistenceError,
+        match=r"committed.*journal is authoritative.*python3 -m core.lifecycle.cli.*rebuild-state",
+    ):
+        rewind_adoption(vault, adoption, rewind_acknowledgement_token(adoption))
+
+    assert (vault / EXISTING_PATH).read_bytes() == OLD
+    assert not (vault / CREATED_PATH).exists()

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -472,6 +472,13 @@
       "note": "post-commit lifecycle receipts; local runtime evidence, never shipped"
     },
     {
+      "id": "runtime-lifecycle-ledger",
+      "path": "System/.dex/ledger",
+      "kind": "dir",
+      "ownership": "runtime",
+      "note": "immutable local lifecycle events and rebuildable state; never shipped or updated"
+    },
+    {
       "id": "generated-manifest",
       "path": "System/.installed-files.manifest",
       "kind": "file",


### PR DESCRIPTION
Chunk D1 of the lifecycle catalog program (spec §5). Opens Phase D.

## What
- Append-only, hash-chained ledger of every lifecycle event (install, adoption, rewind, holdback) under `System/.dex/ledger`, with per-event immutability witnesses and a rebuildable `state.json` projection that acts as a monotonic high-water mark against silent history truncation.
- Crash-residue self-healing: an interrupted write is completed safely on the next record or via `rebuild-state`; read-only commands report and point at the repair, never mutate. Chain-invalid data is refused, never blessed.
- Small stdlib CLI: `status` / `events` / `verify` / `rebuild-state`.
- Engine records adoption/rewind post-commit; ledger failure is loud but never rolls back a committed transaction (tx journal stays authoritative).

## Review trail
- Fable diff review → independent adversarial review (Opus): **DO-NOT-SHIP** (reproducible self-brick on ordinary crash/ENOSPC; silent tail-truncation) → all findings fixed → **original reviewer re-verified with its own probe scripts: SHIP**, noting the fixes strengthened tamper detection beyond the original ask.

## Verification
- 88 tests green (orchestrator re-run); ruff clean; portable-contract gate green (1064 paths, dist byte-identical); founder-content gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42