### PR TITLE
feat(skills): add /initiative-kickoff — turn a new bet into a real project (founder skill)

### DIFF
--- a/.claude/skills/initiative-kickoff/SKILL.md
+++ b/.claude/skills/initiative-kickoff/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: initiative-kickoff
+description: "Turn a decision to start something new — a hire, a partnership, a go-to-market push, an internal bet — into a real initiative: the outcome and why now, what success looks like, who's involved, the first concrete steps, and a project page that ladders to your pillars and goals. Use when the user says 'let's kick off X', 'I'm starting a new initiative', 'set up a project for this', or 'we've decided to do Y'. Also use proactively when the user commits to a new effort mid-conversation. Not for spec'ing a product feature or writing a PRD; use `product-brief`. Not for checking the status of projects already underway; use `project-health`."
+---
+
+# /initiative-kickoff
+
+The moment you decide to start something new is when it's cheapest to make it real — an outcome, an owner, success you can check, and a first step — instead of a vague intention that never lands. This turns "we should do X" into a project that can actually begin.
+
+It is for **non-product** initiatives — a hire, a partnership, a GTM push, an ops or strategy bet. Spec'ing a product feature is `product-brief`; checking on projects already running is `project-health`.
+
+---
+
+## Step 1 — Frame the initiative
+
+Get these crisp, asking only what's genuinely missing (don't interrogate a well-formed brief):
+- **Outcome** — what "won / done" actually looks like, in one line.
+- **Why now** — the reason this is worth starting today.
+- **Scope / not-scope** — one line each, so it doesn't sprawl.
+
+## Step 2 — Success criteria
+
+Name **2–4 checkable signals** that say it worked — concrete and verifiable, not vanity ("signed 3 design-partner LOIs by end of Q3", not "build momentum"). If the user offers only fuzzy aims, sharpen them into something you could actually check later.
+
+## Step 3 — Owner and stakeholders
+
+Name the **owner** (accountable) and the people involved. Link existing person pages via `lookup_person`; for people without a page, follow the vault's `entity_creation` setting (auto/suggest/off) rather than hard-creating.
+
+## Step 4 — Ladder to pillars and goals
+
+Infer the **pillar** it serves (from `System/pillars.yaml`; never assume a fixed set). Then check `get_quarterly_goals` — if a current goal fits, offer to link it via `confirm_goal_link`. If nothing fits, say so and record it as a **standalone bet** — never manufacture a goal link that isn't real.
+
+## Step 5 — First concrete steps (confirm-gated)
+
+Draft the **3–5 next actions** that get it moving. Offer to turn them into tasks — **nothing is created without per-item confirmation.** For each approved one, call `create_task` (carry the owner, the initiative as source; infer the pillar), then **read back the created task IDs**. A failed `create_task` is reported as not created, never counted as done.
+
+## Step 6 — Create the project page, then confirm
+
+Write the project page to `04-Projects/` with the outcome, why-now, scope, success criteria, owner/stakeholders, pillar/goal link (or "standalone"), and the next steps. Then **confirm by reading back** the page path, the created task IDs, and the goal link. Never report "kicked off" without those in hand.
+
+---
+
+## Quality bar
+
+A good kickoff leaves a real project page with a crisp outcome, **checkable** success criteria, a named owner, an honest ladder to a pillar/goal (or "standalone bet"), and the first steps captured as confirmed tasks — enough that the initiative can actually start, not a paragraph of aspiration.
+
+## Anti-patterns (do not do these)
+
+- **Spec'ing a product** (that's `product-brief`) or **reviewing existing projects** (that's `project-health`).
+- **Manufacturing a goal link** when the initiative doesn't ladder to a real one — say "standalone bet."
+- **Vanity success criteria** you couldn't actually check later.
+- **Auto-creating tasks** without per-item confirmation, or **person pages** against the `entity_creation` setting.
+- **Claiming "kicked off"** without reading back the project-page path and created task IDs.
+
+## Degradation
+
+- No quarterly goals set (or `get_quarterly_goals` unavailable) → skip the goal ladder, note it, record as standalone; never fabricate a goal.
+- `System/pillars.yaml` absent → ask which area it serves rather than guessing a fixed pillar set.
+- `entity_creation: off`/`suggest` → track/offer for new people, don't auto-create pages.
+- A `create_task` call fails → report that item as not created; don't count it.
+
+---
+
+## Track Usage (Silent)
+
+Update `System/usage_log.md` to mark initiative-kickoff as used. **Analytics (Silent):** call `track_event` with event_name `initiative_kicked_off` and properties `steps_created` and `linked_to_goal` (count + boolean — no initiative name, no content). Fires only if the user opted into analytics; no action if it returns "analytics_disabled".

--- a/.claude/skills/initiative-kickoff/evals/trigger-cases.yaml
+++ b/.claude/skills/initiative-kickoff/evals/trigger-cases.yaml
@@ -1,0 +1,45 @@
+# Trigger evals for /initiative-kickoff.
+# Shape every shipped skill carries:
+#   3 positive paraphrases  — MUST fire this skill
+#   2 negative / collision  — MUST NOT fire; must route to the named neighbor
+#   1 ambiguous             — should ASK rather than silently fire
+#   1 missing-prerequisite  — should degrade honestly, not fake a result
+#   1 failure-recovery      — must not claim success when the underlying action failed
+#
+# `expect: fire` / `no-fire` / `ask` / `degrade` / `honest-failure`.
+# `route_to` names where a no-fire case should go instead.
+
+skill: initiative-kickoff
+
+positive:
+  - utterance: "We've decided to hire a Head of Sales — let's kick this off properly."
+    expect: fire
+  - utterance: "I'm starting a partnership push with the design tools. Set up a project for it."
+    expect: fire
+  - utterance: "New internal bet: revamp onboarding. Get it off the ground with owners and next steps."
+    expect: fire
+
+negative:
+  - utterance: "Write a PRD for the new dashboard feature."
+    expect: no-fire
+    route_to: product-brief
+    why: spec'ing a product feature into a PRD is product-brief; initiative-kickoff is for non-product initiatives.
+  - utterance: "How's the partnerships project doing — anything stuck?"
+    expect: no-fire
+    route_to: project-health
+    why: checking the status of a project already underway is project-health, not kicking off a new one.
+
+ambiguous:
+  - utterance: "Let's do something about churn."
+    expect: ask
+    why: unclear whether it's a product effort (product-brief), a strategic initiative to kick off, or just a task — ask what they want to start before firing.
+
+missing_prerequisite:
+  - utterance: "Kick this off and tie it to my quarterly goal."  # no quarterly goals set
+    expect: degrade
+    why: no quarterly goals exist to link — record it as a standalone bet and say so; never fabricate a goal link.
+
+failure_recovery:
+  - utterance: "Turn those first steps into tasks."  # a create_task call fails
+    expect: honest-failure
+    why: report any item whose create_task failed as NOT created; never claim tasks that weren't written or call the kickoff done.

--- a/core/tests/test_initiative_kickoff_skill.py
+++ b/core/tests/test_initiative_kickoff_skill.py
@@ -1,0 +1,75 @@
+"""Contract tests for the /initiative-kickoff skill.
+
+Kickoff turns a decision to start a NON-product initiative (hire, partnership,
+GTM, internal bet) into a real project: outcome, checkable success criteria, owner,
+an honest ladder to a pillar/goal, and first steps as confirmed tasks. These tests
+lock the load-bearing promises: it routes cleanly against product-brief and
+project-health, never manufactures a fake goal link, keeps writes confirm-gated,
+respects entity_creation, degrades honestly, and inspects what it created.
+"""
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".claude/skills/initiative-kickoff/SKILL.md"
+EVALS = ROOT / ".claude/skills/initiative-kickoff/evals/trigger-cases.yaml"
+
+
+def _frontmatter_description() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    fm = text.split("---\n", 2)[1]
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError("no description in frontmatter")
+
+
+def test_skill_exists_with_evals() -> None:
+    assert SKILL.is_file()
+    assert EVALS.is_file()
+
+
+def test_description_is_a_router_with_when_and_anti_triggers() -> None:
+    desc = _frontmatter_description().lower()
+    assert "when the user says" in desc
+    assert "product-brief" in desc
+    assert "project-health" in desc
+
+
+def test_ladders_to_goals_without_manufacturing_a_fake_link() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "get_quarterly_goals" in text
+    lower = text.lower()
+    assert "standalone bet" in lower
+    assert "never manufacture" in lower or "manufacturing a goal link" in lower
+
+
+def test_success_criteria_must_be_checkable() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "success criteria" in text
+    assert "checkable" in text
+    assert "vanity" in text  # names the anti-pattern to avoid
+
+
+def test_confirm_gated_writes_and_respects_entity_creation() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "entity_creation" in text
+    assert "per-item confirmation" in text
+    assert "read back the created task ids" in text
+
+
+def test_degrades_when_no_goals_or_pillars() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "no quarterly goals" in text
+    assert "pillars.yaml" in text
+
+
+@pytest.mark.parametrize(
+    "needle",
+    ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],
+)
+def test_evals_carry_the_canonical_case_buckets(needle: str) -> None:
+    text = EVALS.read_text(encoding="utf-8")
+    assert needle in text

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: cde580101a896bd756f52c699fe9df5af9fc7d02d40c85265ec39f8f2109f5fe -->
+<!-- Content SHA-256: 168326306605fbdf30b5d10f07a6dbe8d0e8fb90dc6abbdf9e31838ec0ab9d49 -->
 
 # Architecture Inventory
 
@@ -24,7 +24,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 70<br>
+**Skill count:** 71<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -77,6 +77,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `granola-setup` | `.claude/skills/granola-setup/SKILL.md` | Connect Granola via its official API for automatic meeting sync and transcripts. Use when the user says 'connect Granola', 'my meetings aren't syncing', 'set up meeting notes'. Not for Zoom recordings; use `zoom-setup`. Not for processing meetings already synced; use `process-meetings`. | 287 | when |
 | `identity-snapshot` | `.claude/skills/identity-snapshot/SKILL.md` | Generate a living profile of the user's working patterns, decision tendencies and quality preferences from their Dex data. Use when the user says 'what are my patterns', 'how do I work', or during `week-review`. Also use proactively when the model (older than 7 days) is stale. Not for planning a week; use `week-plan`. | 319 | when |
 | `industry-truths` | `.claude/skills/industry-truths/SKILL.md` | Define time-horizoned assumptions about your industry (today / 6mo / 12mo) that ground strategic thinking. Use when the user is making roadmap, positioning or investment calls, or says 'what am I assuming about the market'. Also use proactively before a big strategic recommendation. Not for capturing a single decision; use `decision-log`. | 340 | when |
+| `initiative-kickoff` | `.claude/skills/initiative-kickoff/SKILL.md` | Turn a decision to start something new — a hire, a partnership, a go-to-market push, an internal bet — into a real initiative: the outcome and why now, what success looks like, who's involved, the first concrete steps, and a project page that ladders to your pillars and goals. Use when the user says 'let's kick off X', 'I'm starting a new initiative', 'set up a project for this', or 'we've decided to do Y'. Also use proactively when the user commits to a new effort mid-conversation. Not for spec'ing a product feature or writing a PRD; use `product-brief`. Not for checking the status of projects already underway; use `project-health`. | 641 | when |
 | `integrate-mcp` | `.claude/skills/integrate-mcp/SKILL.md` | Install and wire up an existing MCP server from Smithery.ai or a GitHub repo. Use when the user names a tool that already has a server — 'add the Notion MCP', 'install this Smithery server'. Not for building a new integration from nothing; use `create-mcp`. Not for adding one already-known server safely; use `dex-add-mcp`. | 324 | when |
 | `journal` | `.claude/skills/journal/SKILL.md` | Toggle journaling or start a morning/evening/weekly journal entry. Use when the user says 'journal', 'morning pages', 'evening reflection'. Also use proactively when a journaling-enabled user starts/ends the day. Not for a structured end-of-day work review; use `daily-review`. | 277 | when |
 | `manage-capabilities` | `.claude/skills/manage-capabilities/SKILL.md` | Turn optional Dex rooms/features on or off without deleting any content. Use when the user says 'turn off X', 'enable the career room', 'hide a feature I don't use'. Not for diagnosing breakage; use `dex-doctor`. Not for a full role restructure; use `reset`. | 258 | when |
@@ -108,7 +109,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
-| `dex-analytics` | 25 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
+| `dex-analytics` | 26 | **over-surfaced** | `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `reset` (`track_event`); `review` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
 | `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `getting-started` (`calendar_get_events`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |
@@ -116,7 +117,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | `dex-onboarding-mcp` | 1 | normal | `getting-started` (`check_onboarding_complete`) |
 | `dex-resume-mcp` | 0 | **under-surfaced** | — |
 | `dex-session-memory` | 0 | **under-surfaced** | — |
-| `dex-work-mcp` | 7 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
+| `dex-work-mcp` | 8 | normal | `create-mcp` (`create_task`, `list_tasks`); `daily-plan` (`analyze_calendar_capacity`, `build_people_index`, `confirm_goal_link`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_week_progress`, `list_tasks`, `process_inbox_with_dedup`, `record_external_task_mapping`, `suggest_task_scheduling`, `update_task_status`); `daily-review` (`analyze_calendar_capacity`, `create_task`, `get_commitments_due`, `get_meeting_context`, `get_skill_ratings`, `get_week_progress`, `list_tasks`, `update_task_status`); `initiative-kickoff` (`confirm_goal_link`, `create_task`, `get_quarterly_goals`, `lookup_person`); `process-meetings` (`create_person`, `create_task`, `lookup_person`); `triage` (`create_task`); `week-plan` (`analyze_calendar_capacity`, `classify_task_effort`, `create_weekly_priority`, `get_commitments_due`, `get_goal_status`, `get_quarterly_goals`, `list_tasks`, `suggest_task_scheduling`); `week-review` (`get_goal_status`, `get_quarterly_goals`, `get_skill_ratings`, `get_week_progress`, `list_tasks`) |
 
 ### Under-surfaced servers
 
@@ -126,7 +127,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 ### Over-surfaced servers
 
-- `dex-analytics` — 25 skills reference its tools.
+- `dex-analytics` — 26 skills reference its tools.
 
 ## Portable ownership classes
 


### PR DESCRIPTION
## What & why

The fifth founder skill (and the last of the net-new founder trio). The moment you decide to start something new is when it's cheapest to make it real — an outcome, an owner, success you can check, a first step — instead of a vague intention that never lands. `/initiative-kickoff` turns "we should do X" into a project that can actually begin.

## Routing carve

Scoped to **non-product** initiatives — a hire, a partnership, a GTM push, an internal bet.

- **vs `product-brief`:** product specs → PRD. `product-brief` **already names this skill reciprocally** ("Not for a non-product initiative like hiring or partnerships (use `initiative-kickoff` once shipped)").
- **vs `project-health`:** the status of projects already underway.

Measured nearest neighbour is `product-brief` at 0.20 — well under the 0.6 threshold — and both `product-brief` and `project-health` are named anti-triggers.

## Behaviour

- Frames **outcome / why-now / scope**, then **2–4 checkable success criteria** (not vanity metrics).
- Names **owner + stakeholders**; links existing person pages via `lookup_person` and **respects `entity_creation`** (auto/suggest/off) for new ones.
- **Ladders to a pillar** (`pillars.yaml`) and, if a quarterly goal fits, links it via `confirm_goal_link` — otherwise records an honest **"standalone bet", never a fabricated link**.
- First 3–5 steps become tasks **only with per-item confirmation** (`create_task`), with task-ID readback; a failed `create_task` is reported, not counted.
- Writes the project page to `04-Projects/` and **confirms by reading back** page path + task IDs.

## Files

- `.claude/skills/initiative-kickoff/SKILL.md` — the skill (63-line thin body).
- `.claude/skills/initiative-kickoff/evals/trigger-cases.yaml` — 8 canonical cases.
- `core/tests/test_initiative_kickoff_skill.py` — contract test: clean routing, no-fake-goal-link, checkable-criteria, confirm-before-create, entity_creation respect, honest degradation.
- `docs/architecture/INVENTORY.md` — regenerated.

## Verification

- **`skill-score`: ~100 → SHIP.** All four hard gates pass (G1 nearest 0.20; G2 confirmation gate present; G3 no external sink; G4 inspects output). Tier-1 60/60, Tier-2 generative 12/12. No routing collision ≥0.6. All 8 eval cases pass.
- **Gates green:** doc-drift, path-contract, test-delta, portable-contract (dist in sync), security, pii, founder-content, path-consistency, architecture-inventory drift.
- **Tests green:** `test_initiative_kickoff_skill` (11), `test_skill_integrity` (103, auto-covers the new skill), frontmatter validator clean.

## Reviewer notes

- The goal-ladder is deliberately honest: it links to a quarterly goal only when one genuinely fits, and records a "standalone bet" otherwise — no manufactured hierarchy.
- Reuses the now-consistent founder-skill discipline (confirm-before-create + task-ID readback + `entity_creation` respect) shared with `/commitments`, `/relationship-radar`, and `/meeting-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)