### PR TITLE
feat(connect): /connect skill + daily health hook, ready but held closed

### DIFF
--- a/.claude/hooks/connection-health-checker.cjs
+++ b/.claude/hooks/connection-health-checker.cjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Connection Health Checker
+ *
+ * Runs at session start at most once per day. Reads the connection manager's
+ * local-only health sweep and surfaces a short note only when a connection is
+ * expired or needs reauthentication.
+ *
+ * ALWAYS exits 0. Missing vaults, missing engine files, and read/write errors
+ * are silent so this can never block a session start.
+ *
+ * Throttle state: {DEX_VAULT}/System/integrations/.connection-health-state.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CM_DIR = path.resolve(__dirname, '..', '..', 'core', 'integrations', 'connection-manager');
+const STATUSES_TO_SURFACE = new Set(['needs_reauth', 'expired']);
+
+function configuredPaths() {
+  const configuredVault = process.env.DEX_VAULT || process.env.VAULT_PATH;
+  if (!configuredVault) return null;
+
+  try {
+    // Keep vault discovery aligned with the neighbouring hooks. DEX_VAULT is
+    // also accepted by the connection manager, so mirror it into VAULT_PATH
+    // for paths.cjs when that is the only configured name.
+    if (!process.env.VAULT_PATH) process.env.VAULT_PATH = configuredVault;
+    const { loadPaths } = require('./paths.cjs');
+    const loaded = loadPaths();
+    const vaultRoot = path.resolve(configuredVault);
+    return {
+      vaultRoot,
+      systemDir:
+        path.resolve(loaded.VAULT_ROOT) === vaultRoot
+          ? loaded.SYSTEM_DIR
+          : path.join(vaultRoot, 'System'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function stateFile(paths) {
+  return path.join(paths.systemDir, 'integrations', '.connection-health-state.json');
+}
+
+function shouldCheck(file) {
+  try {
+    const state = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return state.lastCheck !== new Date().toISOString().slice(0, 10);
+  } catch {
+    return true;
+  }
+}
+
+function saveCheckState(file, needsAttention) {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify(
+        {
+          lastCheck: new Date().toISOString().slice(0, 10),
+          needsAttention,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // The throttle is best-effort; a state write must never block startup.
+  }
+}
+
+function main() {
+  const paths = configuredPaths();
+  if (!paths) return;
+
+  const healthPath = path.join(CM_DIR, 'health.cjs');
+  if (!fs.existsSync(healthPath)) return;
+
+  const file = stateFile(paths);
+  if (!shouldCheck(file)) return;
+
+  // Claim today's attempt before loading the engine. Even a damaged local
+  // connection record must not make every session repeat the sweep.
+  saveCheckState(file, false);
+
+  let rows;
+  try {
+    const health = require(healthPath);
+    rows = health.allConnectionsHealth() || [];
+  } catch {
+    return;
+  }
+
+  const attention = rows.filter((row) => STATUSES_TO_SURFACE.has(row.status));
+  if (attention.length) {
+    console.log('--- Connections Need Attention ---');
+    for (const row of attention) {
+      const reason = row.status === 'expired' ? 'expired' : 'needs re-authentication';
+      console.log(`${row.service} — ${reason}. Run /connect ${row.service} to reconnect.`);
+    }
+    console.log('---\n');
+  }
+
+  saveCheckState(file, attention.length > 0);
+}
+
+try {
+  main();
+} catch {
+  // SessionStart hooks are advisory. Fail open and stay silent.
+}
+process.exitCode = 0;

--- a/.claude/hooks/tests/connection-health-checker.test.cjs
+++ b/.claude/hooks/tests/connection-health-checker.test.cjs
@@ -1,0 +1,152 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const HOOK_PATH = path.join(ROOT, '.claude', 'hooks', 'connection-health-checker.cjs');
+const PATHS_PATH = path.join(ROOT, '.claude', 'hooks', 'paths.cjs');
+const SETTINGS_PATH = path.join(ROOT, '.claude', 'settings.json');
+
+function createFixture(t, rows = []) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connection-health-'));
+  const hooksDir = path.join(vault, '.claude', 'hooks');
+  const managerDir = path.join(vault, 'core', 'integrations', 'connection-manager');
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.mkdirSync(managerDir, { recursive: true });
+  fs.cpSync(HOOK_PATH, path.join(hooksDir, 'connection-health-checker.cjs'));
+  fs.cpSync(PATHS_PATH, path.join(hooksDir, 'paths.cjs'));
+  fs.writeFileSync(
+    path.join(managerDir, 'health.cjs'),
+    [
+      "'use strict';",
+      "const fs = require('node:fs');",
+      'module.exports.allConnectionsHealth = () => {',
+      '  fs.appendFileSync(process.env.HEALTH_CALLS_FILE, "called\\n");',
+      '  if (process.env.HEALTH_THROW === "1") throw new Error("fixture failure");',
+      '  return JSON.parse(process.env.HEALTH_ROWS || "[]");',
+      '};',
+      '',
+    ].join('\n'),
+  );
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return {
+    vault,
+    hookPath: path.join(hooksDir, 'connection-health-checker.cjs'),
+    managerDir,
+    callsFile: path.join(vault, 'health-calls.txt'),
+    rows,
+  };
+}
+
+function runHook(fixture, env = {}) {
+  return spawnSync(process.execPath, [fixture.hookPath], {
+    cwd: fixture.vault,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: fixture.vault,
+      DEX_VAULT: fixture.vault,
+      HEALTH_CALLS_FILE: fixture.callsFile,
+      HEALTH_ROWS: JSON.stringify(fixture.rows),
+      ...env,
+    },
+    timeout: 5_000,
+  });
+}
+
+function assertCleanExit(result) {
+  assert.equal(
+    result.status,
+    0,
+    `hook exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.equal(result.stderr, '');
+}
+
+test('SessionStart runs the connection health checker without changing existing hooks', () => {
+  const settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  const commands = settings.hooks.SessionStart.flatMap((entry) => entry.hooks || []).map((hook) => hook.command);
+  assert.ok(commands.includes('node .claude/hooks/connection-health-checker.cjs'));
+  assert.ok(commands.includes('bash .claude/hooks/session-start.sh'));
+  assert.ok(commands.includes('python3 "$CLAUDE_PROJECT_DIR/core/utils/update_verifier.py" --vault "$CLAUDE_PROJECT_DIR" --session-start'));
+  assert.ok(commands.includes('bash .claude/hooks/dex-core-orientation.sh'));
+});
+
+test('stays silent when no connection needs attention', (t) => {
+  const fixture = createFixture(t, [
+    { service: 'google', status: 'connected' },
+    { service: 'slack', status: 'expiring' },
+    { service: 'linear', status: 'error' },
+  ]);
+
+  const result = runHook(fixture);
+
+  assertCleanExit(result);
+  assert.equal(result.stdout, '');
+});
+
+test('surfaces a connection that needs reauthentication', (t) => {
+  const fixture = createFixture(t, [
+    { service: 'google:work', status: 'needs_reauth' },
+    { service: 'slack', status: 'expired' },
+  ]);
+
+  const result = runHook(fixture);
+
+  assertCleanExit(result);
+  assert.match(result.stdout, /google:work — needs re-authentication/);
+  assert.match(result.stdout, /Run \/connect google:work to reconnect/);
+  assert.match(result.stdout, /slack — expired/);
+});
+
+test('runs the local health sweep at most once per day', (t) => {
+  const fixture = createFixture(t, [
+    { service: 'google', status: 'needs_reauth' },
+  ]);
+
+  const first = runHook(fixture);
+  const second = runHook(fixture);
+
+  assertCleanExit(first);
+  assertCleanExit(second);
+  assert.match(first.stdout, /google — needs re-authentication/);
+  assert.equal(second.stdout, '');
+  assert.equal(fs.readFileSync(fixture.callsFile, 'utf8'), 'called\n');
+});
+
+test('a failed local sweep is still throttled for the rest of the day', (t) => {
+  const fixture = createFixture(t);
+
+  const first = runHook(fixture, { HEALTH_THROW: '1' });
+  const second = runHook(fixture, { HEALTH_THROW: '1' });
+
+  assertCleanExit(first);
+  assertCleanExit(second);
+  assert.equal(first.stdout, '');
+  assert.equal(second.stdout, '');
+  assert.equal(fs.readFileSync(fixture.callsFile, 'utf8'), 'called\n');
+});
+
+test('exits zero and stays silent when the vault or connection manager is missing', (t) => {
+  const noVault = createFixture(t);
+  const vaultResult = runHook(noVault, {
+    CLAUDE_PROJECT_DIR: '',
+    DEX_VAULT: '',
+    VAULT_PATH: '',
+  });
+
+  assertCleanExit(vaultResult);
+  assert.equal(vaultResult.stdout, '');
+  assert.equal(fs.existsSync(noVault.callsFile), false);
+
+  const noManager = createFixture(t);
+  fs.rmSync(noManager.managerDir, { recursive: true, force: true });
+  const managerResult = runHook(noManager);
+
+  assertCleanExit(managerResult);
+  assert.equal(managerResult.stdout, '');
+  assert.equal(fs.existsSync(noManager.callsFile), false);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/dex-core-orientation.sh"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/connection-health-checker.cjs"
           }
         ]
       }

--- a/.claude/skills/connect/SKILL.md
+++ b/.claude/skills/connect/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: connect
+description: Connect, check, and manage your app integrations (Google, Slack, Linear, GitHub, and hundreds more) — OAuth or paste-a-key, with tokens stored encrypted on your machine
+---
+
+# Connect
+
+Connect Dex to the apps you use, see what's working, and fix anything that's broken — all from one conversational command. Dex owns the OAuth runtime and stores every token **encrypted on your machine, never sent to a relay**.
+
+This skill is a friendly driver over the connection manager CLI. You run the CLI verbs; you translate the output into plain language and clear next actions.
+
+## What This Enables
+
+`/connect` is the front door for every integration:
+
+- **See what's connected** — a health sweep of all your connections, with each one mapped to a next action (reconnect, refresh, or nothing needed)
+- **Connect a new app** — two paths:
+  - **OAuth (Class A)** — Google, Slack, Atlassian, and most major apps. Authorize once in your browser; Dex remembers the login locally and auto-refreshes the token.
+  - **Paste a key (Class B)** — Linear, GitHub PATs, and any API-key service. No OAuth app, no consent screen — just paste the secret.
+- **Reconnect** — when a token is revoked or expires beyond refresh, re-run the OAuth flow
+- **Disconnect** — remove a connection and delete its local token
+- **Find a provider** — fuzzy-search 775 catalog entries by name; 627 can be connected today
+
+The connection manager lives at:
+`core/integrations/connection-manager/`
+
+All commands below are run from the dex-core root (paths are relative to it).
+
+## Privacy
+
+- **Tokens are stored AES-256-GCM encrypted on-device** under `{DEX_VAULT}/System/credentials/` (the encryption key lives in macOS Keychain; non-Mac systems and explicitly configured test environments use a local key file).
+- That directory is **gitignored** — credentials are never committed.
+- **Nothing is sent to a relay.** Dex talks directly to the provider for authorization, token exchange, refresh, and any live check.
+- The OAuth catalog (provider URLs, scopes, quirks) is consumed as **config data only** — it carries no credentials.
+- `{DEX_VAULT}` means the vault configured by `DEX_VAULT` or `VAULT_PATH`. Dex stops and asks for a vault if neither is set; it does not guess a default folder.
+
+## When to Run
+
+- User types `/connect`
+- User asks to connect, link, or set up an app (Gmail, Google Calendar, Slack, Linear, GitHub, Jira, etc.)
+- User asks "what's connected?", "is my Google still working?", or "what needs reconnecting?"
+- User asks to disconnect or remove an integration
+- A `/daily-plan` heads-up nudge surfaced a `needs_reauth` or `expired` connection
+
+---
+
+## Setup Flow
+
+### Step 0: Is It Already Available Through Claude? (Check This First)
+
+**Before sending anyone through a Dex connection flow, check whether the tool is already reachable through Claude's own connectors.** If Dex is running inside Claude, the user (or their company) has very likely already approved connectors there — Calendar, Gmail, Drive, Slack, and more — and Dex can simply *use* them. They show up as available tools (e.g. `Google Calendar`, `Gmail`, `Google Drive`). There's nothing to connect: the consent already happened in Claude, the company already approved it, and no Dex token is needed.
+
+So the best first move is to look at what's already there:
+
+- If the tool the user wants is already available via a Claude connector → **use it directly. Don't run a connection flow.** Just tell them "Good news — your Calendar's already connected through Claude, so I can read it right now. Want me to take a look at your day?"
+- If it's *not* available through Claude → that's when Dex's own connection manager earns its place (Steps 1–7 below).
+
+**This Dex flow is for two audiences:** people using Dex **outside** Claude (where there are no Claude connectors), and people who want a tool their **company hasn't given them** through Claude. For everyone else inside Claude, the connectors they already have are the fastest path — lead with those.
+
+When something genuinely needs connecting, use the gaps as a friendly prompt: *"I can see your Calendar and Gmail through Claude already. I can't see Slack — want to connect that one through Dex?"*
+
+### Step 1: Check What's Already Connected
+
+Run the health sweep (this covers Dex's *own* connections — the ones not coming from Claude):
+
+```bash
+node core/integrations/connection-manager/connect.cjs status
+```
+
+This first says whether the encryption key is in macOS Keychain or in the vault folder, then prints one row per connection with an icon and a status. The statuses are exactly:
+`connected` · `expiring` · `expired` · `needs_reauth` · `not_connected`.
+
+**Explain the key line only if it says "vault folder" — and be straight about it.** Keychain is the
+normal case and needs no comment; mentioning it just adds noise. If the key is in the vault folder
+(non-Mac machines, or where the Keychain isn't available), say what that actually means for them in
+one sentence: the key sits in the same folder as the connections it unlocks, so anyone who gets a
+copy of that folder — a backup, a synced Dropbox or iCloud copy, a borrowed laptop — can read those
+sign-ins. Don't alarm them and don't bury it; it's a real difference and they can only account for
+it if they know. If they ask what to do about it, the honest answer today is to keep that folder out
+of shared or synced storage.
+
+**Reformat the icon table into prose**, and map each status to its next action:
+
+| Status | What it means | What you tell the user |
+|--------|---------------|------------------------|
+| `connected` | A saved credential is present and has no known problem | Nothing needed. If no live-check time is shown, say it has not been verified live yet. |
+| `expiring` | Token expires soon | Nothing needed — auto-refresh handles it. (Optionally offer `refresh` if they want it now.) |
+| `expired` | Token lapsed, refresh available | Offer `refresh`; if that fails permanently it becomes `needs_reauth` and must be reconnected |
+| `needs_reauth` | The saved credential can no longer be used | **Reconnect required** — re-run OAuth, or paste the key again for a key-based connection |
+| `not_connected` | No token stored | Offer to connect |
+
+If a row says `needs_reauth (encryption_key_lost)`, Dex can still see the connection record but cannot unlock the saved credential. Tell the user to reconnect it. Reconnecting creates a fresh encryption key and keeps the old encrypted files with a `.keyloss-...` name for inspection; the other saved connections will also need reconnecting.
+
+Example of how to render it:
+
+```
+Here's where your connections stand:
+
+- Google — connected and verified
+- Slack — needs reconnect (the token was revoked). Want me to reconnect it?
+- Linear — connected (API key)
+
+Everything else looks good.
+```
+
+If there are no connections yet, the CLI says so — pivot straight to "Which app would you like to connect?"
+
+Group anything `needs_reauth` / `expired` at the top so the user sees what needs action first.
+
+### Step 2: Figure Out What the User Wants
+
+Branch based on intent:
+
+- **"What's connected?" / status check** → you already answered it in Step 1. Stop here unless they want to act.
+- **Connect a new app** → go to Step 3 (resolve the provider), then Step 4 (OAuth) or Step 5 (paste a key).
+- **Reconnect a broken one** → use Step 4 for OAuth, or Step 5 to paste a fresh key for a key-based connection.
+- **Disconnect** → Step 6.
+
+### Step 3: Resolve the Provider Name (Fuzzy Match)
+
+Users say "Google", "gmail", "my Linear" — resolve that to a real provider id before connecting.
+
+For OAuth providers:
+
+```bash
+node core/integrations/connection-manager/connect.cjs providers <filter>
+```
+
+For API-key providers, include them too:
+
+```bash
+node core/integrations/connection-manager/connect.cjs providers --keys <filter>
+```
+
+Show the matches and confirm which one they mean. Each row shows the provider `id`, display name, and auth mode. The `id` is what you pass to `connect` / `set-key`.
+
+Google, Slack, and Linear have passed Dex's security review. Other catalog providers are marked `advanced` and the CLI requires the user's explicit opt-in with `--allow-unvetted`; explain that plainly before using that flag. Browse-only providers cannot be connected yet.
+
+If the match is unambiguous (one obvious hit), just confirm it inline rather than making them pick.
+
+**Deciding the path:**
+- If the provider's auth mode is OAuth → **Class A** (Step 4).
+- If it's an API-key / basic-auth provider (appears under `--keys`) → **Class B** (Step 5).
+- Not sure what a provider takes? `connect.cjs describe <id>` shows its auth mode, the secret it wants, and any required fields (subdomain/region/accountId…) before you start — handy for confirming the path and pre-empting what you'll need to ask the user.
+
+### Step 4: Connect — Class A (OAuth)
+
+OAuth services need an OAuth app (a client id + secret) to drive the flow. Check whether one already exists before asking the user to register anything.
+
+**Google: Calendar is the simpler first scope; Gmail is more involved.** Dex does not ship a pre-registered Google OAuth app, so the user needs to register their own Google client unless they already saved one or supplied it through the environment. Calendar usually has a lighter setup and reading someone's day/week is a useful first connection. Gmail is a "restricted" scope in Google's eyes and carries extra verification steps, so treat it as a deliberate, later step rather than part of a quick first connect.
+
+**4a. Check for an existing OAuth app.**
+OAuth app credentials live in `{DEX_VAULT}/System/credentials/oauth-apps.json`, keyed by service. Dex does not bundle provider client credentials. If the user has already registered an app there, or supplied `DEX_OAUTH_<SERVICE>_CLIENT_ID` and `_CLIENT_SECRET`, you can connect straight away — skip to 4c.
+
+**4b. Register an OAuth app (only if none exists) — YOU write the file, the user never edits it.**
+
+The user must **never open or edit a config file**. You capture the two values in chat and save them for them with `register-app`:
+
+1. Walk them through creating an OAuth client in the provider's developer console (pick "Desktop app" / "Installed" where offered). If they're stuck, point them at the provider's "OAuth app" / "API credentials" page — that's the most technical they ever get.
+2. If the provider asks for redirect URIs, register the loopback callbacks the engine may choose: `http://127.0.0.1:3847/callback` through `http://127.0.0.1:3855/callback`, plus `http://127.0.0.1:3860/callback`. The engine uses the first free port. The authorization URL printed when connecting shows the exact `redirect_uri` chosen. A provider that requires `localhost` instead of `127.0.0.1` can use `DEX_OAUTH_CALLBACK_HOST=localhost`; register the matching `localhost` callbacks.
+3. Ask them to **paste the client id, then the client secret** into the chat (the secret may be blank for public/PKCE clients).
+4. **You** save them — read the two values from stdin so they never land in shell history:
+
+   ```bash
+   node core/integrations/connection-manager/connect.cjs register-app <service> <<'CREDS'
+   <client-id>
+   <client-secret>
+   CREDS
+   ```
+
+   (Headless/dev alternative: `DEX_OAUTH_<SERVICE>_CLIENT_ID` / `_CLIENT_SECRET` env vars.)
+
+If the user already has a usable OAuth app for that provider, capture its id/secret the same way. Then continue to 4c. **Never tell the user to edit `oauth-apps.json` by hand.**
+
+**4c. Run the OAuth flow.**
+Pick the scopes the user needs (least-privilege; for read-only context, prefer the `…readonly` scopes), then:
+
+```bash
+node core/integrations/connection-manager/connect.cjs connect <service> --scopes scope1,scope2,scope3
+# Google example (shorthand is fine — see note):
+node core/integrations/connection-manager/connect.cjs connect google --scopes gmail.readonly,calendar.readonly
+```
+
+**Scope shorthand:** pass scopes the way the provider names them. For Google you can use the short form (`gmail.readonly`, `calendar.readonly`, `drive.file`) — the connection manager expands them to the full `https://www.googleapis.com/auth/…` URLs Google's auth endpoint requires (`openid`/`email`/`profile` and any value you pass as a full URL are left as-is). Other providers (GitHub, Slack, …) use their bare scope names unchanged.
+
+This opens the browser to the provider's consent screen and waits on the local loopback callback. On success the token is stored encrypted and you'll see a "Connected" confirmation.
+
+**If it fails:**
+- Browser didn't open → copy the URL printed in the output and open it manually.
+- Consent not granted / wrong scopes → re-run with the right scopes.
+- Callback rejected → read the `redirect_uri` in the printed authorization URL, then make sure that exact host, port, and `/callback` path is registered with the provider (4b, step 2).
+- No refresh token came back → confirm the auth URL requests offline access:
+  ```bash
+  node core/integrations/connection-manager/connect.cjs authurl <service> --scopes …
+  ```
+  (look for `access_type=offline`). Retry up to twice, then offer to come back later.
+
+Re-run `connect.cjs status` to confirm the new connection shows 🟢.
+
+### Step 5: Connect — Class B (Paste a Key)
+
+For API-key / token services there's no OAuth app and no consent screen — the user pastes a secret. But many are **host-scoped** (the API lives at `yourcompany.zendesk.com`, a specific region, a NetSuite account id, …), so find out exactly what the provider needs *before* asking for the key.
+
+**5a. See what the provider needs.**
+
+```bash
+node core/integrations/connection-manager/connect.cjs describe <service>
+```
+
+`describe` prints the secret's name, the exact connect command to run, and — crucially — any **required fields** (subdomain, hostname, region, accountId…), each with a one-line hint and example. If it says *"Needs fields: none — a single API key is enough,"* go straight to the key.
+
+**5b. Store the key (plus any required fields).**
+
+The secret is read from **stdin** by default (so it never lands in shell history or argv). Pass each required field from `describe` as its own `--<field>` flag:
+
+```bash
+# Single-key service (most providers):
+node core/integrations/connection-manager/connect.cjs set-key <service>
+
+# Host-scoped service — supply the field(s) describe listed:
+node core/integrations/connection-manager/connect.cjs set-key freshdesk --subdomain acme
+node core/integrations/connection-manager/connect.cjs set-key active-campaign --hostname acme.api-us1.com
+node core/integrations/connection-manager/connect.cjs set-key cin7-core --accountId 1234567
+```
+
+Have the user paste their key when prompted (it's read from stdin). For BASIC services like Freshdesk, pass `--username`; the password is read from the hidden prompt or stdin. Secret flags such as `--key` and `--password` are deliberately rejected so credentials do not appear in shell history or process listings.
+
+**If a required field is missing, `set-key` refuses and names it** (e.g. *"ActiveCampaign needs connection detail: hostname"*) rather than saving a dead connection — so always `describe` first, or just read the error and re-run with the field.
+
+On success the key is encrypted and stored exactly like an OAuth token. For security-reviewed providers, Dex runs a **live check** where it can: a reviewed verification endpoint can confirm the key or flag a rejected credential, while a generic check can only confirm and never condemn. Advanced providers are not auto-checked. Confirm with `connect.cjs status` — key connections show as `connected` or `connected (unverified)` (they don't expire or need refresh).
+
+**Note on how consumers use it:** for an API-key service, the token accessor returns the rendered request recipe so callers don't re-implement the auth scheme:
+
+```bash
+node core/integrations/connection-manager/get-token.cjs <service>
+# → { kind:'api_key', baseUrl, headers:{…rendered…}, query:{…} }
+node core/integrations/connection-manager/get-token.cjs <service> --access-token-only
+# → the raw secret
+```
+
+You normally don't run `get-token.cjs` during `/connect` — it's what other tools call to actually use the connection. Mention it only if the user asks how the key gets used.
+
+### Step 6: Disconnect
+
+To remove a connection and delete its local token:
+
+```bash
+node core/integrations/connection-manager/connect.cjs disconnect <service>
+```
+
+Confirm with the user first (this deletes the stored credential from this machine). After it runs, re-run `connect.cjs status` so they can see it's gone, and remind them they can reconnect anytime with `/connect`. Fully revoking the provider's access also requires removing Dex in the provider's own account settings. For a specific account, pass the connection id (`disconnect google:work`).
+
+### Multiple accounts of one provider
+
+A user can connect several accounts of the same provider (e.g. personal + work Gmail). Add `--as <alias>` (and `--default` to make it the one bare `google` resolves to):
+
+```bash
+node core/integrations/connection-manager/connect.cjs connect google --as work --default
+node core/integrations/connection-manager/connect.cjs set-key linear --as personal
+```
+
+Each account is its own connection id — `google` (the default) and `google:work`. Bare `google` keeps resolving to the existing/default account, so nothing a user already connected ever changes. Refer to a specific one as `provider:alias` in `connect` / `set-key` / `get-token` / `disconnect`.
+
+### Step 7: Confirm and Hand Off
+
+After any connect / reconnect / disconnect, close the loop:
+
+- Re-run `connect.cjs status` and report the new state in prose.
+- For a fresh connection, say the saved credential is ready for Dex tools that use that provider.
+- Remind them they can run `/connect` anytime to check status or manage connections.
+
+---
+
+## Reference: CLI Verbs
+
+All under `core/integrations/connection-manager/`:
+
+| Command | What it does |
+|---------|--------------|
+| `connect.cjs status` | Health sweep of all connections |
+| `connect.cjs connect <svc> --scopes a,b,c [--as <alias>] [--default]` | Run the OAuth flow (Class A); `--as` connects a second account |
+| `connect.cjs register-app <svc>` | Save an OAuth app's client id/secret (reads stdin: id then secret) — so the user never edits a file |
+| `connect.cjs describe <svc>` | Show what a provider needs: secret, required fields, base URL, docs (run before `set-key`) |
+| `connect.cjs set-key <svc> [--<field> v] [--as <alias>] [--default]` | Store a pasted API key (Class B; reads stdin). Host-scoping fields as `--subdomain`, etc.; `--as` for a 2nd account |
+| `connect.cjs disconnect <svc>` | Delete a connection's local token (`<svc>` may be `provider` or `provider:alias`) |
+| `connect.cjs refresh <svc> [--force]` | Refresh an expired or expiring token; `--force` refreshes even when it is still valid |
+| `connect.cjs probe [<svc>]` | Run a bounded live check for one connection, or all connections when omitted |
+| `connect.cjs providers [filter]` | List OAuth providers (add `--keys` to include API-key providers) |
+| `connect.cjs coverage` | Paste-a-key coverage tiering — how many apps connect with just a key (answers "what can I connect?") |
+| `connect.cjs authurl <svc> --scopes …` | Print the auth URL only (dry run, no browser) |
+| `get-token.cjs <svc> [--access-token-only]` | Token accessor for consumers (exit 0 ok · 2 not connected · 3 needs re-auth · 1 error) |
+
+**The registry** lives at `{DEX_VAULT}/System/credentials/connections.json` — one entry per service with `{ service, provider, authMode, status, scopes, expiresAt, connectedAt, lastRefreshedAt, lastUsedAt, error }`. You don't edit it by hand; the CLI maintains it.
+
+---
+
+## Troubleshooting
+
+### "'<service>' has no OAuth app registered yet"
+
+The provider needs a client id + secret that isn't saved yet. Do **not** tell the user to edit a file — follow Step 4b: capture the client id + secret in chat and run `register-app <service>` to save them for them.
+
+### A connection flipped to `needs_reauth`
+
+The saved credential can no longer be used. For OAuth this usually means the refresh token was revoked or expired; reconnect via Step 4 with the same scopes. For a key-based connection, follow Step 5 and paste a fresh key.
+
+If the error is `encryption_key_lost`, the saved files are still present but Dex cannot unlock them. Reconnect the tool to create a fresh key; Dex preserves the old encrypted files as `.keyloss-...` instead of deleting them.
+
+### Browser didn't open during connect
+
+Copy the authorization URL printed in the command output and open it manually. Corporate networks sometimes block the loopback redirect — if so, the user may need to try from a personal network.
+
+### Token works but a tool can't use the key
+
+For API-key services, the auth scheme matters (some use `Bearer`, some `x-api-key`, some a query param, some no scheme at all). `get-token.cjs <service>` returns the **rendered headers and query** so consumers use the right scheme automatically — point tool authors at that JSON rather than hand-rolling the header.
+
+---
+
+## Reconfiguration
+
+Running `/connect` again is always safe — it starts with a status sweep (Step 1), so the user can review everything and choose to connect, reconnect, or disconnect from there. There's no separate "reconfigure" mode; the status-first flow covers it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.75.0] — 🔐 A second look at how your app sign-ins are stored (2026-07-24)
+
+Before the connections doorway opens, I wanted the way Dex stores your sign-ins checked properly rather than taken on trust. So it got reviewed twice, independently — once by me and once by a separate AI model that wasn't shown my findings, each trying to find ways in. The good news up front: the actual sealing of your credentials held up under both reviews. What the reviews found were softer edges around it, and this release tidies all of them. Nothing here was ever exploited, and the feature isn't open to anyone yet — this is the tidying you do *before* opening the door.
+
+**What this gets ready for you:**
+
+* **Dex now tells you where the key to your credentials is kept.** Normally it lives in your Mac's Keychain, sealed away from your notes. On the rare setup where that isn't available, it sits in your vault folder instead — which means a copy of that folder is a copy of your sign-ins. Dex used to look identical either way. Now it just says which, so you can see it rather than assume.
+* **"Disconnect" no longer overpromises.** It removes the credential from your machine — but the app itself can still have permission in your account until you remove it there. Dex now says so, and points you at the right place, instead of leaving you to assume you were fully unhooked.
+* **A disconnect leaves nothing behind.** If a credential file had previously been set aside as damaged, disconnecting didn't clear it. Now it does, so removing a connection really removes it.
+* **Nothing an outside service says gets written down unexamined.** If a connected app sent back an error message, Dex saved it as-is for troubleshooting. A misbehaving service could have used that to get something sensitive written into a plain-text log. Dex now strips anything sensitive out first.
+* **A stray browser tab can't interrupt you mid-connect.** While you were connecting an app, another page open in your browser could quietly cancel it and leave you wondering what went wrong. That window is closed.
+* **Sturdier under odd setups.** If your credentials folder or key arrived from a backup with loose permissions, Dex now tightens them before use rather than trusting them, and refuses outright if something looks tampered with. And account names that could have collided into the same file — quietly breaking one of two connections — are now rejected up front.
+
+Still no change to day-to-day use: this is the last piece of groundwork before connecting your tools becomes something you can actually do.
+
 ## [1.74.0] — 🔌 Groundwork: connecting your other tools, tested against the real world (2026-07-24)
 
 Dex is getting a built-in way to connect the other tools you use — starting with Google Calendar and Linear — so it can work with what's in them instead of asking you to copy-paste. That doorway isn't open yet, but this release lands the machinery behind it, after a security review and live end-to-end testing with real Google and Linear accounts.

--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -369,6 +369,7 @@ async function cmdSetKey(service, flags) {
 function cmdStatus(flags = {}) {
   const meta = store.readRegistry()._meta;
   const rows = health.allConnectionsHealth();
+  const keyCustody = store.keyCustodyMode();
   if (flags.json !== undefined) {
     process.stdout.write(`${JSON.stringify({ connections: rows, registryNotice: meta || null })}\n`);
     return;
@@ -381,6 +382,11 @@ function cmdStatus(flags = {}) {
         ' Check the list below and reconnect anything missing or red.'
     );
   }
+  console.log(
+    keyCustody === 'keychain'
+      ? 'Encryption key: stored in your macOS Keychain.'
+      : 'Encryption key: stored in your vault folder — anyone with a copy of that folder can read these credentials.'
+  );
   if (!rows.length) {
     console.log('No connections yet. Run: node connect.cjs connect <provider>');
     return;
@@ -538,7 +544,10 @@ async function main() {
         break;
       case 'disconnect':
         store.deleteToken(positional[0]);
-        console.log(`Disconnected ${positional[0]}.`);
+        console.log(
+          `Disconnected ${positional[0]}. The credential was removed from this machine. ` +
+            "To fully revoke access, remove Dex in the provider's account settings."
+        );
         break;
       case 'providers':
         cmdProviders(positional[0], flags);

--- a/core/integrations/connection-manager/connection-manager.hardening.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.hardening.test.cjs
@@ -82,6 +82,59 @@ test('atomic: registry and token writes keep 0600 files / 0700 dirs through the 
   store.deleteToken('perm-check');
 });
 
+test('permissions: a pre-existing loose credentials directory is tightened to 0700', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-loose-dir-'));
+  const credentials = path.join(vault, 'System', 'credentials');
+  fs.mkdirSync(credentials, { recursive: true });
+  fs.chmodSync(credentials, 0o755);
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'loose-dir', 'FAKE-key'], {
+      env: { ...childEnv, DEX_VAULT: vault },
+      stdio: 'pipe',
+    });
+    assert.equal(mode(credentials), 0o700);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('permissions: a loose fallback key file is tightened to 0600 before reading', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-loose-key-'));
+  const env = { ...childEnv, DEX_VAULT: vault };
+  const keyFile = path.join(vault, 'System', 'credentials', '.dex-cm.key');
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'loose-key', 'FAKE-key'], { env, stdio: 'pipe' });
+    fs.chmodSync(keyFile, 0o644);
+    execFileSync('node', [CHILD, 'load-token', 'loose-key'], { env, stdio: 'pipe' });
+    assert.equal(mode(keyFile), 0o600);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('permissions: a symlinked fallback key is refused with clear guidance', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-symlink-key-'));
+  const env = { ...childEnv, DEX_VAULT: vault };
+  const keyFile = path.join(vault, 'System', 'credentials', '.dex-cm.key');
+  const target = path.join(vault, 'saved-key');
+  try {
+    execFileSync('node', [CHILD, 'save-key', 'symlink-key', 'FAKE-key'], { env, stdio: 'pipe' });
+    fs.renameSync(keyFile, target);
+    fs.symlinkSync(target, keyFile);
+    let failure;
+    try {
+      execFileSync('node', [CHILD, 'load-token', 'symlink-key'], { env, stdio: 'pipe' });
+    } catch (error) {
+      failure = error;
+    }
+    assert.ok(failure, 'the key must not be read through a symlink');
+    assert.match(failure.stderr.toString(), /encryption key.*symlink/i);
+    assert.match(failure.stderr.toString(), /replace/i);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
 test('atomic: crash between temp write and rename leaves the old registry intact', () => {
   store.upsertConnection('crash-keeper', { provider: 'crash-keeper', status: 'connected' });
 
@@ -267,6 +320,24 @@ test('refresh lock: a dead-PID holder is taken over on the refresh lock specific
 function corruptTokens() {
   return fs.readdirSync(TOKENS_DIR).filter((n) => n.includes('.corrupt-'));
 }
+
+test('disconnect removes only that connection’s corrupt and key-loss residue', () => {
+  store.saveApiKey('residue-target', { apiKey: 'FAKE-target' }, { provider: 'residue-target' });
+  store.saveApiKey('residue-other', { apiKey: 'FAKE-other' }, { provider: 'residue-other' });
+  const targetLive = path.join(TOKENS_DIR, 'residue-target.json');
+  const otherLive = path.join(TOKENS_DIR, 'residue-other.json');
+  const targetCorrupt = `${targetLive}.corrupt-test`;
+  const targetKeyloss = `${targetLive}.keyloss-test`;
+  const otherCorrupt = `${otherLive}.corrupt-test`;
+  fs.copyFileSync(targetLive, targetCorrupt);
+  fs.copyFileSync(targetLive, targetKeyloss);
+  fs.copyFileSync(otherLive, otherCorrupt);
+
+  store.deleteToken('residue-target');
+  assert.ok(!fs.readdirSync(TOKENS_DIR).some((name) => name.startsWith('residue-target.json.')));
+  assert.ok(fs.existsSync(otherCorrupt), 'another connection’s quarantine file is untouched');
+  store.deleteToken('residue-other');
+});
 
 test('corrupt token: truncated file becomes needs_reauth with reason, file quarantined not deleted', () => {
   store.saveApiKey('corrupt-a', { apiKey: 'FAKE-key-a' }, { provider: 'corrupt-a', authMode: 'API_KEY' });
@@ -455,6 +526,24 @@ test('ids: path-traversal connection ids are rejected before they reach the file
   // normal ids still fine
   assert.equal(store.parseConnectionId('google:work').connId, 'google:work');
   assert.equal(store.parseConnectionId('7shifts').provider, '7shifts');
+});
+
+test('ids: a provider containing the reserved filename separator is rejected', () => {
+  assert.throws(() => store.parseConnectionId('google__work'), /reserved.*__|__.*reserved/i);
+});
+
+test('ids: new mixed-case providers are rejected instead of colliding on macOS', () => {
+  assert.throws(() => store.parseConnectionId('Google:work'), /lowercase/i);
+});
+
+test('ids: an existing lowercase connection keeps its token path and still loads', () => {
+  store.saveApiKey('lowercase-existing', { apiKey: 'FAKE-lowercase-key' }, { provider: 'lowercase-existing' });
+  try {
+    assert.ok(fs.existsSync(path.join(TOKENS_DIR, 'lowercase-existing.json')));
+    assert.equal(store.loadToken('lowercase-existing').apiKey, 'FAKE-lowercase-key');
+  } finally {
+    store.deleteToken('lowercase-existing');
+  }
 });
 
 // ---- key loss (fix: never silently mint a new key over existing tokens) -------

--- a/core/integrations/connection-manager/connection-manager.judgment.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.judgment.test.cjs
@@ -155,6 +155,37 @@ test('permanent refresh failure stamps needs_reauth and records refresh + break 
   }
 });
 
+test('provider refresh errors cannot persist the refresh token in plaintext', async () => {
+  const connId = 'refresh-secret-redaction';
+  const refreshToken = 'ACTUAL-REFRESH-TOKEN-TO-REDACT';
+  seedOAuth(connId, 'google', { refresh_token: refreshToken });
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    response(400, {
+      error: 'invalid_grant',
+      error_description: `token ${refreshToken} is expired`,
+    });
+  try {
+    await withProviderConfig(
+      'google',
+      { tokenUrl: 'https://tokens.example/refresh', refreshUrl: null },
+      async () => {
+        await assert.rejects(health.refreshToken(connId, { force: true }), (error) => {
+          assert.ok(!error.message.includes(refreshToken));
+          return true;
+        });
+      }
+    );
+    const ledgerBytes = fs.readFileSync(path.join(store.credentialsDir(), 'ledger', `${connId}.jsonl`), 'utf8');
+    const registryBytes = fs.readFileSync(path.join(store.credentialsDir(), 'connections.json'), 'utf8');
+    assert.ok(!ledgerBytes.includes(refreshToken));
+    assert.ok(!registryBytes.includes(refreshToken));
+  } finally {
+    global.fetch = originalFetch;
+    store.deleteToken(connId);
+  }
+});
+
 test('transient 500 retries once, succeeds, and never stamps a reconnect error', async () => {
   seedOAuth('refresh-transient', 'google');
   let calls = 0;

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -156,13 +156,72 @@ test('rotating refresh tokens persist and the next refresh uses the newest token
   }
 });
 
-test('callback server rejects a mismatched OAuth state', async () => {
+test('macOS Keychain receives the master key on stdin, never in process arguments', () => {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-keychain-argv-'));
+  const storePath = path.join(DIR, 'token-store.cjs');
+  const script = `
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const childProcess = require('node:child_process');
+    const calls = [];
+    childProcess.execFileSync = (file, args, options) => {
+      calls.push({ file, args, input: options && options.input });
+      if (args[0] === 'find-generic-password') throw new Error('not found');
+      return Buffer.alloc(0);
+    };
+    const store = require(${JSON.stringify(storePath)});
+    store.saveApiKey('keychain-argv', { apiKey: 'API-KEY' }, { provider: 'linear' });
+    process.stdout.write(JSON.stringify(calls));
+  `;
+  const env = { ...childEnv, DEX_VAULT: vault };
+  delete env.DEX_CM_NO_KEYCHAIN;
+  const result = spawnSync('node', ['-e', script], { env, encoding: 'utf8' });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const add = JSON.parse(result.stdout).find((call) => call.args[0] === 'add-generic-password');
+    assert.ok(add, 'the test reaches the Keychain write');
+    const keyArg = add.args.find((arg) => /^[A-Za-z0-9+/]{43}=$/.test(arg));
+    assert.equal(keyArg, undefined, 'the base64 master key is absent from argv');
+    assert.match(add.input, /^([A-Za-z0-9+/]{43}=)\n\1\n$/);
+    assert.equal(add.args.at(-1), '-w');
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('callback server escapes provider errors before rendering HTML', async () => {
+  const harness = callbackHarness();
+  const cb = await oauth.startCallbackServer({ ports: [3847], timeoutMs: 1000, createServer: harness.createServer });
+  const pending = cb.waitForCode({ expectedState: 'expected-state' }).catch((error) => error);
+  const response = harness.request(
+    harness.servers[0],
+    `/callback?error=${encodeURIComponent('<img src=x onerror=alert(1)>')}&state=expected-state`
+  );
+  assert.equal(response.status, 200);
+  assert.doesNotMatch(response.body, /<img/i);
+  assert.match((await pending).message, /provider returned error/i);
+});
+
+test('callback server ignores a mismatched state and still accepts the real callback', async () => {
   const harness = callbackHarness();
   const cb = await oauth.startCallbackServer({ ports: [3847], timeoutMs: 1000, createServer: harness.createServer });
   const pending = cb.waitForCode({ expectedState: 'expected-state' });
-  const response = harness.request(harness.servers[0], '/callback?code=abc&state=wrong-state');
-  assert.equal(response.status, 400);
-  await assert.rejects(pending, /state mismatch/i);
+  let settled = false;
+  pending.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+  const wrong = harness.request(harness.servers[0], '/callback?code=wrong-code&state=wrong-state');
+  assert.equal(wrong.status, 400);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(settled, false);
+
+  const correct = harness.request(harness.servers[0], '/callback?code=right-code&state=expected-state');
+  assert.equal(correct.status, 200);
+  assert.deepEqual(await pending, { code: 'right-code', state: 'expected-state' });
 });
 
 test('callback server times out and closes cleanly', async () => {
@@ -244,6 +303,27 @@ test('OAuth app secrets surface the same explicit key-loss state as tokens', () 
   assert.match(read.stderr, /DEX_CM_KEY_LOST/);
   assert.ok(fs.existsSync(path.join(vault, 'System', 'credentials', 'oauth-apps.json')));
   fs.rmSync(vault, { recursive: true, force: true });
+});
+
+test('status reports file custody when the macOS Keychain is disabled', () => {
+  store.saveApiKey('custody-status', { apiKey: 'FAKE-custody-key' }, { provider: 'linear' });
+  try {
+    const result = run([path.join(DIR, 'connect.cjs'), 'status']);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Encryption key: stored in your vault folder/i);
+    assert.match(result.stdout, /anyone with a copy of that folder can read these credentials/i);
+  } finally {
+    store.deleteToken('custody-status');
+  }
+});
+
+test('disconnect explains that provider access must still be revoked', () => {
+  store.saveApiKey('disconnect-wording', { apiKey: 'FAKE-disconnect-key' }, { provider: 'linear' });
+  const result = run([path.join(DIR, 'connect.cjs'), 'disconnect', 'disconnect-wording']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /removed from this machine/i);
+  assert.match(result.stdout, /fully revoke access/i);
+  assert.match(result.stdout, /provider.*account settings/i);
 });
 
 test('secret argv flags are rejected with one-line stdin guidance', () => {

--- a/core/integrations/connection-manager/health.cjs
+++ b/core/integrations/connection-manager/health.cjs
@@ -211,8 +211,8 @@ function tokenRevision(token) {
   ]);
 }
 
-function recordConnectionEvent(connId, op, row = {}) {
-  return ledger.append(connId, { op, ...row });
+function recordConnectionEvent(connId, op, row = {}, secrets = []) {
+  return ledger.append(connId, { op, ...row }, { secrets });
 }
 
 /**
@@ -281,6 +281,14 @@ async function refreshToken(service, { force = false } = {}) {
       const app = store.getOAuthApp(provider); // OAuth app is shared per provider, not per account
       if (!app) throw new Error(`No OAuth app credentials for '${provider}'. Add them to oauth-apps.json.`);
       const providerConfig = catalog.getProviderConfig(provider, reg.connectionConfig || {});
+      const { secretsOf } = require('./auth-context.cjs');
+      const refreshSecrets = secretsOf({
+        headers: {
+          accessToken: current.access_token,
+          refreshToken: current.refresh_token || token.refresh_token,
+          clientSecret: app.clientSecret,
+        },
+      });
       try {
         const result = await refreshOAuthToken({
           tokenUrl: providerConfig.refreshUrl || providerConfig.tokenUrl,
@@ -292,6 +300,7 @@ async function refreshToken(service, { force = false } = {}) {
           retryDelayMs: Number.isFinite(providerConfig.refreshRetryDelayMs)
             ? providerConfig.refreshRetryDelayMs
             : undefined,
+          secrets: refreshSecrets,
         });
         const fresh = normalizeRefreshResult(result, current);
         store.saveToken(connId, fresh, { provider: providerConfig.id, connectedAt: reg.connectedAt });
@@ -303,13 +312,13 @@ async function refreshToken(service, { force = false } = {}) {
         recordConnectionEvent(connId, 'refresh', {
           ok: false,
           error: { category: needsReauth ? 'auth_permanent' : 'transient', code, message: code },
-        });
+        }, refreshSecrets);
         if (needsReauth) {
           store.upsertConnection(connId, { status: 'needs_reauth', error: code });
           recordConnectionEvent(connId, 'break', {
             ok: false,
             error: { category: 'auth_permanent', code, message: code },
-          });
+          }, refreshSecrets);
         }
         throw Object.assign(err, { needsReauth });
       }

--- a/core/integrations/connection-manager/lib/connector-ledger.js
+++ b/core/integrations/connection-manager/lib/connector-ledger.js
@@ -27,13 +27,14 @@ function parseFile(text) {
 	return entries;
 }
 
-function normalizeError(error) {
+function normalizeError(error, secrets = []) {
+	const { redactSecrets } = require("../auth-context.cjs");
 	if (error == null) return null;
-	if (typeof error === "string") return { message: error };
+	if (typeof error === "string") return { message: redactSecrets(error, secrets).slice(0, 500) };
 	if (typeof error !== "object") return null;
 	const safe = {};
 	for (const key of ["code", "category", "message"]) {
-		if (error[key] != null) safe[key] = String(error[key]).slice(0, 500);
+		if (error[key] != null) safe[key] = redactSecrets(error[key], secrets).slice(0, 500);
 	}
 	return Object.keys(safe).length ? safe : null;
 }
@@ -76,7 +77,7 @@ function createConnectorLedger(opts = {}) {
 		}
 	}
 
-	function normalizeRow(connectorId, row = {}) {
+	function normalizeRow(connectorId, row = {}, secrets = []) {
 		return {
 			at: new Date(now()).toISOString(),
 			connectorId,
@@ -84,16 +85,16 @@ function createConnectorLedger(opts = {}) {
 			httpStatus: Number.isFinite(row.httpStatus) ? row.httpStatus : null,
 			ok: row.ok === true,
 			latencyMs: Number.isFinite(row.latencyMs) ? row.latencyMs : null,
-			error: normalizeError(row.error),
+			error: normalizeError(row.error, secrets),
 		};
 	}
 
-	function append(connectorId, row) {
+	function append(connectorId, row, { secrets = [] } = {}) {
 		const safeId = validateConnectorId(connectorId);
 		const dir = stateDir();
 		fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 		const file = filePathFor(safeId);
-		const stored = normalizeRow(safeId, row);
+		const stored = normalizeRow(safeId, row, secrets);
 		return withLockSync(`${file}.lock`, () => {
 			const entries = readDisk(safeId);
 			const next = [...entries, stored].slice(-maxEntriesPerConnector);

--- a/core/integrations/connection-manager/lib/oauth-refresh.js
+++ b/core/integrations/connection-manager/lib/oauth-refresh.js
@@ -108,6 +108,7 @@ async function refreshOAuthToken({
 	retryDelayMs = DEFAULT_REFRESH_RETRY_DELAY_MS,
 	// DEX CORE DIVERGENCE: injectable delay keeps Retry-After/clamp tests instant.
 	delayImpl = delay,
+	secrets = [],
 } = {}) {
 	if (typeof fetchImpl !== "function") {
 		throw new RefreshError("No fetch implementation available for token refresh", { permanent: false });
@@ -123,6 +124,7 @@ async function refreshOAuthToken({
 		...(clientSecret ? { client_secret: clientSecret } : {}),
 		...extraParams,
 	}).toString();
+	const safeMessage = (message) => require("../auth-context.cjs").redactSecrets(message, secrets);
 
 	// One network exchange, bounded by a timeout. A hang or transient network
 	// error throws a non-permanent RefreshError so the retry loop below can try
@@ -144,7 +146,7 @@ async function refreshOAuthToken({
 		} catch (error) {
 			const timedOut = controller.signal.aborted || error?.name === "AbortError";
 			throw new RefreshError(
-				timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`,
+				safeMessage(timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`),
 				{ permanent: false, cause: error },
 			);
 		} finally {
@@ -168,12 +170,12 @@ async function refreshOAuthToken({
 			// (from the body `retry_after` or the response headers). Other error
 			// codes keep the existing permanent/transient classification.
 			if (rateLimit.is429(data)) {
-				throw new RefreshError(data?.error_description || data?.error || "Token refresh was rate limited", {
+				throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rate limited"), {
 					permanent: false,
 					retryAfterMs: rateLimit.retryAfterMs(data) ?? rateLimit.retryAfterMs(response),
 				});
 			}
-			throw new RefreshError(data?.error_description || data?.error || "Token refresh was rejected", {
+			throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rejected"), {
 				permanent: isPermanentError(data),
 			});
 		}

--- a/core/integrations/connection-manager/lifted-conformance.test.cjs
+++ b/core/integrations/connection-manager/lifted-conformance.test.cjs
@@ -25,12 +25,13 @@ const FILES = {
   },
   'oauth-refresh.js': {
     source: '0f29891a988d913c8b4bfddc9ee9d8f4c91328784534107ff65abe3d4cac4783',
-    lifted: 'cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392',
+    lifted: '8ae2f42d507a078aa9f48ac01a0c67bd5a0004742802da9332a95356da57c731',
     mode: 'injectable-delay',
     divergences: [
       'source provenance header',
       'injectable delay used only to prove Retry-After clamping',
       'credential-bearing refresh requests refuse redirects',
+      'known operation secrets redact provider-controlled refresh errors before they escape',
     ],
   },
   'connector-model.js': {
@@ -58,13 +59,14 @@ const FILES = {
   },
   'connector-ledger.js': {
     source: '956612fbebc115fa7512aaf5db91676bfe40fa0c08d0927e52f4508e28e14cbf',
-    lifted: '4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba',
+    lifted: 'd38c8b8fe0e8a3c9e258dd35b25ad8902b336287b304b140a88bdda55eb8ee09',
     mode: 'core-adaptation',
     divergences: [
       'credentials/ledger path and Core connect, refresh, probe, and break vocabulary',
       'Desktop sync counts, cursors, schedules, and page receipts omitted',
       'fs-safe is the sole atomic writer and adds a per-connection cross-process lock',
       'successful probes are scoped to the current connect epoch after a credential replacement',
+      'operation secrets redact provider-controlled error fields before ledger persistence',
     ],
   },
 };
@@ -117,6 +119,20 @@ for (const [name, contract] of Object.entries(FILES)) {
             '\t\t\t\t// Never let a refresh token or client secret cross a redirect.\n' +
             '\t\t\t\tredirect: "error",\n',
           ''
+        )
+        .replace('\tsecrets = [],\n', '')
+        .replace('\tconst safeMessage = (message) => require("../auth-context.cjs").redactSecrets(message, secrets);\n', '')
+        .replace(
+          '\t\t\t\tsafeMessage(timedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`),\n',
+          '\t\t\t\ttimedOut ? `Token refresh timed out after ${timeoutMs}ms` : `Token refresh request failed: ${error?.message || "unknown"}`,\n'
+        )
+        .replace(
+          'throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rate limited"), {',
+          'throw new RefreshError(data?.error_description || data?.error || "Token refresh was rate limited", {'
+        )
+        .replace(
+          'throw new RefreshError(safeMessage(data?.error_description || data?.error || "Token refresh was rejected"), {',
+          'throw new RefreshError(data?.error_description || data?.error || "Token refresh was rejected", {'
         )
         .replace('await delayImpl(waitMs)', 'await delay(waitMs)');
       assert.equal(normalized, source.toString());

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -43,6 +43,15 @@ function listenOnFirstFreePort(ports, createServer) {
   });
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Start a localhost callback server. Returns:
  *   { redirectUri, waitForCode(): Promise<{code,state}>, close() }
@@ -79,19 +88,20 @@ async function startCallbackServer({
         const error = url.searchParams.get('error');
         const code = url.searchParams.get('code');
         const state = url.searchParams.get('state');
-        const stateMismatch = expectedState !== undefined && state !== expectedState;
-        res.writeHead(stateMismatch ? 400 : 200, { 'Content-Type': 'text/html; charset=utf-8' });
+        const stateMatches = expectedState === undefined || state === expectedState;
+        const terminal = stateMatches && Boolean(code || error);
+        res.writeHead(terminal ? 200 : 400, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(
-          stateMismatch
-            ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection aborted</h2><p>OAuth state mismatch.</p></body></html>'
+          !terminal
+            ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Callback not accepted</h2><p>Dex is still waiting for the connection to finish.</p></body></html>'
             : error
-            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${error}</p><p>You can close this tab and return to Dex.</p></body></html>`
+            ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${escapeHtml(error)}</p><p>You can close this tab and return to Dex.</p></body></html>`
             : `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>✅ Connected</h2><p>You can close this tab and return to Dex.</p></body></html>`
         );
+        if (!terminal) return;
         clearTimeout(timeout);
         server.close();
-        if (stateMismatch) reject(new Error('OAuth state mismatch — possible CSRF, aborting.'));
-        else if (error) reject(new Error(`Provider returned error: ${error}`));
+        if (error) reject(new Error(`Provider returned error: ${error}`));
         else resolve({ code, state });
       });
     });

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -40,7 +40,17 @@ function credentialsDir() {
 
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  if (dir === credentialsDir()) ensureCredentialsGitignore(dir);
+  if (dir === credentialsDir()) {
+    const stat = fs.lstatSync(dir);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Your credentials folder at ${dir} is a symlink. Replace it with a real folder owned by your account, then try again.`);
+    }
+    if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+      throw new Error(`Your credentials folder at ${dir} belongs to a different user. Change its owner to your account, then try again.`);
+    }
+    if (stat.mode & 0o077) fs.chmodSync(dir, 0o700);
+    ensureCredentialsGitignore(dir);
+  }
 }
 
 // The credentials dir must ignore EVERYTHING — tokens, the registry, oauth-app secrets, AND the
@@ -99,6 +109,11 @@ function keychainDisabled() {
   return process.env.DEX_CM_NO_KEYCHAIN === '1';
 }
 
+function keyCustodyMode() {
+  if (process.platform !== 'darwin' || keychainDisabled()) return 'file';
+  return fs.existsSync(path.join(credentialsDir(), '.dex-cm.key')) ? 'file' : 'keychain';
+}
+
 function keyFromMacKeychain() {
   if (process.platform !== 'darwin' || keychainDisabled()) return null;
   try {
@@ -120,8 +135,8 @@ function storeKeyInMacKeychain(keyB64) {
   try {
     execFileSync(
       'security',
-      ['add-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-w', keyB64, '-U'],
-      { stdio: 'ignore' }
+      ['add-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-U', '-w'],
+      { input: `${keyB64}\n${keyB64}\n`, stdio: ['pipe', 'ignore', 'ignore'] }
     );
     return true;
   } catch {
@@ -131,8 +146,25 @@ function storeKeyInMacKeychain(keyB64) {
 
 function keyFromFile() {
   const keyPath = path.join(credentialsDir(), '.dex-cm.key');
-  if (fs.existsSync(keyPath)) return Buffer.from(fs.readFileSync(keyPath, 'utf8').trim(), 'base64');
-  return null;
+  let stat;
+  try {
+    stat = fs.lstatSync(keyPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    const error = new Error(`The encryption key at ${keyPath} is a symlink. Replace it with the original .dex-cm.key file, then try again.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    const error = new Error(`The encryption key at ${keyPath} belongs to a different user. Change its owner to your account, then try again.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  if (stat.mode & 0o077) fs.chmodSync(keyPath, 0o600);
+  return Buffer.from(fs.readFileSync(keyPath, 'utf8').trim(), 'base64');
 }
 
 function writeKeyFile(keyB64) {
@@ -178,7 +210,8 @@ function getKey() {
   let lookupFailed = false;
   try {
     found = keyFromMacKeychain() || keyFromFile();
-  } catch {
+  } catch (error) {
+    if (error && error.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH') throw error;
     lookupFailed = true; // unreadable key source counts as loss, not as "fresh start"
   }
   if (found && found.length === 32) {
@@ -331,14 +364,22 @@ function decrypt(envelope, aad = '') {
  * FILENAMES (and the registry rebuild derives ids back from filenames), so a
  * hostile id like '../x' must never reach tokenPath and escape the tokens dir.
  */
-function parseConnectionId(id) {
+function parseConnectionId(id, { allowLegacyProviderCase = false } = {}) {
   const s = String(id);
   const i = s.indexOf(':');
-  const provider = i === -1 ? s : s.slice(0, i);
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(provider)) {
+  const rawProvider = i === -1 ? s : s.slice(0, i);
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(rawProvider)) {
     throw new Error(`Invalid provider in connection id '${id}'. Use letters, digits, '.', '-' or '_' (must start with a letter or digit).`);
   }
-  if (i === -1) return { provider: s, alias: null, connId: s };
+  if (rawProvider.includes('__')) {
+    throw new Error(`Invalid provider in connection id '${id}'. '__' is reserved for separating account names in credential filenames.`);
+  }
+  const lowercaseProvider = rawProvider.toLowerCase();
+  if (rawProvider !== lowercaseProvider && !allowLegacyProviderCase) {
+    throw new Error(`Invalid provider in connection id '${id}'. Use a lowercase provider name.`);
+  }
+  const provider = allowLegacyProviderCase ? rawProvider : lowercaseProvider;
+  if (i === -1) return { provider, alias: null, connId: provider };
   const alias = s.slice(i + 1).toLowerCase();
   if (!/^[a-z0-9_-]+$/.test(alias)) throw new Error(`Invalid connection alias in '${id}'. Use letters, digits, '-' or '_'.`);
   return { provider, alias, connId: `${provider}:${alias}` };
@@ -353,8 +394,8 @@ function parseConnectionId(id) {
  */
 function resolveConnId(id) {
   const reg = readRegistry();
+  if (reg[id] && reg[id].service) return id; // exact legacy match wins before new-id validation
   const { provider, alias } = parseConnectionId(id);
-  if (reg[id] && reg[id].service) return id; // exact match wins (back-compat)
   if (!alias) {
     const def = reg._defaults && reg._defaults[provider];
     if (def && reg[def]) return def;
@@ -376,7 +417,7 @@ function tokenPath(connId) {
 
 /** Persist a token object (encrypted) and refresh the registry entry. `connId` may be `provider` or `provider:alias`. */
 function saveToken(connId, token, meta = {}) {
-  const parsed = parseConnectionId(connId);
+  const parsed = parseConnectionId(connId, { allowLegacyProviderCase: Boolean(readRegistry()[connId]) });
   // Encrypt BEFORE touching the registry: if the key is lost this triggers the
   // loud recovery first, so the entry we then upsert stays 'connected'.
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(token), `token:${connId}`), null, 2);
@@ -413,7 +454,7 @@ function saveToken(connId, token, meta = {}) {
  */
 function saveApiKey(service, secretObj, meta = {}) {
   const stored = { kind: 'api_key', ...secretObj, obtained_at: Date.now() };
-  const parsed = parseConnectionId(service);
+  const parsed = parseConnectionId(service, { allowLegacyProviderCase: Boolean(readRegistry()[service]) });
   const envelope = JSON.stringify(encryptForSave(JSON.stringify(stored), `token:${service}`), null, 2); // key-loss recovery before registry writes; see saveToken
   return withStoreLock(() => {
     const fields = {
@@ -481,7 +522,7 @@ function loadToken(id) {
   } catch (err) {
     // Key loss is store-wide, not a damaged file: keep the (intact) token file
     // where it is and surface the explicit state to the caller instead.
-    if (err && err.code === 'DEX_CM_KEY_LOST') throw err;
+    if (err && (err.code === 'DEX_CM_KEY_LOST' || err.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH')) throw err;
     withStoreLock(() => {
       const bindingMismatch = err && err.code === 'DEX_CM_ENVELOPE_BINDING';
       const quarantined = quarantineFile(p, bindingMismatch ? 'mismatch' : 'corrupt');
@@ -503,9 +544,15 @@ function deleteToken(id) {
   return withStoreLock(() => {
     const p = tokenPath(connId);
     if (fs.existsSync(p)) fs.unlinkSync(p);
+    const base = path.basename(p);
+    for (const file of fs.readdirSync(path.dirname(p))) {
+      if (file.startsWith(`${base}.corrupt-`) || file.startsWith(`${base}.keyloss-`)) {
+        fs.unlinkSync(path.join(path.dirname(p), file));
+      }
+    }
     const reg = readRegistry();
+    const provider = (reg[connId] && reg[connId].provider) || parseConnectionId(connId, { allowLegacyProviderCase: true }).provider;
     delete reg[connId];
-    const { provider } = parseConnectionId(connId);
     if (reg._defaults && reg._defaults[provider] === connId) {
       delete reg._defaults[provider];
       if (!Object.keys(reg._defaults).length) delete reg._defaults;
@@ -597,7 +644,7 @@ function rebuildRegistryFromTokens(reason, quarantinedName) {
   for (const f of listTokenFiles()) {
     let parsed;
     try {
-      parsed = parseConnectionId(f.replace(/\.json$/, '').replace(/__/g, ':'));
+      parsed = parseConnectionId(f.replace(/\.json$/, '').replace(/__/g, ':'), { allowLegacyProviderCase: true });
     } catch {
       continue; // foreign or hostile filename: leave the file alone, add no entry
     }
@@ -608,7 +655,9 @@ function rebuildRegistryFromTokens(reason, quarantinedName) {
       token = JSON.parse(decrypt(JSON.parse(fs.readFileSync(fp, 'utf8')), `token:${parsed.connId}`));
     } catch (err) {
       unreadable++;
-      if (err && err.code === 'DEX_CM_KEY_LOST') {
+      if (err && err.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH') {
+        throw err;
+      } else if (err && err.code === 'DEX_CM_KEY_LOST') {
         // The key is gone, not the file: keep the file untouched and mark the state.
         rebuilt[parsed.connId] = { ...base, status: 'needs_reauth', error: 'encryption_key_lost', recoveredAt: nowIso() };
       } else {
@@ -745,6 +794,7 @@ function nowIso() {
 
 module.exports = {
   credentialsDir,
+  keyCustodyMode,
   parseConnectionId,
   resolveConnId,
   withStoreLock,

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 17,
-      "totalBytes": 172291,
-      "treeHash": "aaa7573e05647bff28a757ba01b300bc9d4e66eafc0d854806be1531a29e7478",
+      "totalBytes": 176402,
+      "treeHash": "5bcb231f548b02b0fa41432882aab41460b5329027bcdeb1934594267ccd0e69",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -26,8 +26,8 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 27241,
-          "sha256": "fdb913096eabc9570644f33263ae93ec6ab4634d931d02e20d1cf8bb5d8de0a8"
+          "bytes": 27667,
+          "sha256": "8e3b5ef4b4c8d0a55e063f7c6beaf5061b6fb9ea983c44db21be16f05264a4ae"
         },
         {
           "path": "contract.cjs",
@@ -51,8 +51,8 @@
         },
         {
           "path": "health.cjs",
-          "bytes": 14672,
-          "sha256": "df063349f49c85a08c8d608905cad6b4dd635af2b0f82814360afb7db24a0f4f"
+          "bytes": 15063,
+          "sha256": "f3cbe31f0e20d82e82f8c0181807fa55bbd21734889d08dda8ae89dff5bdef88"
         },
         {
           "path": "index.cjs",
@@ -61,8 +61,8 @@
         },
         {
           "path": "lib/connector-ledger.js",
-          "bytes": 4799,
-          "sha256": "4a9529e715d9fe9628d766ec5333137e8ecaac3d68aeac4355db08ab86cc5aba"
+          "bytes": 4981,
+          "sha256": "d38c8b8fe0e8a3c9e258dd35b25ad8902b336287b304b140a88bdda55eb8ee09"
         },
         {
           "path": "lib/connector-model.js",
@@ -76,8 +76,8 @@
         },
         {
           "path": "lib/oauth-refresh.js",
-          "bytes": 10609,
-          "sha256": "cdc837a0acfbd7f8e0822f5d8da7c6f2726de8f0d7f5f2ae3daa57fa95616392"
+          "bytes": 10761,
+          "sha256": "8ae2f42d507a078aa9f48ac01a0c67bd5a0004742802da9332a95356da57c731"
         },
         {
           "path": "lib/rate-limit.js",
@@ -86,8 +86,8 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 9195,
-          "sha256": "6ab21fb5139da00a38f98658d38c6c0ef416aa06aba4ef9073d16b450863979d"
+          "bytes": 9416,
+          "sha256": "8e4d0ed9d943d5656f9f98f8ae4d655187703079e77f60636902d8f1d35fcd33"
         },
         {
           "path": "README.md",
@@ -96,8 +96,8 @@
         },
         {
           "path": "token-store.cjs",
-          "bytes": 30324,
-          "sha256": "749230cf3c607a9faf1d55efb7e30639644345e35009b8b86477d07a842f92a8"
+          "bytes": 33063,
+          "sha256": "0512e061571062877d19c762206a467244cff609b57e3c23019f4e8ac80ed97f"
         }
       ]
     }


### PR DESCRIPTION
> ## ⛔ DO NOT MERGE YET
>
> This is **deliberately a draft**. It is the user-facing half of `/connect`, and merging it is what opens the doorway — everything committed to this repo ships to users at the next release, because the repo tree *is* the vault template.
>
> The security programme running in parallel (5a and 5b merged as #230; **5c broker, 5d Touch ID, 5e independent re-review still to come**) explicitly keeps `/connect` closed until those land. This PR exists so the user-facing work is *ready and reviewed* when that gate opens, not so it opens sooner.
>
> **Merge only when the 5a–5e programme says the doorway can open.**

## What this is

Phase 5 step 2. Two artifacts were written before three phases of engine change and held out of the repo on purpose. This corrects the drift against the engine that actually shipped, and wires the hook up.

Built on top of #226 (merged), so it can document that PR's user-visible behaviour.

## `/connect` skill — the drift that mattered

The draft had accumulated real errors, several of which would have actively misled a user:

- **It documented a `set-key --key <secret>` flag.** That flag does not exist, and putting a secret on the command line is precisely the exposure #226 just removed. This was the worst one.
- **It promised a `~/Vault` default** that `credentialsDir()` has never had — it throws if no vault is configured.
- Missing the `probe` verb, the `encryption_key_lost` state and its recovery path, and the fact that the callback port is chosen dynamically from ten rather than always being 3847.
- **Missing the reviewed-provider gate from #230** — that Google, Slack and Linear are security-reviewed and everything else is advanced-tier behind an explicit `--allow-unvetted` opt-in and is never auto-probed. A user needs to know that before connecting something.
- Wrong provider counts, an `error` status the engine doesn't have, wrong BASIC-auth instructions, wrong refresh semantics, wrong `get-token` output shape, and a claim that connecting automatically lights up daily-plan and meeting-prep.

It now also reflects #226: `status` reports where the encryption key lives, and `disconnect` says plainly that access must still be revoked in the provider's own account settings.

**On honesty:** the skill keeps "encrypted on your machine, never sent to a relay" (true) and deliberately makes no claim of protection from software already running as you (not true). Where the key is in the vault folder rather than the Keychain, it now tells the assistant to say what that actually means — a copy of that folder is a copy of those sign-ins — and to stay quiet when the Keychain is in use, so the disclosure lands when it matters instead of becoming noise.

## Health hook

- Used the shared `paths.cjs` loader instead of inventing a `~/Vault` fallback that disagreed with the engine.
- **Dropped a call to `render-dashboard.cjs`** — that module exists nowhere in the repo, so the dashboard refresh had been failing silently inside a `catch` since it was written.
- Claims the daily slot *before* loading the engine, so a damaged local record can't make every session repeat the sweep.
- Surfaces only `needs_reauth` and `expired`; `expiring` stays silent because auto-refresh handles it. No network calls. Always exits 0.
- Wired into `SessionStart` alongside the existing hooks.

**Note for whoever merges this:** the hook does run for every user once wired, even with no connections. It is silent in that case, but it is not literally inert — it executes and writes a small throttle state file. That is fine when the doorway is open; it is worth being deliberate about, which is part of why this is held.

## Verification

- 6/6 new hook tests (silence, reauth/expiry notices, daily throttle, failed-sweep throttle, missing vault/engine, exit-zero, SessionStart wiring)
- 155/155 connection manager, 162/162 scripts
- Contract + engine manifest verified
- All four PR gates pass locally against `origin/main`
- No engine or security-gate file touched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYrZr5tGFNsVzxaAKbpbka
