### PR TITLE
docs: point new users at the hosted Dex Guide (heydex.ai/help)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -652,7 +652,9 @@ This takes about 2 minutes and shows you what Dex can really do.
 
 [Then actually invoke the /getting-started skill, which will have MCPs loaded]
 
-[If no:] No problem! You can run `/getting-started` anytime. For now, try `/daily-plan` to see your day."
+[If no:] No problem! You can run `/getting-started` anytime. For now, try `/daily-plan` to see your day.
+
+📖 One more thing worth bookmarking: the **Dex Guide** at https://heydex.ai/help/ — a plain-English walkthrough of everything Dex can do, with copy-paste prompts to steal. Great for your first week."
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -727,6 +727,8 @@ Each session makes the next one better.
 
 ## Documentation
 
+**📖 Start with the [Dex Guide](https://heydex.ai/help/)** — a plain-English walkthrough from install to making Dex your own, with copy-paste prompts throughout. It's written for non-technical professionals and doubles as a hands-on education in Claude Code itself. (Also readable by AI agents: [llms.txt](https://heydex.ai/help/llms.txt).)
+
 Comprehensive guides included in the repo:
 
 - [Dex_System_Guide.md](06-Resources/Dex_System/Dex_System_Guide.md) - Complete feature reference and workflows


### PR DESCRIPTION
README's Documentation section now leads with the public Dex Guide at https://heydex.ai/help/ (with its llms.txt for AI agents), and the onboarding completion message bookmarks the guide for users who skip the getting-started tour.

Docs-only, release-safe at merge time. Local PR gates green (path-contract: no code files; doc-drift: no production delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rg46zhyLjqh9X6NFgkmvb