### PR TITLE
fix(connections): recover from the broker idle-exit race — kills the exit-1-instead-of-3 flake

### DIFF
--- a/core/integrations/connection-manager/broker-client.cjs
+++ b/core/integrations/connection-manager/broker-client.cjs
@@ -191,7 +191,14 @@ async function startBrokerSingleFlight() {
 }
 
 function isBrokerUnavailable(error) {
-  return error && (error.code === 'ENOENT' || error.code === 'ECONNREFUSED');
+  // EPIPE: the broker accepted our connection but idle-exited before our
+  // request bytes were parsed (an accepted socket only counts as broker
+  // activity once its request starts). The write failed, so the request was
+  // never processed — same recovery as a dead socket: spawn a fresh broker
+  // and send the request once more. Response-side failures (e.g. ECONNRESET
+  // after the request was delivered) stay non-retriable: the broker may have
+  // executed a mutating op.
+  return error && (error.code === 'ENOENT' || error.code === 'ECONNREFUSED' || error.code === 'EPIPE');
 }
 
 async function brokerRequest({ op = 'rendered', connId, targetOrigin, allowUnvetted, privileged: _privileged } = {}) {
@@ -211,4 +218,4 @@ async function brokerRequest({ op = 'rendered', connId, targetOrigin, allowUnvet
   return exchange(request);
 }
 
-module.exports = { brokerRequest, exitCodeForError, ensurePrivateRuntime };
+module.exports = { brokerRequest, exitCodeForError, ensurePrivateRuntime, isBrokerUnavailable };

--- a/core/integrations/connection-manager/broker-client.unavailable.test.cjs
+++ b/core/integrations/connection-manager/broker-client.unavailable.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Module-load env (before requiring the client) mirrors the other suites: keep
+// this file self-contained so it never reads or pollutes shared state.
+process.env.DEX_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-broker-unavailable-'));
+process.env.DEX_CM_RUNTIME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-broker-unavailable-rt-'));
+
+const { isBrokerUnavailable } = require('./broker-client.cjs');
+
+const withCode = (code) => Object.assign(new Error(code), { code });
+
+test('broker-unavailable classification triggers the spawn-and-resend recovery for pre-delivery failures only', () => {
+  // Pre-delivery failures — the request never reached a broker, so a fresh
+  // spawn + single resend is always safe:
+  assert.equal(isBrokerUnavailable(withCode('ENOENT')), true, 'no socket file');
+  assert.equal(isBrokerUnavailable(withCode('ECONNREFUSED')), true, 'nothing listening');
+  // EPIPE is the idle-exit race: the broker accepted the connection but closed
+  // before our request bytes were parsed (accepted sockets only count as
+  // activity once a request starts). Regression guard for the spurious
+  // exit-1 this caused in get-token under load.
+  assert.equal(isBrokerUnavailable(withCode('EPIPE')), true, 'accepted then idle-closed before delivery');
+
+  // Post-delivery / ambiguous failures must NOT be resent — the broker may
+  // have already executed a mutating operation (e.g. a token refresh):
+  assert.equal(isBrokerUnavailable(withCode('ECONNRESET')), false, 'may have executed');
+  assert.equal(isBrokerUnavailable(withCode('ETIMEDOUT')), false, 'may have executed');
+  assert.equal(isBrokerUnavailable(new Error('response exceeded 1 MiB.')), false, 'protocol errors are terminal');
+  assert.ok(!isBrokerUnavailable(undefined), 'no error object is never unavailable');
+});

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 233618,
-      "treeHash": "5a9554645841a8eaf1eb421d7621384d7167d19b3842c6e786c2d9ca2615108e",
+      "totalBytes": 234151,
+      "treeHash": "abc277623e475585b946f6321a7388cb2aeb3e621abfbea8e7f296cb628a52ec",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -21,8 +21,8 @@
         },
         {
           "path": "broker-client.cjs",
-          "bytes": 6636,
-          "sha256": "6cc6bcb45ba1983ce54a1bf60adeb959918c1e3287904437bfb50870eb037086"
+          "bytes": 7169,
+          "sha256": "e684e17121929817e361b28aa5773393a81e44f8f1e8049bf5f32b0f5743c09e"
         },
         {
           "path": "broker.cjs",


### PR DESCRIPTION
## Root cause (handed over from surface:48, investigated to ground truth)

**Not env pollution.** The `DEX_*` environment captured at the exact failure point contains only the four values `connections-contract.test.cjs` sets itself, and an immediate in-place retry exits 3 with the correct `token_file_corrupt` message.

**The real defect:** the broker counts an accepted connection as activity only once its request line is parsed (`broker.cjs` — `activity.begin()` fires in the data handler). The idle timer armed by the *previous* CLI call can therefore destroy a just-accepted socket before the client's request write lands → `write EPIPE` → `isBrokerUnavailable` didn't recognize it → the client's **existing** spawn-fresh-and-resend recovery never engaged → generic exit 1 instead of 3. Load widens the connect-to-write gap, which is why the full concurrent glob hits it and a solo run doesn't. Real consumers face the same race at the broker's 5-minute default idle.

## Fix

One classification line: EPIPE joins ENOENT/ECONNREFUSED as "broker unavailable". Resending is safe **specifically for EPIPE**: a failed write means the request was never delivered, and the broker's idle close only fires with zero requests in flight — so a destroyed socket provably carried no parsed request. Response-side failures (ECONNRESET/ETIMEDOUT) deliberately stay non-retriable — the broker may have executed a mutating op (e.g. token refresh). Unit test pins both directions of that contract.

The hardened invariant "idle shutdown destroys clients that never complete a request" (existing test) is untouched. No test assertion weakened; no test-level retry added.

## Evidence

- Pre-fix: ~4/20 full-glob runs failed at the corrupt-token assertion (deterministic on loaded machines).
- Post-fix: **24/25 full-glob runs clean** on a heavily loaded machine.
- One rare residual (1 occurrence, did not recur in 15 subsequent runs, stderr not captured) — suspected to be the broker dying *after* write delivery (reset/empty-response path, correctly non-retried). Closing it fully needs a broker-side protocol decision — an explicit "shutting down, retry" response to pre-request sockets during idle close, or accept-counts-as-activity with a bounded pre-request socket timeout. Both touch the hardened shutdown invariant, so they belong to the connection-manager security lane, not this PR.

Engine manifest regenerated (new export changes the file hash). All diff/security/contract gates green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZN2Tm3g6z3Hd85SPbv7Vw