### PR TITLE
fix(migrator): refuse to convert a vault inside a cloud-synced folder

### DIFF
--- a/core/data/sync-folder-markers.json
+++ b/core/data/sync-folder-markers.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "markers": [
+    {
+      "provider": "OneDrive",
+      "kind": "path-segment",
+      "values": ["onedrive", "onedrive - "]
+    },
+    {
+      "provider": "OneDrive",
+      "kind": "paired-children",
+      "values": [
+        "desktop.ini",
+        ".849C9593-D756-4E56-8D6E-42412F2A707B"
+      ]
+    },
+    {
+      "provider": "Dropbox",
+      "kind": "child",
+      "values": [".dropbox", ".dropbox.cache"]
+    },
+    {
+      "provider": "a cloud-synced folder",
+      "kind": "cloudstorage-provider",
+      "values": ["library", "cloudstorage"]
+    },
+    {
+      "provider": "iCloud Drive",
+      "kind": "icloud-materialization",
+      "values": [".icloud"]
+    }
+  ],
+  "cloudstorage_provider_prefixes": [
+    {"prefix": "dropbox", "provider": "Dropbox"},
+    {"prefix": "googledrive", "provider": "GoogleDrive"},
+    {"prefix": "onedrive", "provider": "OneDrive"},
+    {"prefix": "box", "provider": "Box"}
+  ]
+}

--- a/core/lifecycle/sqlite_snapshot.py
+++ b/core/lifecycle/sqlite_snapshot.py
@@ -14,7 +14,9 @@ import json
 import os
 import sqlite3
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +28,17 @@ _HEX = frozenset("0123456789abcdef")
 _DEFAULT_BACKUP_TIMEOUT_SECONDS = 5.0
 _BACKUP_PAGES = 256
 _BACKUP_SLEEP_SECONDS = 0.01
+_SYNC_MARKER_SCHEMA_VERSION = 1
+_SYNC_MARKER_DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "sync-folder-markers.json"
+_SYNC_MARKER_KINDS = frozenset(
+    {
+        "path-segment",
+        "cloudstorage-provider",
+        "child",
+        "paired-children",
+        "icloud-materialization",
+    }
+)
 
 
 class SQLiteSnapshotError(RuntimeError):
@@ -67,27 +80,97 @@ class _SyncMarker:
     values: tuple[str, ...]
 
 
-# The table is deliberately declarative so later providers can be added without
-# changing snapshot policy. Specific OneDrive signals precede the generic
-# CloudStorage provider directory.
-SYNC_MARKERS = (
-    _SyncMarker("OneDrive", "path-segment", ("onedrive", "onedrive - ")),
-    _SyncMarker(
-        "OneDrive",
-        "paired-children",
-        ("desktop.ini", ".849C9593-D756-4E56-8D6E-42412F2A707B"),
-    ),
-    _SyncMarker("Dropbox", "child", (".dropbox", ".dropbox.cache")),
-    _SyncMarker("a cloud-synced folder", "cloudstorage-provider", ("library", "cloudstorage")),
-    _SyncMarker("iCloud Drive", "icloud-materialization", (".icloud",)),
-)
+def _sync_marker_data_error(message: str) -> RuntimeError:
+    return RuntimeError(f"Could not safely read sync-folder marker data: {message}")
 
-_CLOUDSTORAGE_PROVIDER_PREFIXES = (
-    ("dropbox", "Dropbox"),
-    ("googledrive", "GoogleDrive"),
-    ("onedrive", "OneDrive"),
-    ("box", "Box"),
-)
+
+def _ascii_marker(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value or not value.isascii():
+        raise _sync_marker_data_error(f"{context} must be a non-empty ASCII string")
+    return value
+
+
+def _load_sync_folder_markers(
+    data_path: Path = _SYNC_MARKER_DATA_PATH,
+) -> tuple[tuple[_SyncMarker, ...], tuple[tuple[str, str], ...]]:
+    try:
+        document = json.loads(Path(data_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise _sync_marker_data_error(f"{data_path}: {error}") from error
+    if (
+        not isinstance(document, dict)
+        or set(document) != {"schema_version", "markers", "cloudstorage_provider_prefixes"}
+        or document.get("schema_version") != _SYNC_MARKER_SCHEMA_VERSION
+        or not isinstance(document.get("markers"), list)
+        or not document["markers"]
+        or not isinstance(document.get("cloudstorage_provider_prefixes"), list)
+    ):
+        raise _sync_marker_data_error(f"{data_path} has an unsupported schema or shape")
+
+    markers: list[_SyncMarker] = []
+    for index, marker in enumerate(document["markers"]):
+        if (
+            not isinstance(marker, dict)
+            or set(marker) != {"provider", "kind", "values"}
+            or not isinstance(marker.get("provider"), str)
+            or not marker["provider"]
+            or marker.get("kind") not in _SYNC_MARKER_KINDS
+            or not isinstance(marker.get("values"), list)
+            or not marker["values"]
+        ):
+            raise _sync_marker_data_error(f"{data_path} marker {index} is invalid")
+        values = tuple(
+            _ascii_marker(value, f"marker {index} value {value_index}")
+            for value_index, value in enumerate(marker["values"])
+        )
+        if marker["kind"] == "path-segment" and len(values) != 2:
+            raise _sync_marker_data_error(
+                f"{data_path} path-segment marker {index} needs exactly two values"
+            )
+        if marker["kind"] == "icloud-materialization" and values != (".icloud",):
+            raise _sync_marker_data_error(f"{data_path} iCloud marker {index} is invalid")
+        markers.append(_SyncMarker(marker["provider"], marker["kind"], values))
+
+    provider_prefixes: list[tuple[str, str]] = []
+    for index, entry in enumerate(document["cloudstorage_provider_prefixes"]):
+        if (
+            not isinstance(entry, dict)
+            or set(entry) != {"prefix", "provider"}
+            or not isinstance(entry.get("provider"), str)
+            or not entry["provider"]
+        ):
+            raise _sync_marker_data_error(
+                f"{data_path} CloudStorage prefix {index} is invalid"
+            )
+        provider_prefixes.append(
+            (
+                _ascii_marker(entry.get("prefix"), f"CloudStorage prefix {index}"),
+                entry["provider"],
+            )
+        )
+    return tuple(markers), tuple(provider_prefixes)
+
+
+@lru_cache(maxsize=1)
+def _sync_folder_marker_data() -> tuple[
+    tuple[_SyncMarker, ...],
+    tuple[tuple[str, str], ...],
+]:
+    return _load_sync_folder_markers()
+
+
+class _LazySyncMarkers(Sequence[_SyncMarker]):
+    """Compatibility view that does not read marker data during module import."""
+
+    def __getitem__(self, index: int | slice) -> _SyncMarker | tuple[_SyncMarker, ...]:
+        return _sync_folder_marker_data()[0][index]
+
+    def __len__(self) -> int:
+        return len(_sync_folder_marker_data()[0])
+
+
+# Keep the existing public name without restoring import-time file I/O.
+SYNC_MARKERS: Sequence[_SyncMarker] = _LazySyncMarkers()
 
 
 def _ancestors(path: Path) -> tuple[Path, ...]:
@@ -102,7 +185,11 @@ def _child_names(directory: Path) -> frozenset[str]:
         return frozenset()
 
 
-def _cloudstorage_provider(folded_parts: tuple[str, ...], sequence: tuple[str, ...]) -> str | None:
+def _cloudstorage_provider(
+    folded_parts: tuple[str, ...],
+    sequence: tuple[str, ...],
+    provider_prefixes: tuple[tuple[str, str], ...],
+) -> str | None:
     width = len(sequence)
     for index in range(len(folded_parts)):
         if folded_parts[index : index + width] != sequence:
@@ -111,7 +198,7 @@ def _cloudstorage_provider(folded_parts: tuple[str, ...], sequence: tuple[str, .
         if provider_index >= len(folded_parts):
             return "a cloud-synced folder"
         provider_directory = folded_parts[provider_index]
-        for prefix, provider in _CLOUDSTORAGE_PROVIDER_PREFIXES:
+        for prefix, provider in provider_prefixes:
             if provider_directory.startswith(prefix):
                 return provider
         return "a cloud-synced folder"
@@ -131,15 +218,16 @@ def detect_sync_folder(path: Path) -> str | None:
     ancestors = _ancestors(Path(path))
     folded_parts = tuple(part.casefold() for part in Path(path).absolute().parts)
     names_by_directory: dict[Path, frozenset[str]] = {}
+    markers, provider_prefixes = _sync_folder_marker_data()
 
-    for marker in SYNC_MARKERS:
+    for marker in markers:
         if marker.kind == "path-segment":
             exact, tenant_prefix = marker.values
             if any(part == exact or part.startswith(tenant_prefix) for part in folded_parts):
                 return marker.provider
             continue
         if marker.kind == "cloudstorage-provider":
-            provider = _cloudstorage_provider(folded_parts, marker.values)
+            provider = _cloudstorage_provider(folded_parts, marker.values, provider_prefixes)
             if provider is not None:
                 return provider
             continue

--- a/core/migrations/sync-folder-detector.cjs
+++ b/core/migrations/sync-folder-detector.cjs
@@ -1,0 +1,200 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DATA_PATH = path.resolve(__dirname, '..', 'data', 'sync-folder-markers.json');
+const SCHEMA_VERSION = 1;
+const MARKER_KINDS = new Set([
+  'path-segment',
+  'cloudstorage-provider',
+  'child',
+  'paired-children',
+  'icloud-materialization',
+]);
+
+function markerDataError(message) {
+  return new Error(`Could not safely read sync-folder marker data: ${message}`);
+}
+
+function asciiFold(value, context) {
+  if (typeof value !== 'string' || !value || !/^[\x00-\x7f]+$/.test(value)) {
+    throw markerDataError(`${context} must be a non-empty ASCII string`);
+  }
+  return value.toLowerCase();
+}
+
+function loadSyncFolderMarkers(dataPath = DATA_PATH) {
+  let document;
+  try {
+    document = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  } catch (error) {
+    throw markerDataError(`${dataPath}: ${error.message}`);
+  }
+  if (
+    !document
+    || typeof document !== 'object'
+    || Array.isArray(document)
+    || Object.keys(document).sort().join(',') !== [
+      'cloudstorage_provider_prefixes',
+      'markers',
+      'schema_version',
+    ].join(',')
+    || document.schema_version !== SCHEMA_VERSION
+    || !Array.isArray(document.markers)
+    || document.markers.length === 0
+    || !Array.isArray(document.cloudstorage_provider_prefixes)
+  ) {
+    throw markerDataError(`${dataPath} has an unsupported schema or shape`);
+  }
+
+  const markers = document.markers.map((marker, index) => {
+    if (
+      !marker
+      || typeof marker !== 'object'
+      || Array.isArray(marker)
+      || Object.keys(marker).sort().join(',') !== ['kind', 'provider', 'values'].join(',')
+      || typeof marker.provider !== 'string'
+      || !marker.provider
+      || !MARKER_KINDS.has(marker.kind)
+      || !Array.isArray(marker.values)
+      || marker.values.length === 0
+    ) {
+      throw markerDataError(`${dataPath} marker ${index} is invalid`);
+    }
+    const values = marker.values.map((value, valueIndex) => (
+      asciiFold(value, `marker ${index} value ${valueIndex}`)
+    ));
+    if (marker.kind === 'path-segment' && values.length !== 2) {
+      throw markerDataError(`${dataPath} path-segment marker ${index} needs exactly two values`);
+    }
+    if (
+      marker.kind === 'icloud-materialization'
+      && (values.length !== 1 || values[0] !== '.icloud')
+    ) {
+      throw markerDataError(`${dataPath} iCloud marker ${index} is invalid`);
+    }
+    return Object.freeze({ provider: marker.provider, kind: marker.kind, values });
+  });
+
+  const cloudstorageProviderPrefixes = document.cloudstorage_provider_prefixes.map(
+    (entry, index) => {
+      if (
+        !entry
+        || typeof entry !== 'object'
+        || Array.isArray(entry)
+        || Object.keys(entry).sort().join(',') !== ['prefix', 'provider'].join(',')
+        || typeof entry.provider !== 'string'
+        || !entry.provider
+      ) {
+        throw markerDataError(`${dataPath} CloudStorage prefix ${index} is invalid`);
+      }
+      return Object.freeze({
+        prefix: asciiFold(entry.prefix, `CloudStorage prefix ${index}`),
+        provider: entry.provider,
+      });
+    },
+  );
+  return Object.freeze({
+    markers: Object.freeze(markers),
+    cloudstorageProviderPrefixes: Object.freeze(cloudstorageProviderPrefixes),
+  });
+}
+
+const SYNC_FOLDER_MARKERS = loadSyncFolderMarkers();
+
+function ancestors(candidate) {
+  const result = [];
+  let current = path.resolve(candidate);
+  while (true) {
+    result.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) return result;
+    current = parent;
+  }
+}
+
+function childNames(directory) {
+  try {
+    return new Set(fs.readdirSync(directory).map((name) => name.toLowerCase()));
+  } catch {
+    return new Set();
+  }
+}
+
+function absolutePathParts(candidate) {
+  const absolute = path.resolve(candidate);
+  const root = path.parse(absolute).root;
+  const relative = path.relative(root, absolute);
+  return [root, ...(relative ? relative.split(path.sep) : [])].map((part) => part.toLowerCase());
+}
+
+function cloudstorageProvider(foldedParts, sequence, providerPrefixes) {
+  for (let index = 0; index < foldedParts.length; index += 1) {
+    if (!sequence.every((value, offset) => foldedParts[index + offset] === value)) continue;
+    const providerIndex = index + sequence.length;
+    if (providerIndex >= foldedParts.length) return 'a cloud-synced folder';
+    const providerDirectory = foldedParts[providerIndex];
+    for (const { prefix, provider } of providerPrefixes) {
+      if (providerDirectory.startsWith(prefix)) return provider;
+    }
+    return 'a cloud-synced folder';
+  }
+  return null;
+}
+
+function detectSyncFolder(candidate, markerData = SYNC_FOLDER_MARKERS) {
+  const candidateAncestors = ancestors(candidate);
+  // JavaScript has no exact equivalent of Python str.casefold(). The shared
+  // marker values are therefore validated as ASCII, where toLowerCase() and
+  // casefold() agree. Path names still use the platform's Unicode lowercase.
+  const foldedParts = absolutePathParts(candidate);
+  const namesByDirectory = new Map();
+
+  for (const marker of markerData.markers) {
+    if (marker.kind === 'path-segment') {
+      const [exact, tenantPrefix] = marker.values;
+      if (foldedParts.some((part) => part === exact || part.startsWith(tenantPrefix))) {
+        return marker.provider;
+      }
+      continue;
+    }
+    if (marker.kind === 'cloudstorage-provider') {
+      const provider = cloudstorageProvider(
+        foldedParts,
+        marker.values,
+        markerData.cloudstorageProviderPrefixes,
+      );
+      if (provider !== null) return provider;
+      continue;
+    }
+
+    for (const directory of candidateAncestors) {
+      if (!namesByDirectory.has(directory)) {
+        namesByDirectory.set(directory, childNames(directory));
+      }
+      const names = namesByDirectory.get(directory);
+      if (marker.kind === 'child' && marker.values.some((value) => names.has(value))) {
+        return marker.provider;
+      }
+      if (
+        marker.kind === 'paired-children'
+        && marker.values.every((value) => names.has(value))
+      ) {
+        return marker.provider;
+      }
+      if (
+        marker.kind === 'icloud-materialization'
+        && [...names].some((name) => name === '.icloud' || name.endsWith('.icloud'))
+      ) {
+        return marker.provider;
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  detectSyncFolder,
+  loadSyncFolderMarkers,
+};

--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
+const { detectSyncFolder } = require('./sync-folder-detector.cjs');
 
 const START_MARKER = '## USER_EXTENSIONS_START';
 const END_MARKER = '## USER_EXTENSIONS_END';
@@ -827,6 +828,7 @@ function renderReport(report) {
   const embeddedRepositories = report.embeddedRepositories || [];
   const skippedPaths = report.skippedPaths || [];
   const capabilityRooms = report.capabilityRooms || [];
+  const syncFolder = report.syncFolder || null;
   return [
     '# Your Dex brain and vault split',
     '',
@@ -841,6 +843,12 @@ function renderReport(report) {
     `- ${embeddedRepositories.length === 1 ? '1 project has its' : `${embeddedRepositories.length} projects have their`} own version history and will stay untouched.`,
     `- Tracked-ignore baseline ${report.baselineVersion || 'unknown'} (${report.transitionPhase || 'unknown transition'}) was read from the installed v1.63 policy.`,
     `- DEX_VAULT will be set to ${report.vaultRoot || '(the current vault root)'}.`,
+    ...(syncFolder ? [
+      `- Dex detected that this vault is inside ${syncFolder.provider}.`,
+      syncFolder.allowedByOverride
+        ? '- The synced-folder safety override was used (--allow-synced-folder), so this risk is recorded after conversion.'
+        : '- No synced-folder safety override was used. A real conversion will refuse until you move the Dex folder outside the synced folder, pause syncing, or explicitly accept the risk.',
+    ] : []),
     '',
     '## Planned brain history',
     '',
@@ -1496,7 +1504,16 @@ function phase3BuildVault(root, state) {
   return { needsResume: false };
 }
 
-function phase0Preflight(root, state) {
+function syncFolderRefusal(provider) {
+  return new Error(
+    `P0 stopped because this Dex folder is inside ${provider}. `
+    + 'Converting it while syncing is active is unsafe because the sync app can copy files while Dex rebuilds the vault. '
+    + 'Move the Dex folder outside the synced folder, or pause syncing until the conversion finishes. '
+    + 'To accept this risk explicitly, run again with --allow-synced-folder.',
+  );
+}
+
+function phase0Preflight(root, state, options = {}) {
   console.log('P0 preflight: checking that this vault is ready.');
   if (!exists(path.join(root, '.git'))) return { zip: true };
   if (!fs.lstatSync(path.join(root, '.git')).isDirectory()) {
@@ -1542,6 +1559,19 @@ function phase0Preflight(root, state) {
     claudeMarkers,
     embeddedRepositories,
   };
+  const syncProvider = detectSyncFolder(root);
+  if (syncProvider !== null) {
+    const allowedByOverride = Boolean(
+      options.allowSyncedFolder || state.syncFolder?.allowedByOverride === true,
+    );
+    state.syncFolder = {
+      provider: syncProvider,
+      allowedByOverride,
+    };
+    if (!allowedByOverride && !options.previewOnly) {
+      throw syncFolderRefusal(syncProvider);
+    }
+  }
   return { zip: false };
 }
 
@@ -1560,6 +1590,7 @@ function phase1Report(root, state, dryRun = false) {
     ...state.analysis,
     dryRun,
     remoteNames: state.preflight.remoteNames,
+    syncFolder: state.syncFolder,
   });
 }
 
@@ -1577,6 +1608,7 @@ function phase2SnapshotAndScan(root, state) {
   writeReport(root, {
     ...state.analysis,
     remoteNames: state.preflight.remoteNames,
+    syncFolder: state.syncFolder,
   });
 }
 
@@ -1813,6 +1845,7 @@ function phase9Finalize(root, state) {
     ...state.analysis,
     complete: true,
     remoteNames: state.preflight?.remoteNames || [],
+    syncFolder: state.syncFolder,
   });
   console.log('P9 finalize complete: your vault and brain now have separate histories.');
 }
@@ -2120,12 +2153,22 @@ function restoreMigration(root) {
   return state;
 }
 
-function dryRun(root) {
+function dryRun(root, options = {}) {
   if (topologyDecision(inspectTopology(root)) === 'invalid') {
     throw new Error('The migration folders are incomplete and the old Git archive is missing. Dex stopped without guessing; restore the folder from backup.');
   }
   const state = { schemaVersion: 1, nextPhase: 0, mode: 'dry-run' };
-  const p0 = phase0Preflight(root, state);
+  const syncProvider = options.syncProvider ?? detectSyncFolder(root);
+  if (syncProvider !== null) {
+    state.syncFolder = {
+      provider: syncProvider,
+      allowedByOverride: Boolean(options.allowSyncedFolder),
+    };
+  }
+  const p0 = phase0Preflight(root, state, {
+    allowSyncedFolder: options.allowSyncedFolder,
+    previewOnly: true,
+  });
   if (p0.zip) {
     writeReport(root, {
       ...analyzeMigrationPlan(root),
@@ -2133,6 +2176,7 @@ function dryRun(root) {
       dryRun: true,
       modifiedBrainPaths: [],
       remoteNames: [],
+      syncFolder: state.syncFolder,
     });
     console.log('P0 found a folder downloaded as a ZIP. No conversion was started. Read System/migration-report-v2.md for the safe choices.');
     return 0;
@@ -2157,7 +2201,7 @@ function journalAfterPhase(root, state, phase) {
   writeJournal(root, state);
 }
 
-function runPhases(root, mode) {
+function runPhases(root, mode, options = {}) {
   let state = readJournal(root);
   if (mode === 'resume' && !state) {
     throw new Error('There is no saved migration to resume. Run --dry-run first, then --auto when you are ready.');
@@ -2175,10 +2219,18 @@ function runPhases(root, mode) {
       startedAt: new Date().toISOString(),
     };
   }
+  if (options.syncProvider !== null && options.syncProvider !== undefined) {
+    state.syncFolder = {
+      provider: options.syncProvider,
+      allowedByOverride: Boolean(options.allowSyncedFolder),
+    };
+  }
 
   reconcileTopology(root, state);
   const phases = [
-    () => phase0Preflight(root, state),
+    () => phase0Preflight(root, state, {
+      allowSyncedFolder: options.allowSyncedFolder,
+    }),
     () => phase1Report(root, state, false),
     () => phase2SnapshotAndScan(root, state),
     () => phase3BuildVault(root, state),
@@ -2199,6 +2251,7 @@ function runPhases(root, mode) {
         zip: true,
         modifiedBrainPaths: [],
         remoteNames: [],
+        syncFolder: state.syncFolder,
       });
       console.log('P0 found a folder downloaded as a ZIP. No conversion was started. Read System/migration-report-v2.md for the safe choices.');
       return 0;
@@ -2260,33 +2313,61 @@ function failureForUser(root, error) {
   return new Error(`${error.message}\n\n${POST_SWAP_RECOVERY}`);
 }
 
-function parseMode(argumentsList) {
-  if (argumentsList.length === 0) return 'dry-run';
-  if (argumentsList.length !== 1) throw new Error('Use one mode: --dry-run, --auto, --resume, --restore, or --status.');
-  const value = argumentsList[0];
-  if (value === '--auto=false') return 'dry-run';
+function parseArguments(argumentsList) {
   const modes = new Map([
     ['--dry-run', 'dry-run'],
+    ['--auto=false', 'dry-run'],
     ['--auto', 'auto'],
     ['--resume', 'resume'],
     ['--restore', 'restore'],
     ['--status', 'status'],
   ]);
-  if (!modes.has(value)) throw new Error('Use one mode: --dry-run, --auto, --resume, --restore, or --status.');
-  return modes.get(value);
+  const allowSyncedFolder = argumentsList.includes('--allow-synced-folder');
+  const modeArguments = argumentsList.filter((value) => value !== '--allow-synced-folder');
+  if (modeArguments.length > 1) {
+    throw new Error('Use one mode: --dry-run, --auto, --resume, --restore, or --status.');
+  }
+  const value = modeArguments[0];
+  if (value !== undefined && !modes.has(value)) {
+    throw new Error('Use one mode: --dry-run, --auto, --resume, --restore, or --status.');
+  }
+  const mode = value === undefined ? 'dry-run' : modes.get(value);
+  if (allowSyncedFolder && !['dry-run', 'auto', 'resume'].includes(mode)) {
+    throw new Error('--allow-synced-folder may only be used with --dry-run, --auto, or --resume.');
+  }
+  return { mode, allowSyncedFolder };
 }
 
 function main(argumentsList = process.argv.slice(2), root = process.cwd()) {
   let mode;
   try {
     assertSafeMutationRoots(root);
-    mode = parseMode(argumentsList);
+    const parsed = parseArguments(argumentsList);
+    mode = parsed.mode;
     process.env.DEX_VAULT = path.resolve(root);
     if (mode === 'status') return statusMigration(root);
+    const syncProvider = mode === 'restore' ? null : detectSyncFolder(root);
+    const rememberedSyncOverride = (
+      mode === 'resume'
+      && readJournal(root)?.syncFolder?.allowedByOverride === true
+    );
+    const allowSyncedFolder = parsed.allowSyncedFolder || rememberedSyncOverride;
+    if (
+      syncProvider !== null
+      && ['auto', 'resume'].includes(mode)
+      && !allowSyncedFolder
+    ) {
+      throw syncFolderRefusal(syncProvider);
+    }
 
     const releaseLock = acquireLock(root);
     try {
-      if (mode === 'dry-run') return dryRun(root);
+      if (mode === 'dry-run') {
+        return dryRun(root, {
+          allowSyncedFolder,
+          syncProvider,
+        });
+      }
 
       const startupTopology = inspectTopology(root);
       if (topologyDecision(startupTopology) === 'zip') {
@@ -2296,6 +2377,10 @@ function main(argumentsList = process.argv.slice(2), root = process.cwd()) {
           zip: true,
           modifiedBrainPaths: [],
           remoteNames: [],
+          syncFolder: syncProvider === null ? null : {
+            provider: syncProvider,
+            allowedByOverride: allowSyncedFolder,
+          },
         });
         console.log('P0 found a folder downloaded as a ZIP. No conversion was started. Read System/migration-report-v2.md for the safe choices.');
         return 0;
@@ -2307,7 +2392,10 @@ function main(argumentsList = process.argv.slice(2), root = process.cwd()) {
         restoreMigration(root);
         return 0;
       }
-      return runPhases(root, mode);
+      return runPhases(root, mode, {
+        allowSyncedFolder,
+        syncProvider,
+      });
     } catch (error) {
       const userError = mode === 'restore' ? error : failureForUser(root, error);
       if (mode !== 'restore') writeFailureReport(root, userError);
@@ -2332,6 +2420,7 @@ module.exports = {
   loadPortableContract,
   loadTrackedIgnoreState,
   main,
+  parseArguments,
   phase6Rematerialize,
   readJournal,
   regenerateClaude,

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -108,6 +108,13 @@ def _r(rule_id: str, path: str, kind: str, ownership: str, note: str = "") -> Ru
 # ---------------------------------------------------------------------------
 RULES: tuple[Rule, ...] = (
     # --- brain: engine + shipped surface, replaced wholesale on update -----
+    _r(
+        "brain-sync-folder-markers",
+        "core/data/sync-folder-markers.json",
+        "file",
+        "brain",
+        "shared release-owned sync-provider table consumed by Python and CommonJS",
+    ),
     _r("brain-core", "core", "dir", "brain"),
     _r("brain-scripts", "scripts", "dir", "brain"),
     _r("brain-dot-scripts", ".scripts", "dir", "brain"),

--- a/core/tests/brain-vault-migrator-integration.test.cjs
+++ b/core/tests/brain-vault-migrator-integration.test.cjs
@@ -42,7 +42,11 @@ function makeFixture(...flags) {
 }
 
 function migrate(vault, mode, options = {}) {
-  return command(process.execPath, [path.join(vault, MIGRATOR_RELATIVE), mode], {
+  return command(process.execPath, [
+    path.join(vault, MIGRATOR_RELATIVE),
+    mode,
+    ...(options.arguments || []),
+  ], {
     cwd: vault,
     ...options,
   });
@@ -119,6 +123,135 @@ function snapshotKnownUserFiles(root) {
   }
   return new Map(relatives.map((relative) => [relative, fs.readFileSync(path.join(root, relative))]));
 }
+
+function exactTreeSnapshot(root) {
+  const snapshot = new Map();
+  function visit(relative) {
+    const absolute = relative ? path.join(root, relative) : root;
+    for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+      const child = relative ? path.join(relative, entry.name) : entry.name;
+      const portable = child.split(path.sep).join('/');
+      const childAbsolute = path.join(root, child);
+      const stat = fs.lstatSync(childAbsolute);
+      if (entry.isDirectory()) {
+        snapshot.set(portable, `dir:${stat.mode & 0o777}`);
+        visit(child);
+      } else if (entry.isSymbolicLink()) {
+        snapshot.set(portable, `link:${stat.mode & 0o777}:${fs.readlinkSync(childAbsolute)}`);
+      } else {
+        const digest = crypto.createHash('sha256').update(fs.readFileSync(childAbsolute)).digest('hex');
+        snapshot.set(portable, `file:${stat.mode & 0o777}:${digest}`);
+      }
+    }
+  }
+  visit('');
+  return snapshot;
+}
+
+function moveFixtureIntoSyncFolder(vault, provider) {
+  const destinationRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-synced-migration-'));
+  let parent;
+  if (provider === 'OneDrive') {
+    parent = path.join(destinationRoot, 'OneDrive - Example Org');
+  } else {
+    parent = path.join(destinationRoot, `${provider}-files`);
+  }
+  fs.mkdirSync(parent, { recursive: true });
+  if (provider === 'Dropbox') fs.mkdirSync(path.join(parent, '.dropbox'));
+  if (provider === 'iCloud Drive') fs.mkdirSync(path.join(parent, '.icloud'));
+  const movedVault = path.join(parent, 'Dex Vault - Aged');
+  fs.renameSync(vault, movedVault);
+  return movedVault;
+}
+
+test('synced-folder conversion refusal leaves Dropbox, iCloud, and OneDrive vaults untouched', { timeout: 300_000 }, () => {
+  for (const provider of ['Dropbox', 'iCloud Drive', 'OneDrive']) {
+    const vault = moveFixtureIntoSyncFolder(makeFixture(), provider);
+    assert.equal(fs.existsSync(path.join(vault, '.dex')), false);
+    assert.equal(fs.existsSync(path.join(vault, 'System', '.dex')), false);
+    const before = exactTreeSnapshot(vault);
+
+    const result = migrate(vault, '--auto', { expectedStatus: 1 });
+
+    assert.match(result.stderr, new RegExp(provider.replace(' ', '\\s+'), 'i'));
+    assert.match(result.stderr, /unsafe.*sync|sync.*unsafe/i);
+    assert.match(result.stderr, /move the Dex folder outside/i);
+    assert.match(result.stderr, /pause syncing/i);
+    assert.deepEqual(exactTreeSnapshot(vault), before, provider);
+    assert.equal(fs.existsSync(path.join(vault, '.dex')), false, provider);
+    assert.equal(fs.existsSync(path.join(vault, 'System', '.dex')), false, provider);
+  }
+});
+
+test('synced-folder override is recorded in migration state and report', { timeout: 180_000 }, () => {
+  const vault = moveFixtureIntoSyncFolder(makeFixture(), 'Dropbox');
+
+  const result = migrate(vault, '--auto', { arguments: ['--allow-synced-folder'] });
+
+  assert.match(result.stdout, /P9 finalize complete/);
+  const state = JSON.parse(
+    fs.readFileSync(path.join(vault, 'System', '.dex', 'migration-v2-state.json'), 'utf8'),
+  );
+  assert.deepEqual(state.syncFolder, {
+    provider: 'Dropbox',
+    allowedByOverride: true,
+  });
+  const report = fs.readFileSync(path.join(vault, 'System', 'migration-report-v2.md'), 'utf8');
+  assert.match(report, /Dropbox/);
+  assert.match(report, /override.*--allow-synced-folder/i);
+});
+
+test('synced-folder override recorded by --auto authorizes a bare --resume', { timeout: 180_000 }, () => {
+  const vault = moveFixtureIntoSyncFolder(makeFixture(), 'Dropbox');
+  const stopped = migrate(vault, '--auto', {
+    arguments: ['--allow-synced-folder'],
+    env: { DEX_MIGRATION_STOP_AFTER: 'P3' },
+    expectedStatus: 75,
+  });
+  assert.match(stopped.stdout, /Stopped safely after P3/);
+  const state = JSON.parse(
+    fs.readFileSync(path.join(vault, 'System', '.dex', 'migration-v2-state.json'), 'utf8'),
+  );
+  assert.equal(state.nextPhase, 4);
+  assert.equal(state.syncFolder?.allowedByOverride, true);
+
+  const resumed = migrate(vault, '--resume');
+
+  assert.match(resumed.stdout, /P9 finalize complete/);
+});
+
+test('bare --resume still refuses when the journal has no recorded sync-folder grant', { timeout: 180_000 }, () => {
+  const vault = moveFixtureIntoSyncFolder(makeFixture(), 'Dropbox');
+  migrate(vault, '--auto', {
+    arguments: ['--allow-synced-folder'],
+    env: { DEX_MIGRATION_STOP_AFTER: 'P3' },
+    expectedStatus: 75,
+  });
+  const statePath = path.join(vault, 'System', '.dex', 'migration-v2-state.json');
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  state.syncFolder.allowedByOverride = false;
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+  const before = exactTreeSnapshot(vault);
+
+  const refused = migrate(vault, '--resume', { expectedStatus: 1 });
+
+  assert.match(refused.stderr, /Dropbox/);
+  assert.match(refused.stderr, /--allow-synced-folder/);
+  assert.deepEqual(exactTreeSnapshot(vault), before);
+});
+
+test('synced-folder dry-run report surfaces the provider before conversion', { timeout: 180_000 }, () => {
+  const vault = moveFixtureIntoSyncFolder(makeFixture(), 'Dropbox');
+
+  const result = migrate(vault, '--dry-run');
+
+  assert.match(result.stdout, /P1 report/);
+  const report = fs.readFileSync(path.join(vault, 'System', 'migration-report-v2.md'), 'utf8');
+  assert.match(report, /Dropbox/);
+  assert.match(report, /conversion will refuse/i);
+  assert.equal(fs.existsSync(path.join(vault, '.dex')), false);
+  assert.equal(fs.existsSync(path.join(vault, 'System', '.dex')), false);
+});
 
 test('dry-run writes only its report and leaves the vault topology and file bytes alone', () => {
   const vault = makeFixture();

--- a/core/tests/brain-vault-migrator-unit.test.cjs
+++ b/core/tests/brain-vault-migrator-unit.test.cjs
@@ -51,6 +51,49 @@ function addV163MigrationMetadata(root) {
   }
 }
 
+test('synced-folder override composes with conversion modes without weakening one-mode parsing', () => {
+  const migrator = require(MIGRATOR_PATH);
+
+  assert.deepEqual(migrator.parseArguments([]), {
+    mode: 'dry-run',
+    allowSyncedFolder: false,
+  });
+  for (const [flag, mode] of [
+    ['--dry-run', 'dry-run'],
+    ['--auto', 'auto'],
+    ['--resume', 'resume'],
+  ]) {
+    assert.deepEqual(migrator.parseArguments([flag, '--allow-synced-folder']), {
+      mode,
+      allowSyncedFolder: true,
+    });
+    assert.deepEqual(migrator.parseArguments(['--allow-synced-folder', flag]), {
+      mode,
+      allowSyncedFolder: true,
+    });
+  }
+  assert.throws(
+    () => migrator.parseArguments(['--auto', '--resume', '--allow-synced-folder']),
+    /one mode/i,
+  );
+  assert.throws(
+    () => migrator.parseArguments(['--status', '--allow-synced-folder']),
+    /only.*dry-run.*auto.*resume/i,
+  );
+  assert.throws(
+    () => migrator.parseArguments(['--restore', '--allow-synced-folder']),
+    /only.*dry-run.*auto.*resume/i,
+  );
+  assert.deepEqual(migrator.parseArguments(['--status']), {
+    mode: 'status',
+    allowSyncedFolder: false,
+  });
+  assert.deepEqual(migrator.parseArguments(['--restore']), {
+    mode: 'restore',
+    allowSyncedFolder: false,
+  });
+});
+
 test('CLAUDE regeneration lifts the legacy extension bytes and removes legacy markers', () => {
   const migrator = require(MIGRATOR_PATH);
   const legacy = [

--- a/core/tests/fixtures/sync-folder-vectors.json
+++ b/core/tests/fixtures/sync-folder-vectors.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": 1,
+  "vectors": [
+    {
+      "name": "Dropbox child marker",
+      "relative_path": ["team-files", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["team-files"], "names": [".dropbox"]}
+      ],
+      "expected_provider": "Dropbox"
+    },
+    {
+      "name": "Dropbox cache child marker is case insensitive",
+      "relative_path": ["team-files", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["team-files"], "names": [".DROPBOX.CACHE"]}
+      ],
+      "expected_provider": "Dropbox"
+    },
+    {
+      "name": "CloudStorage Dropbox provider",
+      "relative_path": ["Library", "CloudStorage", "Dropbox", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "Dropbox"
+    },
+    {
+      "name": "CloudStorage Google Drive tenant",
+      "relative_path": ["Library", "CloudStorage", "GoogleDrive-example.com", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "GoogleDrive"
+    },
+    {
+      "name": "CloudStorage OneDrive tenant",
+      "relative_path": ["Library", "CloudStorage", "OneDrive-ExampleOrg", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "OneDrive"
+    },
+    {
+      "name": "CloudStorage Box provider",
+      "relative_path": ["Library", "CloudStorage", "Box-Box", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "Box"
+    },
+    {
+      "name": "unknown CloudStorage provider",
+      "relative_path": ["Library", "CloudStorage", "AcmeSync-example.com", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "a cloud-synced folder"
+    },
+    {
+      "name": "CloudStorage sequence at path end",
+      "relative_path": ["Library", "CloudStorage"],
+      "ancestor_children": [],
+      "expected_provider": "a cloud-synced folder"
+    },
+    {
+      "name": "iCloud materialization marker",
+      "relative_path": ["Mobile Documents", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["Mobile Documents"], "names": ["pending-note.md.icloud"]}
+      ],
+      "expected_provider": "iCloud Drive"
+    },
+    {
+      "name": "iCloud exact materialization marker is case insensitive",
+      "relative_path": ["Mobile Documents", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["Mobile Documents"], "names": [".ICLOUD"]}
+      ],
+      "expected_provider": "iCloud Drive"
+    },
+    {
+      "name": "OneDrive exact path segment",
+      "relative_path": ["OneDrive", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "OneDrive"
+    },
+    {
+      "name": "OneDrive tenant path segment is case insensitive",
+      "relative_path": ["ONEDRIVE - Example Org", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": "OneDrive"
+    },
+    {
+      "name": "OneDrive paired child markers",
+      "relative_path": ["company-files", "Vault"],
+      "ancestor_children": [
+        {
+          "relative_path": ["company-files"],
+          "names": [
+            "desktop.ini",
+            ".849C9593-D756-4E56-8D6E-42412F2A707B"
+          ]
+        }
+      ],
+      "expected_provider": "OneDrive"
+    },
+    {
+      "name": "specific OneDrive marker precedes generic CloudStorage",
+      "relative_path": ["Library", "CloudStorage", "Dropbox", "Vault"],
+      "ancestor_children": [
+        {
+          "relative_path": ["Library", "CloudStorage", "Dropbox"],
+          "names": [
+            "desktop.ini",
+            ".849C9593-D756-4E56-8D6E-42412F2A707B"
+          ]
+        }
+      ],
+      "expected_provider": "OneDrive"
+    },
+    {
+      "name": "ordinary folder",
+      "relative_path": ["ordinary", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": null
+    },
+    {
+      "name": "partial OneDrive child marker",
+      "relative_path": ["ordinary", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["ordinary"], "names": ["desktop.ini"]}
+      ],
+      "expected_provider": null
+    },
+    {
+      "name": "OneDrive substring is not a path segment match",
+      "relative_path": ["not-onedrive-backup", "Vault"],
+      "ancestor_children": [],
+      "expected_provider": null
+    },
+    {
+      "name": "unknown sync-like marker is honest unknown",
+      "relative_path": ["ordinary", "Vault"],
+      "ancestor_children": [
+        {"relative_path": ["ordinary"], "names": [".sync", "placeholder.cloud"]}
+      ],
+      "expected_provider": null
+    }
+  ]
+}

--- a/core/tests/sync-folder-detector.test.cjs
+++ b/core/tests/sync-folder-detector.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DETECTOR_PATH = path.join(
+  REPO_ROOT,
+  'core',
+  'migrations',
+  'sync-folder-detector.cjs',
+);
+const VECTOR_PATH = path.join(
+  REPO_ROOT,
+  'core',
+  'tests',
+  'fixtures',
+  'sync-folder-vectors.json',
+);
+
+function vectors() {
+  const document = JSON.parse(fs.readFileSync(VECTOR_PATH, 'utf8'));
+  assert.equal(document.schema_version, 1);
+  return document.vectors;
+}
+
+function buildVector(vector, index) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `dex-sync-vector-${index}-`));
+  const vault = path.join(root, ...vector.relative_path);
+  fs.mkdirSync(vault, { recursive: true });
+  for (const ancestor of vector.ancestor_children) {
+    const directory = path.join(root, ...ancestor.relative_path);
+    fs.mkdirSync(directory, { recursive: true });
+    for (const name of ancestor.names) {
+      fs.mkdirSync(path.join(directory, name));
+    }
+  }
+  return vault;
+}
+
+test('shared sync-folder vectors cover the data table and CommonJS reader', () => {
+  const detector = require(DETECTOR_PATH);
+  const { markers, cloudstorageProviderPrefixes } = detector.loadSyncFolderMarkers();
+  const expectedProviders = new Set(
+    vectors()
+      .map((vector) => vector.expected_provider)
+      .filter((provider) => provider !== null),
+  );
+  const declaredProviders = new Set(markers.map((marker) => marker.provider));
+  for (const entry of cloudstorageProviderPrefixes) {
+    declaredProviders.add(entry.provider);
+  }
+  assert.deepEqual([...expectedProviders].sort(), [...declaredProviders].sort());
+
+  for (const [index, vector] of vectors().entries()) {
+    assert.equal(
+      detector.detectSyncFolder(buildVector(vector, index)),
+      vector.expected_provider,
+      vector.name,
+    );
+  }
+});
+
+test('CommonJS sync-folder marker loader fails closed on missing or malformed data', () => {
+  const detector = require(DETECTOR_PATH);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-sync-marker-data-'));
+  const malformed = path.join(root, 'malformed.json');
+  fs.writeFileSync(malformed, '{"schema_version":2,"markers":[]}');
+
+  assert.throws(
+    () => detector.loadSyncFolderMarkers(path.join(root, 'missing.json')),
+    /sync-folder marker data/i,
+  );
+  assert.throws(
+    () => detector.loadSyncFolderMarkers(malformed),
+    /sync-folder marker data/i,
+  );
+});

--- a/core/tests/test_adoption_sqlite_snapshot.py
+++ b/core/tests/test_adoption_sqlite_snapshot.py
@@ -17,10 +17,14 @@ from core.lifecycle.sqlite_snapshot import (
     BACKUP_NAME,
     MANIFEST_NAME,
     SQLiteSnapshotError,
+    _load_sync_folder_markers,
     detect_sync_folder,
     restore_sqlite,
     snapshot_sqlite,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_VECTOR_PATH = REPO_ROOT / "core/tests/fixtures/sync-folder-vectors.json"
 
 
 def _sha256(path: Path) -> str:
@@ -46,6 +50,116 @@ def _create_database(path: Path, rows: int = 3) -> None:
         connection.commit()
     finally:
         connection.close()
+
+
+def _sync_vectors() -> list[dict[str, object]]:
+    document = json.loads(SYNC_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert document["schema_version"] == 1
+    return document["vectors"]
+
+
+def _build_sync_vector(tmp_path: Path, vector: dict[str, object], index: int) -> Path:
+    root = tmp_path / f"case-{index}"
+    relative_path = vector["relative_path"]
+    assert isinstance(relative_path, list)
+    vault = root.joinpath(*relative_path)
+    vault.mkdir(parents=True)
+    ancestor_children = vector["ancestor_children"]
+    assert isinstance(ancestor_children, list)
+    for ancestor in ancestor_children:
+        assert isinstance(ancestor, dict)
+        ancestor_path = ancestor["relative_path"]
+        names = ancestor["names"]
+        assert isinstance(ancestor_path, list)
+        assert isinstance(names, list)
+        directory = root.joinpath(*ancestor_path)
+        directory.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            assert isinstance(name, str)
+            (directory / name).mkdir()
+    return vault
+
+
+def test_shared_sync_folder_vectors_cover_the_data_table_and_python_reader(
+    tmp_path: Path,
+) -> None:
+    markers, provider_prefixes = _load_sync_folder_markers()
+    expected_providers = {
+        vector["expected_provider"]
+        for vector in _sync_vectors()
+        if vector["expected_provider"] is not None
+    }
+    declared_providers = {marker.provider for marker in markers}
+    declared_providers.update(provider for _, provider in provider_prefixes)
+    assert expected_providers == declared_providers
+
+    for index, vector in enumerate(_sync_vectors()):
+        vault = _build_sync_vector(tmp_path, vector, index)
+        assert detect_sync_folder(vault) == vector["expected_provider"], vector["name"]
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {},
+        {"schema_version": 2, "markers": [], "cloudstorage_provider_prefixes": []},
+        {"schema_version": 1, "markers": "not-a-list", "cloudstorage_provider_prefixes": []},
+        {
+            "schema_version": 1,
+            "markers": [{"provider": "Dropbox", "kind": "child", "values": []}],
+            "cloudstorage_provider_prefixes": [],
+        },
+    ],
+)
+def test_sync_folder_marker_loader_fails_closed_on_malformed_data(
+    tmp_path: Path,
+    document: dict[str, object],
+) -> None:
+    candidate = tmp_path / "markers.json"
+    candidate.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="sync-folder marker data"):
+        _load_sync_folder_markers(candidate)
+
+
+def test_sync_folder_marker_loader_fails_closed_when_data_is_missing(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RuntimeError, match="sync-folder marker data"):
+        _load_sync_folder_markers(tmp_path / "missing.json")
+
+
+def test_sync_folder_marker_failure_is_confined_to_detection() -> None:
+    script = """
+from pathlib import Path
+
+original_read_text = Path.read_text
+
+def refuse_marker_data(path, *args, **kwargs):
+    if path.name == "sync-folder-markers.json":
+        raise PermissionError("marker fixture is unreadable")
+    return original_read_text(path, *args, **kwargs)
+
+Path.read_text = refuse_marker_data
+import core.lifecycle.sqlite_snapshot as snapshot
+
+assert snapshot.MANIFEST_NAME == "manifest.json"
+try:
+    snapshot.detect_sync_folder(Path("."))
+except RuntimeError as error:
+    assert "sync-folder marker data" in str(error)
+else:
+    raise AssertionError("sync-folder detection did not fail closed")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_wal_snapshot_restores_all_committed_rows_without_touching_source_database_or_wal(

--- a/core/tests/test_install_convergence.py
+++ b/core/tests/test_install_convergence.py
@@ -101,10 +101,14 @@ exit 0
     return root, environment
 
 
-def _run_install(tmp_path: Path, scenario: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+def _run_install(
+    tmp_path: Path,
+    scenario: str,
+    *arguments: str,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     root, environment = _install_fixture(tmp_path, scenario)
     result = subprocess.run(
-        ["/bin/bash", "install.sh"],
+        ["/bin/bash", "install.sh", *arguments],
         cwd=root,
         env=environment,
         capture_output=True,
@@ -126,6 +130,16 @@ def test_fresh_git_install_routes_bounded_migration_through_auto_then_resume(tmp
     assert "Separating the Dex brain from your vault" in result.stdout
     assert "separate Git histories" in result.stdout
     assert "Dex installation complete" in result.stdout
+
+
+def test_synced_folder_install_carries_explicit_override_into_resume(tmp_path: Path) -> None:
+    result, calls = _run_install(tmp_path, "resume", "--allow-synced-folder")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert calls[1:3] == [
+        f"{MIGRATOR} --auto --allow-synced-folder",
+        f"{MIGRATOR} --resume --allow-synced-folder",
+    ]
 
 
 def test_already_split_install_is_safe_and_keeps_normal_setup_working(tmp_path: Path) -> None:

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -221,6 +221,14 @@ def test_rule_ids_are_unique_and_document_is_deterministic() -> None:
     )
 
 
+def test_sync_folder_marker_data_is_explicitly_release_owned() -> None:
+    resolution = portable_contract.resolve("core/data/sync-folder-markers.json")
+
+    assert resolution is not None
+    assert resolution.rule_id == "brain-sync-folder-markers"
+    assert resolution.ownership == "brain"
+
+
 # ---------------------------------------------------------------------------
 # The gate script: red-when-removed proofs in an isolated fixture repo
 # ---------------------------------------------------------------------------

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 9a910799d0a24ff1f0caa4d7c08be2ffbf268d3f232a8da901254d03798f3bd9 -->
+<!-- Content SHA-256: eaece4ef195792dbce16aae2ba722b510bb83bb3ecec57ee972a3789b0408c71 -->
 
 # Architecture Inventory
 
@@ -139,13 +139,13 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 | Class | Rule count | Update action |
 | --- | ---: | --- |
-| `brain` | 43 | `replace` |
+| `brain` | 44 | `replace` |
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 8 | `regenerate` |
 | `vault` | 17 | `never` |
 | `runtime` | 13 | `never` |
 
-<details><summary><code>brain</code> declared paths (43)</summary>
+<details><summary><code>brain</code> declared paths (44)</summary>
 
 - `.agents` (dir; `brain-agents`)
 - `.claude` (dir; `brain-claude`)
@@ -179,6 +179,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `System/Beta_Communications` (dir; `brain-beta-communications`)
 - `System/README.md` (file; `brain-system-readme`)
 - `core` (dir; `brain-core`)
+- `core/data/sync-folder-markers.json` (file; `brain-sync-folder-markers`)
 - `docs` (dir; `brain-docs`)
 - `install.sh` (file; `brain-install`)
 - `package-lock.json` (file; `brain-package-lock`)

--- a/install.sh
+++ b/install.sh
@@ -259,9 +259,22 @@ if [ ! -f "$MIGRATOR" ]; then
     exit 1
 fi
 
+MIGRATION_SYNC_FOLDER_ARGUMENT=""
+for INSTALL_ARGUMENT in "$@"; do
+    if [ "$INSTALL_ARGUMENT" = "--allow-synced-folder" ]; then
+        MIGRATION_SYNC_FOLDER_ARGUMENT="--allow-synced-folder"
+    fi
+done
+
 MIGRATION_MODE="--auto"
 while true; do
-    if node "$MIGRATOR" "$MIGRATION_MODE"; then
+    if [ -n "$MIGRATION_SYNC_FOLDER_ARGUMENT" ]; then
+        if node "$MIGRATOR" "$MIGRATION_MODE" "$MIGRATION_SYNC_FOLDER_ARGUMENT"; then
+            MIGRATION_STATUS=0
+        else
+            MIGRATION_STATUS=$?
+        fi
+    elif node "$MIGRATOR" "$MIGRATION_MODE"; then
         MIGRATION_STATUS=0
     else
         MIGRATION_STATUS=$?

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -688,6 +688,13 @@
       "ownership": "brain"
     },
     {
+      "id": "brain-sync-folder-markers",
+      "path": "core/data/sync-folder-markers.json",
+      "kind": "file",
+      "ownership": "brain",
+      "note": "shared release-owned sync-provider table consumed by Python and CommonJS"
+    },
+    {
       "id": "vault-mcp-custom",
       "path": "core/mcp-custom",
       "kind": "dir",

--- a/scripts/make-aged-vault-fixture.sh
+++ b/scripts/make-aged-vault-fixture.sh
@@ -38,6 +38,8 @@ git -C "$UPSTREAM" config user.email "fixture-builder@example.com"
 # Include the live migrator even while it is still uncommitted in this worktree.
 # The contract, tracked-ignore policy, and transition metadata come from v1.63.
 D1_FILES=(
+  core/data/sync-folder-markers.json
+  core/migrations/sync-folder-detector.cjs
   core/migrations/v1-to-v2-brain-vault-split.cjs
 )
 for relative in "${D1_FILES[@]}"; do


### PR DESCRIPTION
**Plain version:** if someone keeps their Dex folder in iCloud, Dropbox, OneDrive or Google Drive, the sync app is busy copying files at the same moment the one-time conversion is rebuilding the folder. That is a well-known way to end up with a half-copied mess. Dex now stops and explains the two safe options instead.

Blocking safety fix #2 of two, ahead of offering the split layout to existing users. Plan: `docs/plans/2026-07-23-brain-vault-existing-user-readiness.md` (Lane B).

## The gap

`detect_sync_folder()` already existed and is good — Dropbox markers, Apple's CloudStorage convention, OneDrive path and paired-folder identifiers, honest `None` when unsure. **The migrator never called it.** Its only consumer was the SQLite snapshot path.

It could not simply import it: the migrator is deliberately dependency-free CommonJS that must run before Python is guaranteed available.

## The fix

One versioned data file (`core/data/sync-folder-markers.json`) read by both the Python detector and a new CJS port, with **one shared vector fixture exercised from both languages** so a provider added to the table is proven in both by construction, not by two hand-maintained lists.

`detect_sync_folder()` behaviour is unchanged — the untouched `test_adoption_messy_vault_journey.py` proves it.

P0 refuses **before the lock is taken**, so a refused run leaves the vault byte-for-byte untouched: no `.dex/`, no report, no lock. `--restore` is exempt — recovery must work everywhere. Dry-run reports the provider rather than throwing, so the practice run warns first. `--allow-synced-folder` accepts the risk explicitly and is recorded in the journal and report.

## Stranding bug caught in review

The first cut read resume authorization from the command-line flag alone, ignoring the grant already in its own journal:

1. User in Dropbox runs `--auto --allow-synced-folder`.
2. P3 builds the vault commit in bounded batches → exit 75, needs resume.
3. `install.sh` loops back with a **bare `--resume`**.
4. Refused, exit 1 → install.sh treats non-zero as fatal → user stuck mid-conversion, every retry failing identically.

Reproduced directly: exit 1 while the journal recorded `allowedByOverride: true`. Precisely the half-converted state this programme exists to prevent.

**The flag is how consent is given; the journal is how it is remembered.** Resume now honours the recorded grant; a missing or `false` grant still refuses; `install.sh` carries the flag through its resume loop.

## Blast radius

Marker data loads lazily rather than at import, so a corrupt data file can no longer break importing the lifecycle engine — which would have taken out the recovery tools someone in trouble reaches for. Detection still fails closed.

## Verification

- 93 Python + 51 Node tests, including 28 integration journeys.
- Both new regression tests **confirmed to fail against the pre-fix code** (checked by mutation): the resume test goes red, while "still refuses without a grant" stays green.
- Refusal fixtures for Dropbox, iCloud and OneDrive assert the vault is byte-for-byte unchanged.
- Ruff, portable contract, architecture inventory, and all eight PR-only gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)