### PR TITLE
feat(skills): add /meeting-closeout — lock one meeting while it's fresh (founder skill)

### DIFF
--- a/.claude/skills/meeting-closeout/SKILL.md
+++ b/.claude/skills/meeting-closeout/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: meeting-closeout
+description: "Close out the meeting you just had while it's fresh — lock the decisions, the action items and who owns each, what you personally committed to, and the single next step — then capture it and, only with your OK, turn the actions into tracked tasks. Use when the user says 'wrap up this meeting', 'close out my 3pm', 'here are my notes from the call', or right after a meeting ends. Also use proactively when the user pastes raw notes from a meeting that just happened. Not for bulk-processing many already-synced meetings; use `process-meetings`. Not for prepping a meeting that hasn't happened yet; use `meeting-prep`."
+---
+
+# /meeting-closeout
+
+The gap between walking out of a meeting and the next context switch is where decisions and promises evaporate. This closes **one** meeting the moment it ends — while you still remember who said they'd do what — and locks it down.
+
+It is the single-meeting, in-the-moment ritual. It is **not** the bulk "catch up all my synced notes" pass (`process-meetings`) and **not** pre-meeting prep (`meeting-prep`).
+
+---
+
+## Step 1 — Get the meeting
+
+Work from whichever exists, in this order:
+1. **Notes the user just pasted or dictated** — the common case; use them directly even if the meeting was never synced.
+2. **The meeting they name** ("my 3pm with Acme") — pull it via `get_meeting_context` or the latest file in `00-Inbox/Meetings/`.
+
+If there are no notes and no matching synced meeting, **ask for the notes** (or a two-line recap) — do not fabricate a summary of a meeting you can't see.
+
+## Step 2 — Extract the closeout essentials
+
+Pull only what the notes support — never invent a decision or an owner the meeting didn't produce:
+
+- **Decisions** — what was actually decided (not everything discussed).
+- **Action items + owner + due** — each task, who owns it, by when. Name the owner explicitly; if the notes don't say, mark it "owner TBD" rather than guessing.
+- **Your commitments** — what *you* personally promised (these are the trust-critical ones; they feed the same promise-tracking as `commitments`).
+- **Open questions** — unresolved threads to revisit.
+- **The single next step** — the one thing that moves this forward.
+
+## Step 3 — People (respect the entity setting)
+
+Identify attendees and **update existing person pages** with the relevant context (via `lookup_person`). For people who don't have a page yet, follow the vault's `entity_creation` setting — `auto` creates, `suggest` (the default) offers, `off` just tracks. Do not hard-create person pages against the user's setting.
+
+## Step 4 — Turn actions into tasks (confirm-gated, never automatic)
+
+Offer to create tasks from the action items and your commitments. **Nothing is written without per-item confirmation.** For each one the user approves, call Work MCP `create_task` (carry the owner, due, and the meeting as source; infer the pillar per the CLAUDE.md rules), then **read back the created task IDs**. Items the user skips are left out; a failed `create_task` is reported as not created, never counted as done.
+
+## Step 5 — Capture, then confirm what happened
+
+Save the closeout to the meeting note (or `00-Inbox/Meetings/` if it was pasted, unsynced). Then confirm the real result by reading it back: the note path saved, the tasks created (by ID), and which person pages were updated. Never report "captured / done" without those in hand.
+
+---
+
+## Quality bar
+
+A good closeout leaves the meeting's **decisions, owned actions, your commitments, and one next step** captured while they're fresh — each grounded in what was actually said — so nothing important is lost between the meeting and the next thing. Owners are named or honestly TBD; nothing is created the user didn't confirm.
+
+## Anti-patterns (do not do these)
+
+- **Re-running the bulk sync/catch-up** over many meetings — that's `process-meetings`; closeout is this one meeting.
+- **Inventing decisions, owners, or commitments** the notes don't support — mark unknowns TBD instead.
+- **Auto-creating tasks** without per-item confirmation, or **person pages** against the `entity_creation` setting.
+- **Claiming "captured / done"** without reading back the saved note path and created task IDs.
+- Dumping the whole transcript back as "notes" instead of extracting decisions and owned actions.
+
+## Degradation
+
+- No pasted notes and no matching synced meeting → ask for the notes; never fabricate a recap.
+- `entity_creation: off` → track people, don't create pages; `suggest` → offer, don't auto-create.
+- A `create_task` call fails → report that item as not created; don't count it.
+- QMD/semantic search absent → link people/projects by keyword; the closeout still runs.
+
+---
+
+## Track Usage (Silent)
+
+Update `System/usage_log.md` to mark meeting-closeout as used. **Analytics (Silent):** call `track_event` with event_name `meeting_closed_out` and properties `tasks_created` and `decisions_captured` (counts only — no meeting content, no names). Fires only if the user opted into analytics; no action if it returns "analytics_disabled".

--- a/.claude/skills/meeting-closeout/evals/trigger-cases.yaml
+++ b/.claude/skills/meeting-closeout/evals/trigger-cases.yaml
@@ -1,0 +1,45 @@
+# Trigger evals for /meeting-closeout.
+# Shape every shipped skill carries:
+#   3 positive paraphrases  — MUST fire this skill
+#   2 negative / collision  — MUST NOT fire; must route to the named neighbor
+#   1 ambiguous             — should ASK rather than silently fire
+#   1 missing-prerequisite  — should degrade honestly, not fake a result
+#   1 failure-recovery      — must not claim success when the underlying action failed
+#
+# `expect: fire` / `no-fire` / `ask` / `degrade` / `honest-failure`.
+# `route_to` names where a no-fire case should go instead.
+
+skill: meeting-closeout
+
+positive:
+  - utterance: "Just wrapped my call with Acme — here are my notes, close it out."
+    expect: fire
+  - utterance: "Help me close out my 3pm: decisions, who owns what, next step."
+    expect: fire
+  - utterance: "That meeting just ended — capture the actions and what I committed to."
+    expect: fire
+
+negative:
+  - utterance: "Catch up my notes — process all the meetings that synced from Granola."
+    expect: no-fire
+    route_to: process-meetings
+    why: bulk-processing many already-synced meetings is process-meetings; closeout is one meeting, right now.
+  - utterance: "Prep me for my 2pm with Jordan tomorrow."
+    expect: no-fire
+    route_to: meeting-prep
+    why: a meeting that hasn't happened yet is meeting-prep, not a closeout.
+
+ambiguous:
+  - utterance: "Sort out the Acme meeting."
+    expect: ask
+    why: unclear whether they mean prep for an upcoming one or close out one that just happened — ask which before firing.
+
+missing_prerequisite:
+  - utterance: "Close out my last meeting."  # no pasted notes and no matching synced meeting
+    expect: degrade
+    why: no notes and no synced meeting to read — ask for the notes or a recap; never fabricate a summary.
+
+failure_recovery:
+  - utterance: "Make tasks for all those action items."  # a create_task call fails
+    expect: honest-failure
+    why: report any item whose create_task failed as NOT created; never claim tasks that weren't written.

--- a/core/tests/test_meeting_closeout_skill.py
+++ b/core/tests/test_meeting_closeout_skill.py
@@ -1,0 +1,73 @@
+"""Contract tests for the /meeting-closeout skill.
+
+Closeout is the single-meeting, in-the-moment ritual: capture the decisions,
+owned actions, the user's own commitments, and the next step for ONE meeting that
+just happened. These tests lock the load-bearing promises: it is distinct from the
+bulk process-meetings pass, extracts only what the notes support (owners named or
+TBD, never invented), respects the entity_creation setting, never auto-creates tasks,
+degrades honestly, and inspects what it wrote before claiming done.
+"""
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".claude/skills/meeting-closeout/SKILL.md"
+EVALS = ROOT / ".claude/skills/meeting-closeout/evals/trigger-cases.yaml"
+
+
+def _frontmatter_description() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    fm = text.split("---\n", 2)[1]
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError("no description in frontmatter")
+
+
+def test_skill_exists_with_evals() -> None:
+    assert SKILL.is_file()
+    assert EVALS.is_file()
+
+
+def test_description_is_a_router_with_when_and_anti_triggers() -> None:
+    desc = _frontmatter_description().lower()
+    assert "when the user says" in desc
+    # Anti-triggers naming the true nearest neighbors.
+    assert "process-meetings" in desc
+    assert "meeting-prep" in desc
+
+
+def test_captures_the_closeout_essentials() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    for essential in ["decisions", "action item", "commitment", "next step"]:
+        assert essential in text
+
+
+def test_owners_named_or_honestly_tbd_never_invented() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "tbd" in text
+    assert "never invent" in text or "do not invent" in text or "inventing" in text
+
+
+def test_respects_entity_creation_and_confirm_gates_writes() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "entity_creation" in text
+    assert "never automatic" in text or "never auto-create" in text
+    assert "read back the created task ids" in text
+
+
+def test_degrades_without_fabricating_a_recap() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "never fabricate" in text or "do not fabricate" in text
+    assert "ask for the notes" in text
+
+
+@pytest.mark.parametrize(
+    "needle",
+    ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],
+)
+def test_evals_carry_the_canonical_case_buckets(needle: str) -> None:
+    text = EVALS.read_text(encoding="utf-8")
+    assert needle in text

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 168326306605fbdf30b5d10f07a6dbe8d0e8fb90dc6abbdf9e31838ec0ab9d49 -->
+<!-- Content SHA-256: 19a344ab1b393748af635a584dca34e400c0ca7ba1ec8df440a8d13829918cae -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 71<br>
+**Skill count:** 72<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -81,6 +81,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `integrate-mcp` | `.claude/skills/integrate-mcp/SKILL.md` | Install and wire up an existing MCP server from Smithery.ai or a GitHub repo. Use when the user names a tool that already has a server — 'add the Notion MCP', 'install this Smithery server'. Not for building a new integration from nothing; use `create-mcp`. Not for adding one already-known server safely; use `dex-add-mcp`. | 324 | when |
 | `journal` | `.claude/skills/journal/SKILL.md` | Toggle journaling or start a morning/evening/weekly journal entry. Use when the user says 'journal', 'morning pages', 'evening reflection'. Also use proactively when a journaling-enabled user starts/ends the day. Not for a structured end-of-day work review; use `daily-review`. | 277 | when |
 | `manage-capabilities` | `.claude/skills/manage-capabilities/SKILL.md` | Turn optional Dex rooms/features on or off without deleting any content. Use when the user says 'turn off X', 'enable the career room', 'hide a feature I don't use'. Not for diagnosing breakage; use `dex-doctor`. Not for a full role restructure; use `reset`. | 258 | when |
+| `meeting-closeout` | `.claude/skills/meeting-closeout/SKILL.md` | Close out the meeting you just had while it's fresh — lock the decisions, the action items and who owns each, what you personally committed to, and the single next step — then capture it and, only with your OK, turn the actions into tracked tasks. Use when the user says 'wrap up this meeting', 'close out my 3pm', 'here are my notes from the call', or right after a meeting ends. Also use proactively when the user pastes raw notes from a meeting that just happened. Not for bulk-processing many already-synced meetings; use `process-meetings`. Not for prepping a meeting that hasn't happened yet; use `meeting-prep`. | 618 | when |
 | `meeting-prep` | `.claude/skills/meeting-prep/SKILL.md` | Prepare for a specific upcoming meeting by gathering attendee context, history and related topics. Use when the user says 'prep me for my meeting with X', 'what do I need for the 2pm', or before a calendar event. Also use proactively when a meeting is imminent. Not for writing up a meeting that already happened; use `process-meetings`. | 337 | when |
 | `ms-teams-setup` | `.claude/skills/ms-teams-setup/SKILL.md` | Connect Microsoft Teams for cross-channel context awareness. Use when the user says 'connect Teams', 'hook up Microsoft'. Not for Google email/calendar; use `google-workspace-setup`. | 182 | when |
 | `process-meetings` | `.claude/skills/process-meetings/SKILL.md` | Turn synced meetings into updated person pages, extracted tasks and organized notes. Use when the user says 'process my meetings', 'catch up my notes', or after Granola/Otter syncs. Also use proactively when unprocessed meetings exist. Not for prepping an upcoming meeting; use `meeting-prep`. | 293 | when |
@@ -109,7 +110,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
-| `dex-analytics` | 26 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
+| `dex-analytics` | 27 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-closeout` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
 | `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `getting-started` (`calendar_get_events`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |
@@ -117,7 +118,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | `dex-onboarding-mcp` | 1 | normal | `getting-started` (`check_onboarding_complete`) |
 | `dex-resume-mcp` | 0 | **under-surfaced** | — |
 | `dex-session-memory` | 0 | **under-surfaced** | — |
-| `dex-work-mcp` | 8 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `initiative-kickoff` (`confirm_goal_link`, `create_task`, `get_quarterly_goals`, `lookup_person`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
+| `dex-work-mcp` | 9 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `initiative-kickoff` (`confirm_goal_link`, `create_task`, `get_quarterly_goals`, `lookup_person`); `meeting-closeout` (`create_task`, `get_meeting_context`, `lookup_person`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
 
 ### Under-surfaced servers
 
@@ -127,7 +128,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 ### Over-surfaced servers
 
-- `dex-analytics` — 26 skills reference its tools.
+- `dex-analytics` — 27 skills reference its tools.
 
 ## Portable ownership classes
 


### PR DESCRIPTION
## What & why

The next founder skill. The gap between walking out of a meeting and the next context switch is where decisions and promises evaporate. `/meeting-closeout` closes **one** meeting the moment it ends — decisions, action items + owners, what you personally committed to, and the single next step — while you still remember who said they'd do what.

## Deliberately distinct from its neighbours (the description is the router)

- **vs `process-meetings`:** this is one meeting, right now, from pasted/dictated notes or a just-named meeting — **not** the bulk "catch up all my synced notes" pass.
- **vs `meeting-prep`:** after, not before.

Measured nearest neighbour is `process-meetings` at 0.24 — well under the 0.6 collision threshold — and both neighbours are named as anti-triggers.

## Behaviour

- Works from notes the user just pasted (even if the meeting was never synced) or a named meeting via `get_meeting_context`; **asks for notes rather than fabricating a recap** when it has neither.
- Extracts only what the notes support — **owners named or honestly "TBD", never invented**.
- Updates existing person pages; for new people, **respects the vault's `entity_creation` setting** (auto/suggest/off) instead of hard-creating.
- Action items + the user's commitments become tasks **only with per-item confirmation**; reads back created task IDs; a failed `create_task` is reported, not counted as done.
- Anti-triggers `process-meetings` and `meeting-prep`.

## Files

- `.claude/skills/meeting-closeout/SKILL.md` — the skill (66-line thin body).
- `.claude/skills/meeting-closeout/evals/trigger-cases.yaml` — 8 canonical cases.
- `core/tests/test_meeting_closeout_skill.py` — contract test: distinct-from-bulk boundary, owners-named-or-TBD, entity_creation respect, confirm-before-create, honest degradation.
- `docs/architecture/INVENTORY.md` — regenerated.

## Verification

- **`skill-score`: ~100 → SHIP.** All four hard gates pass (G1 nearest 0.24; G2 confirmation gate; G3 no external sink; G4 inspects output). Tier-1 60/60, Tier-2 generative 12/12. No routing collision ≥0.6. All 8 eval cases pass.
- **Gates green:** doc-drift, path-contract, test-delta, portable-contract (dist in sync), security, pii, founder-content, path-consistency, architecture-inventory drift.
- **Tests green:** `test_meeting_closeout_skill` (11), `test_skill_integrity` (103, auto-covers the new skill), frontmatter validator clean.

## Reviewer notes

- The "your commitments" bucket intentionally overlaps in spirit with `/commitments` — closeout captures them at the source (this meeting), `/commitments` reconciles them across meetings later. Complementary, not competing; both stay confirm-gated.
- Person-page creation defers entirely to `entity_creation` rather than introducing its own policy — no new surface, respects the existing setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)