### PR TITLE
Customization migration Lane B: deeper read-only assessment

### DIFF
--- a/core/customization_migration/inventory.py
+++ b/core/customization_migration/inventory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import stat
 import sys
@@ -25,15 +26,17 @@ from core.customization_migration.model import (
 )
 from core.customization_migration.references import (
     MAX_SOURCE_BYTES,
+    ReferenceParseError,
     extract_reference_edges,
     is_reference_read_restricted_path,
+    read_settings_hook_edges,
 )
 from core.lifecycle.customizations import detect_customizations
 from core.lifecycle.filesystem import FilesystemInspectionError, bounded_read
 from core.lifecycle.inventory import InventoryEntry, InventoryReport, build_inventory
 
 SCRIPT_SUFFIXES = frozenset({".py", ".js", ".cjs", ".mjs", ".sh", ".bash", ".zsh"})
-CONFIG_SUFFIXES = frozenset({".json", ".yaml", ".yml", ".toml"})
+CONFIG_SUFFIXES = frozenset({".json", ".yaml", ".yml", ".toml", ".plist"})
 MAX_TOTAL_SOURCE_BYTES = 64 * 1024 * 1024
 MAX_REFERENCE_FILES = 2000
 USER_CONFIG_PATHS = frozenset(
@@ -129,6 +132,21 @@ def _dependency_root(path: str) -> str | None:
     if path.lower().endswith(ARCHIVE_SUFFIXES):
         return path
     return None
+
+
+def _embedded_repository_root(entry: InventoryEntry) -> str | None:
+    parts = PurePosixPath(entry.actual_path).parts
+    if (
+        entry.kind == "directory"
+        and len(parts) > 1
+        and parts[-1] == ".git"
+    ):
+        return PurePosixPath(*parts[:-1]).as_posix()
+    return None
+
+
+def _is_within(path: str, root: str) -> bool:
+    return path == root or path.startswith(root + "/")
 
 
 def _is_behavior_addition(entry: InventoryEntry, manifest_paths: frozenset[str]) -> bool:
@@ -264,6 +282,27 @@ def _safe_live(
             None,
             False,
         )
+    try:
+        metadata = os.stat(
+            root / entry.actual_path,
+            follow_symlinks=False,
+        )
+    except OSError:
+        return (
+            LiveInfo(None, entry.size, "excluded"),
+            None,
+            AssessmentExclusion(entry.actual_path, "read-error"),
+            len(raw),
+            False,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        return (
+            LiveInfo(None, entry.size, "excluded"),
+            None,
+            AssessmentExclusion(entry.actual_path, "read-error"),
+            len(raw),
+            False,
+        )
     if _contains_embedded_secret(raw):
         return (
             LiveInfo(None, None, "restricted"),
@@ -273,7 +312,12 @@ def _safe_live(
             False,
         )
     return (
-        LiveInfo(hashlib.sha256(raw).hexdigest(), len(raw), "readable"),
+        LiveInfo(
+            hashlib.sha256(raw).hexdigest(),
+            len(raw),
+            "readable",
+            bool(metadata.st_mode & 0o111),
+        ),
         raw,
         None,
         len(raw),
@@ -308,6 +352,8 @@ def _target_resolves(
     if target.startswith("outside-vault:"):
         return False
     if target.startswith("env:"):
+        return True
+    if target.startswith("package:"):
         return True
     if target.startswith("python-relative:"):
         relative = target.removeprefix("python-relative:")
@@ -375,6 +421,7 @@ def _is_symbolic_target(target: str) -> bool:
             "outside-vault:",
             "python:",
             "python-relative:",
+            "package:",
             "skill:",
             "unresolved:",
         )
@@ -446,9 +493,25 @@ def discover(vault_root: Path) -> DiscoveryResult:
 
     entries_by_path = {entry.actual_path: entry for entry in inventory.entries}
     exclusions: dict[tuple[str, str], AssessmentExclusion] = {}
+    embedded_repository_roots = frozenset(
+        repository_root
+        for entry in inventory.entries
+        if (
+            repository_root := _embedded_repository_root(entry)
+        ) is not None
+    )
+    for repository_root in embedded_repository_roots:
+        exclusion = AssessmentExclusion(
+            repository_root,
+            "embedded-repository",
+        )
+        exclusions[(exclusion.path, exclusion.reason)] = exclusion
     for entry in inventory.entries:
         dependency_root = _dependency_root(entry.actual_path)
-        if dependency_root is not None:
+        if dependency_root is not None and not any(
+            _is_within(dependency_root, repository_root)
+            for repository_root in embedded_repository_roots
+        ):
             exclusion = AssessmentExclusion(
                 dependency_root,
                 "dependency-tree-excluded",
@@ -465,7 +528,13 @@ def discover(vault_root: Path) -> DiscoveryResult:
         if _is_behavior_addition(entry, inventory.baseline.manifest_paths)
     )
     candidate_paths = {
-        path for path in candidate_paths if _dependency_root(path) is None
+        path
+        for path in candidate_paths
+        if _dependency_root(path) is None
+        and not any(
+            _is_within(path, repository_root)
+            for repository_root in embedded_repository_roots
+        )
     }
 
     registry = _load_trusted_registry(root)
@@ -570,9 +639,39 @@ def discover(vault_root: Path) -> DiscoveryResult:
             live_by_path[path] = live
             if exclusion is not None:
                 exclusions[(exclusion.path, exclusion.reason)] = exclusion
+            if path in {
+                ".claude/settings.json",
+                ".claude/settings.local.json",
+            }:
+                try:
+                    settings_hook_edges = read_settings_hook_edges(
+                        root,
+                        path,
+                        known_paths=frozenset(entries_by_path),
+                    )
+                except ReferenceParseError:
+                    parse_exclusion = AssessmentExclusion(path, "read-error")
+                    exclusions[
+                        (parse_exclusion.path, parse_exclusion.reason)
+                    ] = parse_exclusion
+                    settings_hook_edges = ()
+                for edge in settings_hook_edges:
+                    all_edges[edge.edge_id] = edge
             if raw is None:
                 continue
-            for edge in extract_reference_edges(path, raw, skill_paths=skill_paths):
+            try:
+                extracted_edges = extract_reference_edges(
+                    path,
+                    raw,
+                    skill_paths=skill_paths,
+                )
+            except ReferenceParseError:
+                parse_exclusion = AssessmentExclusion(path, "read-error")
+                exclusions[
+                    (parse_exclusion.path, parse_exclusion.reason)
+                ] = parse_exclusion
+                continue
+            for edge in extracted_edges:
                 all_edges[edge.edge_id] = edge
                 target_entry = entries_by_path.get(edge.target)
                 if (
@@ -675,6 +774,11 @@ def discover(vault_root: Path) -> DiscoveryResult:
             entry.kind in {"file", "symlink"}
             and entry.actual_path in inventory.unproven_paths
             and entry.actual_path not in accounted_paths
+            and _dependency_root(entry.actual_path) is None
+            and not any(
+                _is_within(entry.actual_path, repository_root)
+                for repository_root in embedded_repository_roots
+            )
         ):
             exclusion = AssessmentExclusion(
                 entry.actual_path,

--- a/core/customization_migration/model.py
+++ b/core/customization_migration/model.py
@@ -18,6 +18,7 @@ SHA256 = re.compile(r"^[0-9a-f]{64}$")
 CUSTOMIZATION_ID = re.compile(r"^cust-[0-9a-f]{12}$")
 EDGE_ID = re.compile(r"^dep-[0-9a-f]{12}$")
 SKILL_REFERENCE_TARGET = re.compile(r"^skill:[a-z0-9][a-z0-9-]*$")
+PACKAGE_REFERENCE_TARGET = re.compile(r"^package:[A-Za-z0-9@/_.-]{1,256}$")
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 READABILITY = frozenset({"readable", "restricted", "excluded", "missing", "hash-only"})
 EXCLUSION_REASONS = frozenset(
@@ -30,6 +31,7 @@ EXCLUSION_REASONS = frozenset(
         "trust-hash-mismatch",
         "release-identity-unproved",
         "dependency-tree-excluded",
+        "embedded-repository",
         "canonical-path-collision",
         "invalid-trust-registry",
         "reference-budget-exhausted",
@@ -72,6 +74,8 @@ class EdgeKind(str, Enum):
     MARKDOWN_LINK = "markdown-link"
     LITERAL_PATH = "literal-path"
     ENV_VAR_NAME = "env-var-name"
+    LAUNCH_AGENT_TO_EXECUTABLE = "launch-agent-to-executable"
+    PACKAGE_DEPENDENCY = "package-dependency"
 
 
 class ReferenceConfidence(str, Enum):
@@ -148,6 +152,7 @@ class LiveInfo:
     sha256: str | None
     byte_size: int | None
     model_readability: str
+    executable: bool | None = None
 
     def __post_init__(self) -> None:
         if self.sha256 is not None and (
@@ -160,25 +165,36 @@ class LiveInfo:
             raise ValueError("live byte_size must be a non-negative integer or null")
         if self.model_readability not in READABILITY:
             raise ValueError("live model_readability is not a closed authority value")
+        if self.executable is not None and type(self.executable) is not bool:
+            raise ValueError("live executable must be a boolean or null")
         if self.model_readability == "readable" and (
             self.sha256 is None or self.byte_size is None
         ):
             raise ValueError("readable live content requires both hash and byte size")
         if self.model_readability in {"restricted", "missing"} and (
-            self.sha256 is not None or self.byte_size is not None
+            self.sha256 is not None
+            or self.byte_size is not None
+            or self.executable is not None
         ):
-            raise ValueError("restricted or missing content cannot expose hash or size")
+            raise ValueError(
+                "restricted or missing content cannot expose hash, size, or executable mode"
+            )
         if self.model_readability == "hash-only" and (
-            self.sha256 is None or self.byte_size is not None
+            self.sha256 is None
+            or self.byte_size is not None
+            or self.executable is not None
         ):
             raise ValueError("hash-only content exposes only a SHA-256")
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        result: dict[str, object] = {
             "sha256": self.sha256,
             "byte_size": self.byte_size,
             "model_readability": self.model_readability,
         }
+        if self.executable is not None:
+            result["executable"] = self.executable
+        return result
 
 
 @dataclass(frozen=True)
@@ -284,6 +300,11 @@ class ReferenceEdge:
         _canonical_path(self.source_path)
         if not isinstance(self.target, str) or not self.target or "\x00" in self.target:
             raise ValueError("reference target must be a non-empty string")
+        if (
+            self.target.startswith("package:")
+            and PACKAGE_REFERENCE_TARGET.fullmatch(self.target) is None
+        ):
+            raise ValueError("package reference target is not canonical")
         symbolic = (
             re.fullmatch(r"env:[A-Z][A-Z0-9_]*", self.target)
             or re.fullmatch(r"unresolved:[0-9a-f]{12}", self.target)
@@ -297,6 +318,7 @@ class ReferenceEdge:
                 self.target,
             )
             or SKILL_REFERENCE_TARGET.fullmatch(self.target)
+            or PACKAGE_REFERENCE_TARGET.fullmatch(self.target)
             or self.target in {"outside-vault:absolute", "outside-vault:escape"}
         )
         if symbolic is None:

--- a/core/customization_migration/references.py
+++ b/core/customization_migration/references.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import ast
 import json
+import plistlib
 import posixpath
 import re
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Mapping
 
 from core.customization_migration.model import (
@@ -16,6 +17,7 @@ from core.customization_migration.model import (
 )
 
 MAX_SOURCE_BYTES = 1024 * 1024
+MAX_STRUCTURED_DEPTH = 64
 PATH_TOKEN = re.compile(
     r"(?<![A-Za-z0-9_.:/-])"
     r"((?:\.{0,2}/)?[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+)"
@@ -32,6 +34,23 @@ ENV_NAME = re.compile(
 )
 JS_REQUIRE = re.compile(r"\brequire\(\s*[\"']([^\"']+)[\"']\s*\)")
 YAML_SCALAR = re.compile(r"^[ \t]*[A-Za-z0-9_.-]+[ \t]*:[ \t]*(.+?)[ \t]*$")
+SHELL_WORD = re.compile(r"""(?:'[^']*'|"[^"]*"|[^\s;&|<>]+)""")
+REQUIREMENTS_NAME = re.compile(
+    r"^\s*([A-Za-z0-9_.-]{1,256})(?:\[[A-Za-z0-9_,.-]+\])?"
+    r"\s*(?:[<>=!~;@]|$)"
+)
+PACKAGE_NAME = re.compile(r"^[A-Za-z0-9@/_.-]{1,256}$")
+
+
+class ReferenceParseError(ValueError):
+    """A structural reference source could not be parsed safely."""
+
+
+def _load_json(value: str | bytes, description: str) -> object:
+    try:
+        return json.loads(value)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+        raise ReferenceParseError(f"{description} is malformed") from error
 
 
 def is_reference_read_restricted_path(path: str) -> bool:
@@ -118,6 +137,193 @@ def _path_edges(
             )
         )
     return edges
+
+
+def _shell_static_text(text: str) -> str:
+    """Blank shell words containing expansion before applying PATH_TOKEN."""
+    if text.startswith("#!"):
+        _, separator, remainder = text.partition("\n")
+        text = (" " * (len(text) - len(remainder) - len(separator))) + separator + remainder
+    return SHELL_WORD.sub(
+        lambda match: " " * len(match.group(0))
+        if "$" in match.group(0)
+        else match.group(0),
+        text,
+    )
+
+
+def _shell_edges(
+    source_path: str,
+    text: str,
+    skill_paths: Mapping[str, str],
+) -> list[ReferenceEdge]:
+    static_text = _shell_static_text(text)
+    edges = _path_edges(
+        source_path,
+        PATH_TOKEN.findall(static_text),
+        confidence=ReferenceConfidence.INFERRED,
+    )
+    for skill_name in SKILL_MENTION.findall(static_text):
+        target = skill_paths.get(skill_name)
+        if target is not None:
+            edges.append(
+                ReferenceEdge.create(
+                    source_path,
+                    target,
+                    EdgeKind.INSTRUCTIONS_TO_SKILL,
+                    ReferenceConfidence.INFERRED,
+                )
+            )
+    return edges
+
+
+def _plist_edges(source_path: str, raw: bytes) -> list[ReferenceEdge]:
+    try:
+        payload = plistlib.loads(raw)
+    except (plistlib.InvalidFileException, ValueError, TypeError) as error:
+        raise ReferenceParseError("launch-agent plist is malformed") from error
+    if not isinstance(payload, dict):
+        raise ReferenceParseError("launch-agent plist root must be a dictionary")
+    values: list[str] = []
+    arguments = payload.get("ProgramArguments")
+    if isinstance(arguments, list):
+        values.extend(value for value in arguments if isinstance(value, str))
+    working_directory = payload.get("WorkingDirectory")
+    if isinstance(working_directory, str):
+        values.append(working_directory)
+    paths = [
+        value
+        for value in values
+        if "$" not in value
+        and "\x00" not in value
+        and not value.startswith("-")
+        and "/" in value
+    ]
+    return [
+        edge
+        for edge in _path_edges(
+            source_path,
+            paths,
+            confidence=ReferenceConfidence.PROVED,
+            kind=EdgeKind.LAUNCH_AGENT_TO_EXECUTABLE,
+        )
+        if not edge.target.startswith("outside-vault:")
+    ]
+
+
+def _package_edges(source_path: str, text: str) -> list[ReferenceEdge]:
+    name = PurePosixPath(source_path).name
+    package_names: set[str] = set()
+    if name == "package.json":
+        payload = _load_json(text, "package manifest")
+        if not isinstance(payload, dict):
+            return []
+        for key in ("dependencies", "devDependencies"):
+            dependencies = payload.get(key)
+            if not isinstance(dependencies, dict):
+                continue
+            package_names.update(
+                dependency
+                for dependency in dependencies
+                if isinstance(dependency, str)
+                and PACKAGE_NAME.fullmatch(dependency) is not None
+            )
+    elif (
+        name == "requirements.txt"
+        or name.startswith("requirements-") and name.endswith(".txt")
+    ):
+        for raw_line in text.splitlines():
+            line = raw_line.split("#", 1)[0]
+            match = REQUIREMENTS_NAME.match(line)
+            if match is not None:
+                package_names.add(match.group(1))
+    return [
+        ReferenceEdge.create(
+            source_path,
+            f"package:{package_name}",
+            EdgeKind.PACKAGE_DEPENDENCY,
+            ReferenceConfidence.PROVED,
+        )
+        for package_name in sorted(package_names)
+    ]
+
+
+def _hook_commands(value: object, depth: int = 0) -> list[str]:
+    if depth > MAX_STRUCTURED_DEPTH:
+        raise ReferenceParseError("hook settings exceed the structural depth bound")
+    if isinstance(value, dict):
+        commands = [
+            nested
+            for key, nested in value.items()
+            if key == "command" and isinstance(nested, str)
+        ]
+        for nested in value.values():
+            commands.extend(_hook_commands(nested, depth + 1))
+        return commands
+    if isinstance(value, list):
+        return [
+            command
+            for nested in value
+            for command in _hook_commands(nested, depth + 1)
+        ]
+    return []
+
+
+def extract_settings_hook_edges(
+    source_path: str,
+    raw: bytes,
+    *,
+    known_paths: frozenset[str],
+) -> tuple[ReferenceEdge, ...]:
+    """Structurally extract existing hook targets without exposing commands."""
+    if source_path not in {
+        ".claude/settings.json",
+        ".claude/settings.local.json",
+    }:
+        raise ValueError("hook settings extractor only accepts Claude settings")
+    if len(raw) > MAX_SOURCE_BYTES:
+        raise ValueError("source exceeds the reference extraction bound")
+    payload = _load_json(raw, "hook settings")
+    if not isinstance(payload, dict):
+        return ()
+    hooks = payload.get("hooks")
+    paths = [
+        path
+        for command in _hook_commands(hooks)
+        for path in PATH_TOKEN.findall(_shell_static_text(command))
+    ]
+    edges = _path_edges(
+        source_path,
+        paths,
+        confidence=ReferenceConfidence.PROVED,
+        kind=EdgeKind.HOOK_TO_SCRIPT,
+    )
+    unique = {
+        edge.edge_id: edge
+        for edge in edges
+        if edge.target in known_paths
+    }
+    return tuple(sorted(unique.values(), key=lambda edge: edge.edge_id))
+
+
+def read_settings_hook_edges(
+    root: Path,
+    source_path: str,
+    *,
+    known_paths: frozenset[str],
+) -> tuple[ReferenceEdge, ...]:
+    """Bounded no-follow read dedicated to the structural hook extractor."""
+    from core.lifecycle.filesystem import FilesystemInspectionError, bounded_read
+
+    try:
+        raw = bounded_read(root, source_path, max_bytes=MAX_SOURCE_BYTES)
+    except FilesystemInspectionError:
+        return ()
+    return extract_settings_hook_edges(
+        source_path,
+        raw,
+        known_paths=known_paths,
+    )
 
 
 def _markdown_edges(
@@ -213,16 +419,22 @@ def _python_edges(source_path: str, text: str) -> list[ReferenceEdge]:
     return edges
 
 
-def _structured_values(value: object) -> list[str]:
+def _structured_values(value: object, depth: int = 0) -> list[str]:
+    if depth > MAX_STRUCTURED_DEPTH:
+        raise ReferenceParseError("configuration exceeds the structural depth bound")
     if isinstance(value, dict):
         return [
             item
             for key, nested in value.items()
             if key != "env"
-            for item in _structured_values(nested)
+            for item in _structured_values(nested, depth + 1)
         ]
     if isinstance(value, list):
-        return [item for nested in value for item in _structured_values(nested)]
+        return [
+            item
+            for nested in value
+            for item in _structured_values(nested, depth + 1)
+        ]
     return [value] if isinstance(value, str) else []
 
 
@@ -276,10 +488,7 @@ def _mcp_edges(source_path: str, payload: object) -> list[ReferenceEdge]:
 def _config_edges(source_path: str, text: str) -> list[ReferenceEdge]:
     values: list[str] = []
     if source_path.endswith(".json"):
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            return []
+        payload = _load_json(text, "JSON configuration")
         values.extend(_structured_values(payload))
     else:
         for raw_line in text.splitlines():
@@ -289,10 +498,9 @@ def _config_edges(source_path: str, text: str) -> list[ReferenceEdge]:
                 continue
             value = match.group(1).strip()
             if value.startswith(("[", "{")):
-                try:
-                    values.extend(_structured_values(json.loads(value)))
-                except json.JSONDecodeError:
-                    continue
+                values.extend(
+                    _structured_values(_load_json(value, "structured YAML value"))
+                )
             else:
                 values.append(value.strip("\"'"))
     paths = [
@@ -329,24 +537,36 @@ def extract_reference_edges(
         return ()
     if len(raw) > MAX_SOURCE_BYTES:
         raise ValueError("source exceeds the reference extraction bound")
+    suffix = PurePosixPath(source_path).suffix.lower()
+    if suffix == ".plist":
+        edges = _plist_edges(source_path, raw)
+        unique = {edge.edge_id: edge for edge in edges}
+        return tuple(sorted(unique.values(), key=lambda edge: edge.edge_id))
     try:
         text = raw.decode("utf-8")
     except UnicodeDecodeError:
         return ()
     if source_path == ".mcp.json":
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            return ()
+        payload = _load_json(text, "MCP configuration")
         edges = _mcp_edges(source_path, payload)
         unique = {edge.edge_id: edge for edge in edges}
         return tuple(sorted(unique.values(), key=lambda edge: edge.edge_id))
-    suffix = PurePosixPath(source_path).suffix.lower()
+    name = PurePosixPath(source_path).name
+    if (
+        name == "package.json"
+        or name == "requirements.txt"
+        or name.startswith("requirements-") and name.endswith(".txt")
+    ):
+        edges = _package_edges(source_path, text)
+        unique = {edge.edge_id: edge for edge in edges}
+        return tuple(sorted(unique.values(), key=lambda edge: edge.edge_id))
     edges: list[ReferenceEdge] = []
     if suffix in {".md", ".markdown"} or PurePosixPath(source_path).name == "SKILL.md":
         edges.extend(_markdown_edges(source_path, text, skill_paths))
     if suffix == ".py":
         edges.extend(_python_edges(source_path, text))
+    elif suffix in {".sh", ".bash", ".zsh"}:
+        edges.extend(_shell_edges(source_path, text, skill_paths))
     elif suffix in {".js", ".cjs", ".mjs"}:
         require_values = JS_REQUIRE.findall(text)
         literal_values = PATH_TOKEN.findall(text)
@@ -375,6 +595,9 @@ def extract_reference_edges(
 
 __all__ = [
     "MAX_SOURCE_BYTES",
+    "ReferenceParseError",
     "extract_reference_edges",
+    "extract_settings_hook_edges",
     "is_reference_read_restricted_path",
+    "read_settings_hook_edges",
 ]

--- a/core/lifecycle/performance-budget-v1.json
+++ b/core/lifecycle/performance-budget-v1.json
@@ -7,6 +7,7 @@
     "build_adoption_plan": 0.00288,
     "build_inventory": 5.580281,
     "collect_adoption_report": 5.7281,
-    "total_measured": 17.029311
+    "customization_assessment": 67.426542,
+    "total_measured": 84.455852
   }
 }

--- a/core/tests/test_customization_assessment_depth.py
+++ b/core/tests/test_customization_assessment_depth.py
@@ -1,0 +1,623 @@
+"""Lane B depth contracts for the read-only customization assessment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import plistlib
+from pathlib import Path
+
+import pytest
+
+from core.customization_migration import inventory as assessment_inventory
+from core.customization_migration import references
+from core.customization_migration.model import (
+    AssessmentGroup,
+    CustomizationKind,
+    EdgeKind,
+    LiveInfo,
+    ReferenceConfidence,
+    ReferenceEdge,
+)
+from core.customization_migration.references import extract_reference_edges
+from core.customization_migration.report import assessment_report
+from core.customization_migration.service import assess, assessment_to_dict
+from core.tests.lifecycle_test_helpers import write_file
+from core.tests.test_customization_assessment import (
+    SHIPPED_BYTES,
+    SHIPPED_SKILL,
+    _install_verified_catalog,
+)
+from core.utils.trust_registry import TrustedMcpEntry, TrustedMcpRegistry
+from scripts.benchmark_adoption_engine import run_benchmark
+
+
+def _edge_set(value) -> set[tuple[str, str, str]]:
+    return {
+        (edge.source_path, edge.target, edge.edge_kind.value)
+        for edge in value.edges
+    }
+
+
+def _record_kinds(value) -> dict[str, CustomizationKind]:
+    return {
+        record.source_paths[0]: record.kind
+        for record in value.records
+    }
+
+
+def _group_set(value) -> set[tuple[str, str]]:
+    paths_by_id = {
+        record.customization_id: record.source_paths[0]
+        for record in value.records
+    }
+    return {
+        (paths_by_id[group.customization_id], group.group.value)
+        for group in value.groups
+    }
+
+
+def test_live_info_executable_is_emitted_only_when_known() -> None:
+    readable = LiveInfo("a" * 64, 7, "readable", executable=True)
+    restricted = LiveInfo(None, None, "restricted")
+
+    assert readable.to_dict()["executable"] is True
+    assert "executable" not in restricted.to_dict()
+    with pytest.raises(ValueError, match="restricted or missing"):
+        LiveInfo(None, None, "restricted", executable=False)
+    with pytest.raises(ValueError, match="boolean or null"):
+        LiveInfo("a" * 64, 7, "readable", executable=1)
+
+
+def test_package_symbolic_target_grammar_is_closed_and_bounded() -> None:
+    edge = ReferenceEdge.create(
+        ".scripts/requirements.txt",
+        "package:@scope/example_pkg",
+        EdgeKind.PACKAGE_DEPENDENCY,
+        ReferenceConfidence.PROVED,
+    )
+
+    assert edge.target == "package:@scope/example_pkg"
+    for invalid in (
+        "package:",
+        "package:name with spaces",
+        "package:name\x00suffix",
+        f"package:{'a' * 257}",
+    ):
+        with pytest.raises(ValueError):
+            ReferenceEdge.create(
+                ".scripts/requirements.txt",
+                invalid,
+                EdgeKind.PACKAGE_DEPENDENCY,
+                ReferenceConfidence.PROVED,
+            )
+
+
+def test_shell_extraction_emits_static_paths_and_skips_interpolation() -> None:
+    edges = extract_reference_edges(
+        ".scripts/run.sh",
+        (
+            b'python3 "./helper.py"\n'
+            b'node scripts/static.js\n'
+            b'python3 "$ROOT/scripts/private.py"\n'
+            b"python3 ${ROOT}/scripts/also-private.py\n"
+            b"/daily-plan\n"
+        ),
+        skill_paths={"daily-plan": SHIPPED_SKILL},
+    )
+
+    assert {
+        (edge.target, edge.edge_kind.value)
+        for edge in edges
+    } == {
+        (".scripts/helper.py", "literal-path"),
+        ("scripts/static.js", "literal-path"),
+        (SHIPPED_SKILL, "instructions-to-skill"),
+        ("env:ROOT", "env-var-name"),
+    }
+
+
+def test_plist_extraction_emits_only_vault_relative_launch_paths() -> None:
+    raw = plistlib.dumps(
+        {
+            "ProgramArguments": [
+                "/usr/bin/python3",
+                "scripts/worker.py",
+                "--flag",
+                "System/config.json",
+            ],
+            "WorkingDirectory": "core/mcp-custom",
+        }
+    )
+
+    edges = extract_reference_edges(
+        "LaunchAgents/com.example.worker.plist",
+        raw,
+        skill_paths={},
+    )
+
+    assert {
+        (edge.target, edge.edge_kind.value)
+        for edge in edges
+    } == {
+        ("scripts/worker.py", "launch-agent-to-executable"),
+        ("System/config.json", "launch-agent-to-executable"),
+        ("core/mcp-custom", "launch-agent-to-executable"),
+    }
+
+
+def test_malformed_plist_becomes_read_error_exclusion(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, "LaunchAgents/broken.plist", b"not a plist")
+
+    discovery = assessment_inventory.discover(vault)
+
+    assert _record_kinds(discovery) == {
+        "LaunchAgents/broken.plist": CustomizationKind.CUSTOM_CONFIG,
+    }
+    assert {
+        (item.path, item.reason)
+        for item in discovery.exclusions
+    } == {("LaunchAgents/broken.plist", "read-error")}
+
+
+def test_settings_hooks_emit_existing_paths_without_leaking_command_canary(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    canary = "CANARY-tenant/SUPERSECRET0123456789"
+    write_file(vault, ".claude/hooks/run.sh", b"#!/bin/sh\nexit 0\n")
+    write_file(
+        vault,
+        ".claude/settings.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        f"{canary} .claude/hooks/run.sh "
+                                        "missing/not-real.sh"
+                                    ),
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "env": {"SECRET": canary},
+            }
+        ).encode(),
+    )
+
+    discovery = assessment_inventory.discover(vault)
+    assessment = assess(vault)
+    outputs = (
+        discovery.records,
+        discovery.edges,
+        discovery.exclusions,
+        assessment_to_dict(assessment),
+        assessment_report(assessment),
+        assessment.canonical_assessment_bytes(),
+    )
+
+    assert (
+        ".claude/settings.json",
+        ".claude/hooks/run.sh",
+        "hook-to-script",
+    ) in _edge_set(discovery)
+    assert not any(edge.target == "missing/not-real.sh" for edge in discovery.edges)
+    assert canary not in repr(outputs)
+    settings = next(
+        record
+        for record in discovery.records
+        if record.source_paths == (".claude/settings.json",)
+    )
+    assert settings.live.model_readability == "restricted"
+    assert settings.live.executable is None
+
+
+def test_deeply_nested_settings_json_becomes_read_error_exclusion(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    raw = b'{"nested":' * 40_000 + b"null" + b"}" * 40_000
+    write_file(vault, ".claude/settings.json", raw)
+
+    discovery = assessment_inventory.discover(vault)
+
+    assert (".claude/settings.json", "read-error") in {
+        (item.path, item.reason)
+        for item in discovery.exclusions
+    }
+
+
+def test_deep_settings_hooks_walker_becomes_read_error_exclusion(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, ".claude/settings.json", b'{"hooks":{"custom":true}}')
+    nested: object = {"command": ".claude/hooks/run.sh"}
+    for _ in range(5_000):
+        nested = {"nested": nested}
+    payload = {"hooks": nested}
+    monkeypatch.setattr(
+        references,
+        "_load_json",
+        lambda _raw, _description: payload,
+    )
+
+    discovery = assessment_inventory.discover(vault)
+
+    assert (".claude/settings.json", "read-error") in {
+        (item.path, item.reason)
+        for item in discovery.exclusions
+    }
+
+
+def test_deeply_nested_mcp_json_becomes_read_error_exclusion(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    raw = b'{"nested":' * 40_000 + b"null" + b"}" * 40_000
+    write_file(vault, ".mcp.json", raw)
+
+    discovery = assessment_inventory.discover(vault)
+
+    assert (".mcp.json", "read-error") in {
+        (item.path, item.reason)
+        for item in discovery.exclusions
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_path", "raw", "targets"),
+    [
+        (
+            ".scripts/requirements.txt",
+            (
+                b"# comment\n"
+                b"requests[security]>=2.31  # pinned elsewhere\n"
+                b"my_pkg~=1.2\n"
+                b"-r other.txt\n"
+            ),
+            {"package:my_pkg", "package:requests"},
+        ),
+        (
+            ".scripts/package.json",
+            json.dumps(
+                {
+                    "dependencies": {"@scope/tool": "^1.0.0"},
+                    "devDependencies": {"test_helper": "2.0.0"},
+                    "scripts": {"secret": "tenant/SUPERSECRET0123456789"},
+                }
+            ).encode(),
+            {"package:@scope/tool", "package:test_helper"},
+        ),
+    ],
+)
+def test_package_manifests_emit_names_only(
+    source_path: str,
+    raw: bytes,
+    targets: set[str],
+) -> None:
+    edges = extract_reference_edges(source_path, raw, skill_paths={})
+
+    assert {edge.target for edge in edges} == targets
+    assert {edge.edge_kind for edge in edges} == {EdgeKind.PACKAGE_DEPENDENCY}
+    assert "SUPERSECRET" not in repr(edges)
+
+
+def test_requirements_skips_overlong_name_and_keeps_other_packages(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    overlong_name = "a" * 300
+    write_file(
+        vault,
+        ".scripts/requirements.txt",
+        f"{overlong_name}==1.0\nrequests>=2\n".encode(),
+    )
+
+    discovery = assessment_inventory.discover(vault)
+
+    package_targets = {
+        edge.target
+        for edge in discovery.edges
+        if edge.edge_kind is EdgeKind.PACKAGE_DEPENDENCY
+    }
+    assert package_targets == {"package:requests"}
+
+
+def test_readable_files_capture_executable_mode(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, ".scripts/run.sh", b"#!/bin/sh\nexit 0\n")
+    os.chmod(vault / ".scripts/run.sh", 0o755)
+    write_file(vault, ".scripts/plain.py", b"VALUE = 1\n")
+
+    discovery = assessment_inventory.discover(vault)
+    records = {
+        record.source_paths[0]: record
+        for record in discovery.records
+    }
+
+    assert records[".scripts/run.sh"].live.executable is True
+    assert records[".scripts/plain.py"].live.executable is False
+
+
+def test_nested_git_is_reported_at_embedded_repository_root(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, "tools/vendor/.git/config", b"[core]\n")
+    write_file(vault, "tools/vendor/run.py", b"VALUE = 1\n")
+
+    discovery = assessment_inventory.discover(vault)
+
+    assert {
+        (item.path, item.reason)
+        for item in discovery.exclusions
+    } == {("tools/vendor", "embedded-repository")}
+    assert "tools/vendor/.git/config" not in _record_kinds(discovery)
+
+
+def test_light_corpus_exact_shape(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, "CLAUDE-custom.md", b"# My instructions\n")
+
+    assessment = assess(vault)
+
+    assert _record_kinds(assessment) == {
+        "CLAUDE-custom.md": CustomizationKind.CUSTOM_INSTRUCTIONS,
+    }
+    assert _edge_set(assessment) == set()
+    assert _group_set(assessment) == {
+        ("CLAUDE-custom.md", "update-untouched-location"),
+    }
+    assert assessment.exclusions == ()
+    assert assessment.completeness == "OK"
+    assert assessment.verdict == "OK"
+
+
+def test_medium_corpus_exact_shape(monkeypatch, tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(
+        vault,
+        SHIPPED_SKILL,
+        SHIPPED_BYTES + b"\n```sh\n.scripts/custom.sh\n```\n",
+    )
+    write_file(
+        vault,
+        ".scripts/custom.sh",
+        b"#!/bin/sh\ncat System/folder-paths.yaml\n",
+    )
+    write_file(vault, "System/folder-paths.yaml", b'projects: "Work/Projects"\n')
+    server = b"TOOLS = ()\n"
+    write_file(vault, "core/mcp-custom/server.py", server)
+    write_file(
+        vault,
+        ".mcp.json",
+        b'{"mcpServers":{"custom-local":{"args":["core/mcp-custom/server.py"]}}}',
+    )
+
+    monkeypatch.setattr(
+        assessment_inventory,
+        "_load_trusted_registry",
+        lambda _root: TrustedMcpRegistry(
+            entries={
+                "custom-local": TrustedMcpEntry(
+                    "custom-local",
+                    "core/mcp-custom/server.py",
+                    hashlib.sha256(server).hexdigest(),
+                )
+            },
+            present=True,
+        ),
+    )
+
+    assessment = assess(vault)
+
+    assert _record_kinds(assessment) == {
+        ".mcp.json": CustomizationKind.CUSTOM_MCP,
+        ".scripts/custom.sh": CustomizationKind.CUSTOM_SCRIPT,
+        SHIPPED_SKILL: CustomizationKind.MODIFIED_SKILL,
+        "System/folder-paths.yaml": CustomizationKind.CUSTOM_CONFIG,
+        "core/mcp-custom/server.py": CustomizationKind.CUSTOM_MCP,
+    }
+    assert _edge_set(assessment) == {
+        (".mcp.json", "core/mcp-custom/server.py", "mcp-to-server"),
+        (".scripts/custom.sh", "System/folder-paths.yaml", "literal-path"),
+        (SHIPPED_SKILL, ".scripts/custom.sh", "skill-to-script"),
+        ("System/folder-paths.yaml", "04-Projects", "literal-path"),
+    }
+    assert _group_set(assessment) == {
+        (".mcp.json", "update-untouched-location"),
+        (".scripts/custom.sh", "update-replaceable-location"),
+        (SHIPPED_SKILL, "update-replaceable-location"),
+        ("System/folder-paths.yaml", "blocked"),
+        ("core/mcp-custom/server.py", "update-untouched-location"),
+    }
+    assert assessment.exclusions == ()
+    assert assessment.completeness == "OK"
+
+
+def test_extreme_corpus_exact_exclusions_and_unknown_honesty(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, "CLAUDE-custom.md", b"# Extreme\n")
+    write_file(
+        vault,
+        SHIPPED_SKILL,
+        SHIPPED_BYTES + b"\n```sh\n.scripts/a-run.sh\n```\n",
+    )
+    write_file(
+        vault,
+        ".scripts/a-run.sh",
+        b"scripts/worker.py\ncat System/folder-paths.yaml\n",
+    )
+    write_file(vault, "scripts/worker.py", b"VALUE = 1\n")
+    write_file(vault, ".scripts/requirements.txt", b"requests>=2\n")
+    write_file(vault, "System/folder-paths.yaml", b'projects: "Work/Projects"\n')
+    server = b"TOOLS = ()\n"
+    write_file(vault, "core/mcp-custom/server.py", server)
+    write_file(
+        vault,
+        ".mcp.json",
+        b'{"mcpServers":{"custom-local":{"args":["core/mcp-custom/server.py"]}}}',
+    )
+    write_file(
+        vault,
+        "LaunchAgents/worker.plist",
+        plistlib.dumps({"ProgramArguments": ["scripts/worker.py"]}),
+    )
+    write_file(vault, "tools/vendor/.git/config", b"[core]\n")
+    write_file(
+        vault,
+        ".claude/settings.json",
+        b'{"hooks":{"Stop":[{"hooks":[{"command":"scripts/worker.py"}]}]}}',
+    )
+    write_file(
+        vault,
+        ".scripts/secret.py",
+        b'API_KEY = "sk-live-SENTINEL0123456789"\n',
+    )
+    monkeypatch.setattr(
+        assessment_inventory,
+        "_load_trusted_registry",
+        lambda _root: TrustedMcpRegistry(
+            entries={
+                "custom-local": TrustedMcpEntry(
+                    "custom-local",
+                    "core/mcp-custom/server.py",
+                    hashlib.sha256(server).hexdigest(),
+                )
+            },
+            present=True,
+        ),
+    )
+    monkeypatch.setattr(assessment_inventory, "MAX_REFERENCE_FILES", 9)
+
+    discovery = assessment_inventory.discover(vault)
+    assessment = assess(vault)
+
+    assert _record_kinds(discovery) == {
+        ".claude/settings.json": CustomizationKind.CUSTOM_CONFIG,
+        SHIPPED_SKILL: CustomizationKind.MODIFIED_SKILL,
+        ".mcp.json": CustomizationKind.CUSTOM_MCP,
+        ".scripts/a-run.sh": CustomizationKind.CUSTOM_SCRIPT,
+        ".scripts/requirements.txt": CustomizationKind.UNKNOWN_ADDITION,
+        ".scripts/secret.py": CustomizationKind.CUSTOM_SCRIPT,
+        "CLAUDE-custom.md": CustomizationKind.CUSTOM_INSTRUCTIONS,
+        "LaunchAgents/worker.plist": CustomizationKind.CUSTOM_CONFIG,
+        "System/folder-paths.yaml": CustomizationKind.CUSTOM_CONFIG,
+        "core/mcp-custom/server.py": CustomizationKind.CUSTOM_MCP,
+    }
+    assert _edge_set(discovery) == {
+        (
+            ".claude/settings.json",
+            "scripts/worker.py",
+            "hook-to-script",
+        ),
+        (
+            ".scripts/a-run.sh",
+            "scripts/worker.py",
+            "literal-path",
+        ),
+        (
+            ".scripts/a-run.sh",
+            "System/folder-paths.yaml",
+            "literal-path",
+        ),
+        (
+            ".scripts/requirements.txt",
+            "package:requests",
+            "package-dependency",
+        ),
+        (
+            "LaunchAgents/worker.plist",
+            "scripts/worker.py",
+            "launch-agent-to-executable",
+        ),
+        (
+            SHIPPED_SKILL,
+            ".scripts/a-run.sh",
+            "skill-to-script",
+        ),
+        (
+            ".mcp.json",
+            "core/mcp-custom/server.py",
+            "mcp-to-server",
+        ),
+        (
+            "System/folder-paths.yaml",
+            "04-Projects",
+            "literal-path",
+        ),
+    }
+    assert _group_set(discovery) == {
+        (".claude/settings.json", "blocked"),
+        (SHIPPED_SKILL, "update-replaceable-location"),
+        (".mcp.json", "update-untouched-location"),
+        (".scripts/a-run.sh", "update-replaceable-location"),
+        (".scripts/requirements.txt", "update-replaceable-location"),
+        (".scripts/secret.py", "blocked"),
+        ("CLAUDE-custom.md", "update-untouched-location"),
+        ("LaunchAgents/worker.plist", "needs-interpretation"),
+        ("System/folder-paths.yaml", "blocked"),
+        ("core/mcp-custom/server.py", "update-untouched-location"),
+    }
+    assert {
+        (item.path, item.reason, item.uninspected_count)
+        for item in discovery.exclusions
+    } == {
+        (".claude/settings.json", "restricted", None),
+        (".scripts/secret.py", "embedded-secret", None),
+        ("tools/vendor", "embedded-repository", None),
+        ("scripts/worker.py", "reference-budget-exhausted", 1),
+    }
+    assert assessment.completeness == "UNKNOWN"
+    assert assessment.verdict == "UNKNOWN"
+    assert assessment.records == ()
+    assert assessment.edges == ()
+    assert assessment.groups == ()
+    assert "assessment-exclusions" in assessment.incomplete_reasons
+
+
+def test_adoption_benchmark_reports_customization_assessment_stage() -> None:
+    result = run_benchmark(1)
+
+    assert "customization_assessment" in result["seconds"]
+    assert result["seconds"]["total_measured"] == round(
+        sum(
+            seconds
+            for stage, seconds in result["seconds"].items()
+            if stage != "total_measured"
+        ),
+        6,
+    )

--- a/scripts/benchmark_adoption_engine.py
+++ b/scripts/benchmark_adoption_engine.py
@@ -20,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 os.environ.setdefault("VAULT_PATH", str(REPO_ROOT))
 
+from core.customization_migration.service import assess
 from core.lifecycle.catalog import canonical_catalog_bytes, with_catalog_identity
 from core.lifecycle.engine import (
     execute_adoption,
@@ -128,6 +129,7 @@ def _load_budgets(path: Path) -> dict[str, object]:
         "build_inventory",
         "build_adoption_plan",
         "collect_adoption_report",
+        "customization_assessment",
         "adoption_and_rewind",
         "total_measured",
     }
@@ -157,6 +159,7 @@ def run_benchmark(file_count: int) -> dict[str, object]:
         adoption_report, doctor_seconds = _timed(
             lambda: collect_adoption_report(context)
         )
+        _, customization_assessment_seconds = _timed(lambda: assess(vault))
 
         def adopt_and_rewind():
             preview = build_adoption_preview(
@@ -185,8 +188,16 @@ def run_benchmark(file_count: int) -> dict[str, object]:
             "build_adoption_plan": plan_seconds,
             "build_inventory": inventory_seconds,
             "collect_adoption_report": doctor_seconds,
+            "customization_assessment": customization_assessment_seconds,
         }
-        seconds["total_measured"] = sum(seconds.values())
+        rounded_seconds = {
+            key: round(value, 6)
+            for key, value in sorted(seconds.items())
+        }
+        rounded_seconds["total_measured"] = round(
+            sum(rounded_seconds.values()),
+            6,
+        )
         return {
             "counts": {
                 "adopted_files": len(receipt.files_written),
@@ -197,7 +208,7 @@ def run_benchmark(file_count: int) -> dict[str, object]:
                 "synthetic_files": file_count,
             },
             "peak_rss_bytes": _peak_rss_bytes(),
-            "seconds": {key: round(value, 6) for key, value in sorted(seconds.items())},
+            "seconds": rounded_seconds,
         }
 
 


### PR DESCRIPTION
Lane B: the assessment now sees shell scripts, launch-agent plists, hook commands from Claude settings (structural extractor — emits only vault-resolved path edges, never command strings; the settings files stay unreadable to the model), package dependencies (names only), executable-mode evidence, and embedded repositories. Read-only throughout.

Adversarial security review applied: its BLOCKER (deep-nested JSON crashing the assessment via stack exhaustion) and SERIOUS (over-long package names) findings are fixed — every parse failure now surfaces as a read-error exclusion, never a crash. Confidentiality probes (secret canaries in hook commands, env values, plists) all held.

Performance: assessment stage benchmarked clean at 51.9s/100k files, budgeted at 67.4s with standard headroom; the benchmark script no longer double-times discovery.

18 new tests incl. LIGHT/MEDIUM/EXTREME corpus journeys, crash-regression cases, and leak canaries; 105 green with all regression suites; gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSS5ozU6tnNYXmEKv5JLje