### PR TITLE
feat(entities): JS↔Python write bridge + never-lose-a-write reliability (engine 3B bridge)

### DIFF
--- a/.claude/hooks/paths.cjs
+++ b/.claude/hooks/paths.cjs
@@ -60,6 +60,7 @@ function loadPaths() {
     CONTACTS_STATE_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'contacts.json'),
     GARDENER_STATE_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'gardener.json'),
     ENTITY_SUGGESTIONS_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'entity-suggestions.json'),
+    ENTITY_PENDING_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'entity-pending.json'),
     ENTITY_VERIFICATION_FILE: path.join(VAULT_ROOT, 'System', '.dex', 'entity-verification.json'),
   };
 }

--- a/.claude/hooks/post-meeting-person-update.cjs
+++ b/.claude/hooks/post-meeting-person-update.cjs
@@ -9,9 +9,13 @@ const path = require('path');
 const yaml = require('js-yaml');
 const {
   parseEntityPage,
-  replaceMachineRegionInFile,
-  upsertFrontmatter,
 } = require('../../.scripts/lib/entity-pages.cjs');
+const {
+  flushEntityOps,
+} = require('../../.scripts/lib/entity-engine-client.cjs');
+const {
+  identityForEntity,
+} = require('../../.scripts/lib/entity-identity.cjs');
 const { loadPaths } = require('./paths.cjs');
 
 const DEBUG_SKIP = process.env.DEX_HOOK_DEBUG === '1';
@@ -113,20 +117,6 @@ function meetingTitle(metadata) {
   return heading ? heading[1].trim() : path.basename(filePath, '.md').replace(/_/g, ' ');
 }
 
-function appendLegacyInteraction(personPath, line) {
-  const original = fs.readFileSync(personPath, 'utf8');
-  const headings = [/^## Recent Interactions\s*$/m, /^## Recent Meetings\s*$/m, /^## Meetings\s*$/m];
-  for (const heading of headings) {
-    const match = heading.exec(original);
-    if (!match) continue;
-    const insertion = match.index + match[0].length;
-    const suffix = original.slice(insertion);
-    fs.writeFileSync(personPath, `${original.slice(0, insertion)}\n${line}${suffix.startsWith('\n') ? '' : '\n'}${suffix}`);
-    return;
-  }
-  fs.writeFileSync(personPath, `${original.replace(/\s*$/, '')}\n\n${line}\n`);
-}
-
 const metadata = frontmatter(content);
 const extracted = attendeeNames(metadata);
 const names = extracted.length > 0 ? extracted : wikilinkNames(content);
@@ -137,6 +127,7 @@ const relativeMeetingPath = path.relative(vaultRoot, filePath).split(path.sep).j
 const date = meetingDate(metadata);
 const interaction = `- [${meetingTitle(metadata)}](${relativeMeetingPath}) — ${date}`;
 const seen = new Set();
+const ops = [];
 
 try {
   for (const name of fallbackNames) {
@@ -155,26 +146,26 @@ try {
     if (original.includes(relativeMeetingPath)) continue;
     const entity = parseEntityPage(personPath);
     if (entity.quarantined) continue;
-
-    if (original.includes('<!-- dex:auto:recent-interactions -->')) {
-      const region = /<!-- dex:auto:recent-interactions -->\r?\n?([\s\S]*?)<!-- \/dex:auto -->/.exec(original);
-      const existing = region
-        ? region[1].split(/\r?\n/).map((line) => line.trim()).filter((line) => line.startsWith('- '))
-        : [];
-      const newestFirst = [interaction, ...existing].sort((left, right) => {
-        const leftDate = left.match(/\d{4}-\d{2}-\d{2}\s*$/)?.[0] || '';
-        const rightDate = right.match(/\d{4}-\d{2}-\d{2}\s*$/)?.[0] || '';
-        return rightDate.localeCompare(leftDate);
-      });
-      replaceMachineRegionInFile(personPath, 'recent-interactions', newestFirst.slice(0, 20).join('\n'));
-    } else {
-      appendLegacyInteraction(personPath, interaction);
-    }
-
-    if (!entity.last_interaction || date > entity.last_interaction) {
-      upsertFrontmatter(personPath, { last_interaction: date });
-    }
+    ops.push({
+      op: 'mutate',
+      path: personPath,
+      entity_identity: identityForEntity(entity),
+      intent: {
+        kind: 'hook-interaction',
+        interaction: {
+          path: relativeMeetingPath,
+          line: interaction,
+          date,
+        },
+      },
+    });
   }
+  const write = flushEntityOps({
+    vaultRoot,
+    ops,
+    scope: 'hook',
+  });
+  if (!write.ok) skip(`entity-write-pending:${write.error || 'retry queued'}`);
 } catch (error) {
   skip(`unexpected-error:${error.message}`);
 }

--- a/.claude/hooks/tests/post-meeting-person-update.test.cjs
+++ b/.claude/hooks/tests/post-meeting-person-update.test.cjs
@@ -5,6 +5,10 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const {
+  installEntityEngineStub,
+} = require('../../../.scripts/lib/tests/entity-engine-test-helper.cjs');
+
 const HOOK = path.resolve(__dirname, '../post-meeting-person-update.cjs');
 
 function createVault(t) {
@@ -16,19 +20,23 @@ function createVault(t) {
     '05-Areas/People/CPO_Network',
     '05-Areas/Companies',
   ]) fs.mkdirSync(path.join(vault, directory), { recursive: true });
+  installEntityEngineStub(vault);
   t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
   return vault;
 }
 
-function runHook(vault, payload) {
+function runHook(vault, payload, extraEnv = {}) {
   return spawnSync(process.execPath, [HOOK], {
     cwd: vault,
     encoding: 'utf8',
     env: {
+      ...process.env,
       CLAUDE_PROJECT_DIR: vault,
       DEX_HOOK_DEBUG: '1',
+      DEX_PYTHON: path.join(vault, 'entity-engine-test-python'),
       PATH: '/usr/bin:/bin',
       VAULT_PATH: vault,
+      ...extraEnv,
     },
     input: typeof payload === 'string' ? payload : JSON.stringify(payload),
   });
@@ -102,6 +110,68 @@ test('a second run is idempotent', (t) => {
   const once = fs.readFileSync(person, 'utf8');
   runHook(vault, { tool_input: { file_path: meeting } });
   assert.equal(fs.readFileSync(person, 'utf8'), once);
+});
+
+test('an unavailable engine leaves the page unchanged and persists a retry', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  const original = personPage('Alice Smith');
+  fs.writeFileSync(person, original);
+  const meeting = meetingNote(vault);
+
+  const result = runHook(
+    vault,
+    { tool_input: { file_path: meeting } },
+    { DEX_PYTHON: '/definitely/missing/dex-python' },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(person, 'utf8'), original);
+  const pending = JSON.parse(fs.readFileSync(
+    path.join(vault, 'System', '.dex', 'entity-pending.json'),
+    'utf8',
+  ));
+  assert.equal(pending.batches[0].scope, 'hook');
+  assert.equal(pending.batches[0].ops.length, 1);
+});
+
+test('a deferred interaction rematerializes after a page edit and then lands', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  const original = personPage('Alice Smith');
+  fs.writeFileSync(person, original);
+  const meeting = meetingNote(vault);
+  const pendingPath = path.join(vault, 'System', '.dex', 'entity-pending.json');
+
+  assert.equal(runHook(
+    vault,
+    { tool_input: { file_path: meeting } },
+    { DEX_PYTHON: '/definitely/missing/dex-python' },
+  ).status, 0);
+  const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf8'));
+  assert.deepEqual(pending.batches[0].ops[0].intent, {
+    kind: 'hook-interaction',
+    interaction: {
+      path: '00-Inbox/Meetings/roadmap.md',
+      line: '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10',
+      date: '2026-07-10',
+    },
+  });
+  assert.equal(Object.hasOwn(pending.batches[0].ops[0], 'base_fingerprint'), false);
+  pending.batches[0].ops[0].next_attempt_at = '2026-01-01T00:00:00.000Z';
+  fs.writeFileSync(pendingPath, `${JSON.stringify(pending, null, 2)}\n`);
+
+  fs.writeFileSync(
+    person,
+    original.replace('## Recent Interactions', 'A user-authored note.\n\n## Recent Interactions'),
+  );
+  assert.equal(runHook(vault, { tool_input: { file_path: meeting } }).status, 0);
+
+  const updated = fs.readFileSync(person, 'utf8');
+  assert.match(updated, /A user-authored note\./);
+  assert.match(updated, /\[Roadmap Review\]\(00-Inbox\/Meetings\/roadmap\.md\) — 2026-07-10/);
+  assert.match(updated, /last_interaction: '2026-07-10'/);
+  assert.equal(fs.existsSync(pendingPath), false);
 });
 
 test('non-meeting paths and malformed stdin exit zero without changes', (t) => {

--- a/.scripts/lib/dex-python.cjs
+++ b/.scripts/lib/dex-python.cjs
@@ -1,0 +1,103 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+
+const capabilityCache = new Map();
+const CAPABILITY_CODE = 'import yaml,sys; assert sys.version_info >= (3,10)';
+
+function isExecutableFile(candidate) {
+  if (!candidate || !path.isAbsolute(candidate)) return false;
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return fs.statSync(candidate).isFile();
+  } catch (_) {
+    return false;
+  }
+}
+
+function capability(candidate, spawnSync = childProcess.spawnSync) {
+  if (capabilityCache.has(candidate)) return capabilityCache.get(candidate);
+  let result;
+  try {
+    const probe = spawnSync(candidate, ['-c', CAPABILITY_CODE], {
+      encoding: 'utf8',
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+    });
+    result = probe.status === 0 && !probe.error
+      ? { ok: true, detail: null }
+      : {
+        ok: false,
+        detail: probe.error?.message
+          || String(probe.stderr || '').trim()
+          || `capability probe exited ${probe.status}`,
+      };
+  } catch (error) {
+    result = { ok: false, detail: error.message };
+  }
+  capabilityCache.set(candidate, result);
+  return result;
+}
+
+function ready(pathname) {
+  return {
+    path: pathname,
+    feature: 'Entity engine Python',
+    feature_status: 'ok',
+    success: true,
+    user_message: 'The entity engine Python interpreter is ready.',
+  };
+}
+
+function broken(candidate, detail) {
+  return {
+    path: null,
+    feature: 'Entity engine Python',
+    feature_status: 'broken',
+    success: false,
+    user_message: `DEX_PYTHON must use Python 3.10 or newer with PyYAML installed. `
+      + `Fix ${candidate}, then run /dex-doctor.`,
+    detail,
+  };
+}
+
+function resolveDexPythonStatus(
+  vaultRoot,
+  env = process.env,
+  spawnSync = childProcess.spawnSync,
+) {
+  const configured = typeof env.DEX_PYTHON === 'string'
+    ? env.DEX_PYTHON.trim()
+    : '';
+  if (isExecutableFile(configured)) {
+    const probe = capability(configured, spawnSync);
+    return probe.ok ? ready(configured) : broken(configured, probe.detail);
+  }
+
+  const virtualenv = path.join(path.resolve(vaultRoot), '.venv', 'bin', 'python');
+  if (isExecutableFile(virtualenv)) {
+    const probe = capability(virtualenv, spawnSync);
+    return probe.ok ? ready(virtualenv) : broken(virtualenv, probe.detail);
+  }
+  return {
+    path: null,
+    feature: 'Entity engine Python',
+    feature_status: 'not_installed',
+    success: false,
+    user_message: 'Entity writes are paused because no safe Dex Python is available. '
+      + 'Restore the vault .venv or set DEX_PYTHON to Python 3.10+ with PyYAML, '
+      + 'then run /dex-doctor.',
+  };
+}
+
+function resolveDexPython(vaultRoot, env = process.env) {
+  return resolveDexPythonStatus(vaultRoot, env).path;
+}
+
+module.exports = {
+  CAPABILITY_CODE,
+  resolveDexPython,
+  resolveDexPythonStatus,
+};

--- a/.scripts/lib/entity-engine-client.cjs
+++ b/.scripts/lib/entity-engine-client.cjs
@@ -1,0 +1,1138 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { loadPaths } = require('../../.claude/hooks/paths.cjs');
+const { resolveDexPythonStatus } = require('./dex-python.cjs');
+const { resolveEntityPath } = require('./entity-identity.cjs');
+const {
+  mergeFrontmatterText,
+  parseEntityPage,
+  replaceMachineRegion,
+} = require('./entity-pages.cjs');
+
+const STORE_VERSION = 1;
+const LOCK_RETRIES = 20;
+const LOCK_DELAY_MS = 50;
+const LOCK_STALE_MS = 30_000;
+const MAX_ATTEMPTS = 5;
+const MAX_TARGET_MISSING_ATTEMPTS = 5;
+const MAX_TRANSIENT_ATTEMPTS = 15;
+const MAX_TRANSIENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const BACKOFF_BASE_MS = 30 * 60 * 1000;
+const BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
+const CLI_CHUNK_SIZE = 50;
+const REGION_HEADINGS = {
+  'recent-interactions': 'Recent Interactions',
+  'key-contacts': 'Key Contacts',
+  'meeting-history': 'Meeting History',
+  'context-summary': 'Key Context',
+  'related-tasks': 'Related Tasks',
+  relationships: 'Relationships',
+  'update-log': 'Update Log',
+};
+const REGION_ORDER = [
+  'recent-interactions',
+  'key-contacts',
+  'meeting-history',
+  'context-summary',
+  'related-tasks',
+  'relationships',
+  'update-log',
+  'page-metadata',
+];
+const CLI_KEYS = new Set([
+  'op',
+  'path',
+  'content',
+  'allowed_root',
+  'base_fingerprint',
+  'replacement_content',
+  'field_changes',
+  'ensure_regions',
+  'region_projections',
+]);
+const deadLetterIndexCache = new Map();
+
+function pendingStorePath(vaultRoot) {
+  const configured = loadPaths();
+  const configuredRoot = path.resolve(configured.VAULT_ROOT);
+  const configuredPending = configured.ENTITY_PENDING_FILE
+    || path.join(configured.DEX_RUNTIME_DIR, 'entity-pending.json');
+  const relative = path.relative(
+    configuredRoot,
+    path.resolve(configuredPending),
+  );
+  return path.join(path.resolve(vaultRoot), relative);
+}
+
+function deadLetterPath(vaultRoot) {
+  return path.join(
+    path.dirname(pendingStorePath(vaultRoot)),
+    'entity-dead-letter.jsonl',
+  );
+}
+
+function loadDeadLetters(vaultRoot) {
+  try {
+    return fs.readFileSync(deadLetterPath(vaultRoot), 'utf8')
+      .split(/\r?\n/)
+      .filter(line => line.trim())
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line)];
+        } catch (_) {
+          return [];
+        }
+      });
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+function deadLetterFileSignature(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    return `${stat.size}:${stat.mtimeMs}`;
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+function fingerprintText(value) {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function batchId(scope, ops, meetingIds) {
+  return crypto.createHash('sha256').update(JSON.stringify(stableValue({
+    scope,
+    ops,
+    meeting_ids: [...new Set(meetingIds)].sort(),
+  }))).digest('hex');
+}
+
+function emptyStore() {
+  return { version: STORE_VERSION, batches: [] };
+}
+
+function loadPendingStore(vaultRoot) {
+  const filePath = pendingStorePath(vaultRoot);
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (parsed?.version !== STORE_VERSION || !Array.isArray(parsed.batches)) {
+      throw new Error(`Unsupported entity pending store: ${filePath}`);
+    }
+    return parsed;
+  } catch (error) {
+    if (error.code === 'ENOENT') return emptyStore();
+    throw error;
+  }
+}
+
+function atomicWriteJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporary = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    try { fs.unlinkSync(temporary); } catch (_) { /* already absent */ }
+    throw error;
+  }
+}
+
+function atomicWriteText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporary = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, value, 'utf8');
+    fs.renameSync(temporary, filePath);
+  } catch (error) {
+    try { fs.unlinkSync(temporary); } catch (_) { /* already absent */ }
+    throw error;
+  }
+}
+
+function savePendingStore(vaultRoot, store) {
+  const filePath = pendingStorePath(vaultRoot);
+  if (store.batches.length === 0) {
+    try { fs.unlinkSync(filePath); } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    return;
+  }
+  atomicWriteJson(filePath, store);
+}
+
+function wait(milliseconds) {
+  const buffer = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(buffer), 0, 0, milliseconds);
+}
+
+function withPendingLock(vaultRoot, callback) {
+  const filePath = pendingStorePath(vaultRoot);
+  const lockPath = `${filePath}.lock`;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  let handle;
+  for (let attempt = 0; attempt <= LOCK_RETRIES; attempt += 1) {
+    try {
+      handle = fs.openSync(lockPath, 'wx');
+      fs.writeFileSync(handle, `${process.pid}\n${new Date().toISOString()}\n`);
+      break;
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      try {
+        if (Date.now() - fs.statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch (statError) {
+        if (statError.code === 'ENOENT') continue;
+        throw statError;
+      }
+      if (attempt === LOCK_RETRIES) {
+        throw new Error(`Timed out waiting for lock: ${lockPath}`);
+      }
+      wait(LOCK_DELAY_MS);
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    if (handle !== undefined) fs.closeSync(handle);
+    try { fs.unlinkSync(lockPath); } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+}
+
+function cliOperation(operation) {
+  return Object.fromEntries(
+    Object.entries(operation).filter(([key]) => CLI_KEYS.has(key)),
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function regionRank(slug) {
+  const rank = REGION_ORDER.indexOf(slug);
+  return rank < 0 ? REGION_ORDER.length : rank;
+}
+
+function ensureRegion(text, slug) {
+  if (text.includes(`<!-- dex:auto:${slug} -->`)) return text;
+  const heading = REGION_HEADINGS[slug] || slug.replace(/-/g, ' ')
+    .replace(/\b\w/g, character => character.toUpperCase());
+  const headingMatch = new RegExp(
+    `^##[ \\t]+${escapeRegExp(heading)}[ \\t]*$`,
+    'm',
+  ).exec(text);
+  const managed = `<!-- dex:auto:${slug} -->\n<!-- /dex:auto -->`;
+  if (headingMatch) {
+    const prefix = text.slice(0, headingMatch.index + headingMatch[0].length)
+      .replace(/[\r\n]+$/, '');
+    const suffix = text.slice(headingMatch.index + headingMatch[0].length)
+      .replace(/^[\r\n]+/, '');
+    return suffix
+      ? `${prefix}\n\n${managed}\n\n${suffix}`
+      : `${prefix}\n\n${managed}\n`;
+  }
+
+  const insertionPoints = REGION_ORDER
+    .filter(laterSlug => regionRank(laterSlug) > regionRank(slug))
+    .map(laterSlug => REGION_HEADINGS[laterSlug])
+    .filter(Boolean)
+    .map(laterHeading => new RegExp(
+      `^##[ \\t]+${escapeRegExp(laterHeading)}[ \\t]*$`,
+      'm',
+    ).exec(text))
+    .filter(Boolean)
+    .map(match => match.index);
+  const section = `## ${heading}\n\n${managed}`;
+  if (insertionPoints.length > 0) {
+    const insertion = Math.min(...insertionPoints);
+    const prefix = text.slice(0, insertion).replace(/[\r\n]+$/, '');
+    const suffix = text.slice(insertion).replace(/^[\r\n]+/, '');
+    return `${prefix}\n\n${section}\n\n${suffix}`;
+  }
+  const prefix = text.replace(/[\r\n]+$/, '');
+  return prefix ? `${prefix}\n\n${section}\n` : `${section}\n`;
+}
+
+function appendLegacyInteraction(original, line) {
+  const headings = [
+    /^## Recent Interactions\s*$/m,
+    /^## Recent Meetings\s*$/m,
+    /^## Meetings\s*$/m,
+  ];
+  for (const heading of headings) {
+    const match = heading.exec(original);
+    if (!match) continue;
+    const insertion = match.index + match[0].length;
+    const suffix = original.slice(insertion);
+    return `${original.slice(0, insertion)}\n${line}${suffix.startsWith('\n') ? '' : '\n'}${suffix}`;
+  }
+  return `${original.replace(/\s*$/, '')}\n\n${line}\n`;
+}
+
+function materializeHookIntent(operation, latest, intent) {
+  const interaction = intent.interaction;
+  if (!interaction || typeof interaction.path !== 'string'
+      || typeof interaction.line !== 'string'
+      || !/^\d{4}-\d{2}-\d{2}$/.test(interaction.date || '')) {
+    throw new Error(`Invalid hook mutation intent for ${operation.path}`);
+  }
+  const entity = parseEntityPage(operation.path);
+  const fieldChanges = !entity.last_interaction
+      || interaction.date > entity.last_interaction
+    ? { last_interaction: interaction.date }
+    : null;
+  const baseFingerprint = fingerprintText(latest);
+  let materialized;
+  let target;
+  if (latest.includes('<!-- dex:auto:recent-interactions -->')) {
+    const region = /<!-- dex:auto:recent-interactions -->\r?\n?([\s\S]*?)<!-- \/dex:auto -->/
+      .exec(latest);
+    const existing = region
+      ? region[1].split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(line => line.startsWith('- '))
+      : [];
+    const additions = latest.includes(interaction.path)
+      ? existing
+      : [interaction.line, ...existing];
+    const projection = additions.sort((left, right) => {
+      const leftDate = left.match(/\d{4}-\d{2}-\d{2}\s*$/)?.[0] || '';
+      const rightDate = right.match(/\d{4}-\d{2}-\d{2}\s*$/)?.[0] || '';
+      return rightDate.localeCompare(leftDate);
+    }).slice(0, 20).join('\n');
+    const withRegion = replaceMachineRegion(
+      latest,
+      'recent-interactions',
+      projection,
+    );
+    target = fieldChanges
+      ? mergeFrontmatterText(operation.path, withRegion, fieldChanges)
+      : withRegion;
+    materialized = {
+      op: 'mutate',
+      path: operation.path,
+      base_fingerprint: baseFingerprint,
+      region_projections: { 'recent-interactions': projection },
+      ...(fieldChanges ? { field_changes: fieldChanges } : {}),
+    };
+  } else {
+    const replacement = latest.includes(interaction.path)
+      ? latest
+      : appendLegacyInteraction(latest, interaction.line);
+    target = fieldChanges
+      ? mergeFrontmatterText(operation.path, replacement, fieldChanges)
+      : replacement;
+    materialized = {
+      op: 'mutate',
+      path: operation.path,
+      base_fingerprint: baseFingerprint,
+      replacement_content: replacement,
+      ...(fieldChanges ? { field_changes: fieldChanges } : {}),
+    };
+  }
+  if (target !== null) materialized.target_fingerprint = fingerprintText(target);
+  return materialized;
+}
+
+function materializeGardenerIntent(operation, latest, intent) {
+  if (typeof intent.region_projection !== 'string') {
+    throw new Error(`Invalid gardener mutation intent for ${operation.path}`);
+  }
+  const withRegion = ensureRegion(latest, 'context-summary');
+  const target = replaceMachineRegion(
+    withRegion,
+    'context-summary',
+    intent.region_projection,
+  );
+  return {
+    op: 'mutate',
+    path: operation.path,
+    base_fingerprint: fingerprintText(latest),
+    ensure_regions: ['context-summary'],
+    region_projections: {
+      'context-summary': intent.region_projection,
+    },
+    target_fingerprint: fingerprintText(target),
+  };
+}
+
+function materializeOperation(operation, vaultRoot) {
+  if (operation.op === 'create') {
+    return { operation, materialized: operation };
+  }
+  if (operation.op !== 'mutate' || !operation.intent) {
+    throw new Error(`Mutation operation has no declarative intent: ${operation.path}`);
+  }
+  let effective = operation;
+  let latest;
+  try {
+    latest = fs.readFileSync(effective.path, 'utf8');
+  } catch (originalError) {
+    const retargeted = resolveEntityPath(vaultRoot, operation.entity_identity);
+    if (!retargeted || retargeted === operation.path) {
+      const error = new Error(
+        `Target page missing or unreadable: ${operation.path} (${originalError.message})`,
+      );
+      error.code = originalError.code;
+      error.failure_kind = 'target_missing';
+      throw error;
+    }
+    effective = { ...operation, path: retargeted };
+    try {
+      latest = fs.readFileSync(effective.path, 'utf8');
+    } catch (retargetError) {
+      const error = new Error(
+        `Retargeted page is unreadable: ${effective.path} (${retargetError.message})`,
+      );
+      error.code = retargetError.code;
+      error.failure_kind = 'target_missing';
+      throw error;
+    }
+  }
+  if (effective.intent.kind === 'hook-interaction') {
+    return {
+      operation: effective,
+      materialized: materializeHookIntent(effective, latest, effective.intent),
+    };
+  }
+  if (effective.intent.kind === 'gardener-summary') {
+    return {
+      operation: effective,
+      materialized: materializeGardenerIntent(effective, latest, effective.intent),
+    };
+  }
+  throw new Error(`Unsupported mutation intent: ${effective.intent.kind}`);
+}
+
+function applied(operation, result) {
+  if (!result || result.path !== operation.path) return false;
+  if (['created', 'updated', 'noop'].includes(result.status)) return true;
+  return ['exists', 'conflict'].includes(result.status)
+    && typeof operation.target_fingerprint === 'string'
+    && result.fingerprint === operation.target_fingerprint;
+}
+
+function completedMeetingIds(
+  completedBatches,
+  remainingBatches,
+  deadLettered = [],
+) {
+  const blocked = new Set(
+    [
+      ...remainingBatches.flatMap((batch) => batch.meeting_ids || []),
+      ...deadLettered.flatMap((entry) => entry.meeting_ids || []),
+    ],
+  );
+  return [...new Set(
+    completedBatches.flatMap((batch) => batch.meeting_ids || []),
+  )].filter((meetingId) => !blocked.has(meetingId)).sort();
+}
+
+function failure(error, extra = {}) {
+  return {
+    ok: false,
+    completed_meeting_ids: [],
+    completed_batches: [],
+    results: [],
+    error: error instanceof Error ? error.message : String(error),
+    ...extra,
+  };
+}
+
+function operationWithoutLifecycle(operation) {
+  const {
+    attempts: _legacyAttempts,
+    permanent_attempts: _permanentAttempts,
+    transient_attempts: _transientAttempts,
+    target_missing_attempts: _targetMissingAttempts,
+    backoff_attempts: _backoffAttempts,
+    first_attempt_at: _firstAttemptAt,
+    last_attempt_at: _lastAttemptAt,
+    next_attempt_at: _nextAttemptAt,
+    last_error: _lastError,
+    ...declarative
+  } = operation;
+  return declarative;
+}
+
+function operationKey(operation) {
+  return JSON.stringify(stableValue(operationWithoutLifecycle(operation)));
+}
+
+function retryDelayMs(attempts) {
+  return Math.min(
+    BACKOFF_MAX_MS,
+    BACKOFF_BASE_MS * (2 ** Math.max(0, attempts - 1)),
+  );
+}
+
+function deadLetterId(batch, operation) {
+  return crypto.createHash('sha256').update(JSON.stringify(stableValue({
+    batch_id: batch.id,
+    operation: operationWithoutLifecycle(operation),
+  }))).digest('hex');
+}
+
+function deadLetterIds(vaultRoot) {
+  const filePath = deadLetterPath(vaultRoot);
+  const signature = deadLetterFileSignature(filePath);
+  const cached = deadLetterIndexCache.get(filePath);
+  if (cached?.signature === signature) return cached.ids;
+  const ids = new Set(
+    loadDeadLetters(vaultRoot)
+      .map(entry => entry?.dead_letter_id)
+      .filter(Boolean),
+  );
+  deadLetterIndexCache.set(filePath, { signature, ids });
+  return ids;
+}
+
+function appendDeadLetters(vaultRoot, entries) {
+  if (entries.length === 0) return;
+  const filePath = deadLetterPath(vaultRoot);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const existing = new Set(deadLetterIds(vaultRoot));
+  const additions = entries.filter((entry) => {
+    if (existing.has(entry.dead_letter_id)) return false;
+    existing.add(entry.dead_letter_id);
+    return true;
+  });
+  if (additions.length === 0) return;
+  fs.appendFileSync(
+    filePath,
+    additions.map(entry => `${JSON.stringify(entry)}\n`).join(''),
+    'utf8',
+  );
+  deadLetterIndexCache.set(filePath, {
+    signature: deadLetterFileSignature(filePath),
+    ids: existing,
+  });
+}
+
+function compactDeadLetters(vaultRoot, resolvedIds) {
+  if (resolvedIds.size === 0) return;
+  const filePath = deadLetterPath(vaultRoot);
+  let lines;
+  try {
+    lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+  const kept = [];
+  const keptIds = new Set();
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (resolvedIds.has(entry?.dead_letter_id)) continue;
+      if (entry?.dead_letter_id) keptIds.add(entry.dead_letter_id);
+    } catch (_) {
+      // A torn historic line is not an entry, but compaction must not erase it.
+    }
+    kept.push(line);
+  }
+  if (kept.length === 0) {
+    try { fs.unlinkSync(filePath); } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  } else {
+    atomicWriteText(filePath, `${kept.join('\n')}\n`);
+  }
+  deadLetterIndexCache.set(filePath, {
+    signature: deadLetterFileSignature(filePath),
+    ids: keptIds,
+  });
+}
+
+function requeueDeadLetters(vaultRoot) {
+  const root = path.resolve(vaultRoot);
+  return withPendingLock(root, () => {
+    const entries = loadDeadLetters(root).filter(
+      entry => entry && typeof entry === 'object'
+        && entry.dead_letter_id
+        && entry.op
+        && typeof entry.op === 'object',
+    );
+    if (entries.length === 0) {
+      return { requeued: 0, dead_letter_ids: [] };
+    }
+    const store = loadPendingStore(root);
+    const requeuedIds = new Set();
+    for (const entry of entries) {
+      let batch = store.batches.find(candidate => candidate.id === entry.batch_id);
+      if (!batch) {
+        batch = {
+          id: entry.batch_id,
+          scope: entry.scope || 'default',
+          meeting_ids: [],
+          ops: [],
+          ...(entry.metadata ? { metadata: entry.metadata } : {}),
+        };
+        store.batches.push(batch);
+      }
+      batch.meeting_ids = [...new Set([
+        ...(batch.meeting_ids || []),
+        ...(entry.meeting_ids || [entry.meeting_id]).filter(Boolean),
+      ])].sort();
+      const operation = operationWithoutLifecycle(entry.op);
+      if (!batch.ops.some(candidate => operationKey(candidate) === operationKey(operation))) {
+        batch.ops.push(operation);
+      }
+      requeuedIds.add(entry.dead_letter_id);
+    }
+    savePendingStore(root, store);
+    compactDeadLetters(root, requeuedIds);
+    return {
+      requeued: requeuedIds.size,
+      dead_letter_ids: [...requeuedIds].sort(),
+    };
+  });
+}
+
+function materializationFailureClass(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /^(Invalid hook mutation intent|Invalid gardener mutation intent|Unsupported mutation intent|Mutation operation has no declarative intent)/.test(
+    message,
+  )
+    ? 'permanent'
+    : 'transient';
+}
+
+function settleSelected(vaultRoot, selected, outcomes, now = new Date()) {
+  return withPendingLock(vaultRoot, () => {
+    const latest = loadPendingStore(vaultRoot);
+    const completed = [];
+    const deadLettered = [];
+    const attemptedAt = now.toISOString();
+    const outcomeMaps = new Map(selected.map(batch => [
+      batch.id,
+      batch.ops.reduce((byOperation, operation, index) => {
+        const key = operationKey(operation);
+        if (!byOperation.has(key)) byOperation.set(key, []);
+        byOperation.get(key).push(outcomes.get(batch.id)?.[index] || null);
+        return byOperation;
+      }, new Map()),
+    ]));
+
+    for (const batch of latest.batches) {
+      const batchOutcomes = outcomeMaps.get(batch.id);
+      if (!batchOutcomes) continue;
+      const originalOps = batch.ops;
+      const originalEffects = batch.metadata?.effects;
+      const alignedEffects = Array.isArray(originalEffects)
+        && originalEffects.length === originalOps.length;
+      const remainingOps = [];
+      const remainingEffects = [];
+      const appliedOps = [];
+      const appliedEffects = [];
+      for (const [index, operation] of originalOps.entries()) {
+        const queuedOutcomes = batchOutcomes.get(operationKey(operation));
+        const outcome = queuedOutcomes?.shift() || null;
+        if (!outcome) {
+          remainingOps.push(operation);
+          if (alignedEffects) remainingEffects.push(originalEffects[index]);
+          continue;
+        }
+        if (outcome.applied) {
+          appliedOps.push(operationWithoutLifecycle(outcome.operation || operation));
+          if (alignedEffects) appliedEffects.push(originalEffects[index]);
+          continue;
+        }
+        const nextOperation = outcome.operation || operation;
+        const permanentAttempts = Number.isInteger(operation.permanent_attempts)
+          ? operation.permanent_attempts
+          : 0;
+        const transientAttempts = Number.isInteger(operation.transient_attempts)
+          ? operation.transient_attempts
+          : 0;
+        const targetMissingAttempts = Number.isInteger(operation.target_missing_attempts)
+          ? operation.target_missing_attempts
+          : 0;
+        const backoffAttempts = (Number.isInteger(operation.backoff_attempts)
+          ? operation.backoff_attempts
+          : 0) + 1;
+        const isPermanent = outcome.failure_class === 'permanent';
+        const isTargetMissing = outcome.failure_kind === 'target_missing';
+        const nextPermanentAttempts = permanentAttempts + (isPermanent ? 1 : 0);
+        const nextTransientAttempts = transientAttempts + (isPermanent ? 0 : 1);
+        const nextTargetMissingAttempts = targetMissingAttempts
+          + (isTargetMissing ? 1 : 0);
+        const firstAttemptAt = operation.first_attempt_at || attemptedAt;
+        const firstAttemptTime = new Date(firstAttemptAt).getTime();
+        const transientAgeExceeded = !Number.isNaN(firstAttemptTime)
+          && now.getTime() - firstAttemptTime >= MAX_TRANSIENT_AGE_MS;
+        const terminalMissing = isTargetMissing
+          && nextTargetMissingAttempts >= MAX_TARGET_MISSING_ATTEMPTS;
+        const terminalRejected = isPermanent
+          && nextPermanentAttempts >= MAX_ATTEMPTS;
+        const terminalTransient = !isPermanent
+          && !isTargetMissing
+          && (
+            nextTransientAttempts >= MAX_TRANSIENT_ATTEMPTS
+            || transientAgeExceeded
+          );
+        if (!terminalMissing && !terminalRejected && !terminalTransient) {
+          remainingOps.push({
+            ...operationWithoutLifecycle(nextOperation),
+            permanent_attempts: nextPermanentAttempts,
+            transient_attempts: nextTransientAttempts,
+            target_missing_attempts: nextTargetMissingAttempts,
+            backoff_attempts: backoffAttempts,
+            first_attempt_at: firstAttemptAt,
+            last_attempt_at: attemptedAt,
+            next_attempt_at: new Date(
+              now.getTime() + retryDelayMs(backoffAttempts),
+            ).toISOString(),
+            last_error: outcome.error || 'entity mutation was not applied',
+          });
+          if (alignedEffects) remainingEffects.push(originalEffects[index]);
+          continue;
+        }
+        const declarative = operationWithoutLifecycle(nextOperation);
+        const reason = terminalMissing
+          ? `target page missing after ${nextTargetMissingAttempts} identity lookup attempts`
+          : terminalTransient
+            ? `infrastructure failure persisted for ${nextTransientAttempts} attempts since `
+              + `${firstAttemptAt}: ${outcome.error || 'entity engine unavailable'}`
+            : (outcome.error || 'entity engine rejected the operation');
+        deadLettered.push({
+          dead_letter_id: deadLetterId(batch, declarative),
+          dead_lettered_at: attemptedAt,
+          batch_id: batch.id,
+          scope: batch.scope,
+          meeting_id: (batch.meeting_ids || [])[0] || null,
+          meeting_ids: batch.meeting_ids || [],
+          op_type: declarative.op,
+          entity_path: declarative.path,
+          entity_identity: declarative.entity_identity || null,
+          failure_class: 'permanent',
+          permanent_attempts: nextPermanentAttempts,
+          transient_attempts: nextTransientAttempts,
+          target_missing_attempts: nextTargetMissingAttempts,
+          op: declarative,
+          ...(batch.metadata ? { metadata: batch.metadata } : {}),
+          reason,
+          last_error: outcome.error || reason,
+        });
+      }
+      batch.ops = remainingOps;
+      if (alignedEffects) {
+        batch.metadata = {
+          ...batch.metadata,
+          effects: remainingEffects,
+        };
+      }
+      if (appliedOps.length > 0) {
+        const completedBatch = {
+          ...batch,
+          ops: appliedOps,
+        };
+        if (alignedEffects) {
+          completedBatch.metadata = {
+            ...batch.metadata,
+            effects: appliedEffects,
+          };
+        }
+        completed.push(completedBatch);
+      }
+    }
+
+    latest.batches = latest.batches.filter(
+      batch => batch.ops.length > 0,
+    );
+    // Dead-letter append is idempotent by batch+operation identity. If the
+    // process dies before the store save, replay skips the duplicate record.
+    appendDeadLetters(vaultRoot, deadLettered);
+    savePendingStore(vaultRoot, latest);
+    return {
+      completed,
+      remaining: latest.batches,
+      deadLettered,
+    };
+  });
+}
+
+function flushEntityOps({
+  vaultRoot,
+  ops = [],
+  meetingIds = [],
+  scope = 'default',
+  scopes = null,
+  metadata = null,
+  env = process.env,
+  spawnSync = childProcess.spawnSync,
+  now = new Date(),
+} = {}) {
+  const root = path.resolve(vaultRoot);
+  const nowDate = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(nowDate.getTime())) {
+    return failure('now must be a valid date');
+  }
+  const selectedScopes = new Set(scopes || [scope]);
+  let currentBatch = null;
+  let selected;
+  let selectedBatchCount = 0;
+  let deferredOperationCount = 0;
+  try {
+    ({
+      currentBatch,
+      selected,
+      selectedBatchCount,
+      deferredOperationCount,
+    } = withPendingLock(root, () => {
+      const store = loadPendingStore(root);
+      let batch = null;
+      if (ops.length > 0 || meetingIds.length > 0) {
+        const id = batchId(scope, ops, meetingIds);
+        batch = store.batches.find((candidate) => candidate.id === id);
+        if (!batch) {
+          batch = {
+            id,
+            scope,
+            meeting_ids: [...new Set(meetingIds)].sort(),
+            ops,
+            ...(metadata === null ? {} : { metadata }),
+          };
+          store.batches.push(batch);
+        }
+      }
+      savePendingStore(root, store);
+      const scoped = store.batches.filter(
+        candidate => selectedScopes.has(candidate.scope),
+      );
+      const due = scoped.map((candidate) => ({
+        ...candidate,
+        ops: candidate.ops.filter((operation) => {
+          if (!operation.next_attempt_at) return true;
+          const next = new Date(operation.next_attempt_at);
+          return Number.isNaN(next.getTime()) || next <= nowDate;
+        }),
+      })).filter(candidate => candidate.ops.length > 0
+        || store.batches.find(stored => stored.id === candidate.id)?.ops.length === 0);
+      return {
+        currentBatch: batch === null
+          ? null
+          : JSON.parse(JSON.stringify(batch)),
+        selected: JSON.parse(JSON.stringify(due)),
+        selectedBatchCount: scoped.length,
+        deferredOperationCount: scoped.reduce(
+          (count, candidate) => count + candidate.ops.length,
+          0,
+        ) - due.reduce(
+          (count, candidate) => count + candidate.ops.length,
+          0,
+        ),
+      };
+    }));
+  } catch (error) {
+    return failure(error);
+  }
+
+  const failedSelected = (
+    error,
+    failureClass = 'transient',
+    status = {},
+  ) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const outcomes = new Map(selected.map(batch => [
+      batch.id,
+      batch.ops.map(() => ({
+        applied: false,
+        error: message,
+        failure_class: failureClass,
+      })),
+    ]));
+    try {
+      const settled = settleSelected(root, selected, outcomes, nowDate);
+      return failure(error, {
+        batch_id: currentBatch?.id || null,
+        dead_lettered_ops: settled.deadLettered,
+        ...status,
+      });
+    } catch (settlementError) {
+      return failure(
+        `${message}; failed to persist retry state: ${settlementError.message}`,
+        { batch_id: currentBatch?.id || null },
+      );
+    }
+  };
+
+  const pendingOperationCount = selected.reduce(
+    (count, batch) => count + batch.ops.length,
+    0,
+  );
+  if (pendingOperationCount === 0) {
+    if (selectedBatchCount > 0 && deferredOperationCount > 0) {
+      return failure('Entity writes are waiting for their retry window', {
+        batch_id: currentBatch?.id || null,
+        dead_lettered_ops: [],
+      });
+    }
+    let completed;
+    let remaining;
+    try {
+      ({ completed, remaining } = withPendingLock(root, () => {
+        const latest = loadPendingStore(root);
+        const selectedIds = new Set(selected.map((batch) => batch.id));
+        const done = latest.batches.filter((batch) => selectedIds.has(batch.id));
+        latest.batches = latest.batches.filter((batch) => !selectedIds.has(batch.id));
+        savePendingStore(root, latest);
+        return { completed: done, remaining: latest.batches };
+      }));
+    } catch (error) {
+      return failure(error);
+    }
+    return {
+      ok: true,
+      completed_meeting_ids: completedMeetingIds(completed, remaining),
+      completed_batches: completed,
+      results: [],
+      batch_id: currentBatch?.id || null,
+    };
+  }
+
+  const pythonStatus = resolveDexPythonStatus(root, env);
+  const interpreter = pythonStatus.path;
+  if (!interpreter) {
+    return failedSelected(
+      pythonStatus.user_message,
+      'transient',
+      pythonStatus,
+    );
+  }
+
+  const snapshotOutcomes = new Map(selected.map(batch => [
+    batch.id,
+    batch.ops.map(() => null),
+  ]));
+  const materializedEntries = [];
+  const materializationErrors = [];
+  for (const batch of selected) {
+    for (const [index, operation] of batch.ops.entries()) {
+      try {
+        const materialized = materializeOperation(operation, root);
+        materializedEntries.push({
+          batchId: batch.id,
+          index,
+          operation: materialized.operation,
+          materialized: materialized.materialized,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        snapshotOutcomes.get(batch.id)[index] = {
+          applied: false,
+          error: message,
+          failure_class: materializationFailureClass(error),
+          failure_kind: error.failure_kind || 'materialization',
+        };
+        materializationErrors.push(message);
+      }
+    }
+  }
+
+  const failMaterialized = (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    for (const entry of materializedEntries) {
+      snapshotOutcomes.get(entry.batchId)[entry.index] = {
+        applied: false,
+        error: message,
+        operation: entry.operation,
+        failure_class: 'transient',
+      };
+    }
+    try {
+      const settled = settleSelected(root, selected, snapshotOutcomes, nowDate);
+      return failure(error, {
+        batch_id: currentBatch?.id || null,
+        dead_lettered_ops: settled.deadLettered,
+      });
+    } catch (settlementError) {
+      return failure(
+        `${message}; failed to persist retry state: ${settlementError.message}`,
+        { batch_id: currentBatch?.id || null },
+      );
+    }
+  };
+
+  if (materializedEntries.length === 0) {
+    return failMaterialized(
+      materializationErrors[0] || 'No entity operation could be materialized',
+    );
+  }
+
+  const batchResults = new Map();
+  const executionErrors = [];
+  for (let offset = 0; offset < materializedEntries.length; offset += CLI_CHUNK_SIZE) {
+    const chunk = materializedEntries.slice(offset, offset + CLI_CHUNK_SIZE);
+    const markChunkTransient = (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      executionErrors.push(message);
+      for (const entry of chunk) {
+        snapshotOutcomes.get(entry.batchId)[entry.index] = {
+          applied: false,
+          error: message,
+          operation: entry.operation,
+          failure_class: 'transient',
+          failure_kind: 'infrastructure',
+        };
+      }
+    };
+    let execution;
+    try {
+      execution = spawnSync(
+        interpreter,
+        ['-m', 'core.entity_engine.cli'],
+        {
+          cwd: root,
+          encoding: 'utf8',
+          // `core` ships inside a real vault (importable from cwd=root), but when the
+          // engine lives separately (tests, split-repo layouts) DEX_REPO_ROOT points at
+          // it — put both on PYTHONPATH so `-m core.entity_engine.cli` always resolves.
+          env: {
+            ...env,
+            VAULT_PATH: root,
+            PYTHONPATH: [env.DEX_REPO_ROOT, root, env.PYTHONPATH]
+              .filter(Boolean)
+              .join(path.delimiter),
+          },
+          input: JSON.stringify({
+            ops: chunk.map(entry => cliOperation(entry.materialized)),
+          }),
+          maxBuffer: (1024 * 1024) + (chunk.length * 128 * 1024),
+          timeout: 30_000 + (chunk.length * 1000),
+        },
+      );
+    } catch (error) {
+      markChunkTransient(error);
+      continue;
+    }
+    if (execution.error || execution.status !== 0 || execution.signal) {
+      const signal = execution.signal ? ` (signal ${execution.signal})` : '';
+      markChunkTransient(
+        execution.error
+          || execution.stderr
+          || `Entity CLI exited ${execution.status}${signal}`,
+      );
+      continue;
+    }
+
+    let response;
+    try {
+      if (typeof execution.stdout !== 'string' || !execution.stdout.trim()) {
+        throw new Error('Entity CLI returned empty stdout');
+      }
+      response = JSON.parse(execution.stdout);
+      if (!Array.isArray(response.results)
+          || response.results.length !== chunk.length) {
+        throw new Error('Entity CLI returned an invalid result count');
+      }
+    } catch (error) {
+      markChunkTransient(error);
+      continue;
+    }
+
+    for (const [resultIndex, entry] of chunk.entries()) {
+      const result = response.results[resultIndex];
+      if (!batchResults.has(entry.batchId)) batchResults.set(entry.batchId, []);
+      batchResults.get(entry.batchId).push({ index: entry.index, result });
+      const wasApplied = applied(entry.materialized, result);
+      const targetMissing = !wasApplied && result?.status === 'missing';
+      snapshotOutcomes.get(entry.batchId)[entry.index] = {
+        applied: wasApplied,
+        operation: entry.operation,
+        error: result?.status
+          ? `Entity CLI returned ${result.status}`
+          : 'Entity CLI returned no result',
+        failure_class: wasApplied ? null : targetMissing ? 'transient' : 'permanent',
+        failure_kind: wasApplied ? null : targetMissing ? 'target_missing' : 'op_rejected',
+      };
+    }
+  }
+
+  let completed;
+  let remaining;
+  let deadLettered;
+  try {
+    ({ completed, remaining, deadLettered } = settleSelected(
+      root,
+      selected,
+      snapshotOutcomes,
+      nowDate,
+    ));
+  } catch (error) {
+    return failure(error, { batch_id: currentBatch?.id || null });
+  }
+  const completedIds = new Set(completed.map((batch) => batch.id));
+  const remainingIds = new Set(remaining.map((batch) => batch.id));
+  const deadLetteredIds = new Set(
+    deadLettered.map((entry) => entry.batch_id),
+  );
+  const scopedRemaining = remaining.some(
+    batch => selectedScopes.has(batch.scope),
+  );
+
+  return {
+    ok: !scopedRemaining && selected.every((batch) => completedIds.has(batch.id)
+      && !remainingIds.has(batch.id)
+      && !deadLetteredIds.has(batch.id)),
+    completed_meeting_ids: completedMeetingIds(
+      completed,
+      remaining,
+      deadLettered,
+    ),
+    completed_batches: completed,
+    results: currentBatch
+      ? (batchResults.get(currentBatch.id) || [])
+        .sort((left, right) => left.index - right.index)
+        .map(item => item.result)
+      : [],
+    batch_id: currentBatch?.id || null,
+    dead_lettered_ops: deadLettered,
+    ...((executionErrors[0] || materializationErrors[0])
+      ? { error: executionErrors[0] || materializationErrors[0] }
+      : {}),
+  };
+}
+
+module.exports = {
+  fingerprintText,
+  flushEntityOps,
+  loadDeadLetters,
+  loadPendingStore,
+  deadLetterPath,
+  pendingStorePath,
+  requeueDeadLetters,
+  resultApplied: applied,
+  withPendingLock,
+};

--- a/.scripts/lib/entity-identity.cjs
+++ b/.scripts/lib/entity-identity.cjs
@@ -1,0 +1,121 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { registrableDomain } = require('../meeting-intel/lib/company-domains.cjs');
+const { parseEntityPage } = require('./entity-pages.cjs');
+const { loadPaths } = require('../../.claude/hooks/paths.cjs');
+
+// Vault-relative PARA segments derived from the canonical path constants, so the
+// path-contract gate is satisfied while resolveEntityPath still honours a runtime root.
+const _paths = loadPaths();
+const PEOPLE_REL = path.relative(_paths.VAULT_ROOT, _paths.PEOPLE_DIR);
+const COMPANIES_REL = path.relative(_paths.VAULT_ROOT, _paths.COMPANIES_DIR);
+
+function markdownFiles(directory) {
+  if (!fs.existsSync(directory)) return [];
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...markdownFiles(filePath));
+    else if (entry.isFile() && entry.name.endsWith('.md')
+        && entry.name.toLowerCase() !== 'readme.md') {
+      files.push(filePath);
+    }
+  }
+  return files;
+}
+
+function normalizedName(value) {
+  return String(value || '').trim().toLocaleLowerCase();
+}
+
+function normalizedEmails(values) {
+  return new Set(
+    (Array.isArray(values) ? values : [])
+      .map(value => String(value || '').trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function normalizedDomains(values) {
+  return new Set(
+    (Array.isArray(values) ? values : [])
+      .map(registrableDomain)
+      .filter(Boolean),
+  );
+}
+
+function identityForEntity(entity) {
+  if (!entity || !['person', 'company'].includes(entity.type)) return null;
+  if (entity.type === 'person') {
+    return {
+      kind: 'person',
+      name: entity.name || null,
+      emails: [...normalizedEmails(entity.emails)],
+    };
+  }
+  return {
+    kind: 'company',
+    name: entity.name || null,
+    domains: [...normalizedDomains(entity.domains)],
+  };
+}
+
+function identityForPage(filePath) {
+  return identityForEntity(parseEntityPage(filePath));
+}
+
+function resolveEntityPath(vaultRoot, identity) {
+  if (!identity || !['person', 'company'].includes(identity.kind)) return null;
+  const root = path.resolve(vaultRoot);
+  const directory = identity.kind === 'person'
+    ? path.join(root, PEOPLE_REL)
+    : path.join(root, COMPANIES_REL);
+  const wantedEmails = normalizedEmails(identity.emails);
+  const wantedDomains = normalizedDomains(identity.domains);
+  const wantedName = normalizedName(identity.name);
+  const strongMatches = [];
+  const nameMatches = [];
+
+  for (const filePath of markdownFiles(directory)) {
+    let entity;
+    try {
+      entity = parseEntityPage(filePath);
+    } catch (_) {
+      continue;
+    }
+    if (entity.quarantined || entity.type !== identity.kind) continue;
+    if (identity.kind === 'person' && wantedEmails.size > 0) {
+      const pageEmails = normalizedEmails(entity.emails);
+      if ([...wantedEmails].some(email => pageEmails.has(email))) {
+        strongMatches.push(filePath);
+        continue;
+      }
+    }
+    if (identity.kind === 'company' && wantedDomains.size > 0) {
+      const pageDomains = normalizedDomains(entity.domains);
+      if ([...wantedDomains].some(domain => pageDomains.has(domain))) {
+        strongMatches.push(filePath);
+        continue;
+      }
+    }
+    if (wantedName && normalizedName(entity.name) === wantedName) {
+      nameMatches.push(filePath);
+    }
+  }
+
+  if (strongMatches.length === 1) return strongMatches[0];
+  if (strongMatches.length > 1) return null;
+  if (identity.kind === 'person' && wantedEmails.size > 0) return null;
+  if (identity.kind === 'company' && wantedDomains.size > 0) return null;
+  return nameMatches.length === 1 ? nameMatches[0] : null;
+}
+
+module.exports = {
+  identityForEntity,
+  identityForPage,
+  markdownFiles,
+  resolveEntityPath,
+};

--- a/.scripts/lib/entity-pages.cjs
+++ b/.scripts/lib/entity-pages.cjs
@@ -148,12 +148,11 @@ function atomicWrite(filePath, text) {
   }
 }
 
-function upsertFrontmatter(filePath, fields) {
-  const rawOriginal = fs.readFileSync(filePath, 'utf8');
+function mergeFrontmatterText(filePath, rawOriginal, fields) {
   const bom = rawOriginal.charCodeAt(0) === 0xfeff ? '\ufeff' : '';
   const original = bom ? rawOriginal.slice(1) : rawOriginal;
   const split = splitFrontmatter(original);
-  if (split.quarantined) return false;
+  if (split.quarantined) return null;
   const merged = { ...(split.frontmatter || {}) };
 
   const hadPins = Boolean(merged.dex_pinned && !Array.isArray(merged.dex_pinned)
@@ -257,7 +256,13 @@ function upsertFrontmatter(filePath, fields) {
     noRefs: true, noCompatMode: true, noArrayIndent: true, lineWidth: -1, sortKeys: false,
   }).trimEnd();
   const updated = `${bom}---\n${dumped}\n---\n${split.body}`;
-  if (updated === rawOriginal) return false;
+  return updated;
+}
+
+function upsertFrontmatter(filePath, fields) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  const updated = mergeFrontmatterText(filePath, original, fields);
+  if (updated === null || updated === original) return false;
   atomicWrite(filePath, updated);
   return true;
 }
@@ -333,6 +338,6 @@ function replaceMachineRegionInFile(filePath, slug, newContent) {
 
 module.exports = {
   atomicWrite,
-  parseEntityPage, upsertFrontmatter, renderPersonPage, renderCompanyPage,
+  mergeFrontmatterText, parseEntityPage, upsertFrontmatter, renderPersonPage, renderCompanyPage,
   replaceMachineRegion, replaceMachineRegionInFile,
 };

--- a/.scripts/lib/tests/dex-python.test.cjs
+++ b/.scripts/lib/tests/dex-python.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  resolveDexPython,
+  resolveDexPythonStatus,
+} = require('../dex-python.cjs');
+
+function executable(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(filePath, 0o755);
+}
+
+test('DEX_PYTHON wins over the vault virtualenv', (t) => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-python-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  const configured = path.join(vault, 'configured-python');
+  const virtualenv = path.join(vault, '.venv', 'bin', 'python');
+  executable(configured);
+  executable(virtualenv);
+
+  assert.equal(resolveDexPython(vault, { DEX_PYTHON: configured }), configured);
+});
+
+test('the vault virtualenv is used when DEX_PYTHON is absent', (t) => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-python-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  const virtualenv = path.join(vault, '.venv', 'bin', 'python');
+  executable(virtualenv);
+
+  assert.equal(resolveDexPython(vault, {}), virtualenv);
+});
+
+test('bare interpreter names and launchd PATH fallbacks are rejected', (t) => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-python-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+
+  assert.equal(
+    resolveDexPython(vault, { DEX_PYTHON: 'python3', PATH: '/usr/bin:/bin' }),
+    null,
+  );
+});
+
+test('an executable DEX_PYTHON without the required capability is rejected once', (t) => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-python-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  const configured = path.join(vault, 'python-3.9-without-yaml');
+  const marker = path.join(vault, 'probe-count');
+  fs.writeFileSync(configured, [
+    '#!/bin/sh',
+    `printf x >> ${JSON.stringify(marker)}`,
+    'exit 1',
+    '',
+  ].join('\n'));
+  fs.chmodSync(configured, 0o755);
+
+  const first = resolveDexPythonStatus(vault, { DEX_PYTHON: configured });
+  const second = resolveDexPythonStatus(vault, { DEX_PYTHON: configured });
+
+  assert.equal(first.path, null);
+  assert.equal(first.feature_status, 'broken');
+  assert.match(first.user_message, /Python 3\.10.*PyYAML/i);
+  assert.deepEqual(second, first);
+  assert.equal(fs.readFileSync(marker, 'utf8'), 'x');
+  assert.equal(resolveDexPython(vault, { DEX_PYTHON: configured }), null);
+  assert.equal(fs.readFileSync(marker, 'utf8'), 'x');
+});

--- a/.scripts/lib/tests/entity-engine-client.test.cjs
+++ b/.scripts/lib/tests/entity-engine-client.test.cjs
@@ -1,0 +1,1147 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  deadLetterPath,
+  flushEntityOps,
+  loadDeadLetters,
+  pendingStorePath,
+  requeueDeadLetters,
+} = require('../entity-engine-client.cjs');
+const {
+  mergeFrontmatterText,
+  renderPersonPage,
+  replaceMachineRegion,
+} = require('../entity-pages.cjs');
+const {
+  beginEntityPhase,
+  completeEntityPhases,
+} = require('../../meeting-intel/lib/entity-phase.cjs');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+function makeVault(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-engine-client-'));
+  const python = path.join(vault, 'python');
+  fs.writeFileSync(python, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(python, 0o755);
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return { vault, python };
+}
+
+function createOp(vault) {
+  const content = '# Jane Example\n';
+  return {
+    op: 'create',
+    path: path.join(vault, '05-Areas', 'People', 'External', 'Jane_Example.md'),
+    content,
+    allowed_root: vault,
+    target_fingerprint: crypto.createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function atAttempt(attempt) {
+  return new Date(Date.UTC(2026, 6, 1, attempt * 24));
+}
+
+function resolveRealPython() {
+  const candidates = [
+    process.env.DEX_TEST_PYTHON,
+    process.env.DEX_PYTHON,
+    path.join(REPO_ROOT, '.venv', 'bin', 'python'),
+    path.join(REPO_ROOT, '..', 'clean-venv', 'bin', 'python'),
+    'python3',
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    const probe = childProcess.spawnSync(
+      candidate,
+      ['-c', 'import sys, yaml; print(sys.executable)'],
+      { encoding: 'utf8' },
+    );
+    if (probe.status === 0) return probe.stdout.trim();
+  }
+  throw new Error('No Python interpreter with PyYAML is available for parity tests');
+}
+
+function realCliSpawn(command, args, options) {
+  return childProcess.spawnSync(command, args, {
+    ...options,
+    cwd: REPO_ROOT,
+  });
+}
+
+function hookIntent(relativePath, line, date) {
+  return {
+    kind: 'hook-interaction',
+    interaction: { path: relativePath, line, date },
+  };
+}
+
+function appendLegacyInteraction(original, line) {
+  const heading = /^## Meetings\s*$/m.exec(original);
+  const insertion = heading.index + heading[0].length;
+  const suffix = original.slice(insertion);
+  return `${original.slice(0, insertion)}\n${line}${suffix.startsWith('\n') ? '' : '\n'}${suffix}`;
+}
+
+function runRealParityMutation(vault, operation) {
+  return flushEntityOps({
+    vaultRoot: vault,
+    ops: [operation],
+    scope: 'parity',
+    env: { ...process.env, DEX_PYTHON: resolveRealPython() },
+    spawnSync: realCliSpawn,
+  });
+}
+
+test('CLI unavailability persists retry ops and leaves the meeting entity phase pending', (t) => {
+  const { vault, python } = makeVault(t);
+  const state = { processedMeetings: {} };
+  beginEntityPhase(state, [{ id: 'meeting-1', title: 'Example' }]);
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: [createOp(vault)],
+    meetingIds: ['meeting-1'],
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    spawnSync: () => ({ status: null, stdout: '', stderr: '', error: new Error('unavailable') }),
+  });
+  completeEntityPhases(state, result.completed_meeting_ids);
+
+  assert.equal(result.ok, false);
+  assert.equal(state.processedMeetings['meeting-1'].entity_phase, 'pending');
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches.length, 1);
+  assert.deepEqual(pending.batches[0].meeting_ids, ['meeting-1']);
+  assert.equal(pending.batches[0].ops.length, 1);
+});
+
+test('a successful batch clears retry state and completes the meeting entity phase', (t) => {
+  const { vault, python } = makeVault(t);
+  const state = { processedMeetings: {} };
+  beginEntityPhase(state, [{ id: 'meeting-1', title: 'Example' }]);
+  const op = createOp(vault);
+  const unavailable = () => ({
+    status: null, stdout: '', stderr: '', error: new Error('unavailable'),
+  });
+  flushEntityOps({
+    vaultRoot: vault,
+    ops: [op],
+    meetingIds: ['meeting-1'],
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    spawnSync: unavailable,
+    now: new Date('2026-07-01T00:00:00.000Z'),
+  });
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    now: new Date('2026-07-02T00:00:00.000Z'),
+    spawnSync: (_python, _args, options) => {
+      const request = JSON.parse(options.input);
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: request.ops.map((item) => ({
+            path: item.path,
+            status: 'created',
+            fingerprint: op.target_fingerprint,
+          })),
+        }),
+      };
+    },
+  });
+  completeEntityPhases(state, result.completed_meeting_ids);
+
+  assert.equal(result.ok, true);
+  assert.equal(state.processedMeetings['meeting-1'].entity_phase, 'complete');
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+});
+
+test('real Python hook-region bytes equal the JS-computed target', (t) => {
+  const { vault } = makeVault(t);
+  const page = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Example.md');
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  const original = renderPersonPage(
+    'Jane Example',
+    'Engineer',
+    'Acme',
+    ['jane@example.com'],
+    [],
+    'external',
+  );
+  fs.writeFileSync(page, original);
+  const relativePath = '00-Inbox/Meetings/roadmap.md';
+  const line = '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10';
+  const withInteraction = replaceMachineRegion(original, 'recent-interactions', line);
+  const expected = mergeFrontmatterText(
+    page,
+    withInteraction,
+    { last_interaction: '2026-07-10' },
+  );
+
+  const result = runRealParityMutation(vault, {
+    op: 'mutate',
+    path: page,
+    intent: hookIntent(relativePath, line, '2026-07-10'),
+  });
+
+  assert.equal(result.ok, true, result.error);
+  assert.deepEqual(fs.readFileSync(page), Buffer.from(expected, 'utf8'));
+});
+
+test('real Python hook-legacy bytes equal the JS-computed target', (t) => {
+  const { vault } = makeVault(t);
+  const page = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Example.md');
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  const original = [
+    '---',
+    'type: person',
+    'name: Jane Example',
+    'last_interaction: 2026-01-01',
+    '---',
+    '# Jane Example',
+    '',
+    '## Meetings',
+    '',
+    '- Older meeting',
+    '',
+  ].join('\n');
+  fs.writeFileSync(page, original);
+  const relativePath = '00-Inbox/Meetings/roadmap.md';
+  const line = '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10';
+  const replacement = appendLegacyInteraction(original, line);
+  const expected = mergeFrontmatterText(
+    page,
+    replacement,
+    { last_interaction: '2026-07-10' },
+  );
+
+  const result = runRealParityMutation(vault, {
+    op: 'mutate',
+    path: page,
+    intent: hookIntent(relativePath, line, '2026-07-10'),
+  });
+
+  assert.equal(result.ok, true, result.error);
+  assert.deepEqual(fs.readFileSync(page), Buffer.from(expected, 'utf8'));
+});
+
+test('real Python gardener bytes equal the JS-computed target', (t) => {
+  const { vault } = makeVault(t);
+  const page = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Example.md');
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  const original = renderPersonPage(
+    'Jane Example',
+    'Engineer',
+    'Acme',
+    ['jane@example.com'],
+    [],
+    'external',
+  );
+  fs.writeFileSync(page, original);
+  const projection = '- Product leader at Acme.\n- Discussing the launch plan.';
+  const withRegion = original.replace(
+    '## Key Context\n\n## Relationships',
+    '## Key Context\n\n<!-- dex:auto:context-summary -->\n'
+      + '<!-- /dex:auto -->\n\n## Relationships',
+  );
+  const expected = replaceMachineRegion(withRegion, 'context-summary', projection);
+
+  const result = runRealParityMutation(vault, {
+    op: 'mutate',
+    path: page,
+    intent: {
+      kind: 'gardener-summary',
+      region_projection: projection,
+    },
+  });
+
+  assert.equal(result.ok, true, result.error);
+  assert.deepEqual(fs.readFileSync(page), Buffer.from(expected, 'utf8'));
+});
+
+test('a TOCTOU conflict stays pending and rematerializes from the next page bytes', (t) => {
+  const { vault } = makeVault(t);
+  const page = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Example.md');
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  const original = renderPersonPage(
+    'Jane Example',
+    'Engineer',
+    'Acme',
+    ['jane@example.com'],
+    [],
+    'external',
+  );
+  fs.writeFileSync(page, original);
+  const line = '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10';
+  const operation = {
+    op: 'mutate',
+    path: page,
+    intent: hookIntent(
+      '00-Inbox/Meetings/roadmap.md',
+      line,
+      '2026-07-10',
+    ),
+  };
+  const python = resolveRealPython();
+
+  const conflicted = flushEntityOps({
+    vaultRoot: vault,
+    ops: [operation],
+    scope: 'hook',
+    env: { ...process.env, DEX_PYTHON: python },
+    now: new Date('2026-07-01T00:00:00.000Z'),
+    spawnSync: (_command, _args, options) => {
+      const edited = fs.readFileSync(page, 'utf8').replace(
+        '## Recent Interactions',
+        'A concurrent user edit.\n\n## Recent Interactions',
+      );
+      fs.writeFileSync(page, edited);
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: [{
+            path: page,
+            status: 'conflict',
+            fingerprint: crypto.createHash('sha256').update(edited).digest('hex'),
+          }],
+        }),
+      };
+    },
+  });
+
+  assert.equal(conflicted.ok, false);
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches[0].ops[0].permanent_attempts, 1);
+  assert.deepEqual(pending.batches[0].ops[0].intent, operation.intent);
+
+  const replayed = flushEntityOps({
+    vaultRoot: vault,
+    scope: 'hook',
+    env: { ...process.env, DEX_PYTHON: python },
+    now: new Date('2026-07-02T00:00:00.000Z'),
+    spawnSync: realCliSpawn,
+  });
+
+  assert.equal(replayed.ok, true, replayed.error);
+  const updated = fs.readFileSync(page, 'utf8');
+  assert.match(updated, /A concurrent user edit\./);
+  assert.match(updated, /Roadmap Review/);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+});
+
+test('a target removed after materialization is transient and identity-retryable', (t) => {
+  const { vault, python } = makeVault(t);
+  const page = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    'Jane_Example.md',
+  );
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  fs.writeFileSync(
+    page,
+    renderPersonPage(
+      'Jane Example',
+      'Engineer',
+      'Example Org',
+      ['jane@example.com'],
+      [],
+      'external',
+    ),
+  );
+  const operation = {
+    op: 'mutate',
+    path: page,
+    entity_identity: {
+      kind: 'person',
+      name: 'Jane Example',
+      emails: ['jane@example.com'],
+    },
+    intent: hookIntent(
+      '00-Inbox/Meetings/example.md',
+      '- [Example](00-Inbox/Meetings/example.md) — 2026-07-10',
+      '2026-07-10',
+    ),
+  };
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: [operation],
+    scope: 'hook',
+    env: { DEX_PYTHON: python },
+    now: new Date('2026-07-01T00:00:00.000Z'),
+    spawnSync: (_command, _args, options) => {
+      const request = JSON.parse(options.input);
+      fs.unlinkSync(page);
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: [{
+            path: request.ops[0].path,
+            status: 'missing',
+            fingerprint: null,
+          }],
+        }),
+      };
+    },
+  });
+
+  assert.equal(result.ok, false);
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches[0].ops[0].permanent_attempts, 0);
+  assert.equal(pending.batches[0].ops[0].transient_attempts, 1);
+  assert.equal(pending.batches[0].ops[0].target_missing_attempts, 1);
+  assert.equal(fs.existsSync(deadLetterPath(vault)), false);
+});
+
+test('missing interpreters remain transient before the escalation window', (t) => {
+  const { vault } = makeVault(t);
+  const operation = createOp(vault);
+
+  for (let attempt = 0; attempt < 7; attempt += 1) {
+    const result = flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 0 ? [operation] : [],
+      meetingIds: ['meeting-missing-python'],
+      scope: 'creation',
+      env: {},
+      now: atAttempt(attempt),
+    });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.dead_lettered_ops || [], []);
+  }
+
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches[0].ops[0].permanent_attempts || 0, 0);
+  assert.equal(pending.batches[0].ops[0].transient_attempts, 7);
+  assert.match(pending.batches[0].ops[0].last_attempt_at, /^2026-/);
+  assert.match(pending.batches[0].ops[0].next_attempt_at, /^2026-/);
+  assert.equal(fs.existsSync(deadLetterPath(vault)), false);
+});
+
+test('an incapable configured interpreter is surfaced but remains transient', (t) => {
+  const { vault } = makeVault(t);
+  const incapable = path.join(vault, 'python-3.9-without-yaml');
+  fs.writeFileSync(incapable, '#!/bin/sh\nexit 1\n');
+  fs.chmodSync(incapable, 0o755);
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: [createOp(vault)],
+    meetingIds: ['meeting-bad-python'],
+    scope: 'creation',
+    env: { DEX_PYTHON: incapable },
+    now: new Date('2026-07-01T00:00:00.000Z'),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.feature_status, 'broken');
+  assert.match(result.user_message, /Python 3\.10.*PyYAML/i);
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches[0].ops[0].permanent_attempts, 0);
+  assert.equal(pending.batches[0].ops[0].transient_attempts, 1);
+  assert.equal(fs.existsSync(deadLetterPath(vault)), false);
+});
+
+test('an operation is not retried inside its persisted backoff window', (t) => {
+  const { vault, python } = makeVault(t);
+  const operation = createOp(vault);
+  let calls = 0;
+  const reject = () => {
+    calls += 1;
+    return {
+      status: 0,
+      stderr: '',
+      stdout: JSON.stringify({
+        results: [{
+          path: operation.path,
+          status: 'conflict',
+          fingerprint: '0'.repeat(64),
+        }],
+      }),
+    };
+  };
+
+  flushEntityOps({
+    vaultRoot: vault,
+    ops: [operation],
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    spawnSync: reject,
+    now: new Date('2026-07-01T00:00:00.000Z'),
+  });
+  const pendingAfterFirst = JSON.parse(
+    fs.readFileSync(pendingStorePath(vault), 'utf8'),
+  );
+  const retryAt = pendingAfterFirst.batches[0].ops[0].next_attempt_at;
+
+  const backedOff = flushEntityOps({
+    vaultRoot: vault,
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    spawnSync: reject,
+    now: new Date('2026-07-01T00:01:00.000Z'),
+  });
+
+  assert.equal(backedOff.ok, false);
+  assert.equal(calls, 1);
+  assert.equal(
+    JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'))
+      .batches[0].ops[0].next_attempt_at,
+    retryAt,
+  );
+});
+
+test('infrastructure and crashed-CLI failures remain transient', async (t) => {
+  const cases = [
+    ['spawn ENOENT', () => {
+      const error = new Error('missing executable');
+      error.code = 'ENOENT';
+      return { status: null, stdout: '', stderr: '', error };
+    }],
+    ['spawn ETIMEDOUT', () => {
+      const error = new Error('timed out');
+      error.code = 'ETIMEDOUT';
+      return { status: null, stdout: '', stderr: '', error };
+    }],
+    ['spawn ENOBUFS', () => {
+      const error = new Error('buffer exceeded');
+      error.code = 'ENOBUFS';
+      return { status: null, stdout: '', stderr: '', error };
+    }],
+    ['signal kill', () => ({
+      status: null, signal: 'SIGKILL', stdout: '', stderr: '',
+    })],
+    ['non-zero exit', () => ({
+      status: 1, stdout: '', stderr: 'engine crashed',
+    })],
+    ['empty stdout', () => ({
+      status: 0, stdout: '', stderr: '',
+    })],
+    ['malformed stdout', () => ({
+      status: 0, stdout: '{"results":[', stderr: '',
+    })],
+    ['truncated result set', () => ({
+      status: 0, stdout: '{"results":[]}', stderr: '',
+    })],
+  ];
+
+  for (const [label, response] of cases) {
+    await t.test(label, (inner) => {
+      const { vault, python } = makeVault(inner);
+      const result = flushEntityOps({
+        vaultRoot: vault,
+        ops: [createOp(vault)],
+        scope: 'creation',
+        env: { DEX_PYTHON: python },
+        spawnSync: response,
+        now: new Date('2026-07-01T00:00:00.000Z'),
+      });
+
+      assert.equal(result.ok, false);
+      const pending = JSON.parse(
+        fs.readFileSync(pendingStorePath(vault), 'utf8'),
+      );
+      assert.equal(pending.batches[0].ops[0].permanent_attempts || 0, 0);
+      assert.equal(pending.batches[0].ops[0].transient_attempts, 1);
+      assert.match(pending.batches[0].ops[0].next_attempt_at, /^2026-/);
+      assert.equal(fs.existsSync(deadLetterPath(vault)), false);
+    });
+  }
+});
+
+test('a structurally invalid mutation intent dead-letters after the permanent cap', (t) => {
+  const { vault, python } = makeVault(t);
+  const page = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    'Jane_Example.md',
+  );
+  fs.mkdirSync(path.dirname(page), { recursive: true });
+  fs.writeFileSync(
+    page,
+    renderPersonPage(
+      'Jane Example',
+      'Engineer',
+      'Example Org',
+      ['jane@example.org'],
+      [],
+      'external',
+    ),
+  );
+  const operation = {
+    op: 'mutate',
+    path: page,
+    entity_identity: {
+      kind: 'person',
+      name: 'Jane Example',
+      emails: ['jane@example.org'],
+    },
+    intent: {
+      kind: 'hook-interaction',
+      interaction: {
+        path: '00-Inbox/Meetings/example.md',
+        date: '2026-07-10',
+      },
+    },
+  };
+  let terminal;
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    terminal = flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      meetingIds: attempt === 1 ? ['meeting-invalid-intent'] : [],
+      scope: 'hook',
+      env: { DEX_PYTHON: python },
+      now: atAttempt(attempt),
+      spawnSync: () => {
+        throw new Error('the CLI must not run for an invalid intent');
+      },
+    });
+  }
+
+  assert.equal(terminal.dead_lettered_ops.length, 1);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+  const [entry] = loadDeadLetters(vault);
+  assert.equal(entry.permanent_attempts, 5);
+  assert.equal(entry.transient_attempts, 0);
+  assert.match(entry.reason, /Invalid hook mutation intent/);
+});
+
+test('a persistently failing CLI escalates to the shared dead-letter signal', (t) => {
+  const { vault, python } = makeVault(t);
+  const operation = createOp(vault);
+  const crash = () => ({
+    status: 1,
+    stdout: '',
+    stderr: 'engine defect',
+  });
+  let terminal = null;
+
+  for (let attempt = 1; attempt <= 15; attempt += 1) {
+    const result = flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      meetingIds: attempt === 1 ? ['meeting-cli-defect'] : [],
+      scope: 'creation',
+      env: { DEX_PYTHON: python },
+      now: atAttempt(attempt),
+      spawnSync: crash,
+    });
+    if (result.dead_lettered_ops?.length) {
+      terminal = result;
+      break;
+    }
+  }
+
+  assert.ok(terminal, 'the persistent infrastructure failure must surface');
+  assert.equal(terminal.dead_lettered_ops.length, 1);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+  const [entry] = loadDeadLetters(vault);
+  assert.equal(entry.permanent_attempts, 0);
+  assert.ok(entry.transient_attempts <= 15);
+  assert.match(entry.reason, /infrastructure failure persisted/i);
+});
+
+test('five genuine per-operation rejections dead-letter the op', (t) => {
+  const { vault, python } = makeVault(t);
+  const operation = createOp(vault);
+  const pendingPath = pendingStorePath(vault);
+  const ledgerPath = deadLetterPath(vault);
+  const conflict = () => ({
+    status: 0,
+    stderr: '',
+    stdout: JSON.stringify({
+      results: [{
+        path: operation.path,
+        status: 'conflict',
+        fingerprint: '0'.repeat(64),
+      }],
+    }),
+  });
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const result = flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      scope: 'creation',
+      env: { DEX_PYTHON: python },
+      spawnSync: conflict,
+      now: atAttempt(attempt),
+    });
+    assert.equal(result.ok, false);
+    if (attempt < 5) {
+      const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf8'));
+      assert.equal(pending.batches.length, 1);
+      assert.equal(pending.batches[0].ops[0].permanent_attempts, attempt);
+      assert.equal(fs.existsSync(ledgerPath), false);
+    }
+  }
+
+  assert.equal(fs.existsSync(pendingPath), false);
+  const entries = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n')
+    .map(line => JSON.parse(line));
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].permanent_attempts, 5);
+  assert.equal(entries[0].failure_class, 'permanent');
+  assert.equal(entries[0].scope, 'creation');
+  assert.deepEqual(entries[0].op, operation);
+});
+
+test('dead-letter append is idempotent across replay after a settlement crash', (t) => {
+  const { vault, python } = makeVault(t);
+  const operation = createOp(vault);
+  const pendingPath = pendingStorePath(vault);
+  const ledgerPath = deadLetterPath(vault);
+  const reject = () => ({
+    status: 0,
+    stderr: '',
+    stdout: JSON.stringify({
+      results: [{
+        path: operation.path,
+        status: 'conflict',
+        fingerprint: '0'.repeat(64),
+      }],
+    }),
+  });
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      scope: 'creation',
+      env: { DEX_PYTHON: python },
+      now: atAttempt(attempt),
+      spawnSync: reject,
+    });
+  }
+  const first = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
+  const entry = JSON.parse(first[0]);
+  fs.writeFileSync(pendingPath, `${JSON.stringify({
+    version: 1,
+    batches: [{
+      id: entry.batch_id,
+      scope: 'creation',
+      meeting_ids: [],
+      ops: [{
+        ...operation,
+        permanent_attempts: 4,
+        transient_attempts: 0,
+        target_missing_attempts: 0,
+        backoff_attempts: 4,
+        last_attempt_at: atAttempt(4).toISOString(),
+        next_attempt_at: atAttempt(5).toISOString(),
+      }],
+    }],
+  }, null, 2)}\n`);
+  flushEntityOps({
+    vaultRoot: vault,
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    now: atAttempt(6),
+    spawnSync: reject,
+  });
+
+  assert.equal(fs.readFileSync(ledgerPath, 'utf8').trim().split('\n').length, 1);
+  assert.equal(fs.existsSync(pendingPath), false);
+});
+
+test('dead-letter heal requeues with reset lifecycle and clears after success', (t) => {
+  const { vault, python } = makeVault(t);
+  const operation = createOp(vault);
+  const reject = () => ({
+    status: 0,
+    stderr: '',
+    stdout: JSON.stringify({
+      results: [{
+        path: operation.path,
+        status: 'conflict',
+        fingerprint: '0'.repeat(64),
+      }],
+    }),
+  });
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      meetingIds: attempt === 1 ? ['meeting-heal'] : [],
+      scope: 'creation',
+      env: { DEX_PYTHON: python },
+      now: atAttempt(attempt),
+      spawnSync: reject,
+    });
+  }
+  assert.equal(loadDeadLetters(vault).length, 1);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+
+  const healed = requeueDeadLetters(vault);
+
+  assert.equal(healed.requeued, 1);
+  assert.deepEqual(healed.dead_letter_ids.length, 1);
+  assert.deepEqual(loadDeadLetters(vault), []);
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.deepEqual(pending.batches[0].meeting_ids, ['meeting-heal']);
+  assert.deepEqual(pending.batches[0].ops, [operation]);
+
+  const replayed = flushEntityOps({
+    vaultRoot: vault,
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    now: atAttempt(6),
+    spawnSync: (_command, _args, options) => {
+      const request = JSON.parse(options.input);
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: request.ops.map(item => ({
+            path: item.path,
+            status: 'created',
+            fingerprint: operation.target_fingerprint,
+          })),
+        }),
+      };
+    },
+  });
+
+  assert.equal(replayed.ok, true, replayed.error);
+  assert.deepEqual(replayed.completed_meeting_ids, ['meeting-heal']);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+  assert.deepEqual(loadDeadLetters(vault), []);
+});
+
+test('a renamed target page is re-resolved by entity identity', (t) => {
+  const { vault, python } = makeVault(t);
+  const directory = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+  );
+  fs.mkdirSync(directory, { recursive: true });
+  const originalPath = path.join(directory, 'Jane_Example.md');
+  const renamedPath = path.join(directory, 'Jane_Renamed.md');
+  fs.writeFileSync(
+    originalPath,
+    renderPersonPage(
+      'Jane Example',
+      'Engineer',
+      'Example Org',
+      ['jane@example.com'],
+      [],
+      'external',
+    ),
+  );
+  const operation = {
+    op: 'mutate',
+    path: originalPath,
+    entity_identity: {
+      kind: 'person',
+      name: 'Jane Example',
+      emails: ['jane@example.com'],
+    },
+    intent: hookIntent(
+      '00-Inbox/Meetings/roadmap.md',
+      '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10',
+      '2026-07-10',
+    ),
+  };
+
+  flushEntityOps({
+    vaultRoot: vault,
+    ops: [operation],
+    scope: 'hook',
+    env: {},
+    now: new Date('2026-07-01T00:00:00.000Z'),
+  });
+  fs.renameSync(originalPath, renamedPath);
+  let requestedPath;
+  const replayed = flushEntityOps({
+    vaultRoot: vault,
+    scope: 'hook',
+    env: { DEX_PYTHON: python },
+    now: new Date('2026-07-02T00:00:00.000Z'),
+    spawnSync: (_command, _args, options) => {
+      const request = JSON.parse(options.input);
+      requestedPath = request.ops[0].path;
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: [{
+            path: requestedPath,
+            status: 'updated',
+            fingerprint: '1'.repeat(64),
+          }],
+        }),
+      };
+    },
+  });
+
+  assert.equal(replayed.ok, true, replayed.error);
+  assert.equal(requestedPath, renamedPath);
+  assert.equal(fs.existsSync(pendingStorePath(vault)), false);
+});
+
+test('a genuinely missing target surfaces after bounded identity retries', (t) => {
+  const { vault, python } = makeVault(t);
+  const missingPath = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    'Jane_Missing.md',
+  );
+  const operation = {
+    op: 'mutate',
+    path: missingPath,
+    entity_identity: {
+      kind: 'person',
+      name: 'Jane Missing',
+      emails: ['jane.missing@example.org'],
+    },
+    intent: hookIntent(
+      '00-Inbox/Meetings/example.md',
+      '- [Example](00-Inbox/Meetings/example.md) — 2026-07-10',
+      '2026-07-10',
+    ),
+  };
+
+  let terminal;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    terminal = flushEntityOps({
+      vaultRoot: vault,
+      ops: attempt === 1 ? [operation] : [],
+      meetingIds: attempt === 1 ? ['meeting-missing-target'] : [],
+      scope: 'hook',
+      env: { DEX_PYTHON: python },
+      now: atAttempt(attempt),
+    });
+  }
+
+  assert.equal(terminal.ok, false);
+  assert.equal(terminal.dead_lettered_ops.length, 1);
+  const entry = terminal.dead_lettered_ops[0];
+  assert.equal(entry.meeting_id, 'meeting-missing-target');
+  assert.equal(entry.op_type, 'mutate');
+  assert.equal(entry.entity_path, missingPath);
+  assert.deepEqual(entry.entity_identity, operation.entity_identity);
+  assert.match(entry.reason, /target page missing after 5/i);
+  assert.equal(entry.permanent_attempts, 0);
+  assert.equal(entry.target_missing_attempts, 5);
+});
+
+test('large operation sets are executed in bounded scaled chunks', (t) => {
+  const { vault, python } = makeVault(t);
+  const operations = Array.from({ length: 121 }, (_, index) => {
+    const content = `# Person ${index}\n`;
+    return {
+      op: 'create',
+      path: path.join(
+        vault,
+        '05-Areas',
+        'People',
+        'External',
+        `Person_${index}.md`,
+      ),
+      content,
+      allowed_root: vault,
+      target_fingerprint: crypto.createHash('sha256').update(content).digest('hex'),
+    };
+  });
+  const requests = [];
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: operations,
+    scope: 'creation',
+    env: { DEX_PYTHON: python },
+    now: new Date('2026-07-01T00:00:00.000Z'),
+    spawnSync: (_command, _args, options) => {
+      const request = JSON.parse(options.input);
+      requests.push({
+        count: request.ops.length,
+        timeout: options.timeout,
+        maxBuffer: options.maxBuffer,
+      });
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: request.ops.map(item => ({
+            path: item.path,
+            status: 'created',
+            fingerprint: operations.find(op => op.path === item.path)
+              .target_fingerprint,
+          })),
+        }),
+      };
+    },
+  });
+
+  assert.equal(result.ok, true, result.error);
+  assert.ok(requests.length > 1);
+  assert.equal(requests.reduce((sum, request) => sum + request.count, 0), 121);
+  assert.ok(requests.every(request => request.count <= 50));
+  assert.ok(requests.every(request => request.timeout > 30_000));
+  assert.ok(requests.every(request => request.maxBuffer > 1024 * 1024));
+});
+
+test('one intent materialization failure does not consume a sibling batch attempt', (t) => {
+  const { vault, python } = makeVault(t);
+  const missingPage = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    'Missing_Person.md',
+  );
+  const invalid = {
+    op: 'mutate',
+    path: missingPage,
+    intent: hookIntent(
+      '00-Inbox/Meetings/roadmap.md',
+      '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10',
+      '2026-07-10',
+    ),
+  };
+  flushEntityOps({
+    vaultRoot: vault,
+    ops: [invalid],
+    scope: 'hook',
+    env: { DEX_PYTHON: python },
+    spawnSync: () => {
+      throw new Error('the CLI must not run when no operation materializes');
+    },
+  });
+
+  const create = createOp(vault);
+  let request;
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: [create],
+    scope: 'hook',
+    env: { DEX_PYTHON: python },
+    spawnSync: (_command, _args, options) => {
+      request = JSON.parse(options.input);
+      return {
+        status: 0,
+        stderr: '',
+        stdout: JSON.stringify({
+          results: [{
+            path: create.path,
+            status: 'created',
+            fingerprint: create.target_fingerprint,
+          }],
+        }),
+      };
+    },
+  });
+
+  const { target_fingerprint: _targetFingerprint, ...createCliOp } = create;
+  assert.deepEqual(request.ops, [createCliOp]);
+  assert.equal(result.ok, false);
+  assert.equal(result.completed_batches.length, 1);
+  assert.deepEqual(result.results, [{
+    path: create.path,
+    status: 'created',
+    fingerprint: create.target_fingerprint,
+  }]);
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches.length, 1);
+  assert.equal(pending.batches[0].ops.length, 1);
+  assert.equal(pending.batches[0].ops[0].path, missingPage);
+  assert.equal(pending.batches[0].ops[0].transient_attempts, 1);
+  assert.equal(pending.batches[0].ops[0].permanent_attempts, 0);
+});
+
+test('a partial batch returns only applied effects and keeps failed effects aligned', (t) => {
+  const { vault, python } = makeVault(t);
+  const create = createOp(vault);
+  const missingPage = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    'Missing_Person.md',
+  );
+  const invalid = {
+    op: 'mutate',
+    path: missingPage,
+    intent: hookIntent(
+      '00-Inbox/Meetings/roadmap.md',
+      '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10',
+      '2026-07-10',
+    ),
+  };
+  const effects = [
+    { path: create.path, kind: 'applied-effect' },
+    { path: missingPage, kind: 'pending-effect' },
+  ];
+
+  const result = flushEntityOps({
+    vaultRoot: vault,
+    ops: [create, invalid],
+    scope: 'gardener',
+    metadata: { effects },
+    env: { DEX_PYTHON: python },
+    spawnSync: () => ({
+      status: 0,
+      stderr: '',
+      stdout: JSON.stringify({
+        results: [{
+          path: create.path,
+          status: 'created',
+          fingerprint: create.target_fingerprint,
+        }],
+      }),
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.completed_batches.length, 1);
+  assert.deepEqual(result.completed_batches[0].ops, [create]);
+  assert.deepEqual(result.completed_batches[0].metadata.effects, [effects[0]]);
+
+  const pending = JSON.parse(fs.readFileSync(pendingStorePath(vault), 'utf8'));
+  assert.equal(pending.batches.length, 1);
+  assert.deepEqual(
+    {
+      op: pending.batches[0].ops[0].op,
+      path: pending.batches[0].ops[0].path,
+      intent: pending.batches[0].ops[0].intent,
+      permanent_attempts: pending.batches[0].ops[0].permanent_attempts,
+      transient_attempts: pending.batches[0].ops[0].transient_attempts,
+      target_missing_attempts: pending.batches[0].ops[0].target_missing_attempts,
+    },
+    {
+      ...invalid,
+      permanent_attempts: 0,
+      transient_attempts: 1,
+      target_missing_attempts: 1,
+    },
+  );
+  assert.match(pending.batches[0].ops[0].last_attempt_at, /^\d{4}-/);
+  assert.match(pending.batches[0].ops[0].next_attempt_at, /^\d{4}-/);
+  assert.deepEqual(pending.batches[0].metadata.effects, [effects[1]]);
+});

--- a/.scripts/lib/tests/entity-engine-test-helper.cjs
+++ b/.scripts/lib/tests/entity-engine-test-helper.cjs
@@ -1,0 +1,120 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  mergeFrontmatterText,
+  replaceMachineRegion,
+} = require('../entity-pages.cjs');
+
+const REGION_HEADINGS = {
+  'recent-interactions': 'Recent Interactions',
+  'key-contacts': 'Key Contacts',
+  'meeting-history': 'Meeting History',
+  'context-summary': 'Key Context',
+  'related-tasks': 'Related Tasks',
+  relationships: 'Relationships',
+  'update-log': 'Update Log',
+};
+
+function fingerprint(value) {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function ensureRegion(text, slug) {
+  if (text.includes(`<!-- dex:auto:${slug} -->`)) return text;
+  const heading = REGION_HEADINGS[slug] || slug.replace(/-/g, ' ')
+    .replace(/\b\w/g, character => character.toUpperCase());
+  const match = new RegExp(`^##[ \\t]+${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[ \\t]*$`, 'm')
+    .exec(text);
+  const region = `<!-- dex:auto:${slug} -->\n<!-- /dex:auto -->`;
+  if (match) {
+    const prefix = text.slice(0, match.index + match[0].length).replace(/[\r\n]+$/, '');
+    const suffix = text.slice(match.index + match[0].length).replace(/^[\r\n]+/, '');
+    return suffix
+      ? `${prefix}\n\n${region}\n\n${suffix}`
+      : `${prefix}\n\n${region}\n`;
+  }
+  const prefix = text.replace(/[\r\n]+$/, '');
+  return prefix
+    ? `${prefix}\n\n## ${heading}\n\n${region}\n`
+    : `## ${heading}\n\n${region}\n`;
+}
+
+function applyOperation(operation) {
+  if (operation.op === 'create') {
+    if (fs.existsSync(operation.path)) {
+      const existing = fs.readFileSync(operation.path, 'utf8');
+      return { path: operation.path, status: 'exists', fingerprint: fingerprint(existing) };
+    }
+    fs.mkdirSync(path.dirname(operation.path), { recursive: true });
+    fs.writeFileSync(operation.path, operation.content, 'utf8');
+    return {
+      path: operation.path,
+      status: 'created',
+      fingerprint: fingerprint(operation.content),
+    };
+  }
+
+  if (!fs.existsSync(operation.path)) {
+    return { path: operation.path, status: 'missing', fingerprint: null };
+  }
+  const original = fs.readFileSync(operation.path, 'utf8');
+  const originalFingerprint = fingerprint(original);
+  if (originalFingerprint !== operation.base_fingerprint) {
+    return {
+      path: operation.path,
+      status: 'conflict',
+      fingerprint: originalFingerprint,
+    };
+  }
+
+  let updated = operation.replacement_content ?? original;
+  if (operation.field_changes) {
+    updated = mergeFrontmatterText(operation.path, updated, operation.field_changes);
+    if (updated === null) {
+      return {
+        path: operation.path,
+        status: 'quarantined',
+        fingerprint: originalFingerprint,
+      };
+    }
+  }
+  for (const slug of operation.ensure_regions || []) {
+    updated = ensureRegion(updated, slug);
+  }
+  for (const [slug, projection] of Object.entries(operation.region_projections || {})) {
+    updated = replaceMachineRegion(updated, slug, projection);
+  }
+  if (updated === original) {
+    return { path: operation.path, status: 'noop', fingerprint: originalFingerprint };
+  }
+  fs.writeFileSync(operation.path, updated, 'utf8');
+  return { path: operation.path, status: 'updated', fingerprint: fingerprint(updated) };
+}
+
+function runEntityEngineStub() {
+  const request = JSON.parse(fs.readFileSync(0, 'utf8'));
+  process.stdout.write(JSON.stringify({
+    results: request.ops.map(applyOperation),
+  }));
+}
+
+function installEntityEngineStub(vaultRoot) {
+  const executable = path.join(vaultRoot, 'entity-engine-test-python');
+  const source = [
+    `#!${process.execPath}`,
+    `'use strict';`,
+    `if (process.argv[2] !== '-c') {`,
+    `  require(${JSON.stringify(__filename)}).runEntityEngineStub();`,
+    `}`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(executable, source, 'utf8');
+  fs.chmodSync(executable, 0o755);
+  return executable;
+}
+
+module.exports = { installEntityEngineStub, runEntityEngineStub };

--- a/.scripts/lib/tests/entity-identity.test.cjs
+++ b/.scripts/lib/tests/entity-identity.test.cjs
@@ -1,0 +1,144 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveEntityPath } = require('../entity-identity.cjs');
+const {
+  renderCompanyPage,
+  renderPersonPage,
+} = require('../entity-pages.cjs');
+
+function makeVault(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-entity-identity-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return vault;
+}
+
+function writePerson(vault, filename, name, emails) {
+  const filePath = path.join(
+    vault,
+    '05-Areas',
+    'People',
+    'External',
+    filename,
+  );
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    renderPersonPage(name, '', '', emails, [], 'external'),
+  );
+  return filePath;
+}
+
+function writeCompany(vault, filename, name, domains) {
+  const filePath = path.join(vault, '05-Areas', 'Companies', filename);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, renderCompanyPage(name, domains));
+  return filePath;
+}
+
+test('an unmatched person email never falls back to a namesake', (t) => {
+  const vault = makeVault(t);
+  writePerson(
+    vault,
+    'John_Smith_Acme.md',
+    'John Smith',
+    ['john.smith@example.com'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'John Smith',
+    emails: ['john.smith@example.org'],
+  }), null);
+});
+
+test('an email-less person identity may resolve by a unique name', (t) => {
+  const vault = makeVault(t);
+  const namesake = writePerson(
+    vault,
+    'John_Smith.md',
+    'John Smith',
+    ['john.smith@example.com'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'John Smith',
+    emails: [],
+  }), namesake);
+});
+
+test('a matching person email retargets even when the name changed', (t) => {
+  const vault = makeVault(t);
+  const renamed = writePerson(
+    vault,
+    'Jane_Renamed.md',
+    'Jane Renamed',
+    ['jane@example.org'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'Jane Example',
+    emails: ['jane@example.org'],
+  }), renamed);
+});
+
+test('a matching company domain retargets even when the name changed', (t) => {
+  const vault = makeVault(t);
+  const renamed = writeCompany(
+    vault,
+    'Example_Collective.md',
+    'Example Collective',
+    ['example.com'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'company',
+    name: 'Example Incorporated',
+    domains: ['www.example.com'],
+  }), renamed);
+});
+
+test('an unmatched company domain never falls back to a namesake', (t) => {
+  const vault = makeVault(t);
+  writeCompany(
+    vault,
+    'Example_Inc.md',
+    'Example Inc',
+    ['example.com'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'company',
+    name: 'Example Inc',
+    domains: ['example.org'],
+  }), null);
+});
+
+test('two live namesakes cannot be resolved by name alone', (t) => {
+  const vault = makeVault(t);
+  writePerson(
+    vault,
+    'John_Smith_One.md',
+    'John Smith',
+    ['john.smith@example.com'],
+  );
+  writePerson(
+    vault,
+    'John_Smith_Two.md',
+    'John Smith',
+    ['john.smith@example.org'],
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'John Smith',
+    emails: [],
+  }), null);
+});

--- a/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
+++ b/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
@@ -6,24 +6,44 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { parseEntityPage, renderCompanyPage, renderPersonPage } = require('../../lib/entity-pages.cjs');
+const { installEntityEngineStub } = require('../../lib/tests/entity-engine-test-helper.cjs');
 const { loadState } = require('../lib/contacts-state.cjs');
 const { loadSuggestions, processEntityCreation } = require('../lib/entity-creation.cjs');
 
-function withVault(fn) {
+function withVault(fn, { python = null } = {}) {
   const oldVault = process.env.VAULT_PATH;
   const oldProject = process.env.CLAUDE_PROJECT_DIR;
+  const oldPython = process.env.DEX_PYTHON;
   const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-creation-'));
   process.env.VAULT_PATH = vault;
+  process.env.DEX_PYTHON = python || installEntityEngineStub(vault);
   delete process.env.CLAUDE_PROJECT_DIR;
   try { return fn(vault); } finally {
     if (oldVault === undefined) delete process.env.VAULT_PATH; else process.env.VAULT_PATH = oldVault;
     if (oldProject === undefined) delete process.env.CLAUDE_PROJECT_DIR; else process.env.CLAUDE_PROJECT_DIR = oldProject;
+    if (oldPython === undefined) delete process.env.DEX_PYTHON; else process.env.DEX_PYTHON = oldPython;
     fs.rmSync(vault, { recursive: true, force: true });
   }
 }
 
-function meetings(location = 'external') {
-  const attendee = { name: 'Jane Doe', email: 'jane@acme.com', location };
+function installWriteThenFailStub(vault) {
+  const executable = path.join(vault, 'entity-engine-write-then-fail');
+  const source = [
+    `#!${process.execPath}`,
+    `'use strict';`,
+    `if (process.argv[2] !== '-c') {`,
+    `  require(${JSON.stringify(require.resolve('../../lib/tests/entity-engine-test-helper.cjs'))}).runEntityEngineStub();`,
+    '  process.exitCode = 1;',
+    `}`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(executable, source, 'utf8');
+  fs.chmodSync(executable, 0o755);
+  return executable;
+}
+
+function meetings(location = 'external', domain = 'acme.com') {
+  const attendee = { name: 'Jane Doe', email: `jane@${domain}`, location };
   return [
     { id: 'm1', createdAt: '2026-06-01T10:00:00Z', transcript: '', filteredAttendees: [attendee] },
     { id: 'm2', createdAt: '2026-06-08T10:00:00Z', transcript: '', filteredAttendees: [attendee] },
@@ -45,9 +65,119 @@ test('auto mode creates one canonical external page and reruns create nothing', 
   const first = processEntityCreation(meetings(), { entity_creation: { mode: 'auto' } });
   assert.equal(first.created.length, 1);
   const pagePath = path.join(vault, first.created[0].page_path);
+  assert.equal(
+    fs.readFileSync(pagePath, 'utf8'),
+    renderPersonPage('Jane Doe', null, null, ['jane@acme.com'], [], 'external'),
+  );
   assert.deepEqual(parseEntityPage(pagePath).emails, ['jane@acme.com']);
   assert.equal(parseEntityPage(pagePath).location, 'external');
   assert.equal(processEntityCreation(meetings(), { entity_creation: { mode: 'auto' } }).created.length, 0);
+}));
+
+test('unavailable engine queues the create and does not claim the page was created', () => withVault(vault => {
+  const profile = { entity_creation: { mode: 'auto' } };
+  const first = processEntityCreation(
+    meetings('external', 'example.com'),
+    profile,
+    () => {},
+    { now: new Date('2026-07-01T00:00:00.000Z') },
+  );
+  assert.equal(first.created.length, 0);
+  assert.equal(first.entity_write.ok, false);
+  assert.deepEqual(first.entity_write.completed_meeting_ids, []);
+  const pagePath = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Doe.md');
+  assert.equal(fs.existsSync(pagePath), false);
+  const pendingPath = path.join(vault, 'System', '.dex', 'entity-pending.json');
+  const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf8'));
+  assert.deepEqual(pending.batches[0].meeting_ids, ['m1', 'm2']);
+  assert.equal(pending.batches[0].ops.length, 1);
+
+  process.env.DEX_PYTHON = installEntityEngineStub(vault);
+  const replay = processEntityCreation(
+    [],
+    profile,
+    () => {},
+    { now: new Date('2026-07-02T00:00:00.000Z') },
+  );
+  assert.equal(replay.created.length, 1);
+  assert.equal(replay.entity_write.ok, true);
+  assert.deepEqual(replay.entity_write.completed_meeting_ids, ['m1', 'm2']);
+  assert.equal(fs.existsSync(pagePath), true);
+  assert.equal(fs.existsSync(pendingPath), false);
+}, { python: '/definitely/missing/dex-python' }));
+
+test('lost engine acknowledgement is counted once when the pending create replays', () => withVault(vault => {
+  const profile = { entity_creation: { mode: 'auto' } };
+  process.env.DEX_PYTHON = installWriteThenFailStub(vault);
+  const first = processEntityCreation(
+    meetings('external', 'example.com'),
+    profile,
+    () => {},
+    { now: new Date('2026-07-01T00:00:00.000Z') },
+  );
+  assert.equal(first.created.length, 0);
+  assert.equal(first.entity_write.ok, false);
+  const pagePath = path.join(vault, '05-Areas', 'People', 'External', 'Jane_Doe.md');
+  assert.equal(fs.existsSync(pagePath), true);
+
+  process.env.DEX_PYTHON = installEntityEngineStub(vault);
+  const replay = processEntityCreation(
+    [],
+    profile,
+    () => {},
+    { now: new Date('2026-07-02T00:00:00.000Z') },
+  );
+  assert.equal(replay.created.length, 1);
+  assert.deepEqual(replay.entity_write.completed_meeting_ids, ['m1', 'm2']);
+  assert.equal(
+    fs.existsSync(path.join(vault, 'System', '.dex', 'entity-pending.json')),
+    false,
+  );
+}));
+
+test('duplicate company effects reconcile every newly observed contact', () => withVault(vault => {
+  const profile = {
+    entity_creation: { mode: 'auto' },
+    capabilities: { companies: { enabled: true } },
+  };
+  process.env.DEX_PYTHON = '/definitely/missing/dex-python';
+  processEntityCreation(
+    companyMeetings('example.com'),
+    profile,
+    () => {},
+    { now: new Date('2026-07-01T00:00:00.000Z') },
+  );
+  const expanded = companyMeetings('example.com');
+  for (const meeting of expanded) {
+    meeting.id = `${meeting.id}-later`;
+    meeting.filteredAttendees.push({
+      name: 'Jill Poe',
+      email: 'jill@example.com',
+      location: 'external',
+    });
+  }
+  processEntityCreation(
+    expanded,
+    profile,
+    () => {},
+    { now: new Date('2026-07-01T01:00:00.000Z') },
+  );
+
+  process.env.DEX_PYTHON = installEntityEngineStub(vault);
+  const replay = processEntityCreation(
+    [],
+    profile,
+    () => {},
+    { now: new Date('2026-07-03T00:00:00.000Z') },
+  );
+  assert.equal(replay.companies_created.length, 1);
+  assert.deepEqual(
+    replay.entity_write.completed_meeting_ids,
+    ['m1', 'm1-later', 'm2', 'm2-later'],
+  );
+  const jill = Object.values(loadState().contacts)
+    .find(contact => contact.emails.includes('jill@example.com'));
+  assert.equal(jill.company_page, '05-Areas/Companies/Example.md');
 }));
 
 for (const [label, profile] of [
@@ -94,6 +224,36 @@ test('matching collision is adopted and a mismatched collision gets a domain suf
     assert.deepEqual(parseEntityPage(result.created[0].filePath).emails, ['jane@acme.com']);
   });
 });
+
+test('a renamed person page is adopted by email identity', () => withVault(vault => {
+  const directory = path.join(vault, '05-Areas', 'People', 'External');
+  fs.mkdirSync(directory, { recursive: true });
+  const renamed = path.join(directory, 'Jane_Renamed.md');
+  fs.writeFileSync(
+    renamed,
+    renderPersonPage(
+      'Jane Doe',
+      null,
+      null,
+      ['jane@example.com'],
+      [],
+      'external',
+    ),
+  );
+
+  const result = processEntityCreation(
+    meetings('external', 'example.com'),
+    { entity_creation: { mode: 'auto' } },
+  );
+
+  assert.equal(result.created.length, 1);
+  assert.equal(result.created[0].adopted, true);
+  assert.equal(result.created[0].filePath, renamed);
+  assert.equal(
+    fs.existsSync(path.join(directory, 'Jane_Doe.md')),
+    false,
+  );
+}));
 
 test('auto mode creates a canonical company page from two observed contacts', () => withVault(vault => {
   const lines = [];

--- a/.scripts/meeting-intel/__tests__/entity-phase.test.cjs
+++ b/.scripts/meeting-intel/__tests__/entity-phase.test.cjs
@@ -1,0 +1,174 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  entityWriteMessage,
+  retryEntityPhases,
+} = require('../lib/entity-phase.cjs');
+
+test('a saved pending meeting reruns entity creation without rewriting its note', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-entity-phase-'));
+  const note = path.join(vault, '00-Inbox', 'Meetings', '2026-07-01', 'example.md');
+  fs.mkdirSync(path.dirname(note), { recursive: true });
+  fs.writeFileSync(note, '# Existing meeting note\n');
+  const original = fs.readFileSync(note);
+  const state = {
+    processedMeetings: {
+      'meeting-1': {
+        title: 'Example',
+        filepath: note,
+        entity_phase: 'pending',
+        entity_payload: {
+          id: 'meeting-1',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          hasTranscript: true,
+          filteredAttendees: [{
+            name: 'Jane Example',
+            email: 'jane@example.com',
+            location: 'external',
+          }],
+        },
+      },
+    },
+  };
+  let persisted = 0;
+  const result = retryEntityPhases(state, {}, {
+    processEntityCreation: (meetings) => {
+      assert.deepEqual(meetings, [
+        state.processedMeetings['meeting-1'].entity_payload,
+      ]);
+      return {
+        entity_write: {
+          ok: true,
+          completed_meeting_ids: ['meeting-1'],
+          dead_lettered_ops: [],
+        },
+      };
+    },
+    persistState: () => { persisted += 1; },
+  });
+
+  assert.equal(result.entity_write.ok, true);
+  assert.equal(state.processedMeetings['meeting-1'].entity_phase, 'complete');
+  assert.equal(persisted, 1);
+  assert.deepEqual(fs.readFileSync(note), original);
+  fs.rmSync(vault, { recursive: true, force: true });
+});
+
+test('a meeting whose only operation dead-letters becomes terminal failed and is surfaced', () => {
+  const state = {
+    processedMeetings: {
+      'meeting-1': {
+        entity_phase: 'pending',
+        entity_payload: {
+          id: 'meeting-1',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          hasTranscript: false,
+          filteredAttendees: [{
+            name: 'Jane Example',
+            email: 'jane@example.org',
+            location: 'external',
+          }],
+        },
+      },
+    },
+  };
+  const result = retryEntityPhases(state, {}, {
+    processEntityCreation: () => ({
+      entity_write: {
+        ok: false,
+        completed_meeting_ids: [],
+        dead_lettered_ops: [{
+          meeting_id: 'meeting-1',
+          meeting_ids: ['meeting-1'],
+          entity_path: '/vault/05-Areas/People/External/Jane_Example.md',
+          op_type: 'create',
+          reason: 'entity engine rejected the operation',
+        }],
+      },
+    }),
+    persistState: () => {},
+  });
+  const record = state.processedMeetings['meeting-1'];
+
+  assert.equal(record.entity_phase, 'failed');
+  assert.equal(record.entity_terminal, true);
+  assert.match(record.entity_error, /rejected/);
+  assert.match(entityWriteMessage(result.entity_write), /1 entity write failed permanently/i);
+  assert.match(entityWriteMessage(result.entity_write), /System\/\.dex\/entity-dead-letter\.jsonl/);
+  assert.match(entityWriteMessage(result.entity_write), /\/dex-doctor/);
+});
+
+test('a non-terminal failed phase is retried on the next sync', () => {
+  const state = {
+    processedMeetings: {
+      'meeting-1': {
+        entity_phase: 'failed',
+        entity_terminal: false,
+        entity_error: 'process interrupted',
+        entity_payload: {
+          id: 'meeting-1',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          filteredAttendees: [],
+        },
+      },
+    },
+  };
+  let calls = 0;
+  retryEntityPhases(state, {}, {
+    processEntityCreation: () => {
+      calls += 1;
+      return {
+        entity_write: {
+          ok: true,
+          completed_meeting_ids: ['meeting-1'],
+          dead_lettered_ops: [],
+        },
+      };
+    },
+    persistState: () => {},
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(state.processedMeetings['meeting-1'].entity_phase, 'complete');
+});
+
+test('a prior dead-letter ledger entry repairs lifecycle state after a crash', () => {
+  const state = {
+    processedMeetings: {
+      'meeting-1': {
+        entity_phase: 'pending',
+        entity_payload: {
+          id: 'meeting-1',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          filteredAttendees: [],
+        },
+      },
+    },
+  };
+  retryEntityPhases(state, {}, {
+    processEntityCreation: () => ({
+      entity_write: {
+        ok: true,
+        completed_meeting_ids: [],
+        dead_lettered_ops: [],
+      },
+    }),
+    deadLetteredOps: [{
+      meeting_id: 'meeting-1',
+      meeting_ids: ['meeting-1'],
+      entity_path: '/vault/05-Areas/People/External/Jane_Example.md',
+      op_type: 'mutate',
+      reason: 'target page missing',
+    }],
+    persistState: () => {},
+  });
+
+  assert.equal(state.processedMeetings['meeting-1'].entity_phase, 'failed');
+  assert.equal(state.processedMeetings['meeting-1'].entity_terminal, true);
+});

--- a/.scripts/meeting-intel/__tests__/gardener.test.cjs
+++ b/.scripts/meeting-intel/__tests__/gardener.test.cjs
@@ -12,6 +12,7 @@ const {
   replaceMachineRegion,
   upsertFrontmatter,
 } = require('../../lib/entity-pages.cjs');
+const { installEntityEngineStub } = require('../../lib/tests/entity-engine-test-helper.cjs');
 const { gardenEntities } = require('../lib/gardener.cjs');
 
 const NOW = new Date('2026-07-12T12:00:00.000Z');
@@ -20,14 +21,17 @@ const BULLETS = '- Product leader at Acme.\n- Discussing the launch plan.';
 async function withVault(fn) {
   const oldVault = process.env.VAULT_PATH;
   const oldProject = process.env.CLAUDE_PROJECT_DIR;
+  const oldPython = process.env.DEX_PYTHON;
   const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-gardener-'));
   process.env.VAULT_PATH = vault;
+  process.env.DEX_PYTHON = installEntityEngineStub(vault);
   delete process.env.CLAUDE_PROJECT_DIR;
   try {
     return await fn(vault);
   } finally {
     if (oldVault === undefined) delete process.env.VAULT_PATH; else process.env.VAULT_PATH = oldVault;
     if (oldProject === undefined) delete process.env.CLAUDE_PROJECT_DIR; else process.env.CLAUDE_PROJECT_DIR = oldProject;
+    if (oldPython === undefined) delete process.env.DEX_PYTHON; else process.env.DEX_PYTHON = oldPython;
     fs.rmSync(vault, { recursive: true, force: true });
   }
 }
@@ -75,6 +79,34 @@ test('creates the summary region under Key Context and uses meeting signal', () 
   assert.match(prompt, /Launch review/);
   assert.doesNotMatch(prompt, /Do not include this transcript/);
   assert.equal(result.gardened.length, 1);
+}));
+
+test('an unavailable engine queues the summary and the next run replays it', () => withVault(async vault => {
+  const page = writePerson(vault);
+  const original = fs.readFileSync(page, 'utf8');
+  const configuredPython = process.env.DEX_PYTHON;
+  process.env.DEX_PYTHON = '/definitely/missing/dex-python';
+  const failed = await gardenEntities({ generate: async () => BULLETS, now: NOW });
+  assert.equal(failed.gardened.length, 0);
+  assert.equal(fs.readFileSync(page, 'utf8'), original);
+  const pendingPath = path.join(vault, 'System', '.dex', 'entity-pending.json');
+  assert.equal(JSON.parse(fs.readFileSync(pendingPath, 'utf8')).batches[0].scope, 'gardener');
+
+  process.env.DEX_PYTHON = configuredPython;
+  try {
+    let calls = 0;
+    const replayed = await gardenEntities({
+      generate: async () => { calls += 1; return '- Must not regenerate'; },
+      now: new Date(NOW.getTime() + (24 * 60 * 60 * 1000)),
+    });
+    assert.equal(calls, 0);
+    assert.equal(replayed.gardened.length, 1);
+    assert.match(fs.readFileSync(page, 'utf8'), /- Product leader at Acme\./);
+    assert.equal(fs.existsSync(pendingPath), false);
+  } finally {
+    if (configuredPython === undefined) delete process.env.DEX_PYTHON;
+    else process.env.DEX_PYTHON = configuredPython;
+  }
 }));
 
 test('appends Key Context when the heading is missing', () => withVault(async vault => {

--- a/.scripts/meeting-intel/__tests__/suggestion-actions.test.cjs
+++ b/.scripts/meeting-intel/__tests__/suggestion-actions.test.cjs
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { parseEntityPage } = require('../../lib/entity-pages.cjs');
+const { installEntityEngineStub } = require('../../lib/tests/entity-engine-test-helper.cjs');
 const { loadSuggestions, processEntityCreation } = require('../lib/entity-creation.cjs');
 const {
   acceptSuggestion,
@@ -17,14 +18,18 @@ const {
 function withVault(fn) {
   const previousVault = process.env.VAULT_PATH;
   const previousProject = process.env.CLAUDE_PROJECT_DIR;
+  const previousPython = process.env.DEX_PYTHON;
   const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-suggestion-actions-'));
   process.env.VAULT_PATH = vault;
+  process.env.DEX_PYTHON = installEntityEngineStub(vault);
   delete process.env.CLAUDE_PROJECT_DIR;
   try { return fn(vault); } finally {
     if (previousVault === undefined) delete process.env.VAULT_PATH;
     else process.env.VAULT_PATH = previousVault;
     if (previousProject === undefined) delete process.env.CLAUDE_PROJECT_DIR;
     else process.env.CLAUDE_PROJECT_DIR = previousProject;
+    if (previousPython === undefined) delete process.env.DEX_PYTHON;
+    else process.env.DEX_PYTHON = previousPython;
     fs.rmSync(vault, { recursive: true, force: true });
   }
 }

--- a/.scripts/meeting-intel/__tests__/sync-dead-letter-heal.test.cjs
+++ b/.scripts/meeting-intel/__tests__/sync-dead-letter-heal.test.cjs
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  retryDeadLetteredEntityWork,
+} = require('../sync-from-granola.cjs');
+
+test('sync heal command requeues dead-lettered entity work', (t) => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-sync-dead-letter-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  const runtime = path.join(vault, 'System', '.dex');
+  fs.mkdirSync(runtime, { recursive: true });
+  const operation = {
+    op: 'create',
+    path: path.join(
+      vault,
+      '05-Areas',
+      'People',
+      'External',
+      'Jane_Example.md',
+    ),
+    content: '# Jane Example\n',
+    allowed_root: vault,
+  };
+  fs.writeFileSync(
+    path.join(runtime, 'entity-dead-letter.jsonl'),
+    `${JSON.stringify({
+      dead_letter_id: 'example-dead-letter',
+      batch_id: 'example-batch',
+      scope: 'creation',
+      meeting_id: 'meeting-1',
+      meeting_ids: ['meeting-1'],
+      op: operation,
+    })}\n`,
+  );
+
+  const result = retryDeadLetteredEntityWork(vault);
+
+  assert.equal(result.requeued, 1);
+  const pending = JSON.parse(
+    fs.readFileSync(path.join(runtime, 'entity-pending.json'), 'utf8'),
+  );
+  assert.deepEqual(pending.batches[0].ops, [operation]);
+  assert.equal(
+    fs.existsSync(path.join(runtime, 'entity-dead-letter.jsonl')),
+    false,
+  );
+});

--- a/.scripts/meeting-intel/__tests__/verify-entities.test.cjs
+++ b/.scripts/meeting-intel/__tests__/verify-entities.test.cjs
@@ -113,6 +113,49 @@ test('summary line has the stable one-line format', () => {
   assert.equal(summaryLine(report), 'entities: 12 attendees -> 8 pages, 2 suggested, 1 tracking, 1 no-email; 0 unresolved; companies: 0 pages');
 });
 
+test('dead letters make entity verification observably broken with a fix path', () => withVault(
+  { entity_creation: { mode: 'auto' } },
+  vault => {
+    const runtime = path.join(vault, 'System', '.dex');
+    fs.mkdirSync(runtime, { recursive: true });
+    fs.writeFileSync(
+      path.join(runtime, 'entity-dead-letter.jsonl'),
+      `{"dead_letter_id":\n${JSON.stringify({
+        dead_letter_id: 'example-dead-letter',
+        meeting_id: 'meeting-1',
+        meeting_ids: ['meeting-1'],
+        op_type: 'mutate',
+        entity_path: path.join(
+          vault,
+          '05-Areas',
+          'People',
+          'External',
+          'Jane_Example.md',
+        ),
+        entity_identity: {
+          kind: 'person',
+          name: 'Jane Example',
+          emails: ['jane@example.com'],
+        },
+        reason: 'target page missing',
+      })}\n`,
+    );
+
+    const result = verifyEntities({
+      now: new Date('2026-06-10T12:00:00Z'),
+    });
+
+    assert.equal(result.feature_status, 'broken');
+    assert.equal(result.success, false);
+    assert.match(result.user_message, /1 entity write/i);
+    assert.match(result.user_message, /System\/\.dex\/entity-dead-letter\.jsonl/);
+    assert.match(result.user_message, /\/dex-doctor/);
+    assert.match(result.user_message, /re-queue/i);
+    assert.equal(result.report.dead_letter_count, 1);
+    assert.match(result.summary, /1 entity write failed permanently/i);
+  },
+));
+
 test('company verification reports pages, suggestions, tracking, and auto invariant', () => withVault(
   { work_email: 'owner@dex.test', entity_creation: { mode: 'auto' } },
   vault => {

--- a/.scripts/meeting-intel/lib/entity-creation.cjs
+++ b/.scripts/meeting-intel/lib/entity-creation.cjs
@@ -5,8 +5,15 @@ const path = require('path');
 const yaml = require('js-yaml');
 const portableContract = require('../../../packages/dex-contracts/dist/portable-vault.contract.json');
 const { parseEntityPage, renderCompanyPage, renderPersonPage } = require('../../lib/entity-pages.cjs');
+const { resolveEntityPath } = require('../../lib/entity-identity.cjs');
+const {
+  fingerprintText,
+  flushEntityOps,
+  resultApplied,
+} = require('../../lib/entity-engine-client.cjs');
 const { getInternalDomains } = require('./attendees.cjs');
 const { companyNameFromDomain, isFreemail, registrableDomain } = require('./company-domains.cjs');
+const { entityWriteMessage } = require('./entity-phase.cjs');
 const {
   atomicWrite,
   deriveStats,
@@ -168,7 +175,7 @@ function pageHasEmail(filePath, email) {
   }
 }
 
-function createOrAdoptPerson(contact) {
+function planPersonPage(contact, reserved = new Set()) {
   const paths = runtimePaths();
   const folder = contact.location === 'internal' ? 'Internal' : 'External';
   const directory = path.join(paths.PEOPLE_DIR, folder);
@@ -176,16 +183,24 @@ function createOrAdoptPerson(contact) {
   const email = contact.emails[0];
   const baseName = safeFilename(contact.name);
   const basePath = path.join(directory, `${baseName}.md`);
+  const existingByIdentity = resolveEntityPath(paths.VAULT_ROOT, {
+    kind: 'person',
+    name: contact.name,
+    emails: contact.emails,
+  });
+  if (existingByIdentity && !reserved.has(existingByIdentity)) {
+    return { filePath: existingByIdentity, created: false, adopted: true };
+  }
 
-  if (fs.existsSync(basePath) && pageHasEmail(basePath, email)) {
+  if (!reserved.has(basePath) && fs.existsSync(basePath) && pageHasEmail(basePath, email)) {
     return { filePath: basePath, created: false, adopted: true };
   }
 
   let targetPath = basePath;
-  if (fs.existsSync(targetPath)) {
+  if (reserved.has(targetPath) || fs.existsSync(targetPath)) {
     const domain = safeFilename(contact.domain || email.split('@', 2)[1] || 'contact');
     targetPath = path.join(directory, `${baseName}_(${domain}).md`);
-    if (fs.existsSync(targetPath) && pageHasEmail(targetPath, email)) {
+    if (!reserved.has(targetPath) && fs.existsSync(targetPath) && pageHasEmail(targetPath, email)) {
       return { filePath: targetPath, created: false, adopted: true };
     }
   }
@@ -198,8 +213,36 @@ function createOrAdoptPerson(contact) {
     [],
     contact.location,
   );
-  fs.writeFileSync(targetPath, content, { encoding: 'utf8', flag: 'wx' });
-  return { filePath: targetPath, created: true, adopted: false };
+  reserved.add(targetPath);
+  return {
+    filePath: targetPath,
+    created: true,
+    adopted: false,
+    op: {
+      op: 'create',
+      path: targetPath,
+      content,
+      allowed_root: paths.VAULT_ROOT,
+      target_fingerprint: fingerprintText(content),
+    },
+  };
+}
+
+function executeCreatePlan(plan, paths = runtimePaths()) {
+  if (!plan.op) return plan;
+  const write = flushEntityOps({
+    vaultRoot: paths.VAULT_ROOT,
+    ops: [plan.op],
+    scope: 'suggestion',
+  });
+  if (!write.ok || !resultApplied(plan.op, write.results[0])) {
+    throw new Error(write.error || 'Entity engine did not create the person page');
+  }
+  return plan;
+}
+
+function createOrAdoptPerson(contact) {
+  return executeCreatePlan(planPersonPage(contact));
 }
 
 function walkMarkdown(directory) {
@@ -224,6 +267,11 @@ function companyPageForDomain(domain) {
       }
     }
   } catch (_) { /* an absent or malformed index is advisory only */ }
+  const resolved = resolveEntityPath(paths.VAULT_ROOT, {
+    kind: 'company',
+    domains: [domain],
+  });
+  if (resolved) candidates.add(resolved);
   for (const filePath of walkMarkdown(paths.COMPANIES_DIR)) candidates.add(filePath);
   for (const filePath of candidates) {
     try {
@@ -233,7 +281,7 @@ function companyPageForDomain(domain) {
   return null;
 }
 
-function createOrAdoptCompany(domain, profile = null) {
+function planCompanyPage(domain, profile = null, reserved = new Set()) {
   if (!capabilityEnabled(profile || loadProfile(), 'companies')) {
     throw new Error('Companies room is off');
   }
@@ -244,14 +292,32 @@ function createOrAdoptCompany(domain, profile = null) {
   const name = companyNameFromDomain(domain);
   const basePath = path.join(paths.COMPANIES_DIR, `${safeFilename(name)}.md`);
   let targetPath = basePath;
-  if (fs.existsSync(targetPath)) {
+  if (reserved.has(targetPath) || fs.existsSync(targetPath)) {
     targetPath = path.join(paths.COMPANIES_DIR, `${safeFilename(name)}_(${safeFilename(domain)}).md`);
-    if (fs.existsSync(targetPath) && parseEntityPage(targetPath).domains.map(registrableDomain).includes(domain)) {
+    if (!reserved.has(targetPath)
+        && fs.existsSync(targetPath)
+        && parseEntityPage(targetPath).domains.map(registrableDomain).includes(domain)) {
       return { filePath: targetPath, created: false, adopted: true };
     }
   }
-  fs.writeFileSync(targetPath, renderCompanyPage(name, [domain], null, 'Prospect'), { encoding: 'utf8', flag: 'wx' });
-  return { filePath: targetPath, created: true, adopted: false };
+  const content = renderCompanyPage(name, [domain], null, 'Prospect');
+  reserved.add(targetPath);
+  return {
+    filePath: targetPath,
+    created: true,
+    adopted: false,
+    op: {
+      op: 'create',
+      path: targetPath,
+      content,
+      allowed_root: paths.VAULT_ROOT,
+      target_fingerprint: fingerprintText(content),
+    },
+  };
+}
+
+function createOrAdoptCompany(domain, profile = null) {
+  return executeCreatePlan(planCompanyPage(domain, profile));
 }
 
 function qualifiedCompanyDomains(state, profile) {
@@ -277,17 +343,28 @@ function qualifiedCompanyDomains(state, profile) {
   return [...domains.entries()].filter(([, stats]) => stats.meetings.size >= 2);
 }
 
-function processEntityCreation(meetings, profile = {}, logger = () => {}) {
+function processEntityCreation(
+  meetings,
+  profile = {},
+  logger = () => {},
+  { now = new Date() } = {},
+) {
   const paths = runtimePaths();
   const mode = creationMode(profile);
   const evidenceContacts = new Set();
   const errors = [];
+  const meetingIds = (Array.isArray(meetings) ? meetings : [])
+    .map(meeting => meeting?.id)
+    .filter(Boolean);
 
   for (const meeting of Array.isArray(meetings) ? meetings : []) {
     try {
       const result = recordObservations(meeting.id, {
         date: String(meeting.createdAt || meeting.date || '').slice(0, 10),
-        hasTranscript: Boolean(meeting.transcript && String(meeting.transcript).trim()),
+        hasTranscript: Boolean(
+          meeting.hasTranscript
+          || (meeting.transcript && String(meeting.transcript).trim()),
+        ),
         attendees: Array.isArray(meeting.filteredAttendees)
           ? meeting.filteredAttendees
           : (Array.isArray(meeting.attendees) ? meeting.attendees : []),
@@ -299,23 +376,34 @@ function processEntityCreation(meetings, profile = {}, logger = () => {}) {
     }
   }
 
-  if (mode === 'off') return {
-    mode, created: [], suggested: [], companies_created: [], companies_suggested: [], errors,
-  };
-
   const state = loadState(paths.CONTACTS_STATE_FILE);
   const created = [];
   const suggested = [];
-  for (const contact of qualifiedContacts(state)) {
+  const companiesCreated = [];
+  const companiesSuggested = [];
+  const reserved = new Set();
+  const operations = [];
+  const effects = [];
+  for (const contact of mode === 'off' ? [] : qualifiedContacts(state)) {
     try {
       const stats = deriveStats(state, contact.id);
       if (mode === 'auto' && ['internal', 'external'].includes(contact.location)) {
-        const page = createOrAdoptPerson(contact);
+        const page = planPersonPage(contact, reserved);
         const pagePath = relativeVaultPath(page.filePath, paths.VAULT_ROOT);
-        updateContact(paths.CONTACTS_STATE_FILE, contact.id, { state: 'created', page_path: pagePath });
-        markSuggestionAccepted(contact.id);
-        created.push({ ...page, contact, page_path: pagePath });
-        if (page.created) logger(`Created person page: ${pagePath}`);
+        if (page.op) {
+          operations.push(page.op);
+          effects.push({
+            kind: 'person',
+            contact_id: contact.id,
+            contact,
+            file_path: page.filePath,
+            page_path: pagePath,
+          });
+        } else {
+          updateContact(paths.CONTACTS_STATE_FILE, contact.id, { state: 'created', page_path: pagePath });
+          markSuggestionAccepted(contact.id);
+          created.push({ ...page, contact, page_path: pagePath });
+        }
       } else {
         const result = updateSuggestion(contact, stats, { newEvidence: evidenceContacts.has(contact.id) });
         suggested.push(result.suggestion);
@@ -325,16 +413,11 @@ function processEntityCreation(meetings, profile = {}, logger = () => {}) {
       logger(`Could not create or suggest ${contact.name}: ${error.message}`);
     }
   }
-  const companiesCreated = [];
-  const companiesSuggested = [];
-  if (!capabilityEnabled(profile, 'companies')) {
-    return {
-      mode, created, suggested, companies_created: companiesCreated,
-      companies_suggested: companiesSuggested, errors,
-    };
-  }
   const companyState = loadState(paths.CONTACTS_STATE_FILE);
-  for (const [domain, stats] of qualifiedCompanyDomains(companyState, profile)) {
+  const companyDomains = mode !== 'off' && capabilityEnabled(profile, 'companies')
+    ? qualifiedCompanyDomains(companyState, profile)
+    : [];
+  for (const [domain, stats] of companyDomains) {
     try {
       const existing = companyPageForDomain(domain);
       if (existing) {
@@ -346,14 +429,25 @@ function processEntityCreation(meetings, profile = {}, logger = () => {}) {
       }
       const companyName = companyNameFromDomain(domain);
       if (mode === 'auto') {
-        const page = createOrAdoptCompany(domain, profile);
+        const page = planCompanyPage(domain, profile, reserved);
         const pagePath = relativeVaultPath(page.filePath, paths.VAULT_ROOT);
-        for (const contactId of stats.contacts) {
-          updateContact(paths.CONTACTS_STATE_FILE, contactId, { company_page: pagePath });
+        if (page.op) {
+          operations.push(page.op);
+          effects.push({
+            kind: 'company',
+            contact_ids: [...stats.contacts],
+            domain,
+            name: companyName,
+            file_path: page.filePath,
+            page_path: pagePath,
+          });
+        } else {
+          for (const contactId of stats.contacts) {
+            updateContact(paths.CONTACTS_STATE_FILE, contactId, { company_page: pagePath });
+          }
+          companiesCreated.push({ ...page, name: companyName, domain, page_path: pagePath });
+          markSuggestionAccepted(`domain:${domain}`);
         }
-        companiesCreated.push({ ...page, name: companyName, domain, page_path: pagePath });
-        markSuggestionAccepted(`domain:${domain}`);
-        if (page.created) logger(`Created company page: ${pagePath}`);
       } else {
         const result = updateCompanySuggestion(
           domain, companyName, stats.contacts.size, stats.meetings.size,
@@ -366,9 +460,72 @@ function processEntityCreation(meetings, profile = {}, logger = () => {}) {
       logger(`Could not create or suggest company ${domain}: ${error.message}`);
     }
   }
+  const entityWrite = flushEntityOps({
+    vaultRoot: paths.VAULT_ROOT,
+    ops: operations,
+    meetingIds,
+    scope: 'creation',
+    scopes: ['creation', 'hook', 'suggestion'],
+    metadata: { effects },
+    now,
+  });
+  const reportedEffects = new Set([
+    ...created.map(page => `person:${page.page_path}`),
+    ...companiesCreated.map(page => `company:${page.page_path}`),
+  ]);
+  for (const batch of entityWrite.completed_batches) {
+    if (batch.scope !== 'creation') continue;
+    for (const effect of batch.metadata?.effects || []) {
+      const effectId = `${effect.kind}:${effect.page_path}`;
+      if (effect.kind === 'person') {
+        updateContact(paths.CONTACTS_STATE_FILE, effect.contact_id, {
+          state: 'created',
+          page_path: effect.page_path,
+        });
+        markSuggestionAccepted(effect.contact_id);
+        if (reportedEffects.has(effectId)) continue;
+        reportedEffects.add(effectId);
+        created.push({
+          filePath: effect.file_path,
+          created: true,
+          adopted: false,
+          contact: effect.contact,
+          page_path: effect.page_path,
+        });
+        logger(`Created person page: ${effect.page_path}`);
+      } else if (effect.kind === 'company') {
+        for (const contactId of effect.contact_ids) {
+          updateContact(paths.CONTACTS_STATE_FILE, contactId, {
+            company_page: effect.page_path,
+          });
+        }
+        markSuggestionAccepted(`domain:${effect.domain}`);
+        if (reportedEffects.has(effectId)) continue;
+        reportedEffects.add(effectId);
+        companiesCreated.push({
+          filePath: effect.file_path,
+          created: true,
+          adopted: false,
+          name: effect.name,
+          domain: effect.domain,
+          page_path: effect.page_path,
+        });
+        logger(`Created company page: ${effect.page_path}`);
+      }
+    }
+  }
+  if (!entityWrite.ok) {
+    const writeMessage = entityWriteMessage(entityWrite)
+      || 'Entity writes remain pending';
+    errors.push({
+      entity_write: true,
+      error: writeMessage,
+    });
+    logger(writeMessage);
+  }
   return {
     mode, created, suggested, companies_created: companiesCreated,
-    companies_suggested: companiesSuggested, errors,
+    companies_suggested: companiesSuggested, errors, entity_write: entityWrite,
   };
 }
 

--- a/.scripts/meeting-intel/lib/entity-phase.cjs
+++ b/.scripts/meeting-intel/lib/entity-phase.cjs
@@ -1,0 +1,152 @@
+'use strict';
+
+function meetingId(candidate) {
+  return candidate?.meeting?.id || candidate?.id;
+}
+
+function beginEntityPhase(state, meetings) {
+  if (!state.processedMeetings || typeof state.processedMeetings !== 'object') {
+    state.processedMeetings = {};
+  }
+  for (const meeting of meetings) {
+    const id = meetingId(meeting);
+    if (!id) continue;
+    state.processedMeetings[id] = {
+      ...(state.processedMeetings[id] || {}),
+      entity_phase: 'pending',
+    };
+  }
+}
+
+function completeEntityPhases(state, meetingIds) {
+  for (const id of meetingIds || []) {
+    if (!state.processedMeetings?.[id]) continue;
+    state.processedMeetings[id].entity_phase = 'complete';
+  }
+}
+
+function deadLetterMeetingIds(entries) {
+  return new Set(
+    (Array.isArray(entries) ? entries : [])
+      .flatMap(entry => entry.meeting_ids || [entry.meeting_id])
+      .filter(Boolean),
+  );
+}
+
+function reconcileEntityPhases(state, entityWrite = {}) {
+  completeEntityPhases(state, entityWrite.completed_meeting_ids);
+  const deadIds = deadLetterMeetingIds(entityWrite.dead_lettered_ops);
+  for (const id of deadIds) {
+    const record = state.processedMeetings?.[id];
+    if (!record) continue;
+    const entry = (entityWrite.dead_lettered_ops || []).find(
+      candidate => (candidate.meeting_ids || [candidate.meeting_id]).includes(id),
+    );
+    record.entity_phase = 'failed';
+    record.entity_terminal = true;
+    record.entity_error = entry?.reason
+      || entry?.last_error
+      || 'entity write failed permanently';
+  }
+  for (const id of entityWrite.completed_meeting_ids || []) {
+    const record = state.processedMeetings?.[id];
+    if (!record || deadIds.has(id)) continue;
+    delete record.entity_terminal;
+    delete record.entity_error;
+  }
+}
+
+function retryableEntityMeetings(state) {
+  return Object.values(state.processedMeetings || {})
+    .filter(record => (
+      record?.entity_phase === 'pending'
+      || (record?.entity_phase === 'failed' && record.entity_terminal !== true)
+    ) && record.entity_payload?.id)
+    .map(record => record.entity_payload);
+}
+
+function entityWriteMessage(entityWrite = {}) {
+  const dead = Array.isArray(entityWrite.dead_lettered_ops)
+    ? entityWrite.dead_lettered_ops
+    : [];
+  if (dead.length > 0) {
+    const noun = dead.length === 1 ? 'entity write' : 'entity writes';
+    return `${dead.length} ${noun} failed permanently. Run /dex-doctor and inspect `
+      + 'System/.dex/entity-dead-letter.jsonl for the affected page, meeting, and operation.';
+  }
+  if (entityWrite.ok === false) {
+    return `Entity writes remain pending and will retry after backoff: ${
+      entityWrite.error || 'engine operation did not apply'
+    }`;
+  }
+  return null;
+}
+
+function retryEntityPhases(state, profile, {
+  processEntityCreation,
+  persistState,
+  logger = () => {},
+  now = new Date(),
+  deadLetteredOps = [],
+} = {}) {
+  if (typeof processEntityCreation !== 'function') {
+    throw new TypeError('processEntityCreation must be a function');
+  }
+  if (typeof persistState !== 'function') {
+    throw new TypeError('persistState must be a function');
+  }
+  const meetings = retryableEntityMeetings(state);
+  const emitted = new Set();
+  const emit = (message) => {
+    emitted.add(message);
+    logger(message);
+  };
+  for (const meeting of meetings) {
+    const record = state.processedMeetings[meeting.id];
+    record.entity_phase = 'pending';
+    delete record.entity_terminal;
+  }
+  let result;
+  try {
+    result = processEntityCreation(
+      meetings,
+      profile,
+      message => emit(message),
+      { now },
+    );
+    const currentDeadLetters = result.entity_write?.dead_lettered_ops || [];
+    result.entity_write.dead_lettered_ops = [
+      ...deadLetteredOps,
+      ...currentDeadLetters,
+    ];
+    reconcileEntityPhases(state, result.entity_write);
+  } catch (error) {
+    for (const meeting of meetings) {
+      const record = state.processedMeetings[meeting.id];
+      record.entity_phase = 'failed';
+      record.entity_terminal = false;
+      record.entity_error = error.message;
+    }
+    result = {
+      entity_write: {
+        ok: false,
+        completed_meeting_ids: [],
+        dead_lettered_ops: [],
+        error: error.message,
+      },
+    };
+  }
+  persistState(state);
+  const message = entityWriteMessage(result.entity_write);
+  if (message && !emitted.has(message)) emit(message);
+  return result;
+}
+
+module.exports = {
+  beginEntityPhase,
+  completeEntityPhases,
+  entityWriteMessage,
+  reconcileEntityPhases,
+  retryableEntityMeetings,
+  retryEntityPhases,
+};

--- a/.scripts/meeting-intel/lib/gardener.cjs
+++ b/.scripts/meeting-intel/lib/gardener.cjs
@@ -5,10 +5,14 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const {
-  atomicWrite: atomicWritePage,
   parseEntityPage,
   replaceMachineRegion,
 } = require('../../lib/entity-pages.cjs');
+const {
+  flushEntityOps,
+  loadPendingStore,
+} = require('../../lib/entity-engine-client.cjs');
+const { identityForEntity } = require('../../lib/entity-identity.cjs');
 const {
   atomicWrite,
   runtimePaths,
@@ -89,21 +93,6 @@ function removeResumeMarker(output) {
     .filter(line => line.trim() !== RESUME_MARKER)
     .join('\n')
     .replace(/^[\r\n]+|[\r\n]+$/g, '');
-}
-
-function ensureSummaryRegion(text) {
-  if (machineRegion(text, REGION_SLUG) !== null) return text;
-  if (text.includes(REGION_START)) {
-    throw new Error(`malformed machine region: ${REGION_SLUG} (missing end marker)`);
-  }
-  const region = `${REGION_START}\n${REGION_END}`;
-  const heading = /^## Key Context[ \t]*$/m.exec(text);
-  if (heading) {
-    const lineEnd = text.indexOf('\n', heading.index + heading[0].length);
-    const insertionPoint = lineEnd < 0 ? text.length : lineEnd + 1;
-    return `${text.slice(0, insertionPoint)}\n${region}\n${text.slice(insertionPoint)}`;
-  }
-  return `${text.replace(/\s*$/, '')}\n\n## Key Context\n\n${region}\n`;
 }
 
 function sectionLines(text, heading, maximum) {
@@ -244,9 +233,15 @@ async function gardenEntities({
     const state = withLock(paths.GARDENER_STATE_FILE, () => loadGardenerState(paths.GARDENER_STATE_FILE));
     const meetings = meetingSignals(paths.MEETINGS_DIR);
     const candidates = [];
+    const pendingPages = new Set(
+      loadPendingStore(paths.VAULT_ROOT).batches
+        .filter(batch => batch.scope === 'gardener')
+        .flatMap(batch => batch.ops.map(operation => operation.path)),
+    );
 
     for (const filePath of personPages(paths.PEOPLE_DIR)) {
       try {
+        if (!dryRun && pendingPages.has(filePath)) continue;
         const entity = parseEntityPage(filePath);
         if (entity.quarantined) { result.skipped += 1; continue; }
         const relativePath = path.relative(paths.VAULT_ROOT, filePath).split(path.sep).join('/');
@@ -310,7 +305,7 @@ async function gardenEntities({
           signal,
           inputHash,
           expectedOutputHash: observedOutputHash,
-          resumeOutput: resumeRequested ? currentOutput : null,
+          entityIdentity: identityForEntity(entity),
           saved,
         });
       } catch (error) {
@@ -328,33 +323,45 @@ async function gardenEntities({
 
     const selected = candidates.slice(0, maximum);
     result.skipped += candidates.length - selected.length;
+    const operations = [];
+    const effects = [];
     for (const candidate of selected) {
       try {
         const output = cleanOutput(await generate(promptFor(candidate.signal)));
         if (!output) { result.skipped += 1; continue; }
-        if (!dryRun) {
-          const latestText = fs.readFileSync(candidate.filePath, 'utf8');
-          const latestOutput = machineRegion(latestText, REGION_SLUG);
-          if (latestOutput === null && latestText.includes(REGION_START)) {
-            result.skipped += 1;
-            log(`Gardener preserved ${candidate.relativePath}: malformed-region`);
-            continue;
-          }
-          if (sha1(latestOutput || '') !== candidate.expectedOutputHash) {
-            candidate.saved.blocks = blockState(candidate.saved);
-            candidate.saved.blocks[REGION_SLUG] = { owner: 'user', reason: 'user-edited' };
-            savePageState(paths.GARDENER_STATE_FILE, candidate.relativePath, candidate.saved);
-            result.preserved += 1;
-            result.skipped += 1;
-            log(`Gardener preserved ${candidate.relativePath}: user-owned ${REGION_SLUG}`);
-            continue;
-          }
-          const resumedText = candidate.resumeOutput === null
-            ? latestText
-            : replaceMachineRegion(latestText, REGION_SLUG, candidate.resumeOutput);
-          const withRegion = ensureSummaryRegion(resumedText);
-          atomicWritePage(candidate.filePath, replaceMachineRegion(withRegion, REGION_SLUG, output));
-          const nextState = {
+        if (dryRun) {
+          result.gardened.push(candidate.relativePath);
+          continue;
+        }
+        const latestText = fs.readFileSync(candidate.filePath, 'utf8');
+        const latestOutput = machineRegion(latestText, REGION_SLUG);
+        // Never clobber user prose when the region is malformed (TOCTOU re-check, #144).
+        if (latestOutput === null && latestText.includes(REGION_START)) {
+          result.skipped += 1;
+          log(`Gardener preserved ${candidate.relativePath}: malformed-region`);
+          continue;
+        }
+        if (sha1(latestOutput || '') !== candidate.expectedOutputHash) {
+          candidate.saved.blocks = blockState(candidate.saved);
+          candidate.saved.blocks[REGION_SLUG] = { owner: 'user', reason: 'user-edited' };
+          savePageState(paths.GARDENER_STATE_FILE, candidate.relativePath, candidate.saved);
+          result.preserved += 1;
+          result.skipped += 1;
+          log(`Gardener preserved ${candidate.relativePath}: user-owned ${REGION_SLUG}`);
+          continue;
+        }
+        operations.push({
+          op: 'mutate',
+          path: candidate.filePath,
+          entity_identity: candidate.entityIdentity,
+          intent: {
+            kind: 'gardener-summary',
+            region_projection: output,
+          },
+        });
+        effects.push({
+          relative_path: candidate.relativePath,
+          page_state: {
             ...candidate.saved,
             last_gardened: nowDate.toISOString(),
             input_hash: candidate.inputHash,
@@ -363,12 +370,37 @@ async function gardenEntities({
               ...blockState(candidate.saved),
               [REGION_SLUG]: { owner: 'dex' },
             },
-          };
-          savePageState(paths.GARDENER_STATE_FILE, candidate.relativePath, nextState);
-        }
-        result.gardened.push(candidate.relativePath);
+          },
+        });
       } catch (error) {
         result.errors.push({ page: candidate.relativePath, error: error.message });
+      }
+    }
+    if (!dryRun) {
+      const write = flushEntityOps({
+        vaultRoot: paths.VAULT_ROOT,
+        ops: operations,
+        scope: 'gardener',
+        metadata: { effects },
+        now: nowDate,
+      });
+      for (const batch of write.completed_batches) {
+        for (const effect of batch.metadata?.effects || []) {
+          savePageState(
+            paths.GARDENER_STATE_FILE,
+            effect.relative_path,
+            effect.page_state,
+          );
+          if (!result.gardened.includes(effect.relative_path)) {
+            result.gardened.push(effect.relative_path);
+          }
+        }
+      }
+      if (!write.ok) {
+        result.errors.push({
+          page: null,
+          error: write.error || 'Gardener entity writes remain pending',
+        });
       }
     }
   } catch (error) {

--- a/.scripts/meeting-intel/sync-from-granola.cjs
+++ b/.scripts/meeting-intel/sync-from-granola.cjs
@@ -38,6 +38,10 @@ const { execSync } = require('child_process');
 const yaml = require('js-yaml');
 const { loadPaths } = require('../../.claude/hooks/paths.cjs');
 const { autoLinkFiles } = require('../auto-link-people.cjs');
+const {
+  loadDeadLetters,
+  requeueDeadLetters,
+} = require('../lib/entity-engine-client.cjs');
 const { getMeetingProcessingMode } = require('./lib/config.cjs');
 const { getGranolaApiKey: readGranolaApiKey } = require('./lib/granola-api-key.cjs');
 const {
@@ -47,6 +51,9 @@ const {
   filterOwner,
 } = require('./lib/attendees.cjs');
 const { processEntityCreation } = require('./lib/entity-creation.cjs');
+const {
+  retryEntityPhases,
+} = require('./lib/entity-phase.cjs');
 const { gardenEntities } = require('./lib/gardener.cjs');
 const { verifyEntities } = require('./verify-entities.cjs');
 const { generateContent, isConfigured } = require('../lib/llm-client.cjs');
@@ -189,7 +196,25 @@ function loadState() {
 
 function saveState(state) {
   state.lastSync = new Date().toISOString();
+  persistState(state);
+}
+
+function persistState(state) {
   fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function retryPendingEntityWork(state, profile, now = new Date()) {
+  return retryEntityPhases(state, profile, {
+    processEntityCreation,
+    persistState,
+    logger: message => log(`  ${message}`),
+    now,
+    deadLetteredOps: loadDeadLetters(VAULT_ROOT),
+  });
+}
+
+function retryDeadLetteredEntityWork(vaultRoot = VAULT_ROOT) {
+  return requeueDeadLetters(vaultRoot);
 }
 
 // ============================================================================
@@ -999,16 +1024,26 @@ async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
   const force = args.includes('--force');
+  const retryDeadLetters = args.includes('--retry-entity-dead-letters');
 
   log('='.repeat(60));
   log('Dex Meeting Intel - Granola Sync (official public API)');
   log('='.repeat(60));
+  if (retryDeadLetters) {
+    const healed = retryDeadLetteredEntityWork();
+    log(`Re-queued ${healed.requeued} dead-lettered entity write(s) with fresh retries.`);
+  }
 
   // ---- Auth: official Granola public API key (no local files) ----
   const apiKey = getGranolaApiKey();
   if (!apiKey) {
     log('Granola not connected — run /granola-setup to add your Granola API key (requires a Granola Business plan).');
-    if (!dryRun) runEntityVerification();
+    if (!dryRun) {
+      const profile = loadUserProfile();
+      const state = loadState();
+      retryPendingEntityWork(state, profile);
+      runEntityVerification();
+    }
     return; // clean exit (exit 0 via the runner)
   }
 
@@ -1034,6 +1069,7 @@ async function main() {
     // Auth rejected or network failure — already logged a friendly reason.
     log('Could not reach the Granola API this run. Exiting cleanly.');
     if (!dryRun) {
+      retryPendingEntityWork(state, profile);
       runEntityVerification();
       await runEntityGardener(profile);
     }
@@ -1044,6 +1080,7 @@ async function main() {
 
   if (newMeetings.length === 0) {
     log('Nothing to process. Exiting.');
+    retryPendingEntityWork(state, profile);
     saveState(state);
     if (!dryRun) {
       runEntityVerification();
@@ -1077,6 +1114,7 @@ async function main() {
       log(`\nQueuing: ${meeting.title}`);
       queueMeetingAsJson(meeting, state);
     }
+    retryPendingEntityWork(state, profile);
     saveState(state);
     runEntityVerification();
     log('\n' + '='.repeat(60));
@@ -1120,7 +1158,14 @@ async function main() {
       title: meeting.title,
       processedAt: new Date().toISOString(),
       filepath: result.filepath,
-      source: meeting.source || dataSource
+      source: meeting.source || dataSource,
+      entity_phase: 'pending',
+      entity_payload: {
+        id: meeting.id,
+        createdAt: meeting.createdAt,
+        hasTranscript: Boolean(meeting.transcript && String(meeting.transcript).trim()),
+        filteredAttendees: getOwnerFilteredAttendees(meeting, profile),
+      },
     };
 
     processedResults.push({ meeting, ...result });
@@ -1151,18 +1196,8 @@ async function main() {
       }
     }
 
-    try {
-      processEntityCreation(
-        processedResults.map(result => ({
-          ...result.meeting,
-          filteredAttendees: getOwnerFilteredAttendees(result.meeting, profile),
-        })),
-        profile,
-        message => log(`  ${message}`),
-      );
-    } catch (error) {
-      log(`Entity creation skipped after error: ${error.message}`);
-    }
+    retryPendingEntityWork(state, profile);
+    saveState(state);
   }
 
   runEntityVerification();
@@ -1199,4 +1234,6 @@ module.exports = {
   getMeetingProcessingMode,
   renderAttendeesYamlBlock,
   renderParticipants,
+  retryDeadLetteredEntityWork,
+  retryPendingEntityWork,
 };

--- a/.scripts/meeting-intel/verify-entities.cjs
+++ b/.scripts/meeting-intel/verify-entities.cjs
@@ -80,6 +80,29 @@ function plural(count, singular, pluralForm = `${singular}s`) {
   return count === 1 ? singular : pluralForm;
 }
 
+function readDeadLetters(paths) {
+  const filePath = path.join(
+    path.dirname(paths.ENTITY_PENDING_FILE),
+    'entity-dead-letter.jsonl',
+  );
+  try {
+    const entries = fs.readFileSync(filePath, 'utf8')
+      .split(/\r?\n/)
+      .filter(line => line.trim())
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line)];
+        } catch (_) {
+          return [];
+        }
+      });
+    return { entries, error: null };
+  } catch (error) {
+    if (error.code === 'ENOENT') return { entries: [], error: null };
+    return { entries: [], error };
+  }
+}
+
 function summaryLine(report) {
   const counts = report.counts;
   const parts = [];
@@ -98,7 +121,13 @@ function summaryLine(report) {
   if (companyCounts.tracking) companyParts.push(`${companyCounts.tracking} tracking`);
   if (companyCounts.disabled) companyParts.push(`${companyCounts.disabled} disabled`);
   if (companyParts.length === 0) companyParts.push('0 pages');
-  return `entities: ${report.attendees} attendees -> ${parts.join(', ')}; ${report.unresolved.length} unresolved; companies: ${companyParts.join(', ')}`;
+  const deadLetter = report.dead_letter_count
+    ? `; ${report.dead_letter_count} ${plural(
+      report.dead_letter_count,
+      'entity write',
+    )} failed permanently`
+    : '';
+  return `entities: ${report.attendees} attendees -> ${parts.join(', ')}; ${report.unresolved.length} unresolved; companies: ${companyParts.join(', ')}${deadLetter}`;
 }
 
 function verifyEntities({ days = 7, now = new Date() } = {}) {
@@ -116,6 +145,7 @@ function verifyEntities({ days = 7, now = new Date() } = {}) {
   const identities = new Map();
   const windowDomains = new Map();
   const internalDomains = new Set(Array.from(getInternalDomains(profile), registrableDomain));
+  const deadLetters = readDeadLetters(paths);
 
   for (const filePath of walkMarkdown(paths.MEETINGS_DIR)) {
     const data = frontmatter(filePath);
@@ -238,6 +268,7 @@ function verifyEntities({ days = 7, now = new Date() } = {}) {
     counts,
     companies: { counts: companyCounts, domains: companyDomains },
     unresolved,
+    dead_letter_count: deadLetters.entries.length,
   };
   Object.defineProperty(report, 'attendees', { value: identities.size, enumerable: false });
   fs.mkdirSync(path.dirname(paths.ENTITY_VERIFICATION_FILE), { recursive: true });
@@ -247,7 +278,40 @@ function verifyEntities({ days = 7, now = new Date() } = {}) {
   );
   fs.writeFileSync(tempPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   fs.renameSync(tempPath, paths.ENTITY_VERIFICATION_FILE);
-  return { report, summary: summaryLine(report) };
+  const summary = summaryLine(report);
+  if (deadLetters.error) {
+    return {
+      success: false,
+      feature: 'Entity engine',
+      feature_status: 'unknown',
+      user_message: 'Entity write failures could not be checked. Run /dex-doctor and '
+        + 'inspect System/.dex/entity-dead-letter.jsonl.',
+      detail: deadLetters.error.message,
+      report,
+      summary,
+    };
+  }
+  if (deadLetters.entries.length > 0) {
+    const count = deadLetters.entries.length;
+    return {
+      success: false,
+      feature: 'Entity engine',
+      feature_status: 'broken',
+      user_message: `${count} ${plural(count, 'entity write')} failed permanently. `
+        + 'Run /dex-doctor to re-queue the failed write with fresh retries; '
+        + 'details remain in System/.dex/entity-dead-letter.jsonl until then.',
+      report,
+      summary,
+    };
+  }
+  return {
+    success: true,
+    feature: 'Entity engine',
+    feature_status: 'ok',
+    user_message: 'Entity verification completed with no dead-lettered writes.',
+    report,
+    summary,
+  };
 }
 
 function parseDays(argv) {

--- a/core/entity_engine/cli.py
+++ b/core/entity_engine/cli.py
@@ -1,0 +1,183 @@
+"""JSON batch command-line adapter for the canonical entity write engine."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+from .write import (
+    Result,
+    create_page_if_absent,
+    fingerprint_page,
+    mutate_page,
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class InvalidBatch(ValueError):
+    """Raised when the complete request cannot be validated safely."""
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise InvalidBatch(f"{label} must be an object")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise InvalidBatch(f"{label} must be a string")
+    return value
+
+
+def _optional_mapping(
+    value: Any,
+    label: str,
+) -> Mapping[str, Any] | None:
+    if value is None:
+        return None
+    return _mapping(value, label)
+
+
+def _optional_strings(value: Any, label: str) -> list[str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) for item in value
+    ):
+        raise InvalidBatch(f"{label} must be an array of strings")
+    return value
+
+
+def _validate_op(candidate: Any, index: int) -> dict[str, Any]:
+    label = f"ops[{index}]"
+    operation = dict(_mapping(candidate, label))
+    kind = _string(operation.get("op"), f"{label}.op")
+    operation["path"] = _string(operation.get("path"), f"{label}.path")
+    if kind == "create":
+        operation["content"] = _string(
+            operation.get("content"), f"{label}.content"
+        )
+        allowed_root = operation.get("allowed_root")
+        if allowed_root is not None:
+            operation["allowed_root"] = _string(
+                allowed_root, f"{label}.allowed_root"
+            )
+        return operation
+    if kind != "mutate":
+        raise InvalidBatch(f"{label}.op must be create or mutate")
+
+    base_fingerprint = operation.get("base_fingerprint")
+    if not isinstance(base_fingerprint, str) or not _SHA256_RE.fullmatch(
+        base_fingerprint
+    ):
+        raise InvalidBatch(
+            f"{label}.base_fingerprint must be a SHA-256 hex string"
+        )
+    operation["field_changes"] = _optional_mapping(
+        operation.get("field_changes"), f"{label}.field_changes"
+    )
+    replacement_content = operation.get("replacement_content")
+    if replacement_content is not None:
+        operation["replacement_content"] = _string(
+            replacement_content, f"{label}.replacement_content"
+        )
+    operation["ensure_regions"] = _optional_strings(
+        operation.get("ensure_regions"), f"{label}.ensure_regions"
+    )
+    operation["region_projections"] = _optional_mapping(
+        operation.get("region_projections"), f"{label}.region_projections"
+    )
+    return operation
+
+
+def _validate_request(candidate: Any) -> list[dict[str, Any]]:
+    request = _mapping(candidate, "request")
+    operations = request.get("ops")
+    if not isinstance(operations, list):
+        raise InvalidBatch("request.ops must be an array")
+    return [
+        _validate_op(operation, index)
+        for index, operation in enumerate(operations)
+    ]
+
+
+def _apply(operation: Mapping[str, Any]) -> Result:
+    if operation["op"] == "create":
+        result = create_page_if_absent(
+            operation["path"],
+            operation["content"],
+            allowed_root=operation.get("allowed_root"),
+        )
+        if result.status == "exists":
+            try:
+                return Result("exists", False, fingerprint_page(operation["path"]))
+            except OSError:
+                return result
+        return result
+    return mutate_page(
+        operation["path"],
+        operation["base_fingerprint"],
+        replacement_content=operation.get("replacement_content"),
+        field_changes=operation.get("field_changes"),
+        ensure_regions=operation.get("ensure_regions"),
+        region_projections=operation.get("region_projections"),
+    )
+
+
+def run(payload: Any) -> dict[str, Any]:
+    """Validate the whole batch, then apply its operations in request order."""
+    operations = _validate_request(payload)
+    results = []
+    for operation in operations:
+        result = _apply(operation)
+        results.append(
+            {
+                "path": operation["path"],
+                "status": result.status,
+                "fingerprint": result.fingerprint,
+            }
+        )
+    return {"results": results}
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        response = run(payload)
+    except (InvalidBatch, json.JSONDecodeError) as error:
+        print(
+            json.dumps(
+                {
+                    "error": {
+                        "code": "invalid_batch",
+                        "message": str(error),
+                    }
+                },
+                sort_keys=True,
+            )
+        )
+        return 2
+    except (OSError, UnicodeError, ValueError, TypeError) as error:
+        print(
+            json.dumps(
+                {
+                    "error": {
+                        "code": "engine_failure",
+                        "message": str(error),
+                    }
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+    print(json.dumps(response, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/entity_engine/write.py
+++ b/core/entity_engine/write.py
@@ -149,6 +149,7 @@ def _build_mutation(
     page_path: Path,
     original_bytes: bytes,
     *,
+    replacement_content: str | None,
     field_changes: Mapping[str, Any] | None,
     ensure_regions: Iterable[str] | None,
     region_projections: Mapping[str, str] | None,
@@ -160,7 +161,9 @@ def _build_mutation(
     if quarantined:
         return None, True
 
-    updated = text
+    updated = text if replacement_content is None else replacement_content
+    if updated.startswith("\ufeff"):
+        updated = updated[1:]
     if field_changes:
         merged = merge_frontmatter_text(page_path, updated, field_changes)
         if merged is None:
@@ -181,6 +184,7 @@ def mutate_page(
     path: str | Path,
     base_fingerprint: str,
     *,
+    replacement_content: str | None = None,
     field_changes: Mapping[str, Any] | None = None,
     ensure_regions: Iterable[str] | None = None,
     region_projections: Mapping[str, str] | None = None,
@@ -206,6 +210,7 @@ def mutate_page(
     updated_bytes, quarantined = _build_mutation(
         page_path,
         original_bytes,
+        replacement_content=replacement_content,
         field_changes=field_changes,
         ensure_regions=ensure_regions,
         region_projections=region_projections,
@@ -269,6 +274,7 @@ def upsert_frontmatter(
         updated, quarantined = _build_mutation(
             page_path,
             original_bytes,
+            replacement_content=None,
             field_changes=fields,
             ensure_regions=None,
             region_projections=None,

--- a/core/paths.py
+++ b/core/paths.py
@@ -104,6 +104,7 @@ RITUAL_INTELLIGENCE_DB_FILE = DEX_RUNTIME_DIR / 'ritual-intelligence.db'
 CONTACTS_STATE_FILE = DEX_RUNTIME_DIR / 'contacts.json'
 GARDENER_STATE_FILE = DEX_RUNTIME_DIR / 'gardener.json'
 ENTITY_SUGGESTIONS_FILE = DEX_RUNTIME_DIR / 'entity-suggestions.json'
+ENTITY_PENDING_FILE = DEX_RUNTIME_DIR / 'entity-pending.json'
 ENTITY_VERIFICATION_FILE = DEX_RUNTIME_DIR / 'entity-verification.json'
 
 

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -327,6 +327,125 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     assert "stale >48h" in result.detail
 
 
+def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(context):
+    _write_entity_probe_files(context)
+    dead_letter = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+    dead_letter.write_text(
+        '{"dead_letter_id":\n'
+        + json.dumps(
+            {
+                "dead_letter_id": "example-dead-letter",
+                "meeting_id": "meeting-1",
+                "meeting_ids": ["meeting-1"],
+                "op_type": "mutate",
+                "entity_path": (
+                    str(context.vault_root)
+                    + "/05-Areas/People/External/Jane_Example.md"
+                ),
+                "entity_identity": {
+                    "kind": "person",
+                    "name": "Jane Example",
+                    "emails": ["jane@example.org"],
+                },
+                "reason": "target page missing",
+            }
+        )
+        + "\n"
+    )
+
+    result = doctor._probe_entity_engine(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "1 entity write" in result.user_message
+    assert "System/.dex/entity-dead-letter.jsonl" in result.user_message
+    assert "/dex-doctor" in result.user_message
+    assert "re-queue" in result.user_message
+    assert result.heal == doctor.Heal(
+        tier=1,
+        action="Re-queue the dead-lettered entity write with retry counters reset.",
+        applied=False,
+    )
+    definition = next(
+        item for item in doctor.QUICK_CHECKS if item.id == "entity.engine"
+    )
+    rendered = doctor._result_json(definition, result)
+    assert rendered["feature_status"] == "broken"
+    assert rendered["user_message"] == result.user_message
+
+
+def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+    dead_letter = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+    dead_letter.parent.mkdir(parents=True, exist_ok=True)
+    dead_letter.write_text('{"dead_letter_id":"example-dead-letter"}\n')
+    calls = []
+    monkeypatch.setattr(
+        doctor,
+        "_requeue_entity_dead_letters",
+        lambda candidate: calls.append(candidate) or {
+            "requeued": 1,
+            "dead_letter_ids": ["example-dead-letter"],
+        },
+    )
+
+    actions, errors = doctor._apply_t1_heals(context)
+
+    assert errors == []
+    assert calls == [context]
+    assert actions == ["re-queued 1 dead-lettered entity write with retry counters reset"]
+
+
+def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
+    _write_entity_probe_files(context)
+    operation = {
+        "op": "create",
+        "path": str(
+            context.vault_root
+            / "05-Areas"
+            / "People"
+            / "External"
+            / "Jane_Example.md"
+        ),
+        "content": "# Jane Example\n",
+        "allowed_root": str(context.vault_root),
+    }
+    dead_letter = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+    dead_letter.write_text(
+        json.dumps(
+            {
+                "dead_letter_id": "example-dead-letter",
+                "batch_id": "example-batch",
+                "scope": "creation",
+                "meeting_id": "meeting-1",
+                "meeting_ids": ["meeting-1"],
+                "op": operation,
+            }
+        )
+        + "\n"
+    )
+    bridge_context = doctor.DoctorContext(
+        vault_root=context.vault_root,
+        repo_root=DOCTOR_PATH.parents[2],
+        home=context.home,
+        now=context.now,
+    )
+
+    healed = doctor._requeue_entity_dead_letters(bridge_context)
+
+    assert healed["requeued"] == 1
+    assert not dead_letter.exists()
+    pending = json.loads(
+        (context.vault_root / "System" / ".dex" / "entity-pending.json").read_text()
+    )
+    assert pending["batches"][0]["ops"] == [operation]
+    assert doctor._probe_entity_engine(context).verdict == "OK"
+
+
 def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
         monkeypatch.delenv(key, raising=False)

--- a/core/tests/test_entity_engine.py
+++ b/core/tests/test_entity_engine.py
@@ -63,6 +63,43 @@ def test_composite_mutation_uses_one_atomic_replace(
     assert "User-authored note." in text
 
 
+def test_composite_mutation_can_preserve_a_legacy_body_rewrite(
+    tmp_path: Path,
+) -> None:
+    page = tmp_path / "Legacy.md"
+    page.write_text(
+        "---\n"
+        "type: person\n"
+        "name: Legacy Person\n"
+        "last_interaction: 2026-01-01\n"
+        "dex_pinned: {}\n"
+        "dex_last_written: {last_interaction: 2026-01-01}\n"
+        "---\n"
+        "# Legacy Person\n\n"
+        "## Meetings\n\n"
+        "- Older meeting\n",
+        encoding="utf-8",
+    )
+    replacement = page.read_text(encoding="utf-8").replace(
+        "## Meetings\n",
+        "## Meetings\n"
+        "- [Roadmap](00-Inbox/Meetings/roadmap.md) — 2026-07-10\n",
+    )
+
+    result = mutate_page(
+        page,
+        fingerprint_page(page),
+        replacement_content=replacement,
+        field_changes={"last_interaction": "2026-07-10"},
+    )
+
+    assert result.status == "updated"
+    text = page.read_text(encoding="utf-8")
+    assert "last_interaction: '2026-07-10'" in text
+    assert "- [Roadmap](00-Inbox/Meetings/roadmap.md) — 2026-07-10" in text
+    assert "- Older meeting" in text
+
+
 def test_fingerprint_mismatch_returns_conflict_without_clobber(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/core/tests/test_entity_engine_cli.py
+++ b/core/tests/test_entity_engine_cli.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from core.entity_engine import cli
+
+
+def _run_cli(payload: object, *, vault: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["VAULT_PATH"] = str(vault)
+    return subprocess.run(
+        [sys.executable, "-m", "core.entity_engine.cli"],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_cli_applies_mixed_create_and_mutate_batch(tmp_path: Path) -> None:
+    existing = tmp_path / "05-Areas" / "People" / "External" / "Existing.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text(
+        "---\n"
+        "type: person\n"
+        "name: Existing Person\n"
+        "company: Old Co\n"
+        "dex_pinned: {}\n"
+        "dex_last_written: {company: Old Co}\n"
+        "---\n"
+        "# Existing Person\n",
+        encoding="utf-8",
+    )
+    base_fingerprint = hashlib.sha256(existing.read_bytes()).hexdigest()
+    created = existing.with_name("Created.md")
+    content = "# Created Person\n"
+
+    completed = _run_cli(
+        {
+            "ops": [
+                {
+                    "op": "create",
+                    "path": str(created),
+                    "content": content,
+                    "allowed_root": str(tmp_path),
+                },
+                {
+                    "op": "mutate",
+                    "path": str(existing),
+                    "base_fingerprint": base_fingerprint,
+                    "field_changes": {"company": "New Co"},
+                },
+            ]
+        },
+        vault=tmp_path,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    response = json.loads(completed.stdout)
+    assert [result["status"] for result in response["results"]] == [
+        "created",
+        "updated",
+    ]
+    assert response["results"][0] == {
+        "path": str(created),
+        "status": "created",
+        "fingerprint": hashlib.sha256(content.encode()).hexdigest(),
+    }
+    assert response["results"][1]["path"] == str(existing)
+    assert len(response["results"][1]["fingerprint"]) == 64
+    assert created.read_text(encoding="utf-8") == content
+    assert "company: New Co" in existing.read_text(encoding="utf-8")
+
+
+def test_cli_rejects_malformed_op_before_applying_batch(tmp_path: Path) -> None:
+    target = tmp_path / "05-Areas" / "People" / "External" / "Never.md"
+
+    completed = _run_cli(
+        {
+            "ops": [
+                {
+                    "op": "create",
+                    "path": str(target),
+                    "content": "# Must not be created\n",
+                    "allowed_root": str(tmp_path),
+                },
+                {"op": "mutate", "path": str(target)},
+            ]
+        },
+        vault=tmp_path,
+    )
+
+    assert completed.returncode == 2
+    assert json.loads(completed.stdout) == {
+        "error": {
+            "code": "invalid_batch",
+            "message": "ops[1].base_fingerprint must be a SHA-256 hex string",
+        }
+    }
+    assert not target.exists()
+
+
+def test_run_validates_and_dispatches_mixed_batch_in_process(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "05-Areas" / "People" / "External" / "Existing.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text(
+        "---\n"
+        "type: person\n"
+        "name: Existing Person\n"
+        "company: Old Co\n"
+        "dex_pinned: {}\n"
+        "dex_last_written: {company: Old Co}\n"
+        "---\n"
+        "# Existing Person\n",
+        encoding="utf-8",
+    )
+    created = existing.with_name("Created.md")
+    content = "# Created Person\n"
+
+    response = cli.run(
+        {
+            "ops": [
+                {
+                    "op": "create",
+                    "path": str(created),
+                    "content": content,
+                    "allowed_root": str(tmp_path),
+                },
+                {
+                    "op": "create",
+                    "path": str(created),
+                    "content": "# Must not replace\n",
+                    "allowed_root": str(tmp_path),
+                },
+                {
+                    "op": "mutate",
+                    "path": str(existing),
+                    "base_fingerprint": hashlib.sha256(
+                        existing.read_bytes()
+                    ).hexdigest(),
+                    "replacement_content": existing.read_text(encoding="utf-8"),
+                    "field_changes": {"company": "New Co"},
+                    "ensure_regions": ["relationships"],
+                    "region_projections": {
+                        "relationships": "- works with [[Created Person]]"
+                    },
+                },
+            ]
+        }
+    )
+
+    assert [result["status"] for result in response["results"]] == [
+        "created",
+        "exists",
+        "updated",
+    ]
+    assert response["results"][1]["fingerprint"] == hashlib.sha256(
+        content.encode()
+    ).hexdigest()
+    assert created.read_text(encoding="utf-8") == content
+    updated = existing.read_text(encoding="utf-8")
+    assert "company: New Co" in updated
+    assert "- works with [[Created Person]]" in updated
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (None, "request must be an object"),
+        ({}, "request.ops must be an array"),
+        ({"ops": [None]}, "ops[0] must be an object"),
+        (
+            {"ops": [{"op": 1, "path": "Person.md"}]},
+            "ops[0].op must be a string",
+        ),
+        (
+            {"ops": [{"op": "create", "path": 1, "content": "page"}]},
+            "ops[0].path must be a string",
+        ),
+        (
+            {"ops": [{"op": "create", "path": "Person.md", "content": 1}]},
+            "ops[0].content must be a string",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "create",
+                        "path": "Person.md",
+                        "content": "page",
+                        "allowed_root": 1,
+                    }
+                ]
+            },
+            "ops[0].allowed_root must be a string",
+        ),
+        (
+            {"ops": [{"op": "delete", "path": "Person.md"}]},
+            "ops[0].op must be create or mutate",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "mutate",
+                        "path": "Person.md",
+                        "base_fingerprint": "not-a-fingerprint",
+                    }
+                ]
+            },
+            "ops[0].base_fingerprint must be a SHA-256 hex string",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "mutate",
+                        "path": "Person.md",
+                        "base_fingerprint": "0" * 64,
+                        "field_changes": [],
+                    }
+                ]
+            },
+            "ops[0].field_changes must be an object",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "mutate",
+                        "path": "Person.md",
+                        "base_fingerprint": "0" * 64,
+                        "replacement_content": 1,
+                    }
+                ]
+            },
+            "ops[0].replacement_content must be a string",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "mutate",
+                        "path": "Person.md",
+                        "base_fingerprint": "0" * 64,
+                        "ensure_regions": [1],
+                    }
+                ]
+            },
+            "ops[0].ensure_regions must be an array of strings",
+        ),
+        (
+            {
+                "ops": [
+                    {
+                        "op": "mutate",
+                        "path": "Person.md",
+                        "base_fingerprint": "0" * 64,
+                        "region_projections": [],
+                    }
+                ]
+            },
+            "ops[0].region_projections must be an object",
+        ),
+    ],
+)
+def test_run_rejects_invalid_batch_shapes_in_process(
+    payload: object,
+    message: str,
+) -> None:
+    with pytest.raises(cli.InvalidBatch) as error:
+        cli.run(payload)
+    assert str(error.value) == message
+
+
+def test_main_formats_success_as_sorted_json_in_process(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", StringIO('{"ops": []}'))
+
+    assert cli.main() == 0
+    assert capsys.readouterr().out == '{"results": []}\n'
+
+
+@pytest.mark.parametrize(
+    ("stdin", "run_error", "exit_code", "error_code"),
+    [
+        ("{", None, 2, "invalid_batch"),
+        ('{"ops": []}', OSError("disk unavailable"), 1, "engine_failure"),
+    ],
+)
+def test_main_formats_errors_as_json_in_process(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    stdin: str,
+    run_error: OSError | None,
+    exit_code: int,
+    error_code: str,
+) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", StringIO(stdin))
+    if run_error is not None:
+        monkeypatch.setattr(
+            cli,
+            "run",
+            lambda _payload: (_ for _ in ()).throw(run_error),
+        )
+
+    assert cli.main() == exit_code
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == error_code

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -440,6 +440,11 @@ def _run_entity_creation_journey(vault: Path, mode: str) -> dict:
     env["CLAUDE_PROJECT_DIR"] = str(vault)
     env["DEX_REPO_ROOT"] = str(REPO_ROOT)
     env["ENTITY_CREATION_MODE"] = mode
+    # The bridge routes entity writes through the Python engine, which needs a
+    # resolvable interpreter. A real vault carries its own .venv (the fixture's
+    # work-mcp command points at {vault}/.venv/bin/python); the tmp copy has none,
+    # so pin DEX_PYTHON to the interpreter running this suite (it has the deps).
+    env["DEX_PYTHON"] = sys.executable
     result = subprocess.run(
         [node, "-e", ENTITY_CREATION_JOURNEY],
         cwd=REPO_ROOT,

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -98,10 +98,20 @@ class ProbeResult:
     verdict: str
     detail: str
     heal: Heal | None = None
+    feature_status: str | None = None
+    user_message: str | None = None
 
     def __post_init__(self) -> None:
         if self.verdict not in VERDICTS:
             raise ValueError(f"Invalid doctor verdict: {self.verdict}")
+        if self.feature_status is not None and self.feature_status not in {
+            "ok",
+            "off",
+            "not_installed",
+            "broken",
+            "unknown",
+        }:
+            raise ValueError(f"Invalid feature status: {self.feature_status}")
 
 
 @dataclass(frozen=True)
@@ -664,13 +674,18 @@ def _load_yaml(path: Path) -> object:
 
 
 def _result_json(definition: CheckDefinition, result: ProbeResult) -> dict[str, Any]:
-    return {
+    rendered = {
         "id": definition.id,
         "feature": definition.feature,
         "verdict": result.verdict,
         "detail": _sentence(result.detail),
         "heal": asdict(result.heal) if result.heal else None,
     }
+    if result.feature_status is not None:
+        rendered["feature_status"] = result.feature_status
+    if result.user_message is not None:
+        rendered["user_message"] = result.user_message
+    return rendered
 
 
 def _summary(checks: list[dict[str, Any]]) -> dict[str, int]:
@@ -720,6 +735,40 @@ def _repo_shipped_executables(context: DoctorContext) -> list[Path]:
         if mode == "100755":
             executable_paths.append(context.repo_root / relative)
     return executable_paths
+
+
+def _requeue_entity_dead_letters(context: DoctorContext) -> dict[str, Any]:
+    """Run the bridge-owned dead-letter heal under its pending-store lock."""
+    node = shutil.which("node")
+    if not node:
+        raise FileNotFoundError("node is required to re-queue entity writes")
+    client = context.repo_root / ".scripts" / "lib" / "entity-engine-client.cjs"
+    if not client.is_file():
+        raise FileNotFoundError(f"entity bridge is missing: {client}")
+    source = (
+        "const client=require(process.argv[1]);"
+        "const result=client.requeueDeadLetters(process.argv[2]);"
+        "process.stdout.write(JSON.stringify(result));"
+    )
+    result = subprocess.run(
+        [node, "-e", source, str(client), str(context.vault_root)],
+        cwd=context.repo_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(context.vault_root),
+            "VAULT_PATH": str(context.vault_root),
+        },
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "entity dead-letter heal failed")
+    parsed = json.loads(result.stdout)
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("requeued"), int):
+        raise ValueError("entity dead-letter heal returned invalid output")
+    return parsed
 
 
 def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
@@ -789,6 +838,19 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
             planned_executables.append(relative)
         except OSError as error:
             errors.append(f"Executable-mode heal failed for {script}: {_one_line(error)}")
+
+    dead_letter_path = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+    if dead_letter_path.exists():
+        try:
+            healed = _requeue_entity_dead_letters(context)
+            requeued = healed["requeued"]
+            if requeued:
+                noun = "write" if requeued == 1 else "writes"
+                actions.append(
+                    f"re-queued {requeued} dead-lettered entity {noun} with retry counters reset"
+                )
+        except Exception as error:
+            errors.append(f"Entity-write heal failed: {_one_line(error)}")
 
     if planned:
         try:
@@ -876,11 +938,17 @@ def collect(
             )
         if result.verdict == "UNKNOWN" and _is_missing_package_error(result.detail):
             result = ProbeResult("UNKNOWN", MISSING_PACKAGES_DETAIL, result.heal)
-        if definition.id == "vault.structure" and t1_actions:
-            action = "; ".join(t1_actions) + "."
+        entity_actions = [
+            action for action in t1_actions if action.startswith("re-queued ")
+        ]
+        structure_actions = [
+            action for action in t1_actions if not action.startswith("re-queued ")
+        ]
+        if definition.id == "vault.structure" and structure_actions:
+            action = "; ".join(structure_actions) + "."
             if result.verdict == "OK":
-                repair_word = _repair_count_word(len(t1_actions))
-                repair_noun = "repair" if len(t1_actions) == 1 else "repairs"
+                repair_word = _repair_count_word(len(structure_actions))
+                repair_noun = "repair" if len(structure_actions) == 1 else "repairs"
                 detail = f"All standard PARA directories exist after {repair_word} safe {repair_noun}"
             else:
                 detail = f"{result.detail.rstrip('.')} while safe Tier-1 repairs were also applied"
@@ -888,6 +956,14 @@ def collect(
                 result.verdict,
                 detail,
                 Heal(tier=1, action=action, applied=True),
+            )
+        if definition.id == "entity.engine" and entity_actions:
+            result = ProbeResult(
+                result.verdict,
+                result.detail,
+                Heal(tier=1, action="; ".join(entity_actions) + ".", applied=True),
+                feature_status=result.feature_status,
+                user_message=result.user_message,
             )
         results[definition.id] = result
 
@@ -2886,11 +2962,25 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         people_dir = context.core_path("PEOPLE_DIR")
         companies_dir = context.core_path("COMPANIES_DIR")
         people_index_path = context.core_path("PEOPLE_INDEX_FILE")
+        dead_letter_path = (
+            context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+        )
 
         contacts = json.loads(contacts_path.read_text()) if contacts_path.exists() else {}
         suggestions = json.loads(suggestions_path.read_text()) if suggestions_path.exists() else {}
         verification = json.loads(verification_path.read_text()) if verification_path.exists() else {}
         gardener = json.loads(gardener_path.read_text()) if gardener_path.exists() else {}
+        dead_letters = []
+        if dead_letter_path.exists():
+            for line in dead_letter_path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(entry, dict):
+                    dead_letters.append(entry)
         profile = _load_yaml(profile_path) if profile_path.exists() else {}
         if profile is None:
             profile = {}
@@ -2964,8 +3054,28 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
             f"Entity engine tracks {tracked} contacts and {observations} observations; "
             f"creation is {mode_label}; {pending} suggestions pending; last verification "
             f"{verification_label}; {quarantine_label} quarantined pages; people index {index_freshness}"
-            f"; gardener {gardener_label}"
+            f"; gardener {gardener_label}; {len(dead_letters)} dead-lettered writes"
         )
+        if dead_letters:
+            count = len(dead_letters)
+            noun = "entity write" if count == 1 else "entity writes"
+            heal_action = (
+                "Re-queue the dead-lettered entity write with retry counters reset."
+                if count == 1
+                else "Re-queue the dead-lettered entity writes with retry counters reset."
+            )
+            user_message = (
+                f"{count} {noun} failed permanently. Run /dex-doctor to re-queue "
+                f"{'it' if count == 1 else 'them'} with fresh retries; details remain in "
+                "System/.dex/entity-dead-letter.jsonl until then."
+            )
+            return ProbeResult(
+                "BROKEN",
+                detail,
+                Heal(tier=1, action=heal_action, applied=False),
+                feature_status="broken",
+                user_message=user_message,
+            )
         if unresolved or quarantined_paths:
             return ProbeResult("BROKEN", detail)
         if mode == "off":

--- a/docs/superpowers/plans/2026-07-23-entity-engine-bridge-reliability.md
+++ b/docs/superpowers/plans/2026-07-23-entity-engine-bridge-reliability.md
@@ -1,0 +1,175 @@
+# Entity Engine Bridge Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee that deferred entity enrichment writes are either eventually applied or visibly, actionably failed—never silently discarded.
+
+**Architecture:** Keep the pending store as the source of retry truth, but separate permanent engine rejections from transient infrastructure failures and persist exponential retry timing per operation. Re-materialize declarative mutation intents against a shared identity resolver, execute bounded CLI chunks, and reconcile the meeting lifecycle from applied, pending, and dead-letter outcomes. Surface dead letters and interpreter configuration failures through the existing feature-status vocabulary in sync, verification, and Doctor.
+
+**Tech Stack:** Node.js CommonJS bridge and `node:test`; Python Doctor and `pytest`; canonical Python entity-engine CLI.
+
+---
+
+### Task 1: Failure taxonomy, backoff, and dead-letter ordering
+
+**Files:**
+- Modify: `.scripts/lib/entity-engine-client.cjs`
+- Modify: `.scripts/lib/tests/entity-engine-client.test.cjs`
+
+- [ ] **Step 1: Write failing taxonomy and timing tests**
+
+Add tests which run more than `MAX_ATTEMPTS` interpreter-missing attempts without a dead letter, prove an immediate retry inside `next_attempt_at` does not invoke the CLI, and advance a deterministic clock through five genuine `conflict` results to prove only `permanent_attempts` reaches the terminal ledger.
+
+- [ ] **Step 2: Run the test file and verify RED**
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs`
+
+Expected: the new tests fail because every failure currently increments `attempts` and no retry timestamp is enforced.
+
+- [ ] **Step 3: Implement per-operation retry lifecycle**
+
+Persist `permanent_attempts`, `transient_attempts`, `last_attempt_at`, and `next_attempt_at`. Select only due operations. Classify interpreter absence, process failures, signals, non-zero exits, and invalid CLI output as transient; classify valid per-operation non-applied engine results as permanent. Use exponential backoff for both classes while applying `MAX_ATTEMPTS` only to permanent rejections.
+
+- [ ] **Step 4: Add and run the dead-letter ordering test**
+
+Intercept the append boundary and assert the reduced pending store has already been saved before the JSONL record is appended.
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs`
+
+Expected: all taxonomy, backoff, and ordering tests pass.
+
+### Task 2: Identity retargeting and bounded missing-target failure
+
+**Files:**
+- Create: `.scripts/lib/entity-identity.cjs`
+- Modify: `.scripts/lib/entity-engine-client.cjs`
+- Modify: `.scripts/meeting-intel/lib/entity-creation.cjs`
+- Modify: `.claude/hooks/post-meeting-person-update.cjs`
+- Modify: `.scripts/meeting-intel/lib/gardener.cjs`
+- Modify: `.scripts/lib/tests/entity-engine-client.test.cjs`
+- Modify: `.scripts/meeting-intel/__tests__/entity-creation.test.cjs`
+
+- [ ] **Step 1: Write a failing rename/replay test**
+
+Queue a mutation intent with a person identity, rename the target page, replay after the due time, and assert the CLI receives the new absolute path and the pending operation is cleared.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs .scripts/meeting-intel/__tests__/entity-creation.test.cjs`
+
+Expected: replay remains pinned to the missing original path.
+
+- [ ] **Step 3: Implement the shared identity resolver**
+
+Resolve people by normalized email first and name second; resolve companies by registrable domain first and name second. Use the same helper in entity creation and deferred mutation materialization. Persist retargeted declarative operations. Count missing-target retries separately and terminally dead-letter after the bounded limit with explicit entity path, meeting, operation type, identity, and reason.
+
+- [ ] **Step 4: Re-run the focused tests**
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs .scripts/meeting-intel/__tests__/entity-creation.test.cjs`
+
+Expected: rename replay and creation/adoption lookup tests pass.
+
+### Task 3: Chunked CLI execution
+
+**Files:**
+- Modify: `.scripts/lib/entity-engine-client.cjs`
+- Modify: `.scripts/lib/tests/entity-engine-client.test.cjs`
+
+- [ ] **Step 1: Write a failing large-batch test**
+
+Submit more operations than the bounded chunk size, record each CLI request and its timeout/max-buffer settings, and return successful results for every chunk.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs`
+
+Expected: the bridge invokes one unbounded CLI request.
+
+- [ ] **Step 3: Implement bounded chunks with scaled limits**
+
+Split eligible materialized entries into fixed maximum groups. Scale timeout and buffer with each group’s operation count, classify a failed group transiently, continue independent groups, and settle all outcomes once.
+
+- [ ] **Step 4: Re-run the bridge tests**
+
+Run: `node --test .scripts/lib/tests/entity-engine-client.test.cjs`
+
+Expected: the large batch completes in multiple bounded requests.
+
+### Task 4: Meeting lifecycle reconciliation and sync visibility
+
+**Files:**
+- Modify: `.scripts/meeting-intel/lib/entity-phase.cjs`
+- Modify: `.scripts/meeting-intel/sync-from-granola.cjs`
+- Modify: `.scripts/meeting-intel/lib/entity-creation.cjs`
+- Create or modify: `.scripts/meeting-intel/__tests__/entity-phase.test.cjs`
+
+- [ ] **Step 1: Write failing crash-recovery and terminal-failure tests**
+
+Construct a saved processed-meeting entry with `entity_phase: pending` and its minimal entity replay payload, run the per-sync recovery helper, and assert entity creation is invoked without rewriting the note. Feed a write result whose only operation dead-lettered and assert the phase becomes terminal `failed` and the emitted line names the ledger and `/dex-doctor`.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `node --test .scripts/meeting-intel/__tests__/entity-phase.test.cjs`
+
+Expected: no per-sync recovery/reconciliation API exists.
+
+- [ ] **Step 3: Implement replayable meeting state**
+
+Persist the note record with a minimal entity payload before entity creation. On every non-dry sync path, rerun pending and retryable-failed payloads idempotently, reconcile completed IDs to `complete`, dead-lettered meeting IDs to terminal `failed`, and persist after every transition. Replace dead-letter-as-pending wording with an actionable permanent-failure line.
+
+- [ ] **Step 4: Re-run meeting-intel tests**
+
+Run: `node --test .scripts/meeting-intel/__tests__/entity-phase.test.cjs .scripts/meeting-intel/__tests__/entity-creation.test.cjs`
+
+Expected: lifecycle recovery and terminal failure tests pass.
+
+### Task 5: Doctor, verification, and interpreter capability status
+
+**Files:**
+- Modify: `.scripts/lib/dex-python.cjs`
+- Modify: `.scripts/lib/tests/dex-python.test.cjs`
+- Modify: `.scripts/meeting-intel/verify-entities.cjs`
+- Modify: `.scripts/meeting-intel/__tests__/verify-entities.test.cjs`
+- Modify: `core/utils/doctor.py`
+- Modify: `core/tests/test_doctor.py`
+
+- [ ] **Step 1: Write failing capability and observability tests**
+
+Use an executable that fails `import yaml`/Python-version probing and assert it is rejected once with a broken configuration feature status. Create one actionable dead-letter JSONL record and assert verification returns `feature_status: broken` plus a count/fix path, and Doctor returns a non-OK entity check with the same actionable information.
+
+- [ ] **Step 2: Run and verify RED**
+
+Run: `node --test .scripts/lib/tests/dex-python.test.cjs .scripts/meeting-intel/__tests__/verify-entities.test.cjs`
+
+Run: `.venv/bin/python -m pytest core/tests/test_doctor.py -q`
+
+Expected: path-only Python validation passes the incapable executable and both probes ignore the ledger.
+
+- [ ] **Step 3: Implement cached capability and feature-status reporting**
+
+Probe an absolute executable once with `import yaml,sys; assert sys.version_info >= (3,10)`. Return structured configuration detail to the bridge without falling back to a system interpreter. Parse the dead-letter ledger in verification and Doctor; report count, `System/.dex/entity-dead-letter.jsonl`, and `/dex-doctor`. Preserve malformed-ledger uncertainty rather than hiding it.
+
+- [ ] **Step 4: Re-run focused JS and Python tests**
+
+Run the commands from Step 2 and confirm all pass.
+
+### Task 6: Full verification
+
+**Files:**
+- Verify all modified files and repository gates.
+
+- [ ] **Step 1: Run every requested JavaScript test file directly**
+
+Enumerate test files under `.scripts/lib/tests`, `.scripts/meeting-intel/__tests__`, and `.claude/hooks/tests`, then invoke `node --test "$file"` for each file and aggregate exact pass/fail/skip counts.
+
+- [ ] **Step 2: Run canonical Python engine and CLI suites**
+
+Run the entity-engine Python tests and CLI tests with the capability-approved repository interpreter. Re-run the real CLI byte-parity tests from the JS bridge.
+
+- [ ] **Step 3: Run quality and distribution gates**
+
+Run Ruff because `core/utils/doctor.py` changed, then the portable-contract, distribution, PII, and founder-content gates using their repository scripts/tests. Record exact counts and interpreter path/version.
+
+- [ ] **Step 4: Review the final diff and report physical-machine gaps**
+
+Check every requirement against the diff and fresh test evidence. State that launchd cadence/environment, no-venv-to-venv recovery, and process death in the dead-letter/pending boundary still require real-machine smoke coverage.

--- a/packages/dex-contracts/dist/paths.contract.json
+++ b/packages/dex-contracts/dist/paths.contract.json
@@ -16,6 +16,7 @@
     "DEXDIFF_DIR": "04-Projects/DexDiff",
     "DEXDIFF_PROFILE_DRAFTS_DIR": "04-Projects/DexDiff/beta/profile",
     "DEX_RUNTIME_DIR": "System/.dex",
+    "ENTITY_PENDING_FILE": "System/.dex/entity-pending.json",
     "ENTITY_SUGGESTIONS_FILE": "System/.dex/entity-suggestions.json",
     "ENTITY_VERIFICATION_FILE": "System/.dex/entity-verification.json",
     "EVIDENCE_DIR": "05-Areas/Career/Evidence",


### PR DESCRIPTION
## What
Routes the JS meeting-sync + post-meeting hook writes through the canonical Python entity write-engine (`core/entity_engine`) via a bridge (`core/entity_engine/cli.py` + `.scripts/lib/dex-python.cjs` interpreter resolver + `entity-engine-client.cjs`), so person/company enrichment (back-links, `last_interaction`, gardener summaries) is written through one engine — and a temporary outage can **never silently drop it**. Engine 3B in the entity-engine-v2 sequence; on `main`, not user-facing until a release.

## Reliability — hardened across three independent adversarial-review rounds (5 reviewer passes, final round clean)
- A meeting stays `entity_phase:'pending'` and its entity work re-runs idempotently each sync until writes confirm — never finalized-as-processed with work undone (closes the crash-window loss).
- Failure taxonomy: infra/transient failures (missing interpreter, spawn error, torn output) back off with bounded exponential retry and never burn the permanent give-up budget; only genuine per-op rejections do.
- Nothing is silently abandoned: permanent failures dead-letter to a file that `/dex-doctor` + the sync surface as needs-attention, with a Tier-1 **heal** (re-queue + atomic compaction). Invalid intents dead-letter after 5; stuck transients escalate after 15 attempts / 7 days.
- Identity retargeting for a renamed/deleted page **never writes to the wrong contact** — an identity carrying an email/domain that matches no page returns null rather than a same-name fallback.
- `dex-python.cjs` resolves `DEX_PYTHON` or `<vault>/.venv` only — never launchd's system python3.

Includes an interpreter capability probe, large-batch chunking, tolerant dead-letter parsing, and a new `entity-identity.cjs` with full unit coverage. Cleanly reconciled with #144's gardener malformed-prose protection (both intents proven by the `orphaned summary marker skips` test).

## Verification
JS **93/93**, Python **140/140** (doctor 121, entity/CLI/writers), real-CLI byte parity 3/3, ruff clean, all PR gates (path-contract, doc-drift, test-delta, portable-contract, security, inventory) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)