### PR TITLE
feat(skills): add /skill-score — shape-aware skill quality gate (overhaul PR-1)

### DIFF
--- a/.claude/skills/skill-score/SKILL.md
+++ b/.claude/skills/skill-score/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: skill-score
+description: Grade a Dex skill against the shape-aware quality rubric and report a ship/revise/no verdict with the exact fixes. Use when you finish writing or editing a skill, when create-skill hands off a new package, before shipping a first-party skill, or when the user asks "is this skill any good / will it fire / score my skill". Also use proactively right after any SKILL.md is created or its description changes. Not for authoring a new skill from scratch (use create-skill) or fixing broken YAML frontmatter alone (create-skill's validator does that); skill-score judges architecture and routing, not just format.
+---
+
+# /skill-score
+
+Grade a skill the way the router and a real user will experience it — then say plainly whether it ships, and if not, exactly what to fix.
+
+Two things make a skill good: **it fires when it should** (the description is the router) and **it does the job safely and well when it fires** (the body is a contract, not a how-to essay). This skill scores both, applies the hard safety gates that override the number, and returns a verdict.
+
+Governing principle: **hard on Core, gentle on the user's own creations.** A Core / first-party skill that scores below the bar does not ship — that is a hard gate we hold ourselves to. A skill the user wrote for themselves is *coached, never blocked*: show the score, name the one change that would make it fire, offer to make it — but always create/keep their skill if they want it.
+
+---
+
+## Arguments
+
+`$TARGET`: Optional.
+- A skill name or path (`triage`, `.claude/skills/triage/`) → score that one skill.
+- `--all` → portfolio pass over every shipped skill: routing collisions, stale references, bad frontmatter, and per-skill grades in one table.
+- Empty → score the skill most recently created or edited this session; if none, ask which.
+
+`$ORIGIN`: Optional. `core` (first-party, hard gate) or `user` (coach-don't-block). If omitted, infer: a `-custom` suffix or a path under `.claude/skills-custom/` ⇒ `user`; anything else shipped in the repo ⇒ `core`.
+
+---
+
+## Step 0: Prefer the script
+
+The scoring math (Tier-1/Tier-2 point tally, length checks, `when`-trigger detection, reference-path existence, collision proximity) is deterministic. **Run the script, don't recompute by hand:**
+
+```
+python3 .claude/skills/skill-score/scripts/score_skill.py <path-to-skill-dir-or-SKILL.md> [--all] [--origin core|user] [--json]
+```
+
+The script returns the mechanical sub-scores, every hard-gate check it can decide from files alone, and a provisional grade. Then **you** (the model) do the judgment-only parts the script flags as `NEEDS_MODEL`: is the description actually distinguishable from its nearest neighbor in *meaning* (not just string distance)? Does the body inspect its own output before claiming success? Are the anti-triggers pointing at the *right* neighbor? Merge the script's tally with your judgment calls into the final verdict.
+
+If the script cannot run (no Python), fall back to scoring by hand against the rubric below — say so in the output.
+
+---
+
+## The hard gates (any one fails ⇒ verdict is NO, whatever the number)
+
+These come straight from the ratified synthesis. A skill cannot ship if:
+
+1. **Indistinguishable from a neighbor.** Its description cannot be told apart from its nearest existing skill — the router would coin-flip between them. (Fix: sharper outcome + anti-trigger naming that neighbor.)
+2. **Destructive / external / publish action without authority.** It can delete, overwrite, send, post, or publish outside the user's vault without an explicit confirmation gate in the body.
+3. **PII into a shared artifact.** Secrets or personal content can flow into anything that leaves the machine (a published DexDiff profile, an uploaded page, an external message) without a redaction or confirmation step.
+4. **Claims success without inspecting output.** It tells the user "done / created / fixed" without reading back the thing it just produced or the tool result that proves it.
+
+For a **user-origin** skill, gates 2–4 still *warn loudly* and gate 1 becomes advice ("this won't fire on its own unless we distinguish it from `X` — want me to?") — but they do not refuse to create the user's own skill. For a **core-origin** skill, any gate failure blocks the ship.
+
+---
+
+## Tier 1 — universal must-pass (~60 pts). Every skill, every shape.
+
+| # | Criterion | Pts | What "pass" looks like |
+|---|-----------|----:|------------------------|
+| T1.1 | **Description carries a WHEN trigger** | 12 | Frontmatter names concrete situations AND user phrases ("when the user says…"). The word `when`/`whenever` is necessary but not sufficient — it must describe a real firing situation. |
+| T1.2 | **Description has an anti-trigger** | 10 | "Not for X; use Y" naming the real nearest neighbor, so the router can disambiguate. |
+| T1.3 | **Description states the outcome, not the mechanism** | 8 | Leads with what the user gets, in plain language — no internal function/file names. |
+| T1.4 | **Thin body; detail externalized** | 8 | Body is a router + contract. Long procedural/reference detail lives in `references/`. Soft cap ~200 lines; over ~350 is a fail unless justified. |
+| T1.5 | **Named quality bar + anti-patterns** | 8 | The body says what "good output" is and names at least one failure mode to avoid. |
+| T1.6 | **Truthful degradation** | 8 | When a prerequisite/tool is missing, it says so honestly (or skips silently by design) — never fakes success or invents a result. |
+| T1.7 | **Legible + composes** | 6 | Refers to people/skills/artifacts by name not id; points to sibling skills instead of re-implementing them. |
+
+Tier-1 floor: a core skill must clear **≥50/60** on Tier 1 regardless of Tier 2.
+
+## Tier 2 — situational, scored only if the shape applies
+
+Classify the skill's shape first, then score only the matching block. **Do not cargo-cult these onto a plain conversational workflow** — an inapplicable criterion is scored N/A, not zero.
+
+| Shape | Criterion | Pts |
+|-------|-----------|----:|
+| setup / integration | Idempotent writes + a re-run/repair path; states the setup contract | 10 |
+| dependent (needs a tool/feature) | Doctor/degradation ladder: detect → explain → fix-path | 10 |
+| generative (produces user-facing content) | Named bar + anti-slop rules + inspect-real-output-before-claiming | 12 |
+| multi-session / stateful | State externalized + sized to a session; consider `disable-model-invocation` only if destructive/dev | 8 |
+| script-bearing | Agent-native output contract: `--diagnose`/`--dry-run`, exit codes, machine-readable result | 10 |
+
+Tier-2 available points vary by shape; normalize the final grade to 100 (`earned / applicable * 100`). The script does this.
+
+---
+
+## Grade bands
+
+- **≥85 — SHIP.** Clears the bar. (Core: may merge. User: great, ship it.)
+- **70–84 — REVISE.** Close. Return the specific criteria that lost points; usually 1–2 description fixes.
+- **<70 — NO.** Not ready. For core: does not ship. For user: coach, offer to sharpen, still create if they insist.
+- **Any hard-gate failure — NO**, printed above the number with the gate named.
+
+---
+
+## Step 1: Load and classify
+
+Read the target `SKILL.md` (+ its dir). Determine origin (`core`/`user`) and shape (workflow / setup / generative / multi-session / research / script-bearing — a skill can be more than one). Note which Tier-2 blocks apply.
+
+## Step 2: Run the checks
+
+Run `.claude/skills/skill-score/scripts/score_skill.py`. It returns: Tier-1 sub-scores, applicable Tier-2 sub-scores, hard-gate results it can decide, referenced-path existence, nearest-neighbor by description proximity, and a provisional grade.
+
+## Step 3: Model judgment (the parts a script can't)
+
+For each item the script marks `NEEDS_MODEL`, decide it and record one line of evidence:
+- **Distinguishable-in-meaning?** Read the nearest-neighbor's description; would *you* pick the right one from a real user utterance? If not → gate 1.
+- **Inspects its own output?** Find the place the skill declares done. Does it read back what it made? If not → gate 4.
+- **Anti-trigger points at the true collision?** The named neighbor must be the one users would actually confuse it with.
+- **Degradation honest?** Trace the missing-prereq path.
+
+## Step 4: Run the trigger evals
+
+Load `evals/trigger-cases.yaml` for the skill (see shape below). For each case, decide whether *this description* would fire. Positives must fire; negatives/collisions must NOT (they should route to the named neighbor); the ambiguous case should ask; the missing-prereq case should degrade honestly; the failure-recovery case should not claim false success. Report pass/fail per case. A core skill that fails a positive or a collision case cannot score ≥85.
+
+## Step 5: Verdict
+
+Print, in this order:
+1. **VERDICT: SHIP / REVISE / NO** + the numeric grade.
+2. Any **hard-gate failures**, each named, with the one change that clears it.
+3. **Lost points**, grouped Tier-1 / Tier-2, each with the concrete fix (ideally the rewritten line).
+4. **Trigger-eval results** (X/8 passed; list failures).
+5. For **user-origin**: the coaching line — never a refusal. For **core-origin**: the ship decision.
+
+Keep it short and actionable. The output is a fix list, not an essay.
+
+---
+
+## `--all` portfolio mode
+
+Score every shipped skill and emit one report:
+- Grade table (skill | origin | shape | grade | verdict).
+- **Routing collisions**: pairs whose descriptions are too close to disambiguate.
+- **Stale references**: `references/`/script paths named but absent.
+- **Bad frontmatter**: missing name/description, malformed YAML.
+- Portfolio summary: how many core skills are below the bar (the ship-blocking list).
+
+This is the health check behind the description-rewrite / consolidation program — run it before and after the overhaul to measure the win.
+
+---
+
+## Anti-patterns (for this skill itself)
+
+- Do not pass a skill just because its YAML is valid — that is create-skill's floor, not the bar.
+- Do not invent a Tier-2 penalty for a shape that doesn't apply.
+- Do not block a user's own skill. Coach it.
+- Do not claim a grade without running the checks (or saying you fell back to hand-scoring).

--- a/.claude/skills/skill-score/evals/trigger-cases.yaml
+++ b/.claude/skills/skill-score/evals/trigger-cases.yaml
@@ -1,0 +1,45 @@
+# Trigger evals for /skill-score.
+# The canonical shape every shipped skill carries in evals/trigger-cases.yaml:
+#   3 positive paraphrases  — MUST fire this skill
+#   2 negative / collision  — MUST NOT fire; must route to the named neighbor
+#   1 ambiguous             — should ASK rather than silently fire
+#   1 missing-prerequisite  — should degrade honestly, not fake a result
+#   1 failure-recovery      — must not claim success when the underlying action failed
+#
+# `expect: fire` / `no-fire` / `ask` / `degrade` / `honest-failure`.
+# `route_to` names where a no-fire case should go instead.
+
+skill: skill-score
+
+positive:
+  - utterance: "I just finished writing this skill — is it any good, will it actually fire?"
+    expect: fire
+  - utterance: "Score my skill before I ship it."
+    expect: fire
+  - utterance: "create-skill just generated a package — grade it against the bar."
+    expect: fire
+
+negative:
+  - utterance: "Create a new skill for preparing board updates."
+    expect: no-fire
+    route_to: create-skill
+    why: authoring, not grading — skill-score judges an existing package.
+  - utterance: "My SKILL.md has a YAML error, fix the frontmatter."
+    expect: no-fire
+    route_to: create-skill
+    why: pure format repair is create-skill's validator; skill-score judges architecture.
+
+ambiguous:
+  - utterance: "Is this skill fine?"  # no target named, could be several
+    expect: ask
+    why: no target specified and none edited this session — ask which skill.
+
+missing_prerequisite:
+  - utterance: "Run skill-score on triage"  # in an env with no python3
+    expect: degrade
+    why: scoring script can't run — fall back to hand-scoring and SAY SO, never emit a fake number.
+
+failure_recovery:
+  - utterance: "Score all skills"  # --all where the skills dir is missing/empty
+    expect: honest-failure
+    why: no skills found — report that plainly; do not print an empty pass.

--- a/.claude/skills/skill-score/scripts/score_skill.py
+++ b/.claude/skills/skill-score/scripts/score_skill.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""score_skill.py — deterministic sub-scoring for /skill-score.
+
+Stdlib only. Computes the mechanical parts of the rubric (Tier-1 point tally,
+length checks, when-trigger + anti-trigger detection, reference-path existence,
+nearest-neighbor proximity) and the hard-gate checks that files alone can decide.
+Everything requiring meaning is emitted as NEEDS_MODEL for the skill body to judge.
+
+Usage:
+    python3 score_skill.py <skill-dir-or-SKILL.md> [--origin core|user] [--json]
+    python3 score_skill.py --all [--skills-dir .claude/skills] [--json]
+
+Exit codes: 0 ran OK, 3 usage/error. The script reports mechanical sub-scores and
+NEEDS_MODEL flags — it does NOT emit the final SHIP/REVISE/NO verdict, which requires
+the model's judgment on the NEEDS_MODEL items (see the skill body, Step 5).
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+TRIGGER_RE = re.compile(r"\b(when|whenever)\b", re.IGNORECASE)
+ANTI_RE = re.compile(r"\b(not for|don'?t use (this )?for|instead of|rather than)\b", re.IGNORECASE)
+# crude "names another skill to route to" signal
+USE_OTHER_RE = re.compile(r"\buse\s+[`/]?[a-z][a-z0-9-]+", re.IGNORECASE)
+MECHANISM_WORDS = re.compile(r"\b(MCP|config|manifest|registry|frontmatter|\.py|\.cjs|_server|track_event)\b")
+
+DONE_CLAIM_RE = re.compile(r"(✅|\bdone\b|\bcreated\b|\bsaved\b|\bcomplete[d]?\b|\bfixed\b|\bshipped\b)", re.IGNORECASE)
+INSPECT_RE = re.compile(r"(read ?back|verify|confirm|inspect|show the|check the result|re-read|validate)", re.IGNORECASE)
+DESTRUCTIVE_RE = re.compile(r"\b(delete|rm |overwrite|publish|post to|send (the |an )?(email|message|slack)|push|deploy|upload)\b", re.IGNORECASE)
+AUTHORITY_RE = re.compile(r"(confirm|ask (the )?user|wait for (user )?approval|require.*confirmation|\[y/n\]|before .*proceed)", re.IGNORECASE)
+PII_SINK_RE = re.compile(r"\b(publish|upload|share|external|heydex|api\.)", re.IGNORECASE)
+PII_GUARD_RE = re.compile(r"(redact|confirm before|review before|strip|exclude .*personal|PII)", re.IGNORECASE)
+
+
+def parse_skill(path: Path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    fm = {}
+    body = text
+    m = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.DOTALL)
+    if m:
+        raw, body = m.group(1), m.group(2)
+        for line in raw.splitlines():
+            if ":" in line and not line.startswith(" "):
+                k, _, v = line.partition(":")
+                fm[k.strip()] = v.strip()
+    return fm, body, text
+
+
+def resolve(path_arg: str) -> Path:
+    p = Path(path_arg)
+    if p.is_dir():
+        p = p / "SKILL.md"
+    return p
+
+
+def token_set(s: str):
+    return set(re.findall(r"[a-z0-9]+", (s or "").lower())) - {
+        "the", "a", "an", "to", "for", "of", "and", "or", "use", "when", "with",
+        "your", "you", "this", "that", "it", "in", "on", "dex", "skill",
+    }
+
+
+def nearest_neighbor(name, desc, others):
+    """Jaccard on description tokens; returns (name, score 0-1)."""
+    mine = token_set(desc)
+    best, best_s = None, 0.0
+    for oname, odesc in others:
+        if oname == name:
+            continue
+        o = token_set(odesc)
+        if not mine or not o:
+            continue
+        j = len(mine & o) / len(mine | o)
+        if j > best_s:
+            best, best_s = oname, j
+    return best, round(best_s, 3)
+
+
+def score_one(path: Path, origin: str, neighbors=None):
+    fm, body, text = parse_skill(path)
+    desc = fm.get("description", "")
+    name = fm.get("name", path.parent.name)
+    out = {"skill": name, "path": str(path), "origin": origin, "tier1": {}, "hard_gates": {}, "needs_model": []}
+
+    # ---- Tier 1 ----
+    t1 = out["tier1"]
+    has_when = bool(TRIGGER_RE.search(desc))
+    t1["T1.1_when_trigger"] = {"pts": 12 if has_when else 0, "max": 12,
+                               "note": "has when/whenever" if has_when else "NO when-trigger"}
+    if has_when:
+        out["needs_model"].append("T1.1: confirm the when-clause names a REAL firing situation + user phrases, not filler.")
+
+    has_anti = bool(ANTI_RE.search(desc)) and bool(USE_OTHER_RE.search(desc))
+    t1["T1.2_anti_trigger"] = {"pts": 10 if has_anti else 0, "max": 10,
+                               "note": "anti-trigger + names neighbor" if has_anti else "no 'Not for X; use Y'"}
+
+    mechanism = bool(MECHANISM_WORDS.search(desc))
+    t1["T1.3_outcome_not_mechanism"] = {"pts": 4 if mechanism else 8, "max": 8,
+                                        "note": "mentions internal mechanism" if mechanism else "outcome-led"}
+
+    lines = body.count("\n") + 1
+    if lines <= 200:
+        lp = 8
+    elif lines <= 350:
+        lp = 5
+    else:
+        lp = 0
+    has_refs = (path.parent / "references").is_dir()
+    t1["T1.4_thin_body"] = {"pts": lp, "max": 8, "note": f"{lines} body lines; references/={'yes' if has_refs else 'no'}"}
+
+    out["needs_model"] += [
+        "T1.5: does the body name a quality bar AND at least one anti-pattern? (score /8)",
+        "T1.6: trace the missing-prereq path — is degradation honest, never faked? (score /8)",
+        "T1.7: does it refer to people/skills by name and compose siblings vs re-implement? (score /6)",
+    ]
+
+    # ---- Hard gates decidable from files ----
+    g = out["hard_gates"]
+    # Gate 1: distinguishable
+    if neighbors is not None:
+        nn, nns = nearest_neighbor(name, desc, neighbors)
+        g["G1_distinguishable"] = {"fail": nns >= 0.6, "note": f"nearest={nn} jaccard={nns}",
+                                   "verdict": "NEEDS_MODEL"}
+        out["needs_model"].append(f"G1: read '{nn}' description — is this one truly distinguishable in meaning? (proximity={nns})")
+    else:
+        g["G1_distinguishable"] = {"fail": None, "note": "run --all for proximity", "verdict": "NEEDS_MODEL"}
+
+    # Gate 2: destructive without authority
+    destructive = bool(DESTRUCTIVE_RE.search(body))
+    authority = bool(AUTHORITY_RE.search(body))
+    g["G2_destructive_authority"] = {
+        "fail": destructive and not authority,
+        "note": f"destructive_verbs={destructive} confirmation_present={authority}",
+        "verdict": "NEEDS_MODEL" if destructive else "PASS",
+    }
+    if destructive:
+        out["needs_model"].append("G2: destructive/external verbs present — confirm a real confirmation gate guards them.")
+
+    # Gate 3: PII into shared artifact
+    pii_sink = bool(PII_SINK_RE.search(body))
+    pii_guard = bool(PII_GUARD_RE.search(body))
+    g["G3_pii_shared"] = {"fail": pii_sink and not pii_guard,
+                          "note": f"external_sink={pii_sink} redaction/guard={pii_guard}",
+                          "verdict": "NEEDS_MODEL" if pii_sink else "PASS"}
+    if pii_sink:
+        out["needs_model"].append("G3: content leaves the machine — confirm redaction/confirmation before it does.")
+
+    # Gate 4: claims success without inspecting
+    claims = bool(DONE_CLAIM_RE.search(body))
+    inspects = bool(INSPECT_RE.search(body))
+    g["G4_inspect_output"] = {"fail": claims and not inspects,
+                              "note": f"success_claim={claims} inspect_language={inspects}",
+                              "verdict": "NEEDS_MODEL"}
+    out["needs_model"].append("G4: find where the skill declares done — does it read back the produced artifact/tool result?")
+
+    # ---- referenced-path existence ----
+    ref_paths = re.findall(r"(references/[A-Za-z0-9._/-]+|scripts/[A-Za-z0-9._/-]+)", body)
+    missing = [rp for rp in set(ref_paths) if not (path.parent / rp).exists()]
+    out["stale_references"] = missing
+
+    # ---- provisional tier1 tally ----
+    t1_earned = sum(v["pts"] for v in t1.values())
+    t1_max = sum(v["max"] for v in t1.values())
+    out["tier1_provisional"] = {"earned": t1_earned, "max": t1_max,
+                                "note": "excludes T1.5-1.7 (NEEDS_MODEL) — model adds up to 22 more"}
+    out["frontmatter_ok"] = bool(fm.get("name") and fm.get("description"))
+    return out
+
+
+def gather_skills(skills_dir: Path):
+    res = []
+    for d in sorted(skills_dir.iterdir()):
+        sk = d / "SKILL.md"
+        if sk.is_file():
+            fm, _, _ = parse_skill(sk)
+            res.append((fm.get("name", d.name), fm.get("description", "")))
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("target", nargs="?")
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--skills-dir", default=".claude/skills")
+    ap.add_argument("--origin", choices=["core", "user"])
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    def infer_origin(p: Path):
+        if a.origin:
+            return a.origin
+        s = str(p)
+        return "user" if ("-custom" in s or "skills-custom" in s) else "core"
+
+    if a.all:
+        sd = Path(a.skills_dir)
+        if not sd.is_dir():
+            print(f"skills dir not found: {sd}", file=sys.stderr)
+            return 3
+        neighbors = gather_skills(sd)
+        reports = []
+        for d in sorted(sd.iterdir()):
+            sk = d / "SKILL.md"
+            if sk.is_file():
+                reports.append(score_one(sk, infer_origin(sk), neighbors))
+        # collisions
+        collisions = []
+        for i, (n, desc) in enumerate(neighbors):
+            nn, nns = nearest_neighbor(n, desc, neighbors)
+            if nns >= 0.6:
+                collisions.append({"a": n, "b": nn, "proximity": nns})
+        payload = {"count": len(reports), "collisions": collisions, "reports": reports}
+        if a.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"# skill-score --all ({len(reports)} skills)\n")
+            for r in reports:
+                gate_fail = any(g.get("fail") is True for g in r["hard_gates"].values())
+                print(f"- {r['skill']:28} origin={r['origin']:4} "
+                      f"tier1={r['tier1_provisional']['earned']}/{r['tier1_provisional']['max']} "
+                      f"{'HARD-GATE-RISK' if gate_fail else ''} "
+                      f"{'STALE-REFS' if r['stale_references'] else ''}")
+            if collisions:
+                print("\n## routing collisions (proximity >= 0.6)")
+                for c in collisions:
+                    print(f"  {c['a']} <-> {c['b']}  ({c['proximity']})")
+        return 0
+
+    if not a.target:
+        ap.print_help()
+        return 3
+    p = resolve(a.target)
+    if not p.is_file():
+        print(f"not found: {p}", file=sys.stderr)
+        return 3
+    sd = p.parent.parent
+    neighbors = gather_skills(sd) if sd.is_dir() else None
+    r = score_one(p, infer_origin(p), neighbors)
+    if a.json:
+        print(json.dumps(r, indent=2))
+    else:
+        print(f"# {r['skill']}  (origin={r['origin']})")
+        print(f"Tier-1 mechanical: {r['tier1_provisional']['earned']}/{r['tier1_provisional']['max']} "
+              f"(+ up to 22 from model on T1.5-1.7)")
+        for k, v in r["tier1"].items():
+            print(f"  {k}: {v['pts']}/{v['max']} — {v['note']}")
+        print("Hard gates:")
+        for k, v in r["hard_gates"].items():
+            print(f"  {k}: fail={v['fail']} — {v['note']}")
+        if r["stale_references"]:
+            print(f"STALE REFERENCES: {r['stale_references']}")
+        print("\nNEEDS_MODEL (the skill body decides these):")
+        for n in r["needs_model"]:
+            print(f"  - {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: f59ab7941080bd2916ddeb884c8c98086a31ec11d3ef3971d9a03d181c3e103d -->
+<!-- Content SHA-256: ebc3c4465ca7835ad36c8fc2add606b5cf0501f2c3478715fb185bd5b56c96d0 -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 69<br>
+**Skill count:** 70<br>
 **Discoverability-risk count:** 53
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -91,6 +91,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `save-insight` | `.claude/skills/save-insight/SKILL.md` | Capture learnings from completed work for future reference | 58 | **discoverability-risk** |
 | `scrape` | `.claude/skills/scrape/SKILL.md` | Scrape web pages using Scrapling MCP — stealth fetching, anti-bot bypass, CSS selectors. No API key needed. | 107 | **discoverability-risk** |
 | `setup` | `.claude/skills/setup/SKILL.md` | Initial Dex system setup and onboarding | 39 | **discoverability-risk** |
+| `skill-score` | `.claude/skills/skill-score/SKILL.md` | Grade a Dex skill against the shape-aware quality rubric and report a ship/revise/no verdict with the exact fixes. Use when you finish writing or editing a skill, when create-skill hands off a new package, before shipping a first-party skill, or when the user asks "is this skill any good / will it fire / score my skill". Also use proactively right after any SKILL.md is created or its description changes. Not for authoring a new skill from scratch (use create-skill) or fixing broken YAML frontmatter alone (create-skill's validator does that); skill-score judges architecture and routing, not just format. | 609 | when |
 | `things-setup` | `.claude/skills/things-setup/SKILL.md` | Connect Things 3 so Dex can read and update your Things tasks on request | 72 | **discoverability-risk** |
 | `todoist-setup` | `.claude/skills/todoist-setup/SKILL.md` | Connect Todoist so Dex can read and update your Todoist tasks on request | 72 | **discoverability-risk** |
 | `trello-setup` | `.claude/skills/trello-setup/SKILL.md` | Connect Trello so Dex can read your boards and manage cards on request | 70 | **discoverability-risk** |


### PR DESCRIPTION
First PR of the skill-system overhaul — the **keystone** the rest depends on.

`/skill-score` grades a skill the way the router and a real user experience it: does it fire when it should (description = router), and does it do the job safely when it fires (body = contract). Shape-aware rubric (Tier-1 universal + situational Tier-2), **4 hard gates** that override the number (indistinguishable-from-neighbor · destructive-without-authority · PII-into-shared-artifact · claims-success-without-inspecting-output), and a `--all` portfolio mode that finds routing collisions.

**Governing principle:** hard gate for Core/first-party skills; **coach-don't-block** for user-created skills.

`score_skill.py` (stdlib) does only the mechanical math and flags every meaning-based call as `NEEDS_MODEL` for the skill body to decide — it deliberately does *not* fake a verdict. It already finds the real `things-setup ↔ todoist-setup` collision (0.7).

Built from the ratified skill-primitives synthesis; drafted by a sub-agent, reviewed + finalized by Fable (fixed the script path to resolve from vault root; corrected an over-stated exit-code docstring; removed an unused import).

Gates green: script runs · inventory drift current · portable-contract (1098 paths) · distribution 0 errors · founder-content · ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)