### PR TITLE
feat: frozen lifecycle API + one-release compatibility bridge (cathedral E1c)

### DIFF
--- a/core/lifecycle/bridge.py
+++ b/core/lifecycle/bridge.py
@@ -1,0 +1,321 @@
+"""One-release handoff from the legacy updater to the lifecycle engine."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from core.lifecycle.catalog import load_catalog
+from core.lifecycle.filesystem import FilesystemInspectionError, bounded_read
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import HEX_SHA256, SEMVER
+from core.path_safety import unsafe_existing_parent
+from core.transaction.engine import Transaction
+from core.transaction.journal import PREVIOUS_SCHEMA_VERSION, SCHEMA_VERSION
+
+BRIDGE_CONTRACT_VERSION = 1
+ACTIVATION_VERSION = 1
+BRIDGE_RELEASE_RELATIVE = Path("core/lifecycle/catalog/bridge-release.json")
+ACTIVATION_RELATIVE = Path("System/.dex/lifecycle/activation.json")
+CATALOG_RELATIVE = Path("System/.release-catalog.json")
+
+
+class BridgeError(RuntimeError):
+    """The bridge declaration or recovery boundary is unsafe."""
+
+
+class BridgeActivationError(BridgeError):
+    """The read-then-record activation could not be proved or persisted."""
+
+
+@dataclass(frozen=True)
+class JournalCompatibility:
+    current_schema: int
+    previous_schema: int
+    minimum_resumable_schema: int
+    incompatible_action: str
+
+
+@dataclass(frozen=True)
+class BridgeRelease:
+    bridge_contract_version: int
+    release_version: str
+    transaction_journal: JournalCompatibility
+
+
+def _strict_json(raw: bytes, context: str) -> object:
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise BridgeError(f"{context} repeats field {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(raw.decode("utf-8"), object_pairs_hook=unique)
+    except BridgeError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BridgeError(f"{context} is not strict JSON: {error}") from error
+
+
+def _closed(raw: object, fields: set[str], context: str) -> Mapping[str, Any]:
+    if not isinstance(raw, Mapping) or not all(isinstance(key, str) for key in raw):
+        raise BridgeError(f"{context} must be an object")
+    missing = fields - set(raw)
+    unknown = set(raw) - fields
+    if missing or unknown:
+        raise BridgeError(
+            f"{context} fields disagree (missing={sorted(missing)}, unknown={sorted(unknown)})"
+        )
+    return raw
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def load_bridge_release(release_root: str | Path) -> BridgeRelease:
+    """Load the shipped declaration and bind it to Transaction.resume's window."""
+    try:
+        raw = bounded_read(Path(release_root), BRIDGE_RELEASE_RELATIVE.as_posix())
+    except FilesystemInspectionError as error:
+        raise BridgeError(f"bridge release declaration is unavailable: {error}") from error
+    value = _closed(
+        _strict_json(raw, "bridge release declaration"),
+        {"bridge_contract_version", "release_version", "transaction_journal"},
+        "bridge release declaration",
+    )
+    if type(value["bridge_contract_version"]) is not int or value["bridge_contract_version"] != 1:
+        raise BridgeError("bridge release declaration has an unsupported contract version")
+    release_version = value["release_version"]
+    if not isinstance(release_version, str) or SEMVER.fullmatch(release_version) is None:
+        raise BridgeError("bridge release version is not strict SemVer")
+    journal = _closed(
+        value["transaction_journal"],
+        {
+            "current_schema",
+            "previous_schema",
+            "minimum_resumable_schema",
+            "incompatible_action",
+        },
+        "bridge journal compatibility",
+    )
+    for field in ("current_schema", "previous_schema", "minimum_resumable_schema"):
+        if type(journal[field]) is not int:
+            raise BridgeError(f"bridge journal compatibility {field} must be an integer")
+    if not isinstance(journal["incompatible_action"], str):
+        raise BridgeError("bridge journal compatibility incompatible_action must be a string")
+    compatibility = JournalCompatibility(
+        journal["current_schema"],
+        journal["previous_schema"],
+        journal["minimum_resumable_schema"],
+        journal["incompatible_action"],
+    )
+    expected = JournalCompatibility(
+        SCHEMA_VERSION,
+        PREVIOUS_SCHEMA_VERSION,
+        PREVIOUS_SCHEMA_VERSION,
+        "rollback-only",
+    )
+    if compatibility != expected:
+        raise BridgeError(
+            "bridge journal compatibility disagrees with Transaction.resume's current+previous window"
+        )
+    if raw != _canonical(
+        {
+            "bridge_contract_version": BRIDGE_CONTRACT_VERSION,
+            "release_version": release_version,
+            "transaction_journal": {
+                "current_schema": compatibility.current_schema,
+                "previous_schema": compatibility.previous_schema,
+                "minimum_resumable_schema": compatibility.minimum_resumable_schema,
+                "incompatible_action": compatibility.incompatible_action,
+            },
+        }
+    ):
+        raise BridgeError("bridge release declaration is not canonical JSON")
+    return BridgeRelease(BRIDGE_CONTRACT_VERSION, release_version, compatibility)
+
+
+def _validate_activation(raw: bytes, bridge: BridgeRelease) -> dict[str, object]:
+    try:
+        value = _closed(
+            _strict_json(raw, "existing activation"),
+            {
+                "activation_version",
+                "api_version",
+                "bridge_release_version",
+                "baseline_inventory_sha256",
+            },
+            "existing activation",
+        )
+        from core.lifecycle.service import api_version
+
+        if type(value["activation_version"]) is not int or value["activation_version"] != 1:
+            raise BridgeActivationError("existing activation has an unsupported version")
+        if value["api_version"] != api_version:
+            raise BridgeActivationError("existing activation belongs to another lifecycle API")
+        if value["bridge_release_version"] != bridge.release_version:
+            raise BridgeActivationError("existing activation belongs to another bridge release")
+        digest = value["baseline_inventory_sha256"]
+        if not isinstance(digest, str) or HEX_SHA256.fullmatch(digest) is None:
+            raise BridgeActivationError("existing activation has an invalid inventory hash")
+        document = dict(value)
+        if raw != _canonical(document):
+            raise BridgeActivationError("existing activation is not canonical JSON")
+        return document
+    except BridgeActivationError:
+        raise
+    except BridgeError as error:
+        raise BridgeActivationError(f"existing activation is invalid: {error}") from error
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _activation_directory(root: Path) -> Path:
+    unsafe = unsafe_existing_parent(root, ACTIVATION_RELATIVE.as_posix())
+    if unsafe is not None:
+        raise BridgeActivationError(f"activation path is unsafe: {unsafe}")
+    directory = root
+    for component in ACTIVATION_RELATIVE.parts[:-1]:
+        directory /= component
+        if directory.is_symlink() or (directory.exists() and not directory.is_dir()):
+            raise BridgeActivationError(f"activation path is unsafe: {directory}")
+        if not directory.exists():
+            directory.mkdir(mode=0o700)
+            os.chmod(directory, 0o700)
+            _fsync_directory(directory.parent)
+    return directory
+
+
+def activate_vault(
+    vault_root: str | Path,
+    *,
+    release_root: str | Path | None = None,
+) -> dict[str, object]:
+    """Read current vault state, then atomically record first-run activation.
+
+    The inventory pass is read-only.  The only durable output is the runtime
+    activation record (plus its same-directory temporary file during publish).
+    """
+    root = Path(vault_root)
+    release = root if release_root is None else Path(release_root)
+    bridge = load_bridge_release(release)
+    target = root / ACTIVATION_RELATIVE
+    if target.exists() or target.is_symlink():
+        if target.is_symlink() or not target.is_file():
+            raise BridgeActivationError("existing activation path is unsafe")
+        try:
+            return _validate_activation(target.read_bytes(), bridge)
+        except OSError as error:
+            raise BridgeActivationError(f"existing activation could not be read: {error}") from error
+
+    try:
+        catalog = load_catalog(root / CATALOG_RELATIVE, release_root=root)
+        if catalog.release.version != bridge.release_version:
+            raise BridgeActivationError(
+                "installed catalog release does not match the designated bridge release"
+            )
+        baseline_hash = build_inventory(root, catalog=catalog).to_dict()["inventory_sha256"]
+    except BridgeActivationError:
+        raise
+    except Exception as error:  # noqa: BLE001 - translate the read-only proof boundary
+        raise BridgeActivationError(f"baseline inventory could not be proved: {error}") from error
+    assert isinstance(baseline_hash, str)
+    from core.lifecycle.service import api_version
+
+    document: dict[str, object] = {
+        "activation_version": ACTIVATION_VERSION,
+        "api_version": api_version,
+        "bridge_release_version": bridge.release_version,
+        "baseline_inventory_sha256": baseline_hash,
+    }
+    data = _canonical(document)
+    directory = _activation_directory(root)
+    temporary = directory / f".activation.json.tmp-{os.getpid()}-{secrets.token_hex(8)}"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        view = memoryview(data)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        if target.exists() or target.is_symlink():
+            existing = _validate_activation(target.read_bytes(), bridge)
+            temporary.unlink()
+            _fsync_directory(directory)
+            return existing
+        os.replace(temporary, target)
+        os.chmod(target, 0o600)
+        _fsync_directory(directory)
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    return document
+
+
+def resume_bridge_transactions(
+    vault_root: str | Path,
+    *,
+    release_root: str | Path | None = None,
+) -> list[dict]:
+    """Converge bridge-release transactions using the declared resume window."""
+    root = Path(vault_root)
+    load_bridge_release(root if release_root is None else release_root)
+    return Transaction.resume(root)
+
+
+def prepare_vault(
+    vault_root: str | Path,
+    *,
+    release_root: str | Path | None = None,
+) -> dict[str, object]:
+    """Recover any interrupted bridge transaction, then activate the vault."""
+    root = Path(vault_root)
+    release = root if release_root is None else Path(release_root)
+    outcomes = resume_bridge_transactions(root, release_root=release)
+    activation = activate_vault(root, release_root=release)
+    return {"resume_outcomes": outcomes, "activation": activation}
+
+
+__all__ = [
+    "ACTIVATION_RELATIVE",
+    "BRIDGE_RELEASE_RELATIVE",
+    "BridgeActivationError",
+    "BridgeError",
+    "BridgeRelease",
+    "JournalCompatibility",
+    "activate_vault",
+    "load_bridge_release",
+    "prepare_vault",
+    "resume_bridge_transactions",
+]

--- a/core/lifecycle/catalog/README.md
+++ b/core/lifecycle/catalog/README.md
@@ -1,8 +1,9 @@
 # Release catalog item declarations
 
 This is the publisher-owned source of truth for lifecycle catalog items. The
-release builder reads every `*.json` file here in filename order and emits the
-canonical `System/.release-catalog.json` through the B1 model and schema.
+release builder reads every JSON file here in filename order, except the
+separately modeled `bridge-release.json`, and emits the canonical
+`System/.release-catalog.json` through the B1 model and schema.
 
 Each source file is a closed document:
 

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,0 +1,1 @@
+{"bridge_contract_version":1,"release_version":"1.68.0","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dex/contracts/lifecycle-api-v1.schema.json",
+  "title": "Dex Frozen Lifecycle Service API v1",
+  "description": "Changing a frozen operation signature or shape requires an API version bump and a compatibility bridge.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["api_version", "x-operations"],
+  "properties": {
+    "api_version": {"const": "1.0.0"},
+    "x-operations": {"type": "object"}
+  },
+  "x-operations": {
+    "build_inventory_and_plan": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/inventoryPlanResponse"}
+    },
+    "build_and_preview_adoption": {
+      "request": {"$ref": "#/$defs/previewRequest"},
+      "response": {"$ref": "#/$defs/previewResponse"}
+    },
+    "execute_approved_adoption": {
+      "request": {"$ref": "#/$defs/executeRequest"},
+      "response": {"$ref": "#/$defs/executeResponse"}
+    },
+    "rewind_adoption_by_receipt": {
+      "request": {"$ref": "#/$defs/rewindRequest"},
+      "response": {"$ref": "#/$defs/rewindResponse"}
+    },
+    "read_lifecycle_state": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/stateResponse"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "path": {"type": "string", "minLength": 1},
+    "itemId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]*$"},
+    "apiEnvelope": {
+      "type": "object",
+      "required": ["api_version"],
+      "properties": {"api_version": {"const": "1.0.0"}}
+    },
+    "vaultRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root"],
+      "properties": {"vault_root": {"$ref": "#/$defs/path"}}
+    },
+    "previewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release_root", "requested_item_ids"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release_root": {"$ref": "#/$defs/path"},
+        "requested_item_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/itemId"}
+        }
+      }
+    },
+    "inventory": {
+      "type": "object",
+      "required": ["inventory_version", "complete", "entries", "inventory_sha256"],
+      "properties": {
+        "inventory_version": {"const": 1},
+        "complete": {"type": "boolean"},
+        "entries": {"type": "array"},
+        "inventory_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plan_version", "release_version", "catalog_sha256", "items", "counts"],
+      "properties": {
+        "plan_version": {"const": 1},
+        "release_version": {"type": "string", "minLength": 1},
+        "catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "items": {"type": "array"},
+        "counts": {"type": "object"}
+      }
+    },
+    "inventoryPlanResponse": {
+      "allOf": [
+        {"$ref": "#/$defs/apiEnvelope"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "inventory", "plan"],
+          "properties": {
+            "api_version": {"const": "1.0.0"},
+            "inventory": {"$ref": "#/$defs/inventory"},
+            "plan": {"$ref": "#/$defs/plan"}
+          }
+        }
+      ]
+    },
+    "previewWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "new_sha256", "byte_size"],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "new_sha256": {"$ref": "#/$defs/sha256"},
+        "byte_size": {"type": "integer", "minimum": 0}
+      }
+    },
+    "preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["preview_version", "catalog_sha256", "inventory_sha256", "items"],
+      "properties": {
+        "preview_version": {"const": 1},
+        "catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "inventory_sha256": {"$ref": "#/$defs/sha256"},
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["item_id", "item_version", "action", "writes"],
+            "properties": {
+              "item_id": {"$ref": "#/$defs/itemId"},
+              "item_version": {"type": "string", "minLength": 1},
+              "action": {"const": "adopt"},
+              "writes": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/previewWrite"}}
+            }
+          }
+        }
+      }
+    },
+    "previewResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "preview", "approval_token"],
+      "properties": {
+        "api_version": {"const": "1.0.0"},
+        "preview": {"$ref": "#/$defs/preview"},
+        "approval_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "executeRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/preview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "receiptFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "path", "sha256", "byte_size"],
+      "properties": {
+        "item_id": {"$ref": "#/$defs/itemId"},
+        "path": {"$ref": "#/$defs/path"},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "byte_size": {"type": "integer", "minimum": 0}
+      }
+    },
+    "adoptionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_version", "items_adopted", "files_written", "transaction_id", "snapshot_ref", "catalog_sha256", "inventory_sha256", "preview_sha256"],
+      "properties": {
+        "receipt_version": {"const": 1},
+        "items_adopted": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/itemId"}},
+        "files_written": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/receiptFile"}},
+        "transaction_id": {"type": "string", "pattern": "^[0-9]{8}T[0-9]{6}-[0-9a-f]{8}$"},
+        "snapshot_ref": {"$ref": "#/$defs/path"},
+        "catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "inventory_sha256": {"$ref": "#/$defs/sha256"},
+        "preview_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "executeResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt", "rewind_acknowledgement_token"],
+      "properties": {
+        "api_version": {"const": "1.0.0"},
+        "receipt": {"$ref": "#/$defs/adoptionReceipt"},
+        "rewind_acknowledgement_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rewindRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "receipt", "acknowledgement_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "receipt": {"$ref": "#/$defs/adoptionReceipt"},
+        "acknowledgement_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rewindFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "path", "existed_before_adoption", "restored_sha256", "byte_size", "mode"],
+      "properties": {
+        "item_id": {"$ref": "#/$defs/itemId"},
+        "path": {"$ref": "#/$defs/path"},
+        "existed_before_adoption": {"type": "boolean"},
+        "restored_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "byte_size": {"anyOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]},
+        "mode": {"anyOf": [{"type": "integer", "minimum": 0, "maximum": 511}, {"type": "null"}]}
+      }
+    },
+    "rewindReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rewind_receipt_version", "adoption_transaction_id", "rewind_transaction_id", "snapshot_ref", "source_receipt_sha256", "files_restored"],
+      "properties": {
+        "rewind_receipt_version": {"const": 1},
+        "adoption_transaction_id": {"type": "string"},
+        "rewind_transaction_id": {"type": "string"},
+        "snapshot_ref": {"$ref": "#/$defs/path"},
+        "source_receipt_sha256": {"$ref": "#/$defs/sha256"},
+        "files_restored": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/rewindFile"}}
+      }
+    },
+    "rewindResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "rewind_receipt"],
+      "properties": {
+        "api_version": {"const": "1.0.0"},
+        "rewind_receipt": {"$ref": "#/$defs/rewindReceipt"}
+      }
+    },
+    "ledgerState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ledger_version", "install_id", "adopted", "held_back", "last_seq", "last_event_sha256"],
+      "properties": {
+        "ledger_version": {"const": 1},
+        "install_id": {"anyOf": [{"type": "string", "format": "uuid"}, {"type": "null"}]},
+        "adopted": {"type": "object"},
+        "held_back": {"type": "array", "items": {"$ref": "#/$defs/itemId"}},
+        "last_seq": {"type": "integer", "minimum": 0},
+        "last_event_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_bytes", "committed_snapshot_count", "warning", "warning_threshold_bytes"],
+      "properties": {
+        "total_bytes": {"type": "integer", "minimum": 0},
+        "committed_snapshot_count": {"type": "integer", "minimum": 0},
+        "warning": {"type": "boolean"},
+        "warning_threshold_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "stateResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "ledger_state", "retention"],
+      "properties": {
+        "api_version": {"const": "1.0.0"},
+        "ledger_state": {"$ref": "#/$defs/ledgerState"},
+        "retention": {"$ref": "#/$defs/retention"}
+      }
+    }
+  }
+}

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -1,0 +1,159 @@
+"""Frozen public lifecycle API (v1).
+
+This module is the sole sanctioned lifecycle entry point for Phase E callers.
+Changing a frozen function signature or JSON shape requires an API version bump
+and a compatibility bridge for callers on the preceding version.
+
+The facade deliberately contains no lifecycle policy.  Read operations compose
+the existing catalog, inventory, planning, ledger, and retention functions;
+mutations delegate to :mod:`core.lifecycle.engine`, which in turn delegates to
+the transaction and portable-contract layers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from core.lifecycle.catalog import load_catalog
+from core.lifecycle.engine import (
+    AdoptionReceipt,
+    execute_adoption,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.filesystem import bounded_read
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.ledger import project_state
+from core.lifecycle.model import AdoptionState
+from core.lifecycle.plan import build_adoption_plan
+from core.lifecycle.preview import AdoptionPreview, build_adoption_preview
+from core.lifecycle.retention import compute_retention_report
+
+api_version = "1.0.0"
+
+_CATALOG_RELATIVE = "System/.release-catalog.json"
+
+
+def _envelope(**values: object) -> dict[str, object]:
+    return {"api_version": api_version, **values}
+
+
+def _inventory_and_plan_models(vault_root: str | Path):
+    root = Path(vault_root)
+    catalog = load_catalog(root / _CATALOG_RELATIVE, release_root=root)
+    inventory = build_inventory(root, catalog=catalog)
+    ledger = project_state(root)
+    adopted = ledger["adopted"]
+    held_back = ledger["held_back"]
+    assert isinstance(adopted, dict)
+    assert isinstance(held_back, list)
+    plan = build_adoption_plan(
+        catalog,
+        inventory,
+        adoption_states={item_id: AdoptionState.ADOPTED for item_id in adopted},
+        held_back=frozenset(held_back),
+    )
+    return catalog, inventory, plan
+
+
+def _release_payload_loader(release_root: str | Path):
+    root = Path(release_root)
+
+    def load(relative: str) -> bytes:
+        return bounded_read(root, relative)
+
+    return load
+
+
+def _prepare(vault_root: str | Path, release_root: str | Path | None = None) -> None:
+    from core.lifecycle.bridge import prepare_vault
+
+    prepare_vault(vault_root, release_root=release_root)
+
+
+def build_inventory_and_plan(vault_root: str | Path) -> dict[str, object]:
+    """Return the current verified inventory and ledger-aware adoption plan."""
+    _prepare(vault_root)
+    _catalog, inventory, plan = _inventory_and_plan_models(vault_root)
+    return _envelope(inventory=inventory.to_dict(), plan=plan.to_dict())
+
+
+def build_and_preview_adoption(
+    vault_root: str | Path,
+    release_root: str | Path,
+    requested_item_ids: Sequence[str],
+) -> dict[str, object]:
+    """Build the exact preview and approval token for requested catalog items."""
+    _prepare(vault_root, release_root)
+    catalog, inventory, plan = _inventory_and_plan_models(vault_root)
+    preview = build_adoption_preview(
+        catalog,
+        inventory,
+        plan,
+        requested_item_ids,
+        _release_payload_loader(release_root),
+    )
+    return _envelope(preview=preview.to_dict(), approval_token=preview.sha256)
+
+
+def execute_approved_adoption(
+    vault_root: str | Path,
+    release_root: str | Path,
+    preview: AdoptionPreview | Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Execute one exactly approved preview and return its durable receipt."""
+    _prepare(vault_root, release_root)
+    modeled = preview if isinstance(preview, AdoptionPreview) else AdoptionPreview.from_dict(preview)
+    receipt = execute_adoption(
+        Path(vault_root),
+        modeled,
+        approved_token,
+        _release_payload_loader(release_root),
+    )
+    return _envelope(
+        receipt=receipt.to_dict(),
+        rewind_acknowledgement_token=rewind_acknowledgement_token(receipt),
+    )
+
+
+def rewind_adoption_by_receipt(
+    vault_root: str | Path,
+    receipt: AdoptionReceipt | Mapping[str, object],
+    acknowledgement_token: str,
+) -> dict[str, object]:
+    """Rewind the adoption identified by an exact receipt and acknowledgement."""
+    _prepare(vault_root)
+    rewind_receipt = rewind_adoption(
+        Path(vault_root),
+        receipt,
+        acknowledgement_token,
+    )
+    return _envelope(rewind_receipt=rewind_receipt.to_dict())
+
+
+def read_lifecycle_state(vault_root: str | Path) -> dict[str, object]:
+    """Return verified ledger state and the advisory snapshot-retention report."""
+    root = Path(vault_root)
+    _prepare(root)
+    retention = compute_retention_report(root)
+    return _envelope(
+        ledger_state=project_state(root),
+        retention={
+            "total_bytes": retention.total_bytes,
+            "committed_snapshot_count": retention.committed_snapshot_count,
+            "warning": retention.warning,
+            "warning_threshold_bytes": retention.warning_threshold_bytes,
+        },
+    )
+
+
+__all__ = [
+    "api_version",
+    "build_inventory_and_plan",
+    "build_and_preview_adoption",
+    "execute_approved_adoption",
+    "rewind_adoption_by_receipt",
+    "read_lifecycle_state",
+]

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -267,6 +267,8 @@ RULES: tuple[Rule, ...] = (
        "post-commit lifecycle receipts; local runtime evidence, never shipped"),
     _r("runtime-lifecycle-ledger", "System/.dex/ledger", "dir", "runtime",
        "immutable local lifecycle events and rebuildable state; never shipped or updated"),
+    _r("runtime-lifecycle-activation", "System/.dex/lifecycle/activation.json", "file", "runtime",
+       "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped"),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -56,13 +56,20 @@ RELEASE_BUILD_INPUTS = (
     "core/migrations/preserve_local_only_paths.py",
     "core/migrations/tracked-ignored-policy.yaml",
     "core/lifecycle/catalog/README.md",
+    "core/lifecycle/catalog/bridge-release.json",
+    "core/lifecycle/bridge.py",
+    "core/lifecycle/contracts/api.schema.json",
+    "core/lifecycle/service.py",
     "core/lifecycle/schemas/release-catalog-v1.schema.json",
     "core/portable_contract.py",
+    "core/transaction/engine.py",
+    "core/transaction/journal.py",
     "core/utils/tracked_ignored.py",
     "core/utils/manifest.py",
     "core/utils/update_verifier.py",
     "core/utils/smoke.py",
     "packages/dex-contracts/dist/release-catalog-v1.schema.json",
+    "packages/dex-contracts/dist/portable-vault.contract.json",
     "scripts/build-release.sh",
     "scripts/build-vault-bundle.sh",
     "scripts/check-catalog-coverage.py",
@@ -99,6 +106,22 @@ def _archive_members() -> set[str]:
     )
     with tarfile.open(fileobj=io.BytesIO(result.stdout), mode="r:") as archive:
         return set(archive.getnames())
+
+
+def test_release_builders_gate_frozen_lifecycle_contract_artifacts() -> None:
+    from core.utils.manifest import REQUIRED_LIFECYCLE_RELEASE_PATHS
+
+    assert REQUIRED_LIFECYCLE_RELEASE_PATHS == (
+        "core/lifecycle/bridge.py",
+        "core/lifecycle/catalog/bridge-release.json",
+        "core/lifecycle/contracts/api.schema.json",
+        "core/lifecycle/service.py",
+        "core/portable_contract.py",
+        "packages/dex-contracts/dist/portable-vault.contract.json",
+    )
+    for script_name in ("build-release.sh", "build-vault-bundle.sh"):
+        script = (REPO_ROOT / "scripts" / script_name).read_text(encoding="utf-8")
+        assert "--require-lifecycle-contracts" in script
 
 
 def test_git_archive_keeps_skill_scripts_but_strips_top_level_scripts() -> None:
@@ -357,6 +380,11 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert "System/.installed-files.manifest" in members
     assert "System/.release-catalog.json" in members
     assert "System/.release-evidence-profile.json" in members
+    assert "core/lifecycle/catalog/bridge-release.json" in members
+    assert "core/lifecycle/contracts/api.schema.json" in members
+    assert "core/lifecycle/service.py" in members
+    assert "core/lifecycle/bridge.py" in members
+    assert "System/.dex/lifecycle/activation.json" not in members
     assert "System/.local-only-preservation-transition.json" in members
     assert "core/migrations/preserve_local_only_paths.py" in members
     assert "core/migrations/tracked-ignored-policy.yaml" in members
@@ -375,8 +403,14 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert manifest == sorted(manifest)
     assert set(manifest) == members
     assert "core/tests/test_distribution_artifacts.py" not in manifest
+    assert "core/lifecycle/catalog/bridge-release.json" in manifest
+    assert "core/lifecycle/contracts/api.schema.json" in manifest
+    assert "System/.dex/lifecycle/activation.json" not in manifest
     catalog = _git_json(clone, "release:System/.release-catalog.json")
     package = _git_json(clone, "release:package.json")
+    bridge_release = _git_json(
+        clone, "release:core/lifecycle/catalog/bridge-release.json"
+    )
     source_commit = subprocess.run(
         ["git", "rev-parse", "release^"],
         cwd=clone,
@@ -399,6 +433,11 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     expected_item_ids = sorted(item["id"] for item in official_registry["items"])
     assert sorted(item["id"] for item in catalog["items"]) == expected_item_ids
     assert catalog["release"]["version"] == package["version"]
+    assert bridge_release == json.loads(
+        (REPO_ROOT / "core/lifecycle/catalog/bridge-release.json").read_text(
+            encoding="utf-8"
+        )
+    )
     assert catalog["release"]["source_commit"] == source_commit
     assert catalog["release"]["manifest"]["sha256"] == hashlib.sha256(manifest_bytes).hexdigest()
     profile = json.loads(
@@ -1326,11 +1365,33 @@ def test_vault_bundle_tree_manifest_and_archive_contain_no_tau(tmp_path: Path) -
         manifest_member = archive.extractfile("./System/.installed-files.manifest")
         assert manifest_member is not None
         manifest = manifest_member.read().decode("utf-8").splitlines()
+        assert "core/lifecycle/catalog/bridge-release.json" in {
+            member.removeprefix("./") for member in members
+        }
+        assert "core/lifecycle/contracts/api.schema.json" in {
+            member.removeprefix("./") for member in members
+        }
+        assert "System/.dex/lifecycle/activation.json" not in {
+            member.removeprefix("./") for member in members
+        }
+        assert "core/lifecycle/catalog/bridge-release.json" in manifest
+        assert "core/lifecycle/contracts/api.schema.json" in manifest
+        assert "System/.dex/lifecycle/activation.json" not in manifest
+        bridge_member = archive.extractfile(
+            "./core/lifecycle/catalog/bridge-release.json"
+        )
+        assert bridge_member is not None
+        bridge_release = json.loads(bridge_member.read())
     _assert_tau_absent(manifest)
     archive_files = _tar_files(archive_path)
     _assert_tau_absent_from_files(archive_files)
     archive_paths = {path.removeprefix("./") for path, _ in archive_files}
     assert ".gitattributes" not in archive_paths
+    assert bridge_release == json.loads(
+        (REPO_ROOT / "core/lifecycle/catalog/bridge-release.json").read_text(
+            encoding="utf-8"
+        )
+    )
     assert not any(path.startswith("core/tests/") for path in archive_paths)
     assert not any(path.startswith("scripts/") for path in archive_paths)
     tau_check = _run_tau_check(clone, "--archive", str(archive_path))

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -1,0 +1,256 @@
+"""Old-engine delivery bridge and first-run activation guarantees."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle.bridge import (
+    ACTIVATION_RELATIVE,
+    BridgeActivationError,
+    activate_vault,
+    load_bridge_release,
+    resume_bridge_transactions,
+)
+from core.lifecycle.catalog import load_catalog
+from core.lifecycle.inventory import build_inventory
+from core.tests.test_adoption_transaction import _setup
+from core.transaction.journal import PREVIOUS_SCHEMA_VERSION, SCHEMA_VERSION
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode()
+
+
+def _write_bridge_release(vault: Path, release_version: str = "1.64.0") -> None:
+    target = vault / "core/lifecycle/catalog/bridge-release.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(
+        _canonical(
+            {
+                "bridge_contract_version": 1,
+                "release_version": release_version,
+                "transaction_journal": {
+                    "current_schema": SCHEMA_VERSION,
+                    "previous_schema": PREVIOUS_SCHEMA_VERSION,
+                    "minimum_resumable_schema": PREVIOUS_SCHEMA_VERSION,
+                    "incompatible_action": "rollback-only",
+                },
+            }
+        )
+    )
+
+
+def _activation_fixture(tmp_path: Path) -> Path:
+    vault, _document, _catalog, _inventory, _plan, _loader = _setup(
+        tmp_path, item_ids=("alpha",)
+    )
+    _write_bridge_release(vault)
+    return vault
+
+
+def test_baseline_import_is_read_only_and_activation_is_atomic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from core.lifecycle import bridge as bridge_module
+
+    vault = _activation_fixture(tmp_path)
+    catalog = load_catalog(vault / "System/.release-catalog.json", release_root=vault)
+    expected_hash = build_inventory(vault, catalog=catalog).to_dict()["inventory_sha256"]
+    protected = vault / ".claude/skills/alpha/SKILL.md"
+    before = protected.read_bytes()
+    system_mode = stat.S_IMODE((vault / "System").stat().st_mode)
+    fsynced_directories: list[Path] = []
+    real_fsync_directory = bridge_module._fsync_directory
+
+    def record_fsync(directory: Path) -> None:
+        fsynced_directories.append(directory.relative_to(vault))
+        real_fsync_directory(directory)
+
+    monkeypatch.setattr(bridge_module, "_fsync_directory", record_fsync)
+
+    activation = activate_vault(vault)
+
+    activation_path = vault / ACTIVATION_RELATIVE
+    assert activation == {
+        "activation_version": 1,
+        "api_version": "1.0.0",
+        "bridge_release_version": "1.64.0",
+        "baseline_inventory_sha256": expected_hash,
+    }
+    assert activation_path.read_bytes() == _canonical(activation)
+    assert stat.S_IMODE(activation_path.stat().st_mode) == 0o600
+    assert protected.read_bytes() == before
+    assert stat.S_IMODE((vault / "System").stat().st_mode) == system_mode
+    assert fsynced_directories == [
+        Path("System"),
+        Path("System/.dex"),
+        Path("System/.dex/lifecycle"),
+    ]
+    assert not list(activation_path.parent.glob(".activation.json.tmp-*"))
+    resolution = portable_contract.resolve(ACTIVATION_RELATIVE.as_posix())
+    assert (resolution.ownership, resolution.denied) == ("runtime", False)
+    assert portable_contract.update_write_verdict(
+        ACTIVATION_RELATIVE.as_posix(), exists=False
+    ).allowed is False
+
+
+def test_reactivation_is_idempotent_but_invalid_existing_record_is_refused(
+    tmp_path: Path,
+) -> None:
+    vault = _activation_fixture(tmp_path)
+    first = activate_vault(vault)
+    activation_path = vault / ACTIVATION_RELATIVE
+    before_bytes = activation_path.read_bytes()
+    before_mtime = activation_path.stat().st_mtime_ns
+
+    assert activate_vault(vault) == first
+    assert activation_path.read_bytes() == before_bytes
+    assert activation_path.stat().st_mtime_ns == before_mtime
+
+    activation_path.write_text('{"activation_version":999}\n', encoding="utf-8")
+    with pytest.raises(BridgeActivationError, match="existing activation"):
+        activate_vault(vault)
+    assert activation_path.read_text(encoding="utf-8") == '{"activation_version":999}\n'
+
+
+_INTERRUPT_WORKER = r"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+
+from core.transaction.engine import PlanEntry, Transaction
+
+vault = Path(sys.argv[1])
+Transaction.begin(
+    vault,
+    [PlanEntry("System/.installed-files.manifest", b"bridge release manifest\n")],
+).run()
+"""
+
+
+@pytest.mark.parametrize(
+    ("seam", "expected"),
+    (
+        ("mid-apply:0", b"old manifest\n"),
+        ("after-commit-record", b"bridge release manifest\n"),
+    ),
+)
+def test_interrupted_bridge_transaction_converges_on_next_run(
+    seam: str, expected: bytes, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    target = vault / "System/.installed-files.manifest"
+    target.write_bytes(b"old manifest\n")
+    _write_bridge_release(vault)
+    process = subprocess.run(
+        [sys.executable, "-c", _INTERRUPT_WORKER, str(vault), str(REPO_ROOT)],
+        env={**os.environ, "DEX_TX_TEST_STOP_AFTER": seam},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert process.returncode == 137, process.stderr
+
+    outcomes = resume_bridge_transactions(vault)
+
+    assert target.read_bytes() == expected
+    if seam == "after-commit-record":
+        assert outcomes == []
+    else:
+        assert len(outcomes) == 1
+        assert outcomes[0]["resumed"] is True
+        assert outcomes[0]["committed"] is False
+
+
+def test_incompatible_journal_schema_is_rollback_only(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    target = vault / "System/.installed-files.manifest"
+    target.write_bytes(b"old manifest\n")
+    _write_bridge_release(vault)
+    process = subprocess.run(
+        [sys.executable, "-c", _INTERRUPT_WORKER, str(vault), str(REPO_ROOT)],
+        env={**os.environ, "DEX_TX_TEST_STOP_AFTER": "mid-apply:0"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert process.returncode == 137, process.stderr
+    journal_path = next((vault / "System/.dex/tx").glob("*/journal.jsonl"))
+    rewritten = []
+    for line in journal_path.read_text(encoding="utf-8").splitlines():
+        record = json.loads(line)
+        record["schema_version"] = 999
+        unsigned = {key: value for key, value in record.items() if key != "sha"}
+        record["sha"] = hashlib.sha256(
+            json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        rewritten.append(json.dumps(record, sort_keys=True, separators=(",", ":")))
+    journal_path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+
+    outcomes = resume_bridge_transactions(vault)
+
+    assert target.read_bytes() == b"old manifest\n"
+    assert len(outcomes) == 1
+    assert outcomes[0]["rollback_only"] is True
+    assert outcomes[0]["committed"] is False
+
+
+def test_previous_journal_schema_resumes_normally(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    target = vault / "System/.installed-files.manifest"
+    target.write_bytes(b"old manifest\n")
+    _write_bridge_release(vault)
+    process = subprocess.run(
+        [sys.executable, "-c", _INTERRUPT_WORKER, str(vault), str(REPO_ROOT)],
+        env={**os.environ, "DEX_TX_TEST_STOP_AFTER": "mid-apply:0"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert process.returncode == 137, process.stderr
+    journal_path = next((vault / "System/.dex/tx").glob("*/journal.jsonl"))
+    rewritten = []
+    for line in journal_path.read_text(encoding="utf-8").splitlines():
+        record = json.loads(line)
+        record["schema_version"] = PREVIOUS_SCHEMA_VERSION
+        unsigned = {key: value for key, value in record.items() if key != "sha"}
+        record["sha"] = hashlib.sha256(
+            json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        rewritten.append(json.dumps(record, sort_keys=True, separators=(",", ":")))
+    journal_path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+
+    outcomes = resume_bridge_transactions(vault)
+
+    assert target.read_bytes() == b"old manifest\n"
+    assert len(outcomes) == 1
+    assert outcomes[0]["resumed"] is True
+    assert "rollback_only" not in outcomes[0]
+
+
+def test_shipped_bridge_release_matches_transaction_resume_window() -> None:
+    bridge = load_bridge_release(REPO_ROOT)
+
+    assert bridge.release_version == "1.68.0"
+    assert bridge.transaction_journal.current_schema == SCHEMA_VERSION
+    assert bridge.transaction_journal.previous_schema == PREVIOUS_SCHEMA_VERSION
+    assert bridge.transaction_journal.minimum_resumable_schema == PREVIOUS_SCHEMA_VERSION
+    assert bridge.transaction_journal.incompatible_action == "rollback-only"

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -1,0 +1,194 @@
+"""Frozen lifecycle-service API contract coverage."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+from core.lifecycle import service
+from core.lifecycle.bridge import ACTIVATION_RELATIVE
+from core.lifecycle.engine import rewind_acknowledgement_token
+from core.tests.test_adoption_transaction import _setup
+from core.tests.test_lifecycle_bridge import _write_bridge_release
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "lifecycle"
+    / "contracts"
+    / "api.schema.json"
+)
+
+
+def _json_type(value: object, expected: str) -> bool:
+    return {
+        "object": isinstance(value, Mapping),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "integer": type(value) is int,
+        "boolean": type(value) is bool,
+        "null": value is None,
+    }[expected]
+
+
+def _validate(schema: dict[str, object], node: object, value: object, path: str = "$") -> None:
+    assert isinstance(node, Mapping), f"{path}: schema node is not an object"
+    if "$ref" in node:
+        reference = node["$ref"]
+        assert isinstance(reference, str) and reference.startswith("#/$defs/")
+        _validate(schema, schema["$defs"][reference.removeprefix("#/$defs/")], value, path)
+        return
+    for child in node.get("allOf", []):
+        _validate(schema, child, value, path)
+    if "anyOf" in node:
+        failures = []
+        for child in node["anyOf"]:
+            try:
+                _validate(schema, child, value, path)
+                break
+            except AssertionError as error:
+                failures.append(str(error))
+        else:
+            raise AssertionError(f"{path}: no anyOf branch matched: {failures}")
+    expected_type = node.get("type")
+    if expected_type is not None:
+        assert isinstance(expected_type, str) and _json_type(value, expected_type), (
+            f"{path}: expected {expected_type}, found {type(value).__name__}"
+        )
+    if "const" in node:
+        assert value == node["const"], f"{path}: expected constant {node['const']!r}"
+    if isinstance(value, str):
+        assert len(value) >= node.get("minLength", 0), f"{path}: string is too short"
+        if "pattern" in node:
+            assert re.search(node["pattern"], value), f"{path}: string does not match pattern"
+    if type(value) is int:
+        assert value >= node.get("minimum", value), f"{path}: integer is below minimum"
+        assert value <= node.get("maximum", value), f"{path}: integer is above maximum"
+    if isinstance(value, list):
+        assert len(value) >= node.get("minItems", 0), f"{path}: array has too few items"
+        if node.get("uniqueItems") is True:
+            encoded = [json.dumps(item, sort_keys=True) for item in value]
+            assert len(encoded) == len(set(encoded)), f"{path}: array items are not unique"
+        if "items" in node:
+            for index, item in enumerate(value):
+                _validate(schema, node["items"], item, f"{path}[{index}]")
+    if isinstance(value, Mapping):
+        required = node.get("required", [])
+        missing = set(required) - set(value)
+        assert not missing, f"{path}: missing fields {sorted(missing)}"
+        properties = node.get("properties", {})
+        if node.get("additionalProperties") is False:
+            unknown = set(value) - set(properties)
+            assert not unknown, f"{path}: unknown fields {sorted(unknown)}"
+        for field, child in properties.items():
+            if field in value:
+                _validate(schema, child, value[field], f"{path}.{field}")
+
+
+def _assert_conforms(
+    schema: dict[str, object], operation: str, request: dict[str, object], response: object
+) -> None:
+    operation_schema = schema["x-operations"][operation]
+    _validate(schema, operation_schema["request"], request)
+    _validate(schema, operation_schema["response"], response)
+
+
+def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> None:
+    vault, _document, _catalog, _inventory, _plan, _loader = _setup(
+        tmp_path, item_ids=("alpha",)
+    )
+    _write_bridge_release(vault)
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    inventory_request = {"vault_root": str(vault)}
+    inventory_response = service.build_inventory_and_plan(vault)
+    assert (vault / ACTIVATION_RELATIVE).is_file()
+    _assert_conforms(
+        schema,
+        "build_inventory_and_plan",
+        inventory_request,
+        inventory_response,
+    )
+
+    preview_request = {
+        "vault_root": str(vault),
+        "release_root": str(vault),
+        "requested_item_ids": ["alpha"],
+    }
+    preview_response = service.build_and_preview_adoption(
+        vault, vault, ("alpha",)
+    )
+    _assert_conforms(
+        schema,
+        "build_and_preview_adoption",
+        preview_request,
+        preview_response,
+    )
+
+    execute_request = {
+        "vault_root": str(vault),
+        "release_root": str(vault),
+        "preview": preview_response["preview"],
+        "approved_token": preview_response["approval_token"],
+    }
+    execute_response = service.execute_approved_adoption(
+        vault,
+        vault,
+        preview_response["preview"],
+        preview_response["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_adoption",
+        execute_request,
+        execute_response,
+    )
+
+    receipt = execute_response["receipt"]
+    rewind_request = {
+        "vault_root": str(vault),
+        "receipt": receipt,
+        "acknowledgement_token": rewind_acknowledgement_token(receipt),
+    }
+    rewind_response = service.rewind_adoption_by_receipt(
+        vault,
+        receipt,
+        rewind_request["acknowledgement_token"],
+    )
+    _assert_conforms(
+        schema,
+        "rewind_adoption_by_receipt",
+        rewind_request,
+        rewind_response,
+    )
+
+    state_request = {"vault_root": str(vault)}
+    state_response = service.read_lifecycle_state(vault)
+    _assert_conforms(
+        schema,
+        "read_lifecycle_state",
+        state_request,
+        state_response,
+    )
+
+
+def test_api_version_is_present_and_frozen_in_schema() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert service.api_version == "1.0.0"
+    assert schema["properties"]["api_version"] == {"const": service.api_version}
+
+
+def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
+    assert service.__all__ == [
+        "api_version",
+        "build_inventory_and_plan",
+        "build_and_preview_adoption",
+        "execute_approved_adoption",
+        "rewind_adoption_by_receipt",
+        "read_lifecycle_state",
+    ]
+    assert "version bump" in service.__doc__.lower()
+    assert "bridge" in service.__doc__.lower()

--- a/core/tests/test_manifest_lifecycle_paths.py
+++ b/core/tests/test_manifest_lifecycle_paths.py
@@ -1,0 +1,52 @@
+"""Focused coverage for the E1c manifest additions: frozen-contract path
+enforcement and canonical manifest reading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.utils.manifest import (
+    REQUIRED_LIFECYCLE_RELEASE_PATHS,
+    ManifestError,
+    read_manifest,
+    require_lifecycle_release_paths,
+)
+
+
+def test_require_lifecycle_release_paths_accepts_a_complete_manifest() -> None:
+    # A superset of the required frozen-contract paths must pass unchanged.
+    paths = (*REQUIRED_LIFECYCLE_RELEASE_PATHS, "README.md", "System/pillars.yaml")
+    require_lifecycle_release_paths(tuple(sorted(paths)))
+
+
+def test_require_lifecycle_release_paths_fails_closed_when_a_contract_is_missing() -> None:
+    assert REQUIRED_LIFECYCLE_RELEASE_PATHS, "there must be frozen contract paths to guard"
+    dropped = REQUIRED_LIFECYCLE_RELEASE_PATHS[0]
+    incomplete = tuple(p for p in REQUIRED_LIFECYCLE_RELEASE_PATHS if p != dropped)
+    with pytest.raises(ManifestError) as excinfo:
+        require_lifecycle_release_paths(incomplete)
+    assert dropped in str(excinfo.value)
+
+
+def test_read_manifest_round_trips_canonical_text(tmp_path: Path) -> None:
+    manifest = tmp_path / "installed.manifest"
+    entries = ("README.md", "System/pillars.yaml", "core/lifecycle/service.py")
+    manifest.write_bytes(("".join(f"{e}\n" for e in sorted(entries))).encode("utf-8"))
+    assert read_manifest(manifest) == tuple(sorted(entries))
+
+
+def test_read_manifest_rejects_unsorted_or_duplicated_paths(tmp_path: Path) -> None:
+    manifest = tmp_path / "installed.manifest"
+    manifest.write_bytes(b"b.md\na.md\n")
+    with pytest.raises(ManifestError):
+        read_manifest(manifest)
+
+
+def test_read_manifest_rejects_non_canonical_bytes(tmp_path: Path) -> None:
+    manifest = tmp_path / "installed.manifest"
+    # Carriage return and a missing trailing newline are both non-canonical.
+    manifest.write_bytes(b"a.md\r\nb.md")
+    with pytest.raises(ManifestError):
+        read_manifest(manifest)

--- a/core/tests/test_update_rollback_journey.py
+++ b/core/tests/test_update_rollback_journey.py
@@ -12,7 +12,12 @@ from pathlib import Path
 
 import yaml
 
+from core.lifecycle import engine as lifecycle_engine
+from core.lifecycle import service as lifecycle_service
+from core.lifecycle.bridge import ACTIVATION_RELATIVE
 from core.migrations import preserve_local_only_paths as preservation
+from core.tests.test_adoption_transaction import _setup as setup_adoption_release
+from core.tests.test_lifecycle_bridge import _write_bridge_release
 from core.utils.manifest import DEFAULT_MANIFEST, generate_manifest, write_manifest
 from core.utils.tracked_ignored import load_exact_policy, load_transition
 
@@ -56,6 +61,43 @@ def test_update_skill_routes_split_topology_to_transaction_updater_without_merge
     assert "System/.dex/mutation.lock" in split
     assert "git merge" not in split
     assert "Combined topology continues to Step 3" in split
+
+
+def test_legacy_updater_can_deliver_bridge_release_then_hand_off_without_invoking_engine(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "release-fixture").mkdir()
+    release, _document, _catalog, _inventory, _plan, _loader = setup_adoption_release(
+        tmp_path / "release-fixture", item_ids=("alpha",)
+    )
+    _write_bridge_release(release)
+    vault = tmp_path / "old-updated-vault"
+    delivered = (
+        "System/.installed-files.manifest",
+        "System/.release-catalog.json",
+        ".claude/skills/alpha/SKILL.md",
+        "core/lifecycle/catalog/bridge-release.json",
+    )
+    calls: list[str] = []
+
+    def forbidden_execute(*_args, **_kwargs):
+        calls.append("execute_adoption")
+        raise AssertionError("the legacy delivery phase invoked the lifecycle engine")
+
+    monkeypatch.setattr(lifecycle_engine, "execute_adoption", forbidden_execute)
+    for relative in delivered:
+        destination = vault / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(release / relative, destination)
+
+    assert calls == []
+    assert not (vault / ACTIVATION_RELATIVE).exists()
+
+    response = lifecycle_service.build_inventory_and_plan(vault)
+
+    assert response["api_version"] == lifecycle_service.api_version
+    assert (vault / ACTIVATION_RELATIVE).is_file()
+    assert calls == []
 
 
 def test_update_and_duplicated_rollback_flows_recognize_both_baselines() -> None:

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from core import portable_contract
 from core.path_safety import unsafe_existing_parent
-from core.transaction.journal import Journal, JournalCorruptError
+from core.transaction.journal import Journal, JournalCorruptError, JournalSchemaError
 from core.transaction.lock import acquire_owned_lock
 from core.transaction.snapshot import Snapshot
 
@@ -501,8 +501,12 @@ class Transaction:
             # others: each is handled independently and a corrupt journal is
             # quarantined (best-effort restore inside rollback), not fatal.
             try:
+                rollback_only = False
                 try:
                     events = {entry.event for entry in tx.journal.read()}
+                except JournalSchemaError:
+                    events = None
+                    rollback_only = True
                 except JournalCorruptError:
                     events = None  # unreadable — rollback handles best-effort
                 if events is not None:
@@ -518,6 +522,8 @@ class Transaction:
                     tx._release = None  # rollback() must not double-release
                     outcome = tx.rollback()
                     outcome["resumed"] = True
+                    if rollback_only:
+                        outcome["rollback_only"] = True
                     outcomes.append(outcome)
                 finally:
                     lock_release()

--- a/core/transaction/journal.py
+++ b/core/transaction/journal.py
@@ -22,11 +22,21 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+PREVIOUS_SCHEMA_VERSION = 1
+RESUMABLE_SCHEMA_VERSIONS = frozenset({PREVIOUS_SCHEMA_VERSION, SCHEMA_VERSION})
 
 
 class JournalCorruptError(RuntimeError):
     """The journal has damage that cannot be attributed to a torn tail."""
+
+
+class JournalSchemaError(JournalCorruptError):
+    """The journal is intact but outside the current+previous resume window."""
+
+    def __init__(self, schema_version: object, path: Path) -> None:
+        self.schema_version = schema_version
+        super().__init__(f"journal has an unsupported schema {schema_version!r}: {path}")
 
 
 @dataclass(frozen=True)
@@ -168,10 +178,9 @@ class Journal:
             raise JournalCorruptError(
                 f"journal line {index + 1} is not an object: {self.path}"
             )
-        if record.get("schema_version") != SCHEMA_VERSION:
-            raise JournalCorruptError(
-                f"journal line {index + 1} has an unsupported schema: {self.path}"
-            )
+        schema_version = record.get("schema_version")
+        if type(schema_version) is not int or schema_version not in RESUMABLE_SCHEMA_VERSIONS:
+            raise JournalSchemaError(schema_version, self.path)
         if record.get("sha") != _entry_sha(record):
             raise JournalCorruptError(
                 f"journal line {index + 1} fails its integrity hash: {self.path}"

--- a/core/utils/manifest.py
+++ b/core/utils/manifest.py
@@ -8,6 +8,14 @@ import subprocess
 from pathlib import Path
 
 DEFAULT_MANIFEST = Path("System/.installed-files.manifest")
+REQUIRED_LIFECYCLE_RELEASE_PATHS = (
+    "core/lifecycle/bridge.py",
+    "core/lifecycle/catalog/bridge-release.json",
+    "core/lifecycle/contracts/api.schema.json",
+    "core/lifecycle/service.py",
+    "core/portable_contract.py",
+    "packages/dex-contracts/dist/portable-vault.contract.json",
+)
 
 
 class ManifestError(RuntimeError):
@@ -49,6 +57,31 @@ def generate_manifest(repo_root: Path, treeish: str = "HEAD") -> str:
     return "".join(f"{path}\n" for path in paths)
 
 
+def require_lifecycle_release_paths(paths: tuple[str, ...]) -> None:
+    """Fail closed when a release omits any frozen lifecycle contract artifact."""
+    missing = sorted(set(REQUIRED_LIFECYCLE_RELEASE_PATHS) - set(paths))
+    if missing:
+        raise ManifestError(
+            "release manifest omits frozen lifecycle contract paths: "
+            + ", ".join(missing)
+        )
+
+
+def read_manifest(path: Path) -> tuple[str, ...]:
+    """Read one canonical sorted/unique newline manifest."""
+    raw = Path(path).read_bytes()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ManifestError("manifest is not UTF-8") from error
+    if not text.endswith("\n") or "\r" in text or "\x00" in text:
+        raise ManifestError("manifest is not canonical newline text")
+    paths = tuple(text.splitlines())
+    if paths != tuple(sorted(set(paths))):
+        raise ManifestError("manifest paths are not sorted and unique")
+    return paths
+
+
 def write_manifest(
     repo_root: Path,
     treeish: str = "HEAD",
@@ -69,11 +102,28 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("treeish", nargs="?", default="HEAD", help="Git tree-ish to list (default: HEAD).")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Git repository root.")
     parser.add_argument("--output", type=Path, help=f"Output path (default: {DEFAULT_MANIFEST}).")
+    parser.add_argument("--validate-file", type=Path, help="Validate an existing manifest instead of generating one.")
+    parser.add_argument(
+        "--require-lifecycle-contracts",
+        action="store_true",
+        help="Fail unless every frozen lifecycle contract artifact is present.",
+    )
     args = parser.parse_args(argv)
 
     try:
+        if args.validate_file is not None:
+            if args.output is not None or args.treeish != "HEAD":
+                raise ManifestError("--validate-file cannot be combined with treeish or --output")
+            paths = read_manifest(args.validate_file)
+            if args.require_lifecycle_contracts:
+                require_lifecycle_release_paths(paths)
+            print(f"Validated {args.validate_file} ({len(paths)} paths)")
+            return 0
         destination = write_manifest(args.repo_root, args.treeish, args.output)
-        count = len(installed_paths(args.repo_root, args.treeish))
+        paths = installed_paths(args.repo_root, args.treeish)
+        if args.require_lifecycle_contracts:
+            require_lifecycle_release_paths(paths)
+        count = len(paths)
     except (ManifestError, OSError, UnicodeError) as error:
         parser.exit(1, f"manifest generation failed: {error}\n")
 

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -479,6 +479,13 @@
       "note": "immutable local lifecycle events and rebuildable state; never shipped or updated"
     },
     {
+      "id": "runtime-lifecycle-activation",
+      "path": "System/.dex/lifecycle/activation.json",
+      "kind": "file",
+      "ownership": "runtime",
+      "note": "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped"
+    },
+    {
       "id": "generated-manifest",
       "path": "System/.installed-files.manifest",
       "kind": "file",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -204,7 +204,8 @@ mkdir -p "$(dirname "$MANIFEST")"
 : > "$CATALOG"
 git add -- "$MANIFEST" "$CATALOG"
 MANIFEST_TREE=$(git write-tree)
-python3 core/utils/manifest.py "$MANIFEST_TREE" --repo-root "$REPO_ROOT" --output "$MANIFEST"
+python3 core/utils/manifest.py "$MANIFEST_TREE" --repo-root "$REPO_ROOT" --output "$MANIFEST" \
+    --require-lifecycle-contracts
 
 # B1 supports stable and beta catalog identities. Custom target names used by
 # local verification retain stable catalog semantics.

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -71,6 +71,9 @@ mkdir -p "$STAGING_DIR/System"
 printf '%s\n' 'System/.installed-files.manifest' >> "$STAGING_DIR/System/.installed-files.manifest"
 LC_ALL=C sort -u -o "$STAGING_DIR/System/.installed-files.manifest" \
   "$STAGING_DIR/System/.installed-files.manifest"
+python3 "$REPO_ROOT/core/utils/manifest.py" \
+  --validate-file "$STAGING_DIR/System/.installed-files.manifest" \
+  --require-lifecycle-contracts
 
 SOURCE_COMMIT="$(git rev-parse HEAD)"
 python3 "$REPO_ROOT/scripts/generate-release-catalog.py" \

--- a/scripts/generate-release-catalog.py
+++ b/scripts/generate-release-catalog.py
@@ -102,7 +102,14 @@ def _source_items(release_root: Path, portable_contract: object) -> list[dict[st
 
     items: list[dict[str, object]] = []
     seen_item_sources: dict[str, Path] = {}
-    for source_path in sorted(source_dir.glob("*.json")):
+    # Preserve arbitrary publisher fragment names while excluding the one
+    # shipped metadata document that has its own closed bridge model.
+    sources = (
+        path
+        for path in source_dir.glob("*.json")
+        if path.name != "bridge-release.json"
+    )
+    for source_path in sorted(sources):
         raw = _mapping(_closed_json(source_path), context=str(source_path))
         _exact_fields(
             raw,


### PR DESCRIPTION
Chunk E1c (spec §5). Opens Phase E.

## What
- **Frozen public lifecycle API** (`core/lifecycle/service.py`, api_version 1.0.0) — the single stable entry the Phase E callers will use. Wraps the existing engine; freezes the approval/receipt/token surface with a drift-tested JSON schema.
- **One-release compatibility bridge** — the legacy updater can deliver a new release's files without invoking the new engine; the engine then resumes any interrupted transaction and does a read-only, atomic activation. bridge-release.json designates 1.68.0.
- **Journal resume window** (schema v1+v2): an unreadable-schema journal rolls back to exact prior bytes — adversarially probed, zero data loss.

## Review trail
- Fable review; independent adversarial review (Opus): **SHIP, no mandatory fixes.** Primary rollback_only risk disproven by direct probe; facade honesty, frozen-contract drift enforcement, activation atomicity, distribution parity all verified. One documented low-severity downgrade behavior carried to the F-gate notes.

## Verification
- 159 tests green (lifecycle + transaction-core + distribution + rollback-journey); ruff; portable-contract (1079 paths); founder-content green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVT6iVqgziVja15aCoiQ42