### PR TITLE
fix(lifecycle): route the customization rebuild through the one safe door (adversarial Blocker 2 + Serious 5)

### DIFF
--- a/core/customization_migration/service.py
+++ b/core/customization_migration/service.py
@@ -18,6 +18,7 @@ from core.customization_migration.capsule_model import (
 )
 from core.customization_migration.inventory import discover
 from core.customization_migration.model import Assessment, AssessmentIdentity
+from core.lifecycle import service as lifecycle_service
 
 if TYPE_CHECKING:
     from core.customization_migration.verification import VerificationReport
@@ -160,11 +161,26 @@ def preview_to_dict(vault_root: Path) -> dict[str, object]:
 
 
 def create_confirmed_capsule(vault_root: Path, preview_sha256: str):
-    from core.customization_migration.capsule import create_capsule
+    from core.customization_migration.capsule import CapsuleReceipt
 
     root = resolve_vault_root(vault_root)
     preview = _confirmation_preview(root)
-    return create_capsule(root, preview, preview_sha256)
+    response = lifecycle_service.execute_approved_rebuild_capsule(
+        root,
+        preview,
+        preview_sha256,
+    )
+    receipt = response["receipt"]
+    if not isinstance(receipt, Mapping):
+        raise TypeError("lifecycle capsule receipt must be an object")
+    return CapsuleReceipt(
+        receipt["schema_version"],
+        receipt["capsule_id"],
+        receipt["manifest_sha256"],
+        receipt["file_count"],
+        receipt["byte_count"],
+        receipt["transaction_id"],
+    )
 
 
 def load_regeneration_candidate(candidate_path: str | Path):
@@ -217,14 +233,30 @@ def stage_confirmed_candidate(
 ):
     from core.customization_migration.staging import (
         StagingError,
+        StagingReceipt,
         preview_staging,
-        stage_candidate,
     )
 
     root = resolve_vault_root(vault_root)
     try:
         preview = preview_staging(root, candidate.capsule_id, candidate)
-        return stage_candidate(root, preview, preview_sha256)
+        response = lifecycle_service.execute_approved_rebuild_staging(
+            root,
+            preview,
+            preview_sha256,
+        )
+        receipt = response["receipt"]
+        if not isinstance(receipt, Mapping):
+            raise TypeError("lifecycle staging receipt must be an object")
+        return StagingReceipt(
+            receipt["schema_version"],
+            receipt["capsule_id"],
+            receipt["proposal_id"],
+            receipt["staged_file_count"],
+            receipt["staged_byte_count"],
+            receipt["staging_digest"],
+            receipt["transaction_id"],
+        )
     except (AttributeError, OSError, StagingError, TypeError, ValueError) as error:
         raise MigrationServiceError(
             "staging-refused",
@@ -308,32 +340,26 @@ def verify_staging_to_dict(
     confirm_token: str,
 ) -> dict[str, object]:
     from core.customization_migration.staging import StagingError
-    from core.customization_migration.verification import (
-        VerificationError,
-        write_verification_report,
-    )
+    from core.customization_migration.verification import VerificationError
 
     root = resolve_vault_root(vault_root)
     try:
-        report, _staging_receipt_sha256, expected_token = _verification_preview(
+        report, _staging_receipt_sha256, _expected_token = _verification_preview(
             root,
             capsule_id,
             proposal_id,
         )
-        if (
-            not isinstance(confirm_token, str)
-            or not hmac.compare_digest(confirm_token, expected_token)
-        ):
-            raise VerificationError(
-                "verification confirmation token does not match staging"
-            )
-        receipt = write_verification_report(
+        response = lifecycle_service.execute_approved_rebuild_verification(
             root,
             capsule_id,
             proposal_id,
             report,
+            confirm_token,
         )
-        return {"report": report.to_dict(), "receipt": receipt.to_dict()}
+        receipt = response["receipt"]
+        if not isinstance(receipt, Mapping):
+            raise TypeError("lifecycle verification receipt must be an object")
+        return {"report": report.to_dict(), "receipt": dict(receipt)}
     except (OSError, StagingError, VerificationError, TypeError, ValueError) as error:
         raise MigrationServiceError(
             "verification-refused",
@@ -444,7 +470,7 @@ def activate_confirmed(
 ):
     from core.customization_migration.activation import (
         ActivationError,
-        activate,
+        ActivationReceipt,
         preview_activation,
     )
     from core.customization_migration.staging import StagingError
@@ -453,7 +479,12 @@ def activate_confirmed(
     root = resolve_vault_root(vault_root)
     try:
         preview = preview_activation(root, capsule_id, proposal_id)
-        return activate(root, preview, approval_token)
+        response = lifecycle_service.execute_approved_rebuild_activation(
+            root,
+            preview,
+            approval_token,
+        )
+        return ActivationReceipt.from_dict(response["receipt"])
     except (
         OSError,
         ActivationError,
@@ -510,13 +541,18 @@ def rewind_acknowledged(
     capsule_id: str,
     acknowledgement_token: str,
 ):
-    from core.customization_migration.activation import ActivationError, rewind
+    from core.customization_migration.activation import ActivationError, RewindReceipt
     from core.customization_migration.staging import StagingError
 
     root = resolve_vault_root(vault_root)
     try:
         receipt = _persisted_activation_receipt(root, capsule_id)
-        return rewind(root, receipt, acknowledgement_token)
+        response = lifecycle_service.rewind_rebuild_activation_by_receipt(
+            root,
+            receipt,
+            acknowledgement_token,
+        )
+        return RewindReceipt.from_dict(response["rewind_receipt"])
     except (OSError, ActivationError, StagingError, TypeError, ValueError) as error:
         raise MigrationServiceError(
             "rewind-refused",
@@ -575,9 +611,10 @@ def activation_status_to_dict(
 
 
 def abandon_existing_capsule(vault_root: Path, capsule_id: str) -> None:
-    from core.customization_migration.capsule import abandon_capsule
-
-    abandon_capsule(resolve_vault_root(vault_root), capsule_id)
+    lifecycle_service.abandon_rebuild_capsule(
+        resolve_vault_root(vault_root),
+        capsule_id,
+    )
 
 
 def _recovery_identity(plan: object) -> dict[str, object] | None:
@@ -707,7 +744,7 @@ def recover_confirmed(
     vault_root: Path,
     confirm_token: str,
 ) -> dict[str, object]:
-    from core.transaction.engine import Transaction, TransactionError
+    from core.transaction.engine import TransactionError
 
     root = resolve_vault_root(vault_root)
     preview = recovery_preview_to_dict(root)
@@ -731,10 +768,10 @@ def recover_confirmed(
         and isinstance(action.get("transaction_id"), str)
     }
     try:
-        outcomes = Transaction.resume(
-            root,
-            transaction_ids=frozenset(by_transaction),
-        )
+        response = lifecycle_service.recover_rebuild_transactions(root)
+        outcomes = response["outcomes"]
+        if not isinstance(outcomes, list):
+            raise TypeError("lifecycle recovery outcomes must be a list")
     except (OSError, TransactionError, TypeError, ValueError) as error:
         raise MigrationServiceError(
             "recovery-refused",

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["api_version", "x-operations"],
   "properties": {
-    "api_version": {"const": "1.1.0"},
+    "api_version": {"const": "1.2.0"},
     "x-operations": {"type": "object"}
   },
   "x-operations": {
@@ -54,6 +54,34 @@
     "execute_approved_topology_migration": {
       "request": {"$ref": "#/$defs/topologyExecuteRequest"},
       "response": {"$ref": "#/$defs/topologyExecuteResponse"}
+    },
+    "execute_approved_rebuild_capsule": {
+      "request": {"$ref": "#/$defs/rebuildExecuteRequest"},
+      "response": {"$ref": "#/$defs/rebuildCapsuleResponse"}
+    },
+    "execute_approved_rebuild_staging": {
+      "request": {"$ref": "#/$defs/rebuildExecuteRequest"},
+      "response": {"$ref": "#/$defs/rebuildStagingResponse"}
+    },
+    "execute_approved_rebuild_verification": {
+      "request": {"$ref": "#/$defs/rebuildVerificationRequest"},
+      "response": {"$ref": "#/$defs/rebuildVerificationResponse"}
+    },
+    "execute_approved_rebuild_activation": {
+      "request": {"$ref": "#/$defs/rebuildExecuteRequest"},
+      "response": {"$ref": "#/$defs/rebuildActivationResponse"}
+    },
+    "rewind_rebuild_activation_by_receipt": {
+      "request": {"$ref": "#/$defs/rebuildRewindRequest"},
+      "response": {"$ref": "#/$defs/rebuildRewindResponse"}
+    },
+    "abandon_rebuild_capsule": {
+      "request": {"$ref": "#/$defs/rebuildAbandonRequest"},
+      "response": {"$ref": "#/$defs/rebuildAbandonResponse"}
+    },
+    "recover_rebuild_transactions": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/rebuildRecoveryResponse"}
     }
   },
   "$defs": {
@@ -71,7 +99,7 @@
     "apiEnvelope": {
       "type": "object",
       "required": ["api_version"],
-      "properties": {"api_version": {"const": "1.1.0"}}
+      "properties": {"api_version": {"const": "1.2.0"}}
     },
     "vaultRequest": {
       "type": "object",
@@ -124,7 +152,7 @@
           "additionalProperties": false,
           "required": ["api_version", "inventory", "plan"],
           "properties": {
-            "api_version": {"const": "1.1.0"},
+            "api_version": {"const": "1.2.0"},
             "inventory": {"$ref": "#/$defs/inventory"},
             "plan": {"$ref": "#/$defs/plan"}
           }
@@ -171,7 +199,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "preview": {"$ref": "#/$defs/preview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -256,7 +284,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -303,7 +331,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "rewind_acknowledgement_token"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "receipt": {"$ref": "#/$defs/adoptionReceipt"},
         "rewind_acknowledgement_token": {"$ref": "#/$defs/sha256"}
       }
@@ -349,7 +377,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "rewind_receipt": {"$ref": "#/$defs/rewindReceipt"}
       }
     },
@@ -394,7 +422,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "preview": {"$ref": "#/$defs/archivePreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -429,7 +457,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "receipt": {"$ref": "#/$defs/archiveReceipt"}
       }
     },
@@ -438,7 +466,7 @@
       "additionalProperties": false,
       "required": ["api_version", "ledger_state", "retention"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "ledger_state": {"$ref": "#/$defs/ledgerState"},
         "retention": {"$ref": "#/$defs/retention"}
       }
@@ -487,7 +515,7 @@
       "additionalProperties": false,
       "required": ["api_version", "topology", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "topology": {"type": "string", "minLength": 1},
         "preview": {"$ref": "#/$defs/topologyPreview"},
         "approval_token": {
@@ -569,9 +597,318 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "receipt_path"],
       "properties": {
-        "api_version": {"const": "1.1.0"},
+        "api_version": {"const": "1.2.0"},
         "receipt": {"$ref": "#/$defs/topologyReceipt"},
         "receipt_path": {"$ref": "#/$defs/path"}
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^cap-[0-9a-f]{16}$"
+    },
+    "proposalId": {
+      "type": "string",
+      "pattern": "^prop-[0-9a-f]{16}$"
+    },
+    "rebuildExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"type": "object"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rebuildCapsuleReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "capsule_id",
+        "manifest_sha256",
+        "file_count",
+        "byte_count",
+        "transaction_id"
+      ],
+      "properties": {
+        "schema_version": {"const": 0},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "file_count": {"type": "integer", "minimum": 0},
+        "byte_count": {"type": "integer", "minimum": 0},
+        "transaction_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "rebuildCapsuleResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "receipt": {"$ref": "#/$defs/rebuildCapsuleReceipt"}
+      }
+    },
+    "rebuildStagingReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "capsule_id",
+        "proposal_id",
+        "staged_file_count",
+        "staged_byte_count",
+        "staging_digest",
+        "transaction_id"
+      ],
+      "properties": {
+        "schema_version": {"const": 0},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "proposal_id": {"$ref": "#/$defs/proposalId"},
+        "staged_file_count": {"type": "integer", "minimum": 0},
+        "staged_byte_count": {"type": "integer", "minimum": 0},
+        "staging_digest": {"$ref": "#/$defs/sha256"},
+        "transaction_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "rebuildStagingResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "receipt": {"$ref": "#/$defs/rebuildStagingReceipt"}
+      }
+    },
+    "rebuildVerificationRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "vault_root",
+        "capsule_id",
+        "proposal_id",
+        "report",
+        "approved_token"
+      ],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "proposal_id": {"$ref": "#/$defs/proposalId"},
+        "report": {"type": "object"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rebuildVerificationReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "capsule_id",
+        "staging_id",
+        "report_path",
+        "report_sha256",
+        "transaction_id"
+      ],
+      "properties": {
+        "schema_version": {"const": 0},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "staging_id": {"$ref": "#/$defs/proposalId"},
+        "report_path": {"$ref": "#/$defs/path"},
+        "report_sha256": {"$ref": "#/$defs/sha256"},
+        "transaction_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "rebuildVerificationResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "receipt": {"$ref": "#/$defs/rebuildVerificationReceipt"}
+      }
+    },
+    "rebuildActivatedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "byte_size", "mode"],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "byte_size": {"type": "integer", "minimum": 1},
+        "mode": {"type": "integer", "minimum": 0, "maximum": 511}
+      }
+    },
+    "rebuildActivationReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "capsule_id",
+        "proposal_id",
+        "verification_report_sha256",
+        "candidate_sha256",
+        "files_written",
+        "transaction_id",
+        "snapshot_ref",
+        "activated_epoch_seconds",
+        "rewind_available"
+      ],
+      "properties": {
+        "schema_version": {"const": 0},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "proposal_id": {"$ref": "#/$defs/proposalId"},
+        "verification_report_sha256": {"$ref": "#/$defs/sha256"},
+        "candidate_sha256": {"$ref": "#/$defs/sha256"},
+        "files_written": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/rebuildActivatedFile"}
+        },
+        "transaction_id": {"type": "string", "minLength": 1},
+        "snapshot_ref": {"$ref": "#/$defs/path"},
+        "activated_epoch_seconds": {"type": "integer", "minimum": 0},
+        "rewind_available": {"const": true}
+      }
+    },
+    "rebuildActivationResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "api_version",
+        "receipt",
+        "rewind_acknowledgement_token"
+      ],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "receipt": {"$ref": "#/$defs/rebuildActivationReceipt"},
+        "rewind_acknowledgement_token": {
+          "anyOf": [
+            {"$ref": "#/$defs/sha256"},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "rebuildRewindRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "receipt", "acknowledgement_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "receipt": {"$ref": "#/$defs/rebuildActivationReceipt"},
+        "acknowledgement_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "rebuildRewindFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "existed_before_activation",
+        "restored_sha256",
+        "byte_size",
+        "mode"
+      ],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "existed_before_activation": {"type": "boolean"},
+        "restored_sha256": {
+          "anyOf": [
+            {"$ref": "#/$defs/sha256"},
+            {"type": "null"}
+          ]
+        },
+        "byte_size": {
+          "anyOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "null"}
+          ]
+        },
+        "mode": {
+          "anyOf": [
+            {"type": "integer", "minimum": 0, "maximum": 511},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "rebuildRewindReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "capsule_id",
+        "proposal_id",
+        "activation_transaction_id",
+        "rewind_transaction_id",
+        "status",
+        "reason",
+        "files_restored",
+        "rewound_epoch_seconds"
+      ],
+      "properties": {
+        "schema_version": {"const": 0},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "proposal_id": {"$ref": "#/$defs/proposalId"},
+        "activation_transaction_id": {"type": "string", "minLength": 1},
+        "rewind_transaction_id": {
+          "anyOf": [
+            {"type": "string", "minLength": 1},
+            {"type": "null"}
+          ]
+        },
+        "status": {"type": "string", "enum": ["OK", "UNKNOWN"]},
+        "reason": {"type": "string", "minLength": 1},
+        "files_restored": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/rebuildRewindFile"}
+        },
+        "rewound_epoch_seconds": {
+          "anyOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "rebuildRewindResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "rewind_receipt"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "rewind_receipt": {"$ref": "#/$defs/rebuildRewindReceipt"}
+      }
+    },
+    "rebuildAbandonRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "capsule_id"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"}
+      }
+    },
+    "rebuildAbandonResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "capsule_id", "abandoned"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "capsule_id": {"$ref": "#/$defs/capsuleId"},
+        "abandoned": {"const": true}
+      }
+    },
+    "rebuildRecoveryResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "outcomes"],
+      "properties": {
+        "api_version": {"const": "1.2.0"},
+        "outcomes": {
+          "type": "array",
+          "items": {"type": "object"}
+        }
       }
     }
   }

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -47,12 +47,19 @@ from core.lifecycle.retention import compute_retention_report
 from core.path_safety import unsafe_existing_parent
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction
 
-api_version = "1.1.0"
+api_version = "1.2.0"
 
 _CATALOG_RELATIVE = "System/.release-catalog.json"
 _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _ARCHIVE_RELATIVE = ".dex/pre-split-archive.git"
 _ARCHIVE_RECEIPTS_RELATIVE = "System/.dex/archive-removals"
+_REBUILD_TRANSACTION_PATH = re.compile(
+    r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
+    r"receipts/(?:capsule|activation|rewind)\.json|"
+    r"verification/prop-[0-9a-f]{16}\.json|"
+    r"candidates/prop-[0-9a-f]{16}/staging/receipt\.json"
+    r")$"
+)
 
 
 def _envelope(**values: object) -> dict[str, object]:
@@ -507,6 +514,185 @@ def execute_approved_topology_migration(
     return _envelope(receipt=receipt, receipt_path=receipt_path)
 
 
+def execute_approved_rebuild_capsule(
+    vault_root: str | Path,
+    preview: object,
+    approved_token: str,
+) -> dict[str, object]:
+    """Create the exact approved customization Capsule through the lifecycle door."""
+    from core.customization_migration.capsule import create_capsule
+
+    receipt = create_capsule(Path(vault_root), preview, approved_token)
+    return _envelope(receipt=receipt.to_dict())
+
+
+def execute_approved_rebuild_staging(
+    vault_root: str | Path,
+    preview: object,
+    approved_token: str,
+) -> dict[str, object]:
+    """Stage the exact approved rebuild candidate through the lifecycle door."""
+    from core.customization_migration.staging import stage_candidate
+
+    receipt = stage_candidate(Path(vault_root), preview, approved_token)
+    return _envelope(receipt=receipt.to_dict())
+
+
+def execute_approved_rebuild_verification(
+    vault_root: str | Path,
+    capsule_id: str,
+    proposal_id: str,
+    report: object,
+    approved_token: str,
+) -> dict[str, object]:
+    """Seal one exact approved verification report through the lifecycle door."""
+    from core.customization_migration.staging import load_staged_candidate
+    from core.customization_migration.verification import (
+        VerificationError,
+        VerificationReport,
+        write_verification_report,
+    )
+
+    if type(report) is not VerificationReport:
+        raise TypeError("report must be VerificationReport")
+    _candidate, staging_receipt, _staging = load_staged_candidate(
+        Path(vault_root),
+        capsule_id,
+        proposal_id,
+    )
+    expected_token = hashlib.sha256(
+        _canonical(
+            {
+                "capsule_id": capsule_id,
+                "proposal_id": proposal_id,
+                "staging_receipt_sha256": hashlib.sha256(
+                    staging_receipt.canonical_bytes()
+                ).hexdigest(),
+                "report_sha256": hashlib.sha256(
+                    report.canonical_bytes()
+                ).hexdigest(),
+            }
+        )
+    ).hexdigest()
+    if not isinstance(approved_token, str) or not hmac.compare_digest(
+        approved_token,
+        expected_token,
+    ):
+        raise VerificationError(
+            "verification confirmation token does not match staging"
+        )
+    receipt = write_verification_report(
+        Path(vault_root),
+        capsule_id,
+        proposal_id,
+        report,
+    )
+    return _envelope(receipt=receipt.to_dict())
+
+
+def execute_approved_rebuild_activation(
+    vault_root: str | Path,
+    preview: object,
+    approved_token: str,
+) -> dict[str, object]:
+    """Activate the exact approved rebuild and return its rewind acknowledgement."""
+    from core.customization_migration import activation
+
+    root = Path(vault_root)
+    receipt = activation.activate(root, preview, approved_token)
+    return _envelope(
+        receipt=receipt.to_dict(),
+        rewind_acknowledgement_token=(
+            activation._rewind_acknowledgement_token(receipt)
+        ),
+    )
+
+
+def rewind_rebuild_activation_by_receipt(
+    vault_root: str | Path,
+    receipt: object,
+    acknowledgement_token: str,
+) -> dict[str, object]:
+    """Rewind one rebuild activation identified by its exact receipt."""
+    from core.customization_migration.activation import (
+        ActivationReceipt,
+        rewind,
+    )
+
+    modeled = (
+        receipt
+        if isinstance(receipt, ActivationReceipt)
+        else ActivationReceipt.from_dict(receipt)
+    )
+    rewind_receipt = rewind(
+        Path(vault_root),
+        modeled,
+        acknowledgement_token,
+    )
+    return _envelope(rewind_receipt=rewind_receipt.to_dict())
+
+
+def abandon_rebuild_capsule(
+    vault_root: str | Path,
+    capsule_id: str,
+) -> dict[str, object]:
+    """Append one rebuild Capsule abandonment event through the lifecycle door."""
+    from core.customization_migration.capsule import abandon_capsule
+
+    abandon_capsule(Path(vault_root), capsule_id)
+    return _envelope(capsule_id=capsule_id, abandoned=True)
+
+
+def _rebuild_transaction_ids(root: Path) -> frozenset[str]:
+    from core.transaction.engine import TX_ROOT_RELATIVE
+    from core.transaction.journal import Journal, JournalCorruptError
+
+    tx_root = root / TX_ROOT_RELATIVE
+    if not tx_root.is_dir() or tx_root.is_symlink():
+        return frozenset()
+    transaction_ids: set[str] = set()
+    for tx_dir in sorted(tx_root.iterdir(), key=lambda path: path.name):
+        if not tx_dir.is_dir() or tx_dir.is_symlink():
+            continue
+        try:
+            entries = Journal(tx_dir / "journal.jsonl").read()
+        except JournalCorruptError:
+            continue
+        events = {entry.event for entry in entries}
+        if not entries or events & {"COMMITTED", "ROLLED-BACK"}:
+            continue
+        begin = next((entry for entry in entries if entry.event == "BEGIN"), None)
+        if begin is None or begin.payload.get("operation") != "customization-migration":
+            continue
+        plan = begin.payload.get("plan")
+        if not isinstance(plan, list):
+            continue
+        relatives = (
+            item.get("relative")
+            for item in plan
+            if isinstance(item, Mapping)
+        )
+        if any(
+            isinstance(relative, str)
+            and _REBUILD_TRANSACTION_PATH.fullmatch(relative) is not None
+            for relative in relatives
+        ):
+            transaction_ids.add(tx_dir.name)
+    return frozenset(transaction_ids)
+
+
+def recover_rebuild_transactions(
+    vault_root: str | Path,
+) -> dict[str, object]:
+    """Converge every interrupted rebuild transaction through the lifecycle door."""
+    root = Path(vault_root)
+    outcomes = Transaction.resume(
+        root,
+        transaction_ids=_rebuild_transaction_ids(root),
+    )
+    return _envelope(outcomes=outcomes)
+
+
 __all__ = [
     "api_version",
     "build_inventory_and_plan",
@@ -520,5 +706,12 @@ __all__ = [
     "execute_approved_archive_removal",
     "build_and_preview_topology_migration",
     "execute_approved_topology_migration",
+    "execute_approved_rebuild_capsule",
+    "execute_approved_rebuild_staging",
+    "execute_approved_rebuild_verification",
+    "execute_approved_rebuild_activation",
+    "rewind_rebuild_activation_by_receipt",
+    "abandon_rebuild_capsule",
+    "recover_rebuild_transactions",
     "TopologyMigrationError",
 ]

--- a/core/tests/test_customization_lifecycle_boundary.py
+++ b/core/tests/test_customization_lifecycle_boundary.py
@@ -1,0 +1,252 @@
+"""Load-bearing boundary coverage for customization rebuild mutations."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from core.customization_migration import activation, cli
+from core.customization_migration import service as migration_service
+from core.lifecycle import service as lifecycle_service
+from core.tests.test_customization_verification import _candidate_with_contract
+from core.tests.vault_observed_writes import snapshot_vault
+from core.transaction.engine import PlanRejected
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORBIDDEN_IMPORTS = {
+    "core.customization_migration.capsule": {
+        "abandon_capsule",
+        "create_capsule",
+    },
+    "core.customization_migration.staging": {"stage_candidate"},
+    "core.customization_migration.verification": {
+        "write_verification_report",
+    },
+    "core.customization_migration.activation": {"activate", "rewind"},
+    "core.transaction.engine": {"Transaction"},
+}
+
+
+def _forbidden_mutator_references(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    module_aliases: dict[str, str] = {}
+    direct_aliases: dict[str, tuple[str, str]] = {}
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _FORBIDDEN_IMPORTS:
+                    module_aliases[alias.asname or alias.name.rsplit(".", 1)[-1]] = (
+                        alias.name
+                    )
+        elif isinstance(node, ast.ImportFrom) and node.module in _FORBIDDEN_IMPORTS:
+            for alias in node.names:
+                if alias.name in _FORBIDDEN_IMPORTS[node.module]:
+                    direct_aliases[alias.asname or alias.name] = (
+                        node.module,
+                        alias.name,
+                    )
+                    violations.append(f"{node.module}.{alias.name}")
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            for alias in node.names:
+                imported_module = f"{node.module}.{alias.name}"
+                if imported_module in _FORBIDDEN_IMPORTS:
+                    module_aliases[alias.asname or alias.name] = imported_module
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id in direct_aliases:
+            module, name = direct_aliases[node.func.id]
+            violations.append(f"{module}.{name}()")
+        elif (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            module = module_aliases.get(node.args[0].id)
+            name = node.args[1].value
+            if module is not None and name in _FORBIDDEN_IMPORTS[module]:
+                violations.append(f"{module}.{name}()")
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+        ):
+            module = module_aliases.get(node.func.value.id)
+            if (
+                module is not None
+                and node.func.attr in _FORBIDDEN_IMPORTS[module]
+            ):
+                violations.append(f"{module}.{node.func.attr}()")
+            if node.func.value.id == "Transaction" and node.func.attr == "resume":
+                violations.append("core.transaction.engine.Transaction.resume()")
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"begin", "resume"}
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "Transaction"
+            and isinstance(node.func.value.value, ast.Name)
+            and module_aliases.get(node.func.value.value.id)
+            == "core.transaction.engine"
+        ):
+            violations.append(
+                "core.transaction.engine.Transaction."
+                f"{node.func.attr}()"
+            )
+    return sorted(set(violations))
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "\n".join(
+                [
+                    "from core.customization_migration import capsule",
+                    "capsule.create_capsule(root, release)",
+                ]
+            ),
+            {"core.customization_migration.capsule.create_capsule()"},
+        ),
+        (
+            "\n".join(
+                [
+                    "from core.customization_migration import staging as module",
+                    'getattr(module, "stage_candidate")(root, candidate)',
+                ]
+            ),
+            {"core.customization_migration.staging.stage_candidate()"},
+        ),
+        (
+            "\n".join(
+                [
+                    "from core.transaction import engine as e",
+                    "e.Transaction.begin(root, plan)",
+                    "e.Transaction.resume(root)",
+                ]
+            ),
+            {
+                "core.transaction.engine.Transaction.begin()",
+                "core.transaction.engine.Transaction.resume()",
+            },
+        ),
+    ],
+    ids=(
+        "submodule-import-attribute",
+        "getattr-module-alias",
+        "transaction-engine-alias",
+    ),
+)
+def test_forbidden_mutator_guard_flags_module_alias_bypasses(
+    tmp_path: Path,
+    source: str,
+    expected: set[str],
+) -> None:
+    candidate = tmp_path / "candidate.py"
+    candidate.write_text(f"{source}\n", encoding="utf-8")
+
+    assert expected <= set(_forbidden_mutator_references(candidate))
+
+
+def test_rebuild_activation_derives_rewind_token_without_post_commit_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Receipt:
+        def to_dict(self) -> dict[str, str]:
+            return {"transaction_id": "tx-approved"}
+
+    receipt = Receipt()
+    derived_from: list[object] = []
+
+    monkeypatch.setattr(
+        activation,
+        "activate",
+        lambda root, preview, token: receipt,
+    )
+    monkeypatch.setattr(
+        activation,
+        "_rewind_acknowledgement_token",
+        lambda value: derived_from.append(value) or "rewind-token",
+    )
+
+    def refuse_post_commit_preview(*args: object) -> None:
+        raise AssertionError("activation must not read the filesystem after commit")
+
+    monkeypatch.setattr(activation, "preview_rewind", refuse_post_commit_preview)
+
+    result = lifecycle_service.execute_approved_rebuild_activation(
+        tmp_path,
+        object(),
+        "approved-token",
+    )
+
+    assert result == {
+        "api_version": lifecycle_service.api_version,
+        "receipt": {"transaction_id": "tx-approved"},
+        "rewind_acknowledgement_token": "rewind-token",
+    }
+    assert derived_from == [receipt]
+
+
+def test_customization_mutation_adapters_import_only_lifecycle_door() -> None:
+    service_path = REPO_ROOT / "core/customization_migration/service.py"
+    cli_path = REPO_ROOT / "core/customization_migration/cli.py"
+
+    assert _forbidden_mutator_references(service_path) == []
+    assert _forbidden_mutator_references(cli_path) == []
+    assert "from core.lifecycle import service as lifecycle_service" in (
+        service_path.read_text(encoding="utf-8")
+    )
+    assert "from core.customization_migration import service as migration_service" in (
+        cli_path.read_text(encoding="utf-8")
+    )
+
+
+def test_cli_stage_fails_closed_when_lifecycle_door_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault, candidate = _candidate_with_contract(tmp_path)
+    candidate_path = tmp_path / "candidate.json"
+    candidate_path.write_bytes(
+        migration_service.canonical_json_bytes(candidate.to_dict())
+    )
+    preview = migration_service.preview_staging_to_dict(vault, candidate)
+    before = snapshot_vault(vault)
+    calls: list[tuple[object, ...]] = []
+
+    def refuse(*args: object, **kwargs: object) -> None:
+        calls.append((*args, kwargs))
+        raise PlanRejected("lifecycle rebuild staging refused")
+
+    monkeypatch.setattr(
+        lifecycle_service,
+        "execute_approved_rebuild_staging",
+        refuse,
+        raising=False,
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+
+    return_code = cli.run(
+        [
+            "stage",
+            str(candidate_path),
+            "--confirm-token",
+            str(preview["preview_sha256"]),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 2
+    assert calls
+    assert captured.err == ""
+    assert "could not complete safely" in captured.out
+    assert snapshot_vault(vault) == before

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import stat
@@ -255,3 +256,54 @@ def test_shipped_bridge_release_matches_transaction_resume_window() -> None:
     assert bridge.transaction_journal.previous_schema == PREVIOUS_SCHEMA_VERSION
     assert bridge.transaction_journal.minimum_resumable_schema == PREVIOUS_SCHEMA_VERSION
     assert bridge.transaction_journal.incompatible_action == "rollback-only"
+
+
+def test_lifecycle_1_1_callers_resolve_unchanged_operations() -> None:
+    """The 1.2 surface is additive: every 1.1 operation keeps its exact call shape."""
+    expected_signatures = {
+        "build_inventory_and_plan": "(vault_root: 'str | Path') -> 'dict[str, object]'",
+        "build_and_preview_adoption": (
+            "(vault_root: 'str | Path', release_root: 'str | Path', "
+            "requested_item_ids: 'Sequence[str]') -> 'dict[str, object]'"
+        ),
+        "execute_approved_adoption": (
+            "(vault_root: 'str | Path', release_root: 'str | Path', "
+            "preview: 'AdoptionPreview | Mapping[str, object]', "
+            "approved_token: 'str') -> 'dict[str, object]'"
+        ),
+        "rewind_adoption_by_receipt": (
+            "(vault_root: 'str | Path', "
+            "receipt: 'AdoptionReceipt | Mapping[str, object]', "
+            "acknowledgement_token: 'str') -> 'dict[str, object]'"
+        ),
+        "read_lifecycle_state": "(vault_root: 'str | Path') -> 'dict[str, object]'",
+        "build_and_preview_conflict_resolution": (
+            "(vault_root: 'str | Path', release_root: 'str | Path', "
+            "resolutions: 'Sequence[Mapping[str, object]]') -> 'dict[str, object]'"
+        ),
+        "execute_approved_conflict_resolution": (
+            "(vault_root: 'str | Path', release_root: 'str | Path', "
+            "preview: 'ConflictResolutionPreview | Mapping[str, object]', "
+            "approved_token: 'str') -> 'dict[str, object]'"
+        ),
+        "build_archive_removal_preview": (
+            "(vault_root: 'str | Path') -> 'dict[str, object]'"
+        ),
+        "execute_approved_archive_removal": (
+            "(vault_root: 'str | Path', approved_token: 'str') "
+            "-> 'dict[str, object]'"
+        ),
+        "build_and_preview_topology_migration": (
+            "(vault_root: 'str | Path') -> 'dict[str, object]'"
+        ),
+        "execute_approved_topology_migration": (
+            "(vault_root: 'str | Path', preview: 'Mapping[str, object]', "
+            "approved_token: 'str') -> 'dict[str, object]'"
+        ),
+    }
+
+    assert service.api_version == "1.2.0"
+    assert {
+        name: str(inspect.signature(getattr(service, name)))
+        for name in expected_signatures
+    } == expected_signatures

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -238,7 +238,7 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 def test_api_version_is_present_and_frozen_in_schema() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
-    assert service.api_version == "1.1.0"
+    assert service.api_version == "1.2.0"
     assert schema["properties"]["api_version"] == {"const": service.api_version}
 
 
@@ -256,14 +256,24 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
         "execute_approved_archive_removal",
         "build_and_preview_topology_migration",
         "execute_approved_topology_migration",
+        "execute_approved_rebuild_capsule",
+        "execute_approved_rebuild_staging",
+        "execute_approved_rebuild_verification",
+        "execute_approved_rebuild_activation",
+        "rewind_rebuild_activation_by_receipt",
+        "abandon_rebuild_capsule",
+        "recover_rebuild_transactions",
         "TopologyMigrationError",
     ]
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    assert list(schema["x-operations"])[-4:] == [
-        "build_archive_removal_preview",
-        "execute_approved_archive_removal",
-        "build_and_preview_topology_migration",
-        "execute_approved_topology_migration",
+    assert list(schema["x-operations"])[-7:] == [
+        "execute_approved_rebuild_capsule",
+        "execute_approved_rebuild_staging",
+        "execute_approved_rebuild_verification",
+        "execute_approved_rebuild_activation",
+        "rewind_rebuild_activation_by_receipt",
+        "abandon_rebuild_capsule",
+        "recover_rebuild_transactions",
     ]
     assert "version bump" in service.__doc__.lower()
     assert "bridge" in service.__doc__.lower()
@@ -279,7 +289,7 @@ def test_archive_removal_is_previewed_approved_and_receipted(tmp_path: Path) -> 
 
     preview = service.build_archive_removal_preview(vault)
 
-    assert preview["api_version"] == "1.1.0"
+    assert preview["api_version"] == "1.2.0"
     assert preview["preview"]["archive_relative"] == ".dex/pre-split-archive.git"
     assert preview["preview"]["size_bytes"] == len(b"ref: refs/heads/main\narchive bytes")
     assert preview["preview"]["retention"] == "one full release cycle after conversion"

--- a/core/tests/test_lifecycle_topology_migration.py
+++ b/core/tests/test_lifecycle_topology_migration.py
@@ -101,7 +101,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
 
     previewed = service.build_and_preview_topology_migration(vault)
 
-    assert previewed["api_version"] == "1.1.0"
+    assert previewed["api_version"] == "1.2.0"
     assert previewed["topology"] == "combined"
     assert previewed["preview"]["operation"] == "brain-vault-topology-migration"
     assert [
@@ -125,7 +125,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
     )
 
     assert (vault / "System/.dex/topology.json").is_file()
-    assert executed["api_version"] == "1.1.0"
+    assert executed["api_version"] == "1.2.0"
     assert executed["receipt"]["operation"] == "brain-vault-topology-migration"
     assert executed["receipt"]["topology_before"] == "combined"
     assert executed["receipt"]["topology_after"] == "post-split"


### PR DESCRIPTION
Closes the highest-severity structural finding on the shipped v1.76.0 rebuild feature (ruled ship-now-fix-this-week): the rebuild adapter reached the vault-mutation engine through a **second write door**, bypassing the repo's rule that every vault mutation enters through `core/lifecycle/service.py`.

## What changed
- Seven first-class, versioned rebuild operations added to the frozen lifecycle interface — capsule create/abandon, staging, verification sealing, activation, activation rewind, and a **rebuild-scoped recovery** (which also closes adversarial Serious #5: interrupted stage/activate/rewind can now be converged through the lifecycle service + CLI, previously reachable only in engine tests).
- Every mutating customization adapter is rerouted through them; the engine mutators are now internal (only lifecycle.service imports them). **No shim.**
- `api_version` 1.1.0 → 1.2.0 (purely additive) with the frozen contract, schema, and bridge updated.
- `cli.py` byte-unchanged, so existing CLI confirmation gates are exactly as before (does not touch the separate Blocker 1 / consent concern, owned elsewhere).

## Verification
- **Two independent adversarial reviews (fresh session): no blocker, no serious.** The second confirmed the door is closed (static + AST + empirical), all safety properties preserved, the recovery selector provably cannot touch adoption/update transactions, 1.2.0 backward-compatible, out-of-scope files byte-unchanged. Its two MINORs (evadeable AST guard; a needless post-commit read) are fixed here.
- **Real-vault rehearsal re-run through the EXACT shipped CLI path** on Dave's actual customizations: assess → preview → create → stage → verify → activate (wrote CLAUDE-custom.md byte-exact) → rewind (restored) → recover (correctly nothing to recover) — all green.
- Full suite 2,377 passed; load-bearing boundary guard + fail-closed test red-before/green-after; all gates green; ruff clean.

Ships as **v1.76.1** (quiet strengthening, no user-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSS5ozU6tnNYXmEKv5JLje