### PR TITLE
docs: full documentation refresh to v1.75.2 ground truth

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,30 @@
+# .agents/ — cross-harness skill surface
+
+This directory ships a small subset of Dex skills in the harness-neutral
+Agent Skills layout, so AI coding harnesses that don't read `.claude/skills/`
+can still run the core journeys:
+
+- `skills/getting-started/` — post-onboarding tour
+- `skills/process-meetings/` — meeting processing
+- `skills/industry-truths/` — strategic context capture
+
+## Relationship to `.claude/skills/`
+
+`.claude/skills/` is the canonical, fully-maintained skill set (74 skills).
+The copies here are **adapters**, not a second source of truth: when a skill
+that exists in both places changes in `.claude/skills/`, the change should be
+mirrored here in the same PR.
+
+> ⚠️ Known drift (2026-07-26): `process-meetings` and `getting-started` here
+> lag their `.claude/skills/` counterparts (e.g. the deterministic
+> soft-commitment pass and pillar-ID resolution are missing from the copies
+> here). Re-syncing is pending a deliberate pass — these files are covered by
+> instruction-honesty and configuration-truth tests
+> (`core/tests/test_instruction_honesty.py`,
+> `core/tests/test_granola_configuration_truth.py`,
+> `scripts/check-instructed-tools.py`), so sync them via a reviewed change,
+> not a blind copy.
+
+This directory is `brain`-classed in the portable ownership contract and is
+provisioned into installs (`core/provision-contract.json`); user-authored
+variants belong in `.agents/skills/*-custom/`, which updates never touch.

--- a/.claude/guides/README.md
+++ b/.claude/guides/README.md
@@ -2,6 +2,12 @@
 
 **Purpose:** System documentation and conventions that explain how Dex works and how to use it effectively.
 
+> **Note (2026-07):** this folder is currently an empty tier — the documentation it
+> describes actually lives in `.claude/reference/` (technical detail docs skills
+> point into) and `docs/Dex_System/` / `06-Resources/Dex_System/` (user-facing
+> system guides). Look there first; add a guide here only if it genuinely fits
+> neither home.
+
 ## What Goes Here
 
 Documentation files that:

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -174,14 +174,12 @@ Invoked with `/skill-name` - automatically discovered by Claude.
 
 ## What's New
 
-### v1.11.0 — Isolated Context & Agent Memory
-
-Skills that run heavy workflows now execute in **isolated context** — your conversation stays clean, no context bleed. Key enhancements:
-
-- **Daily/Weekly workflows** (`/daily-plan`, `/daily-review`, `/week-plan`, `/week-review`) — Isolated context execution. `/daily-plan` generates a quickref summary and is powered by agents with memory that track trends across sessions.
-- **Meetings** (`/meeting-prep`, `/process-meetings`) — Isolated context. `/process-meetings` auto-updates person pages and supports background execution for large batches.
-- **Career** (`/career-coach`) — Isolated context. Auto-captures career evidence when achievements with metrics are discussed.
-- **Triage** (`/triage`) — Tuned for speed. Quick routing decisions without over-analysis.
+Release notes aren't maintained here — run `/dex-whats-new` or read `CHANGELOG.md`
+for what changed recently. For the full, always-current skill catalog (every skill,
+its description, and its trigger analysis), see the generated
+`docs/architecture/INVENTORY.md` § "Skills" in the dex-core repo; in a live vault,
+`/dex-level-up` surfaces the skills you're not using yet. Each skill's frontmatter
+`description` is its authoritative trigger contract.
 
 ---
 

--- a/.distignore
+++ b/.distignore
@@ -31,6 +31,7 @@ core/integrations/connection-manager/hardening.child.cjs
 .scripts/meeting-intel/__tests__/
 
 # Dev scripts and docs
+AGENTS.md
 CONTRIBUTING.md
 DISTRIBUTION_READY.md
 scripts/

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1,7 +1,7 @@
 # Dex Technical Guide
 
 **Version:** 1.0  
-**Last Updated:** July 11, 2026
+**Last Updated:** July 2026
 
 **Audience:** People who want to understand how Dex works under the hood - whether to customize it, contribute to it, or learn from its design patterns.
 

--- a/06-Resources/Dex_System/Distribution_Checklist.md
+++ b/06-Resources/Dex_System/Distribution_Checklist.md
@@ -1,273 +1,74 @@
 # Dex Distribution Checklist
 
-**Status:** ✅ Ready for GitHub Distribution
+**Last Updated:** 2026-07-26 (v1.75.2)
 
-This document verifies that Dex is properly configured for public distribution without exposing credentials or requiring manual path configuration.
-
----
-
-## ✅ 1. Dynamic Paths (SOLVED)
-
-**Problem:** Users will clone to different paths like `/Users/alice/Documents/dex`
-
-**Solution:** Template + install script substitution (already implemented)
-
-### How It Works
-
-1. **Template file:** `System/.mcp.json.example` uses `{{VAULT_PATH}}` placeholder
-2. **Install script:** `install.sh` (lines 49-55) automatically:
-   - Detects current directory: `CURRENT_PATH="$(pwd)"`
-   - Replaces placeholder: `sed "s|{{VAULT_PATH}}|$CURRENT_PATH|g"`
-   - Generates `.mcp.json` (gitignored)
-
-### User Experience
-
-```bash
-cd ~/Documents/dex
-./install.sh
-# ✅ Creates .mcp.json with /Users/alice/Documents/dex
-```
-
-**Status:** No action needed — industry-standard pattern.
+Maintainer reference for how Dex ships and what to check when cutting a release.
+For the standing overview of the distribution system, see `DISTRIBUTION_READY.md`
+at the repo root. This file replaced the original pre-launch checklist (January
+2026); the old content is in git history.
 
 ---
 
-## ✅ 2. MCP Server Architecture (CLARIFIED)
+## 1. Paths — provisioned, not templated
 
-### Dex Core MCP Servers (7 total)
+A fresh install runs `install.sh`, which provisions everything through
+`node core/provision.cjs` + `core/provision-contract.json` + the generated
+portable-vault ownership contract. The vault path is collected once and rendered
+with a receipt.
 
-All shipped with Dex in `core/mcp/`:
+> The old `sed "s|{{VAULT_PATH}}|…|"` templating over `System/.mcp.json.example`
+> no longer exists. If a doc describes it, that doc is stale.
 
-| Server | File | Purpose | External Dependency |
-|--------|------|---------|-------------------|
-| work-mcp | `work_server.py` | Task/goal management | None (local files) |
-| calendar-mcp | `calendar_server.py` | Calendar integration | macOS Calendar.app |
-| granola-mcp | `granola_server.py` | Meeting processing | `GRANOLA_API_KEY` from a Granola Business/Enterprise plan (optional) |
-| career-mcp | `career_server.py` | Career development | None (local files) |
-| resume-mcp | `resume_server.py` | Resume building | None (local files) |
-| dex-improvements-mcp | `dex_improvements_server.py` | System improvements | None (local files) |
-| update-checker | `update_checker.py` | Dex update checking | GitHub API (read-only) |
+## 2. MCP servers — 10 core, external ones stay external
 
-### External MCPs (NOT part of Dex)
+Dex ships **10 MCP servers** in `core/mcp/`. The authoritative, CI-drift-gated
+list (names, tool counts, exact tools) is `docs/architecture/INVENTORY.md`
+§ "MCP engines" — don't hand-copy it here.
 
-These are user-installed separately via Claude Desktop/Cursor settings:
+External MCPs (browser automation, user-installed integrations, hosted vendor
+MCPs) are not part of Dex; users add them via their own Claude settings.
 
-- `cursor-ide-browser` — Browser automation
-- `user-granola` — Official Granola MCP (different from dex granola-mcp)
-- `pendo` — Pendo's hosted MCP server (OAuth, optional for Pendo customers)
-- `user-whatsapp`, `user-apify`, etc. — Other user-installed integrations
+Optional companions degrade gracefully:
+- **Granola** — meeting sync uses Granola's official public API with
+  `GRANOLA_API_KEY` (Business/Enterprise plan); `/granola-setup` connects it.
+  Without it, users can paste transcripts manually.
+- **Apple Calendar/Reminders** — EventKit shims in `core/mcp/scripts/`; macOS
+  only; other platforms degrade gracefully (`docs/support/upgrade-platform-matrix.md`).
 
-### Optional Dependencies
+## 3. Credentials & user data — enforced by CI, not by checklist
 
-**Granola (meeting transcription):**
-- Install script checks for `/Applications/Granola.app` only to offer the right next step
-- If found: "✅ Granola app detected — run /granola-setup to connect it (needs a Granola Business API key)"
-- If not found: "ℹ️ Granola app not detected", followed by the https://granola.ai install pointer
-- Meeting sync uses the official Granola public API and reads `GRANOLA_API_KEY` from the environment, then the vault-root `.env`
-- `/granola-setup` connects the API key; local application data is never treated as authentication
-- System works without it — users can paste meeting transcripts manually
+What used to be manual verification is now automated gates on every push:
 
-**Apple Calendar:**
-- Uses macOS Calendar.app via AppleScript (no API keys needed)
-- Works with any calendar synced to Calendar.app (Google, Outlook, iCloud)
-- macOS only (calendar-mcp gracefully degrades on other platforms)
+| Concern | Gate |
+| --- | --- |
+| No PII in tracked files | `scripts/check-pii.sh` + `scripts/pii_gate.py` |
+| No founder-machine content ships | `scripts/check-founder-content.sh` |
+| No credentials/keys | `scripts/security-gate.sh` + `security-scan.py` |
+| Every path classified (user data never shipped) | `scripts/check-portable-contract.sh` |
+| Distribution safety | `scripts/verify-distribution.sh` |
 
-**Status:** Documentation matches the official API connection model.
+`.env`, `.mcp.json`, `System/user-profile.yaml`, `System/pillars.yaml`, and all
+user data folders are gitignored; the ownership contract additionally guarantees
+updates never write `vault`-class paths.
 
----
+**99% of features work with no API keys.** Optional keys (Anthropic/OpenAI/Gemini)
+only enable background automation; `/setup` offers this and creates `.env` from
+`env.example` on an explicit yes.
 
-## ✅ 3. Credentials & Security (VERIFIED)
+## 4. Cutting a release
 
-### Gitignored Files
+1. Land the changes on `main` with a `CHANGELOG.md` entry in the house voice —
+   CHANGELOG is the single source of release truth.
+2. CI on the `main` push runs the full gate list, then builds and publishes the
+   release branch, tag, and vault bundle, and deploys the release-health page.
+3. Tag `vX.Y.Z` — `release.yml` extracts the matching CHANGELOG section and
+   creates the GitHub Release.
+4. Prerelease work goes through the `beta` branch mirror (prerelease-only guards).
 
-```gitignore
-# Credentials
-.env
-.env.local
+## 5. Manual spot-checks (when touching install/packaging)
 
-# Generated config
-.mcp.json
-
-# User data
-System/user-profile.yaml
-System/pillars.yaml
-00-Inbox/
-01-Quarter_Goals/
-02-Week_Priorities/
-03-Tasks/
-04-Projects/
-05-Areas/
-07-Archives/
-```
-
-### Credential Scan Results
-
-**Python MCP servers:**
-```bash
-✅ No API keys found in core/mcp/*.py
-✅ No hardcoded passwords/tokens
-✅ No personal data
-```
-
-**Environment variables:**
-- Template: `env.example` (safe — no real keys)
-- Actual `.env` is gitignored
-- Created during setup only if user enables optional features
-
-### What Gets Committed to GitHub
-
-**Safe to commit:**
-- ✅ `System/.mcp.json.example` — Template with `{{VAULT_PATH}}`
-- ✅ `env.example` — Template showing structure
-- ✅ `core/mcp/*.py` — MCP server code (no credentials)
-- ✅ Documentation and README
-
-**Never committed:**
-- ❌ `.mcp.json` — Generated, contains user paths
-- ❌ `.env` — Contains API keys if configured
-- ❌ User data folders (00-07)
-- ❌ `System/user-profile.yaml` — Personal info
-
-**Status:** Security verified — ready for public release.
-
----
-
-## 📋 Pre-Release Checklist
-
-Before pushing to GitHub:
-
-### Repository Setup
-- [ ] Remove or sanitize `System/Session_Learnings/` (contains personal work history)
-- [ ] Verify `.gitignore` is committed
-- [ ] Check no `.env` or `.mcp.json` in git history: `git log --all --full-history --name-only -- .env .mcp.json`
-- [ ] Verify no API keys in commit history: `git log --all -S "sk-ant-" -S "ANTHROPIC_API_KEY" -S "OPENAI_API_KEY"`
-
-### Documentation
-- [ ] README links to actual podcast episode (currently placeholder)
-- [ ] README links to blog post (currently placeholder)
-- [ ] Verify GitHub repo URL in clone command
-- [ ] Add LICENSE file (MIT recommended)
-- [ ] Add CONTRIBUTING.md if accepting PRs
-
-### Testing
-- [ ] Fresh clone on different machine
-- [ ] Run `./install.sh` with no prior Dex installation
-- [ ] Verify `.mcp.json` generates with correct paths
-- [ ] Run setup wizard: `/setup` in Cursor
-- [ ] Test without Granola installed (graceful degradation)
-- [ ] Test on Windows if supporting (install.sh needs .bat version)
-
----
-
-## 🔐 Credential Management for Users
-
-### What Users Need to Know
-
-**99% of features work immediately** — no API keys needed:
-- Task management
-- Person pages
-- Project tracking  
-- Daily planning
-- Meeting prep
-- All `/commands`
-
-**Optional API keys** (only if enabling background automation):
-- Anthropic API key — For `/prompt-improver` and background meeting processing
-- OpenAI or Gemini — Alternative to Anthropic
-
-### Setup Flow
-
-1. **First install:** No `.env` file — everything works through Cursor
-2. **Optional:** Run `/setup` → answers "Enable automatic meeting processing?"
-3. **If yes:** System creates `.env` from template, prompts for API key
-4. **If no:** Skip entirely — manual meeting processing works fine
-
-### Security Best Practices
-
-**For users:**
-- Never commit `.env` to their own repos
-- Use separate API keys for different projects
-- Set usage limits in Anthropic console
-
-**For Dex maintainers:**
-- Keep `env.example` up to date
-- Never commit real `.env`
-- Document which features require keys
-
----
-
-## 🚀 Distribution Recommendations
-
-### GitHub Release Strategy
-
-**v1.0.0 - Initial Public Release**
-
-1. **Tag the release:**
-   ```bash
-   git tag -a v1.0.0 -m "Initial public release"
-   git push origin v1.0.0
-   ```
-
-2. **Create GitHub Release:**
-   - Title: "Dex v1.0.0 — Your AI Chief of Staff"
-   - Description: Paste first 3 sections of README
-   - Attach: Installation guide, demo video (if available)
-
-3. **Post-release:**
-   - Monitor issues for Windows compatibility
-   - Create FAQ from common questions
-   - Build community in Discussions tab
-
-### Alternative Distribution
-
-**For teams/organizations:**
-- Fork repo → customize roles/templates → distribute internal URL
-- Include company-specific integrations in `core/mcp-custom/`
-- Company pillars in `System/pillars-company.yaml` template
-
-**For consultants:**
-- Charge for customization/setup services
-- Pre-configured bundles for specific roles (PM, Sales, etc.)
-- Training packages
-
----
-
-## ✅ Final Verification
-
-**Run this before pushing to GitHub:**
-
-```bash
-# Check for credentials in tracked files
-git ls-files | xargs grep -E '(sk-ant-|sk-[a-zA-Z0-9]{48}|AIza[a-zA-Z0-9-_]{35}|ANTHROPIC_API_KEY|OPENAI_API_KEY)' 2>/dev/null
-
-# Expected output: (no matches except in env.example and documentation)
-
-# Check for personal data
-git ls-files | xargs grep -iE '(dave|killeen|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})' | grep -v 'README\|example\|template\|CHANGELOG'
-
-# Expected output: Only documentation/examples, no real emails/names
-
-# Verify .gitignore is working
-git status --ignored | grep -E '(\.env$|\.mcp\.json$|00-Inbox|04-Projects|System/user-profile\.yaml)'
-
-# Expected output: Shows these as ignored, not tracked
-```
-
----
-
-**Status:** ✅ **Ready for distribution**
-
-- Paths dynamically configured via install script
-- MCP servers documented (7 core, others external)
-- No credentials exposed
-- `.gitignore` properly configured
-- User data protected
-- Documentation complete
-
-**Next steps:**
-1. Complete pre-release checklist
-2. Push to GitHub
-3. Announce to audience
-4. Monitor for issues
-
-**Questions?** See `06-Resources/Dex_System/Dex_Technical_Guide.md` for implementation details.
+- [ ] Fresh clone on a clean machine → `./install.sh` completes; provision
+      receipt renders; remote renamed `origin` → `upstream`.
+- [ ] `/setup` onboarding completes without API keys.
+- [ ] Works with Granola absent (graceful degradation).
+- [ ] `./scripts/verify-distribution.sh` passes locally.

--- a/06-Resources/Dex_System/Distribution_Strategy.md
+++ b/06-Resources/Dex_System/Distribution_Strategy.md
@@ -1,5 +1,13 @@
 # Dex Distribution Strategy
 
+**Status: HISTORICAL (January 2026) — mechanisms superseded.** The philosophy below
+("Dex is yours, not ours"; updates enhance without disrupting) still holds, but the
+git-upstream merge mechanics this document describes were replaced in mid-2026 by
+the receipt-backed lifecycle engine (preview → backup → apply → verify → receipt →
+rewind) and the customization-migration system. For current truth read:
+`Updating_Dex.md` (user-facing), `Distribution_Checklist.md` (maintainer),
+`docs/architecture/DEX-CORE-MAP.md` §§1–4, 12 (technical). Kept as a design record.
+
 **Last Updated:** January 29, 2026
 
 This document explains how Dex handles updates, customizations, and distribution to users.

--- a/06-Resources/Dex_System/Updating_Dex.md
+++ b/06-Resources/Dex_System/Updating_Dex.md
@@ -1,765 +1,143 @@
-# Updating Dex - Explained Simply
+# Updating Dex — Explained Simply
 
-**Last Updated:** January 29, 2026
+**Last Updated:** July 26, 2026 (reflects the receipt-backed update system, v1.65+)
 
-This guide explains how to get new features and improvements for Dex, written for people who've never used GitHub or command-line tools before.
+This guide explains how Dex updates work, written for people who've never used
+developer tools. The short version: **you type `/dex-update`, Dex shows you exactly
+what would change, nothing happens without your yes, and every change can be undone.**
 
 ---
 
-## The Big Picture: Why Updates Matter
+## The Big Picture
 
 **What are updates?**
 
-Think of Dex like an app on your phone. Every few weeks, there are improvements:
-- New features that make your work easier
-- Bugs get fixed
-- Things run smoother
+Think of Dex like an app on your phone. Every week or two there are improvements:
+new features, bug fixes, things running smoother. Dex lives on your computer rather
+than in an app store, so you update it by asking Dex itself.
 
-The difference: Dex lives on your computer (not in an app store), so updating works differently.
+**The one promise that matters:**
 
-**What makes Dex updates safe:**
+> Every change goes through one safe door: Dex previews what would change, backs it
+> up, applies it, verifies it, writes a receipt — and can rewind it exactly.
 
-Your data is **completely separate** from the Dex application. Updates only touch the application - never your notes, tasks, or projects.
+Your notes, tasks, projects, and people pages are **never part of an update**. Dex
+keeps a strict map of which files belong to the product and which belong to you, and
+the update machinery refuses to write into yours. A file it can't confidently
+classify is left alone, always.
 
-It's like updating Microsoft Word. The app gets better, but your documents stay exactly as they are.
-
-**Your customizations are preserved too:**
-- **CLAUDE.md personal notes:** Anything between `USER_EXTENSIONS_START/END` is preserved during updates
-- **Custom MCP servers:** Name them with `user-` or `custom-` (e.g., `user-gmail`) so updates always keep them
-
----
-
-## What You Need to Know First
-
-### You Have Two Versions of Dex
-
-When you use Dex, there are actually TWO versions:
-
-1. **Your copy** - Lives on your computer
-   - Your notes, tasks, projects
-   - Your customizations
-   - Your daily work
-
-2. **The main version** - Lives on GitHub
-   - New features being added
-   - Bug fixes
-   - Improvements from other users
-
-**Updating means:** Getting the improvements from the main version and adding them to your copy, without touching your data.
-
-### What is GitHub?
-
-**GitHub is like Dropbox for code.**
-
-Just like Dropbox stores your files in the cloud, GitHub stores Dex's files. But GitHub has special features that help:
-- Track every change made to Dex
-- Let you download improvements
-- Keep your version and the main version in sync
-
-**Do you need a GitHub account?**
-
-Not for basic updates! You can:
-- ✓ Check for updates (no account needed)
-- ✓ Download updates (no account needed)
-- ✓ Use all of Dex (no account needed)
-
-**When you DO need an account:**
-- If you want to save your copy of Dex on GitHub (like a backup)
-- If you want to share improvements you make with others
-- If you want to report problems
-
-**Creating a GitHub account is free** and takes 2 minutes: [github.com/signup](https://github.com/signup)
-
-But again - **not required for updating Dex**.
-
-### What is Git?
-
-**Git is the tool that handles updates.**
-
-Think of it like this:
-- **GitHub** = The website (like Dropbox.com)
-- **Git** = The tool on your computer that talks to GitHub (like the Dropbox app)
-
-**Do you have Git?**
-
-Probably yes! If you followed the setup, you already have it.
-
-To check, you'll type one command later. Don't worry - we'll tell you exactly what to do.
+**No git, no GitHub account, no Terminal required.** Older versions of this guide
+walked through git commands and GitHub setup. That era is over: the update engine
+handles everything behind the scenes.
 
 ---
 
-## Updating Dex: The Simple Way
+## Updating: What Actually Happens
 
-### Step 1: Run the Update Command
+### Step 1 — Ask for the update
 
-**In Cursor, in the chat where you talk to Dex, type:**
+In your Dex chat, type:
 
 ```
 /dex-update
 ```
 
-**Press Enter.**
+Dex checks what's available and shows you a preview sorted into five honest groups:
 
-**What happens:**
+1. **New and safe to adopt** — improvements Dex can apply without touching anything of yours.
+2. **Needs your review** — files where *you've* made changes and the update also
+   carries a new version. Nothing here moves until you decide (see "When you've
+   customized things" below).
+3. **Held back by you** — things you previously said no to. Dex remembers and doesn't re-ask.
+4. **Could not be proved** — anything Dex can't verify with certainty. No change
+   will be made to these, period. Honesty over completeness.
+5. **Already yours** — what you've adopted before, with its undo receipt still available.
 
-Dex connects to GitHub, checks if there's a newer version, and shows you what's available.
+### Step 2 — Say yes (or no)
 
-You'll see one of two things:
+For anything that would actually change, Dex shows the exact files first and asks one
+direct question: *"Apply this exact update?"* Saying "update Dex" earlier doesn't
+count as approval — only a yes to the concrete preview does.
 
-**Option A: You're up to date**
-```
-✅ You're already on the latest version (v1.2.0)
+### Step 3 — The receipt
 
-No update needed!
-```
+After applying, Dex shows a receipt: what changed, applied in one crash-safe step,
+with a backup taken first. If your computer lost power mid-update, you'd end up with
+either the old version or the new one — never a half-done mess.
 
-Great! You're done. Come back in a few weeks.
+### Undoing an update
 
-**Option B: An update is available**
-```
-🎁 Dex v1.3.0 is available
-
-You're on: v1.2.0
-Latest: v1.3.0
-
-What's new:
-- Career coach improvements
-- Task deduplication fix
-- Meeting intelligence enhancement
-
-[View full release notes]
-[Update now]
-[Cancel]
-```
-
-**What this means:**
-- Someone (probably me) made Dex better
-- Version 1.3.0 has new stuff
-- You can get it by clicking [Update now]
-
-**Your choices:**
-
-1. **[Update now]** - Proceeds with the update (recommended)
-2. **[View full release notes]** - Opens GitHub to see all details
-3. **[Cancel]** - Exit without updating (you can run `/dex-update` again later)
-
-**Should you update?**
-
-Usually yes! Updates make things better. But you can cancel if:
-- You're in the middle of something urgent
-- You want to read the full release notes first
-- You want to wait and see if others have problems
-
-**Note about "breaking changes":**
-
-Sometimes you'll see: ⚠️ **BREAKING CHANGES**
-
-This means the update changes how something works in a big way. These are rare and come with extra instructions. Don't worry - the update process will guide you.
+Type `/dex-rollback`. Dex uses the receipt to rewind the exact change — the same
+files, byte for byte. Dex keeps your last 3 rewind points.
 
 ---
 
-### Step 2: Confirm and Update
+## When You've Customized Things
 
-**If you clicked [Update now], here's what happens next:**
+If you've edited a skill, added your own scripts, or tuned your instructions, updates
+respect that — and this got a major upgrade in mid-2026 (v1.75).
 
-```
-/dex-update
-```
+**Conflicts get four choices, per file:**
 
-**Press Enter.**
+- **Keep mine** — your version stays; nothing is written.
+- **Take theirs** — the new release version goes live; yours stays recoverable via rewind.
+- **Keep both** — the release version becomes the standard one, and your edited
+  version is preserved beside it (as `name-custom`) where it still works. Fully rewindable.
+- **Compare** — see the differences first, then choose. Looking never changes anything.
 
-**What happens next:**
-
-Dex will walk you through the update. Here's what to expect:
-
----
-
-#### A. Dex Checks If You Have Git
-
-**You'll see:**
-```
-✓ Git detected
-```
-
-**If you see this instead:**
-```
-❌ Git not detected
-
-Dex updates require Git. Here's how to install...
-```
-
-Don't panic! Follow the simple instructions. It's a one-time thing:
-
-**On Mac:**
-1. Open Terminal (press Cmd+Space, type "Terminal", press Enter)
-2. Type: `xcode-select --install`
-3. Press Enter
-4. Click "Install" when a window pops up
-5. Wait 5 minutes for download
-6. Come back to Cursor and try `/dex-update` again
-
-**On Windows:**
-1. Go to: https://git-scm.com/download/win
-2. Click the download link
-3. Run the installer (click Next on everything)
-4. Restart Cursor
-5. Try `/dex-update` again
-
-This only happens once. After this, updates are automatic.
+**Deeply customized setups get a guided journey.** If Dex's health check
+(`/dex-doctor`) finds you've customized a lot, `/dex-update` offers to walk you
+through it: it inventories everything you've changed, explains what the update would
+affect, and — only with your explicit yes — saves a protected local snapshot of your
+customization evidence (called a **Capsule**, stored inside your vault's
+`System/.dex/` area, never uploaded) before proceeding through the normal
+preview-and-approve flow. Nothing is overwritten, and the Capsule survives the update
+so your work is never lost.
 
 ---
 
-#### B. Dex Checks Your Setup
+## The One-Time "Brain and Vault" Separation
 
-**You'll see:**
-```
-✓ Setup verified
-```
+Older Dex installs kept the product's files and your personal notes together in one
+combined history. Newer Dex separates them — the product (the "brain") and your
+content (the "vault") — so an update can't even theoretically touch your notes, and
+your private vault history is never uploaded anywhere.
 
-If this is your first time updating, Dex might configure a few things behind the scenes. This is normal and automatic.
-
-**What's actually happening:**
-
-Dex is telling Git where to look for updates (on GitHub). Think of it like saving a bookmark in your browser.
-
----
-
-#### C. Dex Downloads the Updates
-
-**You'll see:**
-```
-⬇️ Downloading updates from GitHub...
-✓ Updates downloaded
-```
-
-**What's happening:**
-
-Dex is getting the new files from GitHub and bringing them to your computer.
-
-**This requires internet.** If you see an error about network, check your WiFi and try again.
+If your install still has the combined layout, `/dex-update` offers this move as a
+**one-time step**, with the same rules as everything else: full preview first,
+explicit yes required, and the old combined history is kept locally as an undo
+archive named in the receipt. Dex refuses to attempt it in risky situations (for
+example, a vault living inside a Dropbox- or iCloud-synced folder) rather than gamble
+with your files.
 
 ---
 
-#### D. Dex Protects Your Work
+## Frequently Asked
 
-**You'll see:**
-```
-💾 Saving your work...
-✓ Your work is saved
-```
+**How do I see what's new without updating?** Type `/dex-whats-new`.
 
-**What's happening:**
+**Should I update?** Usually yes. You can always preview first and adopt nothing, and
+anything you adopt can be rewound.
 
-Before changing anything, Dex saves a snapshot of how things are right now. It's like creating a restore point on your computer.
+**Can I skip individual items?** Yes — each item is decided independently, and
+"skip this one" can't affect the rest. Skipped items show up under "Held back by
+you" next time, without nagging.
 
-**Why this matters:**
+**What if an update refuses to proceed?** That's the safety system working, not
+breaking. Dex explains the refusal in plain language and leaves everything untouched.
+Run `/dex-doctor` for a full health check.
 
-If something goes wrong (very rare), you can undo the update instantly with `/dex-rollback`.
+**Do I need a GitHub account, git, or Terminal?** No.
 
-This makes updating completely safe. You can always go back.
+**What about my custom MCP servers and personal instructions?** They're classified as
+yours in the ownership map, so updates never write them. Personal additions to your
+instructions survive updates too.
 
----
-
-#### E. Dex Applies the Updates
-
-**You'll see:**
-```
-🔄 Applying updates...
-```
-
-**What's happening:**
-
-Dex is carefully updating its own files (the application) while leaving your files (your data) completely alone.
-
-**Two possible outcomes:**
-
-**Outcome 1: Clean update (most common)**
-```
-✓ Updates applied successfully
-```
-
-This means the update fit perfectly with your setup. No problems. This happens 95% of the time.
-
-**Outcome 2: Overlapping changes (rare)**
-
-Sometimes both you AND the main version changed the same file. For example:
-- You customized a skill
-- The update also changed that skill
-
-**You'll see:**
-```
-🔍 Resolving overlapping changes...
-
-Found changes in the same files:
-- CLAUDE.md (your version vs update version)
-
-Automatically keeping: Your customizations
-Automatically updating: Core Dex features
-
-✓ Resolved automatically
-```
-
-**What Dex does automatically:**
-
-For each file with overlapping changes:
-
-| File Type | What Dex Keeps |
-|-----------|----------------|
-| Your notes, tasks, projects | **Your version (always)** |
-| Your settings (user-profile, pillars) | **Your version (always)** |
-| Core Dex skills | **Update version (improvements)** |
-| Core Dex features | **Update version (improvements)** |
-| Files you customized | **Your version (your changes)** |
-
-**Translation:** Your stuff stays yours. Dex improvements come through. Conflicts resolved automatically.
-
-**You don't need to do anything.** Dex handles this.
+**Where do I get help?** The Dex Guide at https://heydex.ai/help, or ask Dex
+directly in chat — "something went wrong with the update" routes to `/dex-doctor`.
 
 ---
 
-#### F. Dex Updates Dependencies
-
-**You'll see:**
-```
-📦 Updating dependencies...
-✓ Dependencies updated
-```
-
-**What are dependencies?**
-
-Think of Dex like a car. The car (Dex) needs certain parts to work: tires, battery, engine.
-
-Dependencies are those parts. When Dex updates, sometimes it needs newer parts.
-
-**What's happening:**
-
-Dex is automatically installing or updating these parts. You don't need to do anything.
-
-This takes 30 seconds to 2 minutes depending on your internet.
-
----
-
-#### G. Dex Verifies Everything
-
-**You'll see:**
-```
-✓ Update complete! Now testing...
-✅ Update successful!
-```
-
-**What's happening:**
-
-Dex is checking that everything works:
-- Can it find your tasks?
-- Can it read your profile?
-- Are all the features working?
-
-If anything fails, Dex will offer to undo the update automatically.
-
----
-
-### Step 3: Confirmation
-
-**You'll see a summary:**
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Dex Updated: v1.2.0 → v1.3.0
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-What's new:
-• Career coach improvements
-• Task deduplication fix
-• Meeting intelligence enhancement
-
-Your data:
-✓ All notes preserved
-✓ All tasks preserved
-✓ All customizations preserved
-
-Time taken: 2 minutes
-```
-
-**You're done!** The new features are ready to use.
-
----
-
-### Step 4: Try It Out
-
-**Test that everything works:**
-
-1. Run your daily plan:
-   ```
-   /daily-plan
-   ```
-
-2. Open a person page:
-   - Go to `05-Areas/People/` and open someone
-
-3. Check your tasks:
-   - Open `03-Tasks/Tasks.md`
-
-Everything should work normally, plus you'll have the new features from the update.
-
----
-
-## If Something Goes Wrong
-
-### The Instant Undo Button
-
-**If anything feels wrong after updating, type:**
-
-```
-/dex-rollback
-```
-
-**What happens:**
-
-Dex instantly restores everything to exactly how it was before you updated.
-
-**How long it takes:** 30 seconds
-
-**What gets restored:**
-- ✓ Dex features go back to old version
-- ✓ All your notes, tasks, projects stay as they are
-
-**Translation:** You tried the update, didn't like it, and now you're back to the old version. Your work is completely safe.
-
-You can try updating again later, or just stay on the old version.
-
----
-
-## Understanding How This Works (Optional)
-
-*This section is for people who want to understand what's happening behind the scenes. You can skip this if you're happy just using the commands.*
-
-### Why GitHub?
-
-**Dex is "open source"** - this means:
-- Anyone can see how it works
-- Anyone can improve it
-- It's free forever
-- You're not locked into a company
-
-GitHub is where open source projects live. It's like a public workshop where improvements happen.
-
-**Your copy of Dex is completely yours.** It's on your computer, not on GitHub. But GitHub is where the "official" version lives, with all the latest improvements.
-
-### What Git Actually Does
-
-When you run `/dex-update`, here's what Git does:
-
-1. **Looks at GitHub** - "What's new since I last checked?"
-
-2. **Downloads the changes** - "Let me grab those new features"
-
-3. **Merges them into your copy** - "Let me carefully add these without touching your data"
-
-**Why is this better than just re-downloading Dex?**
-
-If you re-downloaded Dex, you'd have to:
-- Delete your old version
-- Download new version
-- Copy all your files over manually
-- Hope you didn't miss anything
-
-Git does all this automatically in 2 minutes, without you lifting a finger.
-
-### What "Version Control" Means
-
-Git is a "version control" system. Think of it like Track Changes in Microsoft Word, but for an entire application.
-
-Every time someone improves Dex:
-- Git records exactly what changed
-- Git can show you the difference
-- Git can combine improvements from multiple people
-- Git can undo changes if something breaks
-
-**For you, this means:**
-- Updates are precise (only what changed gets updated)
-- Your customizations are preserved (Git knows what you changed)
-- Rollback is instant (Git remembers previous versions)
-
-### The "Upstream" Concept
-
-When you first downloaded Dex, you downloaded it from GitHub. That GitHub location is called the "upstream" source.
-
-Think of it like a river:
-- **Upstream** = Where the water comes from (main Dex on GitHub)
-- **Your location** = Where you are (Dex on your computer)
-
-Updates flow downstream to you.
-
-`/dex-update` is just asking: "What's new upstream? Let me get it."
-
-### Why Your Data Is Safe
-
-Your data is in folders that Git **ignores**:
-- `00-Inbox/`
-- `03-Tasks/`
-- `04-Projects/`
-- `05-Areas/`
-- All your notes and work
-
-Git is told: "Never track these folders. Never change them. Never touch them."
-
-It's in a file called `.gitignore` that explicitly lists everything to ignore.
-
-So when updates come in, Git sees your data and thinks: "Not my job, skip these."
-
-This is why updates can't hurt your data. Git literally doesn't see it.
-
----
-
-## Automatic Update Checks
-
-**You don't have to remember to check for updates.**
-
-Every 7 days, during `/daily-plan`, Dex automatically checks GitHub and tells you if an update is available:
-
-```
-🎁 Dex v1.3.0 is available. Run /dex-update to see what's new and update.
-
----
-
-Here's your plan for today...
-```
-
-It's non-intrusive - just a heads up at the top of your daily plan.
-
-**You decide when to update.** Dex will never update itself without you asking. Running `/dex-update` shows you what's new and asks for confirmation before proceeding.
-
-**Want to disable these notifications?**
-
-Edit `System/user-profile.yaml` and add:
-
-```yaml
-updates:
-  auto_check: false
-```
-
----
-
-## FAQs for Non-Technical Users
-
-### Do I need to update?
-
-Not required, but recommended. Updates make things better:
-- New features
-- Bug fixes
-- Performance improvements
-
-Your current version will keep working fine. But you miss out on improvements.
-
-**Good rule:** Update monthly, or when you see a feature you want.
-
----
-
-### How often do updates come out?
-
-Every few weeks to every few months, depending on what's being improved.
-
-You'll know when they're available because of the automatic check during `/daily-plan`.
-
----
-
-### Will I lose my work?
-
-**No. Never. Impossible.**
-
-Your work is in protected folders that updates don't touch. It's technically impossible for an update to delete your notes, tasks, or projects.
-
-The worst that can happen: A new feature doesn't work right. But your data is always safe.
-
-And if anything breaks, `/dex-rollback` undoes the update in 30 seconds.
-
----
-
-### What if my internet is slow?
-
-The download step might take 3-5 minutes instead of 30 seconds. But it will complete.
-
-The update process is patient - it won't time out.
-
----
-
-### Can I skip an update?
-
-Yes! If v1.3.0 comes out and you don't update, then v1.4.0 comes out, you can jump straight from v1.2.0 to v1.4.0.
-
-Git handles this automatically.
-
----
-
-### What are "breaking changes"?
-
-Very rarely (maybe once a year), an update changes something in a big way. Examples:
-- Renaming a major folder
-- Changing how a feature works
-- Updating the configuration format
-
-These are marked with ⚠️ **BREAKING CHANGES** in the release notes.
-
-**What to do:**
-
-The update process will guide you with extra steps (usually just running one extra command). It's still safe and still has rollback.
-
-Breaking changes come with:
-- Clear explanation of what's changing
-- Why it's changing
-- Step-by-step migration instructions
-- Extra safety checks
-
-Don't avoid them - just read the notes carefully first.
-
----
-
-### Can I see what will change before updating?
-
-Yes! When you run:
-```
-/dex-update
-```
-
-Dex shows you the release notes and asks for confirmation before proceeding. You can:
-- Read what's new
-- View full release notes on GitHub
-- Choose [Update now] or [Cancel]
-
-You're never forced to update - you always confirm first.
-
----
-
-### What if I made changes to Dex itself?
-
-**Customizations in recommended places:**
-- `.claude/skills-custom/` - Your custom skills
-- `core/mcp-custom/` - Your custom integrations
-- `CLAUDE-custom.md` - Your prompt customizations
-
-These are protected. Updates won't touch them.
-
-**Changes to core Dex files:**
-
-If you edited a core file (like `.claude/skills/daily-plan/SKILL.md`), and an update also changes that file, Dex will:
-1. Detect the overlap
-2. Ask which version to keep
-   - If AskUserQuestion is available, Dex shows a guided choice
-   - If not, Dex shows a CLI prompt with the same options + tradeoffs
-3. Usually keep your version (your customizations)
-
-But **better practice:** Put your customizations in the `-custom` folders so they never conflict.
-
----
-
-### Can I undo an undo?
-
-Yes! When you run `/dex-rollback`, Dex saves a snapshot before rolling back.
-
-So if you rollback and then think "wait, I want the update back," you can restore it.
-
-The rollback skill explains this.
-
----
-
-### What if the update fails halfway through?
-
-Dex is careful about this. If something fails:
-
-1. The update stops immediately
-2. Dex offers to restore to before the update
-3. You're back to where you started (safe)
-4. You can report the problem or try again later
-
-**You're never left in a broken state.** Either the update completes successfully, or it rolls back automatically.
-
----
-
-## Different Ways to Update (Summary)
-
-### Option 1: Automatic (Recommended)
-```
-/dex-update
-```
-- Easiest
-- Safest
-- Handles everything
-- **Use this method**
-
-### Option 2: Manual (Advanced Users Only)
-
-If you're comfortable with command-line tools and want to see exactly what's changing:
-
-```bash
-cd ~/Documents/dex
-git fetch upstream
-git merge upstream/release
-```
-
-Only use this if you understand Git. Everyone else should use `/dex-update`.
-
-### Option 3: Re-download (Last Resort)
-
-If Git isn't working or you just want a fresh start:
-
-1. Download latest Dex from GitHub as a ZIP
-2. Copy your data folders (00-07, System/) from old to new
-3. Delete old Dex folder
-4. Rename new folder to 'dex'
-5. Open in Cursor
-
-This works but takes 10-15 minutes vs. 2 minutes for `/dex-update`.
-
----
-
-## Getting Help
-
-### Something Broke and Rollback Didn't Fix It
-
-1. **Don't panic** - Your data is safe (it's in separate folders)
-
-2. **Report the issue:**
-   - Go to: https://github.com/davekilleen/dex/issues
-   - Click "New Issue"
-   - Describe what happened and what you see
-
-3. **Temporary workaround:**
-   - Re-download Dex
-   - Copy your data folders back
-   - Continue working while we fix the bug
-
-### Questions About What Changed
-
-- Read release notes: https://github.com/davekilleen/dex/releases
-- Or run: `/dex-update` (shows release notes before asking to proceed)
-
-### Want to Learn More About Git
-
-- GitHub's guide: https://guides.github.com/introduction/git-handbook/
-- Git for non-programmers: https://www.youtube.com/watch?v=8JJ101D3knE
-
-But remember: **You don't need to learn Git to use Dex.** The `/dex-update` command handles it all.
-
----
-
-## Summary: The 2-Minute Update
-
-**Update Dex:**
-```
-/dex-update
-```
-Shows what's new, you confirm, it updates.
-
-**Undo if needed:**
-```
-/dex-rollback
-```
-Instantly restores previous version.
-
-**That's it.** Two commands. Your data is always safe. You can always undo.
-
-Updates should improve your work, not create anxiety. If you're ever unsure, just ask in Cursor chat: "Should I update to v1.3.0?" and Dex will explain what's new.
-
----
-
-**Remember:** Dex is yours. Update when you want, skip updates if you want, rollback if something feels off. You're in control.
+*For the technical design behind all this, see `docs/architecture/DEX-CORE-MAP.md`
+(lifecycle engine, transaction core, and customization migration sections) in the
+dex-core repository.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Working on dex-core (agent instructions)
+
+Instructions for AI agents (and humans) **developing this repository**. Not the
+product persona — the root `CLAUDE.md` is seed prose shipped into user vaults
+("You are Dex…"); it is a product surface, not contributor guidance. Edit it like
+UI copy, not like docs.
+
+## Orient before you touch anything
+
+1. Run `/dex-orient` (or `python3 scripts/dex_state.py --digest`) — released
+   version, merged-but-unreleased work, where the maps live.
+2. `docs/architecture/DEX-CORE-MAP.md` — the narrative "how it hangs together"
+   map, with SHIPPED / LOCAL / PROTOTYPE / PLANNED status per subsystem.
+3. `docs/architecture/INVENTORY.md` — **generated, CI-drift-gated**: exact MCP
+   servers/tools, skill catalog + trigger analysis, ownership-class path tables.
+   Never hand-edit it; regenerate with `python3 scripts/generate-architecture-inventory.py`.
+4. `CHANGELOG.md` — the single source of release truth, written in house voice.
+
+## Merged is not shipped, and shipped is not always live
+
+- Release truth is the version tag + CHANGELOG entry, not `main`.
+- Some merged work is deliberately **HELD**: customization-migration Lane G
+  (activation + rewind) and the `/connect` doorway (draft PR #231, security no-go
+  not yet lifted). `core/ritual_intelligence/` is code-complete but wired to
+  nothing (PARKED). Never describe held/parked work as available, in code
+  comments, docs, or user-facing copy.
+
+## Hard rules
+
+- **One safe door.** Every vault mutation goes through
+  `core/lifecycle/service.py` → transaction core → portable ownership contract.
+  Never add a code path that writes vault files directly.
+- **Generated files are never hand-edited**: `docs/architecture/INVENTORY.md`,
+  `core/paths.json`, `packages/dex-contracts/dist/*`, `System/.release-catalog.json`.
+  Change the source, re-run the generator (`scripts/generate-*.{py,mjs}`).
+- **New top-level paths must be classified** in `core/portable_contract.py`
+  (brain/seed/generated/vault/runtime) or CI fails — this is deliberate.
+- **No PII, no founder-machine content** — CI gates (`scripts/check-pii.sh`,
+  `scripts/check-founder-content.sh`) block it; don't allowlist around them casually.
+- **Worktree isolation** — never write in a checkout another session is using;
+  work on a branch in its own worktree.
+- GitHub Actions are **pinned to commit SHAs**; keep new workflow edits pinned.
+
+## Tests
+
+- Python: `pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -m "not fuzz"`
+  (flat naming convention: `test_<subsystem>_<behavior>.py`).
+- Node: `npm run test:hooks`, `npm run test:scripts`, `npm run test:integrations`.
+- Contracts: `npm run check:connections-contract`.
+- CI runs the full gate list in `.github/workflows/ci.yml` (macOS runner);
+  nightly quality + fuzz + perf budgets in `.github/workflows/nightly-quality.yml`.
+  Governance: `docs/testing-governance.md`.
+
+## Deeper reading (on demand)
+
+- Update/transaction design: `docs/transaction-core-design.md`,
+  `docs/portable-vault-contract-design.md`
+- Customization migration: `docs/customization-migration-threat-model.md`,
+  `docs/plans/2026-07-24-customization-migration-mcp.md`
+- Doctor: `docs/dex-doctor-spec.md` · Merge gates: `docs/merge-gates.md`
+- Distribution: `DISTRIBUTION_READY.md`, `docs/Dex_System/Distribution_Checklist.md`
+- Past root causes and runbooks: `docs/solutions/`
+- System docs canon: `docs/Dex_System/` is canonical; the copies under
+  `06-Resources/Dex_System/` are compatibility bridge files — keep them
+  byte-identical until the physical move lands (see `docs/Dex_System/README.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # Dex - Your Personal Knowledge System
 
-**Last Updated:** February 19, 2026 (v1.11.0 — Memory ownership, named sessions, background processing)
+<!-- Version note: don't trust any version number written here — run /dex-whats-new
+     or read CHANGELOG.md for the installed release. This file is seed prose that
+     travels across many updates. -->
 
 You are **Dex**, a personal knowledge assistant. You help the user organize their professional life - meetings, projects, people, ideas, and tasks. You're friendly, direct, and focused on making their day-to-day easier.
 
@@ -59,6 +61,19 @@ For detailed information, see:
 - **Skills catalog:** `.claude/skills/README.md` or run `/dex-level-up`
 
 Read these files when users ask about system details, features, or setup.
+
+Other capability surfaces to know about (read on demand, don't preload):
+- **Hooks** — automatic behaviors (session context, person/company context injection,
+  safety guards, release awareness, session-end autocommit) are wired in
+  `.claude/settings.json`; `.claude/hooks/README.md` documents them.
+- **Optional capability rooms** — role-specific skill packs live in
+  `.claude/skills/_available/` and are switched on via `/manage-capabilities`
+  (registry: `core/capabilities.py`). If a user asks for sales/product/marketing/
+  finance workflows they don't seem to have, check there before saying no.
+- **Updates & health** — `/dex-update` (safe, receipt-backed, rewindable via
+  `/dex-rollback`), `/dex-doctor` (honest whole-system checkup), `/dex-whats-new`.
+- **Deeper technical reference** — `.claude/reference/` (MCP servers, integration
+  patterns, meeting intelligence).
 
 ---
 

--- a/DISTRIBUTION_READY.md
+++ b/DISTRIBUTION_READY.md
@@ -1,444 +1,73 @@
-# Dex Distribution Status
+# Dex Distribution — How It Works Today
 
-**Date:** 2026-01-29
-**Status:** ✅ **READY for GitHub distribution** (with minor cleanup recommendations)
+**Last Updated:** 2026-07-26 (v1.75.2)
 
----
+> This file was originally a one-time pre-launch readiness report (January 2026).
+> Dex has since shipped 70+ releases; this is now the standing description of how
+> distribution actually works. History lives in git if you need the old report.
 
-## Executive Summary
+## The short version
 
-All three distribution concerns are **SOLVED**:
+Dex is distributed from this repository. A user installs by cloning and running
+`install.sh`; releases are cut by tagging, and CI does the packaging, safety
+gating, and publishing automatically. Nothing user-owned ever ships in a release,
+and a battery of CI gates enforces that on every push.
 
-1. ✅ **Dynamic paths** — Template + install script handles this automatically
-2. ✅ **MCP servers** — 7 core servers included, external MCPs documented as optional
-3. ✅ **No credentials exposed** — .gitignore configured correctly, no API keys in code
+## Install mechanism
 
-**Users can clone and run immediately** — paths auto-configure, no manual editing needed.
+`install.sh` provisions a new vault through the **sanctioned provision contract**:
+it calls `node core/provision.cjs`, which applies `core/provision-contract.json`
+plus the generated portable-vault ownership contract to lay down exactly the files
+a fresh install should have, with the user's vault path collected once and rendered
+into a receipt.
 
----
+> Historical note: early versions templated `.mcp.json` with a
+> `sed "s|{{VAULT_PATH}}|...|"` substitution over `System/.mcp.json.example`.
+> That mechanism is gone — if you see it described anywhere, the doc is stale.
 
-## Answers to Your Questions
+The install also renames a cloned `origin` remote to `upstream` so a user's vault
+is treated as an independent local project, and detects optional companions
+(e.g. Granola) to point users at the right setup skill.
 
-### 1. "Paths will change when people download — how do we solve for that?"
+## What ships / what never ships
 
-**ALREADY SOLVED** ✅
+The portable ownership contract (`core/portable_contract.py`, §3 of
+`docs/architecture/DEX-CORE-MAP.md`) classifies every path: `brain` (release-owned),
+`seed` (shipped once, then user-owned), `generated`, `vault` (user content — never
+written by an update), `runtime` (never shipped). CI fails if any tracked path is
+unclassified.
 
-Your install script (`install.sh`) uses the template pattern:
+## Release pipeline
 
-```bash
-# Lines 49-54 of install.sh
-CURRENT_PATH="$(pwd)"
-sed "s|{{VAULT_PATH}}|$CURRENT_PATH|g" System/.mcp.json.example > .mcp.json
-```
+1. Merges land on `main`; every push runs the full CI gate list (see
+   `docs/architecture/DEX-CORE-MAP.md` and `.github/workflows/ci.yml`), including
+   the distribution-safety, PII, founder-content, and portable-contract gates.
+2. On a `main` push, CI builds and publishes the release branch, tag, and vault
+   bundle, then deploys the public release-health page (GitHub Pages).
+3. On a `v*` tag, `release.yml` extracts the matching `CHANGELOG.md` section and
+   creates the GitHub Release. `CHANGELOG.md` is the single source of release truth.
+4. A `beta` branch mirror runs the same pipeline with prerelease-only guards.
 
-**User experience:**
-```bash
-git clone https://github.com/yourusername/dex.git
-cd dex
-./install.sh
-# ✅ .mcp.json created with correct paths automatically
-```
+## Safety gates that protect distribution
 
-This is the **industry-standard solution** used by:
-- VS Code extensions
-- Homebrew formulas
-- Docker Compose templates
-- Terraform modules
+- `scripts/verify-distribution.sh` — pre-flight distribution check.
+- `scripts/check-pii.sh` + `scripts/pii_gate.py` — no personal data in tracked files.
+- `scripts/check-founder-content.sh` — no founder-machine-specific content ships.
+- `scripts/check-portable-contract.sh` — every path classified.
+- `scripts/security-gate.sh` / `security-scan.py` — credential/key scanning.
 
-**No action needed.**
+## Platform support
 
----
+macOS-first (calendar/reminders integration uses EventKit). Non-macOS installs
+degrade gracefully; see `docs/support/upgrade-platform-matrix.md`.
 
-### 2. "MCPs like Granola, browser extension — how do we fix that for Claude Desktop?"
+## Licensing
 
-**CLARIFICATION:** You have two different types of MCPs:
-
-#### Dex Core MCPs (7 servers, shipped with the repo)
-
-| MCP | File | Purpose | Requires |
-|-----|------|---------|----------|
-| work-mcp | `work_server.py` | Task/goal management | Nothing |
-| calendar-mcp | `calendar_server.py` | Calendar integration | macOS Calendar.app |
-| granola-mcp | `granola_server.py` | Meeting processing | `GRANOLA_API_KEY` from a Granola Business/Enterprise plan (optional) |
-| career-mcp | `career_server.py` | Career development | Nothing |
-| resume-mcp | `resume_server.py` | Resume building | Nothing |
-| dex-improvements-mcp | `dex_improvements_server.py` | System improvements | Nothing |
-| update-checker | `update_checker.py` | Update checking | GitHub API |
-
-**These are all included** in `core/mcp/` and configured in `System/.mcp.json.example`.
-
-#### External MCPs (NOT part of Dex)
-
-These are **separate user-installed tools** via Claude Desktop settings:
-- `cursor-ide-browser` — Browser automation (Cursor-specific)
-- `user-granola` — Official Granola MCP (different from dex granola-mcp)
-- `user-whatsapp` — WhatsApp integration
-- `user-apify` — Web scraping
-- etc.
-
-**Architecture:**
-```
-Dex Repository
-├── core/mcp/                    ← 7 servers (included)
-│   ├── work_server.py
-│   ├── calendar_server.py
-│   └── ...
-└── System/.mcp.json.example     ← Template for local setup
-
-User's Claude Desktop (separate)
-└── settings.json                ← External MCPs (user installs)
-    ├── cursor-ide-browser
-    ├── user-granola
-    └── user-whatsapp
-```
-
-**Distribution strategy:**
-1. Ship with 7 core MCPs
-2. Document optional integrations in README
-3. User installs external MCPs separately if needed
-
-**Your install.sh already handles this:**
-```bash
-if [ -d "/Applications/Granola.app" ]; then
-    echo "✅ Granola app detected — run /granola-setup to connect it (needs a Granola Business API key)"
-else
-    echo "ℹ️  Granola app not detected"
-    echo "   Install Granola from https://granola.ai for meeting transcription"
-    echo "   Then run /granola-setup to connect it (needs a Granola Business API key)"
-fi
-```
-
-App detection is only an install pointer. Meeting sync itself uses Granola's official public API and reads `GRANOLA_API_KEY` from the environment, then the vault-root `.env`; it never treats local application data as authentication.
+See `LICENSE` and `COMMERCIAL_LICENSE.md`. Note: the connection manager consumes
+Nango's provider catalog (Elastic License 2.0) as a pinned npm dependency — never
+re-expose it as a managed service.
 
 ---
 
-### 3. "Make sure I'm not exposing any credentials"
-
-**VERIFIED SAFE** ✅
-
-#### What's Protected (gitignored)
-
-```gitignore
-.env                          # API keys
-.env.local
-.mcp.json                     # Generated config with user paths
-System/user-profile.yaml      # Personal info
-System/pillars.yaml           # User's strategic pillars
-00-Inbox/                     # User data
-01-Quarter_Goals/
-02-Week_Priorities/
-03-Tasks/
-04-Projects/
-05-Areas/
-07-Archives/
-```
-
-#### Credential Scan Results
-
-**Scanned all tracked Python/JS files:**
-```bash
-✅ No API keys (sk-ant-, sk-proj-, AIza*)
-✅ No hardcoded passwords
-✅ No personal email addresses (except font licenses/docs)
-✅ Template files use placeholders only
-```
-
-#### What Users See
-
-**On first clone:**
-- `env.example` — Template showing structure (no real keys)
-- `System/.mcp.json.example` — Template with `{{VAULT_PATH}}`
-
-**Generated during setup:**
-- `.env` — Created if user enables optional features
-- `.mcp.json` — Generated by install.sh
-- User data folders — Created empty
-
-**Security best practice:** Your `.gitignore` follows the pattern used by popular repos like:
-- Laravel (PHP framework)
-- Next.js (React framework)
-- Django (Python framework)
-
-**No action needed.**
-
----
-
-## Git Remote Issue (RESOLVED)
-
-**Problem:** When users cloned the Dex repo, the git remote remained as `origin` pointing to `github.com/davekilleen/Dex`. This caused Claude Desktop to incorrectly identify their local vault as the upstream project instead of an independent local project.
-
-**Symptoms:**
-- Claude Desktop shows "davekilleen/dex" in project selector
-- Opening folder in Cursor from Claude Desktop may open wrong project
-- User's local vault treated as if it's the main repo
-
-**Solution:** install.sh now silently renames `origin` to `upstream` during setup. This breaks the association and treats the user's vault as independent.
-
-**Implementation:**
-```bash
-# Lines 11-13 of install.sh
-if git remote -v 2>/dev/null | grep -q "davekilleen/[Dd]ex"; then
-    git remote rename origin upstream 2>/dev/null || true
-fi
-```
-
-**User experience:** Completely transparent - no extra steps, no messages, just works.
-
----
-
-## Distribution Checklist
-
-Run before pushing to GitHub:
-
-### Pre-Flight Check
-
-```bash
-./scripts/verify-distribution.sh
-```
-
-**Current results:**
-- ✅ 0 errors
-- ⚠️ Warnings only (all safe — see below)
-
-**Warnings explained:**
-1. **Email addresses found** — Font licenses + documentation examples (safe)
-2. **MCP count mismatch** — Found `task_server.py` (legacy, see cleanup)
-
-### Recommended Cleanup (Optional)
-
-**1. Remove legacy task_server.py**
-
-```bash
-git rm core/mcp/task_server.py
-```
-
-This is an old version superseded by `work_server.py`. No longer used.
-
-**2. Clean up Session_Learnings (if contains personal work history)**
-
-```bash
-git rm -r System/Session_Learnings/
-```
-
-**3. Update README placeholders**
-
-Replace these lines in README.md:
-- Line 9: `[Episode 8 of The Vibe PM Podcast](https://link-tbd)`
-- Line 9: `[full blog post](https://link-tbd)`
-- Line 37: `[companion blog post](https://link-tbd)`
-- Line 633: `[link-tbd]`
-
-With actual URLs when ready to publish.
-
-**4. Add LICENSE file**
-
-```bash
-# MIT License (recommended for open source)
-touch LICENSE
-# Copy MIT license text from https://choosealicense.com/licenses/mit/
-```
-
-**5. Final verification**
-
-```bash
-# Check git history for accidentally committed secrets
-git log --all -S "sk-ant-" --source --all
-
-# Should return empty (or only this DISTRIBUTION_READY.md file)
-```
-
-### Ready to Push
-
-```bash
-git add .
-git commit -m "chore: prepare for distribution - clean up legacy files"
-git push origin main
-
-# Tag the release
-git tag -a v1.0.0 -m "Initial public release"
-git push origin v1.0.0
-```
-
----
-
-## Distribution Artifacts Created
-
-I've created three files to help with distribution:
-
-### 1. `/06-Resources/Dex_System/Distribution_Checklist.md`
-
-Comprehensive distribution guide covering:
-- Path configuration (how the template pattern works)
-- MCP architecture (core vs external servers)
-- Security verification (what's protected, what's exposed)
-- Pre-release checklist
-- GitHub release strategy
-
-**Use this as:** Reference documentation for maintainers.
-
-### 2. `/scripts/verify-distribution.sh`
-
-Automated safety check script that verifies:
-- `.mcp.json` and `.env` are gitignored
-- No API keys in tracked files
-- User data folders protected
-- Template files use placeholders
-- All required files present
-
-**Use this as:** Pre-commit check before pushing to GitHub.
-
-### 3. `/DISTRIBUTION_READY.md` (this file)
-
-Quick reference answering your three questions with action items.
-
-**Use this as:** Quick confirmation that you're ready to distribute.
-
----
-
-## Testing Strategy
-
-Before announcing publicly:
-
-### Test 1: Fresh Clone (Different Machine)
-
-```bash
-# On a different computer or VM
-git clone https://github.com/yourusername/dex.git ~/Desktop/dex-test
-cd ~/Desktop/dex-test
-./install.sh
-# ✅ Should complete without errors
-# ✅ .mcp.json should have correct paths (/Users/testuser/Desktop/dex-test)
-```
-
-### Test 2: Setup Wizard
-
-```bash
-# Open in Cursor
-cursor ~/Desktop/dex-test
-
-# In Cursor chat, run:
-/setup
-
-# ✅ Should complete onboarding
-# ✅ Should create user-profile.yaml
-# ✅ Should create pillars.yaml
-# ✅ Should NOT prompt for API keys (99% of features work without)
-```
-
-### Test 3: Core Features
-
-```bash
-# In Cursor chat
-/daily-plan
-# ✅ Should generate daily plan
-
-/meeting-prep
-# ✅ Should search for person pages
-
-# Create a task
-I need to "Review Q2 roadmap" by Friday
-
-# ✅ Should create task with unique ID
-# ✅ Should show in 03-Tasks/Tasks.md
-```
-
-### Test 4: Without Optional Dependencies
-
-```bash
-# Test on machine WITHOUT Granola installed
-/daily-plan
-
-# ✅ Should work (skip meeting intelligence)
-# ✅ Should NOT crash or show errors
-```
-
----
-
-## Windows Support
-
-**Current status:** macOS only (due to calendar-mcp using AppleScript)
-
-**Options:**
-
-1. **Document as macOS-only for v1.0**
-   ```markdown
-   ## Requirements
-   - macOS 10.15+ (for Calendar integration)
-   - Or: Any OS if not using calendar features
-   ```
-
-2. **Add Windows support later**
-   - Calendar integration via Windows Calendar APIs
-   - PowerShell version of install.sh
-
-3. **Make calendar-mcp optional**
-   - Gracefully degrade on non-macOS
-   - Most features still work
-
-**Recommendation:** Document as macOS-focused for v1.0, add Windows support in v1.1 based on demand.
-
----
-
-## Success Criteria
-
-**Before distribution:**
-- [x] Dynamic paths work automatically
-- [x] No credentials exposed
-- [x] MCP servers documented
-- [x] Git remote issue fixed (install.sh handles automatically)
-- [ ] Legacy task_server.py removed
-- [ ] README placeholders updated
-- [ ] License file added
-
-**After distribution:**
-- [ ] 10+ successful fresh clones (different users)
-- [ ] No GitHub issues about missing files
-- [ ] No GitHub issues about hardcoded paths
-- [ ] Community contributions follow security patterns
-
----
-
-## Next Steps
-
-**Immediate (before push):**
-1. Run `./scripts/verify-distribution.sh`
-2. Review warnings, decide on cleanup items
-3. Update README URLs (podcast, blog post)
-4. Add LICENSE file
-
-**Pre-launch (before announcement):**
-1. Test fresh clone on different machine
-2. Test setup wizard end-to-end
-3. Test without optional dependencies
-4. Record demo video (optional)
-
-**Launch:**
-1. Push to GitHub: `git push origin main`
-2. Create release: `git tag -a v1.0.0 -m "Initial release"`
-3. Announce on podcast/blog/social
-4. Monitor GitHub issues for first 48 hours
-
----
-
-## Questions?
-
-**"Do I need to change anything before pushing to GitHub?"**
-→ No (but recommended cleanup: remove task_server.py, update URLs)
-
-**"Will users need to edit .mcp.json manually?"**
-→ No, install.sh does it automatically
-
-**"Are my credentials exposed?"**
-→ No, verified safe
-
-**"Do I need to include external MCPs?"**
-→ No, they're separate user-installed tools
-
-**"What if someone doesn't have Granola?"**
-→ System works fine without it (graceful degradation)
-
----
-
-**Status:** ✅ **Ready to distribute**
-
-See `/06-Resources/Dex_System/Distribution_Checklist.md` for complete details.
+Maintainer checklist for cutting a release:
+`docs/Dex_System/Distribution_Checklist.md`.

--- a/core/migrations/README.md
+++ b/core/migrations/README.md
@@ -1,202 +1,69 @@
 # Dex Migration Scripts
 
-This folder contains migration scripts for major version updates that require structural changes to user data.
+**Last Updated:** 2026-07-26
+
+Structural migrations for major version changes to a user's install. **Users never
+run anything in this folder by hand** — migrations are owned and driven by the
+lifecycle engine, with one break-glass exception noted below.
 
 ---
 
-## When Migrations Are Needed
+## What's actually live
 
-**Minor/Patch updates (v1.2.0 → v1.3.0):** No migration needed - just merge
-**Major updates (v1.x → v2.0.0):** Migration required for breaking changes
+### `v1-to-v2-brain-vault-split.cjs` — the topology migrator (LIVE)
 
-**Breaking changes include:**
-- Folder renames (e.g., `03-Tasks/` → `03-Backlog/`)
-- File format changes (e.g., YAML schema updates)
-- Configuration structure changes
-- Metadata format updates
+The one-time move that separates Dex's product files (the "brain") from the user's
+content (the "vault") into distinct histories. It is invoked only by:
 
----
+- **`install.sh`** — fresh installs are set up split from the start.
+- **`core/lifecycle/engine.py`** — for existing combined-layout vaults,
+  `/dex-update` runs the lifecycle service's topology flow:
+  `build_and_preview_topology_migration` (dry-run report) → the user's explicit
+  yes to that exact report → `execute_approved_topology_migration` → receipt with
+  transaction ID and a local undo archive. The service also owns resume after
+  interruption (exit code 75 loop).
 
-## How Migrations Work
+**Never run the migrator directly as part of an update.** The `/dex-update` skill
+says this in as many words. The sole sanctioned direct use is **recovery**: when
+`/dex-doctor` diagnoses a topology stuck mid-migration (or disagreeing split
+markers), Doctor's guidance may include running it with `--resume` / `--restore`.
+That is break-glass, not a workflow.
 
-### For Users
+Supporting pieces here:
+- `sync-folder-detector.cjs` — refuses to convert a vault living inside a
+  cloud-synced folder (Dropbox/iCloud), per the v1.75.2 rehearsal findings.
+- `preserve_local_only_paths.py` — keeps local-only paths safe across the split.
+- `tracked-ignored-policy.yaml` — policy input for what the split tracks vs ignores.
+- Tests: `tests/`, `../tests/brain-vault-migrator-*.test.cjs`,
+  `../tests/test_lifecycle_topology_migration.py`.
 
-**Step 1: Check release notes**
-```
-/dex-whats-new
-```
+### `migrate_v1_to_v2.py` — ORPHANED (do not instruct anyone to run it)
 
-If you see ⚠️ **BREAKING CHANGES**, read the release notes carefully.
-
-**Step 2: Back up your vault**
-```bash
-cp -r ~/Documents/dex ~/Documents/dex-backup-$(date +%Y%m%d)
-```
-
-**Step 3: Run the migration script**
-```bash
-python core/migrations/migrate_v1_to_v2.py --apply
-```
-
-The script will:
-- Check if migration is needed
-- Transform your data safely
-- Report what changed
-- Create `.migration-log` file
-
-**Step 4: Review changes**
-```bash
-git status
-git diff
-```
-
-**Step 5: Update Dex**
-```bash
-git fetch upstream
-git merge upstream/release
-```
-
-**Step 6: Test**
-
-Run key workflows to verify everything works:
-- `/daily-plan`
-- Open person pages
-- Check tasks
-
-If anything breaks, restore from backup and report the issue.
+An earlier, generic v1→v2 migration script from the manual-git-update era. Nothing
+in the current install/update system calls it; only its own unit test exercises
+it. Previous versions of this README told users to run it by hand and then
+`git merge upstream/release` — that entire workflow is dead. Kept for reference
+until a deliberate deletion pass; treat it as historical.
 
 ---
 
-## For Maintainers
+## For maintainers: adding a future migration
 
-### Creating a Migration Script
+Don't copy the old shell-script template that used to live here — it predates the
+safety architecture. A new structural migration must:
 
-**Template:**
+1. **Run under the lifecycle service** — surfaced as a previewable, approvable,
+   receipt-backed operation (see how `engine.py` wraps the topology migrator via
+   `TOPOLOGY_MIGRATOR_RELATIVE`), never as a script users invoke.
+2. **Share the transaction core's lock + journal directory** so it can never run
+   concurrently with another vault mutation (`core/transaction/`).
+3. **Be resumable and undoable** — dry-run first, bounded resume on interruption,
+   and a receipt naming the undo path.
+4. **Respect the portable ownership contract** — never write `vault`-class paths
+   beyond the migration's explicit, previewed scope.
+5. **Be rehearsed on real-shaped vaults** before switch-on (large file counts,
+   accented filenames, cloud-synced folders, symlinks — all real findings from
+   the v1.75.2 rehearsal).
 
-```bash
-#!/bin/bash
-# Migration: v1.x → v2.0.0
-# Description: [What this migration does]
-# Date: YYYY-MM-DD
-
-set -e  # Exit on error
-
-echo "================================================"
-echo "Dex Migration: v1.x → v2.0.0"
-echo "Description: [Brief description]"
-echo "================================================"
-echo ""
-
-# Check if migration already ran
-if [ -f ".migration-v2-complete" ]; then
-    echo "✓ Migration already completed"
-    echo "  Remove .migration-v2-complete to run again"
-    exit 0
-fi
-
-# Dry run first
-echo "🔍 Checking what needs migration..."
-echo ""
-
-# [Detection logic - what needs changing?]
-
-echo ""
-read -p "Proceed with migration? (y/n) " -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Migration cancelled"
-    exit 1
-fi
-
-# Actual migration
-echo ""
-echo "🔄 Migrating..."
-
-# [Migration logic]
-
-# Mark as complete
-touch .migration-v2-complete
-echo "2.0.0" > .migration-version
-
-echo ""
-echo "================================================"
-echo "✅ Migration complete!"
-echo "================================================"
-echo ""
-echo "Next steps:"
-echo "1. Review changes: git status && git diff"
-echo "2. Update Dex: git fetch upstream && git merge upstream/release"
-echo "3. Test workflows: /daily-plan, person pages, tasks"
-echo ""
-```
-
-### Migration Best Practices
-
-1. **Idempotent**: Safe to run multiple times
-2. **Reversible**: Can undo if needed (or at least document how)
-3. **Verbose**: Tell user what's happening
-4. **Safe**: Verify before destructive operations
-5. **Tested**: Run on multiple test vaults before release
-
-### Testing Migrations
-
-Before releasing:
-
-1. Create test vaults representing different user states:
-   - Fresh install
-   - Heavily customized
-   - Multiple projects and people
-   - Custom folder names
-
-2. Run migration on each test vault
-
-3. Verify:
-   - All data preserved
-   - No corruption
-   - Skills still work
-   - MCP servers functional
-
----
-
-## Migration Log
-
-Migrations are logged to `System/.migration-log`:
-
-```
-2026-03-15 14:23:11 | v1-to-v2 | Started
-2026-03-15 14:23:15 | v1-to-v2 | Renamed 03-Tasks/ → 03-Backlog/
-2026-03-15 14:23:18 | v1-to-v2 | Updated 47 markdown file references
-2026-03-15 14:23:19 | v1-to-v2 | Complete
-```
-
-This helps debug if something goes wrong.
-
----
-
-## Example: Folder Rename Migration
-
-Use `migrate_v1_to_v2.py` for an executable dry-run/apply/rollback migration flow.
-`v1-to-v2-example.sh` remains as a reference pattern.
-
----
-
-## Emergency Rollback
-
-If migration fails:
-
-```bash
-# Restore from backup
-rm -rf ~/Documents/dex
-cp -r ~/Documents/dex-backup-YYYYMMDD ~/Documents/dex
-
-# Report issue
-# Open GitHub issue with .migration-log contents
-```
-
----
-
-## Questions?
-
-- **GitHub Issues:** Report migration problems
-- **Discussions:** Ask about migration strategy
-- **CHANGELOG.md:** See migration requirements for each major version
+Design references: `docs/transaction-core-design.md`,
+`docs/architecture/DEX-CORE-MAP.md` §§1–4.

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -1,7 +1,7 @@
 # Dex Technical Guide
 
 **Version:** 1.0  
-**Last Updated:** July 11, 2026
+**Last Updated:** July 2026
 
 **Audience:** People who want to understand how Dex works under the hood - whether to customize it, contribute to it, or learn from its design patterns.
 

--- a/docs/Dex_System/Distribution_Checklist.md
+++ b/docs/Dex_System/Distribution_Checklist.md
@@ -1,273 +1,74 @@
 # Dex Distribution Checklist
 
-**Status:** ✅ Ready for GitHub Distribution
+**Last Updated:** 2026-07-26 (v1.75.2)
 
-This document verifies that Dex is properly configured for public distribution without exposing credentials or requiring manual path configuration.
-
----
-
-## ✅ 1. Dynamic Paths (SOLVED)
-
-**Problem:** Users will clone to different paths like `/Users/alice/Documents/dex`
-
-**Solution:** Template + install script substitution (already implemented)
-
-### How It Works
-
-1. **Template file:** `System/.mcp.json.example` uses `{{VAULT_PATH}}` placeholder
-2. **Install script:** `install.sh` (lines 49-55) automatically:
-   - Detects current directory: `CURRENT_PATH="$(pwd)"`
-   - Replaces placeholder: `sed "s|{{VAULT_PATH}}|$CURRENT_PATH|g"`
-   - Generates `.mcp.json` (gitignored)
-
-### User Experience
-
-```bash
-cd ~/Documents/dex
-./install.sh
-# ✅ Creates .mcp.json with /Users/alice/Documents/dex
-```
-
-**Status:** No action needed — industry-standard pattern.
+Maintainer reference for how Dex ships and what to check when cutting a release.
+For the standing overview of the distribution system, see `DISTRIBUTION_READY.md`
+at the repo root. This file replaced the original pre-launch checklist (January
+2026); the old content is in git history.
 
 ---
 
-## ✅ 2. MCP Server Architecture (CLARIFIED)
+## 1. Paths — provisioned, not templated
 
-### Dex Core MCP Servers (7 total)
+A fresh install runs `install.sh`, which provisions everything through
+`node core/provision.cjs` + `core/provision-contract.json` + the generated
+portable-vault ownership contract. The vault path is collected once and rendered
+with a receipt.
 
-All shipped with Dex in `core/mcp/`:
+> The old `sed "s|{{VAULT_PATH}}|…|"` templating over `System/.mcp.json.example`
+> no longer exists. If a doc describes it, that doc is stale.
 
-| Server | File | Purpose | External Dependency |
-|--------|------|---------|-------------------|
-| work-mcp | `work_server.py` | Task/goal management | None (local files) |
-| calendar-mcp | `calendar_server.py` | Calendar integration | macOS Calendar.app |
-| granola-mcp | `granola_server.py` | Meeting processing | `GRANOLA_API_KEY` from a Granola Business/Enterprise plan (optional) |
-| career-mcp | `career_server.py` | Career development | None (local files) |
-| resume-mcp | `resume_server.py` | Resume building | None (local files) |
-| dex-improvements-mcp | `dex_improvements_server.py` | System improvements | None (local files) |
-| update-checker | `update_checker.py` | Dex update checking | GitHub API (read-only) |
+## 2. MCP servers — 10 core, external ones stay external
 
-### External MCPs (NOT part of Dex)
+Dex ships **10 MCP servers** in `core/mcp/`. The authoritative, CI-drift-gated
+list (names, tool counts, exact tools) is `docs/architecture/INVENTORY.md`
+§ "MCP engines" — don't hand-copy it here.
 
-These are user-installed separately via Claude Desktop/Cursor settings:
+External MCPs (browser automation, user-installed integrations, hosted vendor
+MCPs) are not part of Dex; users add them via their own Claude settings.
 
-- `cursor-ide-browser` — Browser automation
-- `user-granola` — Official Granola MCP (different from dex granola-mcp)
-- `pendo` — Pendo's hosted MCP server (OAuth, optional for Pendo customers)
-- `user-whatsapp`, `user-apify`, etc. — Other user-installed integrations
+Optional companions degrade gracefully:
+- **Granola** — meeting sync uses Granola's official public API with
+  `GRANOLA_API_KEY` (Business/Enterprise plan); `/granola-setup` connects it.
+  Without it, users can paste transcripts manually.
+- **Apple Calendar/Reminders** — EventKit shims in `core/mcp/scripts/`; macOS
+  only; other platforms degrade gracefully (`docs/support/upgrade-platform-matrix.md`).
 
-### Optional Dependencies
+## 3. Credentials & user data — enforced by CI, not by checklist
 
-**Granola (meeting transcription):**
-- Install script checks for `/Applications/Granola.app` only to offer the right next step
-- If found: "✅ Granola app detected — run /granola-setup to connect it (needs a Granola Business API key)"
-- If not found: "ℹ️ Granola app not detected", followed by the https://granola.ai install pointer
-- Meeting sync uses the official Granola public API and reads `GRANOLA_API_KEY` from the environment, then the vault-root `.env`
-- `/granola-setup` connects the API key; local application data is never treated as authentication
-- System works without it — users can paste meeting transcripts manually
+What used to be manual verification is now automated gates on every push:
 
-**Apple Calendar:**
-- Uses macOS Calendar.app via AppleScript (no API keys needed)
-- Works with any calendar synced to Calendar.app (Google, Outlook, iCloud)
-- macOS only (calendar-mcp gracefully degrades on other platforms)
+| Concern | Gate |
+| --- | --- |
+| No PII in tracked files | `scripts/check-pii.sh` + `scripts/pii_gate.py` |
+| No founder-machine content ships | `scripts/check-founder-content.sh` |
+| No credentials/keys | `scripts/security-gate.sh` + `security-scan.py` |
+| Every path classified (user data never shipped) | `scripts/check-portable-contract.sh` |
+| Distribution safety | `scripts/verify-distribution.sh` |
 
-**Status:** Documentation matches the official API connection model.
+`.env`, `.mcp.json`, `System/user-profile.yaml`, `System/pillars.yaml`, and all
+user data folders are gitignored; the ownership contract additionally guarantees
+updates never write `vault`-class paths.
 
----
+**99% of features work with no API keys.** Optional keys (Anthropic/OpenAI/Gemini)
+only enable background automation; `/setup` offers this and creates `.env` from
+`env.example` on an explicit yes.
 
-## ✅ 3. Credentials & Security (VERIFIED)
+## 4. Cutting a release
 
-### Gitignored Files
+1. Land the changes on `main` with a `CHANGELOG.md` entry in the house voice —
+   CHANGELOG is the single source of release truth.
+2. CI on the `main` push runs the full gate list, then builds and publishes the
+   release branch, tag, and vault bundle, and deploys the release-health page.
+3. Tag `vX.Y.Z` — `release.yml` extracts the matching CHANGELOG section and
+   creates the GitHub Release.
+4. Prerelease work goes through the `beta` branch mirror (prerelease-only guards).
 
-```gitignore
-# Credentials
-.env
-.env.local
+## 5. Manual spot-checks (when touching install/packaging)
 
-# Generated config
-.mcp.json
-
-# User data
-System/user-profile.yaml
-System/pillars.yaml
-00-Inbox/
-01-Quarter_Goals/
-02-Week_Priorities/
-03-Tasks/
-04-Projects/
-05-Areas/
-07-Archives/
-```
-
-### Credential Scan Results
-
-**Python MCP servers:**
-```bash
-✅ No API keys found in core/mcp/*.py
-✅ No hardcoded passwords/tokens
-✅ No personal data
-```
-
-**Environment variables:**
-- Template: `env.example` (safe — no real keys)
-- Actual `.env` is gitignored
-- Created during setup only if user enables optional features
-
-### What Gets Committed to GitHub
-
-**Safe to commit:**
-- ✅ `System/.mcp.json.example` — Template with `{{VAULT_PATH}}`
-- ✅ `env.example` — Template showing structure
-- ✅ `core/mcp/*.py` — MCP server code (no credentials)
-- ✅ Documentation and README
-
-**Never committed:**
-- ❌ `.mcp.json` — Generated, contains user paths
-- ❌ `.env` — Contains API keys if configured
-- ❌ User data folders (00-07)
-- ❌ `System/user-profile.yaml` — Personal info
-
-**Status:** Security verified — ready for public release.
-
----
-
-## 📋 Pre-Release Checklist
-
-Before pushing to GitHub:
-
-### Repository Setup
-- [ ] Remove or sanitize `System/Session_Learnings/` (contains personal work history)
-- [ ] Verify `.gitignore` is committed
-- [ ] Check no `.env` or `.mcp.json` in git history: `git log --all --full-history --name-only -- .env .mcp.json`
-- [ ] Verify no API keys in commit history: `git log --all -S "sk-ant-" -S "ANTHROPIC_API_KEY" -S "OPENAI_API_KEY"`
-
-### Documentation
-- [ ] README links to actual podcast episode (currently placeholder)
-- [ ] README links to blog post (currently placeholder)
-- [ ] Verify GitHub repo URL in clone command
-- [ ] Add LICENSE file (MIT recommended)
-- [ ] Add CONTRIBUTING.md if accepting PRs
-
-### Testing
-- [ ] Fresh clone on different machine
-- [ ] Run `./install.sh` with no prior Dex installation
-- [ ] Verify `.mcp.json` generates with correct paths
-- [ ] Run setup wizard: `/setup` in Cursor
-- [ ] Test without Granola installed (graceful degradation)
-- [ ] Test on Windows if supporting (install.sh needs .bat version)
-
----
-
-## 🔐 Credential Management for Users
-
-### What Users Need to Know
-
-**99% of features work immediately** — no API keys needed:
-- Task management
-- Person pages
-- Project tracking  
-- Daily planning
-- Meeting prep
-- All `/commands`
-
-**Optional API keys** (only if enabling background automation):
-- Anthropic API key — For `/prompt-improver` and background meeting processing
-- OpenAI or Gemini — Alternative to Anthropic
-
-### Setup Flow
-
-1. **First install:** No `.env` file — everything works through Cursor
-2. **Optional:** Run `/setup` → answers "Enable automatic meeting processing?"
-3. **If yes:** System creates `.env` from template, prompts for API key
-4. **If no:** Skip entirely — manual meeting processing works fine
-
-### Security Best Practices
-
-**For users:**
-- Never commit `.env` to their own repos
-- Use separate API keys for different projects
-- Set usage limits in Anthropic console
-
-**For Dex maintainers:**
-- Keep `env.example` up to date
-- Never commit real `.env`
-- Document which features require keys
-
----
-
-## 🚀 Distribution Recommendations
-
-### GitHub Release Strategy
-
-**v1.0.0 - Initial Public Release**
-
-1. **Tag the release:**
-   ```bash
-   git tag -a v1.0.0 -m "Initial public release"
-   git push origin v1.0.0
-   ```
-
-2. **Create GitHub Release:**
-   - Title: "Dex v1.0.0 — Your AI Chief of Staff"
-   - Description: Paste first 3 sections of README
-   - Attach: Installation guide, demo video (if available)
-
-3. **Post-release:**
-   - Monitor issues for Windows compatibility
-   - Create FAQ from common questions
-   - Build community in Discussions tab
-
-### Alternative Distribution
-
-**For teams/organizations:**
-- Fork repo → customize roles/templates → distribute internal URL
-- Include company-specific integrations in `core/mcp-custom/`
-- Company pillars in `System/pillars-company.yaml` template
-
-**For consultants:**
-- Charge for customization/setup services
-- Pre-configured bundles for specific roles (PM, Sales, etc.)
-- Training packages
-
----
-
-## ✅ Final Verification
-
-**Run this before pushing to GitHub:**
-
-```bash
-# Check for credentials in tracked files
-git ls-files | xargs grep -E '(sk-ant-|sk-[a-zA-Z0-9]{48}|AIza[a-zA-Z0-9-_]{35}|ANTHROPIC_API_KEY|OPENAI_API_KEY)' 2>/dev/null
-
-# Expected output: (no matches except in env.example and documentation)
-
-# Check for personal data
-git ls-files | xargs grep -iE '(dave|killeen|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,})' | grep -v 'README\|example\|template\|CHANGELOG'
-
-# Expected output: Only documentation/examples, no real emails/names
-
-# Verify .gitignore is working
-git status --ignored | grep -E '(\.env$|\.mcp\.json$|00-Inbox|04-Projects|System/user-profile\.yaml)'
-
-# Expected output: Shows these as ignored, not tracked
-```
-
----
-
-**Status:** ✅ **Ready for distribution**
-
-- Paths dynamically configured via install script
-- MCP servers documented (7 core, others external)
-- No credentials exposed
-- `.gitignore` properly configured
-- User data protected
-- Documentation complete
-
-**Next steps:**
-1. Complete pre-release checklist
-2. Push to GitHub
-3. Announce to audience
-4. Monitor for issues
-
-**Questions?** See `06-Resources/Dex_System/Dex_Technical_Guide.md` for implementation details.
+- [ ] Fresh clone on a clean machine → `./install.sh` completes; provision
+      receipt renders; remote renamed `origin` → `upstream`.
+- [ ] `/setup` onboarding completes without API keys.
+- [ ] Works with Granola absent (graceful degradation).
+- [ ] `./scripts/verify-distribution.sh` passes locally.

--- a/docs/Dex_System/Distribution_Strategy.md
+++ b/docs/Dex_System/Distribution_Strategy.md
@@ -1,5 +1,13 @@
 # Dex Distribution Strategy
 
+**Status: HISTORICAL (January 2026) — mechanisms superseded.** The philosophy below
+("Dex is yours, not ours"; updates enhance without disrupting) still holds, but the
+git-upstream merge mechanics this document describes were replaced in mid-2026 by
+the receipt-backed lifecycle engine (preview → backup → apply → verify → receipt →
+rewind) and the customization-migration system. For current truth read:
+`Updating_Dex.md` (user-facing), `Distribution_Checklist.md` (maintainer),
+`docs/architecture/DEX-CORE-MAP.md` §§1–4, 12 (technical). Kept as a design record.
+
 **Last Updated:** January 29, 2026
 
 This document explains how Dex handles updates, customizations, and distribution to users.

--- a/docs/Dex_System/Updating_Dex.md
+++ b/docs/Dex_System/Updating_Dex.md
@@ -1,765 +1,143 @@
-# Updating Dex - Explained Simply
+# Updating Dex — Explained Simply
 
-**Last Updated:** January 29, 2026
+**Last Updated:** July 26, 2026 (reflects the receipt-backed update system, v1.65+)
 
-This guide explains how to get new features and improvements for Dex, written for people who've never used GitHub or command-line tools before.
+This guide explains how Dex updates work, written for people who've never used
+developer tools. The short version: **you type `/dex-update`, Dex shows you exactly
+what would change, nothing happens without your yes, and every change can be undone.**
 
 ---
 
-## The Big Picture: Why Updates Matter
+## The Big Picture
 
 **What are updates?**
 
-Think of Dex like an app on your phone. Every few weeks, there are improvements:
-- New features that make your work easier
-- Bugs get fixed
-- Things run smoother
+Think of Dex like an app on your phone. Every week or two there are improvements:
+new features, bug fixes, things running smoother. Dex lives on your computer rather
+than in an app store, so you update it by asking Dex itself.
 
-The difference: Dex lives on your computer (not in an app store), so updating works differently.
+**The one promise that matters:**
 
-**What makes Dex updates safe:**
+> Every change goes through one safe door: Dex previews what would change, backs it
+> up, applies it, verifies it, writes a receipt — and can rewind it exactly.
 
-Your data is **completely separate** from the Dex application. Updates only touch the application - never your notes, tasks, or projects.
+Your notes, tasks, projects, and people pages are **never part of an update**. Dex
+keeps a strict map of which files belong to the product and which belong to you, and
+the update machinery refuses to write into yours. A file it can't confidently
+classify is left alone, always.
 
-It's like updating Microsoft Word. The app gets better, but your documents stay exactly as they are.
-
-**Your customizations are preserved too:**
-- **CLAUDE.md personal notes:** Anything between `USER_EXTENSIONS_START/END` is preserved during updates
-- **Custom MCP servers:** Name them with `user-` or `custom-` (e.g., `user-gmail`) so updates always keep them
-
----
-
-## What You Need to Know First
-
-### You Have Two Versions of Dex
-
-When you use Dex, there are actually TWO versions:
-
-1. **Your copy** - Lives on your computer
-   - Your notes, tasks, projects
-   - Your customizations
-   - Your daily work
-
-2. **The main version** - Lives on GitHub
-   - New features being added
-   - Bug fixes
-   - Improvements from other users
-
-**Updating means:** Getting the improvements from the main version and adding them to your copy, without touching your data.
-
-### What is GitHub?
-
-**GitHub is like Dropbox for code.**
-
-Just like Dropbox stores your files in the cloud, GitHub stores Dex's files. But GitHub has special features that help:
-- Track every change made to Dex
-- Let you download improvements
-- Keep your version and the main version in sync
-
-**Do you need a GitHub account?**
-
-Not for basic updates! You can:
-- ✓ Check for updates (no account needed)
-- ✓ Download updates (no account needed)
-- ✓ Use all of Dex (no account needed)
-
-**When you DO need an account:**
-- If you want to save your copy of Dex on GitHub (like a backup)
-- If you want to share improvements you make with others
-- If you want to report problems
-
-**Creating a GitHub account is free** and takes 2 minutes: [github.com/signup](https://github.com/signup)
-
-But again - **not required for updating Dex**.
-
-### What is Git?
-
-**Git is the tool that handles updates.**
-
-Think of it like this:
-- **GitHub** = The website (like Dropbox.com)
-- **Git** = The tool on your computer that talks to GitHub (like the Dropbox app)
-
-**Do you have Git?**
-
-Probably yes! If you followed the setup, you already have it.
-
-To check, you'll type one command later. Don't worry - we'll tell you exactly what to do.
+**No git, no GitHub account, no Terminal required.** Older versions of this guide
+walked through git commands and GitHub setup. That era is over: the update engine
+handles everything behind the scenes.
 
 ---
 
-## Updating Dex: The Simple Way
+## Updating: What Actually Happens
 
-### Step 1: Run the Update Command
+### Step 1 — Ask for the update
 
-**In Cursor, in the chat where you talk to Dex, type:**
+In your Dex chat, type:
 
 ```
 /dex-update
 ```
 
-**Press Enter.**
+Dex checks what's available and shows you a preview sorted into five honest groups:
 
-**What happens:**
+1. **New and safe to adopt** — improvements Dex can apply without touching anything of yours.
+2. **Needs your review** — files where *you've* made changes and the update also
+   carries a new version. Nothing here moves until you decide (see "When you've
+   customized things" below).
+3. **Held back by you** — things you previously said no to. Dex remembers and doesn't re-ask.
+4. **Could not be proved** — anything Dex can't verify with certainty. No change
+   will be made to these, period. Honesty over completeness.
+5. **Already yours** — what you've adopted before, with its undo receipt still available.
 
-Dex connects to GitHub, checks if there's a newer version, and shows you what's available.
+### Step 2 — Say yes (or no)
 
-You'll see one of two things:
+For anything that would actually change, Dex shows the exact files first and asks one
+direct question: *"Apply this exact update?"* Saying "update Dex" earlier doesn't
+count as approval — only a yes to the concrete preview does.
 
-**Option A: You're up to date**
-```
-✅ You're already on the latest version (v1.2.0)
+### Step 3 — The receipt
 
-No update needed!
-```
+After applying, Dex shows a receipt: what changed, applied in one crash-safe step,
+with a backup taken first. If your computer lost power mid-update, you'd end up with
+either the old version or the new one — never a half-done mess.
 
-Great! You're done. Come back in a few weeks.
+### Undoing an update
 
-**Option B: An update is available**
-```
-🎁 Dex v1.3.0 is available
-
-You're on: v1.2.0
-Latest: v1.3.0
-
-What's new:
-- Career coach improvements
-- Task deduplication fix
-- Meeting intelligence enhancement
-
-[View full release notes]
-[Update now]
-[Cancel]
-```
-
-**What this means:**
-- Someone (probably me) made Dex better
-- Version 1.3.0 has new stuff
-- You can get it by clicking [Update now]
-
-**Your choices:**
-
-1. **[Update now]** - Proceeds with the update (recommended)
-2. **[View full release notes]** - Opens GitHub to see all details
-3. **[Cancel]** - Exit without updating (you can run `/dex-update` again later)
-
-**Should you update?**
-
-Usually yes! Updates make things better. But you can cancel if:
-- You're in the middle of something urgent
-- You want to read the full release notes first
-- You want to wait and see if others have problems
-
-**Note about "breaking changes":**
-
-Sometimes you'll see: ⚠️ **BREAKING CHANGES**
-
-This means the update changes how something works in a big way. These are rare and come with extra instructions. Don't worry - the update process will guide you.
+Type `/dex-rollback`. Dex uses the receipt to rewind the exact change — the same
+files, byte for byte. Dex keeps your last 3 rewind points.
 
 ---
 
-### Step 2: Confirm and Update
+## When You've Customized Things
 
-**If you clicked [Update now], here's what happens next:**
+If you've edited a skill, added your own scripts, or tuned your instructions, updates
+respect that — and this got a major upgrade in mid-2026 (v1.75).
 
-```
-/dex-update
-```
+**Conflicts get four choices, per file:**
 
-**Press Enter.**
+- **Keep mine** — your version stays; nothing is written.
+- **Take theirs** — the new release version goes live; yours stays recoverable via rewind.
+- **Keep both** — the release version becomes the standard one, and your edited
+  version is preserved beside it (as `name-custom`) where it still works. Fully rewindable.
+- **Compare** — see the differences first, then choose. Looking never changes anything.
 
-**What happens next:**
-
-Dex will walk you through the update. Here's what to expect:
-
----
-
-#### A. Dex Checks If You Have Git
-
-**You'll see:**
-```
-✓ Git detected
-```
-
-**If you see this instead:**
-```
-❌ Git not detected
-
-Dex updates require Git. Here's how to install...
-```
-
-Don't panic! Follow the simple instructions. It's a one-time thing:
-
-**On Mac:**
-1. Open Terminal (press Cmd+Space, type "Terminal", press Enter)
-2. Type: `xcode-select --install`
-3. Press Enter
-4. Click "Install" when a window pops up
-5. Wait 5 minutes for download
-6. Come back to Cursor and try `/dex-update` again
-
-**On Windows:**
-1. Go to: https://git-scm.com/download/win
-2. Click the download link
-3. Run the installer (click Next on everything)
-4. Restart Cursor
-5. Try `/dex-update` again
-
-This only happens once. After this, updates are automatic.
+**Deeply customized setups get a guided journey.** If Dex's health check
+(`/dex-doctor`) finds you've customized a lot, `/dex-update` offers to walk you
+through it: it inventories everything you've changed, explains what the update would
+affect, and — only with your explicit yes — saves a protected local snapshot of your
+customization evidence (called a **Capsule**, stored inside your vault's
+`System/.dex/` area, never uploaded) before proceeding through the normal
+preview-and-approve flow. Nothing is overwritten, and the Capsule survives the update
+so your work is never lost.
 
 ---
 
-#### B. Dex Checks Your Setup
+## The One-Time "Brain and Vault" Separation
 
-**You'll see:**
-```
-✓ Setup verified
-```
+Older Dex installs kept the product's files and your personal notes together in one
+combined history. Newer Dex separates them — the product (the "brain") and your
+content (the "vault") — so an update can't even theoretically touch your notes, and
+your private vault history is never uploaded anywhere.
 
-If this is your first time updating, Dex might configure a few things behind the scenes. This is normal and automatic.
-
-**What's actually happening:**
-
-Dex is telling Git where to look for updates (on GitHub). Think of it like saving a bookmark in your browser.
-
----
-
-#### C. Dex Downloads the Updates
-
-**You'll see:**
-```
-⬇️ Downloading updates from GitHub...
-✓ Updates downloaded
-```
-
-**What's happening:**
-
-Dex is getting the new files from GitHub and bringing them to your computer.
-
-**This requires internet.** If you see an error about network, check your WiFi and try again.
+If your install still has the combined layout, `/dex-update` offers this move as a
+**one-time step**, with the same rules as everything else: full preview first,
+explicit yes required, and the old combined history is kept locally as an undo
+archive named in the receipt. Dex refuses to attempt it in risky situations (for
+example, a vault living inside a Dropbox- or iCloud-synced folder) rather than gamble
+with your files.
 
 ---
 
-#### D. Dex Protects Your Work
+## Frequently Asked
 
-**You'll see:**
-```
-💾 Saving your work...
-✓ Your work is saved
-```
+**How do I see what's new without updating?** Type `/dex-whats-new`.
 
-**What's happening:**
+**Should I update?** Usually yes. You can always preview first and adopt nothing, and
+anything you adopt can be rewound.
 
-Before changing anything, Dex saves a snapshot of how things are right now. It's like creating a restore point on your computer.
+**Can I skip individual items?** Yes — each item is decided independently, and
+"skip this one" can't affect the rest. Skipped items show up under "Held back by
+you" next time, without nagging.
 
-**Why this matters:**
+**What if an update refuses to proceed?** That's the safety system working, not
+breaking. Dex explains the refusal in plain language and leaves everything untouched.
+Run `/dex-doctor` for a full health check.
 
-If something goes wrong (very rare), you can undo the update instantly with `/dex-rollback`.
+**Do I need a GitHub account, git, or Terminal?** No.
 
-This makes updating completely safe. You can always go back.
+**What about my custom MCP servers and personal instructions?** They're classified as
+yours in the ownership map, so updates never write them. Personal additions to your
+instructions survive updates too.
 
----
-
-#### E. Dex Applies the Updates
-
-**You'll see:**
-```
-🔄 Applying updates...
-```
-
-**What's happening:**
-
-Dex is carefully updating its own files (the application) while leaving your files (your data) completely alone.
-
-**Two possible outcomes:**
-
-**Outcome 1: Clean update (most common)**
-```
-✓ Updates applied successfully
-```
-
-This means the update fit perfectly with your setup. No problems. This happens 95% of the time.
-
-**Outcome 2: Overlapping changes (rare)**
-
-Sometimes both you AND the main version changed the same file. For example:
-- You customized a skill
-- The update also changed that skill
-
-**You'll see:**
-```
-🔍 Resolving overlapping changes...
-
-Found changes in the same files:
-- CLAUDE.md (your version vs update version)
-
-Automatically keeping: Your customizations
-Automatically updating: Core Dex features
-
-✓ Resolved automatically
-```
-
-**What Dex does automatically:**
-
-For each file with overlapping changes:
-
-| File Type | What Dex Keeps |
-|-----------|----------------|
-| Your notes, tasks, projects | **Your version (always)** |
-| Your settings (user-profile, pillars) | **Your version (always)** |
-| Core Dex skills | **Update version (improvements)** |
-| Core Dex features | **Update version (improvements)** |
-| Files you customized | **Your version (your changes)** |
-
-**Translation:** Your stuff stays yours. Dex improvements come through. Conflicts resolved automatically.
-
-**You don't need to do anything.** Dex handles this.
+**Where do I get help?** The Dex Guide at https://heydex.ai/help, or ask Dex
+directly in chat — "something went wrong with the update" routes to `/dex-doctor`.
 
 ---
 
-#### F. Dex Updates Dependencies
-
-**You'll see:**
-```
-📦 Updating dependencies...
-✓ Dependencies updated
-```
-
-**What are dependencies?**
-
-Think of Dex like a car. The car (Dex) needs certain parts to work: tires, battery, engine.
-
-Dependencies are those parts. When Dex updates, sometimes it needs newer parts.
-
-**What's happening:**
-
-Dex is automatically installing or updating these parts. You don't need to do anything.
-
-This takes 30 seconds to 2 minutes depending on your internet.
-
----
-
-#### G. Dex Verifies Everything
-
-**You'll see:**
-```
-✓ Update complete! Now testing...
-✅ Update successful!
-```
-
-**What's happening:**
-
-Dex is checking that everything works:
-- Can it find your tasks?
-- Can it read your profile?
-- Are all the features working?
-
-If anything fails, Dex will offer to undo the update automatically.
-
----
-
-### Step 3: Confirmation
-
-**You'll see a summary:**
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Dex Updated: v1.2.0 → v1.3.0
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-What's new:
-• Career coach improvements
-• Task deduplication fix
-• Meeting intelligence enhancement
-
-Your data:
-✓ All notes preserved
-✓ All tasks preserved
-✓ All customizations preserved
-
-Time taken: 2 minutes
-```
-
-**You're done!** The new features are ready to use.
-
----
-
-### Step 4: Try It Out
-
-**Test that everything works:**
-
-1. Run your daily plan:
-   ```
-   /daily-plan
-   ```
-
-2. Open a person page:
-   - Go to `05-Areas/People/` and open someone
-
-3. Check your tasks:
-   - Open `03-Tasks/Tasks.md`
-
-Everything should work normally, plus you'll have the new features from the update.
-
----
-
-## If Something Goes Wrong
-
-### The Instant Undo Button
-
-**If anything feels wrong after updating, type:**
-
-```
-/dex-rollback
-```
-
-**What happens:**
-
-Dex instantly restores everything to exactly how it was before you updated.
-
-**How long it takes:** 30 seconds
-
-**What gets restored:**
-- ✓ Dex features go back to old version
-- ✓ All your notes, tasks, projects stay as they are
-
-**Translation:** You tried the update, didn't like it, and now you're back to the old version. Your work is completely safe.
-
-You can try updating again later, or just stay on the old version.
-
----
-
-## Understanding How This Works (Optional)
-
-*This section is for people who want to understand what's happening behind the scenes. You can skip this if you're happy just using the commands.*
-
-### Why GitHub?
-
-**Dex is "open source"** - this means:
-- Anyone can see how it works
-- Anyone can improve it
-- It's free forever
-- You're not locked into a company
-
-GitHub is where open source projects live. It's like a public workshop where improvements happen.
-
-**Your copy of Dex is completely yours.** It's on your computer, not on GitHub. But GitHub is where the "official" version lives, with all the latest improvements.
-
-### What Git Actually Does
-
-When you run `/dex-update`, here's what Git does:
-
-1. **Looks at GitHub** - "What's new since I last checked?"
-
-2. **Downloads the changes** - "Let me grab those new features"
-
-3. **Merges them into your copy** - "Let me carefully add these without touching your data"
-
-**Why is this better than just re-downloading Dex?**
-
-If you re-downloaded Dex, you'd have to:
-- Delete your old version
-- Download new version
-- Copy all your files over manually
-- Hope you didn't miss anything
-
-Git does all this automatically in 2 minutes, without you lifting a finger.
-
-### What "Version Control" Means
-
-Git is a "version control" system. Think of it like Track Changes in Microsoft Word, but for an entire application.
-
-Every time someone improves Dex:
-- Git records exactly what changed
-- Git can show you the difference
-- Git can combine improvements from multiple people
-- Git can undo changes if something breaks
-
-**For you, this means:**
-- Updates are precise (only what changed gets updated)
-- Your customizations are preserved (Git knows what you changed)
-- Rollback is instant (Git remembers previous versions)
-
-### The "Upstream" Concept
-
-When you first downloaded Dex, you downloaded it from GitHub. That GitHub location is called the "upstream" source.
-
-Think of it like a river:
-- **Upstream** = Where the water comes from (main Dex on GitHub)
-- **Your location** = Where you are (Dex on your computer)
-
-Updates flow downstream to you.
-
-`/dex-update` is just asking: "What's new upstream? Let me get it."
-
-### Why Your Data Is Safe
-
-Your data is in folders that Git **ignores**:
-- `00-Inbox/`
-- `03-Tasks/`
-- `04-Projects/`
-- `05-Areas/`
-- All your notes and work
-
-Git is told: "Never track these folders. Never change them. Never touch them."
-
-It's in a file called `.gitignore` that explicitly lists everything to ignore.
-
-So when updates come in, Git sees your data and thinks: "Not my job, skip these."
-
-This is why updates can't hurt your data. Git literally doesn't see it.
-
----
-
-## Automatic Update Checks
-
-**You don't have to remember to check for updates.**
-
-Every 7 days, during `/daily-plan`, Dex automatically checks GitHub and tells you if an update is available:
-
-```
-🎁 Dex v1.3.0 is available. Run /dex-update to see what's new and update.
-
----
-
-Here's your plan for today...
-```
-
-It's non-intrusive - just a heads up at the top of your daily plan.
-
-**You decide when to update.** Dex will never update itself without you asking. Running `/dex-update` shows you what's new and asks for confirmation before proceeding.
-
-**Want to disable these notifications?**
-
-Edit `System/user-profile.yaml` and add:
-
-```yaml
-updates:
-  auto_check: false
-```
-
----
-
-## FAQs for Non-Technical Users
-
-### Do I need to update?
-
-Not required, but recommended. Updates make things better:
-- New features
-- Bug fixes
-- Performance improvements
-
-Your current version will keep working fine. But you miss out on improvements.
-
-**Good rule:** Update monthly, or when you see a feature you want.
-
----
-
-### How often do updates come out?
-
-Every few weeks to every few months, depending on what's being improved.
-
-You'll know when they're available because of the automatic check during `/daily-plan`.
-
----
-
-### Will I lose my work?
-
-**No. Never. Impossible.**
-
-Your work is in protected folders that updates don't touch. It's technically impossible for an update to delete your notes, tasks, or projects.
-
-The worst that can happen: A new feature doesn't work right. But your data is always safe.
-
-And if anything breaks, `/dex-rollback` undoes the update in 30 seconds.
-
----
-
-### What if my internet is slow?
-
-The download step might take 3-5 minutes instead of 30 seconds. But it will complete.
-
-The update process is patient - it won't time out.
-
----
-
-### Can I skip an update?
-
-Yes! If v1.3.0 comes out and you don't update, then v1.4.0 comes out, you can jump straight from v1.2.0 to v1.4.0.
-
-Git handles this automatically.
-
----
-
-### What are "breaking changes"?
-
-Very rarely (maybe once a year), an update changes something in a big way. Examples:
-- Renaming a major folder
-- Changing how a feature works
-- Updating the configuration format
-
-These are marked with ⚠️ **BREAKING CHANGES** in the release notes.
-
-**What to do:**
-
-The update process will guide you with extra steps (usually just running one extra command). It's still safe and still has rollback.
-
-Breaking changes come with:
-- Clear explanation of what's changing
-- Why it's changing
-- Step-by-step migration instructions
-- Extra safety checks
-
-Don't avoid them - just read the notes carefully first.
-
----
-
-### Can I see what will change before updating?
-
-Yes! When you run:
-```
-/dex-update
-```
-
-Dex shows you the release notes and asks for confirmation before proceeding. You can:
-- Read what's new
-- View full release notes on GitHub
-- Choose [Update now] or [Cancel]
-
-You're never forced to update - you always confirm first.
-
----
-
-### What if I made changes to Dex itself?
-
-**Customizations in recommended places:**
-- `.claude/skills-custom/` - Your custom skills
-- `core/mcp-custom/` - Your custom integrations
-- `CLAUDE-custom.md` - Your prompt customizations
-
-These are protected. Updates won't touch them.
-
-**Changes to core Dex files:**
-
-If you edited a core file (like `.claude/skills/daily-plan/SKILL.md`), and an update also changes that file, Dex will:
-1. Detect the overlap
-2. Ask which version to keep
-   - If AskUserQuestion is available, Dex shows a guided choice
-   - If not, Dex shows a CLI prompt with the same options + tradeoffs
-3. Usually keep your version (your customizations)
-
-But **better practice:** Put your customizations in the `-custom` folders so they never conflict.
-
----
-
-### Can I undo an undo?
-
-Yes! When you run `/dex-rollback`, Dex saves a snapshot before rolling back.
-
-So if you rollback and then think "wait, I want the update back," you can restore it.
-
-The rollback skill explains this.
-
----
-
-### What if the update fails halfway through?
-
-Dex is careful about this. If something fails:
-
-1. The update stops immediately
-2. Dex offers to restore to before the update
-3. You're back to where you started (safe)
-4. You can report the problem or try again later
-
-**You're never left in a broken state.** Either the update completes successfully, or it rolls back automatically.
-
----
-
-## Different Ways to Update (Summary)
-
-### Option 1: Automatic (Recommended)
-```
-/dex-update
-```
-- Easiest
-- Safest
-- Handles everything
-- **Use this method**
-
-### Option 2: Manual (Advanced Users Only)
-
-If you're comfortable with command-line tools and want to see exactly what's changing:
-
-```bash
-cd ~/Documents/dex
-git fetch upstream
-git merge upstream/release
-```
-
-Only use this if you understand Git. Everyone else should use `/dex-update`.
-
-### Option 3: Re-download (Last Resort)
-
-If Git isn't working or you just want a fresh start:
-
-1. Download latest Dex from GitHub as a ZIP
-2. Copy your data folders (00-07, System/) from old to new
-3. Delete old Dex folder
-4. Rename new folder to 'dex'
-5. Open in Cursor
-
-This works but takes 10-15 minutes vs. 2 minutes for `/dex-update`.
-
----
-
-## Getting Help
-
-### Something Broke and Rollback Didn't Fix It
-
-1. **Don't panic** - Your data is safe (it's in separate folders)
-
-2. **Report the issue:**
-   - Go to: https://github.com/davekilleen/dex/issues
-   - Click "New Issue"
-   - Describe what happened and what you see
-
-3. **Temporary workaround:**
-   - Re-download Dex
-   - Copy your data folders back
-   - Continue working while we fix the bug
-
-### Questions About What Changed
-
-- Read release notes: https://github.com/davekilleen/dex/releases
-- Or run: `/dex-update` (shows release notes before asking to proceed)
-
-### Want to Learn More About Git
-
-- GitHub's guide: https://guides.github.com/introduction/git-handbook/
-- Git for non-programmers: https://www.youtube.com/watch?v=8JJ101D3knE
-
-But remember: **You don't need to learn Git to use Dex.** The `/dex-update` command handles it all.
-
----
-
-## Summary: The 2-Minute Update
-
-**Update Dex:**
-```
-/dex-update
-```
-Shows what's new, you confirm, it updates.
-
-**Undo if needed:**
-```
-/dex-rollback
-```
-Instantly restores previous version.
-
-**That's it.** Two commands. Your data is always safe. You can always undo.
-
-Updates should improve your work, not create anxiety. If you're ever unsure, just ask in Cursor chat: "Should I update to v1.3.0?" and Dex will explain what's new.
-
----
-
-**Remember:** Dex is yours. Update when you want, skip updates if you want, rollback if something feels off. You're in control.
+*For the technical design behind all this, see `docs/architecture/DEX-CORE-MAP.md`
+(lifecycle engine, transaction core, and customization migration sections) in the
+dex-core repository.*

--- a/docs/FAQ-DRAFT.md
+++ b/docs/FAQ-DRAFT.md
@@ -1,6 +1,9 @@
 # Dex FAQ (DRAFT)
 
-> **Status:** Internal draft - not yet released
+> **Status: ARCHIVED DRAFT (February 2026) — never published.** User-facing help
+> now lives in the Dex Guide at https://heydex.ai/help. Answers below may be
+> stale (they predate the lifecycle update engine and the brain/vault split);
+> verify against current docs before reusing any of them.
 > **Last Updated:** 2026-02-04
 
 ---

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -4,11 +4,11 @@
 >
 > **Status vocabulary.** `SHIPPED` = in a released version tag. `LOCAL` = merged on `main`, not yet in a release tag. `PROTOTYPE` = built, not verified against live/real use. `PLANNED` = designed, not built.
 >
-> **Ground truth as of** HEAD on `main`, latest release tag **v1.68.0** (2026-07-22). One commit sits after the tag: PR #179 (the inventory grounding suite) — that is the only `LOCAL` delta right now.
+> **Ground truth as of** HEAD on `main`, latest release tag **v1.75.2** (2026-07-26). `LOCAL` delta after the tag: PR #248 (customization-migration Lane G — activation + rewind, merged but **HELD**, see §12) and PR #249 (docs pointing new users at the Dex Guide).
 >
 > **Don't duplicate generated files.** Tool lists, skill lists, ownership-class path tables, and MCP↔skill wiring live in the auto-generated `docs/architecture/INVENTORY.md`. This map cross-references it; it does not restate it.
 >
-> **Stale-header warning.** `CLAUDE.md` still self-labels "v1.11.0". Ignore that; the code is at v1.68.0. The CLAUDE.md header is user-facing seed prose, not a version source.
+> **Version sources.** `CHANGELOG.md` is the release truth; `docs/architecture/STATE.md` (regenerate with `python3 scripts/dex_state.py --write`) is the released-vs-LOCAL snapshot. `CLAUDE.md`'s header is user-facing seed prose, not a version source.
 
 ---
 
@@ -20,13 +20,15 @@
 | Transaction core | **SHIPPED** (v1.66) | `core/transaction/*` | Crash-safe snapshot→apply→verify→commit/rollback substrate the lifecycle engine writes through |
 | Portable ownership contract | **SHIPPED** (v1.64+) | `core/portable_contract.py` | Source of truth: every path is brain/seed/generated/vault/runtime; decides what an update may write |
 | Release catalog + bridge | **SHIPPED** (v1.65–v1.68) | `core/lifecycle/catalog/*`, `bridge.py` | Publisher-declared packing list per release; one-release handoff from the legacy updater |
-| 9 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (43 tools) |
-| Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; Doctor/contract plumbing and live Google/Linear proof exist, but Phase 5e returned no-go on the held doorway |
+| 10 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (46 tools) |
+| Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; hardened through security Phases 0–5g, but the `/connect` doorway stays held (draft PR #231) |
+| Customization migration | **SHIPPED** assess/capsule/guided-journey (v1.75.x) / **LOCAL+HELD** activation (Lane G) | `core/customization_migration/*`, `core/mcp/customization_migration_server.py` | Inventories a user's customizations, snapshots them into a consent-gated Capsule, and guides customized setups through updates; the activation/rewind lane is merged but deliberately not live |
 | DexDiff (methodology sharing) | **SHIPPED** cmd surface / **PARKED** redesign | `.claude/skills/diff-*`, `core/dexdiff_profile_adopt.py` | Generate→publish→adopt-regenerates-locally; redesign parked for the desktop "Vorflux" rebuild |
-| Entity engine + gardener | **SHIPPED** (v1.37 / v1.44) + **LOCAL** cooling | `core/entity_engine/*`, `core/entity_maintenance.py` | Auto-creates person/company pages, logs meeting touches, classifies relationship temperature, and resurfaces consequential relationships going cold |
-| Hooks | **SHIPPED** (wired subset) / dead weight present | `.claude/hooks/`, `.claude/settings.json` | Small wired core; several unwired scripts + one silently-dead hook still in the tree |
-| Skills (68 shipped, ~74 on disk) | **SHIPPED** | `.claude/skills/` | `/command` workflows; consolidation + description-rewrite direction in flight |
-| Grounding suite (inventory + drift gate) | **LOCAL** (PR #179) | `docs/architecture/INVENTORY.md`, `scripts/generate-architecture-inventory.py` | Code-derived inventory + CI drift gate; state ledger + session digest are **PLANNED** |
+| Entity engine + gardener + relationships | **SHIPPED** (v1.37 / v1.44 / v1.71–v1.73) | `core/entity_engine/*`, `core/entity_maintenance.py` | Auto-creates person/company pages, logs meeting touches, classifies relationship temperature, resurfaces relationships going cold, and maintains typed person↔company relationships (suggested-until-confirmed) |
+| Ritual intelligence | **PARKED** (code-complete, unwired) | `core/ritual_intelligence/*` | Meeting-intelligence pipeline built Mar 2026, tested in CI, but never wired to any skill/hook/MCP; its beta preview surface was explicitly retracted (see CHANGELOG) |
+| Hooks | **SHIPPED** (wired subset) | `.claude/hooks/`, `.claude/settings.json` | Small wired core (context injection, safety guards, release awareness, autocommit); the once-dead career-evidence hook is fixed (PR #180) |
+| Skills (74 on disk) | **SHIPPED** | `.claude/skills/` | `/command` workflows; the description-rewrite + `/skill-score` quality-gate pass landed (discoverability-risk 53 → 3) |
+| Grounding suite (inventory + state + orient) | **SHIPPED** (v1.69+) | `docs/architecture/INVENTORY.md`, `STATE.md`, `scripts/dex_state.py`, `/dex-orient` | Code-derived inventory + CI drift gate, released-vs-LOCAL state snapshot, and a session orientation skill |
 
 ---
 
@@ -44,6 +46,8 @@
 - `catalog.py`, `retention.py` (keep last 3 rewind points, ~2 GB warn), `customizations.py`, `machine_state.py`, `runtime_evidence.py`, `secrets.py`, `bridge.py`, `cli.py`.
 
 **Status confirmation.** CHANGELOG v1.65 (look-don't-touch), v1.66 (apply+undo, DB protection), v1.67 (ledger + Doctor UI), v1.68 (every path routed through it). `install.sh`, `core/provision.cjs`, `/dex-update`, and `/dex-rollback` all reference the lifecycle service — confirming the "one door" is really wired, not just present.
+
+**Since v1.68 (v1.69–v1.75.2).** The engine gained the brain/vault-split journey and its safety net: a guided upgrade path wired into `/dex-update` (Lane E, v1.75.0/1.75.1), management of the pre-split undo archive + obvious migration recovery (Lanes C+D), conflict resolution's keep-both writer + choice layer (frozen op pair, PR #205/#208), and the guided journey for deeply customized setups (Lane H, capsule-scoped — see §12). A real-vault rehearsal before switch-on surfaced and fixed four findings (v1.75.2): refusal to convert a vault inside a cloud-synced folder (Dropbox etc.), a 12k-file crash, accented-filename false-failures, and clearer symlink-refusal messaging.
 
 **How it connects.** Consumers (installer, updater, Doctor, rollback skill) → `lifecycle/service.py` → `engine.py` → `transaction` (crash safety) + `portable_contract` (write authorization) → `ledger` (receipts). The release catalog feeds it what a version contains.
 
@@ -78,13 +82,13 @@
 
 **How it connects.** Feeds `lifecycle/plan.py` (what's available to adopt) and the DexDiff-adjacent adoption receipts under `System/.dex/adoptions/`. The v1.67 "two dozen role-specific tools you can turn on safely" are catalog items adopted through this path.
 
-## 5. The 9 MCP servers — SHIPPED
+## 5. The 10 MCP servers — SHIPPED
 
 **What they are.** The tool surface Dex acts through. **Do not restate the tool lists — read `docs/architecture/INVENTORY.md` § "MCP engines" for exact per-server tool names.** Summary:
 
 | Server | Source | Tools | `feature_status` honesty contract |
 | --- | --- | ---: | :---: |
-| `dex-work-mcp` | `work_server.py` (247 KB) | **43** | yes |
+| `dex-work-mcp` | `work_server.py` (247 KB) | **46** | yes |
 | `dex-calendar-mcp` | `calendar_server.py` | 15 | yes |
 | `dex-resume-mcp` | `resume_server.py` | 12 | yes |
 | `dex-improvements-mcp` | `dex_improvements_server.py` | 9 | **no** |
@@ -92,9 +96,10 @@
 | `dex-onboarding-mcp` | `onboarding_server.py` | 8 | **no** |
 | `dex-session-memory` | `session_memory_server.py` | 8 | **no** |
 | `dex-granola-mcp` | `granola_server.py` | 6 | yes |
+| `dex-customization-migration-mcp` | `customization_migration_server.py` | 4 | yes |
 | `dex-analytics` | `analytics_server.py` | 4 | yes |
 
-**The big one.** `dex-work-mcp` is 43 tools (tasks, people/company indexes, goals, priorities, meeting cache, external task sync, focus/scheduling). It is the spine of `/daily-plan`, `/week-plan`, `/process-meetings`. Per INVENTORY's connectedness section, three servers are **under-surfaced** (0 skills reference them): `dex-career-mcp`, `dex-resume-mcp`, `dex-session-memory` — their tools exist but no skill invokes them by name. `dex-analytics` is **over-surfaced** (25 skills call `track_event`).
+**The big one.** `dex-work-mcp` is 46 tools (tasks, people/company indexes, goals, priorities, meeting cache, external task sync, focus/scheduling, relationship confirm/dismiss, soft-commitment detection). It is the spine of `/daily-plan`, `/week-plan`, `/process-meetings`. Per INVENTORY's connectedness section, four servers are **under-surfaced** (0 skills reference them): `dex-career-mcp`, `dex-resume-mcp`, `dex-session-memory`, and `dex-customization-migration-mcp` (the last is intentional — it's invoked by Doctor/agents directly, not via a skill). `dex-analytics` is **over-surfaced** (28 skills call `track_event`).
 
 **Honesty-contract gap.** Three servers lack `feature_status` (`dex-improvements-mcp`, `dex-onboarding-mcp`, `dex-session-memory`) — meaning they don't return the ok/off/not_installed/broken/unknown status envelope the rest do. That's the honest weak spot in the "every MCP tells you its health" story.
 
@@ -104,7 +109,11 @@
 
 **Where it lives.** `core/integrations/connection-manager/`: `catalog.cjs` (Nango entry → Dex OAuth descriptor), `oauth-flow.cjs` (PKCE + localhost callback + refresh), `token-store.cjs` (encrypted store + `connections.json`), `health.cjs` (connected/expiring/expired/needs_reauth state machine), `connect.cjs` (CLI), `get-token.cjs` (Python MCP accessor). Also `CONSUMPTION-LAYER.md`. Tests: `connection-manager.test.cjs`, run in CI via `npm run test:integrations`.
 
-**Status.** The original engine passed its first live-account gate on 2026-07-24 (runbook: `docs/solutions/connection-manager-live-account-gate.md`) and ships from v1.73 onward. Phase 2 then lifted Desktop's judgment layer into `lib/` (pinned at dex-desktop `2b34aa4d`, hash-verified by `lifted-conformance.test.cjs`): one refresher, bounded Google/Slack/Linear probes, a durable evidence ledger, `status --json`, and Doctor reading real engine health. Phase 3 froze the Desktop consumer contract and engine manifest; the post-Phase-2/3 Google + Linear live-account rerun passed on PR #221. **DOORWAY HELD:** `/connect` and its session-start hook exist only on draft PR #231 and do not ship. Phase 5e returned no-go because the current same-user boundary still exposes a direct decryptor, a persistent readable broker capability, and usable credentials through the unprompted default accessor. Caller-controlled presence environment switches and the token-subdirectory path gap are closed, but the OS-bound decryptor/consumer identity plus default-access contract need an explicit redesign before the doorway can be claimed. Licence note: Nango providers is Elastic License 2.0 (source-available), consumed as a pinned npm dependency, not vendored; never re-expose the catalog as a managed service.
+**Status.** The original engine passed its first live-account gate on 2026-07-24 (runbook: `docs/solutions/connection-manager-live-account-gate.md`) and ships from v1.73 onward. Phase 2 then lifted Desktop's judgment layer into `lib/` (pinned at dex-desktop `2b34aa4d`, hash-verified by `lifted-conformance.test.cjs`): one refresher, bounded Google/Slack/Linear probes, a durable evidence ledger, `status --json`, and Doctor reading real engine health. Phase 3 froze the Desktop consumer contract and engine manifest; the post-Phase-2/3 Google + Linear live-account rerun passed on PR #221.
+
+**Security hardening Phases 5a–5g (all merged, v1.74–v1.75.2):** connection-manager hardening (5a, #228), origin pinning + tamper-proof trust (5b, #230), credential broker (5c, #232), user-presence gate on privileged export (5d/B1, #237), fail-closed on untrusted presence configuration (#239), refresh-steering + default-routing critical fixes (5f, #243), and presence op-scoping + broker auth + timeouts + honest docs (5g, #247).
+
+**DOORWAY STILL HELD:** `/connect` and its session-start hook exist only on draft PR #231 and do not ship. The Phase 5e re-review returned a no-go on the same-user credential boundary (direct decryptor, persistent readable broker capability, unprompted default accessor); Phases 5f–5g closed named criticals but the no-go verdict on the doorway itself has not been lifted — CHANGELOG v1.74–v1.75.2 still describes all of this as "groundwork." Do not describe `/connect` as available. Licence note: Nango providers is Elastic License 2.0 (source-available), consumed as a pinned npm dependency, not vendored; never re-expose the catalog as a managed service.
 
 **How it connects.** Doctor consumes the secret-free `status --json` contract, and Desktop can vendor the pinned engine through `@dex/contracts`. The future doorway will sit under integration setup skills and feed fresh tokens to Python MCP servers via `get-token.cjs`; that doorway is not in the tree today. Existing per-integration `detect.py` / `task_sync.py` paths remain parallel.
 
@@ -118,15 +127,15 @@
 - **PII gate is prompt-only.** `diff-generate` has no redaction machinery — just guidance (e.g. "skills with `-dave` suffix are custom"). Nothing structurally stops personal content leaving.
 - **`/diff-adopt` edits CLAUDE.md and hooks.** Confirmed in the skill body: it appends a "Meeting Workflow" section to CLAUDE.md and creates hook scripts in `.claude/hooks/` + registers them in `.claude/settings.json`. That's a broad blast radius for an "adopt a workflow" action, and it runs outside the lifecycle safe-door.
 
-**Status.** The command surface is shipped and usable; a **redesign is PARKED** for the desktop "Vorflux" rebuild. Treat DexDiff as functional-but-frozen — don't invest in hardening the current CLI PII/adopt path; that work moves to Vorflux.
+**Status.** The command surface is shipped and usable; a **redesign is PARKED** for the desktop "Vorflux" rebuild. Treat DexDiff as functional-but-frozen — don't invest in hardening the current CLI PII/adopt path; that work moves to Vorflux. One fix since: the CLI now publishes to DexDiff's own backend rather than the Desktop domain (#245, v1.75.2).
 
-## 8. Entity engine + gardener — SHIPPED (v1.37.0 / v1.44.0) + LOCAL cooling
+## 8. Entity engine + gardener + relationships — SHIPPED (v1.37.0 / v1.44.0 / v1.71–v1.73)
 
-**What it is.** Three layers. (a) **Entity engine** — background meeting sync deterministically creates person/company pages once someone with an email recurs (2+ meetings across 2+ weeks, or 2+ meetings with transcript evidence); `entity_creation` config = `auto`/`suggest`/`off`. (b) **Gardener** (v1.44) — keeps a living "who this person is to you right now" summary block on active pages, refreshed at most weekly, ≤5 pages/sync, only when something new happened, only if an AI key is present. If the user edits inside the marked block, Dex permanently stops maintaining it. (c) **LOCAL relationship cooling** — meeting sync and the post-meeting hook log canonical, idempotent touches; the pure temperature classifier separates warm, cooling, and cold relationships; and the cooling read only surfaces cold people/accounts with engagement on at least two distinct days.
+**What it is.** Three layers. (a) **Entity engine** — background meeting sync deterministically creates person/company pages once someone with an email recurs (2+ meetings across 2+ weeks, or 2+ meetings with transcript evidence); `entity_creation` config = `auto`/`suggest`/`off`. (b) **Gardener** (v1.44) — keeps a living "who this person is to you right now" summary block on active pages, refreshed at most weekly, ≤5 pages/sync, only when something new happened, only if an AI key is present. If the user edits inside the marked block, Dex permanently stops maintaining it. (c) **Relationship cooling — SHIPPED (v1.71)** — meeting sync and the post-meeting hook log canonical, idempotent touches; the pure temperature classifier separates warm, cooling, and cold relationships; and the cooling read only surfaces cold people/accounts with engagement on at least two distinct days. (d) **Typed relationships — SHIPPED (v1.72–v1.73)** — map-first, suggested-until-confirmed person↔company/person↔person relationships (`core/entity_engine/relationships.py`), with the v1.73 fast-follow: confirming one suggestion affects only that suggestion, edge-key ownership + tombstones, a hard `mode: off` gate, and an explicit confirm affordance. Surfaced through Work MCP's `confirm_relationship` / `dismiss_relationship` tools (used by `/daily-plan`). A JS↔Python write bridge (#196) makes the Python engine the canonical writer with never-lose-a-write reliability.
 
 **Where it lives.** `core/entity_engine/contract.py` (canonical parse/render, frontmatter, quarantine and composite writes), `core/entity_engine/index.py` (disposable SQLite projection), `core/entity_engine/temperature.py` (pure classifier), `core/entity_engine/cooling.py` (read + `System/.dex/entity-cooling.json` feed), and `core/entity_maintenance.py` (metadata maintenance CLI). Gardener and cooling-feed refresh both tie into the meeting-sync path. Off switch for the gardener: `entity_gardener: enabled: false`.
 
-**How it connects.** Consumes Work MCP meeting/attendee data; produces the person/company pages and disposable index that `lookup_person`, context-injector hooks, and `/process-meetings` read. Sync refreshes the cooling feed after entity work, and `/daily-plan` turns its consequential `cold` list into one "❄️ Going cold" heads-up line. `07` memory note confirms v1.37 shipped the auto-creation machinery; touch logging, temperature, and cooling remain **LOCAL** until the next release.
+**How it connects.** Consumes Work MCP meeting/attendee data; produces the person/company pages and disposable index that `lookup_person`, context-injector hooks, and `/process-meetings` read. Sync refreshes the cooling feed after entity work, and `/daily-plan` turns its consequential `cold` list into one "❄️ Going cold" heads-up line.
 
 ## 9. Hooks — SHIPPED wired subset / dead weight present
 
@@ -144,21 +153,36 @@
 
 **How it connects.** Wired hooks feed context injection, safety guards, and the bounded release-awareness notice. The observation/health-checker scripts are **untracked local cruft, not product** — treat them as absent when reasoning about what a user's install does.
 
-## 10. Skills — SHIPPED (68 counted by generator; ~74 dirs on disk)
+## 10. Skills — SHIPPED (74 counted by generator)
 
-**What they are.** `/command` workflows in `.claude/skills/`. **Full list + descriptions + trigger analysis: `docs/architecture/INVENTORY.md` § "Skills".** The generator flags **53 of 68 as "discoverability-risk"** — their frontmatter descriptions lack a `when`/`whenever` trigger, so the model is less likely to auto-invoke them. That is the concrete basis for the **description-rewrite / consolidation direction**.
+**What they are.** `/command` workflows in `.claude/skills/`. **Full list + descriptions + trigger analysis: `docs/architecture/INVENTORY.md` § "Skills".** The **discoverability overhaul landed** (v1.69–v1.70): 49 descriptions rewritten with explicit trigger phrases (#184), a `/skill-score` quality gate for new skills (#183), and `create-skill` v2 with collision-check, origin-aware, score-gated authoring (#192). The generator's discoverability-risk count fell from **53 to 3** (the three remaining are Anthropic-bundled artifact/theme skills, not Dex workflows). Role-specific optional skill packs live in `.claude/skills/_available/`, gated by the capability registry (`core/capabilities.py`, `/manage-capabilities`), and are adopted through the lifecycle catalog.
 
 **Governing principle.** "Hard on Core, gentle on user skills": Core-shipped skills get held to the trigger/quality bar and can be consolidated/rewritten; user-authored skills (the `-custom` suffix convention from `create-skill`, and the `.claude/skills-custom/` vault-class dir) are protected from updates and left alone. `create-skill` auto-appends `-custom` so user skills are never overwritten.
 
 **How it connects.** Skills call MCP tools by name (see INVENTORY connectedness). Some skills (`diff-adopt`) write CLAUDE.md/hooks directly — see §7 blast-radius note. Skill payloads that ship as catalog items flow through the lifecycle safe-door (§1/§4).
 
-## 11. Grounding suite — LOCAL (chunk 1) / PLANNED (rest)
+## 11. Grounding suite — SHIPPED (v1.69+)
 
-**What it is.** The effort this very doc is part of: give agents code-derived truth instead of stale assumptions.
-- **Chunk 1 — SHIPPED-locally (LOCAL):** `docs/architecture/INVENTORY.md` (generated) + `scripts/generate-architecture-inventory.py` + the CI drift gate (`scripts/check-architecture-inventory.sh`, wired in `.github/workflows/ci.yml` as "Architecture inventory drift gate"). Landed as **PR #179**, which is the single commit after tag v1.68.0 → merged on main, **not yet in a release**.
-- **Chunk 2+ — PLANNED:** a runtime **state ledger** and a **session digest** (per the task brief). No code found for these in the repo; treat as design intent only.
+**What it is.** The effort this very doc is part of: give agents code-derived truth instead of stale assumptions. All three chunks now exist:
+- `docs/architecture/INVENTORY.md` (generated) + `scripts/generate-architecture-inventory.py` + the CI drift gate (`scripts/check-architecture-inventory.sh`, wired in `.github/workflows/ci.yml` as "Architecture inventory drift gate") — landed as PR #179.
+- **State snapshot:** `docs/architecture/STATE.md` + `scripts/dex_state.py` (`--write` refreshes the generated block; `--digest` prints a compact SessionStart digest).
+- **Session orientation:** the `/dex-orient` skill — prints released version, merged-but-unreleased work, and where map + inventory live.
 
-**How it connects.** The inventory generator parses `core/mcp/*_server.py`, `.claude/skills/*/SKILL.md`, and `core/portable_contract.py` by AST/regex, so the drift gate fails CI if code and INVENTORY diverge. This map is the human narrative layer above that machine inventory — read both: INVENTORY for exact lists, this map for what's real, what's shipped, and how it fits.
+**How it connects.** The inventory generator parses `core/mcp/*_server.py`, `.claude/skills/*/SKILL.md`, and `core/portable_contract.py` by AST/regex, so the drift gate fails CI if code and INVENTORY diverge. This map is the human narrative layer above that machine inventory — read both: INVENTORY for exact lists, this map for what's real, what's shipped, and how it fits. STATE.md has no CI gate — refresh it (`python3 scripts/dex_state.py --write`) whenever you touch this map.
+
+## 12. Customization migration — SHIPPED assess/capsule/guided-journey (v1.75.x) / LOCAL+HELD activation
+
+**What it is.** The machinery that lets an update respect a user's customizations instead of silently overwriting or stranding them. Built as lanes A–H over 2026-07-23→26: Doctor produces a **read-only inventory** of everything the user has customized (edited skills, added scripts, custom instructions) with sensitivity classification (v1.75.1); a consent-gated, protected local **Capsule** snapshots the customization evidence through the sealed transaction (Lanes C/E-staging/F); `/dex-update` offers a **guided journey** for deeply customized setups — shows the inventory, explains impact, walks step by step (Lane H, v1.75.2); regeneration candidates are validated before anything is proposed (#238).
+
+**Where it lives.** `core/customization_migration/` (17 modules: `service.py`, `capsule.py`/`capsule_model.py`, `inventory.py`, `sensitivity.py`, `planning.py`, `staging.py`, `verification.py`, `activation.py`, `behaviour.py`, `registration.py`, `references.py`, `report.py`, `state.py`, `model.py`, `cli.py`, …) + the `dex-customization-migration-mcp` server (4 read-only tools; invoked by Doctor/agents directly, not via a skill). Lane A's binding contracts: `docs/customization-migration-threat-model.md`; build plan: `docs/plans/2026-07-24-customization-migration-mcp.md`.
+
+**⚠️ HELD, not live:** Lane G — **activation + rewind** (make a verified rebuild live, reversibly; PR #248) — is merged on `main` but deliberately **not released and not switched on**, pending a second adversarial review and a real-vault rehearsal. Do not describe activation as a shipped capability.
+
+**How it connects.** Wired into the lifecycle engine (§1) — the guided journey runs inside `/dex-update`; capsule writes go through the sealed transaction (§2); Doctor reads the assessment via the MCP server.
+
+## 13. Ritual intelligence — PARKED (code-complete, unwired)
+
+**What it is.** A meeting-intelligence pipeline (transcript + calendar ingest, ritual matching, meeting reconciliation, brief generation, contact promotion) built March 2026 (#30) at `core/ritual_intelligence/` with a `python -m core.ritual_intelligence` entry point and its own CI-passing tests. **Nothing invokes it**: no skill, hook, MCP server, or the desktop app references it, and the CHANGELOG records the retraction of its beta preview surface ("an unwired ritual beta handout no longer tells testers that `/daily-plan` will surface recurring-meeting previews"). Its tests keep it green in CI, which makes it look alive from a coverage view — it is not. Treat as parked design capital, not a shipped subsystem; wire-or-retire is an open product decision.
 
 ---
 
@@ -166,17 +190,18 @@
 
 Concrete non-obvious things that a fresh agent would get wrong by reasoning from priors:
 
-1. **The Work MCP is a 43-tool monster (247 KB) and it's under-surfaced.** Only 7 skills reference it; most of its 43 tools are never named by any skill. Easy to assume "Dex has a few task tools" and miss the actual breadth.
-2. **A whole local-first OAuth stack (Connection Manager) ships while its product doorway is held** — Nango-catalog-as-data, PKCE, encrypted on-device tokens, a health/refresh state machine, Doctor status, a frozen Desktop contract, and post-Phase-2/3 live Google/Linear proof. `/connect` exists only on draft PR #231; Phase 5e returned no-go on the same-user credential boundary.
-3. **`career-evidence-capture.cjs` was silently dead (now fixed, PR #180).** It read hook input from an env var (`CLAUDE_HOOK_CONTEXT`) when Claude Code delivers it on stdin — so it no-opped on every invocation while looking like a working feature. PR #180 fixes it and adds a contract test guarding the whole hook family.
+1. **The Work MCP is a 46-tool monster (247 KB).** Most of its tools are never named by any skill; the breadth is easy to miss if you assume "Dex has a few task tools."
+2. **A whole local-first OAuth stack (Connection Manager) ships while its product doorway is held** — Nango-catalog-as-data, PKCE, encrypted on-device tokens, a health/refresh state machine, Doctor status, a frozen Desktop contract, live Google/Linear proof, and seven merged security-hardening phases (5a–5g). `/connect` still exists only on draft PR #231; the Phase 5e no-go on the same-user credential boundary has not been lifted.
+3. **`career-evidence-capture.cjs` was silently dead (fixed, PR #180).** It read hook input from an env var (`CLAUDE_HOOK_CONTEXT`) when Claude Code delivers it on stdin — so it no-opped on every invocation while looking like a working feature. PR #180 fixed it and added a contract test guarding the whole hook family.
 4. **Three MCP servers lack the `feature_status` honesty contract** (`dex-improvements`, `dex-onboarding`, `dex-session-memory`) — so the "every feature reports its own health" promise has real holes.
 5. **The observation layer / health-checkers are UNTRACKED local files, not product** — easy to mistake local cruft on the maintainer's disk for shipped Core. Separately, **`/diff-adopt` edits CLAUDE.md + registers hooks outside the lifecycle safe-door** — a real exception to the "one safe door for every change" story worth knowing before you touch it.
-6. **CLAUDE.md self-labels v1.11.0 while the code is v1.68.0.** Trusting the header would put an agent ~57 minor versions behind reality.
+6. **Merged ≠ live, twice over.** Customization-migration Lane G (activation + rewind) is merged on `main` but HELD (§12), and `ritual_intelligence` is a whole CI-green subsystem that nothing invokes (§13). Reasoning from "the code exists and tests pass" to "the feature ships" gets both of these wrong.
 
 ---
 
-## STATUS I could not fully determine from code (flag for Fable)
+## Open questions / statuses to re-verify on next refresh
 
-- **Grounding suite chunk 2 (state ledger + session digest): PLANNED, unverified.** I found no code for either in-repo; I inferred PLANNED from the task brief plus absence. If a design doc exists elsewhere (e.g. Mission Control / a worktree), confirm scope before an agent assumes it's greenfield.
-- **Connection Manager gate status — KNOWN.** The #209 engine and the post-Phase-2/3 PR #221 engine both passed the Google + Linear live-account gate. The held `/connect` doorway still has a Phase 5e security no-go and does not ship.
-- **Observation layer's disposition — RESOLVED.** The observation-*.cjs hooks and the beta-rollout doc are untracked local files (verified via `git ls-files`), not in the repo. There is nothing to "remove" from the product; they are local experimentation only. The one tracked observation-adjacent file (`staging/vault-fixes/delight-capture.cjs`) is deleted by PR #180.
+- **Connection Manager doorway.** Phases 5f–5g closed named criticals; whether they satisfy the Phase 5e redesign requirements (OS-bound decryptor/consumer identity + default-access contract) is a security-review call, not a docs call. Until a review explicitly lifts the no-go, this map says HELD.
+- **Customization-migration Lane G (activation + rewind).** Merged but HELD pending a second adversarial review + real-vault rehearsal. Flip §12 when that gate passes and it ships in a release.
+- **`ritual_intelligence` wire-or-retire.** Parked since March; an open product decision, not an engineering blocker.
+- **Observation layer's disposition — RESOLVED.** The observation-*.cjs hooks and the beta-rollout doc are untracked local files (verified via `git ls-files`), not in the repo. There is nothing to "remove" from the product; they are local experimentation only. The one tracked observation-adjacent file (`staging/vault-fixes/delight-capture.cjs`) was deleted by PR #180.

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -7,13 +7,13 @@ A compact snapshot of released, local, and planned Dex Core work.
 
 SHIPPED/LOCAL are computed live — run `/dex-orient` or `python3 scripts/dex_state.py` for current truth.
 
-Released: v1.68.0 (2026-07-22)
+Released: v1.75.2 (2026-07-26)
 
 ### LOCAL — on main, not yet released (3)
 
-- #181 docs(architecture): add DEX-CORE-MAP grounding narrative
-- #180 fix: restore silently-dead career capture + hooks input-contract test + cleanup
-- #179 feat(docs): code-derived architecture inventory + CI drift gate (grounding foundation)
+- #248 feat(customization-migration): activation + rewind — make a verified rebuild live, reversibly (Lane G)
+- #249 docs: point new users at the Dex Guide (heydex.ai/help)
+- docs(changelog): v1.75.2 — one honest entry: proven vault move + guided customization journey + security groundwork
 <!-- GENERATED:END -->
 
 <!-- PLANNED:START -->

--- a/docs/testing-hardening-merge-runbook.md
+++ b/docs/testing-hardening-merge-runbook.md
@@ -1,6 +1,11 @@
 # Testing Hardening Merge Runbook
 
-This runbook is for the current stacked QA hardening rollout.
+> **Status: HISTORICAL (March 2026).** The stacked QA hardening rollout below
+> (PRs #25–#27) merged long ago; the gates it introduced are now standing CI
+> (see `.github/workflows/ci.yml` and `docs/testing-governance.md`). Kept as a
+> record of the rollout order and rationale.
+
+This runbook was for the stacked QA hardening rollout.
 
 ## PR Stack
 Merge in this exact order:


### PR DESCRIPTION
## What this is

A ground-up refresh of the repo's documentation against what the code actually is at v1.75.2, after ~184 commits / 24 releases in the last two weeks. Built by first mapping the code, the changelog, and every agent-instruction surface with parallel readers, then rewriting from that ground truth. Docs-only (plus one `.distignore` line); no behavior changes.

## Highlights

- **`docs/architecture/DEX-CORE-MAP.md`** re-grounded v1.68.0 → v1.75.2: new **Customization Migration** section (lanes A–H; Lane G merged-but-**HELD**), connection-manager Phases 5a–5g (doorway still held on draft #231), entities typed-relationships + cooling now SHIPPED, skills overhaul results (discoverability-risk 53→3), 10 MCP servers / Work MCP 46 tools, and **`ritual_intelligence` documented as PARKED** (built Mar 2026, CI-green, invoked by nothing — verified by caller trace).
- **`docs/Dex_System/Updating_Dex.md`** rewritten (765 → ~140 lines): it still described git-merge updating; now describes `/dex-update`'s five-group preview, conflict choices, Capsule guided journey, brain/vault split, `/dex-rollback`. Bridge copies in `06-Resources/Dex_System/` kept byte-identical.
- **`core/migrations/README.md`** rewritten: its instructed path (`migrate_v1_to_v2.py` + `git merge upstream`) is **dead code with zero callers**; the live migrator is lifecycle-owned (Doctor `--resume` is break-glass only).
- **New root `AGENTS.md`** — first contributor-agent instruction file (orient chain, merged≠shipped/held registry, hard rules, test commands). Dev-doc: distignored; contract slot already existed.
- **Root `CLAUDE.md`** (product persona — edited minimally): stale v1.11.0 header replaced with a don't-trust-version note; added on-demand pointers to hooks, capability rooms (`/manage-capabilities`), update/health skills, `.claude/reference/`.
- **Distribution docs** (`DISTRIBUTION_READY.md`, `Distribution_Checklist.md`) rewritten — the `sed {{VAULT_PATH}}` install mechanism they described was replaced by `core/provision.cjs` in #165. `Distribution_Strategy.md`, `testing-hardening-merge-runbook.md`, `FAQ-DRAFT.md` get honest HISTORICAL/ARCHIVED banners.
- **`.agents/README.md`** documents the cross-harness adapter dir and its known drift vs `.claude/skills/` (sync deliberately deferred — those files are test-pinned product surface).
- `docs/architecture/STATE.md` regenerated (was frozen at v1.68.0).

## Verification

- Gates run locally, all green: architecture-inventory drift, PII, founder-content, portable-contract (1248 paths incl. new files), instructed-tools, doc-drift.
- Every path reference in touched docs checked; numbers (skill counts, MCP tools, risk counts) taken from the regenerated CI-gated INVENTORY.md, not hand-copied.
- Pre-existing, unrelated: `scripts/check-tracked-ignored.py` reports 3 stale policy rows on clean `main` too (not wired into CI).

## Follow-ups (not in this PR)

- `.agents/` skill-content re-sync with `.claude/skills/` (reviewed change; test-pinned).
- `ritual_intelligence` wire-or-retire decision.
- `FAQ-DRAFT.md`: fold into heydex.ai/help or delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFFucejRNX2Awp6Ne3fgTA