### PR TITLE
feat: Dex Dashboard — one authored page for your whole Dex (all 4 phases)

### DIFF
--- a/.claude/skills/dex-dashboard/SKILL.md
+++ b/.claude/skills/dex-dashboard/SKILL.md
@@ -31,6 +31,16 @@ then read the whole object before writing anything about the user's Dex.
 
 ## 2. Author the session-owned content
 
+### Check the planning ladder FIRST
+
+Before writing anything, read the collected `rituals` section (daily plan, week plan,
+quarter goals, week priorities). Gaps in Dex's planning ladder outrank every other
+observation: a user who has never run a weekly plan or set quarter goals should hear
+that — warmly, with the evidence — before anything about meetings or tasks. If a ritual
+gap exists, at least one observation must name it, and the next-step suggestion should
+usually come from the ladder (e.g. a first `/week-plan`) unless something else is
+clearly more urgent.
+
 ### Dashboard Observation Quality Bar
 
 Write normally 2–3 short observation paragraphs, and fewer or none when the evidence is

--- a/.claude/skills/dex-dashboard/SKILL.md
+++ b/.claude/skills/dex-dashboard/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: dex-dashboard
+description: "A personal, local page showing how the user is using Dex, what stands out, and one evidence-backed next step. Use when the user says \"show my dashboard\", \"open my Dex dashboard\", \"how am I using Dex\", \"what does my Dex look like\", or \"my Dex stats\". Not for system health checks; use `dex-doctor`. Not for a chat list of unused features; use `dex-level-up`."
+---
+
+# /dex-dashboard — Your Dex at a Glance
+
+Build and open one private, local page from the user's real Dex data. Keep the page
+evidence-led: the renderer owns the layout; this session authors only the observations
+and one next step.
+
+## 1. Collect the dashboard data
+
+`VAULT_PATH` must point to an existing Dex vault. If it is unset or invalid, stop and
+ask for the vault path; never guess. Create one unique temporary directory so concurrent
+runs cannot collide:
+
+```bash
+DASHBOARD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/dex-dashboard.XXXXXX")"
+DASHBOARD_DATA="$DASHBOARD_TMP/data.json"
+DASHBOARD_OBSERVATIONS="$DASHBOARD_TMP/observations.json"
+DASHBOARD_HTML="$DASHBOARD_TMP/dex-dashboard.html"
+
+cd "$VAULT_PATH" && .venv/bin/python core/dashboard/collect.py --vault "$VAULT_PATH" --json > "$DASHBOARD_DATA" 2>/dev/null \
+  || python3 core/dashboard/collect.py --vault "$VAULT_PATH" --json > "$DASHBOARD_DATA"
+```
+
+If both collector attempts fail, say the dashboard data could not be collected and stop.
+Do not render a partial or invented page. Validate that `$DASHBOARD_DATA` is a JSON object,
+then read the whole object before writing anything about the user's Dex.
+
+## 2. Author the session-owned content
+
+### Dashboard Observation Quality Bar
+
+Write normally 2–3 short observation paragraphs, and fewer or none when the evidence is
+sparse. Every observation must cite a specific number, file, or event present in the
+collected data. Connect the evidence to what it means in plain “smart friend” language:
+warm, specific, jargon-free, and never scolding. Use absolute dates such as
+“July 27, 2026”; never use relative dates such as “today”, “recently”, or “last week”.
+
+Do not:
+
+- write generic praise such as “Great job using Dex!”
+- invent a metric; estimated hours saved are **FORBIDDEN**
+- make an observation that is not backed by a number, file, or event in the data
+- turn a zero into a trend when there is no analytics evidence
+- give more than one suggestion
+
+Choose exactly one next-best suggestion. Rank unchecked entries from
+`usage.features` against the user's `profile.role` and named `pillars`; choose the
+closest practical fit. The `try_prompt` must be ready to paste and must include real
+role, pillar, feature, count, or event details from this JSON—not placeholders or
+made-up context. If no unchecked feature exists, do not invent one: use a
+getting-started or reflection suggestion grounded in the available profile and counts.
+
+Write this exact JSON shape to `$DASHBOARD_OBSERVATIONS`:
+
+```json
+{
+  "observations": ["Evidence-backed paragraph.", "Evidence-backed paragraph."],
+  "suggestion": {
+    "title": "One concise next step",
+    "why": "Why this fits the user's real role, pillars, and usage.",
+    "try_prompt": "A paste-ready prompt built from the user's real data."
+  }
+}
+```
+
+Validate and re-read the observations JSON. Confirm there are no extra keys, no more
+than three observations, exactly one suggestion, and no claim unsupported by the
+collector JSON.
+
+## 3. Render, inspect, and open
+
+```bash
+cd "$VAULT_PATH" && .venv/bin/python core/dashboard/render.py \
+  --vault "$VAULT_PATH" \
+  --data "$DASHBOARD_DATA" \
+  --observations "$DASHBOARD_OBSERVATIONS" \
+  --out "$DASHBOARD_HTML" 2>/dev/null \
+  || python3 core/dashboard/render.py \
+  --vault "$VAULT_PATH" \
+  --data "$DASHBOARD_DATA" \
+  --observations "$DASHBOARD_OBSERVATIONS" \
+  --out "$DASHBOARD_HTML"
+```
+
+Read back the rendered HTML before claiming success. Confirm it is non-empty and contains
+the `Your Dex` title, every authored observation, and the one suggestion title. Then open it:
+
+```bash
+if command -v open >/dev/null 2>&1; then
+  open "$DASHBOARD_HTML"
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$DASHBOARD_HTML"
+else
+  echo "$DASHBOARD_HTML"
+fi
+```
+
+If no opener exists, give the user the local HTML path and say it could not be opened
+automatically. Keep the page on this machine; this skill has no sharing path.
+
+## 4. Compare with the previous snapshot
+
+After rendering, inspect only the last two lines of
+`System/.dex/dashboard/history.jsonl` with `tail -n 2`. If they are two valid snapshots,
+tell the user in one line what changed from the previous snapshot, citing the previous
+snapshot's absolute date and exact count differences. If fewer than two snapshots exist,
+say nothing about a trend. Never scan the full history for this comparison.
+
+## 5. Degrade truthfully
+
+- No fresh Doctor cache: do not infer health; the page will say “run /dex-doctor for a
+  fresh checkup”.
+- No `System/analytics_log.jsonl`: skip trend claims. A zero is not proof of no activity.
+- Empty or unconfigured vault: lean on getting-started framing and explicit zero counts;
+  never fabricate momentum, history, a role, or a pillar.
+- A collector section with an `error`: omit claims from that section and keep using
+  sections with valid evidence.
+
+## 6. Track usage silently
+
+After a successful render, read `System/usage_log.md`. If a matching unchecked checkbox
+for `Dex Dashboard` or `/dex-dashboard` exists, change only its `- [ ]` to `- [x]`.
+If no matching checkbox exists, do nothing and do not add one. Never announce this
+tracking update to the user.

--- a/.claude/skills/dex-dashboard/SKILL.md
+++ b/.claude/skills/dex-dashboard/SKILL.md
@@ -64,6 +64,14 @@ role, pillar, feature, count, or event details from this JSON—not placeholders
 made-up context. If no unchecked feature exists, do not invent one: use a
 getting-started or reflection suggestion grounded in the available profile and counts.
 
+Then pick 3–5 unused skills worth recommending — "picked for you", shown on the Journey
+tab. Same evidence bar as observations: each `why` must connect the skill to something
+real in this JSON (their role, a pillar by name, a ritual gap, a count, an integration).
+"Great for staying organized" fails the bar; "You have 64 person pages and 28 meetings
+with external people — `/relationship-radar` tells you who's going cold" passes. Prefer
+skills adjacent to what they already do; never recommend a skill the data shows they
+already use.
+
 Write this exact JSON shape to `$DASHBOARD_OBSERVATIONS`:
 
 ```json
@@ -73,13 +81,16 @@ Write this exact JSON shape to `$DASHBOARD_OBSERVATIONS`:
     "title": "One concise next step",
     "why": "Why this fits the user's real role, pillars, and usage.",
     "try_prompt": "A paste-ready prompt built from the user's real data."
-  }
+  },
+  "skill_picks": [
+    {"skill": "week-plan", "why": "One sentence grounded in this user's real data."}
+  ]
 }
 ```
 
 Validate and re-read the observations JSON. Confirm there are no extra keys, no more
-than three observations, exactly one suggestion, and no claim unsupported by the
-collector JSON.
+than three observations, exactly one suggestion, at most five skill picks, and no claim
+unsupported by the collector JSON.
 
 ## 3. Render, inspect, and open
 

--- a/.claude/skills/dex-dashboard/SKILL.md
+++ b/.claude/skills/dex-dashboard/SKILL.md
@@ -102,6 +102,22 @@ fi
 If no opener exists, give the user the local HTML path and say it could not be opened
 automatically. Keep the page on this machine; this skill has no sharing path.
 
+## 3b. Interactive settings (only when asked)
+
+If the user asked to *change* settings ("open my settings", "let me toggle things",
+"interactive dashboard"), render with `--with-settings` added to the render command, then
+start the temporary local server and tell the user the page will close itself:
+
+```bash
+cd "$VAULT_PATH" && { .venv/bin/python core/dashboard/server.py --vault "$VAULT_PATH" --html "$DASHBOARD_HTML" --idle-timeout 900 2>/dev/null \
+  || python3 core/dashboard/server.py --vault "$VAULT_PATH" --html "$DASHBOARD_HTML" --idle-timeout 900; } &
+```
+
+Say one line: the settings page opened in the browser, changes save instantly to their
+Dex files, and the page shuts itself down when closed (or after 15 quiet minutes).
+Nothing keeps running afterwards. For a plain "show my dashboard", do NOT start the
+server — the static page has no settings panel.
+
 ## 4. Compare with the previous snapshot
 
 After rendering, inspect only the last two lines of

--- a/.claude/skills/dex-whats-new/SKILL.md
+++ b/.claude/skills/dex-whats-new/SKILL.md
@@ -414,6 +414,7 @@ Then proceed with first-run behavior.
 
 - `/dex-improve` — Full design partner (includes this + workshopping + audit)
 - `/create-mcp` — Build new integrations when new MCP features enable them
+- `/dex-dashboard` — See what's new alongside what you actually use, on one page
 
 ## Track Usage (Silent)
 

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -775,6 +775,7 @@ At EVERY major decision point:
 - "Want to explore on your own first? That's cool"
 
 After full tour:
+- "Want to see everything you now own on one page? Run `/dex-dashboard`"
 - "Remember - invoke `/dex-level-up` to discover more"
 - "Or `/integrate-mcp` to add tools as you need them"
 - "The system grows with you"

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -467,6 +467,7 @@ After synthesis:
 2. Archive completed items
 3. Update project pages with status changes
 4. Offer to run `/week-plan` for next week
+5. Offer once, lightly: "Want your Dex Dashboard refreshed with this week folded in? (`/dex-dashboard`)" — skip the offer entirely if the user has never run `/dex-dashboard`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.80.0] — 🪞 Meet your Dex Dashboard — one page that shows you your whole Dex (2026-07-28)
+
+Until now, everything Dex knew about you lived in files and chat. There was no *place* — nowhere to see what you own, what it's doing for you, and what to try next. Say "show my dashboard" (or run `/dex-dashboard`) and Dex builds you one: a private page, created fresh on your machine each time, that never leaves it.
+
+**What's on the page:**
+
+* **A value receipt, in real numbers only.** "68 meetings turned into notes. 64 people remembered. 4 tasks closed this week." Nothing estimated, nothing inflated — just what Dex actually held onto for you.
+* **Observations written by Dex, about your Dex.** Not canned stats — each time the page is built, Dex reads your actual data and writes two or three short, honest observations. Every one has to cite a real number, file, or event from your vault; if there's nothing specific to say, it says less rather than vaguer.
+* **One next step, not forty.** Dex picks a single suggestion that fits your role and how you already work, with a ready-to-use prompt built from your real data — copy it, paste it, done.
+* **A map of everything you could be using** — lit up where you've been, dim where you haven't.
+* **Change settings by clicking.** Ask for your settings ("let me toggle things") and the page becomes interactive: flip analytics, communication style, or an integration on the page and it saves straight to your Dex files, with a one-click undo. The helper behind it exists only while the page is open — it shuts itself down when you close the tab and nothing keeps running afterwards. Only a short, vetted list of safe settings can be changed this way, and each change is checked before it's written so a click can't damage your files.
+* **Your history, compounding.** Every time the page is built, Dex saves a small private snapshot. Over weeks that becomes trend lines, "then vs now" moments, and the occasional milestone worth a quiet ✦ — one thousand tasks closed, a year with Dex.
+
+Your weekly review and the getting-started tour now offer the page at natural moments, and it never nags — it only appears when you ask.
+
 ## [1.79.0] — 📋 Your meetings get dealt with without you asking (2026-07-28)
 
 Your meetings did arrive in Dex on their own — but turning them into something useful (updated pages for the people you met, tasks from what you agreed to do, tidy notes) still waited for you to ask. If you never asked, meetings quietly piled up half-done. The docs promised meetings "flow in on their own" — this release makes that promise true.

--- a/core/dashboard/__init__.py
+++ b/core/dashboard/__init__.py
@@ -1,0 +1,3 @@
+"""Deterministic local data and HTML engines for the Dex Dashboard."""
+
+__all__ = ["collect", "render"]

--- a/core/dashboard/collect.py
+++ b/core/dashboard/collect.py
@@ -27,17 +27,20 @@ from core.paths import (
     COMPANIES_DIR,
     COMPANY_INDEX_FILE,
     INTEGRATION_CONFIG_FILE,
+    MCP_CONFIG_TARGET,
     MEETING_CACHE_FILE,
     MEETINGS_DIR,
     PEOPLE_DIR,
     PEOPLE_INDEX_FILE,
     PILLARS_FILE,
     PROJECTS_DIR,
+    QUARTER_GOALS_FILE,
     SKILL_RATINGS_FILE,
     SYSTEM_DIR,
     TASKS_FILE,
     USER_PROFILE_FILE,
     VAULT_ROOT,
+    WEEK_PRIORITIES_FILE,
 )
 
 COLLECTOR_VERSION = "1"
@@ -47,6 +50,45 @@ TASK_DONE = re.compile(r"^\s*-\s+\[[xX]\]", re.MULTILINE)
 COMPLETION_STAMP = re.compile(r"✅\s*(\d{4}-\d{2}-\d{2})\s+\d{2}:\d{2}")
 DATE_FRAGMENT = re.compile(r"(?<!\d)(\d{4})[-_](\d{2})[-_](\d{2})(?!\d)")
 SKILL_COMMAND = re.compile(r"/([a-z0-9][a-z0-9-]*)", re.IGNORECASE)
+GRANOLA_ENV_LINE = re.compile(r"^\s*(?:export\s+)?GRANOLA_API_KEY\s*=")
+EVENT_SUFFIXES = ("_completed", "_viewed", "_started", "_rated")
+EVENT_SKILL_NAMES = {
+    "daily_plan": "daily-plan",
+    "daily_review": "daily-review",
+    "week_plan": "week-plan",
+    "week_review": "week-review",
+    "quarter_plan": "quarter-plan",
+    "quarter_review": "quarter-review",
+    "meeting_prep": "meeting-prep",
+    "process_meetings": "process-meetings",
+    "whats_new": "dex-whats-new",
+    "level_up": "dex-level-up",
+    "career_coach": "career-coach",
+}
+QUARTER_GOALS_BLANK_TEMPLATE = (
+    "# Quarter Goals\n\n"
+    "This file is provisioned only when the Quarter Goals room is enabled."
+)
+WEEK_PRIORITIES_TEMPLATE_PROSE = {
+    "The most important outcomes for this week. Everything else is secondary.",
+    "How does this week's work align to your strategic pillars?",
+    "Tasks from last week that still need attention:",
+}
+WEEK_PRIORITIES_TEMPLATE_TABLE_CELLS = {
+    "balance",
+    "day",
+    "fri",
+    "meeting",
+    "mon",
+    "pillar",
+    "prep needed",
+    "tasks/focus",
+    "thu",
+    "time",
+    "tue",
+    "wed",
+    "⬜",
+}
 
 
 def _short_error(error: Exception) -> str:
@@ -227,6 +269,75 @@ def _collect_integrations(vault: Path) -> dict[str, Any]:
     }
 
 
+def _mcp_server_names(vault: Path) -> tuple[list[str], bool]:
+    path = _at(vault, MCP_CONFIG_TARGET)
+    if not path.is_file():
+        return [], False
+    try:
+        config = _read_json(path)
+    except (OSError, json.JSONDecodeError):
+        return [], False
+    servers = _mapping(_mapping(config).get("mcpServers"))
+    names = sorted(
+        name
+        for raw_name in servers
+        if (name := str(raw_name).strip())
+    )
+    return names, True
+
+
+def _env_file_has_granola_key(vault: Path) -> bool:
+    path = vault / ".env"
+    if not path.is_file():
+        return False
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            return any(
+                GRANOLA_ENV_LINE.match(line) is not None
+                for line in handle
+                if not line.lstrip().startswith("#")
+            )
+    except OSError:
+        return False
+
+
+def _collect_connections(vault: Path, integrations: Any) -> dict[str, Any]:
+    sources: list[str] = []
+    dex_integrations_on = 0
+    config_path = _at(vault, INTEGRATION_CONFIG_FILE)
+    if (
+        config_path.is_file()
+        and isinstance(integrations, dict)
+        and "error" not in integrations
+        and isinstance(integrations.get("enabled_count"), int)
+    ):
+        dex_integrations_on = integrations["enabled_count"]
+        sources.append("integrations config")
+
+    mcp_servers, mcp_readable = _mcp_server_names(vault)
+    if mcp_readable:
+        sources.append(".mcp.json")
+
+    granola_key_present = (
+        "GRANOLA_API_KEY" in os.environ
+        or _env_file_has_granola_key(vault)
+    )
+    sources.append("environment")
+    mcp_count = len(mcp_servers)
+    return {
+        "mcp_servers": mcp_servers,
+        "mcp_count": mcp_count,
+        "dex_integrations_on": dex_integrations_on,
+        "granola_key_present": granola_key_present,
+        "total_connected": (
+            mcp_count
+            + dex_integrations_on
+            + int(granola_key_present)
+        ),
+        "sources": sources,
+    }
+
+
 @contextmanager
 def _vault_environment(vault: Path) -> Iterator[None]:
     previous = os.environ.get("VAULT_PATH")
@@ -279,16 +390,29 @@ def _week_labels(now: datetime) -> list[str]:
     return labels
 
 
+def _normalize_skill_reference(value: str) -> str:
+    return value.strip().lower().lstrip("/").replace("_", "-")
+
+
+def _event_skill_name(value: str) -> str:
+    normalized = value.strip().lower().lstrip("/").replace("-", "_")
+    for suffix in EVENT_SUFFIXES:
+        if normalized.endswith(suffix):
+            normalized = normalized.removesuffix(suffix)
+            break
+    return EVENT_SKILL_NAMES.get(normalized, normalized.replace("_", "-"))
+
+
 def _event_skill_names(entry: dict[str, Any]) -> set[str]:
     names = set()
     event = entry.get("event") or entry.get("event_name")
     if isinstance(event, str):
-        names.add(event.strip().lower().replace("_", "-"))
+        names.add(_event_skill_name(event))
     properties = _mapping(entry.get("properties"))
     for key in ("skill_name", "skill"):
         value = properties.get(key)
         if isinstance(value, str):
-            names.add(value.strip().lower().lstrip("/").replace("_", "-"))
+            names.add(_normalize_skill_reference(value))
     return {name for name in names if name}
 
 
@@ -377,7 +501,25 @@ def _markdown_files(root: Path) -> list[Path]:
     )
 
 
+def _people_from_filesystem(vault: Path, source: str) -> dict[str, Any]:
+    root = _at(vault, PEOPLE_DIR)
+    files = _markdown_files(root)
+    internal = 0
+    external = 0
+    for path in files:
+        parts = {part.casefold() for part in path.relative_to(root).parts}
+        internal += "internal" in parts
+        external += "external" in parts
+    return {
+        "total": len(files),
+        "internal": internal,
+        "external": external,
+        "source": source,
+    }
+
+
 def _collect_people(vault: Path) -> dict[str, Any]:
+    filesystem = _people_from_filesystem(vault, "filesystem")
     index_path = _at(vault, PEOPLE_INDEX_FILE)
     if index_path.is_file():
         try:
@@ -385,6 +527,9 @@ def _collect_people(vault: Path) -> dict[str, Any]:
             people = index.get("people", []) if isinstance(index, dict) else []
             total = index.get("total") if isinstance(index, dict) else None
             if isinstance(total, int) and total >= 0 and isinstance(people, list):
+                if filesystem["total"] > total:
+                    filesystem["source"] = "filesystem (index stale)"
+                    return filesystem
                 internal = 0
                 external = 0
                 for person in people:
@@ -400,20 +545,7 @@ def _collect_people(vault: Path) -> dict[str, Any]:
                 }
         except (OSError, json.JSONDecodeError):
             pass
-    root = _at(vault, PEOPLE_DIR)
-    files = _markdown_files(root)
-    internal = 0
-    external = 0
-    for path in files:
-        parts = {part.casefold() for part in path.relative_to(root).parts}
-        internal += "internal" in parts
-        external += "external" in parts
-    return {
-        "total": len(files),
-        "internal": internal,
-        "external": external,
-        "source": "filesystem",
-    }
+    return filesystem
 
 
 def _collect_companies(vault: Path) -> dict[str, Any]:
@@ -574,6 +706,155 @@ def _collect_ratings(vault: Path) -> dict[str, dict[str, float | int]]:
     }
 
 
+def _ritual_usage_evidence(
+    skill_name: str,
+    usage: Any,
+    analytics: Any,
+) -> dict[str, bool | str]:
+    if isinstance(usage, dict):
+        for feature, used in _mapping(usage.get("features")).items():
+            if not used:
+                continue
+            commands = {
+                _normalize_skill_reference(command)
+                for command in SKILL_COMMAND.findall(str(feature))
+            }
+            if skill_name in commands:
+                return {
+                    "used": True,
+                    "evidence": f"usage_log.md marks /{skill_name} used",
+                }
+    if isinstance(analytics, dict):
+        for event_name, count in _mapping(analytics.get("by_event")).items():
+            if (
+                isinstance(event_name, str)
+                and isinstance(count, int)
+                and count > 0
+                and _event_skill_name(event_name) == skill_name
+            ):
+                return {
+                    "used": True,
+                    "evidence": f"analytics event {event_name}",
+                }
+        used_names = {
+            _normalize_skill_reference(name)
+            for name in analytics.get("skill_names_used", [])
+            if isinstance(name, str)
+        }
+        if skill_name in used_names:
+            return {
+                "used": True,
+                "evidence": f"analytics recorded /{skill_name}",
+            }
+    return {
+        "used": False,
+        "evidence": "no usage or analytics event found",
+    }
+
+
+def _normalized_markdown(content: str) -> str:
+    return "\n".join(line.rstrip() for line in content.splitlines()).strip()
+
+
+def _quarter_goals_set(vault: Path) -> bool:
+    path = _at(vault, QUARTER_GOALS_FILE)
+    if not path.is_file():
+        return False
+    content = _normalized_markdown(
+        path.read_text(encoding="utf-8", errors="replace")
+    )
+    return content not in {
+        "",
+        "# Quarter Goals",
+        QUARTER_GOALS_BLANK_TEMPLATE,
+    }
+
+
+def _table_has_week_priority_content(line: str) -> bool:
+    cells = [
+        cell.strip()
+        for cell in line.strip("|").split("|")
+        if cell.strip()
+    ]
+    for cell in cells:
+        lowered = cell.casefold()
+        if re.fullmatch(r":?-{2,}:?", cell):
+            continue
+        if lowered in WEEK_PRIORITIES_TEMPLATE_TABLE_CELLS:
+            continue
+        if re.fullmatch(r"pillar\s+\d+", lowered):
+            continue
+        return True
+    return False
+
+
+def _week_priorities_set(vault: Path) -> bool:
+    path = _at(vault, WEEK_PRIORITIES_FILE)
+    if not path.is_file():
+        return False
+    content = path.read_text(encoding="utf-8", errors="replace")
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line == "---":
+            continue
+        if line.startswith("**Week of:**"):
+            week = line.partition(":")[2].strip("* ")
+            if week and "{{" not in week and "[" not in week:
+                return True
+            continue
+        numbered = re.fullmatch(r"\d+\.\s*(.*)", line)
+        if numbered is not None:
+            if numbered.group(1).strip():
+                return True
+            continue
+        checkbox = re.fullmatch(r"-\s+\[[ xX]\]\s*(.*)", line)
+        if checkbox is not None:
+            if checkbox.group(1).strip():
+                return True
+            continue
+        bullet = re.fullmatch(r"-\s*(.*)", line)
+        if bullet is not None:
+            if bullet.group(1).strip():
+                return True
+            continue
+        if line.startswith("|"):
+            if _table_has_week_priority_content(line):
+                return True
+            continue
+        if line.startswith("*") and line.endswith("*"):
+            continue
+        if line in WEEK_PRIORITIES_TEMPLATE_PROSE:
+            continue
+        return True
+    return False
+
+
+def _collect_rituals(vault: Path, usage: Any, analytics: Any) -> dict[str, Any]:
+    quarter_goals_set = _quarter_goals_set(vault)
+    week_priorities_set = _week_priorities_set(vault)
+    return {
+        "daily_plan": _ritual_usage_evidence("daily-plan", usage, analytics),
+        "week_plan": _ritual_usage_evidence("week-plan", usage, analytics),
+        "week_review": _ritual_usage_evidence("week-review", usage, analytics),
+        "quarter_goals": {
+            "set": quarter_goals_set,
+            "evidence": (
+                "Quarter_Goals.md differs from blank template"
+                if quarter_goals_set
+                else "Quarter_Goals.md is missing or still blank"
+            ),
+        },
+        "week_priorities": {
+            "set": week_priorities_set,
+            "evidence": (
+                "Week_Priorities.md contains priorities"
+                if week_priorities_set
+                else "Week_Priorities.md has no priorities"
+            ),
+        },
+    }
+
+
 def _collect_skills(
     vault: Path,
     skills_list: Path | None,
@@ -582,6 +863,7 @@ def _collect_skills(
 ) -> dict[str, Any]:
     available = _load_skills_list(skills_list)
     detected: set[str] = set()
+    ratings = _collect_ratings(vault)
     if isinstance(usage, dict):
         for feature, used in _mapping(usage.get("features")).items():
             if not used:
@@ -589,10 +871,11 @@ def _collect_skills(
             detected.update(command.lower() for command in SKILL_COMMAND.findall(str(feature)))
     if isinstance(analytics, dict):
         detected.update(
-            str(name).lower().lstrip("/").replace("_", "-")
+            _normalize_skill_reference(name)
             for name in analytics.get("skill_names_used", [])
             if isinstance(name, str)
         )
+    detected.update(_normalize_skill_reference(name) for name in ratings)
     if available:
         used = sorted(set(available).intersection(detected))
     else:
@@ -601,7 +884,7 @@ def _collect_skills(
         "available": available,
         "used": used,
         "unused": sorted(set(available) - set(used)),
-        "ratings": _collect_ratings(vault),
+        "ratings": ratings,
     }
 
 
@@ -645,6 +928,7 @@ def collect_dashboard(
     vault_path = Path(vault).expanduser().resolve()
     generated = (now or _utc_now()).astimezone(timezone.utc)
     skills_path = Path(skills_list).expanduser().resolve() if skills_list is not None else None
+    integrations = _safe(lambda: _collect_integrations(vault_path))
     usage = _safe(lambda: _collect_usage(vault_path))
     analytics = _safe(lambda: _collect_analytics(vault_path, generated))
     return {
@@ -656,7 +940,9 @@ def collect_dashboard(
         },
         "profile": _safe(lambda: _collect_profile(vault_path)),
         "pillars": _safe(lambda: _collect_pillars(vault_path)),
-        "integrations": _safe(lambda: _collect_integrations(vault_path)),
+        "integrations": integrations,
+        "connections": _safe(lambda: _collect_connections(vault_path, integrations)),
+        "rituals": _safe(lambda: _collect_rituals(vault_path, usage, analytics)),
         "usage": usage,
         "analytics": analytics,
         "tasks": _safe(lambda: _collect_tasks(vault_path, generated)),

--- a/core/dashboard/collect.py
+++ b/core/dashboard/collect.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Collect read-only, privacy-safe data for the local Dex Dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+try:
+    import yaml
+except ImportError:  # Bare system Python is a supported degraded runtime.
+    yaml = None
+
+from core.mcp.analytics_helper import calculate_journey_metadata, load_usage_log
+from core.paths import (
+    COMPANIES_DIR,
+    COMPANY_INDEX_FILE,
+    INTEGRATION_CONFIG_FILE,
+    MEETING_CACHE_FILE,
+    MEETINGS_DIR,
+    PEOPLE_DIR,
+    PEOPLE_INDEX_FILE,
+    PILLARS_FILE,
+    PROJECTS_DIR,
+    SKILL_RATINGS_FILE,
+    SYSTEM_DIR,
+    TASKS_FILE,
+    USER_PROFILE_FILE,
+    VAULT_ROOT,
+)
+
+COLLECTOR_VERSION = "1"
+SECRET_KEY = re.compile(r"(api_key|token|secret|password|credential|key$)", re.IGNORECASE)
+TASK_ID = re.compile(r"\^task-\d{8}-\d{3}\b")
+TASK_DONE = re.compile(r"^\s*-\s+\[[xX]\]", re.MULTILINE)
+COMPLETION_STAMP = re.compile(r"✅\s*(\d{4}-\d{2}-\d{2})\s+\d{2}:\d{2}")
+DATE_FRAGMENT = re.compile(r"(?<!\d)(\d{4})[-_](\d{2})[-_](\d{2})(?!\d)")
+SKILL_COMMAND = re.compile(r"/([a-z0-9][a-z0-9-]*)", re.IGNORECASE)
+
+
+def _short_error(error: Exception) -> str:
+    message = str(error).strip().splitlines()[0] if str(error).strip() else error.__class__.__name__
+    return message[:160]
+
+
+def _safe(collector: Callable[[], Any]) -> Any:
+    try:
+        return collector()
+    except Exception as error:
+        return {"error": _short_error(error)}
+
+
+def _at(vault: Path, configured_path: Path) -> Path:
+    """Rebase a core.paths constant from its configured vault onto this invocation."""
+    return vault / configured_path.relative_to(VAULT_ROOT)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if yaml is None:
+        raise RuntimeError("pyyaml unavailable")
+    try:
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except OSError as error:
+        raise RuntimeError("yaml could not be read") from error
+    except yaml.YAMLError as error:
+        raise ValueError("yaml could not be parsed") from error
+    if not isinstance(parsed, dict):
+        raise ValueError("yaml root must be an object")
+    return parsed
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _bool_mapping(value: Any, keys: tuple[str, ...]) -> dict[str, bool]:
+    source = _mapping(value)
+    return {key: source[key] for key in keys if isinstance(source.get(key), bool)}
+
+
+def _collect_profile(vault: Path) -> dict[str, Any]:
+    path = _at(vault, USER_PROFILE_FILE)
+    if not path.is_file():
+        return {
+            "status": "not configured",
+            "name": "",
+            "role": "",
+            "company": "",
+            "communication": {},
+            "analytics": {"enabled": None},
+            "entity_creation": {},
+            "journaling": {},
+            "quarterly_planning": {"enabled": None},
+        }
+    profile = _load_yaml(path)
+    capabilities = _mapping(profile.get("capabilities"))
+    quarter_room = _mapping(capabilities.get("quarter_goals"))
+    legacy_quarter = _mapping(profile.get("quarterly_planning"))
+    quarter_enabled = quarter_room.get("enabled")
+    if not isinstance(quarter_enabled, bool):
+        quarter_enabled = legacy_quarter.get("enabled")
+    if not isinstance(quarter_enabled, bool):
+        quarter_enabled = None
+    return {
+        "status": "configured",
+        "name": str(profile.get("name") or ""),
+        "role": str(profile.get("role") or ""),
+        "company": str(profile.get("company") or ""),
+        "communication": _bool_or_scalar_preferences(profile.get("communication")),
+        "analytics": {"enabled": _mapping(profile.get("analytics")).get("enabled")},
+        "entity_creation": _selected_mapping(profile.get("entity_creation"), ("mode",)),
+        "journaling": _bool_mapping(profile.get("journaling"), ("morning", "evening", "weekly")),
+        "quarterly_planning": {"enabled": quarter_enabled},
+    }
+
+
+def _bool_or_scalar_preferences(value: Any) -> dict[str, Any]:
+    source = _mapping(value)
+    keys = ("formality", "directness", "detail_level", "career_level", "coaching_style")
+    return {key: source[key] for key in keys if isinstance(source.get(key), (str, bool, int, float))}
+
+
+def _selected_mapping(value: Any, keys: tuple[str, ...]) -> dict[str, Any]:
+    source = _mapping(value)
+    return {key: source[key] for key in keys if isinstance(source.get(key), (str, bool, int, float))}
+
+
+def _collect_pillars(vault: Path) -> list[dict[str, str]]:
+    path = _at(vault, PILLARS_FILE)
+    if not path.is_file():
+        return []
+    raw = _load_yaml(path).get("pillars", [])
+    if not isinstance(raw, list):
+        raise ValueError("pillars must be a list")
+    pillars = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        pillars.append(
+            {
+                "id": str(item.get("id") or ""),
+                "name": str(item.get("name") or ""),
+                "description": str(item.get("description") or ""),
+            }
+        )
+    return pillars
+
+
+def _redact_secrets(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _redact_secrets(item)
+            for key, item in value.items()
+            if not SECRET_KEY.search(str(key))
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(item) for item in value]
+    return value
+
+
+def _json_scalar(value: Any) -> Any:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, (str, bool, int, float)) or value is None:
+        return value
+    return str(value)
+
+
+def _flatten_boolean_features(value: Any, prefix: str = "") -> dict[str, bool]:
+    result: dict[str, bool] = {}
+    if not isinstance(value, dict):
+        return result
+    for key, item in value.items():
+        label = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(item, bool):
+            result[label] = item
+        elif isinstance(item, dict):
+            result.update(_flatten_boolean_features(item, label))
+    return result
+
+
+def _collect_integrations(vault: Path) -> dict[str, Any]:
+    path = _at(vault, INTEGRATION_CONFIG_FILE)
+    if not path.is_file():
+        return {"apps": {}, "enabled_count": 0}
+    config = _redact_secrets(_load_yaml(path))
+    enabled = _mapping(config.get("enabled"))
+    reserved = {"enabled", "hooks", "detected", "last_updated"}
+    app_names = {str(name) for name in enabled}
+    for name, value in config.items():
+        if name not in reserved and isinstance(value, dict):
+            if any(key in value for key in ("enabled", "configured_at", "features")):
+                app_names.add(str(name))
+
+    hooks = _mapping(config.get("hooks"))
+    apps: dict[str, dict[str, Any]] = {}
+    for app_name in sorted(app_names):
+        details = _mapping(config.get(app_name))
+        is_enabled = enabled.get(app_name, details.get("enabled", False))
+        features = _flatten_boolean_features(details.get("features"))
+        for hook_name, hook_config in hooks.items():
+            if not isinstance(hook_config, dict):
+                continue
+            for key, flag in hook_config.items():
+                if isinstance(flag, bool) and key in {app_name, f"use_{app_name}", f"{app_name}_enabled"}:
+                    features[str(hook_name)] = flag
+        app: dict[str, Any] = {"enabled": bool(is_enabled)}
+        if "configured_at" in details:
+            app["configured_at"] = _json_scalar(details["configured_at"])
+        if features:
+            app["features"] = dict(sorted(features.items()))
+        apps[app_name] = app
+    return {
+        "apps": apps,
+        "enabled_count": sum(1 for app in apps.values() if app["enabled"]),
+    }
+
+
+@contextmanager
+def _vault_environment(vault: Path) -> Iterator[None]:
+    previous = os.environ.get("VAULT_PATH")
+    os.environ["VAULT_PATH"] = str(vault)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("VAULT_PATH", None)
+        else:
+            os.environ["VAULT_PATH"] = previous
+
+
+def _collect_usage(vault: Path) -> dict[str, Any]:
+    with _vault_environment(vault):
+        raw = load_usage_log()
+        journey = calculate_journey_metadata()
+    features = _mapping(raw.get("features"))
+    normalized = {str(name): bool(used) for name, used in sorted(features.items())}
+    return {
+        "features": normalized,
+        "metadata": _mapping(raw.get("metadata")),
+        "counts": {
+            "available": len(normalized),
+            "used": sum(normalized.values()),
+        },
+        "journey": journey,
+    }
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _week_labels(now: datetime) -> list[str]:
+    monday = now.date() - timedelta(days=now.weekday())
+    labels = []
+    for weeks_ago in range(11, -1, -1):
+        day = monday - timedelta(weeks=weeks_ago)
+        iso = day.isocalendar()
+        labels.append(f"{iso.year}-W{iso.week:02d}")
+    return labels
+
+
+def _event_skill_names(entry: dict[str, Any]) -> set[str]:
+    names = set()
+    event = entry.get("event") or entry.get("event_name")
+    if isinstance(event, str):
+        names.add(event.strip().lower().replace("_", "-"))
+    properties = _mapping(entry.get("properties"))
+    for key in ("skill_name", "skill"):
+        value = properties.get(key)
+        if isinstance(value, str):
+            names.add(value.strip().lower().lstrip("/").replace("_", "-"))
+    return {name for name in names if name}
+
+
+def _collect_analytics(vault: Path, now: datetime) -> dict[str, Any]:
+    path = _at(vault, SYSTEM_DIR) / "analytics_log.jsonl"
+    labels = _week_labels(now)
+    weekly = {label: 0 for label in labels}
+    by_event: Counter[str] = Counter()
+    total = 0
+    malformed = 0
+    skill_names: set[str] = set()
+    if not path.is_file():
+        return {
+            "total": 0,
+            "by_event": {},
+            "by_iso_week": weekly,
+            "malformed_lines": 0,
+            "skill_names_used": [],
+        }
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if not isinstance(entry, dict):
+                malformed += 1
+                continue
+            event = entry.get("event") or entry.get("event_name")
+            if not isinstance(event, str) or not event.strip():
+                malformed += 1
+                continue
+            total += 1
+            by_event[event.strip()] += 1
+            skill_names.update(_event_skill_names(entry))
+            timestamp = _parse_datetime(entry.get("timestamp") or entry.get("ts"))
+            if timestamp is not None:
+                iso = timestamp.date().isocalendar()
+                label = f"{iso.year}-W{iso.week:02d}"
+                if label in weekly:
+                    weekly[label] += 1
+    return {
+        "total": total,
+        "by_event": dict(sorted(by_event.items())),
+        "by_iso_week": weekly,
+        "malformed_lines": malformed,
+        "skill_names_used": sorted(skill_names),
+    }
+
+
+def _collect_tasks(vault: Path, now: datetime) -> dict[str, int]:
+    path = _at(vault, TASKS_FILE)
+    if not path.is_file():
+        return {"total": 0, "completed": 0, "completed_last_7_days": 0}
+    content = path.read_text(encoding="utf-8", errors="replace")
+    cutoff = now.date() - timedelta(days=6)
+    recent = 0
+    for stamp in COMPLETION_STAMP.findall(content):
+        try:
+            completed_on = date.fromisoformat(stamp)
+        except ValueError:
+            continue
+        if cutoff <= completed_on <= now.date():
+            recent += 1
+    return {
+        "total": len(TASK_ID.findall(content)),
+        "completed": len(TASK_DONE.findall(content)),
+        "completed_last_7_days": recent,
+    }
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _markdown_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in root.rglob("*.md")
+        if path.is_file() and path.name.casefold() != "readme.md"
+    )
+
+
+def _collect_people(vault: Path) -> dict[str, Any]:
+    index_path = _at(vault, PEOPLE_INDEX_FILE)
+    if index_path.is_file():
+        try:
+            index = _read_json(index_path)
+            people = index.get("people", []) if isinstance(index, dict) else []
+            total = index.get("total") if isinstance(index, dict) else None
+            if isinstance(total, int) and total >= 0 and isinstance(people, list):
+                internal = 0
+                external = 0
+                for person in people:
+                    path = str(person.get("path", "")) if isinstance(person, dict) else ""
+                    parts = {part.casefold() for part in Path(path).parts}
+                    internal += "internal" in parts
+                    external += "external" in parts
+                return {
+                    "total": total,
+                    "internal": internal,
+                    "external": external,
+                    "source": "index",
+                }
+        except (OSError, json.JSONDecodeError):
+            pass
+    root = _at(vault, PEOPLE_DIR)
+    files = _markdown_files(root)
+    internal = 0
+    external = 0
+    for path in files:
+        parts = {part.casefold() for part in path.relative_to(root).parts}
+        internal += "internal" in parts
+        external += "external" in parts
+    return {
+        "total": len(files),
+        "internal": internal,
+        "external": external,
+        "source": "filesystem",
+    }
+
+
+def _collect_companies(vault: Path) -> dict[str, Any]:
+    index_path = _at(vault, COMPANY_INDEX_FILE)
+    if index_path.is_file():
+        try:
+            index = _read_json(index_path)
+            total = index.get("total") if isinstance(index, dict) else None
+            companies = index.get("companies") if isinstance(index, dict) else None
+            if isinstance(total, int) and total >= 0 and isinstance(companies, list):
+                return {"total": total, "source": "index"}
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {
+        "total": len(_markdown_files(_at(vault, COMPANIES_DIR))),
+        "source": "filesystem",
+    }
+
+
+def _date_from_path(path: Path) -> date | None:
+    match = DATE_FRAGMENT.search(path.as_posix())
+    if match is None:
+        return None
+    try:
+        return date(*(int(part) for part in match.groups()))
+    except ValueError:
+        return None
+
+
+def _meeting_dates_from_cache(cache_path: Path) -> list[date | None]:
+    if not cache_path.is_file():
+        return []
+    try:
+        cache = _read_json(cache_path)
+    except (OSError, json.JSONDecodeError):
+        return []
+    meetings = cache.get("meetings", []) if isinstance(cache, dict) else []
+    if not isinstance(meetings, list):
+        return []
+    dates = []
+    for meeting in meetings:
+        raw = meeting.get("date") if isinstance(meeting, dict) else None
+        try:
+            dates.append(date.fromisoformat(raw) if isinstance(raw, str) else None)
+        except ValueError:
+            dates.append(None)
+    return dates
+
+
+def _collect_meetings(vault: Path, now: datetime) -> dict[str, int]:
+    root = _at(vault, MEETINGS_DIR)
+    files = _markdown_files(root)
+    meeting_dates: list[date | None] = []
+    for path in files:
+        dated = _date_from_path(path.relative_to(root))
+        if dated is None:
+            dated = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date()
+        meeting_dates.append(dated)
+    if not files:
+        meeting_dates = _meeting_dates_from_cache(_at(vault, MEETING_CACHE_FILE))
+    cutoff_7 = now.date() - timedelta(days=6)
+    cutoff_30 = now.date() - timedelta(days=29)
+    return {
+        "total": len(meeting_dates),
+        "last_7_days": sum(dated is not None and cutoff_7 <= dated <= now.date() for dated in meeting_dates),
+        "last_30_days": sum(dated is not None and cutoff_30 <= dated <= now.date() for dated in meeting_dates),
+    }
+
+
+def _collect_projects(vault: Path) -> dict[str, int]:
+    root = _at(vault, PROJECTS_DIR)
+    if not root.is_dir():
+        return {"total": 0, "directories": 0, "files": 0}
+    entries = [entry for entry in root.iterdir() if not entry.name.startswith(".")]
+    directories = sum(entry.is_dir() for entry in entries)
+    files = sum(entry.is_file() for entry in entries)
+    return {"total": directories + files, "directories": directories, "files": files}
+
+
+def _collect_health(vault: Path, now: datetime) -> dict[str, Any]:
+    path = _at(vault, SYSTEM_DIR) / ".doctor-last-run.json"
+    guidance = "run /dex-doctor for a fresh checkup"
+    if not path.is_file():
+        return {
+            "label": "cached dex-doctor check",
+            "status": "missing",
+            "guidance": guidance,
+        }
+    report = _read_json(path)
+    if not isinstance(report, dict):
+        raise ValueError("doctor cache must contain an object")
+    generated = _parse_datetime(report.get("generated_at"))
+    fresh = generated is not None and now - generated <= timedelta(days=7)
+    checks = []
+    for check in report.get("checks", []):
+        if not isinstance(check, dict):
+            continue
+        checks.append(
+            {
+                "id": str(check.get("id") or ""),
+                "feature": str(check.get("feature") or check.get("id") or "Unknown check"),
+                "verdict": str(check.get("verdict") or "UNKNOWN").upper(),
+            }
+        )
+    summary = {
+        key: value
+        for key, value in sorted(_mapping(report.get("summary")).items())
+        if key in {"ok", "off", "broken", "unknown"} and isinstance(value, int)
+    }
+    result: dict[str, Any] = {
+        "label": "cached dex-doctor check",
+        "status": "fresh" if fresh else "stale",
+        "generated_at": report.get("generated_at"),
+        "mode": str(report.get("mode") or "unknown"),
+        "checks": checks,
+        "summary": summary,
+    }
+    if not fresh:
+        result["guidance"] = guidance
+    return result
+
+
+def _load_skills_list(path: Path | None) -> list[str]:
+    if path is None:
+        return []
+    raw = _read_json(path)
+    if isinstance(raw, dict):
+        raw = raw.get("skills", [])
+    if not isinstance(raw, list):
+        raise ValueError("skills list must be a JSON list")
+    names = []
+    for item in raw:
+        name = item.get("name") if isinstance(item, dict) else item
+        if isinstance(name, str) and name.strip():
+            names.append(name.strip().lstrip("/"))
+    return sorted(set(names))
+
+
+def _collect_ratings(vault: Path) -> dict[str, dict[str, float | int]]:
+    path = _at(vault, SKILL_RATINGS_FILE)
+    scores: defaultdict[str, list[float]] = defaultdict(list)
+    if path.is_file():
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                skill = entry.get("skill")
+                rating = entry.get("rating")
+                if isinstance(skill, str) and isinstance(rating, (int, float)) and 1 <= rating <= 5:
+                    scores[skill].append(float(rating))
+    return {
+        skill: {"average": round(sum(values) / len(values), 1), "count": len(values)}
+        for skill, values in sorted(scores.items())
+    }
+
+
+def _collect_skills(
+    vault: Path,
+    skills_list: Path | None,
+    usage: Any,
+    analytics: Any,
+) -> dict[str, Any]:
+    available = _load_skills_list(skills_list)
+    detected: set[str] = set()
+    if isinstance(usage, dict):
+        for feature, used in _mapping(usage.get("features")).items():
+            if not used:
+                continue
+            detected.update(command.lower() for command in SKILL_COMMAND.findall(str(feature)))
+    if isinstance(analytics, dict):
+        detected.update(
+            str(name).lower().lstrip("/").replace("_", "-")
+            for name in analytics.get("skill_names_used", [])
+            if isinstance(name, str)
+        )
+    if available:
+        used = sorted(set(available).intersection(detected))
+    else:
+        used = sorted(detected)
+    return {
+        "available": available,
+        "used": used,
+        "unused": sorted(set(available) - set(used)),
+        "ratings": _collect_ratings(vault),
+    }
+
+
+def _collect_vault_age(vault: Path, now: datetime) -> dict[str, Any]:
+    candidates: list[date] = []
+    meetings_root = _at(vault, MEETINGS_DIR)
+    for path in _markdown_files(meetings_root):
+        dated = _date_from_path(path.relative_to(meetings_root))
+        if dated is not None:
+            candidates.append(dated)
+    projects_root = _at(vault, PROJECTS_DIR)
+    if projects_root.is_dir():
+        for path in projects_root.rglob("*"):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(projects_root)
+            if any(part.startswith(".") for part in relative.parts):
+                continue
+            candidates.append(datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date())
+    if not candidates:
+        return {"status": "unknown"}
+    started = min(candidates)
+    return {
+        "status": "known",
+        "started_on": started.isoformat(),
+        "age_days": max(0, (now.date() - started).days),
+    }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def collect_dashboard(
+    vault: Path | str,
+    *,
+    skills_list: Path | str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Collect every dashboard section independently so one messy file cannot abort it."""
+    vault_path = Path(vault).expanduser().resolve()
+    generated = (now or _utc_now()).astimezone(timezone.utc)
+    skills_path = Path(skills_list).expanduser().resolve() if skills_list is not None else None
+    usage = _safe(lambda: _collect_usage(vault_path))
+    analytics = _safe(lambda: _collect_analytics(vault_path, generated))
+    return {
+        "meta": {
+            "generated_at": generated.isoformat().replace("+00:00", "Z"),
+            "vault_path": str(vault_path),
+            "collector_version": COLLECTOR_VERSION,
+            "vault_age": _safe(lambda: _collect_vault_age(vault_path, generated)),
+        },
+        "profile": _safe(lambda: _collect_profile(vault_path)),
+        "pillars": _safe(lambda: _collect_pillars(vault_path)),
+        "integrations": _safe(lambda: _collect_integrations(vault_path)),
+        "usage": usage,
+        "analytics": analytics,
+        "tasks": _safe(lambda: _collect_tasks(vault_path, generated)),
+        "people": _safe(lambda: _collect_people(vault_path)),
+        "companies": _safe(lambda: _collect_companies(vault_path)),
+        "meetings": _safe(lambda: _collect_meetings(vault_path, generated)),
+        "projects": _safe(lambda: _collect_projects(vault_path)),
+        "health": _safe(lambda: _collect_health(vault_path, generated)),
+        "skills": _safe(lambda: _collect_skills(vault_path, skills_path, usage, analytics)),
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, required=True, help="Dex vault root")
+    parser.add_argument("--skills-list", type=Path, help="JSON list of vault skill names")
+    parser.add_argument("--json", action="store_true", help="Emit compact JSON")
+    parser.add_argument(
+        "--diagnose",
+        action="store_true",
+        help="Also report section-level collection errors to stderr",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    vault = args.vault.expanduser()
+    if not vault.is_dir():
+        print(f"Error: vault is not a directory: {vault}", file=sys.stderr)
+        return 2
+    try:
+        data = collect_dashboard(vault, skills_list=args.skills_list)
+    except Exception as error:
+        print(f"Error: dashboard collection failed: {_short_error(error)}", file=sys.stderr)
+        return 1
+    print(json.dumps(data, sort_keys=True, ensure_ascii=False, indent=None if args.json else 2))
+    if args.diagnose:
+        errors = sorted(
+            key
+            for key, value in data.items()
+            if isinstance(value, dict) and isinstance(value.get("error"), str)
+        )
+        print(json.dumps({"sections_with_errors": errors}, sort_keys=True), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/dashboard/history.py
+++ b/core/dashboard/history.py
@@ -1,0 +1,237 @@
+"""Read and summarize the private, append-only Dex Dashboard history."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from math import isfinite
+from pathlib import Path
+from typing import Any
+
+from core.paths import DEX_RUNTIME_DIR, VAULT_ROOT
+
+ISO_WEEK = re.compile(r"^\d{4}-W\d{2}$")
+_MILESTONE_RULES = (
+    ("tasks_done", ("tasks_done", "tasks", "completed_tasks"), (100, 500, 1000)),
+    ("meetings", ("meetings", "meeting_notes"), (50, 100, 250)),
+    ("people", ("people", "person_pages"), (50, 100)),
+)
+_MILESTONE_PRIORITY = {"tasks_done": 0, "vault_age": 1, "meetings": 2, "people": 3}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _non_negative_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def _count(source: Any, keys: tuple[str, ...]) -> int:
+    values = _mapping(source)
+    for key in keys:
+        value = _non_negative_int(values.get(key))
+        if value is not None:
+            return value
+    return 0
+
+
+def _optional_count(source: Any, keys: tuple[str, ...]) -> int | None:
+    values = _mapping(source)
+    for key in keys:
+        value = _non_negative_int(values.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso_week(value: datetime) -> str:
+    iso = value.date().isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _history_path(vault: Path) -> Path:
+    return vault / DEX_RUNTIME_DIR.relative_to(VAULT_ROOT) / "dashboard" / "history.jsonl"
+
+
+def load_history(vault: Path | str) -> list[dict[str, Any]]:
+    """Return valid snapshot objects, quietly ignoring damaged history lines."""
+    path = _history_path(Path(vault).expanduser())
+    if not path.is_file():
+        return []
+    snapshots = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            snapshot = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        is_snapshot = isinstance(snapshot, dict) and isinstance(snapshot.get("counts"), dict)
+        if is_snapshot and _parse_timestamp(snapshot.get("ts")):
+            snapshots.append(snapshot)
+    return snapshots
+
+
+def _history_entries(data: Any) -> list[dict[str, Any]]:
+    source = _mapping(data)
+    entries = source.get("history", source.get("entries", []))
+    return [entry for entry in _list(entries) if isinstance(entry, dict)]
+
+
+def weekly_trends(data: dict[str, Any]) -> dict[str, list[Any]]:
+    """Build a shared ISO-week axis from analytics and cumulative history snapshots."""
+    analytics = _mapping(_mapping(data).get("analytics"))
+    raw_activity = _mapping(analytics.get("by_iso_week"))
+    activity = {
+        label: count
+        for label, value in raw_activity.items()
+        if isinstance(label, str)
+        and ISO_WEEK.fullmatch(label)
+        and (count := _non_negative_int(value)) is not None
+    }
+    snapshots_by_week: dict[str, list[tuple[datetime, dict[str, Any]]]] = {}
+    for snapshot in _history_entries(data):
+        timestamp = _parse_timestamp(snapshot.get("ts"))
+        if timestamp is None:
+            continue
+        snapshots_by_week.setdefault(_iso_week(timestamp), []).append((timestamp, snapshot))
+
+    labels = sorted(set(activity) | set(snapshots_by_week))
+    meetings: list[int] = []
+    tasks: list[int] = []
+    snapshots: list[int] = []
+    previous_counts: dict[str, int] | None = None
+    for label in labels:
+        week_entries = sorted(snapshots_by_week.get(label, []), key=lambda item: item[0])
+        snapshots.append(len(week_entries))
+        if not week_entries:
+            meetings.append(0)
+            tasks.append(0)
+            continue
+        current_counts = _mapping(week_entries[-1][1].get("counts"))
+        current_meetings = _count(current_counts, ("meetings", "meeting_notes"))
+        current_tasks = _count(current_counts, ("tasks_done", "tasks", "completed_tasks"))
+        if previous_counts is None:
+            meetings.append(0)
+            tasks.append(0)
+        else:
+            meetings.append(max(0, current_meetings - previous_counts["meetings"]))
+            tasks.append(max(0, current_tasks - previous_counts["tasks_done"]))
+        previous_counts = {"meetings": current_meetings, "tasks_done": current_tasks}
+
+    return {
+        "labels": labels,
+        "activity": [activity.get(label, 0) for label in labels],
+        "meetings": meetings,
+        "tasks": tasks,
+        "snapshots": snapshots,
+    }
+
+
+def _milestone_label(identifier: str, threshold: int) -> str:
+    formatted = f"{threshold:,}"
+    if identifier == "tasks_done":
+        return f"{formatted} completed tasks"
+    if identifier == "meetings":
+        return f"{formatted} meeting notes"
+    if identifier == "people":
+        return f"{formatted} people in Dex"
+    return "Six months with Dex" if threshold == 180 else "One year with Dex"
+
+
+def detect_milestones(
+    prev_counts: dict[str, Any], new_counts: dict[str, Any], vault_age: int | None
+) -> list[dict[str, Any]]:
+    """Return milestones crossed since the prior snapshot, largest threshold first."""
+    milestones = []
+    for identifier, keys, thresholds in _MILESTONE_RULES:
+        previous = _count(prev_counts, keys)
+        current = _count(new_counts, keys)
+        for threshold in thresholds:
+            if previous < threshold <= current:
+                milestones.append(
+                    {
+                        "id": identifier,
+                        "threshold": threshold,
+                        "label": _milestone_label(identifier, threshold),
+                    }
+                )
+
+    current_age = _non_negative_int(vault_age)
+    if current_age is not None:
+        previous_age = _optional_count(prev_counts, ("vault_age_days", "vault_age"))
+        if previous_age is None:
+            previous_age = max(0, current_age - 1)
+        for threshold in (180, 365):
+            if previous_age < threshold <= current_age:
+                milestones.append(
+                    {
+                        "id": "vault_age",
+                        "threshold": threshold,
+                        "label": _milestone_label("vault_age", threshold),
+                    }
+                )
+
+    return sorted(
+        milestones,
+        key=lambda milestone: (-int(milestone["threshold"]), _MILESTONE_PRIORITY[milestone["id"]]),
+    )
+
+
+def sparkline_svg(values: list[int | float], width: int, height: int) -> str:
+    """Render numeric values as a tiny self-contained SVG polyline."""
+    safe_width = (
+        width if isinstance(width, int) and not isinstance(width, bool) and width > 0 else 120
+    )
+    safe_height = (
+        height if isinstance(height, int) and not isinstance(height, bool) and height > 0 else 32
+    )
+    numeric_values = [
+        float(value)
+        for value in values
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(value)
+    ]
+    if not numeric_values:
+        points = ""
+    else:
+        minimum = min(numeric_values)
+        maximum = max(numeric_values)
+        span = maximum - minimum
+        x_step = safe_width / max(1, len(numeric_values) - 1)
+        points_list = []
+        for index, value in enumerate(numeric_values):
+            y = safe_height / 2 if span == 0 else safe_height - (
+                (value - minimum) / span * safe_height
+            )
+            points_list.append(f"{index * x_step:.2f},{y:.2f}")
+        points = " ".join(points_list)
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {safe_width} {safe_height}" '
+        'role="img" aria-label="Trend" focusable="false">'
+        f'<polyline points="{points}" fill="none" stroke="#62d7d1" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round"/></svg>'
+    )

--- a/core/dashboard/journey.py
+++ b/core/dashboard/journey.py
@@ -1,0 +1,219 @@
+"""Build the read-only capability catalog shown in the Dex Dashboard."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from core import capabilities as capability_rooms
+from core.paths import USER_PROFILE_FILE, VAULT_ROOT
+
+SKILLS_ROOT = Path(".claude") / "skills"
+SKILL_FILE = "SKILL.md"
+_SKILL_ID = re.compile(r"^[a-z0-9][a-z0-9_-]*$", re.IGNORECASE)
+_SKILL_COMMAND = re.compile(r"/([a-z0-9][a-z0-9_-]*)", re.IGNORECASE)
+_SENTENCE = re.compile(r"^(.+?[.!?])(?:\s|$)")
+
+
+def _at(vault: Path, configured_path: Path) -> Path:
+    """Rebase a core.paths constant from the configured vault to ``vault``."""
+    return vault / configured_path.relative_to(VAULT_ROOT)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _skill_id(value: Any) -> str:
+    candidate = str(value or "").strip().lower().lstrip("/").replace("_", "-")
+    return candidate if _SKILL_ID.fullmatch(candidate) else ""
+
+
+def _first_sentence(value: str) -> str:
+    text = " ".join(value.split())
+    if not text:
+        return ""
+    match = _SENTENCE.match(text)
+    return match.group(1) if match else text
+
+
+def _frontmatter(path: Path) -> dict[str, str]:
+    """Read the small metadata subset needed by the dashboard without PyYAML."""
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return {}
+    if not lines or lines[0].strip() != "---":
+        return {}
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return metadata
+        key, separator, raw_value = line.partition(":")
+        if not separator:
+            continue
+        normalized_key = key.strip().lower()
+        if normalized_key not in {"name", "description", "category"}:
+            continue
+        value = raw_value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        metadata[normalized_key] = value
+    return {}
+
+
+def _display_name(skill_id: str, metadata: dict[str, str]) -> str:
+    return metadata.get("name") or skill_id.replace("-", " ").title()
+
+
+def _catalog_entry(path: Path, skill_id: str) -> dict[str, str]:
+    metadata = _frontmatter(path)
+    return {
+        "id": skill_id,
+        "name": _display_name(skill_id, metadata),
+        "description": _first_sentence(metadata.get("description", "")),
+        "category": metadata.get("category", "").strip() or "Other",
+    }
+
+
+def _active_skills(vault: Path) -> dict[str, dict[str, str]]:
+    root = vault / SKILLS_ROOT
+    if not root.is_dir():
+        return {}
+    try:
+        directories = sorted(root.iterdir(), key=lambda path: path.name.casefold())
+    except OSError:
+        return {}
+
+    skills = {}
+    for directory in directories:
+        skill_id = _skill_id(directory.name)
+        skill_path = directory / SKILL_FILE
+        if not skill_id or not skill_path.is_file():
+            continue
+        skills[skill_id] = _catalog_entry(skill_path, skill_id)
+    return skills
+
+
+def _used_skill_ids(data: dict[str, Any]) -> set[str]:
+    used = {
+        skill_id
+        for value in _list(_mapping(data.get("skills")).get("used"))
+        if (skill_id := _skill_id(value))
+    }
+
+    usage = _mapping(data.get("usage"))
+    for feature, completed in _mapping(usage.get("features")).items():
+        if completed:
+            used.update(_SKILL_COMMAND.findall(str(feature).lower()))
+            skill_id = _skill_id(feature)
+            if skill_id:
+                used.add(skill_id)
+
+    analytics = _mapping(data.get("analytics"))
+    for value in _list(analytics.get("skill_names_used")):
+        skill_id = _skill_id(value)
+        if skill_id:
+            used.add(skill_id)
+    for event, count in _mapping(analytics.get("by_event")).items():
+        if isinstance(count, (int, float)) and not isinstance(count, bool) and count > 0:
+            used.update(_SKILL_COMMAND.findall(str(event).lower()))
+            skill_id = _skill_id(event)
+            if skill_id:
+                used.add(skill_id)
+    return {_skill_id(skill_id) for skill_id in used if _skill_id(skill_id)}
+
+
+def _pack_skills(vault: Path, room: str) -> list[tuple[str, Path]]:
+    """Find registry-declared pack skills that are physically present in this vault."""
+    try:
+        declared = _list(capability_rooms.surfaces_for(room).get("skills"))
+    except (OSError, ValueError, capability_rooms.CapabilityError):
+        return []
+    root = vault / capability_rooms.DORMANT_CATALOG / room / "skills"
+    skills = []
+    for value in declared:
+        skill_id = _skill_id(value)
+        skill_path = root / skill_id / SKILL_FILE
+        if skill_id and skill_path.is_file():
+            skills.append((skill_id, skill_path))
+    return skills
+
+
+def _room_states(vault: Path) -> list[dict[str, Any]]:
+    profile = _at(vault, USER_PROFILE_FILE)
+    try:
+        rooms = capability_rooms.room_ids()
+    except (OSError, ValueError, capability_rooms.CapabilityError):
+        return []
+    states = []
+    for room in rooms:
+        try:
+            room_enabled = capability_rooms.enabled(room, profile_path=profile)
+        except (OSError, ValueError, capability_rooms.CapabilityError):
+            room_enabled = False
+        states.append({"id": room, "enabled": room_enabled})
+    return states
+
+
+def _group_name(category: str) -> str:
+    return category.strip() or "Other"
+
+
+def build_journey(vault: Path, data: dict) -> dict:
+    """Return a safe, display-ready view of used and available capabilities."""
+    vault = Path(vault).expanduser().resolve()
+    used = _used_skill_ids(data if isinstance(data, dict) else {})
+    catalog = _active_skills(vault)
+    packed_states: dict[str, bool] = {}
+
+    rooms = _room_states(vault)
+    for room_state in rooms:
+        room = room_state["id"]
+        room_enabled = room_state["enabled"]
+        for skill_id, skill_path in _pack_skills(vault, room):
+            if skill_id in catalog:
+                continue
+            entry = _catalog_entry(skill_path, skill_id)
+            if entry["category"] == "Other":
+                entry["category"] = room.replace("_", " ").title()
+            catalog[skill_id] = entry
+            packed_states[skill_id] = room_enabled
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for skill_id, entry in sorted(catalog.items()):
+        available = packed_states.get(skill_id, True)
+        state = "available-in-pack" if not available else ("used" if skill_id in used else "unused")
+        category = _group_name(entry["category"])
+        key = category.casefold()
+        group = grouped.setdefault(
+            key,
+            {"id": _skill_id(category) or "other", "name": category, "skills": []},
+        )
+        group["skills"].append(
+            {
+                "id": skill_id,
+                "name": entry["name"],
+                "description": entry["description"],
+                "state": state,
+            }
+        )
+
+    groups = [grouped[key] for key in sorted(grouped)]
+    for group in groups:
+        group["skills"].sort(key=lambda skill: (skill["name"].casefold(), skill["id"]))
+    skills = [skill for group in groups for skill in group["skills"]]
+    return {
+        "groups": groups,
+        "counts": {
+            "available": sum(skill["state"] != "available-in-pack" for skill in skills),
+            "used": sum(skill["state"] == "used" for skill in skills),
+        },
+        "rooms": rooms,
+    }

--- a/core/dashboard/journey.py
+++ b/core/dashboard/journey.py
@@ -14,6 +14,105 @@ SKILL_FILE = "SKILL.md"
 _SKILL_ID = re.compile(r"^[a-z0-9][a-z0-9_-]*$", re.IGNORECASE)
 _SKILL_COMMAND = re.compile(r"/([a-z0-9][a-z0-9_-]*)", re.IGNORECASE)
 _SENTENCE = re.compile(r"^(.+?[.!?])(?:\s|$)")
+_GROUP_ID_SEPARATOR = re.compile(r"[^a-z0-9]+")
+
+_GROUP_SEQUENCE = (
+    "Plan & Review",
+    "Meetings & People",
+    "Projects & Work",
+    "Career",
+    "Connect & Import",
+    "Sharing",
+    "Dex itself",
+    "More",
+    "Yours",
+)
+_GROUP_RANK = {name.casefold(): position for position, name in enumerate(_GROUP_SEQUENCE)}
+
+# The direct .claude/skills catalog shipped by Dex. Keep every shipped skill here so a
+# real vault is organized by Dex's own intent rather than its optional frontmatter.
+BUILT_IN_SKILL_CATEGORIES = {
+    "daily-plan": "Plan & Review",
+    "daily-review": "Plan & Review",
+    "identity-snapshot": "Plan & Review",
+    "journal": "Plan & Review",
+    "quarter-plan": "Plan & Review",
+    "quarter-review": "Plan & Review",
+    "review": "Plan & Review",
+    "triage": "Plan & Review",
+    "week-plan": "Plan & Review",
+    "week-review": "Plan & Review",
+    "weekly-reflection": "Plan & Review",
+    "commitments": "Meetings & People",
+    "meeting-closeout": "Meetings & People",
+    "meeting-prep": "Meetings & People",
+    "process-meetings": "Meetings & People",
+    "relationship-radar": "Meetings & People",
+    "decision-log": "Projects & Work",
+    "delegate-check": "Projects & Work",
+    "initiative-kickoff": "Projects & Work",
+    "product-brief": "Projects & Work",
+    "project-health": "Projects & Work",
+    "career-coach": "Career",
+    "resume-builder": "Career",
+    "atlassian-setup": "Connect & Import",
+    "calendar-setup": "Connect & Import",
+    "create-mcp": "Connect & Import",
+    "dex-add-mcp": "Connect & Import",
+    "dex-obsidian-setup": "Connect & Import",
+    "enable-semantic-search": "Connect & Import",
+    "google-workspace-setup": "Connect & Import",
+    "granola-setup": "Connect & Import",
+    "integrate-mcp": "Connect & Import",
+    "integrations": "Connect & Import",
+    "ms-teams-setup": "Connect & Import",
+    "scrape": "Connect & Import",
+    "setup": "Connect & Import",
+    "things-setup": "Connect & Import",
+    "todoist-setup": "Connect & Import",
+    "trello-setup": "Connect & Import",
+    "zoom-setup": "Connect & Import",
+    "diff-adopt": "Sharing",
+    "diff-adopt-profile": "Sharing",
+    "diff-generate": "Sharing",
+    "diff-list": "Sharing",
+    "diff-profile": "Sharing",
+    "diff-remove": "Sharing",
+    "create-skill": "Dex itself",
+    "dex-backlog": "Dex itself",
+    "dex-dashboard": "Dex itself",
+    "dex-doctor": "Dex itself",
+    "dex-improve": "Dex itself",
+    "dex-level-up": "Dex itself",
+    "dex-orient": "Dex itself",
+    "dex-rollback": "Dex itself",
+    "dex-update": "Dex itself",
+    "dex-whats-new": "Dex itself",
+    "getting-started": "Dex itself",
+    "manage-capabilities": "Dex itself",
+    "prompt-improver": "Dex itself",
+    "reset": "Dex itself",
+    "save-insight": "Dex itself",
+    "skill-score": "Dex itself",
+    "xray": "Dex itself",
+    "anthropic-algorithmic-art": "More",
+    "anthropic-brand-guidelines": "More",
+    "anthropic-canvas-design": "More",
+    "anthropic-doc-coauthoring": "More",
+    "anthropic-docx": "More",
+    "anthropic-frontend-design": "More",
+    "anthropic-internal-comms": "More",
+    "anthropic-mcp-builder": "More",
+    "anthropic-pdf": "More",
+    "anthropic-pptx": "More",
+    "anthropic-skill-creator": "More",
+    "anthropic-slack-gif-creator": "More",
+    "anthropic-theme-factory": "More",
+    "anthropic-web-artifacts-builder": "More",
+    "anthropic-webapp-testing": "More",
+    "anthropic-xlsx": "More",
+    "industry-truths": "More",
+}
 
 
 def _at(vault: Path, configured_path: Path) -> Path:
@@ -78,7 +177,7 @@ def _catalog_entry(path: Path, skill_id: str) -> dict[str, str]:
         "id": skill_id,
         "name": _display_name(skill_id, metadata),
         "description": _first_sentence(metadata.get("description", "")),
-        "category": metadata.get("category", "").strip() or "Other",
+        "category": metadata.get("category", "").strip(),
     }
 
 
@@ -162,8 +261,31 @@ def _room_states(vault: Path) -> list[dict[str, Any]]:
     return states
 
 
-def _group_name(category: str) -> str:
-    return category.strip() or "Other"
+def _built_in_category(skill_id: str) -> str:
+    if skill_id.startswith("career-"):
+        return "Career"
+    return BUILT_IN_SKILL_CATEGORIES.get(skill_id, "")
+
+
+def _group_name(skill_id: str, category: str) -> str:
+    return category.strip() or _built_in_category(skill_id) or "Yours"
+
+
+def _group_id(category: str) -> str:
+    candidate = _GROUP_ID_SEPARATOR.sub("-", category.casefold()).strip("-")
+    return candidate if _SKILL_ID.fullmatch(candidate) else "other"
+
+
+def _group_sort_key(group: dict[str, Any]) -> tuple[int, int | str]:
+    name = str(group.get("name") or "")
+    rank = _GROUP_RANK.get(name.casefold())
+    if rank is not None and rank < _GROUP_RANK["more"]:
+        return (0, rank)
+    if rank == _GROUP_RANK["more"]:
+        return (2, rank)
+    if rank == _GROUP_RANK["yours"]:
+        return (3, rank)
+    return (1, name.casefold())
 
 
 def build_journey(vault: Path, data: dict) -> dict:
@@ -181,8 +303,6 @@ def build_journey(vault: Path, data: dict) -> dict:
             if skill_id in catalog:
                 continue
             entry = _catalog_entry(skill_path, skill_id)
-            if entry["category"] == "Other":
-                entry["category"] = room.replace("_", " ").title()
             catalog[skill_id] = entry
             packed_states[skill_id] = room_enabled
 
@@ -190,12 +310,14 @@ def build_journey(vault: Path, data: dict) -> dict:
     for skill_id, entry in sorted(catalog.items()):
         available = packed_states.get(skill_id, True)
         state = "available-in-pack" if not available else ("used" if skill_id in used else "unused")
-        category = _group_name(entry["category"])
+        category = _group_name(skill_id, entry["category"])
         key = category.casefold()
         group = grouped.setdefault(
             key,
-            {"id": _skill_id(category) or "other", "name": category, "skills": []},
+            {"id": _group_id(category), "name": category, "skills": []},
         )
+        if key == "yours":
+            group["yours"] = True
         group["skills"].append(
             {
                 "id": skill_id,
@@ -205,9 +327,16 @@ def build_journey(vault: Path, data: dict) -> dict:
             }
         )
 
-    groups = [grouped[key] for key in sorted(grouped)]
+    groups = sorted(grouped.values(), key=_group_sort_key)
     for group in groups:
-        group["skills"].sort(key=lambda skill: (skill["name"].casefold(), skill["id"]))
+        group["skills"].sort(
+            key=lambda skill: (
+                skill["state"] != "used",
+                skill["state"] == "available-in-pack",
+                skill["name"].casefold(),
+                skill["id"],
+            )
+        )
     skills = [skill for group in groups for skill in group["skills"]]
     return {
         "groups": groups,

--- a/core/dashboard/render.py
+++ b/core/dashboard/render.py
@@ -16,6 +16,12 @@ from urllib.parse import urlparse
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from core.dashboard import history as dashboard_history
+from core.dashboard import journey as dashboard_journey
+from core.dashboard.sections.history import render_history
+from core.dashboard.sections.journey import render_journey
+from core.dashboard.sections.settings import render as render_settings
+from core.dashboard.server import PORT_PLACEHOLDER, TOKEN_PLACEHOLDER
 from core.paths import DEX_RUNTIME_DIR, VAULT_ROOT
 
 INLINE_MARKDOWN = re.compile(
@@ -343,6 +349,9 @@ def render_dashboard_html(
     *,
     archive_count: int = 0,
     archived: bool = False,
+    journey: dict[str, Any] | None = None,
+    history_data: dict[str, Any] | None = None,
+    server_ctx: dict[str, Any] | None = None,
 ) -> str:
     """Render escaped data into one self-contained Nightfall HTML document."""
     observations = observations or {}
@@ -351,12 +360,23 @@ def render_dashboard_html(
     identity = f"<p class=\"user-name\">{_escape(name)}</p>" if name else ""
     archive_note = f"snapshot #{archive_count} saved" if archived else "snapshot not saved"
     suggestion = _render_suggestion(observations)
+    journey_section = render_journey(journey) if journey is not None else ""
+    history_section = render_history(history_data) if history_data is not None else ""
+    server_meta = ""
+    settings_section = ""
+    settings_script = ""
+    if server_ctx:
+        settings_section, settings_script = render_settings(data, server_ctx)
+        server_meta = (
+            '\n  <meta name="dashboard-port" '
+            f'content="{_escape(server_ctx.get("port", ""))}">'
+        )
     return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="dark">
+  <meta name="color-scheme" content="dark">{server_meta}
   <title>Your Dex</title>
   <style>
     :root {{
@@ -462,10 +482,167 @@ def render_dashboard_html(
     .health-panel {{ display: grid; grid-template-columns: minmax(12rem, .8fr) minmax(16rem, 1.2fr); gap: 1.5rem; margin-top: 1rem; background: var(--surface-raised); }}
     .health-note {{ margin: 0; font-size: .82rem; }}
     .health-guidance {{ margin: 0; }}
+    .journey-grid {{ align-items: start; }}
+    .territory {{ min-width: 0; }}
+    .journey-chips {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: .55rem;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }}
+    .journey-chip {{
+      padding: .34rem .58rem;
+      border: 1px solid var(--border);
+      border-radius: .55rem;
+      font-size: .78rem;
+      line-height: 1.35;
+    }}
+    .journey-chip.lit {{
+      border-color: rgba(98, 215, 209, .42);
+      background: var(--accent-soft);
+      color: var(--text);
+    }}
+    .journey-chip.dim {{
+      border-color: rgba(255, 255, 255, .06);
+      color: var(--faint);
+    }}
+    .journey-chip.outlined {{
+      border-style: dashed;
+      border-color: rgba(145, 160, 165, .28);
+      color: var(--faint);
+    }}
+    .history-trends {{ gap: 1rem; margin-bottom: 1rem; }}
+    .history-chart svg {{ display: block; width: 100%; height: auto; }}
+    .history-milestone {{ margin: 1rem 0; padding: 1rem 1.25rem; }}
+    .history-milestone h3 {{ margin: 0; color: var(--text); }}
+    .history-looking-back {{ margin-top: 1rem; }}
+    .history-looking-back p {{ margin: 0; }}
+    .settings-list {{
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: .8rem;
+      background: var(--surface);
+    }}
+    .setting-row {{
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 1.25rem;
+      padding: 1rem 1.15rem;
+      border-bottom: 1px solid var(--border);
+    }}
+    .setting-row:last-child {{ border-bottom: 0; }}
+    .setting-row-readonly {{ grid-template-columns: 1fr; }}
+    .setting-copy {{ min-width: 0; }}
+    .setting-copy label, .setting-label {{
+      display: block;
+      color: var(--text);
+      font-size: .94rem;
+      font-weight: 650;
+    }}
+    .setting-copy p {{ margin: .18rem 0 0; color: var(--muted); font-size: .78rem; }}
+    .setting-action {{
+      display: flex;
+      min-width: 8.5rem;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: .25rem;
+    }}
+    .setting-action input[role="switch"] {{
+      appearance: none;
+      position: relative;
+      width: 2.6rem;
+      height: 1.45rem;
+      margin: 0;
+      border: 1px solid rgba(145, 160, 165, .3);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, .06);
+      cursor: pointer;
+      transition: background .16s ease, border-color .16s ease;
+    }}
+    .setting-action input[role="switch"]::after {{
+      content: "";
+      position: absolute;
+      top: .18rem;
+      left: .2rem;
+      width: .96rem;
+      height: .96rem;
+      border-radius: 50%;
+      background: var(--muted);
+      transition: transform .16s ease, background .16s ease;
+    }}
+    .setting-action input[role="switch"]:checked {{
+      border-color: rgba(98, 215, 209, .62);
+      background: rgba(98, 215, 209, .32);
+    }}
+    .setting-action input[role="switch"]:checked::after {{
+      background: var(--accent);
+      transform: translateX(1.16rem);
+    }}
+    .setting-action input[role="switch"]:focus-visible,
+    .setting-action select:focus-visible {{
+      outline: 2px solid var(--accent);
+      outline-offset: 3px;
+    }}
+    .setting-action input:disabled, .setting-action select:disabled {{
+      cursor: not-allowed;
+      opacity: .48;
+    }}
+    .setting-action select {{
+      min-width: 10.5rem;
+      max-width: 15rem;
+      border: 1px solid rgba(145, 160, 165, .26);
+      border-radius: .55rem;
+      background: var(--surface-raised);
+      color: var(--text);
+      padding: .48rem 1.8rem .48rem .62rem;
+      font: inherit;
+      font-size: .82rem;
+    }}
+    .setting-status {{
+      min-height: 1.1rem;
+      color: var(--muted);
+      font-size: .7rem;
+      text-align: right;
+    }}
+    .settings-subsection {{ margin-top: 2rem; }}
+    .settings-subsection h3 {{ margin-bottom: .8rem; }}
+    .handoff-button {{
+      position: static;
+      display: flex;
+      width: 100%;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      border-color: var(--border);
+      background: var(--surface);
+      padding: .85rem 1rem;
+      text-align: left;
+    }}
+    .handoff-button:hover {{ border-color: rgba(98, 215, 209, .28); }}
+    .handoff-button span {{ color: var(--muted); font-size: .75rem; font-weight: 400; }}
+    .handoff-status {{ display: block; min-height: 1.2rem; margin-top: .45rem; color: var(--muted); font-size: .75rem; }}
+    .undo-button {{
+      position: static;
+      margin: 0 0 0 .15rem;
+      border: 0;
+      background: transparent;
+      color: var(--accent);
+      padding: 0;
+      font-size: inherit;
+      text-decoration: underline;
+      text-underline-offset: .15em;
+    }}
     footer {{ display: flex; flex-wrap: wrap; justify-content: space-between; gap: .5rem 1rem; padding-top: 2rem; border-top: 1px solid var(--border); color: var(--faint); font-size: .78rem; }}
     @media (max-width: 600px) {{
       main {{ padding-inline: 1rem; }}
       .health-panel {{ grid-template-columns: 1fr; }}
+      .setting-row {{ grid-template-columns: 1fr; }}
+      .setting-action {{ min-width: 0; align-items: flex-start; }}
+      .setting-status {{ text-align: left; }}
+      .handoff-button {{ align-items: flex-start; flex-direction: column; }}
       pre {{ padding: 2.8rem 0 0; }}
     }}
   </style>
@@ -481,7 +658,10 @@ def render_dashboard_html(
     {_render_receipt(data)}
     {_render_observations(observations)}
     {suggestion}
+    {journey_section}
     {_render_state(data)}
+    {history_section}
+    {settings_section}
     <footer>
       <span>Generated locally by Dex · nothing leaves your machine</span>
       <span>{_escape(archive_note)}</span>
@@ -515,6 +695,7 @@ def render_dashboard_html(
         }}
       }});
     }})();
+    {settings_script}
   </script>
 </body>
 </html>
@@ -567,6 +748,43 @@ def _snapshot(data: dict[str, Any], observations: dict[str, Any], now: datetime)
     }
 
 
+def _history_section_data(
+    vault: Path,
+    data: dict[str, Any],
+    observations: dict[str, Any],
+) -> dict[str, Any] | None:
+    try:
+        entries = dashboard_history.load_history(vault)
+        if not entries:
+            return None
+        previous_counts = _mapping(entries[-2].get("counts")) if len(entries) > 1 else {}
+        new_counts = _mapping(entries[-1].get("counts"))
+        raw_vault_age = _mapping(_mapping(data.get("meta")).get("vault_age")).get("age_days")
+        vault_age = (
+            raw_vault_age
+            if isinstance(raw_vault_age, int)
+            and not isinstance(raw_vault_age, bool)
+            and raw_vault_age >= 0
+            else None
+        )
+        trend_input = {
+            "analytics": _mapping(data.get("analytics")),
+            "history": entries,
+        }
+        return {
+            "history": entries,
+            "trends": dashboard_history.weekly_trends(trend_input),
+            "milestones": dashboard_history.detect_milestones(
+                previous_counts,
+                new_counts,
+                vault_age,
+            ),
+            "looking_back": observations.get("looking_back"),
+        }
+    except Exception:
+        return None
+
+
 def render_dashboard(
     vault: Path | str,
     data: dict[str, Any],
@@ -575,6 +793,7 @@ def render_dashboard(
     *,
     archive: bool = True,
     now: datetime | None = None,
+    server_ctx: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Write the page and, unless disabled, one compact local history line."""
     vault_path = Path(vault).expanduser().resolve()
@@ -596,11 +815,19 @@ def render_dashboard(
                 )
                 + "\n"
             )
+    try:
+        journey_data = dashboard_journey.build_journey(vault_path, data)
+    except Exception:
+        journey_data = None
+    history_data = _history_section_data(vault_path, data, observation_data)
     page = render_dashboard_html(
         data,
         observation_data,
         archive_count=archive_count,
         archived=archive,
+        journey=journey_data,
+        history_data=history_data,
+        server_ctx=server_ctx,
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(page, encoding="utf-8")
@@ -625,6 +852,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--observations", type=Path, help="Authored observations JSON")
     parser.add_argument("--out", type=Path, required=True, help="HTML output path")
     parser.add_argument("--no-archive", action="store_true", help="Do not append a history snapshot")
+    parser.add_argument(
+        "--with-settings",
+        action="store_true",
+        help="Include server-ready local settings controls",
+    )
     return parser.parse_args(argv)
 
 
@@ -646,6 +878,11 @@ def main(argv: list[str] | None = None) -> int:
             observations,
             args.out,
             archive=not args.no_archive,
+            server_ctx=(
+                {"token": TOKEN_PLACEHOLDER, "port": PORT_PLACEHOLDER}
+                if args.with_settings
+                else None
+            ),
         )
     except OSError as error:
         print(f"Error: could not write dashboard output: {str(error).splitlines()[0]}", file=sys.stderr)

--- a/core/dashboard/render.py
+++ b/core/dashboard/render.py
@@ -348,7 +348,7 @@ def render_dashboard_html(
     identity = f'<span class="user-name">for {_escape(name)}</span>' if name else ""
     archive_note = f"snapshot #{archive_count} saved" if archived else "snapshot not saved"
     suggestion = _render_suggestion(observations)
-    journey_section = render_journey(journey or {})
+    journey_section = render_journey(journey or {}, picks=observations.get("skill_picks"))
     history_section = render_history(history_data or {}) or _render_empty_history()
     server_meta = ""
     settings_script = ""
@@ -643,6 +643,52 @@ def render_dashboard_html(
       align-items: start;
       gap: 12px;
     }}
+    .journey-picks {{ margin: 0 0 20px; }}
+    .journey-picks h3 {{ margin: 0 0 10px; color: var(--fg); }}
+    .journey-picks-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 12px;
+    }}
+    .journey-pick-card {{
+      display: flex;
+      min-width: 0;
+      min-height: 146px;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      flex-direction: column;
+      align-items: flex-start;
+      background: var(--surface);
+    }}
+    .journey-pick-skill {{
+      padding: 4px 7px;
+      border: 1px solid var(--accent-dim);
+      border-radius: 3px;
+      background: var(--accent-bg);
+      color: var(--accent);
+      font: 12px/1.35 var(--mono);
+      overflow-wrap: anywhere;
+    }}
+    .journey-pick-card p {{ margin: 10px 0 14px; color: var(--fg2); font-size: 13px; }}
+    .journey-pick-actions {{
+      display: flex;
+      width: 100%;
+      min-height: 29px;
+      margin-top: auto;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }}
+    .journey-pick-copy {{
+      padding: 5px 9px;
+      border-color: var(--line2);
+      color: var(--fg2);
+      font: 12px/1.2 var(--mono);
+    }}
+    .journey-pick-copy:hover {{ border-color: var(--accent); color: var(--accent); }}
+    .journey-pick-prompt {{ display: none; }}
+    .journey-pick-copy-status {{ color: var(--fg3); font: 11px/1.4 var(--mono); }}
     .territory {{ min-width: 0; }}
     .journey-chips {{
       display: flex;
@@ -931,9 +977,7 @@ def render_dashboard_html(
       }});
     }})();
     (() => {{
-      const button = document.getElementById('copyPrompt');
-      const prompt = document.getElementById('tryPrompt');
-      const status = document.getElementById('copyStatus');
+      const wireCopy = (button, prompt, status) => {{
       if (!button || !prompt) return;
       const markCopied = () => {{
         if (status) status.textContent = 'Copied';
@@ -955,6 +999,18 @@ def render_dashboard_html(
           selection.removeAllRanges();
           markCopied();
         }}
+      }});
+      }};
+
+      wireCopy(
+        document.getElementById('copyPrompt'),
+        document.getElementById('tryPrompt'),
+        document.getElementById('copyStatus'),
+      );
+      document.querySelectorAll('[data-skill-copy-target]').forEach((button) => {{
+        const prompt = document.getElementById(button.dataset.skillCopyTarget);
+        const status = document.getElementById(button.dataset.skillCopyStatus);
+        wireCopy(button, prompt, status);
       }});
     }})();
     {settings_script}

--- a/core/dashboard/render.py
+++ b/core/dashboard/render.py
@@ -102,14 +102,10 @@ def _receipt_lines(data: dict[str, Any]) -> tuple[list[str], list[str]]:
     meetings_total = _number(data.get("meetings"), "total")
     tasks_done = _number(data.get("tasks"), "completed")
     people = _number(data.get("people"), "total")
-    skills_used = len(
-        [name for name in _list(_mapping(data.get("skills")).get("used")) if isinstance(name, str)]
-    )
+    skills_used = len([name for name in _list(_mapping(data.get("skills")).get("used")) if isinstance(name, str)])
     weekly = []
     if meetings_week:
-        weekly.append(
-            f"{meetings_week} {_plural(meetings_week, 'meeting')} turned into notes this week"
-        )
+        weekly.append(f"{meetings_week} {_plural(meetings_week, 'meeting')} turned into notes this week")
     if tasks_week:
         weekly.append(f"{tasks_week} {_plural(tasks_week, 'task')} completed this week")
     all_time = []
@@ -154,9 +150,7 @@ def _render_receipt(data: dict[str, Any]) -> str:
 
 def _observation_strings(observations: Any) -> list[str]:
     return [
-        item
-        for item in _list(_mapping(observations).get("observations"))
-        if isinstance(item, str) and item.strip()
+        item for item in _list(_mapping(observations).get("observations")) if isinstance(item, str) and item.strip()
     ]
 
 
@@ -165,10 +159,7 @@ def _render_observations(observations: Any) -> str:
     if items:
         body = "".join(f'<div class="observation">{_markdown(item)}</div>' for item in items)
     else:
-        body = (
-            '<p class="quiet">Open this from a Dex session to get Dex&#x27;s '
-            "observations.</p>"
-        )
+        body = '<p class="quiet">Open this from a Dex session to get Dex&#x27;s observations.</p>'
     return f"""
     <section id="observations" aria-labelledby="observations-heading">
       <div class="section-heading">
@@ -181,10 +172,7 @@ def _render_observations(observations: Any) -> str:
 
 def _suggestion(observations: Any) -> dict[str, str]:
     raw = _mapping(_mapping(observations).get("suggestion"))
-    return {
-        key: str(raw.get(key) or "").strip()
-        for key in ("title", "why", "try_prompt")
-    }
+    return {key: str(raw.get(key) or "").strip() for key in ("title", "why", "try_prompt")}
 
 
 def _render_suggestion(observations: Any) -> str:
@@ -192,11 +180,7 @@ def _render_suggestion(observations: Any) -> str:
     if not any(suggestion.values()):
         return ""
     title = suggestion["title"] or "A useful next step"
-    why = (
-        f'<p class="suggestion-why">{_escape(suggestion["why"])}</p>'
-        if suggestion["why"]
-        else ""
-    )
+    why = f'<p class="suggestion-why">{_escape(suggestion["why"])}</p>' if suggestion["why"] else ""
     prompt = ""
     if suggestion["try_prompt"]:
         prompt = f"""
@@ -237,14 +221,9 @@ def _render_profile_state(data: dict[str, Any]) -> str:
     if role:
         rows.append(f"<div><dt>Role</dt><dd>{_escape(role)}</dd></div>")
     if pillars:
-        rows.append(
-            f"<div><dt>Pillars</dt><dd>{_escape(', '.join(pillars))}</dd></div>"
-        )
+        rows.append(f"<div><dt>Pillars</dt><dd>{_escape(', '.join(pillars))}</dd></div>")
     if communication_parts:
-        rows.append(
-            "<div><dt>Communication style</dt>"
-            f"<dd>{_escape(', '.join(communication_parts))}</dd></div>"
-        )
+        rows.append(f"<div><dt>Communication style</dt><dd>{_escape(', '.join(communication_parts))}</dd></div>")
     if not rows:
         return '<p class="quiet">Your role and preferences are not configured yet.</p>'
     return f'<dl class="state-list">{"".join(rows)}</dl>'
@@ -258,7 +237,7 @@ def _render_integrations(data: dict[str, Any]) -> str:
         state = "connected" if enabled else "not set up"
         css = "on" if enabled else "off"
         rows.append(
-            '<li>'
+            "<li>"
             f'<span class="dot dot-{css}" aria-hidden="true"></span>'
             f'<span class="integration-name">{_escape(name)}</span>'
             f'<span class="integration-state">{state}</span>'
@@ -282,11 +261,7 @@ def _render_health(data: dict[str, Any]) -> str:
     health = _mapping(data.get("health"))
     status = str(health.get("status") or "unknown")
     if status != "fresh":
-        return (
-            '<p class="quiet health-guidance">'
-            "Run /dex-doctor for a fresh checkup."
-            "</p>"
-        )
+        return '<p class="quiet health-guidance">Run /dex-doctor for a fresh checkup.</p>'
     rows = []
     for check in _list(health.get("checks")):
         if not isinstance(check, dict):
@@ -294,7 +269,7 @@ def _render_health(data: dict[str, Any]) -> str:
         css, label = _health_label(str(check.get("verdict") or "UNKNOWN"))
         feature = str(check.get("feature") or check.get("id") or "Unknown check")
         rows.append(
-            '<li>'
+            "<li>"
             f'<span class="dot dot-{css}" aria-hidden="true"></span>'
             f'<span class="health-name">{_escape(feature)}</span>'
             f'<span class="health-state">{label}</span>'
@@ -343,6 +318,19 @@ def _display_date(data: dict[str, Any]) -> str:
     return f"{generated:%A, %B} {generated.day}, {generated.year}"
 
 
+def _render_empty_history() -> str:
+    return """
+    <section id="history" aria-labelledby="history-heading">
+      <div class="section-heading">
+        <p class="kicker">Looking back</p>
+        <h2 id="history-heading">The shape of your Dex</h2>
+      </div>
+      <p class="quiet history-empty">
+        Your first snapshot was saved today — this tab fills in as you come back.
+      </p>
+    </section>"""
+
+
 def render_dashboard_html(
     data: dict[str, Any],
     observations: dict[str, Any] | None = None,
@@ -353,24 +341,32 @@ def render_dashboard_html(
     history_data: dict[str, Any] | None = None,
     server_ctx: dict[str, Any] | None = None,
 ) -> str:
-    """Render escaped data into one self-contained Nightfall HTML document."""
+    """Render escaped data into one self-contained, tabbed Dex app."""
     observations = observations or {}
     profile = _mapping(data.get("profile"))
     name = str(profile.get("name") or "").strip()
-    identity = f"<p class=\"user-name\">{_escape(name)}</p>" if name else ""
+    identity = f'<span class="user-name">for {_escape(name)}</span>' if name else ""
     archive_note = f"snapshot #{archive_count} saved" if archived else "snapshot not saved"
     suggestion = _render_suggestion(observations)
-    journey_section = render_journey(journey) if journey is not None else ""
-    history_section = render_history(history_data) if history_data is not None else ""
+    journey_section = render_journey(journey or {})
+    history_section = render_history(history_data or {}) or _render_empty_history()
     server_meta = ""
-    settings_section = ""
     settings_script = ""
     if server_ctx:
         settings_section, settings_script = render_settings(data, server_ctx)
-        server_meta = (
-            '\n  <meta name="dashboard-port" '
-            f'content="{_escape(server_ctx.get("port", ""))}">'
-        )
+        server_meta = f'\n  <meta name="dashboard-port" content="{_escape(server_ctx.get("port", ""))}">'
+    else:
+        settings_section = f"""
+    <section id="settings" aria-labelledby="settings-heading">
+      <div class="section-heading">
+        <p class="kicker">Settings</p>
+        <h2 id="settings-heading">The shape of your Dex</h2>
+        <p class="quiet settings-readonly-note">
+          Open with 'let me change my settings' to make these live.
+        </p>
+      </div>
+      {_render_state(data)}
+    </section>"""
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -379,295 +375,561 @@ def render_dashboard_html(
   <meta name="color-scheme" content="dark">{server_meta}
   <title>Your Dex</title>
   <style>
-    :root {{
-      color-scheme: dark;
-      --bg: #0B0F14;
-      --surface: #11171e;
-      --surface-raised: #151d25;
-      --text: #edf4f5;
-      --muted: #91a0a5;
-      --faint: #66747a;
-      --border: rgba(255, 255, 255, .08);
-      --accent: #62d7d1;
-      --accent-soft: rgba(98, 215, 209, .11);
-      --good: #74d5a5;
-      --attention: #e7c978;
-    }}
+    :root{{--bg:#0D0E12;--surface:#15161C;--elevated:#1C1D25;--line:#24262E;
+      --line2:#32343F;--fg:#E4E5E7;--fg2:#9B9DA6;--fg3:#787B87;--inv:#111111;
+      --accent:#FF4081;--accent-dim:rgba(255,64,129,0.72);
+      --accent-bg:rgba(255,64,129,0.12);
+      --mono:'Geist Mono','JetBrains Mono',ui-monospace,monospace;
+      --sans:'Inter','Geist',system-ui,-apple-system,sans-serif;color-scheme:dark}}
     * {{ box-sizing: border-box; }}
-    html {{ background: var(--bg); }}
+    [hidden] {{ display: none !important; }}
+    html {{ min-height: 100%; background: var(--bg); }}
     body {{
+      min-height: 100vh;
       margin: 0;
       background: var(--bg);
-      color: var(--text);
-      font-family: -apple-system, "SF Pro", "Segoe UI", sans-serif;
-      font-size: 16px;
-      line-height: 1.6;
+      color: var(--fg);
+      font: 15px/1.6 var(--sans);
       -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
     }}
-    main {{ max-width: 880px; margin: 0 auto; padding: clamp(2rem, 7vw, 6rem) 1.25rem 2.5rem; }}
-    header {{ padding: 0 0 clamp(3.5rem, 9vw, 7rem); }}
-    .kicker {{
-      margin: 0 0 .7rem;
+    body::before {{
+      content: "";
+      position: fixed;
+      z-index: 0;
+      inset: 0;
+      pointer-events: none;
+      background: radial-gradient(
+        880px 560px at 80% -10%,
+        rgba(255,64,129,0.06),
+        transparent 60%
+      );
+    }}
+    .topbar {{
+      position: sticky;
+      z-index: 10;
+      top: 0;
+      border-bottom: 1px solid var(--line);
+      background: rgba(13,14,18,.92);
+      backdrop-filter: blur(14px);
+    }}
+    .nav-shell {{
+      display: grid;
+      max-width: 1020px;
+      min-height: 56px;
+      margin: 0 auto;
+      padding: 0 20px;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: 28px;
+    }}
+    .wordmark {{
+      color: var(--fg);
+      font-size: 21px;
+      font-weight: 600;
+      letter-spacing: -.04em;
+    }}
+    .wordmark-dot {{ color: var(--accent); }}
+    .tab-list {{
+      display: flex;
+      justify-content: flex-end;
+      gap: 4px;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }}
+    .tab-list::-webkit-scrollbar {{ display: none; }}
+    button {{
+      border: 1px solid var(--line2);
+      border-radius: 3px;
+      background: transparent;
+      color: var(--fg);
+      padding: 8px 12px;
+      font: 500 13px/1.25 var(--sans);
+      cursor: pointer;
+      transition: border-color .15s ease, background .15s ease, color .15s ease;
+    }}
+    button:hover {{ border-color: var(--accent); }}
+    button:focus-visible {{
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }}
+    .tab-list button {{
+      border-color: transparent;
+      color: var(--fg2);
+      white-space: nowrap;
+    }}
+    .tab-list button:hover {{ color: var(--fg); }}
+    .tab-list button[aria-selected="true"] {{
+      border-color: var(--line2);
+      background: var(--elevated);
+      color: var(--fg);
+    }}
+    main {{
+      position: relative;
+      z-index: 1;
+      max-width: 1020px;
+      margin: 0 auto;
+      padding: 0 20px;
+    }}
+    .tab-panel {{
+      min-height: calc(100vh - 136px);
+      padding: 42px 0 48px;
+      border: 0;
+    }}
+    .tab-panel > section:first-child {{ padding-top: 0; border-top: 0; }}
+    .overview-intro + section {{ border-top: 0; }}
+    .overview-intro {{
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 24px;
+      padding: 0 0 30px;
+      border-bottom: 1px solid var(--line);
+    }}
+    .greeting-line {{
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 8px;
+    }}
+    h1, h2, h3, h4, p {{ overflow-wrap: anywhere; }}
+    h1, h2, h3, h4 {{
+      font-weight: 500;
+      letter-spacing: -.01em;
+    }}
+    h1 {{ margin: 0; font-size: clamp(26px,3.2vw,36px); line-height: 1.16; }}
+    h2 {{ margin: 0; font-size: clamp(24px,3vw,34px); line-height: 1.18; }}
+    h3, h4 {{ margin: 0; }}
+    h3 {{ font-size: 14px; }}
+    h4 {{ color: var(--fg2); font-size: 13px; }}
+    .user-name {{ color: var(--fg2); font-size: 16px; }}
+    .generated-date {{ margin: 0; color: var(--fg3); font: 12px/1.5 var(--mono); }}
+    section {{
+      padding: 42px 0;
+      border-top: 1px solid var(--line);
+    }}
+    .section-heading {{ max-width: 650px; margin-bottom: 22px; }}
+    .kicker, .settings-group-label {{
+      margin: 0 0 7px;
       color: var(--accent);
-      font-size: .76rem;
-      font-weight: 700;
-      letter-spacing: .1em;
+      font: 500 11px/1.4 var(--mono);
+      letter-spacing: .06em;
       text-transform: uppercase;
     }}
-    h1, h2, h3, p {{ overflow-wrap: anywhere; }}
-    h1 {{ margin: 0; font-size: clamp(3rem, 10vw, 6.8rem); line-height: .94; letter-spacing: -.065em; font-weight: 720; }}
-    .user-name {{ margin: 1rem 0 0; color: var(--text); font-size: clamp(1.25rem, 3vw, 1.7rem); }}
-    .generated-date {{ margin: .2rem 0 0; color: var(--muted); }}
-    section {{ padding: clamp(2.1rem, 6vw, 4rem) 0; border-top: 1px solid var(--border); }}
-    .section-heading {{ max-width: 38rem; margin-bottom: 2rem; }}
-    h2 {{ margin: 0; font-size: clamp(1.75rem, 5vw, 2.8rem); line-height: 1.08; letter-spacing: -.035em; }}
-    h3 {{ margin: 0 0 .7rem; font-size: .82rem; color: var(--muted); letter-spacing: .04em; text-transform: uppercase; }}
-    .quiet, .health-note {{ color: var(--muted); }}
-    .receipt-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 2.5rem; }}
-    .receipt-group p {{ margin: .28rem 0; font-size: clamp(1.08rem, 2vw, 1.28rem); }}
-    .prose {{ max-width: 44rem; }}
-    .observation {{ margin: 0 0 1.5rem; color: #dbe5e7; font-size: clamp(1.05rem, 2.2vw, 1.22rem); }}
+    .quiet, .health-note {{ color: var(--fg2); }}
+    .receipt-grid {{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }}
+    .receipt-group, .observation, .state-panel, .health-panel {{
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: var(--surface);
+      padding: 22px 24px;
+    }}
+    .receipt-group h3 {{
+      margin-bottom: 12px;
+      color: var(--fg3);
+      font: 500 11px/1.4 var(--mono);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }}
+    .receipt-group p {{ margin: 4px 0; color: var(--fg); font-size: 15px; }}
+    .prose {{ display: grid; max-width: 760px; gap: 10px; }}
+    .observation {{ color: var(--fg2); }}
     .observation p {{ margin: 0; }}
-    strong {{ color: var(--text); font-weight: 720; }}
+    strong {{ color: var(--fg); font-weight: 600; }}
     code {{
-      padding: .12em .35em;
-      border: 1px solid var(--border);
-      border-radius: .3rem;
-      background: rgba(255, 255, 255, .04);
-      color: #c8f2ef;
-      font: .9em/1.4 ui-monospace, "SFMono-Regular", Consolas, monospace;
+      padding: 2px 5px;
+      border: 1px solid var(--line2);
+      border-radius: 3px;
+      background: var(--elevated);
+      color: var(--fg);
+      font: .9em/1.4 var(--mono);
     }}
-    a {{ color: var(--accent); text-underline-offset: .2em; }}
+    a {{ color: var(--accent); text-underline-offset: 3px; }}
     .suggestion {{
-      margin: 2rem 0;
-      padding: clamp(1.5rem, 5vw, 2.6rem);
-      border: 1px solid rgba(98, 215, 209, .24);
-      border-radius: 1rem;
-      background: linear-gradient(145deg, var(--accent-soft), rgba(255, 255, 255, .015) 60%);
+      margin: 0;
+      padding: 24px;
+      border: 1px solid var(--accent-dim);
+      border-radius: 9px;
+      background: var(--accent-bg);
     }}
-    .suggestion-why {{ max-width: 42rem; margin: .8rem 0 0; color: var(--muted); }}
-    .try-block {{ position: relative; margin-top: 1.8rem; padding: 1.1rem; border: 1px solid var(--border); border-radius: .7rem; background: rgba(4, 8, 12, .56); }}
-    .try-label {{ margin-bottom: .6rem; color: var(--accent); font-size: .78rem; font-weight: 700; }}
-    pre {{ margin: 0; padding-right: 7rem; white-space: pre-wrap; overflow-wrap: anywhere; }}
-    pre code {{ padding: 0; border: 0; background: transparent; color: var(--text); }}
-    button {{
+    .suggestion-why {{ max-width: 680px; margin: 8px 0 0; color: var(--fg2); }}
+    .try-block {{
+      position: relative;
+      margin-top: 18px;
+      padding: 16px;
+      border: 1px solid var(--line2);
+      border-radius: 8px;
+      background: var(--bg);
+    }}
+    .try-label {{
+      margin-bottom: 6px;
+      color: var(--accent);
+      font: 500 11px/1.4 var(--mono);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }}
+    pre {{ margin: 0; padding-right: 112px; white-space: pre-wrap; overflow-wrap: anywhere; }}
+    pre code {{ padding: 0; border: 0; background: transparent; color: var(--fg); }}
+    #copyPrompt {{
       position: absolute;
-      top: .8rem;
-      right: .8rem;
-      border: 1px solid rgba(98, 215, 209, .35);
-      border-radius: .5rem;
-      background: rgba(98, 215, 209, .12);
-      color: var(--text);
-      padding: .48rem .72rem;
-      font: inherit;
-      font-size: .82rem;
-      cursor: pointer;
+      top: 12px;
+      right: 12px;
+      border-color: transparent;
+      background: var(--accent);
+      color: var(--inv);
     }}
-    button:focus-visible {{ outline: 2px solid var(--accent); outline-offset: 3px; }}
-    .copy-status {{ position: absolute; right: .9rem; bottom: .45rem; color: var(--muted); font-size: .72rem; }}
-    .state-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: 1rem; }}
-    .state-panel, .health-panel {{ padding: 1.25rem; border: 1px solid var(--border); border-radius: .8rem; background: var(--surface); }}
+    #copyPrompt:hover {{ background: #ff6ea2; }}
+    .copy-status {{
+      position: absolute;
+      right: 15px;
+      bottom: 5px;
+      color: var(--fg3);
+      font: 11px/1.4 var(--mono);
+    }}
+    .state-grid {{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }}
+    .state-panel h3, .health-panel h3 {{
+      margin-bottom: 12px;
+      color: var(--fg2);
+    }}
     .state-list {{ margin: 0; }}
-    .state-list div {{ padding: .65rem 0; border-bottom: 1px solid var(--border); }}
+    .state-list div {{
+      padding: 9px 0;
+      border-bottom: 1px solid var(--line);
+    }}
     .state-list div:last-child {{ border-bottom: 0; }}
-    dt {{ color: var(--faint); font-size: .75rem; }}
-    dd {{ margin: .12rem 0 0; }}
-    .integration-list, .health-list {{ list-style: none; margin: 0; padding: 0; }}
-    .integration-list li, .health-list li {{ display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: .65rem; padding: .48rem 0; }}
-    .integration-state, .health-state {{ color: var(--muted); font-size: .84rem; }}
-    .dot {{ width: .48rem; height: .48rem; border-radius: 50%; background: var(--faint); }}
-    .dot-on, .dot-good {{ background: var(--good); box-shadow: 0 0 0 3px rgba(116, 213, 165, .08); }}
-    .dot-attention {{ background: var(--attention); }}
-    .dot-off, .dot-unknown {{ background: var(--faint); }}
-    .health-panel {{ display: grid; grid-template-columns: minmax(12rem, .8fr) minmax(16rem, 1.2fr); gap: 1.5rem; margin-top: 1rem; background: var(--surface-raised); }}
-    .health-note {{ margin: 0; font-size: .82rem; }}
-    .health-guidance {{ margin: 0; }}
-    .journey-grid {{ align-items: start; }}
+    dt {{ color: var(--fg3); font: 11px/1.4 var(--mono); }}
+    dd {{ margin: 2px 0 0; }}
+    .integration-list, .health-list {{
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }}
+    .integration-list li, .health-list li {{
+      display: grid;
+      padding: 5px 0;
+      grid-template-columns: auto 1fr auto;
+      align-items: center;
+      gap: 9px;
+    }}
+    .integration-state, .health-state {{ color: var(--fg2); font-size: 13px; }}
+    .dot {{
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--fg3);
+    }}
+    .dot-on, .dot-good {{ background: var(--accent); }}
+    .dot-attention {{ background: var(--accent-dim); }}
+    .dot-off, .dot-unknown {{ background: var(--fg3); }}
+    .health-panel {{
+      display: grid;
+      margin-top: 12px;
+      grid-template-columns: minmax(180px,.75fr) minmax(260px,1.25fr);
+      gap: 24px;
+      background: var(--elevated);
+    }}
+    .health-note, .health-guidance {{ margin: 0; font-size: 12px; }}
+    .journey-grid {{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start;
+      gap: 12px;
+    }}
     .territory {{ min-width: 0; }}
     .journey-chips {{
       display: flex;
       flex-wrap: wrap;
-      gap: .55rem;
-      list-style: none;
+      gap: 6px;
       margin: 0;
       padding: 0;
+      list-style: none;
     }}
-    .journey-chip {{
-      padding: .34rem .58rem;
-      border: 1px solid var(--border);
-      border-radius: .55rem;
-      font-size: .78rem;
-      line-height: 1.35;
+    .journey-chip, .journey-more {{
+      border: 1px solid var(--line);
+      border-radius: 3px;
+      background: var(--surface);
+      padding: 5px 8px;
+      font: 12px/1.35 var(--mono);
     }}
     .journey-chip.lit {{
-      border-color: rgba(98, 215, 209, .42);
-      background: var(--accent-soft);
-      color: var(--text);
+      border-color: var(--accent-dim);
+      background: var(--accent-bg);
+      color: var(--fg);
     }}
-    .journey-chip.dim {{
-      border-color: rgba(255, 255, 255, .06);
-      color: var(--faint);
-    }}
+    .journey-chip.dim {{ color: var(--fg3); }}
     .journey-chip.outlined {{
+      border-color: var(--line2);
       border-style: dashed;
-      border-color: rgba(145, 160, 165, .28);
-      color: var(--faint);
+      color: var(--fg3);
     }}
-    .history-trends {{ gap: 1rem; margin-bottom: 1rem; }}
-    .history-chart svg {{ display: block; width: 100%; height: auto; }}
-    .history-milestone {{ margin: 1rem 0; padding: 1rem 1.25rem; }}
-    .history-milestone h3 {{ margin: 0; color: var(--text); }}
-    .history-looking-back {{ margin-top: 1rem; }}
-    .history-looking-back p {{ margin: 0; }}
+    .journey-more {{
+      color: var(--fg2);
+      border-color: var(--line2);
+    }}
+    .journey-more:hover {{ color: var(--accent); }}
+    .history-trends {{ margin-bottom: 12px; gap: 12px; }}
+    .history-chart svg {{ display: block; width: 100%; height: auto; color: var(--accent); }}
+    .history-chart polyline {{ stroke: var(--accent); }}
+    .history-milestone {{ margin: 12px 0; }}
+    .history-milestone h3 {{ margin: 0; color: var(--fg); }}
+    .history-looking-back {{ margin-top: 12px; }}
+    .history-looking-back p, .history-empty {{ margin: 0; }}
+    .settings-readonly-note {{ margin: 8px 0 0; }}
+    #settings > #state {{
+      padding-bottom: 0;
+      border-top: 0;
+    }}
+    #settings > #state > .section-heading {{ display: none; }}
+    .settings-group {{ margin-top: 30px; }}
+    .section-heading + .settings-group {{ margin-top: 0; }}
+    .settings-group-label {{ margin-bottom: 9px; }}
     .settings-list {{
       overflow: hidden;
-      border: 1px solid var(--border);
-      border-radius: .8rem;
+      border: 1px solid var(--line);
+      border-radius: 9px;
       background: var(--surface);
     }}
     .setting-row {{
       display: grid;
+      padding: 15px 17px;
+      border-bottom: 1px solid var(--line);
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
-      gap: 1.25rem;
-      padding: 1rem 1.15rem;
-      border-bottom: 1px solid var(--border);
+      gap: 20px;
     }}
     .setting-row:last-child {{ border-bottom: 0; }}
     .setting-row-readonly {{ grid-template-columns: 1fr; }}
     .setting-copy {{ min-width: 0; }}
     .setting-copy label, .setting-label {{
       display: block;
-      color: var(--text);
-      font-size: .94rem;
-      font-weight: 650;
+      color: var(--fg);
+      font-size: 14px;
+      font-weight: 500;
     }}
-    .setting-copy p {{ margin: .18rem 0 0; color: var(--muted); font-size: .78rem; }}
+    .setting-copy p {{ margin: 2px 0 0; color: var(--fg2); font-size: 12px; }}
     .setting-action {{
       display: flex;
-      min-width: 8.5rem;
+      min-width: 136px;
       flex-direction: column;
       align-items: flex-end;
-      gap: .25rem;
+      gap: 4px;
     }}
     .setting-action input[role="switch"] {{
       appearance: none;
       position: relative;
-      width: 2.6rem;
-      height: 1.45rem;
+      width: 38px;
+      height: 21px;
       margin: 0;
-      border: 1px solid rgba(145, 160, 165, .3);
-      border-radius: 999px;
-      background: rgba(255, 255, 255, .06);
+      border: 1px solid var(--line2);
+      border-radius: 11px;
+      background: var(--elevated);
       cursor: pointer;
-      transition: background .16s ease, border-color .16s ease;
+      transition: background .15s ease, border-color .15s ease;
     }}
     .setting-action input[role="switch"]::after {{
       content: "";
       position: absolute;
-      top: .18rem;
-      left: .2rem;
-      width: .96rem;
-      height: .96rem;
+      top: 3px;
+      left: 3px;
+      width: 13px;
+      height: 13px;
       border-radius: 50%;
-      background: var(--muted);
-      transition: transform .16s ease, background .16s ease;
+      background: var(--fg3);
+      transition: transform .15s ease, background .15s ease;
     }}
     .setting-action input[role="switch"]:checked {{
-      border-color: rgba(98, 215, 209, .62);
-      background: rgba(98, 215, 209, .32);
+      border-color: var(--accent);
+      background: var(--accent);
     }}
     .setting-action input[role="switch"]:checked::after {{
-      background: var(--accent);
-      transform: translateX(1.16rem);
+      background: var(--inv);
+      transform: translateX(17px);
     }}
     .setting-action input[role="switch"]:focus-visible,
     .setting-action select:focus-visible {{
       outline: 2px solid var(--accent);
-      outline-offset: 3px;
+      outline-offset: 2px;
     }}
     .setting-action input:disabled, .setting-action select:disabled {{
       cursor: not-allowed;
       opacity: .48;
     }}
     .setting-action select {{
-      min-width: 10.5rem;
-      max-width: 15rem;
-      border: 1px solid rgba(145, 160, 165, .26);
-      border-radius: .55rem;
-      background: var(--surface-raised);
-      color: var(--text);
-      padding: .48rem 1.8rem .48rem .62rem;
-      font: inherit;
-      font-size: .82rem;
+      min-width: 168px;
+      max-width: 240px;
+      border: 1px solid var(--line2);
+      border-radius: 3px;
+      background: var(--elevated);
+      color: var(--fg);
+      padding: 7px 28px 7px 9px;
+      font: 12px/1.4 var(--mono);
     }}
     .setting-status {{
-      min-height: 1.1rem;
-      color: var(--muted);
-      font-size: .7rem;
+      min-height: 16px;
+      color: var(--fg2);
+      font: 10px/1.4 var(--mono);
       text-align: right;
     }}
-    .settings-subsection {{ margin-top: 2rem; }}
-    .settings-subsection h3 {{ margin-bottom: .8rem; }}
+    .settings-subsection {{ margin-top: 16px; }}
+    .settings-subsection h4 {{ margin-bottom: 8px; }}
     .handoff-button {{
-      position: static;
       display: flex;
       width: 100%;
       align-items: center;
       justify-content: space-between;
-      gap: 1rem;
-      border-color: var(--border);
-      background: var(--surface);
-      padding: .85rem 1rem;
+      gap: 16px;
+      border-color: var(--line2);
+      background: transparent;
+      padding: 11px 13px;
       text-align: left;
     }}
-    .handoff-button:hover {{ border-color: rgba(98, 215, 209, .28); }}
-    .handoff-button span {{ color: var(--muted); font-size: .75rem; font-weight: 400; }}
-    .handoff-status {{ display: block; min-height: 1.2rem; margin-top: .45rem; color: var(--muted); font-size: .75rem; }}
+    .handoff-button span {{ color: var(--fg2); font-size: 11px; font-weight: 400; }}
+    .handoff-status {{
+      display: block;
+      min-height: 18px;
+      margin-top: 6px;
+      color: var(--fg2);
+      font: 11px/1.4 var(--mono);
+    }}
     .undo-button {{
-      position: static;
-      margin: 0 0 0 .15rem;
+      margin-left: 2px;
       border: 0;
-      background: transparent;
       color: var(--accent);
       padding: 0;
-      font-size: inherit;
+      font: inherit;
       text-decoration: underline;
-      text-underline-offset: .15em;
+      text-underline-offset: 2px;
     }}
-    footer {{ display: flex; flex-wrap: wrap; justify-content: space-between; gap: .5rem 1rem; padding-top: 2rem; border-top: 1px solid var(--border); color: var(--faint); font-size: .78rem; }}
-    @media (max-width: 600px) {{
-      main {{ padding-inline: 1rem; }}
+    footer {{
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 8px 16px;
+      padding: 20px 0 28px;
+      border-top: 1px solid var(--line);
+      color: var(--fg3);
+      font: 11px/1.5 var(--mono);
+    }}
+    @media (max-width: 700px) {{
+      .nav-shell {{ padding: 0 14px; gap: 12px; }}
+      .tab-list {{ justify-content: flex-start; }}
+      main {{ padding-inline: 14px; }}
+      .tab-panel {{ padding-top: 30px; }}
+      .overview-intro {{ align-items: flex-start; flex-direction: column; gap: 8px; }}
+      .receipt-grid, .state-grid, .journey-grid {{ grid-template-columns: 1fr; }}
       .health-panel {{ grid-template-columns: 1fr; }}
       .setting-row {{ grid-template-columns: 1fr; }}
       .setting-action {{ min-width: 0; align-items: flex-start; }}
       .setting-status {{ text-align: left; }}
       .handoff-button {{ align-items: flex-start; flex-direction: column; }}
-      pre {{ padding: 2.8rem 0 0; }}
+      pre {{ padding: 42px 0 0; }}
     }}
   </style>
 </head>
 <body>
+  <nav class="topbar" aria-label="Dashboard">
+    <div class="nav-shell">
+      <span class="wordmark" aria-label="Dex">dex<span class="wordmark-dot">.</span></span>
+      <div class="tab-list" role="tablist" aria-label="Dashboard sections">
+        <button type="button" role="tab" id="tab-overview" data-tab-target="overview" aria-selected="true" aria-controls="panel-overview">Overview</button>
+        <button type="button" role="tab" id="tab-journey" data-tab-target="journey" aria-selected="false" aria-controls="panel-journey" tabindex="-1">Journey</button>
+        <button type="button" role="tab" id="tab-settings" data-tab-target="settings" aria-selected="false" aria-controls="panel-settings" tabindex="-1">Settings</button>
+        <button type="button" role="tab" id="tab-history" data-tab-target="history" aria-selected="false" aria-controls="panel-history" tabindex="-1">History</button>
+      </div>
+    </div>
+  </nav>
   <main>
-    <header>
-      <p class="kicker">Local overview</p>
-      <h1>Your Dex</h1>
-      {identity}
-      <p class="generated-date">{_escape(_display_date(data))}</p>
-    </header>
-    {_render_receipt(data)}
-    {_render_observations(observations)}
-    {suggestion}
-    {journey_section}
-    {_render_state(data)}
-    {history_section}
-    {settings_section}
+    <section class="tab-panel" id="panel-overview" data-tab="overview" role="tabpanel" aria-labelledby="tab-overview">
+      <header class="overview-intro">
+        <div>
+          <p class="kicker">Local overview</p>
+          <div class="greeting-line"><h1>Your Dex</h1>{identity}</div>
+        </div>
+        <p class="generated-date">{_escape(_display_date(data))}</p>
+      </header>
+      {_render_receipt(data)}
+      {_render_observations(observations)}
+      {suggestion}
+    </section>
+    <section class="tab-panel" id="panel-journey" data-tab="journey" role="tabpanel" aria-labelledby="tab-journey" hidden>
+      {journey_section}
+    </section>
+    <section class="tab-panel" id="panel-settings" data-tab="settings" role="tabpanel" aria-labelledby="tab-settings" hidden>
+      {settings_section}
+    </section>
+    <section class="tab-panel" id="panel-history" data-tab="history" role="tabpanel" aria-labelledby="tab-history" hidden>
+      {history_section}
+    </section>
     <footer>
       <span>Generated locally by Dex · nothing leaves your machine</span>
       <span>{_escape(archive_note)}</span>
     </footer>
   </main>
   <script>
+    (() => {{
+      const tabs = Array.from(document.querySelectorAll('[role="tab"][data-tab-target]'));
+      const panels = Array.from(document.querySelectorAll('.tab-panel[data-tab]'));
+      const validTabs = new Set(tabs.map((tab) => tab.dataset.tabTarget));
+
+      function activateTab(name, focusTab = false) {{
+        const activeName = validTabs.has(name) ? name : 'overview';
+        tabs.forEach((tab) => {{
+          const active = tab.dataset.tabTarget === activeName;
+          tab.setAttribute('aria-selected', String(active));
+          tab.tabIndex = active ? 0 : -1;
+          if (active && focusTab) tab.focus();
+        }});
+        panels.forEach((panel) => {{
+          panel.hidden = panel.dataset.tab !== activeName;
+        }});
+      }}
+
+      tabs.forEach((tab, index) => {{
+        tab.addEventListener('click', () => {{
+          const name = tab.dataset.tabTarget;
+          activateTab(name);
+          if (window.location.hash !== '#' + name) window.location.hash = name;
+        }});
+        tab.addEventListener('keydown', (event) => {{
+          let nextIndex = null;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+          if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+          if (event.key === 'Home') nextIndex = 0;
+          if (event.key === 'End') nextIndex = tabs.length - 1;
+          if (nextIndex === null) return;
+          event.preventDefault();
+          const nextName = tabs[nextIndex].dataset.tabTarget;
+          activateTab(nextName, true);
+          if (window.location.hash !== '#' + nextName) window.location.hash = nextName;
+        }});
+      }});
+
+      window.addEventListener('hashchange', () => {{
+        activateTab(window.location.hash.slice(1));
+      }});
+      activateTab(window.location.hash.slice(1));
+    }})();
+    (() => {{
+      document.querySelectorAll('[data-journey-expand]').forEach((button) => {{
+        button.addEventListener('click', () => {{
+          const group = button.closest('.journey-chips');
+          if (!group) return;
+          group.querySelectorAll('[data-journey-extra]').forEach((extra) => {{
+            extra.hidden = false;
+          }});
+          button.setAttribute('aria-expanded', 'true');
+          button.closest('.journey-more-item').hidden = true;
+        }});
+      }});
+    }})();
     (() => {{
       const button = document.getElementById('copyPrompt');
       const prompt = document.getElementById('tryPrompt');
@@ -724,10 +986,7 @@ def _snapshot(data: dict[str, Any], observations: dict[str, Any], now: datetime)
     integrations = _mapping(data.get("integrations"))
     integrations_on = _number(integrations, "enabled_count")
     if not integrations_on:
-        integrations_on = sum(
-            bool(_mapping(app).get("enabled"))
-            for app in _mapping(integrations.get("apps")).values()
-        )
+        integrations_on = sum(bool(_mapping(app).get("enabled")) for app in _mapping(integrations.get("apps")).values())
     return {
         "ts": _timestamp(now),
         "counts": {
@@ -735,11 +994,7 @@ def _snapshot(data: dict[str, Any], observations: dict[str, Any], now: datetime)
             "people": _number(data.get("people"), "total"),
             "meetings": _number(data.get("meetings"), "total"),
             "skills_used": len(
-                [
-                    name
-                    for name in _list(_mapping(data.get("skills")).get("used"))
-                    if isinstance(name, str)
-                ]
+                [name for name in _list(_mapping(data.get("skills")).get("used")) if isinstance(name, str)]
             ),
             "integrations_on": integrations_on,
         },
@@ -762,9 +1017,7 @@ def _history_section_data(
         raw_vault_age = _mapping(_mapping(data.get("meta")).get("vault_age")).get("age_days")
         vault_age = (
             raw_vault_age
-            if isinstance(raw_vault_age, int)
-            and not isinstance(raw_vault_age, bool)
-            and raw_vault_age >= 0
+            if isinstance(raw_vault_age, int) and not isinstance(raw_vault_age, bool) and raw_vault_age >= 0
             else None
         )
         trend_input = {
@@ -878,11 +1131,7 @@ def main(argv: list[str] | None = None) -> int:
             observations,
             args.out,
             archive=not args.no_archive,
-            server_ctx=(
-                {"token": TOKEN_PLACEHOLDER, "port": PORT_PLACEHOLDER}
-                if args.with_settings
-                else None
-            ),
+            server_ctx=({"token": TOKEN_PLACEHOLDER, "port": PORT_PLACEHOLDER} if args.with_settings else None),
         )
     except OSError as error:
         print(f"Error: could not write dashboard output: {str(error).splitlines()[0]}", file=sys.stderr)

--- a/core/dashboard/render.py
+++ b/core/dashboard/render.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""Render one offline Dex Dashboard page and optionally archive a compact snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.paths import DEX_RUNTIME_DIR, VAULT_ROOT
+
+INLINE_MARKDOWN = re.compile(
+    r"`(?P<code>[^`\n]+)`"
+    r"|\[(?P<label>[^\]\n]+)\]\((?P<url>[^)\n]+)\)"
+    r"|\*\*(?P<strong>[^*\n]+)\*\*"
+)
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_href(value: str) -> str | None:
+    url = value.strip()
+    parsed = urlparse(url)
+    if parsed.scheme in {"http", "https"} and parsed.netloc:
+        return url
+    if parsed.scheme == "mailto" and parsed.path:
+        return url
+    if not parsed.scheme and url.startswith(("#", "/", "./", "../")):
+        return url
+    return None
+
+
+def _inline_markdown(value: str) -> str:
+    output = []
+    cursor = 0
+    for match in INLINE_MARKDOWN.finditer(value):
+        output.append(_escape(value[cursor : match.start()]))
+        if match.group("code") is not None:
+            output.append(f"<code>{_escape(match.group('code'))}</code>")
+        elif match.group("strong") is not None:
+            output.append(f"<strong>{_escape(match.group('strong'))}</strong>")
+        else:
+            label = _escape(match.group("label"))
+            raw_url = match.group("url")
+            href = _safe_href(raw_url)
+            if href is None:
+                output.append(f"{label} ({_escape(raw_url)})")
+            else:
+                rel = ' rel="noreferrer"' if urlparse(href).scheme in {"http", "https"} else ""
+                output.append(f'<a href="{_escape(href)}"{rel}>{label}</a>')
+        cursor = match.end()
+    output.append(_escape(value[cursor:]))
+    return "".join(output)
+
+
+def _markdown(value: str) -> str:
+    paragraphs = []
+    for part in re.split(r"\n\s*\n", value.strip()):
+        if not part:
+            continue
+        paragraphs.append(f"<p>{_inline_markdown(part).replace(chr(10), '<br>')}</p>")
+    return "".join(paragraphs)
+
+
+def _number(section: Any, key: str) -> int:
+    value = _mapping(section).get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _plural(count: int, singular: str, plural: str | None = None) -> str:
+    return singular if count == 1 else (plural or f"{singular}s")
+
+
+def _receipt_lines(data: dict[str, Any]) -> tuple[list[str], list[str]]:
+    meetings_week = _number(data.get("meetings"), "last_7_days")
+    tasks_week = _number(data.get("tasks"), "completed_last_7_days")
+    meetings_total = _number(data.get("meetings"), "total")
+    tasks_done = _number(data.get("tasks"), "completed")
+    people = _number(data.get("people"), "total")
+    skills_used = len(
+        [name for name in _list(_mapping(data.get("skills")).get("used")) if isinstance(name, str)]
+    )
+    weekly = []
+    if meetings_week:
+        weekly.append(
+            f"{meetings_week} {_plural(meetings_week, 'meeting')} turned into notes this week"
+        )
+    if tasks_week:
+        weekly.append(f"{tasks_week} {_plural(tasks_week, 'task')} completed this week")
+    all_time = []
+    if meetings_total:
+        all_time.append(f"{meetings_total} {_plural(meetings_total, 'meeting note')} in Dex")
+    if tasks_done:
+        all_time.append(f"{tasks_done} completed {_plural(tasks_done, 'task')} in Dex")
+    if people:
+        all_time.append(f"{people} {_plural(people, 'person', 'people')} in Dex")
+    if skills_used:
+        all_time.append(f"{skills_used} {_plural(skills_used, 'skill')} used")
+    return weekly, all_time
+
+
+def _render_receipt(data: dict[str, Any]) -> str:
+    weekly, all_time = _receipt_lines(data)
+    groups = []
+    if weekly:
+        groups.append(
+            '<div class="receipt-group"><h3>This week</h3>'
+            + "".join(f"<p>{_escape(line)}</p>" for line in weekly)
+            + "</div>"
+        )
+    if all_time:
+        groups.append(
+            '<div class="receipt-group"><h3>All time</h3>'
+            + "".join(f"<p>{_escape(line)}</p>" for line in all_time)
+            + "</div>"
+        )
+    body = "".join(groups)
+    if not body:
+        body = '<p class="quiet">Your value receipt will grow as you use Dex.</p>'
+    return f"""
+    <section id="receipt" aria-labelledby="receipt-heading">
+      <div class="section-heading">
+        <p class="kicker">Value receipt</p>
+        <h2 id="receipt-heading">What Dex has held onto for you</h2>
+      </div>
+      <div class="receipt-grid">{body}</div>
+    </section>"""
+
+
+def _observation_strings(observations: Any) -> list[str]:
+    return [
+        item
+        for item in _list(_mapping(observations).get("observations"))
+        if isinstance(item, str) and item.strip()
+    ]
+
+
+def _render_observations(observations: Any) -> str:
+    items = _observation_strings(observations)
+    if items:
+        body = "".join(f'<div class="observation">{_markdown(item)}</div>' for item in items)
+    else:
+        body = (
+            '<p class="quiet">Open this from a Dex session to get Dex&#x27;s '
+            "observations.</p>"
+        )
+    return f"""
+    <section id="observations" aria-labelledby="observations-heading">
+      <div class="section-heading">
+        <p class="kicker">A view from Dex</p>
+        <h2 id="observations-heading">What stands out</h2>
+      </div>
+      <div class="prose">{body}</div>
+    </section>"""
+
+
+def _suggestion(observations: Any) -> dict[str, str]:
+    raw = _mapping(_mapping(observations).get("suggestion"))
+    return {
+        key: str(raw.get(key) or "").strip()
+        for key in ("title", "why", "try_prompt")
+    }
+
+
+def _render_suggestion(observations: Any) -> str:
+    suggestion = _suggestion(observations)
+    if not any(suggestion.values()):
+        return ""
+    title = suggestion["title"] or "A useful next step"
+    why = (
+        f'<p class="suggestion-why">{_escape(suggestion["why"])}</p>'
+        if suggestion["why"]
+        else ""
+    )
+    prompt = ""
+    if suggestion["try_prompt"]:
+        prompt = f"""
+        <div class="try-block">
+          <div class="try-label">Try it</div>
+          <pre id="tryPrompt"><code>{_escape(suggestion["try_prompt"])}</code></pre>
+          <button type="button" id="copyPrompt">Copy prompt</button>
+          <span class="copy-status" id="copyStatus" aria-live="polite"></span>
+        </div>"""
+    return f"""
+    <section id="suggestion" class="suggestion" aria-labelledby="suggestion-heading">
+      <p class="kicker">One next step</p>
+      <h2 id="suggestion-heading">{_escape(title)}</h2>
+      {why}
+      {prompt}
+    </section>"""
+
+
+def _pretty_setting(value: Any) -> str:
+    return str(value).replace("_", " ").strip()
+
+
+def _render_profile_state(data: dict[str, Any]) -> str:
+    profile = _mapping(data.get("profile"))
+    role = str(profile.get("role") or "").strip()
+    communication = _mapping(profile.get("communication"))
+    communication_parts = [
+        _pretty_setting(communication[key])
+        for key in ("formality", "directness", "detail_level")
+        if communication.get(key) not in (None, "")
+    ]
+    pillars = [
+        str(item.get("name") or "").strip()
+        for item in _list(data.get("pillars"))
+        if isinstance(item, dict) and str(item.get("name") or "").strip()
+    ]
+    rows = []
+    if role:
+        rows.append(f"<div><dt>Role</dt><dd>{_escape(role)}</dd></div>")
+    if pillars:
+        rows.append(
+            f"<div><dt>Pillars</dt><dd>{_escape(', '.join(pillars))}</dd></div>"
+        )
+    if communication_parts:
+        rows.append(
+            "<div><dt>Communication style</dt>"
+            f"<dd>{_escape(', '.join(communication_parts))}</dd></div>"
+        )
+    if not rows:
+        return '<p class="quiet">Your role and preferences are not configured yet.</p>'
+    return f'<dl class="state-list">{"".join(rows)}</dl>'
+
+
+def _render_integrations(data: dict[str, Any]) -> str:
+    apps = _mapping(_mapping(data.get("integrations")).get("apps"))
+    rows = []
+    for name, raw in sorted(apps.items(), key=lambda item: str(item[0]).casefold()):
+        enabled = bool(_mapping(raw).get("enabled"))
+        state = "connected" if enabled else "not set up"
+        css = "on" if enabled else "off"
+        rows.append(
+            '<li>'
+            f'<span class="dot dot-{css}" aria-hidden="true"></span>'
+            f'<span class="integration-name">{_escape(name)}</span>'
+            f'<span class="integration-state">{state}</span>'
+            "</li>"
+        )
+    if not rows:
+        return '<p class="quiet">No integration setup is recorded.</p>'
+    return f'<ul class="integration-list">{"".join(rows)}</ul>'
+
+
+def _health_label(verdict: str) -> tuple[str, str]:
+    return {
+        "OK": ("good", "looking good"),
+        "OFF": ("off", "not set up"),
+        "UNKNOWN": ("unknown", "unknown"),
+        "BROKEN": ("attention", "needs attention"),
+    }.get(verdict.upper(), ("unknown", "unknown"))
+
+
+def _render_health(data: dict[str, Any]) -> str:
+    health = _mapping(data.get("health"))
+    status = str(health.get("status") or "unknown")
+    if status != "fresh":
+        return (
+            '<p class="quiet health-guidance">'
+            "Run /dex-doctor for a fresh checkup."
+            "</p>"
+        )
+    rows = []
+    for check in _list(health.get("checks")):
+        if not isinstance(check, dict):
+            continue
+        css, label = _health_label(str(check.get("verdict") or "UNKNOWN"))
+        feature = str(check.get("feature") or check.get("id") or "Unknown check")
+        rows.append(
+            '<li>'
+            f'<span class="dot dot-{css}" aria-hidden="true"></span>'
+            f'<span class="health-name">{_escape(feature)}</span>'
+            f'<span class="health-state">{label}</span>'
+            "</li>"
+        )
+    if not rows:
+        return '<p class="quiet">The cached checkup has no individual checks to show.</p>'
+    return f'<ul class="health-list">{"".join(rows)}</ul>'
+
+
+def _render_state(data: dict[str, Any]) -> str:
+    return f"""
+    <section id="state" aria-labelledby="state-heading">
+      <div class="section-heading">
+        <p class="kicker">Configuration</p>
+        <h2 id="state-heading">State of your Dex</h2>
+      </div>
+      <div class="state-grid">
+        <div class="state-panel">
+          <h3>You</h3>
+          {_render_profile_state(data)}
+        </div>
+        <div class="state-panel">
+          <h3>Integrations</h3>
+          {_render_integrations(data)}
+        </div>
+      </div>
+      <div class="health-panel">
+        <div>
+          <h3>Latest Dex checkup</h3>
+          <p class="health-note">This reflects the last saved /dex-doctor check, not a new scan.</p>
+        </div>
+        {_render_health(data)}
+      </div>
+    </section>"""
+
+
+def _display_date(data: dict[str, Any]) -> str:
+    raw = _mapping(data.get("meta")).get("generated_at")
+    if not isinstance(raw, str):
+        return "Date unavailable"
+    try:
+        generated = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return "Date unavailable"
+    return f"{generated:%A, %B} {generated.day}, {generated.year}"
+
+
+def render_dashboard_html(
+    data: dict[str, Any],
+    observations: dict[str, Any] | None = None,
+    *,
+    archive_count: int = 0,
+    archived: bool = False,
+) -> str:
+    """Render escaped data into one self-contained Nightfall HTML document."""
+    observations = observations or {}
+    profile = _mapping(data.get("profile"))
+    name = str(profile.get("name") or "").strip()
+    identity = f"<p class=\"user-name\">{_escape(name)}</p>" if name else ""
+    archive_note = f"snapshot #{archive_count} saved" if archived else "snapshot not saved"
+    suggestion = _render_suggestion(observations)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>Your Dex</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #0B0F14;
+      --surface: #11171e;
+      --surface-raised: #151d25;
+      --text: #edf4f5;
+      --muted: #91a0a5;
+      --faint: #66747a;
+      --border: rgba(255, 255, 255, .08);
+      --accent: #62d7d1;
+      --accent-soft: rgba(98, 215, 209, .11);
+      --good: #74d5a5;
+      --attention: #e7c978;
+    }}
+    * {{ box-sizing: border-box; }}
+    html {{ background: var(--bg); }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, "SF Pro", "Segoe UI", sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }}
+    main {{ max-width: 880px; margin: 0 auto; padding: clamp(2rem, 7vw, 6rem) 1.25rem 2.5rem; }}
+    header {{ padding: 0 0 clamp(3.5rem, 9vw, 7rem); }}
+    .kicker {{
+      margin: 0 0 .7rem;
+      color: var(--accent);
+      font-size: .76rem;
+      font-weight: 700;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }}
+    h1, h2, h3, p {{ overflow-wrap: anywhere; }}
+    h1 {{ margin: 0; font-size: clamp(3rem, 10vw, 6.8rem); line-height: .94; letter-spacing: -.065em; font-weight: 720; }}
+    .user-name {{ margin: 1rem 0 0; color: var(--text); font-size: clamp(1.25rem, 3vw, 1.7rem); }}
+    .generated-date {{ margin: .2rem 0 0; color: var(--muted); }}
+    section {{ padding: clamp(2.1rem, 6vw, 4rem) 0; border-top: 1px solid var(--border); }}
+    .section-heading {{ max-width: 38rem; margin-bottom: 2rem; }}
+    h2 {{ margin: 0; font-size: clamp(1.75rem, 5vw, 2.8rem); line-height: 1.08; letter-spacing: -.035em; }}
+    h3 {{ margin: 0 0 .7rem; font-size: .82rem; color: var(--muted); letter-spacing: .04em; text-transform: uppercase; }}
+    .quiet, .health-note {{ color: var(--muted); }}
+    .receipt-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 2.5rem; }}
+    .receipt-group p {{ margin: .28rem 0; font-size: clamp(1.08rem, 2vw, 1.28rem); }}
+    .prose {{ max-width: 44rem; }}
+    .observation {{ margin: 0 0 1.5rem; color: #dbe5e7; font-size: clamp(1.05rem, 2.2vw, 1.22rem); }}
+    .observation p {{ margin: 0; }}
+    strong {{ color: var(--text); font-weight: 720; }}
+    code {{
+      padding: .12em .35em;
+      border: 1px solid var(--border);
+      border-radius: .3rem;
+      background: rgba(255, 255, 255, .04);
+      color: #c8f2ef;
+      font: .9em/1.4 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }}
+    a {{ color: var(--accent); text-underline-offset: .2em; }}
+    .suggestion {{
+      margin: 2rem 0;
+      padding: clamp(1.5rem, 5vw, 2.6rem);
+      border: 1px solid rgba(98, 215, 209, .24);
+      border-radius: 1rem;
+      background: linear-gradient(145deg, var(--accent-soft), rgba(255, 255, 255, .015) 60%);
+    }}
+    .suggestion-why {{ max-width: 42rem; margin: .8rem 0 0; color: var(--muted); }}
+    .try-block {{ position: relative; margin-top: 1.8rem; padding: 1.1rem; border: 1px solid var(--border); border-radius: .7rem; background: rgba(4, 8, 12, .56); }}
+    .try-label {{ margin-bottom: .6rem; color: var(--accent); font-size: .78rem; font-weight: 700; }}
+    pre {{ margin: 0; padding-right: 7rem; white-space: pre-wrap; overflow-wrap: anywhere; }}
+    pre code {{ padding: 0; border: 0; background: transparent; color: var(--text); }}
+    button {{
+      position: absolute;
+      top: .8rem;
+      right: .8rem;
+      border: 1px solid rgba(98, 215, 209, .35);
+      border-radius: .5rem;
+      background: rgba(98, 215, 209, .12);
+      color: var(--text);
+      padding: .48rem .72rem;
+      font: inherit;
+      font-size: .82rem;
+      cursor: pointer;
+    }}
+    button:focus-visible {{ outline: 2px solid var(--accent); outline-offset: 3px; }}
+    .copy-status {{ position: absolute; right: .9rem; bottom: .45rem; color: var(--muted); font-size: .72rem; }}
+    .state-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: 1rem; }}
+    .state-panel, .health-panel {{ padding: 1.25rem; border: 1px solid var(--border); border-radius: .8rem; background: var(--surface); }}
+    .state-list {{ margin: 0; }}
+    .state-list div {{ padding: .65rem 0; border-bottom: 1px solid var(--border); }}
+    .state-list div:last-child {{ border-bottom: 0; }}
+    dt {{ color: var(--faint); font-size: .75rem; }}
+    dd {{ margin: .12rem 0 0; }}
+    .integration-list, .health-list {{ list-style: none; margin: 0; padding: 0; }}
+    .integration-list li, .health-list li {{ display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: .65rem; padding: .48rem 0; }}
+    .integration-state, .health-state {{ color: var(--muted); font-size: .84rem; }}
+    .dot {{ width: .48rem; height: .48rem; border-radius: 50%; background: var(--faint); }}
+    .dot-on, .dot-good {{ background: var(--good); box-shadow: 0 0 0 3px rgba(116, 213, 165, .08); }}
+    .dot-attention {{ background: var(--attention); }}
+    .dot-off, .dot-unknown {{ background: var(--faint); }}
+    .health-panel {{ display: grid; grid-template-columns: minmax(12rem, .8fr) minmax(16rem, 1.2fr); gap: 1.5rem; margin-top: 1rem; background: var(--surface-raised); }}
+    .health-note {{ margin: 0; font-size: .82rem; }}
+    .health-guidance {{ margin: 0; }}
+    footer {{ display: flex; flex-wrap: wrap; justify-content: space-between; gap: .5rem 1rem; padding-top: 2rem; border-top: 1px solid var(--border); color: var(--faint); font-size: .78rem; }}
+    @media (max-width: 600px) {{
+      main {{ padding-inline: 1rem; }}
+      .health-panel {{ grid-template-columns: 1fr; }}
+      pre {{ padding: 2.8rem 0 0; }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="kicker">Local overview</p>
+      <h1>Your Dex</h1>
+      {identity}
+      <p class="generated-date">{_escape(_display_date(data))}</p>
+    </header>
+    {_render_receipt(data)}
+    {_render_observations(observations)}
+    {suggestion}
+    {_render_state(data)}
+    <footer>
+      <span>Generated locally by Dex · nothing leaves your machine</span>
+      <span>{_escape(archive_note)}</span>
+    </footer>
+  </main>
+  <script>
+    (() => {{
+      const button = document.getElementById('copyPrompt');
+      const prompt = document.getElementById('tryPrompt');
+      const status = document.getElementById('copyStatus');
+      if (!button || !prompt) return;
+      const markCopied = () => {{
+        if (status) status.textContent = 'Copied';
+        window.setTimeout(() => {{ if (status) status.textContent = ''; }}, 1600);
+      }};
+      button.addEventListener('click', async () => {{
+        const text = prompt.textContent || '';
+        try {{
+          if (!navigator.clipboard) throw new Error('clipboard unavailable');
+          await navigator.clipboard.writeText(text);
+          markCopied();
+        }} catch (_) {{
+          const range = document.createRange();
+          range.selectNodeContents(prompt);
+          const selection = window.getSelection();
+          selection.removeAllRanges();
+          selection.addRange(range);
+          document.execCommand('copy');
+          selection.removeAllRanges();
+          markCopied();
+        }}
+      }});
+    }})();
+  </script>
+</body>
+</html>
+"""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _timestamp(now: datetime) -> str:
+    return now.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _history_path(vault: Path) -> Path:
+    return vault / DEX_RUNTIME_DIR.relative_to(VAULT_ROOT) / "dashboard" / "history.jsonl"
+
+
+def _history_count(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    return sum(bool(line.strip()) for line in path.read_text(encoding="utf-8", errors="replace").splitlines())
+
+
+def _snapshot(data: dict[str, Any], observations: dict[str, Any], now: datetime) -> dict[str, Any]:
+    integrations = _mapping(data.get("integrations"))
+    integrations_on = _number(integrations, "enabled_count")
+    if not integrations_on:
+        integrations_on = sum(
+            bool(_mapping(app).get("enabled"))
+            for app in _mapping(integrations.get("apps")).values()
+        )
+    return {
+        "ts": _timestamp(now),
+        "counts": {
+            "tasks_done": _number(data.get("tasks"), "completed"),
+            "people": _number(data.get("people"), "total"),
+            "meetings": _number(data.get("meetings"), "total"),
+            "skills_used": len(
+                [
+                    name
+                    for name in _list(_mapping(data.get("skills")).get("used"))
+                    if isinstance(name, str)
+                ]
+            ),
+            "integrations_on": integrations_on,
+        },
+        "observations": _observation_strings(observations),
+        "suggestion_title": _suggestion(observations)["title"],
+    }
+
+
+def render_dashboard(
+    vault: Path | str,
+    data: dict[str, Any],
+    observations: dict[str, Any] | None,
+    output: Path | str,
+    *,
+    archive: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Write the page and, unless disabled, one compact local history line."""
+    vault_path = Path(vault).expanduser().resolve()
+    output_path = Path(output).expanduser()
+    observation_data = observations or {}
+    generated = now or _utc_now()
+    history = _history_path(vault_path)
+    archive_count = 0
+    if archive:
+        archive_count = _history_count(history) + 1
+        history.parent.mkdir(parents=True, exist_ok=True)
+        with history.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    _snapshot(data, observation_data, generated),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+    page = render_dashboard_html(
+        data,
+        observation_data,
+        archive_count=archive_count,
+        archived=archive,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(page, encoding="utf-8")
+    return {
+        "output": str(output_path),
+        "archived": archive,
+        "archive_count": archive_count,
+    }
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return parsed
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, required=True, help="Dex vault root")
+    parser.add_argument("--data", type=Path, required=True, help="Collected dashboard JSON")
+    parser.add_argument("--observations", type=Path, help="Authored observations JSON")
+    parser.add_argument("--out", type=Path, required=True, help="HTML output path")
+    parser.add_argument("--no-archive", action="store_true", help="Do not append a history snapshot")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.vault.expanduser().is_dir():
+        print(f"Error: vault is not a directory: {args.vault}", file=sys.stderr)
+        return 2
+    try:
+        data = _load_json_object(args.data)
+        observations = _load_json_object(args.observations) if args.observations else {}
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"Error: could not read dashboard input: {str(error).splitlines()[0]}", file=sys.stderr)
+        return 2
+    try:
+        result = render_dashboard(
+            args.vault,
+            data,
+            observations,
+            args.out,
+            archive=not args.no_archive,
+        )
+    except OSError as error:
+        print(f"Error: could not write dashboard output: {str(error).splitlines()[0]}", file=sys.stderr)
+        return 1
+    print(result["output"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/dashboard/sections/__init__.py
+++ b/core/dashboard/sections/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard page section fragments."""

--- a/core/dashboard/sections/history.py
+++ b/core/dashboard/sections/history.py
@@ -1,0 +1,106 @@
+"""Nightfall HTML fragment for the Dex Dashboard's local history."""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+from core.dashboard.history import sparkline_svg, weekly_trends
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _entries(history_data: Any) -> list[dict[str, Any]]:
+    source = _mapping(history_data)
+    entries = source.get("history", source.get("entries", []))
+    return [entry for entry in _list(entries) if isinstance(entry, dict)]
+
+
+def _looking_back(history_data: Any) -> str:
+    source = _mapping(history_data)
+    value = source.get("looking_back")
+    if not isinstance(value, str):
+        value = _mapping(source.get("observations")).get("looking_back")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _trends(history_data: dict[str, Any], entries: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    supplied = _mapping(history_data.get("trends"))
+    if all(isinstance(supplied.get(key), list) for key in ("meetings", "tasks", "snapshots")):
+        return supplied
+    trend_input = dict(history_data)
+    trend_input["history"] = entries
+    return weekly_trends(trend_input)
+
+
+def _milestone(history_data: Any) -> dict[str, Any]:
+    source = _mapping(history_data)
+    candidates = source.get("milestones", source.get("milestone", []))
+    if isinstance(candidates, dict):
+        candidates = [candidates]
+    for candidate in _list(candidates):
+        value = _mapping(candidate)
+        label = value.get("label")
+        if isinstance(label, str) and label.strip():
+            return value
+    return {}
+
+
+def _chart(title: str, values: list[Any]) -> str:
+    return f"""
+        <div class="state-panel history-chart">
+          <h3>{title}</h3>
+          {sparkline_svg(values, width=220, height=42)}
+        </div>"""
+
+
+def render_history(history_data: dict[str, Any]) -> str:
+    """Render the optional history section; an empty history remains invisible."""
+    entries = _entries(history_data)
+    if not entries:
+        return ""
+    source = _mapping(history_data)
+    first_snapshot = len(entries) == 1
+    trend_cards = ""
+    if not first_snapshot:
+        trends = _trends(source, entries)
+        trend_cards = f"""
+        <div class="receipt-grid history-trends">
+          {_chart("Meetings / week", _list(trends.get("meetings")))}
+          {_chart("Tasks completed / week", _list(trends.get("tasks")))}
+          {_chart("Snapshots over time", _list(trends.get("snapshots")))}
+        </div>"""
+    first_note = '<p class="quiet">This is your first snapshot.</p>' if first_snapshot else ""
+    milestone = _milestone(source)
+    milestone_card = ""
+    if milestone:
+        milestone_card = f"""
+        <div class="suggestion history-milestone" aria-label="Milestone">
+          <p class="kicker">✦ Milestone</p>
+          <h3>{html.escape(str(milestone["label"]), quote=True)}</h3>
+        </div>"""
+    looking_back = _looking_back(source)
+    looking_back_card = ""
+    if looking_back:
+        looking_back_card = f"""
+        <div class="state-panel prose history-looking-back">
+          <h3>Looking back</h3>
+          <p>{html.escape(looking_back, quote=True)}</p>
+        </div>"""
+    return f"""
+    <section id="history" aria-labelledby="history-heading">
+      <div class="section-heading">
+        <p class="kicker">Looking back</p>
+        <h2 id="history-heading">The shape of your Dex</h2>
+      </div>
+      {first_note}
+      {trend_cards}
+      {milestone_card}
+      {looking_back_card}
+    </section>"""

--- a/core/dashboard/sections/history.py
+++ b/core/dashboard/sections/history.py
@@ -53,10 +53,14 @@ def _milestone(history_data: Any) -> dict[str, Any]:
 
 
 def _chart(title: str, values: list[Any]) -> str:
+    sparkline = sparkline_svg(values, width=220, height=42).replace(
+        'stroke="#62d7d1"',
+        'stroke="currentColor"',
+    )
     return f"""
         <div class="state-panel history-chart">
           <h3>{title}</h3>
-          {sparkline_svg(values, width=220, height=42)}
+          {sparkline}
         </div>"""
 
 

--- a/core/dashboard/sections/journey.py
+++ b/core/dashboard/sections/journey.py
@@ -10,6 +10,12 @@ _CHIP_CLASS = {
     "unused": "dim",
     "available-in-pack": "outlined",
 }
+_STATE_ORDER = {
+    "used": 0,
+    "unused": 1,
+    "available-in-pack": 2,
+}
+_VISIBLE_CHIPS = 12
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -24,28 +30,51 @@ def _number(value: Any) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
-def _chip(skill: dict[str, Any]) -> str:
+def _chip(skill: dict[str, Any], *, hidden: bool = False) -> str:
     state = str(skill.get("state") or "")
     css_class = _CHIP_CLASS.get(state, "dim")
-    name = html.escape(str(skill.get("name") or skill.get("id") or "Unnamed capability"), quote=True)
+    name = html.escape(
+        str(skill.get("name") or skill.get("id") or "Unnamed capability"),
+        quote=True,
+    )
     description = html.escape(str(skill.get("description") or ""), quote=True)
     label = html.escape(
-        f"{skill.get('name') or skill.get('id') or 'Unnamed capability'}: "
-        f"{state.replace('-', ' ') or 'unused'}",
+        f"{skill.get('name') or skill.get('id') or 'Unnamed capability'}: {state.replace('-', ' ') or 'unused'}",
         quote=True,
     )
     title = f' title="{description}"' if description else ""
-    return f'<li class="journey-chip {css_class}"{title} aria-label="{label}">{name}</li>'
+    extra = " data-journey-extra hidden" if hidden else ""
+    return f'<li class="journey-chip {css_class}"{title} aria-label="{label}"{extra}>{name}</li>'
 
 
-def _territory(group: dict[str, Any]) -> str:
-    name = html.escape(str(group.get("name") or "Other"), quote=True)
+def _territory(group: dict[str, Any], index: int) -> str:
+    raw_name = "Yours" if group.get("yours") is True else group.get("name") or "Other"
+    name = html.escape(str(raw_name), quote=True)
     skills = [skill for skill in _list(group.get("skills")) if isinstance(skill, dict)]
-    chips = "".join(_chip(skill) for skill in skills)
+    ordered = [
+        skill
+        for _, skill in sorted(
+            enumerate(skills),
+            key=lambda item: (
+                _STATE_ORDER.get(str(item[1].get("state") or ""), 1),
+                item[0],
+            ),
+        )
+    ]
+    chips = "".join(_chip(skill, hidden=skill_index >= _VISIBLE_CHIPS) for skill_index, skill in enumerate(ordered))
+    remaining = max(0, len(ordered) - _VISIBLE_CHIPS)
+    group_id = f"journey-group-{index}"
+    more = ""
+    if remaining:
+        more = f"""
+          <li class="journey-more-item">
+            <button type="button" class="journey-more" data-journey-expand aria-expanded="false"
+              aria-controls="{group_id}">+ {remaining} more</button>
+          </li>"""
     return f"""
       <div class="state-panel territory">
         <h3>{name}</h3>
-        <ul class="journey-chips">{chips}</ul>
+        <ul class="journey-chips" id="{group_id}">{chips}{more}</ul>
       </div>"""
 
 
@@ -56,7 +85,7 @@ def render_journey(journey: dict) -> str:
     available = _number(counts.get("available"))
     used = min(_number(counts.get("used")), available)
     groups = [group for group in _list(source.get("groups")) if isinstance(group, dict)]
-    body = "".join(_territory(group) for group in groups)
+    body = "".join(_territory(group, index) for index, group in enumerate(groups))
     if not body:
         body = '<p class="quiet">No capabilities are installed in this Dex yet.</p>'
     return f"""

--- a/core/dashboard/sections/journey.py
+++ b/core/dashboard/sections/journey.py
@@ -78,7 +78,44 @@ def _territory(group: dict[str, Any], index: int) -> str:
       </div>"""
 
 
-def render_journey(journey: dict) -> str:
+def _skill_picks(value: Any) -> str:
+    picks = [
+        pick
+        for pick in _list(value)
+        if isinstance(pick, dict) and str(pick.get("skill") or "").strip()
+    ][:5]
+    if not picks:
+        return ""
+
+    cards = []
+    for index, pick in enumerate(picks):
+        skill = str(pick.get("skill") or "").strip()
+        why = str(pick.get("why") or "").strip()
+        skill_text = html.escape(skill, quote=True)
+        why_text = html.escape(why, quote=True)
+        prompt = html.escape(f"/{skill}", quote=True)
+        cards.append(
+            f"""
+          <article class="journey-pick-card">
+            <span class="journey-pick-skill">{skill_text}</span>
+            <p>{why_text}</p>
+            <div class="journey-pick-actions">
+              <code class="journey-pick-prompt" id="skill-pick-prompt-{index}" hidden>{prompt}</code>
+              <button type="button" class="journey-pick-copy" id="copy-skill-pick-{index}"
+                data-skill-copy-target="skill-pick-prompt-{index}"
+                data-skill-copy-status="skill-pick-status-{index}" aria-label="Copy /{skill_text}">Copy</button>
+              <span class="journey-pick-copy-status" id="skill-pick-status-{index}" aria-live="polite"></span>
+            </div>
+          </article>"""
+        )
+    return f"""
+      <div class="journey-picks" aria-labelledby="journey-picks-heading">
+        <h3 id="journey-picks-heading">Picked for you</h3>
+        <div class="journey-picks-grid">{"".join(cards)}</div>
+      </div>"""
+
+
+def render_journey(journey: dict, picks: list[dict[str, Any]] | None = None) -> str:
     """Render a Nightfall-styled HTML fragment for one capability journey."""
     source = _mapping(journey)
     counts = _mapping(source.get("counts"))
@@ -86,6 +123,7 @@ def render_journey(journey: dict) -> str:
     used = min(_number(counts.get("used")), available)
     groups = [group for group in _list(source.get("groups")) if isinstance(group, dict)]
     body = "".join(_territory(group, index) for index, group in enumerate(groups))
+    skill_picks = _skill_picks(picks)
     if not body:
         body = '<p class="quiet">No capabilities are installed in this Dex yet.</p>'
     return f"""
@@ -95,5 +133,6 @@ def render_journey(journey: dict) -> str:
         <h2 id="journey-heading">Your Dex, growing with you</h2>
         <p class="quiet">You use {used} of {available} capabilities.</p>
       </div>
+      {skill_picks}
       <div class="state-grid journey-grid">{body}</div>
     </section>"""

--- a/core/dashboard/sections/journey.py
+++ b/core/dashboard/sections/journey.py
@@ -49,6 +49,8 @@ def _chip(skill: dict[str, Any], *, hidden: bool = False) -> str:
 
 def _territory(group: dict[str, Any], index: int) -> str:
     raw_name = "Yours" if group.get("yours") is True else group.get("name") or "Other"
+    if raw_name == raw_name.lower():
+        raw_name = raw_name.replace("_", " ").title()
     name = html.escape(str(raw_name), quote=True)
     skills = [skill for skill in _list(group.get("skills")) if isinstance(skill, dict)]
     ordered = [
@@ -121,6 +123,7 @@ def render_journey(journey: dict, picks: list[dict[str, Any]] | None = None) -> 
     counts = _mapping(source.get("counts"))
     available = _number(counts.get("available"))
     used = min(_number(counts.get("used")), available)
+    capabilities_word = "capability" if used == 1 else "capabilities"
     groups = [group for group in _list(source.get("groups")) if isinstance(group, dict)]
     body = "".join(_territory(group, index) for index, group in enumerate(groups))
     skill_picks = _skill_picks(picks)
@@ -131,7 +134,7 @@ def render_journey(journey: dict, picks: list[dict[str, Any]] | None = None) -> 
       <div class="section-heading">
         <p class="kicker">Your journey</p>
         <h2 id="journey-heading">Your Dex, growing with you</h2>
-        <p class="quiet">You use {used} of {available} capabilities.</p>
+        <p class="quiet">{used} {capabilities_word} in your rotation · {available} available to explore.</p>
       </div>
       {skill_picks}
       <div class="state-grid journey-grid">{body}</div>

--- a/core/dashboard/sections/journey.py
+++ b/core/dashboard/sections/journey.py
@@ -1,0 +1,70 @@
+"""Render the dashboard's read-only capability journey map."""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+_CHIP_CLASS = {
+    "used": "lit",
+    "unused": "dim",
+    "available-in-pack": "outlined",
+}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _number(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _chip(skill: dict[str, Any]) -> str:
+    state = str(skill.get("state") or "")
+    css_class = _CHIP_CLASS.get(state, "dim")
+    name = html.escape(str(skill.get("name") or skill.get("id") or "Unnamed capability"), quote=True)
+    description = html.escape(str(skill.get("description") or ""), quote=True)
+    label = html.escape(
+        f"{skill.get('name') or skill.get('id') or 'Unnamed capability'}: "
+        f"{state.replace('-', ' ') or 'unused'}",
+        quote=True,
+    )
+    title = f' title="{description}"' if description else ""
+    return f'<li class="journey-chip {css_class}"{title} aria-label="{label}">{name}</li>'
+
+
+def _territory(group: dict[str, Any]) -> str:
+    name = html.escape(str(group.get("name") or "Other"), quote=True)
+    skills = [skill for skill in _list(group.get("skills")) if isinstance(skill, dict)]
+    chips = "".join(_chip(skill) for skill in skills)
+    return f"""
+      <div class="state-panel territory">
+        <h3>{name}</h3>
+        <ul class="journey-chips">{chips}</ul>
+      </div>"""
+
+
+def render_journey(journey: dict) -> str:
+    """Render a Nightfall-styled HTML fragment for one capability journey."""
+    source = _mapping(journey)
+    counts = _mapping(source.get("counts"))
+    available = _number(counts.get("available"))
+    used = min(_number(counts.get("used")), available)
+    groups = [group for group in _list(source.get("groups")) if isinstance(group, dict)]
+    body = "".join(_territory(group) for group in groups)
+    if not body:
+        body = '<p class="quiet">No capabilities are installed in this Dex yet.</p>'
+    return f"""
+    <section id="journey" aria-labelledby="journey-heading">
+      <div class="section-heading">
+        <p class="kicker">Your journey</p>
+        <h2 id="journey-heading">Your Dex, growing with you</h2>
+        <p class="quiet">You use {used} of {available} capabilities.</p>
+      </div>
+      <div class="state-grid journey-grid">{body}</div>
+    </section>"""

--- a/core/dashboard/sections/settings.py
+++ b/core/dashboard/sections/settings.py
@@ -8,13 +8,23 @@ import re
 from typing import Any
 
 SAFE_INTEGRATION_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
-_SETTING_GROUPS = ("Privacy", "Communication", "Connections", "Behavior")
-_SETTING_GROUP_BY_ID = {
-    "analytics_enabled": "Privacy",
-    "health_telemetry": "Privacy",
-    "formality": "Communication",
-    "directness": "Communication",
-    "entity_creation": "Behavior",
+_MEETING_LABELS = {
+    "extract_customer_intel": "Customer intelligence",
+    "extract_competitive_intel": "Competitive intelligence",
+    "extract_action_items": "Action items",
+    "extract_decisions": "Decisions",
+    "extract_stakeholder_dynamics": "Stakeholder dynamics",
+    "extract_budget_timeline": "Budget and timeline",
+    "extract_technical_decisions": "Technical decisions",
+}
+_MEETING_EXPLANATIONS = {
+    "extract_customer_intel": "Bring customer pain points and themes into view.",
+    "extract_competitive_intel": "Spot competitor mentions and comparisons.",
+    "extract_action_items": "Turn clear meeting commitments into action items.",
+    "extract_decisions": "Keep the decisions a meeting actually settled.",
+    "extract_stakeholder_dynamics": "Remember relationships, influence and concerns.",
+    "extract_budget_timeline": "Surface budget signals and important timing.",
+    "extract_technical_decisions": "Record architecture choices and their context.",
 }
 
 
@@ -30,10 +40,21 @@ def _inline_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
 
 
-def _switch(setting_id: str, label: str, explanation: str, *, value_kind: str = "bool") -> str:
+def _switch(
+    setting_id: str,
+    label: str,
+    explanation: str,
+    *,
+    value: Any = None,
+    value_kind: str = "bool",
+    interactive: bool = True,
+) -> str:
     checked_values = ""
     if value_kind == "health":
         checked_values = ' data-checked-value="opted-in" data-unchecked-value="opted-out"'
+    checked = value is True or (value_kind == "health" and value == "opted-in")
+    checked_attr = " checked" if checked else ""
+    status = "" if interactive else "Read-only"
     return f"""
       <div class="setting-row" data-setting-row>
         <div class="setting-copy">
@@ -47,10 +68,10 @@ def _switch(setting_id: str, label: str, explanation: str, *, value_kind: str = 
             role="switch"
             data-setting-id="{_escape(setting_id)}"
             data-value-kind="{_escape(value_kind)}"
-            {checked_values}
+            {checked_values}{checked_attr}
             disabled
           >
-          <span class="setting-status" data-setting-status aria-live="polite"></span>
+          <span class="setting-status" data-setting-status aria-live="polite">{status}</span>
         </div>
       </div>"""
 
@@ -60,10 +81,19 @@ def _select(
     label: str,
     explanation: str,
     options: tuple[tuple[str, str], ...],
+    *,
+    value: Any = None,
+    interactive: bool = True,
 ) -> str:
     option_html = "".join(
-        f'<option value="{_escape(value)}">{_escape(option_label)}</option>' for value, option_label in options
+        (
+            f'<option value="{_escape(option_value)}"'
+            f'{" selected" if option_value == value else ""}>'
+            f"{_escape(option_label)}</option>"
+        )
+        for option_value, option_label in options
     )
+    status = "" if interactive else "Read-only"
     return f"""
       <div class="setting-row" data-setting-row>
         <div class="setting-copy">
@@ -77,12 +107,12 @@ def _select(
             data-value-kind="enum"
             disabled
           >{option_html}</select>
-          <span class="setting-status" data-setting-status aria-live="polite"></span>
+          <span class="setting-status" data-setting-status aria-live="polite">{status}</span>
         </div>
       </div>"""
 
 
-def _integration_rows(data: dict[str, Any]) -> str:
+def _integration_rows(data: dict[str, Any], *, interactive: bool) -> str:
     apps = _mapping(_mapping(data.get("integrations")).get("apps"))
     rows = []
     for raw_name in sorted(apps, key=lambda item: str(item).casefold()):
@@ -94,6 +124,8 @@ def _integration_rows(data: dict[str, Any]) -> str:
                     setting_id,
                     name.replace("_", " ").replace("-", " ").title(),
                     "Let this existing connection contribute context to Dex.",
+                    value=_mapping(apps[raw_name]).get("enabled"),
+                    interactive=interactive,
                 )
             )
         else:
@@ -111,30 +143,81 @@ def _integration_rows(data: dict[str, Any]) -> str:
     return "".join(rows)
 
 
-def _grouped_controls(controls: list[tuple[str, str]]) -> dict[str, list[str]]:
-    grouped = {name: [] for name in _SETTING_GROUPS}
-    for setting_id, control in controls:
-        group = _SETTING_GROUP_BY_ID.get(setting_id, "Behavior")
-        grouped[group].append(control)
-    return grouped
+def _meeting_label(name: str) -> str:
+    return _MEETING_LABELS.get(
+        name,
+        name.removeprefix("extract_").replace("_", " ").replace("-", " ").title(),
+    )
+
+
+def _meeting_explanation(name: str) -> str:
+    return _MEETING_EXPLANATIONS.get(
+        name,
+        f"Capture {_meeting_label(name).lower()} when Dex processes a meeting.",
+    )
+
+
+def _meeting_rows(profile: dict[str, Any], *, interactive: bool) -> str:
+    meeting_intelligence = _mapping(profile.get("meeting_intelligence"))
+    rows = []
+    for raw_name, value in sorted(
+        meeting_intelligence.items(),
+        key=lambda item: str(item[0]).casefold(),
+    ):
+        name = str(raw_name)
+        if not isinstance(value, bool) or SAFE_INTEGRATION_NAME.fullmatch(name) is None:
+            continue
+        rows.append(
+            _switch(
+                f"meeting_intel:{name}",
+                _meeting_label(name),
+                _meeting_explanation(name),
+                value=value,
+                interactive=interactive,
+            )
+        )
+    return "".join(rows)
+
+
+def _capability_value(profile: dict[str, Any], room: str) -> bool | None:
+    value = _mapping(_mapping(profile.get("capabilities")).get(room)).get("enabled")
+    if isinstance(value, bool):
+        return value
+    if room == "quarter_goals":
+        legacy = _mapping(profile.get("quarterly_planning")).get("enabled")
+        if isinstance(legacy, bool):
+            return legacy
+    return None
 
 
 def render(
     data: dict[str, Any],
-    server_ctx: dict[str, Any],
+    server_ctx: dict[str, Any] | None,
 ) -> tuple[str, str]:
-    """Return the settings HTML fragment and its inline JavaScript."""
-    token = str(server_ctx.get("token") or "")
+    """Return the full settings inventory, live when a server context is present."""
+    context = _mapping(server_ctx)
+    token = str(context.get("token") or "")
+    interactive = bool(server_ctx)
+    profile = _mapping(data.get("profile"))
+    communication = _mapping(profile.get("communication"))
+    analytics = _mapping(profile.get("analytics"))
+    entity_creation = _mapping(profile.get("entity_creation"))
+    entity_gardener = _mapping(profile.get("entity_gardener"))
+    journaling = _mapping(profile.get("journaling"))
     analytics_switch = _switch(
         "analytics_enabled",
         "Anonymous product analytics",
         "Share feature-use counts, never names, notes, or file contents.",
+        value=analytics.get("enabled"),
+        interactive=interactive,
     )
     entity_select = _select(
         "entity_creation",
         "New people and companies",
-        "Choose whether Dex creates pages, suggests them, or stays off.",
+        "Choose whether new people and company pages appear automatically, as suggestions, or not at all.",
         (("auto", "Create automatically"), ("suggest", "Suggest first"), ("off", "Off")),
+        value=entity_creation.get("mode"),
+        interactive=interactive,
     )
     formality_select = _select(
         "formality",
@@ -145,6 +228,8 @@ def render(
             ("professional_casual", "Professional, relaxed"),
             ("casual", "Casual"),
         ),
+        value=communication.get("formality"),
+        interactive=interactive,
     )
     directness_select = _select(
         "directness",
@@ -155,37 +240,141 @@ def render(
             ("balanced", "Balanced"),
             ("supportive", "Supportive"),
         ),
+        value=communication.get("directness"),
+        interactive=interactive,
+    )
+    detail_select = _select(
+        "detail_level",
+        "Detail level",
+        "Choose between quick answers, balanced context, or the full picture.",
+        (
+            ("concise", "Concise"),
+            ("balanced", "Balanced"),
+            ("comprehensive", "Comprehensive"),
+        ),
+        value=communication.get("detail_level"),
+        interactive=interactive,
+    )
+    coaching_select = _select(
+        "coaching_style",
+        "Coaching style",
+        "Choose whether Dex encourages, works alongside you, or pushes harder.",
+        (
+            ("encouraging", "Encouraging"),
+            ("collaborative", "Collaborative"),
+            ("challenging", "Challenging"),
+        ),
+        value=communication.get("coaching_style"),
+        interactive=interactive,
     )
     health_switch = _switch(
         "health_telemetry",
         "Anonymous health telemetry",
         "Share nightly pass/fail counts only; this is separate from analytics.",
+        value=profile.get("health_telemetry"),
         value_kind="health",
+        interactive=interactive,
     )
-    integration_rows = _integration_rows(data)
-    grouped = _grouped_controls(
-        [
-            ("analytics_enabled", analytics_switch),
-            ("entity_creation", entity_select),
-            ("formality", formality_select),
-            ("directness", directness_select),
-            ("health_telemetry", health_switch),
-        ]
+    capability_rows = "".join(
+        (
+            _switch(
+                "capability:career",
+                "Career",
+                "Career coaching, evidence capture and resume tools — unlocks a set of skills.",
+                value=_capability_value(profile, "career"),
+                interactive=interactive,
+            ),
+            _switch(
+                "capability:companies",
+                "Companies",
+                "Richer company pages and commercial context — unlocks a set of skills.",
+                value=_capability_value(profile, "companies"),
+                interactive=interactive,
+            ),
+            _switch(
+                "capability:quarter_goals",
+                "Quarter goals",
+                "Quarter planning, reviews and goal tracking — unlocks a set of skills.",
+                value=_capability_value(profile, "quarter_goals"),
+                interactive=interactive,
+            ),
+        )
     )
+    meeting_rows = _meeting_rows(profile, interactive=interactive)
+    meeting_foundations = "".join(
+        (
+            entity_select,
+            _switch(
+                "entity_gardener",
+                "Keep people pages fresh",
+                "Refresh useful person summaries as new meetings add context.",
+                value=entity_gardener.get("enabled"),
+                interactive=interactive,
+            ),
+        )
+    )
+    journaling_rows = "".join(
+        (
+            _switch(
+                "journaling_morning",
+                "Morning journal",
+                "Start the day by setting an intention and focus.",
+                value=journaling.get("morning"),
+                interactive=interactive,
+            ),
+            _switch(
+                "journaling_evening",
+                "Evening journal",
+                "Close the day with a short reflection.",
+                value=journaling.get("evening"),
+                interactive=interactive,
+            ),
+            _switch(
+                "journaling_weekly",
+                "Weekly journal",
+                "Notice patterns and lessons across the week.",
+                value=journaling.get("weekly"),
+                interactive=interactive,
+            ),
+        )
+    )
+    integration_rows = _integration_rows(data, interactive=interactive)
+    heading = "Tune Dex from here" if interactive else "See the full shape of your Dex"
+    note = (
+        "These changes stay in your local Dex files."
+        if interactive
+        else "Read-only — open with 'let me change my settings' to make these live."
+    )
+    handoff_disabled = "" if interactive else " disabled"
     fragment = f"""
     <section id="settings" aria-labelledby="settings-heading">
       <div class="section-heading">
         <p class="kicker">Settings</p>
-        <h2 id="settings-heading">Tune Dex from here</h2>
-        <p class="quiet">These changes stay in your local Dex files.</p>
+        <h2 id="settings-heading">{heading}</h2>
+        <p class="quiet">{note}</p>
       </div>
       <div class="settings-group" data-settings-group="privacy">
         <h3 class="settings-group-label">Privacy</h3>
-        <div class="settings-list">{"".join(grouped["Privacy"])}</div>
+        <div class="settings-list">{analytics_switch}{health_switch}</div>
       </div>
       <div class="settings-group" data-settings-group="communication">
         <h3 class="settings-group-label">Communication</h3>
-        <div class="settings-list">{"".join(grouped["Communication"])}</div>
+        <div class="settings-list">
+          {formality_select}{directness_select}{detail_select}{coaching_select}
+        </div>
+      </div>
+      <div class="settings-group" data-settings-group="capabilities">
+        <h3 class="settings-group-label">Capabilities</h3>
+        <div class="settings-list">{capability_rows}</div>
+      </div>
+      <div class="settings-group" data-settings-group="meetings">
+        <h3 class="settings-group-label">Meetings</h3>
+        <div class="settings-list" data-meeting-intel-list>{meeting_rows}</div>
+        <div class="settings-list">{meeting_foundations}</div>
+      </div>
+      <div class="settings-group" data-settings-group="journaling">
+        <h3 class="settings-group-label">Journaling</h3>
+        <div class="settings-list">{journaling_rows}</div>
       </div>
       <div class="settings-group" data-settings-group="connections">
         <h3 class="settings-group-label">Connections</h3>
@@ -195,24 +384,29 @@ def render(
         </div>
         <div class="settings-subsection">
           <h4>Set up something new</h4>
-          <button type="button" class="handoff-button" data-command="/todoist-setup">
+          <button type="button" class="handoff-button" data-command="/todoist-setup"{handoff_disabled}>
             Set up Todoist
             <span>Dex walks you through it (run /todoist-setup)</span>
           </button>
           <span class="handoff-status" data-handoff-status aria-live="polite"></span>
         </div>
       </div>
-      <div class="settings-group" data-settings-group="behavior">
-        <h3 class="settings-group-label">Behavior</h3>
-        <div class="settings-list">{"".join(grouped["Behavior"])}</div>
-      </div>
     </section>"""
+
+    if not interactive:
+        return fragment, ""
 
     script = f"""
 (() => {{
   const dashboardToken = {_inline_json(token)};
-  const controls = Array.from(document.querySelectorAll('[data-setting-id]'));
+  const meetingLabels = {_inline_json(_MEETING_LABELS)};
+  const meetingExplanations = {_inline_json(_MEETING_EXPLANATIONS)};
+  const settingsRoot = document.getElementById('settings');
   const currentValues = new Map();
+
+  function controls() {{
+    return Array.from(settingsRoot.querySelectorAll('[data-setting-id]'));
+  }}
 
   function apiUrl(path) {{
     const url = new URL(path, window.location.href);
@@ -230,6 +424,59 @@ def render(
       return control.checked ? control.dataset.checkedValue : control.dataset.uncheckedValue;
     }}
     return control.value;
+  }}
+
+  function meetingLabel(name) {{
+    if (meetingLabels[name]) return meetingLabels[name];
+    const words = name.replace(/^extract_/, '').replace(/[_-]+/g, ' ');
+    return words.replace(/\\b\\w/g, (letter) => letter.toUpperCase());
+  }}
+
+  function addMeetingControls(settings, unavailable) {{
+    const list = settingsRoot.querySelector('[data-meeting-intel-list]');
+    if (!list) return;
+    const existing = new Set(controls().map((control) => control.dataset.settingId));
+    const settingIds = new Set([
+      ...Object.keys(settings || {{}}),
+      ...Object.keys(unavailable || {{}})
+    ]);
+    Array.from(settingIds)
+      .filter((settingId) => settingId.startsWith('meeting_intel:'))
+      .sort()
+      .forEach((settingId) => {{
+        if (existing.has(settingId)) return;
+        const name = settingId.slice('meeting_intel:'.length);
+        const row = document.createElement('div');
+        row.className = 'setting-row';
+        row.dataset.settingRow = '';
+
+        const copy = document.createElement('div');
+        copy.className = 'setting-copy';
+        const label = document.createElement('label');
+        label.htmlFor = 'setting-' + settingId;
+        label.textContent = meetingLabel(name);
+        const explanation = document.createElement('p');
+        explanation.textContent = meetingExplanations[name]
+          || 'Capture ' + meetingLabel(name).toLowerCase() + ' when Dex processes a meeting.';
+        copy.append(label, explanation);
+
+        const action = document.createElement('div');
+        action.className = 'setting-action';
+        const control = document.createElement('input');
+        control.id = 'setting-' + settingId;
+        control.type = 'checkbox';
+        control.setAttribute('role', 'switch');
+        control.dataset.settingId = settingId;
+        control.dataset.valueKind = 'bool';
+        control.disabled = true;
+        const status = document.createElement('span');
+        status.className = 'setting-status';
+        status.dataset.settingStatus = '';
+        status.setAttribute('aria-live', 'polite');
+        action.append(control, status);
+        row.append(copy, action);
+        list.append(row);
+      }});
   }}
 
   function applyValue(control, value) {{
@@ -252,7 +499,8 @@ def render(
       }});
       const payload = await readJson(response);
       const unavailable = payload.unavailable || {{}};
-      controls.forEach((control) => {{
+      addMeetingControls(payload.settings, unavailable);
+      controls().forEach((control) => {{
         const settingId = control.dataset.settingId;
         if (Object.prototype.hasOwnProperty.call(payload.settings, settingId)) {{
           currentValues.set(settingId, payload.settings[settingId]);
@@ -268,7 +516,7 @@ def render(
         }}
       }});
     }} catch (error) {{
-      controls.forEach((control) => {{
+      controls().forEach((control) => {{
         control.disabled = true;
         statusFor(control).textContent = error.message;
       }});
@@ -310,14 +558,16 @@ def render(
     }}
   }}
 
-  controls.forEach((control) => {{
-    control.addEventListener('change', () => {{
-      const settingId = control.dataset.settingId;
-      const previousValue = currentValues.get(settingId);
-      const nextValue = valueFrom(control);
-      currentValues.set(settingId, nextValue);
-      saveValue(control, nextValue, previousValue);
-    }});
+  settingsRoot.addEventListener('change', (event) => {{
+    const control = event.target.closest
+      ? event.target.closest('[data-setting-id]')
+      : null;
+    if (!control) return;
+    const settingId = control.dataset.settingId;
+    const previousValue = currentValues.get(settingId);
+    const nextValue = valueFrom(control);
+    currentValues.set(settingId, nextValue);
+    saveValue(control, nextValue, previousValue);
   }});
 
   document.querySelectorAll('[data-command]').forEach((button) => {{

--- a/core/dashboard/sections/settings.py
+++ b/core/dashboard/sections/settings.py
@@ -8,6 +8,14 @@ import re
 from typing import Any
 
 SAFE_INTEGRATION_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_SETTING_GROUPS = ("Privacy", "Communication", "Connections", "Behavior")
+_SETTING_GROUP_BY_ID = {
+    "analytics_enabled": "Privacy",
+    "health_telemetry": "Privacy",
+    "formality": "Communication",
+    "directness": "Communication",
+    "entity_creation": "Behavior",
+}
 
 
 def _escape(value: Any) -> str:
@@ -103,6 +111,14 @@ def _integration_rows(data: dict[str, Any]) -> str:
     return "".join(rows)
 
 
+def _grouped_controls(controls: list[tuple[str, str]]) -> dict[str, list[str]]:
+    grouped = {name: [] for name in _SETTING_GROUPS}
+    for setting_id, control in controls:
+        group = _SETTING_GROUP_BY_ID.get(setting_id, "Behavior")
+        grouped[group].append(control)
+    return grouped
+
+
 def render(
     data: dict[str, Any],
     server_ctx: dict[str, Any],
@@ -147,6 +163,15 @@ def render(
         value_kind="health",
     )
     integration_rows = _integration_rows(data)
+    grouped = _grouped_controls(
+        [
+            ("analytics_enabled", analytics_switch),
+            ("entity_creation", entity_select),
+            ("formality", formality_select),
+            ("directness", directness_select),
+            ("health_telemetry", health_switch),
+        ]
+    )
     fragment = f"""
     <section id="settings" aria-labelledby="settings-heading">
       <div class="section-heading">
@@ -154,24 +179,32 @@ def render(
         <h2 id="settings-heading">Tune Dex from here</h2>
         <p class="quiet">These changes stay in your local Dex files.</p>
       </div>
-      <div class="settings-list">
-        {analytics_switch}
-        {entity_select}
-        {formality_select}
-        {directness_select}
-        {health_switch}
+      <div class="settings-group" data-settings-group="privacy">
+        <h3 class="settings-group-label">Privacy</h3>
+        <div class="settings-list">{"".join(grouped["Privacy"])}</div>
       </div>
-      <div class="settings-subsection">
-        <h3>Existing integrations</h3>
-        <div class="settings-list">{integration_rows}</div>
+      <div class="settings-group" data-settings-group="communication">
+        <h3 class="settings-group-label">Communication</h3>
+        <div class="settings-list">{"".join(grouped["Communication"])}</div>
       </div>
-      <div class="settings-subsection">
-        <h3>Set up something new</h3>
-        <button type="button" class="handoff-button" data-command="/todoist-setup">
-          Set up Todoist
-          <span>Dex walks you through it (run /todoist-setup)</span>
-        </button>
-        <span class="handoff-status" data-handoff-status aria-live="polite"></span>
+      <div class="settings-group" data-settings-group="connections">
+        <h3 class="settings-group-label">Connections</h3>
+        <div class="settings-subsection">
+          <h4>Existing integrations</h4>
+          <div class="settings-list">{integration_rows}</div>
+        </div>
+        <div class="settings-subsection">
+          <h4>Set up something new</h4>
+          <button type="button" class="handoff-button" data-command="/todoist-setup">
+            Set up Todoist
+            <span>Dex walks you through it (run /todoist-setup)</span>
+          </button>
+          <span class="handoff-status" data-handoff-status aria-live="polite"></span>
+        </div>
+      </div>
+      <div class="settings-group" data-settings-group="behavior">
+        <h3 class="settings-group-label">Behavior</h3>
+        <div class="settings-list">{"".join(grouped["Behavior"])}</div>
       </div>
     </section>"""
 

--- a/core/dashboard/sections/settings.py
+++ b/core/dashboard/sections/settings.py
@@ -1,0 +1,316 @@
+"""Render the interactive, server-backed Dashboard settings section."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from typing import Any
+
+SAFE_INTEGRATION_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _inline_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+
+
+def _switch(setting_id: str, label: str, explanation: str, *, value_kind: str = "bool") -> str:
+    checked_values = ""
+    if value_kind == "health":
+        checked_values = ' data-checked-value="opted-in" data-unchecked-value="opted-out"'
+    return f"""
+      <div class="setting-row" data-setting-row>
+        <div class="setting-copy">
+          <label for="setting-{_escape(setting_id)}">{_escape(label)}</label>
+          <p>{_escape(explanation)}</p>
+        </div>
+        <div class="setting-action">
+          <input
+            id="setting-{_escape(setting_id)}"
+            type="checkbox"
+            role="switch"
+            data-setting-id="{_escape(setting_id)}"
+            data-value-kind="{_escape(value_kind)}"
+            {checked_values}
+            disabled
+          >
+          <span class="setting-status" data-setting-status aria-live="polite"></span>
+        </div>
+      </div>"""
+
+
+def _select(
+    setting_id: str,
+    label: str,
+    explanation: str,
+    options: tuple[tuple[str, str], ...],
+) -> str:
+    option_html = "".join(
+        f'<option value="{_escape(value)}">{_escape(option_label)}</option>' for value, option_label in options
+    )
+    return f"""
+      <div class="setting-row" data-setting-row>
+        <div class="setting-copy">
+          <label for="setting-{_escape(setting_id)}">{_escape(label)}</label>
+          <p>{_escape(explanation)}</p>
+        </div>
+        <div class="setting-action">
+          <select
+            id="setting-{_escape(setting_id)}"
+            data-setting-id="{_escape(setting_id)}"
+            data-value-kind="enum"
+            disabled
+          >{option_html}</select>
+          <span class="setting-status" data-setting-status aria-live="polite"></span>
+        </div>
+      </div>"""
+
+
+def _integration_rows(data: dict[str, Any]) -> str:
+    apps = _mapping(_mapping(data.get("integrations")).get("apps"))
+    rows = []
+    for raw_name in sorted(apps, key=lambda item: str(item).casefold()):
+        name = str(raw_name)
+        if SAFE_INTEGRATION_NAME.fullmatch(name):
+            setting_id = f"integration:{name}.enabled"
+            rows.append(
+                _switch(
+                    setting_id,
+                    name.replace("_", " ").replace("-", " ").title(),
+                    "Let this existing connection contribute context to Dex.",
+                )
+            )
+        else:
+            rows.append(
+                f"""
+      <div class="setting-row setting-row-readonly">
+        <div class="setting-copy">
+          <span class="setting-label">{_escape(name)}</span>
+          <p>Manage this connection with Dex in conversation.</p>
+        </div>
+      </div>"""
+            )
+    if not rows:
+        return '<p class="quiet">No existing integrations are available to switch here.</p>'
+    return "".join(rows)
+
+
+def render(
+    data: dict[str, Any],
+    server_ctx: dict[str, Any],
+) -> tuple[str, str]:
+    """Return the settings HTML fragment and its inline JavaScript."""
+    token = str(server_ctx.get("token") or "")
+    analytics_switch = _switch(
+        "analytics_enabled",
+        "Anonymous product analytics",
+        "Share feature-use counts, never names, notes, or file contents.",
+    )
+    entity_select = _select(
+        "entity_creation",
+        "New people and companies",
+        "Choose whether Dex creates pages, suggests them, or stays off.",
+        (("auto", "Create automatically"), ("suggest", "Suggest first"), ("off", "Off")),
+    )
+    formality_select = _select(
+        "formality",
+        "Formality",
+        "Set how polished or conversational Dex sounds.",
+        (
+            ("formal", "Formal"),
+            ("professional_casual", "Professional, relaxed"),
+            ("casual", "Casual"),
+        ),
+    )
+    directness_select = _select(
+        "directness",
+        "Directness",
+        "Set how directly Dex gives advice and feedback.",
+        (
+            ("very_direct", "Very direct"),
+            ("balanced", "Balanced"),
+            ("supportive", "Supportive"),
+        ),
+    )
+    health_switch = _switch(
+        "health_telemetry",
+        "Anonymous health telemetry",
+        "Share nightly pass/fail counts only; this is separate from analytics.",
+        value_kind="health",
+    )
+    integration_rows = _integration_rows(data)
+    fragment = f"""
+    <section id="settings" aria-labelledby="settings-heading">
+      <div class="section-heading">
+        <p class="kicker">Settings</p>
+        <h2 id="settings-heading">Tune Dex from here</h2>
+        <p class="quiet">These changes stay in your local Dex files.</p>
+      </div>
+      <div class="settings-list">
+        {analytics_switch}
+        {entity_select}
+        {formality_select}
+        {directness_select}
+        {health_switch}
+      </div>
+      <div class="settings-subsection">
+        <h3>Existing integrations</h3>
+        <div class="settings-list">{integration_rows}</div>
+      </div>
+      <div class="settings-subsection">
+        <h3>Set up something new</h3>
+        <button type="button" class="handoff-button" data-command="/todoist-setup">
+          Set up Todoist
+          <span>Dex walks you through it (run /todoist-setup)</span>
+        </button>
+        <span class="handoff-status" data-handoff-status aria-live="polite"></span>
+      </div>
+    </section>"""
+
+    script = f"""
+(() => {{
+  const dashboardToken = {_inline_json(token)};
+  const controls = Array.from(document.querySelectorAll('[data-setting-id]'));
+  const currentValues = new Map();
+
+  function apiUrl(path) {{
+    const url = new URL(path, window.location.href);
+    url.searchParams.set('t', dashboardToken);
+    return url.toString();
+  }}
+
+  function statusFor(control) {{
+    return control.closest('[data-setting-row]').querySelector('[data-setting-status]');
+  }}
+
+  function valueFrom(control) {{
+    if (control.dataset.valueKind === 'bool') return control.checked;
+    if (control.dataset.valueKind === 'health') {{
+      return control.checked ? control.dataset.checkedValue : control.dataset.uncheckedValue;
+    }}
+    return control.value;
+  }}
+
+  function applyValue(control, value) {{
+    if (control.dataset.valueKind === 'bool') control.checked = value === true;
+    else if (control.dataset.valueKind === 'health') control.checked = value === 'opted-in';
+    else control.value = value;
+  }}
+
+  async function readJson(response) {{
+    const payload = await response.json().catch(() => ({{ error: 'Dex could not read the response.' }}));
+    if (!response.ok) throw new Error(payload.error || 'Dex could not save that change.');
+    return payload;
+  }}
+
+  async function loadState() {{
+    try {{
+      const response = await fetch(apiUrl('/api/state'), {{
+        headers: {{ Accept: 'application/json' }},
+        cache: 'no-store'
+      }});
+      const payload = await readJson(response);
+      controls.forEach((control) => {{
+        const settingId = control.dataset.settingId;
+        if (Object.prototype.hasOwnProperty.call(payload.settings, settingId)) {{
+          currentValues.set(settingId, payload.settings[settingId]);
+          applyValue(control, payload.settings[settingId]);
+          control.disabled = false;
+          statusFor(control).textContent = '';
+        }} else {{
+          control.disabled = true;
+          statusFor(control).textContent = 'Unavailable';
+        }}
+      }});
+    }} catch (error) {{
+      controls.forEach((control) => {{
+        control.disabled = true;
+        statusFor(control).textContent = error.message;
+      }});
+    }}
+  }}
+
+  async function saveValue(control, nextValue, previousValue) {{
+    const settingId = control.dataset.settingId;
+    const status = statusFor(control);
+    control.disabled = true;
+    status.textContent = 'Saving…';
+    try {{
+      const response = await fetch(apiUrl('/api/toggle'), {{
+        method: 'POST',
+        headers: {{ 'Content-Type': 'application/json', Accept: 'application/json' }},
+        body: JSON.stringify({{ setting_id: settingId, value: nextValue }})
+      }});
+      const payload = await readJson(response);
+      currentValues.set(settingId, payload.new);
+      applyValue(control, payload.new);
+      status.replaceChildren(document.createTextNode('Changed just now — '));
+      const undo = document.createElement('button');
+      undo.type = 'button';
+      undo.className = 'undo-button';
+      undo.textContent = 'undo';
+      undo.addEventListener('click', () => {{
+        const valueBeforeUndo = currentValues.get(settingId);
+        applyValue(control, payload.old);
+        currentValues.set(settingId, payload.old);
+        saveValue(control, payload.old, valueBeforeUndo);
+      }}, {{ once: true }});
+      status.appendChild(undo);
+    }} catch (error) {{
+      currentValues.set(settingId, previousValue);
+      applyValue(control, previousValue);
+      status.textContent = error.message;
+    }} finally {{
+      control.disabled = false;
+    }}
+  }}
+
+  controls.forEach((control) => {{
+    control.addEventListener('change', () => {{
+      const settingId = control.dataset.settingId;
+      const previousValue = currentValues.get(settingId);
+      const nextValue = valueFrom(control);
+      currentValues.set(settingId, nextValue);
+      saveValue(control, nextValue, previousValue);
+    }});
+  }});
+
+  document.querySelectorAll('[data-command]').forEach((button) => {{
+    button.addEventListener('click', async () => {{
+      const command = button.dataset.command;
+      const status = document.querySelector('[data-handoff-status]');
+      try {{
+        await navigator.clipboard.writeText(command);
+        status.textContent = command + ' copied — paste it into Dex.';
+      }} catch (_error) {{
+        status.textContent = 'Run ' + command + ' in Dex.';
+      }}
+    }});
+  }});
+
+  let closeSent = false;
+  function closeServer() {{
+    if (closeSent) return;
+    closeSent = true;
+    const url = apiUrl('/api/close');
+    if (navigator.sendBeacon) {{
+      navigator.sendBeacon(url, new Blob(['{{}}'], {{ type: 'application/json' }}));
+    }} else {{
+      fetch(url, {{ method: 'POST', body: '{{}}', keepalive: true }}).catch(() => {{}});
+    }}
+  }}
+
+  window.addEventListener('pagehide', closeServer);
+  window.addEventListener('beforeunload', closeServer);
+  loadState();
+}})();
+"""
+    return fragment, script

--- a/core/dashboard/sections/settings.py
+++ b/core/dashboard/sections/settings.py
@@ -518,7 +518,7 @@ def render(
     }} catch (error) {{
       controls().forEach((control) => {{
         control.disabled = true;
-        statusFor(control).textContent = error.message;
+        statusFor(control).textContent = 'Not live right now — reopen from Dex to change this.';
       }});
     }}
   }}

--- a/core/dashboard/sections/settings.py
+++ b/core/dashboard/sections/settings.py
@@ -218,6 +218,7 @@ def render(
         cache: 'no-store'
       }});
       const payload = await readJson(response);
+      const unavailable = payload.unavailable || {{}};
       controls.forEach((control) => {{
         const settingId = control.dataset.settingId;
         if (Object.prototype.hasOwnProperty.call(payload.settings, settingId)) {{
@@ -225,9 +226,12 @@ def render(
           applyValue(control, payload.settings[settingId]);
           control.disabled = false;
           statusFor(control).textContent = '';
+        }} else if (Object.prototype.hasOwnProperty.call(unavailable, settingId)) {{
+          control.disabled = true;
+          statusFor(control).textContent = unavailable[settingId];
         }} else {{
           control.disabled = true;
-          statusFor(control).textContent = 'Unavailable';
+          statusFor(control).textContent = 'Not set up in this vault yet.';
         }}
       }});
     }} catch (error) {{

--- a/core/dashboard/server.py
+++ b/core/dashboard/server.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Serve one interactive Dex Dashboard on loopback for a bounded time."""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import secrets
+import sys
+import threading
+import time
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import parse_qs, quote, urlsplit
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.dashboard.toggles import (
+    StateSnapshot,
+    ToggleConflictError,
+    ToggleEngine,
+    ToggleError,
+)
+
+MAX_REQUEST_BYTES = 64 * 1024
+TOKEN_PLACEHOLDER = "__DEX_DASHBOARD_TOKEN__"
+PORT_PLACEHOLDER = "__DEX_DASHBOARD_PORT__"
+
+
+@dataclass(frozen=True)
+class HTTPResponse:
+    status: int
+    body: bytes
+    headers: dict[str, str]
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> HTTPResponse:
+    return HTTPResponse(
+        status=status,
+        body=(json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8"),
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+        },
+    )
+
+
+def _html_response(body: bytes) -> HTTPResponse:
+    return HTTPResponse(
+        status=200,
+        body=body,
+        headers={
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            "Content-Security-Policy": (
+                "default-src 'none'; style-src 'unsafe-inline'; "
+                "script-src 'unsafe-inline'; connect-src 'self'; "
+                "img-src data:; base-uri 'none'; form-action 'none'"
+            ),
+        },
+    )
+
+
+def _inline_script_text(value: str) -> str:
+    return (
+        json.dumps(value, ensure_ascii=False)[1:-1]
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+class ToggleSession:
+    """Keep the last GET stamps so POST can reject external file changes."""
+
+    def __init__(self, engine: ToggleEngine) -> None:
+        self.engine = engine
+        self.snapshot: StateSnapshot | None = None
+        self._lock = threading.Lock()
+
+    def read_state(self) -> dict[str, Any]:
+        with self._lock:
+            self.snapshot = self.engine.read_state()
+            return dict(self.snapshot.values)
+
+    def write(self, setting_id: str, value: Any):
+        with self._lock:
+            if self.snapshot is None:
+                raise ToggleConflictError("Refresh the dashboard before changing a setting.")
+            expected = self.snapshot.stamps.get(setting_id)
+            result = self.engine.write(setting_id, value, expected=expected)
+            values = dict(self.snapshot.values)
+            values[setting_id] = result.new
+            stamps = {
+                candidate_id: result.stamp if stamp == expected else stamp
+                for candidate_id, stamp in self.snapshot.stamps.items()
+            }
+            self.snapshot = StateSnapshot(values=values, stamps=stamps)
+            return result
+
+
+class DashboardApplication:
+    """Socket-independent request handler used by the HTTP adapter and tests."""
+
+    def __init__(
+        self,
+        *,
+        vault: Path | str,
+        html_path: Path | str,
+        token: str,
+        port: int,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.vault = Path(vault).expanduser().resolve()
+        self.html_path = Path(html_path).expanduser().resolve()
+        self.token = token
+        self.port = port
+        self.clock = clock
+        self.last_activity = clock()
+        self.close_requested = threading.Event()
+        self.session = ToggleSession(ToggleEngine(self.vault))
+        self._activity_lock = threading.Lock()
+
+    def handle(self, method: str, target: str, body: bytes = b"") -> HTTPResponse:
+        self._touch()
+        parsed = urlsplit(target)
+        if not self._authorized(parsed.query):
+            return _json_response(403, {"error": "Forbidden"})
+        return self._handle_authorized(method, parsed.path, body)
+
+    def authorize_target(self, target: str) -> bool:
+        """Authenticate before the HTTP adapter reads or validates a POST body."""
+        self._touch()
+        return self._authorized(urlsplit(target).query)
+
+    def _handle_authorized(self, method: str, path: str, body: bytes) -> HTTPResponse:
+        try:
+            if method == "GET" and path == "/":
+                return self._serve_page()
+            if method == "GET" and path == "/api/state":
+                return _json_response(200, {"settings": self.session.read_state()})
+            if method == "POST" and path == "/api/toggle":
+                return self._toggle(body)
+            if method == "POST" and path == "/api/close":
+                self.close_requested.set()
+                return _json_response(200, {"ok": True})
+            if path in {"/", "/api/state", "/api/toggle", "/api/close"}:
+                return _json_response(405, {"error": "Method not allowed"})
+            return _json_response(404, {"error": "Not found"})
+        except ToggleError as error:
+            if error.status_code == 409:
+                self.session.snapshot = None
+            return _json_response(error.status_code, {"error": str(error)})
+        except (OSError, UnicodeError):
+            return _json_response(500, {"error": "Dex could not read or save the local settings."})
+
+    def idle_for(self) -> float:
+        with self._activity_lock:
+            return self.clock() - self.last_activity
+
+    def _touch(self) -> None:
+        with self._activity_lock:
+            self.last_activity = self.clock()
+
+    def _authorized(self, query: str) -> bool:
+        supplied = parse_qs(query, keep_blank_values=True).get("t", [])
+        candidate = supplied[0] if len(supplied) == 1 else ""
+        return hmac.compare_digest(candidate, self.token)
+
+    def _serve_page(self) -> HTTPResponse:
+        page = self.html_path.read_text(encoding="utf-8")
+        page = page.replace(TOKEN_PLACEHOLDER, _inline_script_text(self.token))
+        page = page.replace(PORT_PLACEHOLDER, str(self.port))
+        return _html_response(page.encode("utf-8"))
+
+    def _toggle(self, body: bytes) -> HTTPResponse:
+        if len(body) > MAX_REQUEST_BYTES:
+            return _json_response(400, {"error": "Request too large"})
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return _json_response(400, {"error": "Request must be valid JSON"})
+        if not isinstance(payload, dict) or set(payload) != {"setting_id", "value"}:
+            return _json_response(
+                400,
+                {"error": "Request must contain setting_id and value only"},
+            )
+        setting_id = payload["setting_id"]
+        if not isinstance(setting_id, str):
+            return _json_response(400, {"error": "setting_id must be a string"})
+        result = self.session.write(setting_id, payload["value"])
+        return _json_response(
+            200,
+            {
+                "ok": True,
+                "setting_id": result.setting_id,
+                "old": result.old,
+                "new": result.new,
+            },
+        )
+
+
+class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
+    """Thin ``http.server`` adapter over ``DashboardApplication``."""
+
+    application: DashboardApplication
+
+    def do_GET(self) -> None:
+        self._dispatch(b"")
+
+    def do_POST(self) -> None:
+        if not self.application.authorize_target(self.path):
+            self._write_response(_json_response(403, {"error": "Forbidden"}))
+            return
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_length)
+        except ValueError:
+            self._write_response(_json_response(400, {"error": "Invalid Content-Length"}))
+            return
+        if length < 0 or length > MAX_REQUEST_BYTES:
+            self._write_response(_json_response(400, {"error": "Request too large"}))
+            return
+        parsed = urlsplit(self.path)
+        response = self.application._handle_authorized(
+            self.command,
+            parsed.path,
+            self.rfile.read(length),
+        )
+        self._write_response(response)
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        """Avoid putting the ephemeral token into request logs."""
+
+    def _dispatch(self, body: bytes) -> None:
+        response = self.application.handle(self.command, self.path, body)
+        self._write_response(response)
+
+    def _write_response(self, response: HTTPResponse) -> None:
+        self.send_response(response.status)
+        for name, value in response.headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", str(len(response.body)))
+        self.end_headers()
+        self.wfile.write(response.body)
+
+
+def make_http_handler(
+    application: DashboardApplication,
+) -> type[DashboardHTTPRequestHandler]:
+    """Bind one application to an injectable ``BaseHTTPRequestHandler`` class."""
+
+    class BoundDashboardHTTPRequestHandler(DashboardHTTPRequestHandler):
+        pass
+
+    BoundDashboardHTTPRequestHandler.application = application
+    return BoundDashboardHTTPRequestHandler
+
+
+def run_server(
+    *,
+    vault: Path | str,
+    html_path: Path | str,
+    idle_timeout: float = 900,
+    open_browser: bool = True,
+    token: str | None = None,
+    server_class: type[ThreadingHTTPServer] = ThreadingHTTPServer,
+    browser_open: Callable[[str], Any] = webbrowser.open,
+) -> dict[str, Any]:
+    """Bind loopback, serve until close/idle/SIGINT, and never daemonize."""
+    if idle_timeout <= 0:
+        raise ValueError("idle_timeout must be greater than zero")
+    run_token = token or secrets.token_urlsafe(32)
+    application = DashboardApplication(
+        vault=vault,
+        html_path=html_path,
+        token=run_token,
+        port=0,
+    )
+    httpd = server_class(
+        ("127.0.0.1", 0),
+        make_http_handler(application),
+    )
+    application.port = int(httpd.server_address[1])
+    httpd.timeout = min(0.5, max(0.01, idle_timeout / 5))
+    url = f"http://127.0.0.1:{application.port}/?t={quote(run_token, safe='')}"
+    reason = "idle"
+    try:
+        if open_browser:
+            browser_open(url)
+        while True:
+            if application.close_requested.is_set():
+                reason = "close"
+                break
+            if application.idle_for() >= idle_timeout:
+                reason = "idle"
+                break
+            httpd.handle_request()
+    except KeyboardInterrupt:
+        reason = "sigint"
+    finally:
+        httpd.server_close()
+    return {"port": application.port, "reason": reason}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Open one interactive Dex Dashboard on this Mac.")
+    parser.add_argument("--vault", type=Path, required=True, help="Dex vault root")
+    parser.add_argument("--html", type=Path, required=True, help="Rendered dashboard HTML")
+    parser.add_argument("--idle-timeout", type=float, default=900)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    vault = args.vault.expanduser().resolve()
+    html_path = args.html.expanduser().resolve()
+    if not vault.is_dir():
+        print("error: vault is not a directory", file=sys.stderr)
+        return 2
+    if not html_path.is_file():
+        print("error: dashboard HTML is not a file", file=sys.stderr)
+        return 2
+    if args.idle_timeout <= 0:
+        print("error: idle timeout must be greater than zero", file=sys.stderr)
+        return 2
+    result = run_server(
+        vault=vault,
+        html_path=html_path,
+        idle_timeout=args.idle_timeout,
+    )
+    print(f"Dashboard closed ({result['reason']}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/dashboard/server.py
+++ b/core/dashboard/server.py
@@ -25,6 +25,7 @@ from core.dashboard.toggles import (
     ToggleConflictError,
     ToggleEngine,
     ToggleError,
+    ToggleSchemaError,
 )
 
 MAX_REQUEST_BYTES = 64 * 1024
@@ -87,10 +88,10 @@ class ToggleSession:
         self.snapshot: StateSnapshot | None = None
         self._lock = threading.Lock()
 
-    def read_state(self) -> dict[str, Any]:
+    def read_state(self) -> StateSnapshot:
         with self._lock:
             self.snapshot = self.engine.read_state()
-            return dict(self.snapshot.values)
+            return self.snapshot
 
     def write(self, setting_id: str, value: Any):
         with self._lock:
@@ -104,7 +105,11 @@ class ToggleSession:
                 candidate_id: result.stamp if stamp == expected else stamp
                 for candidate_id, stamp in self.snapshot.stamps.items()
             }
-            self.snapshot = StateSnapshot(values=values, stamps=stamps)
+            self.snapshot = StateSnapshot(
+                values=values,
+                stamps=stamps,
+                unavailable=dict(self.snapshot.unavailable),
+            )
             return result
 
 
@@ -147,7 +152,14 @@ class DashboardApplication:
             if method == "GET" and path == "/":
                 return self._serve_page()
             if method == "GET" and path == "/api/state":
-                return _json_response(200, {"settings": self.session.read_state()})
+                snapshot = self.session.read_state()
+                return _json_response(
+                    200,
+                    {
+                        "settings": snapshot.values,
+                        "unavailable": snapshot.unavailable,
+                    },
+                )
             if method == "POST" and path == "/api/toggle":
                 return self._toggle(body)
             if method == "POST" and path == "/api/close":
@@ -157,7 +169,12 @@ class DashboardApplication:
                 return _json_response(405, {"error": "Method not allowed"})
             return _json_response(404, {"error": "Not found"})
         except ToggleError as error:
-            if error.status_code == 409:
+            scoped_schema_write = (
+                method == "POST"
+                and path == "/api/toggle"
+                and isinstance(error, ToggleSchemaError)
+            )
+            if error.status_code == 409 and not scoped_schema_write:
                 self.session.snapshot = None
             return _json_response(error.status_code, {"error": str(error)})
         except (OSError, UnicodeError):

--- a/core/dashboard/server.py
+++ b/core/dashboard/server.py
@@ -7,6 +7,7 @@ import argparse
 import hmac
 import json
 import secrets
+import subprocess
 import sys
 import threading
 import time
@@ -78,6 +79,21 @@ def _inline_script_text(value: str) -> str:
         .replace(">", "\\u003e")
         .replace("&", "\\u0026")
     )
+
+
+def _default_browser_open(url: str) -> bool:
+    """Open a browser, with macOS's native launcher as a fallback."""
+    try:
+        if webbrowser.open(url):
+            return True
+    except (OSError, webbrowser.Error):
+        pass
+    if sys.platform != "darwin":
+        return False
+    try:
+        return subprocess.run(["open", url], check=False).returncode == 0
+    except OSError:
+        return False
 
 
 class ToggleSession:
@@ -291,7 +307,7 @@ def run_server(
     open_browser: bool = True,
     token: str | None = None,
     server_class: type[ThreadingHTTPServer] = ThreadingHTTPServer,
-    browser_open: Callable[[str], Any] = webbrowser.open,
+    browser_open: Callable[[str], Any] | None = None,
 ) -> dict[str, Any]:
     """Bind loopback, serve until close/idle/SIGINT, and never daemonize."""
     if idle_timeout <= 0:
@@ -312,8 +328,14 @@ def run_server(
     url = f"http://127.0.0.1:{application.port}/?t={quote(run_token, safe='')}"
     reason = "idle"
     try:
+        print(f"Dashboard: {url}", flush=True)
         if open_browser:
-            browser_open(url)
+            try:
+                opened = (browser_open or _default_browser_open)(url)
+            except Exception:
+                opened = False
+            if not opened:
+                print("Could not open a browser — paste the URL above into Chrome.")
         while True:
             if application.close_requested.is_set():
                 reason = "close"

--- a/core/dashboard/toggles.py
+++ b/core/dashboard/toggles.py
@@ -117,6 +117,7 @@ class FileStamp:
 class StateSnapshot:
     values: dict[str, Any]
     stamps: dict[str, FileStamp]
+    unavailable: dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -276,37 +277,37 @@ def _validate_requested_value(setting_id: str, value: Any, spec: ToggleSpec) -> 
         raise ToggleValidationError(f"{setting_id} accepts only: {choices}.")
 
 
-def _profile_values(text: str) -> tuple[dict[str, Any], dict[str, _YamlEntry]]:
+def _profile_values(
+    text: str,
+) -> tuple[dict[str, Any], dict[str, _YamlEntry], dict[str, str]]:
     entries = _yaml_entries(text)
     by_path = _entry_map(entries)
     values: dict[str, Any] = {}
     anchors: dict[str, _YamlEntry] = {}
+    unavailable: dict[str, str] = {}
     for setting_id, spec in PROFILE_SCHEMA.items():
         assert spec.yaml_path is not None
-        entry = _require_one(by_path, spec.yaml_path, setting_id)
-        value = _parse_scalar(entry.scalar)
-        if not _value_is_allowed(value, spec):
-            raise ToggleSchemaError(
-                f"{setting_id} has a value outside the supported schema; refresh after fixing the file."
-            )
+        if not by_path.get(spec.yaml_path):
+            continue
+        try:
+            entry = _require_one(by_path, spec.yaml_path, setting_id)
+            value = _parse_scalar(entry.scalar)
+            if not _value_is_allowed(value, spec):
+                raise ToggleSchemaError(
+                    f"{setting_id} has a value outside the supported schema; refresh after fixing the file."
+                )
+        except ToggleSchemaError as error:
+            unavailable[setting_id] = str(error)
+            continue
         values[setting_id] = value
         anchors[setting_id] = entry
-    _reject_duplicate_yaml_paths(entries)
-    return values, anchors
+    return values, anchors, unavailable
 
 
-def _reject_duplicate_yaml_paths(entries: list[_YamlEntry]) -> None:
-    duplicates = [path for path, count in Counter(entry.path for entry in entries).items() if count > 1]
-    if duplicates:
-        label = ".".join(duplicates[0])
-        raise ToggleSchemaError(
-            f"{label} must appear exactly once before Dex can change settings; refresh after fixing the file."
-        )
-
-
-def _integration_values(text: str) -> tuple[dict[str, bool], dict[str, _YamlEntry]]:
+def _integration_values(
+    text: str,
+) -> tuple[dict[str, bool], dict[str, _YamlEntry], dict[str, str]]:
     entries = _yaml_entries(text)
-    _reject_duplicate_yaml_paths(entries)
     candidates: dict[str, list[_YamlEntry]] = {}
     for entry in entries:
         name: str | None = None
@@ -324,32 +325,52 @@ def _integration_values(text: str) -> tuple[dict[str, bool], dict[str, _YamlEntr
 
     values: dict[str, bool] = {}
     anchors: dict[str, _YamlEntry] = {}
+    unavailable: dict[str, str] = {}
     for name, matches in sorted(candidates.items()):
-        if len(matches) != 1:
-            raise ToggleSchemaError(
-                f"integration {name} must have exactly one enabled setting; refresh after fixing the file."
-            )
-        value = _parse_scalar(matches[0].scalar)
-        if not isinstance(value, bool):
-            raise ToggleSchemaError(f"integration {name} enabled must be true or false; refresh after fixing the file.")
         setting_id = f"integration:{name}.enabled"
+        try:
+            if len(matches) != 1:
+                raise ToggleSchemaError(
+                    f"integration {name} must have exactly one enabled setting; refresh after fixing the file."
+                )
+            value = _parse_scalar(matches[0].scalar)
+            if not isinstance(value, bool):
+                raise ToggleSchemaError(
+                    f"integration {name} enabled must be true or false; refresh after fixing the file."
+                )
+        except ToggleSchemaError as error:
+            unavailable[setting_id] = str(error)
+            continue
         values[setting_id] = value
         anchors[setting_id] = matches[0]
-    return values, anchors
+    return values, anchors, unavailable
 
 
-def _health_value(text: str) -> tuple[str, re.Match[str]]:
+def _health_state(
+    text: str,
+) -> tuple[str | None, re.Match[str] | None, str | None]:
     matches = list(HEALTH_LINE.finditer(text))
+    if not matches:
+        return None, None, None
     if len(matches) != 1:
-        raise ToggleSchemaError(
+        return None, None, (
             "health_telemetry must appear exactly once before Dex can change it; refresh after fixing the file."
         )
     value = matches[0].group("value").strip()
     if value not in HEALTH_TELEMETRY_STORED_VALUES:
-        raise ToggleSchemaError(
+        return None, None, (
             "health_telemetry has a value outside the supported schema; refresh after fixing the file."
         )
-    return value, matches[0]
+    return value, matches[0], None
+
+
+def _health_value(text: str) -> tuple[str, re.Match[str]]:
+    value, match, unavailable = _health_state(text)
+    if unavailable is not None:
+        raise ToggleSchemaError(unavailable)
+    if value is None or match is None:
+        raise ToggleValidationError("That setting is not present in this Dex's files yet.")
+    return value, match
 
 
 def _replace_yaml_entry(text: str, entry: _YamlEntry, value: Any) -> str:
@@ -437,31 +458,38 @@ class ToggleEngine:
     def read_state(self) -> StateSnapshot:
         values: dict[str, Any] = {}
         stamps: dict[str, FileStamp] = {}
+        unavailable: dict[str, str] = {}
 
         profile_path = _at(self.vault, USER_PROFILE_FILE)
         if profile_path.is_file():
             profile_text, profile_stamp = _read_stamped(profile_path)
-            profile_values, _anchors = _profile_values(profile_text)
+            profile_values, _anchors, profile_unavailable = _profile_values(profile_text)
             values.update(profile_values)
             stamps.update({setting_id: profile_stamp for setting_id in profile_values})
+            unavailable.update(profile_unavailable)
 
         usage_path = _usage_log_file(self.vault)
         if usage_path.is_file():
             usage_text, usage_stamp = _read_stamped(usage_path)
-            health_value, _match = _health_value(usage_text)
-            values["health_telemetry"] = health_value
-            stamps["health_telemetry"] = usage_stamp
+            health_value, _match, health_unavailable = _health_state(usage_text)
+            if health_unavailable is not None:
+                unavailable["health_telemetry"] = health_unavailable
+            elif health_value is not None:
+                values["health_telemetry"] = health_value
+                stamps["health_telemetry"] = usage_stamp
 
         integrations_path = _at(self.vault, INTEGRATION_CONFIG_FILE)
         if integrations_path.is_file():
             integrations_text, integrations_stamp = _read_stamped(integrations_path)
-            integration_values, _anchors = _integration_values(integrations_text)
+            integration_values, _anchors, integration_unavailable = _integration_values(integrations_text)
             values.update(integration_values)
             stamps.update({setting_id: integrations_stamp for setting_id in integration_values})
+            unavailable.update(integration_unavailable)
 
         return StateSnapshot(
             values=dict(sorted(values.items())),
             stamps={setting_id: stamps[setting_id] for setting_id in sorted(stamps)},
+            unavailable=dict(sorted(unavailable.items())),
         )
 
     def write(
@@ -477,13 +505,12 @@ class ToggleEngine:
             raise ToggleValidationError("That setting is not available from the dashboard.")
 
         if spec is not None:
-            _validate_requested_value(setting_id, value, spec)
             path = self._path_for_kind(spec.file_kind)
         else:
-            if not isinstance(value, bool):
-                raise ToggleValidationError(f"{setting_id} accepts only: false, true.")
             path = _at(self.vault, INTEGRATION_CONFIG_FILE)
 
+        if not path.is_file() and spec is not None:
+            raise ToggleValidationError("That setting is not present in this Dex's files yet.")
         if not path.is_file():
             raise ToggleValidationError("That setting is not available from the dashboard.")
 
@@ -530,15 +557,23 @@ class ToggleEngine:
         integration_match: re.Match[str] | None,
     ) -> tuple[Any, str]:
         if spec is not None and spec.file_kind == "profile":
-            values, anchors = _profile_values(current_text)
+            values, anchors, unavailable = _profile_values(current_text)
+            if setting_id in unavailable:
+                raise ToggleSchemaError(unavailable[setting_id])
+            if setting_id not in anchors:
+                raise ToggleValidationError("That setting is not present in this Dex's files yet.")
+            _validate_requested_value(setting_id, value, spec)
             changed = _replace_yaml_entry(current_text, anchors[setting_id], value)
-            _profile_values(changed)
+            _changed_values, changed_anchors, changed_unavailable = _profile_values(changed)
+            if setting_id in changed_unavailable or setting_id not in changed_anchors:
+                raise ToggleSchemaError("The profile shape changed unexpectedly. Refresh and try again.")
             if not _same_yaml_keys(current_text, changed):
                 raise ToggleSchemaError("The profile shape changed unexpectedly. Refresh and try again.")
             return values[setting_id], changed
 
         if spec is not None and spec.file_kind == "usage":
             old, match = _health_value(current_text)
+            _validate_requested_value(setting_id, value, spec)
             changed = (
                 current_text[: match.start()]
                 + match.group("prefix")
@@ -551,11 +586,17 @@ class ToggleEngine:
             return old, changed
 
         assert integration_match is not None
-        values, anchors = _integration_values(current_text)
+        values, anchors, unavailable = _integration_values(current_text)
+        if setting_id in unavailable:
+            raise ToggleSchemaError(unavailable[setting_id])
         if setting_id not in anchors:
             raise ToggleValidationError("That integration is not already present in the config.")
+        if not isinstance(value, bool):
+            raise ToggleValidationError(f"{setting_id} accepts only: false, true.")
         changed = _replace_yaml_entry(current_text, anchors[setting_id], value)
-        _integration_values(changed)
+        _changed_values, changed_anchors, changed_unavailable = _integration_values(changed)
+        if setting_id in changed_unavailable or setting_id not in changed_anchors:
+            raise ToggleSchemaError("The integration config shape changed unexpectedly. Refresh and try again.")
         if not _same_yaml_keys(current_text, changed):
             raise ToggleSchemaError("The integration config shape changed unexpectedly. Refresh and try again.")
         return values[setting_id], changed

--- a/core/dashboard/toggles.py
+++ b/core/dashboard/toggles.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from core import capabilities
 from core.paths import (
     DEX_RUNTIME_DIR,
     INTEGRATION_CONFIG_FILE,
@@ -24,10 +25,14 @@ from core.paths import (
 
 FORMALITY_VALUES = ("formal", "professional_casual", "casual")
 DIRECTNESS_VALUES = ("very_direct", "balanced", "supportive")
+DETAIL_LEVEL_VALUES = ("concise", "balanced", "comprehensive")
+COACHING_STYLE_VALUES = ("encouraging", "collaborative", "challenging")
 ENTITY_CREATION_VALUES = ("auto", "suggest", "off")
 HEALTH_TELEMETRY_VALUES = ("opted-in", "opted-out")
 HEALTH_TELEMETRY_STORED_VALUES = ("pending", *HEALTH_TELEMETRY_VALUES)
 INTEGRATION_SETTING = re.compile(r"^integration:(?P<name>[A-Za-z0-9][A-Za-z0-9_-]*)\.enabled$")
+MEETING_INTEL_SETTING = re.compile(r"^meeting_intel:(?P<name>[A-Za-z_][A-Za-z0-9_-]*)$")
+CAPABILITY_ROOMS = ("career", "companies", "quarter_goals")
 YAML_LINE = re.compile(
     r"^(?P<prefix>(?P<indent> *)"
     r"(?P<key>[A-Za-z_][A-Za-z0-9_-]*):[ \t]*)"
@@ -96,6 +101,51 @@ TOGGLE_REGISTRY = {
         "enum",
         DIRECTNESS_VALUES,
     ),
+    "detail_level": ToggleSpec(
+        "profile",
+        ("communication", "detail_level"),
+        "enum",
+        DETAIL_LEVEL_VALUES,
+    ),
+    "coaching_style": ToggleSpec(
+        "profile",
+        ("communication", "coaching_style"),
+        "enum",
+        COACHING_STYLE_VALUES,
+    ),
+    "entity_gardener": ToggleSpec(
+        "profile",
+        ("entity_gardener", "enabled"),
+        "bool",
+        (False, True),
+    ),
+    "journaling_morning": ToggleSpec(
+        "profile",
+        ("journaling", "morning"),
+        "bool",
+        (False, True),
+    ),
+    "journaling_evening": ToggleSpec(
+        "profile",
+        ("journaling", "evening"),
+        "bool",
+        (False, True),
+    ),
+    "journaling_weekly": ToggleSpec(
+        "profile",
+        ("journaling", "weekly"),
+        "bool",
+        (False, True),
+    ),
+    **{
+        f"capability:{room}": ToggleSpec(
+            "capability",
+            ("capabilities", room, "enabled"),
+            "bool",
+            (False, True),
+        )
+        for room in CAPABILITY_ROOMS
+    },
     "health_telemetry": ToggleSpec(
         "usage",
         None,
@@ -304,6 +354,74 @@ def _profile_values(
     return values, anchors, unavailable
 
 
+def _meeting_intel_values(
+    text: str,
+) -> tuple[dict[str, bool], dict[str, _YamlEntry], dict[str, str]]:
+    candidates: dict[str, list[_YamlEntry]] = {}
+    for entry in _yaml_entries(text):
+        if len(entry.path) != 2 or entry.path[0] != "meeting_intelligence":
+            continue
+        name = entry.path[1]
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", name) is None:
+            continue
+        candidates.setdefault(name, []).append(entry)
+
+    values: dict[str, bool] = {}
+    anchors: dict[str, _YamlEntry] = {}
+    unavailable: dict[str, str] = {}
+    for name, matches in sorted(candidates.items()):
+        setting_id = f"meeting_intel:{name}"
+        try:
+            if len(matches) != 1:
+                raise ToggleSchemaError(
+                    f"meeting intelligence {name} must appear exactly once; "
+                    "refresh after fixing the file."
+                )
+            value = _parse_scalar(matches[0].scalar)
+            if not isinstance(value, bool):
+                raise ToggleSchemaError(
+                    f"meeting intelligence {name} must be true or false; "
+                    "refresh after fixing the file."
+                )
+        except ToggleSchemaError as error:
+            unavailable[setting_id] = str(error)
+            continue
+        values[setting_id] = value
+        anchors[setting_id] = matches[0]
+    return values, anchors, unavailable
+
+
+def _meeting_spec(setting_id: str) -> ToggleSpec | None:
+    match = MEETING_INTEL_SETTING.fullmatch(setting_id)
+    if match is None:
+        return None
+    return ToggleSpec(
+        "profile",
+        ("meeting_intelligence", match.group("name")),
+        "bool",
+        (False, True),
+    )
+
+
+def _capability_values(
+    profile_path: Path,
+) -> tuple[dict[str, bool], dict[str, str]]:
+    values: dict[str, bool] = {}
+    unavailable: dict[str, str] = {}
+    for room in CAPABILITY_ROOMS:
+        setting_id = f"capability:{room}"
+        try:
+            values[setting_id] = capabilities.enabled(
+                room,
+                profile_path=profile_path,
+            )
+        except Exception:
+            unavailable[setting_id] = (
+                "This capability is unavailable until its local configuration is fixed."
+            )
+    return values, unavailable
+
+
 def _integration_values(
     text: str,
 ) -> tuple[dict[str, bool], dict[str, _YamlEntry], dict[str, str]]:
@@ -464,9 +582,26 @@ class ToggleEngine:
         if profile_path.is_file():
             profile_text, profile_stamp = _read_stamped(profile_path)
             profile_values, _anchors, profile_unavailable = _profile_values(profile_text)
+            meeting_values, _meeting_anchors, meeting_unavailable = _meeting_intel_values(
+                profile_text
+            )
+            capability_values, capability_unavailable = _capability_values(profile_path)
             values.update(profile_values)
-            stamps.update({setting_id: profile_stamp for setting_id in profile_values})
+            values.update(meeting_values)
+            values.update(capability_values)
+            stamps.update(
+                {
+                    setting_id: profile_stamp
+                    for setting_id in (
+                        *profile_values,
+                        *meeting_values,
+                        *capability_values,
+                    )
+                }
+            )
             unavailable.update(profile_unavailable)
+            unavailable.update(meeting_unavailable)
+            unavailable.update(capability_unavailable)
 
         usage_path = _usage_log_file(self.vault)
         if usage_path.is_file():
@@ -499,7 +634,7 @@ class ToggleEngine:
         *,
         expected: FileStamp | None,
     ) -> WriteResult:
-        spec = TOGGLE_REGISTRY.get(setting_id)
+        spec = TOGGLE_REGISTRY.get(setting_id) or _meeting_spec(setting_id)
         integration_match = INTEGRATION_SETTING.fullmatch(setting_id)
         if spec is None and integration_match is None:
             raise ToggleValidationError("That setting is not available from the dashboard.")
@@ -515,6 +650,15 @@ class ToggleEngine:
             raise ToggleValidationError("That setting is not available from the dashboard.")
 
         current_text, current_stamp = _read_stamped(path)
+        if spec is not None and spec.file_kind == "capability":
+            return self._write_capability(
+                setting_id,
+                value,
+                spec,
+                path,
+                current_stamp,
+                expected,
+            )
         old, changed_text = self._change_text(
             setting_id,
             value,
@@ -542,11 +686,50 @@ class ToggleEngine:
         return WriteResult(setting_id, old, value, new_stamp)
 
     def _path_for_kind(self, file_kind: str) -> Path:
-        if file_kind == "profile":
+        if file_kind in {"profile", "capability"}:
             return _at(self.vault, USER_PROFILE_FILE)
         if file_kind == "usage":
             return _usage_log_file(self.vault)
         raise ToggleValidationError("That setting is not available from the dashboard.")
+
+    def _write_capability(
+        self,
+        setting_id: str,
+        value: Any,
+        spec: ToggleSpec,
+        profile_path: Path,
+        current_stamp: FileStamp,
+        expected: FileStamp | None,
+    ) -> WriteResult:
+        _validate_requested_value(setting_id, value, spec)
+        room = setting_id.partition(":")[2]
+        try:
+            old = capabilities.enabled(room, profile_path=profile_path)
+        except Exception as error:
+            raise ToggleError(
+                "Dex could not read that capability safely. Refresh and try again."
+            ) from error
+        if expected is None or current_stamp != expected:
+            raise ToggleConflictError(
+                "The settings changed; refresh the dashboard and try again."
+            )
+        if _stamp(profile_path) != current_stamp:
+            raise ToggleConflictError(
+                "The settings changed; refresh the dashboard and try again."
+            )
+        try:
+            capabilities.set_enabled(
+                room,
+                value,
+                vault_root=self.vault,
+            )
+        except Exception as error:
+            raise ToggleError(
+                "Dex could not change that capability safely."
+            ) from error
+        new_stamp = _stamp(profile_path)
+        self._append_audit(setting_id, old, value)
+        return WriteResult(setting_id, old, value, new_stamp)
 
     def _change_text(
         self,
@@ -557,14 +740,25 @@ class ToggleEngine:
         integration_match: re.Match[str] | None,
     ) -> tuple[Any, str]:
         if spec is not None and spec.file_kind == "profile":
-            values, anchors, unavailable = _profile_values(current_text)
+            meeting_setting = MEETING_INTEL_SETTING.fullmatch(setting_id) is not None
+            if meeting_setting:
+                values, anchors, unavailable = _meeting_intel_values(current_text)
+            else:
+                values, anchors, unavailable = _profile_values(current_text)
             if setting_id in unavailable:
                 raise ToggleSchemaError(unavailable[setting_id])
             if setting_id not in anchors:
                 raise ToggleValidationError("That setting is not present in this Dex's files yet.")
             _validate_requested_value(setting_id, value, spec)
             changed = _replace_yaml_entry(current_text, anchors[setting_id], value)
-            _changed_values, changed_anchors, changed_unavailable = _profile_values(changed)
+            if meeting_setting:
+                _changed_values, changed_anchors, changed_unavailable = (
+                    _meeting_intel_values(changed)
+                )
+            else:
+                _changed_values, changed_anchors, changed_unavailable = _profile_values(
+                    changed
+                )
             if setting_id in changed_unavailable or setting_id not in changed_anchors:
                 raise ToggleSchemaError("The profile shape changed unexpectedly. Refresh and try again.")
             if not _same_yaml_keys(current_text, changed):

--- a/core/dashboard/toggles.py
+++ b/core/dashboard/toggles.py
@@ -1,0 +1,575 @@
+"""Vetted, conflict-aware writes for the local Dex Dashboard."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from core.paths import (
+    DEX_RUNTIME_DIR,
+    INTEGRATION_CONFIG_FILE,
+    SYSTEM_DIR,
+    USER_PROFILE_FILE,
+    VAULT_ROOT,
+)
+
+FORMALITY_VALUES = ("formal", "professional_casual", "casual")
+DIRECTNESS_VALUES = ("very_direct", "balanced", "supportive")
+ENTITY_CREATION_VALUES = ("auto", "suggest", "off")
+HEALTH_TELEMETRY_VALUES = ("opted-in", "opted-out")
+HEALTH_TELEMETRY_STORED_VALUES = ("pending", *HEALTH_TELEMETRY_VALUES)
+INTEGRATION_SETTING = re.compile(r"^integration:(?P<name>[A-Za-z0-9][A-Za-z0-9_-]*)\.enabled$")
+YAML_LINE = re.compile(
+    r"^(?P<prefix>(?P<indent> *)"
+    r"(?P<key>[A-Za-z_][A-Za-z0-9_-]*):[ \t]*)"
+    r"(?P<value>[^\r\n]*)(?P<newline>\r?\n?)$"
+)
+HEALTH_LINE = re.compile(
+    r"^(?P<prefix>\*\*Health telemetry:\*\*[ \t]*)"
+    r"(?P<value>[^\r\n]*?)(?P<suffix>[ \t]*)(?P<newline>\r?\n?)$",
+    re.MULTILINE,
+)
+BLOCK_SCALAR = re.compile(r"^[|>](?:[1-9][+-]?|[+-][1-9]?|[+-])?$")
+
+
+class ToggleError(Exception):
+    """Base class for safe, user-presentable toggle failures."""
+
+    status_code = 500
+
+
+class ToggleValidationError(ToggleError):
+    """The requested setting or value is outside the vetted registry."""
+
+    status_code = 400
+
+
+class ToggleConflictError(ToggleError):
+    """The source changed after the page last read it."""
+
+    status_code = 409
+
+
+class ToggleSchemaError(ToggleConflictError):
+    """A target file is not safe for exact, single-line surgery."""
+
+
+@dataclass(frozen=True)
+class ToggleSpec:
+    file_kind: str
+    yaml_path: tuple[str, ...] | None
+    value_kind: str
+    allowed: tuple[Any, ...]
+
+
+TOGGLE_REGISTRY = {
+    "analytics_enabled": ToggleSpec(
+        "profile",
+        ("analytics", "enabled"),
+        "bool",
+        (False, True),
+    ),
+    "entity_creation": ToggleSpec(
+        "profile",
+        ("entity_creation", "mode"),
+        "enum",
+        ENTITY_CREATION_VALUES,
+    ),
+    "formality": ToggleSpec(
+        "profile",
+        ("communication", "formality"),
+        "enum",
+        FORMALITY_VALUES,
+    ),
+    "directness": ToggleSpec(
+        "profile",
+        ("communication", "directness"),
+        "enum",
+        DIRECTNESS_VALUES,
+    ),
+    "health_telemetry": ToggleSpec(
+        "usage",
+        None,
+        "enum",
+        HEALTH_TELEMETRY_VALUES,
+    ),
+}
+
+PROFILE_SCHEMA = {setting_id: spec for setting_id, spec in TOGGLE_REGISTRY.items() if spec.file_kind == "profile"}
+
+
+@dataclass(frozen=True)
+class FileStamp:
+    mtime_ns: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class StateSnapshot:
+    values: dict[str, Any]
+    stamps: dict[str, FileStamp]
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    setting_id: str
+    old: Any
+    new: Any
+    stamp: FileStamp
+
+
+@dataclass(frozen=True)
+class _YamlEntry:
+    line_index: int
+    path: tuple[str, ...]
+    indent: int
+    prefix: str
+    scalar: str
+    suffix: str
+    newline: str
+
+
+def _at(vault: Path, configured_path: Path) -> Path:
+    """Rebase a core.paths constant from its configured vault onto this invocation."""
+    return vault / configured_path.relative_to(VAULT_ROOT)
+
+
+def _usage_log_file(vault: Path) -> Path:
+    return _at(vault, SYSTEM_DIR / "usage_log.md")
+
+
+def _audit_file(vault: Path) -> Path:
+    return _at(vault, DEX_RUNTIME_DIR / "dashboard" / "audit.jsonl")
+
+
+def _split_scalar_suffix(value: str) -> tuple[str, str]:
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and quote == '"':
+            escaped = True
+            continue
+        if quote is not None:
+            if character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+            continue
+        if character == "#" and (index == 0 or value[index - 1].isspace()):
+            before = value[:index]
+            scalar = before.rstrip()
+            return scalar, before[len(scalar) :] + value[index:]
+    return value.rstrip(), value[len(value.rstrip()) :]
+
+
+def _yaml_entries(text: str) -> list[_YamlEntry]:
+    entries: list[_YamlEntry] = []
+    parents: list[tuple[int, tuple[str, ...]]] = []
+    block_scalar_indent: int | None = None
+    for line_index, line in enumerate(text.splitlines(keepends=True)):
+        if block_scalar_indent is not None:
+            if not line.strip():
+                continue
+            line_indent = len(line) - len(line.lstrip(" "))
+            if line_indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+        match = YAML_LINE.match(line)
+        if match is None:
+            continue
+        indent = len(match.group("indent"))
+        while parents and parents[-1][0] >= indent:
+            parents.pop()
+        parent = parents[-1][1] if parents else ()
+        path = (*parent, match.group("key"))
+        scalar, suffix = _split_scalar_suffix(match.group("value"))
+        entry = _YamlEntry(
+            line_index=line_index,
+            path=path,
+            indent=indent,
+            prefix=match.group("prefix"),
+            scalar=scalar,
+            suffix=suffix,
+            newline=match.group("newline"),
+        )
+        entries.append(entry)
+        if BLOCK_SCALAR.fullmatch(scalar.strip()):
+            block_scalar_indent = indent
+        elif not scalar:
+            parents.append((indent, path))
+    return entries
+
+
+def _parse_scalar(scalar: str) -> Any:
+    value = scalar.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ToggleSchemaError("A quoted setting value is malformed; refresh after fixing it.") from error
+        if not isinstance(parsed, str):
+            raise ToggleSchemaError("A quoted setting value has the wrong type; refresh after fixing it.")
+        return parsed
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    if value in {"null", "~"}:
+        return None
+    return value
+
+
+def _render_scalar(value: Any, old_scalar: str) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if old_scalar.startswith('"') and old_scalar.endswith('"'):
+        return json.dumps(value, ensure_ascii=False)
+    if old_scalar.startswith("'") and old_scalar.endswith("'"):
+        return "'" + str(value).replace("'", "''") + "'"
+    return str(value)
+
+
+def _entry_map(entries: list[_YamlEntry]) -> dict[tuple[str, ...], list[_YamlEntry]]:
+    result: dict[tuple[str, ...], list[_YamlEntry]] = {}
+    for entry in entries:
+        result.setdefault(entry.path, []).append(entry)
+    return result
+
+
+def _require_one(
+    by_path: dict[tuple[str, ...], list[_YamlEntry]],
+    path: tuple[str, ...],
+    label: str,
+) -> _YamlEntry:
+    matches = by_path.get(path, [])
+    if len(matches) != 1:
+        raise ToggleSchemaError(
+            f"{label} must appear exactly once before Dex can change it; refresh after fixing the file."
+        )
+    return matches[0]
+
+
+def _value_is_allowed(value: Any, spec: ToggleSpec) -> bool:
+    if spec.value_kind == "bool":
+        return isinstance(value, bool)
+    return isinstance(value, str) and value in spec.allowed
+
+
+def _validate_requested_value(setting_id: str, value: Any, spec: ToggleSpec) -> None:
+    if not _value_is_allowed(value, spec):
+        choices = ", ".join(str(choice).lower() for choice in spec.allowed)
+        raise ToggleValidationError(f"{setting_id} accepts only: {choices}.")
+
+
+def _profile_values(text: str) -> tuple[dict[str, Any], dict[str, _YamlEntry]]:
+    entries = _yaml_entries(text)
+    by_path = _entry_map(entries)
+    values: dict[str, Any] = {}
+    anchors: dict[str, _YamlEntry] = {}
+    for setting_id, spec in PROFILE_SCHEMA.items():
+        assert spec.yaml_path is not None
+        entry = _require_one(by_path, spec.yaml_path, setting_id)
+        value = _parse_scalar(entry.scalar)
+        if not _value_is_allowed(value, spec):
+            raise ToggleSchemaError(
+                f"{setting_id} has a value outside the supported schema; refresh after fixing the file."
+            )
+        values[setting_id] = value
+        anchors[setting_id] = entry
+    _reject_duplicate_yaml_paths(entries)
+    return values, anchors
+
+
+def _reject_duplicate_yaml_paths(entries: list[_YamlEntry]) -> None:
+    duplicates = [path for path, count in Counter(entry.path for entry in entries).items() if count > 1]
+    if duplicates:
+        label = ".".join(duplicates[0])
+        raise ToggleSchemaError(
+            f"{label} must appear exactly once before Dex can change settings; refresh after fixing the file."
+        )
+
+
+def _integration_values(text: str) -> tuple[dict[str, bool], dict[str, _YamlEntry]]:
+    entries = _yaml_entries(text)
+    _reject_duplicate_yaml_paths(entries)
+    candidates: dict[str, list[_YamlEntry]] = {}
+    for entry in entries:
+        name: str | None = None
+        if len(entry.path) == 2 and entry.path[0] == "enabled":
+            name = entry.path[1]
+        elif (
+            len(entry.path) == 2
+            and entry.path[1] == "enabled"
+            and entry.path[0] not in {"enabled", "hooks", "detected"}
+        ):
+            name = entry.path[0]
+        if name is None or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", name) is None:
+            continue
+        candidates.setdefault(name, []).append(entry)
+
+    values: dict[str, bool] = {}
+    anchors: dict[str, _YamlEntry] = {}
+    for name, matches in sorted(candidates.items()):
+        if len(matches) != 1:
+            raise ToggleSchemaError(
+                f"integration {name} must have exactly one enabled setting; refresh after fixing the file."
+            )
+        value = _parse_scalar(matches[0].scalar)
+        if not isinstance(value, bool):
+            raise ToggleSchemaError(f"integration {name} enabled must be true or false; refresh after fixing the file.")
+        setting_id = f"integration:{name}.enabled"
+        values[setting_id] = value
+        anchors[setting_id] = matches[0]
+    return values, anchors
+
+
+def _health_value(text: str) -> tuple[str, re.Match[str]]:
+    matches = list(HEALTH_LINE.finditer(text))
+    if len(matches) != 1:
+        raise ToggleSchemaError(
+            "health_telemetry must appear exactly once before Dex can change it; refresh after fixing the file."
+        )
+    value = matches[0].group("value").strip()
+    if value not in HEALTH_TELEMETRY_STORED_VALUES:
+        raise ToggleSchemaError(
+            "health_telemetry has a value outside the supported schema; refresh after fixing the file."
+        )
+    return value, matches[0]
+
+
+def _replace_yaml_entry(text: str, entry: _YamlEntry, value: Any) -> str:
+    lines = text.splitlines(keepends=True)
+    lines[entry.line_index] = entry.prefix + _render_scalar(value, entry.scalar) + entry.suffix + entry.newline
+    return "".join(lines)
+
+
+def _same_yaml_keys(before: str, after: str) -> bool:
+    return Counter(entry.path for entry in _yaml_entries(before)) == Counter(
+        entry.path for entry in _yaml_entries(after)
+    )
+
+
+def _stamp(path: Path) -> FileStamp:
+    data = path.read_bytes()
+    file_stat = path.stat()
+    return FileStamp(
+        mtime_ns=file_stat.st_mtime_ns,
+        sha256=hashlib.sha256(data).hexdigest(),
+    )
+
+
+def _read_stamped(path: Path) -> tuple[str, FileStamp]:
+    for _attempt in range(2):
+        before = path.stat()
+        data = path.read_bytes()
+        after = path.stat()
+        if before.st_mtime_ns == after.st_mtime_ns and before.st_size == after.st_size:
+            try:
+                text = data.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ToggleSchemaError(
+                    "A dashboard settings file is not valid UTF-8; refresh after fixing it."
+                ) from error
+            return text, FileStamp(
+                mtime_ns=after.st_mtime_ns,
+                sha256=hashlib.sha256(data).hexdigest(),
+            )
+    raise ToggleConflictError("The settings changed while Dex read them; refresh and try again.")
+
+
+def atomic_replace_bytes(
+    path: Path,
+    content: bytes,
+    *,
+    before_replace: Callable[[], None] | None = None,
+) -> None:
+    """Fsync a same-directory temporary file, then atomically replace the target."""
+    mode = stat.S_IMODE(path.stat().st_mode)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        if before_replace is not None:
+            before_replace()
+        os.replace(temporary, path)
+        temporary = None
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+class ToggleEngine:
+    """Read and mutate only the settings named by ``TOGGLE_REGISTRY``."""
+
+    def __init__(self, vault: Path | str) -> None:
+        self.vault = Path(vault).expanduser().resolve()
+
+    def read_state(self) -> StateSnapshot:
+        values: dict[str, Any] = {}
+        stamps: dict[str, FileStamp] = {}
+
+        profile_path = _at(self.vault, USER_PROFILE_FILE)
+        if profile_path.is_file():
+            profile_text, profile_stamp = _read_stamped(profile_path)
+            profile_values, _anchors = _profile_values(profile_text)
+            values.update(profile_values)
+            stamps.update({setting_id: profile_stamp for setting_id in profile_values})
+
+        usage_path = _usage_log_file(self.vault)
+        if usage_path.is_file():
+            usage_text, usage_stamp = _read_stamped(usage_path)
+            health_value, _match = _health_value(usage_text)
+            values["health_telemetry"] = health_value
+            stamps["health_telemetry"] = usage_stamp
+
+        integrations_path = _at(self.vault, INTEGRATION_CONFIG_FILE)
+        if integrations_path.is_file():
+            integrations_text, integrations_stamp = _read_stamped(integrations_path)
+            integration_values, _anchors = _integration_values(integrations_text)
+            values.update(integration_values)
+            stamps.update({setting_id: integrations_stamp for setting_id in integration_values})
+
+        return StateSnapshot(
+            values=dict(sorted(values.items())),
+            stamps={setting_id: stamps[setting_id] for setting_id in sorted(stamps)},
+        )
+
+    def write(
+        self,
+        setting_id: str,
+        value: Any,
+        *,
+        expected: FileStamp | None,
+    ) -> WriteResult:
+        spec = TOGGLE_REGISTRY.get(setting_id)
+        integration_match = INTEGRATION_SETTING.fullmatch(setting_id)
+        if spec is None and integration_match is None:
+            raise ToggleValidationError("That setting is not available from the dashboard.")
+
+        if spec is not None:
+            _validate_requested_value(setting_id, value, spec)
+            path = self._path_for_kind(spec.file_kind)
+        else:
+            if not isinstance(value, bool):
+                raise ToggleValidationError(f"{setting_id} accepts only: false, true.")
+            path = _at(self.vault, INTEGRATION_CONFIG_FILE)
+
+        if not path.is_file():
+            raise ToggleValidationError("That setting is not available from the dashboard.")
+
+        current_text, current_stamp = _read_stamped(path)
+        old, changed_text = self._change_text(
+            setting_id,
+            value,
+            current_text,
+            spec,
+            integration_match,
+        )
+        if expected is None or current_stamp != expected:
+            raise ToggleConflictError("The settings changed; refresh the dashboard and try again.")
+        if changed_text == current_text:
+            self._append_audit(setting_id, old, value)
+            return WriteResult(setting_id, old, value, current_stamp)
+
+        def confirm_unchanged() -> None:
+            if _stamp(path) != current_stamp:
+                raise ToggleConflictError("The settings changed; refresh the dashboard and try again.")
+
+        atomic_replace_bytes(
+            path,
+            changed_text.encode("utf-8"),
+            before_replace=confirm_unchanged,
+        )
+        new_stamp = _stamp(path)
+        self._append_audit(setting_id, old, value)
+        return WriteResult(setting_id, old, value, new_stamp)
+
+    def _path_for_kind(self, file_kind: str) -> Path:
+        if file_kind == "profile":
+            return _at(self.vault, USER_PROFILE_FILE)
+        if file_kind == "usage":
+            return _usage_log_file(self.vault)
+        raise ToggleValidationError("That setting is not available from the dashboard.")
+
+    def _change_text(
+        self,
+        setting_id: str,
+        value: Any,
+        current_text: str,
+        spec: ToggleSpec | None,
+        integration_match: re.Match[str] | None,
+    ) -> tuple[Any, str]:
+        if spec is not None and spec.file_kind == "profile":
+            values, anchors = _profile_values(current_text)
+            changed = _replace_yaml_entry(current_text, anchors[setting_id], value)
+            _profile_values(changed)
+            if not _same_yaml_keys(current_text, changed):
+                raise ToggleSchemaError("The profile shape changed unexpectedly. Refresh and try again.")
+            return values[setting_id], changed
+
+        if spec is not None and spec.file_kind == "usage":
+            old, match = _health_value(current_text)
+            changed = (
+                current_text[: match.start()]
+                + match.group("prefix")
+                + str(value)
+                + match.group("suffix")
+                + match.group("newline")
+                + current_text[match.end() :]
+            )
+            _health_value(changed)
+            return old, changed
+
+        assert integration_match is not None
+        values, anchors = _integration_values(current_text)
+        if setting_id not in anchors:
+            raise ToggleValidationError("That integration is not already present in the config.")
+        changed = _replace_yaml_entry(current_text, anchors[setting_id], value)
+        _integration_values(changed)
+        if not _same_yaml_keys(current_text, changed):
+            raise ToggleSchemaError("The integration config shape changed unexpectedly. Refresh and try again.")
+        return values[setting_id], changed
+
+    def _append_audit(self, setting_id: str, old: Any, new: Any) -> None:
+        path = _audit_file(self.vault)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "setting_id": setting_id,
+            "old": old,
+            "new": new,
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())

--- a/core/tests/test_dashboard_collect.py
+++ b/core/tests/test_dashboard_collect.py
@@ -12,6 +12,17 @@ from pathlib import Path
 
 import pytest
 
+from core.paths import (
+    INTEGRATION_CONFIG_FILE,
+    MCP_CONFIG_TARGET,
+    PEOPLE_DIR,
+    PEOPLE_INDEX_FILE,
+    QUARTER_GOALS_FILE,
+    SKILL_RATINGS_FILE,
+    VAULT_ROOT,
+    WEEK_PRIORITIES_FILE,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COLLECT_SCRIPT = REPO_ROOT / "core" / "dashboard" / "collect.py"
 NOW = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
@@ -25,6 +36,10 @@ def _write(path: Path, content: str) -> Path:
 
 def _collector():
     return importlib.import_module("core.dashboard.collect")
+
+
+def _at(vault: Path, configured_path: Path) -> Path:
+    return vault / configured_path.relative_to(VAULT_ROOT)
 
 
 def _fixture_vault(tmp_path: Path) -> tuple[Path, Path]:
@@ -211,9 +226,13 @@ todoist:
     return vault, skills_list
 
 
-def test_collects_dashboard_data_without_leaking_secrets(tmp_path: Path) -> None:
+def test_collects_dashboard_data_without_leaking_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     collect = _collector()
     vault, skills_list = _fixture_vault(tmp_path)
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
 
     result = collect.collect_dashboard(vault, skills_list=skills_list, now=NOW)
 
@@ -222,6 +241,8 @@ def test_collects_dashboard_data_without_leaking_secrets(tmp_path: Path) -> None
         "profile",
         "pillars",
         "integrations",
+        "connections",
+        "rituals",
         "usage",
         "analytics",
         "tasks",
@@ -264,6 +285,36 @@ def test_collects_dashboard_data_without_leaking_secrets(tmp_path: Path) -> None
         "enabled": True,
         "configured_at": "2026-07-20T09:00:00+00:00",
         "features": {"context": True, "meeting_prep": True},
+    }
+    assert result["connections"] == {
+        "mcp_servers": [],
+        "mcp_count": 0,
+        "dex_integrations_on": 2,
+        "granola_key_present": False,
+        "total_connected": 2,
+        "sources": ["integrations config", "environment"],
+    }
+    assert result["rituals"] == {
+        "daily_plan": {
+            "used": True,
+            "evidence": "usage_log.md marks /daily-plan used",
+        },
+        "week_plan": {
+            "used": False,
+            "evidence": "no usage or analytics event found",
+        },
+        "week_review": {
+            "used": False,
+            "evidence": "no usage or analytics event found",
+        },
+        "quarter_goals": {
+            "set": False,
+            "evidence": "Quarter_Goals.md is missing or still blank",
+        },
+        "week_priorities": {
+            "set": False,
+            "evidence": "Week_Priorities.md has no priorities",
+        },
     }
     assert result["usage"]["counts"] == {"available": 3, "used": 2}
     assert result["usage"]["journey"]["feature_adoption_score"] >= 2
@@ -346,6 +397,221 @@ def test_missing_and_malformed_sections_degrade_independently(tmp_path: Path) ->
     assert result["analytics"]["malformed_lines"] == 1
     assert result["health"]["status"] == "stale"
     assert result["health"]["guidance"] == "run /dex-doctor for a fresh checkup"
+
+
+def test_connections_count_mcp_names_integrations_and_granola_without_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collect = _collector()
+    vault = tmp_path / "connected"
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
+    _write(
+        _at(vault, INTEGRATION_CONFIG_FILE),
+        "enabled:\n  slack: true\n  google: false\n",
+    )
+    _write(
+        _at(vault, MCP_CONFIG_TARGET),
+        json.dumps(
+            {
+                "mcpServers": {
+                    "claude-ai": {
+                        "command": "never-emit-command",
+                        "env": {"TOKEN": "never-emit-token"},
+                    },
+                    "dex-calendar-mcp": {"url": "https://never-emit.example"},
+                    "filesystem": {"args": ["never-emit-path"]},
+                },
+                "unrelated": {"password": "never-emit-password"},
+            }
+        ),
+    )
+    _write(
+        vault / ".env",
+        "# GRANOLA_API_KEY=commented-out\n"
+        "OTHER_KEY=not-relevant\n"
+        "export GRANOLA_API_KEY=never-emit-granola\n",
+    )
+
+    result = collect.collect_dashboard(vault, now=NOW)
+
+    assert result["connections"] == {
+        "mcp_servers": ["claude-ai", "dex-calendar-mcp", "filesystem"],
+        "mcp_count": 3,
+        "dex_integrations_on": 1,
+        "granola_key_present": True,
+        "total_connected": 5,
+        "sources": ["integrations config", ".mcp.json", "environment"],
+    }
+    serialized = json.dumps(result["connections"], sort_keys=True)
+    for forbidden in (
+        "never-emit-command",
+        "never-emit-token",
+        "never-emit-path",
+        "never-emit-password",
+        "never-emit-granola",
+        "https://never-emit.example",
+    ):
+        assert forbidden not in serialized
+
+
+def test_connections_are_explicit_when_mcp_config_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collect = _collector()
+    vault = tmp_path / "not-connected"
+    vault.mkdir()
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
+
+    result = collect.collect_dashboard(vault, now=NOW)
+
+    assert result["connections"] == {
+        "mcp_servers": [],
+        "mcp_count": 0,
+        "dex_integrations_on": 0,
+        "granola_key_present": False,
+        "total_connected": 0,
+        "sources": ["environment"],
+    }
+
+
+def test_rituals_distinguish_blank_and_customized_planning_files(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "planning"
+    quarter_path = _at(vault, QUARTER_GOALS_FILE)
+    priorities_path = _at(vault, WEEK_PRIORITIES_FILE)
+    blank_quarter = (
+        "# Quarter Goals\n\n"
+        "This file is provisioned only when the Quarter Goals room is enabled.\n"
+    )
+    blank_priorities = (
+        REPO_ROOT / WEEK_PRIORITIES_FILE.relative_to(VAULT_ROOT)
+    ).read_text(encoding="utf-8")
+    _write(quarter_path, blank_quarter)
+    _write(priorities_path, blank_priorities)
+
+    blank = collect.collect_dashboard(vault, now=NOW)["rituals"]
+
+    assert blank["quarter_goals"] == {
+        "set": False,
+        "evidence": "Quarter_Goals.md is missing or still blank",
+    }
+    assert blank["week_priorities"] == {
+        "set": False,
+        "evidence": "Week_Priorities.md has no priorities",
+    }
+
+    _write(quarter_path, blank_quarter + "\n## Goal 1\nLaunch the beta.\n")
+    _write(priorities_path, blank_priorities.replace("1. \n", "1. Launch the beta\n", 1))
+
+    customized = collect.collect_dashboard(vault, now=NOW)["rituals"]
+
+    assert customized["quarter_goals"] == {
+        "set": True,
+        "evidence": "Quarter_Goals.md differs from blank template",
+    }
+    assert customized["week_priorities"] == {
+        "set": True,
+        "evidence": "Week_Priorities.md contains priorities",
+    }
+
+
+def test_rituals_use_usage_log_and_analytics_events_as_evidence(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "ritual-evidence"
+    _write(
+        vault / "System" / "usage_log.md",
+        "- [ ] Daily planning (`/daily-plan`)\n"
+        "- [x] Weekly planning (`/week-plan`)\n"
+        "- [ ] Weekly review (`/week-review`)\n",
+    )
+    _write(
+        vault / "System" / "analytics_log.jsonl",
+        json.dumps({"event": "daily_plan_completed"})
+        + "\n"
+        + json.dumps({"event": "week_review_viewed"})
+        + "\n",
+    )
+
+    rituals = collect.collect_dashboard(vault, now=NOW)["rituals"]
+
+    assert rituals["daily_plan"] == {
+        "used": True,
+        "evidence": "analytics event daily_plan_completed",
+    }
+    assert rituals["week_plan"] == {
+        "used": True,
+        "evidence": "usage_log.md marks /week-plan used",
+    }
+    assert rituals["week_review"] == {
+        "used": True,
+        "evidence": "analytics event week_review_viewed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("event_name", "skill_name"),
+    [
+        ("daily_plan_completed", "daily-plan"),
+        ("daily_review_viewed", "daily-review"),
+        ("week_plan_started", "week-plan"),
+        ("week_review_rated", "week-review"),
+        ("quarter_plan_completed", "quarter-plan"),
+        ("quarter_review_viewed", "quarter-review"),
+        ("meeting_prep_started", "meeting-prep"),
+        ("whats_new_rated", "dex-whats-new"),
+        ("level_up_completed", "dex-level-up"),
+    ],
+)
+def test_analytics_event_names_map_to_skill_names(
+    event_name: str,
+    skill_name: str,
+) -> None:
+    collect = _collector()
+
+    assert collect._event_skill_names({"event": event_name}) == {skill_name}
+
+
+def test_skill_ratings_count_as_usage(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "ratings"
+    skills_list = _write(tmp_path / "skills.json", json.dumps(["rated-only", "never-used"]))
+    _write(
+        _at(vault, SKILL_RATINGS_FILE),
+        json.dumps({"skill": "rated-only", "rating": 4}) + "\n",
+    )
+
+    skills = collect.collect_dashboard(vault, skills_list=skills_list, now=NOW)["skills"]
+
+    assert skills["used"] == ["rated-only"]
+    assert skills["unused"] == ["never-used"]
+
+
+def test_people_prefer_filesystem_when_index_is_stale(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "stale-index"
+    people_root = _at(vault, PEOPLE_DIR)
+    _write(people_root / "Internal" / "One.md", "# One\n")
+    _write(people_root / "External" / "Two.md", "# Two\n")
+    _write(
+        _at(vault, PEOPLE_INDEX_FILE),
+        json.dumps(
+            {
+                "total": 1,
+                "people": [{"path": str(people_root / "Internal" / "One.md")}],
+            }
+        ),
+    )
+
+    people = collect.collect_dashboard(vault, now=NOW)["people"]
+
+    assert people == {
+        "total": 2,
+        "internal": 1,
+        "external": 1,
+        "source": "filesystem (index stale)",
+    }
 
 
 def test_missing_profile_and_doctor_cache_are_explicit(tmp_path: Path) -> None:

--- a/core/tests/test_dashboard_collect.py
+++ b/core/tests/test_dashboard_collect.py
@@ -1,0 +1,427 @@
+"""Behavioral coverage for the read-only Dex Dashboard collector."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COLLECT_SCRIPT = REPO_ROOT / "core" / "dashboard" / "collect.py"
+NOW = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _collector():
+    return importlib.import_module("core.dashboard.collect")
+
+
+def _fixture_vault(tmp_path: Path) -> tuple[Path, Path]:
+    vault = tmp_path / "messy vault"
+    _write(
+        vault / "System" / "user-profile.yaml",
+        """
+name: Alex Example
+role: Product lead
+company: Example Co
+communication:
+  formality: professional_casual
+  directness: very_direct
+  detail_level: concise
+analytics:
+  enabled: true
+entity_creation:
+  mode: suggest
+journaling:
+  morning: true
+  evening: false
+  weekly: true
+capabilities:
+  quarter_goals:
+    enabled: true
+quarterly_planning:
+  enabled: false
+""".strip()
+        + "\n",
+    )
+    _write(
+        vault / "System" / "pillars.yaml",
+        """
+pillars:
+  - id: customers
+    name: Customer trust
+    description: Make the product dependable.
+    keywords: [trust, reliability]
+  - id: growth
+    name: Sustainable growth
+    description: Grow without losing quality.
+    keywords: [growth]
+""".strip()
+        + "\n",
+    )
+    _write(
+        vault / "System" / "integrations" / "config.yaml",
+        """
+enabled:
+  slack: true
+  google: false
+hooks:
+  meeting_prep:
+    use_slack: true
+    use_google: false
+slack:
+  configured_at: 2026-07-20T09:00:00Z
+  features:
+    context: true
+  token: do-not-emit
+  nested:
+    api_key: do-not-emit-either
+todoist:
+  enabled: true
+  configured_at: 2026-07-21
+  api_key_env_var: TODOIST_API_KEY
+""".strip()
+        + "\n",
+    )
+    _write(
+        vault / "System" / "usage_log.md",
+        """
+## Core Workflows
+- [x] Daily planning (`/daily-plan`)
+- [ ] Weekly planning (`/week-plan`)
+## Meetings
+- [x] Meeting prep (`/meeting-prep`)
+## Tracking Metadata
+- **Setup date:** 2026-07-01
+""".strip()
+        + "\n",
+    )
+    analytics = [
+        {
+            "timestamp": "2026-07-27T08:00:00Z",
+            "event": "skill_invoked",
+            "properties": {"skill_name": "daily-plan"},
+        },
+        {
+            "timestamp": "2026-07-20T08:00:00+00:00",
+            "event": "meeting-prep",
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00Z",
+            "event": "old_event",
+        },
+    ]
+    _write(
+        vault / "System" / "analytics_log.jsonl",
+        "\n".join([json.dumps(analytics[0]), "{malformed", json.dumps(analytics[1]), json.dumps(analytics[2])])
+        + "\n",
+    )
+    _write(
+        vault / "System" / "Skill_Ratings" / "ratings.jsonl",
+        "\n".join(
+            [
+                json.dumps({"skill": "daily-plan", "rating": 5}),
+                "{malformed",
+                json.dumps({"skill": "daily-plan", "rating": 3}),
+                json.dumps({"skill": "meeting-prep", "rating": 4}),
+            ]
+        )
+        + "\n",
+    )
+    _write(
+        vault / "System" / "People_Index.json",
+        json.dumps(
+            {
+                "total": 3,
+                "people": [
+                    {"path": "05-Areas/People/Internal/Alex.md"},
+                    {"path": "05-Areas/People/External/Sam.md"},
+                    {"path": "05-Areas/People/External/Jo.md"},
+                ],
+            }
+        ),
+    )
+    _write(
+        vault / "System" / "Company_Index.json",
+        json.dumps({"total": 2, "companies": [{"name": "One"}, {"name": "Two"}]}),
+    )
+    _write(
+        vault / "System" / ".doctor-last-run.json",
+        json.dumps(
+            {
+                "generated_at": "2026-07-26T10:00:00+00:00",
+                "mode": "quick",
+                "checks": [
+                    {
+                        "id": "vault.configs",
+                        "feature": "Vault configuration",
+                        "verdict": "OK",
+                        "detail": "Configuration parses.",
+                        "heal": None,
+                    },
+                    {
+                        "id": "calendar",
+                        "feature": "Calendar",
+                        "verdict": "OFF",
+                        "detail": "Not configured.",
+                        "heal": None,
+                    },
+                ],
+                "summary": {"ok": 1, "off": 1, "broken": 0, "unknown": 0},
+            }
+        ),
+    )
+    _write(vault / "System" / "credentials" / "never-read.json", '{"password":"vault-secret"}\n')
+    _write(
+        vault / "03-Tasks" / "Tasks.md",
+        """
+- [x] Finished one ^task-20260701-001 ✅ 2026-07-27 09:30
+- [ ] Open one ^task-20260701-002
+- [x] Old one ^task-20260701-003 ✅ 2026-07-01 08:00
+""".strip()
+        + "\n",
+    )
+    _write(vault / "00-Inbox" / "Meetings" / "2026-07-27" / "customer-sync.md", "# Customer sync\n")
+    _write(vault / "00-Inbox" / "Meetings" / "Planning_sync_2026_07_10.md", "# Planning\n")
+    undated_meeting = _write(vault / "00-Inbox" / "Meetings" / "Undated.md", "# Undated\n")
+    recent_mtime = (NOW - timedelta(days=1)).timestamp()
+    os.utime(undated_meeting, (recent_mtime, recent_mtime))
+    _write(vault / "00-Inbox" / "Meetings" / "README.md", "# Ignore\n")
+    _write(vault / "04-Projects" / "Alpha" / "notes.md", "# Alpha\n")
+    old_project = _write(vault / "04-Projects" / "Beta.md", "# Beta\n")
+    old_mtime = datetime(2026, 6, 1, 12, tzinfo=timezone.utc).timestamp()
+    os.utime(old_project, (old_mtime, old_mtime))
+    _write(vault / "04-Projects" / ".hidden.md", "# Ignore\n")
+    _write(vault / "Unexpected Top Level" / "noise.txt", "safe to ignore\n")
+    skills_list = _write(
+        tmp_path / "skills.json",
+        json.dumps(["daily-plan", "meeting-prep", "week-plan", "unused-skill"]),
+    )
+    return vault, skills_list
+
+
+def test_collects_dashboard_data_without_leaking_secrets(tmp_path: Path) -> None:
+    collect = _collector()
+    vault, skills_list = _fixture_vault(tmp_path)
+
+    result = collect.collect_dashboard(vault, skills_list=skills_list, now=NOW)
+
+    assert set(result) == {
+        "meta",
+        "profile",
+        "pillars",
+        "integrations",
+        "usage",
+        "analytics",
+        "tasks",
+        "people",
+        "companies",
+        "meetings",
+        "projects",
+        "health",
+        "skills",
+    }
+    assert result["profile"] == {
+        "status": "configured",
+        "name": "Alex Example",
+        "role": "Product lead",
+        "company": "Example Co",
+        "communication": {
+            "formality": "professional_casual",
+            "directness": "very_direct",
+            "detail_level": "concise",
+        },
+        "analytics": {"enabled": True},
+        "entity_creation": {"mode": "suggest"},
+        "journaling": {"morning": True, "evening": False, "weekly": True},
+        "quarterly_planning": {"enabled": True},
+    }
+    assert result["pillars"] == [
+        {
+            "id": "customers",
+            "name": "Customer trust",
+            "description": "Make the product dependable.",
+        },
+        {
+            "id": "growth",
+            "name": "Sustainable growth",
+            "description": "Grow without losing quality.",
+        },
+    ]
+    assert result["integrations"]["enabled_count"] == 2
+    assert result["integrations"]["apps"]["slack"] == {
+        "enabled": True,
+        "configured_at": "2026-07-20T09:00:00+00:00",
+        "features": {"context": True, "meeting_prep": True},
+    }
+    assert result["usage"]["counts"] == {"available": 3, "used": 2}
+    assert result["usage"]["journey"]["feature_adoption_score"] >= 2
+    assert result["analytics"]["total"] == 3
+    assert result["analytics"]["malformed_lines"] == 1
+    assert result["analytics"]["by_event"] == {
+        "meeting-prep": 1,
+        "old_event": 1,
+        "skill_invoked": 1,
+    }
+    assert result["analytics"]["by_iso_week"]["2026-W31"] == 1
+    assert result["analytics"]["by_iso_week"]["2026-W30"] == 1
+    assert result["tasks"] == {"total": 3, "completed": 2, "completed_last_7_days": 1}
+    assert result["people"] == {
+        "total": 3,
+        "internal": 1,
+        "external": 2,
+        "source": "index",
+    }
+    assert result["companies"] == {"total": 2, "source": "index"}
+    assert result["meetings"] == {"total": 3, "last_7_days": 2, "last_30_days": 3}
+    assert result["projects"] == {"total": 2, "directories": 1, "files": 1}
+    assert result["health"]["status"] == "fresh"
+    assert result["health"]["summary"] == {"broken": 0, "off": 1, "ok": 1, "unknown": 0}
+    assert result["skills"] == {
+        "available": ["daily-plan", "meeting-prep", "unused-skill", "week-plan"],
+        "used": ["daily-plan", "meeting-prep"],
+        "unused": ["unused-skill", "week-plan"],
+        "ratings": {
+            "daily-plan": {"average": 4.0, "count": 2},
+            "meeting-prep": {"average": 4.0, "count": 1},
+        },
+    }
+    assert result["meta"]["vault_age"]["started_on"] == "2026-06-01"
+    serialized = json.dumps(result, sort_keys=True).lower()
+    for forbidden in (
+        "do-not-emit",
+        "vault-secret",
+        "api_key",
+        "password",
+        "credential",
+        '"token"',
+    ):
+        assert forbidden not in serialized
+
+
+def test_missing_and_malformed_sections_degrade_independently(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "fresh"
+    _write(vault / "System" / "user-profile.yaml", "name: [unfinished\n")
+    _write(vault / "System" / "analytics_log.jsonl", "{bad json\n")
+    _write(vault / "System" / "People_Index.json", "{bad json\n")
+    _write(vault / "05-Areas" / "People" / "Internal" / "One.md", "# One\n")
+    _write(vault / "05-Areas" / "People" / "External" / "README.md", "# Ignore\n")
+    _write(
+        vault / "System" / ".doctor-last-run.json",
+        json.dumps(
+            {
+                "generated_at": "2026-07-01T10:00:00Z",
+                "mode": "quick",
+                "checks": [],
+                "summary": {"ok": 0, "off": 0, "broken": 0, "unknown": 1},
+            }
+        ),
+    )
+
+    result = collect.collect_dashboard(vault, now=NOW)
+
+    assert "error" in result["profile"]
+    assert result["people"] == {
+        "total": 1,
+        "internal": 1,
+        "external": 0,
+        "source": "filesystem",
+    }
+    assert result["companies"] == {"total": 0, "source": "filesystem"}
+    assert result["meetings"] == {"total": 0, "last_7_days": 0, "last_30_days": 0}
+    assert result["tasks"] == {"total": 0, "completed": 0, "completed_last_7_days": 0}
+    assert result["analytics"]["total"] == 0
+    assert result["analytics"]["malformed_lines"] == 1
+    assert result["health"]["status"] == "stale"
+    assert result["health"]["guidance"] == "run /dex-doctor for a fresh checkup"
+
+
+def test_missing_profile_and_doctor_cache_are_explicit(tmp_path: Path) -> None:
+    collect = _collector()
+    vault = tmp_path / "empty-vault"
+    vault.mkdir()
+
+    result = collect.collect_dashboard(vault, now=NOW)
+
+    assert result["profile"]["status"] == "not configured"
+    assert result["profile"]["name"] == ""
+    assert result["health"] == {
+        "label": "cached dex-doctor check",
+        "status": "missing",
+        "guidance": "run /dex-doctor for a fresh checkup",
+    }
+
+
+def test_yaml_sections_degrade_when_pyyaml_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collect = _collector()
+    vault = tmp_path / "vault"
+    _write(vault / "System" / "user-profile.yaml", "name: Alex\n")
+    monkeypatch.setattr(collect, "yaml", None)
+
+    result = collect.collect_dashboard(vault, now=NOW)
+
+    assert result["profile"] == {"error": "pyyaml unavailable"}
+
+
+def test_collect_cli_outputs_sorted_json_and_writes_nothing(tmp_path: Path) -> None:
+    vault, skills_list = _fixture_vault(tmp_path)
+    before = sorted(str(path.relative_to(vault)) for path in vault.rglob("*"))
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(COLLECT_SCRIPT),
+            "--vault",
+            str(vault),
+            "--skills-list",
+            str(skills_list),
+            "--json",
+            "--diagnose",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    data = json.loads(completed.stdout)
+    assert data["profile"]["name"] == "Alex Example"
+    assert '"sections_with_errors": []' in completed.stderr
+    assert sorted(str(path.relative_to(vault)) for path in vault.rglob("*")) == before
+    assert completed.stdout.index('"analytics"') < completed.stdout.index('"companies"')
+
+
+def test_collect_cli_rejects_a_nonexistent_vault(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(COLLECT_SCRIPT),
+            "--vault",
+            str(tmp_path / "missing"),
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "vault is not a directory" in completed.stderr.lower()
+    assert completed.stdout == ""

--- a/core/tests/test_dashboard_history.py
+++ b/core/tests/test_dashboard_history.py
@@ -1,0 +1,170 @@
+"""Behavioral coverage for Dashboard history and its rendered section."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+def _history_module():
+    return importlib.import_module("core.dashboard.history")
+
+
+def _history_section():
+    return importlib.import_module("core.dashboard.sections.history")
+
+
+def _history_file(vault: Path) -> Path:
+    paths = importlib.import_module("core.paths")
+    return (
+        vault
+        / paths.DEX_RUNTIME_DIR.relative_to(paths.VAULT_ROOT)
+        / "dashboard"
+        / "history.jsonl"
+    )
+
+
+def _snapshot(ts: str, *, tasks: int, meetings: int, people: int) -> dict:
+    return {
+        "ts": ts,
+        "counts": {
+            "tasks_done": tasks,
+            "meetings": meetings,
+            "people": people,
+        },
+    }
+
+
+def test_load_history_skips_malformed_jsonl_lines(tmp_path: Path) -> None:
+    history = _history_module()
+    vault = tmp_path / "vault"
+    path = _history_file(vault)
+    path.parent.mkdir(parents=True)
+    first = _snapshot("2026-07-06T12:00:00Z", tasks=90, meetings=45, people=49)
+    last = _snapshot("2026-07-20T12:00:00Z", tasks=105, meetings=51, people=50)
+    path.write_text(
+        "\n".join(
+            [json.dumps(first), "{not json", json.dumps(["not a snapshot"]), json.dumps(last)]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert history.load_history(vault) == [first, last]
+
+
+def test_weekly_trends_uses_analytics_weeks_and_snapshot_count_changes() -> None:
+    history = _history_module()
+    snapshots = [
+        _snapshot("2026-07-06T12:00:00Z", tasks=90, meetings=45, people=40),
+        _snapshot("2026-07-13T12:00:00Z", tasks=95, meetings=48, people=42),
+        _snapshot("2026-07-20T12:00:00Z", tasks=105, meetings=51, people=50),
+    ]
+
+    trends = history.weekly_trends(
+        {
+            "analytics": {"by_iso_week": {"2026-W28": 2, "2026-W29": 4, "2026-W30": 1}},
+            "history": snapshots,
+        }
+    )
+
+    assert trends == {
+        "labels": ["2026-W28", "2026-W29", "2026-W30"],
+        "activity": [2, 4, 1],
+        "meetings": [0, 3, 3],
+        "tasks": [0, 5, 10],
+        "snapshots": [1, 1, 1],
+    }
+
+
+def test_detect_milestones_only_reports_thresholds_crossed_since_last_snapshot() -> None:
+    history = _history_module()
+
+    crossed = history.detect_milestones(
+        {"tasks_done": 99, "meetings": 49, "people": 49},
+        {"tasks_done": 100, "meetings": 50, "people": 50},
+        vault_age=179,
+    )
+    not_crossed = history.detect_milestones(
+        {"tasks_done": 100, "meetings": 50, "people": 50},
+        {"tasks_done": 101, "meetings": 51, "people": 51},
+        vault_age=179,
+    )
+
+    assert [milestone["id"] for milestone in crossed] == ["tasks_done", "meetings", "people"]
+    assert not_crossed == []
+
+
+def test_detect_milestones_orders_simultaneous_crossings_biggest_first() -> None:
+    history = _history_module()
+
+    milestones = history.detect_milestones(
+        {"tasks_done": 499, "meetings": 99, "people": 99, "vault_age_days": 364},
+        {"tasks_done": 500, "meetings": 100, "people": 100},
+        vault_age=365,
+    )
+
+    assert [milestone["id"] for milestone in milestones] == [
+        "tasks_done",
+        "vault_age",
+        "meetings",
+        "people",
+    ]
+    assert milestones[0]["threshold"] == 500
+    assert milestones[0]["label"] == "500 completed tasks"
+
+
+def test_sparkline_svg_is_well_formed_and_contains_a_polyline() -> None:
+    history = _history_module()
+
+    svg = history.sparkline_svg([0, 4, 2, 7], width=120, height=32)
+    root = ElementTree.fromstring(svg)
+
+    assert root.tag == "{http://www.w3.org/2000/svg}svg"
+    assert root.attrib["viewBox"] == "0 0 120 32"
+    assert root.find("{http://www.w3.org/2000/svg}polyline") is not None
+
+
+def test_render_history_hides_empty_history_and_marks_a_first_snapshot() -> None:
+    section = _history_section()
+    first = _snapshot("2026-07-20T12:00:00Z", tasks=3, meetings=1, people=2)
+
+    assert section.render_history({"history": []}) == ""
+
+    page = section.render_history({"history": [first]})
+    assert 'id="history"' in page
+    assert "This is your first snapshot." in page
+    assert "<svg" not in page
+
+
+def test_render_history_shows_three_sparklines_one_milestone_and_escaped_looking_back() -> None:
+    history = _history_module()
+    section = _history_section()
+    snapshots = [
+        _snapshot("2026-07-13T12:00:00Z", tasks=499, meetings=99, people=40),
+        _snapshot("2026-07-20T12:00:00Z", tasks=500, meetings=100, people=42),
+    ]
+    trends = history.weekly_trends(
+        {"analytics": {"by_iso_week": {"2026-W29": 2, "2026-W30": 3}}, "history": snapshots}
+    )
+    milestones = history.detect_milestones(
+        snapshots[0]["counts"], snapshots[-1]["counts"], vault_age=200
+    )
+
+    page = section.render_history(
+        {
+            "history": snapshots,
+            "trends": trends,
+            "milestones": milestones,
+            "looking_back": "Then <now>; now steadier.",
+        }
+    )
+
+    assert page.count("<svg") == 3
+    assert page.count("✦") == 1
+    assert "500 completed tasks" in page
+    assert "Looking back" in page
+    assert "Then &lt;now&gt;; now steadier." in page
+    assert "Then <now>; now steadier." not in page

--- a/core/tests/test_dashboard_journey.py
+++ b/core/tests/test_dashboard_journey.py
@@ -1,0 +1,172 @@
+"""Behavioral coverage for the Dex Dashboard journey catalog."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def _journey():
+    return importlib.import_module("core.dashboard.journey")
+
+
+def _section():
+    return importlib.import_module("core.dashboard.sections.journey")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _fake_rooms(monkeypatch, journey, enabled: bool = False) -> None:
+    monkeypatch.setattr(journey.capability_rooms, "room_ids", lambda: ("career",))
+    monkeypatch.setattr(
+        journey.capability_rooms,
+        "surfaces_for",
+        lambda room: {"skills": ["career-coach"]},
+    )
+    monkeypatch.setattr(
+        journey.capability_rooms,
+        "enabled",
+        lambda room, *, profile_path: enabled,
+    )
+
+
+def test_build_journey_catalogs_active_and_disabled_pack_skills(tmp_path: Path, monkeypatch) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    _write(
+        vault / ".claude/skills/daily-plan/SKILL.md",
+        "---\nname: Daily plan\ndescription: Plan your day around priorities. Later detail.\ncategory: Rituals\n---\n",
+    )
+    _write(
+        vault / ".claude/skills/week-review/SKILL.md",
+        "---\nname: Week review\ndescription: Look back at the week\n---\n",
+    )
+    _write(
+        vault / ".claude/skills/focus/SKILL.md",
+        "---\nname: Focus\ndescription: Protect <today> from distractions.\ncategory: Rituals\n---\n",
+    )
+    _write(
+        vault / ".claude/skills/malformed/SKILL.md",
+        "---\ndescription: [not valid\n---\nThis remains a usable skill.",
+    )
+    _write(
+        vault
+        / ".claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md",
+        "---\nname: Career coach\ndescription: Build a better career story. Then rehearse it.\ncategory: Career\n---\n",
+    )
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(
+        vault,
+        {
+            "skills": {"used": ["daily-plan"]},
+            "usage": {"features": {"Ran /week-review": True}},
+            "analytics": {"skill_names_used": ["focus"]},
+        },
+    )
+
+    skills = {
+        skill["id"]: skill
+        for group in result["groups"]
+        for skill in group["skills"]
+    }
+    assert result["counts"] == {"available": 4, "used": 3}
+    assert result["rooms"] == [{"id": "career", "enabled": False}]
+    assert skills["daily-plan"] == {
+        "id": "daily-plan",
+        "name": "Daily plan",
+        "description": "Plan your day around priorities.",
+        "state": "used",
+    }
+    assert skills["week-review"]["state"] == "used"
+    assert skills["focus"]["state"] == "used"
+    assert skills["malformed"]["state"] == "unused"
+    assert skills["career-coach"] == {
+        "id": "career-coach",
+        "name": "Career coach",
+        "description": "Build a better career story.",
+        "state": "available-in-pack",
+    }
+
+
+def test_build_journey_handles_a_vault_without_skills(tmp_path: Path, monkeypatch) -> None:
+    journey = _journey()
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(tmp_path / "empty-vault", {})
+
+    assert result["groups"] == []
+    assert result["counts"] == {"available": 0, "used": 0}
+    assert result["rooms"] == [{"id": "career", "enabled": False}]
+
+
+def test_build_journey_marks_an_enabled_pack_skill_as_available(tmp_path: Path, monkeypatch) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    _write(
+        vault
+        / ".claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md",
+        "---\nname: Career coach\ndescription: Build a stronger career story.\n---\n",
+    )
+    _fake_rooms(monkeypatch, journey, enabled=True)
+
+    result = journey.build_journey(vault, {"analytics": {"skill_names_used": ["career-coach"]}})
+
+    assert result["counts"] == {"available": 1, "used": 1}
+    assert result["groups"][0]["skills"] == [
+        {
+            "id": "career-coach",
+            "name": "Career coach",
+            "description": "Build a stronger career story.",
+            "state": "used",
+        }
+    ]
+
+
+def test_render_journey_uses_nightfall_states_and_escapes_skill_data() -> None:
+    section = _section()
+
+    page = section.render_journey(
+        {
+            "counts": {"available": 3, "used": 1},
+            "groups": [
+                {
+                    "id": "rituals",
+                    "name": "Rituals <script>",
+                    "skills": [
+                        {
+                            "id": "daily-plan",
+                            "name": "Daily <plan>",
+                            "description": "Plan <today> safely.",
+                            "state": "used",
+                        },
+                        {
+                            "id": "week-review",
+                            "name": "Week review",
+                            "description": "Look back.",
+                            "state": "unused",
+                        },
+                        {
+                            "id": "career-coach",
+                            "name": "Career coach",
+                            "description": "Available after enabling Career.",
+                            "state": "available-in-pack",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert 'id="journey"' in page
+    assert "You use 1 of 3 capabilities" in page
+    assert 'class="journey-chip lit"' in page
+    assert 'class="journey-chip dim"' in page
+    assert 'class="journey-chip outlined"' in page
+    assert "Rituals &lt;script&gt;" in page
+    assert "Daily &lt;plan&gt;" in page
+    assert "Plan &lt;today&gt; safely." in page
+    assert "<script>" not in page

--- a/core/tests/test_dashboard_journey.py
+++ b/core/tests/test_dashboard_journey.py
@@ -126,6 +126,142 @@ def test_build_journey_marks_an_enabled_pack_skill_as_available(tmp_path: Path, 
     ]
 
 
+def test_build_journey_buckets_shipped_skills_across_dex_territories(
+    tmp_path: Path, monkeypatch
+) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    skill_ids = (
+        "daily-plan",
+        "meeting-prep",
+        "project-health",
+        "career-coach",
+        "calendar-setup",
+        "dex-add-mcp",
+        "diff-generate",
+        "dex-dashboard",
+        "anthropic-pdf",
+        "industry-truths",
+    )
+    for skill_id in skill_ids:
+        _write(vault / f".claude/skills/{skill_id}/SKILL.md", "---\n---\n")
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(vault, {})
+
+    groups_by_skill = {
+        skill["id"]: group["name"]
+        for group in result["groups"]
+        for skill in group["skills"]
+    }
+    assert groups_by_skill == {
+        "daily-plan": "Plan & Review",
+        "meeting-prep": "Meetings & People",
+        "project-health": "Projects & Work",
+        "career-coach": "Career",
+        "calendar-setup": "Connect & Import",
+        "dex-add-mcp": "Connect & Import",
+        "diff-generate": "Sharing",
+        "dex-dashboard": "Dex itself",
+        "anthropic-pdf": "More",
+        "industry-truths": "More",
+    }
+
+
+def test_build_journey_puts_unmapped_uncategorized_skills_in_yours(tmp_path: Path, monkeypatch) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    _write(vault / ".claude/skills/my-private-workflow/SKILL.md", "---\n---\n")
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(vault, {})
+
+    assert result["groups"] == [
+        {
+            "id": "yours",
+            "name": "Yours",
+            "yours": True,
+            "skills": [
+                {
+                    "id": "my-private-workflow",
+                    "name": "My Private Workflow",
+                    "description": "",
+                    "state": "unused",
+                }
+            ],
+        }
+    ]
+
+
+def test_build_journey_orders_territories_and_skills_by_relevance(tmp_path: Path, monkeypatch) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    for skill_id in (
+        "daily-plan",
+        "daily-review",
+        "meeting-prep",
+        "project-health",
+        "career-coach",
+        "calendar-setup",
+        "diff-list",
+        "dex-dashboard",
+        "anthropic-pdf",
+        "my-private-workflow",
+    ):
+        _write(vault / f".claude/skills/{skill_id}/SKILL.md", "---\n---\n")
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(
+        vault,
+        {"skills": {"used": ["daily-plan", "daily-review"]}},
+    )
+
+    assert [group["id"] for group in result["groups"]] == [
+        "plan-review",
+        "meetings-people",
+        "projects-work",
+        "career",
+        "connect-import",
+        "sharing",
+        "dex-itself",
+        "more",
+        "yours",
+    ]
+    assert [skill["id"] for skill in result["groups"][0]["skills"]] == [
+        "daily-plan",
+        "daily-review",
+    ]
+
+
+def test_build_journey_keeps_frontmatter_category_over_built_in_bucket(
+    tmp_path: Path, monkeypatch
+) -> None:
+    journey = _journey()
+    vault = tmp_path / "vault"
+    _write(
+        vault / ".claude/skills/daily-plan/SKILL.md",
+        "---\ncategory: Personal rituals\n---\n",
+    )
+    _fake_rooms(monkeypatch, journey)
+
+    result = journey.build_journey(vault, {})
+
+    assert result["groups"] == [
+        {
+            "id": "personal-rituals",
+            "name": "Personal rituals",
+            "skills": [
+                {
+                    "id": "daily-plan",
+                    "name": "Daily Plan",
+                    "description": "",
+                    "state": "unused",
+                }
+            ],
+        }
+    ]
+
+
 def test_render_journey_uses_nightfall_states_and_escapes_skill_data() -> None:
     section = _section()
 

--- a/core/tests/test_dashboard_journey.py
+++ b/core/tests/test_dashboard_journey.py
@@ -306,3 +306,44 @@ def test_render_journey_uses_nightfall_states_and_escapes_skill_data() -> None:
     assert "Daily &lt;plan&gt;" in page
     assert "Plan &lt;today&gt; safely." in page
     assert "<script>" not in page
+
+
+def test_render_journey_renders_at_most_five_escaped_skill_picks_with_copy_prompts() -> None:
+    section = _section()
+
+    page = section.render_journey(
+        {"counts": {"available": 0, "used": 0}, "groups": []},
+        picks=[
+            {
+                "skill": "week-<plan>",
+                "why": "You have <three> open priorities & need a reset.",
+            },
+            {"skill": "daily-plan", "why": "Start each day from the work already in Dex."},
+            {"skill": "meeting-prep", "why": "Your calendar has a full week of meetings."},
+            {"skill": "project-health", "why": "See where projects are drifting."},
+            {"skill": "week-review", "why": "Close the week with evidence."},
+            {"skill": "not-rendered", "why": "This sixth pick stays out of the row."},
+        ],
+    )
+
+    assert "Picked for you" in page
+    assert page.count('class="journey-pick-card"') == 5
+    assert "week-&lt;plan&gt;" in page
+    assert "You have &lt;three&gt; open priorities &amp; need a reset." in page
+    assert "week-<plan>" not in page
+    assert "not-rendered" not in page
+    assert 'id="copy-skill-pick-0"' in page
+    assert 'data-skill-copy-target="skill-pick-prompt-0"' in page
+    assert 'id="skill-pick-prompt-0"' in page
+    assert ">/week-&lt;plan&gt;</code>" in page
+    assert 'id="copy-skill-pick-4"' in page
+    assert 'id="copy-skill-pick-5"' not in page
+
+
+def test_render_journey_omits_skill_picks_without_any() -> None:
+    section = _section()
+
+    page = section.render_journey({"counts": {"available": 0, "used": 0}, "groups": []})
+
+    assert "Picked for you" not in page
+    assert "journey-pick-card" not in page

--- a/core/tests/test_dashboard_journey.py
+++ b/core/tests/test_dashboard_journey.py
@@ -298,7 +298,7 @@ def test_render_journey_uses_nightfall_states_and_escapes_skill_data() -> None:
     )
 
     assert 'id="journey"' in page
-    assert "You use 1 of 3 capabilities" in page
+    assert "1 capability in your rotation" in page
     assert 'class="journey-chip lit"' in page
     assert 'class="journey-chip dim"' in page
     assert 'class="journey-chip outlined"' in page

--- a/core/tests/test_dashboard_render.py
+++ b/core/tests/test_dashboard_render.py
@@ -94,6 +94,60 @@ def _observations() -> dict:
     }
 
 
+def _journey_data() -> dict:
+    return {
+        "counts": {"available": 3, "used": 1},
+        "groups": [
+            {
+                "id": "rituals",
+                "name": "Rituals",
+                "skills": [
+                    {
+                        "id": "daily-plan",
+                        "name": "Daily plan",
+                        "description": "Plan today.",
+                        "state": "used",
+                    },
+                    {
+                        "id": "week-review",
+                        "name": "Week review",
+                        "description": "Look back.",
+                        "state": "unused",
+                    },
+                    {
+                        "id": "career-coach",
+                        "name": "Career coach",
+                        "description": "Available in the Career pack.",
+                        "state": "available-in-pack",
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _history_data() -> dict:
+    return {
+        "history": [
+            {
+                "ts": "2026-07-20T12:00:00Z",
+                "counts": {"tasks_done": 99, "meetings": 49, "people": 49},
+            },
+            {
+                "ts": "2026-07-27T12:00:00Z",
+                "counts": {"tasks_done": 100, "meetings": 50, "people": 50},
+            },
+        ],
+        "trends": {
+            "meetings": [0, 1],
+            "tasks": [0, 1],
+            "snapshots": [1, 1],
+        },
+        "milestones": [{"label": "100 completed tasks"}],
+        "looking_back": "A steadier week.",
+    }
+
+
 def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
     render = _renderer()
 
@@ -138,6 +192,94 @@ def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
     assert "broken" not in page.lower()
     assert "Generated locally by Dex · nothing leaves your machine" in page
     assert "snapshot #7 saved" in page
+
+
+def test_optional_sections_render_in_required_order_and_disappear_when_absent() -> None:
+    render = _renderer()
+
+    page = render.render_dashboard_html(
+        _data(),
+        _observations(),
+        journey=_journey_data(),
+        history_data=_history_data(),
+        server_ctx={
+            "token": "__DEX_DASHBOARD_TOKEN__",
+            "port": "__DEX_DASHBOARD_PORT__",
+        },
+    )
+
+    ordered_markers = [
+        'id="receipt"',
+        'id="observations"',
+        'id="suggestion"',
+        'id="journey"',
+        'id="state"',
+        'id="history"',
+        'id="settings"',
+        "<footer>",
+    ]
+    positions = [page.index(marker) for marker in ordered_markers]
+    assert positions == sorted(positions)
+
+    static_page = render.render_dashboard_html(_data(), _observations())
+    assert 'id="journey"' not in static_page
+    assert 'id="history"' not in static_page
+    assert 'id="settings"' not in static_page
+
+
+def test_static_page_contains_no_settings_markup_or_server_placeholders() -> None:
+    render = _renderer()
+
+    page = render.render_dashboard_html(_data(), _observations())
+
+    assert "__DEX_DASHBOARD_TOKEN__" not in page
+    assert "__DEX_DASHBOARD_PORT__" not in page
+    assert 'id="settings"' not in page
+    assert "data-setting-id" not in page
+    assert "dashboard-port" not in page
+
+
+def test_new_section_fragments_have_css_for_every_emitted_class() -> None:
+    render = _renderer()
+    journey_section = importlib.import_module("core.dashboard.sections.journey")
+    history_section = importlib.import_module("core.dashboard.sections.history")
+    settings_section = importlib.import_module("core.dashboard.sections.settings")
+    settings_fragment, settings_script = settings_section.render(
+        _data(),
+        {"token": "__DEX_DASHBOARD_TOKEN__", "port": "__DEX_DASHBOARD_PORT__"},
+    )
+    fragments = [
+        journey_section.render_journey(_journey_data()),
+        history_section.render_history(_history_data()),
+        settings_fragment,
+    ]
+
+    page = render.render_dashboard_html(
+        _data(),
+        _observations(),
+        journey=_journey_data(),
+        history_data=_history_data(),
+        server_ctx={
+            "token": "__DEX_DASHBOARD_TOKEN__",
+            "port": "__DEX_DASHBOARD_PORT__",
+        },
+    )
+    style = re.search(r"<style>(?P<style>.*?)</style>", page, re.DOTALL)
+    assert style is not None
+    emitted_classes = {
+        css_class
+        for fragment in fragments
+        for class_value in re.findall(r'class="([^"]+)"', fragment)
+        for css_class in class_value.split()
+    }
+    emitted_classes.update(re.findall(r"className = '([^']+)'", settings_script))
+
+    missing = sorted(
+        css_class
+        for css_class in emitted_classes
+        if re.search(rf"\.{re.escape(css_class)}(?![\w-])", style.group("style")) is None
+    )
+    assert missing == []
 
 
 def test_markdown_links_allow_safe_urls_and_reject_javascript() -> None:
@@ -214,6 +356,127 @@ def test_render_appends_one_compact_snapshot_and_reports_its_number(tmp_path: Pa
     assert "snapshot #1 saved" in output.read_text(encoding="utf-8")
 
 
+def test_render_builds_journey_and_history_after_appending_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    render = _renderer()
+    vault = tmp_path / "vault"
+    skill = vault / ".claude" / "skills" / "daily-plan" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\nname: Daily plan\ndescription: Plan today.\ncategory: Rituals\n---\n",
+        encoding="utf-8",
+    )
+    history = vault / "System" / ".dex" / "dashboard" / "history.jsonl"
+    history.parent.mkdir(parents=True)
+    history.write_text(
+        json.dumps(
+            {
+                "ts": "2026-07-20T12:00:00Z",
+                "counts": {
+                    "tasks_done": 99,
+                    "people": 49,
+                    "meetings": 49,
+                    "skills_used": 0,
+                    "integrations_on": 0,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    data = _data()
+    data["tasks"]["completed"] = 100
+    data["people"]["total"] = 50
+    data["meetings"]["total"] = 50
+    data["meta"]["vault_age"] = {"age_days": 180}
+    observations = _observations() | {"looking_back": "A steadier week."}
+    output = tmp_path / "dashboard.html"
+    detected = {}
+    real_detect_milestones = render.dashboard_history.detect_milestones
+
+    def record_milestones(prev_counts, new_counts, vault_age):
+        detected.update(
+            {
+                "prev_counts": prev_counts,
+                "new_counts": new_counts,
+                "vault_age": vault_age,
+            }
+        )
+        return real_detect_milestones(prev_counts, new_counts, vault_age)
+
+    monkeypatch.setattr(
+        render.dashboard_history,
+        "detect_milestones",
+        record_milestones,
+    )
+
+    render.render_dashboard(
+        vault,
+        data,
+        observations,
+        output,
+        archive=True,
+        now=NOW,
+    )
+
+    page = output.read_text(encoding="utf-8")
+    assert history.read_text(encoding="utf-8").count("\n") == 2
+    assert detected == {
+        "prev_counts": {
+            "tasks_done": 99,
+            "people": 49,
+            "meetings": 49,
+            "skills_used": 0,
+            "integrations_on": 0,
+        },
+        "new_counts": {
+            "tasks_done": 100,
+            "people": 50,
+            "meetings": 50,
+            "skills_used": 2,
+            "integrations_on": 1,
+        },
+        "vault_age": 180,
+    }
+    assert 'id="journey"' in page
+    assert "Daily plan" in page
+    assert 'id="history"' in page
+    assert "Six months with Dex" in page
+    assert "A steadier week." in page
+    assert page.count("<svg") == 3
+
+
+def test_render_omits_derived_sections_when_their_builders_fail(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    render = _renderer()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "dashboard.html"
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("simulated optional-section failure")
+
+    monkeypatch.setattr(render.dashboard_journey, "build_journey", fail)
+    monkeypatch.setattr(render.dashboard_history, "load_history", fail)
+
+    render.render_dashboard(
+        vault,
+        _data(),
+        _observations(),
+        output,
+        archive=False,
+        now=NOW,
+    )
+
+    page = output.read_text(encoding="utf-8")
+    assert 'id="journey"' not in page
+    assert 'id="history"' not in page
+
+
 def test_no_archive_writes_only_the_requested_html(tmp_path: Path) -> None:
     render = _renderer()
     vault = tmp_path / "vault"
@@ -264,6 +527,39 @@ def test_render_cli_works_without_observations_and_no_archive(tmp_path: Path) ->
     assert completed.stdout.strip() == str(output)
     assert "Open this from a Dex session" in output.read_text(encoding="utf-8")
     assert not (vault / "System" / ".dex" / "dashboard").exists()
+
+
+def test_render_cli_with_settings_writes_each_server_placeholder_once(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    data_path = tmp_path / "collected.json"
+    data_path.write_text(json.dumps(_data()), encoding="utf-8")
+    output = tmp_path / "dashboard.html"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RENDER_SCRIPT),
+            "--vault",
+            str(vault),
+            "--data",
+            str(data_path),
+            "--out",
+            str(output),
+            "--no-archive",
+            "--with-settings",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    page = output.read_text(encoding="utf-8")
+    assert 'id="settings"' in page
+    assert page.count("__DEX_DASHBOARD_TOKEN__") == 1
+    assert page.count("__DEX_DASHBOARD_PORT__") == 1
 
 
 def test_render_cli_rejects_invalid_json_without_a_traceback(tmp_path: Path) -> None:

--- a/core/tests/test_dashboard_render.py
+++ b/core/tests/test_dashboard_render.py
@@ -288,6 +288,28 @@ def test_journey_collapses_after_twelve_chips_used_first_and_expands_inline() ->
     assert "extra.hidden = false" in page
 
 
+def test_journey_receives_skill_picks_from_observations() -> None:
+    render = _renderer()
+
+    page = render.render_dashboard_html(
+        _data(),
+        {
+            "skill_picks": [
+                {
+                    "skill": "week-plan",
+                    "why": "Your open priorities need a weekly reset.",
+                }
+            ]
+        },
+        journey=_journey_data(),
+    )
+
+    assert "Picked for you" in page
+    assert "week-plan" in page
+    assert "Your open priorities need a weekly reset." in page
+    assert 'data-skill-copy-target="skill-pick-prompt-0"' in page
+
+
 def test_history_tab_has_a_quiet_first_snapshot_empty_state() -> None:
     render = _renderer()
 
@@ -310,15 +332,14 @@ def test_live_settings_are_grouped_without_changing_wire_placeholders() -> None:
     )
 
     settings = page[page.index('id="settings"') : page.index('id="history"')]
-    for label in ("Privacy", "Communication", "Connections", "Behavior"):
+    for label in ("Privacy", "Communication", "Capabilities", "Meetings", "Journaling", "Connections"):
         assert f'<h3 class="settings-group-label">{label}</h3>' in settings
     assert settings.index("Anonymous product analytics") < settings.index("Communication")
     assert settings.index("Formality") < settings.index("Connections")
     assert settings.index("Existing integrations") < settings.index("Set up something new")
-    assert settings.index("New people and companies") > settings.index("Behavior")
+    assert settings.index("New people and companies") > settings.index("Meetings")
     assert page.count("__DEX_DASHBOARD_TOKEN__") == 1
     assert page.count("__DEX_DASHBOARD_PORT__") == 1
-    assert settings_section._grouped_controls([("future-setting", "row")])["Behavior"] == ["row"]
 
 
 def test_new_section_fragments_have_css_for_every_emitted_class() -> None:

--- a/core/tests/test_dashboard_render.py
+++ b/core/tests/test_dashboard_render.py
@@ -1,0 +1,295 @@
+"""Behavioral coverage for the self-contained Dex Dashboard renderer."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RENDER_SCRIPT = REPO_ROOT / "core" / "dashboard" / "render.py"
+NOW = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+
+
+def _renderer():
+    return importlib.import_module("core.dashboard.render")
+
+
+def _data() -> dict:
+    return {
+        "meta": {
+            "generated_at": "2026-07-27T12:00:00Z",
+            "vault_path": "/tmp/private",
+            "collector_version": "1",
+        },
+        "profile": {
+            "status": "configured",
+            "name": "Alex <Admin>",
+            "role": "Product & Strategy",
+            "company": "Example Co",
+            "communication": {
+                "formality": "professional_casual",
+                "directness": "very_direct",
+                "detail_level": "concise",
+            },
+        },
+        "pillars": [
+            {
+                "id": "trust",
+                "name": "Customer <trust>",
+                "description": "Make it dependable.",
+            }
+        ],
+        "integrations": {
+            "apps": {
+                "Google": {"enabled": False},
+                "Slack & Co": {"enabled": True},
+            },
+            "enabled_count": 1,
+        },
+        "usage": {"counts": {"available": 4, "used": 2}},
+        "analytics": {"total": 7},
+        "tasks": {"total": 18, "completed": 12, "completed_last_7_days": 3},
+        "people": {"total": 8, "internal": 2, "external": 6},
+        "companies": {"total": 0},
+        "meetings": {"total": 4, "last_7_days": 2, "last_30_days": 4},
+        "projects": {"total": 0},
+        "health": {
+            "label": "cached dex-doctor check",
+            "status": "fresh",
+            "generated_at": "2026-07-26T10:00:00Z",
+            "mode": "quick",
+            "checks": [
+                {"id": "vault.configs", "feature": "Vault <configuration>", "verdict": "OK"},
+                {"id": "calendar", "feature": "Calendar", "verdict": "OFF"},
+                {"id": "search", "feature": "Search", "verdict": "UNKNOWN"},
+                {"id": "hooks", "feature": "Hooks", "verdict": "BROKEN"},
+            ],
+            "summary": {"ok": 1, "off": 1, "unknown": 1, "broken": 1},
+        },
+        "skills": {
+            "available": ["daily-plan", "meeting-prep", "week-plan"],
+            "used": ["daily-plan", "meeting-prep"],
+            "unused": ["week-plan"],
+            "ratings": {},
+        },
+    }
+
+
+def _observations() -> dict:
+    return {
+        "observations": [
+            "You completed **3 tasks** with `<care>` [inside Dex](#state).",
+            "<script>alert('observation')</script>",
+        ],
+        "suggestion": {
+            "title": "Try <weekly planning>",
+            "why": "It connects your pillars & current work.",
+            "try_prompt": 'Plan my week around "Customer trust" <today>.',
+        },
+    }
+
+
+def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
+    render = _renderer()
+
+    page = render.render_dashboard_html(
+        _data(),
+        _observations(),
+        archive_count=7,
+        archived=True,
+    )
+
+    assert page.startswith("<!doctype html>")
+    assert "#0B0F14" in page
+    assert "max-width: 880px" in page
+    assert '-apple-system, "SF Pro", "Segoe UI", sans-serif' in page
+    assert "<script src=" not in page
+    assert "<link " not in page
+    assert "<img " not in page
+    assert re.search(r"""(?:src|href)=["']https?://""", page, re.IGNORECASE) is None
+    assert page.index('id="receipt"') < page.index('id="observations"')
+    assert page.index('id="observations"') < page.index('id="suggestion"')
+    assert page.index('id="suggestion"') < page.index('id="state"')
+    assert "Your Dex" in page
+    assert "Alex &lt;Admin&gt;" in page
+    assert "Monday, July 27, 2026" in page
+    assert "2 meetings turned into notes this week" in page
+    assert "3 tasks completed this week" in page
+    assert "12 completed tasks in Dex" in page
+    assert "0 companies" not in page
+    assert "<strong>3 tasks</strong>" in page
+    assert "<code>&lt;care&gt;</code>" in page
+    assert '<a href="#state">inside Dex</a>' in page
+    assert "&lt;script&gt;alert(&#x27;observation&#x27;)&lt;/script&gt;" in page
+    assert "<script>alert('observation')</script>" not in page
+    assert "Try &lt;weekly planning&gt;" in page
+    assert 'Plan my week around &quot;Customer trust&quot; &lt;today&gt;.' in page
+    assert "navigator.clipboard" in page
+    assert "document.execCommand('copy')" in page
+    assert "Slack &amp; Co" in page
+    assert "connected" in page
+    assert "not set up" in page
+    assert "needs attention" in page
+    assert "broken" not in page.lower()
+    assert "Generated locally by Dex · nothing leaves your machine" in page
+    assert "snapshot #7 saved" in page
+
+
+def test_markdown_links_allow_safe_urls_and_reject_javascript() -> None:
+    render = _renderer()
+    observations = {
+        "observations": [
+            "[Guide](https://example.test/guide) and [unsafe](javascript:alert(1))"
+        ]
+    }
+
+    page = render.render_dashboard_html(_data(), observations, archived=False)
+
+    assert '<a href="https://example.test/guide"' in page
+    assert 'href="javascript:' not in page
+    assert "unsafe (javascript:alert(1))" in page
+
+
+def test_missing_observations_and_stale_health_degrade_honestly() -> None:
+    render = _renderer()
+    data = _data()
+    data["health"] = {
+        "label": "cached dex-doctor check",
+        "status": "stale",
+        "guidance": "run /dex-doctor for a fresh checkup",
+    }
+
+    page = render.render_dashboard_html(data, {}, archived=False)
+
+    assert "Open this from a Dex session to get Dex&#x27;s observations." in page
+    assert 'id="suggestion"' not in page
+    assert "Run /dex-doctor for a fresh checkup." in page
+    assert "snapshot not saved" in page
+
+
+def test_render_appends_one_compact_snapshot_and_reports_its_number(tmp_path: Path) -> None:
+    render = _renderer()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "dashboard.html"
+
+    result = render.render_dashboard(
+        vault,
+        _data(),
+        _observations(),
+        output,
+        archive=True,
+        now=NOW,
+    )
+
+    history = vault / "System" / ".dex" / "dashboard" / "history.jsonl"
+    assert result == {"output": str(output), "archived": True, "archive_count": 1}
+    assert output.is_file()
+    assert history.is_file()
+    lines = history.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    snapshot = json.loads(lines[0])
+    assert snapshot == {
+        "ts": "2026-07-27T12:00:00Z",
+        "counts": {
+            "tasks_done": 12,
+            "people": 8,
+            "meetings": 4,
+            "skills_used": 2,
+            "integrations_on": 1,
+        },
+        "observations": [
+            "You completed **3 tasks** with `<care>` [inside Dex](#state).",
+            "<script>alert('observation')</script>",
+        ],
+        "suggestion_title": "Try <weekly planning>",
+    }
+    assert "profile" not in snapshot
+    assert "analytics" not in snapshot
+    assert "snapshot #1 saved" in output.read_text(encoding="utf-8")
+
+
+def test_no_archive_writes_only_the_requested_html(tmp_path: Path) -> None:
+    render = _renderer()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "preview.html"
+
+    result = render.render_dashboard(
+        vault,
+        _data(),
+        {},
+        output,
+        archive=False,
+        now=NOW,
+    )
+
+    assert result == {"output": str(output), "archived": False, "archive_count": 0}
+    assert output.is_file()
+    assert not (vault / "System" / ".dex" / "dashboard").exists()
+    assert "snapshot not saved" in output.read_text(encoding="utf-8")
+
+
+def test_render_cli_works_without_observations_and_no_archive(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    data_path = tmp_path / "collected.json"
+    data_path.write_text(json.dumps(_data()), encoding="utf-8")
+    output = tmp_path / "dashboard.html"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RENDER_SCRIPT),
+            "--vault",
+            str(vault),
+            "--data",
+            str(data_path),
+            "--out",
+            str(output),
+            "--no-archive",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == str(output)
+    assert "Open this from a Dex session" in output.read_text(encoding="utf-8")
+    assert not (vault / "System" / ".dex" / "dashboard").exists()
+
+
+def test_render_cli_rejects_invalid_json_without_a_traceback(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    data_path = tmp_path / "invalid.json"
+    data_path.write_text("{invalid", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RENDER_SCRIPT),
+            "--vault",
+            str(vault),
+            "--data",
+            str(data_path),
+            "--out",
+            str(tmp_path / "dashboard.html"),
+            "--no-archive",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "could not read dashboard input" in completed.stderr.lower()
+    assert "traceback" not in completed.stderr.lower()

--- a/core/tests/test_dashboard_render.py
+++ b/core/tests/test_dashboard_render.py
@@ -148,7 +148,7 @@ def _history_data() -> dict:
     }
 
 
-def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
+def test_html_is_self_contained_heydex_styled_and_escapes_user_data() -> None:
     render = _renderer()
 
     page = render.render_dashboard_html(
@@ -159,9 +159,12 @@ def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
     )
 
     assert page.startswith("<!doctype html>")
-    assert "#0B0F14" in page
-    assert "max-width: 880px" in page
-    assert '-apple-system, "SF Pro", "Segoe UI", sans-serif' in page
+    assert "--bg:#0D0E12" in page
+    assert "--accent:#FF4081" in page
+    assert "max-width: 1020px" in page
+    assert "'Inter','Geist',system-ui,-apple-system,sans-serif" in page
+    assert "6.8rem" not in page
+    assert "#62d7d1" not in page
     assert "<script src=" not in page
     assert "<link " not in page
     assert "<img " not in page
@@ -182,7 +185,7 @@ def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
     assert "&lt;script&gt;alert(&#x27;observation&#x27;)&lt;/script&gt;" in page
     assert "<script>alert('observation')</script>" not in page
     assert "Try &lt;weekly planning&gt;" in page
-    assert 'Plan my week around &quot;Customer trust&quot; &lt;today&gt;.' in page
+    assert "Plan my week around &quot;Customer trust&quot; &lt;today&gt;." in page
     assert "navigator.clipboard" in page
     assert "document.execCommand('copy')" in page
     assert "Slack &amp; Co" in page
@@ -194,7 +197,7 @@ def test_html_is_self_contained_composed_and_escapes_user_data() -> None:
     assert "snapshot #7 saved" in page
 
 
-def test_optional_sections_render_in_required_order_and_disappear_when_absent() -> None:
+def test_tab_nav_and_panels_render_in_app_order_with_overview_visible() -> None:
     render = _renderer()
 
     page = render.render_dashboard_html(
@@ -208,35 +211,114 @@ def test_optional_sections_render_in_required_order_and_disappear_when_absent() 
         },
     )
 
-    ordered_markers = [
-        'id="receipt"',
-        'id="observations"',
-        'id="suggestion"',
-        'id="journey"',
-        'id="state"',
-        'id="history"',
-        'id="settings"',
-        "<footer>",
-    ]
-    positions = [page.index(marker) for marker in ordered_markers]
+    tab_labels = ["Overview", "Journey", "Settings", "History"]
+    for tab_name in (label.lower() for label in tab_labels):
+        assert (f'<button type="button" role="tab" id="tab-{tab_name}" data-tab-target="{tab_name}"') in page
+        assert f'data-tab="{tab_name}"' in page
+
+    positions = [page.index(f">{label}</button>") for label in tab_labels]
     assert positions == sorted(positions)
+    assert (
+        '<section class="tab-panel" id="panel-overview" data-tab="overview" '
+        'role="tabpanel" aria-labelledby="tab-overview">'
+    ) in page
+    for tab_name in ("journey", "settings", "history"):
+        assert (
+            f'<section class="tab-panel" id="panel-{tab_name}" data-tab="{tab_name}" '
+            f'role="tabpanel" aria-labelledby="tab-{tab_name}" hidden>'
+        ) in page
+    assert 'id="tab-overview" data-tab-target="overview" aria-selected="true"' in page
+    assert 'id="tab-journey" data-tab-target="journey" aria-selected="false"' in page
+    assert "window.location.hash" in page
+    assert "ArrowRight" in page
+    assert "ArrowLeft" in page
+    assert "#62d7d1" not in page
 
-    static_page = render.render_dashboard_html(_data(), _observations())
-    assert 'id="journey"' not in static_page
-    assert 'id="history"' not in static_page
-    assert 'id="settings"' not in static_page
 
-
-def test_static_page_contains_no_settings_markup_or_server_placeholders() -> None:
+def test_static_page_keeps_read_only_settings_without_server_placeholders() -> None:
     render = _renderer()
 
     page = render.render_dashboard_html(_data(), _observations())
 
     assert "__DEX_DASHBOARD_TOKEN__" not in page
     assert "__DEX_DASHBOARD_PORT__" not in page
-    assert 'id="settings"' not in page
+    assert 'data-tab="settings"' in page
+    assert 'id="state"' in page
+    assert "Open with 'let me change my settings' to make these live." in page
     assert "data-setting-id" not in page
     assert "dashboard-port" not in page
+
+
+def test_journey_collapses_after_twelve_chips_used_first_and_expands_inline() -> None:
+    render = _renderer()
+    skills = [
+        {
+            "id": f"unused-{index}",
+            "name": f"Unused {index}",
+            "state": "unused",
+        }
+        for index in range(1, 11)
+    ] + [
+        {
+            "id": f"used-{index}",
+            "name": f"Used {index}",
+            "state": "used",
+        }
+        for index in range(1, 6)
+    ]
+    journey = {
+        "counts": {"available": 15, "used": 5},
+        "groups": [
+            {
+                "id": "personal",
+                "name": "Personal tools",
+                "yours": True,
+                "skills": skills,
+            }
+        ],
+    }
+
+    page = render.render_dashboard_html(_data(), journey=journey)
+
+    assert "<h3>Yours</h3>" in page
+    assert page.index("Used 1") < page.index("Unused 1")
+    assert page.count("data-journey-extra hidden") == 3
+    assert ('<button type="button" class="journey-more" data-journey-expand aria-expanded="false"') in page
+    assert "+ 3 more" in page
+    assert "extra.hidden = false" in page
+
+
+def test_history_tab_has_a_quiet_first_snapshot_empty_state() -> None:
+    render = _renderer()
+
+    page = render.render_dashboard_html(_data(), history_data=None)
+
+    assert 'id="history"' in page
+    assert "Your first snapshot was saved today — this tab fills in as you come back." in page
+
+
+def test_live_settings_are_grouped_without_changing_wire_placeholders() -> None:
+    render = _renderer()
+    settings_section = importlib.import_module("core.dashboard.sections.settings")
+
+    page = render.render_dashboard_html(
+        _data(),
+        server_ctx={
+            "token": "__DEX_DASHBOARD_TOKEN__",
+            "port": "__DEX_DASHBOARD_PORT__",
+        },
+    )
+
+    settings = page[page.index('id="settings"') : page.index('id="history"')]
+    for label in ("Privacy", "Communication", "Connections", "Behavior"):
+        assert f'<h3 class="settings-group-label">{label}</h3>' in settings
+    assert settings.index("Anonymous product analytics") < settings.index("Communication")
+    assert settings.index("Formality") < settings.index("Connections")
+    assert settings.index("Existing integrations") < settings.index("Set up something new")
+    assert settings.index("New people and companies") > settings.index("Behavior")
+    assert page.count("__DEX_DASHBOARD_TOKEN__") == 1
+    assert page.count("__DEX_DASHBOARD_PORT__") == 1
+    assert settings_section._grouped_controls([("future-setting", "row")])["Behavior"] == ["row"]
 
 
 def test_new_section_fragments_have_css_for_every_emitted_class() -> None:
@@ -284,11 +366,7 @@ def test_new_section_fragments_have_css_for_every_emitted_class() -> None:
 
 def test_markdown_links_allow_safe_urls_and_reject_javascript() -> None:
     render = _renderer()
-    observations = {
-        "observations": [
-            "[Guide](https://example.test/guide) and [unsafe](javascript:alert(1))"
-        ]
-    }
+    observations = {"observations": ["[Guide](https://example.test/guide) and [unsafe](javascript:alert(1))"]}
 
     page = render.render_dashboard_html(_data(), observations, archived=False)
 
@@ -473,8 +551,10 @@ def test_render_omits_derived_sections_when_their_builders_fail(
     )
 
     page = output.read_text(encoding="utf-8")
-    assert 'id="journey"' not in page
-    assert 'id="history"' not in page
+    assert 'id="journey"' in page
+    assert "No capabilities are installed in this Dex yet." in page
+    assert 'id="history"' in page
+    assert "Your first snapshot was saved today — this tab fills in as you come back." in page
 
 
 def test_no_archive_writes_only_the_requested_html(tmp_path: Path) -> None:

--- a/core/tests/test_dashboard_server.py
+++ b/core/tests/test_dashboard_server.py
@@ -183,6 +183,7 @@ def test_state_is_re_read_and_toggle_write_returns_undo_values(tmp_path: Path) -
 
     assert state_response.status == 200
     assert _json(state_response)["settings"]["formality"] == "professional_casual"
+    assert _json(state_response)["unavailable"] == {}
     assert toggle_response.status == 200
     assert _json(toggle_response) == {
         "ok": True,
@@ -193,6 +194,83 @@ def test_state_is_re_read_and_toggle_write_returns_undo_values(tmp_path: Path) -
     assert 'formality: "casual"' in (vault / "System" / "user-profile.yaml").read_text(encoding="utf-8")
     refreshed = app.handle("GET", "/api/state?t=correct-token")
     assert _json(refreshed)["settings"]["formality"] == "casual"
+
+
+def test_missing_entity_creation_keeps_other_settings_live_and_returns_400_on_write(
+    tmp_path: Path,
+) -> None:
+    app, vault = _app(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace(
+            "entity_creation:\n  mode: suggest\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    state_response = app.handle("GET", "/api/state?t=correct-token")
+    state = _json(state_response)
+
+    assert state_response.status == 200
+    assert state["settings"]["formality"] == "professional_casual"
+    assert "entity_creation" not in state["settings"]
+    assert "entity_creation" not in state["unavailable"]
+
+    formality_response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"formality","value":"casual"}',
+    )
+    entity_response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"entity_creation","value":"off"}',
+    )
+
+    assert formality_response.status == 200
+    assert entity_response.status == 400
+    assert _json(entity_response) == {
+        "error": "That setting is not present in this Dex's files yet."
+    }
+
+
+def test_duplicated_setting_is_unavailable_without_blocking_other_writes(
+    tmp_path: Path,
+) -> None:
+    app, vault = _app(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace(
+            '  directness: "balanced"',
+            '  directness: "balanced"\n  directness: "supportive"',
+        ),
+        encoding="utf-8",
+    )
+
+    state_response = app.handle("GET", "/api/state?t=correct-token")
+    state = _json(state_response)
+
+    assert state_response.status == 200
+    assert state["settings"]["formality"] == "professional_casual"
+    assert "directness" not in state["settings"]
+    assert set(state["unavailable"]) == {"directness"}
+    assert "exactly once" in state["unavailable"]["directness"]
+
+    directness_response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"directness","value":"supportive"}',
+    )
+    formality_response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"formality","value":"casual"}',
+    )
+
+    assert directness_response.status == 409
+    assert "exactly once" in _json(directness_response)["error"]
+    assert formality_response.status == 200
 
 
 def test_successful_post_advances_only_the_cached_get_snapshot(
@@ -326,6 +404,8 @@ def test_settings_section_escapes_data_and_returns_interactive_javascript() -> N
     assert "/api/state" in script
     assert "/api/toggle" in script
     assert "/api/close" in script
+    assert "payload.unavailable" in script
+    assert "Not set up in this vault yet." in script
     assert "pagehide" in script
     assert "beforeunload" in script
     assert "undo" in script.lower()

--- a/core/tests/test_dashboard_server.py
+++ b/core/tests/test_dashboard_server.py
@@ -1,0 +1,354 @@
+"""Socket-free HTTP and settings-section coverage for the Dex Dashboard."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import os
+import time
+import warnings
+from pathlib import Path
+
+import pytest
+
+warnings.filterwarnings("ignore", category=pytest.PytestUnknownMarkWarning)
+
+
+def _server():
+    return importlib.import_module("core.dashboard.server")
+
+
+def _settings():
+    return importlib.import_module("core.dashboard.sections.settings")
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _vault(tmp_path: Path) -> tuple[Path, Path]:
+    vault = tmp_path / "vault"
+    _write(
+        vault / "System" / "user-profile.yaml",
+        """\
+name: "Alex"
+communication:
+  formality: "professional_casual"
+  directness: "balanced"
+entity_creation:
+  mode: suggest
+analytics:
+  enabled: true
+""",
+    )
+    _write(
+        vault / "System" / "integrations" / "config.yaml",
+        """\
+enabled:
+  slack: false
+hooks:
+  meeting_prep:
+    use_slack: false
+detected:
+  slack: null
+todoist:
+  enabled: true
+  api_key_env_var: NEVER_RETURN_THIS_SECRET
+""",
+    )
+    _write(
+        vault / "System" / "usage_log.md",
+        "**Health telemetry:** pending\n",
+    )
+    page = _write(
+        tmp_path / "dashboard.html",
+        """<!doctype html>
+<meta name="dashboard-port" content="__DEX_DASHBOARD_PORT__">
+<script>const token = "__DEX_DASHBOARD_TOKEN__";</script>
+""",
+    )
+    return vault, page
+
+
+def _json(response) -> dict:
+    return json.loads(response.body.decode("utf-8"))
+
+
+def _app(tmp_path: Path):
+    server = _server()
+    vault, page = _vault(tmp_path)
+    return (
+        server.DashboardApplication(
+            vault=vault,
+            html_path=page,
+            token="correct-token",
+            port=43123,
+        ),
+        vault,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "target", "body"),
+    [
+        ("GET", "/", b""),
+        ("GET", "/?t=wrong", b""),
+        ("GET", "/api/state", b""),
+        ("POST", "/api/toggle?t=wrong", b"{}"),
+        ("POST", "/api/close", b""),
+    ],
+)
+def test_every_endpoint_requires_the_run_token(
+    tmp_path: Path,
+    method: str,
+    target: str,
+    body: bytes,
+) -> None:
+    app, _vault_path = _app(tmp_path)
+
+    response = app.handle(method, target, body)
+
+    assert response.status == 403
+    assert _json(response) == {"error": "Forbidden"}
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_token_authentication_uses_constant_time_comparison(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _server()
+    app, _vault_path = _app(tmp_path)
+    compared: list[tuple[str, str]] = []
+    real_compare = server.hmac.compare_digest
+
+    def recording_compare(left: str, right: str) -> bool:
+        compared.append((left, right))
+        return real_compare(left, right)
+
+    monkeypatch.setattr(server.hmac, "compare_digest", recording_compare)
+
+    response = app.handle("GET", "/api/state?t=correct-token")
+
+    assert response.status == 200
+    assert compared == [("correct-token", "correct-token")]
+
+
+def test_http_adapter_checks_token_before_content_length(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _server()
+    app, _vault_path = _app(tmp_path)
+    handler = object.__new__(server.DashboardHTTPRequestHandler)
+    handler.application = app
+    handler.path = "/api/toggle"
+    handler.headers = {"Content-Length": str(server.MAX_REQUEST_BYTES + 1)}
+    handler.rfile = io.BytesIO()
+    captured = []
+    monkeypatch.setattr(handler, "_write_response", captured.append)
+
+    handler.do_POST()
+
+    assert len(captured) == 1
+    assert captured[0].status == 403
+
+
+def test_get_root_serves_in_memory_rewritten_html(tmp_path: Path) -> None:
+    app, _vault_path = _app(tmp_path)
+
+    response = app.handle("GET", "/?t=correct-token")
+
+    text = response.body.decode("utf-8")
+    assert response.status == 200
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
+    assert "__DEX_DASHBOARD_TOKEN__" not in text
+    assert "__DEX_DASHBOARD_PORT__" not in text
+    assert '"correct-token"' in text
+    assert 'content="43123"' in text
+
+
+def test_state_is_re_read_and_toggle_write_returns_undo_values(tmp_path: Path) -> None:
+    app, vault = _app(tmp_path)
+
+    state_response = app.handle("GET", "/api/state?t=correct-token")
+    toggle_response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        json.dumps({"setting_id": "formality", "value": "casual"}).encode(),
+    )
+
+    assert state_response.status == 200
+    assert _json(state_response)["settings"]["formality"] == "professional_casual"
+    assert toggle_response.status == 200
+    assert _json(toggle_response) == {
+        "ok": True,
+        "setting_id": "formality",
+        "old": "professional_casual",
+        "new": "casual",
+    }
+    assert 'formality: "casual"' in (vault / "System" / "user-profile.yaml").read_text(encoding="utf-8")
+    refreshed = app.handle("GET", "/api/state?t=correct-token")
+    assert _json(refreshed)["settings"]["formality"] == "casual"
+
+
+def test_successful_post_advances_only_the_cached_get_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app, _vault_path = _app(tmp_path)
+    assert app.handle("GET", "/api/state?t=correct-token").status == 200
+
+    def unexpected_read():
+        raise AssertionError("POST must not accept a fresh disk state as the user's GET state")
+
+    monkeypatch.setattr(app.session.engine, "read_state", unexpected_read)
+
+    response = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"formality","value":"casual"}',
+    )
+
+    assert response.status == 200
+    assert app.session.snapshot is not None
+    assert app.session.snapshot.values["formality"] == "casual"
+
+
+def test_toggle_requires_state_read_and_rejects_concurrent_changes(tmp_path: Path) -> None:
+    app, vault = _app(tmp_path)
+
+    before_state = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"formality","value":"formal"}',
+    )
+    assert before_state.status == 409
+    assert "refresh" in _json(before_state)["error"].lower()
+
+    assert app.handle("GET", "/api/state?t=correct-token").status == 200
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace('name: "Alex"', 'name: "Sam"'),
+        encoding="utf-8",
+    )
+    conflict = app.handle(
+        "POST",
+        "/api/toggle?t=correct-token",
+        b'{"setting_id":"formality","value":"formal"}',
+    )
+
+    assert conflict.status == 409
+    assert "refresh" in _json(conflict)["error"].lower()
+    assert 'formality: "professional_casual"' in profile.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("payload", "status"),
+    [
+        (b"{bad json", 400),
+        (b"[]", 400),
+        (b'{"setting_id":"unknown","value":true}', 400),
+        (b'{"setting_id":"formality","value":"junk"}', 400),
+        (b'{"setting_id":"analytics_enabled","value":1}', 400),
+        (b'{"setting_id":"formality"}', 400),
+    ],
+)
+def test_bad_toggle_requests_are_safe_client_errors(
+    tmp_path: Path,
+    payload: bytes,
+    status: int,
+) -> None:
+    app, _vault_path = _app(tmp_path)
+    app.handle("GET", "/api/state?t=correct-token")
+
+    response = app.handle("POST", "/api/toggle?t=correct-token", payload)
+
+    assert response.status == status
+    assert set(_json(response)) == {"error"}
+    assert b"NEVER_RETURN_THIS_SECRET" not in response.body
+
+
+def test_close_endpoint_requests_shutdown_without_a_socket(tmp_path: Path) -> None:
+    app, _vault_path = _app(tmp_path)
+
+    response = app.handle("POST", "/api/close?t=correct-token", b"")
+
+    assert response.status == 200
+    assert _json(response) == {"ok": True}
+    assert app.close_requested.is_set()
+
+
+def test_unknown_routes_do_not_serve_files(tmp_path: Path) -> None:
+    app, _vault_path = _app(tmp_path)
+
+    response = app.handle("GET", "/../../System/user-profile.yaml?t=correct-token")
+
+    assert response.status == 404
+    assert _json(response) == {"error": "Not found"}
+
+
+def test_settings_section_escapes_data_and_returns_interactive_javascript() -> None:
+    settings = _settings()
+    data = {
+        "integrations": {
+            "apps": {
+                "Slack & Co": {"enabled": True},
+                '<script>alert("x")</script>': {"enabled": False},
+            }
+        },
+        "profile": {"api_key": "NEVER_RENDER"},
+    }
+
+    fragment, script = settings.render(
+        data,
+        {
+            "token": '"</script><script>alert(1)</script>',
+            "port": 43123,
+        },
+    )
+
+    assert 'id="settings"' in fragment
+    assert 'data-setting-id="analytics_enabled"' in fragment
+    assert 'data-setting-id="entity_creation"' in fragment
+    assert 'data-setting-id="formality"' in fragment
+    assert 'data-setting-id="directness"' in fragment
+    assert 'data-setting-id="health_telemetry"' in fragment
+    assert "Slack &amp; Co" in fragment
+    assert '<script>alert("x")</script>' not in fragment
+    assert "NEVER_RENDER" not in fragment
+    assert "Set up Todoist" in fragment
+    assert "/todoist-setup" in fragment
+    assert "fetch(" in script
+    assert "/api/state" in script
+    assert "/api/toggle" in script
+    assert "/api/close" in script
+    assert "pagehide" in script
+    assert "beforeunload" in script
+    assert "undo" in script.lower()
+    assert "\\u003c/script\\u003e" in script
+    assert "</script>" not in script
+
+
+@pytest.mark.socket_smoke
+@pytest.mark.skipif(
+    os.environ.get("DEX_SOCKET_SMOKE") != "1",
+    reason="requires normal local socket permissions; set DEX_SOCKET_SMOKE=1",
+)
+def test_real_server_exits_after_idle_timeout(tmp_path: Path) -> None:
+    server = _server()
+    vault, page = _vault(tmp_path)
+    started = time.monotonic()
+
+    result = server.run_server(
+        vault=vault,
+        html_path=page,
+        idle_timeout=0.05,
+        open_browser=False,
+    )
+
+    assert result["reason"] == "idle"
+    assert time.monotonic() - started < 2

--- a/core/tests/test_dashboard_server.py
+++ b/core/tests/test_dashboard_server.py
@@ -413,6 +413,132 @@ def test_settings_section_escapes_data_and_returns_interactive_javascript() -> N
     assert "</script>" not in script
 
 
+def test_run_server_prints_the_tokened_url_once_and_flushes_before_opening_browser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _server()
+    vault, page = _vault(tmp_path)
+
+    class RecordingStdout:
+        def __init__(self) -> None:
+            self.text = ""
+            self.flush_count = 0
+
+        def write(self, text: str) -> int:
+            self.text += text
+            return len(text)
+
+        def flush(self) -> None:
+            self.flush_count += 1
+
+    class ImmediateServer:
+        instance: "ImmediateServer"
+
+        def __init__(self, _address, _handler) -> None:
+            self.server_address = ("127.0.0.1", 43123)
+            self.timeout = None
+            self.handled_requests = 0
+            self.closed = False
+            type(self).instance = self
+
+        def handle_request(self) -> None:
+            self.handled_requests += 1
+
+        def server_close(self) -> None:
+            self.closed = True
+
+    stdout = RecordingStdout()
+    monkeypatch.setattr(server.sys, "stdout", stdout)
+    opened: list[str] = []
+
+    def browser_open(url: str) -> bool:
+        assert stdout.text == f"Dashboard: {url}\n"
+        assert stdout.flush_count >= 1
+        opened.append(url)
+        return True
+
+    result = server.run_server(
+        vault=vault,
+        html_path=page,
+        idle_timeout=0.01,
+        token="demo-token",
+        server_class=ImmediateServer,
+        browser_open=browser_open,
+    )
+
+    expected_url = "http://127.0.0.1:43123/?t=demo-token"
+    assert result["reason"] == "idle"
+    assert opened == [expected_url]
+    assert stdout.text == f"Dashboard: {expected_url}\n"
+    assert stdout.text.count(expected_url) == 1
+    assert ImmediateServer.instance.handled_requests > 0
+    assert ImmediateServer.instance.closed
+
+
+def test_run_server_keeps_serving_when_injected_browser_open_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    server = _server()
+    vault, page = _vault(tmp_path)
+
+    class ImmediateServer:
+        instance: "ImmediateServer"
+
+        def __init__(self, _address, _handler) -> None:
+            self.server_address = ("127.0.0.1", 43124)
+            self.timeout = None
+            self.handled_requests = 0
+            self.closed = False
+            type(self).instance = self
+
+        def handle_request(self) -> None:
+            self.handled_requests += 1
+
+        def server_close(self) -> None:
+            self.closed = True
+
+    result = server.run_server(
+        vault=vault,
+        html_path=page,
+        idle_timeout=0.01,
+        token="demo-token",
+        server_class=ImmediateServer,
+        browser_open=lambda _url: False,
+    )
+
+    expected_url = "http://127.0.0.1:43124/?t=demo-token"
+    assert result["reason"] == "idle"
+    assert capsys.readouterr().out == (
+        f"Dashboard: {expected_url}\n"
+        "Could not open a browser — paste the URL above into Chrome.\n"
+    )
+    assert ImmediateServer.instance.handled_requests > 0
+    assert ImmediateServer.instance.closed
+
+
+def test_default_browser_open_uses_macos_open_after_webbrowser_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _server()
+    calls: list[tuple[object, ...]] = []
+
+    class CompletedProcess:
+        returncode = 0
+
+    monkeypatch.setattr(server.sys, "platform", "darwin")
+    monkeypatch.setattr(server.webbrowser, "open", lambda _url: False)
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *args, **kwargs: (calls.append((*args, kwargs)), CompletedProcess())[1],
+    )
+
+    assert server._default_browser_open("http://127.0.0.1:43123/?t=demo-token")
+    assert calls == [(["open", "http://127.0.0.1:43123/?t=demo-token"], {"check": False})]
+
+
 @pytest.mark.socket_smoke
 @pytest.mark.skipif(
     os.environ.get("DEX_SOCKET_SMOKE") != "1",

--- a/core/tests/test_dashboard_server.py
+++ b/core/tests/test_dashboard_server.py
@@ -374,11 +374,37 @@ def test_settings_section_escapes_data_and_returns_interactive_javascript() -> N
     data = {
         "integrations": {
             "apps": {
+                "slack": {"enabled": True},
                 "Slack & Co": {"enabled": True},
                 '<script>alert("x")</script>': {"enabled": False},
             }
         },
-        "profile": {"api_key": "NEVER_RENDER"},
+        "profile": {
+            "api_key": "NEVER_RENDER",
+            "communication": {
+                "formality": "professional_casual",
+                "directness": "balanced",
+                "detail_level": "concise",
+                "coaching_style": "collaborative",
+            },
+            "analytics": {"enabled": True},
+            "entity_creation": {"mode": "suggest"},
+            "entity_gardener": {"enabled": True},
+            "meeting_intelligence": {
+                "extract_action_items": True,
+                "extract_decisions": False,
+            },
+            "journaling": {
+                "morning": False,
+                "evening": False,
+                "weekly": True,
+            },
+            "capabilities": {
+                "career": {"enabled": False},
+                "companies": {"enabled": True},
+                "quarter_goals": {"enabled": False},
+            },
+        },
     }
 
     fragment, script = settings.render(
@@ -394,7 +420,44 @@ def test_settings_section_escapes_data_and_returns_interactive_javascript() -> N
     assert 'data-setting-id="entity_creation"' in fragment
     assert 'data-setting-id="formality"' in fragment
     assert 'data-setting-id="directness"' in fragment
+    assert 'data-setting-id="detail_level"' in fragment
+    assert 'data-setting-id="coaching_style"' in fragment
     assert 'data-setting-id="health_telemetry"' in fragment
+    assert 'data-setting-id="capability:career"' in fragment
+    assert 'data-setting-id="capability:companies"' in fragment
+    assert 'data-setting-id="capability:quarter_goals"' in fragment
+    assert 'data-setting-id="meeting_intel:extract_action_items"' in fragment
+    assert 'data-setting-id="meeting_intel:extract_decisions"' in fragment
+    assert 'data-setting-id="entity_gardener"' in fragment
+    assert 'data-setting-id="journaling_morning"' in fragment
+    assert 'data-setting-id="journaling_evening"' in fragment
+    assert 'data-setting-id="journaling_weekly"' in fragment
+    assert 'data-setting-id="integration:slack.enabled"' in fragment
+    group_names = [
+        "privacy",
+        "communication",
+        "capabilities",
+        "meetings",
+        "journaling",
+        "connections",
+    ]
+    positions = [
+        fragment.index(f'data-settings-group="{group_name}"')
+        for group_name in group_names
+    ]
+    assert positions == sorted(positions)
+    for label in (
+        "Privacy",
+        "Communication",
+        "Capabilities",
+        "Meetings",
+        "Journaling",
+        "Connections",
+    ):
+        assert f'<h3 class="settings-group-label">{label}</h3>' in fragment
+    assert "Behavior" not in fragment
+    assert "Career coaching, evidence capture and resume tools" in fragment
+    assert "unlocks a set of skills" in fragment
     assert "Slack &amp; Co" in fragment
     assert '<script>alert("x")</script>' not in fragment
     assert "NEVER_RENDER" not in fragment
@@ -411,6 +474,66 @@ def test_settings_section_escapes_data_and_returns_interactive_javascript() -> N
     assert "undo" in script.lower()
     assert "\\u003c/script\\u003e" in script
     assert "</script>" not in script
+
+
+def test_settings_section_has_the_same_full_inventory_read_only_without_a_server() -> None:
+    settings = _settings()
+    data = {
+        "profile": {
+            "communication": {
+                "formality": "professional_casual",
+                "directness": "balanced",
+                "detail_level": "comprehensive",
+                "coaching_style": "challenging",
+            },
+            "analytics": {"enabled": True},
+            "entity_creation": {"mode": "auto"},
+            "entity_gardener": {"enabled": False},
+            "meeting_intelligence": {
+                "extract_action_items": True,
+                "custom_follow_up_signal": False,
+            },
+            "journaling": {"morning": True, "evening": False, "weekly": True},
+            "capabilities": {
+                "career": {"enabled": True},
+                "companies": {"enabled": False},
+                "quarter_goals": {"enabled": True},
+            },
+        },
+        "integrations": {"apps": {"slack": {"enabled": True}}},
+    }
+
+    fragment, script = settings.render(data, None)
+
+    assert script == ""
+    for setting_id in (
+        "analytics_enabled",
+        "health_telemetry",
+        "formality",
+        "directness",
+        "detail_level",
+        "coaching_style",
+        "capability:career",
+        "capability:companies",
+        "capability:quarter_goals",
+        "meeting_intel:extract_action_items",
+        "meeting_intel:custom_follow_up_signal",
+        "entity_creation",
+        "entity_gardener",
+        "journaling_morning",
+        "journaling_evening",
+        "journaling_weekly",
+        "integration:slack.enabled",
+    ):
+        assert f'data-setting-id="{setting_id}"' in fragment
+    assert "Read-only" in fragment
+    assert "fetch(" not in fragment
+    assert 'value="comprehensive" selected' in fragment
+    assert 'id="setting-capability:career"' in fragment
+    assert 'id="setting-capability:career"\n            type="checkbox"' in fragment
+    assert 'data-setting-id="capability:career"' in fragment
+    assert "checked" in fragment
+    assert fragment.count('data-settings-group="') == 6
 
 
 def test_run_server_prints_the_tokened_url_once_and_flushes_before_opening_browser(

--- a/core/tests/test_dashboard_toggles.py
+++ b/core/tests/test_dashboard_toggles.py
@@ -30,8 +30,30 @@ communication:
   formality: "professional_casual"  # options stay here
   directness: "balanced"
   detail_level: "concise"
+  coaching_style: "collaborative"
 entity_creation:
   mode: suggest
+entity_gardener:
+  enabled: true
+meeting_intelligence:
+  extract_customer_intel: false
+  extract_competitive_intel: false
+  extract_action_items: true
+  extract_decisions: true
+  extract_stakeholder_dynamics: false
+  extract_budget_timeline: false
+  extract_technical_decisions: false
+journaling:
+  morning: false
+  evening: false
+  weekly: true
+capabilities:
+  career:
+    enabled: false
+  companies:
+    enabled: true
+  quarter_goals:
+    enabled: false
 analytics:
   enabled: true  # anonymous counts only
 """
@@ -75,6 +97,41 @@ def _vault(tmp_path: Path) -> Path:
     return vault
 
 
+NEW_PROFILE_SETTING_CASES = (
+    ("detail_level", "concise", "comprehensive", "exhaustive", '  detail_level: "concise"\n'),
+    ("coaching_style", "collaborative", "challenging", "commanding", '  coaching_style: "collaborative"\n'),
+    ("entity_gardener", True, False, "false", "  enabled: true\n"),
+    ("journaling_morning", False, True, "true", "  morning: false\n"),
+    ("journaling_evening", False, True, "true", "  evening: false\n"),
+    ("journaling_weekly", True, False, "false", "  weekly: true\n"),
+    ("meeting_intel:extract_customer_intel", False, True, "true", "  extract_customer_intel: false\n"),
+    ("meeting_intel:extract_competitive_intel", False, True, "true", "  extract_competitive_intel: false\n"),
+    ("meeting_intel:extract_action_items", True, False, "false", "  extract_action_items: true\n"),
+    ("meeting_intel:extract_decisions", True, False, "false", "  extract_decisions: true\n"),
+    (
+        "meeting_intel:extract_stakeholder_dynamics",
+        False,
+        True,
+        "true",
+        "  extract_stakeholder_dynamics: false\n",
+    ),
+    ("meeting_intel:extract_budget_timeline", False, True, "true", "  extract_budget_timeline: false\n"),
+    (
+        "meeting_intel:extract_technical_decisions",
+        False,
+        True,
+        "true",
+        "  extract_technical_decisions: false\n",
+    ),
+)
+
+CAPABILITY_CASES = (
+    ("capability:career", "career", False, True),
+    ("capability:companies", "companies", True, False),
+    ("capability:quarter_goals", "quarter_goals", False, True),
+)
+
+
 def test_read_state_returns_only_vetted_values_with_file_stamps(tmp_path: Path) -> None:
     toggles = _toggles()
     vault = _vault(tmp_path)
@@ -83,13 +140,29 @@ def test_read_state_returns_only_vetted_values_with_file_stamps(tmp_path: Path) 
 
     assert snapshot.values == {
         "analytics_enabled": True,
+        "capability:career": False,
+        "capability:companies": True,
+        "capability:quarter_goals": False,
+        "coaching_style": "collaborative",
+        "detail_level": "concise",
+        "directness": "balanced",
         "entity_creation": "suggest",
+        "entity_gardener": True,
         "formality": "professional_casual",
         "health_telemetry": "pending",
         "integration:google.enabled": True,
         "integration:slack.enabled": False,
         "integration:todoist.enabled": True,
-        "directness": "balanced",
+        "journaling_evening": False,
+        "journaling_morning": False,
+        "journaling_weekly": True,
+        "meeting_intel:extract_action_items": True,
+        "meeting_intel:extract_budget_timeline": False,
+        "meeting_intel:extract_competitive_intel": False,
+        "meeting_intel:extract_customer_intel": False,
+        "meeting_intel:extract_decisions": True,
+        "meeting_intel:extract_stakeholder_dynamics": False,
+        "meeting_intel:extract_technical_decisions": False,
     }
     assert set(snapshot.stamps) == set(snapshot.values)
     assert all(stamp.mtime_ns > 0 for stamp in snapshot.stamps.values())
@@ -98,6 +171,270 @@ def test_read_state_returns_only_vetted_values_with_file_stamps(tmp_path: Path) 
     serialized = json.dumps(snapshot.values, sort_keys=True)
     assert "TODOIST_API_KEY" not in serialized
     assert "keep_me" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "initial", "_new_value", "_invalid_value", "_profile_line"),
+    NEW_PROFILE_SETTING_CASES,
+)
+def test_new_profile_registry_reads_each_present_setting(
+    tmp_path: Path,
+    setting_id: str,
+    initial: object,
+    _new_value: object,
+    _invalid_value: object,
+    _profile_line: str,
+) -> None:
+    snapshot = _toggles().ToggleEngine(_vault(tmp_path)).read_state()
+
+    assert snapshot.values[setting_id] == initial
+    assert setting_id in snapshot.stamps
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "_initial", "new_value", "_invalid_value", "profile_line"),
+    NEW_PROFILE_SETTING_CASES,
+)
+def test_new_profile_registry_writes_each_existing_anchor(
+    tmp_path: Path,
+    setting_id: str,
+    _initial: object,
+    new_value: object,
+    _invalid_value: object,
+    profile_line: str,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    profile = vault / "System" / "user-profile.yaml"
+    before = profile.read_text(encoding="utf-8")
+
+    result = engine.write(setting_id, new_value, expected=snapshot.stamps[setting_id])
+
+    assert result.old == snapshot.values[setting_id]
+    assert result.new == new_value
+    after = profile.read_text(encoding="utf-8")
+    assert after != before
+    assert after.count(profile_line) == before.count(profile_line) - 1
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "_initial", "_new_value", "invalid_value", "_profile_line"),
+    NEW_PROFILE_SETTING_CASES,
+)
+def test_new_profile_registry_rejects_each_invalid_value(
+    tmp_path: Path,
+    setting_id: str,
+    _initial: object,
+    _new_value: object,
+    invalid_value: object,
+    _profile_line: str,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    profile = vault / "System" / "user-profile.yaml"
+    before = profile.read_bytes()
+
+    with pytest.raises(toggles.ToggleValidationError):
+        engine.write(setting_id, invalid_value, expected=snapshot.stamps[setting_id])
+
+    assert profile.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "_initial", "new_value", "_invalid_value", "profile_line"),
+    NEW_PROFILE_SETTING_CASES,
+)
+def test_new_profile_registry_omits_each_absent_key(
+    tmp_path: Path,
+    setting_id: str,
+    _initial: object,
+    new_value: object,
+    _invalid_value: object,
+    profile_line: str,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace(profile_line, "", 1),
+        encoding="utf-8",
+    )
+    engine = toggles.ToggleEngine(vault)
+
+    snapshot = engine.read_state()
+
+    assert setting_id not in snapshot.values
+    assert setting_id not in snapshot.stamps
+    assert setting_id not in snapshot.unavailable
+    with pytest.raises(
+        toggles.ToggleValidationError,
+        match=r"^That setting is not present in this Dex's files yet\.$",
+    ):
+        engine.write(setting_id, new_value, expected=None)
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "room", "initial", "new_value"),
+    CAPABILITY_CASES,
+)
+def test_capability_registry_reads_via_enabled_and_writes_via_set_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    setting_id: str,
+    room: str,
+    initial: bool,
+    new_value: bool,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    real_enabled = toggles.capabilities.enabled
+    enabled_calls: list[tuple[str, Path]] = []
+    set_calls: list[tuple[str, bool, Path]] = []
+
+    def enabled(candidate: str, *, profile_path: Path) -> bool:
+        enabled_calls.append((candidate, profile_path))
+        return real_enabled(candidate, profile_path=profile_path)
+
+    def set_enabled(candidate: str, value: bool, *, vault_root: Path) -> dict[str, object]:
+        set_calls.append((candidate, value, vault_root))
+        return {"room": candidate, "enabled": value}
+
+    monkeypatch.setattr(toggles.capabilities, "enabled", enabled)
+    monkeypatch.setattr(toggles.capabilities, "set_enabled", set_enabled)
+    engine = toggles.ToggleEngine(vault)
+
+    snapshot = engine.read_state()
+    result = engine.write(setting_id, new_value, expected=snapshot.stamps[setting_id])
+
+    assert snapshot.values[setting_id] is initial
+    assert (room, vault / "System" / "user-profile.yaml") in enabled_calls
+    assert set_calls == [(room, new_value, vault.resolve())]
+    assert result.old is initial
+    assert result.new is new_value
+    audit = json.loads(
+        (vault / "System" / ".dex" / "dashboard" / "audit.jsonl").read_text(encoding="utf-8")
+    )
+    assert audit["setting_id"] == setting_id
+    assert audit["old"] is initial
+    assert audit["new"] is new_value
+
+
+@pytest.mark.parametrize(("setting_id", "room", "_initial", "_new_value"), CAPABILITY_CASES)
+def test_capability_registry_rejects_invalid_values_without_calling_set_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    setting_id: str,
+    room: str,
+    _initial: bool,
+    _new_value: bool,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        toggles.capabilities,
+        "set_enabled",
+        lambda *args, **kwargs: calls.append((*args, kwargs)),
+    )
+
+    with pytest.raises(toggles.ToggleValidationError):
+        engine.write(setting_id, "true", expected=snapshot.stamps[setting_id])
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(("setting_id", "room", "_initial", "_new_value"), CAPABILITY_CASES)
+def test_absent_capability_key_reads_its_safe_contract_default(
+    tmp_path: Path,
+    setting_id: str,
+    room: str,
+    _initial: bool,
+    _new_value: bool,
+) -> None:
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace(
+            f"  {room}:\n    enabled: {'true' if room == 'companies' else 'false'}\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = _toggles().ToggleEngine(vault).read_state()
+
+    assert snapshot.values[setting_id] is False
+    assert setting_id in snapshot.stamps
+
+
+def test_capability_api_errors_are_plain_toggle_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+
+    def fail(*_args, **_kwargs) -> None:
+        raise RuntimeError("NEVER_EXPOSE_THIS_INTERNAL_PATH")
+
+    monkeypatch.setattr(toggles.capabilities, "set_enabled", fail)
+
+    with pytest.raises(toggles.ToggleError) as raised:
+        engine.write(
+            "capability:career",
+            True,
+            expected=snapshot.stamps["capability:career"],
+        )
+
+    assert "capability" in str(raised.value).lower()
+    assert "NEVER_EXPOSE" not in str(raised.value)
+
+
+def test_capability_write_rechecks_the_profile_before_calling_set_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    set_calls: list[tuple[object, ...]] = []
+
+    def edit_during_read(_room: str, *, profile_path: Path) -> bool:
+        profile_path.write_text(
+            profile_path.read_text(encoding="utf-8").replace(
+                'name: "Alex Example"',
+                'name: "Externally Changed"',
+            ),
+            encoding="utf-8",
+        )
+        return False
+
+    monkeypatch.setattr(toggles.capabilities, "enabled", edit_during_read)
+    monkeypatch.setattr(
+        toggles.capabilities,
+        "set_enabled",
+        lambda *args, **kwargs: set_calls.append((*args, kwargs)),
+    )
+
+    with pytest.raises(toggles.ToggleConflictError, match="refresh"):
+        engine.write(
+            "capability:career",
+            True,
+            expected=snapshot.stamps["capability:career"],
+        )
+
+    assert set_calls == []
+    assert 'name: "Externally Changed"' in profile.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize("requested_value", ["off", "always"])

--- a/core/tests/test_dashboard_toggles.py
+++ b/core/tests/test_dashboard_toggles.py
@@ -94,9 +94,40 @@ def test_read_state_returns_only_vetted_values_with_file_stamps(tmp_path: Path) 
     assert set(snapshot.stamps) == set(snapshot.values)
     assert all(stamp.mtime_ns > 0 for stamp in snapshot.stamps.values())
     assert all(len(stamp.sha256) == 64 for stamp in snapshot.stamps.values())
+    assert snapshot.unavailable == {}
     serialized = json.dumps(snapshot.values, sort_keys=True)
     assert "TODOIST_API_KEY" not in serialized
     assert "keep_me" not in serialized
+
+
+@pytest.mark.parametrize("requested_value", ["off", "always"])
+def test_missing_profile_setting_is_omitted_while_other_settings_still_work(
+    tmp_path: Path,
+    requested_value: str,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        _profile().replace("entity_creation:\n  mode: suggest\n", ""),
+        encoding="utf-8",
+    )
+    engine = toggles.ToggleEngine(vault)
+
+    snapshot = engine.read_state()
+
+    assert snapshot.values["formality"] == "professional_casual"
+    assert "entity_creation" not in snapshot.values
+    assert "entity_creation" not in snapshot.stamps
+    assert "entity_creation" not in snapshot.unavailable
+
+    engine.write("formality", "casual", expected=snapshot.stamps["formality"])
+
+    with pytest.raises(
+        toggles.ToggleValidationError,
+        match=r"^That setting is not present in this Dex's files yet\.$",
+    ):
+        engine.write("entity_creation", requested_value, expected=None)
 
 
 def test_profile_write_changes_one_scalar_and_appends_audit(tmp_path: Path) -> None:
@@ -273,23 +304,48 @@ def test_concurrent_edit_is_detected_by_sha_even_when_mtime_is_restored(
     assert not (vault / "System" / ".dex" / "dashboard" / "audit.jsonl").exists()
 
 
-def test_duplicate_or_malformed_anchor_fails_closed(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("replacement", "reason"),
+    [
+        (
+            '  directness: "balanced"\n  directness: "very_direct"',
+            "exactly once",
+        ),
+        ('  directness: "unrecognised"', "outside the supported schema"),
+    ],
+)
+def test_malformed_profile_setting_is_scoped_to_that_setting(
+    tmp_path: Path,
+    replacement: str,
+    reason: str,
+) -> None:
     toggles = _toggles()
     vault = _vault(tmp_path)
     profile = vault / "System" / "user-profile.yaml"
     profile.write_text(
         _profile().replace(
             '  directness: "balanced"',
-            '  directness: "balanced"\n  directness: "very_direct"',
+            replacement,
         ),
         encoding="utf-8",
     )
+    engine = toggles.ToggleEngine(vault)
 
-    with pytest.raises(toggles.ToggleSchemaError, match="exactly once"):
-        toggles.ToggleEngine(vault).read_state()
+    snapshot = engine.read_state()
+
+    assert snapshot.values["formality"] == "professional_casual"
+    assert "directness" not in snapshot.values
+    assert "directness" not in snapshot.stamps
+    assert set(snapshot.unavailable) == {"directness"}
+    assert reason in snapshot.unavailable["directness"]
+
+    with pytest.raises(toggles.ToggleSchemaError, match=reason):
+        engine.write("directness", "supportive", expected=None)
+
+    engine.write("formality", "casual", expected=snapshot.stamps["formality"])
 
 
-def test_ambiguous_integration_anchor_fails_closed(tmp_path: Path) -> None:
+def test_ambiguous_integration_anchor_is_scoped_to_that_setting(tmp_path: Path) -> None:
     toggles = _toggles()
     vault = _vault(tmp_path)
     config = vault / "System" / "integrations" / "config.yaml"
@@ -301,9 +357,18 @@ slack:
 """,
         encoding="utf-8",
     )
+    engine = toggles.ToggleEngine(vault)
+
+    snapshot = engine.read_state()
+
+    assert snapshot.values["integration:google.enabled"] is True
+    assert snapshot.values["integration:todoist.enabled"] is True
+    assert "integration:slack.enabled" not in snapshot.values
+    assert set(snapshot.unavailable) == {"integration:slack.enabled"}
+    assert "slack" in snapshot.unavailable["integration:slack.enabled"]
 
     with pytest.raises(toggles.ToggleSchemaError, match="slack"):
-        toggles.ToggleEngine(vault).read_state()
+        engine.write("integration:slack.enabled", True, expected=None)
 
 
 def test_atomic_replace_interruption_leaves_original_file_intact(tmp_path: Path) -> None:

--- a/core/tests/test_dashboard_toggles.py
+++ b/core/tests/test_dashboard_toggles.py
@@ -369,7 +369,12 @@ def test_absent_capability_key_reads_its_safe_contract_default(
 
     snapshot = _toggles().ToggleEngine(vault).read_state()
 
-    assert snapshot.values[setting_id] is False
+    # An absent key means "whatever the shipped contract says" — the contract is the
+    # source of truth for room defaults, so read it rather than hardcoding a value.
+    from core import capabilities as capability_rooms
+
+    expected = capability_rooms.enabled(room, profile_path=profile)
+    assert snapshot.values[setting_id] is expected
     assert setting_id in snapshot.stamps
 
 

--- a/core/tests/test_dashboard_toggles.py
+++ b/core/tests/test_dashboard_toggles.py
@@ -1,0 +1,328 @@
+"""Behavioral coverage for the Dex Dashboard vetted toggle write engine."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _toggles():
+    return importlib.import_module("core.dashboard.toggles")
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _profile() -> str:
+    return """\
+# Keep this comment byte-for-byte.
+name: "Alex Example"
+unknown_root:
+  keep_me: "yes"
+communication:
+  formality: "professional_casual"  # options stay here
+  directness: "balanced"
+  detail_level: "concise"
+entity_creation:
+  mode: suggest
+analytics:
+  enabled: true  # anonymous counts only
+"""
+
+
+def _integrations() -> str:
+    return """\
+# Existing integrations can be switched; new ones cannot be invented.
+last_updated: null
+enabled:
+  slack: false  # preserve this comment
+  google: true
+hooks:
+  meeting_prep:
+    use_slack: false
+detected:
+  slack: null
+todoist:
+  enabled: true
+  api_key_env_var: TODOIST_API_KEY
+"""
+
+
+def _usage_log() -> str:
+    return """\
+## Health Telemetry Consent
+
+Separate from analytics.
+
+**Health telemetry:** pending
+
+## Journey Metadata
+"""
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    _write(vault / "System" / "user-profile.yaml", _profile())
+    _write(vault / "System" / "integrations" / "config.yaml", _integrations())
+    _write(vault / "System" / "usage_log.md", _usage_log())
+    return vault
+
+
+def test_read_state_returns_only_vetted_values_with_file_stamps(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+
+    snapshot = toggles.ToggleEngine(vault).read_state()
+
+    assert snapshot.values == {
+        "analytics_enabled": True,
+        "entity_creation": "suggest",
+        "formality": "professional_casual",
+        "health_telemetry": "pending",
+        "integration:google.enabled": True,
+        "integration:slack.enabled": False,
+        "integration:todoist.enabled": True,
+        "directness": "balanced",
+    }
+    assert set(snapshot.stamps) == set(snapshot.values)
+    assert all(stamp.mtime_ns > 0 for stamp in snapshot.stamps.values())
+    assert all(len(stamp.sha256) == 64 for stamp in snapshot.stamps.values())
+    serialized = json.dumps(snapshot.values, sort_keys=True)
+    assert "TODOIST_API_KEY" not in serialized
+    assert "keep_me" not in serialized
+
+
+def test_profile_write_changes_one_scalar_and_appends_audit(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    profile = vault / "System" / "user-profile.yaml"
+    before = profile.read_text(encoding="utf-8")
+
+    result = engine.write(
+        "formality",
+        "casual",
+        expected=snapshot.stamps["formality"],
+    )
+
+    after = profile.read_text(encoding="utf-8")
+    assert result.old == "professional_casual"
+    assert result.new == "casual"
+    assert result.stamp.sha256 != snapshot.stamps["formality"].sha256
+    assert after == before.replace(
+        '  formality: "professional_casual"  # options stay here',
+        '  formality: "casual"  # options stay here',
+    )
+    audit_path = vault / "System" / ".dex" / "dashboard" / "audit.jsonl"
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert set(audit) == {"ts", "setting_id", "old", "new"}
+    assert audit["setting_id"] == "formality"
+    assert audit["old"] == "professional_casual"
+    assert audit["new"] == "casual"
+    assert audit["ts"].endswith("Z")
+
+
+def test_successful_noop_is_audited_without_rewriting_the_source(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    profile = vault / "System" / "user-profile.yaml"
+    before = profile.read_bytes()
+
+    result = engine.write(
+        "formality",
+        "professional_casual",
+        expected=snapshot.stamps["formality"],
+    )
+
+    assert profile.read_bytes() == before
+    assert result.stamp == snapshot.stamps["formality"]
+    audit_path = vault / "System" / ".dex" / "dashboard" / "audit.jsonl"
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert audit["old"] == audit["new"] == "professional_casual"
+
+
+def test_yaml_like_text_inside_unknown_block_scalar_is_preserved(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace(
+            "communication:\n",
+            """\
+notes: |
+  communication:
+    formality: formal
+communication:
+""",
+        ),
+        encoding="utf-8",
+    )
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+
+    engine.write("directness", "supportive", expected=snapshot.stamps["directness"])
+
+    changed = profile.read_text(encoding="utf-8")
+    assert "notes: |\n  communication:\n    formality: formal\n" in changed
+    assert '  directness: "supportive"' in changed
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "value", "expected_line"),
+    [
+        ("analytics_enabled", False, "  enabled: false  # anonymous counts only"),
+        ("entity_creation", "off", "  mode: off"),
+        ("directness", "very_direct", '  directness: "very_direct"'),
+        ("health_telemetry", "opted-in", "**Health telemetry:** opted-in"),
+        ("integration:slack.enabled", True, "  slack: true  # preserve this comment"),
+        ("integration:todoist.enabled", False, "  enabled: false"),
+    ],
+)
+def test_each_vetted_setting_updates_its_existing_anchor(
+    tmp_path: Path,
+    setting_id: str,
+    value: object,
+    expected_line: str,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+
+    engine.write(setting_id, value, expected=snapshot.stamps[setting_id])
+
+    if setting_id == "health_telemetry":
+        changed = (vault / "System" / "usage_log.md").read_text(encoding="utf-8")
+    elif setting_id.startswith("integration:"):
+        changed = (vault / "System" / "integrations" / "config.yaml").read_text(encoding="utf-8")
+    else:
+        changed = (vault / "System" / "user-profile.yaml").read_text(encoding="utf-8")
+    assert expected_line in changed
+
+
+@pytest.mark.parametrize(
+    ("setting_id", "value"),
+    [
+        ("made_up", True),
+        ("analytics_enabled", 1),
+        ("analytics_enabled", "true"),
+        ("entity_creation", "always"),
+        ("formality", "royal"),
+        ("directness", "rude"),
+        ("health_telemetry", "pending"),
+        ("integration:new-app.enabled", True),
+        ("integration:../escape.enabled", True),
+    ],
+)
+def test_unknown_settings_and_invalid_values_are_rejected_without_writes(
+    tmp_path: Path,
+    setting_id: str,
+    value: object,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    before = {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()}
+    expected = snapshot.stamps.get(setting_id)
+
+    with pytest.raises(toggles.ToggleValidationError):
+        engine.write(setting_id, value, expected=expected)
+
+    after = {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()}
+    assert after == before
+
+
+def test_concurrent_edit_is_detected_by_sha_even_when_mtime_is_restored(
+    tmp_path: Path,
+) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    engine = toggles.ToggleEngine(vault)
+    snapshot = engine.read_state()
+    profile = vault / "System" / "user-profile.yaml"
+    original_stat = profile.stat()
+    externally_changed = profile.read_text(encoding="utf-8").replace(
+        'name: "Alex Example"',
+        'name: "Other Person"',
+    )
+    profile.write_text(externally_changed, encoding="utf-8")
+    os.utime(
+        profile,
+        ns=(original_stat.st_atime_ns, snapshot.stamps["formality"].mtime_ns),
+    )
+
+    with pytest.raises(toggles.ToggleConflictError, match="refresh"):
+        engine.write(
+            "formality",
+            "formal",
+            expected=snapshot.stamps["formality"],
+        )
+
+    assert profile.read_text(encoding="utf-8") == externally_changed
+    assert not (vault / "System" / ".dex" / "dashboard" / "audit.jsonl").exists()
+
+
+def test_duplicate_or_malformed_anchor_fails_closed(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        _profile().replace(
+            '  directness: "balanced"',
+            '  directness: "balanced"\n  directness: "very_direct"',
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(toggles.ToggleSchemaError, match="exactly once"):
+        toggles.ToggleEngine(vault).read_state()
+
+
+def test_ambiguous_integration_anchor_fails_closed(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+    config = vault / "System" / "integrations" / "config.yaml"
+    config.write_text(
+        _integrations()
+        + """\
+slack:
+  enabled: false
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(toggles.ToggleSchemaError, match="slack"):
+        toggles.ToggleEngine(vault).read_state()
+
+
+def test_atomic_replace_interruption_leaves_original_file_intact(tmp_path: Path) -> None:
+    toggles = _toggles()
+    path = _write(tmp_path / "settings.yaml", "original\n")
+
+    def interrupt() -> None:
+        raise RuntimeError("simulated kill before replace")
+
+    with pytest.raises(RuntimeError, match="simulated kill"):
+        toggles.atomic_replace_bytes(path, b"replacement\n", before_replace=interrupt)
+
+    assert path.read_bytes() == b"original\n"
+    assert list(tmp_path.glob(".settings.yaml.*.tmp")) == []
+
+
+def test_write_requires_a_state_snapshot_first(tmp_path: Path) -> None:
+    toggles = _toggles()
+    vault = _vault(tmp_path)
+
+    with pytest.raises(toggles.ToggleConflictError, match="refresh"):
+        toggles.ToggleEngine(vault).write("formality", "formal", expected=None)

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 344f88c8486d129e982e9c51537b5cd46b8ac2b45c6815857b1658e8559e22fe -->
+<!-- Content SHA-256: 142a87eca6f749b9f40bcb873879ace3eb0169a99ccfcde973e41607ce3c8211 -->
 
 # Architecture Inventory
 
@@ -25,7 +25,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 75<br>
+**Skill count:** 76<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -60,6 +60,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `delegate-check` | `.claude/skills/delegate-check/SKILL.md` | Review open delegations — what you handed off, to whom, its status, and the next useful nudge. Use when the user says 'what did I delegate', 'who owes me', 'check my handoffs', 'follow up with someone'. Not for prepping a meeting; use meeting-prep. | 248 | when |
 | `dex-add-mcp` | `.claude/skills/dex-add-mcp/SKILL.md` | Add a known MCP server to config using Dex-safe user scope. Use when the user has server details in hand and says 'add this MCP', 'register this server'. Not for discovering/installing from a marketplace; use `integrate-mcp`. Not for building one; use `create-mcp`. | 265 | when |
 | `dex-backlog` | `.claude/skills/dex-backlog/SKILL.md` | Show the AI-ranked backlog of Dex system-improvement ideas. Use when the user says 'show my Dex ideas', 'what's in the backlog', 'what should we build next'. Not for workshopping one idea into a plan; use `dex-improve`. Not for discovering existing features; use `dex-level-up`. | 278 | when |
+| `dex-dashboard` | `.claude/skills/dex-dashboard/SKILL.md` | A personal, local page showing how the user is using Dex, what stands out, and one evidence-backed next step. Use when the user says "show my dashboard", "open my Dex dashboard", "how am I using Dex", "what does my Dex look like", or "my Dex stats". Not for system health checks; use `dex-doctor`. Not for a chat list of unused features; use `dex-level-up`. | 357 | when |
 | `dex-doctor` | `.claude/skills/dex-doctor/SKILL.md` | Whole-system checkup: verifies every Dex feature honestly (working/off/broken/couldn't-check), self-heals what's provably safe, guides the rest. Use when the user says 'is Dex healthy', 'something's broken', 'check my setup', 'run diagnostics'. Not for discovering unused *features*; use `dex-level-up`. Not for applying an update; use `dex-update`. | 349 | when |
 | `dex-improve` | `.claude/skills/dex-improve/SKILL.md` | Workshop one improvement idea into an implementation plan. Use when the user says 'let's flesh out idea-X', 'turn this into a plan', 'improve Dex's Y'. Not for ranking the whole backlog; use `dex-backlog`. Not for a PRD for the user's own product; use `product-brief`. | 268 | when |
 | `dex-level-up` | `.claude/skills/dex-level-up/SKILL.md` | Surface Dex features the user isn't using yet, based on their usage patterns. Use when the user says 'what am I missing', 'show me new features', 'level up my Dex'. Not for diagnosing what's broken; use `dex-doctor`. Not for what changed in a release; use `dex-whats-new`. | 272 | when |


### PR DESCRIPTION
## What this is

The Dex Dashboard (`/dex-dashboard`): a private, locally generated page that shows a user their whole Dex — what it holds, what it's doing for them, what to try next — with Dex-authored observations, click-to-change settings, a capability journey map, and compounding history. Spec approved by Dave 2026-07-27 (Build Card `dex-dashboard-the-page-your-dex-writes-about-you`); all four phases in one branch, built as reviewed parallel lanes.

## What's inside

- **Phase 1 — authored page**: `core/dashboard/collect.py` (read-only, secret-redacting, per-section failure isolation, reuses `analytics_helper` + `core.paths`) and `render.py` (one self-contained offline HTML page, counts-only value receipt, escaped everywhere) + history snapshots under `System/.dex/dashboard/`.
- **Phase 2 — live settings**: `server.py` (ephemeral 127.0.0.1 server: OS-assigned port, per-run token with constant-time compare, CSP, idle/close/SIGINT exit, never daemonizes) + `toggles.py` (hardcoded vetted registry; single-anchor YAML line surgery with post-change schema revalidation, key-shape invariant, mtime+sha conflict detection, atomic fsynced replace, fsynced audit log).
- **Phase 3 — journey map**: `journey.py` capability catalog (vault skills + capability-pack rooms, read-only) with used/unused/pack-disabled territory chips.
- **Phase 4 — history + rituals**: `history.py` (tolerant snapshot loading, weekly trend deltas, threshold milestones, stdlib SVG sparklines) + one light dashboard touchpoint each in week-review, getting-started, dex-whats-new.
- **Skill**: `.claude/skills/dex-dashboard/` — hard evidence bar for observations (must cite a number/file/event; invented metrics forbidden; absolute dates; truthful degradation). Passes skill-score hard gates.

## Verified

- 80 dashboard tests + real-socket smoke test, all green
- Full suite (outside sandbox): **2,466 passed**, 1 unrelated timing-sensitive flake (`test_create_task_succeeds_over_production_stdio`, passes in isolation; it's the xdist serial_sensitive one)
- All blocking gates green locally: portable contract, path contract, inventory drift, instructed tools, ruff, PII, founder content, node hooks/integrations
- **Tested against a copy of Dave's real 603-day vault**: zero collector section errors, real secret verifiably absent from output, live toggle+undo round-trip on real files with audit entries. That test caught and fixed a real bug (missing profile keys killed the whole settings panel — now scoped per setting).

## Notes for the release session

- CHANGELOG entry added as 1.77.0 (package.json untouched — versioning belongs to the release cut).
- Follow-up improvement plan (journey-map categories/collapse, usage-detection mapping) is with Dave for review; items 1–2 there are recommended before wide release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sqMUvm4eYALmi7PCo9yL9