### PR TITLE
Customization migration Lane A: sealed write authority + content-write preconditions + threat model

### DIFF
--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -364,6 +364,10 @@ MUTATION_POLICY: dict[str, str] = {
     "runtime": "never",           # local machine state; updates never write
 }
 
+CUSTOMIZATION_MIGRATION_SEAMS_VERSION = 0
+CUSTOMIZATION_MIGRATION_SEAM_PREFIXES = ("System/.dex/customization-migrations/",)
+CUSTOMIZATION_MIGRATION_SEAM_PATHS = ("CLAUDE-custom.md",)
+
 
 @dataclass(frozen=True)
 class Resolution:
@@ -393,7 +397,12 @@ class WriteVerdict:
     rule_id: str | None
 
 
-def update_write_verdict(path: str, *, exists: bool) -> WriteVerdict:
+def update_write_verdict(
+    path: str,
+    *,
+    exists: bool,
+    operation: str = "update",
+) -> WriteVerdict:
     """May an update engine write ``path``? The ONLY sanctioned write check.
 
     NOTE (folder remapping): classification assumes the DEFAULT PARA layout.
@@ -402,6 +411,56 @@ def update_write_verdict(path: str, *, exists: bool) -> WriteVerdict:
     remapped paths back to their semantic defaults before calling, or treat
     them as unclassified. Unclassified paths fail safe: never written.
     """
+    if operation not in ("update", "customization-migration"):
+        raise ValueError(f"unknown write operation: {operation}")
+
+    if operation == "customization-migration":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+        except ContractViolation:
+            return WriteVerdict(
+                str(path),
+                False,
+                "unclassified-never-write",
+                None,
+                None,
+            )
+
+        try:
+            resolution = resolve(candidate)
+        except ContractViolation:
+            resolution = None
+
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+
+        if candidate in CUSTOMIZATION_MIGRATION_SEAM_PATHS or any(
+            candidate.startswith(prefix)
+            for prefix in CUSTOMIZATION_MIGRATION_SEAM_PREFIXES
+        ):
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-with-user-approval",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-migration-seams",
+            resolution.ownership if resolution is not None else None,
+            resolution.rule_id if resolution is not None else None,
+        )
+
     try:
         resolution = resolve(path)
     except ContractViolation:
@@ -546,6 +605,7 @@ def build_contract_schema() -> dict[str, object]:
             "vault_schema_supported",
             "ownership_classes",
             "mutation_policy",
+            "customization_migration",
             "hard_deny",
             "vault_regions",
             "rules",
@@ -569,6 +629,30 @@ def build_contract_schema() -> dict[str, object]:
                         ]
                     }
                     for ownership in OWNERSHIP_CLASSES
+                },
+            },
+            "customization_migration": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "version",
+                    "action",
+                    "seam_prefixes",
+                    "seam_paths",
+                ],
+                "properties": {
+                    "version": {"const": CUSTOMIZATION_MIGRATION_SEAMS_VERSION},
+                    "action": {"const": "write-with-user-approval"},
+                    "seam_prefixes": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        "uniqueItems": True,
+                    },
+                    "seam_paths": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        "uniqueItems": True,
+                    },
                 },
             },
             "ownership_classes": {
@@ -656,6 +740,12 @@ def build_contract_document() -> dict[str, object]:
         "vault_schema_supported": VAULT_SCHEMA_SUPPORTED,
         "ownership_classes": list(OWNERSHIP_CLASSES),
         "mutation_policy": dict(sorted(MUTATION_POLICY.items())),
+        "customization_migration": {
+            "version": CUSTOMIZATION_MIGRATION_SEAMS_VERSION,
+            "action": "write-with-user-approval",
+            "seam_prefixes": list(CUSTOMIZATION_MIGRATION_SEAM_PREFIXES),
+            "seam_paths": list(CUSTOMIZATION_MIGRATION_SEAM_PATHS),
+        },
         "hard_deny": list(HARD_DENY_PATTERNS),
         "vault_regions": list(VAULT_REGIONS),
         "rules": [

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -136,6 +136,147 @@ def test_update_write_verdict(path: str, exists: bool, allowed: bool, action: st
     assert verdict.action == action
 
 
+@pytest.mark.parametrize(
+    ("path", "exists"),
+    [
+        ("04-Projects/My_Project/notes.md", True),
+        ("core/utils/doctor.py", True),
+        ("03-Tasks/Tasks.md", False),
+        (".env", False),
+        ("totally/unknown/path.xyz", False),
+    ],
+)
+def test_explicit_default_operation_matches_omitted_operation(
+    path: str,
+    exists: bool,
+) -> None:
+    assert portable_contract.update_write_verdict(
+        path,
+        exists=exists,
+        operation="update",
+    ) == portable_contract.update_write_verdict(path, exists=exists)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "CLAUDE-custom.md",
+        "System/.dex/customization-migrations/abc123/manifest.json",
+    ],
+)
+def test_customization_migration_operation_allows_only_seams(path: str) -> None:
+    verdict = portable_contract.update_write_verdict(
+        path,
+        exists=True,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is True
+    assert verdict.action == "write-with-user-approval"
+
+
+def test_customization_migration_operation_refuses_outside_seams() -> None:
+    verdict = portable_contract.update_write_verdict(
+        "05-Areas/People/Jane_Doe.md",
+        exists=True,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "outside-migration-seams"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".env",
+        "System/.dex/customization-migrations/abc123/.env",
+        "System/.dex/customization-migrations/abc123/private.pem",
+    ],
+)
+def test_customization_migration_hard_deny_wins_inside_or_outside_seams(
+    path: str,
+) -> None:
+    verdict = portable_contract.update_write_verdict(
+        path,
+        exists=False,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "deny"
+
+
+def test_customization_migration_hard_deny_survives_unclassified_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = "uncovered/private.pem"
+    assert portable_contract.is_denied(path) is True
+
+    def unclassified(candidate: str) -> portable_contract.Resolution:
+        raise portable_contract.ContractViolation(
+            f"no ownership rule classifies: {candidate}"
+        )
+
+    monkeypatch.setattr(portable_contract, "resolve", unclassified)
+    with pytest.raises(portable_contract.ContractViolation):
+        portable_contract.resolve(path)
+
+    verdict = portable_contract.update_write_verdict(
+        path,
+        exists=False,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "deny"
+    assert verdict.ownership is None
+    assert verdict.rule_id is None
+
+
+def test_customization_migration_root_escape_is_unclassified() -> None:
+    verdict = portable_contract.update_write_verdict(
+        "../x",
+        exists=False,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "unclassified-never-write"
+
+
+def test_unknown_write_operation_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unknown write operation"):
+        portable_contract.update_write_verdict(
+            "README.md",
+            exists=True,
+            operation="surprise",
+        )
+
+
+def test_customization_migration_contract_view_is_frozen() -> None:
+    assert portable_contract.build_contract_document()["customization_migration"] == {
+        "version": 0,
+        "action": "write-with-user-approval",
+        "seam_prefixes": ["System/.dex/customization-migrations/"],
+        "seam_paths": ["CLAUDE-custom.md"],
+    }
+
+
+def test_ordinary_transaction_still_cannot_write_customization_seam(
+    tmp_path: Path,
+) -> None:
+    from core.transaction.engine import PlanEntry, PlanRejected, Transaction
+
+    vault = tmp_path / "vault"
+    (vault / "System/.dex").mkdir(parents=True)
+
+    with pytest.raises(PlanRejected, match="the ownership contract forbids writing"):
+        Transaction.begin(vault, [PlanEntry("CLAUDE-custom.md", b"migration bytes\n")])
+
+    assert not (vault / "CLAUDE-custom.md").exists()
+
+
 def test_legacy_shipped_runtime_surfaces_the_baseline_debt() -> None:
     debt = portable_contract.legacy_shipped_runtime(_tracked_paths())
     # Runtime debt still exists, but untrack-v1 no longer ships personal

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -7,6 +7,7 @@ passes on the healthy tree.
 
 from __future__ import annotations
 
+import inspect
 import json
 import subprocess
 import sys
@@ -184,6 +185,56 @@ def test_customization_migration_operation_refuses_outside_seams() -> None:
 
     assert verdict.allowed is False
     assert verdict.action == "outside-migration-seams"
+
+
+def test_customization_migration_seam_prefix_requires_trailing_slash() -> None:
+    # This pins the trailing-slash prefix semantics against matcher refactors.
+    verdict = portable_contract.update_write_verdict(
+        "System/.dex/customization-migrations-evil/secret.md",
+        exists=True,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "outside-migration-seams"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "System/.dex/customization-migrations/abc123/token.json",
+        "System/.dex/customization-migrations/abc123/private.key",
+    ],
+)
+def test_customization_migration_denies_additional_seam_secret_types(path: str) -> None:
+    verdict = portable_contract.update_write_verdict(
+        path,
+        exists=False,
+        operation="customization-migration",
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "deny"
+
+
+def test_default_update_denies_customization_migration_seam() -> None:
+    verdict = portable_contract.update_write_verdict(
+        "System/.dex/customization-migrations/abc123/manifest.json",
+        exists=True,
+    )
+
+    assert verdict.allowed is False
+    assert verdict.action == "never"
+
+
+def test_update_write_verdict_operation_is_keyword_only_with_update_default() -> None:
+    # Existing mutation-test monkeypatches use lambda path, *, exists — any future
+    # caller passing operation= must update them.
+    parameters = inspect.signature(portable_contract.update_write_verdict).parameters
+
+    assert "operation" in parameters
+    assert parameters["operation"].default == "update"
+    assert parameters["operation"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -260,6 +260,131 @@ def test_engine_verify_failure_rolls_back_byte_exact(tmp_path: Path) -> None:
     assert target.read_bytes() == b"old manifest\n"
 
 
+def test_engine_content_write_with_matching_precondition_applies_and_verifies(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"captured bytes\n")
+    os.chmod(target, 0o600)
+    expected = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    result = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", b"replacement\n", 0o644, expected_current_sha256=expected)],
+    ).run()
+
+    assert result["committed"] is True
+    assert target.read_bytes() == b"replacement\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_engine_content_write_precondition_mismatch_rejects_without_mutation(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"user changed bytes\n")
+    before = _tree_state(vault, ["README.md"])
+
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", b"replacement\n", expected_current_sha256="0" * 64)],
+    )
+    with pytest.raises(PlanRejected, match="the existing file wins and the transaction aborts"):
+        tx.run()
+
+    assert _tree_state(vault, ["README.md"]) == before
+
+
+def test_engine_content_write_precondition_requires_existing_target(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", b"replacement\n", expected_current_sha256="0" * 64)],
+    )
+
+    with pytest.raises(PlanRejected, match="the existing file wins and the transaction aborts"):
+        tx.run()
+
+    assert not (vault / "README.md").exists()
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        "A" * 64,
+        "not-a-sha256",
+    ],
+)
+def test_engine_content_write_precondition_requires_lowercase_sha256(
+    expected: str,
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+
+    with pytest.raises(PlanRejected, match="must be a lowercase sha256"):
+        Transaction.begin(
+            vault,
+            [PlanEntry("README.md", b"replacement\n", expected_current_sha256=expected)],
+        )
+
+
+def test_engine_content_write_precondition_rejects_symlink_target(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"captured bytes\n")
+    target = vault / "README.md"
+    target.symlink_to(outside)
+    expected = hashlib.sha256(outside.read_bytes()).hexdigest()
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("README.md", b"replacement\n", expected_current_sha256=expected)],
+    )
+
+    with pytest.raises(PlanRejected, match="the existing file wins and the transaction aborts"):
+        tx.run()
+
+    assert target.is_symlink()
+    assert outside.read_bytes() == b"captured bytes\n"
+
+
+def test_engine_rechecks_content_precondition_and_rolls_back_applied_entries(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    first = vault / "System/.installed-files.manifest"
+    first.write_bytes(b"old manifest\n")
+    guarded = vault / "README.md"
+    guarded.write_bytes(b"captured bytes\n")
+    expected = hashlib.sha256(guarded.read_bytes()).hexdigest()
+    tx = Transaction.begin(
+        vault,
+        [
+            PlanEntry("System/.installed-files.manifest", b"new manifest\n"),
+            PlanEntry("README.md", b"replacement\n", expected_current_sha256=expected),
+        ],
+    )
+    original_append = tx.journal.append
+
+    def swap_after_first_apply(event: str, payload=None) -> None:
+        original_append(event, payload)
+        if event == "APPLIED" and payload["index"] == 0:
+            guarded.write_bytes(b"user edit in snapshot-to-apply window\n")
+
+    tx.journal.append = swap_after_first_apply
+
+    with pytest.raises(PlanRejected, match="changed after the mutation snapshot"):
+        tx.run()
+
+    assert first.read_bytes() == b"old manifest\n"
+    assert guarded.read_bytes() == b"user edit in snapshot-to-apply window\n"
+
+
 def test_engine_delete_entry_commits_and_rolls_back_byte_exact(tmp_path: Path) -> None:
     """Updater removals use the same snapshot/apply/verify/undo path as writes."""
     vault = _vault(tmp_path)
@@ -385,6 +510,21 @@ Transaction.begin(vault, [
 
 _RELATIVES = ["03-Tasks/Tasks.md", "System/.installed-files.manifest"]
 
+_PRECONDITION_WORKER = r"""
+import hashlib
+import sys
+sys.path.insert(0, sys.argv[2])
+from pathlib import Path
+from core.transaction.engine import Transaction, PlanEntry
+vault = Path(sys.argv[1])
+target = vault / "README.md"
+expected = hashlib.sha256(target.read_bytes()).hexdigest()
+Transaction.begin(vault, [
+    PlanEntry("README.md", b"replacement\n", 0o600, expected_current_sha256=expected),
+    PlanEntry("System/.installed-files.manifest", b"regenerated\n"),
+]).run()
+"""
+
 
 @pytest.mark.parametrize(
     "seam",
@@ -441,6 +581,32 @@ def test_resume_is_idempotent(tmp_path: Path) -> None:
     second = Transaction.resume(vault)
     assert len(first) == 1
     assert second == []
+
+
+def test_resume_rolls_back_content_precondition_plan_byte_exact(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"original bytes\r\nwith\x00data")
+    os.chmod(target, 0o640)
+    relatives = ["README.md", "System/.installed-files.manifest"]
+    before = _tree_state(vault, relatives)
+    env = dict(os.environ, DEX_TX_TEST_STOP_AFTER="mid-apply:0")
+
+    process = subprocess.run(
+        [sys.executable, "-c", _PRECONDITION_WORKER, str(vault), str(REPO_ROOT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert process.returncode == 137, process.stderr[-300:]
+
+    outcomes = Transaction.resume(vault)
+
+    assert _tree_state(vault, relatives) == before
+    assert len(outcomes) == 1 and outcomes[0]["resumed"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -55,7 +55,9 @@ class PlanRejected(TransactionError):
 class PlanEntry:
     """One intended mutation at vault-relative ``relative``.
 
-    ``content=None`` is an authorized deletion. Deletions use the same
+    ``content=None`` is an authorized deletion. ``expected_current_sha256``
+    guards deletions (required) and content writes (optional) against a target
+    changing after the plan was built. Deletions use the same
     snapshot/apply/verify/rollback lifecycle as replacements, so an updater
     can prune a retired brain file without opening a second mutation path.
     """
@@ -127,12 +129,11 @@ class Transaction:
                     f"{entry.relative}: mode {oct(entry.mode)} carries special "
                     "bits; only permission bits up to 0o777 are allowed"
                 )
-            if entry.expected_current_sha256 is not None and (
-                entry.content is not None or not re.fullmatch(r"[0-9a-f]{64}", entry.expected_current_sha256)
+            if entry.expected_current_sha256 is not None and not re.fullmatch(
+                r"[0-9a-f]{64}", entry.expected_current_sha256
             ):
                 raise PlanRejected(
-                    f"{entry.relative}: current-content preconditions are valid only for "
-                    "deletions and must be a lowercase sha256"
+                    f"{entry.relative}: current-content preconditions must be a lowercase sha256"
                 )
             if entry.content is None and entry.expected_current_sha256 is None:
                 raise PlanRejected(f"{entry.relative}: deletions require expected_current_sha256")
@@ -243,18 +244,15 @@ class Transaction:
                 raise PlanRejected(f"{entry.relative}: {unsafe_parent}")
             if entry.expected_current_sha256 is None:
                 continue
-            target = self.vault_root / entry.relative
-            if not target.exists():
-                continue
-            if (
-                target.is_symlink()
-                or not target.is_file()
-                or hashlib.sha256(target.read_bytes()).hexdigest() != entry.expected_current_sha256
-                or target.stat().st_mode & 0o777 != entry.mode
-            ):
-                raise PlanRejected(
-                    f"{entry.relative} changed after the mutation plan was built; "
-                    "the existing file wins and the transaction aborts"
+            if entry.content is None:
+                self._verify_deletion_precondition(
+                    entry,
+                    changed_when="after the mutation plan was built",
+                )
+            else:
+                self._verify_content_precondition(
+                    entry,
+                    changed_when="after the mutation plan was built",
                 )
         self.snapshot.capture(self.vault_root, [entry.relative for entry in self._plan])
         self.journal.append("SNAPSHOT-DONE")
@@ -307,15 +305,40 @@ class Transaction:
         target = self.vault_root / entry.relative
         if not target.exists():
             return
-        if (
-            target.is_symlink()
-            or not target.is_file()
-            or hashlib.sha256(target.read_bytes()).hexdigest() != entry.expected_current_sha256
-            or target.stat().st_mode & 0o777 != entry.mode
-        ):
+        if not self._matches_current_precondition(entry, check_mode=True):
             raise PlanRejected(
                 f"{entry.relative} changed {changed_when}; the existing file wins and the transaction aborts"
             )
+
+    def _verify_content_precondition(
+        self,
+        entry: PlanEntry,
+        *,
+        changed_when: str,
+    ) -> None:
+        target = self.vault_root / entry.relative
+        if not target.exists() or not self._matches_current_precondition(
+            entry,
+            check_mode=False,
+        ):
+            raise PlanRejected(
+                f"{entry.relative} changed {changed_when}; "
+                "the existing file wins and the transaction aborts"
+            )
+
+    def _matches_current_precondition(
+        self,
+        entry: PlanEntry,
+        *,
+        check_mode: bool,
+    ) -> bool:
+        target = self.vault_root / entry.relative
+        return (
+            not target.is_symlink()
+            and target.is_file()
+            and hashlib.sha256(target.read_bytes()).hexdigest() == entry.expected_current_sha256
+            and (not check_mode or target.stat().st_mode & 0o777 == entry.mode)
+        )
 
     def _apply_one(self, index: int, entry: PlanEntry) -> None:
         relative = entry.relative
@@ -349,6 +372,15 @@ class Transaction:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+        if entry.expected_current_sha256 is not None:
+            try:
+                self._verify_content_precondition(
+                    entry,
+                    changed_when="after the mutation snapshot",
+                )
+            except BaseException:
+                temporary.unlink(missing_ok=True)
+                raise
         os.replace(temporary, target)
         directory = os.open(target.parent, os.O_RDONLY)
         try:

--- a/docs/customization-migration-threat-model.md
+++ b/docs/customization-migration-threat-model.md
@@ -59,8 +59,10 @@ response, never derivable from capsule or preview content.
 
 There is exactly one sanctioned write check:
 `core.portable_contract.update_write_verdict`. The migration authority is its
-`operation="customization-migration"` parameter — not a second function, so the existing
-red-when-removed mutation tests cover the new path. The verdict authorizes writes only
+`operation="customization-migration"` parameter — not a second function. The existing
+red-when-removed mutation tests keep proving that every consumer routes through this one
+check; the migration branch's own boundary (seam matching, deny precedence) is pinned by
+its direct seam-boundary tests, including the sibling-prefix refusal. The verdict authorizes writes only
 inside a versioned, enumerated seam list (`CUSTOMIZATION_MIGRATION_SEAM_*`, v0: the
 protected migration-artifact root and `CLAUDE-custom.md`); hard-deny always wins;
 everything else refuses. Expanding the seam list is a deliberate contract change: it
@@ -97,7 +99,17 @@ collapses to `manual-review`. Model confidence is never verification.
   vault root, symlink refusal, traversal refusal, bounded reads, atomic writes, the
   single-writer lock, journal-before-effect, and byte-exact rollback.
 
-## 6. What later lanes must re-prove
+## 6. Known tripwires for later lanes
+
+- Existing mutation tests monkeypatch `update_write_verdict` with `lambda path, *, exists`
+  signatures. The first caller that passes `operation=` will make those monkeypatches
+  `TypeError` — update them deliberately in the same change, never by loosening.
+- The verdict's path normalization is more lenient than the transaction engine's path
+  gate. The verdict is therefore never a sole path gate: migration writes are only valid
+  behind a `Transaction`, whose `unsafe_existing_parent` checks reject anything
+  non-canonical.
+
+## 7. What later lanes must re-prove
 
 Each write-capable lane (capsule creation, staging, activation) must, before merge:
 re-run the red-when-removed suite; add fault injection at every new mutation seam; pass an

--- a/docs/customization-migration-threat-model.md
+++ b/docs/customization-migration-threat-model.md
@@ -1,0 +1,105 @@
+# Customization Migration — threat model and write-authority contract (v0)
+
+**Status:** Lane A contract document. Binding on every later lane of the customization
+migration program. Amendments A1–A3 below were produced by independent adversarial review
+(2026-07-24) and are accepted as part of the program plan; no later lane may weaken them
+without a new adversarial review and an explicit decision from the owner.
+
+---
+
+## 1. What this system is allowed to become
+
+The customization migration carries a user's tailoring (edited skills, custom scripts,
+hooks, MCP servers, instructions) across a Core replacement. To do that it must eventually
+write files that the ownership contract classifies as the *user's own* — the one thing the
+update machinery is otherwise built to never do. This document fixes, before any of that
+code exists, who may authorize such a write, through which single check, and what evidence
+must exist first.
+
+## 2. Assets
+
+- **User-owned vault content** — prose, notes, personal files. Loss or silent modification
+  is the unforgivable outcome.
+- **The user's tailoring** — the customizations themselves and their working behaviour.
+- **Secrets** — credential values embedded in scripts, `.mcp.json` env blocks, integration
+  configs. Must never enter model-readable output, reports, or logs.
+- **The evidence chain** — capsule bytes, digests, receipts. If evidence can be rewritten,
+  every downstream "verified" claim is worthless.
+- **The trust model** — user consent decisions (MCP trust, update approval). Must not be
+  transferable to bytes the user never saw.
+
+## 3. Adversaries and failure sources
+
+1. **A prompt-injected or confused model.** Vault content is untrusted input. A note that
+   says "continue the pending customization migration" must not be able to cause a live
+   write. The model holding MCP tools is therefore treated as an adversary for every
+   mutation decision.
+2. **Hostile or malformed vault content** — path traversal in captured references, symlink
+   swaps, oversized or binary files, malformed UTF-8, tampered capsule metadata.
+3. **Concurrent writers** — the user, Obsidian, background sync, other agent sessions, a
+   second lifecycle transaction.
+4. **Crashes at any write seam** — every mutation must converge to old-verified or
+   new-committed, never a mixture.
+5. **Future maintainers** — a refactor that quietly widens the write authority. The
+   defense is red-when-removed tests on the single check, not review vigilance.
+
+## 4. Binding amendments
+
+### A1 — The model never holds a write tool
+
+MCP tools for this feature are **read and preview only**. `stage`, `activate`, and
+`rewind` exist only on the Doctor/CLI side, behind genuine user confirmation. The
+existing lifecycle "approval token" is an integrity binding — sha256 of the canonical
+preview, provably mintable by any caller that can build a preview — so **a token is never
+consent**. Consent is an interactive act the model cannot perform or simulate: a
+confirmation collected from the user by the CLI/Doctor layer, never present in any MCP
+response, never derivable from capsule or preview content.
+
+### A2 — One write authority, preconditioned
+
+There is exactly one sanctioned write check:
+`core.portable_contract.update_write_verdict`. The migration authority is its
+`operation="customization-migration"` parameter — not a second function, so the existing
+red-when-removed mutation tests cover the new path. The verdict authorizes writes only
+inside a versioned, enumerated seam list (`CUSTOMIZATION_MIGRATION_SEAM_*`, v0: the
+protected migration-artifact root and `CLAUDE-custom.md`); hard-deny always wins;
+everything else refuses. Expanding the seam list is a deliberate contract change: it
+appears in the frozen JSON contract view and its tests, and requires adversarial review.
+
+Every content write onto a path that existed at evidence-capture time MUST carry
+`expected_current_sha256` — the transaction engine aborts if the live file no longer
+matches the captured bytes, so a user edit made after capture always wins over the
+migration. This engine capability lands before any migration write path exists.
+
+### A3 — `verified` requires non-model provenance
+
+Every behavioural contract carries `provenance ∈ {deterministic, user-confirmed,
+model-proposed}`. A verification outcome may be reported as **verified** only when the
+contract's provenance is non-model (`deterministic` or `user-confirmed`). A
+`native-replacement` disposition additionally requires a deterministic witness (a catalog
+item claiming the capability) **plus** explicit user confirmation; absent either, it
+collapses to `manual-review`. Model confidence is never verification.
+
+## 5. Consequences fixed by this document
+
+- No code path may construct a customization-migration transaction from MCP input.
+  The `operation` value is not accepted from any tool argument, plan file, or capsule
+  field; it is passed only by the lifecycle implementation after Doctor/CLI-side consent.
+- Ordinary update, Doctor repair, and onboarding callers never pass `operation`; a test
+  proves an ordinary transaction targeting `CLAUDE-custom.md` still refuses.
+- Secrets policy: assessment and capsule layers emit reference kinds, counts, and
+  vault-relative paths — never captured strings from credential-bearing files. A leak
+  test plants a fake key and asserts it appears in no output, log, or report.
+- Capsule artifacts live under `System/.dex/customization-migrations/` (mode 0700, files
+  0600), are gitignored in the same PR that first creates one, and are never claimed to be
+  excluded from the user's own sync tools — Dex does not control those.
+- All migration filesystem operations inherit the existing engine invariants: one resolved
+  vault root, symlink refusal, traversal refusal, bounded reads, atomic writes, the
+  single-writer lock, journal-before-effect, and byte-exact rollback.
+
+## 6. What later lanes must re-prove
+
+Each write-capable lane (capsule creation, staging, activation) must, before merge:
+re-run the red-when-removed suite; add fault injection at every new mutation seam; pass an
+independent adversarial review; and demonstrate that removing its consent step makes a
+test fail — not merely that consent exists in prose.

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -16,6 +16,16 @@
     "seed": "write-if-absent",
     "vault": "never"
   },
+  "customization_migration": {
+    "version": 0,
+    "action": "write-with-user-approval",
+    "seam_prefixes": [
+      "System/.dex/customization-migrations/"
+    ],
+    "seam_paths": [
+      "CLAUDE-custom.md"
+    ]
+  },
   "hard_deny": [
     ".env",
     ".env.*",

--- a/packages/dex-contracts/dist/portable-vault.schema.json
+++ b/packages/dex-contracts/dist/portable-vault.schema.json
@@ -10,6 +10,7 @@
     "vault_schema_supported",
     "ownership_classes",
     "mutation_policy",
+    "customization_migration",
     "hard_deny",
     "vault_regions",
     "rules",
@@ -77,6 +78,40 @@
             "regenerate",
             "never"
           ]
+        }
+      }
+    },
+    "customization_migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "action",
+        "seam_prefixes",
+        "seam_paths"
+      ],
+      "properties": {
+        "version": {
+          "const": 0
+        },
+        "action": {
+          "const": "write-with-user-approval"
+        },
+        "seam_prefixes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "seam_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
         }
       }
     },


### PR DESCRIPTION
## What this is

Lane A (PR 1) of the customization-migration program — the two safety seams the independent adversarial review made **binding prerequisites** before any migration code gains write capability, plus the program threat model.

**Grants no new write capability.** Every existing caller uses the default operation; nothing constructs a migration-operation plan yet.

## Changes

1. **`core/transaction/engine.py` — content-write preconditions** (amendment 2). `PlanEntry.expected_current_sha256` is now valid on content writes: the transaction aborts (existing file wins) if the live file is missing, a symlink, or no longer hashes to the captured bytes — checked at snapshot time and re-checked immediately before the atomic replace. Deletion semantics byte-identical.

2. **`core/portable_contract.py` — sealed operation parameter** (amendment 1). `update_write_verdict` gains keyword-only `operation="update"`; it stays the ONLY write check (no parallel authority). `operation="customization-migration"` authorizes writes only inside the versioned v0 seam list (`System/.dex/customization-migrations/` prefix + `CLAUDE-custom.md`); hard-deny always wins; everything else refuses; unknown operations raise. Seam list travels in the frozen contract JSON so drift gates police it.

3. **`docs/customization-migration-threat-model.md`** — encodes all three adversarial-review amendments as binding (read/preview-only MCP + consent is never a token; one preconditioned write authority; verified requires non-model provenance) plus the Lane B tripwires.

## Verification

- 114 contract/transaction tests green (91 → 114, +27 incl. crash-window, resume, and seam-boundary pins)
- Full targeted suite: 177 passed (transaction, contract, adoption mutations/transaction/rewind, apply_update)
- All PR gates green locally: portable-contract, test-delta, doc-drift, path-contract-usage, PII, architecture-inventory; ruff clean
- **Independent adversarial review (Opus): no blockers.** Its one SERIOUS finding (seam boundary unpinned by tests) and all minor pins are fixed in the final commit; empirically probed sibling-prefix, traversal, case, double-slash, absolute-path, and secrets-in-seam attacks all refuse; all nine existing `update_write_verdict` call sites confirmed unable to reach the migration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSS5ozU6tnNYXmEKv5JLje