### PR TITLE
feat: leadership trio catalog items + session-start plist fix (cathedral D3)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -29,7 +29,8 @@ echo ""
 echo "📅 Today: $(date '+%A, %B %d, %Y')"
 echo ""
 
-# Silent self-healing: ensure vault-path breadcrumb and launch agents stay in sync
+# Detect launch agents that still point to this vault's former location.
+# Doctor owns the repair; session start remains read-only for these machine files.
 VAULT_BREADCRUMB="$HOME/.config/dex/vault-path"
 if [[ -f "$ONBOARDING_MARKER" ]]; then
     STORED_VAULT=""
@@ -37,19 +38,18 @@ if [[ -f "$ONBOARDING_MARKER" ]]; then
         STORED_VAULT=$(tr -d '[:space:]' < "$VAULT_BREADCRUMB")
     fi
     if [[ "$STORED_VAULT" != "$CLAUDE_DIR" ]]; then
-        # Vault has moved — update breadcrumb and fix all launch agents
-        mkdir -p "$HOME/.config/dex"
-        echo "$CLAUDE_DIR" > "$VAULT_BREADCRUMB"
         if [[ -n "$STORED_VAULT" ]]; then
+            PLIST_PATH_CONFLICT="false"
             for plist in "$HOME/Library/LaunchAgents"/com.dex.*.plist "$HOME/Library/LaunchAgents"/com.claudesidian.*.plist; do
                 [[ -f "$plist" ]] || continue
-                if grep -q "$STORED_VAULT" "$plist" 2>/dev/null; then
-                    AGENT_NAME=$(basename "$plist" .plist)
-                    launchctl unload "$plist" 2>/dev/null || true
-                    sed -i '' "s|$STORED_VAULT|$CLAUDE_DIR|g" "$plist"
-                    launchctl load "$plist" 2>/dev/null || true
+                if grep -Fq -- "$STORED_VAULT" "$plist" 2>/dev/null; then
+                    PLIST_PATH_CONFLICT="true"
+                    break
                 fi
             done
+            if [[ "$PLIST_PATH_CONFLICT" == "true" ]]; then
+                echo "Dex found a background job that still points to this vault's old location — run /dex-doctor to fix this safely."
+            fi
         fi
     fi
 fi

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -41,6 +41,21 @@ function completeOnboarding(sandbox) {
   fs.writeFileSync(marker, '{}\n');
 }
 
+function installMovedVaultConflict(sandbox, plistName) {
+  const oldVault = path.join(path.dirname(sandbox.vault), 'old-vault');
+  const breadcrumb = path.join(sandbox.home, '.config', 'dex', 'vault-path');
+  const launchAgents = path.join(sandbox.home, 'Library', 'LaunchAgents');
+  const plist = path.join(launchAgents, plistName);
+  fs.mkdirSync(path.dirname(breadcrumb), { recursive: true });
+  fs.mkdirSync(launchAgents, { recursive: true });
+  fs.writeFileSync(breadcrumb, `${oldVault}\n`);
+  fs.writeFileSync(
+    plist,
+    `<plist><string>${oldVault}/.scripts/dex-launcher.sh</string></plist>\n`,
+  );
+  return { oldVault, breadcrumb, plist, plistBytes: fs.readFileSync(plist) };
+}
+
 function writeSmokeResult(sandbox, broken) {
   const resultPath = path.join(sandbox.vault, 'System', '.smoke-last-run.json');
   fs.mkdirSync(path.dirname(resultPath), { recursive: true });
@@ -165,4 +180,33 @@ test('overnight smoke block emits broken journey details', (t) => {
   assert.match(stdout, /--- 🚨 Overnight check found a problem ---/);
   assert.match(stdout, /task_lifecycle — task creation failed after the config changed/);
   assert.match(stdout, /Run \/dex-doctor for diagnosis and the fix\./);
+});
+
+for (const plistName of ['com.dex.meeting-intel.plist', 'com.claudesidian.learning.plist']) {
+  test(`session start reports but never changes moved-vault conflict in ${plistName}`, (t) => {
+    const sandbox = createSandbox(t);
+    completeOnboarding(sandbox);
+    const conflict = installMovedVaultConflict(sandbox, plistName);
+
+    const stdout = runSessionStart(sandbox);
+
+    assert.match(
+      stdout,
+      /Dex found a background job that still points to this vault's old location — run \/dex-doctor to fix this safely\./,
+    );
+    assert.deepEqual(fs.readFileSync(conflict.plist), conflict.plistBytes);
+    assert.equal(fs.readFileSync(conflict.breadcrumb, 'utf8'), `${conflict.oldVault}\n`);
+  });
+}
+
+test('session start stays silent when no plist points to the stored former vault', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  const conflict = installMovedVaultConflict(sandbox, 'com.dex.meeting-intel.plist');
+  fs.writeFileSync(conflict.plist, '<plist><string>/another/vault</string></plist>\n');
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /still points to this vault's old location/);
+  assert.equal(fs.readFileSync(conflict.breadcrumb, 'utf8'), `${conflict.oldVault}\n`);
 });

--- a/.claude/skills/decision-log/SKILL.md
+++ b/.claude/skills/decision-log/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: decision-log
+description: Capture an important decision with its context, options, rationale, and review date, then find it again when it matters.
+context: fork
+---
+
+## Purpose
+
+Keep important decisions from disappearing into meetings, messages, or memory. Record what was decided, why it made sense at the time, and when it should be looked at again.
+
+Use this for decisions that would be costly, confusing, or time-consuming to reconstruct later. Do not turn every small preference into a formal entry.
+
+## When to Use
+
+- The user says "we decided", "I chose", or "the call is"
+- A meeting ends with a meaningful choice
+- Several options were considered and the reasoning may matter later
+- A past decision is shaping today's work
+- The user asks why something was done
+
+## Step 1: Look for Relevant Past Decisions
+
+Before recording a new decision, search for the topic in:
+
+1. The active project's files under `04-Projects/`
+2. `06-Resources/Decisions/Decision_Log.md`
+3. Recent meeting notes under `00-Inbox/Meetings/`
+4. Related person or company pages when the decision concerns them
+
+If semantic search is available, use it to find decisions expressed in different words. Otherwise use a careful text search.
+
+Surface a past decision only when it is genuinely relevant. Say what was decided, when, and whether the new choice confirms, changes, or replaces it.
+
+## Step 2: Confirm the Decision
+
+Gather the minimum information needed for a useful record:
+
+- **Decision:** the choice in one clear sentence
+- **Context:** what made the choice necessary
+- **Options considered:** the real alternatives, including keeping things as they are when relevant
+- **Rationale:** why this option won
+- **Review date:** a date or a clear statement that no review is needed
+- **Related work:** project, goal, people, company, or meeting
+
+If anything important is missing, ask one question at a time. Do not invent options or reasoning the user did not give.
+
+## Step 3: Choose the Right Home
+
+Use the narrowest useful location:
+
+- A decision that belongs to one active project → append to that project's `Decisions.md`
+- A decision that applies across projects or to the user's wider work → append to `06-Resources/Decisions/Decision_Log.md`
+- If the best project is unclear → ask before filing it
+
+Create the parent folder or file when it does not exist. Append to an existing file; never replace earlier decisions.
+
+## Step 4: Write the Entry
+
+Use this structure:
+
+```markdown
+## YYYY-MM-DD — Decision title
+
+**Decision:** One sentence stating the choice.
+
+**Context:** The situation, constraint, or question that prompted it.
+
+**Options considered:**
+- Option A — the main benefit or trade-off
+- Option B — the main benefit or trade-off
+
+**Rationale:** Why this choice made the most sense with the information available.
+
+**Review:** YYYY-MM-DD — what would justify revisiting it
+
+**Related:** [[Project, goal, meeting, person, or company]]
+```
+
+If no review is needed, write `**Review:** No planned review` rather than leaving the field blank.
+
+Keep the entry factual and compact. Preserve uncertainty: if the choice was a trial, say so.
+
+## Step 5: Close the Loop
+
+After saving, confirm:
+
+- The decision in one sentence
+- Where it was saved
+- The review date, if any
+- Any earlier decision it replaces
+
+If the decision creates follow-up work, offer to add the next action through the normal task flow. Do not create a task without the user's confirmation.
+
+## Connection to `/week-review`
+
+Entries with a review date, a changed assumption, or an unresolved follow-up are designed to be surfaced during `/week-review`. When this skill records one of those, mention that `/week-review` can bring it back at the right time. This is a connection between the two skills; do not edit the week-review files.
+
+## Rules
+
+- Record the user's decision, not your preferred answer
+- Separate facts from assumptions
+- Never rewrite an older entry to make history look cleaner
+- When a decision changes, add a new entry and link the earlier one
+- Use absolute dates
+- Keep sensitive personal details out unless the user explicitly wants them recorded

--- a/.claude/skills/delegate-check/SKILL.md
+++ b/.claude/skills/delegate-check/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: delegate-check
+description: Review open delegations — what you handed off, to whom, its status, and the next useful nudge.
+context: fork
+---
+
+## Purpose
+
+Give the user a clear view of work they have handed to other people without turning delegation into hovering. Find what is moving, what is waiting, and where a short follow-up would help.
+
+## When to Use
+
+- The user asks what they are waiting on
+- The user wants to review delegated work or team commitments
+- A weekly planning or review conversation reveals unclear ownership
+- A promised follow-up is approaching or overdue
+
+## Step 1: Gather Open Delegations
+
+Read `03-Tasks/Tasks.md` and recent notes in `00-Inbox/Meetings/`.
+
+Look for plain-language patterns such as:
+
+- An owner or assignee who is not the user
+- "Delegated to", "waiting on", "with", or "owned by"
+- A person promising to send, review, decide, introduce, or deliver something
+- A user task whose next step is to follow up with someone
+- An open action item in a meeting note assigned to another person
+
+Check related person and project pages when they add useful context. If semantic search is available, use it to catch commitments expressed without the exact words above.
+
+Do not count a general hope, discussion point, or completed promise as an open delegation.
+
+## Step 2: Reconcile Duplicates
+
+The same handoff may appear in both `Tasks.md` and a meeting note. Treat matching owner, outcome, and timing as one delegation, and keep links to both sources.
+
+When two records disagree, show the disagreement plainly and ask which status is current. Do not silently choose one.
+
+## Step 3: Build the Review
+
+For each open delegation, capture:
+
+- **What:** the result the user handed off
+- **Who:** the person responsible
+- **Handed off:** the date or source meeting, when known
+- **Expected:** the promised or useful check-in date, when known
+- **Status:** moving, waiting, due soon, overdue, or unclear
+- **Last touch:** the latest relevant update
+- **Next nudge:** one specific, proportionate follow-up
+
+Present the items in this order:
+
+1. Overdue or blocked
+2. Due soon
+3. Waiting normally
+4. Status unclear
+
+Keep healthy items brief. Spend attention where the user may need to act.
+
+## Step 4: Recommend the Next Nudge
+
+A good nudge is short and easy to answer. Draft it in the user's normal tone and include the outcome or date that matters.
+
+Examples:
+
+- "How is the pricing review looking? I need the final call by Thursday to keep the launch on track."
+- "Quick check: are you still able to send the notes this week, or should we reset the date?"
+
+Do not send a message or create a task without the user's approval.
+
+## Step 5: Update the Record
+
+After the user confirms what changed:
+
+- Update a Dex task through the normal task tools, not by hand-editing its checkbox
+- Add a short status line to the relevant meeting or project note when that is the clearest source of truth
+- Mark a delegation complete only when the promised result is actually delivered or the user explicitly closes it
+- If the owner or date changed, preserve the earlier context in the note
+
+## Output
+
+Use a compact review:
+
+```markdown
+## Delegations needing attention
+
+- **Pricing review — Morgan**
+  - Expected: 2026-07-23 · Status: due soon
+  - Last touch: Agreed in the 2026-07-16 launch meeting
+  - Next nudge: Confirm whether Thursday still holds
+
+## Waiting normally
+
+- **Customer notes — Riley** · Expected next week · No action today
+```
+
+If nothing is open, say so plainly: "I found no open delegations in Tasks.md or recent meeting notes."
+
+## Rules
+
+- Never guess that silence means progress or failure
+- Keep the focus on outcomes, not activity
+- Distinguish work delegated by the user from work the user personally owes
+- Name missing owners, dates, or status as unclear
+- Use absolute dates
+- Do not nag when the agreed date has not arrived and there is no sign of risk

--- a/.claude/skills/weekly-reflection/SKILL.md
+++ b/.claude/skills/weekly-reflection/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: weekly-reflection
+description: A short guided reflection on what energized you, what drained you, and one thing to change next week.
+context: fork
+---
+
+## Purpose
+
+Pause for a few minutes and notice the lived experience of the week. This is not a progress report. It helps the user see where their energy went and choose one practical change for the week ahead.
+
+## How This Differs from `/week-review`
+
+`/week-review` looks at progress, completed work, goals, and concrete measures. `/weekly-reflection` looks at experience: what felt alive, what felt heavy, and what the user wants to do differently.
+
+The two can be used together, but neither requires the other.
+
+## Step 1: Set the Frame
+
+Say:
+
+> Let's take five minutes to notice the week, not score it. I'll ask three short questions, one at a time.
+
+If the user wants an even shorter version, accept one sentence per question.
+
+## Step 2: Ask What Energized Them
+
+Ask:
+
+> What gave you energy this week? Think about work, people, pace, or moments that felt worthwhile.
+
+After the answer, reflect back the specific source of energy in one or two sentences. Avoid turning it into advice yet.
+
+## Step 3: Ask What Drained Them
+
+Ask:
+
+> What drained you this week? What felt heavier, more frustrating, or more costly than it should have?
+
+Notice whether the drain came from the work itself, unclear expectations, too many switches, a relationship, or lack of recovery. Offer the pattern as a possibility, not a diagnosis.
+
+## Step 4: Choose One Change
+
+Ask:
+
+> What is one thing you want to change next week?
+
+Help make the answer small and observable. Prefer a change the user can control.
+
+Examples:
+
+- Protect one meeting-free morning
+- Ask for the decision before starting the work
+- End the day with ten minutes to close open loops
+- Spend more time on the work that created energy this week
+
+If the user names several changes, ask which single one would make the biggest difference.
+
+## Step 5: Save the Reflection
+
+Read `System/user-profile.yaml` and check `journaling.weekly`.
+
+### If weekly journaling is enabled
+
+Append the reflection to the current weekly journal under:
+
+`00-Inbox/Journals/YYYY/MM-Month/Weekly/YYYY-Www.md`
+
+Create the file from the existing weekly journal pattern if needed. Never replace an earlier entry.
+
+### If weekly journaling is not enabled
+
+Ask whether the user wants the reflection saved. If yes, append it to:
+
+`06-Resources/Reflections/Weekly_Reflections.md`
+
+If they prefer not to save it, leave the reflection in the conversation only.
+
+Use this structure:
+
+```markdown
+## Week YYYY-Www — ending YYYY-MM-DD
+
+**Energized by:**
+[User's answer]
+
+**Drained by:**
+[User's answer]
+
+**One change for next week:**
+[User's answer]
+```
+
+Keep the user's own words where possible.
+
+## Step 6: Close Gently
+
+End with a short summary:
+
+> This week, [energy source] gave you something back, while [drain] took more than it should. Next week you're trying [one change].
+
+If the chosen change needs a reminder or task, offer to add it through the normal task flow. Do not create one automatically.
+
+## Rules
+
+- Ask one question at a time
+- Do not grade the week or force a positive lesson
+- Do not turn every feeling into a task
+- Keep the reflection short unless the user wants to go deeper
+- Use absolute dates in the saved entry
+- Append to journal files; never overwrite the user's earlier writing

--- a/core/lifecycle/catalog/README.md
+++ b/core/lifecycle/catalog/README.md
@@ -14,7 +14,13 @@ Each source file is a closed document:
       "id": "decision-log",
       "kind": "skill",
       "version": "1.0.0",
-      "files": [".claude/skills/decision-log/SKILL.md"],
+      "files": [
+        {
+          "path": ".claude/skills/decision-log/SKILL.md",
+          "sha256": "<exact lowercase sha256>",
+          "byte_size": 1234
+        }
+      ],
       "dependencies": [],
       "capabilities": []
     }
@@ -22,6 +28,8 @@ Each source file is a closed document:
 }
 ```
 
-The generator derives hashes, ownership classes, and rewind tokens from the
-exact release tree. B2 intentionally ships no items; the first official item
-declarations land in D3.
+The publisher declaration pins each file's exact hash and byte size. The
+generator rejects stale pins, derives ownership classes and rewind tokens from
+the exact release tree, and validates the emitted items through the v1 model
+and schema. The first official item declarations live in
+`official-capabilities.json`.

--- a/core/lifecycle/catalog/official-capabilities.json
+++ b/core/lifecycle/catalog/official-capabilities.json
@@ -1,0 +1,47 @@
+{
+  "catalog_source_version": 1,
+  "items": [
+    {
+      "id": "decision-log",
+      "kind": "skill",
+      "version": "1.0.0",
+      "files": [
+        {
+          "path": ".claude/skills/decision-log/SKILL.md",
+          "sha256": "ba989a5a1030c4963e7d0d2a7fc123be28bbde93befc2a027bc29049d758d4c5",
+          "byte_size": 4156
+        }
+      ],
+      "dependencies": [],
+      "capabilities": []
+    },
+    {
+      "id": "delegate-check",
+      "kind": "skill",
+      "version": "1.0.0",
+      "files": [
+        {
+          "path": ".claude/skills/delegate-check/SKILL.md",
+          "sha256": "6676ef8da895359dc9ce1336e7d0d5174c0bf2cb156e1bbce3899f67ee58e784",
+          "byte_size": 3917
+        }
+      ],
+      "dependencies": [],
+      "capabilities": []
+    },
+    {
+      "id": "weekly-reflection",
+      "kind": "skill",
+      "version": "1.0.0",
+      "files": [
+        {
+          "path": ".claude/skills/weekly-reflection/SKILL.md",
+          "sha256": "e9a78100ffc7612dfb8fa45d7bd2d5aa4ef1a8d73652b639ad3f17c57bcfb233",
+          "byte_size": 3393
+        }
+      ],
+      "dependencies": [],
+      "capabilities": []
+    }
+  ]
+}

--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -950,33 +950,58 @@ def execute_adoption(
         transaction = Transaction.begin(root, entries)
 
         def verify_approval_binding() -> None:
-            """Catch pre-snapshot drift, with one inherited residual window.
+            """Catch pre-snapshot drift, including approved file absence.
 
-            If a target changes after the final preview rebuild but before
-            snapshot capture, the snapshot records those newer bytes; comparing
-            it with the approved catalog bytes catches the drift and rollback
-            restores the newer bytes. A non-transaction writer that changes a
-            target after snapshot capture but before ``_apply_one`` is not
-            caught: apply overwrites the edit with the approved stock bytes,
-            this comparison still sees snapshot(stock) == catalog, and the
-            adoption commits. That sub-millisecond window is inherited from the
-            trusted transaction core because write PlanEntry objects cannot set
-            ``expected_current_sha256``.
+            A target may be either the exact stock file or safely absent when
+            the approved plan creates an additive item. If it changes after the
+            final preview rebuild but before snapshot capture, rollback restores
+            those later bytes or that later absence. The transaction core's
+            documented post-snapshot residual race remains unchanged.
             """
             if not hmac.compare_digest(approved_token, rebuilt.sha256):
                 raise _refuse("approval binding changed before commit")
             snapshot_by_path = {
                 entry.relative: entry for entry in transaction.snapshot.read_manifest()
             }
+            inventory_by_path = {
+                entry.canonical_path: entry
+                for entry in current_inventory.entries
+                if entry.canonical_path
+                in {
+                    write.path
+                    for preview_item in rebuilt.items
+                    for write in preview_item.writes
+                }
+            }
             for item in rebuilt.items:
                 for write in item.writes:
                     captured = snapshot_by_path.get(write.path)
-                    if (
-                        captured is None
-                        or not captured.existed
-                        or captured.sha256 != write.new_sha256
-                        or captured.size != write.byte_size
-                    ):
+                    evidence = inventory_by_path.get(write.path)
+                    approved_absence = bool(
+                        evidence is not None
+                        and evidence.kind == "missing"
+                        and evidence.release_state == "stock-missing"
+                        and evidence.write_allowed
+                    )
+                    captured_matches = bool(
+                        captured is not None
+                        and (
+                            (
+                                approved_absence
+                                and not captured.existed
+                                and captured.sha256 is None
+                                and captured.size is None
+                                and captured.mode is None
+                            )
+                            or (
+                                not approved_absence
+                                and captured.existed
+                                and captured.sha256 == write.new_sha256
+                                and captured.size == write.byte_size
+                            )
+                        )
+                    )
+                    if not captured_matches:
                         raise _refuse(
                             f"requested file {write.path} changed after final preview rebuild; "
                             "the transaction will restore the newer bytes"

--- a/core/lifecycle/plan.py
+++ b/core/lifecycle/plan.py
@@ -366,6 +366,7 @@ def plan_catalog_item(
         ReasonCode.RELEASE_FILES_MODIFIED: set(),
         ReasonCode.RELEASE_FILES_MISSING: set(),
     }
+    safely_creatable: set[str] = set()
     unknown_paths: set[str] = set()
     for path, entries in by_path.items():
         if len(entries) != 1:
@@ -375,7 +376,10 @@ def plan_catalog_item(
         if state == "stock-modified":
             conflict_paths[ReasonCode.RELEASE_FILES_MODIFIED].add(path)
         elif state == "stock-missing":
-            conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(path)
+            if entries[0].write_allowed:
+                safely_creatable.add(path)
+            else:
+                conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(path)
         elif state != "stock-unmodified":
             unknown_paths.add(path)
     for divergence in evidence.divergences:
@@ -384,7 +388,10 @@ def plan_catalog_item(
         if divergence.state == "stock-modified":
             conflict_paths[ReasonCode.RELEASE_FILES_MODIFIED].add(divergence.canonical_path)
         elif divergence.state == "stock-missing":
-            conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(divergence.canonical_path)
+            if divergence.canonical_path not in safely_creatable:
+                conflict_paths[ReasonCode.RELEASE_FILES_MISSING].add(
+                    divergence.canonical_path
+                )
         else:
             unknown_paths.add(divergence.canonical_path)
 

--- a/core/tests/test_adoption_effective_behavior.py
+++ b/core/tests/test_adoption_effective_behavior.py
@@ -1,0 +1,242 @@
+"""D3 effective behavior for the first official catalog items."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle import engine as adoption_engine
+from core.lifecycle.catalog import canonical_catalog_bytes, loads_catalog, with_catalog_identity
+from core.lifecycle.engine import (
+    AdoptionRewindError,
+    execute_adoption,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.ledger import project_state
+from core.lifecycle.model import AdoptionState, ReleaseCatalog
+from core.lifecycle.plan import AdoptionPlan, build_adoption_plan
+from core.lifecycle.preview import build_adoption_preview
+from core.tests.lifecycle_test_helpers import SOURCE_COMMIT
+from core.transaction.engine import PlanEntry, Transaction
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = REPO_ROOT / "core/lifecycle/catalog/official-capabilities.json"
+CATALOG_PATH = "System/.release-catalog.json"
+TRIO = ("decision-log", "delegate-check", "weekly-reflection")
+
+
+def _items_by_id(plan: AdoptionPlan):
+    return {item.item_id: item for item in plan.items}
+
+
+def _source_registry() -> tuple[dict[str, object], dict[str, bytes]]:
+    source = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    assert source["catalog_source_version"] == 1
+    assert tuple(item["id"] for item in source["items"]) == TRIO
+
+    payloads: dict[str, bytes] = {}
+    for item in source["items"]:
+        for declared_file in item["files"]:
+            path = declared_file["path"]
+            content = (REPO_ROOT / path).read_bytes()
+            assert declared_file["sha256"] == hashlib.sha256(content).hexdigest()
+            assert declared_file["byte_size"] == len(content)
+            payloads[path] = content
+    return source, payloads
+
+
+def _catalog_from_source(source: dict[str, object], manifest: bytes) -> ReleaseCatalog:
+    items = []
+    for source_item in source["items"]:
+        files = []
+        for declared_file in source_item["files"]:
+            path = declared_file["path"]
+            resolution = portable_contract.resolve(path)
+            files.append(
+                {
+                    "path": path,
+                    "sha256": declared_file["sha256"],
+                    "ownership_class": resolution.ownership,
+                }
+            )
+        item_id = source_item["id"]
+        version = source_item["version"]
+        items.append(
+            {
+                "id": item_id,
+                "kind": source_item["kind"],
+                "version": version,
+                "files": files,
+                "dependencies": source_item["dependencies"],
+                "capabilities": source_item["capabilities"],
+                "rewind": {
+                    "acknowledgement_required": True,
+                    "token": f"rewind:{item_id}@{version}",
+                },
+            }
+        )
+    document = with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.67.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.67.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": items,
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+    return loads_catalog(json.dumps(document), manifest_bytes=manifest)
+
+
+def _fresh_vault(tmp_path: Path):
+    source, payloads = _source_registry()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    manifest_paths = sorted(
+        set(payloads) | {"System/.installed-files.manifest", CATALOG_PATH}
+    )
+    manifest = "".join(f"{path}\n" for path in manifest_paths).encode()
+    catalog = _catalog_from_source(source, manifest)
+
+    prior_path = ".claude/skills/weekly-reflection/SKILL.md"
+    bootstrap = [
+        PlanEntry("System/.installed-files.manifest", manifest),
+        PlanEntry(CATALOG_PATH, canonical_catalog_bytes(catalog)),
+        PlanEntry(prior_path, payloads[prior_path], mode=0o600),
+    ]
+    Transaction.begin(vault, bootstrap).run()
+    return vault, catalog, payloads, prior_path
+
+
+def _ledger_states(vault: Path) -> dict[str, AdoptionState]:
+    adopted = project_state(vault)["adopted"]
+    assert isinstance(adopted, dict)
+    return {item_id: AdoptionState.ADOPTED for item_id in adopted}
+
+
+def test_trio_adoption_is_effective_replans_and_rewinds_exactly(tmp_path: Path) -> None:
+    vault, catalog, payloads, prior_path = _fresh_vault(tmp_path)
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+    assert {item.item_id: item.action.value for item in plan.items} == {
+        item_id: "adopt" for item_id in TRIO
+    }
+
+    preview = build_adoption_preview(catalog, inventory, plan, TRIO, payloads.__getitem__)
+    receipt = execute_adoption(vault, preview, preview.sha256, payloads.__getitem__)
+
+    assert receipt.items_adopted == TRIO
+    for path, expected in payloads.items():
+        assert (vault / path).read_bytes() == expected
+    assert stat.S_IMODE((vault / prior_path).stat().st_mode) == 0o644
+
+    adopted_plan = build_adoption_plan(
+        catalog,
+        build_inventory(vault, catalog=catalog),
+        adoption_states=_ledger_states(vault),
+    )
+    assert {item.item_id: item.action.value for item in adopted_plan.items} == {
+        item_id: "already-adopted" for item_id in TRIO
+    }
+
+    rewind = rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+    restored = {entry.path: entry.existed_before_adoption for entry in rewind.files_restored}
+    assert restored == {
+        ".claude/skills/decision-log/SKILL.md": False,
+        ".claude/skills/delegate-check/SKILL.md": False,
+        prior_path: True,
+    }
+    assert not (vault / ".claude/skills/decision-log/SKILL.md").exists()
+    assert not (vault / ".claude/skills/delegate-check/SKILL.md").exists()
+    assert (vault / prior_path).read_bytes() == payloads[prior_path]
+    assert stat.S_IMODE((vault / prior_path).stat().st_mode) == 0o600
+    assert project_state(vault)["adopted"] == {}
+
+
+def test_trio_rewind_refuses_an_edited_created_skill_and_preserves_its_bytes(
+    tmp_path: Path,
+) -> None:
+    vault, catalog, payloads, _prior_path = _fresh_vault(tmp_path)
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+    preview = build_adoption_preview(catalog, inventory, plan, TRIO, payloads.__getitem__)
+    receipt = execute_adoption(vault, preview, preview.sha256, payloads.__getitem__)
+    created_path = ".claude/skills/decision-log/SKILL.md"
+    receipt_file = next(
+        entry for entry in receipt.files_written if entry.path == created_path
+    )
+
+    current_modes, drifted = adoption_engine._current_adopted_modes(vault, receipt)
+    assert drifted == ()
+    rewind_plan, _restored = adoption_engine._snapshot_rewind_plan(
+        vault, receipt, current_modes
+    )
+    deletion = next(entry for entry in rewind_plan if entry.relative == created_path)
+    assert deletion.content is None
+    assert deletion.expected_current_sha256 == receipt_file.sha256
+
+    edited = b"# user edit that rewind must preserve\n"
+    target = vault / created_path
+    target.write_bytes(edited)
+
+    with pytest.raises(AdoptionRewindError) as raised:
+        rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+
+    assert "files changed after adoption and were left untouched" in str(raised.value)
+    assert created_path in str(raised.value)
+    assert target.read_bytes() == edited
+
+
+def test_holding_back_one_trio_item_never_changes_the_other_two(tmp_path: Path) -> None:
+    for held_item in TRIO:
+        scenario = tmp_path / held_item
+        scenario.mkdir()
+        vault, catalog, payloads, _prior_path = _fresh_vault(scenario)
+        inventory = build_inventory(vault, catalog=catalog)
+        baseline = _items_by_id(build_adoption_plan(catalog, inventory))
+        held_path = f".claude/skills/{held_item}/SKILL.md"
+        held_target = vault / held_path
+        held_bytes = held_target.read_bytes() if held_target.exists() else None
+        held_mode = stat.S_IMODE(held_target.stat().st_mode) if held_target.exists() else None
+
+        held = _items_by_id(
+            build_adoption_plan(catalog, inventory, held_back={held_item})
+        )
+        assert held[held_item].action.value == "skip-held-back"
+        other_items = tuple(sorted(set(TRIO) - {held_item}))
+        for other_item in other_items:
+            assert held[other_item] == baseline[other_item]
+
+        held_plan = build_adoption_plan(catalog, inventory, held_back={held_item})
+        preview = build_adoption_preview(
+            catalog,
+            inventory,
+            held_plan,
+            other_items,
+            payloads.__getitem__,
+        )
+        receipt = execute_adoption(vault, preview, preview.sha256, payloads.__getitem__)
+
+        assert receipt.items_adopted == other_items
+        for other_item in other_items:
+            other_path = f".claude/skills/{other_item}/SKILL.md"
+            assert (vault / other_path).read_bytes() == payloads[other_path]
+        if held_bytes is None:
+            assert not held_target.exists()
+        else:
+            assert held_target.read_bytes() == held_bytes
+            assert stat.S_IMODE(held_target.stat().st_mode) == held_mode

--- a/core/tests/test_adoption_plan.py
+++ b/core/tests/test_adoption_plan.py
@@ -14,6 +14,7 @@ from core.lifecycle.model import AdoptionState, ReleaseCatalog
 from core.lifecycle.plan import (
     AdoptionPlan,
     AdoptionPlanError,
+    ReasonCode,
     build_adoption_plan,
     canonical_adoption_plan_bytes,
 )
@@ -113,15 +114,41 @@ def test_plan_classifies_each_catalog_item_from_its_own_evidence(tmp_path: Path)
     assert by_id["conflict"].reasons[0].paths == (
         ".claude/skills/conflict/SKILL.md",
     )
-    assert by_id["missing"].action == "conflict"
+    assert by_id["missing"].action == "adopt"
+    assert by_id["missing"].reasons[0].code == "release-files-ready"
     assert by_id["unknown"].action == "unknown"
     assert plan.counts == {
-        "adopt": 1,
+        "adopt": 2,
         "already-adopted": 1,
         "skip-held-back": 1,
-        "conflict": 2,
+        "conflict": 1,
         "unknown": 1,
     }
+
+
+def test_stock_missing_never_write_path_is_a_release_files_missing_conflict(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    path = "04-Projects/Private/notes.md"
+    expected = b"release must not create user content\n"
+    manifest = write_manifest(vault, [path])
+    raw_catalog = _catalog(manifest, {"protected": expected}).to_dict()
+    raw_catalog["items"][0]["files"][0].update(
+        {"path": path, "ownership_class": "vault"}
+    )
+    catalog = ReleaseCatalog.from_dict(raw_catalog)
+    inventory = build_inventory(vault, catalog=catalog)
+
+    entry = next(entry for entry in inventory.entries if entry.canonical_path == path)
+    assert entry.release_state == "stock-missing"
+    assert entry.write_allowed is False
+
+    planned = _items_by_id(build_adoption_plan(catalog, inventory))["protected"]
+    assert planned.action == "conflict"
+    assert planned.reasons[0].code is ReasonCode.RELEASE_FILES_MISSING
+    assert planned.reasons[0].paths == (path,)
 
 
 def test_no_recorded_adoption_state_means_nothing_is_already_adopted(tmp_path: Path) -> None:

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -391,7 +391,13 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
         capture_output=True,
     ).stdout
     assert catalog["catalog_version"] == 1
-    assert catalog["items"] == []
+    official_registry = json.loads(
+        (REPO_ROOT / "core/lifecycle/catalog/official-capabilities.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected_item_ids = sorted(item["id"] for item in official_registry["items"])
+    assert sorted(item["id"] for item in catalog["items"]) == expected_item_ids
     assert catalog["release"]["version"] == package["version"]
     assert catalog["release"]["source_commit"] == source_commit
     assert catalog["release"]["manifest"]["sha256"] == hashlib.sha256(manifest_bytes).hexdigest()

--- a/core/tests/test_release_catalog_generation.py
+++ b/core/tests/test_release_catalog_generation.py
@@ -34,7 +34,13 @@ def _catalog_fixture(tmp_path: Path) -> tuple[Path, Path, bytes]:
                         "id": "decision-log",
                         "kind": "skill",
                         "version": "1.0.0",
-                        "files": [".claude/skills/decision-log/SKILL.md"],
+                        "files": [
+                            {
+                                "path": ".claude/skills/decision-log/SKILL.md",
+                                "sha256": hashlib.sha256(item_bytes).hexdigest(),
+                                "byte_size": len(item_bytes),
+                            }
+                        ],
                         "dependencies": [],
                         "capabilities": [],
                     }
@@ -143,6 +149,35 @@ def test_catalog_coverage_gate_fails_closed_when_an_item_file_is_removed(
     )
     assert red.returncode == 1
     assert "missing catalog file" in red.stderr
+
+
+def test_release_catalog_generation_rejects_stale_source_file_pins(
+    tmp_path: Path,
+) -> None:
+    release_root, item_path, _manifest_bytes = _catalog_fixture(tmp_path)
+    item_path.write_bytes(b"# changed after the registry was reviewed\n")
+
+    result = _generate(release_root)
+
+    assert result.returncode == 1
+    assert "does not match its declared sha256 or byte_size" in result.stderr
+
+
+def test_release_catalog_generation_rejects_duplicate_ids_across_fragments(
+    tmp_path: Path,
+) -> None:
+    release_root, _item_path, _manifest_bytes = _catalog_fixture(tmp_path)
+    source_dir = release_root / "core/lifecycle/catalog"
+    first_source = source_dir / "test-items.json"
+    second_source = source_dir / "more-items.json"
+    second_source.write_bytes(first_source.read_bytes())
+
+    result = _generate(release_root)
+
+    assert result.returncode == 1
+    assert "duplicate catalog item id 'decision-log'" in result.stderr
+    assert str(first_source) in result.stderr
+    assert str(second_source) in result.stderr
 
 
 def test_distributed_release_catalog_schema_matches_b1_source() -> None:

--- a/scripts/generate-release-catalog.py
+++ b/scripts/generate-release-catalog.py
@@ -26,6 +26,7 @@ SCHEMA_SOURCE = Path("core/lifecycle/schemas/release-catalog-v1.schema.json")
 SCHEMA_DISTRIBUTION = Path("packages/dex-contracts/dist/release-catalog-v1.schema.json")
 SOURCE_VERSION = 1
 FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 SHIPPABLE_OWNERSHIP = frozenset({"brain", "seed", "generated"})
 
 
@@ -100,6 +101,7 @@ def _source_items(release_root: Path, portable_contract: object) -> list[dict[st
         raise CatalogGenerationError(f"publisher catalog source is missing: {CATALOG_SOURCE_DIR}")
 
     items: list[dict[str, object]] = []
+    seen_item_sources: dict[str, Path] = {}
     for source_path in sorted(source_dir.glob("*.json")):
         raw = _mapping(_closed_json(source_path), context=str(source_path))
         _exact_fields(
@@ -120,16 +122,51 @@ def _source_items(release_root: Path, portable_contract: object) -> list[dict[st
                 {"id", "kind", "version", "files", "dependencies", "capabilities"},
                 context=context,
             )
+            item_id = item["id"]
+            if isinstance(item_id, str):
+                previous_source = seen_item_sources.get(item_id)
+                if previous_source is not None:
+                    raise CatalogGenerationError(
+                        f"duplicate catalog item id {item_id!r} in "
+                        f"{previous_source} and {source_path}"
+                    )
+                seen_item_sources[item_id] = source_path
             files = item["files"]
             if not isinstance(files, list) or not files:
                 raise CatalogGenerationError(f"{context} files must be a non-empty array")
             generated_files = []
-            for file_index, raw_path in enumerate(files):
+            for file_index, raw_file in enumerate(files):
+                file_context = f"{context} file {file_index}"
+                declared_file = _mapping(raw_file, context=file_context)
+                _exact_fields(
+                    declared_file,
+                    {"path", "sha256", "byte_size"},
+                    context=file_context,
+                )
                 path, absolute = _release_path(
                     release_root,
-                    raw_path,
-                    context=f"{context} file {file_index}",
+                    declared_file["path"],
+                    context=f"{file_context} path",
                 )
+                declared_sha256 = declared_file["sha256"]
+                if (
+                    not isinstance(declared_sha256, str)
+                    or HEX_SHA256.fullmatch(declared_sha256) is None
+                ):
+                    raise CatalogGenerationError(
+                        f"{file_context} sha256 must be a lowercase sha256 digest"
+                    )
+                declared_size = declared_file["byte_size"]
+                if type(declared_size) is not int or declared_size < 0:
+                    raise CatalogGenerationError(
+                        f"{file_context} byte_size must be a non-negative integer"
+                    )
+                actual_sha256 = _sha256(absolute)
+                actual_size = absolute.stat().st_size
+                if actual_sha256 != declared_sha256 or actual_size != declared_size:
+                    raise CatalogGenerationError(
+                        f"{file_context} does not match its declared sha256 or byte_size"
+                    )
                 try:
                     resolution = portable_contract.resolve(path)
                 except portable_contract.ContractViolation as error:
@@ -143,11 +180,10 @@ def _source_items(release_root: Path, portable_contract: object) -> list[dict[st
                 generated_files.append(
                     {
                         "path": path,
-                        "sha256": _sha256(absolute),
+                        "sha256": actual_sha256,
                         "ownership_class": resolution.ownership,
                     }
                 )
-            item_id = item["id"]
             version = item["version"]
             items.append(
                 {


### PR DESCRIPTION
Chunk D3 of the lifecycle catalog program (spec §5). Completes Phase D pre-gate work.

## What
- First real catalog items: **/decision-log, /delegate-check, /weekly-reflection** skills, sha-pinned in the official capabilities registry and release catalog.
- Adoption can now CREATE missing files — only where the ownership contract explicitly permits, proven absent by the locked snapshot; a user's pre-existing file always wins. Rewind removes created files (receipt-sha-bound) and refuses if the user edited them.
- session-start hook no longer silently rewrites launchd plists: read-only detection + one calm line + Doctor routing (gate E11).

## Review trail
- Fable diff review; independent adversarial review (Opus): **SHIP-WITH-FIXES** — creation path held at all three defense layers; all fixes applied incl. mutation-proven red-when-removed test for the planner permission gate.

## Verification
- 56 lifecycle + 10 hook tests green on rebased main; ruff; portable-contract (1069 paths); founder-content; catalog generation/coverage all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42