### PR TITLE
fix(migrator): four real-vault rehearsal findings before switch-on

### DIFF
--- a/core/lifecycle/sqlite_snapshot.py
+++ b/core/lifecycle/sqlite_snapshot.py
@@ -216,6 +216,10 @@ def detect_sync_folder(path: Path) -> str | None:
     """
 
     ancestors = _ancestors(Path(path))
+    home_and_above = frozenset(_ancestors(Path.home()))
+    child_marker_ancestors = tuple(
+        directory for directory in ancestors if directory not in home_and_above
+    )
     folded_parts = tuple(part.casefold() for part in Path(path).absolute().parts)
     names_by_directory: dict[Path, frozenset[str]] = {}
     markers, provider_prefixes = _sync_folder_marker_data()
@@ -232,7 +236,7 @@ def detect_sync_folder(path: Path) -> str | None:
                 return provider
             continue
 
-        for directory in ancestors:
+        for directory in child_marker_ancestors:
             names = names_by_directory.setdefault(directory, _child_names(directory))
             if marker.kind == "child" and any(value.casefold() in names for value in marker.values):
                 return marker.provider

--- a/core/migrations/sync-folder-detector.cjs
+++ b/core/migrations/sync-folder-detector.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const DATA_PATH = path.resolve(__dirname, '..', 'data', 'sync-folder-markers.json');
@@ -145,6 +146,10 @@ function cloudstorageProvider(foldedParts, sequence, providerPrefixes) {
 
 function detectSyncFolder(candidate, markerData = SYNC_FOLDER_MARKERS) {
   const candidateAncestors = ancestors(candidate);
+  const homeAndAbove = new Set(ancestors(os.homedir()));
+  const childMarkerAncestors = candidateAncestors.filter(
+    (directory) => !homeAndAbove.has(directory),
+  );
   // JavaScript has no exact equivalent of Python str.casefold(). The shared
   // marker values are therefore validated as ASCII, where toLowerCase() and
   // casefold() agree. Path names still use the platform's Unicode lowercase.
@@ -169,7 +174,7 @@ function detectSyncFolder(candidate, markerData = SYNC_FOLDER_MARKERS) {
       continue;
     }
 
-    for (const directory of candidateAncestors) {
+    for (const directory of childMarkerAncestors) {
       if (!namesByDirectory.has(directory)) {
         namesByDirectory.set(directory, childNames(directory));
       }

--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -22,6 +22,7 @@ const ARCHIVE_MARKER = 'dex-pre-split-v2-archive.json';
 const OFFICIAL_REMOTE = 'https://github.com/davekilleen/Dex.git';
 const RESUME_EXIT = 75;
 const P3_BATCH_SIZE = 64;
+const DEFAULT_SPAWN_MAX_BUFFER = 1024 * 1024 * 1024;
 const PARA_REGIONS = ['04-Projects', '05-Areas', '06-Resources', '07-Archives'];
 const POST_SWAP_RECOVERY = 'Your files are safe. Run this migrator with --restore to return everything to exactly how it was.';
 const SNAPSHOT_PATHS = [
@@ -491,7 +492,7 @@ function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd,
     encoding: options.encoding === undefined ? 'utf8' : options.encoding,
-    maxBuffer: options.maxBuffer || 16 * 1024 * 1024,
+    maxBuffer: options.maxBuffer || DEFAULT_SPAWN_MAX_BUFFER,
   });
   if (result.error) throw result.error;
   if (!options.allowFailure && result.status !== 0) {
@@ -1421,6 +1422,19 @@ function stagedVaultInventory(root, gitDirectory) {
   return entries.sort((left, right) => left.path.localeCompare(right.path));
 }
 
+function compareVaultInventoryPaths(expected, staged) {
+  const stagedPaths = new Set(staged.map((entry) => entry.path.normalize('NFC')));
+  const expectedPaths = new Set(expected.map((entry) => entry.path.normalize('NFC')));
+  return {
+    unexpectedPaths: staged
+      .map((entry) => entry.path)
+      .filter((relative) => !expectedPaths.has(relative.normalize('NFC'))),
+    reconciledPaths: expected
+      .map((entry) => entry.path)
+      .filter((relative) => !stagedPaths.has(relative.normalize('NFC'))),
+  };
+}
+
 function phase3BuildVault(root, state) {
   const gitDirectory = path.join(root, '.dex', 'vault-staging.git');
   const trackedIgnore = loadTrackedIgnoreState(root);
@@ -1473,17 +1487,13 @@ function phase3BuildVault(root, state) {
 
   if (end < files.length) return { needsResume: true };
   plan.staged = stagedVaultInventory(root, gitDirectory);
-  const stagedPaths = new Set(plan.staged.map((entry) => entry.path));
-  const expectedPaths = new Set(plan.expected.map((entry) => entry.path));
-  const unexpectedPaths = plan.staged
-    .map((entry) => entry.path)
-    .filter((relative) => !expectedPaths.has(relative));
+  const { unexpectedPaths, reconciledPaths } = compareVaultInventoryPaths(
+    plan.expected,
+    plan.staged,
+  );
   if (unexpectedPaths.length > 0) {
     throw new Error(`P3 found unexpected staged paths and stopped before the Git swap: ${unexpectedPaths.join(', ')}`);
   }
-  const reconciledPaths = plan.expected
-    .map((entry) => entry.path)
-    .filter((relative) => !stagedPaths.has(relative));
   plan.reconciledPaths = reconciledPaths;
   writeMigrationFile(root, planPath, `${JSON.stringify(plan, null, 2)}\n`);
   if (reconciledPaths.length > 0) {
@@ -1605,7 +1615,10 @@ function phase2SnapshotAndScan(root, state) {
   snapshotFiles(root, state.startedAt);
   state.analysis = { ...state.analysis, ...analyzeMigrationPlan(root) };
   if (state.analysis.symlinkPaths.length > 0) {
-    throw new Error(`P2 refused symlinked vault entries: ${state.analysis.symlinkPaths.join(', ')}`);
+    throw new Error(
+      `P2 refused symlinked vault entries: ${state.analysis.symlinkPaths.join(', ')}. `
+      + 'Move or delete these symlinked entries, knowing that the targets are not touched, then run the migrator again; nothing has been changed by this refusal.',
+    );
   }
   state.analysis.heldBackPaths = persistHeldBackPaths(
     root,
@@ -1793,16 +1806,18 @@ function phase8Verify(root, state) {
   const treeOutput = gitDir(root, vaultGit, ['ls-tree', '-r', '-z', initialCommit], { encoding: null })
     .stdout.toString('utf8');
   const tree = new Map();
+  let treeEntryCount = 0;
   for (const record of treeOutput.split('\0').filter(Boolean)) {
     const separator = record.indexOf('\t');
     const metadata = record.slice(0, separator).split(/\s+/);
-    tree.set(record.slice(separator + 1), metadata[2]);
+    tree.set(record.slice(separator + 1).normalize('NFC'), metadata[2]);
+    treeEntryCount += 1;
   }
-  if (tree.size !== expectedEntries.length) {
-    throw new Error(`P8 initial vault snapshot differed from what Git staged in P3: staged ${expectedEntries.length} files but committed ${tree.size}.`);
+  if (treeEntryCount !== expectedEntries.length) {
+    throw new Error(`P8 initial vault snapshot differed from what Git staged in P3: staged ${expectedEntries.length} files but committed ${treeEntryCount}.`);
   }
   for (const entry of expectedEntries) {
-    const oid = tree.get(entry.path);
+    const oid = tree.get(entry.path.normalize('NFC'));
     if (!oid) throw new Error(`P8 initial vault snapshot was missing ${entry.path}, which Git staged in P3.`);
     if (entry.sha256) {
       const blob = gitDir(root, vaultGit, ['cat-file', 'blob', oid], { encoding: null }).stdout;
@@ -2416,9 +2431,11 @@ function main(argumentsList = process.argv.slice(2), root = process.cwd()) {
 }
 
 module.exports = {
+  DEFAULT_SPAWN_MAX_BUFFER,
   acquireLock,
   assertMigrationWrite,
   assertSafeMutationRoots,
+  compareVaultInventoryPaths,
   emptyLegacyExtensionBlock,
   extractLegacyExtensions,
   findReleaseRef,
@@ -2434,6 +2451,7 @@ module.exports = {
   restoreSnapshot,
   renderReport,
   snapshotFiles,
+  stagedVaultInventory,
   topologyDecision,
   writeJournal,
 };

--- a/core/tests/brain-vault-migrator-integration.test.cjs
+++ b/core/tests/brain-vault-migrator-integration.test.cjs
@@ -801,6 +801,10 @@ test('a symlink anywhere in migratable content is reported and refused before to
   const result = migrate(vault, '--auto', { expectedStatus: 1 });
 
   assert.match(result.stdout + result.stderr, /refused symlinked vault entries.*04-Projects\/linked\.md/i);
+  assert.match(
+    result.stdout + result.stderr,
+    /move or delete these symlinked entries.*targets are not touched.*run the migrator again.*nothing has been changed/i,
+  );
   assert.equal(fs.readFileSync(outsideFile, 'utf8'), 'outside bytes must never be followed\n');
   assert.equal(fs.existsSync(path.join(vault, '.dex', 'brain.git')), false);
   assert.equal(fs.existsSync(path.join(vault, '.dex', 'pre-split-archive.git')), false);

--- a/core/tests/brain-vault-migrator-unit.test.cjs
+++ b/core/tests/brain-vault-migrator-unit.test.cjs
@@ -94,6 +94,33 @@ test('synced-folder override composes with conversion modes without weakening on
   });
 });
 
+test('Git subprocesses allow at least 512 MiB of captured output by default', () => {
+  const migrator = require(MIGRATOR_PATH);
+
+  assert.ok(migrator.DEFAULT_SPAWN_MAX_BUFFER >= 512 * 1024 * 1024);
+});
+
+test('P3 verification treats decomposed filesystem paths as the same Git path', () => {
+  const migrator = require(MIGRATOR_PATH);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-migration-unicode-path-'));
+  git(root, 'init', '--quiet', '--initial-branch=main');
+  git(root, 'config', 'core.precomposeunicode', 'true');
+  const decomposed = 'Ha\u0308fele.md';
+  fs.writeFileSync(path.join(root, decomposed), 'cabinet hardware\n');
+  git(root, 'add', '--', decomposed);
+
+  const staged = migrator.stagedVaultInventory(root, path.join(root, '.git'));
+  const comparison = migrator.compareVaultInventoryPaths(
+    [{ path: decomposed }],
+    staged,
+  );
+
+  assert.deepEqual(comparison, {
+    unexpectedPaths: [],
+    reconciledPaths: [],
+  });
+});
+
 test('CLAUDE regeneration lifts the legacy extension bytes and removes legacy markers', () => {
   const migrator = require(MIGRATOR_PATH);
   const legacy = [

--- a/core/tests/sync-folder-detector.test.cjs
+++ b/core/tests/sync-folder-detector.test.cjs
@@ -79,3 +79,19 @@ test('CommonJS sync-folder marker loader fails closed on missing or malformed da
     /sync-folder marker data/i,
   );
 });
+
+test('CommonJS detector ignores Dropbox config in the user home directory', (t) => {
+  const detector = require(DETECTOR_PATH);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-sync-home-'));
+  const home = path.join(root, 'home');
+  const ordinaryVault = path.join(home, 'dex', 'rehearsal', 'vault-copy-a');
+  const dropboxVault = path.join(home, 'Dropbox', 'Vault');
+  fs.mkdirSync(path.join(home, '.dropbox'), { recursive: true });
+  fs.mkdirSync(path.join(home, 'Dropbox', '.dropbox.cache'), { recursive: true });
+  fs.mkdirSync(ordinaryVault, { recursive: true });
+  fs.mkdirSync(dropboxVault, { recursive: true });
+  t.mock.method(os, 'homedir', () => home);
+
+  assert.equal(detector.detectSyncFolder(ordinaryVault), null);
+  assert.equal(detector.detectSyncFolder(dropboxVault), 'Dropbox');
+});

--- a/core/tests/test_adoption_sqlite_snapshot.py
+++ b/core/tests/test_adoption_sqlite_snapshot.py
@@ -284,6 +284,23 @@ def test_unknown_folder_is_not_guessed_to_be_synced(tmp_path: Path) -> None:
     assert detect_sync_folder(vault) is None
 
 
+def test_sync_folder_detection_ignores_dropbox_config_in_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    ordinary_vault = home / "dex" / "rehearsal" / "vault-copy-a"
+    dropbox_vault = home / "Dropbox" / "Vault"
+    (home / ".dropbox").mkdir(parents=True)
+    (home / "Dropbox" / ".dropbox.cache").mkdir(parents=True)
+    ordinary_vault.mkdir(parents=True)
+    dropbox_vault.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    assert detect_sync_folder(ordinary_vault) is None
+    assert detect_sync_folder(dropbox_vault) == "Dropbox"
+
+
 def test_onedrive_detection_requires_a_full_provider_path_segment(tmp_path: Path) -> None:
     ordinary = tmp_path / "not-onedrive-backup" / "Vault"
     onedrive = tmp_path / "OneDrive" / "Vault"


### PR DESCRIPTION
Lane F (the rehearsal against a copy of a real vault) caught four defects in the brain/vault conversion path. All four are fixed with regression coverage; dual-twin parity kept.

1. **Dropbox false-positive for every Mac Dropbox user** — the sync-folder detector treated \$HOME like any ancestor, and Dropbox keeps a `.dropbox` CONFIG directory in every home folder. Any vault under \$HOME was refused as "inside Dropbox". Both the CJS detector and the Python twin now skip \$HOME and above for child-marker probing; a vault genuinely inside ~/Dropbox is still detected.
2. **ENOBUFS crash on a 12k-file vault** — git subprocess output limit raised 16 MiB → 1 GiB (constant + regression test). Follow-up noted: P3/P8 pipe file contents through stdout; a streaming redesign is a future card, and >1 GiB single files would still fail safe with resume/restore guidance.
3. **Accented filenames halted the migration** — macOS walks paths in decomposed Unicode while git stores precomposed; files like `Häfele.md` appeared as "unexpected staged paths" and P3 stopped. P3 and P8 comparisons now normalize both sides to NFC (comparison-only; stored paths unchanged).
4. **Symlink refusal now says what to do** — the P2 refusal lists the entries AND explains: move/delete the symlinked entries (targets untouched), rerun; nothing was changed by the refusal.

Every finding reproduced on a real 50 GB / 12,214-file vault copy; the conversion then completed end-to-end (P0–P9) and Doctor reports both histories healthy.

Tests: migrator unit 24/24, integration 28/28, full core CJS suite 55/55, sync-detector 5/5, `test_adoption_sqlite_snapshot.py` 36/36. Gates: path-contract ✅ test-delta ✅ architecture-inventory ✅.

Reviewed by Fable (diff read in full; buffer raised to the empirically-proven 1 GiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDWGkF4Zoe6oCSaisqDcum