### PR TITLE
[HELD for rehearsal] Customization migration Lane G: activation + rewind

### DIFF
--- a/core/customization_migration/__init__.py
+++ b/core/customization_migration/__init__.py
@@ -102,20 +102,51 @@ _LAZY_VERIFICATION_EXPORTS = frozenset(
         "write_verification_report",
     }
 )
+_LAZY_ACTIVATION_EXPORTS = frozenset(
+    {
+        "ActivatedFile",
+        "ActivationError",
+        "ActivationFile",
+        "ActivationPreview",
+        "ActivationReceipt",
+        "ActivationStatus",
+        "RewindFile",
+        "RewindPreview",
+        "RewindReceipt",
+        "activate",
+        "activation_receipt_from_bytes",
+        "preview_activation",
+        "preview_rewind",
+        "read_activation_status",
+        "rewind",
+    }
+)
 
 
 def __getattr__(name: str) -> object:
-    if name not in _LAZY_VERIFICATION_EXPORTS:
+    if name in _LAZY_VERIFICATION_EXPORTS:
+        from core.customization_migration import verification
+
+        value = getattr(verification, name)
+    elif name in _LAZY_ACTIVATION_EXPORTS:
+        from core.customization_migration import activation
+
+        value = getattr(activation, name)
+    else:
         raise AttributeError(
             f"module {__name__!r} has no attribute {name!r}"
         )
-    from core.customization_migration import verification
 
-    value = getattr(verification, name)
     globals()[name] = value
     return value
 
 __all__ = [
+    "ActivatedFile",
+    "ActivationError",
+    "ActivationFile",
+    "ActivationPreview",
+    "ActivationReceipt",
+    "ActivationStatus",
     "Assessment",
     "AssessmentAssignment",
     "AssessmentExclusion",
@@ -157,6 +188,9 @@ __all__ = [
     "RegenerationCandidate",
     "ReferenceConfidence",
     "ReferenceEdge",
+    "RewindFile",
+    "RewindPreview",
+    "RewindReceipt",
     "ReportedVerification",
     "RequirementKind",
     "SECRET_ARCHIVAL_POLICY",
@@ -176,6 +210,8 @@ __all__ = [
     "VerificationReport",
     "VerificationWriteReceipt",
     "assess",
+    "activate",
+    "activation_receipt_from_bytes",
     "abandon_capsule",
     "assessment_report",
     "assessment_to_dict",
@@ -186,8 +222,11 @@ __all__ = [
     "load_staged_candidate",
     "project_state",
     "preview_capsule",
+    "preview_activation",
+    "preview_rewind",
     "preview_staging",
     "read_capsule_status",
+    "read_activation_status",
     "read_staging_status",
     "stage_candidate",
     "validate_transition",
@@ -196,6 +235,7 @@ __all__ = [
     "validate_capsule",
     "validate_staging",
     "verify_staging",
+    "rewind",
     "write_verification_report",
     "CAPSULE_ROOT",
 ]

--- a/core/customization_migration/activation.py
+++ b/core/customization_migration/activation.py
@@ -1,0 +1,1847 @@
+"""Consent-agnostic live activation and receipt-backed rewind.
+
+These primitives are called only after the Doctor/CLI layer has collected a
+real interactive confirmation. The approval and acknowledgement tokens below
+bind integrity; they are reproducible hashes and therefore non-secret by
+construction (threat-model amendment A1).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from core import portable_contract
+from core.customization_migration.capsule import CAPSULE_ROOT
+from core.customization_migration.capsule_model import CAPSULE_ID
+from core.customization_migration.model import SHA256
+from core.customization_migration.planning import (
+    PROPOSAL_ID,
+    Disposition,
+    RegenerationCandidate,
+)
+from core.customization_migration.staging import (
+    STAGING_SUBDIR,
+    StagingError,
+    _append_event,
+    _assessment_from_capsule,
+    _read_event_records_beneath,
+    _read_regular_beneath,
+    _validate_candidate_against_capsule,
+    load_staged_candidate,
+    read_staging_status,
+    validate_staging,
+)
+from core.customization_migration.state import MigrationEvent, MigrationState
+from core.customization_migration.verification import (
+    VerificationError,
+    VerificationReport,
+    validate_persisted_verification_report,
+    verify_staging,
+)
+from core.path_safety import unsafe_existing_parent
+from core.transaction.engine import (
+    TX_ROOT_RELATIVE,
+    PlanEntry,
+    PlanRejected,
+    Transaction,
+    TransactionError,
+)
+from core.transaction.journal import Journal, JournalCorruptError
+from core.transaction.lock import LockBusyError
+from core.transaction.snapshot import SnapshotEntry, SnapshotError
+
+_MAX_LIVE_BYTES = 1024 * 1024
+_MAX_RECEIPT_BYTES = 1024 * 1024
+_SNAPSHOT_RETENTION_NOTE = (
+    "The transaction engine keeps only the newest three committed snapshots."
+)
+_REWIND_NOTE = (
+    "Rewind is available only while this snapshot remains retained and every "
+    "activated live file still matches the receipt."
+)
+_TX_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_PLAN_ENTRY_KEYS = frozenset(
+    {
+        "relative",
+        "operation",
+        "sha256",
+        "mode",
+        "size",
+        "expected_current_sha256",
+        "expected_absent",
+    }
+)
+_SNAPSHOT_ENTRY_KEYS = frozenset(
+    {"relative", "existed", "mode", "sha256", "size"}
+)
+
+
+class ActivationError(RuntimeError):
+    """Activation or rewind refused without claiming a partial result."""
+
+
+def _canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _canonical_relative(value: str, *, name: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise ValueError(f"{name} must be a canonical relative path")
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError(f"{name} must be a canonical relative path")
+    return value
+
+
+def _digest(value: str, *, name: str) -> str:
+    if not isinstance(value, str) or SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase sha256")
+    return value
+
+
+def _mode(value: int, *, name: str) -> int:
+    if type(value) is not int or not 0 <= value <= 0o777:
+        raise ValueError(f"{name} must contain only permission bits")
+    return value
+
+
+def _closed(
+    value: object,
+    *,
+    keys: frozenset[str],
+    name: str,
+) -> dict[str, object]:
+    if not isinstance(value, dict) or frozenset(value) != keys:
+        raise ActivationError(f"{name} has an invalid closed shape")
+    return value
+
+
+@dataclass(frozen=True)
+class ActivationFile:
+    target_path: str
+    previous_sha256: str | None
+    sha256: str
+    mode: int
+    expected_absent: bool
+
+    def __post_init__(self) -> None:
+        _canonical_relative(self.target_path, name="activation target_path")
+        if self.previous_sha256 is not None:
+            _digest(self.previous_sha256, name="activation previous_sha256")
+        _digest(self.sha256, name="activation sha256")
+        _mode(self.mode, name="activation mode")
+        if type(self.expected_absent) is not bool:
+            raise TypeError("activation expected_absent must be boolean")
+        if self.expected_absent != (self.previous_sha256 is None):
+            raise ValueError(
+                "activation expected_absent must exactly match the previous state"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target_path": self.target_path,
+            "previous_sha256": self.previous_sha256,
+            "sha256": self.sha256,
+            "mode": self.mode,
+            "expected_absent": self.expected_absent,
+        }
+
+
+@dataclass(frozen=True)
+class ActivationPreview:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    verification_report_sha256: str
+    candidate_sha256: str
+    files: tuple[ActivationFile, ...]
+    snapshot_retention_note: str
+    rewind_note: str
+    approval_token: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported activation preview schema_version")
+        if CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("activation preview capsule_id is not canonical")
+        if PROPOSAL_ID.fullmatch(self.proposal_id) is None:
+            raise ValueError("activation preview proposal_id is not canonical")
+        _digest(
+            self.verification_report_sha256,
+            name="activation verification_report_sha256",
+        )
+        _digest(self.candidate_sha256, name="activation candidate_sha256")
+        if not isinstance(self.files, tuple) or any(
+            type(item) is not ActivationFile for item in self.files
+        ):
+            raise TypeError("activation preview files must be ActivationFile records")
+        if self.files != tuple(sorted(self.files, key=lambda item: item.target_path)):
+            raise ValueError("activation preview files must be sorted")
+        if len({item.target_path for item in self.files}) != len(self.files):
+            raise ValueError("activation preview target paths must be unique")
+        if (
+            self.snapshot_retention_note != _SNAPSHOT_RETENTION_NOTE
+            or self.rewind_note != _REWIND_NOTE
+        ):
+            raise ValueError("activation preview safety notes are not canonical")
+        _digest(self.approval_token, name="activation approval_token")
+
+    def _unsigned_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "verification_report_sha256": self.verification_report_sha256,
+            "candidate_sha256": self.candidate_sha256,
+            "files": [item.to_dict() for item in self.files],
+            "snapshot_retention_note": self.snapshot_retention_note,
+            "rewind_note": self.rewind_note,
+        }
+
+    def canonical_preview_bytes(self) -> bytes:
+        return _canonical_json(self._unsigned_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._unsigned_dict()
+        result["approval_token"] = self.approval_token
+        return result
+
+
+@dataclass(frozen=True)
+class ActivatedFile:
+    path: str
+    sha256: str
+    byte_size: int
+    mode: int
+
+    def __post_init__(self) -> None:
+        _canonical_relative(self.path, name="activated path")
+        _digest(self.sha256, name="activated sha256")
+        if type(self.byte_size) is not int or self.byte_size <= 0:
+            raise ValueError("activated byte_size must be positive")
+        _mode(self.mode, name="activated mode")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "sha256": self.sha256,
+            "byte_size": self.byte_size,
+            "mode": self.mode,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: object) -> ActivatedFile:
+        value = _closed(
+            raw,
+            keys=frozenset({"path", "sha256", "byte_size", "mode"}),
+            name="activated file",
+        )
+        try:
+            return cls(
+                value["path"],
+                value["sha256"],
+                value["byte_size"],
+                value["mode"],
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError("activated file is invalid") from error
+
+
+@dataclass(frozen=True)
+class ActivationReceipt:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    verification_report_sha256: str
+    candidate_sha256: str
+    files_written: tuple[ActivatedFile, ...]
+    transaction_id: str
+    snapshot_ref: str
+    activated_epoch_seconds: int
+    rewind_available: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported activation receipt schema_version")
+        if CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("activation receipt capsule_id is not canonical")
+        if PROPOSAL_ID.fullmatch(self.proposal_id) is None:
+            raise ValueError("activation receipt proposal_id is not canonical")
+        _digest(
+            self.verification_report_sha256,
+            name="receipt verification_report_sha256",
+        )
+        _digest(self.candidate_sha256, name="receipt candidate_sha256")
+        if not isinstance(self.files_written, tuple) or not self.files_written or any(
+            type(item) is not ActivatedFile for item in self.files_written
+        ):
+            raise TypeError(
+                "activation receipt files_written must be non-empty ActivatedFile records"
+            )
+        if self.files_written != tuple(
+            sorted(self.files_written, key=lambda item: item.path)
+        ):
+            raise ValueError("activation receipt files_written must be sorted")
+        if len({item.path for item in self.files_written}) != len(self.files_written):
+            raise ValueError("activation receipt repeats a live path")
+        if not isinstance(self.transaction_id, str) or _TX_ID.fullmatch(
+            self.transaction_id
+        ) is None:
+            raise ValueError("activation receipt transaction_id is not canonical")
+        expected_snapshot = (
+            f"System/.dex/tx/{self.transaction_id}/snapshot"
+        )
+        if self.snapshot_ref != expected_snapshot:
+            raise ValueError(
+                "activation receipt snapshot_ref does not match its transaction"
+            )
+        if (
+            type(self.activated_epoch_seconds) is not int
+            or self.activated_epoch_seconds < 0
+        ):
+            raise ValueError("activation time must be a non-negative integer")
+        if self.rewind_available is not True:
+            raise ValueError(
+                "a newly committed activation must honestly mark rewind available"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "verification_report_sha256": self.verification_report_sha256,
+            "candidate_sha256": self.candidate_sha256,
+            "files_written": [item.to_dict() for item in self.files_written],
+            "transaction_id": self.transaction_id,
+            "snapshot_ref": self.snapshot_ref,
+            "activated_epoch_seconds": self.activated_epoch_seconds,
+            "rewind_available": self.rewind_available,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, raw: object) -> ActivationReceipt:
+        value = _closed(
+            raw,
+            keys=frozenset(
+                {
+                    "schema_version",
+                    "capsule_id",
+                    "proposal_id",
+                    "verification_report_sha256",
+                    "candidate_sha256",
+                    "files_written",
+                    "transaction_id",
+                    "snapshot_ref",
+                    "activated_epoch_seconds",
+                    "rewind_available",
+                }
+            ),
+            name="activation receipt",
+        )
+        raw_files = value["files_written"]
+        if not isinstance(raw_files, list):
+            raise ActivationError("activation receipt files_written must be a list")
+        try:
+            return cls(
+                value["schema_version"],
+                value["capsule_id"],
+                value["proposal_id"],
+                value["verification_report_sha256"],
+                value["candidate_sha256"],
+                tuple(ActivatedFile.from_dict(item) for item in raw_files),
+                value["transaction_id"],
+                value["snapshot_ref"],
+                value["activated_epoch_seconds"],
+                value["rewind_available"],
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError("activation receipt is invalid") from error
+
+
+def activation_receipt_from_bytes(raw: bytes) -> ActivationReceipt:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ActivationError("activation receipt is unreadable") from error
+    receipt = ActivationReceipt.from_dict(value)
+    if receipt.canonical_bytes() != raw:
+        raise ActivationError("activation receipt is not canonical")
+    return receipt
+
+
+@dataclass(frozen=True)
+class ActivationStatus:
+    capsule_id: str
+    proposal_id: str | None
+    state: MigrationState
+    reason: str
+
+
+@dataclass(frozen=True)
+class RewindFile:
+    path: str
+    existed_before_activation: bool
+    restored_sha256: str | None
+    byte_size: int | None
+    mode: int | None
+
+    def __post_init__(self) -> None:
+        _canonical_relative(self.path, name="rewind path")
+        if type(self.existed_before_activation) is not bool:
+            raise TypeError("rewind existed_before_activation must be boolean")
+        if self.existed_before_activation:
+            _digest(self.restored_sha256, name="rewind restored_sha256")
+            if type(self.byte_size) is not int or self.byte_size < 0:
+                raise ValueError("rewind byte_size must be non-negative")
+            _mode(self.mode, name="rewind mode")
+        elif any(
+            value is not None
+            for value in (self.restored_sha256, self.byte_size, self.mode)
+        ):
+            raise ValueError("an absent rewind state must carry null file evidence")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "existed_before_activation": self.existed_before_activation,
+            "restored_sha256": self.restored_sha256,
+            "byte_size": self.byte_size,
+            "mode": self.mode,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: object) -> RewindFile:
+        value = _closed(
+            raw,
+            keys=frozenset(
+                {
+                    "path",
+                    "existed_before_activation",
+                    "restored_sha256",
+                    "byte_size",
+                    "mode",
+                }
+            ),
+            name="rewind file",
+        )
+        try:
+            return cls(
+                value["path"],
+                value["existed_before_activation"],
+                value["restored_sha256"],
+                value["byte_size"],
+                value["mode"],
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError("rewind file is invalid") from error
+
+
+@dataclass(frozen=True)
+class RewindPreview:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    activation_transaction_id: str
+    status: str
+    reason: str
+    files: tuple[RewindFile, ...]
+    acknowledgement_token: str | None
+
+
+@dataclass(frozen=True)
+class RewindReceipt:
+    schema_version: int
+    capsule_id: str
+    proposal_id: str
+    activation_transaction_id: str
+    rewind_transaction_id: str | None
+    status: str
+    reason: str
+    files_restored: tuple[RewindFile, ...]
+    rewound_epoch_seconds: int | None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 0:
+            raise ValueError("unsupported rewind receipt schema_version")
+        if CAPSULE_ID.fullmatch(self.capsule_id) is None:
+            raise ValueError("rewind receipt capsule_id is not canonical")
+        if PROPOSAL_ID.fullmatch(self.proposal_id) is None:
+            raise ValueError("rewind receipt proposal_id is not canonical")
+        if (
+            not isinstance(self.activation_transaction_id, str)
+            or _TX_ID.fullmatch(self.activation_transaction_id) is None
+        ):
+            raise ValueError(
+                "rewind receipt activation_transaction_id is not canonical"
+            )
+        if not isinstance(self.reason, str) or not self.reason:
+            raise ValueError("rewind receipt reason must be non-empty")
+        if not isinstance(self.files_restored, tuple) or any(
+            type(item) is not RewindFile for item in self.files_restored
+        ):
+            raise TypeError(
+                "rewind receipt files_restored must be RewindFile records"
+            )
+        if self.files_restored != tuple(
+            sorted(self.files_restored, key=lambda item: item.path)
+        ):
+            raise ValueError("rewind receipt files_restored must be sorted")
+        if len({item.path for item in self.files_restored}) != len(
+            self.files_restored
+        ):
+            raise ValueError("rewind receipt repeats a live path")
+        if self.status == "OK":
+            if (
+                not isinstance(self.rewind_transaction_id, str)
+                or _TX_ID.fullmatch(self.rewind_transaction_id) is None
+                or not self.files_restored
+                or type(self.rewound_epoch_seconds) is not int
+                or self.rewound_epoch_seconds < 0
+            ):
+                raise ValueError("successful rewind receipt evidence is incomplete")
+        elif self.status == "UNKNOWN":
+            if (
+                self.rewind_transaction_id is not None
+                or self.files_restored
+                or self.rewound_epoch_seconds is not None
+            ):
+                raise ValueError("unknown rewind receipt must not claim a restore")
+        else:
+            raise ValueError("rewind receipt status must be OK or UNKNOWN")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "capsule_id": self.capsule_id,
+            "proposal_id": self.proposal_id,
+            "activation_transaction_id": self.activation_transaction_id,
+            "rewind_transaction_id": self.rewind_transaction_id,
+            "status": self.status,
+            "reason": self.reason,
+            "files_restored": [item.to_dict() for item in self.files_restored],
+            "rewound_epoch_seconds": self.rewound_epoch_seconds,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, raw: object) -> RewindReceipt:
+        value = _closed(
+            raw,
+            keys=frozenset(
+                {
+                    "schema_version",
+                    "capsule_id",
+                    "proposal_id",
+                    "activation_transaction_id",
+                    "rewind_transaction_id",
+                    "status",
+                    "reason",
+                    "files_restored",
+                    "rewound_epoch_seconds",
+                }
+            ),
+            name="rewind receipt",
+        )
+        raw_files = value["files_restored"]
+        if not isinstance(raw_files, list):
+            raise ActivationError("rewind receipt files_restored must be a list")
+        try:
+            return cls(
+                value["schema_version"],
+                value["capsule_id"],
+                value["proposal_id"],
+                value["activation_transaction_id"],
+                value["rewind_transaction_id"],
+                value["status"],
+                value["reason"],
+                tuple(RewindFile.from_dict(item) for item in raw_files),
+                value["rewound_epoch_seconds"],
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError("rewind receipt is invalid") from error
+
+
+def rewind_receipt_from_bytes(raw: bytes) -> RewindReceipt:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ActivationError("rewind receipt is unreadable") from error
+    receipt = RewindReceipt.from_dict(value)
+    if receipt.canonical_bytes() != raw:
+        raise ActivationError("rewind receipt is not canonical")
+    return receipt
+
+
+@dataclass(frozen=True)
+class _VerifiedEvidence:
+    candidate: RegenerationCandidate
+    report: VerificationReport
+    report_sha256: str
+    journal_relative: str
+    journal_bytes: bytes
+
+
+def _activation_receipt_relative(capsule_id: str) -> str:
+    return f"{CAPSULE_ROOT}/{capsule_id}/receipts/activation.json"
+
+
+def _rewind_receipt_relative(capsule_id: str) -> str:
+    return f"{CAPSULE_ROOT}/{capsule_id}/receipts/rewind.json"
+
+
+def _proposal_journal_relative(capsule_id: str, proposal_id: str) -> str:
+    return (
+        f"{CAPSULE_ROOT}/{capsule_id}/"
+        + STAGING_SUBDIR.format(proposal_id=proposal_id)
+        + "/journal.jsonl"
+    )
+
+
+def _require_report_ok(report: VerificationReport) -> None:
+    if report.verdict != "OK":
+        raise ActivationError(
+            f"activation verification verdict is not OK: {report.verdict}"
+        )
+    if not report.staged_paths_private or not report.writes_confined_to_capsule:
+        raise ActivationError(
+            "activation verification did not prove private, capsule-confined staging"
+        )
+
+
+def _load_verified_evidence(
+    root: Path,
+    capsule_id: str,
+    proposal_id: str,
+) -> _VerifiedEvidence:
+    try:
+        candidate, _receipt, staging = load_staged_candidate(
+            root,
+            capsule_id,
+            proposal_id,
+        )
+        _validate_candidate_against_capsule(root, capsule_id, candidate)
+    except (OSError, StagingError) as error:
+        raise ActivationError(
+            "activation staging evidence is missing, invalid, or drifted"
+        ) from error
+    validation = validate_staging(root, capsule_id, proposal_id)
+    if validation.status != "OK":
+        raise ActivationError(
+            "activation staging integrity is not OK: "
+            + ", ".join(validation.mismatches)
+        )
+    journal_relative = _proposal_journal_relative(capsule_id, proposal_id)
+    try:
+        journal_bytes = _read_regular_beneath(
+            root,
+            journal_relative,
+            _MAX_RECEIPT_BYTES,
+        )
+        records = _read_event_records_beneath(root, journal_relative)
+    except (OSError, StagingError) as error:
+        raise ActivationError("activation staging journal is unreadable") from error
+    if (
+        len(records) != 3
+        or tuple(record["event"] for record in records[:2])
+        != (
+            MigrationEvent.REGENERATION_PROPOSED.value,
+            MigrationEvent.REGENERATION_STAGED.value,
+        )
+        or records[2]["event"]
+        not in {
+            MigrationEvent.VERIFICATION_PASSED.value,
+            MigrationEvent.VERIFICATION_BLOCKED.value,
+        }
+    ):
+        raise ActivationError(
+            "activation staging journal is not at a verified disposition"
+        )
+    binding = records[2]
+    expected_report_relative = (
+        f"{CAPSULE_ROOT}/{capsule_id}/verification/{proposal_id}.json"
+    )
+    if (
+        binding.get("report_path") != expected_report_relative
+        or binding.get("candidate_sha256") != candidate.candidate_sha256
+    ):
+        raise ActivationError("activation verification report binding drifted")
+    try:
+        report_raw = _read_regular_beneath(
+            root,
+            expected_report_relative,
+            _MAX_RECEIPT_BYTES,
+        )
+        report_sha256 = _sha256(report_raw)
+        if report_sha256 != binding.get("report_sha256"):
+            raise ActivationError("activation verification report digest drifted")
+        report = validate_persisted_verification_report(
+            report_raw,
+            candidate,
+            binding["event"],
+        )
+    except (OSError, KeyError, TypeError, VerificationError) as error:
+        if isinstance(error, ActivationError):
+            raise
+        raise ActivationError(
+            "activation persisted verification report is invalid"
+        ) from error
+    _require_report_ok(report)
+    fresh = verify_staging(root, capsule_id, proposal_id)
+    if fresh.canonical_bytes() != report_raw:
+        raise ActivationError("activation verification report drifted on re-derivation")
+
+    assessment, _assessment_digest = _assessment_from_capsule(root, capsule_id)
+    accounted_ids = {item.customization_id for item in candidate.dispositions}
+    expected_ids = {item.customization_id for item in assessment.records}
+    if accounted_ids != expected_ids:
+        raise ActivationError("activation dispositions do not completely account for evidence")
+    if any(
+        item.disposition is Disposition.BLOCKED
+        for item in candidate.dispositions
+    ):
+        raise ActivationError("activation has a blocked disposition")
+    for item in candidate.files:
+        relative = (
+            staging.relative_to(root).as_posix()
+            + f"/files/{item.sha256}"
+        )
+        try:
+            raw = _read_regular_beneath(root, relative, len(item.content))
+        except (OSError, StagingError) as error:
+            raise ActivationError(
+                f"activation staged bytes are unreadable: {item.target_path}"
+            ) from error
+        if raw != item.content or _sha256(raw) != item.sha256:
+            raise ActivationError(
+                f"activation staged bytes drifted: {item.target_path}"
+            )
+    return _VerifiedEvidence(
+        candidate,
+        report,
+        report_sha256,
+        journal_relative,
+        journal_bytes,
+    )
+
+
+def _read_live_state(
+    root: Path,
+    relative: str,
+) -> tuple[bool, str | None]:
+    unsafe_parent = unsafe_existing_parent(root, relative)
+    if unsafe_parent is not None:
+        raise ActivationError(f"activation target is unsafe: {relative} [{unsafe_parent}]")
+    target = root / relative
+    try:
+        metadata = target.lstat()
+    except FileNotFoundError:
+        return False, None
+    if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise ActivationError(
+            f"activation target is not a regular non-symlink file: {relative}"
+        )
+    try:
+        raw = _read_regular_beneath(root, relative, _MAX_LIVE_BYTES)
+    except (OSError, StagingError) as error:
+        raise ActivationError(
+            f"activation target is not safely readable: {relative}"
+        ) from error
+    return True, _sha256(raw)
+
+
+def preview_activation(
+    vault_root: Path,
+    capsule_id: str,
+    proposal_id: str,
+) -> ActivationPreview:
+    """Build a deterministic live plan without changing any vault path."""
+    root = Path(vault_root).resolve()
+    receipt_path = root / _activation_receipt_relative(capsule_id)
+    if receipt_path.exists() or receipt_path.is_symlink():
+        raise ActivationError(f"capsule is already activated: {capsule_id}")
+    evidence = _load_verified_evidence(root, capsule_id, proposal_id)
+    files: list[ActivationFile] = []
+    for item in evidence.candidate.files:
+        exists, previous_sha256 = _read_live_state(root, item.target_path)
+        verdict = portable_contract.update_write_verdict(
+            item.target_path,
+            exists=exists,
+            operation="customization-migration",
+        )
+        if not verdict.allowed:
+            raise ActivationError(
+                "activation target is no longer contract-authorized: "
+                f"{item.target_path} [{verdict.action}]"
+            )
+        files.append(
+            ActivationFile(
+                item.target_path,
+                previous_sha256,
+                item.sha256,
+                0o644,
+                not exists,
+            )
+        )
+    unsigned = ActivationPreview(
+        0,
+        capsule_id,
+        proposal_id,
+        evidence.report_sha256,
+        evidence.candidate.candidate_sha256,
+        tuple(sorted(files, key=lambda item: item.target_path)),
+        _SNAPSHOT_RETENTION_NOTE,
+        _REWIND_NOTE,
+        "0" * 64,
+    )
+    return ActivationPreview(
+        0,
+        capsule_id,
+        proposal_id,
+        evidence.report_sha256,
+        evidence.candidate.candidate_sha256,
+        unsigned.files,
+        _SNAPSHOT_RETENTION_NOTE,
+        _REWIND_NOTE,
+        _sha256(unsigned.canonical_preview_bytes()),
+    )
+
+
+def _transaction_id() -> str:
+    return (
+        time.strftime("%Y%m%dT%H%M%S")
+        + f"{time.time_ns():020d}-"
+        + uuid.uuid4().hex[:8]
+    )
+
+
+def _activation_stop_seam(name: str) -> None:
+    if os.environ.get("DEX_TX_TEST_STOP_AFTER") == name:
+        os._exit(137)
+
+
+def _matching_preview_files(
+    preview: ActivationPreview,
+    candidate: RegenerationCandidate,
+) -> dict[str, ActivationFile]:
+    by_path = {item.target_path: item for item in preview.files}
+    if set(by_path) != {item.target_path for item in candidate.files}:
+        raise ActivationError("activation preview file set drifted from staging")
+    for item in candidate.files:
+        planned = by_path[item.target_path]
+        if planned.sha256 != item.sha256 or planned.mode != 0o644:
+            raise ActivationError(
+                f"activation preview bytes or mode drifted: {item.target_path}"
+            )
+    return by_path
+
+
+def activate(
+    vault_root: Path,
+    preview: ActivationPreview,
+    approval_token: str,
+    *,
+    clock: Callable[[], int | float] = time.time,
+) -> ActivationReceipt:
+    """Commit every live file and its activation evidence in one transaction."""
+    if type(preview) is not ActivationPreview:
+        raise TypeError("preview must be ActivationPreview")
+    expected_token = _sha256(preview.canonical_preview_bytes())
+    if (
+        not isinstance(approval_token, str)
+        or not hmac.compare_digest(approval_token, preview.approval_token)
+        or not hmac.compare_digest(approval_token, expected_token)
+    ):
+        raise ActivationError("activation approval token does not match the preview")
+    root = Path(vault_root).resolve()
+    evidence = _load_verified_evidence(
+        root,
+        preview.capsule_id,
+        preview.proposal_id,
+    )
+    if (
+        evidence.candidate.candidate_sha256 != preview.candidate_sha256
+        or evidence.report_sha256 != preview.verification_report_sha256
+    ):
+        raise ActivationError("activation staging or verification evidence drifted")
+    preview_files = _matching_preview_files(preview, evidence.candidate)
+    activated_at = int(clock())
+    if activated_at < 0:
+        raise ActivationError("activation clock returned a negative time")
+    tx_id = _transaction_id()
+    receipt = ActivationReceipt(
+        0,
+        preview.capsule_id,
+        preview.proposal_id,
+        preview.verification_report_sha256,
+        preview.candidate_sha256,
+        tuple(
+            ActivatedFile(item.target_path, item.sha256, len(item.content), 0o644)
+            for item in evidence.candidate.files
+        ),
+        tx_id,
+        f"System/.dex/tx/{tx_id}/snapshot",
+        activated_at,
+        True,
+    )
+    receipt_relative = _activation_receipt_relative(preview.capsule_id)
+    plan: list[PlanEntry] = []
+    for item in evidence.candidate.files:
+        planned = preview_files[item.target_path]
+        verdict = portable_contract.update_write_verdict(
+            item.target_path,
+            exists=(root / item.target_path).exists(),
+            operation="customization-migration",
+        )
+        if not verdict.allowed:
+            raise ActivationError(
+                "activation target is no longer contract-authorized: "
+                f"{item.target_path} [{verdict.action}]"
+            )
+        plan.append(
+            PlanEntry(
+                item.target_path,
+                item.content,
+                mode=planned.mode,
+                expected_current_sha256=planned.previous_sha256,
+                expected_absent=planned.expected_absent,
+            )
+        )
+    plan.extend(
+        (
+            PlanEntry(
+                receipt_relative,
+                receipt.canonical_bytes(),
+                mode=0o600,
+                expected_absent=True,
+            ),
+            PlanEntry(
+                evidence.journal_relative,
+                evidence.journal_bytes,
+                mode=0o600,
+                expected_current_sha256=_sha256(evidence.journal_bytes),
+            ),
+        )
+    )
+    journal_path = root / evidence.journal_relative
+
+    def finalize_activation() -> None:
+        refreshed = _load_verified_evidence(
+            root,
+            preview.capsule_id,
+            preview.proposal_id,
+        )
+        if (
+            refreshed.candidate.candidate_sha256 != preview.candidate_sha256
+            or refreshed.report_sha256 != preview.verification_report_sha256
+        ):
+            raise ActivationError(
+                "activation evidence drifted during the live transaction"
+            )
+        _append_event(journal_path, MigrationEvent.ACTIVATION_PREVIEWED)
+        _activation_stop_seam("activation-after-previewed")
+        _append_event(journal_path, MigrationEvent.ACTIVATED)
+        _activation_stop_seam("activation-mid-finalize")
+
+    try:
+        transaction = Transaction._begin_with_id(
+            root,
+            plan,
+            allow_empty=False,
+            operation="customization-migration",
+            tx_id=tx_id,
+        )
+        transaction.run(before_commit=finalize_activation)
+    except ActivationError:
+        raise
+    except (
+        LockBusyError,
+        OSError,
+        PlanRejected,
+        SnapshotError,
+        StagingError,
+        TransactionError,
+        VerificationError,
+    ) as error:
+        raise ActivationError(f"activation refused safely: {error}") from error
+    return receipt
+
+
+def _load_activation_receipt(root: Path, capsule_id: str) -> ActivationReceipt:
+    relative = _activation_receipt_relative(capsule_id)
+    try:
+        raw = _read_regular_beneath(root, relative, _MAX_RECEIPT_BYTES)
+    except (OSError, StagingError) as error:
+        raise ActivationError("activation receipt is missing or unsafe") from error
+    receipt = activation_receipt_from_bytes(raw)
+    if receipt.capsule_id != capsule_id:
+        raise ActivationError("activation receipt capsule identity does not match")
+    return receipt
+
+
+def _load_rewind_receipt(root: Path, capsule_id: str) -> RewindReceipt:
+    relative = _rewind_receipt_relative(capsule_id)
+    try:
+        raw = _read_regular_beneath(root, relative, _MAX_RECEIPT_BYTES)
+    except (OSError, StagingError) as error:
+        raise ActivationError("rewind receipt is missing or unsafe") from error
+    receipt = rewind_receipt_from_bytes(raw)
+    if receipt.capsule_id != capsule_id:
+        raise ActivationError("rewind receipt capsule identity does not match")
+    return receipt
+
+
+def read_activation_status(
+    vault_root: Path,
+    capsule_id: str,
+) -> ActivationStatus:
+    """Project activation state; corrupt receipt/journal evidence fails closed."""
+    if not isinstance(capsule_id, str) or CAPSULE_ID.fullmatch(capsule_id) is None:
+        raise ActivationError("capsule_id is not canonical")
+    root = Path(vault_root).resolve()
+    receipt_target = root / _activation_receipt_relative(capsule_id)
+    if receipt_target.is_symlink():
+        return ActivationStatus(
+            capsule_id,
+            None,
+            MigrationState.RECOVERY_REQUIRED,
+            "activation-receipt-unsafe",
+        )
+    try:
+        staging_status = read_staging_status(root, capsule_id)
+    except (OSError, StagingError):
+        return ActivationStatus(
+            capsule_id,
+            None,
+            MigrationState.RECOVERY_REQUIRED,
+            "staging-status-unreadable",
+        )
+    if receipt_target.exists():
+        try:
+            receipt = _load_activation_receipt(root, capsule_id)
+        except ActivationError:
+            return ActivationStatus(
+                capsule_id,
+                None,
+                MigrationState.RECOVERY_REQUIRED,
+                "activation-receipt-invalid",
+            )
+        state = next(
+            (
+                item.state
+                for item in staging_status.proposals
+                if item.proposal_id == receipt.proposal_id
+            ),
+            MigrationState.RECOVERY_REQUIRED,
+        )
+        if state not in {MigrationState.ACTIVATED, MigrationState.REWOUND}:
+            state = MigrationState.RECOVERY_REQUIRED
+        tx_root = (root / receipt.snapshot_ref).parent
+        if tx_root.is_symlink():
+            state = MigrationState.RECOVERY_REQUIRED
+        elif tx_root.is_dir():
+            try:
+                _verify_activation_commit(root, receipt)
+            except ActivationError:
+                state = MigrationState.RECOVERY_REQUIRED
+        if state is MigrationState.REWOUND:
+            try:
+                rewind_receipt = _load_rewind_receipt(root, capsule_id)
+                if (
+                    rewind_receipt.status != "OK"
+                    or rewind_receipt.proposal_id != receipt.proposal_id
+                    or rewind_receipt.activation_transaction_id
+                    != receipt.transaction_id
+                ):
+                    raise ActivationError(
+                        "rewind receipt does not match the activation"
+                    )
+                if rewind_receipt.rewind_transaction_id is None:
+                    raise ActivationError(
+                        "rewind receipt does not name a transaction"
+                    )
+                rewind_tx_root = (
+                    root
+                    / TX_ROOT_RELATIVE
+                    / rewind_receipt.rewind_transaction_id
+                )
+                if rewind_tx_root.is_symlink():
+                    raise ActivationError(
+                        "rewind transaction directory is unsafe"
+                    )
+                if rewind_tx_root.is_dir():
+                    _verify_rewind_commit(root, receipt, rewind_receipt)
+            except ActivationError:
+                state = MigrationState.RECOVERY_REQUIRED
+        return ActivationStatus(
+            capsule_id,
+            receipt.proposal_id,
+            state,
+            state.value,
+        )
+    if len(staging_status.proposals) == 1:
+        proposal = staging_status.proposals[0]
+        return ActivationStatus(
+            capsule_id,
+            proposal.proposal_id,
+            proposal.state,
+            proposal.state.value,
+        )
+    return ActivationStatus(
+        capsule_id,
+        None,
+        MigrationState.UNKNOWN,
+        "activation-not-found",
+    )
+
+
+def _validated_activation_receipt(
+    receipt: ActivationReceipt | object,
+) -> ActivationReceipt:
+    if isinstance(receipt, ActivationReceipt):
+        return ActivationReceipt.from_dict(receipt.to_dict())
+    try:
+        return ActivationReceipt.from_dict(receipt)
+    except (ActivationError, TypeError, ValueError) as error:
+        raise ActivationError("activation receipt is invalid") from error
+
+
+def _current_live_matches(
+    root: Path,
+    receipt: ActivationReceipt,
+) -> tuple[str, ...]:
+    drifted: list[str] = []
+    for item in receipt.files_written:
+        try:
+            exists, digest = _read_live_state(root, item.path)
+            target = root / item.path
+            metadata = target.lstat()
+            if (
+                not exists
+                or digest != item.sha256
+                or not stat.S_ISREG(metadata.st_mode)
+                or stat.S_ISLNK(metadata.st_mode)
+                or metadata.st_size != item.byte_size
+                or stat.S_IMODE(metadata.st_mode) != item.mode
+            ):
+                drifted.append(item.path)
+        except (ActivationError, OSError):
+            drifted.append(item.path)
+    return tuple(sorted(drifted))
+
+
+def _verify_activation_commit(
+    root: Path,
+    receipt: ActivationReceipt,
+) -> dict[str, dict[str, object]]:
+    journal_path = (root / receipt.snapshot_ref).parent / "journal.jsonl"
+    try:
+        entries = Journal(journal_path).read()
+    except (JournalCorruptError, OSError) as error:
+        raise ActivationError("activation transaction journal is damaged") from error
+    begins = [entry for entry in entries if entry.event == "BEGIN"]
+    events = [entry.event for entry in entries]
+    if (
+        len(begins) != 1
+        or begins[0].payload.get("tx_id") != receipt.transaction_id
+        or begins[0].payload.get("operation") != "customization-migration"
+        or events.count("COMMITTED") != 1
+        or "ROLLED-BACK" in events
+    ):
+        raise ActivationError(
+            "activation receipt does not point to one committed transaction"
+        )
+    try:
+        candidate, _staging_receipt, _staging = load_staged_candidate(
+            root,
+            receipt.capsule_id,
+            receipt.proposal_id,
+        )
+    except (OSError, StagingError) as error:
+        raise ActivationError(
+            "activation transaction no longer binds valid staged evidence"
+        ) from error
+    candidate_files = {
+        item.target_path: item
+        for item in candidate.files
+    }
+    receipt_files = {item.path: item for item in receipt.files_written}
+    if (
+        candidate.candidate_sha256 != receipt.candidate_sha256
+        or set(candidate_files) != set(receipt_files)
+    ):
+        raise ActivationError(
+            "activation receipt does not bind the complete staged candidate"
+        )
+    for relative, candidate_file in candidate_files.items():
+        receipt_file = receipt_files[relative]
+        if (
+            receipt_file.sha256 != candidate_file.sha256
+            or receipt_file.byte_size != len(candidate_file.content)
+            or receipt_file.mode != 0o644
+        ):
+            raise ActivationError(
+                f"activation receipt file evidence drifted: {relative}"
+            )
+    report_relative = (
+        f"{CAPSULE_ROOT}/{receipt.capsule_id}/verification/"
+        f"{receipt.proposal_id}.json"
+    )
+    try:
+        report_raw = _read_regular_beneath(
+            root,
+            report_relative,
+            _MAX_RECEIPT_BYTES,
+        )
+        report = validate_persisted_verification_report(
+            report_raw,
+            candidate,
+            MigrationEvent.VERIFICATION_PASSED.value,
+        )
+    except (OSError, StagingError, VerificationError) as error:
+        raise ActivationError(
+            "activation transaction verification evidence is invalid"
+        ) from error
+    if _sha256(report_raw) != receipt.verification_report_sha256:
+        raise ActivationError(
+            "activation receipt verification report digest drifted"
+        )
+    _require_report_ok(report)
+
+    raw_plan = begins[0].payload.get("plan")
+    if not isinstance(raw_plan, list):
+        raise ActivationError("activation transaction plan is invalid")
+    plan_by_path: dict[str, dict[str, object]] = {}
+    for index, raw in enumerate(raw_plan):
+        plan_entry = _closed(
+            raw,
+            keys=_PLAN_ENTRY_KEYS,
+            name=f"activation transaction plan entry {index}",
+        )
+        try:
+            relative = _canonical_relative(
+                plan_entry["relative"],
+                name="activation transaction plan path",
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError(
+                "activation transaction plan path is invalid"
+            ) from error
+        if relative in plan_by_path:
+            raise ActivationError("activation transaction plan repeats a path")
+        plan_by_path[relative] = plan_entry
+    receipt_relative = _activation_receipt_relative(receipt.capsule_id)
+    journal_relative = _proposal_journal_relative(
+        receipt.capsule_id,
+        receipt.proposal_id,
+    )
+    expected_paths = set(receipt_files) | {receipt_relative, journal_relative}
+    if set(plan_by_path) != expected_paths:
+        raise ActivationError(
+            "activation transaction plan does not exactly match its receipt"
+        )
+    for relative, receipt_file in receipt_files.items():
+        plan_entry = plan_by_path[relative]
+        expected_current = plan_entry["expected_current_sha256"]
+        expected_absent = plan_entry["expected_absent"]
+        if (
+            plan_entry["operation"] != "write"
+            or plan_entry["sha256"] != receipt_file.sha256
+            or plan_entry["size"] != receipt_file.byte_size
+            or plan_entry["mode"] != receipt_file.mode
+            or type(expected_absent) is not bool
+            or expected_absent == (expected_current is not None)
+            or (
+                expected_current is not None
+                and (
+                    not isinstance(expected_current, str)
+                    or SHA256.fullmatch(expected_current) is None
+                )
+            )
+        ):
+            raise ActivationError(
+                f"activation transaction plan evidence drifted: {relative}"
+            )
+    receipt_plan = plan_by_path[receipt_relative]
+    if (
+        receipt_plan["operation"] != "write"
+        or receipt_plan["sha256"] != _sha256(receipt.canonical_bytes())
+        or receipt_plan["size"] != len(receipt.canonical_bytes())
+        or receipt_plan["mode"] != 0o600
+        or receipt_plan["expected_current_sha256"] is not None
+        or receipt_plan["expected_absent"] is not True
+    ):
+        raise ActivationError("activation receipt is not bound to its transaction plan")
+    journal_plan = plan_by_path[journal_relative]
+    if (
+        journal_plan["operation"] != "write"
+        or journal_plan["mode"] != 0o600
+        or journal_plan["expected_absent"] is not False
+        or journal_plan["expected_current_sha256"] != journal_plan["sha256"]
+        or not isinstance(journal_plan["sha256"], str)
+        or SHA256.fullmatch(journal_plan["sha256"]) is None
+        or type(journal_plan["size"]) is not int
+        or journal_plan["size"] < 0
+    ):
+        raise ActivationError("activation journal is not bound to its transaction plan")
+    return plan_by_path
+
+
+def _verify_rewind_commit(
+    root: Path,
+    activation_receipt: ActivationReceipt,
+    rewind_receipt: RewindReceipt,
+) -> None:
+    if rewind_receipt.rewind_transaction_id is None:
+        raise ActivationError("rewind receipt does not name a transaction")
+    journal_path = (
+        root
+        / TX_ROOT_RELATIVE
+        / rewind_receipt.rewind_transaction_id
+        / "journal.jsonl"
+    )
+    try:
+        entries = Journal(journal_path).read()
+    except (JournalCorruptError, OSError) as error:
+        raise ActivationError("rewind transaction journal is damaged") from error
+    begins = [entry for entry in entries if entry.event == "BEGIN"]
+    events = [entry.event for entry in entries]
+    if (
+        len(begins) != 1
+        or begins[0].payload.get("tx_id")
+        != rewind_receipt.rewind_transaction_id
+        or begins[0].payload.get("operation") != "customization-migration"
+        or events.count("COMMITTED") != 1
+        or "ROLLED-BACK" in events
+    ):
+        raise ActivationError(
+            "rewind receipt does not point to one committed transaction"
+        )
+    restored_by_path = {
+        item.path: item for item in rewind_receipt.files_restored
+    }
+    activated_by_path = {
+        item.path: item for item in activation_receipt.files_written
+    }
+    if set(restored_by_path) != set(activated_by_path):
+        raise ActivationError(
+            "rewind receipt does not cover the complete activation"
+        )
+    raw_plan = begins[0].payload.get("plan")
+    if not isinstance(raw_plan, list):
+        raise ActivationError("rewind transaction plan is invalid")
+    plan_by_path: dict[str, dict[str, object]] = {}
+    for index, raw in enumerate(raw_plan):
+        plan_entry = _closed(
+            raw,
+            keys=_PLAN_ENTRY_KEYS,
+            name=f"rewind transaction plan entry {index}",
+        )
+        try:
+            relative = _canonical_relative(
+                plan_entry["relative"],
+                name="rewind transaction plan path",
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError(
+                "rewind transaction plan path is invalid"
+            ) from error
+        if relative in plan_by_path:
+            raise ActivationError("rewind transaction plan repeats a path")
+        plan_by_path[relative] = plan_entry
+    receipt_relative = _rewind_receipt_relative(
+        activation_receipt.capsule_id
+    )
+    journal_relative = _proposal_journal_relative(
+        activation_receipt.capsule_id,
+        activation_receipt.proposal_id,
+    )
+    expected_paths = set(restored_by_path) | {
+        receipt_relative,
+        journal_relative,
+    }
+    if set(plan_by_path) != expected_paths:
+        raise ActivationError(
+            "rewind transaction plan does not exactly match its receipt"
+        )
+    for relative, restored in restored_by_path.items():
+        activated = activated_by_path[relative]
+        plan_entry = plan_by_path[relative]
+        if restored.existed_before_activation:
+            valid = (
+                plan_entry["operation"] == "write"
+                and plan_entry["sha256"] == restored.restored_sha256
+                and plan_entry["size"] == restored.byte_size
+                and plan_entry["mode"] == restored.mode
+            )
+        else:
+            valid = (
+                plan_entry["operation"] == "delete"
+                and plan_entry["sha256"] is None
+                and plan_entry["size"] is None
+                and plan_entry["mode"] == activated.mode
+            )
+        if (
+            not valid
+            or plan_entry["expected_current_sha256"] != activated.sha256
+            or plan_entry["expected_absent"] is not False
+        ):
+            raise ActivationError(
+                f"rewind transaction plan evidence drifted: {relative}"
+            )
+    receipt_plan = plan_by_path[receipt_relative]
+    if (
+        receipt_plan["operation"] != "write"
+        or receipt_plan["sha256"] != _sha256(rewind_receipt.canonical_bytes())
+        or receipt_plan["size"] != len(rewind_receipt.canonical_bytes())
+        or receipt_plan["mode"] != 0o600
+        or receipt_plan["expected_current_sha256"] is not None
+        or receipt_plan["expected_absent"] is not True
+    ):
+        raise ActivationError("rewind receipt is not bound to its transaction plan")
+    journal_plan = plan_by_path[journal_relative]
+    if (
+        journal_plan["operation"] != "write"
+        or journal_plan["mode"] != 0o600
+        or journal_plan["expected_absent"] is not False
+        or journal_plan["expected_current_sha256"] != journal_plan["sha256"]
+        or not isinstance(journal_plan["sha256"], str)
+        or SHA256.fullmatch(journal_plan["sha256"]) is None
+        or type(journal_plan["size"]) is not int
+        or journal_plan["size"] < 0
+    ):
+        raise ActivationError("rewind journal is not bound to its transaction plan")
+
+
+def _read_snapshot_manifest(
+    root: Path,
+    receipt: ActivationReceipt,
+) -> tuple[SnapshotEntry, ...]:
+    relative = f"{receipt.snapshot_ref}/manifest.json"
+    try:
+        raw = _read_regular_beneath(root, relative, _MAX_RECEIPT_BYTES)
+        payload = json.loads(raw.decode("utf-8"))
+    except (
+        OSError,
+        StagingError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as error:
+        raise ActivationError("activation snapshot manifest is unreadable") from error
+    if (
+        not isinstance(payload, dict)
+        or frozenset(payload) != frozenset({"schema_version", "entries"})
+        or payload["schema_version"] != 1
+        or not isinstance(payload["entries"], list)
+    ):
+        raise ActivationError("activation snapshot manifest has an invalid shape")
+    manifest: list[SnapshotEntry] = []
+    for index, raw_entry in enumerate(payload["entries"]):
+        entry = _closed(
+            raw_entry,
+            keys=_SNAPSHOT_ENTRY_KEYS,
+            name=f"activation snapshot entry {index}",
+        )
+        try:
+            manifest.append(
+                SnapshotEntry(
+                    _canonical_relative(
+                        entry["relative"],
+                        name="activation snapshot path",
+                    ),
+                    entry["existed"],
+                    entry["mode"],
+                    entry["sha256"],
+                    entry["size"],
+                )
+            )
+        except (TypeError, ValueError) as error:
+            raise ActivationError("activation snapshot entry is invalid") from error
+    return tuple(manifest)
+
+
+def _snapshot_rewind_files(
+    root: Path,
+    receipt: ActivationReceipt,
+) -> tuple[tuple[RewindFile, ...], dict[str, bytes | None]]:
+    plan_by_path = _verify_activation_commit(root, receipt)
+    manifest = _read_snapshot_manifest(root, receipt)
+    by_path: dict[str, tuple[int, SnapshotEntry]] = {}
+    for index, entry in enumerate(manifest):
+        try:
+            relative = _canonical_relative(
+                entry.relative,
+                name="activation snapshot path",
+            )
+        except (AttributeError, TypeError, ValueError) as error:
+            raise ActivationError("activation snapshot path is invalid") from error
+        if relative in by_path:
+            raise ActivationError("activation snapshot repeats a path")
+        by_path[relative] = (index, entry)
+    if set(by_path) != set(plan_by_path):
+        raise ActivationError(
+            "activation snapshot does not exactly match the committed plan"
+        )
+    for relative, plan_entry in plan_by_path.items():
+        _index, entry = by_path[relative]
+        expected_current = plan_entry["expected_current_sha256"]
+        if plan_entry["expected_absent"] is True:
+            if entry.existed is not False or any(
+                value is not None for value in (entry.mode, entry.sha256, entry.size)
+            ):
+                raise ActivationError(
+                    f"activation snapshot absence evidence drifted: {relative}"
+                )
+        elif expected_current is not None:
+            if entry.existed is not True or entry.sha256 != expected_current:
+                raise ActivationError(
+                    f"activation snapshot current-byte evidence drifted: {relative}"
+                )
+        else:
+            raise ActivationError(
+                f"activation snapshot plan lacks a state precondition: {relative}"
+            )
+    files: list[RewindFile] = []
+    contents: dict[str, bytes | None] = {}
+    for receipt_file in receipt.files_written:
+        index, entry = by_path[receipt_file.path]
+        if type(entry.existed) is not bool:
+            raise ActivationError(
+                f"activation snapshot state is invalid: {receipt_file.path}"
+            )
+        if entry.existed:
+            if (
+                type(entry.mode) is not int
+                or not 0 <= entry.mode <= 0o777
+                or not isinstance(entry.sha256, str)
+                or SHA256.fullmatch(entry.sha256) is None
+                or type(entry.size) is not int
+                or not 0 <= entry.size <= _MAX_LIVE_BYTES
+            ):
+                raise ActivationError(
+                    f"activation snapshot evidence is invalid: {receipt_file.path}"
+                )
+            try:
+                raw = _read_regular_beneath(
+                    root,
+                    f"{receipt.snapshot_ref}/{index:06d}.bin",
+                    entry.size,
+                )
+            except (OSError, StagingError) as error:
+                raise ActivationError(
+                    f"activation snapshot blob is unreadable: {receipt_file.path}"
+                ) from error
+            if len(raw) != entry.size or _sha256(raw) != entry.sha256:
+                raise ActivationError(
+                    f"activation snapshot blob is damaged: {receipt_file.path}"
+                )
+            files.append(
+                RewindFile(
+                    receipt_file.path,
+                    True,
+                    entry.sha256,
+                    entry.size,
+                    entry.mode,
+                )
+            )
+            contents[receipt_file.path] = raw
+        else:
+            if any(
+                value is not None
+                for value in (entry.mode, entry.sha256, entry.size)
+            ):
+                raise ActivationError(
+                    f"activation absent snapshot is invalid: {receipt_file.path}"
+                )
+            files.append(
+                RewindFile(receipt_file.path, False, None, None, None)
+            )
+            contents[receipt_file.path] = None
+    return tuple(sorted(files, key=lambda item: item.path)), contents
+
+
+def _rewind_acknowledgement_token(receipt: ActivationReceipt) -> str:
+    payload = {
+        "rewind": receipt.transaction_id,
+        "activation_receipt_sha256": _sha256(receipt.canonical_bytes()),
+        "files": [item.path for item in receipt.files_written],
+    }
+    return _sha256(_canonical_json(payload))
+
+
+def _unknown_rewind_preview(
+    receipt: ActivationReceipt,
+    reason: str,
+) -> RewindPreview:
+    return RewindPreview(
+        0,
+        receipt.capsule_id,
+        receipt.proposal_id,
+        receipt.transaction_id,
+        "UNKNOWN",
+        reason,
+        (),
+        None,
+    )
+
+
+def preview_rewind(
+    vault_root: Path,
+    activation_receipt: ActivationReceipt | object,
+) -> RewindPreview:
+    """Report rewindability without mutating the vault."""
+    receipt = _validated_activation_receipt(activation_receipt)
+    root = Path(vault_root).resolve()
+    status = read_activation_status(root, receipt.capsule_id)
+    if status.state is MigrationState.REWOUND:
+        return _unknown_rewind_preview(receipt, "already-rewound")
+    if status.state is not MigrationState.ACTIVATED:
+        return _unknown_rewind_preview(receipt, "activation-not-active")
+    persisted = _load_activation_receipt(root, receipt.capsule_id)
+    if persisted != receipt:
+        return _unknown_rewind_preview(receipt, "activation-receipt-drift")
+    drifted = _current_live_matches(root, receipt)
+    if drifted:
+        return _unknown_rewind_preview(receipt, "live-drift")
+    snapshot_root = root / receipt.snapshot_ref
+    if snapshot_root.is_symlink() or not snapshot_root.is_dir():
+        return _unknown_rewind_preview(receipt, "snapshot-pruned")
+    try:
+        _verify_activation_commit(root, receipt)
+        files, _contents = _snapshot_rewind_files(root, receipt)
+    except ActivationError:
+        return _unknown_rewind_preview(receipt, "snapshot-damaged")
+    return RewindPreview(
+        0,
+        receipt.capsule_id,
+        receipt.proposal_id,
+        receipt.transaction_id,
+        "OK",
+        "ready",
+        files,
+        _rewind_acknowledgement_token(receipt),
+    )
+
+
+def _unknown_rewind_receipt(
+    receipt: ActivationReceipt,
+    reason: str,
+) -> RewindReceipt:
+    return RewindReceipt(
+        0,
+        receipt.capsule_id,
+        receipt.proposal_id,
+        receipt.transaction_id,
+        None,
+        "UNKNOWN",
+        reason,
+        (),
+        None,
+    )
+
+
+def rewind(
+    vault_root: Path,
+    activation_receipt: ActivationReceipt | object,
+    acknowledgement_token: str | None,
+    *,
+    clock: Callable[[], int | float] = time.time,
+) -> RewindReceipt:
+    """Restore the exact pre-activation live state in one new transaction."""
+    receipt = _validated_activation_receipt(activation_receipt)
+    root = Path(vault_root).resolve()
+    preview = preview_rewind(root, receipt)
+    if preview.status != "OK":
+        return _unknown_rewind_receipt(receipt, preview.reason)
+    if (
+        not isinstance(acknowledgement_token, str)
+        or preview.acknowledgement_token is None
+        or not hmac.compare_digest(
+            acknowledgement_token,
+            preview.acknowledgement_token,
+        )
+    ):
+        raise ActivationError(
+            "rewind acknowledgement token does not match the exact activation"
+        )
+    files, contents = _snapshot_rewind_files(root, receipt)
+    tx_id = _transaction_id()
+    rewound_at = int(clock())
+    if rewound_at < 0:
+        raise ActivationError("rewind clock returned a negative time")
+    result_receipt = RewindReceipt(
+        0,
+        receipt.capsule_id,
+        receipt.proposal_id,
+        receipt.transaction_id,
+        tx_id,
+        "OK",
+        "rewound",
+        files,
+        rewound_at,
+    )
+    journal_relative = _proposal_journal_relative(
+        receipt.capsule_id,
+        receipt.proposal_id,
+    )
+    try:
+        journal_bytes = _read_regular_beneath(
+            root,
+            journal_relative,
+            _MAX_RECEIPT_BYTES,
+        )
+    except (OSError, StagingError) as error:
+        raise ActivationError("rewind activation journal is unreadable") from error
+    plan: list[PlanEntry] = []
+    activated_by_path = {item.path: item for item in receipt.files_written}
+    for item in files:
+        activated = activated_by_path[item.path]
+        content = contents[item.path]
+        if item.existed_before_activation:
+            if content is None or item.mode is None:
+                raise ActivationError(
+                    f"rewind snapshot evidence is incomplete: {item.path}"
+                )
+            plan.append(
+                PlanEntry(
+                    item.path,
+                    content,
+                    mode=item.mode,
+                    expected_current_sha256=activated.sha256,
+                )
+            )
+        else:
+            plan.append(
+                PlanEntry(
+                    item.path,
+                    None,
+                    mode=activated.mode,
+                    expected_current_sha256=activated.sha256,
+                )
+            )
+    plan.extend(
+        (
+            PlanEntry(
+                _rewind_receipt_relative(receipt.capsule_id),
+                result_receipt.canonical_bytes(),
+                mode=0o600,
+                expected_absent=True,
+            ),
+            PlanEntry(
+                journal_relative,
+                journal_bytes,
+                mode=0o600,
+                expected_current_sha256=_sha256(journal_bytes),
+            ),
+        )
+    )
+    journal_path = root / journal_relative
+
+    def finalize_rewind() -> None:
+        for item in files:
+            target = root / item.path
+            if item.existed_before_activation:
+                if (
+                    item.restored_sha256 is None
+                    or item.byte_size is None
+                    or item.mode is None
+                ):
+                    raise ActivationError(
+                        f"rewind snapshot evidence is incomplete: {item.path}"
+                    )
+                exists, digest = _read_live_state(root, item.path)
+                metadata = target.lstat()
+                if (
+                    not exists
+                    or digest != item.restored_sha256
+                    or not stat.S_ISREG(metadata.st_mode)
+                    or stat.S_ISLNK(metadata.st_mode)
+                    or metadata.st_size != item.byte_size
+                    or stat.S_IMODE(metadata.st_mode) != item.mode
+                ):
+                    raise ActivationError(
+                        f"rewind verification failed: {item.path}"
+                    )
+            elif target.exists() or target.is_symlink():
+                raise ActivationError(
+                    f"rewind verification failed to restore absence: {item.path}"
+                )
+        _activation_stop_seam("rewind-before-journal")
+        _append_event(journal_path, MigrationEvent.REWOUND)
+        _activation_stop_seam("rewind-mid-finalize")
+
+    try:
+        transaction = Transaction._begin_with_id(
+            root,
+            plan,
+            allow_empty=False,
+            operation="customization-migration",
+            tx_id=tx_id,
+        )
+        transaction.run(before_commit=finalize_rewind)
+    except ActivationError:
+        raise
+    except PlanRejected as error:
+        if _current_live_matches(root, receipt):
+            return _unknown_rewind_receipt(receipt, "live-drift")
+        raise ActivationError(f"rewind refused safely: {error}") from error
+    except (
+        LockBusyError,
+        OSError,
+        SnapshotError,
+        StagingError,
+        TransactionError,
+    ) as error:
+        raise ActivationError(f"rewind refused safely: {error}") from error
+    return result_receipt
+
+
+__all__ = [
+    "ActivatedFile",
+    "ActivationError",
+    "ActivationFile",
+    "ActivationPreview",
+    "ActivationReceipt",
+    "ActivationStatus",
+    "RewindFile",
+    "RewindPreview",
+    "RewindReceipt",
+    "activate",
+    "activation_receipt_from_bytes",
+    "preview_activation",
+    "preview_rewind",
+    "read_activation_status",
+    "rewind",
+]

--- a/core/tests/test_customization_activation.py
+++ b/core/tests/test_customization_activation.py
@@ -1,0 +1,754 @@
+"""Lane G live activation and receipt-backed rewind journeys."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pickle
+import stat
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.customization_migration.activation import (
+    ActivatedFile,
+    ActivationError,
+    ActivationFile,
+    ActivationPreview,
+    ActivationReceipt,
+    activate,
+    preview_activation,
+    preview_rewind,
+    read_activation_status,
+    rewind,
+)
+from core.customization_migration.capsule import CAPSULE_ROOT
+from core.customization_migration.planning import CandidateFile, Disposition
+from core.customization_migration.staging import preview_staging, stage_candidate
+from core.customization_migration.state import MigrationState
+from core.customization_migration.verification import (
+    verify_staging,
+    write_verification_report,
+)
+from core.tests.lifecycle_test_helpers import write_file
+from core.tests.test_customization_staging import REPO_ROOT
+from core.tests.test_customization_verification import _candidate_with_contract
+from core.transaction.engine import PlanEntry, Transaction
+
+SECOND_TEST_SEAM = "System/Templates/activation-new.md"
+
+
+def test_activation_public_exports_are_available() -> None:
+    import core.customization_migration as customization_migration
+
+    assert customization_migration.ActivationPreview is not None
+    assert customization_migration.ActivationReceipt is not None
+    assert customization_migration.RewindReceipt is not None
+    assert customization_migration.preview_activation is preview_activation
+    assert customization_migration.activate is activate
+    assert customization_migration.preview_rewind is preview_rewind
+    assert customization_migration.rewind is rewind
+    assert customization_migration.read_activation_status is read_activation_status
+
+
+def test_activation_canonical_bytes_ignore_dict_order_with_non_ascii_path_and_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_path = "System/Templates/équipe-☕.md"
+    content = "# Café — déjà vu ☕\n".encode()
+    content_sha256 = hashlib.sha256(content).hexdigest()
+    activation_file = ActivationFile(
+        target_path,
+        None,
+        content_sha256,
+        0o644,
+        True,
+    )
+    preview = ActivationPreview(
+        0,
+        "cap-0123456789abcdef",
+        "prop-fedcba9876543210",
+        "1" * 64,
+        "2" * 64,
+        (activation_file,),
+        "The transaction engine keeps only the newest three committed snapshots.",
+        (
+            "Rewind is available only while this snapshot remains retained and every "
+            "activated live file still matches the receipt."
+        ),
+        "3" * 64,
+    )
+    receipt = ActivationReceipt(
+        0,
+        preview.capsule_id,
+        preview.proposal_id,
+        preview.verification_report_sha256,
+        preview.candidate_sha256,
+        (ActivatedFile(target_path, content_sha256, len(content), 0o644),),
+        "tx-canonical",
+        "System/.dex/tx/tx-canonical/snapshot",
+        1_760_000_000,
+        True,
+    )
+    preview_bytes = preview.canonical_preview_bytes()
+    receipt_bytes = receipt.canonical_bytes()
+    original_preview_dict = ActivationPreview._unsigned_dict
+    original_receipt_dict = ActivationReceipt.to_dict
+
+    def reverse_dict_order(value):
+        if isinstance(value, dict):
+            return {
+                key: reverse_dict_order(value[key])
+                for key in reversed(tuple(value))
+            }
+        if isinstance(value, list):
+            return [reverse_dict_order(item) for item in value]
+        return value
+
+    monkeypatch.setattr(
+        ActivationPreview,
+        "_unsigned_dict",
+        lambda self: reverse_dict_order(original_preview_dict(self)),
+    )
+    monkeypatch.setattr(
+        ActivationReceipt,
+        "to_dict",
+        lambda self: reverse_dict_order(original_receipt_dict(self)),
+    )
+
+    assert preview.canonical_preview_bytes() == preview_bytes
+    assert receipt.canonical_bytes() == receipt_bytes
+    assert target_path.encode() in preview_bytes
+    assert target_path.encode() in receipt_bytes
+    assert content_sha256.encode() in preview_bytes
+    assert content_sha256.encode() in receipt_bytes
+
+
+def _authorize_second_test_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise a mixed plan without widening the committed v0 seam contract."""
+    monkeypatch.setattr(
+        portable_contract,
+        "CUSTOMIZATION_MIGRATION_SEAM_PATHS",
+        (*portable_contract.CUSTOMIZATION_MIGRATION_SEAM_PATHS, SECOND_TEST_SEAM),
+    )
+
+
+def _prepared_verified_candidate(
+    tmp_path: Path,
+    *,
+    existing_target: bool,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    second_target: bool = False,
+    blocked_disposition: bool = False,
+):
+    vault, candidate = _candidate_with_contract(tmp_path)
+    if second_target:
+        assert monkeypatch is not None
+        _authorize_second_test_seam(monkeypatch)
+        generated_id = candidate.files[0].customization_ids[0]
+        candidate = replace(
+            candidate,
+            files=tuple(
+                sorted(
+                    (
+                        *candidate.files,
+                        CandidateFile.create(
+                            SECOND_TEST_SEAM,
+                            b"# Newly generated seam\n",
+                            (generated_id,),
+                        ),
+                    ),
+                    key=lambda item: item.target_path,
+                )
+            ),
+        )
+    if blocked_disposition:
+        generated_id = candidate.files[0].customization_ids[0]
+        blocked = next(
+            item
+            for item in candidate.dispositions
+            if item.customization_id != generated_id
+        )
+        candidate = replace(
+            candidate,
+            dispositions=tuple(
+                replace(item, disposition=Disposition.BLOCKED)
+                if item.customization_id == blocked.customization_id
+                else item
+                for item in candidate.dispositions
+            ),
+        )
+    if existing_target:
+        write_file(vault, "CLAUDE-custom.md", b"# User's original bytes\r\n")
+        os.chmod(vault / "CLAUDE-custom.md", 0o640)
+    staging_preview = preview_staging(vault, candidate.capsule_id, candidate)
+    stage_candidate(vault, staging_preview, staging_preview.preview_sha256)
+    report = verify_staging(vault, candidate.capsule_id, candidate.proposal_id)
+    write_verification_report(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+        report,
+    )
+    return vault, candidate, report
+
+
+def _activation_receipt_path(vault: Path, capsule_id: str) -> Path:
+    return (
+        vault
+        / CAPSULE_ROOT
+        / capsule_id
+        / "receipts"
+        / "activation.json"
+    )
+
+
+def _proposal_journal(vault: Path, capsule_id: str, proposal_id: str) -> Path:
+    return (
+        vault
+        / CAPSULE_ROOT
+        / capsule_id
+        / "candidates"
+        / proposal_id
+        / "staging"
+        / "journal.jsonl"
+    )
+
+
+def _live_state(vault: Path, paths: tuple[str, ...]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for relative in paths:
+        target = vault / relative
+        result[relative] = (
+            (target.read_bytes(), stat.S_IMODE(target.stat().st_mode))
+            if target.exists()
+            else None
+        )
+    return result
+
+
+def test_activation_commits_existing_and_absent_authorized_targets_together(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+
+    preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    receipt = activate(
+        vault,
+        preview,
+        preview.approval_token,
+        clock=lambda: 1_760_000_000,
+    )
+
+    assert tuple(item.target_path for item in preview.files) == (
+        "CLAUDE-custom.md",
+        SECOND_TEST_SEAM,
+    )
+    assert preview.files[0].previous_sha256 is not None
+    assert preview.files[0].expected_absent is False
+    assert preview.files[1].previous_sha256 is None
+    assert preview.files[1].expected_absent is True
+    assert {
+        item.path: (item.sha256, item.mode)
+        for item in receipt.files_written
+    } == {
+        item.target_path: (item.sha256, 0o644)
+        for item in candidate.files
+    }
+    for item in candidate.files:
+        assert (vault / item.target_path).read_bytes() == item.content
+        assert stat.S_IMODE((vault / item.target_path).stat().st_mode) == 0o644
+    assert receipt.verification_report_sha256 == preview.verification_report_sha256
+    assert receipt.verification_report_sha256 == hashlib.sha256(
+        report.canonical_bytes()
+    ).hexdigest()
+    assert receipt.rewind_available is True
+    assert receipt.activated_epoch_seconds == 1_760_000_000
+    assert _activation_receipt_path(
+        vault,
+        candidate.capsule_id,
+    ).read_bytes() == receipt.canonical_bytes()
+    assert read_activation_status(
+        vault,
+        candidate.capsule_id,
+    ).state is MigrationState.ACTIVATED
+
+
+def test_existing_target_edit_after_preview_wins_without_other_live_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+    preview = preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+    journal = _proposal_journal(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    journal_before = journal.read_bytes()
+    (vault / "CLAUDE-custom.md").write_bytes(b"# User edited after preview\n")
+
+    with pytest.raises(ActivationError, match="existing file wins"):
+        activate(vault, preview, preview.approval_token)
+
+    assert (vault / "CLAUDE-custom.md").read_bytes() == (
+        b"# User edited after preview\n"
+    )
+    assert not (vault / SECOND_TEST_SEAM).exists()
+    assert journal.read_bytes() == journal_before
+    assert not _activation_receipt_path(vault, candidate.capsule_id).exists()
+
+
+def test_absent_target_created_after_preview_wins(
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=False,
+    )
+    preview = preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+    target = vault / "CLAUDE-custom.md"
+    target.write_bytes(b"# User created after preview\n")
+
+    with pytest.raises(ActivationError, match="existing file wins"):
+        activate(vault, preview, preview.approval_token)
+
+    assert target.read_bytes() == b"# User created after preview\n"
+    assert not _activation_receipt_path(vault, candidate.capsule_id).exists()
+
+
+def test_blocked_verification_refuses_before_any_live_write(
+    tmp_path: Path,
+) -> None:
+    vault, candidate, report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=False,
+        blocked_disposition=True,
+    )
+    assert report.verdict == "BLOCKED"
+
+    with pytest.raises(ActivationError, match="verification verdict is not OK"):
+        preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert not (vault / "CLAUDE-custom.md").exists()
+    assert not _activation_receipt_path(vault, candidate.capsule_id).exists()
+
+
+def test_approval_token_mismatch_is_load_bearing(
+    tmp_path: Path,
+) -> None:
+    """Red-when-removed: without the token comparison this would write live."""
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+    )
+    before = (vault / "CLAUDE-custom.md").read_bytes()
+    preview = preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+
+    with pytest.raises(ActivationError, match="approval token"):
+        activate(vault, preview, "0" * 64)
+
+    assert (vault / "CLAUDE-custom.md").read_bytes() == before
+    assert not _activation_receipt_path(vault, candidate.capsule_id).exists()
+
+
+def test_verification_ok_gate_is_load_bearing(
+    tmp_path: Path,
+) -> None:
+    """Red-when-removed: a persisted BLOCKED report must never reach live."""
+    vault, candidate, report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        blocked_disposition=True,
+    )
+    before = (vault / "CLAUDE-custom.md").read_bytes()
+    assert report.verdict == "BLOCKED"
+
+    with pytest.raises(ActivationError, match="verification verdict is not OK"):
+        preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+
+    assert (vault / "CLAUDE-custom.md").read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "seam",
+    (
+        "after-begin",
+        "after-snapshot",
+        "mid-apply:0",
+        "mid-apply:1",
+        "mid-apply:2",
+        "mid-apply:3",
+        "after-apply",
+        "after-verify",
+        "before-finalize",
+        "activation-after-previewed",
+        "activation-mid-finalize",
+        "after-commit-record",
+    ),
+)
+def test_activation_crash_converges_to_pre_state_or_full_commit(
+    seam: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+    preview = preview_activation(vault, candidate.capsule_id, candidate.proposal_id)
+    preview_pickle = tmp_path / "activation-preview.pickle"
+    preview_pickle.write_bytes(pickle.dumps(preview))
+    live_paths = tuple(item.target_path for item in candidate.files)
+    before = _live_state(vault, live_paths)
+    script = (
+        "from pathlib import Path\n"
+        "import pickle,sys\n"
+        "from core import portable_contract\n"
+        "from core.customization_migration.activation import activate\n"
+        f"extra={SECOND_TEST_SEAM!r}\n"
+        "portable_contract.CUSTOMIZATION_MIGRATION_SEAM_PATHS=("
+        "*portable_contract.CUSTOMIZATION_MIGRATION_SEAM_PATHS,extra)\n"
+        "preview=pickle.loads(Path(sys.argv[2]).read_bytes())\n"
+        "activate(Path(sys.argv[1]),preview,preview.approval_token)\n"
+    )
+    environment = dict(os.environ)
+    environment["DEX_TX_TEST_STOP_AFTER"] = seam
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(vault),
+            str(preview_pickle),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert child.returncode == 137, (seam, child.stderr[-500:])
+    if seam == "activation-mid-finalize":
+        assert read_activation_status(
+            vault,
+            candidate.capsule_id,
+        ).state is not MigrationState.ACTIVATED
+    Transaction.resume(vault)
+    after = _live_state(vault, live_paths)
+    if seam == "after-commit-record":
+        assert after == {
+            item.target_path: (item.content, 0o644)
+            for item in candidate.files
+        }
+        assert read_activation_status(
+            vault,
+            candidate.capsule_id,
+        ).state is MigrationState.ACTIVATED
+    else:
+        assert after == before
+        assert not _activation_receipt_path(vault, candidate.capsule_id).exists()
+
+
+def test_narrowed_activation_receipt_cannot_authorize_partial_rewind(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+    activation_preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    receipt = activate(
+        vault,
+        activation_preview,
+        activation_preview.approval_token,
+    )
+    narrowed = replace(receipt, files_written=(receipt.files_written[0],))
+    _activation_receipt_path(
+        vault,
+        candidate.capsule_id,
+    ).write_bytes(narrowed.canonical_bytes())
+
+    rewind_preview = preview_rewind(vault, narrowed)
+
+    assert rewind_preview.status == "UNKNOWN"
+    assert rewind_preview.acknowledgement_token is None
+    assert read_activation_status(
+        vault,
+        candidate.capsule_id,
+    ).state is MigrationState.RECOVERY_REQUIRED
+    assert (vault / candidate.files[0].target_path).read_bytes() == (
+        candidate.files[0].content
+    )
+    assert (vault / candidate.files[1].target_path).read_bytes() == (
+        candidate.files[1].content
+    )
+
+
+def test_rewind_restores_exact_pre_activation_state_and_second_is_clean(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+    live_paths = tuple(item.target_path for item in candidate.files)
+    before = _live_state(vault, live_paths)
+    activation_preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    activation_receipt = activate(
+        vault,
+        activation_preview,
+        activation_preview.approval_token,
+    )
+
+    rewind_preview = preview_rewind(vault, activation_receipt)
+    assert rewind_preview.status == "OK"
+    assert rewind_preview.acknowledgement_token is not None
+    rewind_receipt = rewind(
+        vault,
+        activation_receipt,
+        rewind_preview.acknowledgement_token,
+        clock=lambda: 1_760_000_100,
+    )
+
+    assert rewind_receipt.status == "OK"
+    assert rewind_receipt.rewound_epoch_seconds == 1_760_000_100
+    assert _live_state(vault, live_paths) == before
+    assert read_activation_status(
+        vault,
+        candidate.capsule_id,
+    ).state is MigrationState.REWOUND
+
+    state_after_first = _live_state(vault, live_paths)
+    second = rewind(
+        vault,
+        activation_receipt,
+        rewind_preview.acknowledgement_token,
+    )
+    assert second.status == "UNKNOWN"
+    assert second.reason == "already-rewound"
+    assert _live_state(vault, live_paths) == state_after_first
+
+
+def test_live_drift_during_rewind_is_reported_unknown_and_user_bytes_win(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+    )
+    activation_preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    activation_receipt = activate(
+        vault,
+        activation_preview,
+        activation_preview.approval_token,
+    )
+    rewind_preview = preview_rewind(vault, activation_receipt)
+    original_snapshot = Transaction._snapshot_phase
+
+    def drift_then_snapshot(transaction: Transaction) -> None:
+        (vault / "CLAUDE-custom.md").write_bytes(b"# User changed during rewind\n")
+        original_snapshot(transaction)
+
+    monkeypatch.setattr(Transaction, "_snapshot_phase", drift_then_snapshot)
+
+    receipt = rewind(
+        vault,
+        activation_receipt,
+        rewind_preview.acknowledgement_token,
+    )
+
+    assert receipt.status == "UNKNOWN"
+    assert receipt.reason == "live-drift"
+    assert (vault / "CLAUDE-custom.md").read_bytes() == (
+        b"# User changed during rewind\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "seam",
+    (
+        "after-begin",
+        "after-snapshot",
+        "mid-apply:0",
+        "mid-apply:1",
+        "mid-apply:2",
+        "mid-apply:3",
+        "after-apply",
+        "after-verify",
+        "before-finalize",
+        "rewind-before-journal",
+        "rewind-mid-finalize",
+        "after-commit-record",
+    ),
+)
+def test_rewind_crash_converges_to_active_state_or_full_rewind(
+    seam: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+        monkeypatch=monkeypatch,
+        second_target=True,
+    )
+    live_paths = tuple(item.target_path for item in candidate.files)
+    before_activation = _live_state(vault, live_paths)
+    activation_preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    activation_receipt = activate(
+        vault,
+        activation_preview,
+        activation_preview.approval_token,
+    )
+    active = _live_state(vault, live_paths)
+    rewind_preview = preview_rewind(vault, activation_receipt)
+    payload_path = tmp_path / "rewind-input.pickle"
+    payload_path.write_bytes(
+        pickle.dumps(
+            (activation_receipt, rewind_preview.acknowledgement_token)
+        )
+    )
+    script = (
+        "from pathlib import Path\n"
+        "import pickle,sys\n"
+        "from core import portable_contract\n"
+        "from core.customization_migration.activation import rewind\n"
+        f"extra={SECOND_TEST_SEAM!r}\n"
+        "portable_contract.CUSTOMIZATION_MIGRATION_SEAM_PATHS=("
+        "*portable_contract.CUSTOMIZATION_MIGRATION_SEAM_PATHS,extra)\n"
+        "receipt,token=pickle.loads(Path(sys.argv[2]).read_bytes())\n"
+        "rewind(Path(sys.argv[1]),receipt,token)\n"
+    )
+    environment = dict(os.environ)
+    environment["DEX_TX_TEST_STOP_AFTER"] = seam
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(vault),
+            str(payload_path),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert child.returncode == 137, (seam, child.stderr[-500:])
+    if seam == "rewind-mid-finalize":
+        assert read_activation_status(
+            vault,
+            candidate.capsule_id,
+        ).state is not MigrationState.REWOUND
+    Transaction.resume(vault)
+    if seam == "after-commit-record":
+        assert _live_state(vault, live_paths) == before_activation
+        assert read_activation_status(
+            vault,
+            candidate.capsule_id,
+        ).state is MigrationState.REWOUND
+    else:
+        assert _live_state(vault, live_paths) == active
+        assert read_activation_status(
+            vault,
+            candidate.capsule_id,
+        ).state is MigrationState.ACTIVATED
+
+
+def test_pruned_activation_snapshot_reports_honest_non_rewindable_status(
+    tmp_path: Path,
+) -> None:
+    vault, candidate, _report = _prepared_verified_candidate(
+        tmp_path,
+        existing_target=True,
+    )
+    activation_preview = preview_activation(
+        vault,
+        candidate.capsule_id,
+        candidate.proposal_id,
+    )
+    activation_receipt = activate(
+        vault,
+        activation_preview,
+        activation_preview.approval_token,
+    )
+    activated = (vault / "CLAUDE-custom.md").read_bytes()
+    for index in range(3):
+        Transaction._begin_with_id(
+            vault,
+            [
+                PlanEntry(
+                    "System/.installed-files.manifest",
+                    f"later {index}\n".encode(),
+                )
+            ],
+            allow_empty=False,
+            operation="update",
+            tx_id=f"zzzzzzzzTzzzzzz-{index}",
+        ).run()
+
+    rewind_preview = preview_rewind(vault, activation_receipt)
+    rewind_receipt = rewind(
+        vault,
+        activation_receipt,
+        rewind_preview.acknowledgement_token,
+    )
+
+    assert rewind_preview.status == "UNKNOWN"
+    assert rewind_preview.reason == "snapshot-pruned"
+    assert rewind_preview.acknowledgement_token is None
+    assert rewind_receipt.status == "UNKNOWN"
+    assert rewind_receipt.reason == "snapshot-pruned"
+    assert (vault / "CLAUDE-custom.md").read_bytes() == activated

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -417,6 +417,319 @@ def test_engine_content_write_precondition_rejects_symlink_target(
     assert outside.read_bytes() == b"captured bytes\n"
 
 
+def test_engine_expected_absent_write_commits_and_is_journalled(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+
+    result = Transaction.begin(
+        vault,
+        [PlanEntry("CLAUDE-custom.md", b"# Migrated\n", expected_absent=True)],
+        operation="customization-migration",
+    ).run()
+
+    assert result["committed"] is True
+    assert (vault / "CLAUDE-custom.md").read_bytes() == b"# Migrated\n"
+    begin = Journal(
+        vault / "System/.dex/tx" / result["tx_id"] / "journal.jsonl"
+    ).read()[0]
+    assert begin.payload["plan"][0]["expected_absent"] is True
+
+
+def test_engine_expected_absent_rejects_target_present_at_snapshot(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    tx = Transaction.begin(
+        vault,
+        [
+            PlanEntry(
+                "System/.dex/customization-migrations/x/receipt.json",
+                b"{}\n",
+            ),
+            PlanEntry(
+                "CLAUDE-custom.md",
+                b"# Migrated\n",
+                expected_absent=True,
+            ),
+        ],
+        operation="customization-migration",
+    )
+    target = vault / "CLAUDE-custom.md"
+    target.write_bytes(b"# User created this\n")
+
+    with pytest.raises(
+        PlanRejected,
+        match="the existing file wins and the transaction aborts",
+    ):
+        tx.run()
+
+    assert target.read_bytes() == b"# User created this\n"
+    assert not (
+        vault / "System/.dex/customization-migrations/x/receipt.json"
+    ).exists()
+
+
+def test_engine_expected_absent_rechecks_before_write_and_rolls_back(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    first = "System/.dex/customization-migrations/x/receipt.json"
+    guarded = vault / "CLAUDE-custom.md"
+    tx = Transaction.begin(
+        vault,
+        [
+            PlanEntry(first, b"{}\n"),
+            PlanEntry(
+                "CLAUDE-custom.md",
+                b"# Migrated\n",
+                expected_absent=True,
+            ),
+        ],
+        operation="customization-migration",
+    )
+    original_append = tx.journal.append
+
+    def create_after_first_apply(event: str, payload=None) -> None:
+        original_append(event, payload)
+        if event == "APPLIED" and payload["index"] == 0:
+            guarded.write_bytes(b"# User won the race\n")
+
+    tx.journal.append = create_after_first_apply
+
+    with pytest.raises(
+        PlanRejected,
+        match="the existing file wins and the transaction aborts",
+    ):
+        tx.run()
+
+    assert guarded.read_bytes() == b"# User won the race\n"
+    assert not (vault / first).exists()
+
+
+def test_engine_expected_absent_publication_cannot_clobber_final_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.transaction import engine as engine_module
+
+    vault = _vault(tmp_path)
+    target = vault / "CLAUDE-custom.md"
+    original_link = os.link
+
+    def user_wins_immediately_before_publish(source, destination, **kwargs) -> None:
+        target.write_bytes(b"# User created at the final boundary\n")
+        original_link(source, destination, **kwargs)
+
+    monkeypatch.setattr(engine_module.os, "link", user_wins_immediately_before_publish)
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("CLAUDE-custom.md", b"# Migrated\n", expected_absent=True)],
+        operation="customization-migration",
+    )
+
+    with pytest.raises(
+        PlanRejected,
+        match="the existing file wins and the transaction aborts",
+    ):
+        tx.run()
+
+    assert target.read_bytes() == b"# User created at the final boundary\n"
+
+
+def test_engine_expected_absent_applying_record_never_owns_a_user_file(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "CLAUDE-custom.md"
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry("CLAUDE-custom.md", b"# Migrated\n", expected_absent=True)],
+        operation="customization-migration",
+    )
+    original_append = tx.journal.append
+
+    def interrupt_after_apply_intent(event: str, payload=None) -> None:
+        original_append(event, payload)
+        if event == "APPLYING":
+            target.write_bytes(b"# User created before publication\n")
+            raise RuntimeError("crash before expected-absent publication")
+
+    tx.journal.append = interrupt_after_apply_intent
+
+    with pytest.raises(RuntimeError, match="crash before"):
+        tx.run()
+
+    assert target.read_bytes() == b"# User created before publication\n"
+
+
+def test_resume_removes_expected_absent_publish_when_temp_is_gone_but_target_matches_begin(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = "CLAUDE-custom.md"
+    planned = b"# Migrated\n"
+    entry = PlanEntry(relative, planned, expected_absent=True)
+    tx = Transaction.begin(
+        vault,
+        [entry],
+        operation="customization-migration",
+    )
+    tx._snapshot_phase()
+    tx.journal.append("APPLY-START")
+    tx.journal.append(
+        "APPLYING",
+        {"index": 0, "relative": relative, "expected_absent": True},
+    )
+    original_append = tx.journal.append
+
+    def tear_before_published(event: str, payload=None) -> None:
+        if event == "PUBLISHED":
+            raise RuntimeError("crash after link before publication record")
+        original_append(event, payload)
+
+    tx.journal.append = tear_before_published
+
+    with pytest.raises(RuntimeError, match="after link"):
+        tx._apply_one(0, entry)
+
+    target = vault / relative
+    temporary = target.parent / f".{target.name}.tx-{tx.tx_id}"
+    assert target.read_bytes() == planned
+    assert (target.stat().st_dev, target.stat().st_ino) == (
+        temporary.stat().st_dev,
+        temporary.stat().st_ino,
+    )
+    temporary.unlink()
+    assert tx._release is not None
+    tx._release()
+    tx._release = None
+
+    Transaction.resume(vault)
+
+    assert not target.exists()
+
+
+def test_resume_preserves_expected_absent_user_file_matching_plan_when_temp_inode_differs(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = "CLAUDE-custom.md"
+    planned = b"# Migrated\n"
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry(relative, planned, expected_absent=True)],
+        operation="customization-migration",
+    )
+    tx._snapshot_phase()
+    tx.journal.append("APPLY-START")
+    tx.journal.append(
+        "APPLYING",
+        {"index": 0, "relative": relative, "expected_absent": True},
+    )
+    target = vault / relative
+    temporary = target.parent / f".{target.name}.tx-{tx.tx_id}"
+    temporary.write_bytes(planned)
+    target.write_bytes(planned)
+    assert (target.stat().st_dev, target.stat().st_ino) != (
+        temporary.stat().st_dev,
+        temporary.stat().st_ino,
+    )
+    assert tx._release is not None
+    tx._release()
+    tx._release = None
+
+    Transaction.resume(vault)
+
+    assert target.read_bytes() == planned
+
+
+def test_resume_preserves_expected_absent_user_file_when_temp_is_gone_and_bytes_differ(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = "CLAUDE-custom.md"
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry(relative, b"# Migrated\n", expected_absent=True)],
+        operation="customization-migration",
+    )
+    tx._snapshot_phase()
+    tx.journal.append("APPLY-START")
+    tx.journal.append(
+        "APPLYING",
+        {"index": 0, "relative": relative, "expected_absent": True},
+    )
+    target = vault / relative
+    user_bytes = b"# User created during recovery window\n"
+    target.write_bytes(user_bytes)
+    assert tx._release is not None
+    tx._release()
+    tx._release = None
+
+    Transaction.resume(vault)
+
+    assert target.read_bytes() == user_bytes
+
+
+def test_target_matches_planned_content_refuses_symlink_target(
+    tmp_path: Path,
+) -> None:
+    planned = b"# Migrated\n"
+    real_target = tmp_path / "real-target.md"
+    real_target.write_bytes(planned)
+    symlink_target = tmp_path / "symlink-target.md"
+    symlink_target.symlink_to(real_target)
+
+    assert not Transaction._target_matches_planned_content(
+        symlink_target,
+        planned_sha256=hashlib.sha256(planned).hexdigest(),
+        planned_size=len(planned),
+    )
+
+
+def test_engine_expected_absent_is_mutually_exclusive_with_current_hash(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+
+    with pytest.raises(PlanRejected, match="cannot also assert current bytes"):
+        Transaction.begin(
+            vault,
+            [
+                PlanEntry(
+                    "CLAUDE-custom.md",
+                    b"# Migrated\n",
+                    expected_current_sha256="0" * 64,
+                    expected_absent=True,
+                )
+            ],
+            operation="customization-migration",
+        )
+
+
+def test_engine_expected_absent_is_invalid_for_deletion(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    target = vault / "README.md"
+    target.write_bytes(b"shipped bytes\n")
+    expected = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    with pytest.raises(PlanRejected, match="only valid on content writes"):
+        Transaction.begin(
+            vault,
+            [
+                PlanEntry(
+                    "README.md",
+                    None,
+                    expected_current_sha256=expected,
+                    expected_absent=True,
+                )
+            ],
+        )
+
+    assert target.read_bytes() == b"shipped bytes\n"
+
+
 def test_engine_rechecks_content_precondition_and_rolls_back_applied_entries(
     tmp_path: Path,
 ) -> None:

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -28,6 +28,7 @@ import hashlib
 import os
 import re
 import shutil
+import stat
 import time
 import uuid
 from collections.abc import Callable
@@ -57,7 +58,8 @@ class PlanEntry:
 
     ``content=None`` is an authorized deletion. ``expected_current_sha256``
     guards deletions (required) and content writes (optional) against a target
-    changing after the plan was built. Deletions use the same
+    changing after the plan was built. ``expected_absent`` guards a new-file
+    write against a target appearing before apply. Deletions use the same
     snapshot/apply/verify/rollback lifecycle as replacements, so an updater
     can prune a retired brain file without opening a second mutation path.
     """
@@ -66,6 +68,7 @@ class PlanEntry:
     content: bytes | None
     mode: int = 0o644
     expected_current_sha256: str | None = None
+    expected_absent: bool = False
 
     def sha256(self) -> str | None:
         return hashlib.sha256(self.content).hexdigest() if self.content is not None else None
@@ -165,6 +168,18 @@ class Transaction:
                 )
             if entry.content is None and entry.expected_current_sha256 is None:
                 raise PlanRejected(f"{entry.relative}: deletions require expected_current_sha256")
+            if type(entry.expected_absent) is not bool:
+                raise PlanRejected(
+                    f"{entry.relative}: expected_absent must be boolean"
+                )
+            if entry.expected_absent and entry.content is None:
+                raise PlanRejected(
+                    f"{entry.relative}: expected_absent is only valid on content writes"
+                )
+            if entry.expected_absent and entry.expected_current_sha256 is not None:
+                raise PlanRejected(
+                    f"{entry.relative}: an expected-absent create cannot also assert current bytes"
+                )
 
         # All-or-nothing authorization BEFORE the lock: one disallowed entry
         # rejects the plan with nothing acquired and nothing written. For
@@ -221,6 +236,7 @@ class Transaction:
                             "mode": entry.mode,
                             "size": len(entry.content) if entry.content is not None else None,
                             "expected_current_sha256": entry.expected_current_sha256,
+                            "expected_absent": entry.expected_absent,
                         }
                         for entry in plan
                     ],
@@ -279,6 +295,13 @@ class Transaction:
             unsafe_parent = unsafe_existing_parent(self.vault_root, entry.relative)
             if unsafe_parent is not None:
                 raise PlanRejected(f"{entry.relative}: {unsafe_parent}")
+            if entry.expected_absent:
+                target = self.vault_root / entry.relative
+                if target.exists() or target.is_symlink():
+                    raise PlanRejected(
+                        f"{entry.relative} appeared after the mutation plan was built; "
+                        "the existing file wins and the transaction aborts"
+                    )
             if entry.expected_current_sha256 is None:
                 continue
             if entry.content is None:
@@ -322,7 +345,14 @@ class Transaction:
                     entry,
                     changed_when="after the mutation snapshot",
                 )
-            self.journal.append("APPLYING", {"index": index, "relative": entry.relative})
+            self.journal.append(
+                "APPLYING",
+                {
+                    "index": index,
+                    "relative": entry.relative,
+                    "expected_absent": entry.expected_absent,
+                },
+            )
             try:
                 self._apply_one(index, entry)
             except PlanRejected:
@@ -420,6 +450,43 @@ class Transaction:
             except BaseException:
                 temporary.unlink(missing_ok=True)
                 raise
+        if entry.expected_absent and (target.exists() or target.is_symlink()):
+            temporary.unlink(missing_ok=True)
+            raise PlanRejected(
+                f"{entry.relative} appeared after the mutation snapshot; "
+                "the existing file wins and the transaction aborts"
+            )
+        if entry.expected_absent:
+            try:
+                os.link(temporary, target, follow_symlinks=False)
+            except FileExistsError as error:
+                temporary.unlink(missing_ok=True)
+                raise PlanRejected(
+                    f"{entry.relative} appeared after the mutation snapshot; "
+                    "the existing file wins and the transaction aborts"
+                ) from error
+            except BaseException:
+                temporary.unlink(missing_ok=True)
+                raise
+            directory = os.open(target.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+            # Keep the hard-link source until publication is journalled. If
+            # this append tears, rollback can distinguish our inode from a
+            # user file that won the same window.
+            self.journal.append(
+                "PUBLISHED",
+                {"index": index, "relative": entry.relative},
+            )
+            temporary.unlink()
+            directory = os.open(target.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+            return
         os.replace(temporary, target)
         directory = os.open(target.parent, os.O_RDONLY)
         try:
@@ -483,16 +550,139 @@ class Transaction:
 
     # -- recovery / undo -------------------------------------------------------
 
+    @staticmethod
+    def _target_matches_planned_content(
+        target: Path,
+        *,
+        planned_sha256: str,
+        planned_size: int,
+    ) -> bool:
+        try:
+            nofollow = os.O_NOFOLLOW
+        except AttributeError:
+            return False
+        try:
+            descriptor = os.open(
+                target,
+                os.O_RDONLY | nofollow | getattr(os, "O_NONBLOCK", 0),
+            )
+        except OSError:
+            return False
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_size != planned_size
+            ):
+                return False
+            digest = hashlib.sha256()
+            remaining = planned_size
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 64 * 1024))
+                if not chunk:
+                    return False
+                digest.update(chunk)
+                remaining -= len(chunk)
+            if os.read(descriptor, 1):
+                return False
+            return digest.hexdigest() == planned_sha256
+        except OSError:
+            return False
+        finally:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
     def _applied_relatives(self, entries) -> set[str]:
         applied: set[str] = set()
+        expected_absent: set[str] = set()
+        ambiguous_expected_absent: set[str] = set()
+        planned_content: dict[str, tuple[str, int]] = {}
+        for entry in entries:
+            if entry.event != "BEGIN":
+                continue
+            plan = entry.payload.get("plan")
+            if isinstance(plan, list):
+                for planned in plan:
+                    if (
+                        not isinstance(planned, dict)
+                        or planned.get("expected_absent") is not True
+                    ):
+                        continue
+                    relative = planned.get("relative")
+                    planned_sha256 = planned.get("sha256")
+                    planned_size = planned.get("size")
+                    if (
+                        isinstance(relative, str)
+                        and isinstance(planned_sha256, str)
+                        and re.fullmatch(r"[0-9a-f]{64}", planned_sha256)
+                        and type(planned_size) is int
+                        and planned_size >= 0
+                    ):
+                        planned_content[relative] = (
+                            planned_sha256,
+                            planned_size,
+                        )
+            break
         for entry in entries:
             relative = entry.payload.get("relative")
             if not relative:
                 continue
-            if entry.event in {"APPLYING", "APPLIED"}:
+            if entry.event == "APPLYING":
+                if entry.payload.get("expected_absent") is True:
+                    expected_absent.add(relative)
+                    ambiguous_expected_absent.add(relative)
+                else:
+                    applied.add(relative)
+            elif entry.event in {"PUBLISHED", "APPLIED"}:
                 applied.add(relative)
+                ambiguous_expected_absent.discard(relative)
             elif entry.event == "NOT-APPLIED":
                 applied.discard(relative)
+                ambiguous_expected_absent.discard(relative)
+        for relative in expected_absent:
+            if unsafe_existing_parent(self.vault_root, relative) is not None:
+                continue
+            target = self.vault_root / relative
+            temporary = target.parent / f".{target.name}.tx-{self.tx_id}"
+            try:
+                temporary_metadata = temporary.lstat()
+            except OSError:
+                temporary_metadata = None
+            try:
+                target_metadata = target.lstat()
+            except OSError:
+                target_metadata = None
+            if (
+                relative in ambiguous_expected_absent
+                and target_metadata is not None
+            ):
+                planned = planned_content.get(relative)
+                target_is_ours = (
+                    temporary_metadata is not None
+                    and stat.S_ISREG(temporary_metadata.st_mode)
+                    and stat.S_ISREG(target_metadata.st_mode)
+                    and (target_metadata.st_dev, target_metadata.st_ino)
+                    == (temporary_metadata.st_dev, temporary_metadata.st_ino)
+                ) or (
+                    temporary_metadata is None
+                    and planned is not None
+                    and self._target_matches_planned_content(
+                        target,
+                        planned_sha256=planned[0],
+                        planned_size=planned[1],
+                    )
+                )
+                if target_is_ours:
+                    applied.add(relative)
+                else:
+                    applied.discard(relative)
+            if (
+                temporary_metadata is not None
+                and stat.S_ISREG(temporary_metadata.st_mode)
+            ):
+                temporary.unlink(missing_ok=True)
         return applied
 
     def rollback(self) -> dict:


### PR DESCRIPTION
**DO NOT MERGE YET.** This is the first lane that writes a regenerated customization to a real user seam (e.g. `CLAUDE-custom.md`). Per plan §21 it is held for: (1) a SECOND independent adversarial review, and (2) the real-vault rehearsal with Dave. Release sequencing is owned by the Dr Migration session — no release is cut from here.

## What it does
- `activate` refuses unless verification is OK, accounting is complete, and no item is blocked. Every live write goes through ONE lifecycle transaction under the sealed customization-migration operation; its snapshot is the rewind source.
- **User always wins on conflict:** an existing target edited after the preview keeps the user's bytes (`expected_current_sha256`); a target the user newly created wins (the new `expected_absent` guard, published atomically via hard-link — never `os.replace` — so a racing user file is never clobbered).
- **Rewind** restores exact pre-activation bytes, requires an acknowledgement token, and reports honestly (never a fake/partial restore) when its snapshot was pruned or drifted.
- Minimal engine change (`expected_absent`); normal write path unchanged; snapshot/journal/capsule byte-identical to main.

## Verification so far
- First independent adversarial review (Opus): **no blocker, no serious — ship-candidate quality**; all four crash-recovery tears driven empirically; A1/A2/user-wins/token/rewind-honesty confirmed.
- Its one MINOR (a rare recovery wedge) fixed; an over-built recovery quarantine then stripped back to the minimal lock-safe design.
- 156 targeted + full local suite; all gates green; read-only MCP has no reach to the write primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSS5ozU6tnNYXmEKv5JLje