### PR TITLE
ci: finish the Actions pinning (#186 follow-through) + fill the v1.63.0 changelog gap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Keeps pinned GitHub Actions from going stale.
+#
+# Every action in .github/workflows/ is pinned to an exact commit so a moving tag
+# can never be repointed at different code (PR #186). Pinning without this file
+# would freeze us on old versions forever — including missing the actions' own
+# security fixes. Dependabot watches for new releases and opens a PR that bumps
+# the commit and the trailing version comment together.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
       COVERAGE_MIN_TOTAL: "25"
       COVERAGE_MIN_TOUCHED: "10"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements-dev.txt
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: npm
@@ -114,7 +114,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -160,10 +160,10 @@ jobs:
     outputs:
       release_sha: ${{ steps.release_build.outputs.release_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - run: npm ci
@@ -212,10 +212,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - run: npm ci
@@ -283,8 +283,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Download release health inputs

--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -15,11 +15,11 @@ jobs:
       VAULT_PATH: core/tests/fixtures/vault
       SECURITY_STRICT_AUDIT: "0"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -62,8 +62,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   github-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Extract version from tag
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,13 +205,26 @@ This release finishes two stories that began yesterday: making Dex updates funda
 
 ---
 
-## [1.62.0] — 🔐 Some housekeeping on your connection keys, and Dex never updates itself behind your back (2026-07-20)
+## [1.63.0] — 🏠 Dex only sets up the rooms you actually need (2026-07-20)
 
-A round of tidying up. Nothing here was broken or exposed — it's a set of changes that follow good practice more closely and put you back in control of when Dex changes.
+Until now every Dex install arrived fully furnished — career coaching, company pages, quarterly goals — whether or not any of that matched your working life.
 
 **What this changes for you:**
 
-* **Your connection keys now live in a private file of their own.** When you connect a tool like Todoist or Trello, Dex saves a key that lets the two talk to each other. Those keys used to sit in a settings file inside your Dex folder. That's all on your own computer and none of it went anywhere — but the tidier habit is to keep keys out of anything you might one day share, back up or hand to someone else. So Dex now keeps them in a separate private file, away from everything else. If it spots an old key still sitting in the settings file, it'll suggest swapping it for a fresh one. Housekeeping, not an emergency.
+* **Dex asks what your work life actually looks like.** New setups keep the core always on — meetings, people and tasks — then ask three quick yes-or-no questions: do you want a Career room, a Companies room, a Quarterly Goals room? Say no and they simply don't exist in your vault, so you're not left with empty folders about a job you don't have. You can switch any room on or off later, and switching one off never deletes anything you wrote.
+* **If you already use those features, nothing changes.** Existing setups keep every room exactly as it is.
+* **The foundations for worry-free updates are in place.** Dex now has a single rulebook saying, for every file, whether it belongs to Dex or to you — plus a new update engine that backs up before touching anything, checks its own work, and can undo it exactly. If an update is ever interrupted, even by a crash, your files end up either completely untouched or completely updated — never half-done. You'll feel this properly in the next few releases, as updating becomes one command with one-click undo.
+* **The last of my own files are on their way out.** Earlier versions shipped with a few of my personal notes mixed in. Most went in this release, and the machinery to remove the final few safely — without disturbing anyone's update history — ships here too.
+
+---
+
+## [1.62.0] — 🔐 Some housekeeping on your connection keys, and Dex never updates itself behind your back (2026-07-20)
+
+A round of tidying up, and one thing you're now in control of.
+
+**What this changes for you:**
+
+* **Your connection keys now live in a private file of their own.** When you connect a tool like Todoist or Trello, Dex saves a key that lets the two talk to each other. Those keys used to sit in a settings file inside your Dex folder — and that folder keeps its own history. Dex never sent them anywhere, but if you ever share, publish or back up that folder, they'd travel with it, and old copies linger in the history even after the file changes. So Dex now keeps them in a separate private file, away from all that. If it spots an old key sitting where they used to be, it'll suggest swapping it for a fresh one.
 * **Dex's own tidiness check got better at its job.** Dex glances over your files for anything that looks like a key or a password before saving. The old check could be fooled by one written in an unusual way and would say everything was fine. The new one reads your settings properly, and if it genuinely can't tell, it says so rather than assuming.
 * **Dex never updates itself without asking.** Dex used to be able to quietly fetch and apply changes to itself when you started a session. Now it only *notices* that a newer version exists and mentions it. Nothing changes until you say so.
 * **Your own files survive an update.** Files and settings that only exist on your machine are kept safe through an update or a rollback, rather than risking being written over.


### PR DESCRIPTION
## Why

**#186 merged half-done.** My review asked for two things before merge — cover the remaining actions, and add the automation that keeps pins fresh. It merged without either. Result on main today: 9 actions pinned, **16 uses still on moving tags** (`actions/checkout`, `setup-node`, `setup-python`), and no Dependabot — so the 9 that *are* pinned will silently rot, including missing the actions' own security fixes. That's arguably worse than not pinning at all.

This finishes the job the contributor started, in their format.

## What's here

- **The remaining three actions pinned** to exact commits with the version in a trailing comment. No moving tags left in any workflow.
- **`.github/dependabot.yml`** (github-actions, weekly) so the pins get bumped rather than frozen.
- **v1.63.0 changelog entry.** It was the only released version with no entry at all — it exists as a GitHub release with notes, but the changelog skipped from 1.64.0 to 1.62.0. Written from its release notes in house voice.
- **v1.62.0 credential wording corrected** — see below.

## The v1.62.0 wording

The previous text said *"Nothing here was broken or exposed"*. That overstates it. A Dex folder keeps its own history, and folders genuinely do leave people's machines: contributor pull requests have carried personal config into public view (which is why the CI check in 1.55.0 exists), DexDiff exists to share setups, and people sync via a private repo or Dropbox. The rotate-your-key advice only makes sense because of that.

The other direction — the original "could be exposed" — reads to a non-technical user as *my keys leaked onto the internet*, which is not what happened. New wording is accurate without the alarm: no "exposed", but it states plainly that the keys would travel if you share or back up the folder and that old copies linger in the history.

Note: branch `fix/changelog-voice-secframing` carries a competing revert of this same paragraph. This supersedes it — that branch should be dropped rather than merged.

## Verification

- Every changed workflow line is a `uses:` line — confirmed by diff filter, so the workflow structure is untouched.
- Action commits resolved from each repo's own tag refs via the GitHub API, dereferenced through annotated tags.
- CI on this PR exercises the newly pinned actions end to end.