### PR TITLE
fix(health): run daily smoke on first session

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -16,7 +16,7 @@ These commands are wired in `.claude/settings.json` and run independently of any
 
 | Event | Matcher | Command | Purpose |
 |---|---|---|---|
-| `SessionStart` | all | `bash .claude/hooks/session-start.sh` | Inject the current Dex session context. |
+| `SessionStart` | all | `bash .claude/hooks/session-start.sh` | Inject the current Dex session context and run the bounded smoke fallback when no clean check completed on the current local day. |
 | `SessionStart` | all | `python3 "$CLAUDE_PROJECT_DIR/core/utils/update_verifier.py" --vault "$CLAUDE_PROJECT_DIR" --session-start` | Perform the bounded release-evidence check. |
 | `PreToolUse` | `Read` | `node .claude/hooks/person-context-injector.cjs` | Inject matching person context before a file read. |
 | `PreToolUse` | `Read` | `node .claude/hooks/company-context-injector.cjs` | Inject matching company context before a file read. |

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -289,7 +289,33 @@ if errors:
     fi
 fi
 
-# 19. Overnight smoke result — surface only actionable broken journeys.
+# 19. Daily self-check fallback.
+# The 03:15 Launch Agent remains the normal trigger. If the Mac was asleep or
+# off, the first Dex session of the local day runs the same bounded smoke check.
+# A clean report suppresses later session starts; broken, inconclusive, or
+# interrupted checks remain eligible for retry. The Python runner owns the
+# process-safe lock so overlapping sessions cannot launch duplicate checks.
+if [[ -f "$ONBOARDING_MARKER" && -f "$CLAUDE_DIR/core/utils/session_health.py" ]]; then
+    HEALTH_PYTHON="python3"
+    if [[ -f "$CLAUDE_DIR/.venv/bin/python" ]]; then
+        HEALTH_PYTHON="$CLAUDE_DIR/.venv/bin/python"
+    fi
+    "$HEALTH_PYTHON" "$CLAUDE_DIR/core/utils/session_health.py" \
+        --vault "$CLAUDE_DIR" \
+        --repo "$CLAUDE_DIR" >/dev/null 2>&1
+    DAILY_HEALTH_STATUS=$?
+    if [[ "$DAILY_HEALTH_STATUS" -ne 0 \
+        && "$DAILY_HEALTH_STATUS" -ne 1 \
+        && "$DAILY_HEALTH_STATUS" -ne 3 ]]; then
+        echo "⚠️ Dex's daily self-check could not finish — it will try again next session."
+        echo ""
+    elif [[ "$DAILY_HEALTH_STATUS" -eq 3 ]]; then
+        echo "⚠️ Dex's daily self-check was inconclusive — it will try again next session."
+        echo ""
+    fi
+fi
+
+# 20. Latest smoke result — surface only actionable broken journeys.
 SMOKE_LAST_RUN="$CLAUDE_DIR/System/.smoke-last-run.json"
 if [[ -f "$ONBOARDING_MARKER" && -f "$SMOKE_LAST_RUN" ]]; then
     SMOKE_ALERT=$(python3 -c "

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -41,6 +41,22 @@ function completeOnboarding(sandbox) {
   fs.writeFileSync(marker, '{}\n');
 }
 
+function installSessionHealthStub(sandbox, exitStatus = 0) {
+  const script = path.join(sandbox.vault, 'core', 'utils', 'session_health.py');
+  fs.mkdirSync(path.dirname(script), { recursive: true });
+  fs.writeFileSync(
+    script,
+    [
+      'import os',
+      'from pathlib import Path',
+      'Path(os.environ["DEX_SESSION_HEALTH_CALLS"]).write_text("called\\n", encoding="utf-8")',
+      `raise SystemExit(${exitStatus})`,
+      '',
+    ].join('\n'),
+  );
+  return path.join(path.dirname(sandbox.vault), 'session-health-calls');
+}
+
 function installMovedVaultConflict(sandbox, plistName) {
   const oldVault = path.join(path.dirname(sandbox.vault), 'old-vault');
   const breadcrumb = path.join(sandbox.home, '.config', 'dex', 'vault-path');
@@ -89,6 +105,8 @@ function runSessionStart(sandbox) {
       HOME: sandbox.home,
       PATH: process.env.PATH || '/usr/bin:/bin',
       VAULT_PATH: sandbox.vault,
+      DEX_SESSION_HEALTH_CALLS: sandbox.sessionHealthCalls
+        || path.join(path.dirname(sandbox.vault), 'unused-session-health-calls'),
     },
     timeout: 10_000,
   });
@@ -180,6 +198,31 @@ test('overnight smoke block emits broken journey details', (t) => {
   assert.match(stdout, /--- 🚨 Overnight check found a problem ---/);
   assert.match(stdout, /task_lifecycle — task creation failed after the config changed/);
   assert.match(stdout, /Run \/dex-doctor for diagnosis and the fix\./);
+});
+
+test('session start runs the daily self-check fallback after onboarding', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  sandbox.sessionHealthCalls = installSessionHealthStub(sandbox);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.ok(fs.existsSync(sandbox.sessionHealthCalls));
+  assert.doesNotMatch(stdout, /daily self-check could not finish/);
+});
+
+test('session start says an unfinished daily self-check will retry', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  sandbox.sessionHealthCalls = installSessionHealthStub(sandbox, 2);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.ok(fs.existsSync(sandbox.sessionHealthCalls));
+  assert.match(
+    stdout,
+    /Dex's daily self-check could not finish — it will try again next session\./,
+  );
 });
 
 for (const plistName of ['com.dex.meeting-intel.plist', 'com.claudesidian.learning.plist']) {

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ System/.last-update-check
 System/.update-available
 System/.smoke-last-run.json
 System/.dex/smoke-history.jsonl
+System/.dex/session-health.lock
+System/.dex/session-health-success.json
 System/.dex/health-telemetry-log.jsonl
 System/.dex/telemetry-id
 System/.dex/adoption/credential-journals/

--- a/.scripts/nightly-smoke.sh
+++ b/.scripts/nightly-smoke.sh
@@ -39,3 +39,16 @@ fi
 
 mkdir -p .scripts/logs
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] nightly smoke completed" >> .scripts/logs/smoke-nightly.log
+
+# Record completion separately from the report. SessionStart requires both a
+# clean report and this post-success marker, so an interrupted/partial run can
+# never suppress the next retry.
+SUCCESS_MARKER="System/.dex/session-health-success.json"
+SUCCESS_TEMP="System/.dex/.session-health-success.$$.json"
+trap 'rm -f "$SUCCESS_TEMP"' EXIT
+mkdir -p "$(dirname "$SUCCESS_MARKER")"
+printf '{"schema_version":1,"local_date":"%s","completed_at":"%s"}\n' \
+    "$(date +%Y-%m-%d)" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$SUCCESS_TEMP"
+mv "$SUCCESS_TEMP" "$SUCCESS_MARKER"
+trap - EXIT

--- a/core/tests/test_session_health.py
+++ b/core/tests/test_session_health.py
@@ -1,0 +1,197 @@
+"""Regression tests for the once-per-local-day SessionStart health fallback."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from core.utils import session_health
+
+LOCAL = timezone(timedelta(hours=10))
+
+
+def _report(when: datetime, *, broken: int = 0, unknown: int = 0) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "generated_at": when.isoformat(),
+        "journeys": [],
+        "summary": {
+            "ok": 1 if not broken and not unknown else 0,
+            "off": 0,
+            "broken": broken,
+            "unknown": unknown,
+        },
+    }
+
+
+def _write_latest(vault: Path, report: dict[str, object]) -> None:
+    path = vault / "System" / ".smoke-last-run.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report), encoding="utf-8")
+
+
+def _write_success_marker(vault: Path, when: datetime) -> None:
+    path = vault / "System" / ".dex" / "session-health-success.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "local_date": when.date().isoformat(),
+                "completed_at": when.astimezone(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_successful_check_on_same_local_day_suppresses_session_start_run(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    # Stored as 23 July UTC, but this is 24 July in the user's local timezone.
+    _write_latest(vault, _report(datetime(2026, 7, 23, 23, 30, tzinfo=timezone.utc)))
+    _write_success_marker(vault, now)
+
+    assert session_health.needs_session_start_check(vault, now=now) is False
+
+
+def test_missing_stale_or_malformed_report_requires_check(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+    _write_latest(vault, _report(now - timedelta(days=1)))
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+    report_path = vault / "System" / ".smoke-last-run.json"
+    report_path.write_text("{not-json", encoding="utf-8")
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+
+def test_clean_report_without_completed_marker_retries_after_interruption(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    _write_latest(vault, _report(now))
+
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+
+def test_broken_or_unknown_same_day_report_does_not_count_as_success(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+
+    _write_latest(vault, _report(now, broken=1))
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+    _write_latest(vault, _report(now, unknown=1))
+    assert session_health.needs_session_start_check(vault, now=now) is True
+
+
+def test_successful_check_persists_report_then_later_session_skips(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    repo = tmp_path / "repo"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    calls: list[Path] = []
+
+    def fake_smoke(candidate_vault: Path, _repo: Path) -> int:
+        calls.append(candidate_vault)
+        _write_latest(candidate_vault, _report(now))
+        return 0
+
+    monkeypatch.setattr(session_health, "_run_bounded_smoke", fake_smoke)
+
+    assert session_health.run_session_start_check(vault, repo, now=now) == 0
+    assert calls == [vault]
+    assert (
+        vault / "System" / ".dex" / "session-health-success.json"
+    ).is_file()
+    assert session_health.run_session_start_check(vault, repo, now=now) == 0
+    assert calls == [vault]
+
+
+def test_failed_or_inconclusive_check_retries_on_later_session(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    repo = tmp_path / "repo"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    verdicts = iter(((1, 1, 0), (0, 0, 1), (0, 0, 0)))
+    calls: list[int] = []
+
+    def fake_smoke(candidate_vault: Path, _repo: Path) -> int:
+        status, broken, unknown = next(verdicts)
+        calls.append(status)
+        _write_latest(candidate_vault, _report(now, broken=broken, unknown=unknown))
+        return status
+
+    monkeypatch.setattr(session_health, "_run_bounded_smoke", fake_smoke)
+
+    assert session_health.run_session_start_check(vault, repo, now=now) == 1
+    assert session_health.run_session_start_check(vault, repo, now=now) == 3
+    assert session_health.run_session_start_check(vault, repo, now=now) == 0
+    assert session_health.run_session_start_check(vault, repo, now=now) == 0
+    assert calls == [1, 0, 0]
+
+
+def test_runner_failure_without_fresh_report_retries(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    repo = tmp_path / "repo"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    calls: list[str] = []
+
+    def failed_smoke(_vault: Path, _repo: Path) -> int:
+        calls.append("failed")
+        return 2
+
+    monkeypatch.setattr(session_health, "_run_bounded_smoke", failed_smoke)
+
+    assert session_health.run_session_start_check(vault, repo, now=now) == 2
+    assert session_health.run_session_start_check(vault, repo, now=now) == 2
+    assert calls == ["failed", "failed"]
+
+
+def test_overlapping_session_starts_run_only_one_bounded_check(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    repo = tmp_path / "repo"
+    now = datetime(2026, 7, 24, 8, 0, tzinfo=LOCAL)
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[str] = []
+
+    def slow_smoke(candidate_vault: Path, _repo: Path) -> int:
+        calls.append("run")
+        started.set()
+        assert release.wait(timeout=2)
+        _write_latest(candidate_vault, _report(now))
+        return 0
+
+    monkeypatch.setattr(session_health, "_run_bounded_smoke", slow_smoke)
+    first = threading.Thread(
+        target=session_health.run_session_start_check,
+        args=(vault, repo),
+        kwargs={"now": now},
+    )
+    first.start()
+    assert started.wait(timeout=2)
+
+    assert session_health.run_session_start_check(vault, repo, now=now) == 0
+    release.set()
+    first.join(timeout=2)
+
+    assert not first.is_alive()
+    assert calls == ["run"]

--- a/core/tests/test_smoke_automation.py
+++ b/core/tests/test_smoke_automation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import plistlib
 import shutil
@@ -130,6 +131,12 @@ def test_nightly_worker_sends_latest_ledger_before_success_heartbeat(tmp_path: P
     assert f"--repo {vault}" in call
     assert "--channel stable" in call
     assert "nightly smoke completed" in (vault / ".scripts" / "logs" / "smoke-nightly.log").read_text()
+    success = json.loads(
+        (vault / "System" / ".dex" / "session-health-success.json").read_text()
+    )
+    assert success["schema_version"] == 1
+    assert success["local_date"]
+    assert success["completed_at"]
 
 
 def test_nightly_worker_records_broken_verdict_without_success_heartbeat(tmp_path: Path) -> None:
@@ -140,3 +147,4 @@ def test_nightly_worker_records_broken_verdict_without_success_heartbeat(tmp_pat
     assert result.returncode == 1
     assert (vault / "telemetry-called").exists()
     assert not (vault / ".scripts" / "logs" / "smoke-nightly.log").exists()
+    assert not (vault / "System" / ".dex" / "session-health-success.json").exists()

--- a/core/utils/session_health.py
+++ b/core/utils/session_health.py
@@ -1,0 +1,244 @@
+"""Once-per-local-day SessionStart fallback for Dex's smoke health check.
+
+The nightly Launch Agent remains the preferred trigger. This module closes the
+sleep/off gap: when a Dex session starts and no clean smoke report exists for
+the current local calendar day, it runs the same bounded smoke harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+LOCK_RELATIVE_PATH = Path("System/.dex/session-health.lock")
+REPORT_RELATIVE_PATH = Path("System/.smoke-last-run.json")
+SUCCESS_RELATIVE_PATH = Path("System/.dex/session-health-success.json")
+SMOKE_TIMEOUT_SECONDS = 300
+
+
+def _local_now() -> datetime:
+    return datetime.now().astimezone()
+
+
+def _aware_now(now: datetime) -> datetime:
+    return now if now.tzinfo is not None else now.astimezone()
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _read_report(vault_root: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads((vault_root / REPORT_RELATIVE_PATH).read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _success_marker_is_today(vault_root: Path, *, now: datetime) -> bool:
+    current = _aware_now(now)
+    try:
+        marker = json.loads(
+            (vault_root / SUCCESS_RELATIVE_PATH).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, OSError, json.JSONDecodeError, TypeError):
+        return False
+    return (
+        isinstance(marker, dict)
+        and marker.get("schema_version") == 1
+        and marker.get("local_date") == current.date().isoformat()
+    )
+
+
+def _write_success_marker(vault_root: Path, *, now: datetime) -> None:
+    current = _aware_now(now)
+    marker_path = vault_root / SUCCESS_RELATIVE_PATH
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = marker_path.with_name(
+        f".session-health-success.{os.getpid()}.json"
+    )
+    payload = {
+        "schema_version": 1,
+        "local_date": current.date().isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        with temporary_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, marker_path)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _report_is_clean_today(
+    report: dict[str, Any] | None,
+    *,
+    now: datetime,
+) -> bool:
+    current = _aware_now(now)
+    if report is None:
+        return False
+    generated_at = _parse_timestamp(report.get("generated_at"))
+    summary = report.get("summary")
+    if generated_at is None or not isinstance(summary, dict):
+        return False
+    broken = summary.get("broken")
+    unknown = summary.get("unknown")
+    if not isinstance(broken, int) or isinstance(broken, bool):
+        return False
+    if not isinstance(unknown, int) or isinstance(unknown, bool):
+        return False
+    local_timezone = current.tzinfo
+    if local_timezone is None:
+        return False
+    return (
+        generated_at.astimezone(local_timezone).date() == current.date()
+        and broken == 0
+        and unknown == 0
+    )
+
+
+def needs_session_start_check(
+    vault_root: Path,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Return whether today's local calendar day lacks a clean smoke report."""
+    vault = vault_root.resolve()
+    current = now or _local_now()
+    return not (
+        _success_marker_is_today(vault, now=current)
+        and _report_is_clean_today(_read_report(vault), now=current)
+    )
+
+
+def _run_bounded_smoke(vault_root: Path, repo_root: Path) -> int:
+    smoke_path = repo_root / "core" / "utils" / "smoke.py"
+    if not smoke_path.is_file():
+        return 2
+    env = os.environ.copy()
+    env.update(
+        {
+            "VAULT_PATH": str(vault_root),
+            "VAULT_ROOT": str(vault_root),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, str(smoke_path), "--json", "--ledger"],
+            cwd=vault_root,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=SMOKE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 2
+    return result.returncode
+
+
+def run_session_start_check(
+    vault_root: Path,
+    repo_root: Path,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Run today's fallback check at most once concurrently.
+
+    Return codes:
+      0: a clean report already exists, another process owns the check, or the
+         new check completed cleanly.
+      1: the check completed with one or more broken journeys.
+      2: the check could not complete or its report was missing/malformed.
+      3: the check completed but remained inconclusive.
+    """
+    vault = vault_root.resolve()
+    repository = repo_root.resolve()
+    current = now or _local_now()
+    if not needs_session_start_check(vault, now=current):
+        return 0
+
+    lock_path = vault / LOCK_RELATIVE_PATH
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_handle = lock_path.open("a+", encoding="utf-8")
+    except OSError:
+        return 2
+
+    with lock_handle:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return 0
+        except OSError:
+            return 2
+
+        # The nightly job or another session may have finished between the
+        # optimistic read above and acquisition of the process-safe lock.
+        if not needs_session_start_check(vault, now=current):
+            return 0
+
+        smoke_status = _run_bounded_smoke(vault, repository)
+        report = _read_report(vault)
+        if smoke_status == 0 and _report_is_clean_today(report, now=current):
+            try:
+                _write_success_marker(vault, now=current)
+            except OSError:
+                return 2
+            return 0
+
+        generated_at = _parse_timestamp(report.get("generated_at")) if report else None
+        summary = report.get("summary") if report else None
+        local_timezone = current.tzinfo
+        report_is_today = (
+            generated_at is not None
+            and local_timezone is not None
+            and generated_at.astimezone(local_timezone).date() == current.date()
+        )
+        if report_is_today and isinstance(summary, dict):
+            broken = summary.get("broken")
+            unknown = summary.get("unknown")
+            if isinstance(broken, int) and not isinstance(broken, bool) and broken > 0:
+                return 1
+            if isinstance(unknown, int) and not isinstance(unknown, bool) and unknown > 0:
+                return 3
+        return smoke_status if smoke_status in {1, 2} else 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run Dex's smoke health check once per successful local day."
+    )
+    parser.add_argument("--vault", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    args = parser.parse_args(argv)
+    return run_session_start_check(args.vault, args.repo)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changes
- Runs Dex's bounded smoke check on the first session of a local day when no clean check completed that day.
- Skips later sessions after a clean result.
- Retries after broken, unknown, interrupted, or failed checks.
- Uses a process-safe lock so two sessions cannot launch duplicate checks.
- Records successful nightly checks with the same local-day marker.

## Honest boundary
Dex cannot check while the Mac is asleep or off and no Dex session starts. The first later session closes that gap.

## Verified locally after rebasing onto current origin/main
- 13 focused Python tests passed
- 12 SessionStart hook tests passed
- Ruff clean
- Shell syntax clean
- git diff --check clean

Requested by Dave for immediate production release after full CI passes.