### PR TITLE
feat(grounding): live state ledger + /dex-orient + auto session digest (chunk 2)

### DIFF
--- a/.claude/hooks/dex-core-orientation.sh
+++ b/.claude/hooks/dex-core-orientation.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [[ ! -f "${CLAUDE_PROJECT_DIR:-$PWD}/scripts/generate-architecture-inventory.py" ]]; then
+    exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+DEDUP_FILE="${DEX_CORE_ORIENTATION_DEDUP_FILE:-/tmp/dex-core-orientation-dedup}"
+NOW=$(date +%s)
+if [[ -f "$DEDUP_FILE" ]]; then
+    LAST=$(cat "$DEDUP_FILE" 2>/dev/null || echo "0")
+    if (( NOW - LAST < 5 )); then
+        exit 0
+    fi
+fi
+echo "$NOW" > "$DEDUP_FILE" 2>/dev/null || true
+
+OUTPUT=$(python3 - "$PROJECT_DIR/scripts/dex_state.py" "${DEX_CORE_ORIENTATION_TIMEOUT_SECONDS:-5}" <<'PY' 2>/dev/null
+import subprocess
+import sys
+
+try:
+    timeout = float(sys.argv[2])
+    if timeout <= 0:
+        timeout = 5.0
+    result = subprocess.run(
+        [sys.executable, sys.argv[1], "--digest"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+except (OSError, ValueError, subprocess.TimeoutExpired):
+    raise SystemExit(0)
+
+if result.returncode == 0:
+    sys.stdout.write(result.stdout)
+PY
+) || true
+
+if [[ -n "$OUTPUT" ]]; then
+    printf '%s\n' "$OUTPUT"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/core/utils/update_verifier.py\" --vault \"$CLAUDE_PROJECT_DIR\" --session-start"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/dex-core-orientation.sh"
           }
         ]
       }

--- a/.claude/skills/dex-orient/SKILL.md
+++ b/.claude/skills/dex-orient/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: dex-orient
+description: "Orient in the Dex Core codebase: prints the released version, what's merged-but-not-released, and where the architecture map + inventory live. Use at the start of any dex-core development or investigation, or whenever you're unsure what's shipped vs built-locally vs prototype."
+---
+
+# Dex Orient
+
+1. Run `python3 scripts/dex_state.py` from the repository root.
+2. Read `docs/architecture/DEX-CORE-MAP.md` for the narrative and `docs/architecture/INVENTORY.md` for generated tool and skill lists.
+3. Summarize the released version, LOCAL delta, planned work, and the relevant map section for the user.
+
+`docs/architecture/STATE.md` holds the generated delta snapshot and hand-maintained PLANNED block; rerun the command above for live truth.

--- a/.distignore
+++ b/.distignore
@@ -31,6 +31,7 @@ core/migrations/tests/
 CONTRIBUTING.md
 DISTRIBUTION_READY.md
 scripts/
+.claude/skills/dex-orient/
 
 # Issue tracking (worktree artifacts)
 .ao-issue.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ core/migrations/tests/  export-ignore
 CONTRIBUTING.md         export-ignore
 DISTRIBUTION_READY.md   export-ignore
 /scripts/               export-ignore
+.claude/skills/dex-orient/ export-ignore
 .ao-issue.md            export-ignore
 .distignore             export-ignore
 .gitattributes          export-ignore

--- a/core/tests/test_dex_state.py
+++ b/core/tests/test_dex_state.py
@@ -1,0 +1,108 @@
+"""Tests for the live Dex Core shipped/local/planned state ledger."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts import dex_state
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLANNED_START = "<!-- PLANNED:START -->"
+PLANNED_END = "<!-- PLANNED:END -->"
+
+
+def _state_document(planned: str) -> str:
+    return (
+        "# Dex Core State\n\n"
+        "Purpose.\n\n"
+        "<!-- GENERATED:START -->\n"
+        "stale generated content\n"
+        "<!-- GENERATED:END -->\n\n"
+        f"{PLANNED_START}{planned}{PLANNED_END}\n"
+    )
+
+
+def _planned_region(document: str) -> str:
+    start = document.index(PLANNED_START)
+    end = document.index(PLANNED_END) + len(PLANNED_END)
+    return document[start:end]
+
+
+def test_two_write_runs_are_deterministic(tmp_path: Path) -> None:
+    state_path = tmp_path / "STATE.md"
+    state_path.write_text(_state_document("\n- Keep this exactly.  \n"), encoding="utf-8")
+
+    assert dex_state.main(["--write"], repo_root=REPO_ROOT, state_path=state_path) == 0
+    first = state_path.read_bytes()
+    assert dex_state.main(["--write"], repo_root=REPO_ROOT, state_path=state_path) == 0
+
+    assert state_path.read_bytes() == first
+
+
+def test_live_repo_release_and_pull_request_subject_parsing() -> None:
+    expected_tags = subprocess.run(
+        ["git", "tag", "--sort=-v:refname", "--list", "v[0-9]*"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    expected_subjects = subprocess.run(
+        ["git", "log", "--format=%s", f"{expected_tags[0]}..HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+
+    release = dex_state.find_latest_release(REPO_ROOT)
+    unreleased = dex_state.find_unreleased(REPO_ROOT, expected_tags[0])
+    parsed = dex_state.parse_unreleased_subject(
+        "docs(architecture): add DEX-CORE-MAP grounding narrative (#181)"
+    )
+
+    assert release is not None
+    assert release.tag == expected_tags[0]
+    assert release.commit_date
+    assert unreleased is not None
+    assert [commit.subject for commit in unreleased] == expected_subjects
+    assert parsed.subject == "docs(architecture): add DEX-CORE-MAP grounding narrative (#181)"
+    assert parsed.pr_number == 181
+
+
+def test_write_preserves_hand_maintained_planned_block_verbatim(tmp_path: Path) -> None:
+    planned = "\n- First item.  \n\n  Indented continuation.\n- Final item.\n"
+    state_path = tmp_path / "STATE.md"
+    before = _state_document(planned)
+    state_path.write_text(before, encoding="utf-8")
+
+    assert dex_state.main(["--write"], repo_root=REPO_ROOT, state_path=state_path) == 0
+
+    after = state_path.read_text(encoding="utf-8")
+    assert _planned_region(after) == _planned_region(before)
+    assert "stale generated content" not in after
+
+
+def test_no_tag_degrades_to_minimal_success_output(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(dex_state, "find_latest_release", lambda _repo_root: None)
+
+    assert dex_state.main(["--digest"], repo_root=REPO_ROOT) == 0
+
+    output = capsys.readouterr().out
+    assert "Released: unknown (no version tag found)" in output
+    assert "On main, not yet released" not in output
+
+
+def test_detached_head_skips_the_unavailable_delta(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        dex_state,
+        "find_latest_release",
+        lambda _repo_root: dex_state.Release("v1.68.0", "2026-07-22"),
+    )
+    monkeypatch.setattr(dex_state, "_git", lambda _repo_root, *_args: None)
+
+    state = dex_state.collect_state(REPO_ROOT, tmp_path / "missing-state.md")
+
+    assert "Released: v1.68.0 (2026-07-22)" in dex_state.render_digest(state)
+    assert "On main, not yet released" not in dex_state.render_digest(state)

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: dec7170bf1b86c67fd0fdfb2afcc9610cd2d6674728718f268d808b6d9da9307 -->
+<!-- Content SHA-256: f59ab7941080bd2916ddeb884c8c98086a31ec11d3ef3971d9a03d181c3e103d -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 68<br>
+**Skill count:** 69<br>
 **Discoverability-risk count:** 53
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -61,6 +61,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `dex-improve` | `.claude/skills/dex-improve/SKILL.md` | Workshop an improvement idea into implementation plan | 53 | **discoverability-risk** |
 | `dex-level-up` | `.claude/skills/dex-level-up/SKILL.md` | Discover unused Dex features based on your usage patterns | 57 | **discoverability-risk** |
 | `dex-obsidian-setup` | `.claude/skills/dex-obsidian-setup/SKILL.md` | Enable Obsidian integration and migrate existing vault to wiki links | 68 | **discoverability-risk** |
+| `dex-orient` | `.claude/skills/dex-orient/SKILL.md` | Orient in the Dex Core codebase: prints the released version, what's merged-but-not-released, and where the architecture map + inventory live. Use at the start of any dex-core development or investigation, or whenever you're unsure what's shipped vs built-locally vs prototype. | 277 | when |
 | `dex-rollback` | `.claude/skills/dex-rollback/SKILL.md` | Rewind one receipt-backed Dex adoption through the frozen lifecycle service | 75 | **discoverability-risk** |
 | `dex-update` | `.claude/skills/dex-update/SKILL.md` | Preview and safely adopt Dex updates through the frozen lifecycle service | 73 | **discoverability-risk** |
 | `dex-whats-new` | `.claude/skills/dex-whats-new/SKILL.md` | Check for system improvements (learnings + Claude updates) | 58 | **discoverability-risk** |

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -1,0 +1,27 @@
+# Dex Core State
+
+A compact snapshot of released, local, and planned Dex Core work.
+
+<!-- GENERATED:START -->
+## Generated snapshot
+
+SHIPPED/LOCAL are computed live — run `/dex-orient` or `python3 scripts/dex_state.py` for current truth.
+
+Released: v1.68.0 (2026-07-22)
+
+### LOCAL — on main, not yet released (3)
+
+- #181 docs(architecture): add DEX-CORE-MAP grounding narrative
+- #180 fix: restore silently-dead career capture + hooks input-contract test + cleanup
+- #179 feat(docs): code-derived architecture inventory + CI drift gate (grounding foundation)
+<!-- GENERATED:END -->
+
+<!-- PLANNED:START -->
+## PLANNED
+
+- Reconcile `release.sh` with the live state ledger at release cut.
+- `/dex-orient` — now shipping.
+- Add in-flight markers from Dispatch and open PRs — future.
+- Verify brain/vault split migrator adoption end to end.
+- Live-verify the connection manager.
+<!-- PLANNED:END -->

--- a/scripts/dex_state.py
+++ b/scripts/dex_state.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Report Dex Core's released, local, and planned state without network access."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATE_PATH = REPO_ROOT / "docs/architecture/STATE.md"
+GENERATED_START = "<!-- GENERATED:START -->"
+GENERATED_END = "<!-- GENERATED:END -->"
+PLANNED_START = "<!-- PLANNED:START -->"
+PLANNED_END = "<!-- PLANNED:END -->"
+GIT_TIMEOUT_SECONDS = 3
+PR_SUFFIX = re.compile(r"\s*\(#(\d+)\)$")
+
+
+@dataclass(frozen=True)
+class Release:
+    tag: str
+    commit_date: str
+
+
+@dataclass(frozen=True)
+class UnreleasedCommit:
+    subject: str
+    pr_number: int | None
+
+
+@dataclass(frozen=True)
+class CoreState:
+    released: Release | None
+    unreleased: tuple[UnreleasedCommit, ...] | None
+    planned: str
+
+
+def _git(repo_root: Path, *args: str) -> str | None:
+    """Run one bounded git query, returning None for every unavailable state."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def find_latest_release(repo_root: Path = REPO_ROOT) -> Release | None:
+    """Return the newest version-sorted v* tag and its commit date."""
+    tags = _git(repo_root, "tag", "--sort=-v:refname", "--list", "v[0-9]*")
+    if not tags:
+        return None
+    tag = tags.splitlines()[0]
+    commit_timestamp = _git(repo_root, "log", "-1", "--format=%ci", tag)
+    commit_date = commit_timestamp.split(maxsplit=1)[0] if commit_timestamp else "unknown"
+    return Release(tag=tag, commit_date=commit_date)
+
+
+def parse_unreleased_subject(subject: str) -> UnreleasedCommit:
+    """Parse a squash-merge PR number while preserving the exact subject."""
+    match = PR_SUFFIX.search(subject)
+    return UnreleasedCommit(subject=subject, pr_number=int(match.group(1)) if match else None)
+
+
+def find_unreleased(repo_root: Path, release_tag: str) -> tuple[UnreleasedCommit, ...] | None:
+    """Return newest-first commit subjects after the release tag."""
+    subjects = _git(repo_root, "log", "--format=%s", f"{release_tag}..HEAD")
+    if subjects is None:
+        return None
+    return tuple(parse_unreleased_subject(subject) for subject in subjects.splitlines() if subject)
+
+
+def read_planned(state_path: Path = STATE_PATH) -> str:
+    """Read the hand-maintained PLANNED contents verbatim, or return empty."""
+    try:
+        document = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    before, start, rest = document.partition(PLANNED_START)
+    del before
+    if not start:
+        return ""
+    planned, end, _after = rest.partition(PLANNED_END)
+    return planned if end else ""
+
+
+def collect_state(repo_root: Path = REPO_ROOT, state_path: Path = STATE_PATH) -> CoreState:
+    """Collect live git state and hand-maintained planned work."""
+    planned = read_planned(state_path)
+    released = find_latest_release(repo_root)
+    if released is None:
+        return CoreState(released=None, unreleased=None, planned=planned)
+    attached_branch = _git(repo_root, "symbolic-ref", "--quiet", "--short", "HEAD")
+    unreleased = find_unreleased(repo_root, released.tag) if attached_branch else None
+    return CoreState(released=released, unreleased=unreleased, planned=planned)
+
+
+def _released_line(released: Release | None) -> str:
+    if released is None:
+        return "Released: unknown (no version tag found)"
+    return f"Released: {released.tag} ({released.commit_date})"
+
+
+def _display_commit(commit: UnreleasedCommit) -> str:
+    subject_without_pr = PR_SUFFIX.sub("", commit.subject)
+    if commit.pr_number is None:
+        return subject_without_pr
+    return f"#{commit.pr_number} {subject_without_pr}"
+
+
+def render_digest(state: CoreState) -> str:
+    """Render the compact SessionStart grounding digest."""
+    lines = ["=== Dex Core — grounding ===", _released_line(state.released)]
+    if state.unreleased is not None:
+        summary = " · ".join(_display_commit(commit) for commit in state.unreleased) or "none"
+        lines.append(f"On main, not yet released ({len(state.unreleased)}): {summary}")
+    lines.append(
+        "Before Core work read: docs/architecture/DEX-CORE-MAP.md (map) + "
+        "INVENTORY.md (generated)"
+    )
+    return "\n".join(lines)
+
+
+def render_human(state: CoreState) -> str:
+    """Render the fuller on-demand /dex-orient report."""
+    lines = ["=== Dex Core — orientation ===", _released_line(state.released)]
+    if state.unreleased is not None:
+        lines.append(f"On main, not yet released ({len(state.unreleased)}):")
+        if state.unreleased:
+            lines.extend(f"- {_display_commit(commit)}" for commit in state.unreleased)
+        else:
+            lines.append("- none")
+    lines.append("Planned:")
+    lines.append(state.planned.strip("\n") or "- none recorded")
+    lines.append(
+        "Before Core work read: docs/architecture/DEX-CORE-MAP.md (narrative) + "
+        "docs/architecture/INVENTORY.md (generated)"
+    )
+    return "\n".join(lines)
+
+
+def render_generated(state: CoreState) -> str:
+    """Render only STATE.md's deterministic generated snapshot."""
+    lines = [
+        "## Generated snapshot",
+        "",
+        "SHIPPED/LOCAL are computed live — run `/dex-orient` or "
+        "`python3 scripts/dex_state.py` for current truth.",
+        "",
+        _released_line(state.released),
+        "",
+    ]
+    if state.released is None:
+        lines.append("LOCAL delta unavailable without a version tag.")
+    elif state.unreleased is None:
+        lines.append("LOCAL delta unavailable in the current git state.")
+    else:
+        lines.append(f"### LOCAL — on main, not yet released ({len(state.unreleased)})")
+        lines.append("")
+        if state.unreleased:
+            lines.extend(f"- {_display_commit(commit)}" for commit in state.unreleased)
+        else:
+            lines.append("- none")
+    return "\n".join(lines)
+
+
+def _new_state_document() -> str:
+    return (
+        "# Dex Core State\n\n"
+        "A compact snapshot of released, local, and planned Dex Core work.\n\n"
+        f"{GENERATED_START}\n{GENERATED_END}\n\n"
+        f"{PLANNED_START}\n{PLANNED_END}\n"
+    )
+
+
+def write_generated_state(state: CoreState, state_path: Path = STATE_PATH) -> None:
+    """Replace only the GENERATED block, leaving every other byte untouched."""
+    try:
+        document = state_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        document = _new_state_document()
+    before, start, rest = document.partition(GENERATED_START)
+    _old_generated, end, after = rest.partition(GENERATED_END)
+    if not start or not end:
+        return
+    replacement = f"{before}{GENERATED_START}\n{render_generated(state)}\n{GENERATED_END}{after}"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(replacement, encoding="utf-8")
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--digest", action="store_true", help="print a compact SessionStart digest")
+    mode.add_argument("--write", action="store_true", help="refresh STATE.md's generated block")
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    repo_root: Path = REPO_ROOT,
+    state_path: Path = STATE_PATH,
+) -> int:
+    """Run a mode without allowing local environment failures to break a session."""
+    args = _parse_args(argv)
+    try:
+        state = collect_state(repo_root, state_path)
+        if args.write:
+            write_generated_state(state, state_path)
+        else:
+            print(render_digest(state) if args.digest else render_human(state))
+    except (OSError, ValueError):
+        print("Released: unknown (grounding state unavailable)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Chunk 2 of the grounding suite — makes Core grounding **automatic** instead of relying on anyone opening the docs.

## What it adds
- **`scripts/dex_state.py`** — derives, live from git: released version (latest `v*` tag) + the unreleased delta (`git log <tag>..HEAD`, parsing squash-PR numbers). No committed state file, so nothing to drift per-merge. Offline-safe, degrades gracefully (never throws, never breaks a session).
- **`docs/architecture/STATE.md`** — hand-maintained PLANNED block + a generated snapshot; SHIPPED/LOCAL are computed live.
- **`/dex-orient`** — prints current grounding (released, unreleased, planned, read-the-map pointer) on demand.
- **SessionStart digest hook** — injects a compact digest so a dev session opens already grounded.

## Ship-safety (the thing I reviewed hardest)
The hook ships in `.claude/settings.json` to every user, so it **guards on `scripts/generate-architecture-inventory.py`** (present in the dev repo, absent in installed vaults) → `exit 0`, zero output. Proven: outside-repo run prints nothing; repo-root run prints the digest; dedup honored. The `/dex-orient` skill + `dex_state.py` are export-ignored from distribution (both mechanisms) since they'd be broken without `scripts/`, which doesn't ship.

## Gates (all green locally)
5 dex_state tests pass · inventory drift current · portable-contract (1090 paths) · distribution 0 errors · founder-content · ruff · JSON/shell/py syntax.

Built by Codex to a Fable spec; diff reviewed by Fable (logic, graceful degradation, ship-safety guard, distribution config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)