### PR TITLE
fix: old installs can find updates again, and Doctor stops reporting fixed errors as current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.77.1] — 🩺 Dex stops crying wolf, and older setups can find their updates again (2026-07-27)
+
+Both of these came from one user's bug report, and both only affect people who've been using Dex for a while — which is exactly why neither had been spotted.
+
+**What this fixes for you:**
+
+* **Old problems stop being reported as though they're happening right now.** Dex keeps a log of things that have gone wrong. Nothing ever cleared it, so a checkup could tell you your setup was broken because of something that failed weeks ago and was fixed long since. Problems now fade into history after 30 days — and anything that went wrong on a version of Dex you've already moved past is treated as history immediately. When Dex does report a problem, it now tells you the date it happened, so you can see at a glance whether it's news.
+* **Dex admits when it couldn't look, instead of reporting all clear.** If that log couldn't be read at all, the checkup used to come back clean. It now says plainly that it couldn't check — a checkup that can't see something should say so, not reassure you.
+* **Setups on an older version can find updates again.** If you were on an older version of Dex, the update check could get permanently stuck: no version, no explanation, nothing useful, every single time. It was looking for a small file that older versions never had. Dex now recognises an older setup for what it is and gets on with the check.
+* **The update message is finally readable.** It used to open with a warning that Dex "has not authenticated its publisher", followed by two forty-character codes. It now simply tells you a newer version is available, links you to the release notes, and says to run `/dex-update` when you're ready. The technical detail is still there in `/dex-doctor` for anyone who wants it. Dex still never updates itself without you.
+
+**Why this slipped past me:** every test I had imagined someone who'd installed Dex that morning — current, with no history behind them. Both of these problems only bite people with months of real use. Dex is now tested against genuinely old versions, and against a clock wound forward, so this kind of thing gets caught before you ever see it.
+
 ## [1.76.1] — 🔧 A quiet strengthening under the hood (2026-07-27)
 
 Nothing changes in what you see or do. This is internal hardening of the customisation-rebuild feature that shipped in 1.76.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,11 +146,13 @@ The SessionStart hook performs one bounded daily fetch-only evidence attempt aga
 repository. It uses an isolated bare cache and never pulls, merges, resets, stages, installs, changes HEAD, or updates
 automatically.
 
-Only the `release-appears-available-unverified` state creates a notice. Preserve the hook's complete notice verbatim;
-it contains this required caution plus exact version, immutable tag, full commit, selected evidence profile, canonical
-release page, and `/dex-doctor` guidance:
+Only the `release-appears-available-unverified` state creates a notice. Preserve the hook's complete three-line notice
+verbatim; it plainly states that a newer version is available, gives its canonical release page, and points to
+`/dex-update`:
 
-> A newer Dex release appears to exist, but Dex has not authenticated its publisher. Review the exact release/tag before choosing to update.
+> A newer version of Dex is available: v[version]
+> Release notes: https://github.com/davekilleen/Dex/releases/tag/[tag]
+> Run /dex-update when you're ready — Dex never updates itself without you.
 
 Other states are silent during normal conversation:
 - `no-newer-release-observed-unverified` means only that the bounded evidence check observed no higher release. It is
@@ -159,9 +161,9 @@ Other states are silent during normal conversation:
 - `UNKNOWN` means evidence was missing, malformed, contradictory, unsupported, or unverifiable.
 - `skipped` means daily-attempt or exact-release notice dedup applied.
 
-Never shorten the notice to “update available,” and never describe release awareness as authenticated, verified,
-safe, current, or up to date. The notice appears at most once per exact release identity unless `/dex-doctor`
-explicitly requests redisplay. Uncertain evidence never clears an earlier exact notice.
+Never describe release awareness as authenticated, verified, safe, current, or up to date. The notice appears at most
+once per exact release identity unless `/dex-doctor` explicitly requests redisplay. Uncertain evidence never clears
+an earlier exact notice.
 
 If Doctor reports a pending customization migration, continue through the registered
 Customization Migration MCP status tool / `/dex-update`. Do not search for or edit capsule files directly.

--- a/core/tests/test_error_queue_lifecycle.py
+++ b/core/tests/test_error_queue_lifecycle.py
@@ -1,0 +1,283 @@
+"""Regression coverage for the error queue's useful lifetime."""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import inspect
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core.utils import dex_logger, doctor
+
+NOW = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+CURRENT_VERSION = "1.76.1"
+
+
+@pytest.fixture
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    (vault_root / "package.json").write_text(
+        json.dumps({"name": "dex-pkm", "version": CURRENT_VERSION})
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    return vault_root
+
+
+def _context(vault: Path, now: datetime) -> doctor.DoctorContext:
+    return doctor.DoctorContext(
+        vault_root=vault,
+        repo_root=vault,
+        home=vault.parent / "home",
+        now=now,
+    )
+
+
+def _healthy_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor.preflight, "run_preflight", lambda: {"servers": {}})
+
+
+def _queue(vault: Path) -> list[dict[str, object]]:
+    return json.loads((vault / ".logs" / "error-queue.json").read_text())
+
+
+def _called_logger_functions() -> set[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    logger_path = Path(dex_logger.__file__).resolve()
+    called: set[str] = set()
+    for path in (repo_root / "core").rglob("*.py"):
+        if path.resolve() == logger_path or "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text())
+        module_aliases: set[str] = set()
+        direct_aliases: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "core.utils.dex_logger" and alias.asname:
+                        module_aliases.add(alias.asname)
+            elif isinstance(node, ast.ImportFrom) and node.module == "core.utils":
+                for alias in node.names:
+                    if alias.name == "dex_logger":
+                        module_aliases.add(alias.asname or alias.name)
+            elif (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "core.utils.dex_logger"
+            ):
+                direct_aliases.update(
+                    {alias.asname or alias.name: alias.name for alias in node.names}
+                )
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in module_aliases
+            ):
+                called.add(node.func.attr)
+            elif isinstance(node.func, ast.Name) and node.func.id in direct_aliases:
+                called.add(direct_aliases[node.func.id])
+    return called
+
+
+def test_new_errors_and_warnings_are_stamped_with_the_installed_version(vault: Path) -> None:
+    dex_logger.log_error("work-mcp", "task failed")
+    dex_logger.log_warning("calendar-mcp", "calendar delayed")
+
+    assert [entry["dexVersion"] for entry in _queue(vault)] == [
+        CURRENT_VERSION,
+        CURRENT_VERSION,
+    ]
+
+
+def test_logging_omits_version_without_raising_when_package_cannot_be_read(vault: Path) -> None:
+    (vault / "package.json").write_text("not json")
+
+    dex_logger.log_error("work-mcp", "task failed")
+    dex_logger.log_warning("calendar-mcp", "calendar delayed")
+
+    assert all("dexVersion" not in entry for entry in _queue(vault))
+
+
+def test_error_retention_policy_is_thirty_days() -> None:
+    assert dex_logger.STALE_ERROR_DAYS == 30
+
+
+def test_write_prunes_stale_entries_keeps_unknown_dates_and_caps_at_fifty(vault: Path) -> None:
+    recent = [
+        {
+            "id": f"recent-{index}",
+            "timestamp": (NOW - timedelta(minutes=index)).isoformat(),
+        }
+        for index in range(51)
+    ]
+    stale = {
+        "id": "stale",
+        "timestamp": (
+            NOW - timedelta(days=dex_logger.STALE_ERROR_DAYS + 1)
+        ).isoformat(),
+    }
+    unknown = {"id": "unknown", "timestamp": "not-a-date"}
+
+    dex_logger._write_queue([stale, *recent, unknown], now=NOW)
+
+    saved = _queue(vault)
+    assert len(saved) == 50
+    assert all(entry["id"] != "stale" for entry in saved)
+    assert any(entry["id"] == "unknown" for entry in saved)
+
+
+def test_error_ages_into_history_and_no_longer_breaks_doctor(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    logged_at = datetime.now(timezone.utc)
+    dex_logger.log_error("work-mcp", "old failure", human_message="An earlier task failed")
+
+    result = doctor._probe_preflight_queue(
+        _context(vault, logged_at + timedelta(days=dex_logger.STALE_ERROR_DAYS + 1))
+    )
+
+    assert result.verdict == "OK"
+    assert "1 earlier error" in result.detail
+    assert logged_at.date().isoformat() in result.detail
+
+
+def test_error_from_an_older_dex_version_is_history_not_current_breakage(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    (vault / "package.json").write_text(
+        json.dumps({"name": "dex-pkm", "version": "1.75.2"})
+    )
+    dex_logger.log_error("work-mcp", "old version failure", human_message="An old task failed")
+    old_error_date = _queue(vault)[0]["timestamp"][:10]
+    (vault / "package.json").write_text(
+        json.dumps({"name": "dex-pkm", "version": CURRENT_VERSION})
+    )
+
+    result = doctor._probe_preflight_queue(_context(vault, datetime.now(timezone.utc)))
+
+    assert result.verdict == "OK"
+    assert "1 earlier error from a previous Dex version" in result.detail
+    assert old_error_date in result.detail
+
+
+def test_fresh_current_version_error_is_broken_and_includes_its_date(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    dex_logger.log_error(
+        "work-mcp",
+        "current failure",
+        human_message="Task Manager cannot start",
+    )
+    error_date = _queue(vault)[0]["timestamp"][:10]
+
+    result = doctor._probe_preflight_queue(_context(vault, datetime.now(timezone.utc)))
+
+    assert result.verdict == "BROKEN"
+    assert f"Task Manager cannot start (on {error_date})" in result.detail
+
+
+def test_current_version_error_newer_than_retention_threshold_is_current_breakage(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    dex_logger.log_error(
+        "work-mcp",
+        "recent failure",
+        human_message="Task Manager cannot start",
+    )
+    logged_at = datetime.now(timezone.utc)
+
+    result = doctor._probe_preflight_queue(
+        _context(
+            vault,
+            logged_at + timedelta(days=dex_logger.STALE_ERROR_DAYS - 1),
+        )
+    )
+
+    assert result.verdict == "BROKEN"
+    assert "Task Manager cannot start" in result.detail
+
+
+@pytest.mark.parametrize(
+    "queue_contents",
+    ["not json", json.dumps({"unexpected": "object"})],
+    ids=["corrupt-json", "not-a-list"],
+)
+def test_corrupt_or_non_list_error_queue_is_unknown(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    queue_contents: str,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    queue_path = vault / ".logs" / "error-queue.json"
+    queue_path.parent.mkdir()
+    queue_path.write_text(queue_contents)
+
+    result = doctor._probe_preflight_queue(_context(vault, NOW))
+
+    assert result.verdict == "UNKNOWN"
+    assert "error log could not be read" in result.detail.lower()
+    assert "not checked" in result.detail.lower()
+
+
+def test_unreadable_error_queue_is_unknown(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    queue_path = vault / ".logs" / "error-queue.json"
+    queue_path.parent.mkdir()
+    queue_path.write_text("[]")
+    real_open = builtins.open
+
+    def deny_queue_read(path: object, *args: object, **kwargs: object):
+        if Path(path) == queue_path:
+            raise PermissionError("queue is unreadable")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", deny_queue_read)
+
+    result = doctor._probe_preflight_queue(_context(vault, NOW))
+
+    assert result.verdict == "UNKNOWN"
+    assert "error log could not be read" in result.detail.lower()
+    assert "not checked" in result.detail.lower()
+
+
+def test_missing_error_queue_is_ok(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _healthy_preflight(monkeypatch)
+    assert not (vault / ".logs" / "error-queue.json").exists()
+
+    result = doctor._probe_preflight_queue(_context(vault, NOW))
+
+    assert result.verdict == "OK"
+    assert "no server or current queued errors" in result.detail.lower()
+
+
+def test_every_public_error_queue_accessor_is_wired_outside_logger() -> None:
+    public_functions = {
+        name
+        for name, value in inspect.getmembers(dex_logger, inspect.isfunction)
+        if value.__module__ == dex_logger.__name__ and not name.startswith("_")
+    }
+    queue_accessors = public_functions - {"log_error", "log_warning", "mark_healthy"}
+
+    assert queue_accessors
+    assert queue_accessors <= _called_logger_functions()

--- a/core/tests/test_update_checker.py
+++ b/core/tests/test_update_checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 import socket
 import subprocess
@@ -34,12 +35,9 @@ from core.utils.update_verifier import (
     parse_profile,
 )
 
-APPROVED_NOTICE_CAUTION = (
-    "A newer Dex release appears to exist, but Dex has not authenticated its publisher. "
-    "Review the exact release/tag before choosing to update."
-)
+APPROVED_NOTICE_AVAILABLE = "A newer version of Dex is available:"
 APPROVED_NOTICE_GUIDANCE = (
-    "Run /dex-doctor to review this evidence and update guidance. Dex will not update automatically."
+    "Run /dex-update when you're ready — Dex never updates itself without you."
 )
 
 
@@ -197,7 +195,9 @@ def _verifier(vault: Path, remote: Path, state: Path, **kwargs) -> UpdateVerifie
     )
 
 
-def test_legacy_release_notice_has_exact_caution_identity_and_no_positive_trust_claims(tmp_path: Path) -> None:
+def test_legacy_release_notice_is_readable_and_keeps_technical_evidence_out_of_user_copy(
+    tmp_path: Path,
+) -> None:
     vault = _installed_vault(tmp_path / "vault")
     remote = tmp_path / "remote"
     _init_repo(remote)
@@ -222,24 +222,31 @@ def test_legacy_release_notice_has_exact_caution_identity_and_no_positive_trust_
         "release_page": f"https://github.com/davekilleen/Dex/releases/tag/{tag}",
         "notice": "\n".join(
             (
-                APPROVED_NOTICE_CAUTION,
-                "Target version: v1.62.0",
-                f"Immutable tag: {tag}",
-                f"Immutable tag object: {tag_object}",
-                f"Full commit: {commit}",
-                "Evidence profile: legacy-v1",
-                f"Release page: https://github.com/davekilleen/Dex/releases/tag/{tag}",
+                f"{APPROVED_NOTICE_AVAILABLE} v1.62.0",
+                f"Release notes: https://github.com/davekilleen/Dex/releases/tag/{tag}",
                 APPROVED_NOTICE_GUIDANCE,
             )
         ),
         "publisher_authentication": "unavailable",
     }
     notice_lower = result["notice"].lower()
-    assert "update available" not in notice_lower
-    assert "safe" not in notice_lower
-    assert "current" not in notice_lower
-    assert "up to date" not in notice_lower
-    assert "verified" not in notice_lower
+    assert re.search(r"\b[0-9a-f]{40}\b", result["notice"]) is None
+    for banned in (
+        "appears to exist",
+        "has not authenticated its publisher",
+        "unverified",
+        "evidence",
+        "immutable tag",
+        "tag object",
+        "profile",
+        "full commit",
+        "authenticated",
+        "verified",
+        "safe",
+        "current",
+        "up to date",
+    ):
+        assert banned not in notice_lower
     assert all(Path(command[0]).is_absolute() for command in commands)
     assert sum("for-each-ref" in command for command in commands) == 1
     joined_commands = "\n".join(" ".join(command) for command in commands)
@@ -536,7 +543,10 @@ def test_equal_or_lower_release_yields_no_newer_observed_without_currentness_cla
     assert result["status"] == STATUS_NONE
     assert result["should_notify"] is False
     assert "not a currentness claim" in result["message"]
-    assert "up to date" not in result["message"].lower()
+    message_lower = result["message"].lower()
+    assert "up to date" not in message_lower
+    assert "verified" not in message_lower
+    assert "authenticated" not in message_lower
 
 
 def test_daily_attempt_exact_release_dedup_and_doctor_redisplay(tmp_path: Path) -> None:
@@ -554,7 +564,7 @@ def test_daily_attempt_exact_release_dedup_and_doctor_redisplay(tmp_path: Path) 
     assert exact["skip_reason"] == "exact-release-notice"
     redisplay = verifier.check(doctor_redisplay=True)
     assert redisplay["status"] == STATUS_RELEASE
-    assert redisplay["notice"].startswith(APPROVED_NOTICE_CAUTION)
+    assert redisplay["notice"].startswith(f"{APPROVED_NOTICE_AVAILABLE} v1.62.0\n")
 
 
 def test_legacy_notice_is_migrated_to_exact_release_suppression_without_mutating_it(tmp_path: Path) -> None:

--- a/core/tests/test_update_checker_real_installs.py
+++ b/core/tests/test_update_checker_real_installs.py
@@ -1,0 +1,159 @@
+"""Release-awareness checks against vaults archived from real shipped tags."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from core.utils.update_verifier import (
+    MAX_PROFILE_BYTES,
+    PROFILE_PATH,
+    STATUS_NONE,
+    STATUS_RELEASE,
+    EvidenceError,
+    UpdateVerifier,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CURRENT_VERSION = json.loads((REPO_ROOT / "package.json").read_text())["version"]
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=check,
+        capture_output=True,
+    )
+
+
+def _require_tag(tag: str) -> None:
+    result = _git("rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False)
+    if result.returncode != 0:
+        pytest.skip(f"required shipped git tag {tag} is unavailable")
+
+
+def _archive_tag(tag: str, destination: Path) -> Path:
+    _require_tag(tag)
+    archive = _git("archive", "--format=tar", tag).stdout
+    destination.mkdir()
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as release:
+        release.extractall(destination, filter="data")
+    return destination
+
+
+def _real_distribution_remote(tmp_path: Path, version: str) -> Path:
+    pattern = f"dist/release/v{version}-*"
+    tags = _git("tag", "--list", pattern).stdout.decode().splitlines()
+    if not tags:
+        pytest.skip(f"required shipped distribution tag matching {pattern} is unavailable")
+
+    tag = sorted(tags)[0]
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", "--quiet", str(remote)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(remote),
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            str(REPO_ROOT),
+            f"+refs/tags/{tag}:refs/tags/{tag}",
+        ],
+        check=True,
+    )
+    return remote
+
+
+def _verifier(vault: Path, remote: Path, state: Path) -> UpdateVerifier:
+    return UpdateVerifier(
+        vault,
+        state_root=state,
+        remote_url=str(remote),
+        allow_test_transport=True,
+        now=lambda: datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc),
+        wall_clock_seconds=3600.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("installed_version", "expected_status", "expected_notification"),
+    [
+        ("1.61.0", STATUS_RELEASE, True),
+        ("1.62.0", STATUS_RELEASE, True),
+        (CURRENT_VERSION, STATUS_NONE, False),
+    ],
+)
+def test_real_shipped_install_can_complete_release_awareness(
+    tmp_path: Path,
+    installed_version: str,
+    expected_status: str,
+    expected_notification: bool,
+) -> None:
+    vault = _archive_tag(f"v{installed_version}", tmp_path / "vault")
+    remote = _real_distribution_remote(tmp_path, CURRENT_VERSION)
+
+    result = _verifier(vault, remote, tmp_path / "state").check()
+
+    assert result["status"] == expected_status
+    assert result["should_notify"] is expected_notification
+    assert result.get("reason") != "evidence-invalid"
+    assert result["current_version"] == installed_version
+
+
+def test_real_pre_profile_install_is_absent_not_damaged(tmp_path: Path) -> None:
+    vault = _archive_tag("v1.61.0", tmp_path / "vault")
+    remote = _real_distribution_remote(tmp_path, CURRENT_VERSION)
+
+    assert not (vault / PROFILE_PATH).exists()
+    assert _verifier(vault, remote, tmp_path / "state")._current_version() == "1.61.0"
+
+
+def test_modern_install_still_requires_its_shipped_profile(tmp_path: Path) -> None:
+    vault = _archive_tag("v1.62.0", tmp_path / "vault")
+    (vault / PROFILE_PATH).unlink()
+    remote = _real_distribution_remote(tmp_path, CURRENT_VERSION)
+
+    with pytest.raises(EvidenceError):
+        _verifier(vault, remote, tmp_path / "state")._current_version()
+
+
+@pytest.mark.parametrize(
+    "profile_kind",
+    ["directory", "oversized", "symlink", "unreadable"],
+)
+def test_pre_profile_non_regular_or_unreadable_profile_is_not_treated_as_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile_kind: str,
+) -> None:
+    vault = _archive_tag("v1.61.0", tmp_path / "vault")
+    profile = vault / PROFILE_PATH
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    if profile_kind == "directory":
+        profile.mkdir()
+    elif profile_kind == "oversized":
+        profile.write_bytes(b"x" * (MAX_PROFILE_BYTES + 1))
+    elif profile_kind == "symlink":
+        profile.symlink_to(vault / "missing-profile.json")
+    else:
+        profile.write_text("{}")
+        original_read_bytes = Path.read_bytes
+
+        def unreadable(path: Path) -> bytes:
+            if path == profile:
+                raise PermissionError("profile cannot be read")
+            return original_read_bytes(path)
+
+        monkeypatch.setattr(Path, "read_bytes", unreadable)
+    remote = _real_distribution_remote(tmp_path, CURRENT_VERSION)
+
+    with pytest.raises(EvidenceError):
+        _verifier(vault, remote, tmp_path / "state")._current_version()

--- a/core/utils/dex_logger.py
+++ b/core/utils/dex_logger.py
@@ -17,10 +17,16 @@ Usage:
 import fcntl
 import json
 import os
+import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+STALE_ERROR_DAYS = 30
+MAX_ERROR_ENTRIES = 50
+_SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -50,6 +56,21 @@ def _get_queue_path() -> Path:
 
 def _get_health_path() -> Path:
     return _get_logs_dir() / "mcp-health.json"
+
+
+def _installed_dex_version() -> Optional[str]:
+    """Read the installed version without ever disrupting error reporting."""
+    try:
+        package_path = Path(_get_vault_path()) / "package.json"
+        if package_path.is_symlink() or not package_path.is_file():
+            return None
+        package = json.loads(package_path.read_text())
+        version = package.get("version") if isinstance(package, dict) else None
+        if not isinstance(version, str) or _SEMVER_RE.fullmatch(version) is None:
+            return None
+        return version
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -83,30 +104,77 @@ def _generate_human_message(source: str, message: str) -> str:
 # Queue I/O (with file locking for concurrent MCP servers)
 # ---------------------------------------------------------------------------
 
-def _read_queue() -> list:
-    """Read error queue with file locking."""
-    queue_path = _get_queue_path()
-    if not queue_path.exists():
-        return []
+def _read_queue_with_status() -> tuple[str, list]:
+    """Read the queue without throwing and preserve whether it was readable."""
     try:
+        queue_path = _get_queue_path()
+        if not queue_path.exists():
+            return "missing", []
         with open(queue_path, "r") as f:
             fcntl.flock(f, fcntl.LOCK_SH)
             try:
-                return json.load(f)
+                entries = json.load(f)
+                if not isinstance(entries, list):
+                    return "unreadable", []
+                return "readable", entries
             finally:
                 fcntl.flock(f, fcntl.LOCK_UN)
-    except (json.JSONDecodeError, IOError):
-        return []
+    except Exception:
+        return "unreadable", []
 
 
-def _write_queue(entries: list) -> None:
+def _read_queue() -> list:
+    """Read error queue with file locking."""
+    _status, entries = _read_queue_with_status()
+    return entries
+
+
+def _normalized_now(now: Optional[datetime] = None) -> datetime:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _entry_timestamp(entry: object) -> Optional[datetime]:
+    if not isinstance(entry, dict):
+        return None
+    timestamp = entry.get("timestamp")
+    if not isinstance(timestamp, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_stale(entry: object, *, now: datetime) -> bool:
+    timestamp = _entry_timestamp(entry)
+    if timestamp is None:
+        return False
+    return timestamp < now - timedelta(days=STALE_ERROR_DAYS)
+
+
+def _prune_queue(entries: list, *, now: Optional[datetime] = None) -> list:
+    """Apply the queue's age policy and size bound in one place."""
+    reference_time = _normalized_now(now)
+    recent_or_unknown = [
+        entry for entry in entries if not _is_stale(entry, now=reference_time)
+    ]
+    return recent_or_unknown[-MAX_ERROR_ENTRIES:]
+
+
+def _write_queue(entries: list, *, now: Optional[datetime] = None) -> None:
     """Write error queue with file locking."""
     queue_path = _get_queue_path()
     queue_path.parent.mkdir(exist_ok=True)
     with open(queue_path, "w") as f:
         fcntl.flock(f, fcntl.LOCK_EX)
         try:
-            json.dump(entries[-50:], f, indent=2)  # Cap at 50 entries
+            json.dump(_prune_queue(entries, now=now), f, indent=2)
         finally:
             fcntl.flock(f, fcntl.LOCK_UN)
 
@@ -132,10 +200,12 @@ def log_error(
     """
     try:
         queue = _read_queue()
-        now = datetime.utcnow().isoformat() + "Z"
+        now = datetime.now(timezone.utc)
+        timestamp = now.isoformat().replace("+00:00", "Z")
+        dex_version = _installed_dex_version()
 
         # Dedup: if same source+message within last 5 minutes, increment count
-        dedup_cutoff = time.time() - 300  # 5 minutes
+        dedup_cutoff = now.timestamp() - 300  # 5 minutes
         for entry in reversed(queue):
             if (
                 entry.get("source") == source
@@ -148,8 +218,10 @@ def log_error(
                     ).timestamp()
                     if entry_time > dedup_cutoff:
                         entry["count"] = entry.get("count", 1) + 1
-                        entry["timestamp"] = now
-                        _write_queue(queue)
+                        entry["timestamp"] = timestamp
+                        if dex_version is not None:
+                            entry["dexVersion"] = dex_version
+                        _write_queue(queue, now=now)
                         return
                 except (ValueError, KeyError):
                     pass
@@ -161,15 +233,17 @@ def log_error(
             "severity": "error",
             "message": message,
             "humanMessage": human_message or _generate_human_message(source, message),
-            "timestamp": now,
+            "timestamp": timestamp,
             "acknowledged": False,
             "count": 1,
         }
+        if dex_version is not None:
+            entry["dexVersion"] = dex_version
         if context:
             entry["context"] = context
 
         queue.append(entry)
-        _write_queue(queue)
+        _write_queue(queue, now=now)
     except Exception:
         pass  # Never throw from error logging code
 
@@ -182,7 +256,9 @@ def log_warning(
     """Log a warning (less severe than error, same queue)."""
     try:
         queue = _read_queue()
-        now = datetime.utcnow().isoformat() + "Z"
+        now = datetime.now(timezone.utc)
+        timestamp = now.isoformat().replace("+00:00", "Z")
+        dex_version = _installed_dex_version()
 
         entry = {
             "id": f"wrn-{int(time.time())}-{os.urandom(2).hex()}",
@@ -190,13 +266,15 @@ def log_warning(
             "severity": "warning",
             "message": message,
             "humanMessage": human_message or _generate_human_message(source, message),
-            "timestamp": now,
+            "timestamp": timestamp,
             "acknowledged": False,
             "count": 1,
         }
+        if dex_version is not None:
+            entry["dexVersion"] = dex_version
 
         queue.append(entry)
-        _write_queue(queue)
+        _write_queue(queue, now=now)
     except Exception:
         pass
 
@@ -204,6 +282,7 @@ def log_warning(
 def mark_healthy(source: str) -> None:
     """Record that an MCP server started successfully."""
     try:
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         health_path = _get_health_path()
         health = {}
         if health_path.exists():
@@ -217,39 +296,57 @@ def mark_healthy(source: str) -> None:
 
         health["servers"][source] = {
             "status": "ok",
-            "checkedAt": datetime.utcnow().isoformat() + "Z",
+            "checkedAt": now,
         }
-        health["lastCheck"] = datetime.utcnow().isoformat() + "Z"
+        health["lastCheck"] = now
 
         health_path.write_text(json.dumps(health, indent=2))
     except Exception:
         pass
 
 
-def acknowledge_errors(ids: Optional[list] = None) -> int:
-    """
-    Mark errors as acknowledged. Returns count of acknowledged errors.
-    If ids is None, acknowledges all.
-    """
+def get_error_queue_status() -> str:
+    """Return missing, readable, or unreadable without disrupting callers."""
+    status, _entries = _read_queue_with_status()
+    return status
+
+
+def _partition_unacknowledged_errors(
+    *, now: Optional[datetime] = None
+) -> tuple[list, list]:
+    reference_time = _normalized_now(now)
+    current_version = _installed_dex_version()
+    current = []
+    historical = []
+    for entry in _read_queue():
+        if not isinstance(entry, dict) or entry.get("acknowledged", False):
+            continue
+        entry_version = entry.get("dexVersion")
+        from_other_version = (
+            current_version is not None
+            and isinstance(entry_version, str)
+            and entry_version != current_version
+        )
+        if _is_stale(entry, now=reference_time) or from_other_version:
+            historical.append(entry)
+        else:
+            current.append(entry)
+    return current, historical
+
+
+def get_unacknowledged_errors(*, now: Optional[datetime] = None) -> list:
+    """Get recent unacknowledged errors from this Dex version."""
     try:
-        queue = _read_queue()
-        count = 0
-        for entry in queue:
-            if entry.get("acknowledged"):
-                continue
-            if ids is None or entry.get("id") in ids:
-                entry["acknowledged"] = True
-                count += 1
-        _write_queue(queue)
-        return count
+        current, _historical = _partition_unacknowledged_errors(now=now)
+        return current
     except Exception:
-        return 0
+        return []
 
 
-def get_unacknowledged_errors() -> list:
-    """Get all unacknowledged errors for session start display."""
+def get_historical_errors(*, now: Optional[datetime] = None) -> list:
+    """Get unacknowledged errors that are stale or from an older Dex version."""
     try:
-        queue = _read_queue()
-        return [e for e in queue if not e.get("acknowledged", False)]
+        _current, historical = _partition_unacknowledged_errors(now=now)
+        return historical
     except Exception:
         return []

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -36,7 +36,7 @@ from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
 from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry
 from core.transaction.journal import Journal, JournalCorruptError
-from core.utils import preflight, release_channel
+from core.utils import dex_logger, preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_SAFE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
@@ -2432,15 +2432,92 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
 def _preflight_snapshot(context: DoctorContext) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     with _vault_environment(context):
         health = preflight.run_preflight()
-        queue_path = preflight.get_error_queue_path()
-        queued = json.loads(queue_path.read_text()) if queue_path.exists() else []
-    if not isinstance(queued, list):
-        raise ValueError("the preflight error queue must contain a list")
+        queued = dex_logger.get_unacknowledged_errors(now=context.now)
     return health, queued
+
+
+def _historical_preflight_errors(context: DoctorContext) -> list[dict[str, Any]]:
+    with _vault_environment(context):
+        return dex_logger.get_historical_errors(now=context.now)
+
+
+def _preflight_error_queue_status(context: DoctorContext) -> str:
+    with _vault_environment(context):
+        return dex_logger.get_error_queue_status()
+
+
+def _queued_error_date(entry: dict[str, Any]) -> str:
+    timestamp = entry.get("timestamp")
+    if isinstance(timestamp, str):
+        try:
+            return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).date().isoformat()
+        except ValueError:
+            pass
+    return "date unavailable"
+
+
+def _historical_error_summary(
+    context: DoctorContext,
+    entries: list[dict[str, Any]],
+) -> str | None:
+    if not entries:
+        return None
+
+    current_version = None
+    try:
+        package = json.loads((context.vault_root / "package.json").read_text())
+        if isinstance(package, dict) and isinstance(package.get("version"), str):
+            current_version = package["version"]
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    previous_version_count = sum(
+        isinstance(entry.get("dexVersion"), str)
+        and current_version is not None
+        and entry["dexVersion"] != current_version
+        for entry in entries
+    )
+    count = len(entries)
+    subject = "1 earlier error" if count == 1 else f"{count} earlier errors"
+    if previous_version_count == count:
+        reason = (
+            " from a previous Dex version"
+            if count == 1
+            else " from previous Dex versions"
+        )
+    elif previous_version_count:
+        reason = (
+            " from previous Dex versions or more than "
+            f"{dex_logger.STALE_ERROR_DAYS} days ago"
+        )
+    else:
+        reason = (
+            " that is old enough to count as history"
+            if count == 1
+            else " that are old enough to count as history"
+        )
+
+    dated = [
+        _queued_error_date(entry)
+        for entry in entries
+        if _queued_error_date(entry) != "date unavailable"
+    ]
+    if dated:
+        return f"{subject}{reason}, last on {max(dated)}"
+    return f"{subject}{reason}, dates unavailable"
 
 
 def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
     health, queued = _preflight_snapshot(context)
+    if _preflight_error_queue_status(context) == "unreadable":
+        return ProbeResult(
+            "UNKNOWN",
+            "The error log could not be read, so queued errors were not checked",
+        )
+    historical_summary = _historical_error_summary(
+        context,
+        _historical_preflight_errors(context),
+    )
     server_errors = []
     core_server_names = set(preflight.SERVER_MODULES)
     try:
@@ -2454,22 +2531,32 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
         elif result.get("status") == "unknown" and name in core_server_names:
             unknown_core_servers.append(name)
     queued_errors = [
-        error.get("humanMessage") or error.get("message") or "queued background error"
+        (
+            f"{error.get('humanMessage') or error.get('message') or 'queued background error'} "
+            f"(on {_queued_error_date(error)})"
+        )
         for error in queued
-        if not error.get("acknowledged", False)
     ]
     problems = [*server_errors, *queued_errors]
     if problems:
         detail = f"Preflight reported: {'; '.join(str(problem) for problem in problems)}"
+        if historical_summary:
+            detail += f"; {historical_summary}"
         if unknown_core_servers:
             detail += f"; preflight did not check: {', '.join(sorted(unknown_core_servers))}"
         return ProbeResult("BROKEN", detail)
     if unknown_core_servers:
+        detail = f"Preflight did not check registered core servers: {', '.join(sorted(unknown_core_servers))}"
+        if historical_summary:
+            detail += f"; {historical_summary}"
         return ProbeResult(
             "UNKNOWN",
-            f"Preflight did not check registered core servers: {', '.join(sorted(unknown_core_servers))}",
+            detail,
         )
-    return ProbeResult("OK", "Preflight completed with no server or queued errors")
+    detail = "Preflight completed with no server or current queued errors"
+    if historical_summary:
+        detail += f"; {historical_summary}"
+    return ProbeResult("OK", detail)
 
 
 def _display_vault_path(context: DoctorContext, path: Path) -> str:

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -28,11 +28,8 @@ CANONICAL_RELEASE_PAGE = "https://github.com/davekilleen/Dex/releases/tag/{tag}"
 PROFILE_PATH = "System/.release-evidence-profile.json"
 MANIFEST_PATH = "System/.installed-files.manifest"
 CATALOG_PATH = "System/.release-catalog.json"
-NOTICE_CAUTION = (
-    "A newer Dex release appears to exist, but Dex has not authenticated its publisher. "
-    "Review the exact release/tag before choosing to update."
-)
-NOTICE_GUIDANCE = "Run /dex-doctor to review this evidence and update guidance. Dex will not update automatically."
+NOTICE_AVAILABLE = "A newer version of Dex is available:"
+NOTICE_GUIDANCE = "Run /dex-update when you're ready — Dex never updates itself without you."
 
 STATUS_RELEASE = "release-appears-available-unverified"
 STATUS_NONE = "no-newer-release-observed-unverified"
@@ -129,6 +126,10 @@ class SemVer:
 
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}"
+
+
+# The installed release evidence profile first shipped in Dex v1.62.0.
+FIRST_PROFILE_VERSION = SemVer.parse("1.62.0")
 
 
 @dataclass(frozen=True)
@@ -663,9 +664,18 @@ class UpdateVerifier:
         except (UnicodeError, json.JSONDecodeError, EvidenceError) as error:
             raise EvidenceError("installed package version is unreadable") from error
         version = package.get("version") if isinstance(package, dict) else None
-        SemVer.parse(version)
+        installed_version = SemVer.parse(version)
+        profile_path = self.vault_root / PROFILE_PATH
+        try:
+            profile_path.lstat()
+        except FileNotFoundError:
+            if installed_version < FIRST_PROFILE_VERSION:
+                return version
+            raise EvidenceError("installed release evidence profile is not a regular file")
+        except OSError as error:
+            raise EvidenceError("installed release evidence profile is unreadable") from error
         profile_raw = self._bounded_regular_file(
-            self.vault_root / PROFILE_PATH,
+            profile_path,
             max_bytes=MAX_PROFILE_BYTES,
             description="installed release evidence profile",
         )
@@ -966,13 +976,8 @@ class UpdateVerifier:
     def _notice(self, candidate: CandidateEvidence) -> str:
         return "\n".join(
             (
-                NOTICE_CAUTION,
-                f"Target version: v{candidate.version}",
-                f"Immutable tag: {candidate.tag}",
-                f"Immutable tag object: {candidate.tag_object}",
-                f"Full commit: {candidate.commit}",
-                f"Evidence profile: {candidate.profile}",
-                f"Release page: {CANONICAL_RELEASE_PAGE.format(tag=candidate.tag)}",
+                f"{NOTICE_AVAILABLE} v{candidate.version}",
+                f"Release notes: {CANONICAL_RELEASE_PAGE.format(tag=candidate.tag)}",
                 NOTICE_GUIDANCE,
             )
         )


### PR DESCRIPTION
Two defects reported by a user on v1.61.0, plus the safeguards that would have caught them.

## 1. Old installs could never learn an update exists

`System/.release-evidence-profile.json` first shipped in **v1.62.0**. `_current_version()` required it unconditionally, so every install older than that raised `EvidenceError` → `UNKNOWN (evidence-invalid)` on every check, permanently. The users furthest behind were exactly the ones the update notice could not reach.

A genuinely absent profile is now accepted only when the installed version is below `FIRST_PROFILE_VERSION` (1.62.0). Absence is distinguished from a symlink, directory, oversized or unreadable file via `lstat`, so only true absence takes the lenient path — covered by a parametrised test for all four hostile cases. **Remote candidate evidence rules are untouched**; `test_missing_profile_on_a_higher_pre_profile_candidate_is_unknown` still passes.

## 2. Doctor reported long-fixed errors as current breakage

The error queue never expired, and `acknowledge_errors()` had **zero callers anywhere in the repo** — nothing ever cleared it. Any unacknowledged entry made `_probe_preflight_queue` return BROKEN regardless of age or origin. The reporting user's 21–22 June errors, from a version he had long since updated past, were still making Doctor declare his install broken over a month later.

- Entries are stamped with the Dex version that produced them, and pruned after `STALE_ERROR_DAYS` (30, chosen by the product owner).
- Only recent, current-version errors can produce BROKEN. Older ones are summarised as history, with dates.
- A corrupt or unreadable queue now returns **UNKNOWN** rather than a silent OK — restoring a corruption guard that the first pass had dropped.
- The unused `acknowledge_errors()` is removed rather than left as the same trap.

## 3. The update notice was alarming and unreadable

It led with *"Dex has not authenticated its publisher"* followed by two 40-character hashes and an `Evidence profile:` line — in a message whose only job is to say a new version exists. Replaced with:

```
A newer version of Dex is available: v1.77.0
Release notes: https://github.com/davekilleen/Dex/releases/tag/<tag>
Run /dex-update when you're ready — Dex never updates itself without you.
```

The remote URL is hard-coded to the canonical Dex repository and non-canonical remotes are refused, so a reported release genuinely came from the official repo. Technical fields remain available to `/dex-doctor` and in the result dict. `CLAUDE.md`'s release-awareness contract is updated to match, and still forbids claiming a release is verified/authenticated/safe or that the user is up to date.

## Why none of this was caught

Every existing update-checker test built the same fixture install — which **wrote the profile file even when labelled `"1.61.0"`**, a version that never had it. 26 tests all rehearsed a user who cannot exist. The error queue had no tests at all.

Added:
- `test_update_checker_real_installs.py` — builds vaults from **real shipped git tags** (v1.61.0, v1.62.0, current) via `git archive`, rather than a hand-written fixture. CI checks out at `fetch-depth: 0`, so these run rather than skip.
- `test_error_queue_lifecycle.py` — advances the clock past the retention window **in both directions**: a 30-day-old error becomes history, a 29-day-old current-version error still reports BROKEN.
- A wiring guard asserting every public error-queue accessor is reachable from production code, so a future never-called accessor fails a test instead of sitting unnoticed for months. Deliberately narrow — no repo-wide dead-code linter.

## Verification

- `test_update_checker.py`, `test_update_checker_real_installs.py`, `test_error_queue_lifecycle.py`, `test_doctor.py`, `test_work_server_production_paths.py`: **197 passed**
- Full suite: 2,399 passed (3 failures + 2 errors were a missing local `requests` dependency, confirmed passing once installed)
- Ruff clean; doc-drift, path-contract, test-delta and PII gates pass locally against `origin/main`

## Note on versioning

The changelog entry is written as **1.77.1**. v1.77.0 is already released; if another session ships first this needs renumbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMB4xGdHYT6nRo7RcEGkQn