### PR TITLE
build(release): warn when the last release never reached the public page

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,9 +3,10 @@
 # Usage: bash scripts/release.sh [patch|minor|major]
 #
 # Steps:
-#   1. Bump version in package.json
-#   2. Insert dated CHANGELOG header for the new version
-#   3. Commit, tag, and push
+#   1. Check the last release reached the public releases page
+#   2. Bump version in package.json
+#   3. Insert dated CHANGELOG header for the new version
+#   4. Commit, tag, and push
 
 set -euo pipefail
 
@@ -47,6 +48,52 @@ TAG="v${NEW_VERSION}"
 TODAY=$(date +%Y-%m-%d)
 
 echo "Releasing: ${CURRENT_VERSION} -> ${NEW_VERSION} (${BUMP_TYPE})"
+
+# --- Check previous release reached the public page ---------------------------
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Releases page check could not run (curl is unavailable); continuing."
+else
+  FETCH_RESULT=$(
+    if curl -fsS --connect-timeout 5 --max-time 15 \
+      "https://heydex.ai/releases/releases.md" 2>/dev/null; then
+      printf '\n__DEX_RELEASES_FETCH_OK__\n'
+    else
+      printf '\n__DEX_RELEASES_FETCH_FAILED__\n'
+    fi
+  )
+  if [[ "$FETCH_RESULT" == *$'\n__DEX_RELEASES_FETCH_OK__' ]]; then
+    PUBLISHED_CHANGELOG=${FETCH_RESULT%$'\n__DEX_RELEASES_FETCH_OK__'}
+    PUBLISHED_VERSION=$(
+      if printf '%s\n' "$PUBLISHED_CHANGELOG" \
+        | grep -m 1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' \
+        | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/'; then
+        :
+      fi
+    )
+    if [ -n "$PUBLISHED_VERSION" ]; then
+      IFS='.' read -r C_MAJOR C_MINOR C_PATCH <<< "$CURRENT_VERSION"
+      IFS='.' read -r P_MAJOR P_MINOR P_PATCH <<< "$PUBLISHED_VERSION"
+      if [ "$PUBLISHED_VERSION" = "$CURRENT_VERSION" ]; then
+        echo "Releases page check: ${CURRENT_VERSION} is published."
+      elif (( P_MAJOR < C_MAJOR
+        || (P_MAJOR == C_MAJOR && P_MINOR < C_MINOR)
+        || (P_MAJOR == C_MAJOR && P_MINOR == C_MINOR && P_PATCH < C_PATCH) )); then
+        echo ""
+        echo "WARNING: The last release has not reached heydex.ai/releases yet."
+        echo "  Published version: ${PUBLISHED_VERSION}"
+        echo "  Last release:      ${CURRENT_VERSION}"
+        echo "  Publish now: run ./deploy-releases.sh in the heydex-website repo."
+        echo "  If the hourly timer is dead: run ops/releases-republish/install.sh there."
+        echo ""
+      fi
+    else
+      echo "Releases page check could not run (no release version found); continuing."
+    fi
+  else
+    echo "Releases page check could not run (heydex.ai was unavailable); continuing."
+  fi
+fi
 
 # --- Bump package.json --------------------------------------------------------
 


### PR DESCRIPTION
## Why

Four releases shipped on 2026-07-27 (1.76.0, 1.76.1, 1.77.0, 1.77.1) with correct changelog entries and GitHub tags, while `heydex.ai/releases` sat at **v1.75.2**. Publishing that page is a separate manual command in the `heydex-website` repo that nothing here ever mentioned, so every release cut stopped one step early.

The website side now republishes itself hourly (davekilleen/heydex-website#31). This PR is the tripwire for the day that automation dies.

## What

`scripts/release.sh` now checks, before touching anything, whether the *previous* release actually reached the public page — and says so plainly if it did not, naming both versions and both fixes.

**It never blocks or fails a release cut.** A failed fetch, a missing `curl`, or an unparseable response all report "could not run" and continue. Being offline is not evidence of staleness.

## Verified

Ran the check block in isolation across every path:

| case | result |
|---|---|
| published == current | quiet one-line confirmation |
| published behind current | warning naming both versions + both fixes |
| host unreachable | "could not run"; continues |
| `curl` absent from PATH | "could not run"; continues |

In all cases the script ran to completion, exited 0, and the `ERR` trap never fired — confirmed with a trap that prints if it does.

Diff-aware CI gates run locally against `origin/main` before pushing: test-delta, PII, path-contract, doc-drift, founder-content, path-consistency, distribution — all pass.

One deliberate gap: if the published version is *ahead* of local (i.e. you're cutting from a stale checkout), the check stays silent. That's a different problem than the one this guards, and worth its own fix rather than overloading this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkAV32GPAd8qxt5GTbaKFb