### PR TITLE
feat(integrations): Phase 3 — connections contract + engine manifest (the boundary desktop consumes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         run: bash scripts/security-gate.sh
       - name: Portable-vault contract gate
         run: bash scripts/check-portable-contract.sh
+      - name: Connections contract and vendoring manifest gate
+        run: npm run check:connections-contract
       - name: Founder-content gate
         run: bash scripts/check-founder-content.sh
       - name: Distribution safety check

--- a/core/integrations/connection-manager/connection-manager.hardening.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.hardening.test.cjs
@@ -227,6 +227,41 @@ test('lock: losing refresh racer reuses the winner token instead of refreshing a
   store.deleteToken('refresh-race');
 });
 
+test('refresh lock: two real forced-refresh processes make exactly one token-endpoint call', async () => {
+  const connId = 'refresh-force-race';
+  const counter = path.join(TMP_VAULT, 'refresh-endpoint-hits.txt');
+  fs.writeFileSync(counter, '');
+  store.saveToken(
+    connId,
+    { access_token: 'FAKE-ORIGINAL-AT', refresh_token: 'FAKE-ORIGINAL-RT', expires_at: Date.now() + 3600_000 },
+    { provider: 'google' }
+  );
+  store.setOAuthApp('google', { clientId: 'FAKE-CLIENT-ID', clientSecret: 'FAKE-CLIENT-SECRET' });
+  const env = { ...childEnv, DEX_CM_TEST_REFRESH_COUNTER: counter, DEX_CM_TEST_REFRESH_DELAY_MS: '250' };
+  const [first, second] = await Promise.all([
+    execFileP('node', [CHILD, 'refresh-force', connId], { env }),
+    execFileP('node', [CHILD, 'refresh-force', connId], { env }),
+  ]);
+  assert.equal(first.stdout, 'FAKE-CROSS-PROCESS-AT');
+  assert.equal(second.stdout, 'FAKE-CROSS-PROCESS-AT');
+  assert.equal(fs.readFileSync(counter, 'utf8').trim().split(/\n/).filter(Boolean).length, 1);
+  assert.equal(store.loadToken(connId).access_token, 'FAKE-CROSS-PROCESS-AT');
+  store.deleteToken(connId);
+});
+
+test('refresh lock: a dead-PID holder is taken over on the refresh lock specifically', () => {
+  const connId = 'refresh-stale-takeover';
+  const dead = require('node:child_process').spawnSync('node', ['-e', '']);
+  const refreshLock = path.join(CRED_DIR, `.dex-cm.refresh-${connId}.lock`);
+  fs.mkdirSync(CRED_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(refreshLock, JSON.stringify({ pid: dead.pid, createdAt: Date.now() }), { mode: 0o600 });
+  const started = Date.now();
+  const output = execFileSync('node', [CHILD, 'take-refresh-lock', connId], { env: childEnv }).toString();
+  assert.equal(output, 'locked');
+  assert.ok(Date.now() - started < 2000, 'dead refresh holder should be stolen immediately');
+  assert.equal(fs.existsSync(refreshLock), false, 'refresh lock releases after takeover');
+});
+
 // ---- corrupt token files (fix: one bad file must not kill the sweep) ---------
 
 function corruptTokens() {

--- a/core/integrations/connection-manager/connections-contract.test.cjs
+++ b/core/integrations/connection-manager/connections-contract.test.cjs
@@ -1,0 +1,107 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const REPO = path.resolve(__dirname, '../../..');
+const DIST = path.join(REPO, 'packages', 'dex-contracts', 'dist');
+const FIXTURES = path.join(REPO, 'packages', 'dex-contracts', 'fixtures', 'connections');
+const CONTRACT = path.join(DIST, 'connections.contract.json');
+const SCHEMA = path.join(DIST, 'connections.schema.json');
+const MANIFEST = path.join(DIST, 'connections-engine.manifest.json');
+
+test('connections contract, schema, fixtures, and engine manifest are committed generated artifacts', () => {
+  for (const file of [CONTRACT, SCHEMA, MANIFEST]) {
+    assert.equal(fs.existsSync(file), true, `${path.relative(REPO, file)} must exist`);
+  }
+  for (const file of [
+    'token.least-privilege.json',
+    'token.class-b-envelope.json',
+    'token.v2-envelope.json',
+    ...['connected', 'expiring', 'expired', 'needs_reauth', 'not_connected'].map((status) => `status.${status}.json`),
+  ]) {
+    assert.equal(fs.existsSync(path.join(FIXTURES, file)), true, `fixture ${file} must exist`);
+  }
+});
+
+test('connections contract artifacts regenerate without drift and validate every golden fixture', () => {
+  execFileSync('node', [path.join(REPO, 'scripts', 'check-connections-contract.mjs')], { cwd: REPO, stdio: 'pipe' });
+  execFileSync('node', [path.join(REPO, 'scripts', 'build-connections-engine-manifest.mjs'), '--check'], {
+    cwd: REPO,
+    stdio: 'pipe',
+  });
+});
+
+test('foreign smoke consumer uses only CLIs plus contract/schema against a scratch vault', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-consumer-'));
+  const env = { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' };
+  try {
+    execFileSync('node', [path.join(__dirname, 'connect.cjs'), 'set-key', 'linear', '--no-probe'], {
+      cwd: REPO,
+      env,
+      input: 'FAKE-LINEAR-KEY\n',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const output = execFileSync(
+      'node',
+      [
+        path.join(REPO, 'scripts', 'connections-consumer-smoke.mjs'),
+        '--contract',
+        CONTRACT,
+      ],
+      { cwd: REPO, env, stdio: 'pipe' }
+    ).toString();
+    assert.match(output, /connections consumer smoke passed/);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('real accessor and status CLIs conform to the published schemas and exit-code ABI', async () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-conformance-'));
+  const env = { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' };
+  const contract = JSON.parse(fs.readFileSync(CONTRACT, 'utf8'));
+  const schema = JSON.parse(fs.readFileSync(SCHEMA, 'utf8'));
+  const { validateAgainstSchema } = await import(path.join(REPO, 'scripts', 'connections-contract-validation.mjs'));
+  const getToken = path.join(__dirname, contract.cli.getToken.executable);
+  try {
+    execFileSync(
+      'node',
+      [
+        '-e',
+        "require(process.argv[1]).saveToken('fixture-oauth',{access_token:'FAKE-AT',refresh_token:'FAKE-RT',expires_at:1893456000000,scope:'read'},{provider:'google'})",
+        path.join(__dirname, 'token-store.cjs'),
+      ],
+      { env, stdio: 'pipe' }
+    );
+    const least = JSON.parse(execFileSync('node', [getToken, 'fixture-oauth'], { env }).toString());
+    validateAgainstSchema(least, schema.$defs.leastPrivilegeToken, schema);
+    const full = JSON.parse(execFileSync('node', [getToken, 'fixture-oauth', '--full'], { env }).toString());
+    validateAgainstSchema(full, schema.$defs.fullToken, schema);
+    const raw = execFileSync('node', [getToken, 'fixture-oauth', '--access-token-only'], { env }).toString();
+    validateAgainstSchema(raw, schema.$defs.accessTokenOnly, schema);
+
+    const status = JSON.parse(
+      execFileSync('node', [path.join(__dirname, contract.cli.status.executable), 'status', '--json'], { env }).toString()
+    );
+    validateAgainstSchema(status, schema.$defs.statusOutput, schema);
+    const envelope = JSON.parse(
+      fs.readFileSync(path.join(vault, 'System', 'credentials', 'tokens', 'fixture-oauth.json'), 'utf8')
+    );
+    validateAgainstSchema(envelope, schema.$defs.tokenEnvelopeV2, schema);
+
+    assert.equal(spawnSync('node', [getToken, 'missing'], { env }).status, contract.cli.getToken.exitCodes.not_connected);
+    assert.equal(spawnSync('node', [getToken], { env }).status, contract.cli.getToken.exitCodes.error);
+    fs.writeFileSync(path.join(vault, 'System', 'credentials', 'tokens', 'fixture-oauth.json'), 'corrupt');
+    assert.equal(
+      spawnSync('node', [getToken, 'fixture-oauth'], { env }).status,
+      contract.cli.getToken.exitCodes.needs_reauth
+    );
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/core/integrations/connection-manager/contract.cjs
+++ b/core/integrations/connection-manager/contract.cjs
@@ -1,0 +1,273 @@
+'use strict';
+
+const CONTRACT_VERSION = '1.0.0';
+const ENGINE_VERSION = '1.0.0';
+const TOKEN_ENVELOPE_VERSION = 2;
+const CONNECTION_STATUSES = Object.freeze([
+  'connected',
+  'expiring',
+  'expired',
+  'needs_reauth',
+  'not_connected',
+]);
+const VERIFICATION_STATES = Object.freeze(['verified', 'unverified']);
+const GET_TOKEN_EXIT_CODES = Object.freeze({
+  ok: 0,
+  not_connected: 2,
+  needs_reauth: 3,
+  error: 1,
+});
+const LOCK_PROTOCOL = Object.freeze({
+  storeTimeoutMs: 10000,
+  refreshTimeoutMs: 30000,
+  unreadableStaleMs: 30000,
+  hardStaleMs: 10 * 60 * 1000,
+});
+
+function buildConnectionsContract() {
+  return {
+    contract: 'dex.connections',
+    version: CONTRACT_VERSION,
+    engineVersion: ENGINE_VERSION,
+    source: 'core/integrations/connection-manager/contract.cjs',
+    schema: 'connections.schema.json',
+    engine: {
+      relativeRoot: 'core/integrations/connection-manager',
+      manifest: 'connections-engine.manifest.json',
+    },
+    compatibility: {
+      rule: 'Additive changes require a minor version. Breaking or removing any frozen field, value, invocation, or behavior requires a major version.',
+      additive: 'minor',
+      breaking: 'major',
+    },
+    ownership: {
+      rule: 'Consumers are read-only and accessor-only. They MUST NOT write credential files or implement a writer. ALL mutations go through the connection-manager engine CLI.',
+      consumerCapabilities: ['connect.cjs status --json', 'get-token.cjs <connection>'],
+      mutationBoundary: 'core/integrations/connection-manager/connect.cjs',
+    },
+    cli: {
+      getToken: {
+        executable: 'get-token.cjs',
+        invocation: ['node', 'get-token.cjs', '<connection>', '[--full | --access-token-only]'],
+        connectionId: 'provider or provider:alias',
+        modes: {
+          defaultOAuth: {
+            schema: '#/$defs/leastPrivilegeToken',
+            output: '{access_token, expires_at}',
+            leastPrivilege: true,
+          },
+          defaultClassB: {
+            schema: '#/$defs/classBEnvelope',
+            output: '{kind, baseUrl, headers, query}',
+            note: 'Rendered request envelope; credentials may be embedded in headers, query, or baseUrl.',
+          },
+          full: {
+            flag: '--full',
+            schema: '#/$defs/fullToken',
+            note: 'Full stored OAuth token. Explicit privileged mode.',
+          },
+          accessTokenOnly: {
+            flag: '--access-token-only',
+            schema: '#/$defs/accessTokenOnly',
+            note: 'Raw OAuth bearer token or raw Class B secret. Explicit privileged mode.',
+          },
+        },
+        exitCodes: GET_TOKEN_EXIT_CODES,
+      },
+      status: {
+        executable: 'connect.cjs',
+        invocation: ['node', 'connect.cjs', 'status', '--json'],
+        schema: '#/$defs/statusOutput',
+        statuses: CONNECTION_STATUSES,
+        verificationStates: VERIFICATION_STATES,
+      },
+    },
+    storage: {
+      root: '{DEX_VAULT}/System/credentials',
+      layout: {
+        tokens: 'tokens/<connId with colon encoded as __>.json',
+        ledger: 'ledger/<connection>.jsonl',
+        registry: 'connections.json',
+        oauthApps: 'oauth-apps.json',
+        fallbackKey: '.dex-cm.key',
+        gitignore: '.gitignore',
+      },
+      gitignoreGuard: {
+        requiredRule: '*',
+        exceptions: ['!.gitignore', '!README.md'],
+      },
+      tokenEnvelope: {
+        schema: '#/$defs/tokenEnvelopeV2',
+        fields: ['v', 'aad', 'iv', 'tag', 'data'],
+        v: TOKEN_ENVELOPE_VERSION,
+        aad: 'token:<connId>',
+        encoding: 'iv, tag, and data are base64; AES-256-GCM binds aad',
+      },
+    },
+    locks: {
+      protocol: 'Exclusive lockfile creation (O_CREAT|O_EXCL); holder releases by unlink in finally; waiters never proceed unlocked.',
+      fileShape: { pid: 'positive integer', createdAt: 'Unix epoch milliseconds' },
+      store: '{credentialsRoot}/.dex-cm.lock',
+      refresh: '{credentialsRoot}/.dex-cm.refresh-<connId with colon encoded as __>.lock',
+      staleTakeover: {
+        deadPid: 'immediate',
+        unreadableLockfileOlderThanMs: LOCK_PROTOCOL.unreadableStaleMs,
+        anyLockfileOlderThanMs: LOCK_PROTOCOL.hardStaleMs,
+        method: 'unlink then re-race exclusive creation',
+      },
+      timeoutsMs: { store: LOCK_PROTOCOL.storeTimeoutMs, refresh: LOCK_PROTOCOL.refreshTimeoutMs },
+    },
+  };
+}
+
+function nullable(type) {
+  return { type: [type, 'null'] };
+}
+
+function buildConnectionsSchema() {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: 'https://heydex.ai/contracts/connections.schema.json',
+    title: 'Dex connections consumer boundary',
+    $defs: {
+      leastPrivilegeToken: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['access_token', 'expires_at'],
+        properties: {
+          access_token: { type: 'string', minLength: 1 },
+          expires_at: nullable('number'),
+        },
+      },
+      classBEnvelope: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['kind', 'baseUrl', 'headers', 'query'],
+        properties: {
+          kind: { const: 'api_key' },
+          baseUrl: nullable('string'),
+          headers: { type: 'object', additionalProperties: { type: 'string' } },
+          query: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+      },
+      fullToken: { type: 'object', minProperties: 1 },
+      accessTokenOnly: { type: 'string' },
+      verificationState: { enum: VERIFICATION_STATES },
+      connectionStatus: { enum: CONNECTION_STATUSES },
+      statusRow: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'service',
+          'provider',
+          'alias',
+          'status',
+          'expiresAt',
+          'hasRefreshToken',
+          'scopes',
+          'lastRefreshedAt',
+          'error',
+          'verified',
+          'verification',
+          'lastVerifiedAt',
+          'lastProbeAt',
+        ],
+        properties: {
+          service: { type: 'string', minLength: 1 },
+          provider: { type: 'string', minLength: 1 },
+          alias: nullable('string'),
+          status: { $ref: '#/$defs/connectionStatus' },
+          expiresAt: nullable('number'),
+          hasRefreshToken: { type: 'boolean' },
+          scopes: { type: 'array', items: { type: 'string' } },
+          lastRefreshedAt: nullable('string'),
+          error: nullable('string'),
+          message: { type: 'string' },
+          verified: { type: 'boolean' },
+          verification: { $ref: '#/$defs/verificationState' },
+          lastVerifiedAt: nullable('string'),
+          lastProbeAt: nullable('string'),
+        },
+      },
+      registryNotice: {
+        anyOf: [{ type: 'null' }, { type: 'object' }],
+      },
+      statusOutput: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['connections', 'registryNotice'],
+        properties: {
+          connections: { type: 'array', items: { $ref: '#/$defs/statusRow' } },
+          registryNotice: { $ref: '#/$defs/registryNotice' },
+        },
+      },
+      tokenEnvelopeV2: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['v', 'aad', 'iv', 'tag', 'data'],
+        properties: {
+          v: { const: TOKEN_ENVELOPE_VERSION },
+          aad: { type: 'string', pattern: '^token:[A-Za-z0-9][A-Za-z0-9._-]*(?::[a-z0-9_-]+)?$' },
+          iv: { type: 'string', contentEncoding: 'base64' },
+          tag: { type: 'string', contentEncoding: 'base64' },
+          data: { type: 'string', contentEncoding: 'base64' },
+        },
+      },
+    },
+  };
+}
+
+function fixtureStatus(status) {
+  const connected = status !== 'not_connected';
+  return {
+    connections: [{
+      service: `fixture-${status}`,
+      provider: 'fixture',
+      alias: null,
+      status,
+      expiresAt: ['expiring', 'expired'].includes(status) ? 1893456000000 : null,
+      hasRefreshToken: status === 'expiring' || status === 'expired',
+      scopes: connected ? ['read'] : [],
+      lastRefreshedAt: connected ? '2030-01-01T00:00:00.000Z' : null,
+      error: status === 'needs_reauth' ? 'invalid_grant' : null,
+      verified: status === 'connected',
+      verification: status === 'connected' ? 'verified' : 'unverified',
+      lastVerifiedAt: status === 'connected' ? '2030-01-01T00:01:00.000Z' : null,
+      lastProbeAt: status === 'connected' ? '2030-01-01T00:01:00.000Z' : null,
+    }],
+    registryNotice: null,
+  };
+}
+
+function buildConnectionsFixtures() {
+  return {
+    'token.least-privilege.json': { access_token: 'FAKE-ACCESS-TOKEN', expires_at: 1893456000000 },
+    'token.class-b-envelope.json': {
+      kind: 'api_key',
+      baseUrl: 'https://api.example.test',
+      headers: { Authorization: 'FAKE-RENDERED-SECRET' },
+      query: {},
+    },
+    'token.v2-envelope.json': {
+      v: TOKEN_ENVELOPE_VERSION,
+      aad: 'token:fixture',
+      iv: 'MDEyMzQ1Njc4OWFi',
+      tag: 'MDEyMzQ1Njc4OWFiY2RlZg==',
+      data: 'RkFLRS1DSVBIRVJURVhU',
+    },
+    ...Object.fromEntries(CONNECTION_STATUSES.map((status) => [`status.${status}.json`, fixtureStatus(status)])),
+  };
+}
+
+module.exports = {
+  CONTRACT_VERSION,
+  ENGINE_VERSION,
+  TOKEN_ENVELOPE_VERSION,
+  CONNECTION_STATUSES,
+  VERIFICATION_STATES,
+  GET_TOKEN_EXIT_CODES,
+  LOCK_PROTOCOL,
+  buildConnectionsContract,
+  buildConnectionsSchema,
+  buildConnectionsFixtures,
+};

--- a/core/integrations/connection-manager/fs-safe.cjs
+++ b/core/integrations/connection-manager/fs-safe.cjs
@@ -38,6 +38,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { LOCK_PROTOCOL } = require('./contract.cjs');
 const crypto = require('crypto');
 
 /**
@@ -76,9 +77,9 @@ function writeFileAtomic(filePath, data, { mode = 0o600 } = {}) {
 
 // ---- Cross-process lock ------------------------------------------------------
 
-const ACQUIRE_TIMEOUT_MS = 10_000; // default wait for the lock before erroring
-const UNREADABLE_STALE_MS = 30_000; // unreadable lockfile older than this is stale
-const HARD_STALE_MS = 10 * 60 * 1000; // absolute backstop: no lock lives longer
+const ACQUIRE_TIMEOUT_MS = LOCK_PROTOCOL.storeTimeoutMs;
+const UNREADABLE_STALE_MS = LOCK_PROTOCOL.unreadableStaleMs;
+const HARD_STALE_MS = LOCK_PROTOCOL.hardStaleMs;
 
 // Reentrancy bookkeeping: how many times THIS process currently holds each lock path.
 const _heldDepth = new Map();

--- a/core/integrations/connection-manager/get-token.cjs
+++ b/core/integrations/connection-manager/get-token.cjs
@@ -22,6 +22,7 @@
 const health = require('./health.cjs');
 const store = require('./token-store.cjs');
 const { apiKeyContext } = require('./auth-context.cjs');
+const { GET_TOKEN_EXIT_CODES } = require('./contract.cjs');
 
 async function main() {
   const service = process.argv[2];
@@ -29,14 +30,14 @@ async function main() {
   const full = process.argv.includes('--full');
   if (!service) {
     console.error('Usage: node get-token.cjs <service> [--full | --access-token-only]');
-    process.exit(1);
+    process.exit(GET_TOKEN_EXIT_CODES.error);
   }
   let token;
   try {
     token = store.loadToken(service);
   } catch (err) {
     console.error(err.message);
-    process.exit(err.code === 'DEX_CM_KEY_LOST' ? 3 : 1);
+    process.exit(err.code === 'DEX_CM_KEY_LOST' ? GET_TOKEN_EXIT_CODES.needs_reauth : GET_TOKEN_EXIT_CODES.error);
   }
   if (!token) {
     // A corrupt token file was quarantined and stamped by loadToken; that is a
@@ -44,10 +45,10 @@ async function main() {
     const reg = store.getConnection(service);
     if (reg && reg.error) {
       console.error(`${service} needs re-authentication (${reg.error}). Run: node connect.cjs connect ${service}`);
-      process.exit(3);
+      process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
     }
     console.error(`${service} is not connected.`);
-    process.exit(2);
+    process.exit(GET_TOKEN_EXIT_CODES.not_connected);
   }
   try {
     // Class B (paste-a-key): no refresh. Emit the raw secret (--access-token-only)
@@ -60,7 +61,8 @@ async function main() {
         return;
       }
       // Render the auth scheme via the shared seam (same context dex-call uses).
-      process.stdout.write(JSON.stringify(apiKeyContext(token, service)));
+      const { apiKey: _rawSecret, ...rendered } = apiKeyContext(token, service);
+      process.stdout.write(JSON.stringify(rendered));
       return;
     }
 
@@ -77,10 +79,10 @@ async function main() {
   } catch (err) {
     if (err.needsReauth) {
       console.error(`${service} needs re-authentication. Run: node connect.cjs connect ${service}`);
-      process.exit(3);
+      process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
     }
     console.error(err.message);
-    process.exit(1);
+    process.exit(GET_TOKEN_EXIT_CODES.error);
   }
 }
 

--- a/core/integrations/connection-manager/hardening.child.cjs
+++ b/core/integrations/connection-manager/hardening.child.cjs
@@ -60,6 +60,46 @@ async function main() {
       process.stdout.write('refreshed');
       return;
     }
+    case 'refresh-force': {
+      // refresh-force <connId>: run the real refresh state machine in this OS
+      // process. The test-only endpoint is an in-process fetch responder whose
+      // append-only counter is shared by all child processes.
+      const [connId] = args;
+      const counter = process.env.DEX_CM_TEST_REFRESH_COUNTER;
+      if (!counter) throw new Error('DEX_CM_TEST_REFRESH_COUNTER is required');
+      const catalog = require('./catalog.cjs');
+      const realGetProviderConfig = catalog.getProviderConfig;
+      catalog.getProviderConfig = (provider, config) => ({
+        ...realGetProviderConfig(provider, config),
+        tokenUrl: 'https://mock-token-endpoint.invalid/token',
+        refreshUrl: null,
+        refreshRetryDelayMs: 0,
+      });
+      global.fetch = async () => {
+        require('fs').appendFileSync(counter, 'hit\n');
+        await new Promise((resolve) => setTimeout(resolve, Number(process.env.DEX_CM_TEST_REFRESH_DELAY_MS || 0)));
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: async () => ({
+            access_token: 'FAKE-CROSS-PROCESS-AT',
+            refresh_token: 'FAKE-CROSS-PROCESS-RT',
+            expires_in: 3600,
+          }),
+        };
+      };
+      const health = require('./health.cjs');
+      process.stdout.write(await health.refreshToken(connId, { force: true }));
+      return;
+    }
+    case 'take-refresh-lock': {
+      // take-refresh-lock <connId>: proves the exact per-connection refresh
+      // lock path can recover from a dead holder.
+      await store.withRefreshLock(args[0], async () => {});
+      process.stdout.write('locked');
+      return;
+    }
     case 'load-token': {
       // load-token <connId>: prints the decrypted token JSON. Exit 9 on key loss
       // (distinct from generic failure) so tests can assert the explicit state.

--- a/core/integrations/connection-manager/health.cjs
+++ b/core/integrations/connection-manager/health.cjs
@@ -30,6 +30,30 @@ function evidenceFor(connId) {
   return ledger.rollup(connId);
 }
 
+function completeStatusRow(row) {
+  const verification = connectorModel.deriveVerification({
+    lastVerifiedAt: row.lastVerifiedAt,
+    lastProbeAt: row.lastProbeAt,
+  });
+  return {
+    service: row.service,
+    provider: row.provider,
+    alias: row.alias || null,
+    status: row.status,
+    expiresAt: row.expiresAt || null,
+    hasRefreshToken: Boolean(row.hasRefreshToken),
+    scopes: Array.isArray(row.scopes) ? row.scopes : [],
+    lastRefreshedAt: row.lastRefreshedAt || null,
+    error: row.error || null,
+    ...verification,
+    ...row,
+    alias: row.alias || null,
+    expiresAt: row.expiresAt || null,
+    lastRefreshedAt: row.lastRefreshedAt || null,
+    error: row.error || null,
+  };
+}
+
 /** True if this connection is a paste-a-key (Class B) connection (registry mode or stored kind). */
 function isKeyBased(reg, token) {
   if (reg && reg.authMode && catalog.KEY_MODES.has(reg.authMode)) return true;
@@ -49,7 +73,7 @@ function connectionHealth(service) {
     if (err && err.code === 'DEX_CM_KEY_LOST') {
       // Computed at read time and never persisted, so a transient keychain
       // blip self-heals completely the moment the key is readable again.
-      return {
+      return completeStatusRow({
         service: connId,
         provider,
         alias: reg && reg.alias,
@@ -60,7 +84,7 @@ function connectionHealth(service) {
         lastRefreshedAt: reg && reg.lastRefreshedAt,
         error: 'encryption_key_lost',
         message: err.message,
-      };
+      });
     }
     throw err;
   }
@@ -68,7 +92,7 @@ function connectionHealth(service) {
     // Re-read: loadToken may just have stamped a corruption reason on the entry.
     const reg2 = store.readRegistry()[connId] || reg;
     if (reg2 && reg2.error) {
-      return {
+      return completeStatusRow({
         service: connId,
         provider: reg2.provider || provider,
         alias: reg2.alias,
@@ -78,15 +102,15 @@ function connectionHealth(service) {
         scopes: reg2.scopes || [],
         lastRefreshedAt: reg2.lastRefreshedAt,
         error: reg2.error,
-      };
+      });
     }
-    return {
+    return completeStatusRow({
       service: connId,
       status: 'not_connected',
       provider,
       alias: reg && reg.alias,
       ...connectorModel.deriveVerification(evidenceFor(connId)),
-    };
+    });
   }
 
   const keyBased = isKeyBased(reg, token);
@@ -98,7 +122,7 @@ function connectionHealth(service) {
     hasRefreshToken: Boolean(token.refresh_token),
   });
 
-  return {
+  return completeStatusRow({
     service: connId,
     provider,
     alias: reg && reg.alias,
@@ -109,7 +133,7 @@ function connectionHealth(service) {
     lastRefreshedAt: reg && reg.lastRefreshedAt,
     error: reg && reg.error,
     ...connectorModel.deriveVerification(evidenceFor(connId)),
-  };
+  });
 }
 
 /** Sweep every known connection (the monitoring view). One broken connection must never kill the sweep. */
@@ -118,13 +142,13 @@ function allConnectionsHealth() {
     try {
       return connectionHealth(c.service);
     } catch (err) {
-      return {
+      return completeStatusRow({
         service: c.service,
         provider: c.provider,
         alias: c.alias,
         status: 'needs_reauth',
         error: err && err.code === 'DEX_CM_KEY_LOST' ? 'encryption_key_lost' : `health_check_failed: ${err.message}`,
-      };
+      });
     }
   });
 }
@@ -176,6 +200,15 @@ function normalizeRefreshResult(result, previous) {
     ...(raw.id || nested.id || previous.id ? { id: raw.id || nested.id || previous.id } : {}),
     raw,
   };
+}
+
+function tokenRevision(token) {
+  return JSON.stringify([
+    token && token.access_token,
+    token && token.refresh_token,
+    token && token.expires_at,
+    token && token.obtained_at,
+  ]);
 }
 
 function recordConnectionEvent(connId, op, row = {}) {
@@ -235,8 +268,12 @@ async function refreshToken(service, { force = false } = {}) {
   return runSingleFlight(connId, async () =>
     store.withRefreshLock(connId, async () => {
       // Double-check under the lock: another process may have refreshed while
-      // we waited. If the stored token is fresh now, use it: no network call.
+      // we waited. This applies even to `force`: force means this invocation
+      // must cause a refresh, not that every racing process must burn the same
+      // rotating refresh token. If the persisted revision changed while this
+      // caller waited, the invocation's refresh has already been satisfied.
       const current = store.loadToken(connId) || token;
+      if (tokenRevision(current) !== tokenRevision(token)) return current.access_token;
       if (!force && connectionHealth(connId).status === 'connected') return current.access_token;
 
       const reg = store.readRegistry()[connId] || {};

--- a/core/integrations/connection-manager/lib/connector-model.js
+++ b/core/integrations/connection-manager/lib/connector-model.js
@@ -3,13 +3,7 @@
 // Desktop's evidence-only principle while retaining Core's five public states.
 "use strict";
 
-const CONNECTOR_STATUSES = Object.freeze([
-	"connected",
-	"expiring",
-	"expired",
-	"needs_reauth",
-	"not_connected",
-]);
+const { CONNECTION_STATUSES: CONNECTOR_STATUSES } = require("../contract.cjs");
 
 /**
  * Derive Core's credential status strictly from durable evidence.

--- a/core/integrations/connection-manager/lifted-conformance.test.cjs
+++ b/core/integrations/connection-manager/lifted-conformance.test.cjs
@@ -31,12 +31,13 @@ const FILES = {
   },
   'connector-model.js': {
     source: '6d96ababba84dcd0d07b85db52e0427d6434ac57f7c2f7a762ee9f8aad9f822c',
-    lifted: '4c38cbd86fb1c0cdfe66ba649f06045388ca3ddb41f080afb71d6fe1eeabd29c',
+    lifted: '29fcf20f3eab1f3ba65a6bcad33e7e0c9cd0aab2df6d377ad11bd785f58b4ac8',
     mode: 'core-adaptation',
     divergences: [
       'Core five-state credential model',
       'Desktop complete, partial, stale, failed, and sync-schedule fields omitted',
       'live verification remains separate evidence on connected credentials',
+      'status constants come from the generated connections contract source',
     ],
   },
   'connector-verify.js': {

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -4,7 +4,7 @@
  * never leave the machine and never hit a relay.
  *
  * Layout (under {DEX_VAULT}/System/credentials/, which is gitignored):
- *   tokens/<connId>.json    AES-256-GCM envelope { v, iv, tag, data } (base64)
+ *   tokens/<connId>.json    AES-256-GCM v2 envelope { v, aad, iv, tag, data } (binary fields base64)
  *   connections.json        plaintext registry: status/scopes/timestamps (NO secrets)
  *   oauth-apps.json         plaintext client ids + encrypted client-secret envelopes
  *   .dex-cm.key             fallback encryption key (0600) if OS keychain unavailable
@@ -25,6 +25,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const { writeFileAtomic, withLockSync, withLock } = require('./fs-safe.cjs');
+const { TOKEN_ENVELOPE_VERSION, LOCK_PROTOCOL } = require('./contract.cjs');
 
 const KEYCHAIN_SERVICE = 'dex-connection-manager';
 const KEYCHAIN_ACCOUNT = 'token-store-key';
@@ -274,7 +275,7 @@ function withStoreLock(fn) {
  * refreshing again. 30s timeout covers a slow token endpoint.
  */
 function withRefreshLock(connId, fn) {
-  return withLock(refreshLockPath(connId), fn, { timeoutMs: 30_000 });
+  return withLock(refreshLockPath(connId), fn, { timeoutMs: LOCK_PROTOCOL.refreshTimeoutMs });
 }
 
 // ---- Encrypt / decrypt ------------------------------------------------------
@@ -293,11 +294,11 @@ function encrypt(plaintext, aad = '') {
   cipher.setAAD(Buffer.from(aad, 'utf8'));
   const data = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
-  return { v: 2, aad, iv: iv.toString('base64'), tag: tag.toString('base64'), data: data.toString('base64') };
+  return { v: TOKEN_ENVELOPE_VERSION, aad, iv: iv.toString('base64'), tag: tag.toString('base64'), data: data.toString('base64') };
 }
 
 function decrypt(envelope, aad = '') {
-  if (!envelope || envelope.v !== 2) throw new Error('Unsupported encrypted credential envelope version.');
+  if (!envelope || envelope.v !== TOKEN_ENVELOPE_VERSION) throw new Error('Unsupported encrypted credential envelope version.');
   if (envelope.aad !== aad) throw new EnvelopeBindingError();
   const decipher = crypto.createDecipheriv('aes-256-gcm', getKey(), Buffer.from(envelope.iv, 'base64'));
   decipher.setAAD(Buffer.from(aad, 'utf8'));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "meeting-sync:force": "node .scripts/meeting-intel/sync-from-granola.cjs --force",
     "test:hooks": "node --test .claude/hooks/tests/*.test.cjs",
     "test:scripts": "node --test .scripts/lib/tests/*.test.cjs .scripts/meeting-intel/__tests__/*.test.cjs",
-    "test:integrations": "node --test core/integrations/connection-manager/*.test.cjs"
+    "test:integrations": "node --test core/integrations/connection-manager/*.test.cjs",
+    "check:connections-contract": "node scripts/check-connections-contract.mjs && node scripts/build-connections-engine-manifest.mjs --check",
+    "test:connections-consumer-smoke": "node --test core/integrations/connection-manager/connections-contract.test.cjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",

--- a/packages/dex-contracts/README.md
+++ b/packages/dex-contracts/README.md
@@ -8,6 +8,8 @@ From `dex-core` repo root:
 
 ```bash
 python3 scripts/generate-path-contracts.py
+node scripts/generate-connections-contract.mjs
+node scripts/build-connections-engine-manifest.mjs
 ```
 
 ## Outputs
@@ -16,3 +18,7 @@ python3 scripts/generate-path-contracts.py
 - `dist/release-catalog-v1.schema.json`: B1 release-catalog JSON schema
 - `dist/index.js`: runtime helper exports
 - `dist/index.d.ts`: TypeScript declarations
+- `dist/connections.contract.json`: frozen connection-manager CLI, status, storage, locking, ownership, and versioning ABI
+- `dist/connections.schema.json`: JSON Schema definitions for accessor/status/encrypted-envelope outputs
+- `dist/connections-engine.manifest.json`: checksummed vendoring manifest for the consumable engine
+- `fixtures/connections/`: canonical consumer examples for all frozen outputs and five statuses

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "engineVersion": "1.0.0",
+  "contractVersion": "1.0.0",
+  "trees": {
+    "connectionsEngine": {
+      "sourcePath": "core/integrations/connection-manager",
+      "vendorPath": "vendor/dex-core-connections-engine",
+      "entryCount": 1,
+      "entries": [
+        "connection-manager"
+      ],
+      "fileCount": 17,
+      "totalBytes": 166873,
+      "treeHash": "91b5642e73158eb6dd6cab12dec3d6bc2a3ee03d8722659eaa13bbe1659f3dbf",
+      "files": [
+        {
+          "path": "auth-context.cjs",
+          "bytes": 5195,
+          "sha256": "9c9abdaed3b4b8f42d08b259b83281b5b303311cb2ec0017e500eaaca5ea3069"
+        },
+        {
+          "path": "catalog.cjs",
+          "bytes": 20505,
+          "sha256": "2117715e9defc26496526320cd3222b40db0f3bb469c001ff4f970ffba9ee8e7"
+        },
+        {
+          "path": "connect.cjs",
+          "bytes": 24995,
+          "sha256": "296db1b5260f656fd25bea6f7310a64758efcb16a3aa38ac8f4b633b5433347b"
+        },
+        {
+          "path": "contract.cjs",
+          "bytes": 9429,
+          "sha256": "8a313c5e817f723dd2e98e6eb76ba615fb64903f8769a847cd35c85dd75e51c3"
+        },
+        {
+          "path": "dex-call.cjs",
+          "bytes": 6560,
+          "sha256": "521751a487f37f76b3559d1d0b3fd53e60e2c8d7f03d61873ceb5ac14676a3fa"
+        },
+        {
+          "path": "fs-safe.cjs",
+          "bytes": 7285,
+          "sha256": "7db548d0eea98768c53553ea80abf0280940aba0247a0e3a221a19e1103f5570"
+        },
+        {
+          "path": "get-token.cjs",
+          "bytes": 3673,
+          "sha256": "ec46a76f89e0d602196b447212ccdd0dc398f8004e16b8b2644c2fff5c528de4"
+        },
+        {
+          "path": "health.cjs",
+          "bytes": 14672,
+          "sha256": "df063349f49c85a08c8d608905cad6b4dd635af2b0f82814360afb7db24a0f4f"
+        },
+        {
+          "path": "index.cjs",
+          "bytes": 976,
+          "sha256": "405e863f45d3ef8815bda7ed25369a1960639858e40f261df3c861007b740497"
+        },
+        {
+          "path": "lib/connector-ledger.js",
+          "bytes": 4385,
+          "sha256": "451bd6d497da9f54919dcac431025f7ad2bbe37695180d5cef1a366c902ceef8"
+        },
+        {
+          "path": "lib/connector-model.js",
+          "bytes": 1645,
+          "sha256": "29fcf20f3eab1f3ba65a6bcad33e7e0c9cd0aab2df6d377ad11bd785f58b4ac8"
+        },
+        {
+          "path": "lib/connector-verify.js",
+          "bytes": 6446,
+          "sha256": "d8325fd377caf21c6613fb36755dd9bd92e9fae80aff3927ba4ea1e82914c67c"
+        },
+        {
+          "path": "lib/oauth-refresh.js",
+          "bytes": 10452,
+          "sha256": "9540de5ac106f3863552359f0d950c0ef2e182c2a1d17c9aaf2e5dd15a814f35"
+        },
+        {
+          "path": "lib/rate-limit.js",
+          "bytes": 5651,
+          "sha256": "a53b67ad5ea4a02e95d60684b9a6196e0a51652120d5a7c1566f2a4de3e8eff2"
+        },
+        {
+          "path": "oauth-flow.cjs",
+          "bytes": 8995,
+          "sha256": "52edd8f433c567d7b9f9d14a1f7bf19140865ecea206d2de4810bddca88768b9"
+        },
+        {
+          "path": "README.md",
+          "bytes": 6209,
+          "sha256": "7403daa0fd5ff0aa31cf0bc686382b9f47b2c7183df4541362c1918f68bc58dd"
+        },
+        {
+          "path": "token-store.cjs",
+          "bytes": 29800,
+          "sha256": "a9430fc179f1451f1e4edb02396e53da174c90a3d276c1a9361e9ef2bc6ab808"
+        }
+      ]
+    }
+  }
+}

--- a/packages/dex-contracts/dist/connections.contract.json
+++ b/packages/dex-contracts/dist/connections.contract.json
@@ -1,0 +1,135 @@
+{
+  "contract": "dex.connections",
+  "version": "1.0.0",
+  "engineVersion": "1.0.0",
+  "source": "core/integrations/connection-manager/contract.cjs",
+  "schema": "connections.schema.json",
+  "engine": {
+    "relativeRoot": "core/integrations/connection-manager",
+    "manifest": "connections-engine.manifest.json"
+  },
+  "compatibility": {
+    "rule": "Additive changes require a minor version. Breaking or removing any frozen field, value, invocation, or behavior requires a major version.",
+    "additive": "minor",
+    "breaking": "major"
+  },
+  "ownership": {
+    "rule": "Consumers are read-only and accessor-only. They MUST NOT write credential files or implement a writer. ALL mutations go through the connection-manager engine CLI.",
+    "consumerCapabilities": [
+      "connect.cjs status --json",
+      "get-token.cjs <connection>"
+    ],
+    "mutationBoundary": "core/integrations/connection-manager/connect.cjs"
+  },
+  "cli": {
+    "getToken": {
+      "executable": "get-token.cjs",
+      "invocation": [
+        "node",
+        "get-token.cjs",
+        "<connection>",
+        "[--full | --access-token-only]"
+      ],
+      "connectionId": "provider or provider:alias",
+      "modes": {
+        "defaultOAuth": {
+          "schema": "#/$defs/leastPrivilegeToken",
+          "output": "{access_token, expires_at}",
+          "leastPrivilege": true
+        },
+        "defaultClassB": {
+          "schema": "#/$defs/classBEnvelope",
+          "output": "{kind, baseUrl, headers, query}",
+          "note": "Rendered request envelope; credentials may be embedded in headers, query, or baseUrl."
+        },
+        "full": {
+          "flag": "--full",
+          "schema": "#/$defs/fullToken",
+          "note": "Full stored OAuth token. Explicit privileged mode."
+        },
+        "accessTokenOnly": {
+          "flag": "--access-token-only",
+          "schema": "#/$defs/accessTokenOnly",
+          "note": "Raw OAuth bearer token or raw Class B secret. Explicit privileged mode."
+        }
+      },
+      "exitCodes": {
+        "ok": 0,
+        "not_connected": 2,
+        "needs_reauth": 3,
+        "error": 1
+      }
+    },
+    "status": {
+      "executable": "connect.cjs",
+      "invocation": [
+        "node",
+        "connect.cjs",
+        "status",
+        "--json"
+      ],
+      "schema": "#/$defs/statusOutput",
+      "statuses": [
+        "connected",
+        "expiring",
+        "expired",
+        "needs_reauth",
+        "not_connected"
+      ],
+      "verificationStates": [
+        "verified",
+        "unverified"
+      ]
+    }
+  },
+  "storage": {
+    "root": "{DEX_VAULT}/System/credentials",
+    "layout": {
+      "tokens": "tokens/<connId with colon encoded as __>.json",
+      "ledger": "ledger/<connection>.jsonl",
+      "registry": "connections.json",
+      "oauthApps": "oauth-apps.json",
+      "fallbackKey": ".dex-cm.key",
+      "gitignore": ".gitignore"
+    },
+    "gitignoreGuard": {
+      "requiredRule": "*",
+      "exceptions": [
+        "!.gitignore",
+        "!README.md"
+      ]
+    },
+    "tokenEnvelope": {
+      "schema": "#/$defs/tokenEnvelopeV2",
+      "fields": [
+        "v",
+        "aad",
+        "iv",
+        "tag",
+        "data"
+      ],
+      "v": 2,
+      "aad": "token:<connId>",
+      "encoding": "iv, tag, and data are base64; AES-256-GCM binds aad"
+    }
+  },
+  "locks": {
+    "protocol": "Exclusive lockfile creation (O_CREAT|O_EXCL); holder releases by unlink in finally; waiters never proceed unlocked.",
+    "fileShape": {
+      "pid": "positive integer",
+      "createdAt": "Unix epoch milliseconds"
+    },
+    "store": "{credentialsRoot}/.dex-cm.lock",
+    "refresh": "{credentialsRoot}/.dex-cm.refresh-<connId with colon encoded as __>.lock",
+    "staleTakeover": {
+      "deadPid": "immediate",
+      "unreadableLockfileOlderThanMs": 30000,
+      "anyLockfileOlderThanMs": 600000,
+      "method": "unlink then re-race exclusive creation"
+    },
+    "timeoutsMs": {
+      "store": 10000,
+      "refresh": 30000
+    }
+  }
+}

--- a/packages/dex-contracts/dist/connections.schema.json
+++ b/packages/dex-contracts/dist/connections.schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heydex.ai/contracts/connections.schema.json",
+  "title": "Dex connections consumer boundary",
+  "$defs": {
+    "leastPrivilegeToken": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "access_token",
+        "expires_at"
+      ],
+      "properties": {
+        "access_token": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expires_at": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "classBEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "baseUrl",
+        "headers",
+        "query"
+      ],
+      "properties": {
+        "kind": {
+          "const": "api_key"
+        },
+        "baseUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "query": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fullToken": {
+      "type": "object",
+      "minProperties": 1
+    },
+    "accessTokenOnly": {
+      "type": "string"
+    },
+    "verificationState": {
+      "enum": [
+        "verified",
+        "unverified"
+      ]
+    },
+    "connectionStatus": {
+      "enum": [
+        "connected",
+        "expiring",
+        "expired",
+        "needs_reauth",
+        "not_connected"
+      ]
+    },
+    "statusRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service",
+        "provider",
+        "alias",
+        "status",
+        "expiresAt",
+        "hasRefreshToken",
+        "scopes",
+        "lastRefreshedAt",
+        "error",
+        "verified",
+        "verification",
+        "lastVerifiedAt",
+        "lastProbeAt"
+      ],
+      "properties": {
+        "service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/connectionStatus"
+        },
+        "expiresAt": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "hasRefreshToken": {
+          "type": "boolean"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lastRefreshedAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "verified": {
+          "type": "boolean"
+        },
+        "verification": {
+          "$ref": "#/$defs/verificationState"
+        },
+        "lastVerifiedAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lastProbeAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "registryNotice": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "statusOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "connections",
+        "registryNotice"
+      ],
+      "properties": {
+        "connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/statusRow"
+          }
+        },
+        "registryNotice": {
+          "$ref": "#/$defs/registryNotice"
+        }
+      }
+    },
+    "tokenEnvelopeV2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "v",
+        "aad",
+        "iv",
+        "tag",
+        "data"
+      ],
+      "properties": {
+        "v": {
+          "const": 2
+        },
+        "aad": {
+          "type": "string",
+          "pattern": "^token:[A-Za-z0-9][A-Za-z0-9._-]*(?::[a-z0-9_-]+)?$"
+        },
+        "iv": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "tag": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "data": {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      }
+    }
+  }
+}

--- a/packages/dex-contracts/fixtures/connections/status.connected.json
+++ b/packages/dex-contracts/fixtures/connections/status.connected.json
@@ -1,0 +1,22 @@
+{
+  "connections": [
+    {
+      "service": "fixture-connected",
+      "provider": "fixture",
+      "alias": null,
+      "status": "connected",
+      "expiresAt": null,
+      "hasRefreshToken": false,
+      "scopes": [
+        "read"
+      ],
+      "lastRefreshedAt": "2030-01-01T00:00:00.000Z",
+      "error": null,
+      "verified": true,
+      "verification": "verified",
+      "lastVerifiedAt": "2030-01-01T00:01:00.000Z",
+      "lastProbeAt": "2030-01-01T00:01:00.000Z"
+    }
+  ],
+  "registryNotice": null
+}

--- a/packages/dex-contracts/fixtures/connections/status.expired.json
+++ b/packages/dex-contracts/fixtures/connections/status.expired.json
@@ -1,0 +1,22 @@
+{
+  "connections": [
+    {
+      "service": "fixture-expired",
+      "provider": "fixture",
+      "alias": null,
+      "status": "expired",
+      "expiresAt": 1893456000000,
+      "hasRefreshToken": true,
+      "scopes": [
+        "read"
+      ],
+      "lastRefreshedAt": "2030-01-01T00:00:00.000Z",
+      "error": null,
+      "verified": false,
+      "verification": "unverified",
+      "lastVerifiedAt": null,
+      "lastProbeAt": null
+    }
+  ],
+  "registryNotice": null
+}

--- a/packages/dex-contracts/fixtures/connections/status.expiring.json
+++ b/packages/dex-contracts/fixtures/connections/status.expiring.json
@@ -1,0 +1,22 @@
+{
+  "connections": [
+    {
+      "service": "fixture-expiring",
+      "provider": "fixture",
+      "alias": null,
+      "status": "expiring",
+      "expiresAt": 1893456000000,
+      "hasRefreshToken": true,
+      "scopes": [
+        "read"
+      ],
+      "lastRefreshedAt": "2030-01-01T00:00:00.000Z",
+      "error": null,
+      "verified": false,
+      "verification": "unverified",
+      "lastVerifiedAt": null,
+      "lastProbeAt": null
+    }
+  ],
+  "registryNotice": null
+}

--- a/packages/dex-contracts/fixtures/connections/status.needs_reauth.json
+++ b/packages/dex-contracts/fixtures/connections/status.needs_reauth.json
@@ -1,0 +1,22 @@
+{
+  "connections": [
+    {
+      "service": "fixture-needs_reauth",
+      "provider": "fixture",
+      "alias": null,
+      "status": "needs_reauth",
+      "expiresAt": null,
+      "hasRefreshToken": false,
+      "scopes": [
+        "read"
+      ],
+      "lastRefreshedAt": "2030-01-01T00:00:00.000Z",
+      "error": "invalid_grant",
+      "verified": false,
+      "verification": "unverified",
+      "lastVerifiedAt": null,
+      "lastProbeAt": null
+    }
+  ],
+  "registryNotice": null
+}

--- a/packages/dex-contracts/fixtures/connections/status.not_connected.json
+++ b/packages/dex-contracts/fixtures/connections/status.not_connected.json
@@ -1,0 +1,20 @@
+{
+  "connections": [
+    {
+      "service": "fixture-not_connected",
+      "provider": "fixture",
+      "alias": null,
+      "status": "not_connected",
+      "expiresAt": null,
+      "hasRefreshToken": false,
+      "scopes": [],
+      "lastRefreshedAt": null,
+      "error": null,
+      "verified": false,
+      "verification": "unverified",
+      "lastVerifiedAt": null,
+      "lastProbeAt": null
+    }
+  ],
+  "registryNotice": null
+}

--- a/packages/dex-contracts/fixtures/connections/token.class-b-envelope.json
+++ b/packages/dex-contracts/fixtures/connections/token.class-b-envelope.json
@@ -1,0 +1,8 @@
+{
+  "kind": "api_key",
+  "baseUrl": "https://api.example.test",
+  "headers": {
+    "Authorization": "FAKE-RENDERED-SECRET"
+  },
+  "query": {}
+}

--- a/packages/dex-contracts/fixtures/connections/token.least-privilege.json
+++ b/packages/dex-contracts/fixtures/connections/token.least-privilege.json
@@ -1,0 +1,4 @@
+{
+  "access_token": "FAKE-ACCESS-TOKEN",
+  "expires_at": 1893456000000
+}

--- a/packages/dex-contracts/fixtures/connections/token.v2-envelope.json
+++ b/packages/dex-contracts/fixtures/connections/token.v2-envelope.json
@@ -1,0 +1,7 @@
+{
+  "v": 2,
+  "aad": "token:fixture",
+  "iv": "MDEyMzQ1Njc4OWFi",
+  "tag": "MDEyMzQ1Njc4OWFiY2RlZg==",
+  "data": "RkFLRS1DSVBIRVJURVhU"
+}

--- a/packages/dex-contracts/package.json
+++ b/packages/dex-contracts/package.json
@@ -12,13 +12,19 @@
       "default": "./dist/index.js"
     },
     "./paths": "./dist/paths.contract.json",
+    "./connections": "./dist/connections.contract.json",
+    "./connections-schema": "./dist/connections.schema.json",
+    "./connections-engine-manifest": "./dist/connections-engine.manifest.json",
+    "./connections-fixtures/*": "./fixtures/connections/*",
     "./release-catalog-schema": "./dist/release-catalog-v1.schema.json",
     "./schema": "./dist/paths.schema.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "fixtures"
   ],
   "scripts": {
-    "build": "python3 ../../scripts/generate-path-contracts.py"
+    "build": "python3 ../../scripts/generate-path-contracts.py && node ../../scripts/generate-connections-contract.mjs && node ../../scripts/build-connections-engine-manifest.mjs",
+    "check": "node ../../scripts/check-connections-contract.mjs && node ../../scripts/build-connections-engine-manifest.mjs --check"
   }
 }

--- a/scripts/build-connections-engine-manifest.mjs
+++ b/scripts/build-connections-engine-manifest.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_REL = 'core/integrations/connection-manager';
+const SOURCE = path.join(REPO, SOURCE_REL);
+const OUTPUT = path.join(REPO, 'packages/dex-contracts/dist/connections-engine.manifest.json');
+const { CONTRACT_VERSION, ENGINE_VERSION } = require(path.join(SOURCE, 'contract.cjs'));
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function collect(dir) {
+  const output = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const absolute = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) output.push(...collect(absolute));
+    else if (entry.isFile() && !entry.name.endsWith('.test.cjs') && entry.name !== 'hardening.child.cjs') output.push(absolute);
+  }
+  return output;
+}
+
+const files = collect(SOURCE).map((absolute) => {
+  const bytes = fs.readFileSync(absolute);
+  return {
+    path: path.relative(SOURCE, absolute).split(path.sep).join('/'),
+    bytes: bytes.length,
+    sha256: sha256(bytes),
+  };
+});
+const treeHash = crypto.createHash('sha256');
+for (const file of files) {
+  treeHash.update(file.path);
+  treeHash.update('\0');
+  treeHash.update(String(file.bytes));
+  treeHash.update('\0');
+  treeHash.update(file.sha256);
+  treeHash.update('\n');
+}
+const manifest = {
+  version: 1,
+  engineVersion: ENGINE_VERSION,
+  contractVersion: CONTRACT_VERSION,
+  trees: {
+    connectionsEngine: {
+      sourcePath: SOURCE_REL,
+      vendorPath: 'vendor/dex-core-connections-engine',
+      entryCount: 1,
+      entries: ['connection-manager'],
+      fileCount: files.length,
+      totalBytes: files.reduce((sum, file) => sum + file.bytes, 0),
+      treeHash: treeHash.digest('hex'),
+      files,
+    },
+  },
+};
+
+if (process.argv.includes('--check')) {
+  assert.deepStrictEqual(JSON.parse(fs.readFileSync(OUTPUT, 'utf8')), manifest, 'connections engine manifest drifted; run scripts/build-connections-engine-manifest.mjs');
+  console.log(`Connections engine manifest verified (${files.length} files, ${manifest.trees.connectionsEngine.treeHash})`);
+} else {
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Built connections engine manifest (${files.length} files, ${manifest.trees.connectionsEngine.treeHash})`);
+}

--- a/scripts/check-connections-contract.mjs
+++ b/scripts/check-connections-contract.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { readJson, validateAgainstSchema } from './connections-contract-validation.mjs';
+
+const require = createRequire(import.meta.url);
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = require(path.join(REPO, 'core/integrations/connection-manager/contract.cjs'));
+const DIST = path.join(REPO, 'packages/dex-contracts/dist');
+const FIXTURES = path.join(REPO, 'packages/dex-contracts/fixtures/connections');
+
+const contract = readJson(path.join(DIST, 'connections.contract.json'));
+const schema = readJson(path.join(DIST, 'connections.schema.json'));
+assert.deepStrictEqual(contract, source.buildConnectionsContract(), 'connections.contract.json drifted; run scripts/generate-connections-contract.mjs');
+assert.deepStrictEqual(schema, source.buildConnectionsSchema(), 'connections.schema.json drifted; run scripts/generate-connections-contract.mjs');
+
+for (const [name, expected] of Object.entries(source.buildConnectionsFixtures())) {
+  const file = path.join(FIXTURES, name);
+  assert.equal(fs.existsSync(file), true, `missing fixture ${name}`);
+  const actual = readJson(file);
+  assert.deepStrictEqual(actual, expected, `fixture drift: ${name}`);
+  const definition = name.startsWith('status.')
+    ? 'statusOutput'
+    : name === 'token.least-privilege.json'
+      ? 'leastPrivilegeToken'
+      : name === 'token.class-b-envelope.json'
+        ? 'classBEnvelope'
+        : 'tokenEnvelopeV2';
+  validateAgainstSchema(actual, schema.$defs[definition], schema);
+}
+console.log(`Connections contract v${contract.version}: dist and ${Object.keys(source.buildConnectionsFixtures()).length} fixtures conform`);

--- a/scripts/connections-consumer-smoke.mjs
+++ b/scripts/connections-consumer-smoke.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readJson, validateAgainstSchema } from './connections-contract-validation.mjs';
+
+function flags(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) out[argv[i].replace(/^--/, '')] = argv[i + 1];
+  return out;
+}
+
+const args = flags(process.argv.slice(2));
+if (!args.contract) throw new Error('missing --contract');
+if (!process.env.DEX_VAULT) throw new Error('DEX_VAULT is required');
+
+const contract = readJson(args.contract);
+const schemaPath = args.schema || path.join(path.dirname(args.contract), contract.schema);
+const schema = readJson(schemaPath);
+if (contract.contract !== 'dex.connections') throw new Error('foreign contract is not dex.connections');
+if (!contract.ownership.rule.includes('ALL mutations go through')) throw new Error('contract lacks the engine-only mutation rule');
+const engineRoot = args['engine-root'] || path.resolve(path.dirname(args.contract), '../../..', contract.engine.relativeRoot);
+const connection = args.connection || 'linear';
+
+function invoke(executable, cliArgs) {
+  const result = spawnSync(process.execPath, [path.join(engineRoot, executable), ...cliArgs], {
+    env: process.env,
+    encoding: 'utf8',
+  });
+  if (result.status !== contract.cli.getToken.exitCodes.ok) {
+    throw new Error(`${executable} failed (${result.status}): ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+const status = JSON.parse(invoke(contract.cli.status.executable, ['status', '--json']));
+validateAgainstSchema(status, schema.$defs.statusOutput, schema);
+const row = status.connections.find((candidate) => candidate.service === connection);
+if (!row) throw new Error(`status did not include ${connection}`);
+
+const rendered = JSON.parse(invoke(contract.cli.getToken.executable, [connection]));
+validateAgainstSchema(rendered, schema.$defs.classBEnvelope, schema);
+if (rendered.kind !== 'api_key') throw new Error('expected a Class B rendered envelope');
+
+fs.accessSync(process.env.DEX_VAULT, fs.constants.R_OK);
+console.log(`connections consumer smoke passed (contract ${contract.version}, ${connection})`);

--- a/scripts/connections-contract-validation.mjs
+++ b/scripts/connections-contract-validation.mjs
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+
+function typeMatches(value, type) {
+  if (type === 'null') return value === null;
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return value !== null && typeof value === 'object' && !Array.isArray(value);
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'integer') return Number.isInteger(value);
+  return typeof value === type;
+}
+
+export function validateAgainstSchema(value, schema, root = schema, at = '$') {
+  if (schema.$ref) {
+    if (!schema.$ref.startsWith('#/$defs/')) throw new Error(`${at}: unsupported schema ref ${schema.$ref}`);
+    return validateAgainstSchema(value, root.$defs[schema.$ref.slice('#/$defs/'.length)], root, at);
+  }
+  if (schema.anyOf) {
+    const errors = [];
+    for (const option of schema.anyOf) {
+      try {
+        validateAgainstSchema(value, option, root, at);
+        return;
+      } catch (error) {
+        errors.push(error.message);
+      }
+    }
+    throw new Error(`${at}: matched no anyOf option (${errors.join('; ')})`);
+  }
+  if ('const' in schema && value !== schema.const) throw new Error(`${at}: expected constant ${JSON.stringify(schema.const)}`);
+  if (schema.enum && !schema.enum.includes(value)) throw new Error(`${at}: expected one of ${schema.enum.join(', ')}`);
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((type) => typeMatches(value, type))) throw new Error(`${at}: expected ${types.join('|')}`);
+  }
+  if (typeof value === 'string') {
+    if (schema.minLength != null && value.length < schema.minLength) throw new Error(`${at}: string is too short`);
+    if (schema.pattern && !new RegExp(schema.pattern).test(value)) throw new Error(`${at}: does not match ${schema.pattern}`);
+  }
+  if (Array.isArray(value) && schema.items) {
+    value.forEach((item, index) => validateAgainstSchema(item, schema.items, root, `${at}[${index}]`));
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (schema.minProperties != null && Object.keys(value).length < schema.minProperties) {
+      throw new Error(`${at}: expected at least ${schema.minProperties} properties`);
+    }
+    for (const key of schema.required || []) {
+      if (!(key in value)) throw new Error(`${at}: missing required property ${key}`);
+    }
+    for (const [key, child] of Object.entries(value)) {
+      if (schema.properties && schema.properties[key]) {
+        validateAgainstSchema(child, schema.properties[key], root, `${at}.${key}`);
+      } else if (schema.additionalProperties === false) {
+        throw new Error(`${at}: unexpected property ${key}`);
+      } else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+        validateAgainstSchema(child, schema.additionalProperties, root, `${at}.${key}`);
+      }
+    }
+  }
+}
+
+export function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}

--- a/scripts/generate-connections-contract.mjs
+++ b/scripts/generate-connections-contract.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = require(path.join(REPO, 'core/integrations/connection-manager/contract.cjs'));
+const DIST = path.join(REPO, 'packages/dex-contracts/dist');
+const FIXTURES = path.join(REPO, 'packages/dex-contracts/fixtures/connections');
+
+fs.mkdirSync(DIST, { recursive: true });
+fs.mkdirSync(FIXTURES, { recursive: true });
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+writeJson(path.join(DIST, 'connections.contract.json'), source.buildConnectionsContract());
+writeJson(path.join(DIST, 'connections.schema.json'), source.buildConnectionsSchema());
+for (const [name, fixture] of Object.entries(source.buildConnectionsFixtures())) {
+  writeJson(path.join(FIXTURES, name), fixture);
+}
+console.log(`Generated connections contract v${source.CONTRACT_VERSION} and ${Object.keys(source.buildConnectionsFixtures()).length} fixtures`);


### PR DESCRIPTION
Phase 3 of the one-brain integrations program (plan v3.1; MC card `integrations-unification-one-shared-connector-brain-for-core-desktop`). Follows #209 (engine + passed live gate) and #211 (judgment layer).

## What

- **`packages/dex-contracts/dist/connections.contract.json` + schema** — the frozen, semver'd boundary a consumer (dex-desktop) builds against: get-token CLI modes + exit codes, `status --json` shape + the five states, credential-dir layout, v2 AAD envelope format, the lock/stale-takeover protocol, and the consumer ownership rule (**read-only + accessor-only; every mutation goes through the engine CLI** — two writers is the failure mode this exists to prevent).
- **Cannot drift by construction:** generated from `contract.cjs`, a constants module the engine itself imports (exit codes, envelope version, lock timings). CI gates contract + manifest drift.
- **8 golden fixtures** + conformance tests running the real CLIs against a scratch vault.
- **Foreign-consumer smoke** (`scripts/connections-consumer-smoke.mjs`): contract JSON + DEX_VAULT only, zero engine imports.
- **Checksummed engine manifest** (17 files, per-file sha256 + tree hash) — what desktop's pinned vendoring verifies.
- **Cross-process contention proven:** two real OS processes racing a forced refresh produce exactly one network call and one shared stored token; dead-PID refresh-lock takeover covered.
- Least-privilege tightening: rendered Class B envelopes no longer duplicate the raw secret at top level.

## For the release session's changelog
Nothing user-visible — this is the internal boundary for the desktop integration. No entry needed.

## Verification
- 109/109 engine tests (incl. contract conformance + the two-process races), 131/131 hooks locally, contract + manifest gates green, all PR gates green locally vs origin/main.
- Built by Codex (GPT-5.6 Sol) to the reviewed Phase 3 spec; diff reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Z3b5yC99VaJJ6Wqwdcq1o