### PR TITLE
ci: parallelize the pytest suite — checks drop from ~16 to ~8 min, no gate touched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,15 @@ jobs:
         run: python core/paths.py
       - name: Ruff linting (fail fast)
         run: ruff check core/
+      # -n auto spreads tests across the runner's cores (pytest-xdist); --dist loadgroup
+      # keeps the xdist_group("serial_sensitive")-marked tests on one worker because they
+      # share release-build git state or assert wall-clock budgets. Coverage measurement,
+      # thresholds, and the junit report are identical to the former serial run —
+      # pytest-cov combines worker data automatically. Identical test set, same gates.
       - name: Test suites + coverage
-        run: pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -v -m "not fuzz" --junitxml=.logs/pytest-report.xml --cov=core --cov-report=term --cov-report=json:coverage.json --cov-fail-under="${COVERAGE_MIN_TOTAL}"
+        run: |
+          echo "Runner cores: $(sysctl -n hw.ncpu)"
+          pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -v -m "not fuzz" -n auto --dist loadgroup --junitxml=.logs/pytest-report.xml --cov=core --cov-report=term --cov-report=json:coverage.json --cov-fail-under="${COVERAGE_MIN_TOTAL}"
       - name: Touched-file coverage gate
         if: github.event_name == 'pull_request'
         run: python scripts/check-coverage-threshold.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,25 @@ jobs:
         run: ruff check core/
       # -n auto spreads tests across the runner's cores (pytest-xdist); --dist loadgroup
       # keeps the xdist_group("serial_sensitive")-marked tests on one worker because they
-      # share release-build git state or assert wall-clock budgets. Coverage measurement,
-      # thresholds, and the junit report are identical to the former serial run —
-      # pytest-cov combines worker data automatically. Identical test set, same gates.
+      # share release-build git state (grouping serializes them against EACH OTHER only —
+      # it does not quiet the CPU, so load-sensitive tests must carry generous margins
+      # in their own assertions). Coverage measurement, thresholds, and the junit report
+      # are identical to the former serial run — pytest-cov combines worker data
+      # automatically. Identical test set, same gates.
       - name: Test suites + coverage
         run: |
           echo "Runner cores: $(sysctl -n hw.ncpu)"
           pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -v -m "not fuzz" -n auto --dist loadgroup --junitxml=.logs/pytest-report.xml --cov=core --cov-report=term --cov-report=json:coverage.json --cov-fail-under="${COVERAGE_MIN_TOTAL}"
+      # Backstop for the conftest sessionfinish check: that check fires on the xdist
+      # controller today (verified empirically), but it rides on unpinned pytest/xdist
+      # hook internals. This shell gate cannot be version-drifted away.
+      - name: Fixture-vault mutation gate
+        run: |
+          if [ -n "$(git status --porcelain -- core/tests/fixtures/vault)" ]; then
+            echo "Tracked fixture vault was mutated by the test run:" >&2
+            git status --porcelain -- core/tests/fixtures/vault >&2
+            exit 1
+          fi
       - name: Touched-file coverage gate
         if: github.event_name == 'pull_request'
         run: python scripts/check-coverage-threshold.py

--- a/core/mcp/tests/test_customization_migration_server.py
+++ b/core/mcp/tests/test_customization_migration_server.py
@@ -457,7 +457,9 @@ def test_stdio_server_boots_lists_tools_and_exits_cleanly(
         [sys.executable, "-m", "core.mcp.customization_migration_server"],
         cwd=REPO_ROOT,
         env=env,
-        timeout=10,
+        # Hang-guard, not a perf assertion: server boot competes with other
+        # pytest-xdist workers for CPU, so keep several multiples of headroom.
+        timeout=30,
     )
 
     assert result.ok, f"{result.error}\nstderr:\n{result.stderr}"

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -1,4 +1,10 @@
-"""Regression tests for artifacts produced from the public repository."""
+"""Regression tests for artifacts produced from the public repository.
+
+The subprocess timeouts in this module are hang-guards, not performance
+assertions: under pytest-xdist the release builds here run while other workers
+keep every core busy, so the guards carry several multiples of headroom over
+the serial runtime. Tightening them re-introduces load flakes.
+"""
 
 from __future__ import annotations
 
@@ -239,7 +245,7 @@ def _build_release_in_clone(
         check=True,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
     result = subprocess.run(
         ["git", "ls-tree", "-r", "--name-only", target],
@@ -257,7 +263,7 @@ def _run_tau_check(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         cwd=repo,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
 
 
@@ -483,7 +489,7 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
         # Generous sanity ceiling, not a perf assertion: the smoke run spawns several
         # subprocess journeys, which can exceed a tight 30s budget on a loaded CI runner
         # and flake this test even though the run succeeds.
-        timeout=90,
+        timeout=240,
     )
     assert smoke_result.returncode == 0, smoke_result.stderr or smoke_result.stdout
     assert json.loads(smoke_result.stdout)["schema_version"] == 1
@@ -595,7 +601,7 @@ def test_release_build_uses_selected_source_version_for_tree_profile_manifest_an
         check=True,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     assert _git_json(clone, "release-selected:package.json")["version"] == "2.3.4"
@@ -651,7 +657,7 @@ def test_release_build_rejects_malformed_selected_package_before_creating_refs(t
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     assert result.returncode == 1
@@ -678,7 +684,7 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
         check=True,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
     archive_path = next(output.glob("dex-vault-bundle-v*.tar.gz"))
     with tarfile.open(archive_path, "r:gz") as archive:
@@ -737,7 +743,7 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
         check=True,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     package = _git_json(clone, "HEAD:package.json")
@@ -825,7 +831,7 @@ def test_release_build_rejects_unsafe_selected_source_before_creating_ref(
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
 
     assert result.returncode == 1
@@ -872,7 +878,7 @@ def test_release_build_uses_safe_selected_source_despite_unsafe_current_checkout
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -920,7 +926,7 @@ def test_release_build_uses_selected_source_distignore_contract(tmp_path: Path) 
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
 
     assert result.returncode == 1
@@ -941,7 +947,7 @@ def test_manifest_accepts_safe_head_source_tree(tmp_path: Path) -> None:
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -997,7 +1003,7 @@ def test_manifest_rejects_unsafe_requested_tree_without_output_or_ref_mutation(
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
 
     assert result.returncode == 1
@@ -1059,7 +1065,7 @@ def test_release_build_creates_immutable_versioned_tags(tmp_path: Path) -> None:
         check=True,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     second_short_sha = subprocess.run(
@@ -1184,7 +1190,7 @@ def test_distribution_check_rejects_enabled_integration_templates(tmp_path: Path
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=240,
     )
 
     assert result.returncode == 1
@@ -1388,7 +1394,7 @@ def test_vault_distignore_directory_rules_resolve_before_staging(tmp_path: Path)
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         env=environment,
     )
 
@@ -1422,7 +1428,7 @@ def test_vault_bundle_tree_manifest_and_archive_contain_no_tau(tmp_path: Path) -
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         env=environment,
     )
     assert build_result.returncode == 0, build_result.stdout + build_result.stderr
@@ -1715,7 +1721,7 @@ def test_tau_gate_rejects_reintroduced_source_path_and_release_build_input(tmp_p
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
     )
     assert gate.returncode == 1
     assert "removed Tau path" in gate.stdout
@@ -1855,7 +1861,7 @@ def test_vault_build_rejects_tau_before_build_package_or_archive_commands(
         cwd=clone,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=240,
         env=environment,
     )
     assert result.returncode == 1

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -17,6 +17,12 @@ from types import ModuleType
 import pytest
 import yaml
 
+# These tests build release trees from the shared repository checkout; two of them
+# running at once corrupt each other's git state. Under pytest-xdist the group name
+# pins the whole module to a single worker (serial among themselves, parallel to
+# everything else). Harmless no-op without xdist.
+pytestmark = pytest.mark.xdist_group("serial_sensitive")
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 DOCS_BRIDGE_PATHS = tuple(

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -988,6 +988,7 @@ def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path
     assert not sentinel.exists()
 
 
+@pytest.mark.xdist_group("serial_sensitive")
 def test_hanging_preparation_is_killed_within_the_journey_budget(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     monkeypatch.setattr(

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -961,8 +961,12 @@ def test_hanging_journey_is_killed_and_returns_exit_two(monkeypatch, tmp_path: P
 def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     sentinel = tmp_path / "timed-out-descendant-survived"
+    # The survival window and the post-run wait below are seconds apart on purpose:
+    # with a tight margin (formerly 0.7s sleep / 0.8s wait) a CPU-starved descendant
+    # on a loaded runner could be delayed past the check and fake a pass even when
+    # the kill logic is broken. Wide margins keep this test honest under parallel load.
     descendant = (
-        "import time; from pathlib import Path; time.sleep(0.7); "
+        "import time; from pathlib import Path; time.sleep(2.5); "
         f"Path({str(sentinel)!r}).touch()"
     )
     parent = (
@@ -981,7 +985,7 @@ def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path
         repo_root=REPO_ROOT,
         journey_definitions=(_definition("configs", 0.4),),
     )
-    time.sleep(0.8)
+    time.sleep(4.0)
 
     assert run.exit_code == 2
     assert "timed out" in run.report["journeys"][0]["detail"]
@@ -1020,8 +1024,11 @@ def test_hanging_preparation_is_killed_within_the_journey_budget(monkeypatch, tm
 def test_normal_journey_exit_cleans_up_same_group_descendants(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     sentinel = tmp_path / "orphan-survived"
+    # Wide survival/check margins for the same reason as the timed-out-descendant
+    # test above: a starved descendant must not be able to slip past the check
+    # window on a loaded runner and mask broken cleanup.
     descendant = (
-        "import time; from pathlib import Path; time.sleep(0.5); "
+        "import time; from pathlib import Path; time.sleep(2.5); "
         f"Path({str(sentinel)!r}).touch()"
     )
     parent = (
@@ -1041,7 +1048,7 @@ def test_normal_journey_exit_cleans_up_same_group_descendants(monkeypatch, tmp_p
         repo_root=REPO_ROOT,
         journey_definitions=(_definition("configs"),),
     )
-    time.sleep(0.7)
+    time.sleep(4.0)
 
     assert run.exit_code == 0
     assert not sentinel.exists()

--- a/core/tests/test_work_server_production_paths.py
+++ b/core/tests/test_work_server_production_paths.py
@@ -10,6 +10,7 @@ import sys
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
@@ -63,6 +64,7 @@ def _decode_handler_result(result) -> dict:
     return json.loads(result[0].text)
 
 
+@pytest.mark.xdist_group("serial_sensitive")
 def test_create_task_succeeds_over_production_stdio(fixture_vault: Path, tmp_path: Path):
     vault = _copy_fixture_vault(fixture_vault, tmp_path)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Dex development and CI requirements
 pytest
 pytest-cov
+pytest-xdist
 ruff
 hypothesis


### PR DESCRIPTION
## Why

Every PR push costs ~16 minutes, and the pytest step is 14 of them (measured on run 30249462187: 14m16s of a 15m57s job). All ten gate scripts, both JS suites, and the benchmark together are under 2 minutes. Plan reviewed by Dave: ~/dex/artifacts/dex-core-ci-speed-plan.md (delivered 2026-07-27).

## What

- **pytest runs across the runner's cores** (`pytest-xdist`, `-n auto --dist loadgroup`). Measured locally on the full suite: 22m46s serial → 7m07s parallel, identical test set and coverage measurement. Expected CI test step: ~5–8 min.
- **Collision-prone tests pinned to one worker** via `xdist_group("serial_sensitive")`: all of `test_distribution_artifacts.py` (they build release trees from the shared checkout), plus one smoke timing test and one MCP-stdio test.
- **Hardening from the adversarial review** (verdict was fix-first; both findings closed):
  - The two descendant-cleanup smoke tests had ~0.1s of margin between an orphan's survival window and the check — under worker load a starved orphan could fake a pass with broken kill logic. Margins widened to seconds-scale (2.5s/4.0s); stress-looped 10× under parallel load, 10/10 green.
  - The conftest fixture-vault mutation check rides on unpinned pytest/xdist hook internals under parallelism. Verified empirically that it still fires (dirtied fixture → red run with banner), **and** added a version-proof shell gate after pytest — a gate added, none removed.
- Subprocess hang-guards sized for an idle machine widened (release-build 60–120s → 240s, MCP handshake 10s → 30s). Guards, not perf assertions — behavior is asserted by exit codes/verdicts.

## Safety argument

- Identical test selection, same coverage thresholds (`--cov-fail-under`, touched-file gate), same junit path; pytest-cov combines worker data on the controller.
- Coverage equivalence verified against CI's own serial baseline on main: 80.11% serial vs 80.28–80.36% parallel (order-dependent-branch noise; threshold is 25%).
- Diff-aware gates unchanged and merge-base logic verified (`GITHUB_BASE_REF` + `git merge-base`, no per-worker state). All four PR gates run locally against origin/main: green.
- Adversarial review notes for the record: `pytest-xdist`/`execnet` join the (already unpinned) dev-dependency set — pinning the whole file is a recommended follow-up; `test_history_hygiene`'s `os.fork` suite is a known loud-flake candidate under xdist (worker crash, never a silent pass) — first suspect if 'worker crashed' appears.

## Follow-ups (not this PR)

- Repo settings for automatic stale-PR catch-up (auto-merge + update-branch) — flipping after merge.
- Optional: shard across 2–3 runners (→ ~5 min total); test-speed pass on the 10 slowest tests (20–80s each).
- Pin/hash-pin `requirements-dev.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZN2Tm3g6z3Hd85SPbv7Vw