### PR TITLE
sec(integrations): Phase 5a connection-manager hardening

### DIFF
--- a/core/integrations/connection-manager/auth-context.cjs
+++ b/core/integrations/connection-manager/auth-context.cjs
@@ -125,10 +125,34 @@ function secretsOf(ctx) {
   return [...out].sort((a, b) => b.length - a.length);
 }
 
-/** Replace every occurrence of each secret in `text` with '***'. */
+function encodedSecretForms(secret) {
+  const forms = new Set([secret, Buffer.from(secret, 'utf8').toString('base64')]);
+  try {
+    const percentEncoded = encodeURIComponent(secret);
+    forms.add(percentEncoded);
+    forms.add(percentEncoded.replace(/%[0-9A-F]{2}/g, (hex) => hex.toLowerCase()));
+  } catch {
+    /* malformed surrogate: raw + base64 forms still redact */
+  }
+  const formEncoded = new URLSearchParams({ value: secret }).toString().slice('value='.length);
+  forms.add(formEncoded);
+  forms.add(formEncoded.replace(/%[0-9A-F]{2}/g, (hex) => hex.toLowerCase()));
+  return forms;
+}
+
+/** Replace every raw, URL/form-encoded, or base64 occurrence of each secret in `text` with '***'. */
 function redactSecrets(text, secrets) {
   let s = String(text);
-  for (const secret of secrets || []) s = s.split(secret).join('***');
+  const forms = new Set();
+  for (const secret of secrets || []) {
+    if (typeof secret !== 'string' || secret.length < 4) continue;
+    for (const form of encodedSecretForms(secret)) {
+      if (form.length >= 4) forms.add(form);
+    }
+  }
+  for (const form of [...forms].sort((a, b) => b.length - a.length)) {
+    s = s.split(form).join('***');
+  }
   return s;
 }
 

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -156,13 +156,15 @@ test('rotating refresh tokens persist and the next refresh uses the newest token
   }
 });
 
-test('callback server rejects a mismatched OAuth state', async () => {
+test('callback server ignores a mismatched OAuth state and accepts the valid callback', async () => {
   const harness = callbackHarness();
   const cb = await oauth.startCallbackServer({ ports: [3847], timeoutMs: 1000, createServer: harness.createServer });
   const pending = cb.waitForCode({ expectedState: 'expected-state' });
-  const response = harness.request(harness.servers[0], '/callback?code=abc&state=wrong-state');
-  assert.equal(response.status, 400);
-  await assert.rejects(pending, /state mismatch/i);
+  const invalid = harness.request(harness.servers[0], '/callback?code=abc&state=wrong-state');
+  assert.equal(invalid.status, 404);
+  const valid = harness.request(harness.servers[0], '/callback?code=good&state=expected-state');
+  assert.equal(valid.status, 200);
+  assert.deepEqual(await pending, { code: 'good', state: 'expected-state' });
 });
 
 test('callback server times out and closes cleanly', async () => {

--- a/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
@@ -1,0 +1,328 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { EventEmitter } = require('node:events');
+const { spawnSync } = require('node:child_process');
+
+const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5a-'));
+process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_NO_KEYCHAIN = '1';
+
+const store = require('./token-store.cjs');
+const oauth = require('./oauth-flow.cjs');
+const health = require('./health.cjs');
+
+test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+
+function callbackHarness() {
+  const server = new EventEmitter();
+  server.listening = false;
+  server.listen = (port, _host, onListening) => {
+    server.port = port;
+    server.listening = true;
+    queueMicrotask(onListening);
+  };
+  server.address = () => ({ port: server.port });
+  server.close = () => {
+    server.listening = false;
+  };
+  const request = (url) => {
+    const response = {
+      writeHead(status, headers = {}) {
+        response.status = status;
+        response.headers = headers;
+        return response;
+      },
+      end(body) {
+        response.body = body;
+      },
+    };
+    server.emit('request', { url }, response);
+    return response;
+  };
+  return { server, createServer: () => server, request };
+}
+
+test('M1: encrypted envelopes reject truncated GCM tags and preserve normal round-trips', () => {
+  const envelope = store.encrypt('phase5a-secret', 'token:m1');
+
+  assert.equal(store.decrypt(envelope, 'token:m1'), 'phase5a-secret');
+  for (const bytes of [4, 8, 15]) {
+    const truncated = {
+      ...envelope,
+      tag: Buffer.from(envelope.tag, 'base64').subarray(0, bytes).toString('base64'),
+    };
+    assert.throws(
+      () => store.decrypt(truncated, 'token:m1'),
+      /Unsupported encrypted credential envelope/i,
+      `${bytes}-byte tag must be rejected before decryption`
+    );
+  }
+});
+
+test('M2: callback provider errors are HTML-safe and carry browser hardening headers', async () => {
+  const harness = callbackHarness();
+  const callback = await oauth.startCallbackServer({
+    ports: [3847],
+    timeoutMs: 1000,
+    createServer: harness.createServer,
+  });
+  const pending = callback.waitForCode({ expectedState: 'right-state' });
+  const rejected = assert.rejects(pending, /Provider returned error/);
+  const response = harness.request(
+    '/callback?state=right-state&error=%3Cscript%3Ealert(1)%3C%2Fscript%3E'
+  );
+
+  assert.equal(response.headers['Content-Type'], 'text/html; charset=utf-8');
+  assert.equal(response.headers['Content-Security-Policy'], "default-src 'none'");
+  assert.equal(response.headers['X-Content-Type-Options'], 'nosniff');
+  assert.doesNotMatch(response.body, /<script>/i);
+  assert.match(response.body, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  await rejected;
+});
+
+test('M4: connection ids reject the filename separator sentinel', () => {
+  assert.throws(
+    () => store.saveApiKey('foo__bar', { apiKey: 'FAKE-COLLISION-KEY' }),
+    /reserved.*__/i
+  );
+  assert.throws(
+    () => store.saveApiKey('foo:bar__baz', { apiKey: 'FAKE-COLLISION-KEY' }),
+    /reserved.*__/i
+  );
+});
+
+test('L1: invalid callback traffic cannot abort a pending OAuth flow', async () => {
+  const harness = callbackHarness();
+  const callback = await oauth.startCallbackServer({
+    ports: [3847],
+    timeoutMs: 1000,
+    createServer: harness.createServer,
+  });
+  const pending = callback.waitForCode({ expectedState: 'right-state' });
+  let settled = false;
+  pending.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+
+  const unsolicited = harness.request('/callback?code=attacker&state=wrong-state');
+  assert.equal(unsolicited.status, 404);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, 'invalid state must leave the OAuth attempt pending');
+
+  const valid = harness.request('/callback?code=good-code&state=right-state');
+  assert.equal(valid.status, 200);
+  assert.deepEqual(await pending, { code: 'good-code', state: 'right-state' });
+});
+
+test(
+  'H2: a failing macOS keychain cannot silently fall back beside ciphertext',
+  { skip: process.platform === 'darwin' ? false : 'macOS keychain behavior' },
+  () => {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-fake-security-'));
+    const fakeSecurity = path.join(fakeBin, 'security');
+    fs.writeFileSync(fakeSecurity, '#!/bin/sh\nexit 1\n', { mode: 0o700 });
+    const storePath = path.join(__dirname, 'token-store.cjs');
+    const command = `require(${JSON.stringify(storePath)}).encrypt('secret')`;
+
+    const keychainVault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-keychain-fail-'));
+    const keychainEnv = { ...process.env, DEX_VAULT: keychainVault, PATH: `${fakeBin}:${process.env.PATH}` };
+    delete keychainEnv.DEX_CM_NO_KEYCHAIN;
+    const failed = spawnSync(process.execPath, ['-e', command], { env: keychainEnv, encoding: 'utf8' });
+
+    const fileVault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-keyfile-ok-'));
+    const fileEnv = { ...keychainEnv, DEX_VAULT: fileVault, DEX_CM_NO_KEYCHAIN: '1' };
+    const allowed = spawnSync(process.execPath, ['-e', command], { env: fileEnv, encoding: 'utf8' });
+
+    try {
+      assert.notEqual(failed.status, 0);
+      assert.match(failed.stderr, /keychain.*failed|could not.*keychain/i);
+      assert.equal(
+        fs.existsSync(path.join(keychainVault, 'System', 'credentials', '.dex-cm.key')),
+        false
+      );
+      assert.equal(allowed.status, 0, allowed.stderr);
+      assert.equal(
+        fs.existsSync(path.join(fileVault, 'System', 'credentials', '.dex-cm.key')),
+        true
+      );
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+      fs.rmSync(keychainVault, { recursive: true, force: true });
+      fs.rmSync(fileVault, { recursive: true, force: true });
+    }
+  }
+);
+
+test('H5: dex-call --status redacts encoded query-parameter credentials', () => {
+  const secret = '/?+ ';
+  const preloadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-offline-fetch-'));
+  const preload = path.join(preloadDir, 'preload.cjs');
+  fs.writeFileSync(
+    preload,
+    "globalThis.fetch=async()=>({ok:true,status:200,statusText:'OK',text:async()=>'{}'});\n"
+  );
+  store.saveApiKey('google-gemini', { apiKey: secret }, { provider: 'google-gemini', authMode: 'API_KEY' });
+
+  const result = spawnSync(
+    process.execPath,
+    ['--require', preload, path.join(__dirname, 'dex-call.cjs'), 'google-gemini', '/v1/models', '--status', '--raw'],
+    { env: { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' }, encoding: 'utf8' }
+  );
+
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const output = `${result.stdout}\n${result.stderr}`;
+    for (const representation of [
+      secret,
+      encodeURIComponent(secret),
+      new URLSearchParams({ value: secret }).get('value'),
+      new URLSearchParams({ value: secret }).toString().slice('value='.length),
+      Buffer.from(secret).toString('base64'),
+    ]) {
+      assert.ok(!output.includes(representation), `status output leaked ${JSON.stringify(representation)}: ${output}`);
+    }
+    assert.match(result.stderr, /\*\*\*/);
+  } finally {
+    store.deleteToken('google-gemini');
+    fs.rmSync(preloadDir, { recursive: true, force: true });
+  }
+});
+
+test('H5: OAuth code-exchange errors never expose reflected codes or client secrets', async () => {
+  const authorizationCode = 'FAKE-AUTH-CODE-MUST-NOT-LEAK';
+  const clientSecret = 'FAKE-CLIENT-SECRET-MUST-NOT-LEAK';
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: false,
+    status: 400,
+    text: async () =>
+      JSON.stringify({ error: `invalid_grant ${authorizationCode} ${clientSecret}` }),
+  });
+
+  try {
+    await assert.rejects(
+      oauth.exchangeCodeForToken(
+        {
+          tokenUrl: 'https://offline-token-endpoint.invalid/token',
+          tokenRequestAuthMethod: 'body',
+          bodyFormat: 'form',
+        },
+        {
+          code: authorizationCode,
+          clientId: 'FAKE-CLIENT-ID',
+          clientSecret,
+          redirectUri: 'http://127.0.0.1/callback',
+        }
+      ),
+      (error) => {
+        const diagnostic = `${error.message}\n${JSON.stringify(error)}`;
+        assert.ok(!diagnostic.includes(authorizationCode), diagnostic);
+        assert.ok(!diagnostic.includes(clientSecret), diagnostic);
+        assert.equal(error.body, undefined);
+        assert.equal(error.code, 'token_exchange_rejected');
+        return true;
+      }
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('H5: OAuth refresh stores only a normalized error code, never a reflected secret', async () => {
+  const connId = 'h5-refresh';
+  const refreshToken = 'FAKE-REFRESH-TOKEN-MUST-NOT-LEAK';
+  const clientSecret = 'FAKE-REFRESH-CLIENT-SECRET-MUST-NOT-LEAK';
+  store.setOAuthApp('google', { clientId: 'FAKE-CLIENT-ID', clientSecret });
+  store.saveToken(
+    connId,
+    {
+      access_token: 'FAKE-OLD-ACCESS-TOKEN',
+      refresh_token: refreshToken,
+      expires_at: Date.now() - 1,
+    },
+    { provider: 'google' }
+  );
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: false,
+    status: 400,
+    headers: { get: () => null },
+    json: async () => ({
+      error: 'invalid_grant',
+      error_description: `provider echoed ${refreshToken} ${clientSecret}`,
+    }),
+  });
+
+  try {
+    await assert.rejects(health.refreshToken(connId, { force: true }), (error) => {
+      assert.ok(!error.message.includes(refreshToken), error.message);
+      assert.ok(!error.message.includes(clientSecret), error.message);
+      return true;
+    });
+    const registry = store.readRegistry()[connId];
+    const evidence = health.connectionLedger().tail(connId, 10);
+    const persisted = JSON.stringify({ registry, evidence });
+    assert.equal(registry.error, 'invalid_grant');
+    assert.ok(!persisted.includes(refreshToken), persisted);
+    assert.ok(!persisted.includes(clientSecret), persisted);
+  } finally {
+    global.fetch = originalFetch;
+    store.deleteToken(connId);
+  }
+});
+
+test('H6: credential writes fail closed when any credentials path is already git-tracked', () => {
+  const storePath = path.join(__dirname, 'token-store.cjs');
+  const command = `require(${JSON.stringify(storePath)}).saveApiKey('h6-test',{apiKey:'FAKE-H6-KEY'})`;
+  const makeRepo = (prefix) => {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    const init = spawnSync('git', ['init', '-q', vault], { encoding: 'utf8' });
+    assert.equal(init.status, 0, init.stderr);
+    return vault;
+  };
+
+  const trackedVault = makeRepo('dex-cm-h6-tracked-');
+  const trackedCredentials = path.join(trackedVault, 'System', 'credentials');
+  fs.mkdirSync(trackedCredentials, { recursive: true });
+  fs.writeFileSync(path.join(trackedCredentials, 'x'), 'already tracked\n');
+  const add = spawnSync('git', ['-C', trackedVault, 'add', 'System/credentials/x'], {
+    encoding: 'utf8',
+  });
+  assert.equal(add.status, 0, add.stderr);
+
+  const cleanVault = makeRepo('dex-cm-h6-clean-');
+  const run = (vault) =>
+    spawnSync(process.execPath, ['-e', command], {
+      env: { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' },
+      encoding: 'utf8',
+    });
+  const blocked = run(trackedVault);
+  const allowed = run(cleanVault);
+
+  try {
+    assert.notEqual(blocked.status, 0);
+    assert.match(blocked.stderr, /tracked.*System\/credentials|git rm --cached/i);
+    assert.equal(fs.existsSync(path.join(trackedCredentials, '.dex-cm.key')), false);
+    assert.equal(fs.existsSync(path.join(trackedCredentials, 'connections.json')), false);
+    assert.equal(fs.existsSync(path.join(trackedCredentials, 'tokens')), false);
+    assert.equal(allowed.status, 0, allowed.stderr);
+    assert.equal(
+      fs.existsSync(path.join(cleanVault, 'System', 'credentials', 'tokens', 'h6-test.json')),
+      true
+    );
+  } finally {
+    fs.rmSync(trackedVault, { recursive: true, force: true });
+    fs.rmSync(cleanVault, { recursive: true, force: true });
+  }
+});

--- a/core/integrations/connection-manager/connection-manager.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.test.cjs
@@ -21,6 +21,7 @@ const { execFileSync, spawnSync } = require('node:child_process');
 // Point everything at a throwaway vault BEFORE requiring the store modules.
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-test-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const catalog = require('./catalog.cjs');
 const oauth = require('./oauth-flow.cjs');
@@ -31,7 +32,7 @@ const dexcall = require('./dex-call.cjs'); // buildRequest / parseArgs (generic 
 const authctx = require('./auth-context.cjs'); // resolveAuthContext (shared auth seam)
 
 const DIR = __dirname;
-const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT };
+const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
 
 // Pick a real paste-a-key provider for the Class-B path. Prefer one that needs ONLY an
 // API key (no connection_config) so the single-secret round-trip tests stay simple; the

--- a/core/integrations/connection-manager/health.cjs
+++ b/core/integrations/connection-manager/health.cjs
@@ -299,7 +299,10 @@ async function refreshToken(service, { force = false } = {}) {
         return fresh.access_token;
       } catch (err) {
         const needsReauth = err && err.permanent === true;
-        const code = String((err && err.message) || 'refresh_failed').slice(0, 200);
+        const code =
+          err && typeof err.code === 'string' && /^[A-Za-z][A-Za-z0-9._-]{0,79}$/.test(err.code)
+            ? err.code
+            : 'refresh_failed';
         recordConnectionEvent(connId, 'refresh', {
           ok: false,
           error: { category: needsReauth ? 'auth_permanent' : 'transient', code, message: code },

--- a/core/integrations/connection-manager/lib/oauth-refresh.js
+++ b/core/integrations/connection-manager/lib/oauth-refresh.js
@@ -63,10 +63,11 @@ function isRefreshDue(record, bufferMs = DEFAULT_REFRESH_BUFFER_MS) {
 }
 
 class RefreshError extends Error {
-	constructor(message, { permanent = false, cause, retryAfterMs } = {}) {
+	constructor(message, { permanent = false, cause, retryAfterMs, code = "refresh_failed" } = {}) {
 		super(message);
 		this.name = "RefreshError";
 		this.permanent = permanent;
+		this.code = code;
 		// A rate-limit hint (ms) carried on a transient 429 so the retry loop
 		// can back off appropriately. Null when there is no usable hint.
 		this.retryAfterMs = retryAfterMs ?? null;
@@ -110,10 +111,13 @@ async function refreshOAuthToken({
 	delayImpl = delay,
 } = {}) {
 	if (typeof fetchImpl !== "function") {
-		throw new RefreshError("No fetch implementation available for token refresh", { permanent: false });
+		throw new RefreshError("No fetch implementation available for token refresh", {
+			permanent: false,
+			code: "refresh_unavailable",
+		});
 	}
 	if (!refreshToken) {
-		throw new RefreshError("No refresh token on file", { permanent: false });
+		throw new RefreshError("No refresh token on file", { permanent: false, code: "no_refresh_token" });
 	}
 
 	const body = new URLSearchParams({
@@ -144,8 +148,8 @@ async function refreshOAuthToken({
 		} catch (error) {
 			const timedOut = controller.signal.aborted || error?.name === "AbortError";
 			throw new RefreshError(
-				timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`,
-				{ permanent: false, cause: error },
+				timedOut ? `Token refresh timed out after ${timeoutMs}ms` : "Token refresh request failed",
+				{ permanent: false, cause: error, code: timedOut ? "refresh_timeout" : "refresh_request_failed" },
 			);
 		} finally {
 			clearTimeout(timer);
@@ -155,7 +159,11 @@ async function refreshOAuthToken({
 		try {
 			data = await response.json();
 		} catch (error) {
-			throw new RefreshError("Token refresh returned a non-JSON response", { permanent: false, cause: error });
+			throw new RefreshError("Token refresh returned a non-JSON response", {
+				permanent: false,
+				cause: error,
+				code: "refresh_response_invalid",
+			});
 		}
 
 		// Slack signals failure via `ok: false` (HTTP 200, error in the body);
@@ -168,13 +176,19 @@ async function refreshOAuthToken({
 			// (from the body `retry_after` or the response headers). Other error
 			// codes keep the existing permanent/transient classification.
 			if (rateLimit.is429(data)) {
-				throw new RefreshError(data?.error_description || data?.error || "Token refresh was rate limited", {
+				throw new RefreshError("Token refresh was rate limited", {
 					permanent: false,
+					code: "rate_limited",
 					retryAfterMs: rateLimit.retryAfterMs(data) ?? rateLimit.retryAfterMs(response),
 				});
 			}
-			throw new RefreshError(data?.error_description || data?.error || "Token refresh was rejected", {
+			const providerCode =
+				typeof data?.error === "string" && /^[A-Za-z][A-Za-z0-9._-]{0,79}$/.test(data.error.trim())
+					? data.error.trim()
+					: "refresh_rejected";
+			throw new RefreshError(`Token refresh was rejected (${providerCode})`, {
 				permanent: isPermanentError(data),
+				code: providerCode,
 			});
 		}
 		if (response && typeof response.ok === "boolean" && !response.ok) {
@@ -185,6 +199,7 @@ async function refreshOAuthToken({
 			const isRateLimited = status === 429;
 			throw new RefreshError(`Token refresh failed (HTTP ${status})`, {
 				permanent: status >= 400 && status < 500 && !isRateLimited,
+				code: isRateLimited ? "rate_limited" : `http_${status || "error"}`,
 				retryAfterMs: isRateLimited ? rateLimit.retryAfterMs(response) ?? rateLimit.retryAfterMs(data) : null,
 			});
 		}
@@ -194,7 +209,10 @@ async function refreshOAuthToken({
 		const source = data?.authed_user && typeof data.authed_user === "object" ? data.authed_user : data;
 		const parsed = parseTokenResponse(source);
 		if (!parsed || !parsed.accessToken) {
-			throw new RefreshError("Token refresh response did not include a usable access token", { permanent: false });
+			throw new RefreshError("Token refresh response did not include a usable access token", {
+				permanent: false,
+				code: "missing_access_token",
+			});
 		}
 
 		const expiresIn = Number(parsed.expiresIn);

--- a/core/integrations/connection-manager/lifted-conformance.test.cjs
+++ b/core/integrations/connection-manager/lifted-conformance.test.cjs
@@ -25,12 +25,13 @@ const FILES = {
   },
   'oauth-refresh.js': {
     source: '0f29891a988d913c8b4bfddc9ee9d8f4c91328784534107ff65abe3d4cac4783',
-    lifted: 'cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392',
-    mode: 'injectable-delay',
+    lifted: '254ae86b690b851942f888b04a54d1026e12f9a24e7ae35f6a813b2dc22bef96',
+    mode: 'core-adaptation',
     divergences: [
       'source provenance header',
       'injectable delay used only to prove Retry-After clamping',
       'credential-bearing refresh requests refuse redirects',
+      'provider response diagnostics are reduced to normalized error codes and fixed safe messages',
     ],
   },
   'connector-model.js': {

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -43,6 +43,20 @@ function listenOnFirstFreePort(ports, createServer) {
   });
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeProviderErrorCode(value, fallback) {
+  const code = typeof value === 'string' ? value.trim() : '';
+  return /^[A-Za-z][A-Za-z0-9._-]{0,79}$/.test(code) ? code : fallback;
+}
+
 /**
  * Start a localhost callback server. Returns:
  *   { redirectUri, waitForCode(): Promise<{code,state}>, close() }
@@ -80,18 +94,26 @@ async function startCallbackServer({
         const code = url.searchParams.get('code');
         const state = url.searchParams.get('state');
         const stateMismatch = expectedState !== undefined && state !== expectedState;
-        res.writeHead(stateMismatch ? 400 : 200, { 'Content-Type': 'text/html; charset=utf-8' });
+        if (stateMismatch) {
+          res.writeHead(404).end();
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Content-Security-Policy': "default-src 'none'",
+          'X-Content-Type-Options': 'nosniff',
+        });
         res.end(
-          stateMismatch
-            ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection aborted</h2><p>OAuth state mismatch.</p></body></html>'
-            : error
-            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${error}</p><p>You can close this tab and return to Dex.</p></body></html>`
+          error
+            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${escapeHtml(error)}</p><p>You can close this tab and return to Dex.</p></body></html>`
             : `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>✅ Connected</h2><p>You can close this tab and return to Dex.</p></body></html>`
         );
         clearTimeout(timeout);
         server.close();
-        if (stateMismatch) reject(new Error('OAuth state mismatch — possible CSRF, aborting.'));
-        else if (error) reject(new Error(`Provider returned error: ${error}`));
+        if (error) {
+          const code = normalizeProviderErrorCode(error, 'oauth_authorization_rejected');
+          reject(Object.assign(new Error(`Provider returned error: ${code}`), { code }));
+        }
         else resolve({ code, state });
       });
     });
@@ -173,9 +195,10 @@ async function postToken(providerConfig, body, headers) {
     json = { raw: text };
   }
   if (!res.ok) {
-    const err = new Error(`Token endpoint ${res.status}: ${json.error || text.slice(0, 200)}`);
+    const code = normalizeProviderErrorCode(json.error, 'token_exchange_rejected');
+    const err = new Error(`Token endpoint rejected the request (HTTP ${res.status}, ${code}).`);
     err.status = res.status;
-    err.body = json;
+    err.code = code;
     throw err;
   }
   return json;

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -28,6 +28,7 @@ const { TOKEN_ENVELOPE_VERSION, LOCK_PROTOCOL } = require('./contract.cjs');
 
 const KEYCHAIN_SERVICE = 'dex-connection-manager';
 const KEYCHAIN_ACCOUNT = 'token-store-key';
+const MAX_ENCRYPTED_DATA_BYTES = 1024 * 1024;
 
 /** Resolve the credentials directory from the configured vault root. */
 function credentialsDir() {
@@ -76,6 +77,47 @@ function ensureCredentialsGitignore(dir) {
   }
 }
 
+const _gitSafeCredentialDirs = new Set();
+
+function assertCredentialsNotTracked() {
+  const vault = fs.realpathSync(path.resolve(process.env.DEX_VAULT || process.env.VAULT_PATH || ''));
+  const credentialRoot = path.join(vault, 'System', 'credentials');
+  if (_gitSafeCredentialDirs.has(credentialRoot)) return;
+
+  let repoRoot;
+  try {
+    repoRoot = execFileSync('git', ['-C', vault, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const stderr = String((error && error.stderr) || '');
+    if (error && error.status === 128 && /not a git repository|cannot change to/i.test(stderr)) {
+      _gitSafeCredentialDirs.add(credentialRoot);
+      return;
+    }
+    throw new Error(`Cannot verify whether System/credentials is tracked by Git: ${stderr.trim() || error.message}`);
+  }
+
+  const relativeCredentialRoot = path.relative(repoRoot, credentialRoot).split(path.sep).join('/');
+  let tracked;
+  try {
+    tracked = execFileSync('git', ['-C', repoRoot, 'ls-files', '--', relativeCredentialRoot], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    throw new Error(`Cannot verify whether System/credentials is tracked by Git: ${error.message}`);
+  }
+  if (tracked) {
+    throw new Error(
+      `Credential write refused because Git already tracks path(s) under System/credentials:\n${tracked}\n` +
+        `Remove them from Git's index without deleting local files, for example: git rm --cached -r -- ${relativeCredentialRoot}`
+    );
+  }
+  _gitSafeCredentialDirs.add(credentialRoot);
+}
+
 function tokensDir() {
   const dir = path.join(credentialsDir(), 'tokens');
   ensureDir(credentialsDir()); // ensure the .gitignore guard exists before any token lands
@@ -97,6 +139,10 @@ function listTokenFiles() {
 // `security` binary is unavailable or blocked.
 function keychainDisabled() {
   return process.env.DEX_CM_NO_KEYCHAIN === '1';
+}
+
+function fileKeyAllowed() {
+  return process.platform !== 'darwin' || keychainDisabled();
 }
 
 function keyFromMacKeychain() {
@@ -136,6 +182,13 @@ function keyFromFile() {
 }
 
 function writeKeyFile(keyB64) {
+  if (!fileKeyAllowed()) {
+    throw new Error(
+      'Dex could not store its encryption key in macOS Keychain. No credential was saved. ' +
+      'Fix Keychain access, or explicitly set DEX_CM_NO_KEYCHAIN=1 to use file-based key storage.'
+    );
+  }
+  assertCredentialsNotTracked();
   ensureDir(credentialsDir());
   const keyPath = path.join(credentialsDir(), '.dex-cm.key');
   writeFileAtomic(keyPath, keyB64, { mode: 0o600 });
@@ -177,7 +230,7 @@ function getKey() {
   let found = null;
   let lookupFailed = false;
   try {
-    found = keyFromMacKeychain() || keyFromFile();
+    found = keyFromMacKeychain() || (fileKeyAllowed() ? keyFromFile() : null);
   } catch {
     lookupFailed = true; // unreadable key source counts as loss, not as "fresh start"
   }
@@ -200,7 +253,16 @@ function getKey() {
   if (credentialCount > 0) throw new KeyLossError(credentialCount, Boolean(found) || lookupFailed);
   const key = crypto.randomBytes(32);
   const b64 = key.toString('base64');
-  if (!storeKeyInMacKeychain(b64)) writeKeyFile(b64);
+  if (process.platform === 'darwin' && !keychainDisabled()) {
+    if (!storeKeyInMacKeychain(b64)) {
+      throw new Error(
+        'Dex could not store its encryption key in macOS Keychain. No credential was saved. ' +
+          'Fix Keychain access, or explicitly set DEX_CM_NO_KEYCHAIN=1 to use file-based key storage.'
+      );
+    }
+  } else {
+    writeKeyFile(b64);
+  }
   _cachedKey = key;
   return key;
 }
@@ -310,13 +372,36 @@ function encrypt(plaintext, aad = '') {
   return { v: TOKEN_ENVELOPE_VERSION, aad, iv: iv.toString('base64'), tag: tag.toString('base64'), data: data.toString('base64') };
 }
 
+function decodeCanonicalBase64(value, field, { exactBytes, maxBytes } = {}) {
+  const maxEncodedLength = maxBytes === undefined ? Infinity : Math.ceil(maxBytes / 3) * 4;
+  if (
+    typeof value !== 'string' ||
+    value.length > maxEncodedLength ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
+    throw new Error(`Unsupported encrypted credential envelope: invalid ${field}.`);
+  }
+  const decoded = Buffer.from(value, 'base64');
+  if (
+    decoded.toString('base64') !== value ||
+    (exactBytes !== undefined && decoded.length !== exactBytes) ||
+    (maxBytes !== undefined && decoded.length > maxBytes)
+  ) {
+    throw new Error(`Unsupported encrypted credential envelope: invalid ${field}.`);
+  }
+  return decoded;
+}
+
 function decrypt(envelope, aad = '') {
   if (!envelope || envelope.v !== TOKEN_ENVELOPE_VERSION) throw new Error('Unsupported encrypted credential envelope version.');
   if (envelope.aad !== aad) throw new EnvelopeBindingError();
-  const decipher = crypto.createDecipheriv('aes-256-gcm', getKey(), Buffer.from(envelope.iv, 'base64'));
+  const iv = decodeCanonicalBase64(envelope.iv, 'iv', { exactBytes: 12 });
+  const tag = decodeCanonicalBase64(envelope.tag, 'tag', { exactBytes: 16 });
+  const data = decodeCanonicalBase64(envelope.data, 'data', { maxBytes: MAX_ENCRYPTED_DATA_BYTES });
+  const decipher = crypto.createDecipheriv('aes-256-gcm', getKey(), iv);
   decipher.setAAD(Buffer.from(aad, 'utf8'));
-  decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
-  const out = Buffer.concat([decipher.update(Buffer.from(envelope.data, 'base64')), decipher.final()]);
+  decipher.setAuthTag(tag);
+  const out = Buffer.concat([decipher.update(data), decipher.final()]);
   return out.toString('utf8');
 }
 
@@ -338,9 +423,15 @@ function parseConnectionId(id) {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(provider)) {
     throw new Error(`Invalid provider in connection id '${id}'. Use letters, digits, '.', '-' or '_' (must start with a letter or digit).`);
   }
+  if (provider.includes('__')) {
+    throw new Error(`Invalid connection id '${id}': reserved filename separator '__' is not allowed.`);
+  }
   if (i === -1) return { provider: s, alias: null, connId: s };
   const alias = s.slice(i + 1).toLowerCase();
   if (!/^[a-z0-9_-]+$/.test(alias)) throw new Error(`Invalid connection alias in '${id}'. Use letters, digits, '-' or '_'.`);
+  if (alias.includes('__')) {
+    throw new Error(`Invalid connection id '${id}': reserved filename separator '__' is not allowed.`);
+  }
   return { provider, alias, connId: `${provider}:${alias}` };
 }
 
@@ -376,6 +467,7 @@ function tokenPath(connId) {
 
 /** Persist a token object (encrypted) and refresh the registry entry. `connId` may be `provider` or `provider:alias`. */
 function saveToken(connId, token, meta = {}) {
+  assertCredentialsNotTracked();
   const parsed = parseConnectionId(connId);
   // Encrypt BEFORE touching the registry: if the key is lost this triggers the
   // loud recovery first, so the entry we then upsert stays 'connected'.
@@ -412,6 +504,7 @@ function saveToken(connId, token, meta = {}) {
  * @param meta      { provider, scopes, connectedAt, extra }
  */
 function saveApiKey(service, secretObj, meta = {}) {
+  assertCredentialsNotTracked();
   const stored = { kind: 'api_key', ...secretObj, obtained_at: Date.now() };
   const parsed = parseConnectionId(service);
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(stored), `token:${service}`), null, 2); // key-loss recovery before registry writes; see saveToken
@@ -727,6 +820,7 @@ function getOAuthApp(provider) {
  */
 function setOAuthApp(provider, { clientId, clientSecret = '' }) {
   if (!clientId) throw new Error('setOAuthApp requires a clientId.');
+  assertCredentialsNotTracked();
   ensureDir(credentialsDir());
   const encryptedSecret = encryptForSave(clientSecret, `oauth-app:${provider}`);
   return withStoreLock(() => {

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,13 +11,13 @@
         "connection-manager"
       ],
       "fileCount": 17,
-      "totalBytes": 173418,
-      "treeHash": "57238c08d18467668da0c64dd450f45275662b67fbcb639006eb3c1e79c1334e",
+      "totalBytes": 179114,
+      "treeHash": "749f981a8740a218f4189ef69c34e0f685435eb47c1a8da7e5630c0421e4f9ac",
       "files": [
         {
           "path": "auth-context.cjs",
-          "bytes": 5439,
-          "sha256": "6c1f49162f46e4dcc4ceb38aa7c02415970f3e19073d14fe3974c446afd9b585"
+          "bytes": 6351,
+          "sha256": "b90c56e323f0dcd9a2a19044b527b6f3378aa6cf48b6853b72f29a8564b83088"
         },
         {
           "path": "catalog.cjs",
@@ -51,8 +51,8 @@
         },
         {
           "path": "health.cjs",
-          "bytes": 14672,
-          "sha256": "df063349f49c85a08c8d608905cad6b4dd635af2b0f82814360afb7db24a0f4f"
+          "bytes": 14760,
+          "sha256": "6f6a2a68e9da9c5a0807c1325f9aa18444471c533ee9f5607b00d79b8192cc90"
         },
         {
           "path": "index.cjs",
@@ -76,8 +76,8 @@
         },
         {
           "path": "lib/oauth-refresh.js",
-          "bytes": 10609,
-          "sha256": "cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392"
+          "bytes": 11070,
+          "sha256": "254ae86b690b851942f888b04a54d1026e12f9a24e7ae35f6a813b2dc22bef96"
         },
         {
           "path": "lib/rate-limit.js",
@@ -86,8 +86,8 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 9195,
-          "sha256": "6ab21fb5139da00a38f98658d38c6c0ef416aa06aba4ef9073d16b450863979d"
+          "bytes": 9720,
+          "sha256": "162fdc24771a1f041562f835e4ccb0645740db76137b0badaf5536caecf30e22"
         },
         {
           "path": "README.md",
@@ -96,8 +96,8 @@
         },
         {
           "path": "token-store.cjs",
-          "bytes": 30324,
-          "sha256": "749230cf3c607a9faf1d55efb7e30639644345e35009b8b86477d07a842f92a8"
+          "bytes": 34034,
+          "sha256": "17fbe97f5eb97b1145c562149e5f2f638e6b4a230841f1e52a37ef2c2fcf4ed0"
         }
       ]
     }


### PR DESCRIPTION
First phase of the Option B security work (architecture: `~/dex/artifacts/dex-core-connection-manager-option-b-security-architecture.md` §6). These are the cheap, unconditional fixes from the 2026-07-24 adversarial threat model — correct under any threat model, no architecture change. **The `/connect` doorway stays closed**; the broker, origin-pinning, and trust-MAC work are later phases (5b–5e).

Findings closed (see threat model report for full detail):

- **M1 — crypto:** envelope now strictly validated (IV=12 bytes, GCM tag=16 bytes, canonical base64, bounded length) before decryption. A 4-byte auth tag previously decrypted a tampered credential — reproduced independently, now rejected.
- **H2 — key custody:** on keychain-capable platforms, a keychain write failure fails closed instead of silently dropping the AES key as `.dex-cm.key` into the (often synced) vault. Explicit `DEX_CM_NO_KEYCHAIN=1` / non-darwin file path preserved.
- **H5 — leakage:** redaction extended to percent-/form-/base64-encoded secret forms; OAuth refresh + token-exchange errors store normalized codes, never reflected provider bodies.
- **H6 — git:** credential writes fail closed if git already tracks anything under `System/credentials` (ignore rules don't untrack pre-existing paths), with remediation text.
- **M2 — callback page:** provider text HTML-escaped; `Content-Security-Policy: default-src 'none'` + `X-Content-Type-Options: nosniff` added.
- **M4 — filenames:** connection ids reject the `__` sentinel so `foo:bar` and provider `foo__bar` can't collide into one token file.
- **L1 — availability:** an invalid-state callback request now 404s and keeps listening instead of aborting the OAuth attempt.

**Verification (run independently after review):**
- Red-first regression tests per item (new `connection-manager.phase5a-security.test.cjs`, 9/9)
- Serial connection-manager suite: 133/133 pass
- `check:connections-contract`: contract v1.0.0 + engine manifest verified (17 files)
- Local PR gates: path-contract, test-delta, doc-drift all pass
- Fable independently reproduced the M1 fix (tampered 4-byte-tag file now rejected, secret not exposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MUmNHSKhTxdUwGtiJ4SUy