### PR TITLE
fix(integrations): close the Phase 5 security gate on the credential store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.75.0] — 🔐 A second look at how your app sign-ins are stored (2026-07-24)
+
+Before the connections doorway opens, I wanted the way Dex stores your sign-ins checked properly rather than taken on trust. So it got reviewed twice, independently — once by me and once by a separate AI model that wasn't shown my findings, each trying to find ways in. The good news up front: the actual sealing of your credentials held up under both reviews. What the reviews found were softer edges around it, and this release tidies all of them. Nothing here was ever exploited, and the feature isn't open to anyone yet — this is the tidying you do *before* opening the door.
+
+**What this gets ready for you:**
+
+* **Dex now tells you where the key to your credentials is kept.** Normally it lives in your Mac's Keychain, sealed away from your notes. On the rare setup where that isn't available, it sits in your vault folder instead — which means a copy of that folder is a copy of your sign-ins. Dex used to look identical either way. Now it just says which, so you can see it rather than assume.
+* **"Disconnect" no longer overpromises.** It removes the credential from your machine — but the app itself can still have permission in your account until you remove it there. Dex now says so, and points you at the right place, instead of leaving you to assume you were fully unhooked.
+* **A disconnect leaves nothing behind.** If a credential file had previously been set aside as damaged, disconnecting didn't clear it. Now it does, so removing a connection really removes it.
+* **Nothing an outside service says gets written down unexamined.** If a connected app sent back an error message, Dex saved it as-is for troubleshooting. A misbehaving service could have used that to get something sensitive written into a plain-text log. Dex now strips anything sensitive out first.
+* **A stray browser tab can't interrupt you mid-connect.** While you were connecting an app, another page open in your browser could quietly cancel it and leave you wondering what went wrong. That window is closed.
+* **Sturdier under odd setups.** If your credentials folder or key arrived from a backup with loose permissions, Dex now tightens them before use rather than trusting them, and refuses outright if something looks tampered with. And account names that could have collided into the same file — quietly breaking one of two connections — are now rejected up front.
+
+Still no change to day-to-day use: this is the last piece of groundwork before connecting your tools becomes something you can actually do.
+
 ## [1.74.0] — 🔌 Groundwork: connecting your other tools, tested against the real world (2026-07-24)
 
 Dex is getting a built-in way to connect the other tools you use — starting with Google Calendar and Linear — so it can work with what's in them instead of asking you to copy-paste. That doorway isn't open yet, but this release lands the machinery behind it, after a security review and live end-to-end testing with real Google and Linear accounts.

--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -369,6 +369,7 @@ async function cmdSetKey(service, flags) {
 function cmdStatus(flags = {}) {
   const meta = store.readRegistry()._meta;
   const rows = health.allConnectionsHealth();
+  const keyCustody = store.keyCustodyMode();
   if (flags.json !== undefined) {
     process.stdout.write(`${JSON.stringify({ connections: rows, registryNotice: meta || null })}\n`);
     return;
@@ -381,6 +382,11 @@ function cmdStatus(flags = {}) {
         ' Check the list below and reconnect anything missing or red.'
     );
   }
+  console.log(
+    keyCustody === 'keychain'
+      ? 'Encryption key: stored in your macOS Keychain.'
+      : 'Encryption key: stored in your vault folder — anyone with a copy of that folder can read these credentials.'
+  );
   if (!rows.length) {
     console.log('No connections yet. Run: node connect.cjs connect <provider>');
     return;
@@ -538,7 +544,10 @@ async function main() {
         break;
       case 'disconnect':
         store.deleteToken(positional[0]);
-        console.log(`Disconnected ${positional[0]}.`);
+        console.log(
+          `Disconnected ${positional[0]}. The credential was removed from this machine. ` +
+            "To fully revoke access, remove Dex in the provider's account settings."
+        );
         break;
       case 'providers':
         cmdProviders(positional[0], flags);

--- a/core/integrations/connection-manager/connection-manager.hardening.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.hardening.test.cjs
@@ -82,6 +82,59 @@ test('atomic: registry and token writes keep 0600 files / 0700 dirs through the 
   store.deleteToken('perm-check');
 });
 
+test('permissions: a pre-existing loose credentials directory is tightened to 0700', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-loose-dir-'));
+  const credentials = path.join(vault, 'System', 'credentials');
+  fs.mkdirSync(credentials, { recursive: true });
+  fs.chmodSync(credentials, 0o755);
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'loose-dir', 'FAKE-key'], {
+      env: { ...childEnv, DEX_VAULT: vault },
+      stdio: 'pipe',
+    });
+    assert.equal(mode(credentials), 0o700);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('permissions: a loose fallback key file is tightened to 0600 before reading', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-loose-key-'));
+  const env = { ...childEnv, DEX_VAULT: vault };
+  const keyFile = path.join(vault, 'System', 'credentials', '.dex-cm.key');
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'loose-key', 'FAKE-key'], { env, stdio: 'pipe' });
+    fs.chmodSync(keyFile, 0o644);
+    execFileSync('node', [CHILD, 'load-token', 'loose-key'], { env, stdio: 'pipe' });
+    assert.equal(mode(keyFile), 0o600);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('permissions: a symlinked fallback key is refused with clear guidance', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-symlink-key-'));
+  const env = { ...childEnv, DEX_VAULT: vault };
+  const keyFile = path.join(vault, 'System', 'credentials', '.dex-cm.key');
+  const target = path.join(vault, 'saved-key');
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'symlink-key', 'FAKE-key'], { env, stdio: 'pipe' });
+    fs.renameSync(keyFile, target);
+    fs.symlinkSync(target, keyFile);
+    let failure;
+    try {
+      execFileSync('node', [CHILD, 'load-token', 'symlink-key'], { env, stdio: 'pipe' });
+    } catch (error) {
+      failure = error;
+    }
+    assert.ok(failure, 'the key must not be read through a symlink');
+    assert.match(failure.stderr.toString(), /encryption key.*symlink/i);
+    assert.match(failure.stderr.toString(), /replace/i);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
 test('atomic: crash between temp write and rename leaves the old registry intact', () => {
   store.upsertConnection('crash-keeper', { provider: 'crash-keeper', status: 'connected' });
 
@@ -267,6 +320,24 @@ test('refresh lock: a dead-PID holder is taken over on the refresh lock specific
 function corruptTokens() {
   return fs.readdirSync(TOKENS_DIR).filter((n) => n.includes('.corrupt-'));
 }
+
+test('disconnect removes only that connection’s corrupt and key-loss residue', () => {
+  store.saveApiKey('residue-target', { apiKey: 'FAKE-target' }, { provider: 'residue-target' });
+  store.saveApiKey('residue-other', { apiKey: 'FAKE-other' }, { provider: 'residue-other' });
+  const targetLive = path.join(TOKENS_DIR, 'residue-target.json');
+  const otherLive = path.join(TOKENS_DIR, 'residue-other.json');
+  const targetCorrupt = `${targetLive}.corrupt-test`;
+  const targetKeyloss = `${targetLive}.keyloss-test`;
+  const otherCorrupt = `${otherLive}.corrupt-test`;
+  fs.copyFileSync(targetLive, targetCorrupt);
+  fs.copyFileSync(targetLive, targetKeyloss);
+  fs.copyFileSync(otherLive, otherCorrupt);
+
+  store.deleteToken('residue-target');
+  assert.ok(!fs.readdirSync(TOKENS_DIR).some((name) => name.startsWith('residue-target.json.')));
+  assert.ok(fs.existsSync(otherCorrupt), 'another connection’s quarantine file is untouched');
+  store.deleteToken('residue-other');
+});
 
 test('corrupt token: truncated file becomes needs_reauth with reason, file quarantined not deleted', () => {
   store.saveApiKey('corrupt-a', { apiKey: 'FAKE-key-a' }, { provider: 'corrupt-a', authMode: 'API_KEY' });
@@ -455,6 +526,24 @@ test('ids: path-traversal connection ids are rejected before they reach the file
   // normal ids still fine
   assert.equal(store.parseConnectionId('google:work').connId, 'google:work');
   assert.equal(store.parseConnectionId('7shifts').provider, '7shifts');
+});
+
+test('ids: a provider containing the reserved filename separator is rejected', () => {
+  assert.throws(() => store.parseConnectionId('google__work'), /reserved.*__|__.*reserved/i);
+});
+
+test('ids: new mixed-case providers are rejected instead of colliding on macOS', () => {
+  assert.throws(() => store.parseConnectionId('Google:work'), /lowercase/i);
+});
+
+test('ids: an existing lowercase connection keeps its token path and still loads', () => {
+  store.saveApiKey('lowercase-existing', { apiKey: 'FAKE-lowercase-key' }, { provider: 'lowercase-existing' });
+  try {
+    assert.ok(fs.existsSync(path.join(TOKENS_DIR, 'lowercase-existing.json')));
+    assert.equal(store.loadToken('lowercase-existing').apiKey, 'FAKE-lowercase-key');
+  } finally {
+    store.deleteToken('lowercase-existing');
+  }
 });
 
 // ---- key loss (fix: never silently mint a new key over existing tokens) -------

--- a/core/integrations/connection-manager/connection-manager.judgment.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.judgment.test.cjs
@@ -155,6 +155,37 @@ test('permanent refresh failure stamps needs_reauth and records refresh + break 
   }
 });
 
+test('provider refresh errors cannot persist the refresh token in plaintext', async () => {
+  const connId = 'refresh-secret-redaction';
+  const refreshToken = 'ACTUAL-REFRESH-TOKEN-TO-REDACT';
+  seedOAuth(connId, 'google', { refresh_token: refreshToken });
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    response(400, {
+      error: 'invalid_grant',
+      error_description: `token ${refreshToken} is expired`,
+    });
+  try {
+    await withProviderConfig(
+      'google',
+      { tokenUrl: 'https://tokens.example/refresh', refreshUrl: null },
+      async () => {
+        await assert.rejects(health.refreshToken(connId, { force: true }), (error) => {
+          assert.ok(!error.message.includes(refreshToken));
+          return true;
+        });
+      }
+    );
+    const ledgerBytes = fs.readFileSync(path.join(store.credentialsDir(), 'ledger', `${connId}.jsonl`), 'utf8');
+    const registryBytes = fs.readFileSync(path.join(store.credentialsDir(), 'connections.json'), 'utf8');
+    assert.ok(!ledgerBytes.includes(refreshToken));
+    assert.ok(!registryBytes.includes(refreshToken));
+  } finally {
+    global.fetch = originalFetch;
+    store.deleteToken(connId);
+  }
+});
+
 test('transient 500 retries once, succeeds, and never stamps a reconnect error', async () => {
   seedOAuth('refresh-transient', 'google');
   let calls = 0;

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -156,13 +156,72 @@ test('rotating refresh tokens persist and the next refresh uses the newest token
   }
 });
 
-test('callback server rejects a mismatched OAuth state', async () => {
+test('macOS Keychain receives the master key on stdin, never in process arguments', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-keychain-argv-'));
+  const storePath = path.join(DIR, 'token-store.cjs');
+  const script = `
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const childProcess = require('node:child_process');
+    const calls = [];
+    childProcess.execFileSync = (file, args, options) => {
+      calls.push({ file, args, input: options && options.input });
+      if (args[0] === 'find-generic-password') throw new Error('not found');
+      return Buffer.alloc(0);
+    };
+    const store = require(${JSON.stringify(storePath)});
+    store.saveApiKey('keychain-argv', { apiKey: 'API-KEY' }, { provider: 'linear' });
+    process.stdout.write(JSON.stringify(calls));
+  `;
+  const env = { ...childEnv, DEX_VAULT: vault };
+  delete env.DEX_CM_NO_KEYCHAIN;
+  const result = spawnSync('node', ['-e', script], { env, encoding: 'utf8' });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const add = JSON.parse(result.stdout).find((call) => call.args[0] === 'add-generic-password');
+    assert.ok(add, 'the test reaches the Keychain write');
+    const keyArg = add.args.find((arg) => /^[A-Za-z0-9+/]{43}=$/.test(arg));
+    assert.equal(keyArg, undefined, 'the base64 master key is absent from argv');
+    assert.match(add.input, /^([A-Za-z0-9+/]{43}=)\n\1\n$/);
+    assert.equal(add.args.at(-1), '-w');
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('callback server escapes provider errors before rendering HTML', async () => {
+  const harness = callbackHarness();
+  const cb = await oauth.startCallbackServer({ ports: [3847], timeoutMs: 1000, createServer: harness.createServer });
+  const pending = cb.waitForCode({ expectedState: 'expected-state' }).catch((error) => error);
+  const response = harness.request(
+    harness.servers[0],
+    `/callback?error=${encodeURIComponent('<img src=x onerror=alert(1)>')}&state=expected-state`
+  );
+  assert.equal(response.status, 200);
+  assert.doesNotMatch(response.body, /<img/i);
+  assert.match((await pending).message, /provider returned error/i);
+});
+
+test('callback server ignores a mismatched state and still accepts the real callback', async () => {
   const harness = callbackHarness();
   const cb = await oauth.startCallbackServer({ ports: [3847], timeoutMs: 1000, createServer: harness.createServer });
   const pending = cb.waitForCode({ expectedState: 'expected-state' });
-  const response = harness.request(harness.servers[0], '/callback?code=abc&state=wrong-state');
-  assert.equal(response.status, 400);
-  await assert.rejects(pending, /state mismatch/i);
+  let settled = false;
+  pending.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+  const wrong = harness.request(harness.servers[0], '/callback?code=wrong-code&state=wrong-state');
+  assert.equal(wrong.status, 400);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(settled, false);
+
+  const correct = harness.request(harness.servers[0], '/callback?code=right-code&state=expected-state');
+  assert.equal(correct.status, 200);
+  assert.deepEqual(await pending, { code: 'right-code', state: 'expected-state' });
 });
 
 test('callback server times out and closes cleanly', async () => {
@@ -244,6 +303,27 @@ test('OAuth app secrets surface the same explicit key-loss state as tokens', () 
   assert.match(read.stderr, /DEX_CM_KEY_LOST/);
   assert.ok(fs.existsSync(path.join(vault, 'System', 'credentials', 'oauth-apps.json')));
   fs.rmSync(vault, { recursive: true, force: true });
+});
+
+test('status reports file custody when the macOS Keychain is disabled', () => {
+  store.saveApiKey('custody-status', { apiKey: 'FAKE-custody-key' }, { provider: 'linear' });
+  try {
+    const result = run([path.join(DIR, 'connect.cjs'), 'status']);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Encryption key: stored in your vault folder/i);
+    assert.match(result.stdout, /anyone with a copy of that folder can read these credentials/i);
+  } finally {
+    store.deleteToken('custody-status');
+  }
+});
+
+test('disconnect explains that provider access must still be revoked', () => {
+  store.saveApiKey('disconnect-wording', { apiKey: 'FAKE-disconnect-key' }, { provider: 'linear' });
+  const result = run([path.join(DIR, 'connect.cjs'), 'disconnect', 'disconnect-wording']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /removed from this machine/i);
+  assert.match(result.stdout, /fully revoke access/i);
+  assert.match(result.stdout, /provider.*account settings/i);
 });
 
 test('secret argv flags are rejected with one-line stdin guidance', () => {

--- a/core/integrations/connection-manager/health.cjs
+++ b/core/integrations/connection-manager/health.cjs
@@ -211,8 +211,8 @@ function tokenRevision(token) {
   ]);
 }
 
-function recordConnectionEvent(connId, op, row = {}) {
-  return ledger.append(connId, { op, ...row });
+function recordConnectionEvent(connId, op, row = {}, secrets = []) {
+  return ledger.append(connId, { op, ...row }, { secrets });
 }
 
 /**
@@ -281,6 +281,14 @@ async function refreshToken(service, { force = false } = {}) {
       const app = store.getOAuthApp(provider); // OAuth app is shared per provider, not per account
       if (!app) throw new Error(`No OAuth app credentials for '${provider}'. Add them to oauth-apps.json.`);
       const providerConfig = catalog.getProviderConfig(provider, reg.connectionConfig || {});
+      const { secretsOf } = require('./auth-context.cjs');
+      const refreshSecrets = secretsOf({
+        headers: {
+          accessToken: current.access_token,
+          refreshToken: current.refresh_token || token.refresh_token,
+          clientSecret: app.clientSecret,
+        },
+      });
       try {
         const result = await refreshOAuthToken({
           tokenUrl: providerConfig.refreshUrl || providerConfig.tokenUrl,
@@ -292,6 +300,7 @@ async function refreshToken(service, { force = false } = {}) {
           retryDelayMs: Number.isFinite(providerConfig.refreshRetryDelayMs)
             ? providerConfig.refreshRetryDelayMs
             : undefined,
+          secrets: refreshSecrets,
         });
         const fresh = normalizeRefreshResult(result, current);
         store.saveToken(connId, fresh, { provider: providerConfig.id, connectedAt: reg.connectedAt });
@@ -303,13 +312,13 @@ async function refreshToken(service, { force = false } = {}) {
         recordConnectionEvent(connId, 'refresh', {
           ok: false,
           error: { category: needsReauth ? 'auth_permanent' : 'transient', code, message: code },
-        });
+        }, refreshSecrets);
         if (needsReauth) {
           store.upsertConnection(connId, { status: 'needs_reauth', error: code });
           recordConnectionEvent(connId, 'break', {
             ok: false,
             error: { category: 'auth_permanent', code, message: code },
-          });
+          }, refreshSecrets);
         }
         throw Object.assign(err, { needsReauth });
       }

--- a/core/integrations/connection-manager/lib/connector-ledger.js
+++ b/core/integrations/connection-manager/lib/connector-ledger.js
@@ -27,13 +27,14 @@ function parseFile(text) {
 	return entries;
 }
 
-function normalizeError(error) {
+function normalizeError(error, secrets = []) {
+	const { redactSecrets } = require("../auth-context.cjs");
 	if (error == null) return null;
-	if (typeof error === "string") return { message: error };
+	if (typeof error === "string") return { message: redactSecrets(error, secrets).slice(0, 500) };
 	if (typeof error !== "object") return null;
 	const safe = {};
 	for (const key of ["code", "category", "message"]) {
-		if (error[key] != null) safe[key] = String(error[key]).slice(0, 500);
+		if (error[key] != null) safe[key] = redactSecrets(error[key], secrets).slice(0, 500);
 	}
 	return Object.keys(safe).length ? safe : null;
 }
@@ -76,7 +77,7 @@ function createConnectorLedger(opts = {}) {
 		}
 	}
 
-	function normalizeRow(connectorId, row = {}) {
+	function normalizeRow(connectorId, row = {}, secrets = []) {
 		return {
 			at: new Date(now()).toISOString(),
 			connectorId,
@@ -84,16 +85,16 @@ function createConnectorLedger(opts = {}) {
 			httpStatus: Number.isFinite(row.httpStatus) ? row.httpStatus : null,
 			ok: row.ok === true,
 			latencyMs: Number.isFinite(row.latencyMs) ? row.latencyMs : null,
-			error: normalizeError(row.error),
+			error: normalizeError(row.error, secrets),
 		};
 	}
 
-	function append(connectorId, row) {
+	function append(connectorId, row, { secrets = [] } = {}) {
 		const safeId = validateConnectorId(connectorId);
 		const dir = stateDir();
 		fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 		const file = filePathFor(safeId);
-		const stored = normalizeRow(safeId, row);
+		const stored = normalizeRow(safeId, row, secrets);
 		return withLockSync(`${file}.lock`, () => {
 			const entries = readDisk(safeId);
 			const next = [...entries, stored].slice(-maxEntriesPerConnector);

--- a/core/integrations/connection-manager/lib/oauth-refresh.js
+++ b/core/integrations/connection-manager/lib/oauth-refresh.js
@@ -108,6 +108,7 @@ async function refreshOAuthToken({
 	retryDelayMs = DEFAULT_REFRESH_RETRY_DELAY_MS,
 	// DEX CORE DIVERGENCE: injectable delay keeps Retry-After/clamp tests instant.
 	delayImpl = delay,
+	secrets = [],
 } = {}) {
 	if (typeof fetchImpl !== "function") {
 		throw new RefreshError("No fetch implementation available for token refresh", { permanent: false });
@@ -123,6 +124,7 @@ async function refreshOAuthToken({
 		...(clientSecret ? { client_secret: clientSecret } : {}),
 		...extraParams,
 	}).toString();
+	const safeMessage = (message) => require("../auth-context.cjs").redactSecrets(message, secrets);
 
 	// One network exchange, bounded by a timeout. A hang or transient network
 	// error throws a non-permanent RefreshError so the retry loop below can try
@@ -144,7 +146,7 @@ async function refreshOAuthToken({
 		} catch (error) {
 			const timedOut = controller.signal.aborted || error?.name === "AbortError";
 			throw new RefreshError(
-				timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`,
+				safeMessage(timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`),
 				{ permanent: false, cause: error },
 			);
 		} finally {
@@ -168,12 +170,12 @@ async function refreshOAuthToken({
 			// (from the body `retry_after` or the response headers). Other error
 			// codes keep the existing permanent/transient classification.
 			if (rateLimit.is429(data)) {
-				throw new RefreshError(data?.error_description || data?.error || "Token refresh was rate limited", {
+				throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rate limited"), {
 					permanent: false,
 					retryAfterMs: rateLimit.retryAfterMs(data) ?? rateLimit.retryAfterMs(response),
 				});
 			}
-			throw new RefreshError(data?.error_description || data?.error || "Token refresh was rejected", {
+			throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rejected"), {
 				permanent: isPermanentError(data),
 			});
 		}

--- a/core/integrations/connection-manager/lifted-conformance.test.cjs
+++ b/core/integrations/connection-manager/lifted-conformance.test.cjs
@@ -25,12 +25,13 @@ const FILES = {
   },
   'oauth-refresh.js': {
     source: '0f29891a988d913c8b4bfddc9ee9d8f4c91328784534107ff65abe3d4cac4783',
-    lifted: 'cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392',
+    lifted: '8ae2f42d507a078aa9f48ac01a0c67bd5a0004742802da9332a95356da57c731',
     mode: 'injectable-delay',
     divergences: [
       'source provenance header',
       'injectable delay used only to prove Retry-After clamping',
       'credential-bearing refresh requests refuse redirects',
+      'known operation secrets redact provider-controlled refresh errors before they escape',
     ],
   },
   'connector-model.js': {
@@ -58,13 +59,14 @@ const FILES = {
   },
   'connector-ledger.js': {
     source: '956612fbebc115fa7512aaf5db91676bfe40fa0c08d0927e52f4508e28e14cbf',
-    lifted: '4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba',
+    lifted: 'd38c8b8fe0e8a3c9e258dd35b25ad8902b336287b304b140a88bdda55eb8ee09',
     mode: 'core-adaptation',
     divergences: [
       'credentials/ledger path and Core connect, refresh, probe, and break vocabulary',
       'Desktop sync counts, cursors, schedules, and page receipts omitted',
       'fs-safe is the sole atomic writer and adds a per-connection cross-process lock',
       'successful probes are scoped to the current connect epoch after a credential replacement',
+      'operation secrets redact provider-controlled error fields before ledger persistence',
     ],
   },
 };
@@ -117,6 +119,20 @@ for (const [name, contract] of Object.entries(FILES)) {
             '\t\t\t\t// Never let a refresh token or client secret cross a redirect.\n' +
             '\t\t\t\tredirect: "error",\n',
           ''
+        )
+        .replace('\tsecrets = [],\n', '')
+        .replace('\tconst safeMessage = (message) => require("../auth-context.cjs").redactSecrets(message, secrets);\n', '')
+        .replace(
+          '\t\t\t\tsafeMessage(timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`),\n',
+          '\t\t\t\ttimedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`,\n'
+        )
+        .replace(
+          'throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rate limited"), {',
+          'throw new RefreshError(data?.error_description || data?.error || "Token refresh was rate limited", {'
+        )
+        .replace(
+          'throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rejected"), {',
+          'throw new RefreshError(data?.error_description || data?.error || "Token refresh was rejected", {'
         )
         .replace('await delayImpl(waitMs)', 'await delay(waitMs)');
       assert.equal(normalized, source.toString());

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -43,6 +43,15 @@ function listenOnFirstFreePort(ports, createServer) {
   });
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Start a localhost callback server. Returns:
  *   { redirectUri, waitForCode(): Promise<{code,state}>, close() }
@@ -79,19 +88,20 @@ async function startCallbackServer({
         const error = url.searchParams.get('error');
         const code = url.searchParams.get('code');
         const state = url.searchParams.get('state');
-        const stateMismatch = expectedState !== undefined && state !== expectedState;
-        res.writeHead(stateMismatch ? 400 : 200, { 'Content-Type': 'text/html; charset=utf-8' });
+        const stateMatches = expectedState === undefined || state === expectedState;
+        const terminal = stateMatches && Boolean(code || error);
+        res.writeHead(terminal ? 200 : 400, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(
-          stateMismatch
-            ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection aborted</h2><p>OAuth state mismatch.</p></body></html>'
+          !terminal
+            ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Callback not accepted</h2><p>Dex is still waiting for the connection to finish.</p></body></html>'
             : error
-            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${error}</p><p>You can close this tab and return to Dex.</p></body></html>`
+            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${escapeHtml(error)}</p><p>You can close this tab and return to Dex.</p></body></html>`
             : `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>✅ Connected</h2><p>You can close this tab and return to Dex.</p></body></html>`
         );
+        if (!terminal) return;
         clearTimeout(timeout);
         server.close();
-        if (stateMismatch) reject(new Error('OAuth state mismatch — possible CSRF, aborting.'));
-        else if (error) reject(new Error(`Provider returned error: ${error}`));
+        if (error) reject(new Error(`Provider returned error: ${error}`));
         else resolve({ code, state });
       });
     });

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -40,7 +40,17 @@ function credentialsDir() {
 
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  if (dir === credentialsDir()) ensureCredentialsGitignore(dir);
+  if (dir === credentialsDir()) {
+    const stat = fs.lstatSync(dir);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Your credentials folder at ${dir} is a symlink. Replace it with a real folder owned by your account, then try again.`);
+    }
+    if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+      throw new Error(`Your credentials folder at ${dir} belongs to a different user. Change its owner to your account, then try again.`);
+    }
+    if (stat.mode & 0o077) fs.chmodSync(dir, 0o700);
+    ensureCredentialsGitignore(dir);
+  }
 }
 
 // The credentials dir must ignore EVERYTHING — tokens, the registry, oauth-app secrets, AND the
@@ -99,6 +109,11 @@ function keychainDisabled() {
   return process.env.DEX_CM_NO_KEYCHAIN === '1';
 }
 
+function keyCustodyMode() {
+  if (process.platform !== 'darwin' || keychainDisabled()) return 'file';
+  return fs.existsSync(path.join(credentialsDir(), '.dex-cm.key')) ? 'file' : 'keychain';
+}
+
 function keyFromMacKeychain() {
   if (process.platform !== 'darwin' || keychainDisabled()) return null;
   try {
@@ -120,8 +135,8 @@ function storeKeyInMacKeychain(keyB64) {
   try {
     execFileSync(
       'security',
-      ['add-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-w', keyB64, '-U'],
-      { stdio: 'ignore' }
+      ['add-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-U', '-w'],
+      { input: `${keyB64}\n${keyB64}\n`, stdio: ['pipe', 'ignore', 'ignore'] }
     );
     return true;
   } catch {
@@ -131,8 +146,25 @@ function storeKeyInMacKeychain(keyB64) {
 
 function keyFromFile() {
   const keyPath = path.join(credentialsDir(), '.dex-cm.key');
-  if (fs.existsSync(keyPath)) return Buffer.from(fs.readFileSync(keyPath, 'utf8').trim(), 'base64');
-  return null;
+  let stat;
+  try {
+    stat = fs.lstatSync(keyPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    const error = new Error(`The encryption key at ${keyPath} is a symlink. Replace it with the original .dex-cm.key file, then try again.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    const error = new Error(`The encryption key at ${keyPath} belongs to a different user. Change its owner to your account, then try again.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  if (stat.mode & 0o077) fs.chmodSync(keyPath, 0o600);
+  return Buffer.from(fs.readFileSync(keyPath, 'utf8').trim(), 'base64');
 }
 
 function writeKeyFile(keyB64) {
@@ -178,7 +210,8 @@ function getKey() {
   let lookupFailed = false;
   try {
     found = keyFromMacKeychain() || keyFromFile();
-  } catch {
+  } catch (error) {
+    if (error && error.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH') throw error;
     lookupFailed = true; // unreadable key source counts as loss, not as "fresh start"
   }
   if (found && found.length === 32) {
@@ -331,14 +364,22 @@ function decrypt(envelope, aad = '') {
  * FILENAMES (and the registry rebuild derives ids back from filenames), so a
  * hostile id like '../x' must never reach tokenPath and escape the tokens dir.
  */
-function parseConnectionId(id) {
+function parseConnectionId(id, { allowLegacyProviderCase = false } = {}) {
   const s = String(id);
   const i = s.indexOf(':');
-  const provider = i === -1 ? s : s.slice(0, i);
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(provider)) {
+  const rawProvider = i === -1 ? s : s.slice(0, i);
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(rawProvider)) {
     throw new Error(`Invalid provider in connection id '${id}'. Use letters, digits, '.', '-' or '_' (must start with a letter or digit).`);
   }
-  if (i === -1) return { provider: s, alias: null, connId: s };
+  if (rawProvider.includes('__')) {
+    throw new Error(`Invalid provider in connection id '${id}'. '__' is reserved for separating account names in credential filenames.`);
+  }
+  const lowercaseProvider = rawProvider.toLowerCase();
+  if (rawProvider !== lowercaseProvider && !allowLegacyProviderCase) {
+    throw new Error(`Invalid provider in connection id '${id}'. Use a lowercase provider name.`);
+  }
+  const provider = allowLegacyProviderCase ? rawProvider : lowercaseProvider;
+  if (i === -1) return { provider, alias: null, connId: provider };
   const alias = s.slice(i + 1).toLowerCase();
   if (!/^[a-z0-9_-]+$/.test(alias)) throw new Error(`Invalid connection alias in '${id}'. Use letters, digits, '-' or '_'.`);
   return { provider, alias, connId: `${provider}:${alias}` };
@@ -353,8 +394,8 @@ function parseConnectionId(id) {
  */
 function resolveConnId(id) {
   const reg = readRegistry();
+  if (reg[id] && reg[id].service) return id; // exact legacy match wins before new-id validation
   const { provider, alias } = parseConnectionId(id);
-  if (reg[id] && reg[id].service) return id; // exact match wins (back-compat)
   if (!alias) {
     const def = reg._defaults && reg._defaults[provider];
     if (def && reg[def]) return def;
@@ -376,7 +417,7 @@ function tokenPath(connId) {
 
 /** Persist a token object (encrypted) and refresh the registry entry. `connId` may be `provider` or `provider:alias`. */
 function saveToken(connId, token, meta = {}) {
-  const parsed = parseConnectionId(connId);
+  const parsed = parseConnectionId(connId, { allowLegacyProviderCase: Boolean(readRegistry()[connId]) });
   // Encrypt BEFORE touching the registry: if the key is lost this triggers the
   // loud recovery first, so the entry we then upsert stays 'connected'.
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(token), `token:${connId}`), null, 2);
@@ -413,7 +454,7 @@ function saveToken(connId, token, meta = {}) {
  */
 function saveApiKey(service, secretObj, meta = {}) {
   const stored = { kind: 'api_key', ...secretObj, obtained_at: Date.now() };
-  const parsed = parseConnectionId(service);
+  const parsed = parseConnectionId(service, { allowLegacyProviderCase: Boolean(readRegistry()[service]) });
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(stored), `token:${service}`), null, 2); // key-loss recovery before registry writes; see saveToken
   return withStoreLock(() => {
     const fields = {
@@ -481,7 +522,7 @@ function loadToken(id) {
   } catch (err) {
     // Key loss is store-wide, not a damaged file: keep the (intact) token file
     // where it is and surface the explicit state to the caller instead.
-    if (err && err.code === 'DEX_CM_KEY_LOST') throw err;
+    if (err && (err.code === 'DEX_CM_KEY_LOST' || err.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH')) throw err;
     withStoreLock(() => {
       const bindingMismatch = err && err.code === 'DEX_CM_ENVELOPE_BINDING';
       const quarantined = quarantineFile(p, bindingMismatch ? 'mismatch' : 'corrupt');
@@ -503,9 +544,15 @@ function deleteToken(id) {
   return withStoreLock(() => {
     const p = tokenPath(connId);
     if (fs.existsSync(p)) fs.unlinkSync(p);
+    const base = path.basename(p);
+    for (const file of fs.readdirSync(path.dirname(p))) {
+      if (file.startsWith(`${base}.corrupt-`) || file.startsWith(`${base}.keyloss-`)) {
+        fs.unlinkSync(path.join(path.dirname(p), file));
+      }
+    }
     const reg = readRegistry();
+    const provider = (reg[connId] && reg[connId].provider) || parseConnectionId(connId, { allowLegacyProviderCase: true }).provider;
     delete reg[connId];
-    const { provider } = parseConnectionId(connId);
     if (reg._defaults && reg._defaults[provider] === connId) {
       delete reg._defaults[provider];
       if (!Object.keys(reg._defaults).length) delete reg._defaults;
@@ -597,7 +644,7 @@ function rebuildRegistryFromTokens(reason, quarantinedName) {
   for (const f of listTokenFiles()) {
     let parsed;
     try {
-      parsed = parseConnectionId(f.replace(/\.json$/, '').replace(/__/g, ':'));
+      parsed = parseConnectionId(f.replace(/\.json$/, '').replace(/__/g, ':'), { allowLegacyProviderCase: true });
     } catch {
       continue; // foreign or hostile filename: leave the file alone, add no entry
     }
@@ -608,7 +655,9 @@ function rebuildRegistryFromTokens(reason, quarantinedName) {
       token = JSON.parse(decrypt(JSON.parse(fs.readFileSync(fp, 'utf8')), `token:${parsed.connId}`));
     } catch (err) {
       unreadable++;
-      if (err && err.code === 'DEX_CM_KEY_LOST') {
+      if (err && err.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH') {
+        throw err;
+      } else if (err && err.code === 'DEX_CM_KEY_LOST') {
         // The key is gone, not the file: keep the file untouched and mark the state.
         rebuilt[parsed.connId] = { ...base, status: 'needs_reauth', error: 'encryption_key_lost', recoveredAt: nowIso() };
       } else {
@@ -745,6 +794,7 @@ function nowIso() {
 
 module.exports = {
   credentialsDir,
+  keyCustodyMode,
   parseConnectionId,
   resolveConnId,
   withStoreLock,

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 17,
-      "totalBytes": 172291,
-      "treeHash": "aaa7573e05647bff28a757ba01b300bc9d4e66eafc0d854806be1531a29e7478",
+      "totalBytes": 176402,
+      "treeHash": "5bcb231f548b02b0fa41432882aab41460b5329027bcdeb1934594267ccd0e69",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -26,8 +26,8 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 27241,
-          "sha256": "fdb913096eabc9570644f33263ae93ec6ab4634d931d02e20d1cf8bb5d8de0a8"
+          "bytes": 27667,
+          "sha256": "8e3b5ef4b4c8d0a55e063f7c6beaf5061b6fb9ea983c44db21be16f05264a4ae"
         },
         {
           "path": "contract.cjs",
@@ -51,8 +51,8 @@
         },
         {
           "path": "health.cjs",
-          "bytes": 14672,
-          "sha256": "df063349f49c85a08c8d608905cad6b4dd635af2b0f82814360afb7db24a0f4f"
+          "bytes": 15063,
+          "sha256": "f3cbe31f0e20d82e82f8c0181807fa55bbd21734889d08dda8ae89dff5bdef88"
         },
         {
           "path": "index.cjs",
@@ -61,8 +61,8 @@
         },
         {
           "path": "lib/connector-ledger.js",
-          "bytes": 4799,
-          "sha256": "4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba"
+          "bytes": 4981,
+          "sha256": "d38c8b8fe0e8a3c9e258dd35b25ad8902b336287b304b140a88bdda55eb8ee09"
         },
         {
           "path": "lib/connector-model.js",
@@ -76,8 +76,8 @@
         },
         {
           "path": "lib/oauth-refresh.js",
-          "bytes": 10609,
-          "sha256": "cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392"
+          "bytes": 10761,
+          "sha256": "8ae2f42d507a078aa9f48ac01a0c67bd5a0004742802da9332a95356da57c731"
         },
         {
           "path": "lib/rate-limit.js",
@@ -86,8 +86,8 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 9195,
-          "sha256": "6ab21fb5139da00a38f98658d38c6c0ef416aa06aba4ef9073d16b450863979d"
+          "bytes": 9416,
+          "sha256": "8e4d0ed9d943d5656f9f98f8ae4d655187703079e77f60636902d8f1d35fcd33"
         },
         {
           "path": "README.md",
@@ -96,8 +96,8 @@
         },
         {
           "path": "token-store.cjs",
-          "bytes": 30324,
-          "sha256": "749230cf3c607a9faf1d55efb7e30639644345e35009b8b86477d07a842f92a8"
+          "bytes": 33063,
+          "sha256": "0512e061571062877d19c762206a467244cff609b57e3c23019f4e8ac80ed97f"
         }
       ]
     }


### PR DESCRIPTION
## What this is

The Phase 5 security gate from the integrations one-brain plan. It blocks provisioning `/connect` to users, so it had to land first.

Two independent threat models were run on `core/integrations/connection-manager/` — the orchestrating session, and Codex `gpt-5.6-sol` read-only, neither shown the other's findings. Merged, and every finding re-verified against source before acceptance.

Full result: `~/dex/artifacts/integrations-phase5-security-gate.md` (kept out of the repo deliberately — the repo tree is the vault template, so a committed attack cookbook would ship to every user).

## Verdict: the crypto is sound

Both reviewers independently confirmed: AES-256-GCM, random 32-byte key, fresh random 96-bit IV per encryption, auth tags verified, and associated-data binding that is both fed to the cipher *and* explicitly compared — so a token file moved between two accounts fails authentication and is quarantined rather than serving the wrong credential. Atomic writes force the mode with `fchmod` before rename, so no credential is ever momentarily world-readable. Path traversal is blocked at the validator. PKCE and OAuth state are correctly sized and actually checked. Both token paths refuse redirects.

The gaps were in **custody, residue and honesty**.

## The eight fixes

| # | Fix |
|---|---|
| 1 | Master key no longer passed to `security` on the command line — it goes on stdin (the `-w`-with-no-value form, value written twice). Previously any same-user process could read it from the process table. |
| 2 | A hostile token endpoint could echo the refresh token back in `error_description`, and that text was persisted verbatim into the plaintext ledger and registry. Known operation secrets are now redacted through the existing `secretsOf`/`redactSecrets` seam. |
| 3 | The OAuth loopback callback interpolated the provider `error` into HTML unescaped, and treated *any* request as terminal — so any page open in the browser could kill an in-flight connect. Errors are escaped; a request without a matching state gets a neutral 400 while the server keeps waiting. |
| 4 | Credentials dir and fallback key are now `lstat`-checked for symlink and ownership, with loose modes tightened to 0700/0600 before use. `mkdirSync(mode:)` is ignored on an existing directory, so a 0755 dir was never tightened. |
| 5 | Provider ids permitted `_` and mixed case while filenames map `:` → `__`, so `google__work` and `google:work` collided on one file. `__` and new mixed-case ids are rejected; existing ids keep their paths. |
| 6 | Disconnect unlinked only the live token, leaving `*.corrupt-*` residue that could still be decryptable. It now clears that connection's residue too. |
| 7 | Key custody was invisible — `status` looked identical whether the key was in the Keychain or sitting in the vault beside the ciphertext it protects. It now says which, in plain language. |
| 8 | Disconnect implied revocation it does not perform. It now says the credential was removed locally and that access must be revoked at the provider. |

## Deliberately not done

Native Security.framework binding with an app-scoped ACL, credential generation counters, and an authenticated registry. All three defend against an attacker who already has same-user access — which is a documented residual risk for this class of local credential store (the same property as `~/.aws/credentials`, `gh auth token`, npm tokens), not a regression. Reasons recorded in the gate document. The user-facing wording is bound to stay honest about it.

## Verification

- **132/132** `npm run test:integrations`, run independently rather than taken from the implementer's report.
- Every fix landed **red-first**; the failing output for each is in the evidence bundle.
- The one deleted test (`callback server rejects a mismatched OAuth state`) was replaced because that behaviour deliberately changed in fix 3. The replacement asserts the stronger property: a wrong-state request returns 400 and does **not** settle the pending promise, and the real callback still succeeds afterwards.
- Fix 5 carried a regression risk, checked directly: **all 775 catalog provider ids** are lowercase and contain no `__`, so nothing in the catalog breaks.
- All PR diff gates run locally against `origin/main`: doc-drift, path-contract, test-delta, portable-contract, connections-contract — green.
- Lifted-source conformance pins updated with the new divergences **declared**, not loosened.

## Two known nits, left deliberately

- `keyCustodyMode()` reports `file` if a stale `.dex-cm.key` exists even when the Keychain entry is the one in use. Errs pessimistic, which is the safe direction for a security disclosure.
- The custody line prints on every `status` run, including the reassuring Keychain case. Moving it to `/dex-doctor`-only is a reasonable call if preferred.

## Not in this PR

Phase 5 step 2 — provisioning the `/connect` skill and the session-start health hook. That is what opens the feature to real users, so it needs Dave's go-ahead and lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYrZr5tGFNsVzxaAKbpbka