### PR TITLE
feat(onboarding): recognise more of what people use, and tell them /connect exists

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -476,6 +476,8 @@ Say: "Now the fun part — let's connect the tools you use day to day."
 - Atlassian (Jira + Confluence) — Tickets and docs in daily plans. Setup: 3 min
 ```
 
+Dex can also connect hundreds of other tools with `/connect`. The quick ones ask you to paste a key; browser sign-ins need a one-time setup where you register your own app for Dex in that tool's own settings. Only Google and Linear have had Dex's security review; anything else asks for your explicit opt-in before Dex continues.
+
 If any integrations are already connected, briefly note them so you don't re-offer.
 
 ### 8b: Personalize with Vault Signals
@@ -486,39 +488,42 @@ Before asking which to connect, run the integration concierge — it scans for s
 node .claude/hooks/integration-concierge.cjs
 ```
 
-Parse the JSON for the high_value and moderate_value tiers. Each entry has a `reason` field with a ready-made plain-English signal ("installed on your Mac", "already set up as a connector but not switched on yet", or a mention count). If any high_value items came back, surface them first, personalized:
+Parse the JSON for `high_value`, `moderate_value`, and `connect_detected`. Each entry has a `reason` and a `route`: `skill` uses its tested setup skill; `connect` uses `/connect` and deliberately has no `setup` field. Surface curated `high_value` items as before, then add at most the top three `connect_detected` items:
 
 ```
 Based on what's already on your machine and in your vault, these look most useful:
 
-- **[shortName]** — [reason]. [value proposition]. Setup: [setupTime].
+- `skill`: **[shortName]** — [reason]. [value]. Setup: [setupTime].
+- `connect`: **[shortName]** — [reason]. [value]. Connect with `/connect`.
 ```
 
-Then present the rest of the categorized list from 8a for anything not already surfaced. If the concierge returns no high_value signals (common for a brand-new vault), just use the 8a list as-is — don't mention the scan.
+Then present the rest of the curated list from 8a for anything not already surfaced. If both `high_value` and `connect_detected` are empty, just use the 8a list — don't mention the scan.
 
 After presenting, set an `integrations_offered` flag in the `.onboarding-complete` marker so `/getting-started` doesn't re-run this discovery.
 
 **Then ask:**
 
-"Which ones would you like to connect? You can always add more later with `/integrate-mcp` or individual setup commands."
+"Which ones would you like to connect? You can always add more later with `/connect`, `/integrate-mcp`, or individual setup commands."
 
 ### 8c: Connect Selected Integrations
 
-For each integration the user selects:
+For each integration the user selects, follow its `route`:
 
-1. Run its setup skill: invoke the skill referenced in the integration's `setup` field (e.g., `/todoist-setup`, `/google-workspace-setup`)
-2. Wait for the setup skill to complete (each includes auth, config, and verification)
-3. The setup skill shows its **Capability Cascade** at the end (from `integration-patterns.md`):
-   - Which existing skills just got smarter
-   - What new capabilities are now available
-   - Privacy and trust level summary
-4. Move to the next selected integration
+- `skill`:
+  1. Run its setup skill: invoke the skill referenced in the integration's `setup` field (e.g., `/todoist-setup`, `/google-workspace-setup`)
+  2. Wait for the setup skill to complete (each includes auth, config, and verification)
+  3. The setup skill shows its **Capability Cascade** at the end (from `integration-patterns.md`):
+     - Which existing skills just got smarter
+     - What new capabilities are now available
+     - Privacy and trust level summary
+  4. Move to the next selected integration
+- `connect`: invoke `/connect` for that provider; never invent a setup skill or setup time. `/connect` explains whether it needs a pasted key or the browser-sign-in setup. For anything other than Google or Linear, explain that it has not had Dex's security review and get explicit opt-in before using `--allow-unvetted`.
 
 If the user selects multiple, run them in sequence. After each one, confirm success before moving to the next.
 
 If the user says "skip" or "none" or "later":
 
-Say: "No problem! You can connect tools anytime with `/integrate-mcp` or the individual setup commands. Run `/dex-level-up` to see what's available."
+Say: "No problem! You can connect tools anytime with `/connect`, `/integrate-mcp`, or the individual setup commands. Run `/dex-level-up` to see what's available."
 
 ### 8d: Optional Features (After Integrations)
 

--- a/.claude/hooks/integration-concierge.cjs
+++ b/.claude/hooks/integration-concierge.cjs
@@ -6,7 +6,7 @@
  * Returns intelligent integration recommendations ranked by signal strength.
  *
  * Called by:
- * - Onboarding Step 8 (first-time integration discovery)
+ * - Onboarding Step 9 (first-time integration discovery)
  * - /getting-started (post-onboarding tour)
  * - /dex-level-up (feature discovery)
  *
@@ -42,6 +42,7 @@ const INTEGRATIONS = {
     id: 'google-workspace',
     name: 'Google Workspace (Gmail + Calendar + Docs)',
     shortName: 'Gmail',
+    route: 'skill',
     setup: '/google-workspace-setup',
     mcpServers: ['google-workspace-mcp'],
     signals: {
@@ -58,6 +59,7 @@ const INTEGRATIONS = {
     id: 'teams',
     name: 'Microsoft Teams',
     shortName: 'Teams',
+    route: 'skill',
     setup: '/ms-teams-setup',
     apps: ['Microsoft Teams.app'],
     mcpServers: ['teams-mcp'],
@@ -75,6 +77,7 @@ const INTEGRATIONS = {
     id: 'todoist',
     name: 'Todoist',
     shortName: 'Todoist',
+    route: 'skill',
     setup: '/todoist-setup',
     apps: ['Todoist.app'],
     mcpServers: ['todoist-mcp'],
@@ -90,6 +93,7 @@ const INTEGRATIONS = {
     id: 'things',
     name: 'Things 3',
     shortName: 'Things 3',
+    route: 'skill',
     setup: '/things-setup',
     apps: ['Things3.app'],
     mcpServers: ['things3-mcp'],
@@ -105,6 +109,7 @@ const INTEGRATIONS = {
     id: 'trello',
     name: 'Trello',
     shortName: 'Trello',
+    route: 'skill',
     setup: '/trello-setup',
     apps: ['Trello.app'],
     mcpServers: ['mcp-server-trello'],
@@ -120,6 +125,7 @@ const INTEGRATIONS = {
     id: 'zoom',
     name: 'Zoom',
     shortName: 'Zoom',
+    route: 'skill',
     setup: '/zoom-setup',
     apps: ['zoom.us.app'],
     mcpServers: ['zoom-mcp'],
@@ -137,6 +143,7 @@ const INTEGRATIONS = {
     id: 'atlassian',
     name: 'Atlassian (Jira + Confluence)',
     shortName: 'Jira/Confluence',
+    route: 'skill',
     setup: '/atlassian-setup',
     mcpServers: ['atlassian-mcp'],
     signals: {
@@ -147,6 +154,76 @@ const INTEGRATIONS = {
     value: 'Jira tickets and Confluence docs in daily plans, sprint tracking',
     setupTime: '3 min',
     auth: 'OAuth (Atlassian Cloud)',
+  },
+  slack: {
+    id: 'slack',
+    name: 'Slack',
+    shortName: 'Slack',
+    route: 'connect',
+    apps: ['Slack.app'],
+    signals: {},
+    value: 'Work conversations and decisions as context when a Dex workflow supports Slack',
+  },
+  notion: {
+    id: 'notion',
+    name: 'Notion',
+    shortName: 'Notion',
+    route: 'connect',
+    apps: ['Notion.app'],
+    signals: {},
+    value: 'Knowledge and project docs as context when a Dex workflow supports Notion',
+  },
+  linear: {
+    id: 'linear',
+    name: 'Linear',
+    shortName: 'Linear',
+    route: 'connect',
+    apps: ['Linear.app'],
+    signals: {},
+    value: 'Issues and project updates as context when a Dex workflow supports Linear',
+  },
+  obsidian: {
+    id: 'obsidian',
+    name: 'Obsidian',
+    shortName: 'Obsidian',
+    route: 'connect',
+    apps: ['Obsidian.app'],
+    signals: {},
+    value: 'Your existing notes workspace as context for choosing the right setup',
+  },
+  granola: {
+    id: 'granola',
+    name: 'Granola',
+    shortName: 'Granola',
+    // Routed to its own setup skill, NOT /connect: granola_server.py reads
+    // GRANOLA_API_KEY from the environment or the vault's .env file, so a
+    // credential stored by the connection manager would be invisible to it and
+    // the user would be told they had connected something that still cannot work.
+    route: 'skill',
+    setup: '/granola-setup',
+    apps: ['Granola.app'],
+    signals: {},
+    value: 'Your meeting notes and transcripts as context in planning and prep',
+    setupTime: '2 min',
+    auth: 'API key (needs a Granola Business or Enterprise plan)',
+  },
+  cursor: {
+    id: 'cursor',
+    name: 'Cursor',
+    shortName: 'Cursor',
+    route: 'connect',
+    apps: ['Cursor.app'],
+    signals: {},
+    value: 'Your coding environment as a signal for relevant developer workflows',
+  },
+  figma: {
+    id: 'figma',
+    name: 'Figma',
+    shortName: 'Figma',
+    route: 'connect',
+    apps: ['Figma.app'],
+    signals: {},
+    value: 'Design files and comments as context when a Dex workflow supports Figma',
   },
 };
 
@@ -476,21 +553,15 @@ function generateRecommendations(signals) {
     moderate_value: [], // Score 1-4 and not enabled
     available: [],     // Score 0, not enabled
     already_connected: [], // Already enabled
+    connect_detected: [], // Installed apps that route through /connect
   };
 
   for (const [key, data] of Object.entries(signals)) {
-    if (enabled.includes(key)) {
-      recommendations.already_connected.push({
-        id: key,
-        name: data.shortName,
-      });
-      continue;
-    }
-
     const entry = {
       id: key,
       name: data.name,
       shortName: data.shortName,
+      route: data.route,
       setup: data.setup,
       value: data.value,
       setupTime: data.setupTime,
@@ -508,6 +579,21 @@ function generateRecommendations(signals) {
             ? `${data.mentions} mention${data.mentions === 1 ? '' : 's'} in your notes${data.examples.length > 0 ? ` (e.g. ${data.examples[0]})` : ''}`
             : 'available to connect',
     };
+
+    if (data.route === 'connect') {
+      if (data.score > 0) {
+        recommendations.connect_detected.push(entry);
+      }
+      continue;
+    }
+
+    if (enabled.includes(key)) {
+      recommendations.already_connected.push({
+        id: key,
+        name: data.shortName,
+      });
+      continue;
+    }
 
     // Add Granola note to Zoom
     if (key === 'zoom' && hasGranola) {
@@ -531,6 +617,7 @@ function generateRecommendations(signals) {
   // Sort each tier by score descending
   recommendations.high_value.sort((a, b) => b.score - a.score);
   recommendations.moderate_value.sort((a, b) => b.score - a.score);
+  recommendations.connect_detected.sort((a, b) => b.score - a.score);
 
   return recommendations;
 }

--- a/.claude/hooks/tests/integration-concierge.test.cjs
+++ b/.claude/hooks/tests/integration-concierge.test.cjs
@@ -74,14 +74,83 @@ function recommendationFor(output, id) {
   ].find((entry) => entry.id === id);
 }
 
-function assertFourTiers(output) {
+function assertOutputShape(output) {
   assert.deepEqual(Object.keys(output), [
     'high_value',
     'moderate_value',
     'available',
     'already_connected',
+    'connect_detected',
   ]);
 }
+
+const CURATED_SETUP_ROUTES = {
+  'google-workspace': '/google-workspace-setup',
+  teams: '/ms-teams-setup',
+  todoist: '/todoist-setup',
+  things: '/things-setup',
+  trello: '/trello-setup',
+  zoom: '/zoom-setup',
+  atlassian: '/atlassian-setup',
+  // Granola is curated, not a /connect route: granola_server.py reads
+  // GRANOLA_API_KEY from the environment or the vault .env, so a credential
+  // stored by the connection manager would be invisible to it.
+  granola: '/granola-setup',
+};
+
+const CONNECT_APP_ROUTES = {
+  slack: { name: 'Slack', shortName: 'Slack', app: 'Slack.app' },
+  notion: { name: 'Notion', shortName: 'Notion', app: 'Notion.app' },
+  linear: { name: 'Linear', shortName: 'Linear', app: 'Linear.app' },
+  obsidian: { name: 'Obsidian', shortName: 'Obsidian', app: 'Obsidian.app' },
+  cursor: { name: 'Cursor', shortName: 'Cursor', app: 'Cursor.app' },
+  figma: { name: 'Figma', shortName: 'Figma', app: 'Figma.app' },
+};
+
+test('curated integrations preserve their setup skills and ordering', (t) => {
+  const fixture = createFixture(t);
+  const output = runConcierge(fixture.env);
+
+  assert.deepEqual(
+    output.available.map((entry) => entry.id),
+    Object.keys(CURATED_SETUP_ROUTES),
+  );
+  assert.deepEqual(output.connect_detected, []);
+  for (const [id, setup] of Object.entries(CURATED_SETUP_ROUTES)) {
+    const entry = recommendationFor(output, id);
+    assert.equal(entry.route, 'skill', id);
+    assert.equal(entry.setup, setup, id);
+  }
+});
+
+test('installed detection-only apps use connect routes without fabricated setup skills', (t) => {
+  const fixture = createFixture(t);
+  for (const { app } of Object.values(CONNECT_APP_ROUTES)) {
+    fs.mkdirSync(path.join(fixture.appDir, app));
+  }
+
+  const output = runConcierge(fixture.env);
+  const legacyEntries = [
+    ...output.high_value,
+    ...output.moderate_value,
+    ...output.available,
+    ...output.already_connected,
+  ];
+
+  for (const [id, expected] of Object.entries(CONNECT_APP_ROUTES)) {
+    const entry = output.connect_detected.find((candidate) => candidate.id === id);
+    assert.ok(entry, id);
+    assert.equal(entry.route, 'connect', id);
+    assert.equal(Object.hasOwn(entry, 'setup'), false, id);
+    assert.equal(Object.hasOwn(entry, 'setupSkill'), false, id);
+    assert.equal(entry.name, expected.name, id);
+    assert.equal(entry.shortName, expected.shortName, id);
+    assert.deepEqual(entry.installedApps, [expected.app], id);
+    assert.equal(entry.reason, 'installed on your Mac', id);
+    assert.ok(entry.value, id);
+    assert.equal(legacyEntries.some((candidate) => candidate.id === id), false, id);
+  }
+});
 
 test('installed Things app promotes the integration to high value', (t) => {
   const fixture = createFixture(t);
@@ -192,7 +261,7 @@ test('malformed MCP config is ignored without changing the output tiers', (t) =>
   const output = runConcierge(fixture.env);
   const trello = output.available.find((entry) => entry.id === 'trello');
 
-  assertFourTiers(output);
+  assertOutputShape(output);
   assert.ok(trello, JSON.stringify(output, null, 2));
   assert.equal(trello.reason, 'available to connect');
   assert.deepEqual(trello.configuredMcp, []);

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -376,6 +376,40 @@ def test_onboarding_runs_the_first_week_reveal_before_tool_discovery() -> None:
     assert "draft_weekly_plan" in finale
 
 
+def test_onboarding_step_nine_explains_connect_without_overpromising() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    connect_step = flow.split("## Step 9:", 1)[1].split("## Step 10:", 1)[0]
+    lowered = connect_step.lower()
+
+    assert "/connect" in connect_step
+    assert "hundreds" in lowered
+    assert "paste a key" in lowered
+    assert "browser sign-in" in lowered
+    assert "one-time setup" in lowered
+    assert "register your own app for dex" in lowered
+    assert "tool's own settings" in lowered
+    assert "google and linear" in lowered
+    assert "--allow-unvetted" in connect_step
+    assert "explicit opt-in" in lowered
+    assert connect_step.index("get explicit opt-in") < connect_step.index(
+        "--allow-unvetted"
+    )
+    for forbidden_claim in ("secure", "safe", "malware"):
+        assert forbidden_claim not in lowered
+
+
+def test_onboarding_step_nine_preserves_the_curated_setup_skill_flow() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    connect_step = flow.split("## Step 9:", 1)[1].split("## Step 10:", 1)[0]
+
+    assert "invoke the skill referenced in the integration's `setup` field" in connect_step
+    assert "Wait for the setup skill to complete" in connect_step
+    assert "Which existing skills just got smarter" in connect_step
+    assert "What new capabilities are now available" in connect_step
+    assert "Privacy and trust level summary" in connect_step
+    assert "Move to the next selected integration" in connect_step
+
+
 def test_getting_started_treats_the_reveal_as_already_presented() -> None:
     skill = _read(".claude/skills/getting-started/SKILL.md")
 


### PR DESCRIPTION
Setup offered seven hand-written services and **never mentioned `/connect`**, which shipped in v1.77.0 and can reach hundreds of tools. Verified: `/connect` appeared nowhere in the onboarding flow.

## What changes for a new user

- **Dex now notices more of what you actually have.** The concierge already scanned installed apps but only recognised seven. It now also detects Slack, Notion, Linear, Obsidian, Granola, Cursor and Figma. Detections appear **only when the app is genuinely installed**, so the default list doesn't silently double for someone with a bare machine.
- **Setup finally mentions `/connect`** — honestly. Pasted keys are quick; browser sign-ins need a one-time setup where you register your own app in that tool's settings. Only Google and Linear have had the security review, and anything else asks for explicit opt-in first. No "secure" or "protected" language, per the shipped skill's own honesty rules.
- **The seven curated integrations are untouched** — same tested setup skills, same ordering, same copy. They remain the headline; detections are additive.

## The defect this review caught

Codex had routed **Granola to `/connect`**. That would have been a real over-promise: `granola_server.py` reads `GRANOLA_API_KEY` from the environment or the vault's `.env`, so a credential stored by the connection manager is **invisible to it**. A user would connect Granola, be told it worked, and find Granola features still didn't function.

Granola now routes to `/granola-setup`, which actually works. This is the same promise-versus-enforcement mismatch class as the Slack review claim flagged earlier today. It changes when Granola moves onto the catalog — a deliberate, separate piece of work — not before.

Detected tools that route to `/connect` carry **no `setup` field at all**, so nothing can invent a setup skill that doesn't exist (there's a CI gate for exactly that).

## Verification

- Concierge: 12/12 tests pass; valid JSON and exit 0 with no vault; run on a real machine it correctly sorts Granola into the curated skill route and Slack/Linear/Obsidian/Cursor into `/connect`.
- Python: 81 tests pass. Ruff clean. PII, instructed-tools, architecture-inventory, path-contract and test-delta gates all pass **after committing** (running them pre-commit gives a false pass — they inspect committed changes).
- `npm run test:scripts` shows 11 failures in the entity-engine/gardener suites. **These are pre-existing** — I ran the identical suite on a clean checkout of current `origin/main` and got the same 11 failures, so they are unrelated to this change.
- No file under `core/integrations/connection-manager/`, `dex-credd`, or the `/connect` skill was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
