### PR TITLE
feat(skills): add /commitments — reconcile promises & asks into tracked tasks (overhaul PR-9)

### DIFF
--- a/.claude/skills/commitments/SKILL.md
+++ b/.claude/skills/commitments/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: commitments
+description: "Reconcile the promises you made and the asks you received across meetings and notes into a clear owner/due/source list, then — only with your confirmation — turn the real ones into tracked tasks. Use when the user says 'what did I promise', 'what am I on the hook for', 'anything I owe people', 'loose ends', or after a run of meetings. Also use proactively during daily-plan/daily-review when uncaptured commitments surface. Not for tracking work you handed off to others; use `delegate-check`. Not for recording a decision you made; use `decision-log`."
+---
+
+# /commitments
+
+Small interpersonal promises are where trust is won or lost — "I'll send that over," "can you review this?" — and they evaporate because they never become tracked commitments. This skill surfaces them from what you already captured, and turns the real ones into tasks **only when you say so**.
+
+Governing rule: **do not rebuild the data layer.** The Work MCP already ships the scanner — `get_commitments_due` reads recent meeting notes and person-page action items and returns them bucketed by due date. This skill is a thin **present → confirm → create** layer on top of it. It does not re-scan, add a store, or touch the extraction logic.
+
+---
+
+## Arguments
+
+`$RANGE`: optional — `today` (default), `this-week`, or `all`. Maps to the tool's `date_range`.
+
+## Step 1 — Scan (existing tool, don't reinvent)
+
+Call `get_commitments_due(date_range=$RANGE)`. It returns `commitments_due_today`, `commitments_due_this_week`, and `commitments_no_date` — each item carries `commitment`, `due_date`, `source` (the meeting file or person page), and, for person-page items, `to_person`.
+
+If `get_commitments_due` returns a `feature_status` other than `ok`, follow the standard contract (surface the tool's `user_message`; never invent a result). If it errors or the Work MCP is unavailable, say so plainly and stop — do not fabricate a commitments list.
+
+**Optional enrichment (degrades silently):** if ScreenPipe is active and opted-in, you may also fold in the `commitment-scan` (agent skill) results as an extra source. If ScreenPipe is absent — the normal case — skip it entirely and say nothing about it. The shipped skill must never depend on the beta.
+
+## Step 2 — Dedup against existing tasks
+
+For each candidate, check it isn't already a task before showing it (Work MCP's `create_task` similarity gate is the backstop, but pre-filtering means the user isn't asked about things already captured). Drop obvious duplicates; keep near-matches but mark them "possibly already tracked."
+
+## Step 3 — Present, grouped by direction
+
+Show two short lists so the user sees both sides of the ledger:
+
+- **Promises you made** (outbound — you owe someone)
+- **Asks you received** (inbound — someone owes you, or asked you to do something)
+
+Direction is **inferred** from phrasing and `to_person`, not a field the scanner provides — so when a commitment's direction is genuinely unclear, put it under a third **Unclear** heading rather than guessing wrong. Each row shows: the commitment, the person (by name), the `source` (meeting or person page, by name), and the `due_date` (or "no date"). Refer to people and sources by name, never by id or file path noise.
+
+If nothing is found, say so plainly ("No open commitments surfaced from the last two weeks of meetings and your person pages") — do not pad the list.
+
+## Step 4 — Confirm before creating (hard gate — never auto-create)
+
+Nothing is written without the user's say-so. Offer, per item, three choices: **create a task** / **already handled** / **not a real commitment**. Only the items the user picks become tasks. This is the no-write-without-authority discipline — do not batch-create, and do not create anything the user didn't confirm.
+
+## Step 5 — Create, then inspect before claiming done
+
+For each confirmed item, call Work MCP `create_task` (infer the pillar per the CLAUDE.md pillar-inference rules; carry the `source` into the task context so the commitment stays traceable). Then **read back what was created** — confirm each task ID and title — before reporting. Say exactly what you made: "Created 3 tasks: [task-…] …, [task-…] …". Never report "done / captured" without the created task IDs in hand. If a `create_task` call fails or is deduped as an existing task, say that honestly for that item rather than counting it as created.
+
+---
+
+## Quality bar
+
+A good run reflects **only real, still-open commitments**, splits them into what the user owes vs is owed, creates **exactly** the tasks the user confirmed, and reports them back by their real task IDs. The user should never be surprised by a task they didn't approve, nor told something was captured that wasn't.
+
+## Anti-patterns (do not do these)
+
+- **Auto-creating tasks** from the scan without per-item confirmation.
+- **Guessing direction** (made vs received) when the phrasing is ambiguous — use the Unclear group instead.
+- **Re-implementing the scan** — inventing a new commitment store or extraction logic instead of calling `get_commitments_due`.
+- **Depending on ScreenPipe** — the skill must work fully without it; enrichment is optional and silent when absent.
+- **Claiming "captured / done"** without reading back the created task IDs.
+- Padding an empty result with vague "maybe follow up on…" filler.
+
+## Degradation
+
+- `get_commitments_due` unavailable / errors → say so and stop; never fabricate commitments.
+- ScreenPipe / `commitment-scan` absent → skip silently; the vault scan alone is the product.
+- A `create_task` call fails → report that item as not created; do not silently count it.
+
+---
+
+## Track Usage (Silent)
+
+Update `System/usage_log.md` to mark commitments review as used. **Analytics (Silent):** call `track_event` with event_name `commitments_reviewed` and property `created_count` (the number of tasks actually created — no commitment text, no names). Fires only if the user opted into analytics; no action if it returns "analytics_disabled".

--- a/.claude/skills/commitments/evals/trigger-cases.yaml
+++ b/.claude/skills/commitments/evals/trigger-cases.yaml
@@ -1,0 +1,45 @@
+# Trigger evals for /commitments.
+# Shape every shipped skill carries:
+#   3 positive paraphrases  — MUST fire this skill
+#   2 negative / collision  — MUST NOT fire; must route to the named neighbor
+#   1 ambiguous             — should ASK rather than silently fire
+#   1 missing-prerequisite  — should degrade honestly, not fake a result
+#   1 failure-recovery      — must not claim success when the underlying action failed
+#
+# `expect: fire` / `no-fire` / `ask` / `degrade` / `honest-failure`.
+# `route_to` names where a no-fire case should go instead.
+
+skill: commitments
+
+positive:
+  - utterance: "What did I promise people this week?"
+    expect: fire
+  - utterance: "Anything I'm on the hook for / owe anyone?"
+    expect: fire
+  - utterance: "Help me catch the loose ends from my last few meetings."
+    expect: fire
+
+negative:
+  - utterance: "What did I delegate, and who owes me an update on it?"
+    expect: no-fire
+    route_to: delegate-check
+    why: delegations flow the other way — work you handed off — which delegate-check tracks; commitments are what you personally owe or are owed.
+  - utterance: "Record the decision we made to go with the annual pricing plan."
+    expect: no-fire
+    route_to: decision-log
+    why: capturing a decision + rationale is decision-log, not a promise/ask to reconcile.
+
+ambiguous:
+  - utterance: "Follow up on the Acme thing."
+    expect: ask
+    why: unclear whether they mean an open commitment, a delegated item, or prepping a meeting — ask what "the Acme thing" is before firing.
+
+missing_prerequisite:
+  - utterance: "What am I on the hook for?"  # Work MCP / get_commitments_due unavailable
+    expect: degrade
+    why: the commitments scanner can't run — say so plainly and stop; never fabricate a commitments list.
+
+failure_recovery:
+  - utterance: "Turn all of those into tasks."  # a create_task call fails / is deduped
+    expect: honest-failure
+    why: report the item that failed or was already a task as NOT created; never count it toward "done" or claim tasks that weren't written.

--- a/core/tests/test_commitments_skill.py
+++ b/core/tests/test_commitments_skill.py
@@ -1,0 +1,81 @@
+"""Contract tests for the /commitments skill.
+
+The skill is a thin present -> confirm -> create layer over the EXISTING
+Work-MCP `get_commitments_due` scanner. These tests lock the load-bearing
+promises: it composes the existing tool (does not rebuild the data layer),
+never auto-creates tasks, degrades honestly, and routes cleanly against its
+nearest neighbors.
+"""
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".claude/skills/commitments/SKILL.md"
+EVALS = ROOT / ".claude/skills/commitments/evals/trigger-cases.yaml"
+
+
+def _frontmatter_description() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    fm = text.split("---\n", 2)[1]
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError("no description in frontmatter")
+
+
+def test_commitments_skill_exists_with_evals() -> None:
+    assert SKILL.is_file()
+    assert EVALS.is_file()
+
+
+def test_description_is_a_router_with_when_and_anti_triggers() -> None:
+    desc = _frontmatter_description().lower()
+    # WHEN trigger with real user phrasing.
+    assert "when the user says" in desc
+    # Anti-triggers naming the true nearest neighbors.
+    assert "delegate-check" in desc
+    assert "decision-log" in desc
+
+
+def test_body_composes_existing_scanner_and_does_not_rebuild_it() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    # Uses the existing Work-MCP tool by name...
+    assert "get_commitments_due" in text
+    # ...and explicitly refuses to rebuild the data layer.
+    assert "do not rebuild the data layer" in text.lower()
+
+
+def test_confirm_before_create_hard_gate_is_present() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    # No task write without per-item authority, and it precedes the create step.
+    assert "confirm before creating" in text
+    assert "never auto-create" in text
+    confirm = text.index("confirm before creating")
+    create = text.index("create, then inspect")
+    assert confirm < create
+
+
+def test_degrades_honestly_without_fabricating() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    # Tool unavailable -> stop, never invent a list.
+    assert "never fabricate" in text or "do not fabricate" in text
+    # ScreenPipe enrichment is optional and silent, never a dependency.
+    assert "screenpipe" in text
+    assert "must never depend on the beta" in text
+
+
+def test_inspects_output_before_claiming_done() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "read back what was created" in text
+    assert "task id" in text
+
+
+@pytest.mark.parametrize(
+    "needle",
+    ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],
+)
+def test_evals_carry_the_canonical_case_buckets(needle: str) -> None:
+    text = EVALS.read_text(encoding="utf-8")
+    assert needle in text

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: cde580101a896bd756f52c699fe9df5af9fc7d02d40c85265ec39f8f2109f5fe -->
+<!-- Content SHA-256: 4b9e89f2bd3464171a9d4c0f3efcdd8bb117b2bd08950e732296241314aea502 -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 70<br>
+**Skill count:** 71<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -49,6 +49,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `anthropic-xlsx` | `.claude/skills/anthropic-xlsx/SKILL.md` | Comprehensive spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization. When Claude needs to work with spreadsheets (.xlsx, .xlsm, .csv, .tsv, etc) for: (1) Creating new spreadsheets with formulas and formatting, (2) Reading or analyzing data, (3) Modify existing spreadsheets while preserving formulas, (4) Data analysis and visualization in spreadsheets, or (5) Recalculating formulas | 445 | when |
 | `atlassian-setup` | `.claude/skills/atlassian-setup/SKILL.md` | Connect Jira and Confluence for project tracking and knowledge search. Use when the user says 'connect Jira', 'hook up Confluence', 'my tickets/board'. Not for a personal task app like Todoist/Things/Trello; use `todoist-setup`/`things-setup`/`trello-setup`. | 258 | when |
 | `calendar-setup` | `.claude/skills/calendar-setup/SKILL.md` | Grant Python calendar access for ~30x faster calendar queries. Use when the user says 'connect my calendar', 'calendar is slow', 'set up calendar access'. Not for connecting Google Workspace as a whole; use `google-workspace-setup`. | 232 | when |
+| `commitments` | `.claude/skills/commitments/SKILL.md` | Reconcile the promises you made and the asks you received across meetings and notes into a clear owner/due/source list, then — only with your confirmation — turn the real ones into tracked tasks. Use when the user says 'what did I promise', 'what am I on the hook for', 'anything I owe people', 'loose ends', or after a run of meetings. Also use proactively during daily-plan/daily-review when uncaptured commitments surface. Not for tracking work you handed off to others; use `delegate-check`. Not for recording a decision you made; use `decision-log`. | 554 | when |
 | `create-mcp` | `.claude/skills/create-mcp/SKILL.md` | Build a brand-new MCP integration from scratch with a guided wizard. Use when the user wants Dex to talk to a tool that has no existing server — 'build an integration for X', 'Dex can't connect to Y yet'. Not for installing an MCP that already exists; use `integrate-mcp`. Not for a prompt-only workflow with no external tool; use `create-skill`. | 346 | when |
 | `create-skill` | `.claude/skills/create-skill/SKILL.md` | Author a new Dex skill — a reusable `/command` — that actually fires and passes the quality bar. Runs a collision check, classifies the shape, writes a router-grade description, generates the real package (SKILL.md + evals), and grades it with `skill-score` before calling it done. Use when the user says 'make a skill', 'I want a /command for X', 'turn this into a skill'. A skill the user builds for themselves is saved as `-custom` (protected from updates) and coached, never blocked; a first-party skill is held to the hard gate. Not for connecting an external tool; use `create-mcp`. Not for grading a skill that already exists; use `skill-score`. | 652 | when |
 | `daily-plan` | `.claude/skills/daily-plan/SKILL.md` | Build today's plan from calendar, tasks, priorities and commitments, with smart scheduling suggestions. Use when the user says 'plan my day', 'what's on today', 'help me focus', or starts the morning. Also use proactively at the first session of the day. Not for reviewing a finished day; use `daily-review`. | 308 | when |
@@ -108,7 +109,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
-| `dex-analytics` | 25 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
+| `dex-analytics` | 26 | **over-surfaced** | `commitments` (`track_event`); `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
 | `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `getting-started` (`calendar_get_events`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |
@@ -116,7 +117,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | `dex-onboarding-mcp` | 1 | normal | `getting-started` (`check_onboarding_complete`) |
 | `dex-resume-mcp` | 0 | **under-surfaced** | — |
 | `dex-session-memory` | 0 | **under-surfaced** | — |
-| `dex-work-mcp` | 7 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
+| `dex-work-mcp` | 8 | normal | `commitments` (`create_task`, `get_commitments_due`); `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
 
 ### Under-surfaced servers
 
@@ -126,7 +127,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 ### Over-surfaced servers
 
-- `dex-analytics` — 25 skills reference its tools.
+- `dex-analytics` — 26 skills reference its tools.
 
 ## Portable ownership classes
 


### PR DESCRIPTION
## What & why

Ships the **founder wedge** from the overhaul synthesis. Small interpersonal promises — *"I'll send that over," "can you review this?"* — are where trust is won or lost, and they evaporate because they never become tracked commitments. `/commitments` surfaces them from what the user already captured and turns the real ones into tasks **only on confirmation**.

Picked by evidence: measurement (`skill-score --all`) shows the routing/consolidation surface is essentially closed after #184 — only 4 discoverability-risks remain (3 vendored Anthropic + `review`), and the only ≥0.6 collision is a benign lexical artifact. So the highest-value remaining clean PR is net-new founder capability, and this is the self-contained, ratified-design one with no frozen-contract risk.

## Design: thin layer, no data-layer rebuild

`/commitments` is a **present → confirm → create** layer over the **existing** Work-MCP `get_commitments_due` scanner (meetings + person-page action items). It does not re-scan, add a store, or touch extraction logic.

- **Scan** via `get_commitments_due`; honours the `feature_status` contract; refuses to fabricate a list if the tool is unavailable.
- **Present grouped by direction** — promises made vs asks received — with direction **inferred** (an *Unclear* bucket when phrasing is ambiguous), because the scanner doesn't label direction. Deliberately does not over-claim a field that isn't there.
- **Hard gate: never auto-creates.** Per-item confirm (create / already handled / not a real commitment), then **reads back the created task IDs** before claiming done.
- **Optional ScreenPipe/`commitment-scan` enrichment that degrades silently** — the vault scan alone is the shipped product; no beta dependency.
- **Anti-triggers** `delegate-check` (work handed off) and `decision-log` (recording a decision).

## Files

- `.claude/skills/commitments/SKILL.md` — the skill (71-line thin body).
- `.claude/skills/commitments/evals/trigger-cases.yaml` — 8 canonical cases (3 positive / 2 negative→delegate-check,decision-log / ambiguous / missing-prereq / failure-recovery).
- `core/tests/test_commitments_skill.py` — contract test: compose-not-rebuild, confirm-before-create precedes create, honest degradation, inspects output, clean routing.
- `docs/architecture/INVENTORY.md` — regenerated.

## Verification

- **`skill-score`: ~100 → SHIP.** All four hard gates pass (G1 nearest neighbour 0.15; G2 confirmation gate present; G3 no external sink; G4 inspects output). Tier-1 60/60, generative Tier-2 12/12. No routing collision ≥0.6. All 8 eval cases pass.
- **Gates green:** doc-drift, path-contract, test-delta, portable-contract (1108 paths, dist in sync), security, pii, founder-content, path-consistency, architecture-inventory drift.
- **Tests green:** `test_commitments_skill` (11), `test_skill_integrity` (103, auto-covers the new skill), frontmatter validator clean.

## Reviewer notes

- The promises/asks **direction split is a presentation heuristic**, not a scanner field — flagged in the body and the Unclear bucket keeps it honest. If you'd prefer a single reconciled list, easy to collapse.
- `commitments` vs `delegate-check` boundary: commitments = what *you* owe or are owed; delegate-check = work you *handed off*. Both anti-trigger each other; measured proximity is well under the collision threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)