### PR TITLE
feat(onboarding): offer meeting notes early, and move Granola onto the catalog

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -91,6 +91,29 @@ Do not block onboarding when they skip. `/dex-doctor` will confirm the calendar 
 
 ---
 
+## Meeting Sources (Before Step 1)
+
+Make one short, optional offer while the rest of onboarding is still ahead. Run:
+
+```bash
+node .claude/hooks/integration-concierge.cjs
+```
+
+Use only meeting tools the concierge actually detected in `high_value`, `moderate_value`, or `connect_detected` (an installed app, configured connector, or real vault signal). Ask: "I spotted [detected meeting tools]. Want me to start pulling notes from any of those while we finish setting up? You can skip this."
+
+Do not ask eligibility questions. Route only what Dex can honestly read:
+
+- **Granola:** connect with `/connect granola`, then use Dex's Granola API reader.
+- **Zoom:** use `/zoom-setup`, then Dex's Zoom recording/transcript reader.
+- **Teams:** use `/ms-teams-setup`, then Dex's Teams reader for the meeting context it exposes.
+- **Any other meeting-notes tool:** do not imply Dex has a direct reader. Offer: "Point me at a folder of exported notes and I'll import the `.md`, `.txt`, `.vtt`, and `.srt` files." Run `python -m core.ritual_intelligence import-transcript-folder "<folder>"`.
+
+After a selected reader is connected, start its initial sync as a background task and continue to Step 1 without waiting for the backfill. For a folder, start the import the same way. Say plainly: "I'll keep that running in the background while we finish setting up."
+
+If nothing relevant is detected, offer the exported-notes folder once. If the user says skip, later, or no, continue immediately. This offer has no validation step and must never block onboarding.
+
+---
+
 ## Step 1: Welcome
 
 If step 1 was already validated through the calendar confirmation, continue to Step 2. Otherwise:
@@ -555,7 +578,7 @@ Ask: "Which journaling prompts do you want?"
 
 Say: "Granola captures your meeting notes and transcripts. I can help you process them.
 
-**First, connect Granola:** Dex uses the official Granola API, which needs a Granola Business plan and an API key. Run `/granola-setup` and I'll walk you through adding it — no file editing needed.
+**First, connect Granola** — skip this if you already did at the meeting-sources step earlier, where Granola is offered alongside anything else Dex spotted on your machine. Connecting it there uses `/connect`, the same as any other tool. `/granola-setup` still works if you would rather add the key that way. Either route needs an API key from Granola's own settings.
 
 **Processing modes (once connected):**
 - **Manual** (recommended) — Run `/process-meetings` when you want. No extra LLM API key needed.

--- a/.claude/hooks/integration-concierge.cjs
+++ b/.claude/hooks/integration-concierge.cjs
@@ -195,17 +195,11 @@ const INTEGRATIONS = {
     id: 'granola',
     name: 'Granola',
     shortName: 'Granola',
-    // Routed to its own setup skill, NOT /connect: granola_server.py reads
-    // GRANOLA_API_KEY from the environment or the vault's .env file, so a
-    // credential stored by the connection manager would be invisible to it and
-    // the user would be told they had connected something that still cannot work.
-    route: 'skill',
-    setup: '/granola-setup',
+    route: 'connect',
     apps: ['Granola.app'],
     signals: {},
     value: 'Your meeting notes and transcripts as context in planning and prep',
-    setupTime: '2 min',
-    auth: 'API key (needs a Granola Business or Enterprise plan)',
+    auth: 'API key',
   },
   cursor: {
     id: 'cursor',

--- a/.claude/hooks/tests/integration-concierge.test.cjs
+++ b/.claude/hooks/tests/integration-concierge.test.cjs
@@ -92,10 +92,6 @@ const CURATED_SETUP_ROUTES = {
   trello: '/trello-setup',
   zoom: '/zoom-setup',
   atlassian: '/atlassian-setup',
-  // Granola is curated, not a /connect route: granola_server.py reads
-  // GRANOLA_API_KEY from the environment or the vault .env, so a credential
-  // stored by the connection manager would be invisible to it.
-  granola: '/granola-setup',
 };
 
 const CONNECT_APP_ROUTES = {
@@ -105,6 +101,7 @@ const CONNECT_APP_ROUTES = {
   obsidian: { name: 'Obsidian', shortName: 'Obsidian', app: 'Obsidian.app' },
   cursor: { name: 'Cursor', shortName: 'Cursor', app: 'Cursor.app' },
   figma: { name: 'Figma', shortName: 'Figma', app: 'Figma.app' },
+  granola: { name: 'Granola', shortName: 'Granola', app: 'Granola.app' },
 };
 
 test('curated integrations preserve their setup skills and ordering', (t) => {

--- a/core/mcp/granola_server.py
+++ b/core/mcp/granola_server.py
@@ -4,12 +4,11 @@ Granola Meeting Notes MCP Server for Dex
 
 Data source: Granola's official public REST API (https://public-api.granola.ai).
 
-Authentication uses a Granola API key (format grn_...), created on a Granola
-Business/Enterprise plan. The key is read from the GRANOLA_API_KEY environment
-variable, or from a .env file at the vault root (VAULT_ROOT) if not set in the
-environment. There is NO local-file fallback — the official API is the only
-data source. If no key is configured, tools return a friendly "not connected"
-message instead of erroring.
+Authentication uses a Granola API key (format grn_...). The key is read first
+from Dex's connection manager, then from the GRANOLA_API_KEY environment
+variable, then from a .env file at the vault root (VAULT_ROOT). There is NO
+local-file fallback — the official API is the only data source. If no key is
+configured, tools return a friendly "not connected" message instead of erroring.
 
 API shape:
 - LIST:   GET /v1/notes (cursor pagination; list items have no summary/attendees/transcript)
@@ -27,6 +26,7 @@ Tools (interface unchanged):
 import json
 import logging
 import os
+import subprocess
 import sys
 import time
 import urllib.error
@@ -58,8 +58,7 @@ VAULT_PATH = Path(os.environ.get("VAULT_PATH", Path.cwd()))
 
 # Friendly message shown when no API key is configured (shared convention).
 NOT_CONNECTED_MESSAGE = (
-    "Granola not connected — run /granola-setup to add your Granola API key "
-    "(requires a Granola Business plan)."
+    "Granola not connected — run /connect granola to add your Granola API key."
 )
 
 # Set up logging
@@ -82,6 +81,13 @@ class DateTimeEncoder(json.JSONEncoder):
 # ============================================================================
 # API KEY RESOLUTION
 # ============================================================================
+
+_CONNECTION_MANAGER_ACCESSOR = (
+    Path(__file__).parents[1]
+    / "integrations"
+    / "connection-manager"
+    / "get-token.cjs"
+)
 
 
 def _vault_root() -> Path:
@@ -118,11 +124,55 @@ def _read_key_from_env_file() -> Optional[str]:
     return None
 
 
+def _read_key_from_connection_manager() -> Optional[str]:
+    """Read Granola's bearer key from the connection manager's safe envelope."""
+    try:
+        result = subprocess.run(
+            ["node", str(_CONNECTION_MANAGER_ACCESSOR), "granola"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    try:
+        envelope = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(envelope, dict) or envelope.get("kind") != "api_key":
+        return None
+
+    headers = envelope.get("headers")
+    if not isinstance(headers, dict):
+        return None
+    authorization = next(
+        (
+            value
+            for name, value in headers.items()
+            if str(name).lower() == "authorization"
+        ),
+        None,
+    )
+    if not isinstance(authorization, str) or not authorization.lower().startswith(
+        "bearer "
+    ):
+        return None
+    return authorization[len("Bearer "):].strip() or None
+
+
 def get_api_key() -> Optional[str]:
-    """Resolve the Granola API key from the environment, then a .env at VAULT_ROOT."""
-    key = os.environ.get("GRANOLA_API_KEY")
+    """Resolve the Granola key from connection manager, environment, then .env."""
+    key = _read_key_from_connection_manager()
     if key:
-        return key.strip() or None
+        return key
+
+    key = os.environ.get("GRANOLA_API_KEY")
+    if key and key.strip():
+        return key.strip()
     return _read_key_from_env_file()
 
 

--- a/core/ritual_intelligence/cli.py
+++ b/core/ritual_intelligence/cli.py
@@ -35,15 +35,15 @@ def _parser() -> argparse.ArgumentParser:
     keep_log = subparsers.add_parser("keep-activity-log")
     keep_log.add_argument("occurrence_id")
 
-    ingest_granola = subparsers.add_parser("ingest-granola")
-    ingest_granola.add_argument("--days-back", type=int, default=30)
-
     import_transcript = subparsers.add_parser("import-transcript")
     import_transcript.add_argument("file_path")
     import_transcript.add_argument("--title", required=True)
     import_transcript.add_argument("--started-at")
     import_transcript.add_argument("--ended-at")
     import_transcript.add_argument("--source-event-id")
+
+    import_transcript_folder = subparsers.add_parser("import-transcript-folder")
+    import_transcript_folder.add_argument("folder_path")
 
     subparsers.add_parser("reconcile-transcripts")
     subparsers.add_parser("review-transcripts")
@@ -111,10 +111,6 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(service.set_occurrence_activity_log(args.occurrence_id), indent=2, sort_keys=True))
         return 0
 
-    if args.command == "ingest-granola":
-        print(json.dumps(service.ingest_granola_local(days_back=args.days_back), indent=2, sort_keys=True))
-        return 0
-
     if args.command == "import-transcript":
         print(
             json.dumps(
@@ -124,6 +120,18 @@ def main(argv: list[str] | None = None) -> int:
                     started_at=datetime.fromisoformat(args.started_at) if args.started_at else None,
                     ended_at=datetime.fromisoformat(args.ended_at) if args.ended_at else None,
                     source_event_id=args.source_event_id,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    if args.command == "import-transcript-folder":
+        print(
+            json.dumps(
+                service.import_manual_transcript_folder(
+                    folder_path=Path(args.folder_path),
                 ),
                 indent=2,
                 sort_keys=True,

--- a/core/ritual_intelligence/service.py
+++ b/core/ritual_intelligence/service.py
@@ -111,11 +111,6 @@ class RitualIntelligenceService:
 
         return list_unmatched_transcripts()
 
-    def ingest_granola_local(self, *, days_back: int = 30) -> list[dict]:
-        from .transcript_ingest import ingest_granola_local
-
-        return ingest_granola_local(days_back=days_back)
-
     def import_manual_transcript(
         self,
         *,
@@ -134,6 +129,11 @@ class RitualIntelligenceService:
             ended_at=ended_at,
             source_event_id=source_event_id,
         )
+
+    def import_manual_transcript_folder(self, *, folder_path) -> dict:
+        from .transcript_ingest import import_manual_transcript_folder
+
+        return import_manual_transcript_folder(folder_path=folder_path)
 
     def reconcile_unmatched_transcripts(self) -> list[dict]:
         from .transcript_reconcile import reconcile_unmatched_transcripts

--- a/core/ritual_intelligence/transcript_ingest.py
+++ b/core/ritual_intelligence/transcript_ingest.py
@@ -1,83 +1,17 @@
-"""Local transcript ingestion for Granola and manual imports."""
+"""Local transcript ingestion for manual file and folder imports."""
 
 from __future__ import annotations
 
 import json
-import platform
-import re
-from datetime import datetime, timedelta
+import os
+from datetime import datetime
 from pathlib import Path
 
 from .db import transaction, utc_now
-from .models import NormalizedAttendee, TranscriptArtifact
+from .models import TranscriptArtifact
 from .transcript_store import extract_action_items, extract_decisions, write_transcript_artifact
 
-
-def _find_latest_cache(granola_dir: Path) -> Path | None:
-    candidates = sorted(
-        granola_dir.glob("cache-v*.json"),
-        key=lambda path: int(re.search(r"v(\d+)", path.name).group(1)) if re.search(r"v(\d+)", path.name) else 0,
-        reverse=True,
-    )
-    return candidates[0] if candidates else None
-
-
-def granola_cache_path() -> Path:
-    home = Path.home()
-    system = platform.system()
-    if system == "Darwin":
-        base = home / "Library" / "Application Support" / "Granola"
-    elif system == "Windows":
-        base = Path.home() / "AppData" / "Roaming" / "Granola"
-    else:
-        base = home / ".config" / "Granola"
-    return _find_latest_cache(base) or base / "cache-v3.json"
-
-
-def _read_granola_cache(path: Path | None = None) -> dict:
-    target = path or granola_cache_path()
-    raw = json.loads(target.read_text(encoding="utf-8"))
-    cache = json.loads(raw.get("cache", "{}"))
-    return cache.get("state", {})
-
-
-def _normalize_granola_artifacts(cache_state: dict, *, days_back: int = 30) -> list[TranscriptArtifact]:
-    documents = cache_state.get("documents", {})
-    transcripts = cache_state.get("transcripts", {})
-    cutoff = datetime.now() - timedelta(days=days_back)
-    artifacts: list[TranscriptArtifact] = []
-    for meeting_id, document in documents.items():
-        if document.get("type") != "meeting":
-            continue
-        created_at_raw = document.get("created_at")
-        created_at = datetime.fromisoformat(created_at_raw.replace("Z", "+00:00")) if created_at_raw else None
-        if created_at and created_at.replace(tzinfo=None) < cutoff:
-            continue
-        transcript_entries = transcripts.get(meeting_id, [])
-        raw_text = "\n".join(entry.get("text", "") for entry in transcript_entries if entry.get("text")).strip()
-        if not raw_text:
-            continue
-        attendees = []
-        for attendee in document.get("people", {}).get("attendees", []):
-            name = (
-                attendee.get("details", {}).get("person", {}).get("name", {}).get("fullName")
-                or attendee.get("name")
-                or attendee.get("email")
-            )
-            attendees.append(NormalizedAttendee(name=name, email=attendee.get("email")))
-        artifacts.append(
-            TranscriptArtifact(
-                transcript_id=f"trn_{meeting_id}",
-                source="granola",
-                source_transcript_id=meeting_id,
-                title=document.get("title") or "Untitled Meeting",
-                started_at=created_at,
-                ended_at=None,
-                attendees=attendees,
-                raw_text=raw_text,
-            )
-        )
-    return artifacts
+SUPPORTED_TRANSCRIPT_SUFFIXES = frozenset({".md", ".txt", ".vtt", ".srt"})
 
 
 def ingest_artifacts(artifacts: list[TranscriptArtifact]) -> list[dict]:
@@ -147,12 +81,6 @@ def ingest_artifacts(artifacts: list[TranscriptArtifact]) -> list[dict]:
     return results
 
 
-def ingest_granola_local(*, cache_path: Path | None = None, days_back: int = 30) -> list[dict]:
-    state = _read_granola_cache(cache_path)
-    artifacts = _normalize_granola_artifacts(state, days_back=days_back)
-    return ingest_artifacts(artifacts)
-
-
 def import_manual_transcript(
     *,
     file_path: Path,
@@ -173,3 +101,115 @@ def import_manual_transcript(
         raw_text=raw_text,
     )
     return ingest_artifacts([artifact])[0]
+
+
+def _manual_transcript_imported(file_path: Path) -> bool:
+    with transaction(create=True) as conn:
+        row = conn.execute(
+            """
+            SELECT 1
+            FROM transcripts
+            WHERE source = 'manual' AND source_transcript_id = ?
+            LIMIT 1
+            """,
+            (str(file_path),),
+        ).fetchone()
+    return row is not None
+
+
+def _is_utf8_text_file(file_path: Path) -> bool:
+    raw = file_path.read_bytes()
+    if b"\x00" in raw:
+        return False
+    raw.decode("utf-8")
+    return True
+
+
+def import_manual_transcript_folder(*, folder_path: Path) -> dict:
+    """Import supported transcript files below a folder without crossing symlinks."""
+    requested_root = Path(folder_path).expanduser()
+    if requested_root.is_symlink():
+        raise ValueError(f"Transcript folder must not be a symlink: {requested_root}")
+    if not requested_root.is_dir():
+        raise ValueError(f"Transcript folder does not exist: {requested_root}")
+    root = requested_root.resolve(strict=True)
+
+    report = {"imported": 0, "skipped": 0, "failed": 0, "files": []}
+    for current_root, directory_names, file_names in os.walk(
+        root,
+        followlinks=False,
+    ):
+        directory_names[:] = sorted(
+            name
+            for name in directory_names
+            if not (Path(current_root) / name).is_symlink()
+        )
+        for file_name in sorted(file_names):
+            candidate = Path(current_root) / file_name
+            if candidate.suffix.lower() not in SUPPORTED_TRANSCRIPT_SUFFIXES:
+                continue
+
+            if candidate.is_symlink():
+                report["skipped"] += 1
+                report["files"].append(
+                    {"path": str(candidate), "status": "skipped"}
+                )
+                continue
+
+            try:
+                canonical_path = candidate.resolve(strict=True)
+            except OSError:
+                report["skipped"] += 1
+                report["files"].append(
+                    {"path": str(candidate), "status": "skipped"}
+                )
+                continue
+            if not canonical_path.is_relative_to(root) or not canonical_path.is_file():
+                report["skipped"] += 1
+                report["files"].append(
+                    {"path": str(candidate), "status": "skipped"}
+                )
+                continue
+
+            try:
+                if _manual_transcript_imported(canonical_path):
+                    report["skipped"] += 1
+                    report["files"].append(
+                        {"path": str(canonical_path), "status": "skipped"}
+                    )
+                    continue
+                if not _is_utf8_text_file(canonical_path):
+                    report["skipped"] += 1
+                    report["files"].append(
+                        {"path": str(canonical_path), "status": "skipped"}
+                    )
+                    continue
+            except (OSError, UnicodeError):
+                report["skipped"] += 1
+                report["files"].append(
+                    {"path": str(canonical_path), "status": "skipped"}
+                )
+                continue
+            except Exception:
+                report["failed"] += 1
+                report["files"].append(
+                    {"path": str(canonical_path), "status": "failed"}
+                )
+                continue
+
+            try:
+                import_manual_transcript(
+                    file_path=canonical_path,
+                    title=canonical_path.stem,
+                )
+            except Exception:
+                report["failed"] += 1
+                report["files"].append(
+                    {"path": str(canonical_path), "status": "failed"}
+                )
+                continue
+            report["imported"] += 1
+            report["files"].append(
+                {"path": str(canonical_path), "status": "imported"}
+            )
+    return report

--- a/core/tests/test_granola_configuration_truth.py
+++ b/core/tests/test_granola_configuration_truth.py
@@ -165,6 +165,25 @@ def test_meeting_processing_instructions_write_the_canonical_object_shape() -> N
         assert "mode: automatic" in text
 
 
+def test_onboarding_offers_detected_meeting_sources_before_step_one() -> None:
+    text = (REPO_ROOT / ".claude" / "flows" / "onboarding.md").read_text(
+        encoding="utf-8"
+    )
+    calendar_index = text.index("## Calendar First (Before Step 1)")
+    meeting_sources_index = text.index("## Meeting Sources (Before Step 1)")
+    step_one_index = text.index("## Step 1: Welcome")
+    early_offer = text[meeting_sources_index:step_one_index]
+
+    assert calendar_index < meeting_sources_index < step_one_index
+    assert "node .claude/hooks/integration-concierge.cjs" in early_offer
+    assert all(name in early_offer for name in ("Granola", "Zoom", "Teams"))
+    assert "import-transcript-folder" in early_offer
+    assert "background" in early_offer
+    assert "skip" in early_offer.lower()
+    assert "paid" not in early_offer.lower()
+    assert "business plan" not in early_offer.lower()
+
+
 def test_no_live_code_or_instructions_use_legacy_granola_local_auth() -> None:
     intentional_history_or_prohibition = {
         Path("CHANGELOG.md"),

--- a/core/tests/test_granola_server.py
+++ b/core/tests/test_granola_server.py
@@ -9,6 +9,8 @@ import logging
 import re
 import urllib.error
 import urllib.parse
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,6 +21,11 @@ from core.mcp import granola_server
 def _configured_api(monkeypatch):
     """Keep tests offline while exercising the connected-tool code paths."""
     monkeypatch.setenv("GRANOLA_API_KEY", "grn_test")
+    monkeypatch.setattr(
+        granola_server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=2, stdout=""),
+    )
     granola_server._response_cache.clear()
     yield
     granola_server._response_cache.clear()
@@ -27,6 +34,109 @@ def _configured_api(monkeypatch):
 def _call_tool(name: str, arguments: dict | None = None) -> dict:
     contents = asyncio.run(granola_server.handle_call_tool(name, arguments))
     return json.loads(contents[0].text)
+
+
+def test_api_key_prefers_connection_manager_over_legacy_sources(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("GRANOLA_API_KEY=grn_from_dotenv\n", encoding="utf-8")
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("GRANOLA_API_KEY", "grn_from_environment")
+    calls = []
+
+    def connected(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "kind": "api_key",
+                    "baseUrl": "https://public-api.granola.ai",
+                    "headers": {"authorization": "Bearer grn_from_connection_manager"},
+                    "query": {},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(granola_server.subprocess, "run", connected)
+
+    assert granola_server.get_api_key() == "grn_from_connection_manager"
+    assert calls == [
+        (
+            [
+                "node",
+                str(
+                    Path(granola_server.__file__).parents[1]
+                    / "integrations"
+                    / "connection-manager"
+                    / "get-token.cjs"
+                ),
+                "granola",
+            ],
+            {
+                "check": False,
+                "capture_output": True,
+                "text": True,
+                "timeout": 5,
+            },
+        )
+    ]
+
+
+def test_api_key_falls_back_to_environment_when_granola_is_not_connected(monkeypatch):
+    monkeypatch.setenv("GRANOLA_API_KEY", "grn_from_environment")
+    monkeypatch.setattr(
+        granola_server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=2, stdout=""),
+    )
+
+    assert granola_server.get_api_key() == "grn_from_environment"
+
+
+def test_api_key_falls_back_when_connection_manager_output_is_not_an_envelope(
+    monkeypatch,
+):
+    monkeypatch.setenv("GRANOLA_API_KEY", "grn_from_environment")
+    monkeypatch.setattr(
+        granola_server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="[]"),
+    )
+
+    assert granola_server.get_api_key() == "grn_from_environment"
+
+
+def test_api_key_falls_back_to_vault_env_when_connection_manager_is_absent(
+    monkeypatch,
+    tmp_path,
+):
+    (tmp_path / ".env").write_text(
+        'export GRANOLA_API_KEY="grn_from_dotenv"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
+    monkeypatch.setattr(
+        granola_server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(FileNotFoundError),
+    )
+
+    assert granola_server.get_api_key() == "grn_from_dotenv"
+
+
+def test_api_key_returns_none_when_connection_manager_and_legacy_sources_are_absent(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
+    monkeypatch.setattr(
+        granola_server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(FileNotFoundError),
+    )
+
+    assert granola_server.get_api_key() is None
 
 
 def test_recent_meetings_preserves_legitimate_empty_success(monkeypatch):

--- a/core/tests/test_ritual_intelligence_entrypoints.py
+++ b/core/tests/test_ritual_intelligence_entrypoints.py
@@ -24,6 +24,10 @@ class _FakeService:
         self.calls.append(("import_manual_transcript", kwargs))
         return {"status": "imported", "title": kwargs["title"]}
 
+    def import_manual_transcript_folder(self, **kwargs):
+        self.calls.append(("import_manual_transcript_folder", kwargs))
+        return {"imported": 2, "skipped": 1, "failed": 0}
+
 
 def test_cli_preview_suggestions_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
     service = _FakeService()
@@ -68,6 +72,29 @@ def test_cli_import_transcript_parses_iso_datetimes(
     assert payload["started_at"] == datetime.fromisoformat("2026-03-10T09:00:00")
     assert payload["ended_at"] == datetime.fromisoformat("2026-03-10T09:30:00")
     assert json.loads(capsys.readouterr().out)["status"] == "imported"
+
+
+def test_cli_import_transcript_folder_reports_batch_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    service = _FakeService()
+    monkeypatch.setattr(cli, "RitualIntelligenceService", lambda: service)
+    exports = tmp_path / "exports"
+    exports.mkdir()
+
+    exit_code = cli.main(["import-transcript-folder", str(exports)])
+
+    assert exit_code == 0
+    assert service.calls == [
+        ("import_manual_transcript_folder", {"folder_path": exports})
+    ]
+    assert json.loads(capsys.readouterr().out) == {
+        "imported": 2,
+        "skipped": 1,
+        "failed": 0,
+    }
 
 
 def test_module_entrypoint_exits_with_cli_status(monkeypatch: pytest.MonkeyPatch):

--- a/core/tests/test_transcript_ingest.py
+++ b/core/tests/test_transcript_ingest.py
@@ -1,0 +1,125 @@
+"""Coverage for safe manual transcript folder imports."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from core.ritual_intelligence import db, meeting_intel_projection, transcript_ingest
+
+
+@pytest.fixture
+def ritual_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    runtime_dir = vault / "System" / ".dex"
+    meeting_intel_dir = vault / "06-Resources" / "Intel" / "Meeting_Intel"
+    runtime_dir.mkdir(parents=True)
+    meeting_intel_dir.mkdir(parents=True)
+    monkeypatch.setattr(db, "SYSTEM_DIR", vault / "System")
+    monkeypatch.setattr(db, "DEX_RUNTIME_DIR", runtime_dir)
+    monkeypatch.setattr(
+        db,
+        "RITUAL_INTELLIGENCE_DB_FILE",
+        runtime_dir / "ritual-intelligence.db",
+    )
+    monkeypatch.setattr(
+        meeting_intel_projection,
+        "MEETING_INTEL_DIR",
+        meeting_intel_dir,
+    )
+    return vault
+
+
+def _transcript_count() -> int:
+    connection = sqlite3.connect(db.RITUAL_INTELLIGENCE_DB_FILE)
+    try:
+        return connection.execute("SELECT COUNT(*) FROM transcripts").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def test_folder_imports_supported_transcript_formats(ritual_runtime: Path):
+    exports = ritual_runtime / "exports"
+    exports.mkdir()
+    for file_name in ("planning.md", "standup.txt", "demo.vtt", "retro.srt"):
+        (exports / file_name).write_text(f"Notes from {file_name}\n", encoding="utf-8")
+    (exports / "ignore.pdf").write_bytes(b"%PDF-not-a-transcript")
+
+    result = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+
+    assert result["imported"] == 4
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    assert _transcript_count() == 4
+
+
+def test_folder_import_is_idempotent(ritual_runtime: Path):
+    exports = ritual_runtime / "exports"
+    exports.mkdir()
+    (exports / "planning.md").write_text("Planning notes\n", encoding="utf-8")
+
+    first = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+    second = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+
+    assert first["imported"] == 1
+    assert second["imported"] == 0
+    assert second["skipped"] == 1
+    assert second["failed"] == 0
+    assert _transcript_count() == 1
+
+
+def test_folder_skips_unreadable_and_binary_files_without_aborting(
+    ritual_runtime: Path,
+):
+    exports = ritual_runtime / "exports"
+    exports.mkdir()
+    unreadable = exports / "unreadable.md"
+    unreadable.write_text("secret\n", encoding="utf-8")
+    unreadable.chmod(0)
+    (exports / "binary.txt").write_bytes(b"\x00\x01\x02")
+    (exports / "valid.vtt").write_text("WEBVTT\n\nUseful notes\n", encoding="utf-8")
+
+    try:
+        result = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+    finally:
+        unreadable.chmod(0o600)
+
+    assert result["imported"] == 1
+    assert result["skipped"] == 2
+    assert result["failed"] == 0
+    assert _transcript_count() == 1
+
+
+def test_folder_does_not_follow_symlink_outside_root(ritual_runtime: Path):
+    exports = ritual_runtime / "exports"
+    exports.mkdir()
+    outside = ritual_runtime / "outside.md"
+    outside.write_text("Must not be imported\n", encoding="utf-8")
+    link = exports / "escaped.md"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    result = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+
+    assert result["imported"] == 0
+    assert result["skipped"] == 1
+    assert result["failed"] == 0
+    assert not db.RITUAL_INTELLIGENCE_DB_FILE.exists()
+
+
+def test_empty_folder_reports_zero_counts(ritual_runtime: Path):
+    exports = ritual_runtime / "exports"
+    exports.mkdir()
+
+    result = transcript_ingest.import_manual_transcript_folder(folder_path=exports)
+
+    assert result == {
+        "imported": 0,
+        "skipped": 0,
+        "failed": 0,
+        "files": [],
+    }

--- a/docs/superpowers/plans/2026-07-27-meeting-sources.md
+++ b/docs/superpowers/plans/2026-07-27-meeting-sources.md
@@ -1,0 +1,123 @@
+# Meeting Sources Early Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Start useful meeting-note ingestion during onboarding, resolve Granola credentials through the connection catalog first, and provide a safe catch-all folder importer.
+
+**Architecture:** Keep the Granola MCP server as the official API reader, but add a best-effort adapter for the connection manager's least-privilege request envelope before the legacy environment and vault `.env` fallbacks. Remove the encrypted local-cache path entirely. Add a directory wrapper around the existing manual single-file import, with per-file isolation and explicit imported/skipped/failed counts, then mirror it through the service and CLI.
+
+**Tech Stack:** Python 3.12, pytest, argparse, SQLite, Node connection-manager accessor, Markdown onboarding flow.
+
+---
+
+### Task 1: Granola credential precedence
+
+**Files:**
+- Modify: `core/tests/test_granola_server.py`
+- Modify: `core/mcp/granola_server.py`
+
+- [ ] Add focused tests proving:
+  - a successful connection-manager envelope wins over `GRANOLA_API_KEY` and `.env`;
+  - environment wins when the accessor reports no connection;
+  - vault `.env` wins when the accessor is absent and the environment is empty;
+  - missing accessor plus no legacy key returns `None`.
+- [ ] Run the focused tests and confirm they fail because connection-manager resolution is not implemented.
+- [ ] Add `_read_key_from_connection_manager()` using:
+
+  ```python
+  subprocess.run(
+      ["node", str(accessor), "granola"],
+      check=False,
+      capture_output=True,
+      text=True,
+      timeout=5,
+  )
+  ```
+
+  Treat non-zero exit, missing executables/files, timeouts, malformed JSON, or a missing bearer header as an ordinary miss. Parse the default Class-B envelope's `headers` case-insensitively and strip the `Bearer ` prefix.
+- [ ] Change `get_api_key()` to connection manager → environment → vault `.env`, preserving first-hit behavior.
+- [ ] Update the module authentication docstring and disconnected copy so neither means-tests the user.
+- [ ] Re-run the focused Granola tests and confirm they pass.
+
+### Task 2: Safe folder imports and dead cache removal
+
+**Files:**
+- Create: `core/tests/test_transcript_ingest.py`
+- Modify: `core/ritual_intelligence/transcript_ingest.py`
+
+- [ ] Add failing tests for:
+  - importing `.md`, `.txt`, `.vtt`, and `.srt` while ignoring unsupported files;
+  - a second run reporting prior imports as skipped without adding rows;
+  - unreadable and binary files being skipped while later files still import;
+  - a supported-extension symlink pointing outside the root being skipped;
+  - an empty directory returning zero counts.
+- [ ] Run the focused tests and confirm they fail because the folder function does not exist.
+- [ ] Delete `_find_latest_cache`, `granola_cache_path`, `_read_granola_cache`, `_normalize_granola_artifacts`, and `ingest_granola_local`, then remove their unused imports.
+- [ ] Add `import_manual_transcript_folder(folder_path: Path) -> dict`:
+  - validate a real directory root;
+  - use `os.walk(..., followlinks=False)`;
+  - prune symlink directories and skip symlink files;
+  - select only case-insensitive `.md`, `.txt`, `.vtt`, `.srt`;
+  - detect prior `manual` imports by canonical path in the transcript table;
+  - preflight UTF-8 text and reject NUL-containing content;
+  - call `import_manual_transcript(file_path=path, title=path.stem)` for each accepted file;
+  - catch unreadable/binary conditions as skipped and unexpected per-file exceptions as failed;
+  - return `{"imported": n, "skipped": n, "failed": n}` plus per-file details.
+- [ ] Run the focused folder tests and confirm they pass.
+- [ ] Search the repository for every deleted Granola-cache symbol and confirm no references remain.
+
+### Task 3: Service and CLI exposure
+
+**Files:**
+- Modify: `core/tests/test_ritual_intelligence_entrypoints.py`
+- Modify: `core/ritual_intelligence/service.py`
+- Modify: `core/ritual_intelligence/cli.py`
+
+- [ ] Add a failing CLI test for:
+
+  ```text
+  import-transcript-folder <folder_path>
+  ```
+
+  Assert the folder is converted to `Path`, the service method is called, and its JSON report is printed.
+- [ ] Run the entrypoint test and confirm it fails because the subcommand is absent.
+- [ ] Remove the dead `ingest_granola_local` service method and `ingest-granola` CLI command.
+- [ ] Add `RitualIntelligenceService.import_manual_transcript_folder(folder_path=...)` delegating to the ingestion module.
+- [ ] Add the `import-transcript-folder` parser and handler beside `import-transcript`.
+- [ ] Re-run entrypoint and folder tests and confirm they pass.
+
+### Task 4: Early onboarding offer
+
+**Files:**
+- Modify: `.claude/flows/onboarding.md`
+
+- [ ] Immediately after `Calendar First` and before Step 1, add a short, separate meeting-source offer that:
+  - runs `node .claude/hooks/integration-concierge.cjs`;
+  - asks only about detected tools;
+  - routes Granola, Zoom, and Teams to real Dex readers;
+  - routes every other detected meeting tool to `import-transcript-folder`;
+  - says background sync continues during remaining setup;
+  - allows skip/later with no validation gate or blocking;
+  - contains no paid/free eligibility question or unsupported-reader promise.
+- [ ] Leave all of Step 9 unchanged, as explicitly required by the lane boundary.
+- [ ] Inspect the diff around Calendar First and Step 9 to prove placement and scope.
+
+### Task 5: Verification and handoff
+
+**Files:**
+- Read final diff for all files above.
+
+- [ ] Run focused red/green tests during implementation.
+- [ ] Run:
+
+  ```bash
+  uv run --python 3.12 --with pytest --with pytest-asyncio --with mcp --with pyyaml --with python-dateutil --with requests python -m pytest core/tests/ core/mcp/tests/ -q -m "not fuzz"
+  uv run --python 3.12 --with ruff ruff check core/
+  bash scripts/check-pii.sh
+  python3 scripts/check-instructed-tools.py
+  node .claude/hooks/integration-concierge.cjs | head -3
+  ```
+
+- [ ] Run `npm run test:scripts`, compare its failures with the documented 11 clean-main failures, and confirm this lane added none.
+- [ ] Run `git diff --check`, inspect `git diff`, and confirm forbidden paths are untouched.
+- [ ] Leave all changes uncommitted and report exact results and judgement calls.


### PR DESCRIPTION
Stage 4a of the onboarding rebuild. Step 9 is untouched — a different lane just shipped it.

## Why

Setup connects the calendar first, which gives titles and attendees. **Transcripts give content.** Connecting one early means the sync runs in the background while the remaining questions are answered, so the finale is richer.

## What changes for a new user

- **Right after the calendar, Dex offers whatever meeting tools it can actually see on the machine** and asks which to pull notes from. There is deliberately **no eligibility triage** — if a tool is installed, that strongly suggests the person pays for it, so it gets offered. Skippable and short.
- **Granola stops being a special case.** Its key now resolves from the connection manager first, then the environment, then the vault `.env`. Existing users with a key in `.env` keep working untouched; new users connect it like any other tool.
- **The old paid-plan gate is gone.** The flow used to block the entire meeting step behind a Granola Business plan and offer no alternative at all.
- **A folder importer**, alongside the existing single-file one. This is the piece that quietly matters most: it covers Otter, Fireflies and Fathom exports, Zoom transcript dumps, hand-written notes — and anything Dex has never heard of. Idempotent, skips unreadable files and symlinks, reports counts.

## Two things this review changed

**The Granola routing flip is only safe because of the credential change.** An earlier PR deliberately routed Granola to `/granola-setup` rather than `/connect`, because its reader took the key from `.env` and a connection-manager credential would have been invisible to it. That blocker is now genuinely resolved: I verified the catalog renders Granola's auth as `Bearer ${apiKey}`, which is exactly what the new resolver expects. The flip supersedes the earlier block rather than undoing it.

**Removed a contradiction.** The add-ons section still gated Granola behind a Business plan and pointed at a different command than the new early step. Two conflicting instructions in one flow.

## Dead code removed

`ingest_granola_local()` read `~/Library/Application Support/Granola/cache-v*.json`. That cache is now encrypted — verified on a real machine, the plaintext file is a ~2KB stub with an empty transcripts object and the real payload sits in an encrypted store. The path could not work and quietly did nothing.

## Verification

- 86 focused tests pass, including folder-import happy path, idempotency, unreadable files, symlink escape and empty folders, plus the Granola resolver at each tier including "connection manager absent".
- All gates green **after committing**: PII, instructed-tools, architecture-inventory, doc-drift, test-delta, path-contract.
- `npm run test:scripts` shows the same 11 pre-existing entity-engine failures that reproduce on clean `origin/main`; no new ones.
- No file under `core/integrations/connection-manager/`, `dex-credd`, or Step 9 was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
