### PR TITLE
fix(integrations): polish connection-manager failure UX from live-gate findings

### DIFF
--- a/core/integrations/connection-manager/README.md
+++ b/core/integrations/connection-manager/README.md
@@ -73,9 +73,21 @@ The original engine passed its live-account gate on 2026-07-24. Phase 2 adds Des
 judgment layer without changing the token accessor or encrypted-envelope
 contracts: stored credentials show as connected but unverified until a live
 probe succeeds, and only permanent refresh or 401/403-class probe evidence
-marks a connection `needs_reauth`. Phase 3 freezes the Desktop consumer
-contract and engine manifest. The post-Phase-2/3 Google + Linear rerun remains
-the final manual gate before any user-facing doorway can ship.
+marks a connection `needs_reauth`.
+
+`status` and `verified` answer different questions in `status --json`:
+
+- `verified: true` is durable evidence that the current credential epoch passed
+  a live probe at least once. A later failure does not erase that historical proof.
+- `status` is the connection's current health. A previously verified credential
+  can therefore correctly show `verified: true` alongside
+  `status: "needs_reauth"`.
+- Consumers must gate credential use on `status`, not `verified`.
+
+Phase 3 freezes the Desktop consumer contract and engine manifest. The
+post-Phase-2/3 Google + Linear live rerun passed on 2026-07-24 (recorded on
+PR #221); the remaining gate before any user-facing doorway ships is the
+Phase 5 security review.
 
 The held-back consumption surfaces remain outside this shipped engine:
 `/connect`, `dex-google`, `gog-mcp-launch`, and `render-dashboard.cjs`. Do not

--- a/core/integrations/connection-manager/auth-context.cjs
+++ b/core/integrations/connection-manager/auth-context.cjs
@@ -69,6 +69,12 @@ async function resolveAuthContext(service) {
     throw e;
   }
   if (token.kind === 'api_key') {
+    const reg = store.getConnection(service);
+    if (reg && reg.status === 'needs_reauth') {
+      const e = new Error(`${service} needs re-authentication. Run: node connect.cjs set-key ${service}`);
+      e.exitCode = 3;
+      throw e;
+    }
     store.touchUsed(service);
     return apiKeyContext(token, service);
   }

--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -362,7 +362,11 @@ async function cmdSetKey(service, flags) {
     // and status derive verification strictly from successful probe rows.
     health.recordConnectionEvent(connId, 'probe', { ok: true });
   }
-  const note = probe === 'ok' ? ' Verified live.' : probe === 'failed' ? ' (probe failed — marked needs_reauth)' : '';
+  const note = probe === 'ok'
+    ? ' Verified live.'
+    : probe === 'failed'
+      ? ' (probe failed — marked needs_reauth)'
+      : ` (not yet verified — run: node connect.cjs probe ${connId})`;
   console.log(`✅ Stored ${descriptor.displayName}${alias ? ` (${connId})` : ''} key (encrypted) in ${store.credentialsDir()}/tokens/.${note}`);
 }
 

--- a/core/integrations/connection-manager/connection-manager.judgment.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.judgment.test.cjs
@@ -331,6 +331,26 @@ test('probe stamps only permanent auth failures and records every attempt withou
   }
 });
 
+test('a needs_reauth API-key connection can still be probed for recovery', async () => {
+  const connId = 'linear:probe-recovery';
+  const secret = 'RECOVERED-LINEAR-TOKEN';
+  store.saveApiKey(connId, { apiKey: secret }, { provider: 'linear', authMode: 'API_KEY' });
+  store.upsertConnection(connId, { status: 'needs_reauth', error: 'authentication_failed' });
+  let authorization;
+  try {
+    const result = await health.probeConnection(connId, {
+      fetchImpl: async (_url, options) => {
+        authorization = options.headers.Authorization;
+        return response(200, { data: { viewer: { id: 'viewer-1' } } });
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(authorization, secret);
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
 test('timeout, 429, and network probe failures stay unknown and never stamp needs_reauth', async () => {
   const cases = [
     [
@@ -497,6 +517,24 @@ test('set-key records a secret-free connect event', () => {
     assert.ok(!text.includes('CONNECT-SECRET'));
   } finally {
     store.deleteToken('linear:connect-ledger');
+  }
+});
+
+test('set-key says when a stored credential is not yet verified', () => {
+  const connId = 'linear:unverified-on-save';
+  const run = spawnSync(
+    'node',
+    [path.join(DIR, 'connect.cjs'), 'set-key', connId, '--no-probe'],
+    { env: childEnv, input: 'UNVERIFIED-SECRET\n', encoding: 'utf8' }
+  );
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(
+      run.stdout,
+      new RegExp(`not yet verified — run: node connect\\.cjs probe ${connId}`)
+    );
+  } finally {
+    store.deleteToken(connId);
   }
 });
 

--- a/core/integrations/connection-manager/connection-manager.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.test.cjs
@@ -304,6 +304,27 @@ test('dex-call: resolveAuthContext + buildRequest sign a request from a stored k
   store.deleteToken('dexcall-signed-test');
 });
 
+test('dex-call: a needs_reauth API-key connection is refused before a request', async () => {
+  const connId = 'linear:known-dead';
+  store.saveApiKey(connId, { apiKey: 'REVOKED-KEY' }, { provider: 'linear', authMode: 'API_KEY' });
+  store.upsertConnection(connId, { status: 'needs_reauth', error: 'authentication_failed' });
+  try {
+    await assert.rejects(authctx.resolveAuthContext(connId), (error) => {
+      assert.equal(error.exitCode, 3);
+      assert.match(error.message, new RegExp(`node connect\\.cjs set-key ${connId}`));
+      return true;
+    });
+    const run = spawnSync('node', [path.join(DIR, 'dex-call.cjs'), connId, 'file:///no-network'], {
+      env: childEnv,
+      encoding: 'utf8',
+    });
+    assert.equal(run.status, 3);
+    assert.match(run.stderr, new RegExp(`node connect\\.cjs set-key ${connId}`));
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
 // ---- token store ------------------------------------------------------------
 
 test('store: OAuth token encrypt/decrypt roundtrip', () => {
@@ -383,6 +404,23 @@ test('cli: get-token exits 2 when service is not connected', () => {
     code = err.status;
   }
   assert.equal(code, 2);
+});
+
+test('cli: get-token exits 3 for a needs_reauth API-key connection', () => {
+  const connId = 'linear:dead-accessor';
+  store.saveApiKey(connId, { apiKey: 'REVOKED-ACCESSOR-KEY' }, { provider: 'linear', authMode: 'API_KEY' });
+  store.upsertConnection(connId, { status: 'needs_reauth', error: 'authentication_failed' });
+  try {
+    const run = spawnSync('node', [path.join(DIR, 'get-token.cjs'), connId], {
+      env: childEnv,
+      encoding: 'utf8',
+    });
+    assert.equal(run.status, 3);
+    assert.match(run.stderr, new RegExp(`node connect\\.cjs set-key ${connId}`));
+    assert.equal(run.stdout, '');
+  } finally {
+    store.deleteToken(connId);
+  }
 });
 
 test('cli: set-key on a host-scoped provider FAILS without the field (no dead connection)', { skip: FIELD_PROV ? false : 'no field provider' }, () => {

--- a/core/integrations/connection-manager/get-token.cjs
+++ b/core/integrations/connection-manager/get-token.cjs
@@ -55,6 +55,11 @@ async function main() {
     // or a JSON envelope with the catalog's auth scheme already rendered, so the
     // consumer never re-implements per-provider header/query placement.
     if (token.kind === 'api_key') {
+      const reg = store.getConnection(service);
+      if (reg && reg.status === 'needs_reauth') {
+        console.error(`${service} needs re-authentication. Run: node connect.cjs set-key ${service}`);
+        process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
+      }
       store.touchUsed(service);
       if (accessOnly) {
         process.stdout.write(token.apiKey || token.password || '');

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,13 +11,13 @@
         "connection-manager"
       ],
       "fileCount": 17,
-      "totalBytes": 172291,
-      "treeHash": "aaa7573e05647bff28a757ba01b300bc9d4e66eafc0d854806be1531a29e7478",
+      "totalBytes": 173418,
+      "treeHash": "57238c08d18467668da0c64dd450f45275662b67fbcb639006eb3c1e79c1334e",
       "files": [
         {
           "path": "auth-context.cjs",
-          "bytes": 5195,
-          "sha256": "9c9abdaed3b4b8f42d08b259b83281b5b303311cb2ec0017e500eaaca5ea3069"
+          "bytes": 5439,
+          "sha256": "6c1f49162f46e4dcc4ceb38aa7c02415970f3e19073d14fe3974c446afd9b585"
         },
         {
           "path": "catalog.cjs",
@@ -26,8 +26,8 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 27241,
-          "sha256": "fdb913096eabc9570644f33263ae93ec6ab4634d931d02e20d1cf8bb5d8de0a8"
+          "bytes": 27322,
+          "sha256": "89b1316386c4bd93dc446c2e49b8b0677df505baf0d42d2e4826738b7c8bba70"
         },
         {
           "path": "contract.cjs",
@@ -46,8 +46,8 @@
         },
         {
           "path": "get-token.cjs",
-          "bytes": 3673,
-          "sha256": "ec46a76f89e0d602196b447212ccdd0dc398f8004e16b8b2644c2fff5c528de4"
+          "bytes": 3939,
+          "sha256": "1451395df939cd0202b30cb4f3b4526c87a8e3ba56f765f594b89ba978be2b68"
         },
         {
           "path": "health.cjs",
@@ -91,8 +91,8 @@
         },
         {
           "path": "README.md",
-          "bytes": 7255,
-          "sha256": "7a4e5e4491e408b59ed9b396c1b57906d11c129ef260ee180d1487a7dc616a43"
+          "bytes": 7791,
+          "sha256": "d4925a0119849ee366709a9cdb932bc1728a704c26b98272b9ef633f346eb850"
         },
         {
           "path": "token-store.cjs",


### PR DESCRIPTION
Three follow-ups observed during the 2026-07-24 live release-readiness run (recorded on PR #221). No behavior changes for healthy connections; no contract changes.

**1. `set-key` says when a key is still unverified.** When the save-time auto-probe is inconclusive (network) or skipped (`--no-probe`), the success message now appends `(not yet verified — run: node connect.cjs probe <connId>)` instead of reading as ready-to-use. Live finding: a stored-but-unverified Linear key looked done.

**2. Dead API keys are refused up-front (exit 3), matching OAuth.** `resolveAuthContext` (dex-call) and `get-token` now check the registry and refuse `needs_reauth` API-key connections with exit 3 and a `set-key` pointer, instead of replaying the dead key and surfacing the provider's 401 as exit 4. The recovery path is protected by a regression test: probing a `needs_reauth` key still works, so a restored key can be re-verified.

**3. README documents `verified` vs `status`.** Durable evidence ("this credential epoch passed a live probe at least once") vs current health; consumers must gate on `status`. Also records that the post-Phase-2/3 Google + Linear live rerun passed (the remaining doorway gate is the Phase 5 security review).

**Verification (run independently after review):**
- Red-first regression tests for both behavior changes (red output captured in the work log)
- Serial connection-manager suite: 124/124 pass
- `check:connections-contract`: contract v1.0.0 + engine manifest verified (17 files)
- Local PR gates: path-contract, test-delta, doc-drift all pass against origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MUmNHSKhTxdUwGtiJ4SUy