### PR TITLE
feat(instructions): capture soft commitments at the moment they're made (task-capture)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,26 @@ When the user shares meeting notes or says they had a meeting:
 
 **Automation:** Background sync records attendee emails and locations, runs entity creation, and verifies coverage after every sync; attendees without email remain tracked but are never auto-created. `/process-meetings` can still update existing pages with extracted context, while ad-hoc notes are handled manually. In Obsidian mode, `.scripts/auto-link-people.cjs` links names to the actual person-page paths.
 
+### Soft Commitment Capture (Natural Language)
+
+Small interpersonal promises are where trust is won or lost, and they evaporate because they're never phrased as an explicit "create a task." When the user makes a soft commitment in ordinary conversation, notice it and *offer* to capture it — so it doesn't get dropped.
+
+**Trigger phrases (the user committing to something):**
+- "I'll follow up with…", "I'll get back to you / them on…", "I'll send you / them…"
+- "Let me look into…", "I'll circle back on…", "I'll check and let you know…"
+- "We should revisit…", "I need to reach out to…", "I'll ping…", "I owe [person] a…"
+
+**When detected:**
+1. Don't interrupt the flow — acknowledge naturally.
+2. **Offer, never auto-create:** "Sounds like you committed to [X] — want me to capture that as a task?" Only on a yes do you create it (then follow the Task Creation pillar-inference flow below). This is the same confirm-before-create discipline as the founder skills — nothing is written without the user's say-so.
+3. On confirmation, create via `create_task` and **read back the task ID and title** so the user sees exactly what was captured. Carry the person and any due date the phrasing gives.
+
+**Rules:**
+- **Offer once, don't nag.** If the user declines or ignores it, drop it — don't re-ask for the same promise this session.
+- **Only real commitments.** "I might look at that someday" is not a commitment; "I'll send Priya the deck by Friday" is.
+- **If the user is mid-flow on something urgent,** note it silently and offer at a natural pause, not mid-thought.
+- **Complements, doesn't replace:** this catches promises *as they are made, live*. Reconciling promises already scattered across meetings and notes is `/commitments`; capturing one finished meeting's promises is `/meeting-closeout`. Don't re-scan the vault here — just catch what was said now.
+
 ### Task Creation (Smart Pillar Inference)
 When the user requests task creation without specifying a pillar:
 - "Create a task to review Q1 numbers"

--- a/core/tests/test_soft_commitment_capture.py
+++ b/core/tests/test_soft_commitment_capture.py
@@ -1,0 +1,56 @@
+"""Contract test for the Soft Commitment Capture behavior in CLAUDE.md.
+
+Task capture must catch soft commitments made in ordinary conversation
+("I'll follow up", "let me get back to you", "we should revisit") — not just
+explicit "create a task" requests — and surface them for confirmation, never
+auto-creating. This behavior complements (does not duplicate) /commitments
+(reconciliation across meetings) and /meeting-closeout (one finished meeting).
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLAUDE_MD = ROOT / "CLAUDE.md"
+
+
+def _section() -> str:
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+    marker = "### Soft Commitment Capture"
+    assert marker in text, "Soft Commitment Capture behavior missing from CLAUDE.md"
+    start = text.index(marker)
+    # Section runs until the next top-level behavior heading.
+    rest = text[start + len(marker):]
+    end = rest.find("\n### ")
+    return (marker + rest[: end if end != -1 else len(rest)])
+
+
+def test_behavior_section_exists() -> None:
+    assert "### Soft Commitment Capture" in CLAUDE_MD.read_text(encoding="utf-8")
+
+
+def test_detects_soft_promise_phrasing_not_just_explicit_requests() -> None:
+    section = _section().lower()
+    # At least the canonical soft-promise cues.
+    assert "i'll follow up" in section
+    assert "get back to" in section
+    assert "revisit" in section
+
+
+def test_offers_but_never_auto_creates() -> None:
+    section = _section().lower()
+    assert "never auto-create" in section
+    assert "confirm-before-create" in section
+    # Reads back what it captured (no false "done").
+    assert "read back the task id" in section
+
+
+def test_does_not_nag() -> None:
+    section = _section().lower()
+    assert "offer once" in section and "don't nag" in section
+
+
+def test_complements_commitments_and_meeting_closeout_rather_than_duplicating() -> None:
+    section = _section()
+    assert "/commitments" in section
+    assert "/meeting-closeout" in section
+    # Explicitly does not re-scan the vault (that is /commitments' job).
+    assert "Don't re-scan the vault here" in section


### PR DESCRIPTION
## What & why

Task capture used to fire only on explicit "create a task" requests — so the small interpersonal promises that actually erode trust ("I'll follow up," "let me get back to you," "we should revisit") slipped straight through. This adds a **Soft Commitment Capture** behavior to the shipped `CLAUDE.md`: Dex notices soft-promise phrasing in ordinary conversation and **offers** to capture it, never auto-creating.

## Why a behavior, not a new `/command`

Soft-promise detection is **ambient** — it should fire in *any* conversation, the same way "Proactive Improvement Capture (Innovation Concierge)" already does — so it belongs in `CLAUDE.md`'s Core Behaviors, not behind a slash command the user has to remember to invoke. No skill is added, so `skill-score` is not applicable here.

## Behaviour

- **Detects soft-promise cues live** ("I'll follow up with…", "I'll get back to you on…", "let me look into…", "I'll circle back…", "we should revisit…", "I need to reach out to…"), not just explicit task requests.
- **Offer once, never auto-create, never nag.** On a yes, creates via `create_task` and **reads back the task ID + title** — the same confirm-before-create discipline as the four founder skills.
- **Only real commitments** (not vague "someday" musings); carries the person + any due date the phrasing gives.
- **Complements, does not duplicate:** this catches promises *as they're made, live*. `/commitments` reconciles promises already scattered across meetings; `/meeting-closeout` captures one finished meeting. It explicitly does **not** re-scan the vault.

## Files

- `CLAUDE.md` — new "Soft Commitment Capture (Natural Language)" behavior, placed just before "Task Creation (Smart Pillar Inference)" (detect-implicit → then create-explicit).
- `core/tests/test_soft_commitment_capture.py` — contract test locking: detects soft phrasing, offers-never-auto-creates, doesn't nag, reads back task IDs, and complements `/commitments` + `/meeting-closeout` without re-scanning.

## Verification

- **Gates green:** doc-drift, path-contract, test-delta, portable-contract (dist in sync), security, pii, founder-content, path-consistency, architecture-inventory (unchanged — CLAUDE.md is not a skill).
- **Tests green:** `test_soft_commitment_capture` (5), `test_instruction_honesty` (17, audits CLAUDE.md — still passes with the addition).

## Reviewer notes

- Illustrative names in the examples ("Priya", "the deck by Friday") match the existing CLAUDE.md house style ("Sarah's demo", "Acme Corp") — no real PII, confirmed by the pii + founder-content gates.
- The three-way split is now explicit and non-overlapping: **soft-capture** (live, at the moment) → **meeting-closeout** (one finished meeting) → **commitments** (reconcile across meetings). All four share the confirm-before-create + task-ID-readback discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)