### PR TITLE
feat(connections): R2 Core-side sealed credential custody (held — /connect stays closed)

### DIFF
--- a/core/integrations/connection-manager/connect.cjs
+++ b/core/integrations/connection-manager/connect.cjs
@@ -404,7 +404,7 @@ function cmdStatus(flags = {}) {
   const rows = health.allConnectionsHealth();
   const keyCustody = store.keyCustodyMode();
   if (flags.json !== undefined) {
-    process.stdout.write(`${JSON.stringify({ connections: rows, registryNotice: meta || null })}\n`);
+    process.stdout.write(`${JSON.stringify({ connections: rows, registryNotice: meta || null, keyCustody })}\n`);
     return;
   }
   if (meta && meta.notice === 'registry_rebuilt') {
@@ -416,7 +416,9 @@ function cmdStatus(flags = {}) {
     );
   }
   console.log(
-    keyCustody === 'keychain'
+    keyCustody === 'sealed-host'
+      ? 'Encryption key: sealed inside the signed Dex desktop host.'
+      : keyCustody === 'keychain'
       ? 'Encryption key: stored in your macOS Keychain.'
       : 'Encryption key: stored in your vault folder — anyone with a copy of that folder can read these credentials.'
   );

--- a/core/integrations/connection-manager/connection-manager.custody.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.custody.test.cjs
@@ -1,0 +1,348 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-custody-'));
+process.env.DEX_VAULT = TMP_VAULT;
+process.env.DEX_CM_NO_KEYCHAIN = '1';
+
+const store = require('./token-store.cjs');
+const { cmdStatus } = require('./connect.cjs');
+
+const CREDENTIALS_DIR = path.join(TMP_VAULT, 'System', 'credentials');
+const SEALED_MARKER = path.join(CREDENTIALS_DIR, '.dex-cm.sealed');
+const KEY_FILE = path.join(CREDENTIALS_DIR, '.dex-cm.key');
+const REGISTRY_FILE = path.join(CREDENTIALS_DIR, 'connections.json');
+const OAUTH_APPS_FILE = path.join(CREDENTIALS_DIR, 'oauth-apps.json');
+const TOKENS_DIR = path.join(CREDENTIALS_DIR, 'tokens');
+let sealedHostAfterMigration;
+
+test.after(() => {
+  fs.rmSync(TMP_VAULT, { recursive: true, force: true });
+});
+
+test('sealed marker without a reachable host fails closed with a typed error', () => {
+  store.saveApiKey(
+    'sealed-host-required',
+    { apiKey: 'FAKE-SEALED-HOST-REQUIRED' },
+    { provider: 'sealed-host-required' }
+  );
+  fs.writeFileSync(
+    SEALED_MARKER,
+    JSON.stringify({ v: 1, custody: 'sealed-host' }),
+    { mode: 0o600 }
+  );
+  const tokenPath = path.join(TOKENS_DIR, 'sealed-host-required.json');
+  const before = fs.readFileSync(tokenPath);
+
+  assert.throws(
+    () => store.loadToken('sealed-host-required'),
+    (error) => error && error.code === 'DEX_CM_SEALED_HOST_REQUIRED'
+  );
+  assert.deepEqual(fs.readFileSync(tokenPath), before);
+  assert.equal(
+    fs.readdirSync(TOKENS_DIR).some((name) => name.includes('.corrupt-')),
+    false
+  );
+});
+
+test('sealed host availability must be synchronously confirmed', () => {
+  const legacyTrustMacKey = store.trustMacKey();
+  store.setHostDecryptor({
+    available: async () => true,
+    decrypt: () => JSON.stringify({ apiKey: 'FAKE-ASYNC-HOST' }),
+    mac: (payload) => crypto
+      .createHmac('sha256', legacyTrustMacKey)
+      .update(payload)
+      .digest('base64'),
+  });
+
+  assert.throws(
+    () => store.loadToken('sealed-host-required'),
+    (error) => error && error.code === 'DEX_CM_SEALED_HOST_REQUIRED'
+  );
+});
+
+test('sealed marker with a reachable host decrypts through the host seam', () => {
+  const calls = [];
+  const legacyTrustMacKey = store.trustMacKey();
+  store.setHostDecryptor({
+    available: () => true,
+    decrypt(connId, envelope) {
+      calls.push({ connId, envelope });
+      return JSON.stringify({ kind: 'api_key', apiKey: 'FAKE-FROM-SEALED-HOST' });
+    },
+    mac(payload) {
+      return crypto
+        .createHmac('sha256', legacyTrustMacKey)
+        .update(payload)
+        .digest('base64');
+    },
+  });
+
+  assert.equal(
+    store.loadToken('sealed-host-required').apiKey,
+    'FAKE-FROM-SEALED-HOST'
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].connId, 'sealed-host-required');
+});
+
+test('an unmarked store keeps the existing in-process decrypt path', () => {
+  fs.rmSync(SEALED_MARKER);
+  store.setHostDecryptor({
+    available: () => true,
+    decrypt() {
+      throw new Error('unmarked stores must not call the sealed host');
+    },
+  });
+
+  assert.equal(
+    store.loadToken('sealed-host-required').apiKey,
+    'FAKE-SEALED-HOST-REQUIRED'
+  );
+});
+
+function createMockHostDecryptor() {
+  const masterKey = crypto.randomBytes(32);
+  const macKey = Buffer.from(
+    crypto.hkdfSync('sha256', masterKey, Buffer.alloc(0), 'dex-cm-trust-mac-v1', 32)
+  );
+  const calls = { seal: [], decrypt: [], mac: [] };
+  return {
+    calls,
+    available: () => true,
+    seal(connId, plaintext, aad) {
+      calls.seal.push(connId);
+      const iv = crypto.randomBytes(12);
+      const cipher = crypto.createCipheriv('aes-256-gcm', masterKey, iv);
+      cipher.setAAD(Buffer.from(aad, 'utf8'));
+      const data = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+      return {
+        v: 1,
+        custody: 'sealed-host',
+        aad,
+        iv: iv.toString('base64'),
+        tag: cipher.getAuthTag().toString('base64'),
+        data: data.toString('base64'),
+      };
+    },
+    decrypt(connId, envelope) {
+      calls.decrypt.push(connId);
+      assert.equal(envelope.custody, 'sealed-host');
+      const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        masterKey,
+        Buffer.from(envelope.iv, 'base64')
+      );
+      decipher.setAAD(Buffer.from(envelope.aad, 'utf8'));
+      decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
+      return Buffer.concat([
+        decipher.update(Buffer.from(envelope.data, 'base64')),
+        decipher.final(),
+      ]).toString('utf8');
+    },
+    mac(payload) {
+      calls.mac.push(payload);
+      return crypto.createHmac('sha256', macKey).update(payload).digest('base64');
+    },
+  };
+}
+
+function snapStoreFiles() {
+  const files = [KEY_FILE, REGISTRY_FILE, OAUTH_APPS_FILE];
+  for (const name of fs.readdirSync(TOKENS_DIR)) {
+    if (name.endsWith('.json')) files.push(path.join(TOKENS_DIR, name));
+  }
+  return new Map(files.map((file) => [file, fs.readFileSync(file)]));
+}
+
+test('sealStore refuses to start when no host seam is reachable', () => {
+  store.setOAuthApp('sealed-oauth-app', {
+    clientId: 'FAKE-SEALED-CLIENT-ID',
+    clientSecret: 'FAKE-SEALED-CLIENT-SECRET',
+  });
+  store.saveApiKey(
+    'sealed-second-token',
+    { apiKey: 'FAKE-SEALED-SECOND-TOKEN' },
+    { provider: 'sealed-second-token' }
+  );
+  const before = snapStoreFiles();
+  store.setHostDecryptor(null);
+
+  assert.throws(
+    () => store.sealStore(),
+    (error) => error && error.code === 'DEX_CM_SEALED_HOST_REQUIRED'
+  );
+  assert.equal(fs.existsSync(SEALED_MARKER), false);
+  for (const [file, bytes] of before) assert.deepEqual(fs.readFileSync(file), bytes);
+});
+
+test('sealStore rolls back rewritten credentials and restores the legacy key when purge fails', () => {
+  const before = snapStoreFiles();
+  const mockHost = createMockHostDecryptor();
+  store.setHostDecryptor(mockHost);
+  const legacyKeyCustody = {
+    capture() {
+      return { fileKey: fs.readFileSync(KEY_FILE) };
+    },
+    purge() {
+      fs.unlinkSync(KEY_FILE);
+      throw new Error('injected keychain purge failure');
+    },
+    verifyPurged() {
+      return false;
+    },
+    restore(snapshot) {
+      fs.writeFileSync(KEY_FILE, snapshot.fileKey, { mode: 0o600 });
+    },
+  };
+
+  assert.throws(
+    () => store.sealStore({ legacyKeyCustody }),
+    /injected keychain purge failure/
+  );
+  assert.equal(fs.existsSync(SEALED_MARKER), false);
+  for (const [file, bytes] of before) assert.deepEqual(fs.readFileSync(file), bytes);
+  assert.equal(
+    store.loadToken('sealed-host-required').apiKey,
+    'FAKE-SEALED-HOST-REQUIRED'
+  );
+});
+
+test('sealStore seals every credential, writes the marker, and verifiably purges the legacy key', () => {
+  const mockHost = createMockHostDecryptor();
+  sealedHostAfterMigration = mockHost;
+  store.setHostDecryptor(mockHost);
+
+  const result = store.sealStore();
+
+  assert.equal(result.sealed, true);
+  assert.equal(result.tokenCount, 2);
+  assert.equal(result.oauthAppCount, 1);
+  assert.equal(fs.existsSync(KEY_FILE), false);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(SEALED_MARKER, 'utf8')),
+    { v: 1, custody: 'sealed-host' }
+  );
+  for (const file of fs.readdirSync(TOKENS_DIR).filter((name) => name.endsWith('.json'))) {
+    assert.equal(
+      JSON.parse(fs.readFileSync(path.join(TOKENS_DIR, file), 'utf8')).custody,
+      'sealed-host'
+    );
+  }
+  assert.equal(
+    JSON.parse(fs.readFileSync(OAUTH_APPS_FILE, 'utf8'))['sealed-oauth-app'].clientSecret.custody,
+    'sealed-host'
+  );
+  assert.equal(
+    store.loadToken('sealed-host-required').apiKey,
+    'FAKE-SEALED-HOST-REQUIRED'
+  );
+  assert.deepEqual(store.getOAuthApp('sealed-oauth-app'), {
+    clientId: 'FAKE-SEALED-CLIENT-ID',
+    clientSecret: 'FAKE-SEALED-CLIENT-SECRET',
+  });
+  assert.deepEqual(
+    [...new Set(mockHost.calls.seal)].sort(),
+    ['oauth-app:sealed-oauth-app', 'sealed-host-required', 'sealed-second-token']
+  );
+});
+
+test('a Core process that ignores the marker still refuses sealed ciphertext after legacy-key purge', () => {
+  store.setHostDecryptor(null);
+  const tokenPath = path.join(TOKENS_DIR, 'sealed-host-required.json');
+  const sealedBytes = fs.readFileSync(tokenPath);
+  fs.renameSync(SEALED_MARKER, `${SEALED_MARKER}.held`);
+  try {
+    assert.throws(
+      () => store.loadToken('sealed-host-required'),
+      (error) => error && error.code === 'DEX_CM_KEY_LOST'
+    );
+    assert.equal(fs.existsSync(KEY_FILE), false);
+  } finally {
+    fs.writeFileSync(tokenPath, sealedBytes, { mode: 0o600 });
+    for (const name of fs.readdirSync(TOKENS_DIR)) {
+      if (name.startsWith('sealed-host-required.json.corrupt-')) {
+        fs.rmSync(path.join(TOKENS_DIR, name));
+      }
+    }
+    fs.renameSync(`${SEALED_MARKER}.held`, SEALED_MARKER);
+  }
+});
+
+test('credential writes in a sealed store use the host seam and never recreate a Core key', () => {
+  store.setHostDecryptor(sealedHostAfterMigration);
+
+  store.saveApiKey(
+    'sealed-new-write',
+    { apiKey: 'FAKE-SEALED-NEW-WRITE' },
+    { provider: 'sealed-new-write' }
+  );
+
+  assert.equal(fs.existsSync(KEY_FILE), false);
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(TOKENS_DIR, 'sealed-new-write.json'), 'utf8')).custody,
+    'sealed-host'
+  );
+  assert.equal(
+    store.loadToken('sealed-new-write').apiKey,
+    'FAKE-SEALED-NEW-WRITE'
+  );
+  store.deleteToken('sealed-new-write');
+});
+
+test('sealStore is a no-op when the store is already sealed', () => {
+  store.setHostDecryptor(null);
+
+  assert.deepEqual(store.sealStore(), {
+    sealed: false,
+    alreadySealed: true,
+    tokenCount: 0,
+    oauthAppCount: 0,
+  });
+  assert.equal(fs.existsSync(KEY_FILE), false);
+});
+
+test('key custody and status distinguish sealed-host without mislabelling standalone Core', () => {
+  store.setHostDecryptor(sealedHostAfterMigration);
+  assert.equal(store.keyCustodyMode(), 'sealed-host');
+
+  fs.renameSync(SEALED_MARKER, `${SEALED_MARKER}.held`);
+  try {
+    assert.equal(store.keyCustodyMode(), 'file');
+  } finally {
+    fs.renameSync(`${SEALED_MARKER}.held`, SEALED_MARKER);
+  }
+
+  let jsonOutput = '';
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (chunk) => {
+    jsonOutput += String(chunk);
+    return true;
+  };
+  try {
+    cmdStatus({ json: 'true' });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  const status = JSON.parse(jsonOutput);
+  assert.equal(status.keyCustody, 'sealed-host');
+  assert.ok(Array.isArray(status.connections));
+  assert.ok(Object.prototype.hasOwnProperty.call(status, 'registryNotice'));
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    cmdStatus();
+  } finally {
+    console.log = originalLog;
+  }
+  assert.match(lines.join('\n'), /signed Dex desktop host/i);
+});

--- a/core/integrations/connection-manager/contract.cjs
+++ b/core/integrations/connection-manager/contract.cjs
@@ -199,6 +199,7 @@ function buildConnectionsSchema() {
         properties: {
           connections: { type: 'array', items: { $ref: '#/$defs/statusRow' } },
           registryNotice: { $ref: '#/$defs/registryNotice' },
+          keyCustody: { enum: ['keychain', 'file', 'sealed-host'] },
         },
       },
       tokenEnvelopeV2: {
@@ -236,6 +237,7 @@ function fixtureStatus(status) {
       lastProbeAt: status === 'connected' ? '2030-01-01T00:01:00.000Z' : null,
     }],
     registryNotice: null,
+    keyCustody: 'keychain',
   };
 }
 

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -8,6 +8,7 @@
  *   connections.json        plaintext registry: status/scopes/timestamps (NO secrets)
  *   oauth-apps.json         plaintext client ids + encrypted client-secret envelopes
  *   .dex-cm.key             fallback encryption key (0600) if OS keychain unavailable
+ *   .dex-cm.sealed          durable { custody:'sealed-host' } host-custody marker
  *   .gitignore              auto-written ('*') so a git-tracked vault never commits secrets
  *
  * Multi-account: a connection id is `provider` or `provider:alias`. Bare `provider`
@@ -28,6 +29,7 @@ const { TOKEN_ENVELOPE_VERSION, LOCK_PROTOCOL } = require('./contract.cjs');
 
 const KEYCHAIN_SERVICE = 'dex-connection-manager';
 const KEYCHAIN_ACCOUNT = 'token-store-key';
+const SEALED_MARKER_NAME = '.dex-cm.sealed';
 const MAX_ENCRYPTED_DATA_BYTES = 1024 * 1024;
 const DEFAULTS_TRUST_ERROR = Symbol('defaultsTrustError');
 
@@ -162,7 +164,80 @@ function keychainDisabled() {
   return process.env.DEX_CM_NO_KEYCHAIN === '1';
 }
 
+class SealedHostRequiredError extends Error {
+  constructor() {
+    super('This credential store is sealed to the signed Dex desktop host, which is not reachable.');
+    this.name = 'SealedHostRequiredError';
+    this.code = 'DEX_CM_SEALED_HOST_REQUIRED';
+  }
+}
+
+// TODO(native/XPC lane): inject the real dex-credd client from the signed
+// Desktop host. This Core lane intentionally provides only the seam and a mock.
+let _hostDecryptor = null;
+
+function setHostDecryptor(hostDecryptor) {
+  _hostDecryptor = hostDecryptor || null;
+}
+
+function sealedMarkerPath() {
+  return path.join(credentialsDir(), SEALED_MARKER_NAME);
+}
+
+function sealedHostMarked() {
+  const markerPath = sealedMarkerPath();
+  let stat;
+  try {
+    stat = fs.lstatSync(markerPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return false;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    const error = new Error(`The sealed-custody marker at ${markerPath} is not a regular file.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    const error = new Error(`The sealed-custody marker at ${markerPath} belongs to a different user.`);
+    error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+    throw error;
+  }
+  let marker;
+  try {
+    marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+  } catch {
+    const error = new Error(`The sealed-custody marker at ${markerPath} is unreadable.`);
+    error.code = 'DEX_CM_SEALED_MARKER_INVALID';
+    throw error;
+  }
+  if (!marker || marker.v !== 1 || marker.custody !== 'sealed-host') {
+    const error = new Error(`The sealed-custody marker at ${markerPath} is invalid.`);
+    error.code = 'DEX_CM_SEALED_MARKER_INVALID';
+    throw error;
+  }
+  return true;
+}
+
+function requireHostDecryptor(requiredMethods = ['decrypt']) {
+  let available = false;
+  try {
+    available = Boolean(_hostDecryptor && typeof _hostDecryptor.available === 'function') &&
+      _hostDecryptor.available() === true;
+  } catch {
+    available = false;
+  }
+  if (
+    !available ||
+    requiredMethods.some((method) => typeof _hostDecryptor[method] !== 'function')
+  ) {
+    throw new SealedHostRequiredError();
+  }
+  return _hostDecryptor;
+}
+
 function keyCustodyMode() {
+  if (sealedHostMarked()) return 'sealed-host';
   if (process.platform !== 'darwin' || keychainDisabled()) return 'file';
   return fs.existsSync(path.join(credentialsDir(), '.dex-cm.key')) ? 'file' : 'keychain';
 }
@@ -200,6 +275,89 @@ function storeKeyInMacKeychain(keyB64) {
     return false;
   }
 }
+
+function strictMacKeychainSnapshot() {
+  if (process.platform !== 'darwin' || keychainDisabled()) {
+    return { applicable: false, present: false, value: null };
+  }
+  try {
+    const value = execFileSync(
+      'security',
+      ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-w'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    ).trim();
+    return { applicable: true, present: true, value };
+  } catch (error) {
+    if (error && error.status === 44) {
+      return { applicable: true, present: false, value: null };
+    }
+    throw new Error(`Cannot verify the legacy macOS Keychain item before sealing: ${error.message}`);
+  }
+}
+
+const systemLegacyKeyCustody = {
+  capture() {
+    const keyPath = path.join(credentialsDir(), '.dex-cm.key');
+    let fileKey = null;
+    try {
+      const stat = fs.lstatSync(keyPath);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        const error = new Error(`The encryption key at ${keyPath} is a symlink or not a regular file.`);
+        error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+        throw error;
+      }
+      fileKey = { contents: fs.readFileSync(keyPath), mode: stat.mode & 0o777 };
+    } catch (error) {
+      if (!error || error.code !== 'ENOENT') throw error;
+    }
+    return { fileKey, keychain: strictMacKeychainSnapshot() };
+  },
+
+  purge(snapshot) {
+    const keyPath = path.join(credentialsDir(), '.dex-cm.key');
+    if (snapshot.fileKey) fs.unlinkSync(keyPath);
+    if (snapshot.keychain.present) {
+      try {
+        execFileSync(
+          'security',
+          ['delete-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT],
+          { stdio: ['ignore', 'ignore', 'pipe'] }
+        );
+      } catch (error) {
+        throw new Error(`Cannot delete the legacy macOS Keychain item while sealing: ${error.message}`);
+      }
+    }
+  },
+
+  verifyPurged() {
+    const keyPath = path.join(credentialsDir(), '.dex-cm.key');
+    if (fs.existsSync(keyPath)) return false;
+    return !strictMacKeychainSnapshot().present;
+  },
+
+  restore(snapshot) {
+    const keyPath = path.join(credentialsDir(), '.dex-cm.key');
+    if (snapshot.fileKey) {
+      writeFileAtomic(keyPath, snapshot.fileKey.contents, { mode: snapshot.fileKey.mode || 0o600 });
+    } else if (fs.existsSync(keyPath)) {
+      fs.unlinkSync(keyPath);
+    }
+    if (snapshot.keychain.applicable) {
+      const current = strictMacKeychainSnapshot();
+      if (snapshot.keychain.present) {
+        if (!storeKeyInMacKeychain(snapshot.keychain.value)) {
+          throw new Error('Cannot restore the legacy macOS Keychain item after sealing failed.');
+        }
+      } else if (current.present) {
+        execFileSync(
+          'security',
+          ['delete-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT],
+          { stdio: ['ignore', 'ignore', 'pipe'] }
+        );
+      }
+    }
+  },
+};
 
 function keyFromFile() {
   const keyPath = path.join(credentialsDir(), '.dex-cm.key');
@@ -341,7 +499,22 @@ function canonicalJSON(value) {
 }
 
 function trustMac(payload) {
+  if (sealedHostMarked()) {
+    return trustMacViaHost(requireHostDecryptor(['mac']), payload);
+  }
   return crypto.createHmac('sha256', trustMacKey()).update(canonicalJSON(payload)).digest('base64');
+}
+
+function trustMacViaHost(hostDecryptor, payload) {
+  const mac = hostDecryptor.mac(canonicalJSON(payload));
+  if (
+    typeof mac !== 'string' ||
+    Buffer.from(mac, 'base64').length !== 32 ||
+    Buffer.from(mac, 'base64').toString('base64') !== mac
+  ) {
+    throw new Error('The sealed host returned an invalid trust MAC.');
+  }
+  return mac;
 }
 
 function macMatches(actual, payload) {
@@ -471,6 +644,9 @@ class EnvelopeBindingError extends Error {
 }
 
 function encrypt(plaintext, aad = '') {
+  if (sealedHostMarked()) {
+    return sealViaHost(requireHostDecryptor(['seal']), plaintext, aad);
+  }
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv('aes-256-gcm', getKey(), iv);
   cipher.setAAD(Buffer.from(aad, 'utf8'));
@@ -500,6 +676,14 @@ function decodeCanonicalBase64(value, field, { exactBytes, maxBytes } = {}) {
 }
 
 function decrypt(envelope, aad = '') {
+  if (sealedHostMarked()) {
+    if (!envelope || envelope.aad !== aad) throw new EnvelopeBindingError();
+    const plaintext = requireHostDecryptor().decrypt(hostCredentialId(aad), envelope);
+    if (typeof plaintext !== 'string') {
+      throw new Error('The sealed host returned an invalid credential payload.');
+    }
+    return plaintext;
+  }
   if (!envelope || envelope.v !== TOKEN_ENVELOPE_VERSION) throw new Error('Unsupported encrypted credential envelope version.');
   if (envelope.aad !== aad) throw new EnvelopeBindingError();
   const iv = decodeCanonicalBase64(envelope.iv, 'iv', { exactBytes: 12 });
@@ -510,6 +694,210 @@ function decrypt(envelope, aad = '') {
   decipher.setAuthTag(tag);
   const out = Buffer.concat([decipher.update(data), decipher.final()]);
   return out.toString('utf8');
+}
+
+function hostCredentialId(aad) {
+  return aad.startsWith('token:') ? aad.slice('token:'.length) : aad;
+}
+
+function sealViaHost(hostDecryptor, plaintext, aad) {
+  const envelope = hostDecryptor.seal(hostCredentialId(aad), plaintext, aad);
+  if (
+    !isPlainObject(envelope) ||
+    envelope.custody !== 'sealed-host' ||
+    envelope.aad !== aad
+  ) {
+    throw new Error('The sealed host returned an invalid credential envelope.');
+  }
+  return envelope;
+}
+
+function snapshotFileForSeal(file) {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      const error = new Error(`Credential migration refused an unsafe file at ${file}.`);
+      error.code = 'DEX_CM_UNSAFE_CREDENTIAL_PATH';
+      throw error;
+    }
+    return { exists: true, contents: fs.readFileSync(file), mode: stat.mode & 0o777 };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { exists: false, contents: null, mode: 0o600 };
+    throw error;
+  }
+}
+
+function restoreFileAfterSeal(file, snapshot) {
+  if (snapshot.exists) {
+    writeFileAtomic(file, snapshot.contents, { mode: snapshot.mode || 0o600 });
+  } else if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+  }
+}
+
+function serializedEnvelope(envelope) {
+  return Buffer.from(`${JSON.stringify(envelope, null, 2)}\n`);
+}
+
+function clearLegacyKeyCache() {
+  if (_cachedKey) _cachedKey.fill(0);
+  if (_cachedTrustMacKey) _cachedTrustMacKey.fill(0);
+  _cachedKey = null;
+  _cachedTrustMacKey = null;
+}
+
+/**
+ * One-way migration from Core-held AES custody to the signed host seam.
+ *
+ * Every output is prepared before mutation. Token/app/registry/marker writes
+ * happen under the existing store lock, and byte snapshots plus legacy-key
+ * custody snapshots are restored if any write, purge, or purge verification
+ * fails. The real host implementation is deliberately left to the native/XPC
+ * lane; this function only consumes the injected synchronous seam.
+ */
+function sealStore({ legacyKeyCustody = systemLegacyKeyCustody } = {}) {
+  if (sealedHostMarked()) {
+    return { sealed: false, alreadySealed: true, tokenCount: 0, oauthAppCount: 0 };
+  }
+  const hostDecryptor = requireHostDecryptor(['decrypt', 'seal', 'mac']);
+
+  return withStoreLock(() => {
+    if (sealedHostMarked()) {
+      return { sealed: false, alreadySealed: true, tokenCount: 0, oauthAppCount: 0 };
+    }
+    assertCredentialsNotTracked();
+
+    const registry = readRegistry();
+    for (const [connId, entry] of Object.entries(registry)) {
+      if (connId === '_defaults' || connId === '_meta' || !entry || !entry.service) continue;
+      if (entry.error === 'trust_unverified' || entry.error === 'encryption_key_lost') {
+        const error = new Error(`Credential store sealing refused an untrusted registry entry for ${connId}.`);
+        error.code = 'DEX_CM_SEAL_STORE_UNTRUSTED';
+        throw error;
+      }
+    }
+
+    const tokenFiles = listTokenFiles();
+    const tokenOutputs = new Map();
+    for (const file of tokenFiles) {
+      const parsed = parseConnectionId(
+        file.replace(/\.json$/, '').replace(/__/g, ':'),
+        { allowLegacyProviderCase: true }
+      );
+      const filePath = path.join(credentialsDir(), 'tokens', file);
+      const aad = `token:${parsed.connId}`;
+      const legacyEnvelope = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      const plaintext = decrypt(legacyEnvelope, aad);
+      tokenOutputs.set(
+        filePath,
+        serializedEnvelope(sealViaHost(hostDecryptor, plaintext, aad))
+      );
+    }
+
+    const appsPath = oauthAppsPath();
+    const appsSnapshot = snapshotFileForSeal(appsPath);
+    let oauthAppCount = 0;
+    let sealedAppsBytes = null;
+    if (appsSnapshot.exists) {
+      const apps = JSON.parse(appsSnapshot.contents.toString('utf8'));
+      for (const [provider, app] of Object.entries(apps)) {
+        if (!app || !app.clientSecret) continue;
+        const aad = `oauth-app:${provider}`;
+        const plaintext = decrypt(app.clientSecret, aad);
+        app.clientSecret = sealViaHost(hostDecryptor, plaintext, aad);
+        oauthAppCount++;
+      }
+      sealedAppsBytes = Buffer.from(`${JSON.stringify(apps, null, 2)}\n`);
+    }
+
+    const registryPathname = registryPath();
+    const registrySnapshot = snapshotFileForSeal(registryPathname);
+    const markerPath = sealedMarkerPath();
+    const markerSnapshot = snapshotFileForSeal(markerPath);
+    const fileSnapshots = new Map([
+      ...[...tokenOutputs.keys()].map((file) => [file, snapshotFileForSeal(file)]),
+      [appsPath, appsSnapshot],
+      [registryPathname, registrySnapshot],
+      [markerPath, markerSnapshot],
+    ]);
+    const custodySnapshot = legacyKeyCustody.capture();
+
+    const sealedRegistry = JSON.parse(JSON.stringify(registry));
+    for (const [filePath, bytes] of tokenOutputs) {
+      const connId = path.basename(filePath, '.json').replace(/__/g, ':');
+      if (!sealedRegistry[connId] || !sealedRegistry[connId].service) {
+        throw new Error(`Credential store sealing could not match ${connId} to its registry entry.`);
+      }
+      sealedRegistry[connId].credentialDigest = crypto.createHash('sha256').update(bytes).digest('hex');
+      sealedRegistry[connId].mac = trustMacViaHost(
+        hostDecryptor,
+        registryMacPayload(connId, sealedRegistry[connId])
+      );
+    }
+    if (sealedRegistry._meta) {
+      sealedRegistry._meta.mac = trustMacViaHost(
+        hostDecryptor,
+        registryMetaPayload(sealedRegistry)
+      );
+    }
+    const sealedRegistryBytes = Buffer.from(`${JSON.stringify(sealedRegistry, null, 2)}\n`);
+
+    let mutated = false;
+    try {
+      mutated = true;
+      for (const [file, bytes] of tokenOutputs) {
+        writeFileAtomic(file, bytes, { mode: 0o600 });
+      }
+      if (sealedAppsBytes) writeFileAtomic(appsPath, sealedAppsBytes, { mode: 0o600 });
+      if (registrySnapshot.exists || hasServiceEntries(sealedRegistry)) {
+        writeFileAtomic(registryPathname, sealedRegistryBytes, { mode: 0o600 });
+      }
+      writeFileAtomic(
+        markerPath,
+        `${JSON.stringify({ v: 1, custody: 'sealed-host' })}\n`,
+        { mode: 0o600 }
+      );
+
+      legacyKeyCustody.purge(custodySnapshot);
+      if (!legacyKeyCustody.verifyPurged()) {
+        throw new Error('Legacy credential key material still exists after sealing.');
+      }
+    } catch (error) {
+      const rollbackErrors = [];
+      if (mutated) {
+        for (const [file, snapshot] of fileSnapshots) {
+          try {
+            restoreFileAfterSeal(file, snapshot);
+          } catch (rollbackError) {
+            rollbackErrors.push(rollbackError);
+          }
+        }
+        try {
+          legacyKeyCustody.restore(custodySnapshot);
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+        }
+      }
+      clearLegacyKeyCache();
+      if (rollbackErrors.length) {
+        const rollbackFailure = new Error(
+          `Credential store sealing failed and rollback could not restore the prior state: ${rollbackErrors.map((item) => item.message).join('; ')}`
+        );
+        rollbackFailure.code = 'DEX_CM_SEAL_ROLLBACK_FAILED';
+        rollbackFailure.cause = error;
+        throw rollbackFailure;
+      }
+      throw error;
+    }
+
+    clearLegacyKeyCache();
+    return {
+      sealed: true,
+      alreadySealed: false,
+      tokenCount: tokenOutputs.size,
+      oauthAppCount,
+    };
+  });
 }
 
 // ---- Connection ids (multi-account) -----------------------------------------
@@ -706,13 +1094,21 @@ function quarantineFile(p, reason) {
  * keeps working.
  */
 function loadToken(id) {
+  const sealedHost = sealedHostMarked() ? requireHostDecryptor() : null;
   const connId = resolveConnId(id);
   const p = tokenPath(connId);
   if (!fs.existsSync(p)) return null;
   try {
     const envelope = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (sealedHost) {
+      if (envelope.aad !== `token:${connId}`) throw new EnvelopeBindingError();
+      return JSON.parse(sealedHost.decrypt(connId, envelope));
+    }
     return JSON.parse(decrypt(envelope, `token:${connId}`));
   } catch (err) {
+    // A host failure is not evidence that sealed ciphertext is corrupt. Keep the
+    // file untouched and surface the host's typed failure to the caller.
+    if (sealedHost) throw err;
     // Key loss is store-wide, not a damaged file: keep the (intact) token file
     // where it is and surface the explicit state to the caller instead.
     if (err && (err.code === 'DEX_CM_KEY_LOST' || err.code === 'DEX_CM_UNSAFE_CREDENTIAL_PATH')) throw err;
@@ -1204,6 +1600,9 @@ function nowIso() {
 
 module.exports = {
   credentialsDir,
+  sealedMarkerPath,
+  setHostDecryptor,
+  sealStore,
   keyCustodyMode,
   parseConnectionId,
   resolveConnId,
@@ -1231,6 +1630,7 @@ module.exports = {
   verifyLedgerRow,
   ledgerRowMatchesCurrentCredential,
   KeyLossError,
+  SealedHostRequiredError,
   EnvelopeBindingError,
   recoverFromKeyLoss,
 };

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 233211,
-      "treeHash": "f59bf17c7aa624318939e6ede3309d6ed15f30c9dff190c62804527a7cfa5f26",
+      "totalBytes": 247582,
+      "treeHash": "a5f2e2f1a9d7ef947ac398946d1b1ea646b9e03f8ff06cbe12907ee66d13fec7",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -36,13 +36,13 @@
         },
         {
           "path": "connect.cjs",
-          "bytes": 29599,
-          "sha256": "ca86c82c154122392ec9cbd0c607edc2230f4b4ef8b4989cef6e04ed567a3284"
+          "bytes": 29717,
+          "sha256": "39083ad8efb5985c5401f9270971f90a5cdfa1f83dfe0d830b7320e49f1b28b6"
         },
         {
           "path": "contract.cjs",
-          "bytes": 9429,
-          "sha256": "8a313c5e817f723dd2e98e6eb76ba615fb64903f8769a847cd35c85dd75e51c3"
+          "bytes": 9526,
+          "sha256": "71805b045f0e031b8a7f5356e53d6934a19ff056fa316af243b24bc820c4437e"
         },
         {
           "path": "dex-call.cjs",
@@ -116,8 +116,8 @@
         },
         {
           "path": "token-store.cjs",
-          "bytes": 47006,
-          "sha256": "30877cdcb1f7b16124974b88af7c170402eb07cc2cfd784e3b45a33af351764f"
+          "bytes": 61162,
+          "sha256": "a05c1bef0087edf038fca04926131a2b0a115d4f87b68a694135a776d3c7959c"
         }
       ]
     }

--- a/packages/dex-contracts/dist/connections.schema.json
+++ b/packages/dex-contracts/dist/connections.schema.json
@@ -190,6 +190,13 @@
         },
         "registryNotice": {
           "$ref": "#/$defs/registryNotice"
+        },
+        "keyCustody": {
+          "enum": [
+            "keychain",
+            "file",
+            "sealed-host"
+          ]
         }
       }
     },

--- a/packages/dex-contracts/fixtures/connections/status.connected.json
+++ b/packages/dex-contracts/fixtures/connections/status.connected.json
@@ -18,5 +18,6 @@
       "lastProbeAt": "2030-01-01T00:01:00.000Z"
     }
   ],
-  "registryNotice": null
+  "registryNotice": null,
+  "keyCustody": "keychain"
 }

--- a/packages/dex-contracts/fixtures/connections/status.expired.json
+++ b/packages/dex-contracts/fixtures/connections/status.expired.json
@@ -18,5 +18,6 @@
       "lastProbeAt": null
     }
   ],
-  "registryNotice": null
+  "registryNotice": null,
+  "keyCustody": "keychain"
 }

--- a/packages/dex-contracts/fixtures/connections/status.expiring.json
+++ b/packages/dex-contracts/fixtures/connections/status.expiring.json
@@ -18,5 +18,6 @@
       "lastProbeAt": null
     }
   ],
-  "registryNotice": null
+  "registryNotice": null,
+  "keyCustody": "keychain"
 }

--- a/packages/dex-contracts/fixtures/connections/status.needs_reauth.json
+++ b/packages/dex-contracts/fixtures/connections/status.needs_reauth.json
@@ -18,5 +18,6 @@
       "lastProbeAt": null
     }
   ],
-  "registryNotice": null
+  "registryNotice": null,
+  "keyCustody": "keychain"
 }

--- a/packages/dex-contracts/fixtures/connections/status.not_connected.json
+++ b/packages/dex-contracts/fixtures/connections/status.not_connected.json
@@ -16,5 +16,6 @@
       "lastProbeAt": null
     }
   ],
-  "registryNotice": null
+  "registryNotice": null,
+  "keyCustody": "keychain"
 }


### PR DESCRIPTION
> ## ⛔ HELD — part of the closed-door `/connect` redesign. Do not merge to ship.
> This is the **Core half of R2** (sealed credential custody). `/connect` stays closed; there is no
> user-facing change. It builds against a **mock** of the signed `dex-credd` helper — the real native
> XPC/Keychain/Touch-ID helper is a separate lane and must land (and the on-device live re-gate must
> pass) before any of this is exercised for real. Safe to merge to `main` as inert plumbing once
> reviewed, but it does nothing until the helper exists.

## What this is
R2 from the doorway redesign plan (`~/dex/artifacts/integrations-connect-doorway-redesign-plan.md`),
Core side. Threat-modelled in R0; this implements the Core plumbing the sealed design needs.

## What it does
- **Sealed marker + fail-closed reads.** A `.dex-cm.sealed` marker records host-custody. Once sealed,
  Core with no reachable helper throws a typed `SealedHostRequiredError` (`DEX_CM_SEALED_HOST_REQUIRED`)
  — it never falls back to a local key and never misreads the ciphertext. The marker carries the same
  symlink/ownership/regular-file guards as the rest of the credentials dir.
- **Host-decryptor seam** (`available`/`decrypt`/`seal`/`mac`) with a clearly-marked native/XPC TODO.
  On a sealed store the **trust-MAC delegates to the host**, not a Core-derived key — this closes the
  structural finding from R0 (the trust-MAC key derives from the master key, so it must move with it).
- **One-way `sealStore()` migration.** Re-encrypts every token + OAuth client secret via the host,
  re-attests registry MACs, writes the marker, then verifiably deletes **both** the `.dex-cm.key` file
  and the macOS Keychain item. Snapshots every file and the legacy key first and restores byte-for-byte
  on any failure — never a half-seal. Idempotent; refuses with no host; refuses to seal untrusted entries.
- **Honest custody labelling.** `status` reports `sealed-host` distinctly; standalone never claims it.
  `status --json` gains optional `keyCustody` with no breaking rename.

## Verification
- **218/218** integration tests (incl. 11 new custody tests) on a normal run. The socket/broker tests
  that `EPERM` inside Codex's sandbox all pass outside it — reviewer confirmed independently.
- All #226/#239 hardening preserved (AAD binding, atomic writes, lstat/ownership, key-loss, trust-MAC) —
  verified by grep + reading the diff, not assumed.
- Local PR gates (doc-drift, path-contract, test-delta, portable-contract, connections-contract): green.

## Not in this PR (later lanes)
The native `dex-credd` helper (XPC, real Keychain/Touch-ID, presence-per-use, helper-owned credential
use), the app-bundle + Apple provisioning profile, and the live re-gate. This is inert until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYrZr5tGFNsVzxaAKbpbka
