### PR TITLE
feat(lifecycle): conflict-resolution keep-both writer + choice layer (frozen op pair)

### DIFF
--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -15,10 +15,11 @@ Use the service operations in this order:
 
 1. Ask `build_inventory_and_plan` for the verified inventory and ledger-aware plan.
 2. Render the five groups below without changing anything.
-3. After the user chooses items, ask `build_and_preview_adoption` for the exact preview and approval token.
-4. Show every proposed file from that preview. Execution requires an explicit yes to that exact preview.
-5. Pass the unchanged preview and token to `execute_approved_adoption`.
-6. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render the receipt.
+3. For safe `adopt` items, ask `build_and_preview_adoption` for the exact preview and approval token.
+4. For conflict items, collect the choices below. Keep mine and Compare are read-only; Take theirs and Keep both go through `build_and_preview_conflict_resolution`.
+5. Show every proposed file from each preview. Execution requires an explicit yes to that exact preview.
+6. Pass unchanged adoption previews and tokens to `execute_approved_adoption`, and unchanged resolution previews and tokens to `execute_approved_conflict_resolution`.
+7. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render every receipt.
 
 If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a rejected transaction, stop. Explain the refusal in ordinary language and leave the vault untouched. A refusal is a safety result, not an invitation to work around the engine.
 
@@ -27,7 +28,7 @@ If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a
 Always show these groups in this order, even when a group is empty:
 
 1. **New and safe to adopt** — items whose plan action is `adopt`.
-2. **Needs your review** — conflicts or customized release files. Say which files caused the hold and that Dex preserved them.
+2. **Needs your review** — conflicts or customized release files. Say which files caused the hold, then offer the four choices below. Dex leaves each file untouched until the user makes and approves a choice.
 3. **Held back by you** — items whose plan action is `skip-held-back`.
 4. **Could not be proved** — UNKNOWN items or incomplete lifecycle evidence. Say no change will be made to them.
 5. **Already yours** — adopted items and their receipt-backed rewind status.
@@ -37,6 +38,21 @@ Example register:
 > Here’s exactly what this changes for you. Two items are new and safe, one customized item stays untouched, and everything else is already current.
 
 Do not describe an item as safe merely because its name looks familiar. Use only the action and reasons returned by the service.
+
+## Conflict choices
+
+For each conflicted file, explain that the user changed it and the update carries a new release version. Offer:
+
+- **Keep mine** — “Leave your version exactly as it is. Nothing is written.” Make no service call for this choice.
+- **Take theirs** — “Put the new release version live. Your current version remains recoverable with rewind.”
+- **Keep both** — “Put the new release version live and save your version beside it as `{name}-custom`, where it stays invocable. The whole change remains rewindable.” Offer this only for a modified skill file. A missing file has nothing to preserve.
+- **Compare** — “Show the differences first. Nothing is written.” Read the current and verified release byte sources, render a concise inline diff, then offer the same four choices again. For a large file, summarize the changed regions instead of dumping the whole file.
+
+Collect one `take-theirs` or `keep-both` strategy for each item the user wants resolved. Leave Keep mine items out of the request. Pass only those selected strategies to `build_and_preview_conflict_resolution` as `{item_id, strategy}` objects.
+
+The resolution preview is a separate approval boundary. Show every write exactly as returned, including its path, `release` or `preserved` source, SHA-256, and byte size. Explain which canonical file becomes live and which `-custom` sidecar preserves the user's bytes. Ask: “Apply this exact resolution?” Only an explicit yes to that unchanged preview and approval token permits `execute_approved_conflict_resolution`.
+
+If Keep both is refused because a `{name}-custom` already exists, reassure the user that neither file changed and re-offer Keep mine, Take theirs, or Compare. Never overwrite, rename, merge, or number the existing sidecar.
 
 ## Approval
 
@@ -48,11 +64,11 @@ Before execution, show:
 - that one crash-safe transaction will apply the complete approved set;
 - that the receipt is the source for a later rewind.
 
-Ask one direct question: “Apply this exact update?” A vague earlier request to “update Dex” is not approval of a later concrete preview. If anything changes between preview and execution, render the service refusal and build a fresh preview only after the user asks to continue.
+Ask one direct question: “Apply this exact update?” for an adoption preview, or “Apply this exact resolution?” for a conflict preview. A vague earlier request to “update Dex” is not approval of a later concrete preview. If anything changes between preview and execution, render the service refusal and build a fresh preview only after the user asks to continue.
 
 ## Receipt view
 
-After success, render the receipt returned by `execute_approved_adoption`:
+After success, render the receipt returned by `execute_approved_adoption` or `execute_approved_conflict_resolution`:
 
 - adopted items;
 - transaction identifier;
@@ -70,6 +86,7 @@ Never claim success from a command exit alone. Success means the service returne
 ## Boundaries
 
 - Never perform a raw vault write.
+- Read-only Compare may render differences, but it must never mutate either byte source.
 - Never instruct the user to move files around as part of an update.
 - Never bypass a conflict by replacing the customized file.
 - Never synthesize, edit, or shorten an approval token or receipt.

--- a/core/lifecycle/conflict.py
+++ b/core/lifecycle/conflict.py
@@ -1,0 +1,517 @@
+"""Canonical, read-only previews for explicit conflict resolution."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from core.lifecycle.inventory import InventoryReport
+from core.lifecycle.model import HEX_SHA256, ITEM_ID, SEMVER, ReleaseCatalog
+from core.lifecycle.plan import AdoptionPlan, PlannedAction, ReasonCode
+from core.lifecycle.preview import _requested_inventory_sha256
+
+RESOLUTION_PREVIEW_VERSION = 1
+STRATEGIES = ("take-theirs", "keep-both")
+SOURCES = ("release", "preserved")
+PayloadLoader = Callable[[str], bytes]
+CurrentBytesLoader = Callable[[str], bytes]
+_SKILL_PATH = re.compile(r"^\.claude/skills/([^/]+)/(.+)$")
+
+
+class ConflictResolutionPreviewError(ValueError):
+    """A conflict-resolution preview cannot be proved exactly and safely."""
+
+
+def _refuse(message: str) -> ConflictResolutionPreviewError:
+    return ConflictResolutionPreviewError(
+        f"conflict resolution preview refused: {message}"
+    )
+
+
+def _mapping(value: object, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or not all(
+        isinstance(key, str) for key in value
+    ):
+        raise _refuse(f"{context} must be an object with string field names")
+    return value
+
+
+def _closed_fields(
+    value: Mapping[str, Any], *, required: set[str], context: str
+) -> None:
+    missing = required - set(value)
+    unknown = set(value) - required
+    if missing:
+        raise _refuse(
+            f"{context} is missing required fields: {', '.join(sorted(missing))}"
+        )
+    if unknown:
+        raise _refuse(
+            f"{context} has unknown fields: {', '.join(sorted(unknown))}"
+        )
+
+
+def _string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise _refuse(f"{context} must be a non-empty string")
+    return value
+
+
+def _sha256(value: object, context: str) -> str:
+    digest = _string(value, context)
+    if HEX_SHA256.fullmatch(digest) is None:
+        raise _refuse(f"{context} must be a lowercase sha256 digest")
+    return digest
+
+
+def _item_id(value: object, context: str) -> str:
+    item_id = _string(value, context)
+    if ITEM_ID.fullmatch(item_id) is None:
+        raise _refuse(f"{context} is not a canonical item id")
+    return item_id
+
+
+def _version(value: object, context: str) -> str:
+    version = _string(value, context)
+    if SEMVER.fullmatch(version) is None:
+        raise _refuse(f"{context} is not strict SemVer")
+    return version
+
+
+def _relative_path(value: object, context: str) -> str:
+    path = _string(value, context)
+    if "\\" in path or path.startswith("/") or any(ord(char) < 32 for char in path):
+        raise _refuse(f"{context} must be a release-relative POSIX path")
+    normalized = posixpath.normpath(path)
+    if normalized != path or normalized in ("", ".", "..") or normalized.startswith("../"):
+        raise _refuse(f"{context} is not a canonical release-relative path")
+    return path
+
+
+def _canonical_bytes(value: object, context: str) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise _refuse(
+            f"{context} cannot be serialized canonically: {error}"
+        ) from error
+
+
+@dataclass(frozen=True)
+class ResolutionWrite:
+    path: str
+    new_sha256: str
+    byte_size: int
+    source: str
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ResolutionWrite":
+        value = _mapping(raw, "resolution write")
+        _closed_fields(
+            value,
+            required={"path", "new_sha256", "byte_size", "source"},
+            context="resolution write",
+        )
+        byte_size = value["byte_size"]
+        if type(byte_size) is not int or byte_size < 0:
+            raise _refuse(
+                "resolution write byte_size must be a non-negative integer"
+            )
+        source = _string(value["source"], "resolution write source")
+        if source not in SOURCES:
+            raise _refuse(f"resolution write source must be one of {SOURCES}")
+        return cls(
+            _relative_path(value["path"], "resolution write path"),
+            _sha256(value["new_sha256"], "resolution write new_sha256"),
+            byte_size,
+            source,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "new_sha256": self.new_sha256,
+            "byte_size": self.byte_size,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class ResolutionItem:
+    item_id: str
+    item_version: str
+    strategy: str
+    writes: tuple[ResolutionWrite, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ResolutionItem":
+        value = _mapping(raw, "resolution item")
+        _closed_fields(
+            value,
+            required={"item_id", "item_version", "strategy", "writes"},
+            context="resolution item",
+        )
+        item_id = _item_id(value["item_id"], "resolution item_id")
+        strategy = _string(
+            value["strategy"], f"resolution item {item_id} strategy"
+        )
+        if strategy not in STRATEGIES:
+            raise _refuse(
+                f"resolution item {item_id} strategy must be one of {STRATEGIES}"
+            )
+        if not isinstance(value["writes"], list) or not value["writes"]:
+            raise _refuse(f"resolution item {item_id} needs at least one write")
+        writes = tuple(
+            ResolutionWrite.from_dict(write) for write in value["writes"]
+        )
+        if writes != tuple(sorted(writes, key=lambda write: write.path)):
+            raise _refuse(
+                f"resolution item {item_id} writes must be sorted by path"
+            )
+        if len({write.path for write in writes}) != len(writes):
+            raise _refuse(f"resolution item {item_id} repeats a write path")
+        if strategy == "take-theirs" and any(
+            write.source != "release" for write in writes
+        ):
+            raise _refuse(
+                f"resolution item {item_id} take-theirs writes must come from release"
+            )
+        if strategy == "keep-both" and not any(
+            write.source == "preserved" for write in writes
+        ):
+            raise _refuse(
+                f"resolution item {item_id} keep-both needs a preserved write"
+            )
+        return cls(
+            item_id,
+            _version(
+                value["item_version"], f"resolution item {item_id} version"
+            ),
+            strategy,
+            writes,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "item_id": self.item_id,
+            "item_version": self.item_version,
+            "strategy": self.strategy,
+            "writes": [write.to_dict() for write in self.writes],
+        }
+
+
+@dataclass(frozen=True)
+class ConflictResolutionPreview:
+    resolution_preview_version: int
+    catalog_sha256: str
+    inventory_sha256: str
+    items: tuple[ResolutionItem, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ConflictResolutionPreview":
+        value = _mapping(raw, "conflict resolution preview")
+        _closed_fields(
+            value,
+            required={
+                "resolution_preview_version",
+                "catalog_sha256",
+                "inventory_sha256",
+                "items",
+            },
+            context="conflict resolution preview",
+        )
+        if (
+            type(value["resolution_preview_version"]) is not int
+            or value["resolution_preview_version"] != RESOLUTION_PREVIEW_VERSION
+        ):
+            raise _refuse(
+                "resolution_preview_version must be exactly "
+                f"{RESOLUTION_PREVIEW_VERSION}"
+            )
+        if not isinstance(value["items"], list) or not value["items"]:
+            raise _refuse("conflict resolution preview needs at least one item")
+        items = tuple(ResolutionItem.from_dict(item) for item in value["items"])
+        if items != tuple(sorted(items, key=lambda item: item.item_id)):
+            raise _refuse(
+                "conflict resolution preview items must be sorted by item_id"
+            )
+        if len({item.item_id for item in items}) != len(items):
+            raise _refuse("conflict resolution preview repeats an item_id")
+        all_paths = [write.path for item in items for write in item.writes]
+        if len(set(all_paths)) != len(all_paths):
+            raise _refuse(
+                "conflict resolution preview assigns one path to multiple items"
+            )
+        return cls(
+            RESOLUTION_PREVIEW_VERSION,
+            _sha256(
+                value["catalog_sha256"],
+                "conflict resolution preview catalog_sha256",
+            ),
+            _sha256(
+                value["inventory_sha256"],
+                "conflict resolution preview inventory_sha256",
+            ),
+            items,
+        )
+
+    @property
+    def sha256(self) -> str:
+        """The approval token for these exact canonical preview bytes."""
+        return hashlib.sha256(
+            canonical_conflict_resolution_preview_bytes(self)
+        ).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "resolution_preview_version": self.resolution_preview_version,
+            "catalog_sha256": self.catalog_sha256,
+            "inventory_sha256": self.inventory_sha256,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+def sidecar_path(canonical_path: str) -> str:
+    """Return the skills-only ``-custom`` preservation path."""
+    path = _relative_path(canonical_path, "canonical path")
+    match = _SKILL_PATH.fullmatch(path)
+    if match is None:
+        raise _refuse(
+            f"keep-both is skills-only; {path} is not under "
+            ".claude/skills/{name}/"
+        )
+    name, rest = match.groups()
+    return f".claude/skills/{name}-custom/{rest}"
+
+
+def _load_bytes(
+    loader: Callable[[str], bytes],
+    path: str,
+    *,
+    context: str,
+) -> bytes:
+    try:
+        payload = loader(path)
+    except Exception as error:
+        raise _refuse(f"{context} {path} could not be loaded: {error}") from error
+    if not isinstance(payload, bytes):
+        raise _refuse(f"{context} {path} loader must return bytes")
+    return payload
+
+
+def build_conflict_resolution_preview(
+    catalog: ReleaseCatalog,
+    inventory: InventoryReport,
+    plan: AdoptionPlan,
+    resolutions: Sequence[Mapping[str, object]],
+    payload_loader: PayloadLoader,
+    current_bytes_loader: CurrentBytesLoader,
+) -> ConflictResolutionPreview:
+    """Build exact, payload-verified writes for requested conflict choices."""
+    if not isinstance(catalog, ReleaseCatalog):
+        raise _refuse("catalog must be a loaded ReleaseCatalog")
+    if not isinstance(inventory, InventoryReport):
+        raise _refuse("inventory must be an InventoryReport")
+    if not isinstance(plan, AdoptionPlan):
+        raise _refuse("plan must be an AdoptionPlan")
+    if plan.catalog_sha256 != catalog.integrity.catalog_sha256:
+        raise _refuse("plan catalog identity does not match the supplied catalog")
+    if plan.release_version != catalog.release.version:
+        raise _refuse("plan release version does not match the supplied catalog")
+    if isinstance(resolutions, (str, bytes)) or not isinstance(
+        resolutions, Sequence
+    ):
+        raise _refuse("resolutions must be a sequence")
+    if not resolutions:
+        raise _refuse("at least one conflict resolution is required")
+    if not callable(payload_loader):
+        raise _refuse("payload_loader must be callable")
+    if not callable(current_bytes_loader):
+        raise _refuse("current_bytes_loader must be callable")
+
+    requested: list[tuple[str, str]] = []
+    for index, raw in enumerate(resolutions):
+        value = _mapping(raw, f"resolution {index}")
+        _closed_fields(
+            value,
+            required={"item_id", "strategy"},
+            context=f"resolution {index}",
+        )
+        item_id = _item_id(value["item_id"], f"resolution {index} item_id")
+        strategy = _string(
+            value["strategy"], f"resolution for {item_id} strategy"
+        )
+        if strategy not in STRATEGIES:
+            raise _refuse(
+                f"resolution for {item_id} strategy must be one of {STRATEGIES}"
+            )
+        requested.append((item_id, strategy))
+    requested.sort()
+    if len({item_id for item_id, _strategy in requested}) != len(requested):
+        raise _refuse("resolution item_ids must be unique")
+
+    catalog_by_id = {item.id: item for item in catalog.items}
+    plan_by_id = {item.item_id: item for item in plan.items}
+    unknown = {item_id for item_id, _strategy in requested} - set(catalog_by_id)
+    if unknown:
+        raise _refuse(f"unknown requested item: {', '.join(sorted(unknown))}")
+
+    items: list[ResolutionItem] = []
+    item_paths: dict[str, frozenset[str]] = {}
+    for item_id, strategy in requested:
+        catalog_item = catalog_by_id[item_id]
+        planned = plan_by_id.get(item_id)
+        if planned is None:
+            raise _refuse(
+                f"requested item {item_id} is absent from the adoption plan"
+            )
+        if planned.item_version != catalog_item.version:
+            raise _refuse(
+                f"requested item {item_id} version disagrees with the catalog"
+            )
+        if planned.action is not PlannedAction.CONFLICT:
+            raise _refuse(
+                f"requested item {item_id} has planned action "
+                f"{planned.action.value}; only conflict may be resolved"
+            )
+
+        modified_paths = {
+            path
+            for reason in planned.reasons
+            if reason.code is ReasonCode.RELEASE_FILES_MODIFIED
+            for path in reason.paths
+        }
+        missing_paths = {
+            path
+            for reason in planned.reasons
+            if reason.code is ReasonCode.RELEASE_FILES_MISSING
+            for path in reason.paths
+        }
+        catalog_paths = frozenset(
+            catalog_file.path for catalog_file in catalog_item.files
+        )
+        if not (modified_paths | missing_paths).issubset(catalog_paths):
+            raise _refuse(
+                f"requested item {item_id} conflict paths disagree with the catalog"
+            )
+        inventory_by_path = {
+            entry.canonical_path: entry
+            for entry in inventory.entries
+            if entry.canonical_path in modified_paths
+        }
+
+        writes: list[ResolutionWrite] = []
+        for catalog_file in sorted(
+            catalog_item.files, key=lambda entry: entry.path
+        ):
+            payload = _load_bytes(
+                payload_loader,
+                catalog_file.path,
+                context=f"item {item_id} release payload",
+            )
+            digest = hashlib.sha256(payload).hexdigest()
+            if digest != catalog_file.sha256:
+                raise _refuse(
+                    f"item {item_id} payload {catalog_file.path} sha256 "
+                    "does not match the catalog"
+                )
+            writes.append(
+                ResolutionWrite(
+                    catalog_file.path,
+                    digest,
+                    len(payload),
+                    "release",
+                )
+            )
+
+        if strategy == "keep-both":
+            if not modified_paths:
+                raise _refuse(
+                    f"item {item_id} has nothing to preserve; choose take-theirs"
+                )
+            for canonical_path in sorted(modified_paths):
+                preserved_path = sidecar_path(canonical_path)
+                current = _load_bytes(
+                    current_bytes_loader,
+                    canonical_path,
+                    context=f"item {item_id} current bytes",
+                )
+                current_digest = hashlib.sha256(current).hexdigest()
+                evidence = inventory_by_path.get(canonical_path)
+                if (
+                    evidence is None
+                    or evidence.kind != "file"
+                    or evidence.release_state != "stock-modified"
+                    or evidence.sha256 != current_digest
+                    or evidence.size != len(current)
+                ):
+                    raise _refuse(
+                        f"item {item_id} current bytes {canonical_path} "
+                        "changed while the preview was being built"
+                    )
+                writes.append(
+                    ResolutionWrite(
+                        preserved_path,
+                        current_digest,
+                        len(current),
+                        "preserved",
+                    )
+                )
+
+        item_paths[item_id] = catalog_paths
+        items.append(
+            ResolutionItem(
+                item_id,
+                catalog_item.version,
+                strategy,
+                tuple(sorted(writes, key=lambda write: write.path)),
+            )
+        )
+
+    preview = ConflictResolutionPreview(
+        RESOLUTION_PREVIEW_VERSION,
+        catalog.integrity.catalog_sha256,
+        _requested_inventory_sha256(inventory, item_paths),
+        tuple(items),
+    )
+    return ConflictResolutionPreview.from_dict(preview.to_dict())
+
+
+def canonical_conflict_resolution_preview_bytes(
+    preview: ConflictResolutionPreview,
+) -> bytes:
+    if not isinstance(preview, ConflictResolutionPreview):
+        raise _refuse("preview must be a ConflictResolutionPreview")
+    return _canonical_bytes(
+        preview.to_dict(), "conflict resolution preview"
+    )
+
+
+__all__ = [
+    "ConflictResolutionPreview",
+    "ConflictResolutionPreviewError",
+    "CurrentBytesLoader",
+    "PayloadLoader",
+    "RESOLUTION_PREVIEW_VERSION",
+    "ResolutionItem",
+    "ResolutionWrite",
+    "SOURCES",
+    "STRATEGIES",
+    "build_conflict_resolution_preview",
+    "canonical_conflict_resolution_preview_bytes",
+    "sidecar_path",
+]

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -30,12 +30,28 @@
     "read_lifecycle_state": {
       "request": {"$ref": "#/$defs/vaultRequest"},
       "response": {"$ref": "#/$defs/stateResponse"}
+    },
+    "build_and_preview_conflict_resolution": {
+      "request": {"$ref": "#/$defs/resolutionsRequest"},
+      "response": {"$ref": "#/$defs/conflictPreviewResponse"}
+    },
+    "execute_approved_conflict_resolution": {
+      "request": {"$ref": "#/$defs/conflictExecuteRequest"},
+      "response": {"$ref": "#/$defs/executeResponse"}
     }
   },
   "$defs": {
     "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "path": {"type": "string", "minLength": 1},
     "itemId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]*$"},
+    "resolutionStrategy": {
+      "type": "string",
+      "enum": ["take-theirs", "keep-both"]
+    },
+    "resolutionSource": {
+      "type": "string",
+      "enum": ["release", "preserved"]
+    },
     "apiEnvelope": {
       "type": "object",
       "required": ["api_version"],
@@ -152,6 +168,91 @@
         "vault_root": {"$ref": "#/$defs/path"},
         "release_root": {"$ref": "#/$defs/path"},
         "preview": {"$ref": "#/$defs/preview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "resolutionWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "new_sha256", "byte_size", "source"],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "new_sha256": {"$ref": "#/$defs/sha256"},
+        "byte_size": {"type": "integer", "minimum": 0},
+        "source": {"$ref": "#/$defs/resolutionSource"}
+      }
+    },
+    "resolutionItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "item_version", "strategy", "writes"],
+      "properties": {
+        "item_id": {"$ref": "#/$defs/itemId"},
+        "item_version": {"type": "string", "minLength": 1},
+        "strategy": {"$ref": "#/$defs/resolutionStrategy"},
+        "writes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/resolutionWrite"}
+        }
+      }
+    },
+    "conflictResolutionPreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resolution_preview_version", "catalog_sha256", "inventory_sha256", "items"],
+      "properties": {
+        "resolution_preview_version": {"const": 1},
+        "catalog_sha256": {"$ref": "#/$defs/sha256"},
+        "inventory_sha256": {"$ref": "#/$defs/sha256"},
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/resolutionItem"}
+        }
+      }
+    },
+    "resolutionsRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release_root", "resolutions"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release_root": {"$ref": "#/$defs/path"},
+        "resolutions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["item_id", "strategy"],
+            "properties": {
+              "item_id": {"$ref": "#/$defs/itemId"},
+              "strategy": {"$ref": "#/$defs/resolutionStrategy"}
+            }
+          }
+        }
+      }
+    },
+    "conflictPreviewResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "preview", "approval_token"],
+      "properties": {
+        "api_version": {"const": "1.0.0"},
+        "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
+        "approval_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "conflictExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
         "approved_token": {"$ref": "#/$defs/sha256"}
       }
     },

--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -15,12 +15,21 @@ from pathlib import Path
 from typing import Any
 
 from core.lifecycle.catalog import CatalogError, load_catalog
+from core.lifecycle.conflict import (
+    ConflictResolutionPreview,
+    ConflictResolutionPreviewError,
+    CurrentBytesLoader,
+    build_conflict_resolution_preview,
+    canonical_conflict_resolution_preview_bytes,
+    sidecar_path,
+)
 from core.lifecycle.inventory import build_inventory
 from core.lifecycle.model import HEX_SHA256, ITEM_ID, ReleaseCatalog
 from core.lifecycle.plan import (
     PLAN_VERSION,
     AdoptionPlan,
     PlannedAction,
+    ReasonCode,
     isolate_item_evidence,
     plan_catalog_item,
 )
@@ -1064,6 +1073,304 @@ def execute_adoption(
     return receipt
 
 
+def _rebuild_requested_conflict_plan(
+    catalog: ReleaseCatalog,
+    inventory,
+    requested: tuple[str, ...],
+) -> AdoptionPlan:
+    by_id = {item.id: item for item in catalog.items}
+    rebuilt_items = []
+    for item_id in requested:
+        item = by_id.get(item_id)
+        if item is None:
+            raise _refuse(f"requested item {item_id} is no longer in the catalog")
+        planned = plan_catalog_item(
+            item,
+            isolate_item_evidence(item, inventory, inventory.customizations),
+        )
+        if planned.action is not PlannedAction.CONFLICT:
+            raise _refuse(
+                f"item {item_id} planned action changed from conflict to "
+                f"{planned.action.value} since preview; review the current plan"
+            )
+        rebuilt_items.append(planned)
+    return AdoptionPlan(
+        PLAN_VERSION,
+        catalog.release.version,
+        catalog.integrity.catalog_sha256,
+        tuple(rebuilt_items),
+    )
+
+
+def execute_conflict_resolution(
+    vault_root: Path,
+    preview: ConflictResolutionPreview,
+    approved_token: str,
+    payload_loader: PayloadLoader,
+    current_bytes_loader: CurrentBytesLoader,
+) -> AdoptionReceipt:
+    """Re-prove and atomically execute explicit conflict-resolution choices."""
+    if not isinstance(preview, ConflictResolutionPreview):
+        raise _refuse("preview must be a ConflictResolutionPreview")
+    if not isinstance(approved_token, str) or not hmac.compare_digest(
+        approved_token, preview.sha256
+    ):
+        raise _refuse("approval token does not match the exact canonical preview")
+    if not callable(payload_loader):
+        raise _refuse("payload_loader must be callable")
+    if not callable(current_bytes_loader):
+        raise _refuse("current_bytes_loader must be callable")
+
+    root = Path(vault_root)
+    try:
+        current_catalog = load_catalog(root / CATALOG_RELATIVE, release_root=root)
+    except CatalogError as error:
+        raise _refuse(f"current catalog could not be verified: {error}") from error
+    if current_catalog.integrity.catalog_sha256 != preview.catalog_sha256:
+        raise _refuse("catalog changed since preview; build and approve a fresh preview")
+
+    requested = tuple(item.item_id for item in preview.items)
+    current_inventory = build_inventory(
+        root,
+        catalog=_catalog_inventory_scope(current_catalog, requested),
+    )
+    current_plan = _rebuild_requested_conflict_plan(
+        current_catalog,
+        current_inventory,
+        requested,
+    )
+    payload_cache: dict[str, bytes] = {}
+    current_cache: dict[str, bytes] = {}
+
+    def cached_payload_loader(path: str) -> bytes:
+        if path not in payload_cache:
+            payload_cache[path] = payload_loader(path)
+        return payload_cache[path]
+
+    def cached_current_loader(path: str) -> bytes:
+        if path not in current_cache:
+            current_cache[path] = current_bytes_loader(path)
+        return current_cache[path]
+
+    resolutions = [
+        {"item_id": item.item_id, "strategy": item.strategy}
+        for item in preview.items
+    ]
+    try:
+        rebuilt = build_conflict_resolution_preview(
+            current_catalog,
+            current_inventory,
+            current_plan,
+            resolutions,
+            cached_payload_loader,
+            cached_current_loader,
+        )
+    except ConflictResolutionPreviewError as error:
+        raise _refuse(
+            f"current conflict preview could not be rebuilt: {error}"
+        ) from error
+    if canonical_conflict_resolution_preview_bytes(
+        rebuilt
+    ) != canonical_conflict_resolution_preview_bytes(preview):
+        if rebuilt.inventory_sha256 != preview.inventory_sha256:
+            raise _refuse(
+                "requested file inventory changed since preview; "
+                "build and approve a fresh preview"
+            )
+        raise _refuse(
+            "rebuilt conflict preview differs from the approved preview; "
+            "approve a fresh preview"
+        )
+
+    preserved_writes = [
+        write
+        for item in rebuilt.items
+        for write in item.writes
+        if write.source == "preserved"
+    ]
+    # write-if-absent for the preserved sidecar is enforced HERE, in engine
+    # logic, not by the ownership contract: the sidecar resolves to a brain
+    # (replace) path, so the Transaction's own update_write_verdict would
+    # permit an overwrite. This pre-check plus the before_commit
+    # snapshot-absence check below are the only guards. A non-transaction
+    # writer that creates this exact path in the narrow window between snapshot
+    # capture and the atomic replace is still not detected here — the same
+    # documented post-snapshot residual race the adoption path carries, but
+    # without a contract backstop; making the sidecar contract-owned (so the
+    # contract itself vetoes an overwrite) is the tracked -custom follow-up.
+    for write in preserved_writes:
+        target = root / write.path
+        if target.exists() or target.is_symlink():
+            custom_name = Path(write.path).parts[2]
+            raise _refuse(
+                f"you already have a {custom_name}; "
+                "choose keep-mine or take-theirs"
+            )
+
+    preserved_sources: dict[str, str] = {}
+    planned_by_id = {item.item_id: item for item in current_plan.items}
+    for item in rebuilt.items:
+        if not any(write.source == "preserved" for write in item.writes):
+            continue
+        planned = planned_by_id[item.item_id]
+        modified_paths = {
+            path
+            for reason in planned.reasons
+            if reason.code is ReasonCode.RELEASE_FILES_MODIFIED
+            for path in reason.paths
+        }
+        for canonical_path in modified_paths:
+            preserved_sources[sidecar_path(canonical_path)] = canonical_path
+
+    entries: list[PlanEntry] = []
+    for item in rebuilt.items:
+        for write in item.writes:
+            if write.source == "release":
+                content = payload_cache[write.path]
+            else:
+                content = current_cache[preserved_sources[write.path]]
+            entries.append(PlanEntry(write.path, content))
+
+    inventory_by_path = {
+        entry.canonical_path: entry
+        for entry in current_inventory.entries
+        if entry.canonical_path
+        in {
+            write.path
+            for item in rebuilt.items
+            for write in item.writes
+            if write.source == "release"
+        }
+    }
+
+    try:
+        transaction = Transaction.begin(root, entries)
+
+        def verify_approval_binding() -> None:
+            """Bind approval to captured canonical bytes and sidecar absence."""
+            if not hmac.compare_digest(approved_token, rebuilt.sha256):
+                raise _refuse("approval binding changed before commit")
+            snapshot_by_path = {
+                entry.relative: entry
+                for entry in transaction.snapshot.read_manifest()
+            }
+            for item in rebuilt.items:
+                for write in item.writes:
+                    captured = snapshot_by_path.get(write.path)
+                    if write.source == "preserved":
+                        captured_absent = bool(
+                            captured is not None
+                            and not captured.existed
+                            and captured.sha256 is None
+                            and captured.size is None
+                            and captured.mode is None
+                        )
+                        if not captured_absent:
+                            raise _refuse(
+                                f"preservation path {write.path} appeared after "
+                                "final preview rebuild; the transaction will "
+                                "restore the existing bytes"
+                            )
+                        continue
+
+                    evidence = inventory_by_path.get(write.path)
+                    if evidence is None:
+                        raise _refuse(
+                            f"requested file {write.path} has no current inventory evidence"
+                        )
+                    approved_absence = (
+                        evidence.kind == "missing"
+                        and evidence.release_state == "stock-missing"
+                    )
+                    captured_matches = bool(
+                        captured is not None
+                        and (
+                            (
+                                approved_absence
+                                and not captured.existed
+                                and captured.sha256 is None
+                                and captured.size is None
+                                and captured.mode is None
+                            )
+                            or (
+                                not approved_absence
+                                and captured.existed
+                                and captured.sha256 == evidence.sha256
+                                and captured.size == evidence.size
+                            )
+                        )
+                    )
+                    if not captured_matches:
+                        raise _refuse(
+                            f"requested file {write.path} changed after final "
+                            "preview rebuild; the transaction will restore "
+                            "the newer bytes"
+                        )
+
+        result = transaction.run(before_commit=verify_approval_binding)
+    except PlanRejected as error:
+        raise _refuse(
+            "the ownership contract rejected the complete conflict resolution: "
+            f"{error}"
+        ) from error
+    except TransactionError as error:
+        raise _refuse(
+            f"the conflict-resolution transaction could not complete safely: {error}"
+        ) from error
+
+    files = tuple(
+        sorted(
+            (
+                ReceiptFile(
+                    item.item_id,
+                    write.path,
+                    write.new_sha256,
+                    write.byte_size,
+                )
+                for item in rebuilt.items
+                for write in item.writes
+            ),
+            key=lambda entry: (entry.path, entry.item_id),
+        )
+    )
+    transaction_id = result["tx_id"]
+    receipt = AdoptionReceipt(
+        RECEIPT_VERSION,
+        tuple(sorted(set(requested))),
+        files,
+        transaction_id,
+        f"System/.dex/tx/{transaction_id}/snapshot",
+        rebuilt.catalog_sha256,
+        rebuilt.inventory_sha256,
+        rebuilt.sha256,
+    )
+    try:
+        _persist_adoption_receipt(root, receipt)
+    except AdoptionReceiptPersistenceError:
+        raise
+    except (OSError, AdoptionExecutionError) as error:
+        raise AdoptionReceiptPersistenceError(
+            f"adoption {transaction_id} committed, but its receipt could not be "
+            f"persisted; the transaction journal is authoritative: {error}"
+        ) from error
+    try:
+        from core.lifecycle.ledger import LedgerError, record_adoption
+
+        record_adoption(
+            root,
+            receipt,
+            {item.item_id: item.item_version for item in rebuilt.items},
+        )
+    except (LedgerError, OSError) as error:
+        raise LifecycleLedgerPersistenceError(
+            f"adoption {transaction_id} committed, but its lifecycle ledger refresh did not "
+            f"complete; its event may already be durable and the transaction journal is "
+            f"authoritative: {error}. Run 'python3 -m core.lifecycle.cli --vault-root "
+            f"{root} rebuild-state' to repair the lifecycle ledger"
+        ) from error
+    return receipt
+
+
 __all__ = [
     "AdoptionExecutionError",
     "AdoptionReceipt",
@@ -1076,6 +1383,7 @@ __all__ = [
     "canonical_adoption_receipt_bytes",
     "canonical_rewind_receipt_bytes",
     "execute_adoption",
+    "execute_conflict_resolution",
     "load_adoption_receipt",
     "rewind_acknowledgement_token",
     "rewind_adoption",

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -21,9 +21,14 @@ from pathlib import Path
 
 from core import portable_contract
 from core.lifecycle.catalog import load_catalog, load_catalog_payload_sources
+from core.lifecycle.conflict import (
+    ConflictResolutionPreview,
+    build_conflict_resolution_preview,
+)
 from core.lifecycle.engine import (
     AdoptionReceipt,
     execute_adoption,
+    execute_conflict_resolution,
     rewind_acknowledgement_token,
     rewind_adoption,
 )
@@ -322,6 +327,51 @@ def read_lifecycle_state(vault_root: str | Path) -> dict[str, object]:
     )
 
 
+def build_and_preview_conflict_resolution(
+    vault_root: str | Path,
+    release_root: str | Path,
+    resolutions: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    """Build exact conflict-resolution writes and their approval token."""
+    _prepare(vault_root, release_root)
+    catalog, inventory, plan = _inventory_and_plan_models(vault_root)
+    preview = build_conflict_resolution_preview(
+        catalog,
+        inventory,
+        plan,
+        resolutions,
+        _release_payload_loader(release_root),
+        lambda path: bounded_read(Path(vault_root), path),
+    )
+    return _envelope(preview=preview.to_dict(), approval_token=preview.sha256)
+
+
+def execute_approved_conflict_resolution(
+    vault_root: str | Path,
+    release_root: str | Path,
+    preview: ConflictResolutionPreview | Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Execute one exactly approved conflict-resolution preview."""
+    _prepare(vault_root, release_root)
+    modeled = (
+        preview
+        if isinstance(preview, ConflictResolutionPreview)
+        else ConflictResolutionPreview.from_dict(preview)
+    )
+    receipt = execute_conflict_resolution(
+        Path(vault_root),
+        modeled,
+        approved_token,
+        _release_payload_loader(release_root),
+        lambda path: bounded_read(Path(vault_root), path),
+    )
+    return _envelope(
+        receipt=receipt.to_dict(),
+        rewind_acknowledgement_token=rewind_acknowledgement_token(receipt),
+    )
+
+
 __all__ = [
     "api_version",
     "build_inventory_and_plan",
@@ -329,4 +379,6 @@ __all__ = [
     "execute_approved_adoption",
     "rewind_adoption_by_receipt",
     "read_lifecycle_state",
+    "build_and_preview_conflict_resolution",
+    "execute_approved_conflict_resolution",
 ]

--- a/core/tests/test_conflict_resolution.py
+++ b/core/tests/test_conflict_resolution.py
@@ -1,0 +1,264 @@
+"""Conflict resolution: exact choices, atomic keep-both, and free rewind."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle.catalog import canonical_catalog_bytes
+from core.lifecycle.conflict import (
+    ConflictResolutionPreviewError,
+    build_conflict_resolution_preview,
+)
+from core.lifecycle.engine import (
+    AdoptionExecutionError,
+    AdoptionReceipt,
+    execute_conflict_resolution,
+    rewind_acknowledgement_token,
+    rewind_adoption,
+)
+from core.lifecycle.filesystem import bounded_read
+from core.lifecycle.inventory import build_inventory
+from core.lifecycle.model import ReleaseCatalog
+from core.lifecycle.plan import PlannedAction, build_adoption_plan
+from core.tests.lifecycle_test_helpers import write_file, write_manifest
+from core.tests.test_adoption_transaction import _document, _setup
+
+CANONICAL = ".claude/skills/alpha/SKILL.md"
+SIDECAR = ".claude/skills/alpha-custom/SKILL.md"
+RELEASE_BYTES = b"# alpha\n"
+USER_BYTES = b"# alpha\n\nMy local instructions.\n"
+
+
+def _current_loader(vault: Path):
+    return lambda path: bounded_read(vault, path)
+
+
+def _conflicted_preview(tmp_path: Path, strategy: str):
+    vault, _document_value, catalog, _inventory, _plan, release_loader = _setup(
+        tmp_path, item_ids=("alpha",)
+    )
+    write_file(vault, CANONICAL, USER_BYTES)
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+    preview = build_conflict_resolution_preview(
+        catalog,
+        inventory,
+        plan,
+        [{"item_id": "alpha", "strategy": strategy}],
+        release_loader,
+        _current_loader(vault),
+    )
+    return vault, catalog, preview, release_loader
+
+
+def _non_skill_conflict(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    canonical = ".claude/commands/alpha.md"
+    payloads = {"alpha": {canonical: RELEASE_BYTES}}
+    manifest_bytes = write_manifest(vault, [canonical])
+    document = _document(manifest_bytes, payloads)
+    catalog = ReleaseCatalog.from_dict(document)
+    write_file(vault, "System/.release-catalog.json", canonical_catalog_bytes(document))
+    write_file(vault, canonical, RELEASE_BYTES)
+
+    def release_loader(path: str) -> bytes:
+        return payloads["alpha"][path]
+
+    write_file(vault, canonical, USER_BYTES)
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+    return vault, catalog, inventory, plan, release_loader, canonical
+
+
+def test_take_theirs_writes_release_and_rewind_restores_user_edit(tmp_path: Path) -> None:
+    vault, _catalog, preview, release_loader = _conflicted_preview(
+        tmp_path, "take-theirs"
+    )
+
+    receipt = execute_conflict_resolution(
+        vault,
+        preview,
+        preview.sha256,
+        release_loader,
+        _current_loader(vault),
+    )
+
+    assert isinstance(receipt, AdoptionReceipt)
+    assert (vault / CANONICAL).read_bytes() == RELEASE_BYTES
+    assert receipt.items_adopted == ("alpha",)
+    assert [
+        (entry.item_id, entry.path, entry.sha256, entry.byte_size)
+        for entry in receipt.files_written
+    ] == [
+        (
+            "alpha",
+            CANONICAL,
+            hashlib.sha256(RELEASE_BYTES).hexdigest(),
+            len(RELEASE_BYTES),
+        )
+    ]
+    rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+    assert (vault / CANONICAL).read_bytes() == USER_BYTES
+
+
+def test_keep_both_writes_sidecar_and_rewind_removes_it(tmp_path: Path) -> None:
+    vault, _catalog, preview, release_loader = _conflicted_preview(
+        tmp_path, "keep-both"
+    )
+
+    receipt = execute_conflict_resolution(
+        vault,
+        preview,
+        preview.sha256,
+        release_loader,
+        _current_loader(vault),
+    )
+
+    assert (vault / CANONICAL).read_bytes() == RELEASE_BYTES
+    assert (vault / SIDECAR).read_bytes() == USER_BYTES
+    assert [entry.path for entry in receipt.files_written] == sorted(
+        [CANONICAL, SIDECAR]
+    )
+
+    rewind_adoption(vault, receipt, rewind_acknowledgement_token(receipt))
+    assert (vault / CANONICAL).read_bytes() == USER_BYTES
+    assert not (vault / SIDECAR).exists()
+
+
+def test_keep_both_refuses_existing_sidecar_without_partial_write(tmp_path: Path) -> None:
+    vault, _catalog, preview, release_loader = _conflicted_preview(
+        tmp_path, "keep-both"
+    )
+    existing_sidecar = b"# existing custom skill\n"
+    write_file(vault, SIDECAR, existing_sidecar)
+
+    with pytest.raises(AdoptionExecutionError, match=r"already have.*alpha-custom"):
+        execute_conflict_resolution(
+            vault,
+            preview,
+            preview.sha256,
+            release_loader,
+            _current_loader(vault),
+        )
+
+    assert (vault / CANONICAL).read_bytes() == USER_BYTES
+    assert (vault / SIDECAR).read_bytes() == existing_sidecar
+
+
+def test_execute_refuses_drift_after_preview_without_writing(tmp_path: Path) -> None:
+    vault, _catalog, preview, release_loader = _conflicted_preview(
+        tmp_path, "keep-both"
+    )
+    drifted = b"# changed again after preview\n"
+    write_file(vault, CANONICAL, drifted)
+
+    with pytest.raises(AdoptionExecutionError, match="inventory changed"):
+        execute_conflict_resolution(
+            vault,
+            preview,
+            preview.sha256,
+            release_loader,
+            _current_loader(vault),
+        )
+
+    assert (vault / CANONICAL).read_bytes() == drifted
+    assert not (vault / SIDECAR).exists()
+
+
+def test_preview_refuses_non_conflict_item(tmp_path: Path) -> None:
+    _vault, _document_value, catalog, inventory, plan, release_loader = _setup(
+        tmp_path, item_ids=("alpha",)
+    )
+
+    with pytest.raises(ConflictResolutionPreviewError, match=r"alpha.*adopt.*conflict"):
+        build_conflict_resolution_preview(
+            catalog,
+            inventory,
+            plan,
+            [{"item_id": "alpha", "strategy": "take-theirs"}],
+            release_loader,
+            lambda _path: b"unused",
+        )
+
+
+def test_keep_both_refuses_non_skill_conflict_but_take_theirs_succeeds(
+    tmp_path: Path,
+) -> None:
+    vault, catalog, inventory, plan, release_loader, canonical = _non_skill_conflict(
+        tmp_path
+    )
+
+    with pytest.raises(ConflictResolutionPreviewError, match="skills-only"):
+        build_conflict_resolution_preview(
+            catalog,
+            inventory,
+            plan,
+            [{"item_id": "alpha", "strategy": "keep-both"}],
+            release_loader,
+            _current_loader(vault),
+        )
+
+    preview = build_conflict_resolution_preview(
+        catalog,
+        inventory,
+        plan,
+        [{"item_id": "alpha", "strategy": "take-theirs"}],
+        release_loader,
+        _current_loader(vault),
+    )
+    execute_conflict_resolution(
+        vault,
+        preview,
+        preview.sha256,
+        release_loader,
+        _current_loader(vault),
+    )
+    assert (vault / canonical).read_bytes() == RELEASE_BYTES
+
+
+def test_deleted_shipped_file_is_adoptable_not_a_conflict(
+    tmp_path: Path,
+) -> None:
+    """A deleted shipped file is restored by normal adoption, not conflict
+    resolution. Conflict resolution is scoped to edited-in-place (stock-modified)
+    files, so it refuses a non-conflict item."""
+    vault, _document_value, catalog, _inventory, _plan, release_loader = _setup(
+        tmp_path, item_ids=("alpha",)
+    )
+    (vault / CANONICAL).unlink()
+    inventory = build_inventory(vault, catalog=catalog)
+    plan = build_adoption_plan(catalog, inventory)
+    # Deletion of a shipped (brain) file is re-adoptable, not a conflict.
+    assert plan.items[0].action is PlannedAction.ADOPT
+
+    for strategy in ("take-theirs", "keep-both"):
+        with pytest.raises(ConflictResolutionPreviewError, match="only conflict"):
+            build_conflict_resolution_preview(
+                catalog,
+                inventory,
+                plan,
+                [{"item_id": "alpha", "strategy": strategy}],
+                release_loader,
+                _current_loader(vault),
+            )
+
+
+def test_approval_token_mismatch_refuses_without_writing(tmp_path: Path) -> None:
+    vault, _catalog, preview, release_loader = _conflicted_preview(
+        tmp_path, "take-theirs"
+    )
+
+    with pytest.raises(AdoptionExecutionError, match="approval token"):
+        execute_conflict_resolution(
+            vault,
+            preview,
+            "0" * 64,
+            release_loader,
+            _current_loader(vault),
+        )
+
+    assert (vault / CANONICAL).read_bytes() == USER_BYTES

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -99,6 +100,8 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         tmp_path, item_ids=("alpha",)
     )
     _write_bridge_release(vault)
+    release_root = tmp_path / "release"
+    shutil.copytree(vault, release_root)
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
 
@@ -114,11 +117,11 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 
     preview_request = {
         "vault_root": str(vault),
-        "release_root": str(vault),
+        "release_root": str(release_root),
         "requested_item_ids": ["alpha"],
     }
     preview_response = service.build_and_preview_adoption(
-        vault, vault, ("alpha",)
+        vault, release_root, ("alpha",)
     )
     _assert_conforms(
         schema,
@@ -129,13 +132,13 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 
     execute_request = {
         "vault_root": str(vault),
-        "release_root": str(vault),
+        "release_root": str(release_root),
         "preview": preview_response["preview"],
         "approved_token": preview_response["approval_token"],
     }
     execute_response = service.execute_approved_adoption(
         vault,
-        vault,
+        release_root,
         preview_response["preview"],
         preview_response["approval_token"],
     )
@@ -164,6 +167,63 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         rewind_response,
     )
 
+    conflict_path = ".claude/skills/alpha/SKILL.md"
+    (vault / conflict_path).write_bytes(b"# alpha\n\nMy local instructions.\n")
+    resolutions = [{"item_id": "alpha", "strategy": "keep-both"}]
+    conflict_preview_request = {
+        "vault_root": str(vault),
+        "release_root": str(release_root),
+        "resolutions": resolutions,
+    }
+    conflict_preview_response = service.build_and_preview_conflict_resolution(
+        vault,
+        release_root,
+        resolutions,
+    )
+    _assert_conforms(
+        schema,
+        "build_and_preview_conflict_resolution",
+        conflict_preview_request,
+        conflict_preview_response,
+    )
+
+    conflict_execute_request = {
+        "vault_root": str(vault),
+        "release_root": str(release_root),
+        "preview": conflict_preview_response["preview"],
+        "approved_token": conflict_preview_response["approval_token"],
+    }
+    conflict_execute_response = service.execute_approved_conflict_resolution(
+        vault,
+        release_root,
+        conflict_preview_response["preview"],
+        conflict_preview_response["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_conflict_resolution",
+        conflict_execute_request,
+        conflict_execute_response,
+    )
+
+    conflict_receipt = conflict_execute_response["receipt"]
+    conflict_rewind_request = {
+        "vault_root": str(vault),
+        "receipt": conflict_receipt,
+        "acknowledgement_token": rewind_acknowledgement_token(conflict_receipt),
+    }
+    conflict_rewind_response = service.rewind_adoption_by_receipt(
+        vault,
+        conflict_receipt,
+        conflict_rewind_request["acknowledgement_token"],
+    )
+    _assert_conforms(
+        schema,
+        "rewind_adoption_by_receipt",
+        conflict_rewind_request,
+        conflict_rewind_response,
+    )
+
     state_request = {"vault_root": str(vault)}
     state_response = service.read_lifecycle_state(vault)
     _assert_conforms(
@@ -189,6 +249,8 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
         "execute_approved_adoption",
         "rewind_adoption_by_receipt",
         "read_lifecycle_state",
+        "build_and_preview_conflict_resolution",
+        "execute_approved_conflict_resolution",
     ]
     assert "version bump" in service.__doc__.lower()
     assert "bridge" in service.__doc__.lower()

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -35,9 +35,9 @@
 **What it is.** The single protected path through which Dex changes a user's vault: installing, updating, adopting a feature, self-healing via Doctor, or undoing. The user-facing promise (v1.68 changelog): "one safe door for every change" — preview what changes, back it up, apply, verify, write a receipt, and be able to rewind exactly.
 
 **Where it lives.** `core/lifecycle/`:
-- `service.py` — the **frozen public API v1** (`api_version = "1.0.0"`). Sole sanctioned entry point; contains no policy, composes catalog/inventory/plan/ledger/retention for reads and delegates mutations to `engine.py`.
+- `service.py` — the **frozen public API v1** (`api_version = "1.0.0"`). Sole sanctioned entry point; contains no policy, composes catalog/inventory/plan/ledger/retention for reads and delegates mutations to `engine.py`. Its additive conflict path is `build_and_preview_conflict_resolution` → `execute_approved_conflict_resolution`; the original five operation shapes remain unchanged.
 - `engine.py` (42 KB) — the mutation engine; delegates every write to `core/transaction` + `core/portable_contract`.
-- `plan.py` / `preview.py` — build the per-item adoption plan and the human preview (each item decided independently so "skip this one" can't affect the rest — v1.65 guarantee).
+- `plan.py` / `preview.py` / `conflict.py` — build the per-item adoption plan and canonical approval previews (each item decided independently so "skip this one" can't affect the rest — v1.65 guarantee). Conflict resolution can take the release version or atomically keep both for skills: the release becomes canonical while the user's edited bytes are preserved at `.claude/skills/{name}-custom/`; the ordinary adoption receipt makes either choice rewindable.
 - `inventory.py` — reads a vault "like a map without touching it": classifies what's Dex's, what's customized, what's the user's, what's unrecognized.
 - `ledger.py` (40 KB) — the **tamper-evident receipt ledger** under `System/.dex/ledger`; detects altered/missing entries and self-heals torn writes (v1.67).
 - `sqlite_snapshot.py` — safe backup of SQLite DBs (the v1.66 "databases get real protection" + power-loss-safe restore order).

--- a/docs/superpowers/plans/2026-07-23-conflict-resolution-ux.md
+++ b/docs/superpowers/plans/2026-07-23-conflict-resolution-ux.md
@@ -1,0 +1,184 @@
+# Conflict-resolution UX — design doc
+
+**Status:** DESIGN — awaiting review (orchestrator → Dave) before any implementation.
+**Date:** 2026-07-23
+**Branch:** `feat/conflict-ux` (worktree off `origin/main`, HEAD post-v1.70.0)
+**Surface touched:** `core/lifecycle/service.py` (ABI-frozen, `api_version 1.0.0`), `core/portable_contract.py` (contract), `.claude/skills/dex-update/SKILL.md` (choice layer).
+
+---
+
+## 1. Problem in one line
+
+When a Dex update ships a new version of a skill (or other shipped file) that the user has **edited in place**, the user should get a clean, reversible choice — **keep mine / take theirs / keep both / compare** — instead of the update silently doing nothing.
+
+---
+
+## 2. What already exists (verified in code — do NOT rebuild)
+
+### 2.1 Detection is complete
+`core/lifecycle/plan.py` already produces the conflict signal:
+
+- A shipped catalog file the user edited hashes as `stock-modified` (bytes differ from the verified release catalog). The per-item planner (`plan_catalog_item`) turns that into `PlannedAction.CONFLICT` with reason `ReasonCode.RELEASE_FILES_MODIFIED` and the offending paths attached.
+- A shipped catalog file the user deleted hashes as `stock-missing` → `CONFLICT` / `RELEASE_FILES_MISSING`.
+- `core/lifecycle/customizations.py` (`detect_customizations`, `classify_release_state`) is the byte-vs-catalog comparator underneath. It emits honest `stock-modified` / `stock-missing` / `unknown` states.
+
+**Consequence today:** conflicted items reach the plan as `CONFLICT`, land in the dex-update "Needs your review" group, and **nothing happens to them**. `build_adoption_preview` and `execute_adoption` both hard-refuse any item whose planned action is not `ADOPT` (preview.py L318, engine.py L853). So the *safe default* (never clobber) exists; the *resolve-it-now* path does not.
+
+### 2.2 Revert is complete
+`service.rewind_adoption_by_receipt` → `engine.rewind_adoption` restores an adoption's exact pre-state from a captured snapshot, drift-safe, under keep-last-3 snapshot retention. It is receipt-bound: the caller must present the exact `AdoptionReceipt` plus a matching `rewind_acknowledgement_token`.
+
+### 2.3 `-custom` protection exists — but weaker than it looks (IMPORTANT FINDING)
+Two separate mechanisms are in play and they disagree:
+
+- **Contract expectation:** `core/portable_contract.py` classifies `.claude/skills-custom/` as ownership `vault` → `MUTATION_POLICY["vault"] = "never"`. The `brain-claude` rule note literally says *"user skills belong in .claude/skills-custom/ (vault)"*.
+- **What `/create-skill` v2 actually does** (shipped in #192): it writes user skills to **`.claude/skills/{name}-custom/`** — i.e. a `-custom`-*suffixed folder inside* `.claude/skills/`, which resolves under the `brain-claude` rule → ownership `brain` → `MUTATION_POLICY["brain"] = "replace"`.
+
+So a `/create-skill` user skill is **not** protected by the ownership contract's `never` rule. It is protected only by **absence from the release catalog** — no catalog item names a `-custom` path, so no adopt write ever targets it. That is real protection today, but it is incidental, not contract-guaranteed. **This mismatch is load-bearing for keep-both placement (§5) and is decision D1.**
+
+### 2.4 The choice layer today
+`.claude/skills/dex-update/SKILL.md` is the entire UX. It calls the five frozen ops, renders a five-group preview, and asks for one approval. It explicitly forbids working around a conflict ("Never bypass a conflict by replacing the customized file"). There is no keep-both, no compare, no per-file choice.
+
+### 2.5 The frozen surface, precisely
+`service.py` exposes exactly five ops, `api_version = "1.0.0"`, each returning `_envelope(api_version=..., ...)`. The contract is `core/lifecycle/contracts/api.schema.json` (closed, `additionalProperties: false`, `api_version` pinned `{"const": "1.0.0"}` in ~30 places). Two guard tests in `core/tests/test_lifecycle_service_contract.py`:
+
+- `test_public_surface_requires_a_version_bump_and_bridge_to_change` — asserts `service.__all__` is **exactly** the current 5-op list.
+- `test_api_version_is_present_and_frozen_in_schema` — asserts `service.api_version == "1.0.0"` and the schema pins it.
+
+**Every PlanEntry is contract-checked twice** (`core/transaction/engine.py` L153 at `begin`, L274 at `run`) via `portable_contract.update_write_verdict`. One disallowed write aborts the whole transaction. This is the wall the keep-both writer must pass through — see §5.
+
+---
+
+## 3. What is genuinely new
+
+1. **A keep-both writer** — one new frozen lifecycle operation that, for a conflicted item, atomically (a) lands the incoming release bytes at the canonical path and (b) preserves the user's edited bytes at a sidecar `-custom` path, producing a receipt that the *existing* rewind can undo.
+2. **A choice layer** in `dex-update` that, per conflicted file, offers keep-mine / take-theirs / keep-both / compare and routes each to the right operation.
+
+---
+
+## 4. The new frozen operation
+
+### 4.1 Backward-compatibility strategy (the critical constraint)
+
+**Recommendation: keep `api_version = "1.0.0"` and ADD one operation. Do not bump the version.**
+
+Rationale: the frozen-contract rule (service.py docstring) is *"changing a frozen function signature or JSON shape requires an API version bump and a compatibility bridge."* Adding a brand-new operation changes **no existing** signature or shape — all five current ops are byte-for-byte untouched, so every existing caller keeps working. A version bump would be actively harmful here: `api_version` is embedded as a `const "1.0.0"` in every response envelope and asserted ~30× in the schema, so bumping to `1.1.0` would change the value of every existing response and break the very callers the freeze protects. Additive-without-bump is the backward-compatible move.
+
+What the addition costs (all deliberate, all reviewed):
+- Add the new op to `service.__all__` and update the `test_public_surface...` guard test's expected list — a **deliberate, reviewed** edit. The test exists precisely to force this to be a conscious act, not to forbid it.
+- Add the new op's request/response to `api.schema.json` `x-operations` and `$defs`, and add a contract-conformance case to `test_frozen_service_contract`.
+- `api_version` stays `1.0.0`; the two version-pinning assertions stay green untouched.
+
+> Decision D2 for Dave: confirm "additive op, no version bump" vs. a formal `1.1.0`. Recommend additive.
+
+### 4.2 Shape: mirror the existing preview → approve → execute → receipt chain
+
+The keep-both writer must reuse the double-authorization + receipt + rewind machinery so revert is free. Two frozen ops, mirroring `build_and_preview_adoption` / `execute_approved_adoption`:
+
+```
+build_and_preview_conflict_resolution(
+    vault_root, release_root, resolutions
+) -> {api_version, preview, approval_token}
+
+execute_approved_conflict_resolution(
+    vault_root, release_root, preview, approved_token
+) -> {api_version, receipt, rewind_acknowledgement_token}
+```
+
+- `resolutions`: an array of `{item_id, strategy}` where `strategy ∈ {"take-theirs", "keep-both"}`. (keep-mine and compare are pure UX — see §6 — and never reach the service; keep-mine = do nothing, compare = read-only.)
+- The **receipt reuses the existing `AdoptionReceipt` shape** so `rewind_adoption_by_receipt` undoes a keep-both with **zero new rewind code**. The keep-both transaction writes 1–2 files per conflicted file (canonical + sidecar); the snapshot captures the pre-state of both (the user's edited canonical file, and the absence of the sidecar), so rewind restores exactly "user's edit back at the canonical path, sidecar removed."
+
+> Decision D3 for Dave: one combined op with a `strategy` field (above), **or** a single `execute_approved_adoption` extended to accept conflict items? Recommend the **separate new op** — it keeps `execute_approved_adoption`'s frozen shape and its "only adopt may be approved" invariant untouched, and isolates the riskier keep-both semantics behind its own contract-tested surface.
+
+### 4.3 Semantics per strategy
+
+- **take-theirs:** write incoming release bytes → canonical path. This is byte-identical to a normal adopt of that item; the only reason it needs a distinct entry point is that the *plan action is CONFLICT, not ADOPT*, so it must re-prove the user genuinely asked to discard their edit. The user's edit is **not** preserved (they chose to drop it) — but it is still recoverable via rewind (snapshot captured the pre-state).
+- **keep-both:** one transaction, two writes:
+  1. incoming release bytes → canonical path (e.g. `.claude/skills/foo/SKILL.md`),
+  2. user's current edited bytes → sidecar preservation path (see §5).
+
+Both strategies re-prove the conflict is still exactly as previewed before committing (same "rebuild preview, compare canonical bytes" guard the adoption path uses), and refuse on any drift.
+
+---
+
+## 5. Where the preserved copy lands — and the contract wall
+
+This is the hardest design point. The keep-both preservation write goes through `Transaction`, which enforces `update_write_verdict` on every entry. So the sidecar path **must be contract-writable**:
+
+| Candidate sidecar path | Ownership | `update_write_verdict` | Verdict |
+|---|---|---|---|
+| `.claude/skills-custom/foo/SKILL.md` | `vault` | `never` | **REJECTED** — transaction aborts |
+| `.claude/skills/foo-custom/SKILL.md` | `brain` | `replace` | **allowed** (matches create-skill v2's real convention) |
+
+The contract-clean choices:
+
+- **Option A (recommended): sidecar under `.claude/skills/{name}-custom/`, authorized as write-if-absent.** This matches where `/create-skill` v2 already puts user skills, so the two systems converge on one `-custom` convention. But it currently resolves to `brain/replace`. Two ways to make it honest:
+  - **A1:** add a `portable_contract` rule that `.claude/skills/*-custom/**` is a preservation namespace with `write-if-absent` semantics (create it when absent, never overwrite). This gives the keep-both write a legal, minimal, *user-content-preserving* authorization and simultaneously makes the create-skill protection contract-guaranteed instead of incidental. Repeated updates then refuse to overwrite an existing sidecar (edge case §7).
+  - **A2:** leave the contract alone; rely on `brain/replace` allowing the write and on catalog-absence protecting it afterward. Cheapest, but perpetuates the "protected by accident" weakness from §2.3.
+- **Option B: preserve the user's edit into the `vault`-owned `.claude/skills-custom/` namespace.** Semantically the "right" home per the contract note, but requires giving that namespace a `write-if-absent` exception (it is `never` today), which weakens the guarantee that updates never touch `vault`. Not recommended.
+
+> Decision D1 for Dave (the big one): **keep-both sidecar placement + naming.** Recommend **Option A1**: place the preserved user copy at `.claude/skills/{name}-custom/`, and add a narrow `write-if-absent` preservation rule to the contract so the write is legal, minimal, and never overwrites an existing user file. This unifies with create-skill and upgrades `-custom` from incidental to contract-guaranteed protection. Second frozen surface touched (`portable_contract`) — but it is the honest place for the change.
+
+Note: this design generalizes beyond skills (any conflicted shipped file), but the `-custom` sidecar naming only reads naturally for skills/docs. For a non-skill conflicted file (e.g. a shipped System doc), the sidecar would be `{stem}-custom{suffix}` beside the original. Confirm we scope the first cut to skills + docs and refuse keep-both elsewhere (falling back to keep-mine/take-theirs), rather than inventing sidecar names for arbitrary paths.
+
+---
+
+## 6. Choice-layer UX (in `dex-update`)
+
+The five-group preview stays. Group 2 ("Needs your review") stops being a dead end. For each conflicted file the user sees, in plain language:
+
+- **what changed:** "You edited `foo`. The update ships a newer `foo`."
+- **four choices:**
+  - **Keep mine** — nothing is written. (Pure UX; no service call. The update leaves your edit exactly as-is; you stay on your version.)
+  - **Take theirs** — the new version replaces yours. Your old version is still recoverable via rewind. (→ `..._conflict_resolution`, strategy `take-theirs`.)
+  - **Keep both** — the new version becomes active; your edit is saved beside it as `{name}-custom` and stays invocable. (→ strategy `keep-both`.)
+  - **Compare** — show me the difference first, then ask again. (Pure UX; read-only.)
+
+**Compare rendering (Decision D4):** recommend **inline** in the update conversation — a short, plain unified-diff-style summary the skill renders from the two byte sources (user's current file vs. incoming preview bytes), never an external editor or a raw git call. It keeps the "the skill renders, the service owns mutations" boundary intact and works headless. For large files, summarize (N changed regions) rather than dumping.
+
+The approval discipline is unchanged: after the user picks strategies, the skill calls `build_and_preview_conflict_resolution`, shows every exact write it will make, and requires one explicit "apply this exact resolution?" yes bound to that exact preview + token. A refusal (drift, changed evidence, unsafe path) stops and leaves the vault untouched.
+
+---
+
+## 7. Edge cases
+
+1. **Both files already exist** (canonical edited *and* a `{name}-custom` sidecar already present from a prior keep-both or from `/create-skill`): keep-both's sidecar write is `write-if-absent`, so it **refuses** rather than overwriting the user's existing `-custom`. UX falls back to offering keep-mine / take-theirs, or a numbered sidecar (`{name}-custom-2`) only if Dave wants that (Decision D5 — recommend refuse-and-explain over silent numbering, to avoid fragmenting discoverability, consistent with create-skill's "no `-v2` forks" rule).
+2. **A `-custom` already exists** (create-skill case): same as (1) — the sidecar namespace is occupied; keep-both refuses the preservation write and the UX explains "you already have a `foo-custom`."
+3. **Repeated updates** (user takes an update, edits the shipped file again, next update conflicts again): each resolution is its own receipt-backed transaction. take-theirs re-proves current bytes each time. keep-both refuses if the sidecar is occupied (see 1). No state accumulates in the service beyond receipts + ledger events.
+4. **Drift between preview and execute:** reuse the adoption path's guard — rebuild the preview, compare canonical bytes and the sidecar's absence; any mismatch → refuse, no write.
+5. **stock-missing conflict** (user deleted a shipped file): keep-both is meaningless (nothing to preserve); offer only take-theirs (restore the shipped file) or keep-mine (stay deleted).
+6. **Rewind after keep-both:** the receipt records both writes; rewind restores the user's edit at the canonical path and removes the sidecar. Under keep-last-3 snapshot retention the snapshot may be pruned after 3 further transactions — rewind already fails safe on a missing snapshot (engine.py L762). No new rewind code.
+7. **Folder remapping** (`System/folder-paths.yaml`): `update_write_verdict` assumes default PARA layout; a remapped skills dir must be canonicalized before the sidecar path is classified, or the write fails safe (unclassified → never). Confirm dex-update passes canonical paths.
+
+---
+
+## 8. Contract-test plan
+
+1. **Extend `test_lifecycle_service_contract.py`:**
+   - update the `test_public_surface...` expected `__all__` to include the two new ops (deliberate, reviewed).
+   - add a `build_and_preview_conflict_resolution` → `execute_approved_conflict_resolution` → `rewind_adoption_by_receipt` round trip to `test_frozen_service_contract`, asserting request+response conform to the schema.
+   - keep `test_api_version_is_present_and_frozen_in_schema` untouched and green (proves no version bump leaked in).
+2. **New op unit/behaviour tests** (mirror `test_adoption_transaction`):
+   - take-theirs writes canonical bytes, produces a valid `AdoptionReceipt`, and rewind restores the user's edit.
+   - keep-both writes both files atomically; rewind restores canonical edit + removes sidecar.
+   - keep-both **refuses** when the sidecar exists (write-if-absent), leaving the vault untouched.
+   - drift between preview and execute → refusal, no partial write.
+   - a non-CONFLICT item passed to the conflict op → refusal (symmetry with "only adopt may be approved").
+3. **`portable_contract` tests** (if Option A1): a new rule test that `.claude/skills/*-custom/**` is `write-if-absent` and that an existing sidecar refuses overwrite; regenerate/gate the path-contract test.
+4. **Schema self-consistency:** the closed-schema validator already walks `additionalProperties:false`; the new `$defs` must round-trip the new receipt/preview through it.
+5. **Regenerate `docs/architecture/INVENTORY.md`** (drift-gated) and update `DEX-CORE-MAP.md` narrative for the new op.
+
+---
+
+## 9. Decisions Dave should weigh (summary)
+
+- **D1 (biggest): keep-both sidecar placement + naming.** Recommend `.claude/skills/{name}-custom/` + a narrow `write-if-absent` preservation rule in the contract (Option A1) — unifies with create-skill and makes `-custom` protection contract-guaranteed, at the cost of touching a second contract surface.
+- **D2: version bump?** Recommend additive op, keep `api_version 1.0.0` (a bump would break every existing response envelope).
+- **D3: op shape.** Recommend a **separate** new pair of ops with a `strategy` field, not an extension of `execute_approved_adoption`.
+- **D4: compare = inline vs external.** Recommend inline, skill-rendered, read-only.
+- **D5: repeated keep-both collision.** Recommend refuse-and-explain over silent `-custom-2` numbering.
+
+---
+
+## 10. Scope guard
+
+First cut: skills (and shipped docs) only, `take-theirs` + `keep-both` + read-only `compare`. keep-mine is the existing no-op default. Everything routes through the frozen service; the skill renders and the service owns every mutation. No implementation until this design is approved (orchestrator → Dave).


### PR DESCRIPTION
## What & why

When a Dex update ships a new version of a shipped skill the user **edited in place**, they now get a real choice — **keep mine / take theirs / keep both / compare** — instead of the update silently doing nothing. Previously such a file planned as `CONFLICT` and landed in dex-update's "Needs your review" group as a dead end.

Design doc (approved, orchestrator → Dave): `docs/superpowers/plans/2026-07-23-conflict-resolution-ux.md`.

## The frozen surface (additive, no version bump)

Adds **two new** operations to the ABI-frozen `core.lifecycle.service` (`api_version` stays **1.0.0**). The five existing ops are **byte-identical** (zero deletions in the diff):

- `build_and_preview_conflict_resolution(vault_root, release_root, resolutions)`
- `execute_approved_conflict_resolution(vault_root, release_root, preview, approved_token)`

`resolutions` is a list of `{item_id, strategy}` where strategy ∈ `take-theirs | keep-both` (keep-mine and compare are pure UX and never call the service).

## keep-both semantics

One crash-safe transaction: the incoming release bytes land at the canonical path **and** the user's edited bytes are preserved at a sidecar `.claude/skills/{name}-custom/…`. It **reuses the existing `AdoptionReceipt`**, so the existing receipt-backed rewind undoes a keep-both with **zero new revert code** — restoring the user's edit at the canonical path and removing the sidecar.

## Key design decisions (all approved)

- **Additive op / no version bump** — a bump would break every response envelope's `api_version` const.
- **Separate op pair** — keeps `execute_approved_adoption`'s "only adopt may be approved" invariant intact.
- **write-if-absent enforced in engine logic** (pre-check + `before_commit` snapshot-absence re-check), **not** a `portable_contract` change — so no ownership-contract surface is touched and `vault=never` is not weakened. Making the `-custom` namespace contract-guaranteed is a **tracked follow-up** (today the sidecar is protected by catalog-absence, same as `/create-skill`).
- **Scope**: skills-only sidecars; keep-both refuses non-skill conflicts; a *deleted* shipped file remains `adopt` (handled by normal adoption), not a conflict.

## Detection & revert (reused unchanged)

`PlannedAction.CONFLICT` / `RELEASE_FILES_MODIFIED` and `rewind_adoption_by_receipt` already existed; this PR builds on them without changing them.

## UX

`dex-update`'s "Needs your review" group now offers the four choices and routes each to the right operation, with the resolution preview as its own approval boundary. Inline read-only compare.

## Review & verification

- **My diff review** caught and reverted one unrequested scope-creep change (a `plan.py` tweak making deleted files conflict + a flipped golden-test assertion); the affected test was reframed to assert the correct boundary.
- **Adversarial review (Opus)** verified rewind-restores-exactly, approval binding, freeze intactness, and sidecar path safety as SAFE; its main finding is the known Option-A ownership tradeoff (→ follow-up card). A residual post-snapshot sidecar race is documented in-code, consistent with the codebase's existing transaction-race posture.
- **Gates/tests (local):** 116 Python + 15 node tests pass incl. both lifecycle contract guard tests, full conflict suite, adoption, golden journeys. Green: ruff, path-contract, doc-drift, test-delta, portable-contract (1107 paths, no new rules), architecture-inventory (no drift), security, PII.
- **Freeze confirmed:** 5 existing ops byte-identical, `api_version` 1.0.0, `portable_contract.py` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)