### PR TITLE
sec(integrations): Phase 5c — credential broker (closes C2 structure)

### DIFF
--- a/core/integrations/connection-manager/README.md
+++ b/core/integrations/connection-manager/README.md
@@ -22,7 +22,9 @@ The engine code ships in Dex Core, but remains product-inert: no user-facing
 | `lib/connector-verify.js` | Five-second Google, Slack, and Linear live probes; only 401/403-class evidence marks reconnect. |
 | `lib/connector-ledger.js` | Secret-free per-connection evidence under `System/credentials/ledger/` (500-row cap, atomic rewrite). |
 | `connect.cjs` | CLI: `connect` / `status [--json]` / `probe` / `refresh` / `disconnect` / `providers` / `authurl`. |
-| `get-token.cjs` | Accessor so Python MCP servers read fresh tokens without the encryption key. |
+| `broker.cjs` / `broker-client.cjs` | Machine-local Unix-socket broker and client. Accessors request rendered or explicitly privileged credential views here instead of decrypting the store in their own process. |
+| `get-token.cjs` | Contract-frozen accessor for Python MCP servers; all credential reads go through the broker. |
+| `dex-call.cjs` | Generic authenticated caller; obtains rendered auth from the broker, then sends and redacts its own outbound request. |
 
 ## Maintainer smoke path
 
@@ -67,7 +69,15 @@ The store is designed so that nothing fails silently and nothing user-recoverabl
 | Credential file copied to another connection id | AES-GCM additional authenticated data binds every envelope to its connection id. The copied envelope is quarantined, and the target becomes `needs_reauth` with `token_envelope_account_mismatch`. |
 | Secrets in logs | No CLI prints token material (refresh prints none; `dex-call` diagnostics are redacted via `auth-context.secretsOf`/`redactSecrets`). Exception by contract: `get-token` IS the credential accessor; consume it via the pp-* env-injection pattern, never echo it. |
 
-Env switches: `DEX_CM_NO_KEYCHAIN=1` forces the file-based key (tests, sandboxes without `security`); `DEX_CM_TEST_CRASH_BEFORE_RENAME=1` is test-only fault injection used by the crash-simulation test.
+The broker is an honest hardening boundary, not a same-user malware sandbox:
+another process running as the same OS user can read user-owned `0600` files or
+scrape a blessed consumer's memory. The broker removes routine in-process
+decryption from accessors, centralises pinned-origin and trust checks, and puts
+privileged `--full` / `--access-token-only` exports behind the Phase 5d
+`assertPresence` seam. The default `get-token` operation remains unprivileged
+and returns only the frozen OAuth or rendered Class-B contract shape.
+
+Env switches: `DEX_CM_NO_KEYCHAIN=1` forces the file-based key (tests, sandboxes without `security`); `DEX_CM_RUNTIME_DIR` selects the machine-local broker runtime directory (tests use a unique temp directory); `DEX_CM_TEST_CRASH_BEFORE_RENAME=1` is test-only fault injection used by the crash-simulation test.
 
 Tests: `npm run test:integrations` from the repository root (offline, throwaway temp vaults, fake fixtures only).
 

--- a/core/integrations/connection-manager/auth-context.cjs
+++ b/core/integrations/connection-manager/auth-context.cjs
@@ -135,6 +135,32 @@ function secretsOf(ctx) {
   }
   for (const v of Object.values((ctx && ctx.query) || {})) add(v);
   if (ctx && ctx.apiKey) add(ctx.apiKey);
+  // Broker-rendered contexts deliberately omit the raw apiKey field. Recover
+  // only the credential-shaped portion of catalog URLs such as Telegram's
+  // .../bot${apiKey}, so dex-call diagnostics retain their pre-broker
+  // redaction without widening the broker response.
+  if (ctx && ctx.provider && ctx.baseUrl) {
+    try {
+      const template = catalog.getProviderConfig(ctx.provider).proxyBaseUrl || '';
+      const marker = '${apiKey}';
+      const markerAt = template.indexOf(marker);
+      if (markerAt !== -1) {
+        const prefix = template.slice(0, markerAt);
+        const suffix = template.slice(markerAt + marker.length);
+        if (
+          !prefix.includes('${') &&
+          !suffix.includes('${') &&
+          ctx.baseUrl.startsWith(prefix) &&
+          ctx.baseUrl.endsWith(suffix)
+        ) {
+          const end = suffix ? ctx.baseUrl.length - suffix.length : undefined;
+          add(ctx.baseUrl.slice(prefix.length, end));
+        }
+      }
+    } catch {
+      /* header/query forms above still redact when catalog lookup is unavailable */
+    }
+  }
   // Longest first so overlapping values redact fully.
   return [...out].sort((a, b) => b.length - a.length);
 }

--- a/core/integrations/connection-manager/broker-client.cjs
+++ b/core/integrations/connection-manager/broker-client.cjs
@@ -1,0 +1,138 @@
+'use strict';
+/**
+ * Client for the local credential broker.
+ *
+ * `DEX_CM_CAPABILITY` is the stronger per-launch handoff. Reading cm.cap is the
+ * same-uid compatibility fallback: any process running as the user can read
+ * that 0600 file, matching the explicitly documented security ceiling in
+ * broker.cjs.
+ */
+
+const fs = require('node:fs');
+const net = require('node:net');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const broker = require('./broker.cjs');
+const { withLock } = require('./fs-safe.cjs');
+
+const READY_TIMEOUT_MS = 3000;
+let startFlight = null;
+
+function exitCodeForError(category) {
+  return {
+    forbidden: 1,
+    unvetted: 1,
+    needs_reauth: 3,
+    not_connected: 2,
+    http: 4,
+  }[category] || 1;
+}
+
+function capability() {
+  if (process.env.DEX_CM_CAPABILITY) return process.env.DEX_CM_CAPABILITY;
+  return fs.readFileSync(broker.capabilityPath(), 'utf8').trim();
+}
+
+function exchange(request) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(broker.socketPath());
+    let output = '';
+    socket.setEncoding('utf8');
+    socket.once('connect', () => {
+      let token;
+      try {
+        token = capability();
+      } catch (error) {
+        socket.destroy();
+        reject(error);
+        return;
+      }
+      socket.end(`${JSON.stringify({ capability: token, ...request })}\n`);
+    });
+    socket.on('data', (chunk) => {
+      output += chunk;
+      if (output.length > 1024 * 1024) {
+        socket.destroy();
+        reject(new Error('Credential broker response exceeded 1 MiB.'));
+      }
+    });
+    socket.once('error', reject);
+    socket.once('end', () => {
+      try {
+        resolve(JSON.parse(output.trim()));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function socketReady() {
+  return new Promise((resolve) => {
+    const socket = net.createConnection(broker.socketPath());
+    let settled = false;
+    const finish = (ready) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ready);
+    };
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.setTimeout(100, () => finish(false));
+  });
+}
+
+async function pollUntilReady() {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await socketReady()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error('Credential broker did not become ready within 3 seconds.');
+}
+
+async function startBrokerSingleFlight() {
+  if (startFlight) return startFlight;
+  startFlight = withLock(
+    path.join(broker.runtimeDir(), 'client-start.lock'),
+    async () => {
+      if (await socketReady()) return;
+      fs.mkdirSync(broker.runtimeDir(), { recursive: true, mode: 0o700 });
+      fs.chmodSync(broker.runtimeDir(), 0o700);
+      const child = spawn(process.execPath, [path.join(__dirname, 'broker.cjs')], {
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env },
+      });
+      child.unref();
+      await pollUntilReady();
+    },
+    { timeoutMs: READY_TIMEOUT_MS + 500 }
+  ).finally(() => {
+    startFlight = null;
+  });
+  return startFlight;
+}
+
+function isBrokerUnavailable(error) {
+  return error && (error.code === 'ENOENT' || error.code === 'ECONNREFUSED');
+}
+
+async function brokerRequest({ op = 'rendered', connId, targetOrigin, allowUnvetted, privileged: _privileged } = {}) {
+  const request = {
+    op,
+    ...(connId ? { connId } : {}),
+    ...(targetOrigin ? { targetOrigin } : {}),
+    ...(allowUnvetted ? { allowUnvetted: true } : {}),
+  };
+  try {
+    return await exchange(request);
+  } catch (error) {
+    if (!isBrokerUnavailable(error)) throw error;
+  }
+  await startBrokerSingleFlight();
+  return exchange(request);
+}
+
+module.exports = { brokerRequest, exitCodeForError };

--- a/core/integrations/connection-manager/broker.cjs
+++ b/core/integrations/connection-manager/broker.cjs
@@ -133,7 +133,7 @@ async function renderedResponse(request) {
   const context = await authContext.resolveAuthContext(request.connId);
   const provider = providerFor(request.connId, context);
   if (!pinned.isVetted(provider)) {
-    if (!request.allowUnvetted) return { ok: false, error: { category: 'unvetted' } };
+    if (!request.allowUnvetted) return { ok: false, error: { category: 'unvetted', provider } };
   } else {
     if (context.baseUrl) pinned.assertPinnedOrigin(provider, 'api', context.baseUrl);
     if (request.targetOrigin) pinned.assertPinnedOrigin(provider, 'api', request.targetOrigin);
@@ -144,6 +144,30 @@ async function renderedResponse(request) {
     baseUrl: context.baseUrl,
     headers: context.headers,
     query: context.query,
+    provider,
+  };
+}
+
+async function getTokenDefaultResponse(request) {
+  const context = await authContext.resolveAuthContext(request.connId);
+  if (context.kind === 'api_key') {
+    return {
+      ok: true,
+      value: {
+        kind: context.kind,
+        baseUrl: context.baseUrl,
+        headers: context.headers,
+        query: context.query,
+      },
+    };
+  }
+  const fresh = store.loadToken(request.connId);
+  return {
+    ok: true,
+    value: {
+      access_token: fresh.access_token,
+      expires_at: fresh.expires_at || null,
+    },
   };
 }
 
@@ -167,6 +191,7 @@ async function processRequest(request, capability) {
   const op = request.op || 'rendered';
   try {
     if (op === 'rendered') return await renderedResponse(request);
+    if (op === 'get-token-default') return await getTokenDefaultResponse(request);
     if (op === 'access-token' || op === 'full') return await privilegedResponse({ ...request, op });
     if (op === 'status') {
       return {
@@ -177,7 +202,14 @@ async function processRequest(request, capability) {
     }
     return { ok: false, error: { category: 'unsupported' } };
   } catch (error) {
-    return { ok: false, error: { category: errorCategory(error) } };
+    const category = errorCategory(error);
+    return {
+      ok: false,
+      error: {
+        category,
+        ...(category !== 'forbidden' && error && error.message ? { message: error.message } : {}),
+      },
+    };
   }
 }
 
@@ -293,6 +325,7 @@ module.exports = {
   capabilityPath,
   socketPath,
   assertPresence,
+  processRequest,
   startBroker,
   main,
 };

--- a/core/integrations/connection-manager/broker.cjs
+++ b/core/integrations/connection-manager/broker.cjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Local credential broker.
+ *
+ * Honest security boundary: on a single-user OS, another process running as
+ * this user can read any 0600 file the user owns and scrape a blessed
+ * consumer's memory. This broker alone therefore does NOT stop same-user
+ * malware. It removes raw-secret-to-stdout as the default, centralises release
+ * at the Phase 5d user-presence gate, and enforces capability, pinned-origin,
+ * and trust-MAC policy in one place.
+ *
+ * Node has no portable SO_PEERCRED API and this project deliberately carries no
+ * native addon. The 0700 runtime directory limits socket access to the same uid;
+ * the capability is a weak blessed-consumer distinction subject to the ceiling
+ * above.
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const authContext = require('./auth-context.cjs');
+const health = require('./health.cjs');
+const pinned = require('./pinned-providers.cjs');
+const store = require('./token-store.cjs');
+const { withLock, writeFileAtomic } = require('./fs-safe.cjs');
+
+const DEFAULT_IDLE_MS = 5 * 60 * 1000;
+const MAX_REQUEST_BYTES = 64 * 1024;
+
+function pathIsWithin(child, parent) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function runtimeDir() {
+  let dir;
+  if (process.env.DEX_CM_RUNTIME_DIR) {
+    dir = path.resolve(process.env.DEX_CM_RUNTIME_DIR);
+  } else if (process.platform === 'darwin') {
+    dir = path.join(os.homedir(), 'Library', 'Application Support', 'Dex', 'cm');
+  } else if (process.env.XDG_RUNTIME_DIR) {
+    dir = path.join(process.env.XDG_RUNTIME_DIR, 'dex-cm');
+  } else {
+    dir = path.join(os.homedir(), '.local', 'state', 'dex-cm');
+  }
+  const vault = process.env.DEX_VAULT || process.env.VAULT_PATH;
+  if (vault && pathIsWithin(dir, vault)) {
+    throw new Error('DEX_CM_RUNTIME_DIR must be machine-local and must not be inside DEX_VAULT.');
+  }
+  return dir;
+}
+
+function socketPath() {
+  return path.join(runtimeDir(), 'cm.sock');
+}
+
+function capabilityPath() {
+  return path.join(runtimeDir(), 'cm.cap');
+}
+
+function ensurePrivateRuntime() {
+  const dir = runtimeDir();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const stat = fs.lstatSync(dir);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Credential broker runtime path is not a real directory: ${dir}`);
+  }
+  fs.chmodSync(dir, 0o700);
+}
+
+function ensureCapability() {
+  const file = capabilityPath();
+  if (!fs.existsSync(file)) {
+    writeFileAtomic(file, crypto.randomBytes(32).toString('base64'), { mode: 0o600 });
+  }
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`Credential broker capability path is not a regular file: ${file}`);
+  }
+  fs.chmodSync(file, 0o600);
+  const capability = fs.readFileSync(file, 'utf8').trim();
+  if (Buffer.from(capability, 'base64').length !== 32) {
+    throw new Error('Credential broker capability file is invalid.');
+  }
+  return capability;
+}
+
+function capabilityMatches(actual, expected) {
+  if (typeof actual !== 'string') return false;
+  const actualBytes = Buffer.from(actual, 'utf8');
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  return actualBytes.length === expectedBytes.length && crypto.timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function socketIsLive(file) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection(file);
+    let settled = false;
+    const finish = (live) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(live);
+    };
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.setTimeout(150, () => finish(false));
+  });
+}
+
+async function assertPresence(_connId, _op) {
+  // Phase 5d: bind privileged export to OS user-presence (Touch ID) here.
+}
+
+function errorCategory(error) {
+  if (error && error.code === 'DEX_CM_ORIGIN_UNPINNED') return 'forbidden';
+  if (error && (error.exitCode === 3 || error.needsReauth)) return 'needs_reauth';
+  if (error && error.exitCode === 2) return 'not_connected';
+  if (error && (error.exitCode === 4 || error.category === 'http')) return 'http';
+  return (error && error.category) || 'error';
+}
+
+function providerFor(connId, context) {
+  if (context && context.provider) return context.provider;
+  const connection = store.getConnection(connId) || {};
+  return connection.provider || store.parseConnectionId(connId).provider;
+}
+
+async function renderedResponse(request) {
+  const context = await authContext.resolveAuthContext(request.connId);
+  const provider = providerFor(request.connId, context);
+  if (!pinned.isVetted(provider)) {
+    if (!request.allowUnvetted) return { ok: false, error: { category: 'unvetted' } };
+  } else {
+    if (context.baseUrl) pinned.assertPinnedOrigin(provider, 'api', context.baseUrl);
+    if (request.targetOrigin) pinned.assertPinnedOrigin(provider, 'api', request.targetOrigin);
+  }
+  return {
+    ok: true,
+    kind: context.kind,
+    baseUrl: context.baseUrl,
+    headers: context.headers,
+    query: context.query,
+  };
+}
+
+async function privilegedResponse(request) {
+  // Resolve first: this is the shared refresh + MAC-verified needs_reauth gate.
+  const context = await authContext.resolveAuthContext(request.connId);
+  await module.exports.assertPresence(request.connId, request.op);
+  const token = store.loadToken(request.connId);
+  if (request.op === 'full') return { ok: true, token };
+  const value =
+    context.kind === 'api_key'
+      ? token.apiKey || token.password || ''
+      : String(context.headers.Authorization || '').replace(/^Bearer\s+/i, '');
+  return { ok: true, value };
+}
+
+async function processRequest(request, capability) {
+  if (!capabilityMatches(request && request.capability, capability)) {
+    return { ok: false, error: { category: 'forbidden' } };
+  }
+  const op = request.op || 'rendered';
+  try {
+    if (op === 'rendered') return await renderedResponse(request);
+    if (op === 'access-token' || op === 'full') return await privilegedResponse({ ...request, op });
+    if (op === 'status') {
+      return {
+        ok: true,
+        connections: health.allConnectionsHealth(),
+        registryNotice: store.readRegistry()._meta || null,
+      };
+    }
+    return { ok: false, error: { category: 'unsupported' } };
+  } catch (error) {
+    return { ok: false, error: { category: errorCategory(error) } };
+  }
+}
+
+function createServer(capability, activity) {
+  return net.createServer((socket) => {
+    socket.setEncoding('utf8');
+    let input = '';
+    let handled = false;
+    socket.on('data', (chunk) => {
+      if (handled) return;
+      input += chunk;
+      if (input.length > MAX_REQUEST_BYTES) {
+        handled = true;
+        socket.end(`${JSON.stringify({ ok: false, error: { category: 'invalid_request' } })}\n`);
+        return;
+      }
+      const newline = input.indexOf('\n');
+      if (newline === -1) return;
+      handled = true;
+      activity.begin();
+      Promise.resolve()
+        .then(() => JSON.parse(input.slice(0, newline)))
+        .then((request) => processRequest(request, capability))
+        .catch(() => ({ ok: false, error: { category: 'invalid_request' } }))
+        .then((response) => socket.end(`${JSON.stringify(response)}\n`))
+        .finally(() => activity.end());
+    });
+  });
+}
+
+async function startBroker({ idleMs } = {}) {
+  ensurePrivateRuntime();
+  const configuredIdle = Number(idleMs ?? process.env.DEX_CM_BROKER_IDLE_MS ?? DEFAULT_IDLE_MS);
+  const effectiveIdle = Number.isFinite(configuredIdle) && configuredIdle >= 0 ? configuredIdle : DEFAULT_IDLE_MS;
+  const startLock = path.join(runtimeDir(), 'broker-start.lock');
+
+  return withLock(
+    startLock,
+    async () => {
+      if (await socketIsLive(socketPath())) {
+        return {
+          alreadyRunning: true,
+          close: async () => {},
+        };
+      }
+      fs.rmSync(socketPath(), { force: true });
+      const capability = ensureCapability();
+      let activeRequests = 0;
+      let idleTimer = null;
+      let closed = false;
+      let server;
+
+      const close = () =>
+        new Promise((resolve, reject) => {
+          if (closed) {
+            resolve();
+            return;
+          }
+          closed = true;
+          if (idleTimer) clearTimeout(idleTimer);
+          server.close((error) => {
+            fs.rmSync(socketPath(), { force: true });
+            if (error && error.code !== 'ERR_SERVER_NOT_RUNNING') reject(error);
+            else resolve();
+          });
+        });
+      const scheduleIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          if (activeRequests === 0) void close();
+          else scheduleIdle();
+        }, effectiveIdle);
+        idleTimer.unref();
+      };
+      const activity = {
+        begin() {
+          activeRequests += 1;
+          if (idleTimer) clearTimeout(idleTimer);
+        },
+        end() {
+          activeRequests = Math.max(0, activeRequests - 1);
+          if (activeRequests === 0) scheduleIdle();
+        },
+      };
+      server = createServer(capability, activity);
+      await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(socketPath(), () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
+      fs.chmodSync(socketPath(), 0o600);
+      scheduleIdle();
+      return { server, alreadyRunning: false, close };
+    },
+    { timeoutMs: 3500 }
+  );
+}
+
+async function main() {
+  const running = await startBroker();
+  if (running.alreadyRunning) return;
+  const shutdown = () => {
+    void running.close().finally(() => process.exit(0));
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+module.exports = {
+  runtimeDir,
+  capabilityPath,
+  socketPath,
+  assertPresence,
+  startBroker,
+  main,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/core/integrations/connection-manager/connection-manager.broker.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.broker.test.cjs
@@ -1,0 +1,263 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-broker-test-'));
+const TMP_VAULT = path.join(TMP_ROOT, 'vault');
+const TMP_RUNTIME = path.join(os.tmpdir(), `dex-cm-broker-runtime-${process.pid}`);
+fs.mkdirSync(TMP_VAULT, { recursive: true });
+process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_NO_KEYCHAIN = '1';
+process.env.DEX_CM_BROKER_IDLE_MS = '150';
+
+const store = require('./token-store.cjs');
+const authContext = require('./auth-context.cjs');
+const broker = require('./broker.cjs');
+const client = require('./broker-client.cjs');
+
+function mode(file) {
+  return fs.statSync(file).mode & 0o777;
+}
+
+function rawRequest(request) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(broker.socketPath());
+    let data = '';
+    socket.setEncoding('utf8');
+    socket.on('connect', () => socket.end(`${JSON.stringify(request)}\n`));
+    socket.on('data', (chunk) => {
+      data += chunk;
+    });
+    socket.on('error', reject);
+    socket.on('end', () => {
+      try {
+        resolve(JSON.parse(data.trim()));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function runClientChild(connId) {
+  const script = [
+    `const client = require(${JSON.stringify(path.join(__dirname, 'broker-client.cjs'))});`,
+    `client.brokerRequest({op:'rendered',connId:${JSON.stringify(connId)}})`,
+    ".then((result)=>process.stdout.write(JSON.stringify(result)))",
+    '.catch((error)=>{console.error(error);process.exit(1);});',
+  ].join('');
+  const child = spawn(process.execPath, ['-e', script], {
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8').on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding('utf8').on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`broker client child exited ${code}: ${stderr}`));
+        return;
+      }
+      resolve(JSON.parse(stdout));
+    });
+  });
+}
+
+async function waitForGone(file, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (fs.existsSync(file) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+test.after(async () => {
+  await waitForGone(broker.socketPath());
+  fs.rmSync(TMP_ROOT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
+
+test('runtime paths are machine-local and permissions are private', async () => {
+  assert.equal(path.resolve(broker.runtimeDir()).startsWith(`${path.resolve(TMP_VAULT)}${path.sep}`), false);
+  const running = await broker.startBroker({ idleMs: 60_000 });
+  try {
+    assert.equal(mode(broker.runtimeDir()), 0o700);
+    assert.equal(mode(broker.socketPath()), 0o600);
+    assert.equal(mode(broker.capabilityPath()), 0o600);
+    assert.equal(Buffer.from(fs.readFileSync(broker.capabilityPath(), 'utf8').trim(), 'base64').length, 32);
+  } finally {
+    await running.close();
+  }
+});
+
+test('broker gates every operation, renders least privilege, pins origins, and verifies trust', async (t) => {
+  const linear = 'linear:broker';
+  const google = 'google:broker';
+  const unvetted = 'airtable-pat:broker';
+  const forged = 'linear:broker-forged';
+  store.saveApiKey(linear, { apiKey: 'LINEAR-BROKER-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  store.saveToken(
+    google,
+    {
+      access_token: 'GOOGLE-BROKER-ACCESS',
+      refresh_token: 'GOOGLE-BROKER-REFRESH',
+      expires_at: Date.now() + 3_600_000,
+    },
+    { provider: 'google' }
+  );
+  store.saveApiKey(
+    unvetted,
+    { apiKey: 'UNVETTED-BROKER-SECRET' },
+    { provider: 'airtable-pat', authMode: 'API_KEY' }
+  );
+  store.saveApiKey(
+    forged,
+    { apiKey: 'FORGED-BROKER-SECRET' },
+    { provider: 'linear', authMode: 'API_KEY' }
+  );
+
+  const running = await broker.startBroker({ idleMs: 60_000 });
+  const capability = fs.readFileSync(broker.capabilityPath(), 'utf8').trim();
+  const presenceCalls = [];
+  const originalPresence = broker.assertPresence;
+  broker.assertPresence = async (connId, op) => {
+    presenceCalls.push([connId, op]);
+  };
+  try {
+    await t.test('missing or wrong capability returns forbidden with no credential data', async () => {
+      for (const badCapability of [undefined, Buffer.alloc(32, 7).toString('base64')]) {
+        const response = await rawRequest({
+          ...(badCapability ? { capability: badCapability } : {}),
+          op: 'rendered',
+          connId: linear,
+        });
+        assert.deepEqual(response, { ok: false, error: { category: 'forbidden' } });
+        assert.equal(JSON.stringify(response).includes('LINEAR-BROKER-SECRET'), false);
+      }
+    });
+
+    await t.test('rendered matches resolveAuthContext without returning raw apiKey', async () => {
+      const expected = await authContext.resolveAuthContext(linear);
+      const response = await rawRequest({ capability, op: 'rendered', connId: linear });
+      assert.deepEqual(response, {
+        ok: true,
+        kind: expected.kind,
+        baseUrl: expected.baseUrl,
+        headers: expected.headers,
+        query: expected.query,
+      });
+      assert.equal(Object.hasOwn(response, 'apiKey'), false);
+      assert.deepEqual(presenceCalls, []);
+    });
+
+    await t.test('privileged access-token and full exports invoke presence', async () => {
+      const access = await rawRequest({ capability, op: 'access-token', connId: linear });
+      assert.deepEqual(access, { ok: true, value: 'LINEAR-BROKER-SECRET' });
+      const full = await rawRequest({ capability, op: 'full', connId: google });
+      assert.equal(full.ok, true);
+      assert.equal(full.token.access_token, 'GOOGLE-BROKER-ACCESS');
+      assert.equal(full.token.refresh_token, 'GOOGLE-BROKER-REFRESH');
+      assert.deepEqual(presenceCalls, [
+        [linear, 'access-token'],
+        [google, 'full'],
+      ]);
+    });
+
+    await t.test('vetted targets must stay pinned and unvetted providers need consent', async () => {
+      assert.equal(
+        (await rawRequest({
+          capability,
+          op: 'rendered',
+          connId: linear,
+          targetOrigin: 'https://api.linear.app/graphql',
+        })).ok,
+        true
+      );
+      assert.deepEqual(
+        await rawRequest({
+          capability,
+          op: 'rendered',
+          connId: linear,
+          targetOrigin: 'https://evil.example/graphql',
+        }),
+        { ok: false, error: { category: 'forbidden' } }
+      );
+      assert.deepEqual(
+        await rawRequest({ capability, op: 'rendered', connId: unvetted }),
+        { ok: false, error: { category: 'unvetted' } }
+      );
+      assert.equal(
+        (await rawRequest({
+          capability,
+          op: 'rendered',
+          connId: unvetted,
+          allowUnvetted: true,
+        })).ok,
+        true
+      );
+    });
+
+    await t.test('forged registry trust is rejected through the broker', async () => {
+      const registryPath = path.join(store.credentialsDir(), 'connections.json');
+      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+      registry[forged].status = 'connected';
+      delete registry[forged].mac;
+      fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+      assert.deepEqual(
+        await rawRequest({ capability, op: 'access-token', connId: forged }),
+        { ok: false, error: { category: 'needs_reauth' } }
+      );
+    });
+
+    await t.test('status returns the same MAC-verified monitoring data', async () => {
+      const response = await rawRequest({ capability, op: 'status' });
+      assert.equal(response.ok, true);
+      assert.deepEqual(response.connections, require('./health.cjs').allConnectionsHealth());
+      assert.deepEqual(response.registryNotice, store.readRegistry()._meta || null);
+    });
+  } finally {
+    broker.assertPresence = originalPresence;
+    await running.close();
+    for (const connId of [linear, google, unvetted, forged]) {
+      if (store.getConnection(connId)) store.deleteToken(connId);
+    }
+  }
+});
+
+test('client maps legacy CLI exit codes', () => {
+  assert.equal(client.exitCodeForError('forbidden'), 1);
+  assert.equal(client.exitCodeForError('unvetted'), 1);
+  assert.equal(client.exitCodeForError('needs_reauth'), 3);
+  assert.equal(client.exitCodeForError('not_connected'), 2);
+  assert.equal(client.exitCodeForError('http'), 4);
+  assert.equal(client.exitCodeForError('anything_else'), 1);
+});
+
+test('concurrent clients auto-spawn exactly one usable broker', async () => {
+  const connId = 'linear:auto-spawn';
+  fs.rmSync(broker.socketPath(), { force: true });
+  store.saveApiKey(connId, { apiKey: 'AUTO-SPAWN-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  try {
+    const [first, second] = await Promise.all([runClientChild(connId), runClientChild(connId)]);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(fs.existsSync(broker.socketPath()), true);
+    assert.equal(mode(broker.socketPath()), 0o600);
+  } finally {
+    if (store.getConnection(connId)) store.deleteToken(connId);
+    await waitForGone(broker.socketPath());
+  }
+});

--- a/core/integrations/connection-manager/connection-manager.broker.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.broker.test.cjs
@@ -77,6 +77,25 @@ function runClientChild(connId) {
   });
 }
 
+function runCli(file, args, extraEnv = {}) {
+  const child = spawn(process.execPath, [file, ...args], {
+    env: { ...process.env, ...extraEnv },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8').on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding('utf8').on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
 async function waitForGone(file, timeoutMs = 2000) {
   const deadline = Date.now() + timeoutMs;
   while (fs.existsSync(file) && Date.now() < deadline) {
@@ -90,7 +109,177 @@ test.after(async () => {
   fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
 });
 
-test('runtime paths are machine-local and permissions are private', async () => {
+test('broker request processing preserves accessor shapes without a live socket', async () => {
+  const capability = 'test-capability';
+  const oauth = 'google:broker-unit';
+  const classB = 'linear:broker-unit';
+  store.saveToken(
+    oauth,
+    {
+      access_token: 'UNIT-OAUTH-ACCESS',
+      refresh_token: 'UNIT-OAUTH-REFRESH',
+      expires_at: Date.now() + 3_600_000,
+    },
+    { provider: 'google' }
+  );
+  store.saveApiKey(classB, { apiKey: 'UNIT-CLASS-B-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  const originalPresence = broker.assertPresence;
+  const presenceCalls = [];
+  broker.assertPresence = async (connId, op) => presenceCalls.push([connId, op]);
+  try {
+    assert.deepEqual(
+      await broker.processRequest({ capability, op: 'get-token-default', connId: oauth }, capability),
+      {
+        ok: true,
+        value: {
+          access_token: 'UNIT-OAUTH-ACCESS',
+          expires_at: store.loadToken(oauth).expires_at,
+        },
+      }
+    );
+    const rendered = await authContext.resolveAuthContext(classB);
+    assert.deepEqual(
+      await broker.processRequest({ capability, op: 'get-token-default', connId: classB }, capability),
+      {
+        ok: true,
+        value: {
+          kind: rendered.kind,
+          baseUrl: rendered.baseUrl,
+          headers: rendered.headers,
+          query: rendered.query,
+        },
+      }
+    );
+    assert.deepEqual(presenceCalls, []);
+
+    await broker.processRequest({ capability, op: 'full', connId: oauth }, capability);
+    await broker.processRequest({ capability, op: 'access-token', connId: classB }, capability);
+    assert.deepEqual(presenceCalls, [
+      [oauth, 'full'],
+      [classB, 'access-token'],
+    ]);
+  } finally {
+    broker.assertPresence = originalPresence;
+    store.deleteToken(oauth);
+    store.deleteToken(classB);
+  }
+});
+
+test('rendered broker auth retains key-in-URL redaction without exposing an apiKey field', async () => {
+  const capability = 'redaction-capability';
+  const connId = 'telegram:broker-redaction';
+  const secret = '123456:UNIT-BROKER-URL-SECRET';
+  store.saveApiKey(connId, { apiKey: secret }, { provider: 'telegram', authMode: 'API_KEY' });
+  try {
+    const response = await broker.processRequest(
+      { capability, op: 'rendered', connId, allowUnvetted: true },
+      capability
+    );
+    assert.equal(response.ok, true);
+    assert.equal(response.baseUrl.includes(secret), true);
+    assert.equal(Object.hasOwn(response, 'apiKey'), false);
+    assert.equal(authContext.secretsOf(response).includes(secret), true);
+  } finally {
+    store.deleteToken(connId);
+  }
+});
+
+test('accessor CLIs preserve their contracts while calling the broker client', async () => {
+  const recordFile = path.join(TMP_ROOT, 'broker-client-records.jsonl');
+  const preload = path.join(TMP_ROOT, 'broker-client-preload.cjs');
+  const clientPath = path.join(__dirname, 'broker-client.cjs');
+  fs.writeFileSync(
+    preload,
+    [
+      "'use strict';",
+      "const fs = require('node:fs');",
+      `const clientPath = ${JSON.stringify(clientPath)};`,
+      'require.cache[clientPath] = {',
+      '  id: clientPath, filename: clientPath, loaded: true,',
+      '  exports: {',
+      '    exitCodeForError(category) { return ({needs_reauth:3,not_connected:2,http:4})[category] || 1; },',
+      '    async brokerRequest(request) {',
+      '      fs.appendFileSync(process.env.BROKER_RECORD_FILE, JSON.stringify(request) + "\\n");',
+      "      if (request.op === 'get-token-default' && request.connId === 'oauth-cli')",
+      "        return {ok:true,value:{access_token:'CLI-ACCESS',expires_at:1893456000000}};",
+      "      if (request.op === 'get-token-default')",
+      "        return {ok:true,value:{kind:'api_key',baseUrl:'https://api.linear.app',headers:{Authorization:'CLI-KEY'},query:{}}};",
+      "      if (request.op === 'full')",
+      "        return {ok:true,token:{access_token:'CLI-ACCESS',refresh_token:'CLI-REFRESH',expires_at:1893456000000}};",
+      "      if (request.op === 'access-token') return {ok:true,value:'CLI-KEY'};",
+      "      if (request.op === 'rendered')",
+      "        return {ok:true,kind:'api_key',baseUrl:'https://api.linear.app',headers:{Authorization:'CLI-KEY'},query:{},provider:'linear'};",
+      "      return {ok:false,error:{category:'error',message:'unexpected broker request'}};",
+      '    },',
+      '  },',
+      '};',
+      'globalThis.fetch = async (url, options) => ({',
+      '  ok: true, status: 200, statusText: "OK",',
+      '  text: async () => JSON.stringify({url, method: options.method, authorization: options.headers.Authorization}),',
+      '});',
+    ].join('\n')
+  );
+  const env = {
+    NODE_OPTIONS: `--require=${preload}`,
+    BROKER_RECORD_FILE: recordFile,
+  };
+
+  const oauthDefault = await runCli(path.join(__dirname, 'get-token.cjs'), ['oauth-cli'], env);
+  assert.equal(oauthDefault.status, 0, oauthDefault.stderr);
+  assert.deepEqual(JSON.parse(oauthDefault.stdout), {
+    access_token: 'CLI-ACCESS',
+    expires_at: 1893456000000,
+  });
+
+  const classBDefault = await runCli(path.join(__dirname, 'get-token.cjs'), ['linear:cli'], env);
+  assert.equal(classBDefault.status, 0, classBDefault.stderr);
+  assert.deepEqual(JSON.parse(classBDefault.stdout), {
+    kind: 'api_key',
+    baseUrl: 'https://api.linear.app',
+    headers: { Authorization: 'CLI-KEY' },
+    query: {},
+  });
+
+  const full = await runCli(path.join(__dirname, 'get-token.cjs'), ['oauth-cli', '--full'], env);
+  assert.equal(full.status, 0, full.stderr);
+  assert.equal(JSON.parse(full.stdout).refresh_token, 'CLI-REFRESH');
+
+  const raw = await runCli(path.join(__dirname, 'get-token.cjs'), ['linear:cli', '--access-token-only'], env);
+  assert.equal(raw.status, 0, raw.stderr);
+  assert.equal(raw.stdout, 'CLI-KEY');
+
+  const call = await runCli(
+    path.join(__dirname, 'dex-call.cjs'),
+    ['linear:cli', 'POST', 'https://api.linear.app/graphql', '--body', '{"query":"{ viewer { id } }"}'],
+    env
+  );
+  assert.equal(call.status, 0, call.stderr);
+  assert.deepEqual(JSON.parse(call.stdout), {
+    url: 'https://api.linear.app/graphql',
+    method: 'POST',
+    authorization: 'CLI-KEY',
+  });
+
+  const requests = fs
+    .readFileSync(recordFile, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  assert.deepEqual(requests, [
+    { op: 'get-token-default', connId: 'oauth-cli' },
+    { op: 'get-token-default', connId: 'linear:cli' },
+    { op: 'full', connId: 'oauth-cli', privileged: true },
+    { op: 'access-token', connId: 'linear:cli', privileged: true },
+    {
+      op: 'rendered',
+      connId: 'linear:cli',
+      targetOrigin: 'https://api.linear.app/graphql',
+      allowUnvetted: false,
+    },
+  ]);
+});
+
+test('socket (verify outside sandbox): runtime paths are machine-local and permissions are private', async () => {
   assert.equal(path.resolve(broker.runtimeDir()).startsWith(`${path.resolve(TMP_VAULT)}${path.sep}`), false);
   const running = await broker.startBroker({ idleMs: 60_000 });
   try {
@@ -103,7 +292,7 @@ test('runtime paths are machine-local and permissions are private', async () => 
   }
 });
 
-test('broker gates every operation, renders least privilege, pins origins, and verifies trust', async (t) => {
+test('socket (verify outside sandbox): broker gates operations and accessor CLIs end to end', async (t) => {
   const linear = 'linear:broker';
   const google = 'google:broker';
   const unvetted = 'airtable-pat:broker';
@@ -158,8 +347,30 @@ test('broker gates every operation, renders least privilege, pins origins, and v
         baseUrl: expected.baseUrl,
         headers: expected.headers,
         query: expected.query,
+        provider: 'linear',
       });
       assert.equal(Object.hasOwn(response, 'apiKey'), false);
+      assert.deepEqual(presenceCalls, []);
+    });
+
+    await t.test('get-token default op preserves OAuth and Class-B least-privilege shapes without presence', async () => {
+      assert.deepEqual(await rawRequest({ capability, op: 'get-token-default', connId: google }), {
+        ok: true,
+        value: {
+          access_token: 'GOOGLE-BROKER-ACCESS',
+          expires_at: store.loadToken(google).expires_at,
+        },
+      });
+      const rendered = await authContext.resolveAuthContext(linear);
+      assert.deepEqual(await rawRequest({ capability, op: 'get-token-default', connId: linear }), {
+        ok: true,
+        value: {
+          kind: rendered.kind,
+          baseUrl: rendered.baseUrl,
+          headers: rendered.headers,
+          query: rendered.query,
+        },
+      });
       assert.deepEqual(presenceCalls, []);
     });
 
@@ -174,6 +385,64 @@ test('broker gates every operation, renders least privilege, pins origins, and v
         [linear, 'access-token'],
         [google, 'full'],
       ]);
+    });
+
+    await t.test('get-token CLI preserves all four output modes through the broker', async () => {
+      const oauthDefault = await runCli(path.join(__dirname, 'get-token.cjs'), [google]);
+      assert.equal(oauthDefault.status, 0, oauthDefault.stderr);
+      assert.deepEqual(JSON.parse(oauthDefault.stdout), {
+        access_token: 'GOOGLE-BROKER-ACCESS',
+        expires_at: store.loadToken(google).expires_at,
+      });
+
+      const classBDefault = await runCli(path.join(__dirname, 'get-token.cjs'), [linear]);
+      assert.equal(classBDefault.status, 0, classBDefault.stderr);
+      const expectedClassB = await authContext.resolveAuthContext(linear);
+      assert.deepEqual(JSON.parse(classBDefault.stdout), {
+        kind: expectedClassB.kind,
+        baseUrl: expectedClassB.baseUrl,
+        headers: expectedClassB.headers,
+        query: expectedClassB.query,
+      });
+
+      const full = await runCli(path.join(__dirname, 'get-token.cjs'), [google, '--full']);
+      assert.equal(full.status, 0, full.stderr);
+      assert.equal(JSON.parse(full.stdout).refresh_token, 'GOOGLE-BROKER-REFRESH');
+
+      const accessOnly = await runCli(path.join(__dirname, 'get-token.cjs'), [linear, '--access-token-only']);
+      assert.equal(accessOnly.status, 0, accessOnly.stderr);
+      assert.equal(accessOnly.stdout, 'LINEAR-BROKER-SECRET');
+      assert.deepEqual(presenceCalls.slice(-2), [
+        [google, 'full'],
+        [linear, 'access-token'],
+      ]);
+    });
+
+    await t.test('dex-call CLI obtains rendered auth from the broker and still sends its own request', async () => {
+      const preload = path.join(TMP_ROOT, 'dex-call-fetch-preload.cjs');
+      fs.writeFileSync(
+        preload,
+        [
+          "'use strict';",
+          'globalThis.fetch = async (url, options) => ({',
+          '  ok: true, status: 200, statusText: "OK",',
+          '  text: async () => JSON.stringify({ url, method: options.method, authorization: options.headers.Authorization }),',
+          '});',
+        ].join('\n')
+      );
+      const presenceBefore = presenceCalls.length;
+      const result = await runCli(
+        path.join(__dirname, 'dex-call.cjs'),
+        [linear, 'POST', 'https://api.linear.app/graphql', '--body', '{"query":"{ viewer { id } }"}'],
+        { NODE_OPTIONS: `--require=${preload}` }
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        url: 'https://api.linear.app/graphql',
+        method: 'POST',
+        authorization: 'LINEAR-BROKER-SECRET',
+      });
+      assert.equal(presenceCalls.length, presenceBefore);
     });
 
     await t.test('vetted targets must stay pinned and unvetted providers need consent', async () => {
@@ -197,7 +466,7 @@ test('broker gates every operation, renders least privilege, pins origins, and v
       );
       assert.deepEqual(
         await rawRequest({ capability, op: 'rendered', connId: unvetted }),
-        { ok: false, error: { category: 'unvetted' } }
+        { ok: false, error: { category: 'unvetted', provider: 'airtable-pat' } }
       );
       assert.equal(
         (await rawRequest({
@@ -216,10 +485,12 @@ test('broker gates every operation, renders least privilege, pins origins, and v
       registry[forged].status = 'connected';
       delete registry[forged].mac;
       fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
-      assert.deepEqual(
-        await rawRequest({ capability, op: 'access-token', connId: forged }),
-        { ok: false, error: { category: 'needs_reauth' } }
-      );
+      const response = await rawRequest({ capability, op: 'access-token', connId: forged });
+      assert.equal(response.ok, false);
+      // 5b trust verification downgrades the un-MAC'd forged entry to
+      // needs_reauth on read, so the broker refuses before releasing anything.
+      assert.equal(response.error.category, 'needs_reauth');
+      assert.match(response.error.message, /needs re-authentication/i);
     });
 
     await t.test('status returns the same MAC-verified monitoring data', async () => {
@@ -246,7 +517,7 @@ test('client maps legacy CLI exit codes', () => {
   assert.equal(client.exitCodeForError('anything_else'), 1);
 });
 
-test('concurrent clients auto-spawn exactly one usable broker', async () => {
+test('socket (verify outside sandbox): concurrent clients auto-spawn exactly one usable broker', async () => {
   const connId = 'linear:auto-spawn';
   fs.rmSync(broker.socketPath(), { force: true });
   store.saveApiKey(connId, { apiKey: 'AUTO-SPAWN-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });

--- a/core/integrations/connection-manager/connection-manager.hardening.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.hardening.test.cjs
@@ -27,7 +27,10 @@ const { execFileSync, execFile, spawn } = require('node:child_process');
 // Point everything at a throwaway vault BEFORE requiring the store modules,
 // and keep the real keychain out of the picture entirely.
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-hardening-'));
+const TMP_RUNTIME = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-hardening-runtime-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_BROKER_IDLE_MS = '100';
 process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const store = require('./token-store.cjs');
@@ -43,7 +46,10 @@ const TOKENS_DIR = path.join(CRED_DIR, 'tokens');
 const REGISTRY = path.join(CRED_DIR, 'connections.json');
 const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
 
-test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
 
 function mode(p) {
   return fs.statSync(p).mode & 0o777;

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -9,7 +9,10 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase05-'));
+const TMP_RUNTIME = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase05-runtime-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_BROKER_IDLE_MS = '100';
 process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const catalog = require('./catalog.cjs');
@@ -28,7 +31,10 @@ const childEnv = {
   DEX_CM_ALLOW_UNVETTED: '1',
 };
 
-test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
 
 function callbackHarness({ busyPorts = [] } = {}) {
   const servers = [];

--- a/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
@@ -9,14 +9,20 @@ const { EventEmitter } = require('node:events');
 const { spawnSync } = require('node:child_process');
 
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5a-'));
+const TMP_RUNTIME = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5a-runtime-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_BROKER_IDLE_MS = '100';
 process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const store = require('./token-store.cjs');
 const oauth = require('./oauth-flow.cjs');
 const health = require('./health.cjs');
 
-test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
 
 function callbackHarness() {
   const server = new EventEmitter();

--- a/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
@@ -10,7 +10,10 @@ const { spawnSync } = require('node:child_process');
 
 const pinned = require('./pinned-providers.cjs');
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5b-'));
+const TMP_RUNTIME = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-phase5b-runtime-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_BROKER_IDLE_MS = '100';
 process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const catalog = require('./catalog.cjs');
@@ -23,7 +26,10 @@ const health = require('./health.cjs');
 const DIR = __dirname;
 const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
 
-test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
 
 test('reviewed providers expose immutable origin pins and reject every unpinned destination', () => {
   assert.equal(pinned.isVetted('google'), true);

--- a/core/integrations/connection-manager/connection-manager.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.test.cjs
@@ -20,7 +20,10 @@ const { execFileSync, spawnSync } = require('node:child_process');
 
 // Point everything at a throwaway vault BEFORE requiring the store modules.
 const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-test-'));
+const TMP_RUNTIME = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-test-runtime-'));
 process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_RUNTIME_DIR = TMP_RUNTIME;
+process.env.DEX_CM_BROKER_IDLE_MS = '100';
 process.env.DEX_CM_NO_KEYCHAIN = '1';
 
 const catalog = require('./catalog.cjs');
@@ -61,7 +64,10 @@ const NULL_TARGET_PROV = KEY_PROVIDERS.find(
     cli.buildProbeTarget(catalog.getProviderConfig(p.id), { apiKey: 'k' }) === null
 );
 
-test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+  fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
+});
 
 // ---- vault path resolution --------------------------------------------------
 

--- a/core/integrations/connection-manager/connections-contract.test.cjs
+++ b/core/integrations/connection-manager/connections-contract.test.cjs
@@ -38,7 +38,14 @@ test('connections contract artifacts regenerate without drift and validate every
 
 test('foreign smoke consumer uses only CLIs plus contract/schema against a scratch vault', () => {
   const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-consumer-'));
-  const env = { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' };
+  const runtime = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-consumer-runtime-'));
+  const env = {
+    ...process.env,
+    DEX_VAULT: vault,
+    DEX_CM_RUNTIME_DIR: runtime,
+    DEX_CM_BROKER_IDLE_MS: '100',
+    DEX_CM_NO_KEYCHAIN: '1',
+  };
   try {
     execFileSync('node', [path.join(__dirname, 'connect.cjs'), 'set-key', 'linear', '--no-probe'], {
       cwd: REPO,
@@ -58,12 +65,20 @@ test('foreign smoke consumer uses only CLIs plus contract/schema against a scrat
     assert.match(output, /connections consumer smoke passed/);
   } finally {
     fs.rmSync(vault, { recursive: true, force: true });
+    fs.rmSync(runtime, { recursive: true, force: true });
   }
 });
 
 test('real accessor and status CLIs conform to the published schemas and exit-code ABI', async () => {
   const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-conformance-'));
-  const env = { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' };
+  const runtime = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-connections-conformance-runtime-'));
+  const env = {
+    ...process.env,
+    DEX_VAULT: vault,
+    DEX_CM_RUNTIME_DIR: runtime,
+    DEX_CM_BROKER_IDLE_MS: '100',
+    DEX_CM_NO_KEYCHAIN: '1',
+  };
   const contract = JSON.parse(fs.readFileSync(CONTRACT, 'utf8'));
   const schema = JSON.parse(fs.readFileSync(SCHEMA, 'utf8'));
   const { validateAgainstSchema } = await import(path.join(REPO, 'scripts', 'connections-contract-validation.mjs'));
@@ -103,5 +118,6 @@ test('real accessor and status CLIs conform to the published schemas and exit-co
     );
   } finally {
     fs.rmSync(vault, { recursive: true, force: true });
+    fs.rmSync(runtime, { recursive: true, force: true });
   }
 });

--- a/core/integrations/connection-manager/dex-call.cjs
+++ b/core/integrations/connection-manager/dex-call.cjs
@@ -14,7 +14,8 @@
  * Exit codes: 0 ok · 2 not connected · 3 needs re-auth · 4 HTTP 4xx/5xx · 1 other error.
  */
 
-const { resolveAuthContext, secretsOf, redactSecrets } = require('./auth-context.cjs');
+const { secretsOf, redactSecrets } = require('./auth-context.cjs');
+const { brokerRequest, exitCodeForError } = require('./broker-client.cjs');
 const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
 
 const HTTP_VERBS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
@@ -135,6 +136,20 @@ function fetchAuthenticated(url, options, fetchImpl = globalThis.fetch) {
   return fetchImpl(url, { ...options, redirect: 'error' });
 }
 
+function brokerTargetOrigin(service, pathOrUrl) {
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(pathOrUrl || '')) return undefined;
+  const provider = String(service || '').split(':')[0];
+  if (!isVetted(provider)) return pathOrUrl;
+  try {
+    assertPinnedOrigin(provider, 'api', pathOrUrl);
+    return pathOrUrl;
+  } catch {
+    // A cross-host absolute URL remains allowed, but buildRequest will not
+    // attach the service credential to it.
+    return undefined;
+  }
+}
+
 async function main() {
   const { service, method, path, query, headers, flags } = parseArgs(process.argv.slice(2));
   if (!service || !path) {
@@ -147,12 +162,33 @@ async function main() {
   let body = flags.body;
   if (flags.bodyFile) body = require('fs').readFileSync(flags.bodyFile, 'utf8');
 
+  const allowed = flags['allow-unvetted'] !== undefined || process.env.DEX_CM_ALLOW_UNVETTED === '1';
   let ctx;
   try {
-    ctx = await resolveAuthContext(service);
+    const response = await brokerRequest({
+      op: 'rendered',
+      connId: service,
+      targetOrigin: brokerTargetOrigin(service, path),
+      allowUnvetted: allowed,
+    });
+    if (!response.ok) {
+      const brokerError = response.error || {};
+      if (brokerError.category === 'unvetted') {
+        const provider = brokerError.provider || String(service).split(':')[0];
+        console.error(
+          `Refusing authenticated call for '${provider}': this provider is not security-reviewed. ` +
+            'Re-run with --allow-unvetted or DEX_CM_ALLOW_UNVETTED=1 to opt in.'
+        );
+      } else {
+        console.error(brokerError.message || 'Credential broker request failed.');
+      }
+      process.exit(exitCodeForError(brokerError.category));
+    }
+    const { ok: _ok, ...rendered } = response;
+    ctx = rendered;
   } catch (e) {
     console.error(e.message);
-    process.exit(e.exitCode || 1);
+    process.exit(1);
   }
 
   let req;
@@ -163,14 +199,6 @@ async function main() {
     process.exit(e.exitCode || 1);
   }
   if (req.authAttached && ctx.provider && !isVetted(ctx.provider)) {
-    const allowed = flags['allow-unvetted'] !== undefined || process.env.DEX_CM_ALLOW_UNVETTED === '1';
-    if (!allowed) {
-      console.error(
-        `Refusing authenticated call for '${ctx.provider}': this provider is not security-reviewed. ` +
-          'Re-run with --allow-unvetted or DEX_CM_ALLOW_UNVETTED=1 to opt in.'
-      );
-      process.exit(1);
-    }
     console.error(`warning: '${ctx.provider}' is not security-reviewed; sending credentials because you explicitly opted in.`);
   }
 

--- a/core/integrations/connection-manager/get-token.cjs
+++ b/core/integrations/connection-manager/get-token.cjs
@@ -19,9 +19,7 @@
  * Exit codes: 0 ok · 2 not connected · 3 needs re-auth · 1 other error.
  */
 
-const health = require('./health.cjs');
-const store = require('./token-store.cjs');
-const { apiKeyContext } = require('./auth-context.cjs');
+const { brokerRequest, exitCodeForError } = require('./broker-client.cjs');
 const { GET_TOKEN_EXIT_CODES } = require('./contract.cjs');
 
 async function main() {
@@ -32,63 +30,32 @@ async function main() {
     console.error('Usage: node get-token.cjs <service> [--full | --access-token-only]');
     process.exit(GET_TOKEN_EXIT_CODES.error);
   }
-  let token;
+  const op = accessOnly ? 'access-token' : full ? 'full' : 'get-token-default';
+  let response;
   try {
-    token = store.loadToken(service);
+    response = await brokerRequest({
+      op,
+      connId: service,
+      ...(accessOnly || full ? { privileged: true } : {}),
+    });
   } catch (err) {
-    console.error(err.message);
-    process.exit(err.code === 'DEX_CM_KEY_LOST' ? GET_TOKEN_EXIT_CODES.needs_reauth : GET_TOKEN_EXIT_CODES.error);
-  }
-  if (!token) {
-    // A corrupt token file was quarantined and stamped by loadToken; that is a
-    // reconnect (exit 3 with the reason), not a plain "not connected" (exit 2).
-    const reg = store.getConnection(service);
-    if (reg && reg.error) {
-      console.error(`${service} needs re-authentication (${reg.error}). Run: node connect.cjs connect ${service}`);
-      process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
-    }
-    console.error(`${service} is not connected.`);
-    process.exit(GET_TOKEN_EXIT_CODES.not_connected);
-  }
-  try {
-    // Class B (paste-a-key): no refresh. Emit the raw secret (--access-token-only)
-    // or a JSON envelope with the catalog's auth scheme already rendered, so the
-    // consumer never re-implements per-provider header/query placement.
-    if (token.kind === 'api_key') {
-      const reg = store.getConnection(service);
-      if (reg && reg.status === 'needs_reauth') {
-        console.error(`${service} needs re-authentication. Run: node connect.cjs set-key ${service}`);
-        process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
-      }
-      store.touchUsed(service);
-      if (accessOnly) {
-        process.stdout.write(token.apiKey || token.password || '');
-        return;
-      }
-      // Render the auth scheme via the shared seam (same context dex-call uses).
-      const { apiKey: _rawSecret, ...rendered } = apiKeyContext(token, service);
-      process.stdout.write(JSON.stringify(rendered));
-      return;
-    }
-
-    const accessToken = await health.ensureFreshToken(service);
-    store.touchUsed(service);
-    if (accessOnly) {
-      process.stdout.write(accessToken);
-    } else {
-      const fresh = store.loadToken(service);
-      process.stdout.write(
-        JSON.stringify(full ? fresh : { access_token: fresh.access_token, expires_at: fresh.expires_at || null })
-      );
-    }
-  } catch (err) {
-    if (err.needsReauth) {
-      console.error(`${service} needs re-authentication. Run: node connect.cjs connect ${service}`);
-      process.exit(GET_TOKEN_EXIT_CODES.needs_reauth);
-    }
     console.error(err.message);
     process.exit(GET_TOKEN_EXIT_CODES.error);
   }
+  if (!response.ok) {
+    const error = response.error || {};
+    console.error(
+      error.message ||
+        (error.category === 'not_connected'
+          ? `${service} is not connected.`
+          : error.category === 'needs_reauth'
+            ? `${service} needs re-authentication. Run: node connect.cjs connect ${service}`
+            : 'Credential broker request failed.')
+    );
+    process.exit(exitCodeForError(error.category));
+  }
+  if (accessOnly) process.stdout.write(response.value);
+  else process.stdout.write(JSON.stringify(full ? response.token : response.value));
 }
 
 main();

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,13 +11,13 @@
         "connection-manager"
       ],
       "fileCount": 20,
-      "totalBytes": 209836,
-      "treeHash": "119d458dc651c64da5b5d70ad53635209dcb071a87bbd6fe47ea267d4f71e1a4",
+      "totalBytes": 212279,
+      "treeHash": "9da4fa61c93ab9ddc735b084c8f624fc29a3ddc94ae16373072876ba3c35cf20",
       "files": [
         {
           "path": "auth-context.cjs",
-          "bytes": 6854,
-          "sha256": "23cf5358e043c22c5fce9777a06f4aaa7d1ef4c3156f9f13ca23443669e53185"
+          "bytes": 7937,
+          "sha256": "6ac769de82c12600998e2f5df51ca37a27249c5517509ef33c94b832f8ded764"
         },
         {
           "path": "broker-client.cjs",
@@ -26,8 +26,8 @@
         },
         {
           "path": "broker.cjs",
-          "bytes": 10243,
-          "sha256": "1cbe4719f42698982d29c92cf8adb11dad338ed686fde810c69c711ab5fdc6e6"
+          "bytes": 11054,
+          "sha256": "ef91c1e9d9a6d12a00e1dde1dabefac75fb22f80c043e1acc635ac77ef2e8fd5"
         },
         {
           "path": "catalog.cjs",
@@ -46,8 +46,8 @@
         },
         {
           "path": "dex-call.cjs",
-          "bytes": 7631,
-          "sha256": "95fb3f328fc5465a73345be96dec7e39d8654fb4cf0df8deb7186ce28e51018e"
+          "bytes": 8671,
+          "sha256": "aa6ed4007fd21b6d304fd915361b4c0e87a49fb1458de1783042d08cc94a6642"
         },
         {
           "path": "fs-safe.cjs",
@@ -56,8 +56,8 @@
         },
         {
           "path": "get-token.cjs",
-          "bytes": 3939,
-          "sha256": "1451395df939cd0202b30cb4f3b4526c87a8e3ba56f765f594b89ba978be2b68"
+          "bytes": 2438,
+          "sha256": "e03b67d3007c3afd225ecdf2506e0eee9c8f1fa3d044d98ae03d80d2e84642f4"
         },
         {
           "path": "health.cjs",
@@ -106,8 +106,8 @@
         },
         {
           "path": "README.md",
-          "bytes": 8809,
-          "sha256": "a016fb03bcf4586f49ce744d8608a6357639f0bbfcde94ca965377e77d5a2cd5"
+          "bytes": 9819,
+          "sha256": "255bbc4a7a318a4d8fd04283a7405569bbf4833a579372766bbea51a150e27f0"
         },
         {
           "path": "token-store.cjs",

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -10,14 +10,24 @@
       "entries": [
         "connection-manager"
       ],
-      "fileCount": 18,
-      "totalBytes": 195705,
-      "treeHash": "4b3b01156e76dbfd29d49d909a100ce26051eb489be6bff97ff342375ad4e617",
+      "fileCount": 20,
+      "totalBytes": 209836,
+      "treeHash": "119d458dc651c64da5b5d70ad53635209dcb071a87bbd6fe47ea267d4f71e1a4",
       "files": [
         {
           "path": "auth-context.cjs",
           "bytes": 6854,
           "sha256": "23cf5358e043c22c5fce9777a06f4aaa7d1ef4c3156f9f13ca23443669e53185"
+        },
+        {
+          "path": "broker-client.cjs",
+          "bytes": 3888,
+          "sha256": "fc5e0d82ea12a048745d52541c5c02a99319bf5d1b2700735913d754b9a644a1"
+        },
+        {
+          "path": "broker.cjs",
+          "bytes": 10243,
+          "sha256": "1cbe4719f42698982d29c92cf8adb11dad338ed686fde810c69c711ab5fdc6e6"
         },
         {
           "path": "catalog.cjs",


### PR DESCRIPTION
Option B security work, phase 5c (architecture doc §2). Addresses **C2** — today any same-user process can run `get-token.cjs --access-token-only` and get raw secrets, an unauthenticated decryption oracle. **`/connect` stays closed**; 5d (Touch ID) and 5e (independent re-review) still to come.

## Honest boundary (stated in the code, not over-claimed)
On a single-user OS a same-user process can read a 0600 capability file and scrape a blessed consumer's memory, so the broker **alone does not stop same-user malware**. What it does: removes raw-secret-to-stdout as the default, and **centralises every credential release at one gate** where Phase 5d binds OS user-presence (Touch ID) to privileged exports. Broker + 5d together close C2 as far as a Mac allows. Node has no portable `SO_PEERCRED`; no native addon is added — the 0700 runtime dir limits the socket to the same uid, and the capability is a (deliberately-labelled weak) blessed-consumer signal.

## What landed
- **`broker.cjs`** — a machine-local broker (unix socket in a 0700 runtime dir *outside* the vault; 0600 socket + capability) that is the only key holder. Ops: `rendered` (auth placed, no raw key), `get-token-default` (exact frozen output shapes), `access-token`/`full` (privileged raw exports, routed through the `assertPresence` **5d seam**), `status`. Constant-time capability check, pinned-origin enforcement (5b), trust-MAC checks (5b), request-size cap, single-flight startup, idle-exit.
- **`broker-client.cjs`** — auto-spawns the broker single-flight, maps broker error categories back to the CLI exit codes.
- **`get-token.cjs` / `dex-call.cjs`** — rewired to obtain credentials via the broker, **external CLI contract unchanged** (argv, output shapes, exit codes; contract v1.0.0 intact). `connect.cjs` (the writer) stays direct.

## Verification (run by Fable OUTSIDE the Codex sandbox — unix `listen()` is EPERM in-sandbox, a sandbox artifact)
- **159/159** serial connection-manager suite (incl. socket-backed broker tests).
- `check:connections-contract`: contract v1.0.0 + engine manifest verified (20 files; broker files included).
- Local PR gates: path-contract, test-delta, doc-drift all pass.
- **Live end-to-end via the real CLI:** `get-token linear` returns the rendered envelope (no separate raw-key field); `--access-token-only` returns the raw key via the privileged path (exit 0); a **forged `connections.json` (status flipped to connected, MAC removed) is refused end-to-end with exit 3.**
- Fixed one over-strict test assertion (forgery *is* rejected as `needs_reauth`; the message doesn't contain the literal "trust_unverified").

Built in two checkpoints (5c-i broker+client, 5c-ii rewiring) to fit the worker's task window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MUmNHSKhTxdUwGtiJ4SUy