### PR TITLE
fix(onboarding): domain normalization, solo-user path, company name, honest timing

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -1,6 +1,6 @@
 # Dex Onboarding Flow
 
-Guide new users through setup in a friendly ~5 minute conversation. Keep it simple, practical, and focused on getting them working quickly.
+Guide new users through setup in a friendly conversation of about 10 minutes. Keep it simple, practical, and focused on getting them working quickly.
 
 ## Before Starting
 
@@ -96,7 +96,9 @@ Call `validate_and_save_step(step_number=2, step_data={"role_number": [selected 
 
 ## Step 3: Company Size
 
-Ask: "What's your company size?"
+Ask: "What's your company name? (Optional — leave it blank if you don't have one.)"
+
+Then ask: "What's your company size?"
 
 Present options using your detected platform tool:
 ```json
@@ -121,7 +123,7 @@ Present options using your detected platform tool:
 
 ## Step 4: Email Domain (MANDATORY)
 
-**⚠️ DO NOT SKIP THIS STEP - Required for Internal/External person routing**
+**⚠️ ASK EVERY USER - Required for Internal/External person routing**
 
 Ask: "What's your company email domain? This helps me automatically:
 - Identify internal colleagues vs external contacts
@@ -133,13 +135,12 @@ Ask: "What's your company email domain? This helps me automatically:
 
 **Store in** `System/user-profile.yaml` as `email_domain` field.
 
-**If they're unsure or don't have one:** Set to empty string, system will default to External for all people.
+**If they don't have a company domain:** Call `validate_and_save_step(step_number=4, step_data={"email_domain": "", "no_company_domain": true})`. This explicitly completes the required step and defaults all people to External.
 
 **After receiving email domain:** Call `validate_and_save_step(step_number=4, step_data={"email_domain": "..."})` to validate and save. The MCP enforces:
-- Non-empty value
-- No @ symbol
 - Valid domain format with dot
-- This step CANNOT be skipped
+- Normalization of a leading @ or a pasted full email address
+- A validated domain or an explicit "I don't have one" answer before the step is complete
 
 ---
 

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -161,33 +161,40 @@ def create_new_session() -> Dict:
         "data": {}
     }
 
-def validate_email_domain(domain: str) -> tuple[bool, Optional[str]]:
-    """Validate email domain format (supports multiple domains separated by commas)"""
+def validate_email_domain(domain: str) -> tuple[bool, Optional[str], str]:
+    """Validate and normalize email domains separated by commas"""
     if not domain or not domain.strip():
-        return False, "Email domain cannot be empty"
-    
-    domain = domain.strip()
-    
-    # Check for @ symbol
-    if '@' in domain:
-        return False, "Domain should not include @ symbol (e.g., 'pendo.io' not '@pendo.io')"
-    
-    # Split by comma if multiple domains
-    domains = [d.strip() for d in domain.split(',')]
-    
-    for d in domains:
+        return False, "Email domain cannot be empty", ""
+
+    domains = []
+    for raw_domain in domain.split(','):
+        d = raw_domain.strip()
         if not d:
             continue
-        
+
+        if d.startswith('@'):
+            d = d[1:]
+        if '@' in d:
+            d = d.rsplit('@', 1)[1]
+        d = d.strip()
+
+        if not d or '@' in d:
+            return False, f"Could not determine a domain from '{raw_domain.strip()}'", ""
+
         # Check for at least one dot (basic domain validation)
         if '.' not in d:
-            return False, f"Domain '{d}' should include at least one dot (e.g., 'acme.com')"
-        
+            return False, f"Domain '{d}' should include at least one dot (e.g., 'acme.com')", ""
+
         # Check for valid characters (alphanumeric, dots, hyphens)
         if not re.match(r'^[a-zA-Z0-9\-\.]+$', d):
-            return False, f"Domain '{d}' contains invalid characters"
-    
-    return True, None
+            return False, f"Domain '{d}' contains invalid characters", ""
+
+        domains.append(d)
+
+    if not domains:
+        return False, "Email domain cannot be empty", ""
+
+    return True, None, ", ".join(domains)
 
 def validate_pillars(pillars: List[str]) -> tuple[bool, Optional[str]]:
     """Validate strategic pillars"""
@@ -797,23 +804,31 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
             # Step 4: Email Domain (CRITICAL)
             elif step_number == 4:
                 email_domain = step_data.get('email_domain', '').strip()
-                
-                valid, error_msg = validate_email_domain(email_domain)
+                no_company_domain = step_data.get('no_company_domain') is True
+
+                if not email_domain and no_company_domain:
+                    valid, error_msg, normalized_domain = True, None, ""
+                else:
+                    valid, error_msg, normalized_domain = validate_email_domain(email_domain)
+
                 if not valid:
                     result = create_error_response(
                         error_msg,
                         step=4,
                         field="email_domain",
-                        suggestion="Provide domain without @ (e.g., 'pendo.io' or 'acme.com')"
+                        suggestion=(
+                            "Provide a domain (e.g., 'pendo.io' or 'acme.com'). "
+                            "If you do not have a company domain, set no_company_domain to true."
+                        )
                     )
                 else:
-                    session['data']['email_domain'] = email_domain
+                    session['data']['email_domain'] = normalized_domain
                     if step_number not in session['completed_steps']:
                         session['completed_steps'].append(step_number)
                     session['current_step'] = 5
                     save_session(session)
                     result = create_success_response(
-                        {"step": 4, "completed": True, "email_domain": email_domain},
+                        {"step": 4, "completed": True, "email_domain": normalized_domain},
                         "Step 4 complete - email domain validated"
                     )
             
@@ -1126,7 +1141,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
             # Critical check for Step 4
-            if 4 not in completed or not session['data'].get('email_domain'):
+            if 4 not in completed:
                 result = create_error_response(
                     "Cannot finalize: email_domain is required",
                     step=4,

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -6,6 +6,8 @@ import shutil
 import sys
 from pathlib import Path
 
+import pytest
+
 # core/mcp/tests -> repo root (for `core.paths`) and core/mcp (for the module).
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
@@ -16,6 +18,99 @@ import onboarding_server  # noqa: E402
 
 def _decode_tool_result(result) -> dict:
     return json.loads(result[0].text)
+
+
+class TestEmailDomainStep:
+    @pytest.mark.parametrize(
+        ("entered_domain", "normalized_domain"),
+        (
+            ("@acme.com", "acme.com"),
+            ("dave@acme.com", "acme.com"),
+            ("acme.com, @acme.io", "acme.com, acme.io"),
+        ),
+    )
+    def test_normalizes_and_saves_email_domains(
+        self, tmp_path, monkeypatch, entered_domain, normalized_domain
+    ):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {
+                        "step_number": 4,
+                        "step_data": {"email_domain": entered_domain},
+                    },
+                )
+            )
+        )
+
+        assert payload["success"] is True
+        assert payload["data"]["email_domain"] == normalized_domain
+        assert onboarding_server.load_session()["data"]["email_domain"] == normalized_domain
+
+    def test_explicit_no_company_domain_completes_step_and_allows_finalize(
+        self, tmp_path, monkeypatch
+    ):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        monkeypatch.setattr(onboarding_server, "BASE_DIR", tmp_path)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {
+                        "step_number": 4,
+                        "step_data": {
+                            "email_domain": "",
+                            "no_company_domain": True,
+                        },
+                    },
+                )
+            )
+        )
+
+        assert payload["success"] is True
+        session = onboarding_server.load_session()
+        assert session["data"]["email_domain"] == ""
+        assert 4 in session["completed_steps"]
+
+        session["completed_steps"] = [1, 2, 3, 4, 5, 6]
+        onboarding_server.save_session(session)
+        finalized = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "finalize_onboarding", {"dry_run": True}
+                )
+            )
+        )
+
+        assert finalized["success"] is True
+        assert finalized["data"]["preview_user_profile"]["email_domain"] == ""
+
+    def test_rejects_plain_empty_domain_with_explicit_opt_out_guidance(
+        self, tmp_path, monkeypatch
+    ):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {"step_number": 4, "step_data": {"email_domain": ""}},
+                )
+            )
+        )
+
+        assert payload["success"] is False
+        assert "no_company_domain" in f"{payload['error']} {payload['suggestion']}"
 
 
 class TestCapabilityStep:

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -25,7 +25,7 @@ class TestEmailDomainStep:
         ("entered_domain", "normalized_domain"),
         (
             ("@acme.com", "acme.com"),
-            ("dave@acme.com", "acme.com"),
+            ("jane@acme.com", "acme.com"),
             ("acme.com, @acme.io", "acme.com, acme.io"),
         ),
     )

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -242,6 +242,30 @@ def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     )
 
 
+def test_onboarding_gives_an_honest_time_estimate() -> None:
+    opening = _read(".claude/flows/onboarding.md").splitlines()[2]
+
+    assert "about 10 minutes" in opening
+    assert "~5 minute" not in opening
+
+
+def test_onboarding_collects_the_optional_company_name_it_saves() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    company_step = flow.split("## Step 3:", 1)[1].split("## Step 4:", 1)[0]
+
+    assert "company name" in company_step.lower()
+    assert "optional" in company_step.lower()
+
+
+def test_onboarding_documents_the_explicit_no_company_domain_path() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    domain_step = flow.split("## Step 4:", 1)[1].split("## Step 4b:", 1)[0]
+
+    assert '"no_company_domain": true' in domain_step
+    assert "Non-empty value" not in domain_step
+    assert "This step CANNOT be skipped" not in domain_step
+
+
 def test_core_behavior_defines_feature_status_rendering() -> None:
     instructions = _read("CLAUDE.md")
     heading = "### When an MCP tool returns `feature_status`"


### PR DESCRIPTION
Four onboarding bug fixes found during the 2026-07-27 onboarding review.

## What this fixes for users

- **Typing "@acme.com" (or pasting "dave@acme.com") no longer bounces.** The email-domain step now cleans the input to "acme.com" instead of rejecting the most natural ways people type it. Multi-domain input is normalized per entry and the *cleaned* value is what gets saved.
- **Solo users are no longer hard-stuck.** The flow copy promised "if unsure, set to empty string" while the validator and the finalize gate both rejected empty — a genuine dead end for anyone without a company domain. There is now an explicit `no_company_domain: true` opt-out that completes the mandatory step with an empty domain (everyone routes External, as the copy already promised). Plain empty *without* the explicit flag is still rejected, and the finalize gate now checks step completion rather than domain truthiness.
- **The company name is finally asked.** Step 3's save call always passed `company`, but the flow never asked for it — silently blank for every user ever onboarded. One optional question added.
- **Honest timing.** "~5 minute conversation" → "about 10 minutes", matching what the flow actually takes.

## Verification

- 31 focused tests green (normalization matrix, opt-out completes step 4 AND passes finalize, plain-empty still rejected, flow-copy honesty pins in `test_instruction_honesty.py`).
- Full CI-scope Python suite run locally under a CI-matched 3.12 env: 2348 passed; the 31 failures are all in `test_smoke.py`/`test_trusted_mcp_safety.py` and reproduce identically on untouched `origin/main` (environmental — they need CI's release-snapshot setup).
- PR gates (path-contract, test-delta, doc-drift) run locally against `origin/main`: passed (doc-drift advisory only; changelog entry routed via release-handoff at release-cut time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR