### PR TITLE
test+harden: Phase D gate — hostile-vault journey + 100k benchmark + symlink containment (D-GATE)

### DIFF
--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -3,6 +3,9 @@ name: Nightly Quality
 on:
   schedule:
     - cron: "0 3 * * *"
+  push:
+    tags:
+      - "v*-rc*"
   workflow_dispatch:
 
 jobs:
@@ -53,3 +56,39 @@ jobs:
         with:
           name: nightly-quality-artifacts
           path: .logs/flaky/
+
+  adoption-gates:
+    name: Adoption journey + 100k performance gate
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install mcp pyyaml python-dateutil requests
+
+      - name: Messy-vault adoption journey
+        run: |
+          mkdir -p .logs/adoption-gates
+          pytest core/tests/test_adoption_messy_vault_journey.py -q \
+            --junitxml=.logs/adoption-gates/messy-vault-junit.xml
+
+      - name: 100k-file adoption performance budget
+        run: |
+          python scripts/benchmark_adoption_engine.py --files 100000 \
+            | tee .logs/adoption-gates/benchmark-100k.json
+
+      - name: Upload adoption gate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: adoption-gate-evidence
+          path: .logs/adoption-gates/
+          if-no-files-found: warn

--- a/core/lifecycle/inventory.py
+++ b/core/lifecycle/inventory.py
@@ -28,6 +28,7 @@ from core.lifecycle.filesystem import (
 from core.lifecycle.machine_state import MachineStateReport, probe_machine_state
 from core.lifecycle.model import ReleaseCatalog
 from core.lifecycle.secrets import assert_no_denied_metadata, redact_document
+from core.path_safety import unsafe_existing_parent
 
 FOLDER_MAP_PATH = "System/folder-paths.yaml"
 MAX_FOLDER_MAP_BYTES = 256 * 1024
@@ -335,6 +336,13 @@ def build_inventory(
             continue
         actual = folder_map.materialize(expected_path)
         ownership, rule, denied, write_allowed, write_action = _contract_facts(expected_path, exists=False)
+        unsafe_parent = unsafe_existing_parent(root, actual)
+        release_state = "stock-missing"
+        if unsafe_parent is not None:
+            write_allowed = False
+            write_action = "unsafe-parent"
+            release_state = "unknown"
+            errors.append(f"{actual}: {unsafe_parent}; refusing missing-path write evidence")
         entries.append(
             InventoryEntry(
                 actual,
@@ -343,7 +351,7 @@ def build_inventory(
                 ownership,
                 rule,
                 denied,
-                "stock-missing",
+                release_state,
                 write_allowed,
                 write_action,
                 redacted=denied,

--- a/core/lifecycle/performance-budget-v1.json
+++ b/core/lifecycle/performance-budget-v1.json
@@ -1,0 +1,12 @@
+{
+  "budget_version": 1,
+  "files": 100000,
+  "machine_class_note": "Calibrated 2026-07-21 on a MacBook Pro (Mac17,8), Apple M5 Pro 18-core, 48 GB RAM, using ../creds-venv Python 3.14; each seconds budget is the observed 100k stage time plus 30% headroom.",
+  "seconds": {
+    "adoption_and_rewind": 5.718049,
+    "build_adoption_plan": 0.00288,
+    "build_inventory": 5.580281,
+    "collect_adoption_report": 5.7281,
+    "total_measured": 17.029311
+  }
+}

--- a/core/path_safety.py
+++ b/core/path_safety.py
@@ -1,0 +1,50 @@
+"""Filesystem path-safety checks shared by inventory and mutation engines."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path, PurePosixPath
+
+
+def unsafe_existing_parent(vault_root: Path, relative: str) -> str | None:
+    """Describe the first symlink/non-directory parent, without following it.
+
+    Missing parents are safe evidence: a sanctioned writer may create them.
+    Every parent that already exists must be a real directory.
+    """
+    candidate = PurePosixPath(relative)
+    if (
+        not relative
+        or candidate.is_absolute()
+        or candidate.as_posix() != relative
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+    ):
+        return f"unsafe relative path {relative!r}"
+
+    root = Path(vault_root)
+    try:
+        root_metadata = root.lstat()
+    except OSError as error:
+        return f"vault root metadata is unavailable ({error.__class__.__name__})"
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        return "vault root is not a real directory"
+
+    current = root
+    traversed: list[str] = []
+    for part in candidate.parts[:-1]:
+        current /= part
+        traversed.append(part)
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as error:
+            return f"parent {'/'.join(traversed)} is unavailable ({error.__class__.__name__})"
+        if stat.S_ISLNK(metadata.st_mode):
+            return f"symlinked parent {'/'.join(traversed)}"
+        if not stat.S_ISDIR(metadata.st_mode):
+            return f"non-directory parent {'/'.join(traversed)}"
+    return None
+
+
+__all__ = ["unsafe_existing_parent"]

--- a/core/tests/test_adoption_messy_vault_journey.py
+++ b/core/tests/test_adoption_messy_vault_journey.py
@@ -1,0 +1,506 @@
+"""D-GATE: one hostile-vault adoption journey with observed-write proof."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from core.lifecycle.catalog import (
+    CatalogError,
+    canonical_catalog_bytes,
+    load_catalog,
+    with_catalog_identity,
+)
+from core.lifecycle.engine import (
+    execute_adoption,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.ledger import (
+    LedgerError,
+    project_state,
+    read_events,
+    record_holdback,
+    register_install,
+    repair_state,
+)
+from core.lifecycle.model import AdoptionState, ReleaseCatalog
+from core.lifecycle.plan import build_adoption_plan
+from core.lifecycle.preview import build_adoption_preview
+from core.lifecycle.sqlite_snapshot import detect_sync_folder
+from core.tests.vault_observed_writes import (
+    assert_observed_writes,
+    snapshot_vault,
+)
+from core.transaction.engine import PlanEntry, PlanRejected, Transaction
+from core.transaction.snapshot import SnapshotError
+from core.utils import doctor
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NOW = datetime(2026, 7, 21, 20, 0, tzinfo=timezone.utc)
+SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+CATALOG_PATH = "System/.release-catalog.json"
+LEGACY_CATALOG_PATH = "core/lifecycle/catalog/release.json"
+
+PAYLOADS = {
+    "linked-dir": b"# must not traverse a linked directory\n",
+    "modified-stock": b"# release-owned stock\n",
+    "safe-new": b"# safely adopted\nOwner: journey@example.com\n",
+    "symlink-file": b"# must not replace a symlink\n",
+    "user-wins": b"# catalog seed that must not replace user content\n",
+}
+
+_INTERRUPTED_WORKER = r"""
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+from core.transaction.engine import PlanEntry, Transaction
+vault = Path(sys.argv[1])
+manifest = (vault / "System/.installed-files.manifest").read_bytes()
+Transaction.begin(
+    vault,
+    [PlanEntry("System/.installed-files.manifest", manifest + b"interrupted-only\n")],
+).run()
+"""
+
+
+def _write(path: Path, content: bytes, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(mode)
+
+
+def _catalog_document(manifest: bytes) -> dict[str, object]:
+    items = []
+    for item_id, content in sorted(PAYLOADS.items()):
+        path = f".claude/skills/{item_id}/SKILL.md"
+        items.append(
+            {
+                "id": item_id,
+                "kind": "skill",
+                "version": "1.0.0",
+                "files": [
+                    {
+                        "path": path,
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "ownership_class": "brain",
+                    }
+                ],
+                "dependencies": [],
+                "capabilities": [],
+                "rewind": {
+                    "acknowledgement_required": True,
+                    "token": f"rewind:{item_id}@1.0.0",
+                },
+            }
+        )
+    return with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.67.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.67.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": items,
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+
+
+def _hostile_vault(tmp_path: Path) -> tuple[Path, Path, ReleaseCatalog, bytes, Path, bytes]:
+    sync_root = tmp_path / "Dropbox"
+    (sync_root / ".dropbox").mkdir(parents=True)
+    vault = sync_root / "Dex Vault – hostile"
+    vault.mkdir(parents=True)
+    outside = tmp_path / "outside-linked-skills"
+    outside.mkdir()
+
+    manifest_paths = sorted(
+        f".claude/skills/{item_id}/SKILL.md" for item_id in PAYLOADS
+    )
+    manifest = "".join(f"{path}\n" for path in manifest_paths).encode()
+    document = _catalog_document(manifest)
+    catalog = ReleaseCatalog.from_dict(document)
+    _write(vault / "System/.installed-files.manifest", manifest)
+    _write(vault / CATALOG_PATH, canonical_catalog_bytes(document))
+    _write(vault / LEGACY_CATALOG_PATH, b'{"catalog_version":')
+
+    # Broken folder map: inventory must report UNKNOWN rather than guess.
+    _write(vault / "System/folder-paths.yaml", b"projects: [not-a-flat-path]\n")
+
+    # Two different user-owned conflicts: edited stock and a user-created file
+    # at a path a catalog item wants. Both byte sequences must win.
+    _write(
+        vault / ".claude/skills/modified-stock/SKILL.md",
+        b"# user's edited stock; preserve exactly\n",
+        0o600,
+    )
+    _write(
+        vault / ".claude/skills/user-wins/SKILL.md",
+        b"# user's independently-created skill; preserve exactly\n",
+    )
+
+    # A catalog file replaced by a symlink and a catalog parent replaced by a
+    # directory symlink. Neither target may be followed or replaced.
+    symlink_source = vault / "00-Inbox/linked source.md"
+    _write(symlink_source, b"linked source stays unchanged\n")
+    file_link = vault / ".claude/skills/symlink-file/SKILL.md"
+    file_link.parent.mkdir(parents=True)
+    os.symlink(symlink_source, file_link)
+    _write(outside / "SKILL.md", b"outside directory target stays unchanged\n")
+    os.symlink(outside, vault / ".claude/skills/linked-dir")
+
+    # Unicode, spaces, case-collision-prone names, zero bytes, and a seeded
+    # few-megabyte file keep the fixture deterministic on every filesystem.
+    _write(vault / "00-Inbox/naïve café – 東京 notes.md", "Olá 東京\n".encode())
+    _write(vault / "00-Inbox/Case Collision Prone.md", b"upper\n")
+    lower_case = vault / "00-Inbox/case collision prone.md"
+    if not lower_case.exists():
+        _write(lower_case, b"lower\n")
+    _write(vault / "04-Resources/zero byte.bin", b"")
+    seeded = random.Random(17_067)
+    _write(vault / "04-Resources/huge-ish deterministic.bin", seeded.randbytes(3 << 20))
+
+    # Stay near (but below) macOS's practical path limit without oversized
+    # individual components.
+    deep = vault / "04-Resources" / "near macOS path limit"
+    depth = 0
+    while len(os.fsencode(deep / "deep payload.md")) < 860:
+        deep /= f"segment {depth:02d} – abcdefghijklmnopqrstuvwxyz"
+        depth += 1
+    _write(deep / "deep payload.md", b"deep and deterministic\n")
+
+    # D1 hostile state: a committed historical event is tampered while the
+    # valid terminal event's commitment is missing.
+    register_install(vault, UUID("12345678-1234-4678-9234-567812345678"))
+    record_holdback(vault, "legacy-item")
+    first_event = vault / "System/.dex/ledger/events/00000001-install-registered.json"
+    original_first_event = first_event.read_bytes()
+    first_event.write_bytes(
+        original_first_event.replace(b'"ledger_version":1', b'"ledger_version":9', 1)
+    )
+    (vault / "System/.dex/ledger/commitments/00000002.sha256").unlink()
+
+    # Crash after BEGIN: the journal is interrupted but user-visible bytes have
+    # not changed. Doctor must surface it and resume must converge it.
+    process = subprocess.run(
+        [sys.executable, "-c", _INTERRUPTED_WORKER, str(vault), str(REPO_ROOT)],
+        env={**os.environ, "DEX_TX_TEST_STOP_AFTER": "after-begin"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert process.returncode == 137, process.stderr[-500:]
+    return vault, outside, catalog, manifest, first_event, original_first_event
+
+
+def _doctor_context(vault: Path, tmp_path: Path) -> doctor.DoctorContext:
+    return doctor.DoctorContext(vault, vault, tmp_path / "home", NOW)
+
+
+def _action_map(plan) -> dict[str, str]:
+    return {item.item_id: item.action.value for item in plan.items}
+
+
+def _created_ancestors(path: str, before: dict[str, object]) -> set[str]:
+    ancestors: set[str] = set()
+    current = Path(path).parent
+    while current.as_posix() != ".":
+        relative = current.as_posix()
+        if relative not in before:
+            ancestors.add(relative)
+        current = current.parent
+    return ancestors
+
+
+def _transaction_paths(tx_id: str, *, writes_payload: bool, snapshot_blob: bool) -> set[str]:
+    root = f"System/.dex/tx/{tx_id}"
+    paths = {
+        root,
+        f"{root}/journal.jsonl",
+        f"{root}/snapshot",
+        f"{root}/snapshot/manifest.json",
+        f"{root}/staged",
+    }
+    if writes_payload:
+        paths.add(f"{root}/staged/000000.bin")
+    if snapshot_blob:
+        paths.add(f"{root}/snapshot/000000.bin")
+    return paths
+
+
+def test_messy_vault_adoption_journey(tmp_path: Path) -> None:
+    vault, outside, catalog, manifest, first_event, original_first_event = _hostile_vault(
+        tmp_path
+    )
+    outside_before = snapshot_vault(outside)
+
+    # INVENTORY: without an explicit authority, the valid canonical catalog
+    # and corrupt legacy candidate are ambiguous. The loader picks neither.
+    before_inventory = snapshot_vault(vault)
+    ambiguous = build_inventory(vault)
+    assert ambiguous.baseline.identity_state == "MANIFEST_ONLY"
+    assert ambiguous.baseline.errors == (
+        "multiple installed release catalogs are present; identity is ambiguous",
+    )
+    assert load_catalog(vault / CATALOG_PATH, release_root=vault) == catalog
+    with pytest.raises(CatalogError, match=r"UNKNOWN.*JSON cannot be parsed"):
+        load_catalog(vault / LEGACY_CATALOG_PATH, release_root=vault)
+
+    inventory = build_inventory(vault, catalog=catalog)
+    assert inventory.baseline.identity_state == "VERIFIED"
+    assert inventory.folder_map.state == "UNKNOWN"
+    assert any("flat scalar" in error or "path must be" in error for error in inventory.errors)
+    kinds = {entry.actual_path: entry.kind for entry in inventory.entries}
+    assert kinds[".claude/skills/symlink-file/SKILL.md"] == "symlink"
+    assert kinds[".claude/skills/linked-dir"] == "symlink"
+    assert any(entry.actual_path.endswith("deep payload.md") for entry in inventory.entries)
+    assert detect_sync_folder(vault) == "Dropbox"
+    assert (vault / "04-Resources/zero byte.bin").stat().st_size == 0
+    assert (vault / "04-Resources/huge-ish deterministic.bin").stat().st_size == 3 << 20
+    assert_observed_writes(before_inventory, snapshot_vault(vault), set())
+
+    before_transaction_refusal = snapshot_vault(vault)
+    with pytest.raises(PlanRejected, match="symlinked parent"):
+        Transaction.begin(
+            vault,
+            [
+                PlanEntry(
+                    ".claude/skills/linked-dir/SKILL.md",
+                    b"transaction must never reach outside the vault\n",
+                )
+            ],
+        ).run()
+    assert_observed_writes(before_transaction_refusal, snapshot_vault(vault), set())
+    assert snapshot_vault(outside) == outside_before
+
+    # PLAN: only the genuinely absent path is adoptable. User bytes and both
+    # symlink attacks are withheld from writes.
+    before_plan = snapshot_vault(vault)
+    plan = build_adoption_plan(catalog, inventory)
+    assert _action_map(plan) == {
+        "linked-dir": "unknown",
+        "modified-stock": "conflict",
+        "safe-new": "adopt",
+        "symlink-file": "unknown",
+        "user-wins": "conflict",
+    }
+    assert_observed_writes(before_plan, snapshot_vault(vault), set())
+
+    # DOCTOR first refuses the tampered ledger exactly; repairing while the
+    # committed event is still changed also refuses per D1.
+    context = _doctor_context(vault, tmp_path)
+    before_refusals = snapshot_vault(vault)
+    refused = doctor.collect_adoption_report(context)
+    assert refused.verdict == "UNKNOWN"
+    recovery = refused.groups[3]
+    assert recovery.ledger is not None
+    assert "integrity hash" in recovery.ledger.detail or "unsupported ledger" in recovery.ledger.detail
+    with pytest.raises(LedgerError, match=r"integrity hash|unsupported ledger"):
+        repair_state(vault)
+    assert_observed_writes(before_refusals, snapshot_vault(vault), set())
+
+    # Restore the known event bytes, leaving only the valid missing terminal
+    # commitment. D1 may now heal that incomplete publication. Resume then
+    # rolls back the BEGIN-only transaction and is idempotent.
+    before_recovery = snapshot_vault(vault)
+    first_event.write_bytes(original_first_event)
+    _state, repair_actions = repair_state(vault)
+    assert repair_actions == ("completed publication commitment for valid event 2",)
+    outcomes = Transaction.resume(vault)
+    assert len(outcomes) == 1
+    assert outcomes[0]["resumed"] is True
+    assert outcomes[0]["committed"] is False
+    assert Transaction.resume(vault) == []
+    after_recovery = snapshot_vault(vault)
+    interrupted_tx = outcomes[0]["tx_id"]
+    assert_observed_writes(
+        before_recovery,
+        after_recovery,
+        {
+            "System/.dex/ledger/events/00000001-install-registered.json",
+            "System/.dex/ledger/commitments/00000002.sha256",
+            "System/.dex/mutation.lock",
+            f"System/.dex/tx/{interrupted_tx}/journal.jsonl",
+        },
+    )
+    assert (vault / "System/.installed-files.manifest").read_bytes() == manifest
+
+    # The complete five-group collector now exposes safe, review, preserved,
+    # recovery, and receipt authority without performing another write.
+    before_doctor = snapshot_vault(vault)
+    report = doctor.collect_adoption_report(context)
+    assert_observed_writes(before_doctor, snapshot_vault(vault), set())
+    assert [group.id for group in report.groups] == list(doctor.ADOPTION_GROUP_IDS)
+    assert report.verdict == "UNKNOWN"
+    assert report.groups[1].verdict == "UNKNOWN"
+    assert [item.item_id for item in report.groups[0].items] == ["safe-new"]
+    assert {item.item_id for item in report.groups[1].items} == {
+        "linked-dir",
+        "modified-stock",
+        "symlink-file",
+        "user-wins",
+    }
+    assert [item.item_id for item in report.groups[2].held_back_items] == ["legacy-item"]
+    assert report.groups[3].count == 0
+    assert report.groups[4].count == 0
+
+    # PREVIEW + ADOPT: the approved preview names one file. The complete vault
+    # diff must equal the target plus transaction, receipt, and ledger evidence
+    # that the returned receipt identifies.
+    before_preview = snapshot_vault(vault)
+    preview = build_adoption_preview(
+        catalog,
+        inventory,
+        plan,
+        ("safe-new",),
+        lambda path: PAYLOADS[path.split("/")[-2]],
+    )
+    assert [write.path for write in preview.items[0].writes] == [
+        ".claude/skills/safe-new/SKILL.md"
+    ]
+    assert_observed_writes(before_preview, snapshot_vault(vault), set())
+    before_adoption = snapshot_vault(vault)
+    receipt = execute_adoption(
+        vault,
+        preview,
+        preview.sha256,
+        lambda path: PAYLOADS[path.split("/")[-2]],
+    )
+    after_adoption = snapshot_vault(vault)
+    target = receipt.files_written[0].path
+    declared_adoption = {
+        target,
+        f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json",
+        "System/.dex/ledger/events/00000003-adoption-recorded.json",
+        "System/.dex/ledger/commitments/00000003.sha256",
+        "System/.dex/ledger/state.json",
+    }
+    declared_adoption |= _created_ancestors(target, before_adoption)
+    declared_adoption |= _created_ancestors(
+        f"System/.dex/adoptions/{receipt.transaction_id}.receipt.json",
+        before_adoption,
+    )
+    declared_adoption |= _transaction_paths(
+        receipt.transaction_id,
+        writes_payload=True,
+        snapshot_blob=False,
+    )
+    assert_observed_writes(before_adoption, after_adoption, declared_adoption)
+    adoption_event = read_events(vault)[-1]
+    assert adoption_event["event_type"] == "adoption-recorded"
+    assert adoption_event["payload"]["receipt"] == receipt.to_dict()
+
+    # EFFECTIVE BEHAVIOR: bytes are live, the ledger makes the item adopted,
+    # replanning suppresses a second adoption, and Doctor shows a rewindable receipt.
+    before_effective_verification = snapshot_vault(vault)
+    assert (vault / target).read_bytes() == PAYLOADS["safe-new"]
+    state = project_state(vault)
+    assert state["adopted"]["safe-new"]["tx_id"] == receipt.transaction_id
+    adopted_plan = build_adoption_plan(
+        catalog,
+        build_inventory(vault, catalog=catalog),
+        adoption_states={"safe-new": AdoptionState.ADOPTED},
+    )
+    assert _action_map(adopted_plan)["safe-new"] == "already-adopted"
+    adopted_report = doctor.collect_adoption_report(context)
+    assert adopted_report.groups[4].count == 1
+    assert adopted_report.groups[4].receipts[0].rewindable is True
+    assert_observed_writes(
+        before_effective_verification,
+        snapshot_vault(vault),
+        set(),
+    )
+
+    # REWIND: one item returns to exact absence through another transaction.
+    # Again, no path outside the receipt-derived set may change.
+    before_rewind = snapshot_vault(vault)
+    rewind = rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+    after_rewind = snapshot_vault(vault)
+    assert [(entry.item_id, entry.path, entry.existed_before_adoption) for entry in rewind.files_restored] == [
+        ("safe-new", target, False)
+    ]
+    declared_rewind = {
+        target,
+        "System/.dex/ledger/events/00000004-rewind-recorded.json",
+        "System/.dex/ledger/commitments/00000004.sha256",
+        "System/.dex/ledger/state.json",
+    }
+    declared_rewind |= _transaction_paths(
+        rewind.rewind_transaction_id,
+        writes_payload=False,
+        snapshot_blob=True,
+    )
+    assert_observed_writes(before_rewind, after_rewind, declared_rewind)
+    rewind_event = read_events(vault)[-1]
+    assert rewind_event["event_type"] == "rewind-recorded"
+    assert rewind_event["payload"]["receipt"] == rewind.to_dict()
+    assert not (vault / target).exists()
+
+    # LEDGER VERIFY + E5: the full chain verifies, the item is no longer
+    # adopted, and even the symlink targets outside the vault are byte-identical.
+    before_ledger_verification = snapshot_vault(vault)
+    events = read_events(vault)
+    assert [event["event_type"] for event in events] == [
+        "install-registered",
+        "holdback-recorded",
+        "adoption-recorded",
+        "rewind-recorded",
+    ]
+    assert project_state(vault)["adopted"] == {}
+    assert snapshot_vault(outside) == outside_before
+    assert (vault / ".claude/skills/modified-stock/SKILL.md").read_bytes() == (
+        b"# user's edited stock; preserve exactly\n"
+    )
+    assert (vault / ".claude/skills/user-wins/SKILL.md").read_bytes() == (
+        b"# user's independently-created skill; preserve exactly\n"
+    )
+    assert (outside / "SKILL.md").read_bytes() == b"outside directory target stays unchanged\n"
+    assert_observed_writes(
+        before_ledger_verification,
+        snapshot_vault(vault),
+        set(),
+    )
+
+    # Recovery must apply the same ancestor rule. Simulate a parent becoming a
+    # symlink after snapshot/apply but before rollback; resume may refuse, but
+    # it must never restore bytes through that link into another directory.
+    recovery_vault = tmp_path / "recovery-vault"
+    recovery_target = recovery_vault / ".claude/skills/recovery-race/SKILL.md"
+    _write(recovery_target, b"original recovery bytes\n")
+    transaction = Transaction.begin(
+        recovery_vault,
+        [
+            PlanEntry(
+                ".claude/skills/recovery-race/SKILL.md",
+                b"applied before interrupted rollback\n",
+            )
+        ],
+    )
+    transaction._snapshot_phase()
+    transaction._apply_phase()
+    real_parent = tmp_path / "detached-real-parent"
+    recovery_target.parent.rename(real_parent)
+    recovery_outside = tmp_path / "recovery-outside"
+    recovery_outside.mkdir()
+    _write(recovery_outside / "SKILL.md", b"outside recovery sentinel\n")
+    os.symlink(recovery_outside, recovery_target.parent)
+
+    with pytest.raises(SnapshotError, match="symlinked parent"):
+        transaction.rollback()
+    assert (recovery_outside / "SKILL.md").read_bytes() == b"outside recovery sentinel\n"

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from core.transaction.engine import PlanEntry, PlanRejected, Transaction
+from core.transaction.engine import PlanEntry, PlanRejected, Transaction, TransactionError
 from core.transaction.journal import Journal, JournalCorruptError
 from core.transaction.lock import LockBusyError, acquire_owned_lock
 from core.transaction.snapshot import Snapshot, SnapshotError
@@ -184,6 +184,22 @@ def test_engine_happy_path_commits_and_reports(tmp_path: Path) -> None:
     ).run()
     assert result["committed"] is True
     assert (vault / "03-Tasks/Tasks.md").read_bytes() == b"# Tasks\n"
+
+
+def test_engine_refuses_symlinked_transaction_infrastructure(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (vault / "System" / ".dex").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(TransactionError, match=r"System/\.dex"):
+        Transaction.begin(
+            vault,
+            [PlanEntry("System/.installed-files.manifest", b"new manifest\n")],
+        ).run()
+
+    assert list(outside.iterdir()) == []
 
 
 def test_engine_rejects_seed_overwrite_vault_deny_and_unclassified(

--- a/core/tests/vault_observed_writes.py
+++ b/core/tests/vault_observed_writes.py
@@ -1,0 +1,166 @@
+"""Reusable E5 observed-write assertions for vault-mutating tests.
+
+The snapshot is content-addressed, ignores timestamps, and never follows a
+symlink.  That makes a before/after diff an exact statement about persistent
+vault mutations rather than incidental filesystem activity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class ObservedPath:
+    """Stable identity for one node beneath a vault root."""
+
+    kind: str
+    mode: int
+    size: int | None = None
+    sha256: str | None = None
+    link_target: str | None = None
+
+
+VaultSnapshot = dict[str, ObservedPath]
+
+
+def _file_sha256(descriptor: int) -> str:
+    digest = hashlib.sha256()
+    while chunk := os.read(descriptor, 1 << 20):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        left.st_mode,
+        left.st_size,
+        left.st_mtime_ns,
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        right.st_mode,
+        right.st_size,
+        right.st_mtime_ns,
+    )
+
+
+def snapshot_vault(vault_root: Path) -> VaultSnapshot:
+    """Hash every vault node without following directory or file symlinks."""
+    root = Path(vault_root)
+    root_metadata = root.lstat()
+    if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(root_metadata.st_mode):
+        raise ValueError("vault root must be a real directory")
+
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    nofollow_flag = getattr(os, "O_NOFOLLOW", 0)
+    root_descriptor = os.open(root, os.O_RDONLY | directory_flag | nofollow_flag)
+    observed: VaultSnapshot = {}
+    pending: list[tuple[int, str]] = [(root_descriptor, "")]
+    try:
+        while pending:
+            directory_descriptor, prefix = pending.pop()
+            try:
+                with os.scandir(directory_descriptor) as iterator:
+                    children = sorted(iterator, key=lambda child: child.name)
+                for child in children:
+                    relative = f"{prefix}/{child.name}" if prefix else child.name
+                    metadata = child.stat(follow_symlinks=False)
+                    mode = stat.S_IMODE(metadata.st_mode)
+                    if stat.S_ISLNK(metadata.st_mode):
+                        observed[relative] = ObservedPath(
+                            "symlink",
+                            mode,
+                            link_target=os.readlink(
+                                child.name, dir_fd=directory_descriptor
+                            ),
+                        )
+                    elif stat.S_ISDIR(metadata.st_mode):
+                        child_descriptor = os.open(
+                            child.name,
+                            os.O_RDONLY | directory_flag | nofollow_flag,
+                            dir_fd=directory_descriptor,
+                        )
+                        opened = os.fstat(child_descriptor)
+                        if not _same_identity(metadata, opened):
+                            os.close(child_descriptor)
+                            raise RuntimeError(
+                                f"vault path changed during snapshot: {relative}"
+                            )
+                        observed[relative] = ObservedPath("directory", mode)
+                        pending.append((child_descriptor, relative))
+                    elif stat.S_ISREG(metadata.st_mode):
+                        descriptor = os.open(
+                            child.name,
+                            os.O_RDONLY | nofollow_flag,
+                            dir_fd=directory_descriptor,
+                        )
+                        try:
+                            opened = os.fstat(descriptor)
+                            if not _same_identity(metadata, opened):
+                                raise RuntimeError(
+                                    f"vault path changed during snapshot: {relative}"
+                                )
+                            digest = _file_sha256(descriptor)
+                            if not _same_identity(opened, os.fstat(descriptor)):
+                                raise RuntimeError(
+                                    f"vault file changed while hashing: {relative}"
+                                )
+                        finally:
+                            os.close(descriptor)
+                        observed[relative] = ObservedPath(
+                            "file", mode, metadata.st_size, digest
+                        )
+                    else:
+                        observed[relative] = ObservedPath(
+                            "special", mode, metadata.st_size
+                        )
+            finally:
+                os.close(directory_descriptor)
+    finally:
+        for descriptor, _prefix in pending:
+            os.close(descriptor)
+    return dict(sorted(observed.items()))
+
+
+def changed_vault_paths(
+    before: Mapping[str, ObservedPath],
+    after: Mapping[str, ObservedPath],
+) -> frozenset[str]:
+    """Return every created, deleted, content-changed, type-changed, or mode-changed path."""
+    return frozenset(
+        path
+        for path in before.keys() | after.keys()
+        if before.get(path) != after.get(path)
+    )
+
+
+def assert_observed_writes(
+    before: Mapping[str, ObservedPath],
+    after: Mapping[str, ObservedPath],
+    declared_paths: set[str] | frozenset[str],
+) -> frozenset[str]:
+    """Assert that the full vault diff equals the caller's declared mutation set."""
+    changed = changed_vault_paths(before, after)
+    expected = frozenset(declared_paths)
+    assert changed == expected, {
+        "unexplained": sorted(changed - expected),
+        "declared_but_unchanged": sorted(expected - changed),
+    }
+    return changed
+
+
+__all__ = [
+    "ObservedPath",
+    "VaultSnapshot",
+    "assert_observed_writes",
+    "changed_vault_paths",
+    "snapshot_vault",
+]

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from core import portable_contract
+from core.path_safety import unsafe_existing_parent
 from core.transaction.journal import Journal, JournalCorruptError
 from core.transaction.lock import acquire_owned_lock
 from core.transaction.snapshot import Snapshot
@@ -75,6 +76,20 @@ class PlanEntry:
 def _stop_seam(seam: str) -> None:
     if os.environ.get("DEX_TX_TEST_STOP_AFTER") == seam:
         os._exit(137)
+
+
+def _unsafe_infrastructure_directory(vault_root: Path, directory: Path) -> str | None:
+    try:
+        relative = directory.relative_to(vault_root)
+    except ValueError:
+        return f"path resolves outside the vault: {directory}"
+    unsafe_parent = unsafe_existing_parent(
+        vault_root,
+        (relative / ".path-safety-check").as_posix(),
+    )
+    if unsafe_parent is None:
+        return None
+    return f"{relative.as_posix()}: {unsafe_parent}"
 
 
 class Transaction:
@@ -131,6 +146,10 @@ class Transaction:
         rejections = []
         for entry in plan:
             target = Path(vault_root) / entry.relative
+            unsafe_parent = unsafe_existing_parent(Path(vault_root), entry.relative)
+            if unsafe_parent is not None:
+                rejections.append(f"{entry.relative} [{unsafe_parent}]")
+                continue
             verdict = portable_contract.update_write_verdict(entry.relative, exists=target.exists())
             if not verdict.allowed:
                 rejections.append(f"{entry.relative} [{verdict.action}]")
@@ -139,8 +158,18 @@ class Transaction:
 
         tx = cls(vault_root, time.strftime("%Y%m%dT%H%M%S-") + uuid.uuid4().hex[:8])
         tx._plan = list(plan)
+        unsafe_directory = _unsafe_infrastructure_directory(tx.vault_root, tx.tx_dir)
+        if unsafe_directory is not None:
+            raise TransactionError(
+                f"refusing unsafe transaction directory {unsafe_directory}"
+            )
         tx._release = acquire_owned_lock(tx.vault_root, f"transaction:{tx.tx_id}")
         try:
+            unsafe_directory = _unsafe_infrastructure_directory(tx.vault_root, tx.tx_dir)
+            if unsafe_directory is not None:
+                raise TransactionError(
+                    f"refusing unsafe transaction directory {unsafe_directory}"
+                )
             tx.tx_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             tx.journal.append(
                 "BEGIN",
@@ -162,6 +191,11 @@ class Transaction:
             # The intended content must survive a crash for resume to finish
             # the apply: stage it in the tx dir before anything mutates.
             staged = tx.tx_dir / "staged"
+            unsafe_directory = _unsafe_infrastructure_directory(tx.vault_root, staged)
+            if unsafe_directory is not None:
+                raise TransactionError(
+                    f"refusing unsafe staging directory {unsafe_directory}"
+                )
             staged.mkdir(mode=0o700, exist_ok=True)
             for index, entry in enumerate(plan):
                 if entry.content is None:
@@ -204,6 +238,9 @@ class Transaction:
         assert self._plan is not None
         self.journal.append("SNAPSHOT-START")
         for entry in self._plan:
+            unsafe_parent = unsafe_existing_parent(self.vault_root, entry.relative)
+            if unsafe_parent is not None:
+                raise PlanRejected(f"{entry.relative}: {unsafe_parent}")
             if entry.expected_current_sha256 is None:
                 continue
             target = self.vault_root / entry.relative
@@ -226,6 +263,9 @@ class Transaction:
         assert self._plan is not None
         self.journal.append("APPLY-START")
         for index, entry in enumerate(self._plan):
+            unsafe_parent = unsafe_existing_parent(self.vault_root, entry.relative)
+            if unsafe_parent is not None:
+                raise PlanRejected(f"{entry.relative}: {unsafe_parent}")
             # F1 guard: the begin()-time authorization was provisional for
             # write-if-absent paths. The vault is live — if the user (or any
             # non-transaction writer) created this file since, THEIR file
@@ -446,6 +486,11 @@ class Transaction:
         root = Path(vault_root).resolve()
         outcomes: list[dict] = []
         tx_root = root / TX_ROOT_RELATIVE
+        unsafe_directory = _unsafe_infrastructure_directory(root, tx_root)
+        if unsafe_directory is not None:
+            raise TransactionError(
+                f"refusing unsafe transaction root {unsafe_directory}"
+            )
         if not tx_root.is_dir():
             return outcomes
         for tx_dir in sorted(tx_root.iterdir()):

--- a/core/transaction/lock.py
+++ b/core/transaction/lock.py
@@ -26,8 +26,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from core.path_safety import unsafe_existing_parent
+
 LOCK_RELATIVE = Path("System") / ".dex" / "mutation.lock"
 _MAX_ACQUIRE_ATTEMPTS = 32
+
+
+class LockError(RuntimeError):
+    """The mutation lock path is unsafe."""
 
 
 class LockBusyError(RuntimeError):
@@ -128,7 +134,14 @@ def acquire_owned_lock(vault_root: Path, kind: str):
     Raises :class:`LockBusyError` when a live process holds it and
     :class:`LockContentionError` when ownership churns for 32 attempts.
     """
-    lock = Path(vault_root) / LOCK_RELATIVE
+    root = Path(vault_root).resolve()
+    unsafe_parent = unsafe_existing_parent(root, LOCK_RELATIVE.as_posix())
+    if unsafe_parent is not None:
+        raise LockError(
+            f"refusing unsafe mutation lock path {LOCK_RELATIVE.as_posix()}: "
+            f"{unsafe_parent}"
+        )
+    lock = root / LOCK_RELATIVE
     lock.parent.mkdir(parents=True, exist_ok=True)
     token = secrets.token_hex(24)
 

--- a/core/transaction/snapshot.py
+++ b/core/transaction/snapshot.py
@@ -20,6 +20,8 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from core.path_safety import unsafe_existing_parent
+
 MANIFEST_NAME = "manifest.json"
 
 
@@ -77,6 +79,20 @@ class Snapshot:
         restore onto) the wrong object.
         """
         vault = Path(vault_root)
+        try:
+            manifest_relative = (self.root / MANIFEST_NAME).relative_to(vault)
+        except ValueError:
+            manifest_relative = None
+        if manifest_relative is not None:
+            unsafe_parent = unsafe_existing_parent(
+                vault,
+                manifest_relative.as_posix(),
+            )
+            if unsafe_parent is not None:
+                raise SnapshotError(
+                    f"refusing unsafe snapshot path {manifest_relative.parent.as_posix()}: "
+                    f"{unsafe_parent}"
+                )
         self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
         entries: list[SnapshotEntry] = []
         for index, relative in enumerate(relatives):
@@ -180,6 +196,9 @@ class Snapshot:
         for index, entry in enumerate(entries):
             if restore_relatives is not None and entry.relative not in restore_relatives:
                 continue
+            unsafe_parent = unsafe_existing_parent(vault, entry.relative)
+            if unsafe_parent is not None:
+                raise SnapshotError(f"refusing to restore {entry.relative}: {unsafe_parent}")
             target = vault / entry.relative
             if entry.existed:
                 store = self.root / _store_name(index)

--- a/scripts/benchmark_adoption_engine.py
+++ b/scripts/benchmark_adoption_engine.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""E16 performance gate for adoption over a synthetic large vault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import resource
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, TypeVar
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+os.environ.setdefault("VAULT_PATH", str(REPO_ROOT))
+
+from core.lifecycle.catalog import canonical_catalog_bytes, with_catalog_identity
+from core.lifecycle.engine import (
+    execute_adoption,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import ReleaseCatalog
+from core.lifecycle.plan import build_adoption_plan
+from core.lifecycle.preview import build_adoption_preview
+from core.utils.doctor import ADOPTION_GROUP_IDS, DoctorContext, collect_adoption_report
+
+DEFAULT_BUDGET = REPO_ROOT / "core/lifecycle/performance-budget-v1.json"
+BENCHMARK_ITEM = "benchmark-adoption"
+BENCHMARK_PATH = ".claude/skills/benchmark-adoption/SKILL.md"
+BENCHMARK_PAYLOAD = b"# benchmark adoption payload\n"
+SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+T = TypeVar("T")
+
+
+def _write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def create_synthetic_vault(root: Path, file_count: int) -> ReleaseCatalog:
+    """Create exactly ``file_count`` ordinary user files plus release evidence."""
+    benchmark_root = root / "04-Resources" / "adoption-benchmark"
+    benchmark_root.mkdir(parents=True)
+    shard_count = min(256, max(1, (file_count + 999) // 1000))
+    shard_paths = [benchmark_root / f"shard-{index:03d}" for index in range(shard_count)]
+    for shard in shard_paths:
+        shard.mkdir()
+    payload = b"synthetic vault entry\n"
+    for index in range(file_count):
+        target = shard_paths[index % shard_count] / f"file-{index:06d}.md"
+        target.write_bytes(payload)
+
+    manifest = f"{BENCHMARK_PATH}\n".encode()
+    _write(root / "System/.installed-files.manifest", manifest)
+    document = with_catalog_identity(
+        {
+            "catalog_version": 1,
+            "release": {
+                "version": "1.67.0",
+                "channel": "release",
+                "immutable_distribution_tag": "dist/release/v1.67.0-0123456",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            },
+            "items": [
+                {
+                    "id": BENCHMARK_ITEM,
+                    "kind": "skill",
+                    "version": "1.0.0",
+                    "files": [
+                        {
+                            "path": BENCHMARK_PATH,
+                            "sha256": hashlib.sha256(BENCHMARK_PAYLOAD).hexdigest(),
+                            "ownership_class": "brain",
+                        }
+                    ],
+                    "dependencies": [],
+                    "capabilities": [],
+                    "rewind": {
+                        "acknowledgement_required": True,
+                        "token": f"rewind:{BENCHMARK_ITEM}@1.0.0",
+                    },
+                }
+            ],
+            "integrity": {"catalog_sha256": "0" * 64, "signatures": []},
+        }
+    )
+    _write(root / "System/.release-catalog.json", canonical_catalog_bytes(document))
+    return ReleaseCatalog.from_dict(document)
+
+
+def _timed(operation: Callable[[], T]) -> tuple[T, float]:
+    started = time.perf_counter()
+    result = operation()
+    return result, time.perf_counter() - started
+
+
+def _peak_rss_bytes() -> int | None:
+    try:
+        rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except (AttributeError, OSError, ValueError):
+        return None
+    return int(rss if sys.platform == "darwin" else rss * 1024)
+
+
+def _load_budgets(path: Path) -> dict[str, object]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not load performance budget {path}: {error}") from error
+    if not isinstance(raw, dict) or raw.get("budget_version") != 1:
+        raise ValueError(f"performance budget {path} is not version 1")
+    if type(raw.get("files")) is not int or raw["files"] <= 0:
+        raise ValueError(f"performance budget {path} files must be a positive integer")
+    seconds = raw.get("seconds")
+    required = {
+        "build_inventory",
+        "build_adoption_plan",
+        "collect_adoption_report",
+        "adoption_and_rewind",
+        "total_measured",
+    }
+    if not isinstance(seconds, dict) or set(seconds) != required:
+        raise ValueError(f"performance budget {path} has the wrong seconds stages")
+    if any(type(value) not in {int, float} or value <= 0 for value in seconds.values()):
+        raise ValueError(f"performance budget {path} seconds must be positive numbers")
+    return raw
+
+
+def run_benchmark(file_count: int) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="dex-adoption-benchmark-") as temporary:
+        vault = Path(temporary) / "vault"
+        vault.mkdir()
+        catalog = create_synthetic_vault(vault, file_count)
+
+        inventory, inventory_seconds = _timed(
+            lambda: build_inventory(vault, catalog=catalog)
+        )
+        plan, plan_seconds = _timed(lambda: build_adoption_plan(catalog, inventory))
+        context = DoctorContext(
+            vault,
+            vault,
+            Path(temporary) / "home",
+            datetime(2026, 7, 21, tzinfo=timezone.utc),
+        )
+        adoption_report, doctor_seconds = _timed(
+            lambda: collect_adoption_report(context)
+        )
+
+        def adopt_and_rewind():
+            preview = build_adoption_preview(
+                catalog,
+                inventory,
+                plan,
+                (BENCHMARK_ITEM,),
+                lambda _path: BENCHMARK_PAYLOAD,
+            )
+            receipt = execute_adoption(
+                vault,
+                preview,
+                preview.sha256,
+                lambda _path: BENCHMARK_PAYLOAD,
+            )
+            rewind = rewind_adoption(
+                vault,
+                receipt,
+                rewind_acknowledgement_token(receipt),
+            )
+            return receipt, rewind
+
+        (receipt, rewind), cycle_seconds = _timed(adopt_and_rewind)
+        seconds = {
+            "adoption_and_rewind": cycle_seconds,
+            "build_adoption_plan": plan_seconds,
+            "build_inventory": inventory_seconds,
+            "collect_adoption_report": doctor_seconds,
+        }
+        seconds["total_measured"] = sum(seconds.values())
+        return {
+            "counts": {
+                "adopted_files": len(receipt.files_written),
+                "catalog_items": len(catalog.items),
+                "doctor_groups": len(adoption_report.groups),
+                "inventory_entries": len(inventory.entries),
+                "rewound_files": len(rewind.files_restored),
+                "synthetic_files": file_count,
+            },
+            "peak_rss_bytes": _peak_rss_bytes(),
+            "seconds": {key: round(value, 6) for key, value in sorted(seconds.items())},
+        }
+
+
+def _budget_failures(result: dict[str, object], budgets: dict[str, object]) -> list[str]:
+    measured = result["seconds"]
+    allowed = budgets["seconds"]
+    assert isinstance(measured, dict) and isinstance(allowed, dict)
+    return [
+        f"{stage} took {float(measured[stage]):.3f}s (budget {float(allowed[stage]):.3f}s)"
+        for stage in sorted(allowed)
+        if float(measured[stage]) > float(allowed[stage])
+    ]
+
+
+def _count_failures(result: dict[str, object], requested_files: int) -> list[str]:
+    counts = result["counts"]
+    assert isinstance(counts, dict)
+    expected = {
+        "adopted_files": 1,
+        "catalog_items": 1,
+        "doctor_groups": len(ADOPTION_GROUP_IDS),
+        "rewound_files": 1,
+        "synthetic_files": requested_files,
+    }
+    failures = [
+        f"{name} was {counts.get(name)!r}, expected {value}"
+        for name, value in expected.items()
+        if counts.get(name) != value
+    ]
+    if not isinstance(counts.get("inventory_entries"), int) or counts["inventory_entries"] < requested_files:
+        failures.append(
+            f"inventory_entries was {counts.get('inventory_entries')!r}, expected at least {requested_files}"
+        )
+    return failures
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark inventory, planning, Doctor, adoption, and rewind"
+    )
+    parser.add_argument(
+        "--files",
+        type=int,
+        default=100_000,
+        help="number of synthetic user files (default: 100000)",
+    )
+    parser.add_argument(
+        "--budget-file",
+        type=Path,
+        default=DEFAULT_BUDGET,
+        help="versioned JSON performance budget",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.files <= 0 or args.files > 190_000:
+        print("--files must be between 1 and 190000", file=sys.stderr)
+        return 2
+    try:
+        budgets = _load_budgets(args.budget_file)
+        if args.files > int(budgets["files"]):
+            raise ValueError(
+                f"requested {args.files} files exceeds the calibrated {budgets['files']}-file budget"
+            )
+        result = run_benchmark(args.files)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"Adoption benchmark could not run: {error}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            result,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    count_failures = _count_failures(result, args.files)
+    if count_failures:
+        print(
+            "Adoption benchmark produced unexpected counts: "
+            + "; ".join(count_failures)
+            + ".",
+            file=sys.stderr,
+        )
+        return 1
+    failures = _budget_failures(result, budgets)
+    if failures:
+        print(
+            "Performance budget exceeded: " + "; ".join(failures) + ".",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The Phase D gate (spec §5). Stress-tests the whole lifecycle stack and closes a real defect it found.

## What
- **Hostile-vault journey test**: one deterministic fixture combining every nasty condition (symlink/dir swaps, tampered history, interrupted updates, corrupt catalog, unicode/case-collision names, sync-marker folder, huge + zero-byte files) driven through the full inventory→plan→doctor→adopt→verify→rewind→ledger journey. Every stage is bracketed by a full-vault before/after hash diff, so any unexplained byte change fails the test.
- **100k-file benchmark** + budget file, wired into nightly (not per-PR).
- **Real defect found & fixed**: a file under a symlinked parent could let an operation escape the vault. Closed in the transaction core with a no-follow parent-safety guard at every write/snapshot/restore site.

## Review trail
- Fable diff review; independent adversarial review (Opus): **SHIP**. Its one completeness finding (transaction bookkeeping dir under a symlinked System/.dex) is also closed with a resolved-containment guard + red-then-green regression test. Documented apply-time TOCTOU residual left as-is to preserve atomic rename.

## Verification
- 111 lifecycle + transaction-core tests green; benchmark ~13s/100k files, within budget; ruff, portable-contract (1074 paths), YAML all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42