### PR TITLE
feat: Doctor five-group adoption UX + renderer contract (cathedral D2)

### DIFF
--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -180,9 +180,10 @@ described only from its returned transaction authority; do not call `Transaction
 while rendering Doctor. A receipt is rewindable only when the collector says
 `rewindable: true` and `rewind_verdict: OK`. Rewind only through the existing
 receipt-backed lifecycle flow:
-load that exact receipt, derive its exact acknowledgement with
-`rewind_acknowledgement_token(receipt)`, then call
-`rewind_adoption(vault_root, receipt, acknowledgement)`. There is no lifecycle rewind
+load that exact receipt, derive its exact acknowledgement with the
+rewind-acknowledgement helper in the Python lifecycle engine
+(core/lifecycle/engine.py), then perform the rewind through that same engine
+module's receipt-backed rewind function. There is no lifecycle rewind
 shell command, so do not invent one. If `rewindable: false` with `rewind_verdict: OK`,
 say the retained snapshot was pruned. If `rewind_verdict: UNKNOWN`, say the receipt,
 current bytes, committed journal, or snapshot could not be verified. In both cases, do

--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -148,6 +148,46 @@ creation is working, off, or needs attention, include the contact/observation co
 and call out unresolved verification results or quarantined pages. Mention stale
 verification or a stale/missing People index as a follow-up signal.
 
+### Step 3a: Render the adoption section
+
+Read the collector's top-level `adoption` object and render its `groups` in the exact
+order returned. It always contains these five groups: `new-and-safe`,
+`needs-your-review`, `preserved-for-now`, `continue-or-recover`, and
+`receipts-and-rewind`.
+
+Authority fields are not prose. Render every item id, item version, action, status,
+verdict, count, transaction id, reason, path, and `rewindable` boolean verbatim. Never
+change an action or verdict, combine authority records, infer a missing record, or hide
+a zero count. The collector's `surface` line is the only field that may be rephrased.
+Keep that rephrasing to one plain-English line per group in this register:
+"Here's exactly what this changes for you" and, for recovery, "I found an interrupted
+update — resume or undo?"
+
+`needs-your-review` normally contains `conflict` actions. If the deterministic planner
+returns `action: unknown`, keep that item and its reasons in this group verbatim, render
+the group's `UNKNOWN` verdict, and say the evidence needs rechecking; never silently
+drop it or translate it into a conflict.
+
+If `adoption.verdict` is `OFF`, say calmly that adoption reporting is off because no
+release catalog is installed. If it is `UNKNOWN`, say what could not be verified and
+do not turn empty authority arrays into proposed actions. For ledger recovery, reproduce
+`continue-or-recover.ledger.repair_command` exactly; this is the existing
+`python3 -m core.lifecycle.cli --vault-root <vault> rebuild-state` command, not a prompt
+to improvise ledger repair.
+
+Never offer an action the engine does not expose. An interrupted transaction may be
+described only from its returned transaction authority; do not call `Transaction.resume`
+while rendering Doctor. A receipt is rewindable only when the collector says
+`rewindable: true` and `rewind_verdict: OK`. Rewind only through the existing
+receipt-backed lifecycle flow:
+load that exact receipt, derive its exact acknowledgement with
+`rewind_acknowledgement_token(receipt)`, then call
+`rewind_adoption(vault_root, receipt, acknowledgement)`. There is no lifecycle rewind
+shell command, so do not invent one. If `rewindable: false` with `rewind_verdict: OK`,
+say the retained snapshot was pruned. If `rewind_verdict: UNKNOWN`, say the receipt,
+current bytes, committed journal, or snapshot could not be verified. In both cases, do
+not offer rewind.
+
 ### Step 4: Heal, tiered
 
 - **Tier 1 (already applied by the collector):** report plainly — "Fixed automatically:

--- a/core/tests/test_adoption_doctor_journey.py
+++ b/core/tests/test_adoption_doctor_journey.py
@@ -1,0 +1,370 @@
+"""D2 Doctor journey: adoption choices, recovery, and rewind evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle.catalog import with_catalog_identity
+from core.lifecycle.engine import AdoptionReceipt, canonical_adoption_receipt_bytes
+from core.lifecycle.ledger import record_adoption, record_holdback
+from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
+from core.transaction.journal import Journal
+from core.transaction.snapshot import Snapshot
+from core.utils import doctor
+
+NOW = datetime(2026, 7, 21, 14, 30, tzinfo=timezone.utc)
+ADOPTION_TX_ID = "20260721T120000-00000001"
+INTERRUPTED_TX_ID = "20260721T121500-00000002"
+
+
+def _tree_snapshot(root: Path) -> dict[str, tuple[object, ...]]:
+    snapshot: dict[str, tuple[object, ...]] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        mode = stat.S_IMODE(path.stat().st_mode)
+        snapshot[relative] = (
+            ("dir", mode) if path.is_dir() else ("file", mode, path.read_bytes())
+        )
+    return snapshot
+
+
+def _catalog_document(vault: Path, contents: dict[str, bytes]) -> dict[str, object]:
+    manifest = write_manifest(
+        vault,
+        sorted(f".claude/skills/{item_id}/SKILL.md" for item_id in contents),
+    )
+    items = []
+    for item_id, content in sorted(contents.items()):
+        path = f".claude/skills/{item_id}/SKILL.md"
+        items.append(
+            {
+                "id": item_id,
+                "kind": "skill",
+                "version": "1.0.0",
+                "files": [
+                    {
+                        "path": path,
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "ownership_class": "brain",
+                    }
+                ],
+                "dependencies": [],
+                "capabilities": [],
+                "rewind": {
+                    "acknowledgement_required": True,
+                    "token": f"rewind:{item_id}@1.0.0",
+                },
+            }
+        )
+    return with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.67.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.67.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": items,
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+
+
+def _adoption_receipt(item_id: str) -> AdoptionReceipt:
+    content = b"# adopted\n"
+    return AdoptionReceipt.from_dict(
+        {
+            "receipt_version": 1,
+            "items_adopted": [item_id],
+            "files_written": [
+                {
+                    "item_id": item_id,
+                    "path": f".claude/skills/{item_id}/SKILL.md",
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "byte_size": len(content),
+                }
+            ],
+            "transaction_id": ADOPTION_TX_ID,
+            "snapshot_ref": f"System/.dex/tx/{ADOPTION_TX_ID}/snapshot",
+            "catalog_sha256": "a" * 64,
+            "inventory_sha256": "b" * 64,
+            "preview_sha256": "c" * 64,
+        }
+    )
+
+
+def _journey_vault(tmp_path: Path) -> tuple[doctor.DoctorContext, Path]:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    contents = {
+        "adoptable": b"# adoptable\n",
+        "adopted-receipt": b"# adopted\n",
+        "conflicted": b"# stock conflict\n",
+        "held-back": b"# held\n",
+    }
+    for item_id, content in contents.items():
+        write_file(vault, f".claude/skills/{item_id}/SKILL.md", content)
+    document = _catalog_document(vault, contents)
+    catalog_path = vault / "System/.release-catalog.json"
+    catalog_path.write_text(json.dumps(document), encoding="utf-8")
+
+    # A real customization: installed bytes no longer match the catalog.
+    write_file(vault, ".claude/skills/conflicted/SKILL.md", b"# user customization\n")
+
+    record_holdback(vault, "held-back")
+    adoption_receipt = _adoption_receipt("adopted-receipt")
+    record_adoption(
+        vault,
+        adoption_receipt,
+        {"adopted-receipt": "1.0.0"},
+    )
+    adoption_tx = vault / f"System/.dex/tx/{ADOPTION_TX_ID}"
+    Snapshot(adoption_tx / "snapshot").capture(
+        vault,
+        [".claude/skills/adopted-receipt/SKILL.md"],
+    )
+    adoption_journal = Journal(adoption_tx / "journal.jsonl")
+    adoption_journal.append("BEGIN", {"tx_id": ADOPTION_TX_ID, "plan": []})
+    adoption_journal.append("COMMITTED")
+    receipt_path = vault / f"System/.dex/adoptions/{ADOPTION_TX_ID}.receipt.json"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_bytes(canonical_adoption_receipt_bytes(adoption_receipt))
+
+    # Fabricate the same mid-state journal shape used by txcore tests, but do
+    # not call Transaction.resume: collection must remain inspection-only.
+    journal = Journal(vault / f"System/.dex/tx/{INTERRUPTED_TX_ID}/journal.jsonl")
+    journal.append(
+        "BEGIN",
+        {
+            "tx_id": INTERRUPTED_TX_ID,
+            "plan": [
+                {
+                    "relative": "System/.installed-files.manifest",
+                    "operation": "write",
+                    "sha256": "d" * 64,
+                    "mode": 0o644,
+                    "size": 8,
+                    "expected_current_sha256": None,
+                }
+            ],
+        },
+    )
+    journal.append("STAGED")
+    journal.append("SNAPSHOT-START")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    return doctor.DoctorContext(vault, vault, home, NOW), catalog_path
+
+
+def _groups(report: doctor.AdoptionReport) -> dict[str, dict[str, object]]:
+    return {group["id"]: group for group in report.to_dict()["groups"]}
+
+
+def test_adoption_report_binds_all_five_groups_and_degrades_honestly(
+    tmp_path: Path,
+) -> None:
+    context, catalog_path = _journey_vault(tmp_path)
+    before = _tree_snapshot(context.vault_root)
+
+    report = doctor.collect_adoption_report(context)
+
+    assert _tree_snapshot(context.vault_root) == before
+    assert report.verdict == "BROKEN"
+    groups = _groups(report)
+    assert list(groups) == [
+        "new-and-safe",
+        "needs-your-review",
+        "preserved-for-now",
+        "continue-or-recover",
+        "receipts-and-rewind",
+    ]
+    assert groups["new-and-safe"]["items"] == [
+        {"item_id": "adoptable", "item_version": "1.0.0", "action": "adopt"}
+    ]
+    assert groups["new-and-safe"]["count"] == 1
+
+    review = groups["needs-your-review"]
+    assert review["count"] == 1
+    assert review["items"][0]["item_id"] == "conflicted"
+    assert review["items"][0]["action"] == "conflict"
+    assert review["items"][0]["files"] == [
+        {
+            "path": ".claude/skills/conflicted/SKILL.md",
+            "reason": "release-files-modified",
+        }
+    ]
+
+    preserved = groups["preserved-for-now"]
+    assert preserved["count"] == 2
+    assert preserved["held_back_items"] == [
+        {"item_id": "held-back", "item_version": "1.0.0", "action": "skip-held-back"}
+    ]
+    assert preserved["customized_files"] == [
+        {
+            "path": ".claude/skills/conflicted/SKILL.md",
+            "state": "stock-modified",
+            "reason": "installed bytes differ from the verified release catalog",
+        }
+    ]
+
+    recovery = groups["continue-or-recover"]
+    assert recovery["count"] == 1
+    assert recovery["transactions"] == [
+        {
+            "tx_id": INTERRUPTED_TX_ID,
+            "verdict": "BROKEN",
+            "last_event": "SNAPSHOT-START",
+            "snapshot_present": False,
+        }
+    ]
+    assert recovery["ledger"] is None
+
+    receipts = groups["receipts-and-rewind"]
+    assert receipts["count"] == 1
+    assert receipts["receipts"] == [
+        {
+            "item_id": "adopted-receipt",
+            "item_version": "1.0.0",
+            "status": "adopted",
+            "transaction_id": ADOPTION_TX_ID,
+            "when": "2026-07-21T12:00:00",
+            "rewindable": True,
+            "rewind_verdict": "OK",
+        }
+    ]
+
+    canonical = doctor.canonical_adoption_report_bytes(report)
+    assert canonical == (
+        json.dumps(
+            report.to_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+    assert json.loads(canonical)["groups"] == report.to_dict()["groups"]
+
+    catalog_bytes = catalog_path.read_bytes()
+    catalog_path.unlink()
+    off = doctor.collect_adoption_report(context)
+    assert off.verdict == "OFF"
+    assert all(group["count"] == 0 for group in off.to_dict()["groups"])
+
+    catalog_path.write_bytes(catalog_bytes)
+    first_event = sorted((context.vault_root / "System/.dex/ledger/events").glob("*.json"))[0]
+    first_event_bytes = first_event.read_bytes()
+    first_event.write_bytes(b"{corrupt ledger")
+    unknown = doctor.collect_adoption_report(context)
+    assert unknown.verdict == "UNKNOWN"
+    recovery = _groups(unknown)["continue-or-recover"]
+    assert recovery["ledger"]["verdict"] == "UNKNOWN"
+    assert recovery["ledger"]["incomplete_publication"] is False
+    assert recovery["ledger"]["repair_command"] == (
+        f"python3 -m core.lifecycle.cli --vault-root {context.vault_root} rebuild-state"
+    )
+    assert "rebuild-state" in recovery["surface"]
+
+    first_event.write_bytes(first_event_bytes)
+    terminal_commitment = sorted(
+        (context.vault_root / "System/.dex/ledger/commitments").glob("*.sha256")
+    )[-1]
+    terminal_commitment.unlink()
+    incomplete = doctor.collect_adoption_report(context)
+    incomplete_recovery = _groups(incomplete)["continue-or-recover"]["ledger"]
+    assert incomplete.verdict == "UNKNOWN"
+    assert incomplete_recovery["incomplete_publication"] is True
+    assert "rebuild-state" in incomplete_recovery["repair_command"]
+
+
+def test_receipt_rewindable_fails_closed_when_snapshot_evidence_is_damaged(
+    tmp_path: Path,
+) -> None:
+    context, _catalog_path = _journey_vault(tmp_path)
+    manifest = context.vault_root / f"System/.dex/tx/{ADOPTION_TX_ID}/snapshot/manifest.json"
+    manifest.unlink()
+
+    receipt = _groups(doctor.collect_adoption_report(context))["receipts-and-rewind"][
+        "receipts"
+    ][0]
+
+    assert receipt["rewindable"] is False
+    assert receipt["rewind_verdict"] == "UNKNOWN"
+
+
+def test_unknown_planner_item_is_visible_and_makes_report_unknown(tmp_path: Path) -> None:
+    context, _catalog_path = _journey_vault(tmp_path)
+    Journal(
+        context.vault_root / f"System/.dex/tx/{INTERRUPTED_TX_ID}/journal.jsonl"
+    ).append("ROLLED-BACK")
+    adoptable = context.vault_root / ".claude/skills/adoptable/SKILL.md"
+    adoptable.unlink()
+    adoptable.symlink_to("../conflicted/SKILL.md")
+
+    report = doctor.collect_adoption_report(context)
+    review = _groups(report)["needs-your-review"]
+
+    assert report.verdict == "UNKNOWN"
+    assert review["verdict"] == "UNKNOWN"
+    assert review["count"] == 2
+    unknown = next(item for item in review["items"] if item["item_id"] == "adoptable")
+    assert unknown["action"] == "unknown"
+    assert unknown["reasons"] == ["release-files-unknown"]
+    assert unknown["files"] == [
+        {
+            "path": ".claude/skills/adoptable/SKILL.md",
+            "reason": "release-files-unknown",
+        }
+    ]
+
+
+def test_adoption_authority_dataclasses_reject_invalid_vocabulary_and_shape(
+    tmp_path: Path,
+) -> None:
+    context, _catalog_path = _journey_vault(tmp_path)
+    report = doctor.collect_adoption_report(context)
+
+    with pytest.raises(ValueError, match="action"):
+        doctor.AdoptionItem("adoptable", "1.0.0", "invented-action")
+    with pytest.raises(ValueError, match="status"):
+        doctor.AdoptionReceiptSummary(
+            "adopted-receipt",
+            "1.0.0",
+            "invented-status",
+            ADOPTION_TX_ID,
+            "2026-07-21T12:00:00",
+            True,
+            "OK",
+        )
+
+    mismatched_count = replace(report.groups[0], count=999)
+    with pytest.raises(ValueError, match="count"):
+        replace(report, groups=(mismatched_count, *report.groups[1:]))
+
+    boolean_count = replace(report.groups[0], count=True)
+    with pytest.raises(ValueError, match="count"):
+        replace(report, groups=(boolean_count, *report.groups[1:]))
+
+    wrong_group_type = doctor.NeedsReviewGroup(
+        "new-and-safe",
+        "OK",
+        0,
+        (),
+        "Wrong authority type.",
+    )
+    with pytest.raises(ValueError, match="group types"):
+        replace(report, groups=(wrong_group_type, *report.groups[1:]))

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -621,7 +621,14 @@ def test_json_contract_shape_and_last_run_file(monkeypatch, context, deep, expec
 
     report = doctor.collect(deep=deep, context=context)
 
-    assert set(report) == {"generated_at", "mode", "instruments", "checks", "summary"}
+    assert set(report) == {
+        "generated_at",
+        "mode",
+        "instruments",
+        "checks",
+        "summary",
+        "adoption",
+    }
     assert report["generated_at"] == NOW.isoformat()
     assert report["mode"] == ("deep" if deep else "quick")
     assert report["instruments"] == {

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -27,9 +27,14 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from core import paths, portable_contract
+from core.lifecycle import engine as lifecycle_engine
+from core.lifecycle import ledger as lifecycle_ledger
 from core.lifecycle.catalog import CatalogError, load_catalog
 from core.lifecycle.inventory import build_inventory
-from core.lifecycle.plan import build_adoption_plan
+from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
+from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
+from core.transaction.engine import TX_ROOT_RELATIVE
+from core.transaction.journal import Journal, JournalCorruptError
 from core.utils import preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
@@ -40,6 +45,31 @@ MISSING_PACKAGES_DETAIL = (
     "then re-run /dex-doctor"
 )
 RELEASE_CATALOG_PATH = "System/.release-catalog.json"
+ADOPTION_REPORT_VERSION = 1
+ADOPTION_GROUP_IDS = (
+    "new-and-safe",
+    "needs-your-review",
+    "preserved-for-now",
+    "continue-or-recover",
+    "receipts-and-rewind",
+)
+ADOPTION_ACTIONS = frozenset(action.value for action in PlannedAction)
+ADOPTION_STATUSES = frozenset(state.value for state in AdoptionState)
+ADOPTION_REASON_CODES = frozenset(reason.value for reason in ReasonCode)
+
+
+def _validate_authority_item(item_id: object, item_version: object) -> None:
+    if not isinstance(item_id, str) or ITEM_ID.fullmatch(item_id) is None:
+        raise ValueError("Adoption authority item_id is not canonical")
+    if item_version is not None and (
+        not isinstance(item_version, str) or SEMVER.fullmatch(item_version) is None
+    ):
+        raise ValueError("Adoption authority item_version is not strict SemVer")
+
+
+def _validate_surface(surface: object) -> None:
+    if not isinstance(surface, str) or not surface.strip():
+        raise ValueError("Adoption group surface must be a non-empty string")
 
 
 @dataclass(frozen=True)
@@ -116,6 +146,399 @@ class DoctorContext:
     @property
     def launch_agents_dir(self) -> Path:
         return self.home / "Library" / "LaunchAgents"
+
+
+@dataclass(frozen=True)
+class AdoptionItem:
+    """One catalog item and its planner-owned action."""
+
+    item_id: str
+    item_version: str | None
+    action: str
+
+    def __post_init__(self) -> None:
+        _validate_authority_item(self.item_id, self.item_version)
+        if self.action not in ADOPTION_ACTIONS:
+            raise ValueError(f"Invalid adoption authority action: {self.action!r}")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdoptionReviewFile:
+    """One conflict path and the planner-owned reason for reviewing it."""
+
+    path: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path:
+            raise ValueError("Adoption review path must be a non-empty string")
+        if self.reason not in ADOPTION_REASON_CODES:
+            raise ValueError(f"Invalid adoption review reason: {self.reason!r}")
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdoptionReviewItem:
+    """One conflicted catalog item with item- and path-level reasons."""
+
+    item_id: str
+    item_version: str
+    action: str
+    reasons: tuple[str, ...]
+    files: tuple[AdoptionReviewFile, ...]
+
+    def __post_init__(self) -> None:
+        _validate_authority_item(self.item_id, self.item_version)
+        if self.action not in {
+            PlannedAction.CONFLICT.value,
+            PlannedAction.UNKNOWN.value,
+        }:
+            raise ValueError(f"Invalid review authority action: {self.action!r}")
+        if (
+            not isinstance(self.reasons, tuple)
+            or not self.reasons
+            or any(reason not in ADOPTION_REASON_CODES for reason in self.reasons)
+        ):
+            raise ValueError("Adoption review reasons use an invalid authority value")
+        if not isinstance(self.files, tuple) or any(
+            type(entry) is not AdoptionReviewFile for entry in self.files
+        ):
+            raise ValueError("Adoption review files must be AdoptionReviewFile records")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "item_version": self.item_version,
+            "action": self.action,
+            "reasons": list(self.reasons),
+            "files": [entry.to_dict() for entry in self.files],
+        }
+
+
+@dataclass(frozen=True)
+class PreservedCustomization:
+    """One customized installed file that adoption will preserve."""
+
+    path: str
+    state: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path:
+            raise ValueError("Preserved customization path must be a non-empty string")
+        if self.state != "stock-modified":
+            raise ValueError("Preserved customization state must be stock-modified")
+        if not isinstance(self.reason, str) or not self.reason:
+            raise ValueError("Preserved customization reason must be a non-empty string")
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InterruptedTransaction:
+    """Read-only recovery evidence mirroring Transaction.resume classification."""
+
+    tx_id: str
+    verdict: str
+    last_event: str | None
+    snapshot_present: bool
+
+    def __post_init__(self) -> None:
+        if lifecycle_engine.TRANSACTION_ID.fullmatch(self.tx_id) is None:
+            raise ValueError("Interrupted transaction id is not canonical")
+        if self.verdict not in {"BROKEN", "UNKNOWN"}:
+            raise ValueError(f"Invalid interrupted-transaction verdict: {self.verdict}")
+        if self.last_event is not None and not isinstance(self.last_event, str):
+            raise ValueError("Interrupted transaction last_event must be a string or null")
+        if type(self.snapshot_present) is not bool:
+            raise ValueError("Interrupted transaction snapshot_present must be a boolean")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LedgerRecovery:
+    """A ledger error and the ledger-owned command that can repair its state."""
+
+    verdict: str
+    incomplete_publication: bool
+    repair_command: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if self.verdict != "UNKNOWN":
+            raise ValueError(f"Invalid ledger recovery verdict: {self.verdict}")
+        if type(self.incomplete_publication) is not bool:
+            raise ValueError("Ledger incomplete_publication must be a boolean")
+        if not isinstance(self.repair_command, str) or not self.repair_command:
+            raise ValueError("Ledger repair_command must be a non-empty string")
+        if not isinstance(self.detail, str) or not self.detail:
+            raise ValueError("Ledger recovery detail must be a non-empty string")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdoptionReceiptSummary:
+    """Current ledger receipt authority plus snapshot-retention evidence."""
+
+    item_id: str
+    item_version: str
+    status: str
+    transaction_id: str
+    when: str
+    rewindable: bool
+    rewind_verdict: str
+
+    def __post_init__(self) -> None:
+        _validate_authority_item(self.item_id, self.item_version)
+        if self.status not in ADOPTION_STATUSES:
+            raise ValueError(f"Invalid adoption receipt status: {self.status!r}")
+        if lifecycle_engine.TRANSACTION_ID.fullmatch(self.transaction_id) is None:
+            raise ValueError("Adoption receipt transaction_id is not canonical")
+        if not isinstance(self.when, str) or not self.when:
+            raise ValueError("Adoption receipt when must be a non-empty string")
+        if type(self.rewindable) is not bool:
+            raise ValueError("Adoption receipt rewindable must be a boolean")
+        if self.rewind_verdict not in {"OK", "UNKNOWN"}:
+            raise ValueError("Adoption receipt rewind_verdict must be OK or UNKNOWN")
+        if self.rewindable and self.rewind_verdict != "OK":
+            raise ValueError("A rewindable receipt must have rewind_verdict OK")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class NewAndSafeGroup:
+    id: str
+    verdict: str
+    count: int
+    items: tuple[AdoptionItem, ...]
+    surface: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "count": self.count,
+            "items": [item.to_dict() for item in self.items],
+            "surface": self.surface,
+        }
+
+
+@dataclass(frozen=True)
+class NeedsReviewGroup:
+    id: str
+    verdict: str
+    count: int
+    items: tuple[AdoptionReviewItem, ...]
+    surface: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "count": self.count,
+            "items": [item.to_dict() for item in self.items],
+            "surface": self.surface,
+        }
+
+
+@dataclass(frozen=True)
+class PreservedForNowGroup:
+    id: str
+    verdict: str
+    count: int
+    held_back_items: tuple[AdoptionItem, ...]
+    customized_files: tuple[PreservedCustomization, ...]
+    surface: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "count": self.count,
+            "held_back_items": [item.to_dict() for item in self.held_back_items],
+            "customized_files": [entry.to_dict() for entry in self.customized_files],
+            "surface": self.surface,
+        }
+
+
+@dataclass(frozen=True)
+class ContinueOrRecoverGroup:
+    id: str
+    verdict: str
+    count: int
+    transactions: tuple[InterruptedTransaction, ...]
+    ledger: LedgerRecovery | None
+    inspection_error: str | None
+    surface: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "count": self.count,
+            "transactions": [entry.to_dict() for entry in self.transactions],
+            "ledger": self.ledger.to_dict() if self.ledger else None,
+            "inspection_error": self.inspection_error,
+            "surface": self.surface,
+        }
+
+
+@dataclass(frozen=True)
+class ReceiptsAndRewindGroup:
+    id: str
+    verdict: str
+    count: int
+    receipts: tuple[AdoptionReceiptSummary, ...]
+    surface: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "verdict": self.verdict,
+            "count": self.count,
+            "receipts": [entry.to_dict() for entry in self.receipts],
+            "surface": self.surface,
+        }
+
+
+AdoptionGroup = (
+    NewAndSafeGroup
+    | NeedsReviewGroup
+    | PreservedForNowGroup
+    | ContinueOrRecoverGroup
+    | ReceiptsAndRewindGroup
+)
+
+
+@dataclass(frozen=True)
+class AdoptionReport:
+    """Strict authority/surface contract for Doctor's adoption section.
+
+    All item ids, actions, verdicts, counts, transaction ids, statuses, and
+    rewindable booleans are deterministic authority emitted here. Renderers
+    may paraphrase only each group's ``surface`` line; they must reproduce all
+    other fields verbatim and must never infer, promote, or suppress actions.
+    """
+
+    report_version: int
+    verdict: str
+    groups: tuple[AdoptionGroup, ...]
+
+    def __post_init__(self) -> None:
+        if self.report_version != ADOPTION_REPORT_VERSION:
+            raise ValueError("Unsupported adoption report version")
+        if self.verdict not in VERDICTS:
+            raise ValueError(f"Invalid adoption report verdict: {self.verdict}")
+        if not isinstance(self.groups, tuple):
+            raise ValueError("Adoption report groups must be a tuple")
+        expected_types = (
+            NewAndSafeGroup,
+            NeedsReviewGroup,
+            PreservedForNowGroup,
+            ContinueOrRecoverGroup,
+            ReceiptsAndRewindGroup,
+        )
+        if tuple(type(group) for group in self.groups) != expected_types:
+            raise ValueError("Adoption report group types must match the exact contract")
+        if tuple(group.id for group in self.groups) != ADOPTION_GROUP_IDS:
+            raise ValueError("Adoption report must contain the exact five ordered groups")
+        for group in self.groups:
+            if group.verdict not in VERDICTS:
+                raise ValueError(f"Invalid adoption group verdict: {group.verdict}")
+            if type(group.count) is not int or group.count < 0:
+                raise ValueError("Adoption group count must be a non-negative integer")
+            _validate_surface(group.surface)
+        new_group, review_group, preserved_group, recovery_group, receipt_group = self.groups
+        if not isinstance(new_group.items, tuple) or any(
+            type(item) is not AdoptionItem for item in new_group.items
+        ):
+            raise ValueError("new-and-safe items must be AdoptionItem records")
+        if any(item.action != PlannedAction.ADOPT.value for item in new_group.items):
+            raise ValueError("new-and-safe items must have action adopt")
+        if not isinstance(review_group.items, tuple) or any(
+            type(item) is not AdoptionReviewItem for item in review_group.items
+        ):
+            raise ValueError("needs-your-review items must be AdoptionReviewItem records")
+        if not isinstance(preserved_group.held_back_items, tuple) or any(
+            type(item) is not AdoptionItem for item in preserved_group.held_back_items
+        ):
+            raise ValueError("preserved held-back items must be AdoptionItem records")
+        if any(
+            item.action != PlannedAction.SKIP_HELD_BACK.value
+            for item in preserved_group.held_back_items
+        ):
+            raise ValueError("preserved held-back items must have action skip-held-back")
+        if not isinstance(preserved_group.customized_files, tuple) or any(
+            type(item) is not PreservedCustomization
+            for item in preserved_group.customized_files
+        ):
+            raise ValueError("preserved customized files must be strict authority records")
+        if not isinstance(recovery_group.transactions, tuple) or any(
+            type(item) is not InterruptedTransaction
+            for item in recovery_group.transactions
+        ):
+            raise ValueError("recovery transactions must be strict authority records")
+        if recovery_group.ledger is not None and type(recovery_group.ledger) is not LedgerRecovery:
+            raise ValueError("recovery ledger must be a LedgerRecovery record or null")
+        if recovery_group.inspection_error is not None and not isinstance(
+            recovery_group.inspection_error, str
+        ):
+            raise ValueError("recovery inspection_error must be a string or null")
+        if not isinstance(receipt_group.receipts, tuple) or any(
+            type(item) is not AdoptionReceiptSummary for item in receipt_group.receipts
+        ):
+            raise ValueError("receipt summaries must be strict authority records")
+        if any(
+            item.status != AdoptionState.ADOPTED.value
+            for item in receipt_group.receipts
+        ):
+            raise ValueError("receipt summaries must have status adopted")
+        expected_counts = (
+            len(new_group.items),
+            len(review_group.items),
+            len(preserved_group.held_back_items) + len(preserved_group.customized_files),
+            len(recovery_group.transactions)
+            + int(recovery_group.ledger is not None)
+            + int(recovery_group.inspection_error is not None),
+            len(receipt_group.receipts),
+        )
+        if tuple(group.count for group in self.groups) != expected_counts:
+            raise ValueError("Adoption report group count does not match authority records")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "report_version": self.report_version,
+            "verdict": self.verdict,
+            "groups": [group.to_dict() for group in self.groups],
+        }
+
+
+def canonical_adoption_report_bytes(report: AdoptionReport) -> bytes:
+    """Return canonical JSON bytes for the strict Doctor adoption report."""
+    if not isinstance(report, AdoptionReport):
+        raise TypeError("report must be an AdoptionReport")
+    return (
+        json.dumps(
+            report.to_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
 
 
 PARA_PATH_NAMES = (
@@ -442,6 +865,7 @@ def collect(
     results["doctor.self"] = self_result
 
     checks = [_result_json(definition, results[definition.id]) for definition in definitions]
+    adoption = collect_adoption_report(context)
     report = {
         "generated_at": context.now.isoformat(),
         "mode": "deep" if deep else "quick",
@@ -452,6 +876,7 @@ def collect(
         },
         "checks": checks,
         "summary": _summary(checks),
+        "adoption": adoption.to_dict(),
     }
 
     try:
@@ -534,6 +959,384 @@ def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
 
 def _release_catalog_path(context: DoctorContext) -> Path:
     return context.vault_root / RELEASE_CATALOG_PATH
+
+
+def _empty_adoption_report(
+    verdict: str,
+    surface: str,
+    *,
+    transactions: tuple[InterruptedTransaction, ...] = (),
+    ledger: LedgerRecovery | None = None,
+    inspection_error: str | None = None,
+) -> AdoptionReport:
+    recovery_count = len(transactions) + int(ledger is not None) + int(inspection_error is not None)
+    recovery_surface = (
+        _recovery_surface(transactions, ledger, inspection_error)
+        if recovery_count
+        else surface
+    )
+    return AdoptionReport(
+        ADOPTION_REPORT_VERSION,
+        verdict,
+        (
+            NewAndSafeGroup("new-and-safe", verdict, 0, (), surface),
+            NeedsReviewGroup("needs-your-review", verdict, 0, (), surface),
+            PreservedForNowGroup("preserved-for-now", verdict, 0, (), (), surface),
+            ContinueOrRecoverGroup(
+                "continue-or-recover",
+                verdict,
+                recovery_count,
+                transactions,
+                ledger,
+                inspection_error,
+                recovery_surface,
+            ),
+            ReceiptsAndRewindGroup("receipts-and-rewind", verdict, 0, (), surface),
+        ),
+    )
+
+
+def _inspect_interrupted_transactions(
+    context: DoctorContext,
+) -> tuple[tuple[InterruptedTransaction, ...], str | None]:
+    """Classify transaction journals like ``Transaction.resume`` without resuming.
+
+    This deliberately does not instantiate a mutating recovery flow or acquire
+    the mutation lock. It only reads journals and snapshot-directory presence.
+    """
+    tx_root = context.vault_root / TX_ROOT_RELATIVE
+    if not os.path.lexists(tx_root):
+        return (), None
+    if tx_root.is_symlink() or not tx_root.is_dir():
+        return (), f"Transaction store is unsafe or not a directory: {tx_root}"
+
+    interrupted: list[InterruptedTransaction] = []
+    inspection_errors: list[str] = []
+    try:
+        candidates = sorted(tx_root.iterdir(), key=lambda candidate: candidate.name)
+    except OSError as error:
+        return (), f"Transaction store could not be inspected: {_one_line(error)}"
+    for tx_dir in candidates:
+        if lifecycle_engine.TRANSACTION_ID.fullmatch(tx_dir.name) is None:
+            inspection_errors.append(
+                f"Transaction store contains a non-canonical entry: {tx_dir.name}"
+            )
+            continue
+        if tx_dir.is_symlink() or not tx_dir.is_dir():
+            interrupted.append(
+                InterruptedTransaction(tx_dir.name, "UNKNOWN", None, False)
+            )
+            continue
+        try:
+            entries = Journal(tx_dir / "journal.jsonl").read()
+        except (JournalCorruptError, OSError):
+            interrupted.append(
+                InterruptedTransaction(
+                    tx_dir.name,
+                    "UNKNOWN",
+                    None,
+                    _safe_snapshot_present(tx_dir / "snapshot"),
+                )
+            )
+            continue
+        events = {entry.event for entry in entries}
+        if not entries or "ROLLED-BACK" in events or "COMMITTED" in events:
+            continue
+        interrupted.append(
+            InterruptedTransaction(
+                tx_dir.name,
+                "BROKEN",
+                entries[-1].event,
+                _safe_snapshot_present(tx_dir / "snapshot"),
+            )
+        )
+    return tuple(interrupted), "; ".join(inspection_errors) or None
+
+
+def _safe_snapshot_present(path: Path) -> bool:
+    return not path.is_symlink() and path.is_dir()
+
+
+def _receipt_rewind_evidence(
+    context: DoctorContext,
+    transaction_id: str,
+    item_id: str,
+) -> tuple[bool, str]:
+    """Run the rewind engine's complete read-only eligibility preflight."""
+    snapshot_root = context.vault_root / TX_ROOT_RELATIVE / transaction_id / "snapshot"
+    if not os.path.lexists(snapshot_root):
+        return False, "OK"
+    if snapshot_root.is_symlink() or not snapshot_root.is_dir():
+        return False, "UNKNOWN"
+    try:
+        receipt = lifecycle_engine.load_adoption_receipt(
+            context.vault_root,
+            transaction_id,
+        )
+        if item_id not in receipt.items_adopted:
+            return False, "UNKNOWN"
+        current_modes, drifted = lifecycle_engine._current_adopted_modes(
+            context.vault_root,
+            receipt,
+        )
+        if drifted:
+            return False, "UNKNOWN"
+        lifecycle_engine._verify_adoption_commit(context.vault_root, receipt)
+        lifecycle_engine._snapshot_rewind_plan(
+            context.vault_root,
+            receipt,
+            current_modes,
+        )
+    except Exception:
+        return False, "UNKNOWN"
+    return True, "OK"
+
+
+def _receipt_when(transaction_id: str) -> str:
+    """Expose the transaction id's zone-less local timestamp without guessing a zone."""
+    try:
+        return datetime.strptime(transaction_id[:15], "%Y%m%dT%H%M%S").isoformat()
+    except ValueError:
+        return transaction_id[:15]
+
+
+def _ledger_recovery(context: DoctorContext, error: Exception) -> LedgerRecovery:
+    detail = _one_line(error)
+    return LedgerRecovery(
+        "UNKNOWN",
+        "publication is incomplete" in detail,
+        lifecycle_ledger._repair_command(context.vault_root),
+        detail,
+    )
+
+
+def _recovery_surface(
+    transactions: tuple[InterruptedTransaction, ...],
+    ledger: LedgerRecovery | None,
+    inspection_error: str | None,
+) -> str:
+    parts: list[str] = []
+    if transactions:
+        parts.append("I found an interrupted update — resume or undo?")
+    if ledger is not None:
+        parts.append(f"Ledger history is UNKNOWN; run {ledger.repair_command}.")
+    if inspection_error is not None:
+        parts.append("Transaction recovery evidence could not be checked safely.")
+    return " ".join(parts) or "No interrupted update or ledger recovery is waiting."
+
+
+def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
+    """Collect Doctor's deterministic five-group adoption section, read-only.
+
+    This collector never resumes transactions, repairs ledger publication, or
+    writes caches. Its authority/surface non-alteration contract is documented
+    on :class:`AdoptionReport` and in ``docs/dex-doctor-spec.md``.
+    """
+    catalog_path = _release_catalog_path(context)
+    if not os.path.lexists(catalog_path):
+        return _empty_adoption_report(
+            "OFF",
+            "Adoption reporting is off because no release catalog is installed.",
+        )
+
+    transactions, inspection_error = _inspect_interrupted_transactions(context)
+    try:
+        catalog = load_catalog(catalog_path, release_root=context.vault_root)
+    except (CatalogError, UnicodeError) as error:
+        return _empty_adoption_report(
+            "BROKEN",
+            f"Adoption reporting is unavailable because the release catalog is invalid: {_one_line(error)}.",
+            transactions=transactions,
+            inspection_error=inspection_error,
+        )
+    except Exception as error:
+        return _empty_adoption_report(
+            "UNKNOWN",
+            f"Adoption reporting could not inspect the release catalog: {_one_line(error)}.",
+            transactions=transactions,
+            inspection_error=inspection_error,
+        )
+
+    try:
+        inventory = build_inventory(context.vault_root, catalog=catalog)
+    except Exception as error:
+        return _empty_adoption_report(
+            "UNKNOWN",
+            f"Adoption reporting could not build the read-only inventory: {_one_line(error)}.",
+            transactions=transactions,
+            inspection_error=inspection_error,
+        )
+
+    ledger_recovery: LedgerRecovery | None = None
+    try:
+        ledger_state = lifecycle_ledger.project_state(context.vault_root)
+    except (lifecycle_ledger.LedgerError, OSError) as error:
+        ledger_recovery = _ledger_recovery(context, error)
+        return _empty_adoption_report(
+            "UNKNOWN",
+            "Adoption actions are withheld until lifecycle history is verified.",
+            transactions=transactions,
+            ledger=ledger_recovery,
+            inspection_error=inspection_error,
+        )
+    except Exception as error:
+        ledger_recovery = _ledger_recovery(context, error)
+        return _empty_adoption_report(
+            "UNKNOWN",
+            "Adoption actions are withheld until lifecycle history is verified.",
+            transactions=transactions,
+            ledger=ledger_recovery,
+            inspection_error=inspection_error,
+        )
+
+    catalog_ids = {item.id for item in catalog.items}
+    adopted = ledger_state["adopted"]
+    held_back = set(ledger_state["held_back"])
+    assert isinstance(adopted, dict)
+    try:
+        plan = build_adoption_plan(
+            catalog,
+            inventory,
+            adoption_states={
+                item_id: AdoptionState.ADOPTED
+                for item_id in adopted
+                if item_id in catalog_ids
+            },
+            held_back=frozenset(held_back & catalog_ids),
+        )
+    except Exception as error:
+        return _empty_adoption_report(
+            "UNKNOWN",
+            f"Adoption actions are withheld because the plan is UNKNOWN: {_one_line(error)}.",
+            transactions=transactions,
+            inspection_error=inspection_error,
+        )
+
+    new_items = tuple(
+        AdoptionItem(item.item_id, item.item_version, item.action.value)
+        for item in plan.items
+        if item.action is PlannedAction.ADOPT
+    )
+    review_items = tuple(
+        AdoptionReviewItem(
+            item.item_id,
+            item.item_version,
+            item.action.value,
+            tuple(reason.code.value for reason in item.reasons),
+            tuple(
+                AdoptionReviewFile(path, reason.code.value)
+                for reason in item.reasons
+                for path in reason.paths
+            ),
+        )
+        for item in plan.items
+        if item.action in {PlannedAction.CONFLICT, PlannedAction.UNKNOWN}
+    )
+    held_items = tuple(
+        AdoptionItem(item.item_id, item.item_version, item.action.value)
+        for item in plan.items
+        if item.action is PlannedAction.SKIP_HELD_BACK
+    )
+    held_catalog_ids = {item.item_id for item in held_items}
+    held_items += tuple(
+        AdoptionItem(item_id, None, PlannedAction.SKIP_HELD_BACK.value)
+        for item_id in sorted(held_back - held_catalog_ids)
+    )
+    customized_files = tuple(
+        PreservedCustomization(entry.path, entry.state, entry.reason)
+        for entry in inventory.customizations.divergences
+        if entry.state == "stock-modified"
+    )
+
+    receipt_summaries: list[AdoptionReceiptSummary] = []
+    for item_id, entry in sorted(
+        adopted.items(),
+        key=lambda pair: (str(pair[1]["tx_id"]), pair[0]),
+        reverse=True,
+    ):
+        transaction_id = str(entry["tx_id"])
+        rewindable, rewind_verdict = _receipt_rewind_evidence(
+            context,
+            transaction_id,
+            item_id,
+        )
+        receipt_summaries.append(
+            AdoptionReceiptSummary(
+                item_id,
+                str(entry["version"]),
+                AdoptionState.ADOPTED.value,
+                transaction_id,
+                _receipt_when(transaction_id),
+                rewindable,
+                rewind_verdict,
+            )
+        )
+    receipts = tuple(receipt_summaries)
+
+    recovery_verdict = (
+        "UNKNOWN"
+        if inspection_error is not None or any(tx.verdict == "UNKNOWN" for tx in transactions)
+        else "BROKEN" if transactions else "OK"
+    )
+    review_verdict = (
+        "UNKNOWN"
+        if any(item.action is PlannedAction.UNKNOWN for item in plan.items)
+        else "OK"
+    )
+    receipts_verdict = (
+        "UNKNOWN"
+        if any(receipt.rewind_verdict == "UNKNOWN" for receipt in receipts)
+        else "OK"
+    )
+    report_verdict = (
+        "UNKNOWN"
+        if "UNKNOWN" in {recovery_verdict, review_verdict, receipts_verdict}
+        else "BROKEN" if recovery_verdict == "BROKEN" else "OK"
+    )
+    return AdoptionReport(
+        ADOPTION_REPORT_VERSION,
+        report_verdict,
+        (
+            NewAndSafeGroup(
+                "new-and-safe",
+                "OK",
+                len(new_items),
+                new_items,
+                f"Here's exactly what this changes for you: {len(new_items)} item(s) are new and safe to adopt.",
+            ),
+            NeedsReviewGroup(
+                "needs-your-review",
+                review_verdict,
+                len(review_items),
+                review_items,
+                f"{len(review_items)} item(s) need your review because installed files differ from the release or could not be verified.",
+            ),
+            PreservedForNowGroup(
+                "preserved-for-now",
+                "OK",
+                len(held_items) + len(customized_files),
+                held_items,
+                customized_files,
+                f"{len(held_items)} held-back item(s) and {len(customized_files)} customized file(s) are preserved for now.",
+            ),
+            ContinueOrRecoverGroup(
+                "continue-or-recover",
+                recovery_verdict,
+                len(transactions) + int(inspection_error is not None),
+                transactions,
+                None,
+                inspection_error,
+                _recovery_surface(transactions, None, inspection_error),
+            ),
+            ReceiptsAndRewindGroup(
+                "receipts-and-rewind",
+                receipts_verdict,
+                len(receipts),
+                receipts,
+                f"{len(receipts)} adopted item receipt record(s); {sum(entry.rewindable for entry in receipts)} pass the receipt-backed rewind preflight.",
+            ),
+        ),
+    )
 
 
 def _probe_release_catalog(context: DoctorContext) -> ProbeResult:

--- a/docs/dex-doctor-spec.md
+++ b/docs/dex-doctor-spec.md
@@ -146,3 +146,48 @@ stub all external probes.
 
 One PR: collector + tests + skill + `/health-check` deletion + reference repoints +
 CHANGELOG (house style) + version bump. Ships as v1.27.0 via the normal release pipeline.
+
+## Adoption, holdback, and recovery section (D2)
+
+Doctor's additive `adoption` section is a deterministic, read-only report. Shell and
+skills collect inputs and render; they never own lifecycle mutation. The collector emits
+canonical JSON from a frozen `AdoptionReport` with exactly five ordered groups:
+
+1. `new-and-safe` — catalog items whose planner action is `adopt`.
+2. `needs-your-review` — items whose action is `conflict`, with planner reason codes
+   and per-file reason/path pairs. Planner `unknown` items are retained here verbatim
+   and make the group/report `UNKNOWN`; unprovable authority never disappears.
+3. `preserved-for-now` — ledger-held items plus `stock-modified` files preserved from
+   the `CustomizationReport`.
+4. `continue-or-recover` — unfinished transaction journals found by read-only,
+   `Transaction.resume`-style classification, transaction-inspection errors, and
+   incomplete or invalid ledger publication.
+5. `receipts-and-rewind` — current ledger adoption receipts: item, version,
+   transaction-id-derived local time, `rewind_verdict`, and whether the canonical
+   receipt, current bytes, committed journal, and retained snapshot all pass the
+   engine's read-only rewind preflight (`rewindable: true`). A cleanly absent snapshot
+   is pruned (`false` with `rewind_verdict: OK`); invalid evidence is `UNKNOWN`.
+
+Every group has `id`, `verdict`, `count`, authority records, and one fixed `surface`
+line. Authority includes item ids and versions, actions, statuses, verdicts, counts,
+paths, reasons, transaction ids, and rewindable booleans. A renderer reproduces these
+verbatim. It may paraphrase only `surface`, as one plain-English sentence; it never
+upgrades, downgrades, merges, omits, infers, or manufactures authority.
+
+The fixed adoption-status vocabulary is `applied` / `adopted` / `rewound` /
+`held-for-review` / `customization-review-required` /
+`external-reconciliation-pending` / `needs-recheck` / `skipped-by-user` /
+`failed-rolled-back`. Planner actions such as `adopt`, `conflict`, and
+`skip-held-back` are also rendered exactly, never translated into a new status.
+
+Degradation uses Doctor's existing vocabulary: `OFF` when no catalog is installed;
+`BROKEN` for an invalid catalog or unfinished transaction; `UNKNOWN` when ledger or
+transaction evidence cannot be verified; otherwise `OK`. Unknown ledger evidence
+withholds unprovable adoption actions and carries the ledger-owned
+`python3 -m core.lifecycle.cli --vault-root <vault> rebuild-state` command.
+
+The collector never resumes, rolls back, rebuilds, quarantines, creates locks, or writes
+a cache. The renderer may name only mechanisms the engine exposes: ledger
+`rebuild-state`, read-only transaction evidence, and the exact receipt-backed
+`rewind_adoption` flow when `rewindable` is true. It never invents a rewind CLI or
+offers rewind after snapshot pruning.


### PR DESCRIPTION
Chunk D2 of the lifecycle catalog program (spec §4/§5).

## What
- `/dex-doctor` gains the five-group adoption view: **new & safe · needs your review · preserved for now · continue or recover · receipts & rewind** — all facts computed by deterministic read-only code; the AI renderer may rephrase wording but cannot alter authority fields (stated contract in code, skill, and docs/dex-doctor-spec.md).
- Interrupted updates are detected by read-only inspection and surfaced as "resume or undo?" — Doctor never mutates.
- Honest degradation everywhere (OFF on older installs, UNKNOWN with the exact repair command on ledger damage).

## Review
- Read-only chunk (zero write paths added — verified). Fable diff review passed; adversarial review not required for non-vault-touching surface per program quality bar.

## Verification
- 121 tests green on rebased main (4 journey + 117 doctor); ruff clean; portable-contract (1068 paths) + founder-content gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42