### PR TITLE
fix(dexdiff): CLI publishes to DexDiff's backend, not the Desktop domain

### DIFF
--- a/.claude/skills/diff-generate/scripts/publish_diff.py
+++ b/.claude/skills/diff-generate/scripts/publish_diff.py
@@ -462,14 +462,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     link = subparsers.add_parser("link", help="link this terminal to Heydex with a sign-in code")
     link.add_argument("--code", required=True, help="six-character sign-in code from Heydex")
-    link.add_argument("--api-base", default=None, help="API base, default https://api.heydex.ai")
+    link.add_argument("--api-base", default=None, help="API base, default https://gallant-reindeer-229.eu-west-1.convex.site")
     link.add_argument("--site-base", default=None, help="site base, default https://heydex.ai")
     link.set_defaults(func=command_link)
 
     publish = subparsers.add_parser("publish", help="open a browser review for one or more methodology files")
     publish.add_argument("files", nargs="+", help="generated methodology YAML file")
     publish.add_argument("--no-wait", action="store_true", help="open review and return without waiting")
-    publish.add_argument("--api-base", default=None, help="API base, default https://api.heydex.ai")
+    publish.add_argument("--api-base", default=None, help="API base, default https://gallant-reindeer-229.eu-west-1.convex.site")
     publish.add_argument("--site-base", default=None, help="site base, default https://heydex.ai")
     publish.set_defaults(func=command_publish)
 

--- a/.claude/skills/diff-generate/scripts/publish_diff.py
+++ b/.claude/skills/diff-generate/scripts/publish_diff.py
@@ -25,7 +25,10 @@ import urllib.request
 import webbrowser
 from pathlib import Path
 
-HEYDEX_API_BASE_URL = "https://api.heydex.ai"
+# DexDiff's own backend (HTTP Actions). Must match the deployment the /diff web
+# app reads from (gallant-reindeer-229) — NOT api.heydex.ai, which routes to the
+# separate Dex Desktop backend (focused-mouse-723). Override with DEXDIFF_API_BASE.
+HEYDEX_API_BASE_URL = "https://gallant-reindeer-229.eu-west-1.convex.site"
 HEYDEX_SITE_BASE_URL = "https://heydex.ai"
 AUTH_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
 HTTP_TIMEOUT_SECONDS = 20.0


### PR DESCRIPTION
**Pre-existing misconfig, surfaced during the DexDiff private-beta go-live.**

`publish_diff.py` (the `/diff-generate` publish CLI) defaulted its API base to `https://api.heydex.ai`. That domain is a Convex custom domain for the **Dex Desktop** backend (`focused-mouse-723`) — its `CONVEX_SITE_URL` is overridden to it. DexDiff's data, the private-beta gate, and the live `/diff` web app all run on a **different** deployment, `gallant-reindeer-229`. So CLI publishes were landing on the wrong backend (nothing the web app reads).

**Fix:** default `HEYDEX_API_BASE_URL` to `https://gallant-reindeer-229.eu-west-1.convex.site` (the same deployment the `/diff` web app connects to). `DEXDIFF_API_BASE` / `--api-base` still override. `HEYDEX_SITE_BASE_URL` stays `https://heydex.ai` (browser sign-in/review is correct). Help text updated to match.

Verified: the CLI's routes (`/api/connect/redeem`, `/api/publish`, `/api/review/create`) exist on `gallant-reindeer-229` and are behind the beta gate. `api.heydex.ai` (Desktop) is untouched.

Follow-up (optional): give DexDiff its own branded custom domain (e.g. `diff-api.heydex.ai` → `gallant-reindeer-229`) and point the default there instead of the raw deployment URL.