### PR TITLE
Customization migration Lane E-staging + F: private staging + honest verification

### DIFF
--- a/core/customization_migration/__init__.py
+++ b/core/customization_migration/__init__.py
@@ -66,6 +66,21 @@ from core.customization_migration.sensitivity import (
     capsule_readability,
 )
 from core.customization_migration.service import assess, assessment_to_dict
+from core.customization_migration.staging import (
+    STAGING_SUBDIR,
+    PlannedStagedFile,
+    ProposalStagingStatus,
+    StagingError,
+    StagingPreview,
+    StagingReceipt,
+    StagingStatus,
+    StagingValidation,
+    load_staged_candidate,
+    preview_staging,
+    read_staging_status,
+    stage_candidate,
+    validate_staging,
+)
 from core.customization_migration.state import (
     ALLOWED_TRANSITIONS,
     MigrationEvent,
@@ -74,6 +89,31 @@ from core.customization_migration.state import (
     project_state,
     validate_transition,
 )
+
+_LAZY_VERIFICATION_EXPORTS = frozenset(
+    {
+        "StaticFileResult",
+        "VerificationAttempt",
+        "VerificationCheckOutcome",
+        "VerificationError",
+        "VerificationReport",
+        "VerificationWriteReceipt",
+        "verify_staging",
+        "write_verification_report",
+    }
+)
+
+
+def __getattr__(name: str) -> object:
+    if name not in _LAZY_VERIFICATION_EXPORTS:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        )
+    from core.customization_migration import verification
+
+    value = getattr(verification, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "Assessment",
@@ -112,15 +152,29 @@ __all__ = [
     "MigrationStatus",
     "PlanValidation",
     "PlannedCapsuleFile",
+    "PlannedStagedFile",
+    "ProposalStagingStatus",
     "RegenerationCandidate",
     "ReferenceConfidence",
     "ReferenceEdge",
     "ReportedVerification",
     "RequirementKind",
     "SECRET_ARCHIVAL_POLICY",
+    "STAGING_SUBDIR",
     "ShimExpiry",
+    "StagingError",
+    "StagingPreview",
+    "StagingReceipt",
+    "StagingStatus",
+    "StagingValidation",
+    "StaticFileResult",
+    "VerificationAttempt",
+    "VerificationCheckOutcome",
     "VerificationClass",
+    "VerificationError",
     "VerificationOutcome",
+    "VerificationReport",
+    "VerificationWriteReceipt",
     "assess",
     "abandon_capsule",
     "assessment_report",
@@ -129,12 +183,19 @@ __all__ = [
     "create_capsule",
     "derive_reported_status",
     "is_allowed_transition",
+    "load_staged_candidate",
     "project_state",
     "preview_capsule",
+    "preview_staging",
     "read_capsule_status",
+    "read_staging_status",
+    "stage_candidate",
     "validate_transition",
     "validate_disposition_plan",
     "validate_regeneration_candidate",
     "validate_capsule",
+    "validate_staging",
+    "verify_staging",
+    "write_verification_report",
     "CAPSULE_ROOT",
 ]

--- a/core/customization_migration/staging.py
+++ b/core/customization_migration/staging.py
@@ -1,0 +1,1621 @@
+"""Consent-agnostic private staging for regeneration candidates.
+
+This module has no authority to write a live customization seam. Every
+mutation is confined to an existing capsule and passes through one sealed
+``customization-migration`` transaction. ``preview_sha256`` binds integrity;
+it is non-secret by construction and is never evidence of consent (A1).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import itertools
+import json
+import os
+import stat
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from core import portable_contract
+from core.customization_migration.behaviour import (
+    BehaviouralContract,
+    ContractProvenance,
+    VerificationClass,
+)
+from core.customization_migration.capsule import (
+    CAPSULE_ROOT,
+    CapsuleError,
+    _manifest_from_bytes,
+    validate_capsule,
+)
+from core.customization_migration.capsule_model import CAPSULE_ID
+from core.customization_migration.model import (
+    SHA256,
+    Assessment,
+    AssessmentAssignment,
+    AssessmentExclusion,
+    AssessmentGroup,
+    AssessmentIdentity,
+    BaselineInfo,
+    CustomizationEvidence,
+    CustomizationKind,
+    CustomizationRecord,
+    EdgeKind,
+    LiveInfo,
+    ReferenceConfidence,
+    ReferenceEdge,
+)
+from core.customization_migration.planning import (
+    PROPOSAL_ID,
+    CandidateFile,
+    DeclaredRequirement,
+    DependencyRemapping,
+    DependencyResolution,
+    Disposition,
+    DispositionPlanItem,
+    RegenerationCandidate,
+    RequirementKind,
+    ShimExpiry,
+    validate_regeneration_candidate,
+)
+from core.customization_migration.state import (
+    MigrationEvent,
+    MigrationState,
+    project_state,
+)
+from core.transaction.engine import PlanEntry, Transaction
+
+STAGING_SUBDIR = "candidates/{proposal_id}/staging"
+_MAX_JSON_BYTES = 1024 * 1024
+_MAX_STAGED_BYTES = 8 * 1024 * 1024
+_MAX_STAGED_FILES = 1024
+_MAX_PROPOSALS = 256
+_EVENT_KEYS = frozenset({"schema_version", "event"})
+_VERIFICATION_EVENT_KEYS = frozenset(
+    {
+        "schema_version",
+        "event",
+        "candidate_sha256",
+        "report_path",
+        "report_sha256",
+    }
+)
+
+
+class StagingError(RuntimeError):
+    """The candidate could not safely enter or leave private staging."""
+
+
+def _canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _canonical_relative(value: str, *, name: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise ValueError(f"{name} must be a non-empty canonical relative path")
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError(f"{name} must be a canonical relative path")
+    return value
+
+
+def _open_directory_beneath(root: Path, relative: str) -> int:
+    normalized = _canonical_relative(relative, name="private directory")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(root, flags)
+    try:
+        for part in PurePosixPath(normalized).parts:
+            next_descriptor = os.open(
+                part,
+                flags,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _read_regular_beneath(
+    root: Path,
+    relative: str,
+    limit: int = _MAX_JSON_BYTES,
+) -> bytes:
+    normalized = _canonical_relative(relative, name="private file")
+    parts = PurePosixPath(normalized).parts
+    parent_relative = PurePosixPath(*parts[:-1]).as_posix()
+    parent = _open_directory_beneath(root, parent_relative)
+    try:
+        descriptor = os.open(
+            parts[-1],
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent,
+        )
+    finally:
+        os.close(parent)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > limit:
+            raise StagingError(f"not a bounded regular file: {relative}")
+        chunks: list[bytes] = []
+        remaining = limit + 1
+        while remaining:
+            chunk = os.read(descriptor, min(65_536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > limit:
+            raise StagingError(f"bounded read exceeded: {relative}")
+        return raw
+    finally:
+        os.close(descriptor)
+
+
+def _scan_directory_beneath(
+    root: Path,
+    relative: str,
+    *,
+    limit: int,
+) -> dict[str, os.stat_result]:
+    descriptor = _open_directory_beneath(root, relative)
+    result: dict[str, os.stat_result] = {}
+    try:
+        with os.scandir(descriptor) as iterator:
+            for entry in iterator:
+                if len(result) >= limit:
+                    raise StagingError(
+                        f"private directory exceeds its entry bound: {relative}"
+                    )
+                result[entry.name] = entry.stat(follow_symlinks=False)
+    finally:
+        os.close(descriptor)
+    return result
+
+
+@dataclass(frozen=True)
+class PlannedStagedFile:
+    target_path: str
+    staging_path: str
+    sha256: str
+    byte_size: int
+    mode: int = 0o600
+
+    def __post_init__(self) -> None:
+        _canonical_relative(self.target_path, name="planned target_path")
+        _canonical_relative(self.staging_path, name="planned staging_path")
+        if not self.staging_path.endswith("/files/" + self.sha256):
+            raise ValueError("planned staging path is not content-addressed")
+        if not isinstance(self.sha256, str) or SHA256.fullmatch(self.sha256) is None:
+            raise ValueError("planned staged sha256 must be canonical")
+        if type(self.byte_size) is not int or self.byte_size <= 0:
+            raise ValueError("planned staged byte_size must be positive")
+        if self.mode != 0o600:
+            raise ValueError("staged files must remain mode 0600")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target_path": self.target_path,
+            "staging_path": self.staging_path,
+            "sha256": self.sha256,
+            "byte_size": self.byte_size,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True)
+class StagingPreview:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    candidate: RegenerationCandidate
+    files: tuple[PlannedStagedFile, ...]
+    preview_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported staging preview schema_version")
+        if not isinstance(self.capsule_id, str) or CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("staging preview capsule_id is not canonical")
+        if not isinstance(self.proposal_id, str) or PROPOSAL_ID.fullmatch(self.proposal_id) is None:
+            raise ValueError("staging preview proposal_id is not canonical")
+        if type(self.candidate) is not RegenerationCandidate:
+            raise TypeError("staging preview candidate must be RegenerationCandidate")
+        if (
+            self.candidate.capsule_id != self.capsule_id
+            or self.candidate.proposal_id != self.proposal_id
+        ):
+            raise ValueError("staging preview identity does not match candidate")
+        if not isinstance(self.files, tuple) or any(
+            type(item) is not PlannedStagedFile for item in self.files
+        ):
+            raise TypeError("staging preview files must be PlannedStagedFile records")
+        if tuple(sorted(self.files, key=lambda item: item.target_path)) != self.files:
+            raise ValueError("staging preview files must be sorted")
+        if len({item.target_path for item in self.files}) != len(self.files):
+            raise ValueError("staging preview target paths must be unique")
+        if not isinstance(self.preview_sha256, str) or SHA256.fullmatch(
+            self.preview_sha256
+        ) is None:
+            raise ValueError("staging preview digest must be canonical")
+
+    def _unsigned_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "candidate": self.candidate.to_dict(),
+            "files": [item.to_dict() for item in self.files],
+        }
+
+    def canonical_preview_bytes(self) -> bytes:
+        return _canonical_json(self._unsigned_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._unsigned_dict()
+        result["preview_sha256"] = self.preview_sha256
+        return result
+
+
+@dataclass(frozen=True)
+class StagingReceipt:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    staged_file_count: int
+    staged_byte_count: int
+    staging_digest: str
+    transaction_id: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported staging receipt schema_version")
+        if not isinstance(self.capsule_id, str) or CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("staging receipt capsule_id is not canonical")
+        if not isinstance(self.proposal_id, str) or PROPOSAL_ID.fullmatch(self.proposal_id) is None:
+            raise ValueError("staging receipt proposal_id is not canonical")
+        if type(self.staged_file_count) is not int or self.staged_file_count < 0:
+            raise ValueError("staged_file_count must be non-negative")
+        if type(self.staged_byte_count) is not int or self.staged_byte_count < 0:
+            raise ValueError("staged_byte_count must be non-negative")
+        if not isinstance(self.staging_digest, str) or SHA256.fullmatch(
+            self.staging_digest
+        ) is None:
+            raise ValueError("staging_digest must be canonical")
+        if (
+            not isinstance(self.transaction_id, str)
+            or not self.transaction_id
+            or "/" in self.transaction_id
+            or "\x00" in self.transaction_id
+        ):
+            raise ValueError("staging receipt transaction_id is invalid")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "staged_file_count": self.staged_file_count,
+            "staged_byte_count": self.staged_byte_count,
+            "staging_digest": self.staging_digest,
+            "transaction_id": self.transaction_id,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+
+@dataclass(frozen=True)
+class ProposalStagingStatus:
+    proposal_id: str
+    state: MigrationState
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.proposal_id, str)
+            or not self.proposal_id
+            or "/" in self.proposal_id
+            or "\x00" in self.proposal_id
+        ):
+            raise ValueError("proposal status id is invalid")
+        if not isinstance(self.state, MigrationState):
+            raise TypeError("proposal status state must be MigrationState")
+
+
+@dataclass(frozen=True)
+class StagingStatus:
+    capsule_id: str
+    proposals: tuple[ProposalStagingStatus, ...]
+    truncated: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.capsule_id, str) or CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("staging status capsule_id is not canonical")
+        if not isinstance(self.proposals, tuple) or any(
+            type(item) is not ProposalStagingStatus for item in self.proposals
+        ):
+            raise TypeError("staging status proposals must be a tuple")
+        if tuple(sorted(self.proposals, key=lambda item: item.proposal_id)) != self.proposals:
+            raise ValueError("staging status proposals must be sorted")
+        if type(self.truncated) is not bool:
+            raise TypeError("staging status truncated must be boolean")
+
+
+@dataclass(frozen=True)
+class StagingValidation:
+    status: str
+    mismatches: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.status not in {"OK", "BROKEN", "UNKNOWN"}:
+            raise ValueError("staging validation status is invalid")
+        if tuple(sorted(set(self.mismatches))) != self.mismatches:
+            raise ValueError("staging validation mismatches must be sorted and unique")
+
+
+def _strict_object(raw: bytes, *, context: str) -> dict[str, object]:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StagingError(f"{context} is unreadable") from error
+    if not isinstance(value, dict) or _canonical_json(value) != raw:
+        raise StagingError(f"{context} is not canonical")
+    return value
+
+
+def _closed_mapping(
+    value: object,
+    *,
+    keys: frozenset[str],
+    context: str,
+) -> dict[str, object]:
+    if not isinstance(value, dict) or frozenset(value) != keys:
+        raise StagingError(f"{context} has an invalid shape")
+    return value
+
+
+def _closed_list(value: object, *, context: str) -> list[object]:
+    if not isinstance(value, list):
+        raise StagingError(f"{context} must be a list")
+    return value
+
+
+def _strings(value: object, *, context: str) -> tuple[str, ...]:
+    items = _closed_list(value, context=context)
+    if any(not isinstance(item, str) for item in items):
+        raise StagingError(f"{context} must contain only strings")
+    return tuple(items)
+
+
+def _record_from_dict(value: object) -> CustomizationRecord:
+    item = _closed_mapping(
+        value,
+        keys=frozenset(
+            {
+                "customization_id",
+                "kind",
+                "source_paths",
+                "baseline",
+                "live",
+                "evidence",
+                "required_disposition",
+            }
+        ),
+        context="capsule customization record",
+    )
+    baseline = _closed_mapping(
+        item["baseline"],
+        keys=frozenset({"release_version", "sha256"}),
+        context="capsule baseline",
+    )
+    live = item["live"]
+    if not isinstance(live, dict) or frozenset(live) not in {
+        frozenset({"sha256", "byte_size", "model_readability"}),
+        frozenset({"sha256", "byte_size", "model_readability", "executable"}),
+    }:
+        raise StagingError("capsule live evidence has an invalid shape")
+    evidence = _closed_mapping(
+        item["evidence"],
+        keys=frozenset({"release_state", "reference_edge_ids"}),
+        context="capsule customization evidence",
+    )
+    try:
+        return CustomizationRecord(
+            item["customization_id"],
+            CustomizationKind(item["kind"]),
+            _strings(item["source_paths"], context="source_paths"),
+            BaselineInfo(baseline["release_version"], baseline["sha256"]),
+            LiveInfo(
+                live["sha256"],
+                live["byte_size"],
+                live["model_readability"],
+                live.get("executable"),
+            ),
+            CustomizationEvidence(
+                evidence["release_state"],
+                _strings(evidence["reference_edge_ids"], context="reference_edge_ids"),
+            ),
+            item["required_disposition"],
+        )
+    except (TypeError, ValueError) as error:
+        raise StagingError("capsule customization record is invalid") from error
+
+
+def _edge_from_dict(value: object) -> ReferenceEdge:
+    item = _closed_mapping(
+        value,
+        keys=frozenset(
+            {"edge_id", "source_path", "target", "edge_kind", "confidence"}
+        ),
+        context="capsule dependency edge",
+    )
+    try:
+        return ReferenceEdge(
+            item["edge_id"],
+            item["source_path"],
+            item["target"],
+            EdgeKind(item["edge_kind"]),
+            ReferenceConfidence(item["confidence"]),
+        )
+    except (TypeError, ValueError) as error:
+        raise StagingError("capsule dependency edge is invalid") from error
+
+
+def _exclusion_from_dict(value: object) -> AssessmentExclusion:
+    if not isinstance(value, dict) or frozenset(value) not in {
+        frozenset({"path", "reason"}),
+        frozenset({"path", "reason", "uninspected_count"}),
+    }:
+        raise StagingError("capsule exclusion has an invalid shape")
+    try:
+        return AssessmentExclusion(
+            value["path"],
+            value["reason"],
+            value.get("uninspected_count"),
+        )
+    except (TypeError, ValueError) as error:
+        raise StagingError("capsule exclusion is invalid") from error
+
+
+def _frozen_group_options(
+    records: tuple[CustomizationRecord, ...],
+    edges: tuple[ReferenceEdge, ...],
+) -> tuple[tuple[CustomizationRecord, tuple[AssessmentGroup, ...]], ...]:
+    edges_by_source: dict[str, list[ReferenceEdge]] = {}
+    for edge in edges:
+        edges_by_source.setdefault(edge.source_path, []).append(edge)
+    known_paths = {
+        path
+        for record in records
+        for path in record.source_paths
+    }
+    result: list[tuple[CustomizationRecord, tuple[AssessmentGroup, ...]]] = []
+    for record in records:
+        verdict = portable_contract.update_write_verdict(
+            record.source_paths[0],
+            exists=record.kind is not CustomizationKind.DELETED_SHIPPED_FILE,
+        )
+        outgoing = tuple(
+            edge
+            for source in record.source_paths
+            for edge in edges_by_source.get(source, ())
+        )
+        unresolved = any(
+            edge.target.startswith(("unresolved:", "outside-vault:"))
+            for edge in outgoing
+        )
+        if (
+            record.live.model_readability in {"restricted", "excluded"}
+            or unresolved
+            or verdict.action == "deny"
+        ):
+            options = (AssessmentGroup.BLOCKED,)
+        elif verdict.action == "unclassified-never-write":
+            options = (AssessmentGroup.NEEDS_INTERPRETATION,)
+        elif verdict.allowed:
+            options = (AssessmentGroup.UPDATE_REPLACEABLE_LOCATION,)
+        else:
+            options = (AssessmentGroup.UPDATE_UNTOUCHED_LOCATION,)
+        # Capsule evidence canonicalizes an unresolved inferred target to
+        # ``unresolved:*``. A concrete inferred target was therefore known to
+        # resolve at capture time. A proved concrete target can still have
+        # been absent (for example a configured folder), and v0 capsules do
+        # not store the original group alongside the record. The sealed
+        # assessment digest disambiguates that one missing bit without any
+        # live-vault read.
+        ambiguous_proved_target = any(
+            edge.confidence is ReferenceConfidence.PROVED
+            and ":" not in edge.target
+            and edge.target not in known_paths
+            for edge in outgoing
+        )
+        if (
+            ambiguous_proved_target
+            and options != (AssessmentGroup.BLOCKED,)
+        ):
+            options = (*options, AssessmentGroup.BLOCKED)
+        result.append((record, options))
+    return tuple(result)
+
+
+def _assessment_from_capsule(root: Path, capsule_id: str) -> tuple[Assessment, str]:
+    if validate_capsule(root, capsule_id).status != "OK":
+        raise StagingError("selected capsule integrity is not OK")
+    capsule_relative = f"{CAPSULE_ROOT}/{capsule_id}"
+    try:
+        manifest = _manifest_from_bytes(
+            _read_regular_beneath(
+                root,
+                f"{capsule_relative}/manifest.json",
+                _MAX_JSON_BYTES,
+            )
+        )
+        customizations = _strict_object(
+            _read_regular_beneath(
+                root,
+                f"{capsule_relative}/evidence/customizations.json",
+                _MAX_JSON_BYTES,
+            ),
+            context="customization evidence",
+        )
+        dependencies = _strict_object(
+            _read_regular_beneath(
+                root,
+                f"{capsule_relative}/evidence/dependencies.json",
+                _MAX_JSON_BYTES,
+            ),
+            context="dependency evidence",
+        )
+        exclusions = _strict_object(
+            _read_regular_beneath(
+                root,
+                f"{capsule_relative}/evidence/exclusions.json",
+                _MAX_JSON_BYTES,
+            ),
+            context="exclusion evidence",
+        )
+        environment = _strict_object(
+            _read_regular_beneath(
+                root,
+                f"{capsule_relative}/evidence/environment.json",
+                _MAX_JSON_BYTES,
+            ),
+            context="environment evidence",
+        )
+    except (CapsuleError, OSError) as error:
+        raise StagingError("selected capsule evidence is unreadable") from error
+
+    for section, name in (
+        (customizations, "customization evidence"),
+        (dependencies, "dependency evidence"),
+    ):
+        if frozenset(section) != frozenset({"schema_version", "items"}):
+            raise StagingError(f"{name} has an invalid shape")
+        if section["schema_version"] != 0:
+            raise StagingError(f"{name} schema_version is unsupported")
+    if frozenset(exclusions) != frozenset(
+        {
+            "schema_version",
+            "items",
+            "restricted_findings",
+            "secret_archival_policy",
+        }
+    ) or exclusions["schema_version"] != 0:
+        raise StagingError("exclusion evidence has an invalid shape")
+    if (
+        not isinstance(exclusions["restricted_findings"], list)
+        or not isinstance(exclusions["secret_archival_policy"], str)
+    ):
+        raise StagingError("exclusion evidence metadata is invalid")
+    if frozenset(environment) != frozenset(
+        {
+            "schema_version",
+            "identity",
+            "baseline_identity_state",
+            "baseline_errors",
+            "completeness",
+            "verdict",
+        }
+    ) or environment["schema_version"] != 0:
+        raise StagingError("environment evidence has an invalid shape")
+    records = tuple(
+        _record_from_dict(item)
+        for item in _closed_list(customizations["items"], context="customization items")
+    )
+    edges = tuple(
+        _edge_from_dict(item)
+        for item in _closed_list(dependencies["items"], context="dependency items")
+    )
+    exclusion_items = _closed_list(exclusions.get("items"), context="exclusion items")
+    identity = _closed_mapping(
+        environment.get("identity"),
+        keys=frozenset(
+            {
+                "release_version",
+                "inventory_path_count",
+                "customization_count",
+                "edge_count",
+            }
+        ),
+        context="capsule assessment identity",
+    )
+    try:
+        assessment_identity = AssessmentIdentity(
+            identity["release_version"],
+            identity["inventory_path_count"],
+            identity["customization_count"],
+            identity["edge_count"],
+        )
+        baseline_errors = _strings(
+            environment["baseline_errors"],
+            context="baseline_errors",
+        )
+        assessment_exclusions = tuple(
+            _exclusion_from_dict(item) for item in exclusion_items
+        )
+        group_options = _frozen_group_options(records, edges)
+    except (KeyError, TypeError, ValueError) as error:
+        raise StagingError("capsule evidence cannot rebuild an assessment") from error
+    ambiguous_count = sum(len(options) > 1 for _record, options in group_options)
+    if ambiguous_count > 16:
+        raise StagingError("capsule evidence has too many ambiguous frozen groups")
+    for selected in itertools.product(
+        *(options for _record, options in group_options)
+    ):
+        groups = tuple(
+            sorted(
+                (
+                    AssessmentAssignment(record.customization_id, group)
+                    for (record, _options), group in zip(
+                        group_options,
+                        selected,
+                        strict=True,
+                    )
+                ),
+                key=lambda item: item.customization_id,
+            )
+        )
+        try:
+            assessment = Assessment(
+                0,
+                assessment_identity,
+                environment["baseline_identity_state"],
+                baseline_errors,
+                (),
+                records,
+                edges,
+                groups,
+                assessment_exclusions,
+                environment["completeness"],
+                environment["verdict"],
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise StagingError(
+                "capsule evidence cannot rebuild an assessment"
+            ) from error
+        if _sha256(assessment.canonical_assessment_bytes()) == manifest.assessment_digest:
+            return assessment, manifest.assessment_digest
+    raise StagingError("capsule evidence does not rebuild its assessment digest")
+
+
+def _planned_files(candidate: RegenerationCandidate) -> tuple[PlannedStagedFile, ...]:
+    prefix = STAGING_SUBDIR.format(proposal_id=candidate.proposal_id)
+    return tuple(
+        PlannedStagedFile(
+            item.target_path,
+            f"{prefix}/files/{item.sha256}",
+            item.sha256,
+            len(item.content),
+        )
+        for item in candidate.files
+    )
+
+
+def _validate_candidate_against_capsule(
+    root: Path,
+    capsule_id: str,
+    candidate: RegenerationCandidate,
+) -> None:
+    if candidate.capsule_id != capsule_id:
+        raise StagingError("candidate capsule id does not match selected capsule")
+    assessment, evidence_digest = _assessment_from_capsule(root, capsule_id)
+    if candidate.evidence_digest != evidence_digest:
+        raise StagingError("candidate evidence digest does not match current capsule")
+    validation = validate_regeneration_candidate(
+        assessment,
+        candidate,
+        expected_capsule_id=capsule_id,
+    )
+    if not validation.accepted:
+        raise StagingError("candidate validation failed: " + "; ".join(validation.errors))
+
+
+def preview_staging(
+    vault_root: Path,
+    capsule_id: str,
+    candidate: RegenerationCandidate,
+) -> StagingPreview:
+    """Build a deterministic private-staging plan without writing the vault."""
+    if not isinstance(capsule_id, str) or CAPSULE_ID.fullmatch(capsule_id) is None:
+        raise StagingError("capsule_id is not canonical")
+    if type(candidate) is not RegenerationCandidate:
+        raise TypeError("candidate must be RegenerationCandidate")
+    if len(candidate.files) > _MAX_STAGED_FILES:
+        raise StagingError("candidate exceeds the staged-file limit")
+    if sum(len(item.content) for item in candidate.files) > _MAX_STAGED_BYTES:
+        raise StagingError("candidate exceeds the private staging byte limit")
+    root = Path(vault_root).resolve()
+    _validate_candidate_against_capsule(root, capsule_id, candidate)
+    files = _planned_files(candidate)
+    unsigned = StagingPreview(
+        0,
+        capsule_id,
+        candidate.proposal_id,
+        candidate,
+        files,
+        "0" * 64,
+    )
+    digest = _sha256(unsigned.canonical_preview_bytes())
+    return StagingPreview(
+        0,
+        capsule_id,
+        candidate.proposal_id,
+        candidate,
+        files,
+        digest,
+    )
+
+
+def _transaction_id() -> str:
+    return time.strftime("%Y%m%dT%H%M%S-") + uuid.uuid4().hex[:8]
+
+
+def _event_bytes(
+    event: MigrationEvent,
+    **payload: str,
+) -> bytes:
+    return _canonical_json(
+        {
+            "schema_version": 0,
+            "event": event.value,
+            **payload,
+        }
+    )
+
+
+def _staging_stop_seam(name: str) -> None:
+    if os.environ.get("DEX_TX_TEST_STOP_AFTER") == name:
+        os._exit(137)
+
+
+def _append_event(
+    path: Path,
+    event: MigrationEvent,
+    **payload: str,
+) -> None:
+    raw = _event_bytes(event, **payload)
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_APPEND | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise StagingError(f"staging journal is not a regular file: {path}")
+        written = os.write(descriptor, raw)
+        if written != len(raw):
+            raise StagingError(f"short append to staging journal: {path}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def _secure_staging_directories(root: Path, staging_dir: Path) -> None:
+    capsule_dir = staging_dir.parents[2]
+    current = staging_dir
+    directories: list[Path] = []
+    while current != capsule_dir:
+        directories.append(current)
+        current = current.parent
+    for directory in reversed(directories):
+        descriptor = _open_directory_beneath(
+            root,
+            directory.relative_to(root).as_posix(),
+        )
+        try:
+            os.fchmod(descriptor, 0o700)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    files_dir = staging_dir / "files"
+    if files_dir.exists() and files_dir not in directories:
+        descriptor = _open_directory_beneath(
+            root,
+            files_dir.relative_to(root).as_posix(),
+        )
+        try:
+            os.fchmod(descriptor, 0o700)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def stage_candidate(
+    vault_root: Path,
+    preview: StagingPreview,
+    preview_sha256: str,
+) -> StagingReceipt:
+    """Commit one candidate under its capsule without touching a live seam.
+
+    This is an internal lifecycle primitive, not a consent adapter. A1 still
+    requires its Doctor/CLI caller to collect genuine interactive consent;
+    the reproducible preview digest below binds integrity and never consent.
+    MCP/read-only surfaces must not expose this write primitive.
+    """
+    if type(preview) is not StagingPreview:
+        raise TypeError("preview must be StagingPreview")
+    recomputed = _sha256(preview.canonical_preview_bytes())
+    if preview_sha256 != preview.preview_sha256 or preview_sha256 != recomputed:
+        raise StagingError("staging preview digest mismatch")
+    root = Path(vault_root).resolve()
+    refreshed = preview_staging(root, preview.capsule_id, preview.candidate)
+    if refreshed != preview:
+        raise StagingError("staging preview drifted")
+    prefix = f"{CAPSULE_ROOT}/{preview.capsule_id}/" + STAGING_SUBDIR.format(
+        proposal_id=preview.proposal_id
+    )
+    staging_dir = root / prefix
+    if staging_dir.exists() or staging_dir.is_symlink():
+        raise StagingError(f"staging already exists: {preview.proposal_id}")
+
+    transaction_id = _transaction_id()
+    receipt = StagingReceipt(
+        0,
+        preview.capsule_id,
+        preview.proposal_id,
+        len(preview.candidate.files),
+        sum(len(item.content) for item in preview.candidate.files),
+        preview.preview_sha256,
+        transaction_id,
+    )
+    proposed_journal = _event_bytes(MigrationEvent.REGENERATION_PROPOSED)
+    materials: dict[str, bytes] = {
+        f"{prefix}/manifest.json": _canonical_json(preview.candidate.to_dict()),
+        f"{prefix}/journal.jsonl": proposed_journal,
+        f"{prefix}/receipt.json": receipt.canonical_bytes(),
+    }
+    for item in preview.candidate.files:
+        relative = f"{prefix}/files/{item.sha256}"
+        existing = materials.setdefault(relative, item.content)
+        if existing != item.content:
+            raise StagingError(f"content-address collision for {item.sha256}")
+    plan = [
+        PlanEntry(relative, raw, mode=0o600)
+        for relative, raw in sorted(materials.items())
+    ]
+    transaction = Transaction._begin_with_id(
+        root,
+        plan,
+        allow_empty=False,
+        operation="customization-migration",
+        tx_id=transaction_id,
+    )
+    journal_path = staging_dir / "journal.jsonl"
+
+    def finalize_staging() -> None:
+        _validate_candidate_against_capsule(
+            root,
+            preview.capsule_id,
+            preview.candidate,
+        )
+        _secure_staging_directories(root, staging_dir)
+        _staging_stop_seam("staging-after-layout")
+        _append_event(journal_path, MigrationEvent.REGENERATION_STAGED)
+        _staging_stop_seam("staging-mid-finalize")
+        _validate_candidate_against_capsule(
+            root,
+            preview.capsule_id,
+            preview.candidate,
+        )
+
+    transaction.run(before_commit=finalize_staging)
+    return receipt
+
+
+def _event_records(raw: bytes) -> tuple[dict[str, object], ...]:
+    if not raw.endswith(b"\n"):
+        raise StagingError("staging journal has a torn final record")
+    records: list[dict[str, object]] = []
+    for line in raw.splitlines():
+        try:
+            record = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise StagingError("staging journal is malformed") from error
+        if (
+            not isinstance(record, dict)
+            or record.get("schema_version") != 0
+            or not isinstance(record.get("event"), str)
+            or _canonical_json(record).rstrip(b"\n") != line
+        ):
+            raise StagingError("staging journal record is not canonical")
+        keys = frozenset(record)
+        if keys == _EVENT_KEYS:
+            pass
+        elif keys == _VERIFICATION_EVENT_KEYS:
+            if (
+                record["event"]
+                not in {
+                    MigrationEvent.VERIFICATION_PASSED.value,
+                    MigrationEvent.VERIFICATION_BLOCKED.value,
+                }
+                or not isinstance(record["candidate_sha256"], str)
+                or SHA256.fullmatch(record["candidate_sha256"]) is None
+                or not isinstance(record["report_sha256"], str)
+                or SHA256.fullmatch(record["report_sha256"]) is None
+                or not isinstance(record["report_path"], str)
+            ):
+                raise StagingError(
+                    "verification journal record is invalid"
+                )
+        else:
+            raise StagingError("staging journal record has an invalid shape")
+        records.append(record)
+    return tuple(records)
+
+
+def _read_event_records_beneath(
+    root: Path,
+    relative: str,
+) -> tuple[dict[str, object], ...]:
+    return _event_records(_read_regular_beneath(root, relative))
+
+
+def _verification_binding_problems(
+    root: Path,
+    capsule_id: str,
+    candidate: RegenerationCandidate,
+    binding: dict[str, object],
+) -> tuple[set[str], set[str]]:
+    missing: set[str] = set()
+    mismatches: set[str] = set()
+    report_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/verification/"
+        f"{candidate.proposal_id}.json"
+    )
+    if (
+        binding.get("report_path") != report_relative
+        or binding.get("candidate_sha256") != candidate.candidate_sha256
+    ):
+        mismatches.add("verification/report-binding")
+        return missing, mismatches
+    verification_relative = f"{CAPSULE_ROOT}/{capsule_id}/verification"
+    try:
+        directory = _open_directory_beneath(root, verification_relative)
+    except FileNotFoundError:
+        missing.add("verification/report-missing")
+        return missing, mismatches
+    except OSError:
+        mismatches.add("verification/report-mode")
+        return missing, mismatches
+    try:
+        directory_metadata = os.fstat(directory)
+        if stat.S_IMODE(directory_metadata.st_mode) != 0o700:
+            mismatches.add("verification/report-mode")
+        try:
+            descriptor = os.open(
+                f"{candidate.proposal_id}.json",
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=directory,
+            )
+        except FileNotFoundError:
+            missing.add("verification/report-missing")
+            return missing, mismatches
+        except OSError:
+            mismatches.add("verification/report-mode")
+            return missing, mismatches
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or metadata.st_size > _MAX_JSON_BYTES
+            ):
+                mismatches.add("verification/report-mode")
+            chunks: list[bytes] = []
+            remaining = _MAX_JSON_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, min(65_536, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            report_raw = b"".join(chunks)
+            if len(report_raw) > _MAX_JSON_BYTES:
+                mismatches.add("verification/report-schema")
+                return missing, mismatches
+        finally:
+            os.close(descriptor)
+    finally:
+        os.close(directory)
+    if _sha256(report_raw) != binding.get("report_sha256"):
+        mismatches.add("verification/report-digest")
+        return missing, mismatches
+    try:
+        from core.customization_migration.verification import (
+            VerificationError,
+            validate_persisted_verification_report,
+        )
+
+        validate_persisted_verification_report(
+            report_raw,
+            candidate,
+            binding["event"],
+        )
+    except (KeyError, TypeError, ValueError, VerificationError):
+        mismatches.add("verification/report-schema")
+    return missing, mismatches
+
+
+def read_staging_status(vault_root: Path, capsule_id: str) -> StagingStatus:
+    """Project each bounded proposal journal; malformed evidence never raises."""
+    if not isinstance(capsule_id, str) or CAPSULE_ID.fullmatch(capsule_id) is None:
+        raise StagingError("capsule_id is not canonical")
+    root = Path(vault_root).resolve()
+    candidates_dir = root / CAPSULE_ROOT / capsule_id / "candidates"
+    if not candidates_dir.exists():
+        return StagingStatus(capsule_id, ())
+    if candidates_dir.is_symlink() or not candidates_dir.is_dir():
+        return StagingStatus(
+            capsule_id,
+            (ProposalStagingStatus("<candidates>", MigrationState.RECOVERY_REQUIRED),),
+        )
+    entries: list[Path] = []
+    with os.scandir(candidates_dir) as iterator:
+        for entry in iterator:
+            entries.append(Path(entry.path))
+            if len(entries) > _MAX_PROPOSALS:
+                break
+    truncated = len(entries) > _MAX_PROPOSALS
+    proposals: list[ProposalStagingStatus] = []
+    for proposal_dir in sorted(entries[:_MAX_PROPOSALS], key=lambda item: item.name):
+        state = MigrationState.RECOVERY_REQUIRED
+        try:
+            if proposal_dir.is_symlink() or not proposal_dir.is_dir():
+                raise StagingError("proposal entry is unsafe")
+            proposal_id = proposal_dir.name
+            staging_relative = (
+                f"{CAPSULE_ROOT}/{capsule_id}/"
+                + STAGING_SUBDIR.format(proposal_id=proposal_id)
+            )
+            capsule_records = _read_event_records_beneath(
+                root,
+                f"{CAPSULE_ROOT}/{capsule_id}/journal.jsonl",
+            )
+            capsule_events = tuple(
+                record["event"] for record in capsule_records
+            )
+            if project_state(capsule_events) is not MigrationState.CAPSULE_CREATED:
+                raise StagingError("capsule state is not capsule-created")
+            candidate, _receipt, _staging = load_staged_candidate(
+                root,
+                capsule_id,
+                proposal_id,
+            )
+            _validate_candidate_against_capsule(
+                root,
+                capsule_id,
+                candidate,
+            )
+            proposal_records = _read_event_records_beneath(
+                root,
+                f"{staging_relative}/journal.jsonl",
+            )
+            proposal_events = tuple(
+                record["event"] for record in proposal_records
+            )
+            if len(proposal_records) == 3:
+                binding = proposal_records[2]
+                report_missing, report_mismatches = (
+                    _verification_binding_problems(
+                        root,
+                        capsule_id,
+                        candidate,
+                        binding,
+                    )
+                )
+                if report_missing or report_mismatches:
+                    raise StagingError(
+                        "verification report seal is incomplete"
+                    )
+            state = project_state(
+                (
+                    *capsule_events,
+                    MigrationEvent.TARGET_VERIFIED.value,
+                    *proposal_events,
+                )
+            )
+        except (OSError, StagingError):
+            pass
+        proposals.append(ProposalStagingStatus(proposal_dir.name, state))
+    return StagingStatus(capsule_id, tuple(proposals), truncated)
+
+
+def _candidate_file_from_dict(value: object) -> CandidateFile:
+    item = _closed_mapping(
+        value,
+        keys=frozenset({"target_path", "content_base64", "sha256", "customization_ids"}),
+        context="candidate file",
+    )
+    encoded = item["content_base64"]
+    if not isinstance(encoded, str):
+        raise StagingError("candidate content_base64 must be text")
+    try:
+        content = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, ValueError) as error:
+        raise StagingError("candidate content_base64 is invalid") from error
+    return CandidateFile(
+        item["target_path"],
+        content,
+        item["sha256"],
+        _strings(item["customization_ids"], context="candidate customization_ids"),
+    )
+
+
+def _contract_from_dict(value: object) -> BehaviouralContract:
+    item = _closed_mapping(
+        value,
+        keys=frozenset(
+            {
+                "contract_id",
+                "customization_id",
+                "statement",
+                "provenance",
+                "verification_class",
+            }
+        ),
+        context="candidate behaviour contract",
+    )
+    return BehaviouralContract(
+        item["contract_id"],
+        item["customization_id"],
+        item["statement"],
+        ContractProvenance(item["provenance"]),
+        VerificationClass(item["verification_class"]),
+    )
+
+
+def _candidate_from_dict(value: object) -> RegenerationCandidate:
+    item = _closed_mapping(
+        value,
+        keys=frozenset(
+            {
+                "schema_version",
+                "proposal_id",
+                "capsule_id",
+                "evidence_digest",
+                "dispositions",
+                "files",
+                "dependency_remappings",
+                "behaviour_contracts",
+                "declared_requirements",
+                "confidence",
+                "unresolved_questions",
+                "shim_expiries",
+                "candidate_sha256",
+            }
+        ),
+        context="staging manifest",
+    )
+    try:
+        candidate = RegenerationCandidate(
+            item["schema_version"],
+            item["proposal_id"],
+            item["capsule_id"],
+            item["evidence_digest"],
+            tuple(
+                DispositionPlanItem(
+                    part["customization_id"],
+                    Disposition(part["disposition"]),
+                    part["assessment_digest"],
+                    part["native_witness"],
+                    _strings(part["evidence_edge_ids"], context="evidence_edge_ids"),
+                    _strings(
+                        part["behaviour_contract_ids"],
+                        context="behaviour_contract_ids",
+                    ),
+                )
+                for part in (
+                    _closed_mapping(
+                        value,
+                        keys=frozenset(
+                            {
+                                "customization_id",
+                                "disposition",
+                                "assessment_digest",
+                                "native_witness",
+                                "evidence_edge_ids",
+                                "behaviour_contract_ids",
+                            }
+                        ),
+                        context="candidate disposition",
+                    )
+                    for value in _closed_list(
+                        item["dispositions"],
+                        context="candidate dispositions",
+                    )
+                )
+            ),
+            tuple(
+                _candidate_file_from_dict(part)
+                for part in _closed_list(item["files"], context="candidate files")
+            ),
+            tuple(
+                DependencyRemapping(
+                    part["edge_id"],
+                    DependencyResolution(part["resolution"]),
+                    part["target_path"],
+                )
+                for part in (
+                    _closed_mapping(
+                        value,
+                        keys=frozenset({"edge_id", "resolution", "target_path"}),
+                        context="candidate dependency remapping",
+                    )
+                    for value in _closed_list(
+                        item["dependency_remappings"],
+                        context="candidate dependency remappings",
+                    )
+                )
+            ),
+            tuple(
+                _contract_from_dict(part)
+                for part in _closed_list(
+                    item["behaviour_contracts"],
+                    context="candidate behaviour contracts",
+                )
+            ),
+            tuple(
+                DeclaredRequirement(
+                    RequirementKind(part["kind"]),
+                    part["description"],
+                    _strings(
+                        part["customization_ids"],
+                        context="requirement customization_ids",
+                    ),
+                )
+                for part in (
+                    _closed_mapping(
+                        value,
+                        keys=frozenset(
+                            {"kind", "description", "customization_ids"}
+                        ),
+                        context="candidate declared requirement",
+                    )
+                    for value in _closed_list(
+                        item["declared_requirements"],
+                        context="candidate declared requirements",
+                    )
+                )
+            ),
+            item["confidence"],
+            _strings(
+                item["unresolved_questions"],
+                context="candidate unresolved_questions",
+            ),
+            tuple(
+                ShimExpiry(
+                    part["customization_id"],
+                    part["review_release"],
+                    part["removal_condition"],
+                )
+                for part in (
+                    _closed_mapping(
+                        value,
+                        keys=frozenset(
+                            {
+                                "customization_id",
+                                "review_release",
+                                "removal_condition",
+                            }
+                        ),
+                        context="candidate shim expiry",
+                    )
+                    for value in _closed_list(
+                        item["shim_expiries"],
+                        context="candidate shim expiries",
+                    )
+                )
+            ),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise StagingError("staging manifest candidate is invalid") from error
+    if item["candidate_sha256"] != candidate.candidate_sha256:
+        raise StagingError("candidate_sha256 does not bind the staging manifest")
+    return candidate
+
+
+def load_staged_candidate(
+    vault_root: Path,
+    capsule_id: str,
+    proposal_id: str,
+) -> tuple[RegenerationCandidate, StagingReceipt, Path]:
+    """Load canonical, receipt-bound staging evidence for verification."""
+    if not isinstance(capsule_id, str) or CAPSULE_ID.fullmatch(capsule_id) is None:
+        raise StagingError("capsule_id is not canonical")
+    if not isinstance(proposal_id, str) or PROPOSAL_ID.fullmatch(proposal_id) is None:
+        raise StagingError("proposal_id is not canonical")
+    root = Path(vault_root).resolve()
+    staging_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/"
+        + STAGING_SUBDIR.format(proposal_id=proposal_id)
+    )
+    staging = root / staging_relative
+    manifest = _strict_object(
+        _read_regular_beneath(
+            root,
+            f"{staging_relative}/manifest.json",
+        ),
+        context="staging manifest",
+    )
+    candidate = _candidate_from_dict(manifest)
+    receipt_value = _strict_object(
+        _read_regular_beneath(
+            root,
+            f"{staging_relative}/receipt.json",
+        ),
+        context="staging receipt",
+    )
+    try:
+        receipt = StagingReceipt(
+            receipt_value["schema_version"],
+            receipt_value["capsule_id"],
+            receipt_value["proposal_id"],
+            receipt_value["staged_file_count"],
+            receipt_value["staged_byte_count"],
+            receipt_value["staging_digest"],
+            receipt_value["transaction_id"],
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise StagingError("staging receipt is invalid") from error
+    if receipt.canonical_bytes() != _canonical_json(receipt_value):
+        raise StagingError("staging receipt is not canonical")
+    if (
+        candidate.capsule_id != capsule_id
+        or candidate.proposal_id != proposal_id
+        or receipt.capsule_id != capsule_id
+        or receipt.proposal_id != proposal_id
+        or receipt.staged_file_count != len(candidate.files)
+        or receipt.staged_byte_count != sum(len(item.content) for item in candidate.files)
+    ):
+        raise StagingError("staging identity or receipt does not match")
+    return candidate, receipt, staging
+
+
+def validate_staging(
+    vault_root: Path,
+    capsule_id: str,
+    proposal_id: str,
+) -> StagingValidation:
+    """Recompute canonical manifest and blob integrity without executing bytes."""
+    root = Path(vault_root).resolve()
+    staging_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/"
+        + STAGING_SUBDIR.format(proposal_id=proposal_id)
+    )
+    staging = root / staging_relative
+    try:
+        top_entries = _scan_directory_beneath(
+            root,
+            staging_relative,
+            limit=5,
+        )
+    except FileNotFoundError:
+        return StagingValidation("UNKNOWN", ())
+    except (OSError, StagingError):
+        return StagingValidation("BROKEN", ("staging",))
+
+    missing: set[str] = set()
+    mismatches: set[str] = set()
+    required_top = {"manifest.json", "journal.jsonl", "receipt.json"}
+    for name in required_top - top_entries.keys():
+        missing.add(name)
+    for name in top_entries.keys() - {
+        *required_top,
+        "files",
+    }:
+        mismatches.add(name)
+    for name in required_top & top_entries.keys():
+        metadata = top_entries[name]
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            mismatches.add(name + ":mode-or-type")
+    if "files" in top_entries and (
+        not stat.S_ISDIR(top_entries["files"].st_mode)
+        or stat.S_IMODE(top_entries["files"].st_mode) != 0o700
+    ):
+        mismatches.add("files:mode-or-type")
+    for directory_relative in (
+        f"{CAPSULE_ROOT}/{capsule_id}/candidates",
+        f"{CAPSULE_ROOT}/{capsule_id}/candidates/{proposal_id}",
+        staging_relative,
+    ):
+        try:
+            descriptor = _open_directory_beneath(root, directory_relative)
+            metadata = os.fstat(descriptor)
+            os.close(descriptor)
+            if stat.S_IMODE(metadata.st_mode) != 0o700:
+                mismatches.add(
+                    directory_relative.removeprefix(
+                        f"{CAPSULE_ROOT}/{capsule_id}/"
+                    )
+                    + ":mode"
+                )
+        except OSError:
+            mismatches.add("staging:unsafe-parent")
+    if missing:
+        return StagingValidation("UNKNOWN", tuple(sorted(missing)))
+    if mismatches:
+        return StagingValidation("BROKEN", tuple(sorted(mismatches)))
+
+    try:
+        candidate, receipt, staging = load_staged_candidate(
+            root,
+            capsule_id,
+            proposal_id,
+        )
+    except (OSError, StagingError):
+        return StagingValidation("BROKEN", ("manifest.json",))
+
+    manifest_raw = _read_regular_beneath(
+        root,
+        f"{staging_relative}/manifest.json",
+    )
+    preview = StagingPreview(
+        0,
+        capsule_id,
+        proposal_id,
+        candidate,
+        _planned_files(candidate),
+        receipt.staging_digest,
+    )
+    if _sha256(preview.canonical_preview_bytes()) != receipt.staging_digest:
+        mismatches.add("receipt.json:staging-digest")
+    if _canonical_json(candidate.to_dict()) != manifest_raw:
+        mismatches.add("manifest.json")
+    try:
+        records = _read_event_records_beneath(
+            root,
+            f"{staging_relative}/journal.jsonl",
+        )
+    except (OSError, StagingError):
+        mismatches.add("journal.jsonl")
+        records = ()
+    events = tuple(record["event"] for record in records)
+    if events == (MigrationEvent.REGENERATION_PROPOSED.value,):
+        missing.add("journal.jsonl:incomplete")
+    elif (
+        len(events) not in {2, 3}
+        or events[:2]
+        != (
+            MigrationEvent.REGENERATION_PROPOSED.value,
+            MigrationEvent.REGENERATION_STAGED.value,
+        )
+        or (
+            len(events) == 3
+            and events[2]
+            not in {
+                MigrationEvent.VERIFICATION_PASSED.value,
+                MigrationEvent.VERIFICATION_BLOCKED.value,
+            }
+        )
+    ):
+        mismatches.add("journal.jsonl")
+    if len(records) == 3:
+        report_missing, report_mismatches = _verification_binding_problems(
+            root,
+            capsule_id,
+            candidate,
+            records[2],
+        )
+        missing.update(report_missing)
+        mismatches.update(report_mismatches)
+
+    expected_names = {item.sha256 for item in candidate.files}
+    if not expected_names:
+        if "files" in top_entries:
+            mismatches.add("files")
+        actual_entries: dict[str, os.stat_result] = {}
+    else:
+        if "files" not in top_entries:
+            missing.add("files")
+            actual_entries = {}
+        else:
+            try:
+                actual_entries = _scan_directory_beneath(
+                    root,
+                    f"{staging_relative}/files",
+                    limit=len(expected_names) + 1,
+                )
+            except (OSError, StagingError):
+                mismatches.add("files:entry-bound-or-unsafe")
+                actual_entries = {}
+    actual_names = set(actual_entries)
+    for name in sorted(expected_names - actual_names):
+        missing.add(f"files/{name}")
+    for name in sorted(actual_names - expected_names):
+        mismatches.add(f"files/{name}")
+    for item in candidate.files:
+        if item.sha256 not in actual_names:
+            continue
+        relative = f"files/{item.sha256}"
+        try:
+            metadata = actual_entries[item.sha256]
+            raw = _read_regular_beneath(
+                root,
+                f"{staging_relative}/{relative}",
+                _MAX_STAGED_BYTES,
+            )
+            if _sha256(raw) != item.sha256 or raw != item.content:
+                mismatches.add(relative)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                mismatches.add(relative + ":mode")
+        except (OSError, StagingError):
+            mismatches.add(relative)
+    if missing:
+        return StagingValidation("UNKNOWN", tuple(sorted(missing)))
+    if mismatches:
+        return StagingValidation("BROKEN", tuple(sorted(mismatches)))
+    return StagingValidation("OK", ())
+
+
+__all__ = [
+    "STAGING_SUBDIR",
+    "PlannedStagedFile",
+    "ProposalStagingStatus",
+    "StagingError",
+    "StagingPreview",
+    "StagingReceipt",
+    "StagingStatus",
+    "StagingValidation",
+    "load_staged_candidate",
+    "preview_staging",
+    "read_staging_status",
+    "stage_candidate",
+    "validate_staging",
+]

--- a/core/customization_migration/verification.py
+++ b/core/customization_migration/verification.py
@@ -1,0 +1,1495 @@
+"""Read-only-first verification for privately staged regeneration candidates.
+
+Staged bytes are parsed and compared but never imported, invoked, registered,
+or run against the real vault or network. The optional fixture and
+read-only-live rungs remain explicit seams; when no safe runner or consent
+token exists they collapse to ``unsafe-unverified`` rather than being
+silently promoted. Model-proposed provenance can therefore never become
+``verified`` (A3).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import yaml
+
+from core import portable_contract
+from core.customization_migration.behaviour import (
+    BehaviouralContract,
+    ContractProvenance,
+    ReportedVerification,
+    VerificationClass,
+    VerificationOutcome,
+    derive_reported_status,
+)
+from core.customization_migration.capsule import CAPSULE_ROOT
+from core.customization_migration.model import SHA256
+from core.customization_migration.planning import (
+    CandidateFile,
+    Disposition,
+    RegenerationCandidate,
+)
+from core.customization_migration.staging import (
+    STAGING_SUBDIR,
+    StagingError,
+    _append_event,
+    _assessment_from_capsule,
+    _open_directory_beneath,
+    _read_event_records_beneath,
+    _read_regular_beneath,
+    _sha256,
+    _validate_candidate_against_capsule,
+    load_staged_candidate,
+    read_staging_status,
+    validate_staging,
+)
+from core.customization_migration.state import (
+    MigrationEvent,
+    MigrationState,
+)
+from core.transaction.engine import PlanEntry, Transaction
+
+_OUTCOMES = frozenset({"pass", "fail", "unknown"})
+_REPORT_VERDICTS = frozenset({"OK", "BLOCKED", "UNKNOWN"})
+_REGISTERED_STATIC_STATEMENT = (
+    "The required static verification ladder proves the staged candidate's "
+    "schema, paths, bytes, modes, dependency closure, syntax, release "
+    "compatibility, trust requirements, and capsule isolation."
+)
+_MAX_LIVE_INODE_SCAN_ENTRIES = 100_000
+_REQUIRED_STATIC_CHECKS = (
+    "schema",
+    "canonical-path",
+    "ownership-authorization",
+    "content-digest",
+    "mode",
+    "dependency-closure",
+    "syntax",
+    "target-release-compatibility",
+    "trust-permission-delta",
+    "private-staging",
+)
+
+
+class VerificationError(RuntimeError):
+    """A staged verification or report write refused to proceed safely."""
+
+
+def _canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _closed_object(
+    value: object,
+    *,
+    keys: frozenset[str],
+    context: str,
+) -> dict[str, object]:
+    if not isinstance(value, dict) or frozenset(value) != keys:
+        raise VerificationError(f"{context} is not a closed object")
+    return value
+
+
+def _closed_list(value: object, *, context: str) -> list[object]:
+    if not isinstance(value, list):
+        raise VerificationError(f"{context} must be a list")
+    return value
+
+
+@dataclass(frozen=True)
+class VerificationCheckOutcome:
+    name: str
+    verification_class: VerificationClass
+    outcome: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.name, str)
+            or not self.name
+            or len(self.name) > 128
+            or "\x00" in self.name
+        ):
+            raise ValueError("verification check name is invalid")
+        if not isinstance(self.verification_class, VerificationClass):
+            raise TypeError("verification_class must reuse VerificationClass")
+        if self.outcome not in _OUTCOMES:
+            raise ValueError("verification check outcome is invalid")
+        if (
+            not isinstance(self.detail, str)
+            or not self.detail
+            or len(self.detail) > 2000
+            or "\x00" in self.detail
+        ):
+            raise ValueError("verification check detail is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "verification_class": self.verification_class.value,
+            "outcome": self.outcome,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class StaticFileResult:
+    target_path: str
+    staged_path: str
+    checks: tuple[VerificationCheckOutcome, ...]
+    status: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("target_path", self.target_path),
+            ("staged_path", self.staged_path),
+        ):
+            if not isinstance(value, str) or not value or "\x00" in value:
+                raise ValueError(f"static result {name} is invalid")
+        if not isinstance(self.checks, tuple) or any(
+            type(item) is not VerificationCheckOutcome for item in self.checks
+        ):
+            raise TypeError("static result checks must be VerificationCheckOutcome")
+        if len({item.name for item in self.checks}) != len(self.checks):
+            raise ValueError("static result check names must be unique")
+        expected = (
+            "BLOCKED"
+            if any(item.outcome == "fail" for item in self.checks)
+            else "UNKNOWN"
+            if any(item.outcome == "unknown" for item in self.checks)
+            else "OK"
+        )
+        if self.status != expected:
+            raise ValueError("static result status contradicts its checks")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target_path": self.target_path,
+            "staged_path": self.staged_path,
+            "checks": [item.to_dict() for item in self.checks],
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class VerificationAttempt:
+    """Closed result shape for optional fixture/live/manual runner seams."""
+
+    requested_class: VerificationClass
+    effective_class: VerificationClass
+    outcome: str
+    executed: bool
+    evidence_note: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_class, VerificationClass):
+            raise TypeError("requested_class must reuse VerificationClass")
+        if not isinstance(self.effective_class, VerificationClass):
+            raise TypeError("effective_class must reuse VerificationClass")
+        if self.outcome not in _OUTCOMES:
+            raise ValueError("verification attempt outcome is invalid")
+        if type(self.executed) is not bool:
+            raise TypeError("verification attempt executed must be boolean")
+        if (
+            not isinstance(self.evidence_note, str)
+            or not self.evidence_note
+            or len(self.evidence_note) > 2000
+            or "\x00" in self.evidence_note
+        ):
+            raise ValueError("verification attempt evidence_note is invalid")
+        if (
+            not self.executed
+            and self.effective_class is not VerificationClass.UNSAFE_UNVERIFIED
+        ):
+            raise ValueError(
+                "an unexercised attempt must remain unsafe-unverified"
+            )
+
+
+@dataclass(frozen=True)
+class VerificationReport:
+    schema_version: int
+    staging_id: str
+    capsule_id: str
+    proposal_id: str
+    candidate_sha256: str
+    static_results: tuple[StaticFileResult, ...]
+    reported_verifications: tuple[ReportedVerification, ...]
+    verdict: str
+    staged_paths_private: bool
+    writes_confined_to_capsule: bool
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported verification report schema_version")
+        if self.staging_id != self.proposal_id:
+            raise ValueError("v0 staging_id must be the proposal id")
+        if (
+            not isinstance(self.capsule_id, str)
+            or not self.capsule_id.startswith("cap-")
+            or "/" in self.capsule_id
+            or not isinstance(self.proposal_id, str)
+            or not self.proposal_id.startswith("prop-")
+            or "/" in self.proposal_id
+        ):
+            raise ValueError("verification report identity is invalid")
+        if (
+            not isinstance(self.candidate_sha256, str)
+            or SHA256.fullmatch(self.candidate_sha256) is None
+        ):
+            raise ValueError("candidate_sha256 must be canonical")
+        if not isinstance(self.static_results, tuple) or any(
+            type(item) is not StaticFileResult for item in self.static_results
+        ):
+            raise TypeError("static_results must be StaticFileResult records")
+        if tuple(
+            sorted(self.static_results, key=lambda item: item.target_path)
+        ) != self.static_results:
+            raise ValueError("static_results must be sorted")
+        if not isinstance(self.reported_verifications, tuple) or any(
+            type(item) is not ReportedVerification
+            for item in self.reported_verifications
+        ):
+            raise TypeError(
+                "reported_verifications must be ReportedVerification records"
+            )
+        if tuple(
+            sorted(
+                self.reported_verifications,
+                key=lambda item: item.contract.contract_id,
+            )
+        ) != self.reported_verifications:
+            raise ValueError("reported_verifications must be sorted")
+        if self.verdict not in _REPORT_VERDICTS:
+            raise ValueError("verification report verdict is invalid")
+        if type(self.staged_paths_private) is not bool:
+            raise TypeError("staged_paths_private must be boolean")
+        if type(self.writes_confined_to_capsule) is not bool:
+            raise TypeError("writes_confined_to_capsule must be boolean")
+        if (
+            not isinstance(self.notes, tuple)
+            or tuple(sorted(set(self.notes))) != self.notes
+            or any(not isinstance(item, str) or not item for item in self.notes)
+        ):
+            raise ValueError("verification report notes must be sorted unique text")
+        if self.verdict == "OK" and (
+            not self.staged_paths_private
+            or not self.writes_confined_to_capsule
+            or any(item.status != "OK" for item in self.static_results)
+            or any(
+                item.status != "verified"
+                for item in self.reported_verifications
+            )
+        ):
+            raise ValueError("OK verification report contradicts its evidence")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "staging_id": self.staging_id,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "candidate_sha256": self.candidate_sha256,
+            "static_results": [item.to_dict() for item in self.static_results],
+            "reported_verifications": [
+                item.to_dict() for item in self.reported_verifications
+            ],
+            "verdict": self.verdict,
+            "staged_paths_private": self.staged_paths_private,
+            "writes_confined_to_capsule": self.writes_confined_to_capsule,
+            "notes": list(self.notes),
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+
+def _contract_from_report(value: object) -> BehaviouralContract:
+    item = _closed_object(
+        value,
+        keys=frozenset(
+            {
+                "contract_id",
+                "customization_id",
+                "statement",
+                "provenance",
+                "verification_class",
+            }
+        ),
+        context="reported contract",
+    )
+    try:
+        return BehaviouralContract(
+            item["contract_id"],
+            item["customization_id"],
+            item["statement"],
+            ContractProvenance(item["provenance"]),
+            VerificationClass(item["verification_class"]),
+        )
+    except (TypeError, ValueError) as error:
+        raise VerificationError("reported contract is invalid") from error
+
+
+def verification_report_from_bytes(raw: bytes) -> VerificationReport:
+    """Parse one canonical, schema-closed persisted report."""
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise VerificationError("verification report is not JSON") from error
+    if _canonical_json(value) != raw:
+        raise VerificationError("verification report is not canonical")
+    item = _closed_object(
+        value,
+        keys=frozenset(
+            {
+                "schema_version",
+                "staging_id",
+                "capsule_id",
+                "proposal_id",
+                "candidate_sha256",
+                "static_results",
+                "reported_verifications",
+                "verdict",
+                "staged_paths_private",
+                "writes_confined_to_capsule",
+                "notes",
+            }
+        ),
+        context="verification report",
+    )
+    static_results: list[StaticFileResult] = []
+    for raw_result in _closed_list(
+        item["static_results"],
+        context="static_results",
+    ):
+        result = _closed_object(
+            raw_result,
+            keys=frozenset(
+                {"target_path", "staged_path", "checks", "status"}
+            ),
+            context="static result",
+        )
+        checks: list[VerificationCheckOutcome] = []
+        for raw_check in _closed_list(
+            result["checks"],
+            context="static checks",
+        ):
+            check = _closed_object(
+                raw_check,
+                keys=frozenset(
+                    {"name", "verification_class", "outcome", "detail"}
+                ),
+                context="static check",
+            )
+            try:
+                checks.append(
+                    VerificationCheckOutcome(
+                        check["name"],
+                        VerificationClass(check["verification_class"]),
+                        check["outcome"],
+                        check["detail"],
+                    )
+                )
+            except (TypeError, ValueError) as error:
+                raise VerificationError("static check is invalid") from error
+        try:
+            static_results.append(
+                StaticFileResult(
+                    result["target_path"],
+                    result["staged_path"],
+                    tuple(checks),
+                    result["status"],
+                )
+            )
+        except (TypeError, ValueError) as error:
+            raise VerificationError("static result is invalid") from error
+
+    reported: list[ReportedVerification] = []
+    for raw_reported in _closed_list(
+        item["reported_verifications"],
+        context="reported_verifications",
+    ):
+        reported_item = _closed_object(
+            raw_reported,
+            keys=frozenset({"contract", "outcome", "status"}),
+            context="reported verification",
+        )
+        contract = _contract_from_report(reported_item["contract"])
+        outcome_item = _closed_object(
+            reported_item["outcome"],
+            keys=frozenset({"contract_id", "outcome", "evidence_note"}),
+            context="reported outcome",
+        )
+        try:
+            outcome = VerificationOutcome(
+                outcome_item["contract_id"],
+                outcome_item["outcome"],
+                outcome_item["evidence_note"],
+            )
+            reported.append(
+                ReportedVerification(
+                    contract,
+                    outcome,
+                    reported_item["status"],
+                )
+            )
+        except (TypeError, ValueError) as error:
+            raise VerificationError(
+                "reported verification is invalid"
+            ) from error
+    try:
+        report = VerificationReport(
+            item["schema_version"],
+            item["staging_id"],
+            item["capsule_id"],
+            item["proposal_id"],
+            item["candidate_sha256"],
+            tuple(static_results),
+            tuple(reported),
+            item["verdict"],
+            item["staged_paths_private"],
+            item["writes_confined_to_capsule"],
+            tuple(
+                _closed_list(
+                    item["notes"],
+                    context="verification notes",
+                )
+            ),
+        )
+    except (TypeError, ValueError) as error:
+        raise VerificationError("verification report is invalid") from error
+    if report.canonical_bytes() != raw:
+        raise VerificationError("verification report did not round-trip")
+    return report
+
+
+@dataclass(frozen=True)
+class VerificationWriteReceipt:
+    schema_version: int
+    capsule_id: str
+    staging_id: str
+    report_path: str
+    report_sha256: str
+    transaction_id: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported verification receipt schema_version")
+        if not self.report_path.startswith(
+            f"{CAPSULE_ROOT}/{self.capsule_id}/verification/"
+        ):
+            raise ValueError("verification receipt report path escapes capsule")
+        if not isinstance(self.report_sha256, str) or SHA256.fullmatch(
+            self.report_sha256
+        ) is None:
+            raise ValueError("verification receipt report_sha256 is invalid")
+        if (
+            not isinstance(self.transaction_id, str)
+            or not self.transaction_id
+            or "/" in self.transaction_id
+            or "\x00" in self.transaction_id
+        ):
+            raise ValueError("verification receipt transaction_id is invalid")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "staging_id": self.staging_id,
+            "report_path": self.report_path,
+            "report_sha256": self.report_sha256,
+            "transaction_id": self.transaction_id,
+        }
+
+
+@dataclass(frozen=True)
+class _StaticContext:
+    root: Path
+    staging: Path
+    capsule_dir: Path
+    candidate: RegenerationCandidate
+    candidate_file: CandidateFile
+    staged_path: Path
+    staged_relative: str
+    staging_integrity_error: str | None
+    dependency_error: str | None
+
+
+def _check(
+    name: str,
+    passed: bool,
+    success: str,
+    failure: str,
+) -> VerificationCheckOutcome:
+    return VerificationCheckOutcome(
+        name,
+        VerificationClass.STATIC,
+        "pass" if passed else "fail",
+        success if passed else failure,
+    )
+
+
+def _schema_check(context: _StaticContext) -> VerificationCheckOutcome:
+    return _check(
+        "schema",
+        type(context.candidate) is RegenerationCandidate
+        and type(context.candidate_file) is CandidateFile
+        and context.staging_integrity_error is None,
+        "The canonical v0 candidate schema was reconstructed.",
+        context.staging_integrity_error
+        or "The staged candidate schema is not the closed v0 shape.",
+    )
+
+
+def _canonical_path_check(context: _StaticContext) -> VerificationCheckOutcome:
+    target = context.candidate_file.target_path
+    path = PurePosixPath(target)
+    canonical = (
+        not path.is_absolute()
+        and path.as_posix() == target
+        and all(part not in {"", ".", ".."} for part in path.parts)
+    )
+    return _check(
+        "canonical-path",
+        canonical,
+        "The eventual target is canonical and vault-relative.",
+        f"The eventual target is not canonical: {target}",
+    )
+
+
+def _ownership_check(context: _StaticContext) -> VerificationCheckOutcome:
+    target = context.root / context.candidate_file.target_path
+    if target.is_symlink():
+        return _check(
+            "ownership-authorization",
+            False,
+            "",
+            "The eventual target is a symlink and cannot receive migration bytes.",
+        )
+    verdict = portable_contract.update_write_verdict(
+        context.candidate_file.target_path,
+        exists=target.exists(),
+        operation="customization-migration",
+    )
+    return _check(
+        "ownership-authorization",
+        verdict.allowed,
+        "The single customization-migration write authority allows the target.",
+        "The ownership contract refuses the eventual target: "
+        f"{context.candidate_file.target_path} [{verdict.action}]",
+    )
+
+
+def _content_check(context: _StaticContext) -> VerificationCheckOutcome:
+    try:
+        raw = _read_regular_beneath(
+            context.root,
+            context.staged_relative,
+            len(context.candidate_file.content),
+        )
+    except (OSError, StagingError):
+        return _check(
+            "content-digest",
+            False,
+            "",
+            f"The staged blob is missing or unreadable: {context.staged_path.name}",
+        )
+    passed = (
+        raw == context.candidate_file.content
+        and _sha256(raw) == context.candidate_file.sha256
+    )
+    return _check(
+        "content-digest",
+        passed,
+        "The staged bytes exactly match the candidate digest.",
+        f"The staged bytes do not match: {context.staged_path.name}",
+    )
+
+
+def _mode_check(context: _StaticContext) -> VerificationCheckOutcome:
+    try:
+        parent_relative = PurePosixPath(
+            context.staged_relative
+        ).parent.as_posix()
+        parent = _open_directory_beneath(context.root, parent_relative)
+        try:
+            descriptor = os.open(
+                PurePosixPath(context.staged_relative).name,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent,
+            )
+        finally:
+            os.close(parent)
+        try:
+            metadata = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        passed = (
+            stat.S_ISREG(metadata.st_mode)
+            and not stat.S_ISLNK(metadata.st_mode)
+            and stat.S_IMODE(metadata.st_mode) == 0o600
+        )
+    except OSError:
+        passed = False
+    return _check(
+        "mode",
+        passed,
+        "The staged blob remains a regular 0600 file.",
+        f"The staged blob is not a regular 0600 file: {context.staged_path.name}",
+    )
+
+
+def _dependency_check(context: _StaticContext) -> VerificationCheckOutcome:
+    return _check(
+        "dependency-closure",
+        context.dependency_error is None,
+        "The candidate remains closed over the capsule's frozen dependencies.",
+        context.dependency_error or "The frozen dependency check failed.",
+    )
+
+
+def _syntax_check(context: _StaticContext) -> VerificationCheckOutcome:
+    target = context.candidate_file.target_path
+    suffix = PurePosixPath(target).suffix.lower()
+    try:
+        raw = _read_regular_beneath(
+            context.root,
+            context.staged_relative,
+            len(context.candidate_file.content),
+        )
+        if suffix == ".py":
+            compile(raw.decode("utf-8"), target, "exec", dont_inherit=True)
+        elif suffix == ".json":
+            json.loads(raw.decode("utf-8"))
+        elif suffix in {".yaml", ".yml"}:
+            yaml.safe_load(raw.decode("utf-8"))
+    except (OSError, StagingError, SyntaxError, UnicodeDecodeError, json.JSONDecodeError, yaml.YAMLError):
+        return _check(
+            "syntax",
+            False,
+            "",
+            f"The staged bytes fail static {suffix or 'text'} parsing: {target}",
+        )
+    return _check(
+        "syntax",
+        True,
+        "Relevant Python, JSON, or YAML syntax parses without execution.",
+        "",
+    )
+
+
+def _release_check(context: _StaticContext) -> VerificationCheckOutcome:
+    verdict = portable_contract.update_write_verdict(
+        context.candidate_file.target_path,
+        exists=False,
+        operation="customization-migration",
+    )
+    return _check(
+        "target-release-compatibility",
+        verdict.allowed,
+        "The target path still classifies in the current release contract.",
+        "The target path no longer classifies for customization migration.",
+    )
+
+
+def _trust_permission_check(
+    context: _StaticContext,
+) -> VerificationCheckOutcome:
+    requirements = tuple(
+        requirement
+        for requirement in context.candidate.declared_requirements
+        if set(requirement.customization_ids)
+        & set(context.candidate_file.customization_ids)
+    )
+    return _check(
+        "trust-permission-delta",
+        not requirements,
+        "No new trust or permission requirement is declared for this file.",
+        "The candidate declares a new trust or permission requirement: "
+        + ", ".join(item.description for item in requirements),
+    )
+
+
+def _private_staging_check(context: _StaticContext) -> VerificationCheckOutcome:
+    try:
+        capsule_relative = context.capsule_dir.relative_to(
+            context.root
+        ).as_posix()
+        private = context.staged_relative.startswith(
+            capsule_relative + "/"
+        )
+        parent = _open_directory_beneath(
+            context.root,
+            PurePosixPath(context.staged_relative).parent.as_posix(),
+        )
+        try:
+            descriptor = os.open(
+                PurePosixPath(context.staged_relative).name,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent,
+            )
+        finally:
+            os.close(parent)
+        try:
+            staged_metadata = os.fstat(descriptor)
+            private = private and stat.S_ISREG(staged_metadata.st_mode)
+        finally:
+            os.close(descriptor)
+    except (OSError, ValueError, StagingError):
+        private = False
+    live_target = context.root / context.candidate_file.target_path
+    try:
+        live_metadata = live_target.lstat()
+        private = private and (
+            not stat.S_ISLNK(live_metadata.st_mode)
+            and (
+                staged_metadata.st_dev != live_metadata.st_dev
+                or staged_metadata.st_ino != live_metadata.st_ino
+            )
+        )
+    except FileNotFoundError:
+        private = private and not live_target.is_symlink()
+    except OSError:
+        private = False
+    return _check(
+        "private-staging",
+        private,
+        "The staged blob is capsule-private and is not its live target path.",
+        "A staged blob aliases or escapes to a live vault path.",
+    )
+
+
+_STATIC_CHECK_RUNNERS = {
+    "schema": _schema_check,
+    "canonical-path": _canonical_path_check,
+    "ownership-authorization": _ownership_check,
+    "content-digest": _content_check,
+    "mode": _mode_check,
+    "dependency-closure": _dependency_check,
+    "syntax": _syntax_check,
+    "target-release-compatibility": _release_check,
+    "trust-permission-delta": _trust_permission_check,
+    "private-staging": _private_staging_check,
+}
+
+
+def _static_results(
+    root: Path,
+    staging: Path,
+    candidate: RegenerationCandidate,
+) -> tuple[StaticFileResult, ...]:
+    try:
+        _validate_candidate_against_capsule(root, candidate.capsule_id, candidate)
+    except (OSError, StagingError) as error:
+        dependency_error = f"Frozen candidate validation failed: {error}"
+    else:
+        dependency_error = None
+    try:
+        assessment, _digest = _assessment_from_capsule(
+            root,
+            candidate.capsule_id,
+        )
+    except (OSError, StagingError) as error:
+        dependency_error = (
+            dependency_error
+            or f"Frozen assessment reconstruction failed: {error}"
+        )
+    else:
+        blocked_ids = {
+            item.customization_id
+            for item in assessment.groups
+            if item.group.value == "blocked"
+        }
+        generated_ids = {
+            item.customization_id
+            for item in candidate.dispositions
+            if item.disposition
+            in {Disposition.REWRITE, Disposition.COMPATIBILITY_SHIM}
+        }
+        blocked_generated = tuple(sorted(blocked_ids & generated_ids))
+        if blocked_generated:
+            dependency_error = (
+                "Frozen capsule evidence classified generated customization "
+                "as blocked: "
+                + ", ".join(blocked_generated)
+            )
+    staging_validation = validate_staging(
+        root,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    staging_integrity_error = (
+        None
+        if staging_validation.status == "OK"
+        else (
+            "Private staging integrity is "
+            f"{staging_validation.status}: "
+            + ", ".join(staging_validation.mismatches)
+        )
+    )
+    capsule_dir = root / CAPSULE_ROOT / candidate.capsule_id
+    results: list[StaticFileResult] = []
+    for candidate_file in candidate.files:
+        staged_path = staging / "files" / candidate_file.sha256
+        staged_relative = staged_path.relative_to(root).as_posix()
+        context = _StaticContext(
+            root,
+            staging,
+            capsule_dir,
+            candidate,
+            candidate_file,
+            staged_path,
+            staged_relative,
+            staging_integrity_error,
+            dependency_error,
+        )
+        checks: list[VerificationCheckOutcome] = []
+        for name in _REQUIRED_STATIC_CHECKS:
+            runner = _STATIC_CHECK_RUNNERS.get(name)
+            if runner is None:
+                checks.append(
+                    VerificationCheckOutcome(
+                        name,
+                        VerificationClass.STATIC,
+                        "fail",
+                        f"Required static check is disabled: {name}",
+                    )
+                )
+                continue
+            try:
+                checks.append(runner(context))
+            except Exception as error:  # noqa: BLE001 - fail closed per check
+                checks.append(
+                    VerificationCheckOutcome(
+                        name,
+                        VerificationClass.STATIC,
+                        "fail",
+                        f"Required static check failed closed: {type(error).__name__}",
+                    )
+                )
+        ordered = tuple(checks)
+        status = (
+            "BLOCKED"
+            if any(item.outcome == "fail" for item in ordered)
+            else "UNKNOWN"
+            if any(item.outcome == "unknown" for item in ordered)
+            else "OK"
+        )
+        results.append(
+            StaticFileResult(
+                candidate_file.target_path,
+                (
+                    STAGING_SUBDIR.format(proposal_id=candidate.proposal_id)
+                    + f"/files/{candidate_file.sha256}"
+                ),
+                ordered,
+                status,
+            )
+        )
+    return tuple(sorted(results, key=lambda item: item.target_path))
+
+
+def _run_isolated_fixture(
+    contract: BehaviouralContract,
+    candidate: RegenerationCandidate,
+    staging: Path,
+) -> VerificationAttempt:
+    """Optional v0 runner seam; no candidate code is run without a safe harness."""
+    del contract, candidate, staging
+    return VerificationAttempt(
+        VerificationClass.ISOLATED_FIXTURE,
+        VerificationClass.UNSAFE_UNVERIFIED,
+        "unknown",
+        False,
+        (
+            "unsafe-unverified: no closed synthetic fixture harness exists "
+            "for this customization kind."
+        ),
+    )
+
+
+def _unexercised_attempt(
+    requested: VerificationClass,
+    note: str,
+) -> VerificationAttempt:
+    return VerificationAttempt(
+        requested,
+        VerificationClass.UNSAFE_UNVERIFIED,
+        "unknown",
+        False,
+        f"unsafe-unverified: {note}",
+    )
+
+
+def _attempt_for_contract(
+    contract: BehaviouralContract,
+    candidate: RegenerationCandidate,
+    staging: Path,
+    static_results: tuple[StaticFileResult, ...],
+) -> VerificationAttempt:
+    if contract.verification_class is VerificationClass.STATIC:
+        static_passed = bool(static_results) and all(
+            item.status == "OK" for item in static_results
+        )
+        return VerificationAttempt(
+            VerificationClass.STATIC,
+            VerificationClass.STATIC,
+            "pass" if static_passed else "fail",
+            True,
+            (
+                "All required deterministic static checks passed."
+                if static_passed
+                else "One or more required deterministic static checks failed."
+            ),
+        )
+    if contract.verification_class is VerificationClass.ISOLATED_FIXTURE:
+        return _run_isolated_fixture(contract, candidate, staging)
+    if contract.verification_class is VerificationClass.READ_ONLY_LIVE:
+        return _unexercised_attempt(
+            VerificationClass.READ_ONLY_LIVE,
+            "read-only-live verification requires a fresh explicit consent token.",
+        )
+    if contract.verification_class is VerificationClass.MANUAL:
+        return _unexercised_attempt(
+            VerificationClass.MANUAL,
+            "manual verification was recorded but cannot be auto-promoted.",
+        )
+    return _unexercised_attempt(
+        VerificationClass.UNSAFE_UNVERIFIED,
+        "the declared behaviour cannot be exercised safely in v0.",
+    )
+
+
+def _trusted_contract(
+    candidate_contract: BehaviouralContract,
+) -> BehaviouralContract:
+    registered = BehaviouralContract.create(
+        candidate_contract.customization_id,
+        _REGISTERED_STATIC_STATEMENT,
+        ContractProvenance.DETERMINISTIC,
+        VerificationClass.STATIC,
+    )
+    if candidate_contract == registered:
+        return candidate_contract
+    return BehaviouralContract.create(
+        candidate_contract.customization_id,
+        candidate_contract.statement,
+        ContractProvenance.MODEL_PROPOSED,
+        candidate_contract.verification_class,
+    )
+
+
+def _reported_verifications(
+    candidate: RegenerationCandidate,
+    staging: Path,
+    static_results: tuple[StaticFileResult, ...],
+) -> tuple[tuple[ReportedVerification, ...], tuple[VerificationAttempt, ...]]:
+    reported: list[ReportedVerification] = []
+    attempts: list[VerificationAttempt] = []
+    for candidate_contract in candidate.behaviour_contracts:
+        contract = _trusted_contract(candidate_contract)
+        attempt = _attempt_for_contract(
+            contract,
+            candidate,
+            staging,
+            static_results,
+        )
+        outcome = VerificationOutcome(
+            contract.contract_id,
+            attempt.outcome,
+            attempt.evidence_note,
+        )
+        reported.append(
+            ReportedVerification(
+                contract,
+                outcome,
+                derive_reported_status(contract, outcome),
+            )
+        )
+        attempts.append(attempt)
+    return (
+        tuple(sorted(reported, key=lambda item: item.contract.contract_id)),
+        tuple(attempts),
+    )
+
+
+def validate_persisted_verification_report(
+    raw: bytes,
+    candidate: RegenerationCandidate,
+    event: str,
+) -> VerificationReport:
+    """Validate the full persisted report seal against its staged candidate."""
+    report = verification_report_from_bytes(raw)
+    if (
+        report.capsule_id != candidate.capsule_id
+        or report.proposal_id != candidate.proposal_id
+        or report.staging_id != candidate.proposal_id
+        or report.candidate_sha256 != candidate.candidate_sha256
+    ):
+        raise VerificationError(
+            "verification report identity does not match staging"
+        )
+    expected_targets = tuple(item.target_path for item in candidate.files)
+    if tuple(item.target_path for item in report.static_results) != expected_targets:
+        raise VerificationError(
+            "verification report static results do not cover candidate files"
+        )
+    for result in report.static_results:
+        if tuple(check.name for check in result.checks) != _REQUIRED_STATIC_CHECKS:
+            raise VerificationError(
+                "verification report static ladder is incomplete"
+            )
+        if any(
+            check.verification_class is not VerificationClass.STATIC
+            for check in result.checks
+        ):
+            raise VerificationError(
+                "verification report static ladder has the wrong class"
+            )
+    expected_contracts = tuple(
+        sorted(
+            (
+                _trusted_contract(contract)
+                for contract in candidate.behaviour_contracts
+            ),
+            key=lambda contract: contract.contract_id,
+        )
+    )
+    if tuple(
+        item.contract for item in report.reported_verifications
+    ) != expected_contracts:
+        raise VerificationError(
+            "verification report contracts do not match trusted semantics"
+        )
+    expected_event = (
+        MigrationEvent.VERIFICATION_PASSED.value
+        if report.verdict == "OK"
+        else MigrationEvent.VERIFICATION_BLOCKED.value
+    )
+    if event != expected_event:
+        raise VerificationError(
+            "verification report verdict contradicts its journal event"
+        )
+    return report
+
+
+def _unknown_report(capsule_id: str, proposal_id: str, note: str) -> VerificationReport:
+    return VerificationReport(
+        0,
+        proposal_id,
+        capsule_id,
+        proposal_id,
+        "0" * 64,
+        (),
+        (),
+        "UNKNOWN",
+        False,
+        True,
+        (note,),
+    )
+
+
+def _staged_paths_are_private(
+    root: Path,
+    capsule_dir: Path,
+    staging: Path,
+    candidate: RegenerationCandidate,
+) -> bool:
+    del capsule_dir
+    staged_inodes: set[tuple[int, int]] = set()
+    for item in candidate.files:
+        staged = staging / "files" / item.sha256
+        try:
+            relative = staged.relative_to(root).as_posix()
+            parent = _open_directory_beneath(
+                root,
+                PurePosixPath(relative).parent.as_posix(),
+            )
+            try:
+                descriptor = os.open(
+                    PurePosixPath(relative).name,
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=parent,
+                )
+            finally:
+                os.close(parent)
+            try:
+                metadata = os.fstat(descriptor)
+            finally:
+                os.close(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                return False
+            staged_inodes.add((metadata.st_dev, metadata.st_ino))
+        except (OSError, ValueError, StagingError):
+            return False
+    if not staged_inodes:
+        return True
+
+    excluded_roots = {
+        CAPSULE_ROOT,
+        "System/.dex/tx",
+    }
+    scanned = 0
+
+    def scan_directory(descriptor: int, prefix: str) -> bool:
+        nonlocal scanned
+        try:
+            names = sorted(os.listdir(descriptor))
+        except OSError:
+            return False
+        for name in names:
+            scanned += 1
+            if scanned > _MAX_LIVE_INODE_SCAN_ENTRIES:
+                return False
+            relative = f"{prefix}/{name}" if prefix else name
+            try:
+                metadata = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except OSError:
+                return False
+            if stat.S_ISREG(metadata.st_mode):
+                if (metadata.st_dev, metadata.st_ino) in staged_inodes:
+                    return False
+                continue
+            if not stat.S_ISDIR(metadata.st_mode):
+                continue
+            if relative in excluded_roots:
+                continue
+            try:
+                child = os.open(
+                    name,
+                    os.O_RDONLY
+                    | getattr(os, "O_DIRECTORY", 0)
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=descriptor,
+                )
+            except OSError:
+                return False
+            try:
+                if not scan_directory(child, relative):
+                    return False
+            finally:
+                os.close(child)
+        return True
+
+    root_descriptor = os.open(
+        root,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        return scan_directory(root_descriptor, "")
+    finally:
+        os.close(root_descriptor)
+
+
+def verify_staging(
+    vault_root: Path,
+    capsule_id: str,
+    proposal_id: str,
+) -> VerificationReport:
+    """Run the ordered safe ladder without writing any vault path."""
+    root = Path(vault_root).resolve()
+    status = read_staging_status(root, capsule_id)
+    state = next(
+        (
+            item.state
+            for item in status.proposals
+            if item.proposal_id == proposal_id
+        ),
+        MigrationState.UNKNOWN,
+    )
+    if state not in {
+        MigrationState.REGENERATION_STAGED,
+        MigrationState.VERIFICATION_PASSED,
+        MigrationState.VERIFICATION_BLOCKED,
+    }:
+        return _unknown_report(
+            capsule_id,
+            proposal_id,
+            f"Private staging state is not regeneration-staged: {state.value}",
+        )
+    try:
+        candidate, _receipt, staging = load_staged_candidate(
+            root,
+            capsule_id,
+            proposal_id,
+        )
+    except (OSError, StagingError) as error:
+        return _unknown_report(
+            capsule_id,
+            proposal_id,
+            f"Private staging is missing or unreadable: {type(error).__name__}",
+        )
+    static_results = _static_results(root, staging, candidate)
+    reported, attempts = _reported_verifications(
+        candidate,
+        staging,
+        static_results,
+    )
+    capsule_dir = root / CAPSULE_ROOT / capsule_id
+    staged_paths_private = _staged_paths_are_private(
+        root,
+        capsule_dir,
+        staging,
+        candidate,
+    )
+    notes: set[str] = set()
+    if candidate.declared_requirements:
+        notes.add("Declared trust or permission requirements remain pending.")
+    if candidate.unresolved_questions:
+        notes.add("Candidate questions remain unresolved.")
+    unsafe_equivalence = any(
+        attempt.effective_class is VerificationClass.UNSAFE_UNVERIFIED
+        for attempt in attempts
+    )
+    if unsafe_equivalence:
+        notes.add(
+            "Claimed behavioural equivalence remains unsafe-unverified."
+        )
+    plans_by_id = {
+        item.customization_id: item for item in candidate.dispositions
+    }
+    generated_or_native = {
+        item.customization_id
+        for item in candidate.dispositions
+        if item.disposition
+        in {
+            Disposition.REWRITE,
+            Disposition.COMPATIBILITY_SHIM,
+            Disposition.NATIVE_REPLACEMENT,
+        }
+    }
+    missing_contract_coverage = any(
+        not plans_by_id[customization_id].behaviour_contract_ids
+        for customization_id in generated_or_native
+    )
+    if missing_contract_coverage:
+        notes.add(
+            "Generated or native dispositions lack complete "
+            "behavioural-contract coverage."
+        )
+    native_without_confirmation = any(
+        item.disposition is Disposition.NATIVE_REPLACEMENT
+        for item in candidate.dispositions
+    )
+    if native_without_confirmation:
+        notes.add(
+            "Native replacement lacks authenticated user-confirmation evidence."
+        )
+    manual_or_blocked = any(
+        item.disposition in {Disposition.MANUAL_REVIEW, Disposition.BLOCKED}
+        for item in candidate.dispositions
+    )
+    if manual_or_blocked:
+        notes.add("One or more dispositions remain manual or blocked.")
+    static_blocked = any(item.status == "BLOCKED" for item in static_results)
+    has_generated_files = bool(candidate.files)
+    static_unknown = (has_generated_files and not static_results) or any(
+        item.status == "UNKNOWN" for item in static_results
+    )
+    failed_contract = any(item.status == "failed" for item in reported)
+    unknown_contract = any(item.status == "unknown" for item in reported)
+    non_verified_contract = any(
+        item.status != "verified" for item in reported
+    )
+    if (
+        static_blocked
+        or failed_contract
+        or unsafe_equivalence
+        or candidate.declared_requirements
+        or candidate.unresolved_questions
+        or not staged_paths_private
+        or missing_contract_coverage
+        or native_without_confirmation
+        or manual_or_blocked
+        or non_verified_contract
+    ):
+        verdict = "BLOCKED"
+    elif static_unknown or unknown_contract:
+        verdict = "UNKNOWN"
+    else:
+        verdict = "OK"
+    return VerificationReport(
+        0,
+        proposal_id,
+        capsule_id,
+        proposal_id,
+        candidate.candidate_sha256,
+        static_results,
+        reported,
+        verdict,
+        staged_paths_private,
+        staged_paths_private,
+        tuple(sorted(notes)),
+    )
+
+
+def _transaction_id() -> str:
+    return time.strftime("%Y%m%dT%H%M%S-") + uuid.uuid4().hex[:8]
+
+
+def _verification_stop_seam(name: str) -> None:
+    if os.environ.get("DEX_TX_TEST_STOP_AFTER") == name:
+        os._exit(137)
+
+
+def write_verification_report(
+    vault_root: Path,
+    capsule_id: str,
+    proposal_id: str,
+    report: VerificationReport,
+) -> VerificationWriteReceipt:
+    """Persist one fresh report and journal transition in a sealed transaction."""
+    if type(report) is not VerificationReport:
+        raise TypeError("report must be VerificationReport")
+    if report.capsule_id != capsule_id or report.proposal_id != proposal_id:
+        raise VerificationError("verification report identity does not match")
+    root = Path(vault_root).resolve()
+    refreshed = verify_staging(root, capsule_id, proposal_id)
+    if refreshed.canonical_bytes() != report.canonical_bytes():
+        raise VerificationError("verification report drifted before persistence")
+    status = read_staging_status(root, capsule_id)
+    state = next(
+        (
+            item.state
+            for item in status.proposals
+            if item.proposal_id == proposal_id
+        ),
+        MigrationState.UNKNOWN,
+    )
+    if state is not MigrationState.REGENERATION_STAGED:
+        raise VerificationError(
+            f"staging is not ready for report persistence: {state.value}"
+        )
+
+    capsule_dir = root / CAPSULE_ROOT / capsule_id
+    staging = capsule_dir / STAGING_SUBDIR.format(proposal_id=proposal_id)
+    staging_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/"
+        + STAGING_SUBDIR.format(proposal_id=proposal_id)
+    )
+    journal_path = staging / "journal.jsonl"
+    try:
+        journal_before = _read_regular_beneath(
+            root,
+            f"{staging_relative}/journal.jsonl",
+        )
+        journal_records = _read_event_records_beneath(
+            root,
+            f"{staging_relative}/journal.jsonl",
+        )
+        if tuple(record["event"] for record in journal_records) != (
+            MigrationEvent.REGENERATION_PROPOSED.value,
+            MigrationEvent.REGENERATION_STAGED.value,
+        ):
+            raise VerificationError("staging journal is not regeneration-staged")
+    except (OSError, StagingError) as error:
+        raise VerificationError("staging journal is unreadable") from error
+    event = (
+        MigrationEvent.VERIFICATION_PASSED
+        if report.verdict == "OK"
+        else MigrationEvent.VERIFICATION_BLOCKED
+    )
+    report_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/verification/{report.staging_id}.json"
+    )
+    report_raw = report.canonical_bytes()
+    report_sha256 = hashlib.sha256(report_raw).hexdigest()
+    report_path = root / report_relative
+    if report_path.exists() or report_path.is_symlink():
+        raise VerificationError("verification report already exists")
+    journal_relative = journal_path.relative_to(root).as_posix()
+    transaction_id = _transaction_id()
+    transaction = Transaction._begin_with_id(
+        root,
+        [
+            PlanEntry(
+                report_relative,
+                report_raw,
+                mode=0o600,
+            ),
+            PlanEntry(
+                journal_relative,
+                journal_before,
+                mode=0o600,
+                expected_current_sha256=hashlib.sha256(journal_before).hexdigest(),
+            ),
+        ],
+        allow_empty=False,
+        operation="customization-migration",
+        tx_id=transaction_id,
+    )
+
+    def assert_verification_fresh() -> None:
+        final_report = verify_staging(root, capsule_id, proposal_id)
+        if final_report.canonical_bytes() != report.canonical_bytes():
+            raise VerificationError(
+                "verification report drifted during persistence"
+            )
+
+    def finalize_verification() -> None:
+        verification_dir = capsule_dir / "verification"
+        descriptor = _open_directory_beneath(
+            root,
+            verification_dir.relative_to(root).as_posix(),
+        )
+        try:
+            os.fchmod(descriptor, 0o700)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _verification_stop_seam("verification-after-layout")
+        assert_verification_fresh()
+        _append_event(
+            journal_path,
+            event,
+            candidate_sha256=report.candidate_sha256,
+            report_path=report_relative,
+            report_sha256=report_sha256,
+        )
+        _verification_stop_seam("verification-mid-finalize")
+
+    transaction.run(before_commit=finalize_verification)
+    return VerificationWriteReceipt(
+        0,
+        capsule_id,
+        report.staging_id,
+        report_relative,
+        report_sha256,
+        transaction_id,
+    )
+
+
+__all__ = [
+    "StaticFileResult",
+    "VerificationAttempt",
+    "VerificationCheckOutcome",
+    "VerificationError",
+    "VerificationReport",
+    "VerificationWriteReceipt",
+    "verify_staging",
+    "write_verification_report",
+]

--- a/core/tests/test_customization_staging.py
+++ b/core/tests/test_customization_staging.py
@@ -1,0 +1,538 @@
+"""Lane F private staging journeys."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pickle
+import stat
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.customization_migration.capsule import (
+    CAPSULE_ROOT,
+    create_capsule,
+    preview_capsule,
+)
+from core.customization_migration.planning import (
+    CandidateFile,
+    DependencyRemapping,
+    DependencyResolution,
+    Disposition,
+    DispositionPlanItem,
+    RegenerationCandidate,
+)
+from core.customization_migration.staging import (
+    StagingError,
+    preview_staging,
+    read_staging_status,
+    stage_candidate,
+    validate_staging,
+)
+from core.customization_migration.state import MigrationState
+from core.tests.test_customization_assessment import _linked_customized_vault
+from core.transaction.engine import Transaction
+
+PROPOSAL_ID = "prop-0123456789abcdef"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _candidate_with_capsule(tmp_path: Path) -> tuple[Path, RegenerationCandidate]:
+    vault = _linked_customized_vault(tmp_path)
+    capsule_preview = preview_capsule(vault, clock=lambda: 1_750_000_000)
+    create_capsule(vault, capsule_preview, capsule_preview.preview_sha256)
+    assessment = capsule_preview.assessment
+    digest = hashlib.sha256(assessment.canonical_assessment_bytes()).hexdigest()
+    record = next(
+        item
+        for item in assessment.records
+        if any(edge.source_path in item.source_paths for edge in assessment.edges)
+    )
+    owned_edges = tuple(
+        edge for edge in assessment.edges if edge.source_path in record.source_paths
+    )
+    dispositions = tuple(
+        sorted(
+            (
+                DispositionPlanItem(
+                    item.customization_id,
+                    Disposition.REWRITE
+                    if item.customization_id == record.customization_id
+                    else Disposition.KEEP_DISABLED,
+                    digest,
+                    evidence_edge_ids=(owned_edges[0].edge_id,)
+                    if item.customization_id == record.customization_id
+                    else (),
+                )
+                for item in assessment.records
+            ),
+            key=lambda item: item.customization_id,
+        )
+    )
+    candidate = RegenerationCandidate(
+        schema_version=0,
+        proposal_id=PROPOSAL_ID,
+        capsule_id=capsule_preview.capsule_id,
+        evidence_digest=digest,
+        dispositions=dispositions,
+        files=(
+            CandidateFile.create(
+                "CLAUDE-custom.md",
+                b"# Migrated customization\n",
+                (record.customization_id,),
+            ),
+        ),
+        dependency_remappings=tuple(
+            DependencyRemapping(edge.edge_id, DependencyResolution.PRESERVE)
+            for edge in owned_edges
+        ),
+        behaviour_contracts=(),
+        declared_requirements=(),
+        confidence=100,
+        unresolved_questions=(),
+        shim_expiries=(),
+    )
+    return vault, candidate
+
+
+def _non_lifecycle_bytes(vault: Path) -> dict[str, bytes]:
+    result: dict[str, bytes] = {}
+    for path in vault.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(vault).as_posix()
+        if relative.startswith(CAPSULE_ROOT + "/"):
+            continue
+        if relative.startswith("System/.dex/tx/"):
+            continue
+        result[relative] = path.read_bytes()
+    return result
+
+
+def test_stage_places_content_addressed_candidate_only_inside_capsule(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    outside_before = _non_lifecycle_bytes(vault)
+
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    receipt = stage_candidate(vault, preview, preview.preview_sha256)
+
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    blob = staging / "files" / candidate.files[0].sha256
+    assert blob.read_bytes() == candidate.files[0].content
+    assert stat.S_IMODE(blob.stat().st_mode) == 0o600
+    assert stat.S_IMODE(staging.stat().st_mode) == 0o700
+    assert {
+        stat.S_IMODE(path.stat().st_mode)
+        for path in (
+            staging.parent.parent,
+            staging.parent,
+            staging,
+            staging / "files",
+        )
+    } == {0o700}
+    assert {
+        stat.S_IMODE(path.stat().st_mode)
+        for path in staging.rglob("*")
+        if path.is_file()
+    } == {0o600}
+    assert json.loads((staging / "manifest.json").read_bytes()) == candidate.to_dict()
+    assert (staging / "receipt.json").read_bytes() == receipt.canonical_bytes()
+    assert receipt.capsule_id == candidate.capsule_id
+    assert receipt.proposal_id == candidate.proposal_id
+    assert receipt.staged_file_count == 1
+    assert receipt.staged_byte_count == len(candidate.files[0].content)
+    assert validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    ).status == "OK"
+    assert read_staging_status(vault, candidate.capsule_id).proposals[0].state is (
+        MigrationState.REGENERATION_STAGED
+    )
+    assert not (vault / candidate.files[0].target_path).exists()
+    assert _non_lifecycle_bytes(vault) == outside_before
+
+
+def test_accepted_candidate_without_generated_files_stages_closed_metadata(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    generated_id = candidate.files[0].customization_ids[0]
+    candidate = replace(
+        candidate,
+        dispositions=tuple(
+            replace(
+                item,
+                disposition=Disposition.MANUAL_REVIEW,
+                evidence_edge_ids=(),
+            )
+            if item.customization_id == generated_id
+            else item
+            for item in candidate.dispositions
+        ),
+        files=(),
+        dependency_remappings=(),
+    )
+
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    receipt = stage_candidate(vault, preview, preview.preview_sha256)
+
+    assert receipt.staged_file_count == 0
+    assert receipt.staged_byte_count == 0
+    assert validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    ).status == "OK"
+
+
+def test_candidate_capsule_digest_drift_refuses_without_writing(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    before = {
+        path.relative_to(vault).as_posix(): path.read_bytes()
+        for path in vault.rglob("*")
+        if path.is_file()
+    }
+    drifted = replace(candidate, evidence_digest="0" * 64)
+
+    with pytest.raises(StagingError, match="evidence digest"):
+        preview_staging(vault, candidate.capsule_id, drifted)
+
+    assert {
+        path.relative_to(vault).as_posix(): path.read_bytes()
+        for path in vault.rglob("*")
+        if path.is_file()
+    } == before
+
+
+def test_staging_preview_digest_mismatch_refuses_before_write(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+
+    with pytest.raises(StagingError, match="preview digest mismatch"):
+        stage_candidate(vault, preview, "0" * 64)
+
+    assert not staging.exists()
+    assert not (vault / candidate.files[0].target_path).exists()
+
+
+def test_restaging_same_proposal_refuses_without_clobber(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    before = {
+        path.relative_to(staging).as_posix(): path.read_bytes()
+        for path in staging.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(StagingError, match="already exists"):
+        stage_candidate(vault, preview, preview.preview_sha256)
+
+    assert {
+        path.relative_to(staging).as_posix(): path.read_bytes()
+        for path in staging.rglob("*")
+        if path.is_file()
+    } == before
+
+
+def test_existing_staging_artifact_refuses_without_clobber(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    competing = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "manifest.json"
+    )
+    competing.parent.mkdir(parents=True, exist_ok=True)
+    competing.write_bytes(b"competing private artifact\n")
+
+    with pytest.raises(StagingError, match="already exists"):
+        stage_candidate(vault, preview, preview.preview_sha256)
+
+    assert competing.read_bytes() == b"competing private artifact\n"
+    assert not (vault / candidate.files[0].target_path).exists()
+
+
+def test_existing_empty_staging_directory_is_not_adopted(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    staging.mkdir(parents=True)
+
+    with pytest.raises(StagingError, match="already exists"):
+        stage_candidate(vault, preview, preview.preview_sha256)
+
+    assert staging.is_dir()
+    assert list(staging.iterdir()) == []
+
+
+def test_capsule_drift_after_transaction_begin_rolls_staging_back(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    evidence = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "evidence"
+        / "environment.json"
+    )
+    original_snapshot = Transaction._snapshot_phase
+
+    def drift_capsule_then_snapshot(transaction: Transaction) -> None:
+        evidence.write_bytes(evidence.read_bytes() + b" ")
+        original_snapshot(transaction)
+
+    monkeypatch.setattr(
+        Transaction,
+        "_snapshot_phase",
+        drift_capsule_then_snapshot,
+    )
+
+    with pytest.raises(StagingError, match="capsule"):
+        stage_candidate(vault, preview, preview.preview_sha256)
+
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    assert not staging.exists()
+
+
+def test_validate_staging_reports_missing_unknown_and_tamper_broken(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+
+    missing = validate_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert missing.status == "UNKNOWN"
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    blob = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+        / candidate.files[0].sha256
+    )
+    blob.write_bytes(b"tampered staged bytes\n")
+
+    broken = validate_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert broken.status == "BROKEN"
+    assert broken.mismatches == (f"files/{candidate.files[0].sha256}",)
+
+
+@pytest.mark.parametrize("kind", ("directory", "symlink"))
+def test_validate_staging_rejects_undeclared_tree_entries(
+    kind: str,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    unexpected = staging / "unexpected"
+    if kind == "directory":
+        unexpected.mkdir()
+    else:
+        unexpected.symlink_to(staging / "manifest.json")
+
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert validation.status == "BROKEN"
+    assert validation.mismatches == ("unexpected",)
+
+
+def test_incomplete_staging_journal_is_unknown_not_ok(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    journal = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+    journal.write_bytes(
+        b'{"event":"regeneration-proposed","schema_version":0}\n'
+    )
+
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert validation.status == "UNKNOWN"
+    assert validation.mismatches == ("journal.jsonl:incomplete",)
+
+
+def test_symlinked_capsule_parent_cannot_validate_private_staging(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    migration_root = vault / CAPSULE_ROOT
+    moved_root = migration_root.with_name("customization-migrations-moved")
+    migration_root.rename(moved_root)
+    migration_root.symlink_to(moved_root, target_is_directory=True)
+
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert validation.status == "BROKEN"
+
+
+def test_malformed_staging_journal_projects_recovery_required(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+    journal = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+    journal.write_bytes(journal.read_bytes() + b"{garbage")
+
+    status = read_staging_status(vault, candidate.capsule_id)
+
+    assert status.proposals[0].state is MigrationState.RECOVERY_REQUIRED
+
+
+@pytest.mark.parametrize(
+    "seam",
+    (
+        "after-begin",
+        "after-snapshot",
+        "mid-apply:0",
+        "mid-apply:1",
+        "mid-apply:2",
+        "mid-apply:3",
+        "after-apply",
+        "after-verify",
+        "before-finalize",
+        "staging-after-layout",
+        "staging-mid-finalize",
+    ),
+)
+def test_staging_crash_resumes_to_absent_without_live_changes(
+    seam: str,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    outside_before = _non_lifecycle_bytes(vault)
+    candidate_path = tmp_path / "candidate.pickle"
+    candidate_path.write_bytes(pickle.dumps(candidate))
+    script = (
+        "from pathlib import Path\n"
+        "import pickle,sys\n"
+        "from core.customization_migration.staging import "
+        "preview_staging,stage_candidate\n"
+        "vault=Path(sys.argv[1])\n"
+        "candidate=pickle.loads(Path(sys.argv[2]).read_bytes())\n"
+        "preview=preview_staging(vault,candidate.capsule_id,candidate)\n"
+        "stage_candidate(vault,preview,preview.preview_sha256)\n"
+    )
+    environment = dict(os.environ)
+    environment["DEX_TX_TEST_STOP_AFTER"] = seam
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+
+    child = subprocess.run(
+        [sys.executable, "-c", script, str(vault), str(candidate_path)],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert child.returncode == 137, (seam, child.stderr[-500:])
+    Transaction.resume(vault)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    assert not staging.exists()
+    assert not (vault / candidate.files[0].target_path).exists()
+    assert _non_lifecycle_bytes(vault) == outside_before

--- a/core/tests/test_customization_verification.py
+++ b/core/tests/test_customization_verification.py
@@ -1,0 +1,994 @@
+"""Lane F conservative staged-candidate verification journeys."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pickle
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import core.customization_migration.verification as verification_module
+from core.customization_migration.behaviour import (
+    BehaviouralContract,
+    ContractProvenance,
+    VerificationClass,
+)
+from core.customization_migration.capsule import CAPSULE_ROOT
+from core.customization_migration.planning import (
+    CandidateFile,
+    DeclaredRequirement,
+    DependencyRemapping,
+    DependencyResolution,
+    Disposition,
+    RequirementKind,
+)
+from core.customization_migration.staging import (
+    preview_staging,
+    read_staging_status,
+    stage_candidate,
+    validate_staging,
+)
+from core.customization_migration.state import MigrationState
+from core.customization_migration.verification import (
+    VerificationError,
+    verify_staging,
+    write_verification_report,
+)
+from core.tests.test_customization_staging import (
+    REPO_ROOT,
+    _candidate_with_capsule,
+    _non_lifecycle_bytes,
+)
+from core.transaction.engine import Transaction
+
+_REGISTERED_STATIC_STATEMENT = (
+    "The required static verification ladder proves the staged candidate's "
+    "schema, paths, bytes, modes, dependency closure, syntax, release "
+    "compatibility, trust requirements, and capsule isolation."
+)
+
+
+def _candidate_with_contract(
+    tmp_path: Path,
+    *,
+    provenance: ContractProvenance = ContractProvenance.DETERMINISTIC,
+    verification_class: VerificationClass = VerificationClass.STATIC,
+    statement: str = _REGISTERED_STATIC_STATEMENT,
+):
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    customization_id = candidate.files[0].customization_ids[0]
+    contract = BehaviouralContract.create(
+        customization_id,
+        statement,
+        provenance,
+        verification_class,
+    )
+    dispositions = tuple(
+        replace(item, behaviour_contract_ids=(contract.contract_id,))
+        if item.customization_id == customization_id
+        else item
+        for item in candidate.dispositions
+    )
+    return vault, replace(
+        candidate,
+        dispositions=dispositions,
+        behaviour_contracts=(contract,),
+    )
+
+
+def _stage(vault: Path, candidate) -> None:
+    preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, preview, preview.preview_sha256)
+
+
+def _capsule_bytes(vault: Path, capsule_id: str) -> dict[str, bytes]:
+    capsule = vault / CAPSULE_ROOT / capsule_id
+    return {
+        path.relative_to(capsule).as_posix(): path.read_bytes()
+        for path in capsule.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_clean_static_ladder_is_ok_and_deterministic_contract_is_verified(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    before = _non_lifecycle_bytes(vault)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "OK"
+    assert report.staging_id == candidate.proposal_id
+    assert report.static_results[0].status == "OK"
+    assert report.reported_verifications[0].status == "verified"
+    assert tuple(
+        check.name for check in report.static_results[0].checks
+    ) == (
+        "schema",
+        "canonical-path",
+        "ownership-authorization",
+        "content-digest",
+        "mode",
+        "dependency-closure",
+        "syntax",
+        "target-release-compatibility",
+        "trust-permission-delta",
+        "private-staging",
+    )
+    assert report.staged_paths_private is True
+    assert report.writes_confined_to_capsule is True
+    assert _non_lifecycle_bytes(vault) == before
+    assert not (vault / candidate.files[0].target_path).exists()
+
+
+def test_tampered_staged_bytes_block_static_verification(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    staged_blob = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+        / candidate.files[0].sha256
+    )
+    staged_blob.write_bytes(b"tampered staged bytes\n")
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.static_results[0].status == "BLOCKED"
+    assert any(
+        check.name == "content-digest" and check.outcome == "fail"
+        for check in report.static_results[0].checks
+    )
+    assert not (vault / candidate.files[0].target_path).exists()
+
+
+def test_tampered_staging_receipt_blocks_static_verification(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    receipt_path = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "receipt.json"
+    )
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["staging_digest"] = "0" * 64
+    receipt_path.write_text(
+        json.dumps(receipt, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert any(
+        check.name == "schema" and check.outcome == "fail"
+        for check in report.static_results[0].checks
+    )
+
+
+def test_frozen_blocked_dependency_cannot_pass_static_closure(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    capsule = vault / CAPSULE_ROOT / candidate.capsule_id
+    customizations = json.loads(
+        (capsule / "evidence/customizations.json").read_text(encoding="utf-8")
+    )
+    dependencies = json.loads(
+        (capsule / "evidence/dependencies.json").read_text(encoding="utf-8")
+    )
+    blocked_record = next(
+        item
+        for item in customizations["items"]
+        if item["source_paths"] == ["System/folder-paths.yaml"]
+    )
+    blocked_edges = tuple(
+        item["edge_id"]
+        for item in dependencies["items"]
+        if item["source_path"] == "System/folder-paths.yaml"
+    )
+    candidate = replace(
+        candidate,
+        dispositions=tuple(
+            replace(
+                item,
+                disposition=Disposition.REWRITE,
+                evidence_edge_ids=blocked_edges,
+            )
+            if item.customization_id == blocked_record["customization_id"]
+            else replace(
+                item,
+                disposition=Disposition.MANUAL_REVIEW,
+                evidence_edge_ids=(),
+            )
+            for item in candidate.dispositions
+        ),
+        files=(
+            CandidateFile.create(
+                "CLAUDE-custom.md",
+                b"# Regenerated folder-map customization\n",
+                (blocked_record["customization_id"],),
+            ),
+        ),
+        dependency_remappings=tuple(
+            DependencyRemapping(edge_id, DependencyResolution.PRESERVE)
+            for edge_id in blocked_edges
+        ),
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert any(
+        check.name == "dependency-closure" and check.outcome == "fail"
+        for check in report.static_results[0].checks
+    )
+
+
+def test_model_proposed_passing_check_is_never_reported_verified(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(
+        tmp_path,
+        provenance=ContractProvenance.MODEL_PROPOSED,
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.reported_verifications[0].outcome.outcome == "pass"
+    assert report.reported_verifications[0].status == "model-claimed-pass"
+    assert report.reported_verifications[0].status != "verified"
+
+
+def test_candidate_cannot_self_label_arbitrary_contract_deterministic(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(
+        tmp_path,
+        provenance=ContractProvenance.DETERMINISTIC,
+        statement="An arbitrary candidate-authored equivalence claim.",
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.reported_verifications[0].outcome.outcome == "pass"
+    assert (
+        report.reported_verifications[0].contract.provenance
+        is ContractProvenance.MODEL_PROPOSED
+    )
+    assert report.reported_verifications[0].status == "model-claimed-pass"
+
+
+@pytest.mark.parametrize(
+    ("provenance", "expected_status", "expected_verdict"),
+    (
+        (
+            ContractProvenance.MODEL_PROPOSED,
+            "model-claimed-pass",
+            "BLOCKED",
+        ),
+        (
+            ContractProvenance.DETERMINISTIC,
+            "model-claimed-pass",
+            "BLOCKED",
+        ),
+    ),
+)
+def test_passing_fixture_respects_contract_provenance(
+    provenance: ContractProvenance,
+    expected_status: str,
+    expected_verdict: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(
+        tmp_path,
+        provenance=provenance,
+        verification_class=VerificationClass.ISOLATED_FIXTURE,
+    )
+    _stage(vault, candidate)
+
+    def fixture_pass(*_arguments) -> verification_module.VerificationAttempt:
+        return verification_module.VerificationAttempt(
+            VerificationClass.ISOLATED_FIXTURE,
+            VerificationClass.ISOLATED_FIXTURE,
+            "pass",
+            True,
+            "A closed synthetic fixture passed without real-vault or network access.",
+        )
+
+    monkeypatch.setattr(
+        verification_module,
+        "_run_isolated_fixture",
+        fixture_pass,
+    )
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == expected_verdict
+    assert report.reported_verifications[0].status == expected_status
+
+
+def test_generated_disposition_without_behaviour_contract_is_blocked(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert (
+        "Generated or native dispositions lack complete behavioural-contract "
+        "coverage."
+    ) in report.notes
+
+
+def test_native_replacement_without_authenticated_user_confirmation_is_blocked(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_capsule(tmp_path)
+    customization_id = candidate.files[0].customization_ids[0]
+    candidate = replace(
+        candidate,
+        dispositions=tuple(
+            replace(
+                item,
+                disposition=Disposition.NATIVE_REPLACEMENT,
+                native_witness="skill:daily-plan",
+                evidence_edge_ids=(),
+                behaviour_contract_ids=(),
+            )
+            if item.customization_id == customization_id
+            else item
+            for item in candidate.dispositions
+        ),
+        files=(),
+        dependency_remappings=(),
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert (
+        "Native replacement lacks authenticated user-confirmation evidence."
+        in report.notes
+    )
+
+
+def test_static_trust_permission_delta_blocks_declared_requirement(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    customization_id = candidate.files[0].customization_ids[0]
+    candidate = replace(
+        candidate,
+        declared_requirements=(
+            DeclaredRequirement(
+                RequirementKind.PERMISSION,
+                "Needs a new external permission.",
+                (customization_id,),
+            ),
+        ),
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert any(
+        check.name == "trust-permission-delta"
+        and check.outcome == "fail"
+        for check in report.static_results[0].checks
+    )
+
+
+def test_incomplete_staging_state_cannot_verify_ok(tmp_path: Path) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    journal = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+    journal.write_bytes(
+        b'{"event":"regeneration-proposed","schema_version":0}\n'
+    )
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "UNKNOWN"
+
+
+def test_live_target_hardlink_alias_blocks_private_staging(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    live = vault / candidate.files[0].target_path
+    live.write_bytes(candidate.files[0].content)
+    os.chmod(live, 0o600)
+    staged = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+        / candidate.files[0].sha256
+    )
+    staged.unlink()
+    os.link(live, staged)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.staged_paths_private is False
+
+
+@pytest.mark.parametrize(
+    "verification_class",
+    (
+        VerificationClass.ISOLATED_FIXTURE,
+        VerificationClass.READ_ONLY_LIVE,
+        VerificationClass.MANUAL,
+        VerificationClass.UNSAFE_UNVERIFIED,
+    ),
+)
+def test_unexercised_equivalence_is_unsafe_and_blocks(
+    verification_class: VerificationClass,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(
+        tmp_path,
+        verification_class=verification_class,
+    )
+    _stage(vault, candidate)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.reported_verifications[0].status == "unknown"
+    assert "unsafe-unverified" in (
+        report.reported_verifications[0].outcome.evidence_note
+    )
+
+
+def test_required_static_check_cannot_be_disabled_without_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    monkeypatch.delitem(
+        verification_module._STATIC_CHECK_RUNNERS,
+        "ownership-authorization",
+    )
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert any(
+        check.name == "ownership-authorization"
+        and check.outcome == "fail"
+        for check in report.static_results[0].checks
+    )
+
+
+def test_equal_byte_hardlink_at_another_live_path_blocks_private_staging(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    staged_blob = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+        / candidate.files[0].sha256
+    )
+    live_alias = vault / "Notes" / "alias.md"
+    live_alias.parent.mkdir()
+    os.link(staged_blob, live_alias)
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.staged_paths_private is False
+
+
+def test_staging_parent_symlink_swap_during_static_read_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    files = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+    )
+    moved_files = files.with_name("files-moved")
+    original_content_check = verification_module._STATIC_CHECK_RUNNERS[
+        "content-digest"
+    ]
+    swapped = False
+
+    def swap_then_check(context):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            files.rename(moved_files)
+            files.symlink_to(moved_files, target_is_directory=True)
+        return original_content_check(context)
+
+    monkeypatch.setitem(
+        verification_module._STATIC_CHECK_RUNNERS,
+        "content-digest",
+        swap_then_check,
+    )
+
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert report.verdict == "BLOCKED"
+    assert report.static_results[0].status == "BLOCKED"
+    assert report.staged_paths_private is False
+
+
+def test_writing_report_is_capsule_confined_and_advances_staging_journal(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    outside_before = _non_lifecycle_bytes(vault)
+    capsule_before = _capsule_bytes(vault, candidate.capsule_id)
+
+    receipt = write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+
+    capsule_after = _capsule_bytes(vault, candidate.capsule_id)
+    changed = {
+        path
+        for path in capsule_before.keys() | capsule_after.keys()
+        if capsule_before.get(path) != capsule_after.get(path)
+    }
+    report_path = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    )
+    assert report_path.read_bytes() == report.canonical_bytes()
+    assert receipt.report_path.endswith(
+        f"/verification/{candidate.proposal_id}.json"
+    )
+    assert changed == {
+        f"verification/{candidate.proposal_id}.json",
+        f"candidates/{candidate.proposal_id}/staging/journal.jsonl",
+    }
+    assert _non_lifecycle_bytes(vault) == outside_before
+    assert read_staging_status(vault, candidate.capsule_id).proposals[0].state is (
+        MigrationState.VERIFICATION_PASSED
+    )
+    assert not (vault / candidate.files[0].target_path).exists()
+
+
+def test_stale_ok_report_cannot_commit_after_staged_bytes_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    journal = staging / "journal.jsonl"
+    journal_before = journal.read_bytes()
+    blob = staging / "files" / candidate.files[0].sha256
+    original_snapshot = Transaction._snapshot_phase
+
+    def tamper_then_snapshot(transaction: Transaction) -> None:
+        blob.write_bytes(b"changed after report refresh\n")
+        original_snapshot(transaction)
+
+    monkeypatch.setattr(Transaction, "_snapshot_phase", tamper_then_snapshot)
+
+    with pytest.raises(VerificationError, match="drifted"):
+        write_verification_report(
+            vault,
+            candidate.capsule_id,
+            candidate.proposal_id,
+            report,
+        )
+
+    assert journal.read_bytes() == journal_before
+    assert not (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    ).exists()
+
+
+def test_staged_drift_after_engine_verify_cannot_commit_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    journal = staging / "journal.jsonl"
+    journal_before = journal.read_bytes()
+    blob = staging / "files" / candidate.files[0].sha256
+
+    def tamper_after_layout(name: str) -> None:
+        if name == "verification-after-layout":
+            blob.write_bytes(b"changed after engine verify\n")
+
+    monkeypatch.setattr(
+        verification_module,
+        "_verification_stop_seam",
+        tamper_after_layout,
+    )
+
+    with pytest.raises(VerificationError, match="drifted"):
+        write_verification_report(
+            vault,
+            candidate.capsule_id,
+            candidate.proposal_id,
+            report,
+        )
+
+    assert journal.read_bytes() == journal_before
+    assert not (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    ).exists()
+
+
+def test_tampered_persisted_report_projects_recovery_required(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+    report_path = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    )
+    report_path.write_bytes(b"{}\n")
+
+    status = read_staging_status(vault, candidate.capsule_id)
+
+    assert status.proposals[0].state is MigrationState.RECOVERY_REQUIRED
+
+
+def test_rehashed_but_schema_invalid_report_is_recovery_required_and_broken(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+    capsule = vault / CAPSULE_ROOT / candidate.capsule_id
+    report_path = capsule / "verification" / f"{candidate.proposal_id}.json"
+    report_path.write_bytes(b"{}\n")
+    journal = (
+        capsule
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+    records = [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+    ]
+    records[-1]["report_sha256"] = hashlib.sha256(b"{}\n").hexdigest()
+    journal.write_bytes(
+        b"".join(
+            (
+                json.dumps(
+                    record,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            ).encode("utf-8")
+            for record in records
+        )
+    )
+
+    status = read_staging_status(vault, candidate.capsule_id)
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert status.proposals[0].state is MigrationState.RECOVERY_REQUIRED
+    assert validation.status == "BROKEN"
+    assert "verification/report-schema" in validation.mismatches
+
+
+@pytest.mark.parametrize("mode_target", ("report", "directory"))
+def test_verification_report_modes_are_sealed(
+    mode_target: str,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+    verification_dir = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+    )
+    report_path = verification_dir / f"{candidate.proposal_id}.json"
+    os.chmod(
+        report_path if mode_target == "report" else verification_dir,
+        0o644 if mode_target == "report" else 0o777,
+    )
+
+    status = read_staging_status(vault, candidate.capsule_id)
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert status.proposals[0].state is MigrationState.RECOVERY_REQUIRED
+    assert validation.status == "BROKEN"
+    assert "verification/report-mode" in validation.mismatches
+
+
+def test_missing_bound_verification_report_is_unknown_not_ok(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+    (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    ).unlink()
+
+    status = read_staging_status(vault, candidate.capsule_id)
+    validation = validate_staging(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+
+    assert status.proposals[0].state is MigrationState.RECOVERY_REQUIRED
+    assert validation.status == "UNKNOWN"
+    assert "verification/report-missing" in validation.mismatches
+
+
+def test_existing_verification_report_refuses_without_clobber(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    report_path = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    )
+    journal = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+    journal_before = journal.read_bytes()
+    report_path.parent.mkdir()
+    report_path.write_bytes(b"competing verification report\n")
+
+    with pytest.raises(VerificationError, match="already exists"):
+        write_verification_report(
+            vault,
+            candidate.capsule_id,
+            candidate.proposal_id,
+            report,
+        )
+
+    assert report_path.read_bytes() == b"competing verification report\n"
+    assert journal.read_bytes() == journal_before
+
+
+@pytest.mark.parametrize(
+    "seam",
+    (
+        "after-begin",
+        "after-snapshot",
+        "mid-apply:0",
+        "mid-apply:1",
+        "after-apply",
+        "after-verify",
+        "before-finalize",
+        "verification-after-layout",
+        "verification-mid-finalize",
+    ),
+)
+def test_verification_report_crash_resumes_to_absent_and_staged(
+    seam: str,
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    report_pickle = tmp_path / "report.pickle"
+    report_pickle.write_bytes(pickle.dumps(report))
+    staging = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+    )
+    journal = staging / "journal.jsonl"
+    journal_before = journal.read_bytes()
+    script = (
+        "from pathlib import Path\n"
+        "import pickle,sys\n"
+        "from core.customization_migration.verification import "
+        "write_verification_report\n"
+        "vault=Path(sys.argv[1])\n"
+        "report=pickle.loads(Path(sys.argv[2]).read_bytes())\n"
+        "write_verification_report("
+        "vault,report.capsule_id,report.proposal_id,report)\n"
+    )
+    environment = dict(os.environ)
+    environment["DEX_TX_TEST_STOP_AFTER"] = seam
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+
+    child = subprocess.run(
+        [sys.executable, "-c", script, str(vault), str(report_pickle)],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert child.returncode == 137, (seam, child.stderr[-500:])
+    Transaction.resume(vault)
+    assert journal.read_bytes() == journal_before
+    assert not (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "verification"
+        / f"{candidate.proposal_id}.json"
+    ).exists()
+    assert read_staging_status(vault, candidate.capsule_id).proposals[0].state is (
+        MigrationState.REGENERATION_STAGED
+    )
+
+
+def test_blocked_report_advances_journal_to_verification_blocked(
+    tmp_path: Path,
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    _stage(vault, candidate)
+    staged_blob = (
+        vault
+        / CAPSULE_ROOT
+        / candidate.capsule_id
+        / "candidates"
+        / candidate.proposal_id
+        / "staging"
+        / "files"
+        / candidate.files[0].sha256
+    )
+    staged_blob.write_bytes(b"tampered staged bytes\n")
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+
+    assert report.verdict == "BLOCKED"
+    assert read_staging_status(vault, candidate.capsule_id).proposals[0].state is (
+        MigrationState.VERIFICATION_BLOCKED
+    )


### PR DESCRIPTION
Stages an accepted regeneration candidate and proves it — without ever touching a live user seam.

**Staging** writes only into the capsule's own `candidates/<proposal>/staging/` area, through the existing sealed customization-migration transaction. No new engine surface, no second write path, app-level no-clobber, and capsule-style converge-to-absent crash recovery — mirroring the merged `create_capsule` exactly. Staged files are never placed at their live target paths.

**Verification** runs the static ladder over staged candidates and persists a closed report through the same sealed authority. **Amendment 3 holds:** a reported status of `verified` is impossible for model-proposed provenance — only the exact code-registered deterministic contract can reach it when the ladder actually passes; everything else is model-claimed-pass / blocked / unknown. Isolated-fixture and read-only-live are declared but resolve to unsafe-unverified in v0; nothing is auto-promoted; no candidate code is ever executed (parse-only).

## Scope discipline
Two new modules + exports + two test files only. The core transaction engine, snapshot, journal, and capsule.py are **byte-identical to main** (an earlier build over-reached into the engine; that was rejected and reverted).

## Verification
- 139 targeted + full local suite green; all PR gates green (portable-contract, distribution, test-delta, path-contract, PII, architecture-inventory); ruff clean.
- **Independent adversarial review (Opus): no blocker, no serious.** All seven probed invariants held empirically — confinement, one-write-authority, Amendment-3 provenance, crash-convergence, drift/replay refusal, no-code-execution, hostile-dir robustness. Engine/capsule confirmed unchanged. The read-only MCP server has no reach to any write primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSS5ozU6tnNYXmEKv5JLje