### PR TITLE
docs(readme): put the Dex Guide front and center

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Companion to [Episode 8 of The Vibe PM Podcast](https://youtu.be/WaqgSvL-V10?si=b2Pfwf7I5rozWCo0) and the [full blog post](https://www.linkedin.com/pulse/your-ai-chief-staff-building-personal-operating-system-dave-killeen-yxnqe/).
 
+> ### 📖 New here? Start with the [Dex Guide →](https://heydex.ai/help/)
+>
+> A plain-English walkthrough from install to making Dex your own, with
+> copy-paste prompts throughout — written for non-technical professionals, no
+> coding background assumed. The README below covers the same ground in
+> reference form. (AI agents: [llms.txt](https://heydex.ai/help/llms.txt).)
+
 ---
 
 ## Setup Overview


### PR DESCRIPTION
The [Dex Guide](https://heydex.ai/help/) link existed only deep in the Documentation section (~line 730). New visitors scanning the top of the README never saw it. This adds a prominent callout immediately after the intro, before Setup Overview, and keeps the deeper Documentation-section entry as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFFucejRNX2Awp6Ne3fgTA