### PR TITLE
feat(entities): SQLite-backed people/company index (engine 3B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ System/Dex_Backlog.md
 System/highlights.json
 System/Innovation_Research/
 System/.dex/*.json
+System/.dex/entity-index/
 
 # Onboarding state
 System/.onboarding/state.json

--- a/core/entity_engine/index.py
+++ b/core/entity_engine/index.py
@@ -1,0 +1,994 @@
+"""Disposable SQLite projection of Dex person and company pages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Callable, Iterable, TypeVar
+
+from core.entity_engine.contract import parse_entity_page
+from core.lifecycle.inventory import load_folder_map
+from core.paths import COMPANIES_DIR, PEOPLE_DIR, VAULT_ROOT
+from core.utils.company_domains import registrable_domain
+
+# Vault-relative PARA roots derived from the canonical core.paths constants
+# (POSIX strings, computed at import time). Using these instead of raw PARA path
+# literals keeps the path-contract gate satisfied while staying folder-map aware.
+_PEOPLE_INTERNAL_REL = (PEOPLE_DIR / "Internal").relative_to(VAULT_ROOT).as_posix()
+_PEOPLE_EXTERNAL_REL = (PEOPLE_DIR / "External").relative_to(VAULT_ROOT).as_posix()
+_PEOPLE_CPO_REL = (PEOPLE_DIR / "CPO_Network").relative_to(VAULT_ROOT).as_posix()
+_COMPANIES_REL = COMPANIES_DIR.relative_to(VAULT_ROOT).as_posix()
+
+SCHEMA_VERSION = "1"
+DEFAULT_DEBOUNCE_SECONDS = 0.25
+_DATABASE_RELATIVE_PATH = Path("System/.dex/entity-index/database.sqlite3")
+_PEOPLE_EXPORT_RELATIVE_PATH = Path("System/People_Index.json")
+_COMPANY_EXPORT_RELATIVE_PATH = Path("System/Company_Index.json")
+_GOES_BY_RE = re.compile(
+    r"^\s*(?:\*\*)?Goes by(?::\*\*|\*\*\s*:|\s+)(?:\s*)(.+?)\s*$",
+    re.IGNORECASE,
+)
+_INVERSE_EDGE_LABELS = {
+    "works_at": "employs",
+    "part_of": "contains",
+}
+_T = TypeVar("_T")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS source_files (
+    path TEXT PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    mtime_ns INTEGER NOT NULL,
+    entity_type TEXT,
+    quarantined INTEGER NOT NULL DEFAULT 0,
+    indexed_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nodes (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    name TEXT,
+    role TEXT,
+    company TEXT,
+    status TEXT,
+    location TEXT,
+    last_interaction TEXT,
+    fields_json TEXT NOT NULL,
+    source_path TEXT NOT NULL REFERENCES source_files(path) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes(type);
+CREATE INDEX IF NOT EXISTS idx_nodes_company ON nodes(company);
+
+CREATE TABLE IF NOT EXISTS node_keys (
+    node_id TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (node_id, kind, value)
+);
+CREATE INDEX IF NOT EXISTS idx_node_keys_value ON node_keys(kind, value);
+
+CREATE TABLE IF NOT EXISTS edges (
+    src_id TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    edge_type TEXT NOT NULL,
+    dst_id TEXT,
+    dst_ref TEXT,
+    source_path TEXT NOT NULL REFERENCES source_files(path) ON DELETE CASCADE,
+    PRIMARY KEY (src_id, edge_type, dst_id, dst_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst_id, edge_type);
+
+CREATE TABLE IF NOT EXISTS touches (
+    node_id TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    ts TEXT NOT NULL,
+    touch_type TEXT NOT NULL,
+    direction TEXT,
+    source TEXT,
+    nature TEXT,
+    source_path TEXT NOT NULL REFERENCES source_files(path) ON DELETE CASCADE,
+    PRIMARY KEY (node_id, ts, touch_type, source)
+);
+CREATE INDEX IF NOT EXISTS idx_touches_node ON touches(node_id, ts);
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+class _FailedQuickCheck(sqlite3.DatabaseError):
+    pass
+
+
+@dataclass(frozen=True)
+class _Source:
+    path: Path
+    relative_path: str
+    entity_type: str
+    people_type: str | None
+    size: int
+    mtime_ns: int
+
+
+@dataclass(frozen=True)
+class _PreparedSource:
+    source: _Source
+    content: bytes
+    fingerprint: str
+    parsed: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    expires_at: float
+    signature: tuple[tuple[str, int, int], ...]
+
+
+_RECONCILE_CACHE: dict[Path, _CacheEntry] = {}
+
+
+def database_path(vault_root: str | Path) -> Path:
+    return Path(vault_root) / _DATABASE_RELATIVE_PATH
+
+
+def clear_reconcile_cache() -> None:
+    """Clear the short-lived process cache, primarily for run boundaries and tests."""
+    _RECONCILE_CACHE.clear()
+
+
+def remove_database(path: str | Path) -> None:
+    """Remove the disposable database and both SQLite sidecars as one rebuild unit."""
+    db_path = Path(path)
+    for candidate in (db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm")):
+        candidate.unlink(missing_ok=True)
+    _RECONCILE_CACHE.pop(db_path.resolve(), None)
+
+
+def connect(path: str | Path) -> sqlite3.Connection:
+    """Open a configured connection and reject a database that fails quick_check."""
+    db_path = Path(path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db_path, timeout=5.0)
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = NORMAL")
+        quick_check = connection.execute("PRAGMA quick_check").fetchall()
+        if quick_check != [("ok",)]:
+            raise _FailedQuickCheck(f"SQLite quick_check failed: {quick_check!r}")
+        return connection
+    except BaseException:
+        connection.close()
+        raise
+
+
+def _is_corruption(error: BaseException) -> bool:
+    if isinstance(error, _FailedQuickCheck):
+        return True
+    if not isinstance(error, sqlite3.Error):
+        return False
+    error_code = getattr(error, "sqlite_errorcode", None)
+    if error_code is not None and error_code & 0xFF in {
+        sqlite3.SQLITE_CORRUPT,
+        sqlite3.SQLITE_NOTADB,
+    }:
+        return True
+    message = str(error).casefold()
+    return (
+        "database disk image is malformed" in message
+        or "file is not a database" in message
+    )
+
+
+def _is_busy(error: BaseException) -> bool:
+    if not isinstance(error, sqlite3.OperationalError):
+        return False
+    error_code = getattr(error, "sqlite_errorcode", None)
+    if error_code is not None and error_code & 0xFF == sqlite3.SQLITE_BUSY:
+        return True
+    message = str(error).casefold()
+    return "database is locked" in message or "database is busy" in message
+
+
+def _safe_relative(path: Path, vault_root: Path) -> str:
+    return path.resolve().relative_to(vault_root.resolve()).as_posix()
+
+
+def _scan_root(
+    vault_root: Path,
+    root: Path,
+    entity_type: str,
+    *,
+    people_type: str | None = None,
+    recursive: bool,
+) -> Iterable[_Source]:
+    if not root.exists():
+        return
+    paths = root.rglob("*.md") if recursive else root.glob("*.md")
+    for path in sorted(paths):
+        if path.name == "README.md":
+            continue
+        stat = path.stat()
+        yield _Source(
+            path=path,
+            relative_path=_safe_relative(path, vault_root),
+            entity_type=entity_type,
+            people_type=people_type,
+            size=stat.st_size,
+            mtime_ns=stat.st_mtime_ns,
+        )
+
+
+def _scan_sources(
+    vault_root: Path,
+    *,
+    people_dir: str | Path | None,
+    companies_dir: str | Path | None,
+) -> dict[str, _Source]:
+    sources: dict[str, _Source] = {}
+    if people_dir is not None:
+        people_root = Path(people_dir)
+        roots = [
+            (people_root / "Internal", "person", "internal", False),
+            (people_root / "External", "person", "external", False),
+            (people_root / "CPO_Network", "person", "cpo_network", False),
+        ]
+    else:
+        folder_map = load_folder_map(vault_root)
+        roots = [
+            (
+                vault_root / folder_map.materialize(_PEOPLE_INTERNAL_REL),
+                "person",
+                "internal",
+                False,
+            ),
+            (
+                vault_root / folder_map.materialize(_PEOPLE_EXTERNAL_REL),
+                "person",
+                "external",
+                False,
+            ),
+            (
+                vault_root / _PEOPLE_CPO_REL,
+                "person",
+                "cpo_network",
+                False,
+            ),
+        ]
+    if companies_dir is not None:
+        roots.append((Path(companies_dir), "company", None, True))
+    else:
+        folder_map = load_folder_map(vault_root)
+        roots.append(
+            (
+                vault_root / folder_map.materialize(_COMPANIES_REL),
+                "company",
+                None,
+                True,
+            )
+        )
+    for root, entity_type, people_type, recursive in roots:
+        for source in _scan_root(
+            vault_root,
+            root,
+            entity_type,
+            people_type=people_type,
+            recursive=recursive,
+        ):
+            sources[source.relative_path] = source
+    return sources
+
+
+def _fingerprint(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _person_compatibility_entry(
+    source: _Source,
+    parsed: dict[str, Any],
+    content: str,
+) -> dict[str, Any]:
+    aliases = list(parsed.get("aliases") or [])
+    folded_aliases = {value.casefold() for value in aliases}
+    for line in content.splitlines():
+        match = _GOES_BY_RE.match(line)
+        if not match:
+            continue
+        alias = match.group(1).strip()
+        if alias and alias.casefold() not in folded_aliases:
+            aliases.append(alias)
+            folded_aliases.add(alias.casefold())
+
+    tags: list[str] = []
+    for line in content.splitlines():
+        if "**Tags**" in line and "|" in line:
+            parts = line.split("|")
+            if len(parts) >= 3:
+                tags = [tag.strip() for tag in parts[2].strip().split(",") if tag.strip()]
+            break
+
+    name = parsed.get("name") or source.path.stem.replace("_", " ")
+    has_content = bool(
+        parsed.get("role")
+        or parsed.get("emails")
+        or "## Meeting" in content
+        or "## Notes" in content
+    )
+    return {
+        "name": name,
+        "company": parsed.get("company"),
+        "role": parsed.get("role"),
+        "email": (parsed.get("emails") or [None])[0],
+        "emails": parsed.get("emails") or [],
+        "aliases": aliases,
+        "first_name": name.split()[0].lower() if name.split() else "",
+        "type": source.people_type or "external",
+        "path": source.relative_path,
+        "last_interaction": parsed.get("last_interaction"),
+        "tags": tags,
+        "status": "populated" if has_content else "stub",
+    }
+
+
+def _company_compatibility_entry(
+    source: _Source,
+    parsed: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "name": parsed.get("name") or source.path.stem.replace("_", " "),
+        "path": source.relative_path,
+        "domains": parsed.get("domains") or [],
+        "website": parsed.get("website"),
+        "status": parsed.get("status"),
+    }
+
+
+def _project_source(
+    connection: sqlite3.Connection,
+    prepared: _PreparedSource,
+    *,
+    indexed_at: str,
+) -> None:
+    source = prepared.source
+    parsed = prepared.parsed
+    quarantined = bool(parsed.get("quarantined"))
+    connection.execute("DELETE FROM source_files WHERE path = ?", (source.relative_path,))
+    connection.execute(
+        """
+        INSERT INTO source_files(
+            path, fingerprint, size, mtime_ns, entity_type, quarantined, indexed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            source.relative_path,
+            prepared.fingerprint,
+            source.size,
+            source.mtime_ns,
+            source.entity_type,
+            int(quarantined),
+            indexed_at,
+        ),
+    )
+    if quarantined:
+        name = source.path.stem.replace("_", " ")
+        if source.entity_type == "person":
+            first_name = name.split()[0].lower() if name.split() else ""
+            compatibility = {
+                "name": name,
+                "company": None,
+                "role": None,
+                "email": None,
+                "emails": [],
+                "aliases": [],
+                "first_name": first_name,
+                "type": source.people_type or "external",
+                "path": source.relative_path,
+                "last_interaction": None,
+                "tags": [],
+                "status": "quarantined",
+            }
+        else:
+            compatibility = {
+                "name": name,
+                "path": source.relative_path,
+                "domains": [],
+                "website": None,
+                "status": "quarantined",
+            }
+        fields = {
+            "name": name,
+            "status": "quarantined",
+            "_compat": compatibility,
+        }
+    else:
+        decoded = prepared.content.decode("utf-8-sig")
+        compatibility = (
+            _person_compatibility_entry(source, parsed, decoded)
+            if source.entity_type == "person"
+            else _company_compatibility_entry(source, parsed)
+        )
+        fields = {**parsed, "_compat": compatibility}
+    connection.execute(
+        """
+        INSERT INTO nodes(
+            id, type, name, role, company, status, location, last_interaction,
+            fields_json, source_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            source.relative_path,
+            source.entity_type,
+            compatibility.get("name"),
+            None if quarantined else parsed.get("role"),
+            None if quarantined else parsed.get("company"),
+            "quarantined" if quarantined else parsed.get("status"),
+            None if quarantined else parsed.get("location"),
+            None if quarantined else parsed.get("last_interaction"),
+            json.dumps(fields, ensure_ascii=False, sort_keys=True),
+            source.relative_path,
+        ),
+    )
+    if quarantined:
+        return
+
+    keys: list[tuple[str, str]] = []
+    if source.entity_type == "person":
+        keys.extend(("email", value.casefold()) for value in compatibility["emails"])
+        keys.extend(("alias", value.casefold()) for value in compatibility["aliases"])
+    else:
+        keys.extend(("domain", value.casefold()) for value in compatibility["domains"])
+    connection.executemany(
+        "INSERT OR IGNORE INTO node_keys(node_id, kind, value) VALUES (?, ?, ?)",
+        [(source.relative_path, kind, value) for kind, value in keys],
+    )
+
+
+def _initialize_schema(connection: sqlite3.Connection) -> None:
+    connection.executescript(_SCHEMA)
+    connection.execute(
+        """
+        INSERT INTO meta(key, value) VALUES ('schema_version', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (SCHEMA_VERSION,),
+    )
+
+
+def _compatibility_rows(
+    connection: sqlite3.Connection,
+    entity_type: str,
+) -> list[dict[str, Any]]:
+    rows = []
+    for (fields_json,) in connection.execute(
+        "SELECT fields_json FROM nodes WHERE type = ?",
+        (entity_type,),
+    ):
+        fields = json.loads(fields_json)
+        rows.append(fields["_compat"])
+    if entity_type == "person":
+        type_order = {"internal": 0, "external": 1, "cpo_network": 2}
+        rows.sort(
+            key=lambda item: (
+                type_order.get(item["type"], 3),
+                item["path"].casefold(),
+            )
+        )
+    else:
+        rows.sort(key=lambda item: (item["name"].casefold(), item["path"]))
+    return rows
+
+
+def _built_at(connection: sqlite3.Connection) -> str:
+    row = connection.execute(
+        "SELECT value FROM meta WHERE key = 'built_at'"
+    ).fetchone()
+    return row[0] if row else datetime.now().isoformat()
+
+
+def _views(connection: sqlite3.Connection) -> tuple[dict[str, Any], dict[str, Any]]:
+    built_at = _built_at(connection)
+    people = _compatibility_rows(connection, "person")
+    companies = _compatibility_rows(connection, "company")
+    people_view = {
+        "version": 2,
+        "built_at": built_at,
+        "total": len(people),
+        "by_type": {
+            "internal": sum(item["type"] == "internal" for item in people),
+            "external": sum(item["type"] == "external" for item in people),
+            "cpo_network": sum(item["type"] == "cpo_network" for item in people),
+        },
+        "people": people,
+    }
+    company_view = {
+        "version": 1,
+        "built_at": built_at,
+        "total": len(companies),
+        "companies": companies,
+    }
+    return people_view, company_view
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def dump_json_views(
+    connection: sqlite3.Connection,
+    vault_root: str | Path,
+    *,
+    people_index_path: str | Path | None = None,
+    company_index_path: str | Path | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Export compatibility JSON views from the reconciled SQLite projection."""
+    root = Path(vault_root)
+    people_view, company_view = _views(connection)
+    _write_json(
+        Path(people_index_path)
+        if people_index_path is not None
+        else root / _PEOPLE_EXPORT_RELATIVE_PATH,
+        people_view,
+    )
+    _write_json(
+        Path(company_index_path)
+        if company_index_path is not None
+        else root / _COMPANY_EXPORT_RELATIVE_PATH,
+        company_view,
+    )
+    return people_view, company_view
+
+
+def _reconcile_open_database(
+    connection: sqlite3.Connection,
+    vault_root: Path,
+    sources: dict[str, _Source],
+    *,
+    people_index_path: str | Path | None,
+    company_index_path: str | Path | None,
+) -> dict[str, int]:
+    with connection:
+        _initialize_schema(connection)
+    indexed = {
+        row[0]: (row[1], row[2], row[3])
+        for row in connection.execute(
+            "SELECT path, fingerprint, size, mtime_ns FROM source_files"
+        )
+    }
+    current_paths = set(sources)
+    indexed_paths = set(indexed)
+    removed = indexed_paths - current_paths
+    added = current_paths - indexed_paths
+    present = current_paths & indexed_paths
+    changed = 0
+    indexed_at = datetime.now().isoformat()
+    prepared: dict[str, _PreparedSource] = {}
+
+    for relative_path in sorted(added):
+        source = sources[relative_path]
+        content = source.path.read_bytes()
+        prepared[relative_path] = _PreparedSource(
+            source=source,
+            content=content,
+            fingerprint=_fingerprint(content),
+            parsed=parse_entity_page(source.path),
+        )
+    for relative_path in sorted(present):
+        source = sources[relative_path]
+        _old_fingerprint, old_size, old_mtime_ns = indexed[relative_path]
+        # Accepted risk: unchanged size and mtime skip re-hashing on normal filesystems.
+        if (source.size, source.mtime_ns) == (old_size, old_mtime_ns):
+            continue
+        content = source.path.read_bytes()
+        prepared[relative_path] = _PreparedSource(
+            source=source,
+            content=content,
+            fingerprint=_fingerprint(content),
+            parsed=parse_entity_page(source.path),
+        )
+
+    with connection:
+        connection.executemany(
+            "DELETE FROM source_files WHERE path = ?",
+            [(path,) for path in sorted(removed)],
+        )
+        for relative_path in sorted(added):
+            _project_source(
+                connection,
+                prepared[relative_path],
+                indexed_at=indexed_at,
+            )
+        for relative_path in sorted(present):
+            candidate = prepared.get(relative_path)
+            if candidate is None:
+                continue
+            source = candidate.source
+            old_fingerprint, old_size, old_mtime_ns = indexed[relative_path]
+            if candidate.fingerprint == old_fingerprint:
+                connection.execute(
+                    """
+                    UPDATE source_files
+                    SET size = ?, mtime_ns = ?, indexed_at = ?
+                    WHERE path = ?
+                    """,
+                    (
+                        source.size,
+                        source.mtime_ns,
+                        indexed_at,
+                        relative_path,
+                    ),
+                )
+                continue
+            _project_source(
+                connection,
+                candidate,
+                indexed_at=indexed_at,
+            )
+            changed += 1
+        connection.execute(
+            """
+            INSERT INTO meta(key, value) VALUES ('built_at', ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (indexed_at,),
+        )
+
+    dump_json_views(
+        connection,
+        vault_root,
+        people_index_path=people_index_path,
+        company_index_path=company_index_path,
+    )
+    return {"added": len(added), "changed": changed, "removed": len(removed)}
+
+
+def reconcile(
+    vault_root: str | Path,
+    *,
+    people_dir: str | Path | None = None,
+    companies_dir: str | Path | None = None,
+    people_index_path: str | Path | None = None,
+    company_index_path: str | Path | None = None,
+    force: bool = False,
+    debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS,
+) -> dict[str, int]:
+    """Reconcile the materialized view using a complete path-set diff."""
+    root = Path(vault_root)
+    db_path = database_path(root)
+    sources = _scan_sources(
+        root,
+        people_dir=people_dir,
+        companies_dir=companies_dir,
+    )
+    signature = tuple(
+        (path, source.size, source.mtime_ns)
+        for path, source in sorted(sources.items())
+    )
+    cache_key = db_path.resolve()
+    cached = _RECONCILE_CACHE.get(cache_key)
+    if (
+        not force
+        and db_path.exists()
+        and cached is not None
+        and cached.expires_at >= time.monotonic()
+        and cached.signature == signature
+    ):
+        return {"added": 0, "changed": 0, "removed": 0}
+
+    try:
+        with closing(connect(db_path)) as connection:
+            result = _reconcile_open_database(
+                connection,
+                root,
+                sources,
+                people_index_path=people_index_path,
+                company_index_path=company_index_path,
+            )
+    except sqlite3.Error as error:
+        if not _is_corruption(error):
+            raise
+        remove_database(db_path)
+        with closing(connect(db_path)) as connection:
+            result = _reconcile_open_database(
+                connection,
+                root,
+                sources,
+                people_index_path=people_index_path,
+                company_index_path=company_index_path,
+            )
+
+    _RECONCILE_CACHE[cache_key] = _CacheEntry(
+        expires_at=time.monotonic() + debounce_seconds,
+        signature=signature,
+    )
+    return result
+
+
+def build_from_vault(
+    vault_root: str | Path,
+    *,
+    people_dir: str | Path | None = None,
+    companies_dir: str | Path | None = None,
+    people_index_path: str | Path | None = None,
+    company_index_path: str | Path | None = None,
+) -> dict[str, int]:
+    """Delete any prior projection and rebuild it entirely from entity pages."""
+    remove_database(database_path(vault_root))
+    return reconcile(
+        vault_root,
+        people_dir=people_dir,
+        companies_dir=companies_dir,
+        people_index_path=people_index_path,
+        company_index_path=company_index_path,
+        force=True,
+    )
+
+
+def _read_after_reconcile(
+    vault_root: str | Path,
+    reconcile_kwargs: dict[str, Any],
+    reader: Callable[[sqlite3.Connection], _T],
+) -> _T:
+    db_path = database_path(vault_root)
+    try:
+        with closing(connect(db_path)) as connection:
+            return reader(connection)
+    except sqlite3.Error as error:
+        if not _is_corruption(error):
+            raise
+        remove_database(db_path)
+        reconcile(vault_root, force=True, **reconcile_kwargs)
+        with closing(connect(db_path)) as connection:
+            return reader(connection)
+
+
+def people_index_data(
+    vault_root: str | Path,
+    *,
+    people_dir: str | Path | None = None,
+    companies_dir: str | Path | None = None,
+    people_index_path: str | Path | None = None,
+    company_index_path: str | Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    reconcile_kwargs = {
+        "people_dir": people_dir,
+        "companies_dir": companies_dir,
+        "people_index_path": people_index_path,
+        "company_index_path": company_index_path,
+    }
+    try:
+        reconcile(
+            vault_root,
+            **reconcile_kwargs,
+            force=force,
+        )
+        return _read_after_reconcile(
+            vault_root,
+            reconcile_kwargs,
+            lambda connection: _views(connection)[0],
+        )
+    except sqlite3.Error as error:
+        if not _is_busy(error):
+            raise
+        export_path = (
+            Path(people_index_path)
+            if people_index_path is not None
+            else Path(vault_root) / _PEOPLE_EXPORT_RELATIVE_PATH
+        )
+        try:
+            return json.loads(export_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            raise error
+
+
+def company_index_data(
+    vault_root: str | Path,
+    *,
+    people_dir: str | Path | None = None,
+    companies_dir: str | Path | None = None,
+    people_index_path: str | Path | None = None,
+    company_index_path: str | Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    reconcile_kwargs = {
+        "people_dir": people_dir,
+        "companies_dir": companies_dir,
+        "people_index_path": people_index_path,
+        "company_index_path": company_index_path,
+    }
+    try:
+        reconcile(
+            vault_root,
+            **reconcile_kwargs,
+            force=force,
+        )
+        return _read_after_reconcile(
+            vault_root,
+            reconcile_kwargs,
+            lambda connection: _views(connection)[1],
+        )
+    except sqlite3.Error as error:
+        if not _is_busy(error):
+            raise
+        export_path = (
+            Path(company_index_path)
+            if company_index_path is not None
+            else Path(vault_root) / _COMPANY_EXPORT_RELATIVE_PATH
+        )
+        try:
+            return json.loads(export_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            raise error
+
+
+def lookup_person(
+    vault_root: str | Path,
+    name: str,
+    company: str | None = None,
+    **reconcile_kwargs: Any,
+) -> dict[str, Any]:
+    """Return the legacy Work-MCP lookup shape from reconciled SQLite rows."""
+    index = people_index_data(vault_root, **reconcile_kwargs)
+    people = index["people"]
+    if company:
+        company_lower = company.lower()
+        people = [
+            person
+            for person in people
+            if company_lower in (person.get("company") or "").lower()
+        ]
+
+    query = name.strip()
+    query_lower = query.casefold()
+    ambiguous = False
+
+    def scored(candidates: list[dict[str, Any]], score: float) -> list[dict[str, Any]]:
+        return [{**person, "_score": score} for person in candidates]
+
+    matches: list[dict[str, Any]] = []
+    if "@" in query:
+        matches = scored(
+            [
+                person
+                for person in people
+                if query_lower
+                in {email.casefold() for email in person.get("emails", [])}
+            ],
+            1.0,
+        )
+    if not matches:
+        matches = scored(
+            [
+                person
+                for person in people
+                if query_lower
+                in {alias.casefold() for alias in person.get("aliases", [])}
+            ],
+            1.0,
+        )
+    if not matches:
+        matches = scored(
+            [
+                person
+                for person in people
+                if query_lower == (person.get("name") or "").casefold()
+            ],
+            1.0,
+        )
+    if not matches:
+        first_name_matches = [
+            person
+            for person in people
+            if query_lower == (person.get("first_name") or "").casefold()
+        ]
+        if first_name_matches:
+            matches = scored(first_name_matches, 0.9)
+            ambiguous = len(first_name_matches) > 1
+    if not matches:
+        fuzzy_matches = []
+        for person in people:
+            person_name = (person.get("name") or "").casefold()
+            if query_lower in person_name or person_name in query_lower:
+                score = 0.8
+            else:
+                score = SequenceMatcher(None, query_lower, person_name).ratio()
+            if score >= 0.5:
+                fuzzy_matches.append((score, person))
+        fuzzy_matches.sort(key=lambda item: item[0], reverse=True)
+        if (
+            len(fuzzy_matches) >= 2
+            and fuzzy_matches[0][0] - fuzzy_matches[1][0] <= 0.05
+        ):
+            ambiguous = True
+        matches = [
+            {**person, "_score": round(score, 2)}
+            for score, person in fuzzy_matches
+        ]
+
+    result: dict[str, Any] = {
+        "query": name,
+        "company_filter": company,
+        "matches": matches[:10],
+        "total_matches": len(matches),
+        "index_age": index["built_at"],
+    }
+    if ambiguous:
+        result["ambiguous"] = True
+    return result
+
+
+def find_company_by_domain(
+    vault_root: str | Path,
+    domain: str,
+    **reconcile_kwargs: Any,
+) -> dict[str, Any] | None:
+    """Find a company by registrable domain from the reconciled projection."""
+    index = company_index_data(vault_root, **reconcile_kwargs)
+    target = registrable_domain(domain)
+    for company in index["companies"]:
+        if target in {
+            registrable_domain(value) for value in company.get("domains", [])
+        }:
+            return company
+    return None
+
+
+def neighbors(
+    vault_root: str | Path,
+    node_id: str,
+    **reconcile_kwargs: Any,
+) -> list[dict[str, str | None]]:
+    """Return stored outgoing edges and query-derived inverse edges."""
+    people_index_data(vault_root, **reconcile_kwargs)
+
+    def read(connection: sqlite3.Connection) -> list[dict[str, str | None]]:
+        result = [
+            {
+                "other": dst_id or dst_ref,
+                "edge_type": edge_type,
+                "direction": "out",
+                "label": edge_type,
+            }
+            for edge_type, dst_id, dst_ref in connection.execute(
+                """
+                SELECT edge_type, dst_id, dst_ref
+                FROM edges
+                WHERE src_id = ?
+                ORDER BY edge_type, COALESCE(dst_id, dst_ref)
+                """,
+                (node_id,),
+            )
+        ]
+        result.extend(
+            {
+                "other": src_id,
+                "edge_type": edge_type,
+                "direction": "in",
+                "label": _INVERSE_EDGE_LABELS.get(edge_type, edge_type),
+            }
+            for edge_type, src_id in connection.execute(
+                """
+                SELECT edge_type, src_id
+                FROM edges
+                WHERE dst_id = ?
+                ORDER BY edge_type, src_id
+                """,
+                (node_id,),
+            )
+        )
+        return result
+
+    return _read_after_reconcile(vault_root, reconcile_kwargs, read)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -111,6 +111,7 @@ if _repo_root not in sys.path:
     sys.path.append(_repo_root)
 from core import capabilities as capability_rooms
 from core.entity_engine import create_page_if_absent
+from core.entity_engine import index as entity_index
 from core.paths import (
     COMPANIES_DIR,
     COMPANY_INDEX_FILE,
@@ -1066,249 +1067,81 @@ def _resolve_people_dir() -> Path:
     return get_people_dir()
 
 
-def build_people_index_data() -> Dict[str, Any]:
-    """Scan all person pages and build a lightweight JSON index."""
-    people_dir = _resolve_people_dir()
-    entries = []
+# Vault-relative fallbacks derived from the canonical core.paths constants
+# (computed at import time, when BASE_DIR == VAULT_ROOT). Using these instead of
+# raw PARA string literals keeps the path-contract gate satisfied while preserving
+# the BASE_DIR-relative redirect that monkeypatched tests rely on.
+_PEOPLE_DIR_REL = PEOPLE_DIR.relative_to(BASE_DIR)
+_COMPANIES_DIR_REL = COMPANIES_DIR.relative_to(BASE_DIR)
+_PEOPLE_INDEX_FILE_REL = PEOPLE_INDEX_FILE.relative_to(BASE_DIR)
+_COMPANY_INDEX_FILE_REL = COMPANY_INDEX_FILE.relative_to(BASE_DIR)
 
-    for subdir_name in ['Internal', 'External', 'CPO_Network']:
-        subdir = people_dir / subdir_name
-        if not subdir.exists():
-            continue
 
-        for person_file in subdir.glob('*.md'):
-            if person_file.name == 'README.md':
-                continue
-            person = parse_entity_page(person_file)
+def _index_path(candidate: Path, fallback: Path) -> Path:
+    """Keep monkeypatched test/runtime paths inside the active vault root."""
+    try:
+        candidate.resolve().relative_to(BASE_DIR.resolve())
+    except ValueError:
+        return BASE_DIR / fallback
+    return candidate
 
-            # Determine populated vs stub
-            content = person_file.read_text()
-            has_content = bool(person.get('role') or person.get('emails') or
-                            '## Meeting' in content or '## Notes' in content)
 
-            aliases = list(person.get('aliases') or [])
-            for line in content.splitlines():
-                match = re.match(r'^\s*(?:\*\*)?Goes by(?::\*\*|\*\*\s*:|\s+)(?:\s*)(.+?)\s*$', line, re.IGNORECASE)
-                if match:
-                    alias = match.group(1).strip()
-                    if alias and alias.casefold() not in {value.casefold() for value in aliases}:
-                        aliases.append(alias)
-
-            person_name = person.get('name') or person_file.stem.replace('_', ' ')
-
-            # Extract tags from content
-            tags = []
-            for line in content.split('\n'):
-                if '**Tags**' in line and '|' in line:
-                    parts = line.split('|')
-                    if len(parts) >= 3:
-                        tags = [t.strip() for t in parts[2].strip().split(',') if t.strip()]
-                    break
-
-            entries.append({
-                'name': person_name,
-                'company': person.get('company'),
-                'role': person.get('role'),
-                'email': (person.get('emails') or [None])[0],
-                'emails': person.get('emails') or [],
-                'aliases': aliases,
-                'first_name': person_name.split()[0].lower() if person_name.split() else '',
-                'type': subdir_name.lower(),
-                'path': str(person_file.relative_to(BASE_DIR)),
-                'last_interaction': person.get('last_interaction'),
-                'tags': tags,
-                'status': 'populated' if has_content else 'stub',
-            })
-
-    index = {
-        'version': 2,
-        'built_at': datetime.now().isoformat(),
-        'total': len(entries),
-        'by_type': {
-            'internal': sum(1 for e in entries if e['type'] == 'internal'),
-            'external': sum(1 for e in entries if e['type'] == 'external'),
-            'cpo_network': sum(1 for e in entries if e['type'] == 'cpo_network'),
-        },
-        'people': entries,
+def _entity_index_kwargs() -> Dict[str, Path]:
+    return {
+        'people_dir': _index_path(
+            _resolve_people_dir(),
+            _PEOPLE_DIR_REL,
+        ),
+        'companies_dir': _index_path(
+            get_companies_dir(),
+            _COMPANIES_DIR_REL,
+        ),
+        'people_index_path': _index_path(
+            PEOPLE_INDEX_FILE,
+            _PEOPLE_INDEX_FILE_REL,
+        ),
+        'company_index_path': _index_path(
+            COMPANY_INDEX_FILE,
+            _COMPANY_INDEX_FILE_REL,
+        ),
     }
 
-    # Write to file
-    PEOPLE_INDEX_FILE.parent.mkdir(parents=True, exist_ok=True)
-    PEOPLE_INDEX_FILE.write_text(json.dumps(index, indent=2, cls=DateTimeEncoder) + '\n')
 
-    return index
-
-
-def _people_tree_max_mtime() -> float:
-    """Return the newest modification time among People markdown pages."""
-    people_dir = _resolve_people_dir()
-    if not people_dir.exists():
-        return 0.0
-    return max(
-        (person_file.stat().st_mtime for person_file in people_dir.rglob('*.md')),
-        default=0.0,
+def build_people_index_data() -> Dict[str, Any]:
+    """Reconcile SQLite and return its People_Index compatibility export."""
+    return entity_index.people_index_data(
+        BASE_DIR,
+        force=True,
+        **_entity_index_kwargs(),
     )
 
 
 def build_company_index_data() -> Dict[str, Any]:
-    """Scan company pages and build the canonical lightweight JSON index."""
-    entries = []
-    companies_dir = get_companies_dir()
-    if companies_dir.exists():
-        for company_file in companies_dir.rglob('*.md'):
-            if company_file.name == 'README.md':
-                continue
-            company = parse_entity_page(company_file)
-            entries.append({
-                'name': company.get('name') or company_file.stem.replace('_', ' '),
-                'path': str(company_file.relative_to(BASE_DIR)),
-                'domains': company.get('domains') or [],
-                'website': company.get('website'),
-                'status': company.get('status'),
-            })
-    entries.sort(key=lambda item: (item['name'].casefold(), item['path']))
-    index = {
-        'version': 1,
-        'built_at': datetime.now().isoformat(),
-        'total': len(entries),
-        'companies': entries,
-    }
-    COMPANY_INDEX_FILE.parent.mkdir(parents=True, exist_ok=True)
-    COMPANY_INDEX_FILE.write_text(json.dumps(index, indent=2, cls=DateTimeEncoder) + '\n')
-    return index
-
-
-def _company_tree_max_mtime() -> float:
-    """Return the newest modification time among company markdown pages."""
-    companies_dir = get_companies_dir()
-    if not companies_dir.exists():
-        return 0.0
-    return max(
-        (company_file.stat().st_mtime for company_file in companies_dir.rglob('*.md')),
-        default=0.0,
+    """Reconcile SQLite and return its Company_Index compatibility export."""
+    return entity_index.company_index_data(
+        BASE_DIR,
+        force=True,
+        **_entity_index_kwargs(),
     )
 
 
 def find_company_by_domain(domain: str) -> Dict[str, Any] | None:
-    """Find a company by registrable domain, rebuilding an absent or stale index."""
-    index = None
-    if COMPANY_INDEX_FILE.exists():
-        try:
-            index = json.loads(COMPANY_INDEX_FILE.read_text())
-        except (json.JSONDecodeError, OSError):
-            pass
-    if not isinstance(index, dict):
-        index = None
-    try:
-        built_at = datetime.fromisoformat(index.get('built_at', '')) if index else None
-        if not index or index.get('version') != 1 or built_at.timestamp() < _company_tree_max_mtime():
-            index = build_company_index_data()
-    except (ValueError, TypeError):
-        index = build_company_index_data()
-    target = registrable_domain(domain)
-    for company in index.get('companies', []):
-        if target in {registrable_domain(value) for value in company.get('domains', [])}:
-            return company
-    return None
+    """Find a company by registrable domain in the disposable SQLite index."""
+    return entity_index.find_company_by_domain(
+        BASE_DIR,
+        domain,
+        **_entity_index_kwargs(),
+    )
 
 
 def lookup_person_data(name: str, company: str = None) -> Dict[str, Any]:
-    """Fast person lookup using the index with fuzzy matching."""
-
-    # Try reading the index file
-    index = None
-    if PEOPLE_INDEX_FILE.exists():
-        try:
-            index = json.loads(PEOPLE_INDEX_FILE.read_text())
-        except (json.JSONDecodeError, OSError):
-            pass
-
-    # Auto-rebuild if index is missing/old, older than a person page, or stale (>24h).
-    index_version = index.get('version') if isinstance(index, dict) else None
-    if not index or not isinstance(index_version, int) or index_version < 2:
-        index = build_people_index_data()
-    else:
-        built_at = index.get('built_at', '')
-        try:
-            built_dt = datetime.fromisoformat(built_at)
-            tree_mtime = _people_tree_max_mtime()
-            if built_dt.timestamp() < tree_mtime:
-                logger.info("People index predates a person page, rebuilding...")
-                index = build_people_index_data()
-            elif (datetime.now() - built_dt) > timedelta(hours=24):
-                logger.info("People index is stale (>24h), rebuilding...")
-                index = build_people_index_data()
-        except (ValueError, TypeError):
-            index = build_people_index_data()
-
-    people = index.get('people', [])
-    if company:
-        company_lower = company.lower()
-        people = [
-            person for person in people
-            if company_lower in (person.get('company') or '').lower()
-        ]
-
-    query = name.strip()
-    query_lower = query.casefold()
-    ambiguous = False
-
-    def scored(candidates: List[Dict[str, Any]], score: float) -> List[Dict[str, Any]]:
-        return [{**person, '_score': score} for person in candidates]
-
-    matches: List[Dict[str, Any]] = []
-    if '@' in query:
-        matches = scored([
-            person for person in people
-            if query_lower in {email.casefold() for email in person.get('emails', [])}
-        ], 1.0)
-
-    if not matches:
-        matches = scored([
-            person for person in people
-            if query_lower in {alias.casefold() for alias in person.get('aliases', [])}
-        ], 1.0)
-
-    if not matches:
-        matches = scored([
-            person for person in people
-            if query_lower == (person.get('name') or '').casefold()
-        ], 1.0)
-
-    if not matches:
-        first_name_matches = [
-            person for person in people
-            if query_lower == (person.get('first_name') or '').casefold()
-        ]
-        if first_name_matches:
-            matches = scored(first_name_matches, 0.9)
-            ambiguous = len(first_name_matches) > 1
-
-    if not matches:
-        fuzzy_matches = []
-        for person in people:
-            person_name = (person.get('name') or '').casefold()
-            if query_lower in person_name or person_name in query_lower:
-                score = 0.8
-            else:
-                score = SequenceMatcher(None, query_lower, person_name).ratio()
-            if score >= 0.5:
-                fuzzy_matches.append((score, person))
-        fuzzy_matches.sort(key=lambda item: item[0], reverse=True)
-        if len(fuzzy_matches) >= 2 and fuzzy_matches[0][0] - fuzzy_matches[1][0] <= 0.05:
-            ambiguous = True
-        matches = [{**person, '_score': round(score, 2)} for score, person in fuzzy_matches]
-
-    result = {
-        'query': name,
-        'company_filter': company,
-        'matches': matches[:10],
-        'total_matches': len(matches),
-        'index_age': index.get('built_at'),
-    }
-    if ambiguous:
-        result['ambiguous'] = True
-    return result
+    """Fast person lookup using reconciled SQLite rows and legacy scoring."""
+    return entity_index.lookup_person(
+        BASE_DIR,
+        name,
+        company,
+        **_entity_index_kwargs(),
+    )
 
 
 def _looks_like_page_path(value: str) -> bool:

--- a/core/tests/test_entity_index.py
+++ b/core/tests/test_entity_index.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from core.entity_engine import index as entity_index
+from core.entity_engine.contract import render_company_page, render_person_page
+
+
+@pytest.fixture(autouse=True)
+def _clear_reconcile_cache() -> None:
+    entity_index.clear_reconcile_cache()
+    yield
+    entity_index.clear_reconcile_cache()
+
+
+@pytest.fixture
+def entity_vault(tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "root": tmp_path,
+        "people": tmp_path / "05-Areas" / "People",
+        "companies": tmp_path / "05-Areas" / "Companies",
+        "people_export": tmp_path / "System" / "People_Index.json",
+        "company_export": tmp_path / "System" / "Company_Index.json",
+    }
+    (paths["people"] / "External").mkdir(parents=True)
+    paths["companies"].mkdir(parents=True)
+    return paths
+
+
+def _kwargs(vault: dict[str, Path]) -> dict[str, Path]:
+    return {
+        "people_dir": vault["people"],
+        "companies_dir": vault["companies"],
+        "people_index_path": vault["people_export"],
+        "company_index_path": vault["company_export"],
+    }
+
+
+def _write_person(vault: dict[str, Path], name: str = "Alice Smith") -> Path:
+    path = vault["people"] / "External" / f"{name.replace(' ', '_')}.md"
+    path.write_text(
+        render_person_page(
+            name,
+            role="VP Product",
+            company="Acme",
+            emails=["fixture-alice@example.com"],
+            aliases=["Al"],
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_company(vault: dict[str, Path], name: str = "Acme") -> Path:
+    path = vault["companies"] / f"{name.replace(' ', '_')}.md"
+    path.write_text(
+        render_company_page(
+            name,
+            domains=["acme.test"],
+            website="https://acme.test",
+            status="Customer",
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_build_from_frontmatter_creates_schema_nodes_keys_and_json_exports(
+    entity_vault: dict[str, Path],
+) -> None:
+    _write_person(entity_vault)
+    _write_company(entity_vault)
+
+    result = entity_index.build_from_vault(
+        entity_vault["root"],
+        **_kwargs(entity_vault),
+    )
+
+    assert result == {"added": 2, "changed": 0, "removed": 0}
+    db_path = entity_index.database_path(entity_vault["root"])
+    with sqlite3.connect(db_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {
+            "source_files",
+            "nodes",
+            "node_keys",
+            "edges",
+            "touches",
+            "meta",
+        } <= tables
+        assert connection.execute("SELECT COUNT(*) FROM nodes").fetchone() == (2,)
+        assert connection.execute(
+            "SELECT kind, value FROM node_keys ORDER BY kind, value"
+        ).fetchall() == [
+            ("alias", "al"),
+            ("domain", "acme.test"),
+            ("email", "fixture-alice@example.com"),
+        ]
+        assert connection.execute("SELECT COUNT(*) FROM edges").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM touches").fetchone() == (0,)
+
+    people_export = json.loads(entity_vault["people_export"].read_text())
+    company_export = json.loads(entity_vault["company_export"].read_text())
+    assert people_export["people"][0]["name"] == "Alice Smith"
+    assert company_export["companies"][0]["name"] == "Acme"
+
+
+def test_path_set_reconcile_removes_deleted_person_and_old_company_name(
+    entity_vault: dict[str, Path],
+) -> None:
+    person = _write_person(entity_vault)
+    company = _write_company(entity_vault)
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+
+    person.unlink()
+    renamed = company.with_name("Acme_Corporation.md")
+    company.rename(renamed)
+    result = entity_index.reconcile(entity_vault["root"], **_kwargs(entity_vault))
+
+    assert result == {"added": 1, "changed": 0, "removed": 2}
+    assert entity_index.lookup_person(
+        entity_vault["root"], "Alice", **_kwargs(entity_vault)
+    )["matches"] == []
+    company_match = entity_index.find_company_by_domain(
+        entity_vault["root"], "mail.acme.test", **_kwargs(entity_vault)
+    )
+    assert company_match is not None
+    assert company_match["path"].endswith("Acme_Corporation.md")
+    with sqlite3.connect(entity_index.database_path(entity_vault["root"])) as connection:
+        paths = {
+            row[0] for row in connection.execute("SELECT path FROM source_files")
+        }
+    assert paths == {"05-Areas/Companies/Acme_Corporation.md"}
+
+
+def test_foreign_keys_are_enabled_and_source_delete_cascades(
+    entity_vault: dict[str, Path],
+) -> None:
+    person = _write_person(entity_vault)
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+    source_path = person.relative_to(entity_vault["root"]).as_posix()
+    db_path = entity_index.database_path(entity_vault["root"])
+
+    with entity_index.connect(db_path) as connection:
+        assert connection.execute("PRAGMA foreign_keys").fetchone() == (1,)
+        connection.execute(
+            """
+            INSERT INTO edges(src_id, edge_type, dst_id, dst_ref, source_path)
+            VALUES (?, 'works_at', NULL, 'Acme', ?)
+            """,
+            (source_path, source_path),
+        )
+        connection.execute(
+            """
+            INSERT INTO touches(
+                node_id, ts, touch_type, direction, source, nature, source_path
+            ) VALUES (?, '2026-07-20T10:00:00', 'meeting', 'none',
+                      'meeting-1', 'Planning', ?)
+            """,
+            (source_path, source_path),
+        )
+
+    person.unlink()
+    entity_index.reconcile(
+        entity_vault["root"], force=True, **_kwargs(entity_vault)
+    )
+
+    with entity_index.connect(db_path) as connection:
+        for table in ("source_files", "nodes", "node_keys", "edges", "touches"):
+            assert connection.execute(
+                f"SELECT COUNT(*) FROM {table}"  # noqa: S608 - fixed table names
+            ).fetchone() == (0,)
+
+
+def test_neighbors_derives_inverse_without_storing_a_second_edge(
+    entity_vault: dict[str, Path],
+) -> None:
+    alice = _write_person(entity_vault)
+    bob = _write_person(entity_vault, "Bob Jones")
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+    alice_id = alice.relative_to(entity_vault["root"]).as_posix()
+    bob_id = bob.relative_to(entity_vault["root"]).as_posix()
+
+    with entity_index.connect(
+        entity_index.database_path(entity_vault["root"])
+    ) as connection:
+        connection.execute(
+            """
+            INSERT INTO edges(src_id, edge_type, dst_id, dst_ref, source_path)
+            VALUES (?, 'works_at', ?, NULL, ?)
+            """,
+            (alice_id, bob_id, alice_id),
+        )
+
+    assert entity_index.neighbors(
+        entity_vault["root"], alice_id, **_kwargs(entity_vault)
+    ) == [
+        {
+            "other": bob_id,
+            "edge_type": "works_at",
+            "direction": "out",
+            "label": "works_at",
+        }
+    ]
+    assert entity_index.neighbors(
+        entity_vault["root"], bob_id, **_kwargs(entity_vault)
+    ) == [
+        {
+            "other": alice_id,
+            "edge_type": "works_at",
+            "direction": "in",
+            "label": "employs",
+        }
+    ]
+    with entity_index.connect(
+        entity_index.database_path(entity_vault["root"])
+    ) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM edges").fetchone() == (1,)
+
+
+def test_delete_disposable_index_then_lookup_rebuilds_identical_results(
+    entity_vault: dict[str, Path],
+) -> None:
+    _write_person(entity_vault)
+    before = entity_index.lookup_person(
+        entity_vault["root"], "fixture-alice@example.com", **_kwargs(entity_vault)
+    )
+    entity_index.remove_database(entity_index.database_path(entity_vault["root"]))
+
+    after = entity_index.lookup_person(
+        entity_vault["root"], "fixture-alice@example.com", **_kwargs(entity_vault)
+    )
+
+    assert after["matches"] == before["matches"]
+    assert entity_index.database_path(entity_vault["root"]).exists()
+
+
+def test_reconcile_debounces_unchanged_tree_but_not_a_deletion(
+    entity_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    person = _write_person(entity_vault)
+    calls = 0
+    original = entity_index._reconcile_open_database
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(entity_index, "_reconcile_open_database", counted)
+
+    entity_index.reconcile(entity_vault["root"], **_kwargs(entity_vault))
+    entity_index.reconcile(entity_vault["root"], **_kwargs(entity_vault))
+    assert calls == 1
+
+    person.unlink()
+    entity_index.reconcile(entity_vault["root"], **_kwargs(entity_vault))
+    assert calls == 2
+
+
+def test_busy_database_error_does_not_remove_the_index(
+    entity_vault: dict[str, Path],
+) -> None:
+    person = _write_person(entity_vault)
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+    db_path = entity_index.database_path(entity_vault["root"])
+    inode = db_path.stat().st_ino
+    person.write_text(
+        render_person_page("Alice Smith", role="Chief Product Officer"),
+        encoding="utf-8",
+    )
+
+    blocker = sqlite3.connect(db_path, timeout=0)
+    blocker.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            entity_index.reconcile(
+                entity_vault["root"], force=True, **_kwargs(entity_vault)
+            )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert db_path.exists()
+    assert db_path.stat().st_ino == inode
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM nodes").fetchone() == (1,)
+
+
+def test_connect_allows_five_seconds_for_busy_writes(
+    entity_vault: dict[str, Path],
+) -> None:
+    with entity_index.connect(
+        entity_index.database_path(entity_vault["root"])
+    ) as connection:
+        assert connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
+
+
+def test_lookup_person_uses_last_good_json_while_database_is_busy(
+    entity_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_person(entity_vault)
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+    exported = json.loads(entity_vault["people_export"].read_text())
+    db_path = entity_index.database_path(entity_vault["root"])
+
+    original_connect = entity_index.connect
+
+    def connect_with_short_test_wait(path: str | Path) -> sqlite3.Connection:
+        connection = original_connect(path)
+        connection.execute("PRAGMA busy_timeout = 1")
+        return connection
+
+    blocker = sqlite3.connect(db_path, timeout=0)
+    blocker.execute("BEGIN IMMEDIATE")
+    monkeypatch.setattr(entity_index, "connect", connect_with_short_test_wait)
+    try:
+        result = entity_index.lookup_person(
+            entity_vault["root"],
+            "Alice Smith",
+            force=True,
+            **_kwargs(entity_vault),
+        )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert result["matches"][0]["name"] == "Alice Smith"
+    assert result["index_age"] == exported["built_at"]
+
+
+def test_reconcile_reads_and_parses_sources_before_write_transaction(
+    entity_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_person(entity_vault)
+    captured_connection: sqlite3.Connection | None = None
+    original_connect = entity_index.connect
+    original_parse = entity_index.parse_entity_page
+    original_read_bytes = Path.read_bytes
+
+    def capture_connection(path: str | Path) -> sqlite3.Connection:
+        nonlocal captured_connection
+        captured_connection = original_connect(path)
+        return captured_connection
+
+    def parse_outside_transaction(path: str | Path) -> dict[str, object]:
+        assert captured_connection is not None
+        assert captured_connection.in_transaction is False
+        return original_parse(path)
+
+    def read_outside_transaction(path: Path) -> bytes:
+        if path.suffix == ".md":
+            assert captured_connection is not None
+            assert captured_connection.in_transaction is False
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(entity_index, "connect", capture_connection)
+    monkeypatch.setattr(entity_index, "parse_entity_page", parse_outside_transaction)
+    monkeypatch.setattr(Path, "read_bytes", read_outside_transaction)
+
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+
+
+def test_corrupt_database_and_sidecars_are_removed_then_rebuilt(
+    entity_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_person(entity_vault)
+    db_path = entity_index.database_path(entity_vault["root"])
+    db_path.parent.mkdir(parents=True)
+    db_path.write_bytes(b"not a sqlite database")
+    wal_path = Path(f"{db_path}-wal")
+    shm_path = Path(f"{db_path}-shm")
+    wal_path.write_bytes(b"stale wal")
+    shm_path.write_bytes(b"stale shm")
+    removed_together = False
+    original_remove = entity_index.remove_database
+
+    def checked_remove(path: str | Path) -> None:
+        nonlocal removed_together
+        original_remove(path)
+        removed_together = not any(
+            candidate.exists() for candidate in (db_path, wal_path, shm_path)
+        )
+
+    monkeypatch.setattr(entity_index, "remove_database", checked_remove)
+
+    result = entity_index.lookup_person(
+        entity_vault["root"], "Alice", **_kwargs(entity_vault)
+    )
+
+    assert result["matches"][0]["name"] == "Alice Smith"
+    assert removed_together is True
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
+
+
+def test_failed_quick_check_rebuilds_from_frontmatter(
+    entity_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_person(entity_vault)
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+    original_connect = entity_index.connect
+    calls = 0
+
+    def fail_quick_check_once(path: str | Path) -> sqlite3.Connection:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise entity_index._FailedQuickCheck("simulated quick_check failure")
+        return original_connect(path)
+
+    monkeypatch.setattr(entity_index, "connect", fail_quick_check_once)
+
+    result = entity_index.reconcile(
+        entity_vault["root"], force=True, **_kwargs(entity_vault)
+    )
+
+    assert result == {"added": 1, "changed": 0, "removed": 0}
+    assert calls == 2
+
+
+def test_quarantined_page_is_findable_without_trusting_frontmatter(
+    entity_vault: dict[str, Path],
+) -> None:
+    broken = entity_vault["people"] / "External" / "Broken_Profile.md"
+    broken.write_text(
+        "---\n"
+        "type: person\n"
+        "name: [not closed\n"
+        "role: CEO\n"
+        "company: Unsafe Co\n"
+        "emails: [unsafe@example.com]\n"
+        "aliases: [Bad Data]\n",
+        encoding="utf-8",
+    )
+
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+
+    with entity_index.connect(
+        entity_index.database_path(entity_vault["root"])
+    ) as connection:
+        assert connection.execute(
+            "SELECT quarantined FROM source_files"
+        ).fetchone() == (1,)
+        node = connection.execute(
+            """
+            SELECT name, type, role, company, status, last_interaction, fields_json
+            FROM nodes
+            """
+        ).fetchone()
+        assert node is not None
+        assert node[:6] == (
+            "Broken Profile",
+            "person",
+            None,
+            None,
+            "quarantined",
+            None,
+        )
+        compatibility = json.loads(node[6])["_compat"]
+        assert compatibility == {
+            "aliases": [],
+            "company": None,
+            "email": None,
+            "emails": [],
+            "first_name": "broken",
+            "last_interaction": None,
+            "name": "Broken Profile",
+            "path": "05-Areas/People/External/Broken_Profile.md",
+            "role": None,
+            "status": "quarantined",
+            "tags": [],
+            "type": "external",
+        }
+        assert connection.execute("SELECT COUNT(*) FROM node_keys").fetchone() == (0,)
+
+    result = entity_index.lookup_person(
+        entity_vault["root"], "Broken Profile", **_kwargs(entity_vault)
+    )
+    assert result["matches"][0]["name"] == "Broken Profile"
+    assert result["matches"][0]["status"] == "quarantined"
+    assert result["matches"][0]["emails"] == []
+
+
+def test_people_scan_skips_nested_archive_and_stray_root_pages(
+    entity_vault: dict[str, Path],
+) -> None:
+    included = entity_vault["people"] / "Internal" / "Included.md"
+    archived = entity_vault["people"] / "Internal" / "_archive" / "Archived.md"
+    stray = entity_vault["people"] / "Z.md"
+    nested_company = entity_vault["companies"] / "Archive" / "Nested_Co.md"
+    included.parent.mkdir(parents=True)
+    archived.parent.mkdir(parents=True)
+    nested_company.parent.mkdir(parents=True)
+    included.write_text(render_person_page("Included"), encoding="utf-8")
+    archived.write_text(render_person_page("Archived"), encoding="utf-8")
+    stray.write_text(render_person_page("Z"), encoding="utf-8")
+    nested_company.write_text(
+        render_company_page("Nested Co", domains=["nested.example.com"]),
+        encoding="utf-8",
+    )
+
+    entity_index.build_from_vault(entity_vault["root"], **_kwargs(entity_vault))
+
+    people = entity_index.people_index_data(
+        entity_vault["root"], **_kwargs(entity_vault)
+    )
+    assert [person["name"] for person in people["people"]] == ["Included"]
+    company = entity_index.find_company_by_domain(
+        entity_vault["root"], "mail.nested.example.com", **_kwargs(entity_vault)
+    )
+    assert company is not None
+    assert company["name"] == "Nested Co"
+
+
+def test_default_scan_respects_folder_path_remapping(tmp_path: Path) -> None:
+    folder_map = tmp_path / "System" / "folder-paths.yaml"
+    folder_map.parent.mkdir(parents=True)
+    folder_map.write_text(
+        'people_internal: "Relationships/Team"\n'
+        'people_external: "Relationships/Contacts"\n'
+        'companies: "Relationships/Accounts"\n',
+        encoding="utf-8",
+    )
+    person = tmp_path / "Relationships" / "Contacts" / "Ada_Lovelace.md"
+    company = tmp_path / "Relationships" / "Accounts" / "Analytical_Engines.md"
+    person.parent.mkdir(parents=True)
+    company.parent.mkdir(parents=True)
+    person.write_text(
+        render_person_page("Ada Lovelace", emails=["fixture-ada@example.org"]),
+        encoding="utf-8",
+    )
+    company.write_text(
+        render_company_page("Analytical Engines", domains=["engines.test"]),
+        encoding="utf-8",
+    )
+
+    entity_index.build_from_vault(tmp_path)
+
+    assert entity_index.lookup_person(tmp_path, "Ada")["matches"][0]["path"] == (
+        "Relationships/Contacts/Ada_Lovelace.md"
+    )
+    assert entity_index.find_company_by_domain(
+        tmp_path, "mail.engines.test"
+    )["path"] == "Relationships/Accounts/Analytical_Engines.md"

--- a/core/tests/test_messy_vault_parsers.py
+++ b/core/tests/test_messy_vault_parsers.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta, timezone
 
+from core.entity_engine import index as entity_index
 from core.mcp import work_server
 from core.mcp.update_checker import parse_version
 from core.ritual_intelligence.models import NormalizedAttendee, NormalizedCalendarEvent, TranscriptArtifact
@@ -94,7 +96,10 @@ def test_vault_builder_unicode_content_survives_ritual_matching(tmp_path, monkey
     assert suggestions[0]["title"].strip()
 
 
-def test_vault_builder_malformed_frontmatter_survives_people_index(tmp_path, monkeypatch):
+def test_vault_builder_malformed_frontmatter_is_quarantined_but_findable(
+    tmp_path,
+    monkeypatch,
+):
     vault = build_messy_vault(tmp_path, file_count=5)
     monkeypatch.setattr(work_server, "BASE_DIR", vault.root)
     monkeypatch.setattr(work_server, "PEOPLE_INDEX_FILE", vault.people_index)
@@ -105,9 +110,22 @@ def test_vault_builder_malformed_frontmatter_survives_people_index(tmp_path, mon
     assert index["total"] >= 2
     assert index["people"]
     assert all(person["name"] and person["path"].endswith(".md") for person in index["people"])
-    recovered = next(person for person in index["people"] if person["name"] == "Recovered Person")
-    assert recovered["email"] == "recovered@example.com"
-    assert "Malformed YAML" in recovered["path"]
+    quarantined_entry = next(
+        person
+        for person in index["people"]
+        if person["name"] == "Malformed YAML – 東京"
+    )
+    assert quarantined_entry["status"] == "quarantined"
+    assert quarantined_entry["email"] is None
+    assert quarantined_entry["emails"] == []
+    assert quarantined_entry["aliases"] == []
+    with sqlite3.connect(entity_index.database_path(vault.root)) as connection:
+        quarantined = connection.execute(
+            "SELECT path FROM source_files WHERE quarantined = 1"
+        ).fetchall()
+    assert quarantined == [
+        ("05-Areas/People/External/Malformed YAML – 東京.md",)
+    ]
 
 
 def test_parse_version_accepts_release_prerelease_forms():

--- a/core/tests/test_people_index_v2.py
+++ b/core/tests/test_people_index_v2.py
@@ -28,26 +28,26 @@ def test_people_index_v2_contains_canonical_emails_aliases_and_first_name(tmp_pa
     people_dir, _ = _setup(tmp_path, monkeypatch)
     _write_person(
         people_dir, "External", "Jessica_Jolly.md", "Jessica Jolly",
-        emails=["jess@example.com", "jj@other.test"], aliases=["JJ"],
+        emails=["jess@example.com", "jj@example.org"], aliases=["JJ"],
         body="\nGoes by Jess\n**Goes by:** Jolly\n",
     )
 
     index = work_server.build_people_index_data()
 
     assert index["version"] == 2
-    assert index["people"][0]["emails"] == ["jess@example.com", "jj@other.test"]
+    assert index["people"][0]["emails"] == ["jess@example.com", "jj@example.org"]
     assert index["people"][0]["aliases"] == ["JJ", "Jess", "Jolly"]
     assert index["people"][0]["first_name"] == "jessica"
 
 
 def test_lookup_ladder_and_ambiguity(tmp_path, monkeypatch):
     people_dir, _ = _setup(tmp_path, monkeypatch)
-    _write_person(people_dir, "External", "Jessica_Jolly.md", "Jessica Jolly", ["jess@a.test"], ["JJ"])
-    _write_person(people_dir, "Internal", "Alice_Smith.md", "Alice Smith", ["alice@dex.test"], ["Al"])
-    _write_person(people_dir, "External", "Jessica_Jones.md", "Jessica Jones", ["jones@b.test"])
+    _write_person(people_dir, "External", "Jessica_Jolly.md", "Jessica Jolly", ["jess@example.com"], ["JJ"])
+    _write_person(people_dir, "Internal", "Alice_Smith.md", "Alice Smith", ["alice@anthropic.com"], ["Al"])
+    _write_person(people_dir, "External", "Jessica_Jones.md", "Jessica Jones", ["jones@example.org"])
     work_server.build_people_index_data()
 
-    assert work_server.lookup_person_data("ALICE@DEX.TEST")["matches"][0]["name"] == "Alice Smith"
+    assert work_server.lookup_person_data("ALICE@ANTHROPIC.COM")["matches"][0]["name"] == "Alice Smith"
     assert work_server.lookup_person_data("al")["matches"][0]["name"] == "Alice Smith"
     assert work_server.lookup_person_data("alice smith")["matches"][0]["_score"] == 1.0
     assert work_server.lookup_person_data("alice")["matches"][0]["name"] == "Alice Smith"
@@ -61,11 +61,34 @@ def test_lookup_ladder_and_ambiguity(tmp_path, monkeypatch):
 
 def test_lookup_rebuilds_version_one_index(tmp_path, monkeypatch):
     people_dir, index_file = _setup(tmp_path, monkeypatch)
-    _write_person(people_dir, "External", "Ava_Stone.md", "Ava Stone", ["ava@test.dev"])
+    _write_person(people_dir, "External", "Ava_Stone.md", "Ava Stone", ["ava@example.com"])
     index_file.parent.mkdir(parents=True)
     index_file.write_text(json.dumps({"version": 1, "built_at": datetime.now().isoformat(), "people": []}))
 
-    result = work_server.lookup_person_data("ava@test.dev")
+    result = work_server.lookup_person_data("ava@example.com")
 
     assert result["matches"][0]["name"] == "Ava Stone"
     assert json.loads(index_file.read_text())["version"] == 2
+
+
+def test_lookup_removes_deleted_person_from_sqlite_and_json_export(
+    tmp_path,
+    monkeypatch,
+):
+    people_dir, index_file = _setup(tmp_path, monkeypatch)
+    person = _write_person(
+        people_dir,
+        "External",
+        "Ghost_User.md",
+        "Ghost User",
+        ["placeholder@example.org"],
+    )
+    work_server.build_people_index_data()
+
+    person.unlink()
+    result = work_server.lookup_person_data("placeholder@example.org")
+
+    assert result["matches"] == []
+    exported = json.loads(index_file.read_text())
+    assert exported["total"] == 0
+    assert exported["people"] == []


### PR DESCRIPTION
## What

Replaces the JSON-scan people/company index with a **disposable SQLite projection** (`core/entity_engine/index.py`) derived entirely from person/company Markdown pages. Files stay the source of truth; the DB is rebuildable at any time and is gitignored. Exports the legacy `People_Index.json` / `Company_Index.json` byte-shape for compatibility; `work_server` routes `lookup_person` / `find_company_by_domain` / `build_people_index` through the projection. A path-set reconcile fixes the long-standing ghost-entry bug (deleted/renamed pages left stale rows) via `ON DELETE CASCADE`.

This is engine **3B** in the entity-engine-v2 sequence — on `main`, **not** released (follows #187/#188).

## Hardened after two independent adversarial reviews

- **No crash under lock contention:** the read path is no longer clobbered by a concurrent writer — 5s busy timeout, file parsing moved out of the write transaction, and a busy-error fallback to the last-good JSON export (restores the old lock-free no-crash guarantee).
- **Disposable DB (+ `-wal`/`-shm`) gitignored** so it can't be committed into a synced vault and cause cross-machine conflicts.
- **Person scan scoped** to the known people subfolders (non-recursive, folder-map aware) so archived/nested pages don't silently surface in lookups; company scan stays recursive.
- **Quarantined pages stay findable** by filename-derived name (`status="quarantined"`, untrusted frontmatter fields left empty) instead of vanishing from search over a YAML typo.

## Tests / gates

- entity-index **15/15**; people/company/messy-vault, work-server-entity-links (15), entity-engine-writers (6), work-server-roundtrip — all green.
- PR gates run locally against `origin/main`: doc-drift, path-contract, test-delta, portable-contract, security — **all pass**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)