### PR TITLE
feat(onboarding): calendar first, one confirmation instead of three questions, and a kinder role step

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -24,7 +24,76 @@ Remember this for the rest of onboarding. Every step that says "present options"
 
 ---
 
+## Calendar First (Before Step 1)
+
+Say: "Welcome to Dex. Before I ask you anything, let's connect your calendar — at the end of setup I'll show you your actual week, organised. It takes a few seconds, and you can skip it."
+
+This opening is separate from the seven validated profile steps. It must stay non-blocking.
+
+Detect the host platform first. Run `uname -s` when available; if that command is unavailable, use the runtime-reported operating system.
+
+**On non-macOS platforms (anything other than `Darwin`):**
+
+Say: "Calendar sync is currently available only on macOS, so I'll skip calendar setup on this computer."
+
+Call `save_calendar_selection(skipped=true)`, then continue to Step 1. Do not call `calendar_list_calendars`, show macOS settings guidance, or block onboarding.
+
+**On macOS:**
+
+Call `calendar_list_calendars` from the Calendar MCP to get the calendar names Calendar.app can see.
+
+**If the listing succeeds:**
+
+Say: "Which calendar should I use for your work schedule?"
+
+Present every returned calendar name as a numbered list:
+```
+1. [exact calendar name]
+2. [exact calendar name]
+3. [exact calendar name]
+```
+
+The user can reply with a number or type the calendar name. Resolve a number to the exact returned name, then call `save_calendar_selection` from the Onboarding MCP with:
+- `work_calendar`: the exact selected calendar name
+- `calendar_count`: the `count` returned by `calendar_list_calendars`
+- `work_email`: the selected name only when that calendar name is an email address; otherwise omit it
+
+Example:
+```
+save_calendar_selection(
+  work_calendar="user@company.com",
+  work_email="user@company.com",
+  calendar_count=4
+)
+```
+
+If the save returns `success: false`, show the available names from its error response and ask the user to choose again. If it succeeds, say: "✓ Got it — I'll use [calendar name] for your work schedule."
+
+The successful save response includes `derived_identity`, with conservative `name` and `domain` guesses when `work_email` is usable:
+
+- **If both `name` and `domain` are present:** Say: "You're [name], at [domain] — right?" Present two choices: **Yes, that's right** and **Let me correct that**.
+  - On **Yes, that's right**, call `validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})`, then call `validate_and_save_step(step_number=4, step_data={"email_domain": "[confirmed domain]"})`.
+  - On **Let me correct that**, collect both normally: ask for their name and company email domain, including the existing no-company-domain option, then save each answer through those same step 1 and step 4 calls.
+- **If only `domain` is present:** Offer the domain for confirmation: "It looks like your company domain is [domain] — right?" Confirm or correct it through `validate_and_save_step(step_number=4, step_data={"email_domain": "[confirmed domain]"})`, including the existing explicit no-company-domain path when correcting. Then ask for the name normally in Step 1.
+- **If there is no `work_email`, or neither value can be derived:** Do not guess or mention the failed derivation. Follow Steps 1 and 4 exactly as written.
+
+Do not bypass either validation call. Only skip the corresponding later question after that step's validation call succeeds.
+
+**If the listing fails or calendar permission is denied:**
+
+Say: "macOS hasn't let this terminal app read your calendars yet — open **System Settings** → **Privacy & Security** → **Calendars** and enable the terminal app you're using."
+
+Offer two choices:
+1. Try again after granting access — call `calendar_list_calendars` again
+2. Skip for now — call `save_calendar_selection(skipped=true)`
+
+Do not block onboarding when they skip. `/dex-doctor` will confirm the calendar setup later. Continue to Step 1.
+
+---
+
 ## Step 1: Welcome
+
+If step 1 was already validated through the calendar confirmation, continue to Step 2. Otherwise:
 
 Say: "Welcome to Dex! I'm your personal knowledge assistant.
 
@@ -123,6 +192,8 @@ Present options using your detected platform tool:
 
 ## Step 4: Email Domain (MANDATORY)
 
+If step 4 was already validated through the calendar confirmation, continue to Step 5. Otherwise:
+
 **⚠️ ASK EVERY USER - Required for Internal/External person routing**
 
 Ask: "What's your company email domain? This helps me automatically:
@@ -141,61 +212,6 @@ Ask: "What's your company email domain? This helps me automatically:
 - Valid domain format with dot
 - Normalization of a leading @ or a pasted full email address
 - A validated domain or an explicit "I don't have one" answer before the step is complete
-
----
-
-## Step 4b: Calendar Selection
-
-**Purpose:** Optimize calendar queries for performance (45s → 0.3s) by identifying the user's actual work calendar instead of guessing its name.
-
-Detect the host platform first. Run `uname -s` when available; if that command is unavailable, use the runtime-reported operating system.
-
-**On non-macOS platforms (anything other than `Darwin`):**
-
-Say: "Calendar sync is currently available only on macOS, so I'll skip calendar setup on this computer."
-
-Call `save_calendar_selection(skipped=true)`, then continue to Step 5. Do not call `calendar_list_calendars`, show macOS settings guidance, or block onboarding.
-
-**On macOS:**
-
-Call `calendar_list_calendars` from the Calendar MCP to get the calendar names Calendar.app can see.
-
-**If the listing succeeds:**
-
-Say: "Which calendar should I use for your work schedule?"
-
-Present every returned calendar name as a numbered list:
-```
-1. [exact calendar name]
-2. [exact calendar name]
-3. [exact calendar name]
-```
-
-The user can reply with a number or type the calendar name. Resolve a number to the exact returned name, then call `save_calendar_selection` from the Onboarding MCP with:
-- `work_calendar`: the exact selected calendar name
-- `calendar_count`: the `count` returned by `calendar_list_calendars`
-- `work_email`: the selected name only when that calendar name is an email address; otherwise omit it
-
-Example:
-```
-save_calendar_selection(
-  work_calendar="user@company.com",
-  work_email="user@company.com",
-  calendar_count=4
-)
-```
-
-If the save returns `success: false`, show the available names from its error response and ask the user to choose again. If it succeeds, say: "✓ Got it — I'll use [calendar name] for your work schedule."
-
-**If the listing fails or calendar permission is denied:**
-
-Say: "macOS hasn't let this terminal app read your calendars yet — open **System Settings** → **Privacy & Security** → **Calendars** and enable the terminal app you're using."
-
-Offer two choices:
-1. Try again after granting access — call `calendar_list_calendars` again
-2. Skip for now — call `save_calendar_selection(skipped=true)`
-
-Do not block onboarding when they skip. `/dex-doctor` will confirm the calendar setup later.
 
 ---
 

--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -61,8 +61,8 @@ The user can reply with a number or type the calendar name. Resolve a number to 
 Example:
 ```
 save_calendar_selection(
-  work_calendar="user@company.com",
-  work_email="user@company.com",
+  work_calendar="jane@example.com",
+  work_email="jane@example.com",
   calendar_count=4
 )
 ```
@@ -107,58 +107,48 @@ Let's get you set up. First, what's your name?"
 
 ## Step 2: Role
 
-Ask: "What's your role?"
+First ask for their AREA:
+
+Ask: "Which area is closest to your work?"
 
 Present options using your detected platform tool (see "Platform Detection" above):
 ```json
 {
   "questions": [{
-    "id": "role",
-    "prompt": "What's your role?",
+    "id": "role_area",
+    "prompt": "Which area is closest to your work?",
     "allow_multiple": false,
     "options": [
-      {"id": "1", "label": "Product Manager"},
-      {"id": "2", "label": "Sales / Account Executive"},
-      {"id": "3", "label": "Marketing"},
-      {"id": "4", "label": "Engineering"},
-      {"id": "5", "label": "Design"},
-      {"id": "6", "label": "Customer Success"},
-      {"id": "7", "label": "Solutions Engineering"},
-      {"id": "8", "label": "Product Operations"},
-      {"id": "9", "label": "RevOps / BizOps"},
-      {"id": "10", "label": "Data / Analytics"},
-      {"id": "11", "label": "Finance"},
-      {"id": "12", "label": "People (HR)"},
-      {"id": "13", "label": "Legal"},
-      {"id": "14", "label": "IT Support"},
-      {"id": "15", "label": "Founder"},
-      {"id": "16", "label": "CEO"},
-      {"id": "17", "label": "CFO"},
-      {"id": "18", "label": "COO"},
-      {"id": "19", "label": "CMO"},
-      {"id": "20", "label": "CRO"},
-      {"id": "21", "label": "CTO"},
-      {"id": "22", "label": "CPO"},
-      {"id": "23", "label": "CIO"},
-      {"id": "24", "label": "CISO"},
-      {"id": "25", "label": "CHRO / Chief People Officer"},
-      {"id": "26", "label": "CLO / General Counsel"},
-      {"id": "27", "label": "CCO (Chief Customer Officer)"},
-      {"id": "28", "label": "Fractional CPO"},
-      {"id": "29", "label": "Consultant"},
-      {"id": "30", "label": "Coach"},
-      {"id": "31", "label": "Venture Capital / Private Equity"},
-      {"id": "other", "label": "My role isn't listed"}
+      {"id": "product", "label": "Product"},
+      {"id": "sales", "label": "Sales"},
+      {"id": "marketing", "label": "Marketing"},
+      {"id": "engineering", "label": "Engineering / Data / IT"},
+      {"id": "design", "label": "Design"},
+      {"id": "customer_success", "label": "Customer Success"},
+      {"id": "operations", "label": "Operations / Finance / People / Legal"},
+      {"id": "leadership", "label": "Leadership / Exec / Advisory"},
+      {"id": "other", "label": "Something else"}
     ]
   }]
 }
 ```
 
-**If user selects "My role isn't listed" (id: "other"):**
+Then ask for their ROLE using only the roles mapped to the selected area. Keep each existing number as the option id:
+
+- **Product:** `1` Product Manager; `8` Product Operations; `22` CPO; `28` Fractional CPO
+- **Sales:** `2` Sales / Account Executive; `7` Solutions Engineering; `20` CRO
+- **Marketing:** `3` Marketing; `19` CMO
+- **Engineering / Data / IT:** `4` Engineering; `10` Data / Analytics; `14` IT Support; `21` CTO; `23` CIO; `24` CISO
+- **Design:** `5` Design
+- **Customer Success:** `6` Customer Success; `27` CCO (Chief Customer Officer)
+- **Operations / Finance / People / Legal:** `9` RevOps / BizOps; `11` Finance; `12` People (HR); `13` Legal; `17` CFO; `18` COO; `25` CHRO / Chief People Officer; `26` CLO / General Counsel
+- **Leadership / Exec / Advisory:** `15` Founder; `16` CEO; `29` Consultant; `30` Coach; `31` Venture Capital / Private Equity
+
+**If user selects "Something else" (id: "other"):**
 Ask: "What's your role? Describe it however makes sense — I'll tailor the system accordingly."
 Then call `validate_and_save_step(step_number=2, step_data={"role": "[their description]", "role_group": "Custom"})`.
 
-**If user selects a numbered role:**
+**If user selects a role from an area:**
 Call `validate_and_save_step(step_number=2, step_data={"role_number": [selected id as integer]})` to validate and save.
 
 ---
@@ -216,6 +206,18 @@ Ask: "What's your company email domain? This helps me automatically:
 ---
 
 ## Step 5: Strategic Pillars
+
+Before asking, call `run_first_week_analysis()` from onboarding-mcp. This is evidence for the question, never an answer to it. Do not infer or guess pillars from calendar activity.
+
+- If `available: true` and `meeting_count` is greater than zero, show one compact evidence block using only `pillar_evidence`:
+  - Show `recurring_commitments`; if the list is empty, say that no recurring commitments were identifiable from this week.
+  - Show the meeting counts in `internal_external_split`.
+  - Show the returned `observations` (at most two).
+  - Do not recalculate any count or hours. The MCP has already excluded all-day entries such as flights, holidays, and days off.
+
+Then say: "That's where your time went. Pillars are what you want to be true in a year — and there's often something important that owns none of your calendar yet. That counts too."
+
+- If `available: false` or `meeting_count: 0`, show no evidence block and no apology. Do not mention the failed or empty calendar analysis; continue directly to the unchanged question below.
 
 Ask: "What are the 2-3 long-term areas of focus for your role? Think broad themes, not specific goals.
 

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -100,6 +100,43 @@ COMPANY_SIZES = ["startup", "scaling", "enterprise", "large_enterprise"]
 FORMALITY_LEVELS = ["formal", "professional_casual", "casual"]
 DIRECTNESS_LEVELS = ["very_direct", "balanced", "supportive"]
 CAREER_LEVELS = ["junior", "mid", "senior", "leadership", "c_suite"]
+ROLE_EMAIL_LOCALS = {
+    "accounts",
+    "admin",
+    "administrator",
+    "billing",
+    "careers",
+    "contact",
+    "customerservice",
+    "enquiries",
+    "enquiry",
+    "events",
+    "finance",
+    "hello",
+    "help",
+    "hr",
+    "info",
+    "jobs",
+    "legal",
+    "mail",
+    "marketing",
+    "media",
+    "noreply",
+    "notifications",
+    "office",
+    "partners",
+    "partnerships",
+    "people",
+    "press",
+    "privacy",
+    "recruiting",
+    "recruitment",
+    "sales",
+    "security",
+    "service",
+    "support",
+    "team",
+}
 
 # ============================================================================
 # UTILITY FUNCTIONS
@@ -195,6 +232,43 @@ def validate_email_domain(domain: str) -> tuple[bool, Optional[str], str]:
         return False, "Email domain cannot be empty", ""
 
     return True, None, ", ".join(domains)
+
+
+def derive_identity_from_email(address: str) -> Dict[str, Optional[str]]:
+    """Return only identity details that are safe to offer for confirmation."""
+    empty_identity = {"name": None, "domain": None}
+    if not isinstance(address, str):
+        return empty_identity
+
+    cleaned = address.strip()
+    if cleaned.count("@") != 1:
+        return empty_identity
+
+    local_part, domain = cleaned.split("@", 1)
+    if (
+        not local_part
+        or local_part.startswith(".")
+        or local_part.endswith(".")
+        or ".." in local_part
+        or re.fullmatch(r"[A-Za-z0-9!#$%&'*+/=?^_`{|}~.-]+", local_part) is None
+    ):
+        return empty_identity
+
+    valid_domain, _, normalized_domain = validate_email_domain(domain)
+    if not valid_domain:
+        return empty_identity
+
+    first_token = local_part.split(".", 1)[0].lower()
+    name = None
+    if (
+        len(first_token) >= 3
+        and first_token.isalpha()
+        and first_token not in ROLE_EMAIL_LOCALS
+    ):
+        name = first_token.title()
+
+    return {"name": name, "domain": normalized_domain.lower()}
+
 
 def validate_pillars(pillars: List[str]) -> tuple[bool, Optional[str]]:
     """Validate strategic pillars"""
@@ -1213,7 +1287,11 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
             save_session(session)
 
             result = create_success_response(
-                {"work_email": work_email, "calendar": calendar},
+                {
+                    "work_email": work_email,
+                    "calendar": calendar,
+                    "derived_identity": derive_identity_from_email(work_email),
+                },
                 f"Work calendar saved.{verification_note}"
             )
             return [types.TextContent(type="text", text=json.dumps(result, indent=2))]

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -96,6 +96,17 @@ ROLES = {
     31: ("Venture Capital / Private Equity", "advisory"),
 }
 
+ROLE_AREAS = {
+    "Product": (1, 8, 22, 28),
+    "Sales": (2, 7, 20),
+    "Marketing": (3, 19),
+    "Engineering / Data / IT": (4, 10, 14, 21, 23, 24),
+    "Design": (5,),
+    "Customer Success": (6, 27),
+    "Operations / Finance / People / Legal": (9, 11, 12, 13, 17, 18, 25, 26),
+    "Leadership / Exec / Advisory": (15, 16, 29, 30, 31),
+}
+
 COMPANY_SIZES = ["startup", "scaling", "enterprise", "large_enterprise"]
 FORMALITY_LEVELS = ["formal", "professional_casual", "casual"]
 DIRECTNESS_LEVELS = ["very_direct", "balanced", "supportive"]
@@ -442,17 +453,20 @@ def _finalize_through_provisioner(session: Dict) -> Dict[str, Any]:
 # ============================================================================
 
 def _load_first_week_profile() -> Dict[str, Any]:
-    """Load the finalized profile used to personalize the first-week draft."""
+    """Load finalized or in-progress profile data for calendar analysis."""
+    profile = {}
     profile_path = BASE_DIR / 'System' / 'user-profile.yaml'
-    if not profile_path.exists():
-        return {}
+    if profile_path.exists():
+        try:
+            import yaml
+            profile = yaml.safe_load(profile_path.read_text(encoding='utf-8')) or {}
+        except Exception as e:
+            logger.warning(f"Failed to load user profile for first-week analysis: {e}")
 
-    try:
-        import yaml
-        return yaml.safe_load(profile_path.read_text(encoding='utf-8')) or {}
-    except Exception as e:
-        logger.warning(f"Failed to load user profile for first-week analysis: {e}")
-        return {}
+    session = load_session()
+    if session and isinstance(session.get('data'), dict):
+        profile.update(session['data'])
+    return profile
 
 
 def _calendar_event_datetime(value: Any) -> Optional[datetime]:
@@ -608,6 +622,112 @@ def analyze_calendar_events(events: List[Dict]) -> Dict:
         'busiest_day_count': busiest_day[1],
         'top_people': [{'email': email, 'count': count} for email, count in top_people]
     }
+
+
+def build_pillar_evidence(events: List[Dict], email_domain: str) -> Dict[str, Any]:
+    """Summarize timed calendar evidence without inferring strategic pillars."""
+    timed_events = _timed_calendar_events(events)
+    calendar_analysis = analyze_calendar_events(timed_events)
+
+    calendar_series = {}
+    for event in timed_events:
+        provider_series_id = event.get('provider_series_id')
+        if not provider_series_id:
+            continue
+
+        title = (event.get('title') or 'Untitled meeting').strip()
+        commitment = calendar_series.setdefault(
+            str(provider_series_id),
+            {
+                'title': title,
+                'meeting_count': 0,
+                'meeting_seconds': 0.0,
+            },
+        )
+        commitment['meeting_count'] += 1
+        start = _calendar_event_datetime(event.get('start'))
+        end = _calendar_event_datetime(event.get('end'))
+        commitment['meeting_seconds'] += max(0.0, (end - start).total_seconds())
+
+    recurring_commitments = [
+        {
+            'title': commitment['title'],
+            'meeting_count': commitment['meeting_count'],
+            'meeting_hours': round(commitment['meeting_seconds'] / 3600, 2),
+        }
+        for commitment in sorted(
+            (
+                commitment
+                for commitment in calendar_series.values()
+                if commitment['meeting_count'] > 1
+            ),
+            key=lambda item: (
+                -item['meeting_count'],
+                -item['meeting_seconds'],
+                item['title'].casefold(),
+            ),
+        )[:3]
+    ]
+
+    internal_domains = {
+        domain.strip().lower()
+        for domain in email_domain.split(',')
+        if domain.strip()
+    }
+    meeting_split = {
+        'internal_meeting_count': 0,
+        'external_meeting_count': 0,
+        'unknown_meeting_count': 0,
+    }
+    for event in timed_events:
+        attendee_domains = []
+        for attendee in _meeting_attendees(event):
+            if attendee.get('is_current_user') is True:
+                continue
+            email = attendee.get('email', '')
+            if '@' in email:
+                attendee_domains.append(email.rsplit('@', 1)[1].lower())
+
+        if not attendee_domains:
+            meeting_split['unknown_meeting_count'] += 1
+        elif internal_domains and all(
+            domain in internal_domains for domain in attendee_domains
+        ):
+            meeting_split['internal_meeting_count'] += 1
+        else:
+            meeting_split['external_meeting_count'] += 1
+
+    total_meetings = calendar_analysis['total_meetings']
+    observations = []
+    if calendar_analysis['busiest_day']:
+        count = calendar_analysis['busiest_day_count']
+        meeting_label = 'timed meeting' if count == 1 else 'timed meetings'
+        observations.append(
+            f"{calendar_analysis['busiest_day']} is your busiest day, "
+            f"with {count} {meeting_label}."
+        )
+
+    one_on_ones = calendar_analysis['one_on_ones']
+    if one_on_ones:
+        meeting_label = 'timed meeting' if total_meetings == 1 else 'timed meetings'
+        verb = 'is' if one_on_ones == 1 else 'are'
+        observations.append(
+            f"{one_on_ones} of your {total_meetings} {meeting_label} "
+            f"{verb} {'a 1:1' if one_on_ones == 1 else '1:1s'}."
+        )
+    elif total_meetings:
+        meeting_label = 'timed meeting takes' if total_meetings == 1 else 'timed meetings take'
+        observations.append(
+            f"Your {total_meetings} {meeting_label} "
+            f"{calendar_analysis['meeting_hours']:g} hours this week."
+        )
+
+    return {
+        'recurring_commitments': recurring_commitments,
+        'internal_external_split': meeting_split,
+        'observations': observations[:2],
+    }
+
 
 def generate_weekly_plan(events: List[Dict], pillars: List[str], role: str) -> str:
     """Generate weekly plan markdown content from calendar events"""
@@ -787,6 +907,10 @@ def run_first_week_analysis() -> Dict[str, Any]:
             profile.get('email_domain', ''),
         ),
         "recent_meeting_count": len(recent_meetings),
+        "pillar_evidence": build_pillar_evidence(
+            timed_events,
+            profile.get('email_domain', ''),
+        ),
         "draft_weekly_plan": generate_weekly_plan(
             timed_events,
             pillars,

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 import shutil
 import sys
 from datetime import date, datetime
@@ -50,6 +51,68 @@ def mixed_calendar_events():
             "start": "2026-07-29T00:00:00+01:00",
             "end": "2026-07-30T00:00:00+01:00",
             "duration_minutes": 24 * 60,
+            "all_day": True,
+            "attendees": [
+                {"name": "John", "email": "john@example.com"},
+            ],
+        },
+    ]
+
+
+@pytest.fixture
+def pillar_evidence_events():
+    return [
+        {
+            "title": "Weekly planning",
+            "provider_event_id": "weekly-planning-2026-07-27",
+            "provider_series_id": "weekly-planning",
+            "start": datetime(2026, 7, 27, 9, 0),
+            "end": datetime(2026, 7, 27, 10, 0),
+            "attendees": [
+                {
+                    "name": "Jane",
+                    "email": "jane@acme.com",
+                    "is_current_user": True,
+                },
+                {"name": "John", "email": "john@acme.com"},
+            ],
+        },
+        {
+            "title": "Customer review",
+            "provider_event_id": "customer-review-2026-07-27",
+            "provider_series_id": "customer-review",
+            "start": datetime(2026, 7, 27, 11, 0),
+            "end": datetime(2026, 7, 27, 12, 30),
+            "attendees": [
+                {
+                    "name": "Jane",
+                    "email": "jane@acme.com",
+                    "is_current_user": True,
+                },
+                {"name": "John", "email": "john@example.com"},
+            ],
+        },
+        {
+            "title": "Weekly planning",
+            "provider_event_id": "weekly-planning-2026-07-28",
+            "provider_series_id": "weekly-planning",
+            "start": datetime(2026, 7, 28, 9, 0),
+            "end": datetime(2026, 7, 28, 10, 0),
+            "attendees": [
+                {
+                    "name": "Jane",
+                    "email": "jane@acme.com",
+                    "is_current_user": True,
+                },
+                {"name": "John", "email": "john@acme.com"},
+            ],
+        },
+        {
+            "title": "Holiday",
+            "provider_event_id": "holiday-2026-07-29",
+            "provider_series_id": "holiday",
+            "start": datetime(2026, 7, 29, 0, 0),
+            "end": datetime(2026, 7, 30, 0, 0),
             "all_day": True,
             "attendees": [
                 {"name": "John", "email": "john@example.com"},
@@ -114,6 +177,7 @@ class TestFirstWeekAnalysis:
             "unique_people_count",
             "external_company_count",
             "recent_meeting_count",
+            "pillar_evidence",
             "draft_weekly_plan",
         }
         assert analysis["available"] is True
@@ -223,6 +287,79 @@ class TestFirstWeekAnalysis:
         assert capacity["meeting_count"] == 1
         assert capacity["meeting_hours"] == 1.5
 
+    def test_pillar_evidence_uses_only_timed_calendar_events(
+        self,
+        tmp_path,
+        monkeypatch,
+        pillar_evidence_events,
+    ):
+        system = tmp_path / "System"
+        system.mkdir()
+        (system / "user-profile.yaml").write_text(
+            "role: Founder\nemail_domain: acme.com\npillars: []\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(onboarding_server, "BASE_DIR", tmp_path)
+        monkeypatch.setattr(
+            onboarding_server,
+            "SESSION_FILE",
+            system / ".onboarding-session.json",
+        )
+        monkeypatch.setattr(
+            onboarding_server,
+            "get_calendar_events_for_week",
+            lambda: pillar_evidence_events,
+        )
+        monkeypatch.setattr(
+            onboarding_server,
+            "get_recent_granola_meetings",
+            lambda days=7: [],
+        )
+
+        analysis = onboarding_server.run_first_week_analysis()
+
+        assert analysis["meeting_count"] == 3
+        assert analysis["meeting_hours"] == 3.5
+        assert analysis["pillar_evidence"] == {
+            "recurring_commitments": [
+                {
+                    "title": "Weekly planning",
+                    "meeting_count": 2,
+                    "meeting_hours": 2.0,
+                }
+            ],
+            "internal_external_split": {
+                "internal_meeting_count": 2,
+                "external_meeting_count": 1,
+                "unknown_meeting_count": 0,
+            },
+            "observations": [
+                "Monday is your busiest day, with 2 timed meetings.",
+                "3 of your 3 timed meetings are 1:1s.",
+            ],
+        }
+        assert "Holiday" not in json.dumps(analysis["pillar_evidence"])
+        assert "24" not in json.dumps(analysis["pillar_evidence"])
+
+    def test_analysis_context_uses_active_onboarding_session_before_finalize(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        system = tmp_path / "System"
+        system.mkdir()
+        session_file = system / ".onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "BASE_DIR", tmp_path)
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        session = onboarding_server.create_new_session()
+        session["data"] = {
+            "email_domain": "acme.com",
+            "calendar": {"work_calendar": "jane@acme.com"},
+        }
+        onboarding_server.save_session(session)
+
+        assert onboarding_server._load_first_week_profile() == session["data"]
+
 
 class TestIdentityDerivation:
     @pytest.mark.parametrize(
@@ -286,6 +423,99 @@ class TestIdentityDerivation:
         assert payload["data"]["derived_identity"] == {
             "name": "Jane",
             "domain": "example.com",
+        }
+
+
+class TestRoleStep:
+    def test_role_areas_cover_all_existing_role_numbers_once(self):
+        mapped_numbers = [
+            role_number
+            for role_numbers in onboarding_server.ROLE_AREAS.values()
+            for role_number in role_numbers
+        ]
+
+        assert len(onboarding_server.ROLE_AREAS) == 8
+        assert list(onboarding_server.ROLES) == list(range(1, 32))
+        assert sorted(mapped_numbers) == list(onboarding_server.ROLES)
+        assert len(mapped_numbers) == len(set(mapped_numbers))
+
+        role_step = (
+            REPO_ROOT / ".claude/flows/onboarding.md"
+        ).read_text(encoding="utf-8").split("## Step 2:", 1)[1].split(
+            "## Step 3:", 1
+        )[0]
+        documented_numbers = []
+        for area, role_numbers in onboarding_server.ROLE_AREAS.items():
+            area_line = next(
+                line
+                for line in role_step.splitlines()
+                if line.startswith(f"- **{area}:**")
+            )
+            documented_area_numbers = [
+                int(number) for number in re.findall(r"`(\d+)`", area_line)
+            ]
+            assert documented_area_numbers == list(role_numbers)
+            documented_numbers.extend(documented_area_numbers)
+
+        assert sorted(documented_numbers) == list(onboarding_server.ROLES)
+        assert len(documented_numbers) == len(set(documented_numbers))
+        for role_number, (label, _) in onboarding_server.ROLES.items():
+            assert role_step.count(f"`{role_number}` {label}") == 1
+
+    @pytest.mark.parametrize("role_number", (1, 31))
+    def test_numbered_role_contract_is_unchanged(
+        self,
+        tmp_path,
+        monkeypatch,
+        role_number,
+    ):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {
+                        "step_number": 2,
+                        "step_data": {"role_number": role_number},
+                    },
+                )
+            )
+        )
+
+        expected_role, expected_group = onboarding_server.ROLES[role_number]
+        assert payload["success"] is True
+        assert onboarding_server.load_session()["data"] == {
+            "role": expected_role,
+            "role_group": expected_group,
+        }
+
+    def test_custom_role_contract_is_unchanged(self, tmp_path, monkeypatch):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {
+                        "step_number": 2,
+                        "step_data": {
+                            "role": "Researcher",
+                            "role_group": "Custom",
+                        },
+                    },
+                )
+            )
+        )
+
+        assert payload["success"] is True
+        assert onboarding_server.load_session()["data"] == {
+            "role": "Researcher",
+            "role_group": "Custom",
         }
 
 
@@ -380,6 +610,22 @@ class TestEmailDomainStep:
 
         assert payload["success"] is False
         assert "no_company_domain" in f"{payload['error']} {payload['suggestion']}"
+
+
+class TestPillarStep:
+    def test_requires_at_least_two_pillars(self):
+        assert onboarding_server.validate_pillars(["Product"]) == (
+            False,
+            "Need at least 2 pillars",
+        )
+
+    def test_more_than_three_pillars_still_warns(self):
+        valid, warning = onboarding_server.validate_pillars(
+            ["Product", "Customers", "Team", "Operations"]
+        )
+
+        assert valid is True
+        assert warning == "Warning: 4 pillars provided. 2-3 is recommended for focus."
 
 
 class TestCapabilityStep:

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -224,6 +224,71 @@ class TestFirstWeekAnalysis:
         assert capacity["meeting_hours"] == 1.5
 
 
+class TestIdentityDerivation:
+    @pytest.mark.parametrize(
+        ("address", "expected"),
+        (
+            (
+                "jane.smith@example.com",
+                {"name": "Jane", "domain": "example.com"},
+            ),
+            ("js@example.com", {"name": None, "domain": "example.com"}),
+            ("info@example.com", {"name": None, "domain": "example.com"}),
+            ("j.smith@example.com", {"name": None, "domain": "example.com"}),
+            ("jane@acme.com", {"name": "Jane", "domain": "acme.com"}),
+        ),
+    )
+    def test_derives_only_confident_identity_guesses(self, address, expected):
+        assert onboarding_server.derive_identity_from_email(address) == expected
+
+    @pytest.mark.parametrize(
+        "address",
+        ("", "not-an-email", "jane@@example.com", "@example.com", "jane@example"),
+    )
+    def test_rejects_malformed_addresses(self, address):
+        assert onboarding_server.derive_identity_from_email(address) == {
+            "name": None,
+            "domain": None,
+        }
+
+    def test_calendar_save_returns_identity_for_confirmation(
+        self, tmp_path, monkeypatch
+    ):
+        from core.mcp import calendar_server
+
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        monkeypatch.setattr(
+            calendar_server,
+            "_get_calendar_list_result",
+            lambda: {
+                "success": True,
+                "calendars": ["jane.smith@example.com"],
+                "count": 1,
+            },
+        )
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "save_calendar_selection",
+                    {
+                        "work_calendar": "jane.smith@example.com",
+                        "work_email": "jane.smith@example.com",
+                        "calendar_count": 1,
+                    },
+                )
+            )
+        )
+
+        assert payload["success"] is True
+        assert payload["data"]["derived_identity"] == {
+            "name": "Jane",
+            "domain": "example.com",
+        }
+
+
 class TestEmailDomainStep:
     @pytest.mark.parametrize(
         ("entered_domain", "normalized_domain"),

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -225,21 +225,62 @@ def test_missing_anthropic_key_points_to_env_file() -> None:
 
 def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Step 4b: Calendar Selection", 1)[1].split(
-        "## Step 5:", 1
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
     )[0]
 
     assert "uname -s" in calendar_step
     assert "non-macOS" in calendar_step
     assert "calendar sync is currently available only on macos" in calendar_step.lower()
     assert "save_calendar_selection(skipped=true)" in calendar_step
-    assert "continue to Step 5" in calendar_step
+    assert "continue to Step 1" in calendar_step
     assert "Do not call `calendar_list_calendars`" in calendar_step
     assert "show macOS settings guidance" in calendar_step
     assert "block onboarding" in calendar_step
     assert calendar_step.index("uname -s") < calendar_step.index(
         "calendar_list_calendars"
     )
+    assert flow.index("## Calendar First (Before Step 1)") < flow.index("## Step 1:")
+
+
+def test_onboarding_confirms_calendar_identity_through_existing_validation() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
+
+    assert "Before I ask you anything" in calendar_step
+    assert "your actual week, organised" in calendar_step
+    assert "you can skip it" in calendar_step
+    assert "derived_identity" in calendar_step
+    assert "You're [name], at [domain] — right?" in calendar_step
+    assert "Yes, that's right" in calendar_step
+    assert "Let me correct that" in calendar_step
+    assert (
+        'validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})'
+        in calendar_step
+    )
+    assert (
+        'validate_and_save_step(step_number=4, step_data={"email_domain": '
+        '"[confirmed domain]"})' in calendar_step
+    )
+    assert "Do not bypass either validation call" in calendar_step
+
+
+def test_onboarding_keeps_conservative_identity_fallbacks() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
+    name_step = flow.split("## Step 1:", 1)[1].split("## Step 2:", 1)[0]
+    domain_step = flow.split("## Step 4:", 1)[1].split("## Step 5:", 1)[0]
+
+    assert "If only `domain` is present" in calendar_step
+    assert "ask for the name normally in Step 1" in calendar_step
+    assert "If there is no `work_email`" in calendar_step
+    assert "follow steps 1 and 4 exactly as written" in calendar_step.lower()
+    assert "First, what's your name?" in name_step
+    assert "What's your company email domain?" in domain_step
 
 
 def test_onboarding_gives_an_honest_time_estimate() -> None:
@@ -259,7 +300,7 @@ def test_onboarding_collects_the_optional_company_name_it_saves() -> None:
 
 def test_onboarding_documents_the_explicit_no_company_domain_path() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    domain_step = flow.split("## Step 4:", 1)[1].split("## Step 4b:", 1)[0]
+    domain_step = flow.split("## Step 4:", 1)[1].split("## Step 5:", 1)[0]
 
     assert '"no_company_domain": true' in domain_step
     assert "Non-empty value" not in domain_step

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -283,6 +283,63 @@ def test_onboarding_keeps_conservative_identity_fallbacks() -> None:
     assert "What's your company email domain?" in domain_step
 
 
+def test_onboarding_narrows_roles_by_area_before_saving_existing_role_number() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    role_step = flow.split("## Step 2:", 1)[1].split("## Step 3:", 1)[0]
+
+    assert "First ask for their AREA" in role_step
+    assert "Then ask for their ROLE" in role_step
+    for area in (
+        "Product",
+        "Sales",
+        "Marketing",
+        "Engineering / Data / IT",
+        "Design",
+        "Customer Success",
+        "Operations / Finance / People / Legal",
+        "Leadership / Exec / Advisory",
+        "Something else",
+    ):
+        assert area in role_step
+    assert role_step.index("First ask for their AREA") < role_step.index(
+        "Then ask for their ROLE"
+    )
+    assert (
+        'validate_and_save_step(step_number=2, step_data={"role_number": '
+        "[selected id as integer]})" in role_step
+    )
+    assert (
+        'validate_and_save_step(step_number=2, step_data={"role": '
+        '"[their description]", "role_group": "Custom"})' in role_step
+    )
+
+
+def test_onboarding_keeps_pillars_intentional_and_grounds_them_in_calendar_evidence() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    pillar_step = flow.split("## Step 5:", 1)[1].split("## Step 6:", 1)[0]
+    unchanged_question = (
+        'Ask: "What are the 2-3 long-term areas of focus for your role? '
+        "Think broad themes, not specific goals."
+    )
+
+    assert "run_first_week_analysis()" in pillar_step
+    assert pillar_step.index("run_first_week_analysis()") < pillar_step.index(
+        unchanged_question
+    )
+    assert "`recurring_commitments`" in pillar_step
+    assert "`internal_external_split`" in pillar_step
+    assert "`observations`" in pillar_step
+    assert (
+        "That's where your time went. Pillars are what you want to be true in a "
+        "year — and there's often something important that owns none of your "
+        "calendar yet. That counts too."
+    ) in pillar_step
+    assert "Do not infer or guess pillars" in pillar_step
+    assert "`available: false` or `meeting_count: 0`" in pillar_step
+    assert "no evidence block and no apology" in pillar_step
+    assert unchanged_question in pillar_step
+
+
 def test_onboarding_gives_an_honest_time_estimate() -> None:
     opening = _read(".claude/flows/onboarding.md").splitlines()[2]
 


### PR DESCRIPTION
Stages 2 and 3 of the onboarding rebuild. Two commits, reviewable separately. **Step 9 (Connect Your Tools) is byte-identical** — the integrations screen is a separate piece of work.

## What this changes for a new user

**Setup now opens by connecting your calendar, with a reason.** It used to be asked halfway through, which meant that on a Mac the permission prompt arrived in the middle of a form with no explanation of why. It now comes first, framed with what it buys you: at the end of setup, Dex shows you your actual week. Skipping is still fine and still leads to a complete setup.

**Your name and company are confirmed, not typed twice.** If your work calendar is named after your email address, Dex works out who you are and asks once — "You're Dave, at pendo.io — right?" — instead of asking for your name and then your domain.

The guessing is deliberately cautious, because a confidently wrong guess is worse than a question. A name needs at least three alphabetic characters and must not be one of thirty-four role addresses (info@, admin@, team@ and friends). If only the domain can be worked out, the name is asked normally. If neither can be, both are asked exactly as before and Dex never mentions that it tried. Both confirmed values still save through the existing validation calls, so the no-company-domain path for people working solo is untouched.

**The role question is no longer a 32-row list.** It was the second thing anyone saw, and fifteen of the rows were C-suite variants. It's now an area first, then the roles inside it. Every one of the original thirty-one roles is still reachable through exactly one area and the saved values are unchanged, so nothing downstream shifts.

**Pillars are asked against evidence rather than a blank page.** Dex shows your recurring commitments and your internal-versus-external split first, then asks. Pillars are deliberately *not* guessed — tested against real calendar data, the guess was confident and wrong: it described where time had gone rather than what the person was building, and it had no idea about work that owns no calendar space yet. The copy now explicitly invites that. With no calendar data, the original question is asked as before, with no evidence block and no apology.

## Verification

- 87 tests pass, including a mapping test that pins all 31 roles to exactly one of 8 areas with no gaps or repeats, **and cross-checks the written flow against the code** so the two cannot drift apart.
- All evidence figures reuse the all-day filter shipped in #269, so flights, holidays and days off contribute no hours or counts. A commitment is only called recurring when the same series appears more than once.
- Gates run **after** committing (a pre-commit run gives a false pass, since they inspect committed changes): PII, path-contract, test-delta, doc-drift, architecture-inventory, instructed-tools, security, ruff — all green.
- Confirmed no diff inside Step 9 or anywhere in the connections code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
