### PR TITLE
docs(instructions): repoint Learning Capture to /daily-review [HELD for Dave — CLAUDE.md]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,9 +329,9 @@ When making significant system changes:
 ### Learning Capture
 After significant work (new features, complex integrations), ask: "Worth capturing any learnings from this?" Don't prompt after routine tasks.
 
-### Learning Capture via `/review`
+### Learning Capture via `/daily-review`
 
-Learnings are captured during the daily review process. When the user runs `/review`, you will:
+Learnings are captured during the daily review process. When the user runs `/daily-review`, you will:
 
 1. **Scan the current session** for learning opportunities:
    - Mistakes or corrections made
@@ -354,7 +354,7 @@ Learnings are captured during the daily review process. When the user runs `/rev
 
 3. **Tell the user** how many learnings you captured, then ask if they want to add more
 
-This happens during `/review` - you don't need to capture learnings silently during the session. The review process handles it systematically.
+This happens during `/daily-review` - you don't need to capture learnings silently during the session. The review process handles it systematically.
 
 ### Background Self-Learning Automation
 

--- a/core/tests/test_learning_capture_command_name.py
+++ b/core/tests/test_learning_capture_command_name.py
@@ -1,0 +1,25 @@
+"""Guard for the product CLAUDE.md 'Learning Capture' command name.
+
+Part of the /review -> /daily-review retirement: the "Learning Capture" behavior
+section in the shipped CLAUDE.md must name the canonical /daily-review command, not
+the retired /review. This is the one product-CLAUDE.md repoint, split into its own PR
+so it can be reviewed separately.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLAUDE_MD = ROOT / "CLAUDE.md"
+
+
+def test_learning_capture_section_names_daily_review() -> None:
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+    assert "### Learning Capture via `/daily-review`" in text
+    assert "### Learning Capture via `/review`" not in text
+
+
+def test_no_bare_review_command_in_learning_capture_body() -> None:
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+    # The learning-capture behavior body should reference /daily-review, not the retired
+    # /review command. (Other "review" words like "daily review process" are fine.)
+    assert "When the user runs `/daily-review`" in text
+    assert "When the user runs `/review`" not in text


### PR DESCRIPTION
> ⚠️ **HELD for Dave's sign-off** — this PR edits the shipped product `CLAUDE.md` (the "You are Dex" file every user gets), so per the standing rule it is called out separately and should not merge routinely. Batch with the #201 replacement.

## What this is

The **single product-`CLAUDE.md` change** from the `/review → /daily-review` retirement, split out of #202 so the alias + all non-master-file sweeps could land on the normal track while this one waits for sign-off.

## The exact change (3 lines, no behavior change)

In the **"Learning Capture" behavior section**, the retired `/review` command name is repointed to the canonical `/daily-review`:

- Heading: `### Learning Capture via `/review`` → `### Learning Capture via `/daily-review``
- Body: "When the user runs `/review`, you will…" → "When the user runs `/daily-review`, you will…"
- Body: "This happens during `/review`…" → "This happens during `/daily-review`…"

**What a user sees differently:** nothing in behavior — learning capture works identically. The doc simply names `/daily-review` instead of the retired `/review`, and `/review` still redirects there via its deprecation alias (#202), so users who type the old name are unaffected too. This is the lowest-stakes kind of CLAUDE.md edit — a rename to match a retired command.

## Verification

- **Gates green:** doc-drift, path-contract, test-delta, portable-contract, security, pii, founder-content, path-consistency, architecture-inventory.
- **Tests green:** `test_learning_capture_command_name` (2, locks the section to `/daily-review`), `test_instruction_honesty` (16, CLAUDE.md still honest).

## Depends on

The `/review` alias lands in #202 (unblocked, no CLAUDE.md). This PR is safe to merge before or after #202 — the alias makes `/review` keep working regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)