### PR TITLE
sec(integrations): Phase 5d — B1 user-presence gate on privileged export

### DIFF
--- a/core/integrations/connection-manager/README.md
+++ b/core/integrations/connection-manager/README.md
@@ -23,8 +23,30 @@ The engine code ships in Dex Core, but remains product-inert: no user-facing
 | `lib/connector-ledger.js` | Secret-free per-connection evidence under `System/credentials/ledger/` (500-row cap, atomic rewrite). |
 | `connect.cjs` | CLI: `connect` / `status [--json]` / `probe` / `refresh` / `disconnect` / `providers` / `authurl`. |
 | `broker.cjs` / `broker-client.cjs` | Machine-local Unix-socket broker and client. Accessors request rendered or explicitly privileged credential views here instead of decrypting the store in their own process. |
+| `presence.cjs` | B1 user-presence gate for raw exports and first connect, with a short in-process grant cache. |
 | `get-token.cjs` | Contract-frozen accessor for Python MCP servers; all credential reads go through the broker. |
 | `dex-call.cjs` | Generic authenticated caller; obtains rendered auth from the broker, then sends and redacts its own outbound request. |
+
+## User-presence provider (B1)
+
+Rendered authentication, default token access, and status checks never prompt,
+so unattended sync keeps working. Raw `access-token` / `full` exports and the
+first successful connect require verified user presence.
+
+Real Touch ID is not implemented by a dialog or by JavaScript in this repo.
+macOS requires an OS-signed app/helper for a genuine biometric prompt. The Dex
+desktop app supplies that helper through `DEX_CM_PRESENCE_CMD`; the value is
+argv-split and spawned directly without a shell. Exit 0 grants presence;
+non-zero or timeout denies it.
+
+Without a usable helper, the built-in macOS provider is honestly
+`unavailable`, and privileged operations fail closed. Headless/CI environments
+may explicitly set `DEX_CM_PRESENCE_OPTIONAL=1` to bypass an *unavailable*
+provider; this prints a warning that presence was not verified. It never turns
+an explicit denial into approval. Successful grants are cached in the broker
+process per connection for 60 seconds by default
+(`DEX_CM_PRESENCE_TTL_MS`; helper timeout:
+`DEX_CM_PRESENCE_TIMEOUT_MS`, default 30 seconds).
 
 ## Maintainer smoke path
 

--- a/core/integrations/connection-manager/broker-client.cjs
+++ b/core/integrations/connection-manager/broker-client.cjs
@@ -22,6 +22,7 @@ function exitCodeForError(category) {
   return {
     forbidden: 1,
     unvetted: 1,
+    presence_required: 1,
     needs_reauth: 3,
     not_connected: 2,
     http: 4,

--- a/core/integrations/connection-manager/broker.cjs
+++ b/core/integrations/connection-manager/broker.cjs
@@ -24,6 +24,7 @@ const path = require('node:path');
 const authContext = require('./auth-context.cjs');
 const health = require('./health.cjs');
 const pinned = require('./pinned-providers.cjs');
+const presence = require('./presence.cjs');
 const store = require('./token-store.cjs');
 const { withLock, writeFileAtomic } = require('./fs-safe.cjs');
 
@@ -111,8 +112,10 @@ function socketIsLive(file) {
   });
 }
 
-async function assertPresence(_connId, _op) {
-  // Phase 5d: bind privileged export to OS user-presence (Touch ID) here.
+async function assertPresence(connId, op) {
+  // Keep this exported indirection: tests and the desktop host can observe the
+  // broker seam without weakening the provider policy in presence.cjs.
+  return presence.assertPresence(connId, op);
 }
 
 function errorCategory(error) {
@@ -214,7 +217,13 @@ async function processRequest(request, capability) {
 }
 
 function createServer(capability, activity) {
-  return net.createServer((socket) => {
+  // allowHalfOpen: the client half-closes its write side after sending the
+  // request (socket.end). Without this, the server auto-closes its write side on
+  // that FIN, and a slow async handler (e.g. a presence check that spawns a
+  // child process) would finish after the socket is already closing — dropping
+  // the response. Keeping the write side open lets every response land; the
+  // handler still explicitly ends the socket once it has written.
+  return net.createServer({ allowHalfOpen: true }, (socket) => {
     socket.setEncoding('utf8');
     let input = '';
     let handled = false;

--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -25,6 +25,7 @@ const catalog = require('./catalog.cjs');
 const store = require('./token-store.cjs');
 const oauth = require('./oauth-flow.cjs');
 const health = require('./health.cjs');
+const presence = require('./presence.cjs');
 const { assertPinnedOrigin, isVetted } = require('./pinned-providers.cjs');
 
 function allowUnvetted(flags = {}) {
@@ -61,7 +62,11 @@ function openBrowser(url) {
   spawn(cmd, [url], { stdio: 'ignore', detached: true }).unref();
 }
 
-async function cmdConnect(provider, flags) {
+async function cmdConnect(
+  provider,
+  flags,
+  { presenceProvider, oauthProvider = oauth, openBrowser: openBrowserFn = openBrowser } = {}
+) {
   if (!provider) throw new Error('Usage: node connect.cjs connect <provider> [--scopes a,b,c] [--as <alias>]');
   requireUnvettedConsent(provider, flags);
   const providerConfig = catalog.getProviderConfig(provider);
@@ -88,8 +93,8 @@ async function cmdConnect(provider, flags) {
   }
   const scopes = catalog.normalizeScopes(provider, flags.scopes ? flags.scopes.split(',') : []);
 
-  const cb = await oauth.startCallbackServer();
-  const { url, codeVerifier, state } = oauth.buildAuthorizationUrl(providerConfig, {
+  const cb = await oauthProvider.startCallbackServer();
+  const { url, codeVerifier, state } = oauthProvider.buildAuthorizationUrl(providerConfig, {
     clientId: app.clientId,
     scopes,
     redirectUri: cb.redirectUri,
@@ -97,17 +102,18 @@ async function cmdConnect(provider, flags) {
 
   console.log(`\nOpening browser to connect ${providerConfig.displayName}${alias ? ` (as ${alias})` : ''}…`);
   console.log(`(If it doesn't open, visit:)\n${url}\n`);
-  openBrowser(url);
+  openBrowserFn(url);
 
   const { code } = await cb.waitForCode({ expectedState: state });
 
-  const token = await oauth.exchangeCodeForToken(providerConfig, {
+  const token = await oauthProvider.exchangeCodeForToken(providerConfig, {
     code,
     codeVerifier,
     clientId: app.clientId,
     clientSecret: app.clientSecret,
     redirectUri: cb.redirectUri,
   });
+  await presence.assertPresence(connId, 'connect', { provider: presenceProvider });
   store.saveToken(connId, token, { provider: providerConfig.id });
   health.recordConnectionEvent(connId, 'connect', { ok: true });
   if (flags.default) store.setDefault(provider, alias);
@@ -300,7 +306,7 @@ async function probeKey(service, descriptor, secret) {
   }
 }
 
-async function cmdSetKey(service, flags) {
+async function cmdSetKey(service, flags, { presenceProvider, readSecret = readSecretOrPrompt } = {}) {
   if (!service) throw new Error('Usage: node connect.cjs set-key <provider> [--username <u>] [--<field> <value> …] [--no-probe] (secret via stdin)');
   if (flags.key !== undefined || flags.password !== undefined) {
     throw new Error('Secret flags are not accepted; pipe the API key or password on stdin.');
@@ -351,7 +357,7 @@ async function cmdSetKey(service, flags) {
   let secret;
   if (descriptor.authMode === 'BASIC') {
     const username = flags.username;
-    const password = await readSecretOrPrompt('Password (hidden): ');
+    const password = await readSecret('Password (hidden): ');
     if (!username || !password) {
       throw new Error(
         'BASIC auth needs --username and a password. Run this command in an interactive terminal for a hidden prompt, ' +
@@ -360,7 +366,7 @@ async function cmdSetKey(service, flags) {
     }
     secret = { username, password };
   } else {
-    const apiKey = await readSecretOrPrompt('API key (hidden): ');
+    const apiKey = await readSecret('API key (hidden): ');
     if (!apiKey) {
       throw new Error(
         'No API key received. Run this command in an interactive terminal for a hidden prompt, or pipe the key on stdin.'
@@ -370,6 +376,7 @@ async function cmdSetKey(service, flags) {
   }
   if (Object.keys(connectionConfig).length) secret.connectionConfig = connectionConfig;
 
+  await presence.assertPresence(connId, 'connect', { provider: presenceProvider });
   store.saveApiKey(connId, secret, { provider: descriptor.id, authMode: descriptor.authMode });
   health.recordConnectionEvent(connId, 'connect', { ok: true });
   if (flags.default) store.setDefault(provider, alias);
@@ -607,4 +614,14 @@ async function main() {
 }
 
 if (require.main === module) main();
-module.exports = { main, buildProbeTarget, classifyProbeStatus, probeKey, cmdRefresh, cmdStatus, cmdProbe };
+module.exports = {
+  main,
+  buildProbeTarget,
+  classifyProbeStatus,
+  probeKey,
+  cmdConnect,
+  cmdSetKey,
+  cmdRefresh,
+  cmdStatus,
+  cmdProbe,
+};

--- a/core/integrations/connection-manager/connection-manager.broker.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.broker.test.cjs
@@ -19,8 +19,10 @@ process.env.DEX_CM_BROKER_IDLE_MS = '150';
 
 const store = require('./token-store.cjs');
 const authContext = require('./auth-context.cjs');
+const presence = require('./presence.cjs');
 const broker = require('./broker.cjs');
 const client = require('./broker-client.cjs');
+const connect = require('./connect.cjs');
 
 function mode(file) {
   return fs.statSync(file).mode & 0o777;
@@ -109,6 +111,15 @@ test.after(async () => {
   fs.rmSync(TMP_RUNTIME, { recursive: true, force: true });
 });
 
+test('broker presence seam delegates to the provider-based presence layer', async (t) => {
+  const calls = [];
+  t.mock.method(presence, 'assertPresence', async (connId, op) => calls.push([connId, op]));
+
+  await broker.assertPresence('linear:delegated', 'access-token');
+
+  assert.deepEqual(calls, [['linear:delegated', 'access-token']]);
+});
+
 test('broker request processing preserves accessor shapes without a live socket', async () => {
   const capability = 'test-capability';
   const oauth = 'google:broker-unit';
@@ -163,6 +174,166 @@ test('broker request processing preserves accessor shapes without a live socket'
     store.deleteToken(oauth);
     store.deleteToken(classB);
   }
+});
+
+test('privileged broker denial returns presence_required without releasing a secret', async () => {
+  const capability = 'presence-denial-capability';
+  const connId = 'linear:presence-denial';
+  const secret = 'MUST-NOT-BE-RELEASED';
+  store.saveApiKey(connId, { apiKey: secret }, { provider: 'linear', authMode: 'API_KEY' });
+  const originalPresence = broker.assertPresence;
+  broker.assertPresence = async () => {
+    const error = new Error('User presence is required for this credential operation.');
+    error.code = 'DEX_CM_PRESENCE_REQUIRED';
+    error.category = 'presence_required';
+    throw error;
+  };
+  try {
+    const response = await broker.processRequest(
+      { capability, op: 'access-token', connId },
+      capability
+    );
+    assert.equal(response.ok, false);
+    assert.equal(response.error.category, 'presence_required');
+    assert.match(response.error.message, /presence/i);
+    assert.equal(JSON.stringify(response).includes(secret), false);
+  } finally {
+    broker.assertPresence = originalPresence;
+    store.deleteToken(connId);
+  }
+});
+
+test('set-key requires mocked presence before the first credential save', async () => {
+  const connId = 'linear:first-connect-approved';
+  const prompts = [];
+  const provider = {
+    available: true,
+    async verify(request) {
+      prompts.push(request);
+      return true;
+    },
+  };
+  try {
+    await connect.cmdSetKey(connId, { 'no-probe': 'true' }, {
+      presenceProvider: provider,
+      readSecret: async () => 'FIRST-CONNECT-SECRET',
+    });
+
+    assert.equal(store.loadToken(connId).apiKey, 'FIRST-CONNECT-SECRET');
+    assert.deepEqual(prompts, [{ connId, op: 'connect' }]);
+  } finally {
+    if (store.getConnection(connId)) store.deleteToken(connId);
+  }
+});
+
+test('set-key denial stores nothing and cannot overwrite an existing credential', async () => {
+  const deniedId = 'linear:first-connect-denied';
+  const deniedProvider = { available: true, verify: async () => false };
+  await assert.rejects(
+    connect.cmdSetKey(deniedId, { 'no-probe': 'true' }, {
+      presenceProvider: deniedProvider,
+      readSecret: async () => 'DENIED-FIRST-CONNECT-SECRET',
+    }),
+    { code: 'DEX_CM_PRESENCE_REQUIRED', category: 'presence_required' }
+  );
+  assert.equal(store.getConnection(deniedId), null);
+
+  const reconnectId = 'linear:reconnect-denied';
+  store.saveApiKey(reconnectId, { apiKey: 'OLD-SECRET' }, { provider: 'linear', authMode: 'API_KEY' });
+  let reconnectPrompts = 0;
+  try {
+    await assert.rejects(
+      connect.cmdSetKey(reconnectId, { 'no-probe': 'true' }, {
+        presenceProvider: {
+          available: true,
+          async verify() {
+            reconnectPrompts += 1;
+            return false;
+          },
+        },
+        readSecret: async () => 'NEW-SECRET',
+      }),
+      { code: 'DEX_CM_PRESENCE_REQUIRED', category: 'presence_required' }
+    );
+    assert.equal(store.loadToken(reconnectId).apiKey, 'OLD-SECRET');
+    assert.equal(reconnectPrompts, 1);
+  } finally {
+    if (store.getConnection(reconnectId)) store.deleteToken(reconnectId);
+  }
+});
+
+test('OAuth connect requires mocked presence before the first token save', async () => {
+  const connId = 'google:presence-oauth';
+  store.setOAuthApp('google', { clientId: 'TEST-CLIENT', clientSecret: 'TEST-SECRET' });
+  const prompts = [];
+  const oauthProvider = {
+    async startCallbackServer() {
+      return {
+        redirectUri: 'http://127.0.0.1:3847/callback',
+        waitForCode: async () => ({ code: 'TEST-CODE' }),
+      };
+    },
+    buildAuthorizationUrl() {
+      return { url: 'https://accounts.google.com/test', codeVerifier: 'VERIFIER', state: 'STATE' };
+    },
+    async exchangeCodeForToken() {
+      return { access_token: 'OAUTH-FIRST-CONNECT', refresh_token: 'OAUTH-REFRESH' };
+    },
+  };
+  try {
+    await connect.cmdConnect('google', { as: 'presence-oauth' }, {
+      oauthProvider,
+      openBrowser: () => {},
+      presenceProvider: {
+        available: true,
+        async verify(request) {
+          prompts.push(request);
+          return true;
+        },
+      },
+    });
+
+    assert.equal(store.loadToken(connId).access_token, 'OAUTH-FIRST-CONNECT');
+    assert.deepEqual(prompts, [{ connId, op: 'connect' }]);
+  } finally {
+    if (store.getConnection(connId)) store.deleteToken(connId);
+  }
+});
+
+test('accessor CLIs clearly surface presence_required with exit code 1', async () => {
+  const preload = path.join(TMP_ROOT, 'presence-required-preload.cjs');
+  const clientPath = path.join(__dirname, 'broker-client.cjs');
+  fs.writeFileSync(
+    preload,
+    [
+      "'use strict';",
+      `const clientPath = ${JSON.stringify(clientPath)};`,
+      'require.cache[clientPath] = {',
+      '  id: clientPath, filename: clientPath, loaded: true,',
+      '  exports: {',
+      "    exitCodeForError(category) { return category === 'presence_required' ? 1 : 99; },",
+      "    async brokerRequest() { return {ok:false,error:{category:'presence_required'}}; },",
+      '  },',
+      '};',
+    ].join('\n')
+  );
+  const env = { NODE_OPTIONS: `--require=${preload}` };
+
+  const getToken = await runCli(
+    path.join(__dirname, 'get-token.cjs'),
+    ['linear:presence-cli', '--access-token-only'],
+    env
+  );
+  assert.equal(getToken.status, 1);
+  assert.match(getToken.stderr, /user presence/i);
+
+  const dexCall = await runCli(
+    path.join(__dirname, 'dex-call.cjs'),
+    ['linear:presence-cli', 'GET', 'https://api.linear.app/graphql'],
+    env
+  );
+  assert.equal(dexCall.status, 1);
+  assert.match(dexCall.stderr, /user presence/i);
 });
 
 test('rendered broker auth retains key-in-URL redaction without exposing an apiKey field', async () => {
@@ -374,6 +545,24 @@ test('socket (verify outside sandbox): broker gates operations and accessor CLIs
       assert.deepEqual(presenceCalls, []);
     });
 
+    await t.test('denying presence returns presence_required without releasing the raw secret', async () => {
+      const acceptingPresence = broker.assertPresence;
+      broker.assertPresence = async () => {
+        const error = new Error('User presence is required for this credential operation.');
+        error.code = 'DEX_CM_PRESENCE_REQUIRED';
+        error.category = 'presence_required';
+        throw error;
+      };
+      try {
+        const response = await rawRequest({ capability, op: 'access-token', connId: linear });
+        assert.equal(response.ok, false);
+        assert.equal(response.error.category, 'presence_required');
+        assert.equal(JSON.stringify(response).includes('LINEAR-BROKER-SECRET'), false);
+      } finally {
+        broker.assertPresence = acceptingPresence;
+      }
+    });
+
     await t.test('privileged access-token and full exports invoke presence', async () => {
       const access = await rawRequest({ capability, op: 'access-token', connId: linear });
       assert.deepEqual(access, { ok: true, value: 'LINEAR-BROKER-SECRET' });
@@ -511,6 +700,7 @@ test('socket (verify outside sandbox): broker gates operations and accessor CLIs
 test('client maps legacy CLI exit codes', () => {
   assert.equal(client.exitCodeForError('forbidden'), 1);
   assert.equal(client.exitCodeForError('unvetted'), 1);
+  assert.equal(client.exitCodeForError('presence_required'), 1);
   assert.equal(client.exitCodeForError('needs_reauth'), 3);
   assert.equal(client.exitCodeForError('not_connected'), 2);
   assert.equal(client.exitCodeForError('http'), 4);

--- a/core/integrations/connection-manager/connection-manager.judgment.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.judgment.test.cjs
@@ -20,7 +20,12 @@ const { refreshOAuthToken } = require('./lib/oauth-refresh.js');
 const { createConnectorVerify, CATEGORY } = require('./lib/connector-verify.js');
 const { createConnectorLedger } = require('./lib/connector-ledger.js');
 
-const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
+const childEnv = {
+  ...process.env,
+  DEX_VAULT: TMP_VAULT,
+  DEX_CM_NO_KEYCHAIN: '1',
+  DEX_CM_PRESENCE_OPTIONAL: '1',
+};
 
 test.after(() => fs.rmSync(TMP_VAULT, { recursive: true, force: true }));
 

--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -29,6 +29,7 @@ const childEnv = {
   DEX_VAULT: TMP_VAULT,
   DEX_CM_NO_KEYCHAIN: '1',
   DEX_CM_ALLOW_UNVETTED: '1',
+  DEX_CM_PRESENCE_OPTIONAL: '1',
 };
 
 test.after(() => {

--- a/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5b-security.test.cjs
@@ -24,7 +24,12 @@ const dexCall = require('./dex-call.cjs');
 const health = require('./health.cjs');
 
 const DIR = __dirname;
-const childEnv = { ...process.env, DEX_VAULT: TMP_VAULT, DEX_CM_NO_KEYCHAIN: '1' };
+const childEnv = {
+  ...process.env,
+  DEX_VAULT: TMP_VAULT,
+  DEX_CM_NO_KEYCHAIN: '1',
+  DEX_CM_PRESENCE_OPTIONAL: '1',
+};
 
 test.after(() => {
   fs.rmSync(TMP_VAULT, { recursive: true, force: true });

--- a/core/integrations/connection-manager/connection-manager.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.test.cjs
@@ -40,6 +40,7 @@ const childEnv = {
   DEX_VAULT: TMP_VAULT,
   DEX_CM_NO_KEYCHAIN: '1',
   DEX_CM_ALLOW_UNVETTED: '1',
+  DEX_CM_PRESENCE_OPTIONAL: '1',
 };
 
 // Pick a real paste-a-key provider for the Class-B path. Prefer one that needs ONLY an

--- a/core/integrations/connection-manager/connections-contract.test.cjs
+++ b/core/integrations/connection-manager/connections-contract.test.cjs
@@ -45,6 +45,7 @@ test('foreign smoke consumer uses only CLIs plus contract/schema against a scrat
     DEX_CM_RUNTIME_DIR: runtime,
     DEX_CM_BROKER_IDLE_MS: '100',
     DEX_CM_NO_KEYCHAIN: '1',
+    DEX_CM_PRESENCE_OPTIONAL: '1',
   };
   try {
     execFileSync('node', [path.join(__dirname, 'connect.cjs'), 'set-key', 'linear', '--no-probe'], {
@@ -78,6 +79,7 @@ test('real accessor and status CLIs conform to the published schemas and exit-co
     DEX_CM_RUNTIME_DIR: runtime,
     DEX_CM_BROKER_IDLE_MS: '100',
     DEX_CM_NO_KEYCHAIN: '1',
+    DEX_CM_PRESENCE_OPTIONAL: '1',
   };
   const contract = JSON.parse(fs.readFileSync(CONTRACT, 'utf8'));
   const schema = JSON.parse(fs.readFileSync(SCHEMA, 'utf8'));

--- a/core/integrations/connection-manager/dex-call.cjs
+++ b/core/integrations/connection-manager/dex-call.cjs
@@ -179,6 +179,11 @@ async function main() {
           `Refusing authenticated call for '${provider}': this provider is not security-reviewed. ` +
             'Re-run with --allow-unvetted or DEX_CM_ALLOW_UNVETTED=1 to opt in.'
         );
+      } else if (brokerError.category === 'presence_required') {
+        console.error(
+          brokerError.message ||
+            `${service} requires verified user presence. Approve the OS prompt and try again.`
+        );
       } else {
         console.error(brokerError.message || 'Credential broker request failed.');
       }

--- a/core/integrations/connection-manager/get-token.cjs
+++ b/core/integrations/connection-manager/get-token.cjs
@@ -50,6 +50,8 @@ async function main() {
           ? `${service} is not connected.`
           : error.category === 'needs_reauth'
             ? `${service} needs re-authentication. Run: node connect.cjs connect ${service}`
+            : error.category === 'presence_required'
+              ? `${service} requires verified user presence. Approve the OS prompt and try again.`
             : 'Credential broker request failed.')
     );
     process.exit(exitCodeForError(error.category));

--- a/core/integrations/connection-manager/presence.cjs
+++ b/core/integrations/connection-manager/presence.cjs
@@ -1,0 +1,171 @@
+'use strict';
+
+const { spawn } = require('node:child_process');
+
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const grants = new Map();
+const inFlightChecks = new Map();
+
+/**
+ * B1 user-presence policy.
+ *
+ * `connect` is the synthetic operation used by connect.cjs for the first
+ * credential save. Rendered credentials and default token access deliberately
+ * remain silent so background sync keeps working.
+ */
+function requiresPresence(op) {
+  return op === 'access-token' || op === 'full' || op === 'connect';
+}
+
+function presenceRequiredError() {
+  const error = new Error('User presence is required for this credential operation.');
+  error.code = 'DEX_CM_PRESENCE_REQUIRED';
+  error.category = 'presence_required';
+  return error;
+}
+
+function configuredMs(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function currentTime(now) {
+  return typeof now === 'function' ? now() : now == null ? Date.now() : Number(now);
+}
+
+function splitCommand(value) {
+  const argv = [];
+  let current = '';
+  let quote = null;
+  let escaped = false;
+  let started = false;
+  for (const char of String(value || '')) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      started = true;
+    } else if (char === '\\' && quote !== "'") {
+      escaped = true;
+      started = true;
+    } else if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      started = true;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+      started = true;
+    } else if (/\s/.test(char)) {
+      if (started) {
+        argv.push(current);
+        current = '';
+        started = false;
+      }
+    } else {
+      current += char;
+      started = true;
+    }
+  }
+  if (escaped || quote) return [];
+  if (started) argv.push(current);
+  return argv;
+}
+
+function commandProvider(commandValue) {
+  const argv = splitCommand(commandValue);
+  if (!argv.length || !argv[0]) {
+    return { available: false, reason: 'DEX_CM_PRESENCE_CMD could not be parsed into a command.' };
+  }
+  return {
+    available: true,
+    kind: 'command',
+    verify() {
+      return new Promise((resolve) => {
+        let settled = false;
+        let timer;
+        let child;
+        const finish = (approved) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(approved);
+        };
+        try {
+          child = spawn(argv[0], argv.slice(1), {
+            shell: false,
+            stdio: 'ignore',
+          });
+        } catch {
+          finish(false);
+          return;
+        }
+        child.once('error', () => finish(false));
+        child.once('exit', (code) => finish(code === 0));
+        timer = setTimeout(() => {
+          child.kill('SIGKILL');
+          finish(false);
+        }, configuredMs('DEX_CM_PRESENCE_TIMEOUT_MS', DEFAULT_TIMEOUT_MS));
+      });
+    },
+  };
+}
+
+function unavailableProvider(reason) {
+  return { available: false, kind: 'unavailable', reason };
+}
+
+/**
+ * This module cannot honestly create a Touch ID prompt by itself: macOS
+ * requires an OS-signed application/helper to make that claim meaningful. The
+ * desktop app supplies that helper through DEX_CM_PRESENCE_CMD. A plain dialog
+ * would be theatre, so the built-in Darwin adapter is deliberately unavailable.
+ */
+function resolveProvider() {
+  if (process.env.DEX_CM_PRESENCE_CMD) return commandProvider(process.env.DEX_CM_PRESENCE_CMD);
+  if (process.platform === 'darwin') {
+    return unavailableProvider(
+      'Real biometric presence requires the Dex-signed helper configured by DEX_CM_PRESENCE_CMD.'
+    );
+  }
+  return unavailableProvider('OS user presence is unavailable on this platform without DEX_CM_PRESENCE_CMD.');
+}
+
+async function assertPresence(connId, op, { provider, now } = {}) {
+  if (!requiresPresence(op)) return;
+  const checkedAt = currentTime(now);
+  const grantExpiresAt = grants.get(connId);
+  if (Number.isFinite(grantExpiresAt) && checkedAt < grantExpiresAt) return;
+  grants.delete(connId);
+
+  provider = provider || resolveProvider();
+  if (!provider || provider.available === false || typeof provider.verify !== 'function') {
+    if (process.env.DEX_CM_PRESENCE_OPTIONAL === '1') {
+      console.error(
+        `warning: user presence was NOT verified for ${connId}; ` +
+          'DEX_CM_PRESENCE_OPTIONAL=1 explicitly allowed this headless/CI operation.'
+      );
+      return;
+    }
+    throw presenceRequiredError();
+  }
+  if (inFlightChecks.has(connId)) return inFlightChecks.get(connId);
+
+  const check = (async () => {
+    let approved = false;
+    try {
+      approved = (await provider.verify({ connId, op })) === true;
+    } catch {
+      approved = false;
+    }
+    if (!approved) throw presenceRequiredError();
+    grants.set(connId, currentTime(now) + configuredMs('DEX_CM_PRESENCE_TTL_MS', DEFAULT_TTL_MS));
+  })();
+  inFlightChecks.set(connId, check);
+  try {
+    return await check;
+  } finally {
+    if (inFlightChecks.get(connId) === check) inFlightChecks.delete(connId);
+  }
+}
+
+module.exports = { requiresPresence, assertPresence, resolveProvider };

--- a/core/integrations/connection-manager/presence.test.cjs
+++ b/core/integrations/connection-manager/presence.test.cjs
@@ -1,0 +1,186 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const presence = require('./presence.cjs');
+
+test('B1 requires presence only for privileged raw exports and first connect', () => {
+  assert.equal(presence.requiresPresence('access-token'), true);
+  assert.equal(presence.requiresPresence('full'), true);
+  assert.equal(presence.requiresPresence('connect'), true);
+  assert.equal(presence.requiresPresence('rendered'), false);
+  assert.equal(presence.requiresPresence('get-token-default'), false);
+  assert.equal(presence.requiresPresence('status'), false);
+});
+
+test('unprivileged operations return without consulting the provider', async () => {
+  let prompts = 0;
+  const provider = {
+    available: true,
+    async verify() {
+      prompts += 1;
+      return true;
+    },
+  };
+
+  for (const op of ['rendered', 'get-token-default', 'status']) {
+    await presence.assertPresence(`unprivileged-${op}`, op, { provider });
+  }
+
+  assert.equal(prompts, 0);
+});
+
+test('privileged operations require an approving provider', async () => {
+  const calls = [];
+  const provider = {
+    available: true,
+    async verify(request) {
+      calls.push(request);
+      return true;
+    },
+  };
+
+  await presence.assertPresence('linear:approved', 'access-token', { provider, now: () => 1_000 });
+  await presence.assertPresence('google:approved', 'full', { provider, now: () => 1_000 });
+
+  assert.deepEqual(calls, [
+    { connId: 'linear:approved', op: 'access-token' },
+    { connId: 'google:approved', op: 'full' },
+  ]);
+});
+
+test('provider denial throws the typed presence-required error', async () => {
+  const provider = { available: true, verify: async () => false };
+
+  await assert.rejects(
+    presence.assertPresence('linear:denied', 'access-token', { provider }),
+    (error) =>
+      error.code === 'DEX_CM_PRESENCE_REQUIRED' &&
+      error.category === 'presence_required' &&
+      /presence/i.test(error.message)
+  );
+});
+
+test('unavailable provider fails closed unless the explicit optional escape hatch is set', async (t) => {
+  const originalOptional = process.env.DEX_CM_PRESENCE_OPTIONAL;
+  const warnings = [];
+  t.mock.method(console, 'error', (message) => warnings.push(message));
+  const provider = { available: false, verify: async () => true };
+
+  delete process.env.DEX_CM_PRESENCE_OPTIONAL;
+  await assert.rejects(
+    presence.assertPresence('linear:unavailable-denied', 'access-token', { provider }),
+    { code: 'DEX_CM_PRESENCE_REQUIRED', category: 'presence_required' }
+  );
+
+  process.env.DEX_CM_PRESENCE_OPTIONAL = '1';
+  await presence.assertPresence('linear:unavailable-optional', 'access-token', { provider });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /not verified/i);
+
+  if (originalOptional === undefined) delete process.env.DEX_CM_PRESENCE_OPTIONAL;
+  else process.env.DEX_CM_PRESENCE_OPTIONAL = originalOptional;
+});
+
+test('optional mode never converts an explicit denial into approval', async () => {
+  const originalOptional = process.env.DEX_CM_PRESENCE_OPTIONAL;
+  process.env.DEX_CM_PRESENCE_OPTIONAL = '1';
+  try {
+    await assert.rejects(
+      presence.assertPresence('linear:explicit-denial', 'access-token', {
+        provider: { available: true, verify: async () => false },
+      }),
+      { code: 'DEX_CM_PRESENCE_REQUIRED', category: 'presence_required' }
+    );
+  } finally {
+    if (originalOptional === undefined) delete process.env.DEX_CM_PRESENCE_OPTIONAL;
+    else process.env.DEX_CM_PRESENCE_OPTIONAL = originalOptional;
+  }
+});
+
+test('successful grants are cached per connection until the configured TTL expires', async () => {
+  const originalTtl = process.env.DEX_CM_PRESENCE_TTL_MS;
+  process.env.DEX_CM_PRESENCE_TTL_MS = '100';
+  let clock = 10_000;
+  let prompts = 0;
+  const provider = {
+    available: true,
+    async verify() {
+      prompts += 1;
+      return true;
+    },
+  };
+  try {
+    await presence.assertPresence('linear:cached', 'access-token', { provider, now: () => clock });
+    clock += 99;
+    await presence.assertPresence('linear:cached', 'full', { provider, now: () => clock });
+    assert.equal(prompts, 1);
+
+    clock += 2;
+    await presence.assertPresence('linear:cached', 'access-token', { provider, now: () => clock });
+    assert.equal(prompts, 2);
+  } finally {
+    if (originalTtl === undefined) delete process.env.DEX_CM_PRESENCE_TTL_MS;
+    else process.env.DEX_CM_PRESENCE_TTL_MS = originalTtl;
+  }
+});
+
+test('concurrent privileged calls share one in-flight presence prompt', async () => {
+  let prompts = 0;
+  let approve;
+  const approval = new Promise((resolve) => {
+    approve = resolve;
+  });
+  const provider = {
+    available: true,
+    async verify() {
+      prompts += 1;
+      return approval;
+    },
+  };
+
+  const first = presence.assertPresence('linear:concurrent', 'access-token', { provider });
+  const second = presence.assertPresence('linear:concurrent', 'full', { provider });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(prompts, 1);
+  approve(true);
+  await Promise.all([first, second]);
+});
+
+test('command provider argv-splits without a shell and maps exit status to presence', async () => {
+  const originalCommand = process.env.DEX_CM_PRESENCE_CMD;
+  const originalTimeout = process.env.DEX_CM_PRESENCE_TIMEOUT_MS;
+  try {
+    process.env.DEX_CM_PRESENCE_CMD = `"${process.execPath}" -e "process.exit(0)"`;
+    let provider = presence.resolveProvider();
+    assert.equal(provider.available, true);
+    assert.equal(await provider.verify({ connId: 'linear:command-ok', op: 'access-token' }), true);
+
+    process.env.DEX_CM_PRESENCE_CMD = `"${process.execPath}" -e "process.exit(7)"`;
+    provider = presence.resolveProvider();
+    assert.equal(await provider.verify({ connId: 'linear:command-denied', op: 'access-token' }), false);
+
+    process.env.DEX_CM_PRESENCE_TIMEOUT_MS = '20';
+    process.env.DEX_CM_PRESENCE_CMD = `"${process.execPath}" -e "setTimeout(() => {}, 1000)"`;
+    provider = presence.resolveProvider();
+    assert.equal(await provider.verify({ connId: 'linear:command-timeout', op: 'access-token' }), false);
+  } finally {
+    if (originalCommand === undefined) delete process.env.DEX_CM_PRESENCE_CMD;
+    else process.env.DEX_CM_PRESENCE_CMD = originalCommand;
+    if (originalTimeout === undefined) delete process.env.DEX_CM_PRESENCE_TIMEOUT_MS;
+    else process.env.DEX_CM_PRESENCE_TIMEOUT_MS = originalTimeout;
+  }
+});
+
+test('the platform default is honestly unavailable when no signed helper is configured', () => {
+  const originalCommand = process.env.DEX_CM_PRESENCE_CMD;
+  delete process.env.DEX_CM_PRESENCE_CMD;
+  try {
+    const provider = presence.resolveProvider();
+    assert.equal(provider.available, false);
+    assert.match(provider.reason, /signed|biometric|unavailable/i);
+  } finally {
+    if (originalCommand !== undefined) process.env.DEX_CM_PRESENCE_CMD = originalCommand;
+  }
+});

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -10,9 +10,9 @@
       "entries": [
         "connection-manager"
       ],
-      "fileCount": 20,
-      "totalBytes": 216249,
-      "treeHash": "e3b0d9c958e4776be81a7167928034700443c3c95e09ca72f5ed3d52501fdd28",
+      "fileCount": 21,
+      "totalBytes": 224117,
+      "treeHash": "d6c68f6799a465314b37d6595a84a2ad7a43ff1d477f14642e1ba99355aa109a",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -21,13 +21,13 @@
         },
         {
           "path": "broker-client.cjs",
-          "bytes": 3888,
-          "sha256": "fc5e0d82ea12a048745d52541c5c02a99319bf5d1b2700735913d754b9a644a1"
+          "bytes": 3914,
+          "sha256": "e64dce819d68e3dccf85ec3d32f39ff621fa8dc1c18d0e014bb3fa6fd2554f41"
         },
         {
           "path": "broker.cjs",
-          "bytes": 11054,
-          "sha256": "ef91c1e9d9a6d12a00e1dde1dabefac75fb22f80c043e1acc635ac77ef2e8fd5"
+          "bytes": 11705,
+          "sha256": "df8b64e3418d2b81adda32ef0d248572a501e5c7afbdb61a8b8c660fcc1487ef"
         },
         {
           "path": "catalog.cjs",
@@ -36,8 +36,8 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 29175,
-          "sha256": "10da37b67d8911448fb4b86fdc95296ebff5ec64c29b750ddf9dabcf2e4a8cc1"
+          "bytes": 29599,
+          "sha256": "ca86c82c154122392ec9cbd0c607edc2230f4b4ef8b4989cef6e04ed567a3284"
         },
         {
           "path": "contract.cjs",
@@ -46,8 +46,8 @@
         },
         {
           "path": "dex-call.cjs",
-          "bytes": 8671,
-          "sha256": "aa6ed4007fd21b6d304fd915361b4c0e87a49fb1458de1783042d08cc94a6642"
+          "bytes": 8898,
+          "sha256": "e5a818e25fa78555e737574a7a0cc029da924a831842cd5a60e573cf34e3ea82"
         },
         {
           "path": "fs-safe.cjs",
@@ -56,8 +56,8 @@
         },
         {
           "path": "get-token.cjs",
-          "bytes": 2438,
-          "sha256": "e03b67d3007c3afd225ecdf2506e0eee9c8f1fa3d044d98ae03d80d2e84642f4"
+          "bytes": 2590,
+          "sha256": "404fcc147e0a53faa6e2d43a6098e089601f8bb2c2e02a037c6e0a3a2620d194"
         },
         {
           "path": "health.cjs",
@@ -105,9 +105,14 @@
           "sha256": "bfaa66151cdd7995bdfee132d2febad6527d788798c9b62ba81cb13e83a9dada"
         },
         {
+          "path": "presence.cjs",
+          "bytes": 5170,
+          "sha256": "9260ab7be1ef50f3ef5103c432ee2e85778eb77ab3b953670ec48049672e0a3d"
+        },
+        {
           "path": "README.md",
-          "bytes": 9819,
-          "sha256": "255bbc4a7a318a4d8fd04283a7405569bbf4833a579372766bbea51a150e27f0"
+          "bytes": 11037,
+          "sha256": "4572e44c522567a6a2efdc14e4adc0dae66e24829bc4d200c00f8f91c944d42e"
         },
         {
           "path": "token-store.cjs",


### PR DESCRIPTION
Option B, phase 5d (architecture §5, policy **B1** chosen by Dave). Adds the OS user-presence gate — the piece that actually defends stored keys against a same-user program — to the broker's `assertPresence` seam. **`/connect` stays closed**; 5e (independent re-review) is next.

## B1 policy
- **Presence required** for privileged raw exports (`get-token --access-token-only`, `--full`) and **first connect** (`connect`/`set-key`).
- **No prompt** for the rendered / default-token / status paths — so silent background sync (the Python MCPs' normal path) keeps working untouched.
- A successful check caches a grant per connection for 60s (concurrent single-flight), so a burst of privileged calls prompts once.

## Honest biometric boundary (in the code, not over-claimed)
`presence.cjs` does not fake Touch ID. Real biometrics happen only when an **OS-signed helper** is wired via `DEX_CM_PRESENCE_CMD` — which the **desktop app** supplies. The built-in darwin adapter is deliberately *unavailable* rather than showing a hollow dialog. So on a bare CLI, privileged export **fails closed** until that helper is present (or `DEX_CM_PRESENCE_OPTIONAL=1` is set for headless/CI, which prints a "presence NOT verified" warning). This is the correct Option-B behavior and is why the doorway stays closed until desktop ships the helper.

## A real bug live-testing caught (Fable fix)
The broker's server socket used the default `allowHalfOpen:false`. The client half-closes its write side after sending the request; the server then auto-closed *its* write side on that FIN. For fast responses that was fine, but the presence path **spawns a child process**, so the response was produced *after* the socket was already closing — and got dropped (client saw an empty reply). Fixed with `allowHalfOpen:true` on the server; the handler still explicitly ends the socket after writing. Invisible to in-sandbox tests (sockets are EPERM there) — only the live end-to-end run surfaced it.

## Verification (run by Fable OUTSIDE the Codex sandbox)
- **188/188** serial connection-manager suite; presence unit tests included.
- `check:connections-contract`: contract v1.0.0 + engine manifest verified (21 files; `presence.cjs` included). Existing CLI exit codes unchanged.
- Local PR gates: path-contract, test-delta, doc-drift pass.
- **Live via the real `get-token` CLI:** approving provider releases the secret (exit 0); denying provider refuses with no secret (exit 1); no provider fails closed (exit 1); the rendered default read stays silent and succeeds (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MUmNHSKhTxdUwGtiJ4SUy