### PR TITLE
feat(skills): add /relationship-radar — surface relationships going cold (founder skill)

### DIFF
--- a/.claude/skills/relationship-radar/SKILL.md
+++ b/.claude/skills/relationship-radar/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: relationship-radar
+description: "Spot the relationships going cold — people you were in regular contact with and haven't touched in a while, and important contacts who are slipping — ranked by how stale each has become, so you can reconnect before it costs you. Use when the user says 'who should I reach out to', 'who am I losing touch with', 'who's going cold', 'who needs attention', or during a weekly review. Also use proactively when someone important hasn't come up in a long time. Not for prepping a specific upcoming meeting; use `meeting-prep`. Not for specific promises you owe people; use `commitments`."
+---
+
+# /relationship-radar
+
+Relationships decay quietly — the person you spoke to every week three months ago just… stopped coming up. This surfaces who is going cold while you can still do something about it, ranked by how long it's been.
+
+**Honest scope (read this):** today the radar reads the signal that exists now — each person page's recorded **last-interaction date**, corroborated by **meeting recency**. It does *not* yet have the entity engine's automatic "temperature / what's cooling" surface — that isn't built. So the radar is only as good as the last-interaction dates on your person pages, and it says so plainly when the signal is thin rather than inventing a coldness score. When the entity temperature surface ships, this skill gets richer; it does not block on it.
+
+---
+
+## Step 1 — Load the people signal
+
+Call `build_people_index` (writes/refreshes `System/People_Index.json`) and read its `people[]`: each carries `name`, `role`, `company`, `status`, and `last_interaction` (a date, or empty). Drop anyone whose `status` marks them archived/inactive — the radar is about live relationships.
+
+If the index is empty or absent, say so and point to the fix (add person pages, or set last-interaction dates) — do not present an empty radar as "all healthy."
+
+## Step 2 — Rank by staleness
+
+For each remaining person with a `last_interaction` date, compute **days since last contact** (today − last_interaction) and bucket by these stated heuristics (not a hidden score):
+
+- **Going cold** — ~30–60 days since contact. Was a real relationship; the gap is opening.
+- **Slipping** — 60+ days. At risk of going dark.
+- **Warm** — under ~30 days. Not shown unless asked; the radar is about what needs attention.
+
+Weight toward people whose `role`/`company` signals they matter (a key customer, a manager, a close collaborator) — surface those first even at a shorter gap. Say *why* each surfaced ("was weekly in Q1, nothing for 7 weeks").
+
+## Step 3 — Handle the people you can't assess (degrade honestly)
+
+People with **no last-interaction date** can't be ranked by it. Don't guess a coldness. Instead:
+- Try to corroborate from **meeting recency** — scan recent meetings for their name/email and use the latest as an interaction proxy, saying that's what you did.
+- If there's still no signal, list them under **"Can't assess — no interaction date recorded"** and offer to backfill (a last-interaction date on the page, or running `process-meetings`). Never silently drop them and never fake a date.
+
+## Step 4 — Present the radar
+
+Show a short ranked list, most-stale-and-important first. Each row, by name: person (and role/company), **last contact** (date + "N days ago"), the bucket, and one line of why it matters. Refer to people by name, never by id or raw file path. If genuinely nobody is cold, say that plainly — a quiet radar is a real, good result, not a reason to pad the list.
+
+## Step 5 — Optional reconnect (confirm-gated, never automatic)
+
+Offer — don't impose — to turn a surfaced person into a "reach out to {name}" task. **Nothing is created without the user's per-item say-so.** For each one they pick, call Work MCP `create_task` (infer the pillar per the CLAUDE.md rules; carry the person's name + last-contact into the task), then **read back the created task IDs** before reporting. If they just want to see the radar, stop after Step 4.
+
+---
+
+## Quality bar
+
+A good radar surfaces the *right* people — real, still-active relationships that have genuinely gone quiet — ranked so the most costly gaps are on top, each with a plain reason. It is honest about thin signal (missing dates, no meetings) instead of manufacturing a temperature, and it never creates a task the user didn't confirm.
+
+## Anti-patterns (do not do these)
+
+- **Inventing a coldness score** for people with no interaction date — surface them as "can't assess," don't fake it.
+- **Claiming the entity "temperature" surface** — it isn't built; use last-interaction + meeting recency and say so.
+- **Padding a quiet radar** with warm contacts or vague "maybe reconnect with…" filler.
+- **Auto-creating reach-out tasks** without per-item confirmation, or reporting tasks as created without their IDs.
+- Surfacing archived/inactive people as if the relationship were live.
+
+## Degradation
+
+- `build_people_index` unavailable / empty → say so and point to the fix (add person pages / dates); never present an empty radar as "all good."
+- A person has no `last_interaction` → corroborate via meeting recency, else list under "can't assess"; never guess.
+- Meetings dir absent → skip the recency corroboration silently; the last-interaction pass alone still runs.
+- Entity temperature surface (not yet built) → simply not used; the skill works on today's signal.
+
+---
+
+## Track Usage (Silent)
+
+Update `System/usage_log.md` to mark relationship-radar as used. **Analytics (Silent):** call `track_event` with event_name `relationship_radar_run` and property `surfaced_count` (how many people surfaced — no names, no roles). Fires only if the user opted into analytics; no action if it returns "analytics_disabled".

--- a/.claude/skills/relationship-radar/evals/trigger-cases.yaml
+++ b/.claude/skills/relationship-radar/evals/trigger-cases.yaml
@@ -1,0 +1,45 @@
+# Trigger evals for /relationship-radar.
+# Shape every shipped skill carries:
+#   3 positive paraphrases  — MUST fire this skill
+#   2 negative / collision  — MUST NOT fire; must route to the named neighbor
+#   1 ambiguous             — should ASK rather than silently fire
+#   1 missing-prerequisite  — should degrade honestly, not fake a result
+#   1 failure-recovery      — must not claim success when the underlying action failed
+#
+# `expect: fire` / `no-fire` / `ask` / `degrade` / `honest-failure`.
+# `route_to` names where a no-fire case should go instead.
+
+skill: relationship-radar
+
+positive:
+  - utterance: "Who am I losing touch with?"
+    expect: fire
+  - utterance: "Who should I reach out to — anyone going cold?"
+    expect: fire
+  - utterance: "Which important contacts have I not spoken to in a while?"
+    expect: fire
+
+negative:
+  - utterance: "Prep me for my 2pm with Jordan."
+    expect: no-fire
+    route_to: meeting-prep
+    why: prepping a specific upcoming meeting is meeting-prep, not a portfolio-wide coldness sweep.
+  - utterance: "What did I promise Priya last week?"
+    expect: no-fire
+    route_to: commitments
+    why: a specific promise owed to a person is a commitment to reconcile, not relationship coldness.
+
+ambiguous:
+  - utterance: "How are things with the Acme account?"
+    expect: ask
+    why: could mean relationship health, deal status, or a specific person — ask whether they want the coldness radar or account status before firing.
+
+missing_prerequisite:
+  - utterance: "Who's going cold?"  # People_Index empty / no person pages yet
+    expect: degrade
+    why: no people signal to rank — say so and point to adding person pages / last-interaction dates; never present an empty radar as "all healthy."
+
+failure_recovery:
+  - utterance: "Make reach-out tasks for all of them."  # a create_task call fails
+    expect: honest-failure
+    why: report any item whose create_task failed as NOT created; never claim tasks that weren't written or count them as done.

--- a/core/tests/test_relationship_radar_skill.py
+++ b/core/tests/test_relationship_radar_skill.py
@@ -1,0 +1,75 @@
+"""Contract tests for the /relationship-radar skill.
+
+The skill surfaces relationships going cold using the signal that exists TODAY
+(person-page last-interaction + meeting recency), and is explicit that the entity
+engine's automatic temperature surface is not yet built. These tests lock the
+load-bearing promises: it composes the existing people index, degrades honestly
+when signal is thin, never fabricates a coldness score, never auto-creates tasks,
+and routes cleanly against its nearest neighbors.
+"""
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".claude/skills/relationship-radar/SKILL.md"
+EVALS = ROOT / ".claude/skills/relationship-radar/evals/trigger-cases.yaml"
+
+
+def _frontmatter_description() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    fm = text.split("---\n", 2)[1]
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError("no description in frontmatter")
+
+
+def test_skill_exists_with_evals() -> None:
+    assert SKILL.is_file()
+    assert EVALS.is_file()
+
+
+def test_description_is_a_router_with_when_and_anti_triggers() -> None:
+    desc = _frontmatter_description().lower()
+    assert "when the user says" in desc
+    assert "meeting-prep" in desc
+    assert "commitments" in desc
+
+
+def test_body_uses_the_existing_people_index() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "build_people_index" in text
+    assert "last_interaction" in text or "last-interaction" in text
+
+
+def test_is_honest_about_the_unbuilt_temperature_surface() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    # Must not claim the entity temperature surface exists...
+    assert "isn't built" in text or "not yet built" in text or "not built" in text
+    # ...and must scope to today's signal instead.
+    assert "meeting recency" in text
+
+
+def test_degrades_without_faking_coldness() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "can't assess" in text
+    assert "never guess" in text or "don't guess" in text or "do not guess" in text
+    # An empty index is not reported as "all healthy".
+    assert "all healthy" in text  # appears in the "never present ... as all healthy" guard
+
+
+def test_reconnect_is_confirm_gated_and_inspects_output() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "never automatic" in text or "never auto-create" in text
+    assert "read back the created task ids" in text
+
+
+@pytest.mark.parametrize(
+    "needle",
+    ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],
+)
+def test_evals_carry_the_canonical_case_buckets(needle: str) -> None:
+    text = EVALS.read_text(encoding="utf-8")
+    assert needle in text

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 168326306605fbdf30b5d10f07a6dbe8d0e8fb90dc6abbdf9e31838ec0ab9d49 -->
+<!-- Content SHA-256: 0b2017be7015ef13c6f3837f8d13ef1cce2f4d37717dd891487805921b659d8b -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 71<br>
+**Skill count:** 72<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -87,6 +87,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `product-brief` | `.claude/skills/product-brief/SKILL.md` | Extract a product idea through guided questions and generate a PRD. Use when the user says 'write a PRD', 'spec this feature', 'turn this idea into a brief'. Not for a non-product initiative like hiring or partnerships (use `initiative-kickoff` once shipped); not for checking existing projects' status (use `project-health`). | 326 | when |
 | `project-health` | `.claude/skills/project-health/SKILL.md` | Scan active projects for status, blockers and next actions. Use when the user says 'how are my projects', 'what's stuck', 'project status'. Also use proactively when projects have gone quiet. Not for writing a spec for a new product idea; use `product-brief`. | 259 | when |
 | `prompt-improver` | `.claude/skills/prompt-improver/SKILL.md` | Rewrite a vague prompt into a rich, structured one, with automatic fallback. Use when the user says 'improve this prompt', 'make this prompt better', or hands over a thin instruction. Not for creating a reusable skill; use `create-skill`. | 238 | when |
+| `relationship-radar` | `.claude/skills/relationship-radar/SKILL.md` | Spot the relationships going cold — people you were in regular contact with and haven't touched in a while, and important contacts who are slipping — ranked by how stale each has become, so you can reconnect before it costs you. Use when the user says 'who should I reach out to', 'who am I losing touch with', 'who's going cold', 'who needs attention', or during a weekly review. Also use proactively when someone important hasn't come up in a long time. Not for prepping a specific upcoming meeting; use `meeting-prep`. Not for specific promises you owe people; use `commitments`. | 582 | when |
 | `reset` | `.claude/skills/reset/SKILL.md` | Restructure an existing Dex vault for a new role or changed preferences, without losing data. Use when the user says 'I changed jobs', 'restructure my Dex', 'my role is different now'. Not for first-time setup; use `setup`. Not for just toggling one feature; use `manage-capabilities`. | 285 | when |
 | `review` | `.claude/skills/review/SKILL.md` | End of day review with learning capture. Integrates with evening journaling if enabled. | 87 | **discoverability-risk** |
 | `save-insight` | `.claude/skills/save-insight/SKILL.md` | Capture a reusable learning from completed work so future similar work is easier. Use when the user says 'save this learning', 'capture this insight', or finishes something tricky. Also use proactively after non-routine work. Not for recording a *decision* and its rationale; use `decision-log`. | 295 | when |
@@ -109,7 +110,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
-| `dex-analytics` | 26 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
+| `dex-analytics` | 27 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `relationship-radar` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
 | `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `getting-started` (`calendar_get_events`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |
@@ -117,7 +118,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | `dex-onboarding-mcp` | 1 | normal | `getting-started` (`check_onboarding_complete`) |
 | `dex-resume-mcp` | 0 | **under-surfaced** | — |
 | `dex-session-memory` | 0 | **under-surfaced** | — |
-| `dex-work-mcp` | 8 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `initiative-kickoff` (`confirm_goal_link`, `create_task`, `get_quarterly_goals`, `lookup_person`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
+| `dex-work-mcp` | 9 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `initiative-kickoff` (`confirm_goal_link`, `create_task`, `get_quarterly_goals`, `lookup_person`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `relationship-radar` (`build_people_index`, `create_task`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
 
 ### Under-surfaced servers
 
@@ -127,7 +128,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 ### Over-surfaced servers
 
-- `dex-analytics` — 26 skills reference its tools.
+- `dex-analytics` — 27 skills reference its tools.
 
 ## Portable ownership classes
 


### PR DESCRIPTION
## What & why

The highest-value remaining founder skill. Relationships decay quietly — the person you spoke to weekly three months ago just stopped coming up, and by the time you notice, it's often too late. `/relationship-radar` surfaces who's going cold **while you can still reconnect**, ranked by how stale each has become.

## Scoped honestly to the signal that exists TODAY

Per the steer, this is scoped to what's available now and degrades honestly where the richer signal isn't there — it does **not** block on unbuilt entity-engine work.

- **Reads the existing people index** (`build_people_index`) — each person's recorded `last_interaction` date — and ranks days-since-contact into **stated** buckets (going cold ~30–60d / slipping 60+d), weighting people whose role/company signal they matter.
- **Corroborates via meeting recency** where a last-interaction date is missing; anyone still without signal is listed under **"can't assess"**, never given a faked coldness score.
- **Explicit that the entity engine's automatic "temperature / what's cooling" surface is not built yet.** The skill works on today's signal and gets richer when that ships.
- **Empty index → says so** and points to the fix (add person pages / dates), never presents an empty radar as "all healthy."
- **Optional reconnect: confirm-gated per item**, reads back created task IDs, never auto-creates.
- **Anti-triggers** `meeting-prep` (single upcoming meeting) and `commitments` (specific promises owed).

## Files

- `.claude/skills/relationship-radar/SKILL.md` — the skill (66-line thin body).
- `.claude/skills/relationship-radar/evals/trigger-cases.yaml` — 8 canonical cases (positive / negative→meeting-prep,commitments / ambiguous / missing-prereq / failure-recovery).
- `core/tests/test_relationship_radar_skill.py` — contract test: compose-not-rebuild, honest-about-unbuilt-signal, no-faked-coldness, confirm-before-create, clean routing.
- `docs/architecture/INVENTORY.md` — regenerated.

## Verification

- **`skill-score`: ~100 → SHIP.** All four hard gates pass (G1 nearest neighbour meeting-prep 0.16; G2 confirmation gate present; G3 no external sink; G4 inspects output). Tier-1 60/60, Tier-2 generative+dependent 12/12. No routing collision ≥0.6. All 8 eval cases pass.
- **Gates green:** doc-drift, path-contract, test-delta, portable-contract (1110 paths, dist in sync), security, pii, founder-content, path-consistency, architecture-inventory drift.
- **Tests green:** `test_relationship_radar_skill` (11), `test_skill_integrity` (103, auto-covers the new skill), frontmatter validator clean.

## Reviewer notes

- The staleness thresholds (30–60 / 60+ days) are **stated heuristics** in the body, not a hidden score — easy to tune.
- The honest-degradation posture is the whole point: where `last_interaction` is missing and no meetings corroborate, people go to "can't assess" rather than getting a manufactured temperature. This is what keeps it truthful until the entity temperature surface lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)