### PR TITLE
sec(integrations): Phase 5b — origin pinning + tamper-proof trust

### DIFF
--- a/core/integrations/connection-manager/README.md
+++ b/core/integrations/connection-manager/README.md
@@ -14,6 +14,7 @@ The engine code ships in Dex Core, but remains product-inert: no user-facing
 | File | Role |
 |------|------|
 | `catalog.cjs` | Normalizes a Nango provider entry → Dex OAuth descriptor (URLs, scopes, PKCE, quirks). |
+| `pinned-providers.cjs` | Frozen, Dex-reviewed HTTPS destination policy for vetted providers. |
 | `oauth-flow.cjs` | PKCE auth-URL, localhost callback server (dynamic port), and code→token exchange. |
 | `token-store.cjs` | Encrypted on-device token store + `connections.json` registry. Keychain-or-file key. |
 | `health.cjs` | Connection health (`connected`/`expiring`/`expired`/`needs_reauth`) + the single lifted refresh/probe path. |
@@ -58,6 +59,9 @@ The store is designed so that nothing fails silently and nothing user-recoverabl
 | Two processes mutating at once | `.dex-cm.lock` (lockfile with PID + staleness: dead-PID steal, 30s unreadable, 10min hard cap; 10s acquire timeout that errors rather than running unlocked). Reads stay lock-free thanks to atomic writes. Same-machine scope only. |
 | Two processes refreshing the same OAuth token | `.dex-cm.refresh-<conn>.lock` held across the network call; the loser re-checks freshness after acquiring and reuses the winner's token (safe for refresh-token rotation). |
 | Provider redirects a credential-bearing request | OAuth exchange, OAuth refresh, verification probes, and generic authenticated calls reject redirects. Codes, refresh tokens, client secrets, and API-key headers are never replayed to a redirect target. |
+| Catalog destination drifts away from a reviewed origin | Google and Linear credential-bearing requests fail closed before sending. Other catalog providers require explicit `--allow-unvetted` or `DEX_CM_ALLOW_UNVETTED=1` consent and are never auto-probed. |
+| Registry or ledger trust data is edited or replayed | Registry entries, the store counter, and every ledger row are MAC-authenticated with a key derived from the credential master key. Entries with a missing/invalid MAC or a mismatched encrypted-credential digest are reported as `needs_reauth` / `trust_unverified`; unauthenticated or pre-reconnect probe rows cannot verify a credential. |
+| Upgrade from an older unsigned `connections.json` | The unsigned entry is deliberately treated as `trust_unverified` and needs one reconnect. Reconnecting writes authenticated state; registry rebuilds from decryptable token files also create authenticated entries. |
 | Credential is replaced after a prior successful probe | The durable ledger retains the historical proof, but verification starts a new connect epoch. The replacement credential is unverified until it passes its own live probe. |
 | Encryption key missing/unreadable with encrypted credentials on disk | Explicit state, never silent re-keying: reads throw/report `encryption_key_lost` (computed at read time, nothing persisted, so a transient keychain blip self-heals). The one recovery path is reconnecting a tool, which preserves old token/app files as `*.keyloss-<timestamp>`, flags every other connection, prints why once, then issues a fresh key. |
 | Credential file copied to another connection id | AES-GCM additional authenticated data binds every envelope to its connection id. The copied envelope is quarantined, and the target becomes `needs_reauth` with `token_envelope_account_mismatch`. |

--- a/core/integrations/connection-manager/auth-context.cjs
+++ b/core/integrations/connection-manager/auth-context.cjs
@@ -31,7 +31,17 @@ function apiKeyContext(token, service) {
     const baseUrl = (descriptor.proxyBaseUrl || '').replace(/\$\{apiKey\}/g, token.apiKey || '');
     // apiKey rides along so CLIs can REDACT it from anything they print (the
     // envelope itself is secret-bearing by contract: headers/baseUrl carry it).
-    return { kind: 'api_key', baseUrl: baseUrl || null, headers, query, ...(token.apiKey ? { apiKey: token.apiKey } : {}) };
+    const context = {
+      kind: 'api_key',
+      baseUrl: baseUrl || null,
+      headers,
+      query,
+      ...(token.apiKey ? { apiKey: token.apiKey } : {}),
+    };
+    // Internal routing metadata for dex-call's origin policy. Keep it
+    // non-enumerable so the published get-token response contract stays v1.
+    Object.defineProperty(context, 'provider', { value: provider });
+    return context;
   } catch {
     // Not in catalog (or BASIC-only) — hand back the raw secret with no scheme; a caller can
     // still hit a full URL and supply its own header.
@@ -99,7 +109,11 @@ async function resolveAuthContext(service) {
   } catch {
     /* no catalog base — caller must pass a full URL */
   }
-  return { kind: 'oauth', baseUrl, headers: { Authorization: `Bearer ${accessToken}` }, query: {} };
+  const reg = store.getConnection(service) || {};
+  const provider = reg.provider || store.parseConnectionId(service).provider;
+  const context = { kind: 'oauth', baseUrl, headers: { Authorization: `Bearer ${accessToken}` }, query: {} };
+  Object.defineProperty(context, 'provider', { value: provider });
+  return context;
 }
 
 /**

--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -25,6 +25,22 @@ const catalog = require('./catalog.cjs');
 const store = require('./token-store.cjs');
 const oauth = require('./oauth-flow.cjs');
 const health = require('./health.cjs');
+const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
+
+function allowUnvetted(flags = {}) {
+  return flags['allow-unvetted'] !== undefined || process.env.DEX_CM_ALLOW_UNVETTED === '1';
+}
+
+function requireUnvettedConsent(provider, flags = {}) {
+  if (isVetted(provider)) return;
+  if (!allowUnvetted(flags)) {
+    throw new Error(
+      `'${provider}' is not security-reviewed. Re-run with --allow-unvetted or ` +
+        'DEX_CM_ALLOW_UNVETTED=1 to explicitly opt in.'
+    );
+  }
+  console.log(`warning: '${provider}' is not security-reviewed; continuing because you explicitly opted in.`);
+}
 
 function parseFlags(args) {
   const flags = {};
@@ -47,6 +63,7 @@ function openBrowser(url) {
 
 async function cmdConnect(provider, flags) {
   if (!provider) throw new Error('Usage: node connect.cjs connect <provider> [--scopes a,b,c] [--as <alias>]');
+  requireUnvettedConsent(provider, flags);
   const providerConfig = catalog.getProviderConfig(provider);
   if (!providerConfig.supported) {
     throw new Error(`'${provider}' is not connectable yet: ${providerConfig.reason} It remains available to browse in providers.`);
@@ -262,8 +279,11 @@ function buildProbeTarget(descriptor, secret) {
  * condemn; everything inconclusive (network error, timeout, 403, 404, 5xx, redirect) is 'skipped'.
  */
 async function probeKey(service, descriptor, secret) {
+  const provider = (descriptor && descriptor.id) || store.parseConnectionId(service).provider;
+  if (!isVetted(provider)) return 'skipped';
   const t = buildProbeTarget(descriptor, secret);
   if (!t) return 'skipped';
+  assertPinnedOrigin(provider, 'verification', t.url);
   try {
     const res = await fetch(t.url, {
       method: t.method,
@@ -291,6 +311,7 @@ async function cmdSetKey(service, flags) {
   // Catalog lookups go by PROVIDER (the auth scheme); the key is SAVED under the connId.
   const parsed = store.parseConnectionId(service);
   const provider = parsed.provider;
+  requireUnvettedConsent(provider, flags);
   const alias = flags.as || parsed.alias || null;
   const connId = alias ? `${provider}:${alias}` : provider;
 
@@ -352,11 +373,10 @@ async function cmdSetKey(service, flags) {
   store.saveApiKey(connId, secret, { provider: descriptor.id, authMode: descriptor.authMode });
   health.recordConnectionEvent(connId, 'connect', { ok: true });
   if (flags.default) store.setDefault(provider, alias);
-  if (!descriptor.verified) {
-    console.log('Unverified provider — advanced tier, expect quirks.');
-  }
-
-  const probe = flags['no-probe'] === undefined && flags.probe !== 'false' ? await probeKey(connId, descriptor, secret) : 'skipped';
+  const probe =
+    isVetted(provider) && flags['no-probe'] === undefined && flags.probe !== 'false'
+      ? await probeKey(connId, descriptor, secret)
+      : 'skipped';
   if (probe === 'ok') {
     // "Verified live" is durable evidence, not a console-only claim. Doctor
     // and status derive verification strictly from successful probe rows.
@@ -366,7 +386,9 @@ async function cmdSetKey(service, flags) {
     ? ' Verified live.'
     : probe === 'failed'
       ? ' (probe failed — marked needs_reauth)'
-      : ` (not yet verified — run: node connect.cjs probe ${connId})`;
+      : isVetted(provider)
+        ? ` (not yet verified — run: node connect.cjs probe ${connId})`
+        : ' (automatic verification skipped because this provider is not security-reviewed)';
   console.log(`✅ Stored ${descriptor.displayName}${alias ? ` (${connId})` : ''} key (encrypted) in ${store.credentialsDir()}/tokens/.${note}`);
 }
 
@@ -411,7 +433,17 @@ function cmdStatus(flags = {}) {
 }
 
 async function cmdProbe(service, flags = {}) {
-  const results = await health.probeConnections(service);
+  if (service) {
+    const reg = store.getConnection(service) || {};
+    const provider = reg.provider || store.parseConnectionId(service).provider;
+    requireUnvettedConsent(provider, flags);
+  } else {
+    const unvetted = new Set(
+      store.listConnections().map((entry) => entry.provider).filter((provider) => provider && !isVetted(provider))
+    );
+    for (const provider of unvetted) requireUnvettedConsent(provider, flags);
+  }
+  const results = await health.probeConnections(service, { allowUnvetted: allowUnvetted(flags) });
   const broken = results.some((result) => result.status === 'needs_reauth');
   if (flags.json !== undefined) {
     process.stdout.write(`${JSON.stringify({ results })}\n`);

--- a/core/integrations/connection-manager/connection-manager.judgment.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.judgment.test.cjs
@@ -133,7 +133,7 @@ test('permanent refresh failure stamps needs_reauth and records refresh + break 
   try {
     await withProviderConfig(
       'google',
-      { tokenUrl: 'https://tokens.example/refresh', refreshUrl: null },
+      { tokenUrl: 'https://oauth2.googleapis.com/token', refreshUrl: null },
       async () => {
         await assert.rejects(health.refreshToken('refresh-permanent', { force: true }), (error) => {
           assert.equal(error.needsReauth, true);
@@ -168,7 +168,7 @@ test('transient 500 retries once, succeeds, and never stamps a reconnect error',
   try {
     await withProviderConfig(
       'google',
-      { tokenUrl: 'https://tokens.example/refresh', refreshUrl: null, refreshRetryDelayMs: 0 },
+      { tokenUrl: 'https://oauth2.googleapis.com/token', refreshUrl: null, refreshRetryDelayMs: 0 },
       async () => {
         assert.equal(await health.refreshToken('refresh-transient', { force: true }), 'NEW-AT');
       }
@@ -245,7 +245,7 @@ test('two concurrent forced refreshes share one network call', async () => {
   try {
     await withProviderConfig(
       'google',
-      { tokenUrl: 'https://tokens.example/refresh', refreshUrl: null },
+      { tokenUrl: 'https://oauth2.googleapis.com/token', refreshUrl: null },
       async () => {
         const first = health.refreshToken('refresh-single-flight', { force: true });
         const second = health.ensureFreshToken('refresh-single-flight');

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -21,7 +21,12 @@ const cli = require('./connect.cjs');
 const DIR = __dirname;
 const CRED_DIR = path.join(TMP_VAULT, 'System', 'credentials');
 const TOKENS_DIR = path.join(CRED_DIR, 'tokens');
-const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
+const childEnv = {
+  ...process.env,
+  DEX_VAULT: TMP_VAULT,
+  DEX_CM_NO_KEYCHAIN: '1',
+  DEX_CM_ALLOW_UNVETTED: '1',
+};
 
 test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
 
@@ -98,7 +103,7 @@ test('refresh --force hits the token endpoint for a fresh token; default refresh
   const originalGetProviderConfig = catalog.getProviderConfig;
   catalog.getProviderConfig = () => ({
     ...originalGetProviderConfig('google'),
-    tokenUrl: 'http://mock-token-endpoint.test/token',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
     refreshUrl: null,
   });
   try {
@@ -130,7 +135,7 @@ test('rotating refresh tokens persist and the next refresh uses the newest token
   const originalGetProviderConfig = catalog.getProviderConfig;
   catalog.getProviderConfig = () => ({
     ...originalGetProviderConfig('google'),
-    tokenUrl: 'http://mock-token-endpoint.test/token',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
     refreshUrl: null,
   });
   try {
@@ -324,7 +329,8 @@ test('verified providers are identified and supported unverified providers remai
   assert.equal(catalog.getProviderConfig(unverified.id).supported, true);
 
   const attempted = run([path.join(DIR, 'connect.cjs'), 'connect', unverified.id]);
-  assert.match(attempted.stdout, /^Unverified provider — advanced tier, expect quirks\.\n$/);
+  assert.match(attempted.stdout, /warning: .*not security-reviewed/i);
+  assert.match(attempted.stdout, /Unverified provider — advanced tier, expect quirks\./);
 });
 
 test('providers that depend on Nango post-connection scripts are browse-only', () => {

--- a/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
@@ -176,7 +176,15 @@ test('H5: dex-call --status redacts encoded query-parameter credentials', () => 
   const result = spawnSync(
     process.execPath,
     ['--require', preload, path.join(__dirname, 'dex-call.cjs'), 'google-gemini', '/v1/models', '--status', '--raw'],
-    { env: { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' }, encoding: 'utf8' }
+    {
+      env: {
+        ...process.env,
+        DEX_VAULT: TMP_VAULT,
+        DEX_CM_NO_KEYCHAIN: '1',
+        DEX_CM_ALLOW_UNVETTED: '1',
+      },
+      encoding: 'utf8',
+    }
   );
 
   try {

--- a/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
@@ -1,0 +1,415 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const pinned = require('./pinned-providers.cjs');
+const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5b-'));
+process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_NO_KEYCHAIN = '1';
+
+const catalog = require('./catalog.cjs');
+const oauth = require('./oauth-flow.cjs');
+const store = require('./token-store.cjs');
+const connect = require('./connect.cjs');
+const dexCall = require('./dex-call.cjs');
+const health = require('./health.cjs');
+
+const DIR = __dirname;
+const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
+
+test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+
+test('reviewed providers expose immutable origin pins and reject every unpinned destination', () => {
+  assert.equal(pinned.isVetted('google'), true);
+  assert.equal(pinned.isVetted('linear'), true);
+  assert.equal(pinned.isVetted('active-campaign'), false);
+  assert.deepEqual(pinned.pinnedOriginsFor('google'), {
+    authorizationOrigin: 'https://accounts.google.com',
+    tokenOrigin: 'https://oauth2.googleapis.com',
+    refreshOrigin: 'https://oauth2.googleapis.com',
+    apiOrigins: ['https://www.googleapis.com'],
+    verificationOrigin: 'https://www.googleapis.com',
+    tenant: null,
+  });
+  assert.equal(Object.isFrozen(pinned.pinnedOriginsFor('google')), true);
+  assert.equal(Object.isFrozen(pinned.pinnedOriginsFor('google').apiOrigins), true);
+
+  assert.doesNotThrow(() => pinned.assertPinnedOrigin('google', 'authorization', 'https://accounts.google.com/o/oauth2/v2/auth'));
+  assert.doesNotThrow(() => pinned.assertPinnedOrigin('google', 'token', 'https://oauth2.googleapis.com/token'));
+  assert.doesNotThrow(() => pinned.assertPinnedOrigin('linear', 'api', 'https://api.linear.app/graphql'));
+
+  for (const [provider, kind, url] of [
+    ['google', 'api', 'https://evil.example/calendar'],
+    ['google', 'api', 'http://www.googleapis.com/calendar'],
+    ['linear', 'token', 'https://api.linear.app/oauth/token'],
+    ['unknown-provider', 'api', 'https://api.example.test'],
+  ]) {
+    assert.throws(
+      () => pinned.assertPinnedOrigin(provider, kind, url),
+      (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED' && error.exitCode === 1
+    );
+  }
+});
+
+test('tenant origin pins accept exactly one reviewed subdomain label', () => {
+  pinned.__setPinnedForTest({
+    'tenant-fixture': {
+      apiOrigins: [],
+      verificationOrigin: null,
+      tenant: {
+        pinnedSuffix: 'activehosted.com',
+        labelPattern: '^[a-z0-9][a-z0-9-]{0,62}$',
+      },
+    },
+  });
+  try {
+    assert.doesNotThrow(() =>
+      pinned.assertPinnedOrigin('tenant-fixture', 'api', 'https://acme.activehosted.com/api/3')
+    );
+    for (const url of [
+      'https://activehosted.com/api/3',
+      'https://a.b.activehosted.com/api/3',
+      'https://acme.activehosted.com.evil.example/api/3',
+      'http://acme.activehosted.com/api/3',
+    ]) {
+      assert.throws(
+        () => pinned.assertPinnedOrigin('tenant-fixture', 'api', url),
+        (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED'
+      );
+    }
+  } finally {
+    pinned.__setPinnedForTest(null);
+  }
+});
+
+test('credential-bearing request builders refuse catalog drift away from vetted origins', async () => {
+  const googleContext = {
+    provider: 'google',
+    baseUrl: 'https://evil.example',
+    headers: { Authorization: 'Bearer SECRET' },
+    query: {},
+  };
+  assert.throws(
+    () => dexCall.buildRequest(googleContext, 'GET', '/calendar', {}),
+    (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED' && error.exitCode === 1
+  );
+
+  const google = catalog.getProviderConfig('google');
+  assert.throws(
+    () => oauth.buildAuthorizationUrl(
+      { ...google, authorizationUrl: 'https://evil.example/oauth' },
+      { clientId: 'CID', redirectUri: 'http://127.0.0.1/callback' }
+    ),
+    (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED'
+  );
+
+  let fetchCalled = false;
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('must not send');
+  };
+  try {
+    await assert.rejects(
+      oauth.exchangeCodeForToken(
+        { ...google, tokenUrl: 'https://evil.example/token' },
+        {
+          code: 'CODE',
+          clientId: 'CID',
+          clientSecret: 'SECRET',
+          redirectUri: 'http://127.0.0.1/callback',
+        }
+      ),
+      (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED'
+    );
+    assert.equal(fetchCalled, false);
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  fetchCalled = false;
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('must not send');
+  };
+  try {
+    await assert.rejects(
+      connect.probeKey(
+        'linear',
+        { ...catalog.getProviderConfig('linear'), proxyBaseUrl: 'https://evil.example' },
+        { apiKey: 'SECRET' }
+      ),
+      (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED'
+    );
+    assert.equal(fetchCalled, false);
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  const refreshConn = 'google:origin-drift';
+  store.setOAuthApp('google', { clientId: 'CID', clientSecret: 'SECRET' });
+  store.saveToken(
+    refreshConn,
+    { access_token: 'OLD', refresh_token: 'REFRESH', expires_at: Date.now() - 1 },
+    { provider: 'google' }
+  );
+  const originalGetProviderConfig = catalog.getProviderConfig;
+  catalog.getProviderConfig = (id, config) =>
+    id === 'google'
+      ? { ...originalGetProviderConfig(id, config), tokenUrl: 'https://evil.example/token', refreshUrl: null }
+      : originalGetProviderConfig(id, config);
+  fetchCalled = false;
+  global.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('must not send');
+  };
+  try {
+    await assert.rejects(
+      health.refreshToken(refreshConn, { force: true }),
+      (error) => error && error.code === 'DEX_CM_ORIGIN_UNPINNED'
+    );
+    assert.equal(fetchCalled, false);
+  } finally {
+    global.fetch = originalFetch;
+    catalog.getProviderConfig = originalGetProviderConfig;
+    store.deleteToken(refreshConn);
+  }
+});
+
+test('unvetted connect use needs explicit consent and never auto-probes', async () => {
+  const provider = 'airtable-pat';
+  const refused = spawnSync(
+    process.execPath,
+    [path.join(DIR, 'connect.cjs'), 'set-key', provider, '--no-probe'],
+    { env: childEnv, input: 'UNVETTED-SECRET\n', encoding: 'utf8' }
+  );
+  assert.equal(refused.status, 1);
+  assert.match(refused.stderr, /not security-reviewed/i);
+
+  const allowed = spawnSync(
+    process.execPath,
+    [path.join(DIR, 'connect.cjs'), 'set-key', provider, '--allow-unvetted', '--no-probe'],
+    { env: childEnv, input: 'UNVETTED-SECRET\n', encoding: 'utf8' }
+  );
+  try {
+    assert.equal(allowed.status, 0, allowed.stderr);
+    assert.match(allowed.stdout, /warning.*not security-reviewed/i);
+  } finally {
+    if (store.getConnection(provider)) store.deleteToken(provider);
+  }
+
+  let probeCalls = 0;
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    probeCalls += 1;
+    throw new Error('must not send');
+  };
+  try {
+    const outcome = await connect.probeKey(
+      provider,
+      catalog.getProviderConfig(provider),
+      { apiKey: 'UNVETTED-SECRET' }
+    );
+    assert.equal(outcome, 'skipped');
+    assert.equal(probeCalls, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('unvetted dex-call refuses by default and warns after explicit consent', () => {
+  const connId = 'airtable-pat:call-consent';
+  const preload = path.join(TMP_VAULT, 'offline-fetch.cjs');
+  fs.writeFileSync(
+    preload,
+    "globalThis.fetch=async()=>({ok:true,status:200,statusText:'OK',text:async()=>'{}'});\n"
+  );
+  store.saveApiKey(connId, { apiKey: 'UNVETTED-CALL-SECRET' }, { provider: 'airtable-pat', authMode: 'API_KEY' });
+  try {
+    const refused = spawnSync(
+      process.execPath,
+      ['--require', preload, path.join(DIR, 'dex-call.cjs'), connId, '/v0/meta'],
+      { env: childEnv, encoding: 'utf8' }
+    );
+    assert.equal(refused.status, 1);
+    assert.match(refused.stderr, /not security-reviewed/i);
+
+    const allowed = spawnSync(
+      process.execPath,
+      ['--require', preload, path.join(DIR, 'dex-call.cjs'), connId, '/v0/meta', '--allow-unvetted'],
+      { env: childEnv, encoding: 'utf8' }
+    );
+    assert.equal(allowed.status, 0, allowed.stderr);
+    assert.match(allowed.stderr, /warning.*not security-reviewed/i);
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
+function registryFile() {
+  return path.join(store.credentialsDir(), 'connections.json');
+}
+
+function tokenFile(connId) {
+  return path.join(store.credentialsDir(), 'tokens', `${connId.replace(/:/g, '__')}.json`);
+}
+
+function readRawRegistry() {
+  return JSON.parse(fs.readFileSync(registryFile(), 'utf8'));
+}
+
+function registryMacPayload(connId, entry) {
+  return {
+    connId,
+    service: entry.service,
+    provider: entry.provider,
+    status: entry.status,
+    error: entry.error,
+    verification: entry.verification,
+    credentialDigest: entry.credentialDigest,
+    epoch: entry.epoch,
+    counter: entry.counter,
+  };
+}
+
+test('trust records derive a separate HKDF key and MAC registry plus ledger state', () => {
+  const connId = 'linear:mac-shape';
+  store.saveApiKey(connId, { apiKey: 'MAC-SHAPE-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  health.recordConnectionEvent(connId, 'connect', { ok: true });
+  try {
+    const masterKey = Buffer.from(
+      fs.readFileSync(path.join(store.credentialsDir(), '.dex-cm.key'), 'utf8').trim(),
+      'base64'
+    );
+    const expectedMacKey = Buffer.from(
+      crypto.hkdfSync('sha256', masterKey, Buffer.alloc(0), 'dex-cm-trust-mac-v1', 32)
+    );
+    assert.deepEqual(store.trustMacKey(), expectedMacKey);
+
+    const raw = readRawRegistry();
+    const entry = raw[connId];
+    assert.equal(entry.credentialDigest, crypto.createHash('sha256').update(fs.readFileSync(tokenFile(connId))).digest('hex'));
+    assert.equal(entry.epoch, 1);
+    assert.equal(Number.isInteger(entry.counter), true);
+    assert.equal(typeof entry.mac, 'string');
+    assert.equal(Number.isInteger(raw._meta.counter), true);
+    assert.equal(typeof raw._meta.mac, 'string');
+
+    const expectedEntryMac = crypto
+      .createHmac('sha256', expectedMacKey)
+      .update(store.canonicalJSON(registryMacPayload(connId, entry)))
+      .digest('base64');
+    assert.equal(entry.mac, expectedEntryMac);
+
+    const ledgerRow = health.connectionLedger().tail(connId, 1)[0];
+    assert.equal(ledgerRow.connId, connId);
+    assert.equal(Number.isInteger(ledgerRow.counter), true);
+    assert.equal(typeof ledgerRow.mac, 'string');
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
+test('hand-edited registry trust is downgraded and blocked by get-token plus dex-call', () => {
+  const connId = 'linear:forged-registry';
+  store.saveApiKey(connId, { apiKey: 'FORGED-REGISTRY-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  try {
+    const raw = readRawRegistry();
+    raw[connId].status = 'needs_reauth';
+    fs.writeFileSync(registryFile(), JSON.stringify(raw, null, 2));
+    raw[connId].status = 'connected';
+    delete raw[connId].mac;
+    fs.writeFileSync(registryFile(), JSON.stringify(raw, null, 2));
+
+    const downgraded = store.getConnection(connId);
+    assert.equal(downgraded.status, 'needs_reauth');
+    assert.equal(downgraded.verification, 'unverified');
+    assert.equal(downgraded.error, 'trust_unverified');
+
+    const getToken = spawnSync(
+      process.execPath,
+      [path.join(DIR, 'get-token.cjs'), connId, '--access-token-only'],
+      { env: childEnv, encoding: 'utf8' }
+    );
+    assert.equal(getToken.status, 3, getToken.stderr);
+    assert.match(getToken.stderr, /needs re-authentication/i);
+
+    const call = spawnSync(
+      process.execPath,
+      [path.join(DIR, 'dex-call.cjs'), connId, 'POST', '/graphql', '--body', '{"query":"{ viewer { id } }"}'],
+      { env: childEnv, encoding: 'utf8' }
+    );
+    assert.equal(call.status, 3, call.stderr);
+    assert.match(call.stderr, /needs re-authentication/i);
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
+test('credential digest changes and legacy unsigned entries both become trust_unverified', () => {
+  const digestConn = 'linear:digest-tamper';
+  const legacyConn = 'linear:legacy-unsigned';
+  store.saveApiKey(digestConn, { apiKey: 'DIGEST-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  store.saveApiKey(legacyConn, { apiKey: 'LEGACY-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  try {
+    fs.appendFileSync(tokenFile(digestConn), '\n');
+    assert.equal(store.getConnection(digestConn).error, 'trust_unverified');
+
+    const raw = readRawRegistry();
+    delete raw[legacyConn].mac;
+    delete raw[legacyConn].credentialDigest;
+    delete raw[legacyConn].epoch;
+    delete raw[legacyConn].counter;
+    fs.writeFileSync(registryFile(), JSON.stringify(raw, null, 2));
+    const legacy = store.getConnection(legacyConn);
+    assert.equal(legacy.status, 'needs_reauth');
+    assert.equal(legacy.verification, 'unverified');
+    assert.equal(legacy.error, 'trust_unverified');
+  } finally {
+    store.deleteToken(digestConn);
+    store.deleteToken(legacyConn);
+  }
+});
+
+test('only authenticated probes from the current connect counter can verify a credential', () => {
+  const connId = 'linear:ledger-replay';
+  store.saveApiKey(connId, { apiKey: 'FIRST-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  health.recordConnectionEvent(connId, 'connect', { ok: true });
+  health.recordConnectionEvent(connId, 'probe', { ok: true });
+  assert.equal(health.connectionHealth(connId).verified, true);
+  const oldProbe = health.connectionLedger().tail(connId, 1)[0];
+  const ledgerPath = health.connectionLedger().filePathFor(connId);
+  try {
+    const rows = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n').map(JSON.parse);
+    rows[rows.length - 1].ok = false;
+    fs.writeFileSync(ledgerPath, `${rows.map(JSON.stringify).join('\n')}\n`);
+    assert.equal(health.connectionHealth(connId).verified, false, 'wrong-MAC probe is not evidence');
+
+    store.saveApiKey(connId, { apiKey: 'SECOND-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+    health.recordConnectionEvent(connId, 'connect', { ok: true });
+    fs.appendFileSync(ledgerPath, `${JSON.stringify(oldProbe)}\n`);
+    assert.equal(health.connectionHealth(connId).verified, false, 'old valid probe cannot cross reconnect');
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
+test('registry rebuild from encrypted tokens creates authenticated entries', () => {
+  const connId = 'linear:rebuilt-trust';
+  store.saveApiKey(connId, { apiKey: 'REBUILD-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  try {
+    fs.unlinkSync(registryFile());
+    const rebuilt = store.getConnection(connId);
+    assert.equal(rebuilt.status, 'connected');
+    assert.equal(rebuilt.error, null);
+    assert.equal(typeof readRawRegistry()[connId].mac, 'string');
+  } finally {
+    store.deleteToken(connId);
+  }
+});

--- a/core/integrations/connection-manager/connection-manager.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.test.cjs
@@ -32,7 +32,12 @@ const dexcall = require('./dex-call.cjs'); // buildRequest / parseArgs (generic 
 const authctx = require('./auth-context.cjs'); // resolveAuthContext (shared auth seam)
 
 const DIR = __dirname;
-const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
+const childEnv = {
+  ...process.env,
+  DEX_VAULT: TMP_VAULT,
+  DEX_CM_NO_KEYCHAIN: '1',
+  DEX_CM_ALLOW_UNVETTED: '1',
+};
 
 // Pick a real paste-a-key provider for the Class-B path. Prefer one that needs ONLY an
 // API key (no connection_config) so the single-secret round-trip tests stay simple; the

--- a/core/integrations/connection-manager/dex-call.cjs
+++ b/core/integrations/connection-manager/dex-call.cjs
@@ -15,6 +15,7 @@
  */
 
 const { resolveAuthContext, secretsOf, redactSecrets } = require('./auth-context.cjs');
+const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
 
 const HTTP_VERBS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
 
@@ -68,6 +69,9 @@ function buildRequest(ctx, method, pathOrUrl, { query = {}, headers = {}, body }
   const sameHost = !absolute || (!!baseHost && url.host === baseHost);
   const authHeaders = sameHost ? ctx.headers || {} : {};
   const authQuery = sameHost ? ctx.query || {} : {};
+  if (sameHost && ctx.provider && isVetted(ctx.provider)) {
+    assertPinnedOrigin(ctx.provider, 'api', url.toString());
+  }
 
   for (const [k, v] of Object.entries(authQuery)) url.searchParams.set(k, v);
   for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
@@ -157,6 +161,17 @@ async function main() {
   } catch (e) {
     console.error(e.message);
     process.exit(e.exitCode || 1);
+  }
+  if (req.authAttached && ctx.provider && !isVetted(ctx.provider)) {
+    const allowed = flags['allow-unvetted'] !== undefined || process.env.DEX_CM_ALLOW_UNVETTED === '1';
+    if (!allowed) {
+      console.error(
+        `Refusing authenticated call for '${ctx.provider}': this provider is not security-reviewed. ` +
+          'Re-run with --allow-unvetted or DEX_CM_ALLOW_UNVETTED=1 to opt in.'
+      );
+      process.exit(1);
+    }
+    console.error(`warning: '${ctx.provider}' is not security-reviewed; sending credentials because you explicitly opted in.`);
   }
 
   const reqHeaders = { ...req.headers };

--- a/core/integrations/connection-manager/hardening.child.cjs
+++ b/core/integrations/connection-manager/hardening.child.cjs
@@ -71,7 +71,9 @@ async function main() {
       const realGetProviderConfig = catalog.getProviderConfig;
       catalog.getProviderConfig = (provider, config) => ({
         ...realGetProviderConfig(provider, config),
-        tokenUrl: 'https://mock-token-endpoint.invalid/token',
+        // Fetch is intercepted below; keep the effective destination on
+        // Google's reviewed origin so the origin-policy layer is exercised.
+        tokenUrl: 'https://oauth2.googleapis.com/token',
         refreshUrl: null,
         refreshRetryDelayMs: 0,
       });

--- a/core/integrations/connection-manager/health.cjs
+++ b/core/integrations/connection-manager/health.cjs
@@ -15,11 +15,15 @@ const connectorModel = require('./lib/connector-model.js');
 const { createConnectorLedger } = require('./lib/connector-ledger.js');
 const { createConnectorVerify, CATEGORY } = require('./lib/connector-verify.js');
 const { createSingleFlight, refreshOAuthToken } = require('./lib/oauth-refresh.js');
+const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
 
 const EXPIRY_SKEW_MS = 5 * 60 * 1000; // treat tokens expiring within 5 min as "expiring"
 const runSingleFlight = createSingleFlight();
 const ledger = createConnectorLedger({
   stateDir: () => path.join(store.credentialsDir(), 'ledger'),
+  attest: (connId, row) => store.attestLedgerRow(connId, row),
+  verify: (connId, row) => store.verifyLedgerRow(connId, row),
+  isCurrent: (connId, row) => store.ledgerRowMatchesCurrentCredential(connId, row),
 });
 
 function connectionLedger() {
@@ -282,6 +286,9 @@ async function refreshToken(service, { force = false } = {}) {
       if (!app) throw new Error(`No OAuth app credentials for '${provider}'. Add them to oauth-apps.json.`);
       const providerConfig = catalog.getProviderConfig(provider, reg.connectionConfig || {});
       try {
+        if (isVetted(provider)) {
+          assertPinnedOrigin(provider, 'refresh', providerConfig.refreshUrl || providerConfig.tokenUrl);
+        }
         const result = await refreshOAuthToken({
           tokenUrl: providerConfig.refreshUrl || providerConfig.tokenUrl,
           refreshToken: current.refresh_token || token.refresh_token,
@@ -328,12 +335,19 @@ async function probeConnection(service, options = {}) {
   const connId = store.resolveConnId(service);
   const reg = store.readRegistry()[connId] || {};
   const provider = reg.provider || store.parseConnectionId(connId).provider;
+  if (!isVetted(provider) && options.allowUnvetted !== true) {
+    throw new Error(`${provider} is not security-reviewed; verification was skipped.`);
+  }
   const token = store.loadToken(connId);
   if (!token) throw new Error(`${connId} is not connected.`);
   const credential = isKeyBased(reg, token)
     ? token.apiKey || token.password || null
     : await ensureFreshToken(connId);
   const verifier = createConnectorVerify(options);
+  if (isVetted(provider) && verifier.PROBES[provider]) {
+    const request = verifier.PROBES[provider].buildRequest(credential, {});
+    assertPinnedOrigin(provider, 'verification', request.url);
+  }
   const result = await verifier.verify(connId, { provider, token: credential });
   recordConnectionEvent(connId, 'probe', verifier.toLedgerRow(connId, result));
   if (result.error && result.error.category === CATEGORY.AUTH_PERMANENT) {

--- a/core/integrations/connection-manager/lib/connector-ledger.js
+++ b/core/integrations/connection-manager/lib/connector-ledger.js
@@ -42,6 +42,11 @@ function createConnectorLedger(opts = {}) {
 	const fs = opts.fs || nodeFs;
 	const stateDirOpt = opts.stateDir;
 	const now = typeof opts.now === "function" ? opts.now : Date.now;
+	// DEX CORE DIVERGENCE: production callers attest every row with the
+	// token-store trust key and reject unauthenticated evidence on read.
+	const attest = typeof opts.attest === "function" ? opts.attest : null;
+	const verify = typeof opts.verify === "function" ? opts.verify : null;
+	const isCurrent = typeof opts.isCurrent === "function" ? opts.isCurrent : null;
 	const maxEntriesPerConnector =
 		Number.isFinite(opts.maxEntriesPerConnector) && opts.maxEntriesPerConnector > 0
 			? Math.floor(opts.maxEntriesPerConnector)
@@ -70,7 +75,8 @@ function createConnectorLedger(opts = {}) {
 		const file = filePathFor(connectorId);
 		if (!fs.existsSync(file)) return [];
 		try {
-			return parseFile(fs.readFileSync(file, "utf8"));
+			const parsed = parseFile(fs.readFileSync(file, "utf8"));
+			return verify ? parsed.filter((row) => verify(connectorId, row)) : parsed;
 		} catch {
 			return [];
 		}
@@ -93,8 +99,9 @@ function createConnectorLedger(opts = {}) {
 		const dir = stateDir();
 		fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 		const file = filePathFor(safeId);
-		const stored = normalizeRow(safeId, row);
 		return withLockSync(`${file}.lock`, () => {
+			const normalized = normalizeRow(safeId, row);
+			const stored = attest ? attest(safeId, normalized) : normalized;
 			const entries = readDisk(safeId);
 			const next = [...entries, stored].slice(-maxEntriesPerConnector);
 			writeFileAtomic(file, serialize(next), { mode: 0o600 });
@@ -121,9 +128,17 @@ function createConnectorLedger(opts = {}) {
 			(lastIndex, entry, index) => (entry.op === "connect" ? index : lastIndex),
 			-1
 		);
+		const lastConnectCounter = latestConnect >= 0 ? entries[latestConnect].counter : null;
 		const currentEpoch = latestConnect >= 0 ? entries.slice(latestConnect) : entries;
 		const probes = currentEpoch.filter((entry) => entry.op === "probe");
-		const successful = probes.filter((entry) => entry.ok === true);
+		// DEX CORE DIVERGENCE: even a valid old probe cannot verify a credential
+		// after a newer connect counter.
+		const successful = probes.filter(
+			(entry) =>
+				entry.ok === true &&
+				(lastConnectCounter == null || entry.counter >= lastConnectCounter) &&
+				(!isCurrent || isCurrent(connectorId, entry))
+		);
 		const lastVerified = successful.length ? successful[successful.length - 1] : null;
 		const lastProbe = probes.length ? probes[probes.length - 1] : null;
 		return {

--- a/core/integrations/connection-manager/lifted-conformance.test.cjs
+++ b/core/integrations/connection-manager/lifted-conformance.test.cjs
@@ -59,13 +59,15 @@ const FILES = {
   },
   'connector-ledger.js': {
     source: '956612fbebc115fa7512aaf5db91676bfe40fa0c08d0927e52f4508e28e14cbf',
-    lifted: '4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba',
+    lifted: 'b3e7b926c77d3e2a45d8c751040ba3e306d0158be6d0d4dbc29f5415068b9c59',
     mode: 'core-adaptation',
     divergences: [
       'credentials/ledger path and Core connect, refresh, probe, and break vocabulary',
       'Desktop sync counts, cursors, schedules, and page receipts omitted',
       'fs-safe is the sole atomic writer and adds a per-connection cross-process lock',
       'successful probes are scoped to the current connect epoch after a credential replacement',
+      'production ledger rows are MAC-attested and unauthenticated evidence is ignored',
+      'successful probe counters must not predate the current connect counter',
     ],
   },
 };

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -11,6 +11,7 @@
 
 const http = require('http');
 const crypto = require('crypto');
+const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
 
 const CALLBACK_PORTS = [3847, 3848, 3849, 3850, 3851, 3852, 3853, 3854, 3855, 3860];
 
@@ -131,6 +132,9 @@ async function startCallbackServer({
  */
 function buildAuthorizationUrl(providerConfig, { clientId, scopes = [], redirectUri }) {
   const url = new URL(providerConfig.authorizationUrl);
+  if (providerConfig.id && isVetted(providerConfig.id)) {
+    assertPinnedOrigin(providerConfig.id, 'authorization', url.toString());
+  }
   const params = url.searchParams;
 
   // Defaults + catalog-declared authorization_params (response_type, access_type, prompt, ...)
@@ -171,6 +175,9 @@ function buildTokenAuth(providerConfig, clientId, clientSecret, body) {
 }
 
 async function postToken(providerConfig, body, headers) {
+  if (providerConfig.id && isVetted(providerConfig.id)) {
+    assertPinnedOrigin(providerConfig.id, 'token', providerConfig.tokenUrl);
+  }
   let payload;
   if (providerConfig.bodyFormat === 'json') {
     headers['Content-Type'] = 'application/json';

--- a/core/integrations/connection-manager/pinned-providers.cjs
+++ b/core/integrations/connection-manager/pinned-providers.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+const ORIGIN_KINDS = new Set(['authorization', 'token', 'refresh', 'api', 'verification']);
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+const REVIEWED_PROVIDERS = deepFreeze({
+  google: {
+    authorizationOrigin: 'https://accounts.google.com',
+    tokenOrigin: 'https://oauth2.googleapis.com',
+    refreshOrigin: 'https://oauth2.googleapis.com',
+    apiOrigins: ['https://www.googleapis.com'],
+    verificationOrigin: 'https://www.googleapis.com',
+    tenant: null,
+  },
+  linear: {
+    apiOrigins: ['https://api.linear.app'],
+    verificationOrigin: 'https://api.linear.app',
+    tenant: null,
+  },
+});
+
+let testPins = null;
+
+class OriginUnpinnedError extends Error {
+  constructor(providerId, kind, urlString) {
+    super(`Refusing credential-bearing ${kind} request for '${providerId}': destination is not a reviewed HTTPS origin.`);
+    this.name = 'OriginUnpinnedError';
+    this.code = 'DEX_CM_ORIGIN_UNPINNED';
+    this.exitCode = 1;
+    this.providerId = providerId;
+    this.kind = kind;
+    this.url = urlString;
+  }
+}
+
+function registry() {
+  return testPins ? { ...REVIEWED_PROVIDERS, ...testPins } : REVIEWED_PROVIDERS;
+}
+
+function isVetted(providerId) {
+  return Object.prototype.hasOwnProperty.call(registry(), providerId);
+}
+
+function pinnedOriginsFor(providerId) {
+  return registry()[providerId] || null;
+}
+
+function tenantMatches(pin, kind, url) {
+  if (!pin.tenant || (kind !== 'api' && kind !== 'verification')) return false;
+  const suffix = String(pin.tenant.pinnedSuffix || '').toLowerCase();
+  const labelPattern = new RegExp(pin.tenant.labelPattern);
+  const suffixWithDot = `.${suffix}`;
+  if (!url.hostname.endsWith(suffixWithDot)) return false;
+  const label = url.hostname.slice(0, -suffixWithDot.length);
+  return !label.includes('.') && labelPattern.test(label);
+}
+
+function assertPinnedOrigin(providerId, kind, urlString) {
+  if (!ORIGIN_KINDS.has(kind)) throw new OriginUnpinnedError(providerId, kind, urlString);
+  const pin = pinnedOriginsFor(providerId);
+  let url;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new OriginUnpinnedError(providerId, kind, urlString);
+  }
+  if (!pin || url.protocol !== 'https:') throw new OriginUnpinnedError(providerId, kind, urlString);
+
+  const expected =
+    kind === 'api'
+      ? pin.apiOrigins
+      : pin[`${kind}Origin`]
+        ? [pin[`${kind}Origin`]]
+        : [];
+  if ((Array.isArray(expected) && expected.includes(url.origin)) || tenantMatches(pin, kind, url)) return url.origin;
+  throw new OriginUnpinnedError(providerId, kind, urlString);
+}
+
+function __setPinnedForTest(map) {
+  if (!process.env.NODE_TEST_CONTEXT) {
+    throw new Error('__setPinnedForTest is available only under the Node test runner.');
+  }
+  testPins = map ? deepFreeze({ ...map }) : null;
+}
+
+module.exports = {
+  isVetted,
+  pinnedOriginsFor,
+  assertPinnedOrigin,
+  __setPinnedForTest,
+  OriginUnpinnedError,
+};

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -216,6 +216,7 @@ class KeyLossError extends Error {
 }
 
 let _cachedKey = null;
+let _cachedTrustMacKey = null;
 /**
  * Get-or-create the 32-byte AES key. Prefers OS keychain; falls back to a 0600 file.
  *
@@ -268,6 +269,63 @@ function getKey() {
 }
 
 /**
+ * Derive the trust-record MAC key from the encryption master key. The derived
+ * key is never stored separately and therefore inherits the same machine-local
+ * custody and key-loss behavior as encrypted credentials.
+ */
+function trustMacKey() {
+  if (_cachedTrustMacKey) return _cachedTrustMacKey;
+  _cachedTrustMacKey = Buffer.from(
+    crypto.hkdfSync('sha256', getKey(), Buffer.alloc(0), 'dex-cm-trust-mac-v1', 32)
+  );
+  return _cachedTrustMacKey;
+}
+
+function canonicalValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (!isPlainObject(value)) return value;
+  const ordered = {};
+  for (const key of Object.keys(value).sort()) {
+    if (value[key] !== undefined) ordered[key] = canonicalValue(value[key]);
+  }
+  return ordered;
+}
+
+/** Stable JSON encoding shared by registry, metadata, and ledger MACs. */
+function canonicalJSON(value) {
+  return JSON.stringify(canonicalValue(value));
+}
+
+function trustMac(payload) {
+  return crypto.createHmac('sha256', trustMacKey()).update(canonicalJSON(payload)).digest('base64');
+}
+
+function macMatches(actual, payload) {
+  if (typeof actual !== 'string') return false;
+  let provided;
+  try {
+    provided = Buffer.from(actual, 'base64');
+  } catch {
+    return false;
+  }
+  const expected = Buffer.from(trustMac(payload), 'base64');
+  return provided.length === expected.length && crypto.timingSafeEqual(provided, expected);
+}
+
+function reloadCachedKeyFromCustody() {
+  let found = null;
+  try {
+    found = keyFromMacKeychain() || (fileKeyAllowed() ? keyFromFile() : null);
+  } catch {
+    return false;
+  }
+  if (!found || found.length !== 32 || (_cachedKey && found.equals(_cachedKey))) return false;
+  _cachedKey = found;
+  _cachedTrustMacKey = null;
+  return true;
+}
+
+/**
  * Explicit recovery from key loss, invoked when the user RECONNECTS a tool
  * while the key is gone (never on a read path). Preserves every old token
  * file as *.keyloss-<timestamp> (they are undecryptable without the lost
@@ -288,11 +346,16 @@ function recoverFromKeyLoss() {
     let stamped = 0;
     for (const k of Object.keys(reg)) {
       if (k === '_defaults' || k === '_meta' || !reg[k] || !reg[k].service) continue;
-      reg[k] = { ...reg[k], status: 'needs_reauth', error: 'encryption_key_lost' };
+      upsertConnectionInRegistry(reg, k, {
+        status: 'needs_reauth',
+        verification: 'unverified',
+        error: 'encryption_key_lost',
+      });
       stamped++;
     }
     writeRegistry(reg);
     _cachedKey = null;
+    _cachedTrustMacKey = null;
     return Math.max(stamped, files.length);
   });
 }
@@ -465,6 +528,12 @@ function tokenPath(connId) {
   return path.join(tokensDir(), `${String(connId).replace(/:/g, '__')}.json`);
 }
 
+function credentialDigest(connId) {
+  const p = tokenPath(connId);
+  if (!fs.existsSync(p)) return 'none';
+  return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+}
+
 /** Persist a token object (encrypted) and refresh the registry entry. `connId` may be `provider` or `provider:alias`. */
 function saveToken(connId, token, meta = {}) {
   assertCredentialsNotTracked();
@@ -473,6 +542,7 @@ function saveToken(connId, token, meta = {}) {
   // loud recovery first, so the entry we then upsert stays 'connected'.
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(token), `token:${connId}`), null, 2);
   return withStoreLock(() => {
+    const reg = readRegistry();
     const fields = {
       provider: meta.provider || parsed.provider,
       status: 'connected',
@@ -484,11 +554,13 @@ function saveToken(connId, token, meta = {}) {
       ...meta.extra,
     };
     if (parsed.alias) fields.alias = parsed.alias;
-    // Registry first, then the token file: a crash in between leaves a registry
-    // entry with no token (harmless "not connected"), never a token file with no
-    // registry entry (which would look like registry data loss).
-    upsertConnection(connId, fields);
+    // The entry MAC binds the exact encrypted envelope, so the token must land
+    // first. A crash in this narrow window fails closed: the old entry's digest
+    // no longer matches, and the existing rebuild path can recover a token that
+    // landed before its registry entry.
     writeFileAtomic(tokenPath(connId), envelope, { mode: 0o600 });
+    upsertConnectionInRegistry(reg, connId, fields, { freshCredential: true });
+    writeRegistry(reg);
     return token;
   });
 }
@@ -509,6 +581,7 @@ function saveApiKey(service, secretObj, meta = {}) {
   const parsed = parseConnectionId(service);
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(stored), `token:${service}`), null, 2); // key-loss recovery before registry writes; see saveToken
   return withStoreLock(() => {
+    const reg = readRegistry();
     const fields = {
       provider: meta.provider || parsed.provider,
       authMode: meta.authMode || 'API_KEY',
@@ -521,8 +594,9 @@ function saveApiKey(service, secretObj, meta = {}) {
       ...meta.extra,
     };
     if (parsed.alias) fields.alias = parsed.alias;
-    upsertConnection(service, fields); // registry first; see saveToken
     writeFileAtomic(tokenPath(service), envelope, { mode: 0o600 });
+    upsertConnectionInRegistry(reg, service, fields, { freshCredential: true });
+    writeRegistry(reg);
     return stored;
   });
 }
@@ -621,6 +695,163 @@ function isPlainObject(v) {
   return Boolean(v) && typeof v === 'object' && !Array.isArray(v);
 }
 
+function registryMacPayload(connId, entry) {
+  return {
+    connId,
+    service: entry.service,
+    provider: entry.provider,
+    status: entry.status,
+    error: entry.error,
+    verification: entry.verification,
+    credentialDigest: entry.credentialDigest,
+    epoch: entry.epoch,
+    counter: entry.counter,
+  };
+}
+
+function registryMetaPayload(meta) {
+  return { counter: meta.counter };
+}
+
+function registryMetaVerified(reg) {
+  const meta = reg && reg._meta;
+  return Boolean(
+    isPlainObject(meta) &&
+      Number.isInteger(meta.counter) &&
+      meta.counter >= 0 &&
+      macMatches(meta.mac, registryMetaPayload(meta))
+  );
+}
+
+function registryEntryVerified(connId, entry, metaCounter = Infinity) {
+  return Boolean(
+    isPlainObject(entry) &&
+      Number.isInteger(entry.counter) &&
+      entry.counter >= 1 &&
+      entry.counter <= metaCounter &&
+      Number.isInteger(entry.epoch) &&
+      entry.epoch >= 1 &&
+      typeof entry.credentialDigest === 'string' &&
+      entry.credentialDigest === credentialDigest(connId) &&
+      macMatches(entry.mac, registryMacPayload(connId, entry))
+  );
+}
+
+function downgradeUntrustedEntry(entry, error = 'trust_unverified') {
+  return {
+    ...entry,
+    status: 'needs_reauth',
+    verification: 'unverified',
+    error,
+  };
+}
+
+function verifyRegistryTrust(reg) {
+  if (!hasServiceEntries(reg)) return reg;
+  let metaVerified = false;
+  let metaCounter = -1;
+  let keyLost = false;
+  try {
+    metaVerified = registryMetaVerified(reg);
+    if (!metaVerified && reloadCachedKeyFromCustody()) metaVerified = registryMetaVerified(reg);
+    if (metaVerified) metaCounter = reg._meta.counter;
+  } catch (error) {
+    if (error && error.code === 'DEX_CM_KEY_LOST') keyLost = true;
+    else throw error;
+  }
+  const verified = { ...reg };
+  for (const [connId, entry] of Object.entries(reg)) {
+    if (connId === '_defaults' || connId === '_meta' || !entry || !entry.service) continue;
+    let trusted = false;
+    if (metaVerified && !keyLost) {
+      try {
+        trusted = registryEntryVerified(connId, entry, metaCounter);
+      } catch (error) {
+        if (error && error.code === 'DEX_CM_KEY_LOST') keyLost = true;
+        else throw error;
+      }
+    }
+    verified[connId] = trusted
+      ? entry
+      : downgradeUntrustedEntry(entry, keyLost ? 'encryption_key_lost' : 'trust_unverified');
+  }
+  return verified;
+}
+
+function allocateCounter(reg) {
+  let current = 0;
+  try {
+    if (registryMetaVerified(reg)) current = reg._meta.counter;
+  } catch (error) {
+    if (!error || error.code !== 'DEX_CM_KEY_LOST') throw error;
+  }
+  const counter = current + 1;
+  reg._meta = { ...(isPlainObject(reg._meta) ? reg._meta : {}), counter };
+  reg._meta.mac = trustMac(registryMetaPayload(reg._meta));
+  return counter;
+}
+
+function upsertConnectionInRegistry(reg, service, fields, { freshCredential = false } = {}) {
+  const previous = isPlainObject(reg[service]) ? reg[service] : {};
+  const merged = { ...previous, service, ...fields };
+  const priorEpoch = Number.isInteger(previous.epoch) && previous.epoch >= 1 ? previous.epoch : 0;
+  merged.provider = merged.provider || parseConnectionId(service).provider;
+  merged.status = merged.status || 'connected';
+  merged.error = merged.error === undefined ? null : merged.error;
+  merged.verification = merged.verification || 'unverified';
+  merged.credentialDigest = credentialDigest(service);
+  merged.epoch = freshCredential ? priorEpoch + 1 : Math.max(1, priorEpoch);
+  merged.counter = allocateCounter(reg);
+  merged.mac = trustMac(registryMacPayload(service, merged));
+  reg[service] = merged;
+  return merged;
+}
+
+function ledgerMacPayload(row) {
+  const { mac: _mac, ...payload } = row;
+  return payload;
+}
+
+function attestLedgerRow(connId, row) {
+  return withStoreLock(() => {
+    const reg = readRegistry();
+    const entry = reg[connId];
+    const counter = allocateCounter(reg);
+    const attested = {
+      ...row,
+      connId,
+      credentialDigest: credentialDigest(connId),
+      epoch: entry && Number.isInteger(entry.epoch) ? entry.epoch : 1,
+      counter,
+    };
+    attested.mac = trustMac(ledgerMacPayload(attested));
+    writeRegistry(reg);
+    return attested;
+  });
+}
+
+function verifyLedgerRow(connId, row) {
+  if (!isPlainObject(row) || row.connId !== connId || !Number.isInteger(row.counter) || row.counter < 1) return false;
+  try {
+    return macMatches(row.mac, ledgerMacPayload(row));
+  } catch {
+    return false;
+  }
+}
+
+function ledgerRowMatchesCurrentCredential(connId, row) {
+  try {
+    const entry = readRegistry()[connId];
+    return Boolean(
+      entry &&
+        row.credentialDigest === credentialDigest(connId) &&
+        row.epoch === entry.epoch
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Read the connection registry. A damaged registry must NEVER silently reset
  * to empty (the old behaviour: every connection looked "not connected" and the
@@ -635,16 +866,22 @@ function isPlainObject(v) {
 function readRegistry() {
   const p = registryPath();
   if (fs.existsSync(p)) {
+    let reg;
     try {
-      const reg = JSON.parse(fs.readFileSync(p, 'utf8'));
-      if (isPlainObject(reg) && (hasServiceEntries(reg) || !listTokenFiles().length)) return reg;
+      reg = JSON.parse(fs.readFileSync(p, 'utf8'));
     } catch {
       /* unparseable: fall through to recovery */
+    }
+    // Trust verification stays outside the parse recovery catch. A filesystem
+    // or key-custody failure must fail closed, never quarantine a valid registry
+    // as if its JSON were corrupt.
+    if (isPlainObject(reg) && (hasServiceEntries(reg) || !listTokenFiles().length)) {
+      return verifyRegistryTrust(reg);
     }
   } else if (!listTokenFiles().length) {
     return {}; // genuine first run: nothing saved yet
   }
-  return recoverRegistry();
+  return verifyRegistryTrust(recoverRegistry());
 }
 
 /** Quarantine a damaged registry and rebuild it from the token files on disk. Idempotent and cross-process safe. */
@@ -745,6 +982,16 @@ function rebuildRegistryFromTokens(reason, quarantinedName) {
     recovered,
     unreadable,
   };
+  try {
+    for (const [connId, entry] of Object.entries(rebuilt)) {
+      if (connId === '_meta' || !entry || !entry.service) continue;
+      upsertConnectionInRegistry(rebuilt, connId, entry, { freshCredential: true });
+    }
+  } catch (error) {
+    if (!error || error.code !== 'DEX_CM_KEY_LOST') throw error;
+    delete rebuilt._meta.counter;
+    delete rebuilt._meta.mac;
+  }
   return rebuilt;
 }
 
@@ -756,9 +1003,9 @@ function writeRegistry(reg) {
 function upsertConnection(service, fields) {
   return withStoreLock(() => {
     const reg = readRegistry();
-    reg[service] = { ...(reg[service] || {}), service, ...fields };
+    const entry = upsertConnectionInRegistry(reg, service, fields);
     writeRegistry(reg);
-    return reg[service];
+    return entry;
   });
 }
 
@@ -858,6 +1105,12 @@ module.exports = {
   setOAuthApp,
   encrypt,
   decrypt,
+  trustMacKey,
+  canonicalJSON,
+  credentialDigest,
+  attestLedgerRow,
+  verifyLedgerRow,
+  ledgerRowMatchesCurrentCredential,
   KeyLossError,
   EnvelopeBindingError,
   recoverFromKeyLoss,

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -10,14 +10,14 @@
       "entries": [
         "connection-manager"
       ],
-      "fileCount": 17,
-      "totalBytes": 179114,
-      "treeHash": "749f981a8740a218f4189ef69c34e0f685435eb47c1a8da7e5630c0421e4f9ac",
+      "fileCount": 18,
+      "totalBytes": 195705,
+      "treeHash": "4b3b01156e76dbfd29d49d909a100ce26051eb489be6bff97ff342375ad4e617",
       "files": [
         {
           "path": "auth-context.cjs",
-          "bytes": 6351,
-          "sha256": "b90c56e323f0dcd9a2a19044b527b6f3378aa6cf48b6853b72f29a8564b83088"
+          "bytes": 6854,
+          "sha256": "23cf5358e043c22c5fce9777a06f4aaa7d1ef4c3156f9f13ca23443669e53185"
         },
         {
           "path": "catalog.cjs",
@@ -26,8 +26,8 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 27322,
-          "sha256": "89b1316386c4bd93dc446c2e49b8b0677df505baf0d42d2e4826738b7c8bba70"
+          "bytes": 28749,
+          "sha256": "d7c669b902c61ea8c2fc8cde00721b19273dcead150684f237b53d5a04cb3ab7"
         },
         {
           "path": "contract.cjs",
@@ -36,8 +36,8 @@
         },
         {
           "path": "dex-call.cjs",
-          "bytes": 6863,
-          "sha256": "d3a058ca725b98b6988c6a3f647961010d476cf3396a21adecf809daf073b719"
+          "bytes": 7631,
+          "sha256": "95fb3f328fc5465a73345be96dec7e39d8654fb4cf0df8deb7186ce28e51018e"
         },
         {
           "path": "fs-safe.cjs",
@@ -51,8 +51,8 @@
         },
         {
           "path": "health.cjs",
-          "bytes": 14760,
-          "sha256": "6f6a2a68e9da9c5a0807c1325f9aa18444471c533ee9f5607b00d79b8192cc90"
+          "bytes": 15550,
+          "sha256": "ee07cea0da798c7e68a21ea47228f2abad85641be2a3bd8579b3b9a2ffec4a57"
         },
         {
           "path": "index.cjs",
@@ -61,8 +61,8 @@
         },
         {
           "path": "lib/connector-ledger.js",
-          "bytes": 4799,
-          "sha256": "4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba"
+          "bytes": 5664,
+          "sha256": "b3e7b926c77d3e2a45d8c751040ba3e306d0158be6d0d4dbc29f5415068b9c59"
         },
         {
           "path": "lib/connector-model.js",
@@ -86,18 +86,23 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 9720,
-          "sha256": "162fdc24771a1f041562f835e4ccb0645740db76137b0badaf5536caecf30e22"
+          "bytes": 10073,
+          "sha256": "8efafa17b0a57306599508e142e69682c7c559d3e03b9e6106fc7bca19817d3f"
+        },
+        {
+          "path": "pinned-providers.cjs",
+          "bytes": 3066,
+          "sha256": "bfaa66151cdd7995bdfee132d2febad6527d788798c9b62ba81cb13e83a9dada"
         },
         {
           "path": "README.md",
-          "bytes": 7791,
-          "sha256": "d4925a0119849ee366709a9cdb932bc1728a704c26b98272b9ef633f346eb850"
+          "bytes": 8809,
+          "sha256": "a016fb03bcf4586f49ce744d8608a6357639f0bbfcde94ca965377e77d5a2cd5"
         },
         {
           "path": "token-store.cjs",
-          "bytes": 34034,
-          "sha256": "17fbe97f5eb97b1145c562149e5f2f638e6b4a230841f1e52a37ef2c2fcf4ed0"
+          "bytes": 41835,
+          "sha256": "2530302d7c28e7904ec885d29fda80d99a7529d164bc2b37bf1e8f8afad218a2"
         }
       ]
     }


### PR DESCRIPTION
Option B security work, phase 5b (architecture doc §3 + §4). Closes **C1/H1** (a malicious/wrong catalog descriptor could choose where your keys are sent) and **H4** (plaintext trust records could be forged to revive a dead credential). No contract or CLI exit-code changes. **`/connect` stays closed** — 5c (broker), 5d (Touch ID), 5e (independent re-review) still to come.

## Origin pinning (new `pinned-providers.cjs`) — C1, H1
- A Dex-reviewed registry pins each vetted provider's authorization / token / refresh / api / verification **origins**, independent of catalog data. Seeded with **google + linear** (origins confirmed against the real installed catalog descriptors).
- Every credential-bearing egress for a vetted provider — `dex-call`, token exchange/refresh, the authorization URL, the verification probe — asserts the pinned origin (HTTPS + exact origin, or `<label>.<pinnedSuffix>` for tenant-templated providers) and **refuses before sending a byte** on mismatch.
- The other ~829 catalog providers keep working **only** behind an explicit opt-in (`--allow-unvetted` / `DEX_CM_ALLOW_UNVETTED=1`) with a warning, and are **never auto-probed**. This is the public-doorway safety floor.

## Tamper-proof trust (`token-store.cjs`) — H4
- A machine-local MAC key **derived from the master key** (HKDF-SHA256 — no new stored secret) seals every registry entry and ledger row with an HMAC over `{connId, status, verification, credentialDigest, epoch, counter}`.
- `credentialDigest` binds the evidence to the exact encrypted credential on disk; a monotonic MAC'd counter defeats rollback/replay of an old "verified" row.
- Read paths verify the MAC and **downgrade any unauthenticated / forged / legacy entry to `needs_reauth`** — plaintext is never trusted. Tokens are written before the registry so the digest binds; the rebuild-from-tokens path re-seals.
- One-time cost: legacy un-MAC'd installs need one reconnect per tool to establish sealed trust.

## Verification (re-run independently after review)
- New security suite 10/10; **143/143** serial connection-manager suite.
- `check:connections-contract`: contract v1.0.0 + engine manifest verified (18 files; `pinned-providers.cjs` included).
- Local PR gates: path-contract, test-delta, doc-drift all pass.
- **Fable ran its own adversarial test:** a hand-edited `connections.json` flipping status to `connected` with a forged MAC is refused (`needs_reauth` / `trust_unverified`) by both `get-token` and `dex-call`.

### Existing tests updated for the unvetted opt-in (behavior intact, just now explicit)
Garmin browse-only, Gemini `--status` redaction, `affinity-v2` roundtrip/`--as`, `1password-events` host-scoped ×2, `aws-scim` probe-skip, and the advanced-tier OAuth case — each now passes `--allow-unvetted` or uses the test-only pin injection because its provider isn't in the vetted seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MUmNHSKhTxdUwGtiJ4SUy