### PR TITLE
fix: release awareness was returning UNKNOWN for every user — two causes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Documentation drift gate
         if: github.event_name == 'pull_request'
         run: bash scripts/check-doc-drift.sh
+      - name: Release-tag uniqueness gate
+        run: bash scripts/check-release-tag-uniqueness.sh
       - name: Architecture inventory drift gate
         run: bash scripts/check-architecture-inventory.sh
       - name: Instructed-tool existence gate
@@ -290,11 +292,43 @@ jobs:
     permissions:
       contents: write
     outputs:
-      release_sha: ${{ steps.release_build.outputs.release_sha }}
+      release_sha: ${{ steps.release_guard.outputs.release_sha || steps.release_build.outputs.release_sha }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+      # A second artifact for one version makes every update check ambiguous,
+      # while --clobber silently replaces the already-released bundle.
+      - name: Check whether this version is already published
+        id: release_guard
+        run: |
+          VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
+          PUBLISHED_TAGS="$(git ls-remote --tags origin "refs/tags/dist/release/v${VERSION}-*")"
+          if [ -n "$PUBLISHED_TAGS" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            # Historical versions may have multiple immutable tags. Choose the
+            # lexicographically first tag name so health reporting stays stable
+            # on every merge; the uniqueness gate prevents this for new versions.
+            PUBLISHED_TAG="$(
+              printf '%s\n' "$PUBLISHED_TAGS" |
+                awk '$2 !~ /\^\{\}$/ { print $2 }' |
+                LC_ALL=C sort |
+                sed -n '1p'
+            )"
+            PEELED_REF="${PUBLISHED_TAG}^{}"
+            RELEASE_SHA="$(
+              printf '%s\n' "$PUBLISHED_TAGS" |
+                awk -v peeled_ref="$PEELED_REF" '$2 == peeled_ref { print $1 }'
+            )"
+            if [ -z "$RELEASE_SHA" ]; then
+              echo "Unable to resolve the published release commit from $PEELED_REF." >&2
+              exit 1
+            fi
+            echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "Version v$VERSION is already published; publishing runs only when package.json is bumped."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
@@ -305,6 +339,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Build release branch
         id: release_build
+        if: steps.release_guard.outputs.already_published != 'true'
         run: |
           bash scripts/build-release.sh
           echo "release_sha=$(git rev-parse release)" >> "$GITHUB_OUTPUT"
@@ -313,12 +348,15 @@ jobs:
           git rev-parse --verify "refs/tags/$RELEASE_TAG"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
       - name: Push release branch and immutable tag
+        if: steps.release_guard.outputs.already_published != 'true'
         run: |
           git push origin release --force
           git push origin "${{ steps.release_build.outputs.release_tag }}"
       - name: Build self-contained vault bundle
+        if: steps.release_guard.outputs.already_published != 'true'
         run: bash scripts/build-vault-bundle.sh
       - name: Upload vault bundle to versioned GitHub Release
+        if: steps.release_guard.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -1,0 +1,170 @@
+"""Regression tests for the one-published-artifact-per-version CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE = REPO_ROOT / "scripts/check-release-tag-uniqueness.sh"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _repository_with_remote_tags(tmp_path: Path, *tags: str) -> Path:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "-b", "main")
+    _git(repository, "config", "user.name", "Dex Tests")
+    _git(repository, "config", "user.email", "tests@example.com")
+    (repository / "README.md").write_text("# Fixture\n", encoding="utf-8")
+    _git(repository, "add", "README.md")
+    _git(repository, "commit", "-m", "fixture")
+    _git(repository, "remote", "add", "origin", str(remote))
+
+    for tag in tags:
+        _git(repository, "tag", "-a", tag, "-m", tag)
+    _git(repository, "push", "origin", "main", "--tags")
+    return repository
+
+
+def test_gate_accepts_one_annotated_tag_per_version(tmp_path: Path) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.76.1-1111111",
+        "dist/release/v1.78.0-2222222",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_gate_allows_historical_duplicates_at_or_below_threshold(
+    tmp_path: Path,
+) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.76.0-1111111",
+        "dist/release/v1.76.0-2222222",
+        "dist/release/v1.77.1-3333333",
+        "dist/release/v1.77.1-4444444",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Historical exception: v1.76.0" in result.stdout
+    assert "Historical exception: v1.77.1" in result.stdout
+    assert "at or below v1.77.1" in result.stdout
+    gate_source = GATE.read_text(encoding="utf-8")
+    assert 'HISTORICAL_VERSION_THRESHOLD="1.77.1"' in gate_source
+    assert "1.77.0|1.77.1" not in gate_source
+
+
+def test_gate_reports_every_new_version_with_duplicate_tags(tmp_path: Path) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.77.2-1111111",
+        "dist/release/v1.77.2-2222222",
+        "dist/release/v1.79.0-3333333",
+        "dist/release/v1.79.0-4444444",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "v1.77.2" in result.stderr
+    assert "v1.79.0" in result.stderr
+
+
+def test_stable_release_ci_publishes_each_version_at_most_once() -> None:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    quality_steps = workflow["jobs"]["quality"]["steps"]
+    assert any(
+        step.get("run") == "bash scripts/check-release-tag-uniqueness.sh"
+        for step in quality_steps
+    )
+
+    stable_job = workflow["jobs"]["build-release"]
+    assert stable_job["outputs"]["release_sha"] == (
+        "${{ steps.release_guard.outputs.release_sha || "
+        "steps.release_build.outputs.release_sha }}"
+    )
+    steps = stable_job["steps"]
+    named_steps = {step["name"]: step for step in steps if "name" in step}
+    guard = named_steps["Check whether this version is already published"]
+    assert guard["id"] == "release_guard"
+    assert (
+        'git ls-remote --tags origin "refs/tags/dist/release/v${VERSION}-*"'
+        in guard["run"]
+    )
+    assert "already_published=true" in guard["run"]
+    assert "already_published=false" in guard["run"]
+    assert 'echo "release_sha=$RELEASE_SHA"' in guard["run"]
+    assert 'PEELED_REF="${PUBLISHED_TAG}^{}"' in guard["run"]
+    assert "LC_ALL=C sort" in guard["run"]
+    assert "lexicographically first" in guard["run"]
+
+    publish_condition = (
+        "steps.release_guard.outputs.already_published != 'true'"
+    )
+    for step_name in (
+        "Build release branch",
+        "Push release branch and immutable tag",
+        "Build self-contained vault bundle",
+        "Upload vault bundle to versioned GitHub Release",
+    ):
+        assert named_steps[step_name]["if"] == publish_condition
+
+    deploy_health = workflow["jobs"]["deploy-health"]
+    assert deploy_health["needs"] == ["quality", "build-release"]
+    assert "needs['build-release'].result == 'success'" in deploy_health["if"]
+    deploy_steps = {
+        step["name"]: step for step in deploy_health["steps"] if "name" in step
+    }
+    assert (
+        deploy_steps["Download release health inputs"]["with"]["name"]
+        == "release-health-inputs"
+    )
+    assert deploy_steps["Build release health page"]["env"]["RELEASE_SHA"] == (
+        "${{ needs['build-release'].outputs.release_sha }}"
+    )

--- a/core/tests/test_update_checker.py
+++ b/core/tests/test_update_checker.py
@@ -167,6 +167,12 @@ def _tag_object(repo: Path, tag: str) -> str:
     return _git(repo, "rev-parse", f"refs/tags/{tag}")
 
 
+def _lightweight_release_tag(repo: Path, version: str, suffix: str) -> str:
+    tag = f"dist/release/v{version}-{suffix}"
+    _git(repo, "tag", tag)
+    return tag
+
+
 @pytest.fixture(autouse=True)
 def deny_external_sockets(monkeypatch: pytest.MonkeyPatch):
     def denied_socket(*_args, **_kwargs):
@@ -219,17 +225,18 @@ def test_legacy_release_notice_is_readable_and_keeps_technical_evidence_out_of_u
         "commit": commit,
         "tree": tree,
         "profile": "legacy-v1",
-        "release_page": f"https://github.com/davekilleen/Dex/releases/tag/{tag}",
+        "release_page": "https://github.com/davekilleen/Dex/releases/tag/v1.62.0",
         "notice": "\n".join(
             (
                 f"{APPROVED_NOTICE_AVAILABLE} v1.62.0",
-                f"Release notes: https://github.com/davekilleen/Dex/releases/tag/{tag}",
+                "Release notes: https://github.com/davekilleen/Dex/releases/tag/v1.62.0",
                 APPROVED_NOTICE_GUIDANCE,
             )
         ),
         "publisher_authentication": "unavailable",
     }
     notice_lower = result["notice"].lower()
+    assert "dist/release/" not in result["notice"]
     assert re.search(r"\b[0-9a-f]{40}\b", result["notice"]) is None
     for banned in (
         "appears to exist",
@@ -399,21 +406,81 @@ def test_missing_profile_on_a_higher_pre_profile_candidate_is_unknown(tmp_path: 
     assert commit not in json.dumps(result)
 
 
-def test_two_distinct_candidates_for_the_same_higher_version_are_ambiguous(tmp_path: Path) -> None:
+def test_more_than_candidate_bound_higher_releases_reports_and_notifies_newest(
+    tmp_path: Path,
+) -> None:
     vault = _installed_vault(tmp_path / "vault")
     remote = tmp_path / "remote"
     _init_repo(remote)
-    _release(remote, "1.62.0")
+    newest_version = "9.0.0"
+    newest_tag, _commit = _release(remote, newest_version)
+    lower_tags = []
+    for index in range(update_verifier_module.MAX_RELEASE_TAGS):
+        lower_tags.append(_lightweight_release_tag(remote, f"2.0.{index}", f"{index + 1:064x}"))
+    commands: list[tuple[str, ...]] = []
+    runner = GitRunner(allowed_protocol="file", command_observer=commands.append)
+
+    result = _verifier(vault, remote, tmp_path / "state", git_runner=runner).check()
+
+    assert result["status"] == STATUS_RELEASE
+    assert result["should_notify"] is True
+    assert result["version"] == newest_version
+    assert result["tag"] == newest_tag
+    assert f"{APPROVED_NOTICE_AVAILABLE} v{newest_version}" in result["notice"]
+    fetch_commands = [command for command in commands if "fetch" in command]
+    assert len(fetch_commands) == 1
+    assert f"refs/tags/{newest_tag}:refs/tags/{newest_tag}" in fetch_commands[0]
+    assert all(f"refs/tags/{tag}:refs/tags/{tag}" not in fetch_commands[0] for tag in lower_tags)
+
+
+def test_highest_version_remains_ambiguous_with_many_lower_releases(tmp_path: Path) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    first_tag, _commit = _release(remote, "9.0.0")
+    for index in range(update_verifier_module.MAX_RELEASE_TAGS):
+        _lightweight_release_tag(remote, f"2.0.{index}", f"{index + 1:064x}")
     (remote / "README.md").write_text("second release identity\n")
     _git(remote, "add", "README.md")
     _git(remote, "commit", "--quiet", "-m", "conflicting release identity")
     second_short = _git(remote, "rev-parse", "--short", "HEAD")
-    _git(remote, "tag", "-a", f"dist/release/v1.62.0-{second_short}", "-m", "conflicting identity")
+    second_tag = f"dist/release/v9.0.0-{second_short}"
+    _git(remote, "tag", "-a", second_tag, "-m", "conflicting identity")
+    commands: list[tuple[str, ...]] = []
+    runner = GitRunner(allowed_protocol="file", command_observer=commands.append)
 
-    result = _verifier(vault, remote, tmp_path / "state").check()
+    result = _verifier(vault, remote, tmp_path / "state", git_runner=runner).check()
 
     assert result["status"] == STATUS_UNKNOWN
     assert result["should_notify"] is False
+    assert result["reason"] == "evidence-invalid"
+    fetch_commands = [command for command in commands if "fetch" in command]
+    assert len(fetch_commands) == 1
+    assert f"refs/tags/{first_tag}:refs/tags/{first_tag}" in fetch_commands[0]
+    assert f"refs/tags/{second_tag}:refs/tags/{second_tag}" in fetch_commands[0]
+
+
+def test_single_highest_version_candidate_bound_remains_an_anomaly_guard(
+    tmp_path: Path,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "9.0.0")
+    for index in range(update_verifier_module.MAX_RELEASE_TAGS):
+        _lightweight_release_tag(remote, "9.0.0", f"{index + 1:064x}")
+    commands: list[tuple[str, ...]] = []
+    runner = GitRunner(allowed_protocol="file", command_observer=commands.append)
+
+    result = _verifier(vault, remote, tmp_path / "state", git_runner=runner).check()
+
+    assert result == {
+        "status": STATUS_UNKNOWN,
+        "should_notify": False,
+        "current_version": "1.61.0",
+        "reason": "evidence-invalid",
+    }
+    assert not any("fetch" in command for command in commands)
 
 
 def test_moved_annotated_tag_is_unknown_and_never_re_notified(tmp_path: Path) -> None:

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -24,7 +24,7 @@ from pathlib import Path, PurePosixPath
 from typing import Callable, Protocol
 
 CANONICAL_REMOTE_URL = "https://github.com/davekilleen/Dex.git"
-CANONICAL_RELEASE_PAGE = "https://github.com/davekilleen/Dex/releases/tag/{tag}"
+CANONICAL_RELEASE_PAGE = "https://github.com/davekilleen/Dex/releases/tag/v{version}"
 PROFILE_PATH = "System/.release-evidence-profile.json"
 MANIFEST_PATH = "System/.installed-files.manifest"
 CATALOG_PATH = "System/.release-catalog.json"
@@ -63,9 +63,9 @@ SESSION_WALL_CLOCK_SECONDS = 10.0
 MAX_AGGREGATE_OUTPUT_BYTES = 64 * 1024 * 1024
 MAX_GIT_OUTPUT_BYTES = 32 * 1024 * 1024
 MAX_REMOTE_RELEASE_REFS = 128
-# Normal operation has one higher stable target. Thirty-two preserves ample
-# overlap for skipped releases and same-version ambiguity checks while keeping
-# adversarial tag fan-out within the single SessionStart deadline/disk budget.
+# Normal operation has one tag at the highest stable version. Thirty-two keeps
+# the complete same-version group available for ambiguity checks while bounding
+# anomalous tag fan-out within the single SessionStart deadline/disk budget.
 MAX_RELEASE_TAGS = 32
 MAX_RELEASE_TREE_ENTRIES = 100_000
 MAX_RELEASE_TREE_PATH_BYTES = 16 * 1024 * 1024
@@ -977,7 +977,7 @@ class UpdateVerifier:
         return "\n".join(
             (
                 f"{NOTICE_AVAILABLE} v{candidate.version}",
-                f"Release notes: {CANONICAL_RELEASE_PAGE.format(tag=candidate.tag)}",
+                f"Release notes: {CANONICAL_RELEASE_PAGE.format(version=candidate.version)}",
                 NOTICE_GUIDANCE,
             )
         )
@@ -1131,12 +1131,19 @@ class UpdateVerifier:
                     self._evidence_cache = persistent_cache
                     self._validate_cache()
                 remote_tags = self._remote_release_tags()
+                highest_remote_version: SemVer | None = None
                 selected_remote_tags: list[RemoteTagEvidence] = []
                 for remote_tag in remote_tags:
                     match = _TAG_RE.fullmatch(remote_tag.tag)
                     if match is None:
                         raise EvidenceError("candidate release tag shape is malformed")
-                    if SemVer.parse(match.group("version")) > current_semver:
+                    remote_version = SemVer.parse(match.group("version"))
+                    if remote_version <= current_semver:
+                        continue
+                    if highest_remote_version is None or remote_version > highest_remote_version:
+                        highest_remote_version = remote_version
+                        selected_remote_tags = [remote_tag]
+                    elif remote_version == highest_remote_version:
                         selected_remote_tags.append(remote_tag)
                 if len(selected_remote_tags) > MAX_RELEASE_TAGS:
                     raise EvidenceError("higher release candidate count exceeded its bound")
@@ -1227,7 +1234,7 @@ class UpdateVerifier:
                     "commit": candidate.commit,
                     "tree": candidate.tree,
                     "profile": candidate.profile,
-                    "release_page": CANONICAL_RELEASE_PAGE.format(tag=candidate.tag),
+                    "release_page": CANONICAL_RELEASE_PAGE.format(version=candidate.version),
                     "notice": notice,
                     "publisher_authentication": "unavailable",
                 }

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+# Every release at or below this version was published before this uniqueness
+# guard existed, so duplicate tags there are history rather than a CI failure.
+HISTORICAL_VERSION_THRESHOLD="1.77.1"
+
+REMOTE_TAGS="$(
+  git ls-remote --tags origin 'refs/tags/dist/release/v*'
+)"
+
+version_is_at_or_below_threshold() {
+  local version="$1"
+  local threshold="$2"
+  local version_major version_minor version_patch
+  local threshold_major threshold_minor threshold_patch
+
+  IFS=. read -r version_major version_minor version_patch <<<"$version"
+  IFS=. read -r threshold_major threshold_minor threshold_patch <<<"$threshold"
+
+  if ((version_major != threshold_major)); then
+    ((version_major < threshold_major))
+    return
+  fi
+  if ((version_minor != threshold_minor)); then
+    ((version_minor < threshold_minor))
+    return
+  fi
+  ((version_patch <= threshold_patch))
+}
+
+# Annotated tags also produce a peeled ^{} ref; count only the tag ref itself.
+DUPLICATE_VERSIONS="$(
+  printf '%s\n' "$REMOTE_TAGS" |
+    awk '
+      $2 !~ /\^\{\}$/ &&
+      $2 ~ /^refs\/tags\/dist\/release\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/ {
+        version = $2
+        sub(/^refs\/tags\/dist\/release\/v/, "", version)
+        sub(/-[0-9a-f]+$/, "", version)
+        counts[version]++
+      }
+      END {
+        for (version in counts) {
+          if (counts[version] > 1) {
+            print version, counts[version]
+          }
+        }
+      }
+    ' |
+    sort
+)"
+
+FAILED=0
+while read -r VERSION COUNT; do
+  [ -n "${VERSION:-}" ] || continue
+  if version_is_at_or_below_threshold "$VERSION" "$HISTORICAL_VERSION_THRESHOLD"; then
+    echo "Historical exception: v$VERSION has $COUNT release tags; it is at or below v$HISTORICAL_VERSION_THRESHOLD and predates the uniqueness guard."
+  else
+    echo "❌ v$VERSION has $COUNT dist/release tags; each version may publish exactly one artifact." >&2
+    FAILED=1
+  fi
+done <<EOF
+$DUPLICATE_VERSIONS
+EOF
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "❌ Release-tag uniqueness gate failed. Bump the version before publishing another artifact." >&2
+  exit 1
+fi
+
+echo "Release-tag uniqueness gate passed."


### PR DESCRIPTION
Follow-up to #273. While proving that fix end-to-end **against the live repository**, the check still failed — which uncovered two further defects. Both are pre-existing, and together they meant release awareness returned `UNKNOWN` for **every user**, not just old installs.

## 1. The candidate bound stranded anyone more than a fortnight behind

`check()` raised `"higher release candidate count exceeded its bound"` when more than `MAX_RELEASE_TAGS` (32) higher tags existed. Measured against the live remote:

| Installed | Higher tags | Result |
|---|---|---|
| v1.77.0 | 1 | ok |
| v1.76.1 | 4 | ok |
| v1.76.0 | 10 | ok |
| **v1.75.0** | **40** | **fails** |
| v1.61.0 | 112 | fails |

The further behind an install was, the more certain it became that it would never be told anything.

The check only ever needs the newest release — everything downstream computes `highest_version` and discards the rest. It now selects every tag **at** the single highest version and fetches only those. The bound survives as a genuine anomaly guard on that group.

**Ambiguity detection is deliberately preserved.** All tags at the highest version are kept, so two different releases claiming one version still raise `"higher release evidence is ambiguous"`. Truncating within that group would have hidden exactly the conflict the check exists to catch.

## 2. Every merge to main minted another artifact for the already-released version

`build-release` runs on every push to `main` and tags `dist/release/v${package.json version}-${sha}`. The version only changes when a release is cut, so **every subsequent merge produced another tag for the same version with different contents** — and re-uploaded the vault bundle over the published one with `--clobber`.

Live today: **3** tags for v1.77.0, **2** for v1.77.1, **6** for v1.76.1, **10** for v1.75.2.

Several different trees claiming one version is precisely what the ambiguity check refuses. So release awareness died on the first merge after each release — a window of minutes at the current pace.

**Direct evidence:** a v1.61.0 vault was correctly offered v1.77.1 by the live check; PR #274 then merged; the identical check returned `UNKNOWN` immediately after.

`build-release` now publishes only when the version has no existing artifact. The job still concludes `success` when it skips, and now reports the already-published release commit so `deploy-health` keeps reporting a real sha rather than `UNKNOWN`. `scripts/check-release-tag-uniqueness.sh` enforces one artifact per version from v1.77.1 onward, reporting earlier versions as historical.

## 3. The "Release notes" link had no release notes

The notice linked to the internal build tag. `gh release view "dist/release/v1.77.1-3626537"` → **release not found**; `gh release view v1.77.1` → 2,105 characters of notes. GitHub serves a bare tag page at that URL and even titles it "Release …", so it looks fine until you click it. Now points at the `v<version>` page.

## Why none of this was caught

The tests build remotes with two or three releases, so a bound of 32 and a duplicate-tag collision could never occur. Added tests that exceed `MAX_RELEASE_TAGS`, assert the newest version wins, prove ambiguity still fires at the highest version, and cover the uniqueness gate above and below its threshold.

More importantly: **the acceptance test is now the live repository.** A vault archived from a real shipped tag, checked against the real remote. That is what caught all three of these after the synthetic tests were green.

## Verification

- 201 tests pass across the update checker, real-install, error-queue, doctor and uniqueness suites
- `scripts/check-release-tag-uniqueness.sh` passes against the live remote
- `ci.yml` parses; `deploy-health` still runs and receives a real release sha on ordinary merges
- End-to-end from a real v1.61.0 vault against the live remote:

```
A newer version of Dex is available: v1.77.1
Release notes: https://github.com/davekilleen/Dex/releases/tag/v1.77.1
Run /dex-update when you're ready — Dex never updates itself without you.
```

## Note

The duplicates at v1.77.0/v1.77.1 remain as history. Cutting the next version produces the first release with exactly one artifact, which unblocks every user's update check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMB4xGdHYT6nRo7RcEGkQn