### PR TITLE
feat(companies): on by default for new vaults, existing users left exactly as they are

### DIFF
--- a/.scripts/lib/tests/provision.test.cjs
+++ b/.scripts/lib/tests/provision.test.cjs
@@ -121,11 +121,11 @@ test('fresh provision creates the full profile, seeds, MCP config, paths, and by
     assert.equal(profile.ignored_key, undefined);
     assert.deepEqual(profile.capabilities, {
       career: { enabled: false },
-      companies: { enabled: false },
+      companies: { enabled: true },
       quarter_goals: { enabled: false },
     });
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Career')), false);
-    assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), false);
+    assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), true);
     assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), false);
 
     const pillars = yaml.load(fs.readFileSync(path.join(vault, 'System', 'pillars.yaml'), 'utf8'));
@@ -189,9 +189,10 @@ test('fresh provision fills omitted capability rooms from template defaults', ()
     const profile = yaml.load(fs.readFileSync(path.join(vault, 'System', 'user-profile.yaml'), 'utf8'));
     assert.deepEqual(profile.capabilities, {
       career: { enabled: true },
-      companies: { enabled: false },
+      companies: { enabled: true },
       quarter_goals: { enabled: false },
     });
+    assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), true);
   });
 });
 

--- a/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
+++ b/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
@@ -110,7 +110,10 @@ test('auto mode NFC-normalizes decomposed names at filename ingestion', () => wi
 }));
 
 test('unavailable engine queues the create and does not claim the page was created', () => withVault(vault => {
-  const profile = { entity_creation: { mode: 'auto' } };
+  const profile = {
+    entity_creation: { mode: 'auto' },
+    capabilities: { companies: { enabled: false } },
+  };
   const first = processEntityCreation(
     meetings('external', 'example.com'),
     profile,
@@ -524,7 +527,10 @@ test('suggest mode writes one deduplicated company suggestion', () => withVault(
 }));
 
 test('companies room off records people but neither creates nor suggests companies', () => withVault(vault => {
-  const result = processEntityCreation(companyMeetings(), { entity_creation: { mode: 'auto' } });
+  const result = processEntityCreation(companyMeetings(), {
+    entity_creation: { mode: 'auto' },
+    capabilities: { companies: { enabled: false } },
+  });
   assert.equal(result.created.length, 2);
   assert.deepEqual(result.companies_created, []);
   assert.deepEqual(result.companies_suggested, []);

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -126,7 +126,7 @@ capabilities:
   career:
     enabled: false
   companies:
-    enabled: false
+    enabled: true
   quarter_goals:
     enabled: false
 

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -23,6 +23,10 @@ timezone: ""
 updates:
   channel: stable
 
+# Optional local Git snapshots after the brain/vault split. This never pushes.
+vault:
+  auto_commit: false
+
 # Role Intelligence
 # This section is populated during onboarding based on the role definition
 role_context:
@@ -122,7 +126,7 @@ capabilities:
   career:
     enabled: false
   companies:
-    enabled: false
+    enabled: true
   quarter_goals:
     enabled: false
 

--- a/core/capabilities.py
+++ b/core/capabilities.py
@@ -9,6 +9,7 @@ feature lists.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import os
 import shutil
@@ -233,13 +234,12 @@ def migrate_legacy_room_state(
 ) -> list[str]:
     """One-time bridge for vaults onboarded before capability rooms existed.
 
-    Before rooms shipped, every install had all three rooms' surfaces active —
-    so the faithful migration for an ALREADY-ONBOARDED vault whose profile has
-    no ``capabilities`` key is to seed every room ``enabled: true``, preserving
-    the user's status quo. Fresh installs write explicit room answers at
-    onboarding and are never touched here. Returns the rooms seeded (empty
-    when no migration was needed). Runs before any reconcile on the upgrade
-    path so a months-long Career user is never silently switched off.
+    Preserve each room's pre-migration behavior without overriding an explicit
+    capability value or a legacy config value. Companies is pinned off because
+    its fresh-vault default is now on; Career and Quarter Goals keep the earlier
+    bridge's on default when they have no prior opinion. Fresh installs write
+    explicit room answers at onboarding and are never touched here. Returns the
+    rooms seeded (empty when no migration was needed).
     """
     root = Path(vault_root).resolve()
     profile_file = Path(profile_path or root / "System/user-profile.yaml")
@@ -247,13 +247,42 @@ def migrate_legacy_room_state(
     if not onboarded:
         return []
     profile = _read_profile(profile_file, strict=True)
-    if isinstance(profile.get("capabilities"), Mapping):
-        return []  # already migrated or freshly onboarded with explicit answers
+    capability_state = profile.get("capabilities")
+    room_defaults = (
+        {"companies": False}
+        if isinstance(capability_state, Mapping)
+        else {
+            "career": True,
+            "companies": False,
+            "quarter_goals": True,
+        }
+    )
     seeded: list[str] = []
     for room in room_ids(contract_path=contract_path):
+        room_state = (
+            capability_state.get(room)
+            if isinstance(capability_state, Mapping)
+            else None
+        )
+        if (
+            isinstance(room_state, Mapping)
+            and isinstance(room_state.get("enabled"), bool)
+        ):
+            continue
+        surfaces = surfaces_for(room, contract_path=contract_path)
+        legacy_config = surfaces.get("config")
+        if isinstance(legacy_config, str):
+            legacy = profile.get(legacy_config)
+            if (
+                isinstance(legacy, Mapping)
+                and isinstance(legacy.get("enabled"), bool)
+            ):
+                continue
+        if room not in room_defaults:
+            continue
         set_enabled(
             room,
-            True,
+            room_defaults[room],
             vault_root=root,
             profile_path=profile_file,
             contract_path=contract_path,
@@ -270,9 +299,8 @@ def reconcile_all(
 ) -> list[dict[str, Any]]:
     """Reconcile every contract-declared room against the current profile.
 
-    Runs the legacy migration first: an already-onboarded vault with no
-    ``capabilities`` state keeps all rooms on (its pre-rooms status quo)
-    rather than being silently reset to the fresh-install defaults.
+    Runs the legacy migration first so an already-onboarded vault keeps each
+    room's pre-migration behavior rather than inheriting fresh-install defaults.
     """
     root = Path(vault_root).resolve()
     profile = Path(profile_path or root / "System/user-profile.yaml")
@@ -367,6 +395,107 @@ def _set_block_enabled(text: str, block_key: str, room: str | None, value: bool)
             return "".join(lines)
     lines.insert(start + 1, f"{target_indent}enabled: {rendered}{newline}")
     return "".join(lines)
+
+
+def render_missing_companies_compatibility_pin(
+    original: str,
+    *,
+    contract_path: Path | str | None = None,
+) -> str | None:
+    """Render the one-time Companies-off pin without rewriting profile prose.
+
+    ``None`` means the profile already has an explicit or legacy opinion.
+    Invalid state fails closed so an update cannot fall through to the new
+    contract default or replace user-owned data. Profiles with no capability
+    map also retain the earlier Career/Quarter bridge defaults in the same
+    transaction; partial maps gain only the Companies pin.
+    """
+    try:
+        profile = yaml.safe_load(original) or {}
+    except yaml.YAMLError as exc:
+        raise CapabilityError("Profile must contain valid YAML") from exc
+    if not isinstance(profile, dict):
+        raise CapabilityError("Profile must contain an object")
+
+    capability_state = profile.get("capabilities")
+    if capability_state is not None and not isinstance(capability_state, Mapping):
+        raise CapabilityError("Profile capabilities must contain an object")
+    company_state = (
+        capability_state.get("companies")
+        if isinstance(capability_state, Mapping)
+        else None
+    )
+    if company_state is not None and not isinstance(company_state, Mapping):
+        raise CapabilityError("Profile capabilities.companies must contain an object")
+    if isinstance(company_state, Mapping) and "enabled" in company_state:
+        if not isinstance(company_state["enabled"], bool):
+            raise CapabilityError(
+                "Profile capabilities.companies.enabled must be true or false"
+            )
+        return None
+    company_surfaces = surfaces_for("companies", contract_path=contract_path)
+    company_legacy_config = company_surfaces.get("config")
+    if isinstance(company_legacy_config, str):
+        company_legacy_state = profile.get(company_legacy_config)
+        if (
+            isinstance(company_legacy_state, Mapping)
+            and "enabled" in company_legacy_state
+        ):
+            if not isinstance(company_legacy_state["enabled"], bool):
+                raise CapabilityError(
+                    f"Profile {company_legacy_config}.enabled must be true or false"
+                )
+            return None
+
+    room_defaults = (
+        {"companies": False}
+        if isinstance(capability_state, Mapping)
+        else {
+            "career": True,
+            "companies": False,
+            "quarter_goals": True,
+        }
+    )
+    expected = copy.deepcopy(profile)
+    rendered = original
+    for room, default in room_defaults.items():
+        room_state = (
+            capability_state.get(room)
+            if isinstance(capability_state, Mapping)
+            else None
+        )
+        if isinstance(room_state, Mapping) and "enabled" in room_state:
+            if not isinstance(room_state["enabled"], bool):
+                raise CapabilityError(
+                    f"Profile capabilities.{room}.enabled must be true or false"
+                )
+            continue
+        surfaces = surfaces_for(room, contract_path=contract_path)
+        legacy_config = surfaces.get("config")
+        if isinstance(legacy_config, str):
+            legacy_state = profile.get(legacy_config)
+            if isinstance(legacy_state, Mapping) and "enabled" in legacy_state:
+                if not isinstance(legacy_state["enabled"], bool):
+                    raise CapabilityError(
+                        f"Profile {legacy_config}.enabled must be true or false"
+                    )
+                continue
+        expected.setdefault("capabilities", {})
+        expected["capabilities"].setdefault(room, {})
+        expected["capabilities"][room]["enabled"] = default
+        rendered = _set_block_enabled(
+            rendered,
+            "capabilities",
+            room,
+            default,
+        )
+    try:
+        reparsed = yaml.safe_load(rendered) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - guarded by byte-level tests
+        raise CapabilityError("Companies compatibility pin produced invalid YAML") from exc
+    if reparsed != expected:
+        raise CapabilityError("Companies compatibility pin changed unrelated profile state")
+    return rendered
 
 
 def set_enabled(

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -84,6 +84,7 @@ def _transaction_preview_document(
     plan: Sequence[PlanEntry],
     *,
     purpose: str,
+    operation: str = "update",
 ) -> dict[str, object]:
     """Build the private service-to-Transaction approval binding.
 
@@ -111,6 +112,7 @@ def _transaction_preview_document(
         verdict = portable_contract.update_write_verdict(
             entry.relative,
             exists=target.exists(),
+            operation=operation,
         )
         if not verdict.allowed:
             raise PlanRejected(
@@ -137,10 +139,13 @@ def _transaction_preview_document(
                 "current": current,
             }
         )
-    return {
+    preview = {
         "purpose": purpose,
         "writes": sorted(writes, key=lambda write: str(write["path"])),
     }
+    if operation != "update":
+        preview["operation"] = operation
+    return preview
 
 
 def _preview_transaction(
@@ -148,9 +153,15 @@ def _preview_transaction(
     plan: Sequence[PlanEntry],
     *,
     purpose: str,
+    operation: str = "update",
 ) -> dict[str, object]:
     """Preview a private, contract-authorized transaction without writing."""
-    preview = _transaction_preview_document(vault_root, plan, purpose=purpose)
+    preview = _transaction_preview_document(
+        vault_root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+    )
     return _envelope(
         preview=preview,
         approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
@@ -184,10 +195,16 @@ def _execute_approved_transaction(
     *,
     purpose: str,
     approved_token: str,
+    operation: str = "update",
 ) -> dict[str, object]:
     """Execute an exact private preview through the one Transaction engine."""
     root = Path(vault_root)
-    rebuilt = _preview_transaction(root, plan, purpose=purpose)
+    rebuilt = _preview_transaction(
+        root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+    )
     expected = rebuilt["approval_token"]
     if not isinstance(approved_token, str) or not hmac.compare_digest(
         approved_token,
@@ -202,7 +219,7 @@ def _execute_approved_transaction(
     )
     tx_root_relative = Path("System/.dex/tx")
     tx_paths_before = _tree_paths(root, tx_root_relative)
-    result = Transaction.begin(root, list(plan)).run()
+    result = Transaction.begin(root, list(plan), operation=operation).run()
     tx_paths_after = _tree_paths(root, tx_root_relative)
     declared_paths = (
         set(targets)
@@ -227,6 +244,99 @@ def _execute_approved_transaction(
             "declared_paths": sorted(declared_paths),
         }
     )
+
+
+def _missing_companies_default_plan(
+    vault_root: str | Path,
+) -> tuple[list[PlanEntry], dict[str, bool]]:
+    """Build the exact compatibility plan and room-state summary."""
+    import yaml
+
+    from core.capabilities import render_missing_companies_compatibility_pin
+
+    root = Path(vault_root)
+    profile = root / "System/user-profile.yaml"
+    if profile.is_symlink():
+        raise PlanRejected("System/user-profile.yaml must not be a symlink")
+    exists = profile.exists()
+    if exists and not profile.is_file():
+        raise PlanRejected("System/user-profile.yaml must be a regular file")
+    original = profile.read_text(encoding="utf-8") if exists else ""
+    rendered = render_missing_companies_compatibility_pin(original)
+    if rendered is None:
+        return [], {}
+
+    before = yaml.safe_load(original) or {}
+    after = yaml.safe_load(rendered) or {}
+    before_capabilities = before.get("capabilities", {})
+    after_capabilities = after.get("capabilities", {})
+    states = {
+        room: state["enabled"]
+        for room, state in after_capabilities.items()
+        if isinstance(state, Mapping)
+        and isinstance(state.get("enabled"), bool)
+        and (
+            not isinstance(before_capabilities, Mapping)
+            or before_capabilities.get(room) != state
+        )
+    }
+
+    raw = original.encode("utf-8")
+    return [
+        PlanEntry(
+            "System/user-profile.yaml",
+            rendered.encode("utf-8"),
+            mode=(profile.stat().st_mode & 0o777) if exists else 0o644,
+            expected_current_sha256=(
+                hashlib.sha256(raw).hexdigest() if exists else None
+            ),
+            expected_absent=not exists,
+        )
+    ], states
+
+
+def _preview_missing_companies_default(
+    vault_root: str | Path,
+) -> dict[str, object]:
+    """Preview the compatibility transaction without recovering or writing."""
+    root = Path(vault_root)
+    plan, states = _missing_companies_default_plan(root)
+    if not plan:
+        return _envelope(pinned=False, preview=None, states={})
+    purpose = "companies-default-compatibility"
+    operation = "capability-state"
+    preview = _preview_transaction(
+        root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+    )
+    return _envelope(pinned=True, preview=preview["preview"], states=states)
+
+
+def _pin_missing_companies_default(vault_root: str | Path) -> dict[str, object]:
+    """Recover first, then transactionally pin legacy Companies state."""
+    root = Path(vault_root)
+    Transaction.resume(root)
+    plan, states = _missing_companies_default_plan(root)
+    if not plan:
+        return _envelope(pinned=False, receipt=None, states={})
+    purpose = "companies-default-compatibility"
+    operation = "capability-state"
+    preview = _preview_transaction(
+        root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+    )
+    executed = _execute_approved_transaction(
+        root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+        approved_token=str(preview["approval_token"]),
+    )
+    return _envelope(pinned=True, receipt=executed["receipt"], states=states)
 
 
 def _inventory_and_plan_models(vault_root: str | Path):

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -368,11 +368,25 @@ def check_granola() -> Dict[str, Any]:
         "setup": "/granola-setup",
     }
 
+def _capability_states(
+    selected: Dict[str, bool] | None = None,
+) -> Dict[str, bool]:
+    selected = selected or {}
+    states: Dict[str, bool] = {}
+    for room in capability_rooms.room_ids():
+        if room in selected:
+            states[room] = selected[room] is True
+            continue
+        default = capability_rooms.surfaces_for(room).get("default_enabled", False)
+        states[room] = default if isinstance(default, bool) else False
+    return states
+
+
 def _provision_folders(capability_states: Dict[str, bool] | None = None) -> List[str]:
     folders = list(PROVISION_CONTRACT["para_directories"])
-    states = capability_states or {}
+    states = _capability_states(capability_states)
     for room in capability_rooms.room_ids():
-        if states.get(room, False) is True:
+        if states[room] is True:
             folders.extend(capability_rooms.surfaces_for(room).get("folders", []))
     return list(dict.fromkeys(folders))
 
@@ -384,9 +398,9 @@ def _finalize_through_provisioner(session: Dict) -> Dict[str, Any]:
         {"name": pillar, "description": ""}
         for pillar in data.get("pillars", [])
     ]
-    selected = data.get("capabilities", {})
+    selected = _capability_states(data.get("capabilities"))
     data["capabilities"] = {
-        room: {"enabled": selected.get(room, False) is True}
+        room: {"enabled": selected[room]}
         for room in capability_rooms.room_ids()
     }
     profile_path: Path | None = None
@@ -1291,7 +1305,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 save_session(session)
                 result = create_success_response({"step": 6, "completed": True}, "Step 6 complete")
 
-            # Step 7: Optional capability rooms (all default off)
+            # Step 7: Optional capability rooms (contract-declared defaults)
             elif step_number == 7:
                 supplied = step_data.get('capabilities', {})
                 if not isinstance(supplied, dict):
@@ -1311,11 +1325,10 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                     for room in capability_rooms.room_ids():
                         if invalid_field:
                             break
-                        value = supplied.get(room, False)
-                        if not isinstance(value, bool):
+                        if room in supplied and not isinstance(supplied[room], bool):
                             invalid_field = f"capabilities.{room}"
                             break
-                        selected[room] = value
+                    selected = _capability_states(supplied)
                     if invalid_field:
                         result = create_error_response(
                             f"{invalid_field} must be true or false",
@@ -1534,7 +1547,9 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 logger.info("Finalize (DRY RUN) - previewing what would be created")
 
                 # Compute folders that would be created
-                selected_capabilities = session['data'].get('capabilities', {})
+                selected_capabilities = _capability_states(
+                    session['data'].get('capabilities')
+                )
                 para_folders = _provision_folders(selected_capabilities)
                 would_create_folders = [f for f in para_folders if not (BASE_DIR / f).exists()]
                 already_exist_folders = [f for f in para_folders if (BASE_DIR / f).exists()]
@@ -1576,7 +1591,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                     'entity_creation': {'mode': 'auto'},
                     'communication': data.get('communication', {}),
                     'capabilities': {
-                        room: {'enabled': selected_capabilities.get(room, False) is True}
+                        room: {'enabled': selected_capabilities[room]}
                         for room in capability_rooms.room_ids()
                     },
                 }

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -668,6 +668,30 @@ class TestCapabilityStep:
         assert 7 in session["completed_steps"]
         assert session["current_step"] == 8
 
+    def test_omitted_room_answers_use_contract_defaults(self, tmp_path, monkeypatch):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        onboarding_server.save_session(onboarding_server.create_new_session())
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "validate_and_save_step",
+                    {
+                        "step_number": 7,
+                        "step_data": {"capabilities": {"career": True}},
+                    },
+                )
+            )
+        )
+
+        assert payload["success"] is True
+        assert onboarding_server.load_session()["data"]["capabilities"] == {
+            "career": True,
+            "companies": True,
+            "quarter_goals": False,
+        }
+
     def test_rejects_non_boolean_room_answers(self, tmp_path, monkeypatch):
         session_file = tmp_path / "System/.onboarding-session.json"
         monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
@@ -752,6 +776,39 @@ class TestCapabilityStep:
             "career": {"enabled": True},
             "companies": {"enabled": False},
             "quarter_goals": {"enabled": False},
+        }
+
+    def test_dry_run_uses_contract_defaults_when_capabilities_are_omitted(
+        self, tmp_path, monkeypatch
+    ):
+        session_file = tmp_path / "System/.onboarding-session.json"
+        monkeypatch.setattr(onboarding_server, "SESSION_FILE", session_file)
+        monkeypatch.setattr(onboarding_server, "BASE_DIR", tmp_path)
+        session = onboarding_server.create_new_session()
+        session["completed_steps"] = [1, 2, 3, 4, 5, 6, 7]
+        session["current_step"] = 8
+        session["data"] = {
+            "name": "Test User",
+            "role": "Founder",
+            "company_size": "startup",
+            "email_domain": "example.test",
+            "pillars": ["Build", "Learn"],
+            "communication": {},
+        }
+        onboarding_server.save_session(session)
+
+        payload = _decode_tool_result(
+            asyncio.run(
+                onboarding_server.handle_call_tool(
+                    "finalize_onboarding", {"dry_run": True}
+                )
+            )
+        )
+
+        preview = payload["data"]
+        assert "05-Areas/Companies" in preview["would_create_folders"]
+        assert preview["preview_user_profile"]["capabilities"]["companies"] == {
+            "enabled": True
         }
 
     def test_finalize_provisions_only_selected_room_assets(self, tmp_path, monkeypatch):

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -114,6 +114,7 @@ from core.entity_engine import (
     create_page_if_absent,
     fingerprint_page,
     mutate_relationships,
+    render_company_page,
 )
 from core.entity_engine import index as entity_index
 from core.paths import (
@@ -1964,21 +1965,19 @@ def list_companies() -> List[Dict[str, Any]]:
     
     for company_file in COMPANIES_DIR.glob('*.md'):
         content = company_file.read_text()
+        entity = parse_entity_page(company_file)
         
-        # Extract basic info
+        # Canonical pages keep status in frontmatter; parse_entity_page also
+        # retains the old table/inline fallbacks for legacy pages.
         company = {
-            'name': company_file.stem.replace('_', ' '),
+            'name': entity.get('name') or company_file.stem.replace('_', ' '),
             'filepath': str(company_file),
-            'stage': None,
+            'stage': entity.get('status'),
             'industry': None
         }
         
         for line in content.split('\n'):
-            if '**Stage**' in line and '|' in line:
-                parts = line.split('|')
-                if len(parts) >= 3:
-                    company['stage'] = parts[2].strip()
-            elif '**Industry**' in line and '|' in line:
+            if '**Industry**' in line and '|' in line:
                 parts = line.split('|')
                 if len(parts) >= 3:
                     company['industry'] = parts[2].strip()
@@ -1993,7 +1992,7 @@ def list_companies() -> List[Dict[str, Any]]:
 def create_company_page(name: str, website: str = '', industry: str = '', 
                        size: str = '', stage: str = 'Prospect', 
                        domains: List[str] = None) -> Dict[str, Any]:
-    """Create a new company page from template"""
+    """Create a new company page from the canonical entity template."""
 
     if not capability_rooms.enabled("companies", profile_path=USER_PROFILE_FILE):
         return feature_status(
@@ -2015,82 +2014,37 @@ def create_company_page(name: str, website: str = '', industry: str = '',
             'error': f'Company page already exists: {filepath}'
         }
     
-    # Build domains string
+    # Derive the domain exactly as this tool always has when callers only
+    # provide a website; canonical rendering normalizes the final list.
     if not domains:
-        # Extract domain from website
         if website:
             domain = website.replace('https://', '').replace('http://', '').replace('www.', '').split('/')[0]
             domains = [domain]
         else:
             domains = []
-    
-    domains_str = ', '.join(domains) if domains else '{{company.com}}'
-    
-    timestamp = _tz_now().strftime('%Y-%m-%d')
-    
-    content = f"""# {name}
+    content = render_company_page(
+        name,
+        domains=domains,
+        website=website or None,
+        status=stage,
+    )
 
-## Overview
+    # The canonical renderer has no frontmatter field for industry or size, but
+    # this tool has always accepted both. Dropping them silently would lose the
+    # caller's input with no error, so record them under Notes where the user
+    # can see and edit them, leaving the machine-managed frontmatter canonical.
+    supplied_details = [
+        f"- **Industry:** {industry}" if industry else None,
+        f"- **Size:** {size}" if size else None,
+    ]
+    supplied_details = [line for line in supplied_details if line]
+    if supplied_details:
+        content = content.replace(
+            "## Notes\n\n",
+            "## Notes\n\n" + "\n".join(supplied_details) + "\n\n",
+            1,
+        )
 
-| Field | Value |
-|-------|-------|
-| **Website** | {website or '{{company.com}}'} |
-| **Industry** | {industry or '{{Industry}}'} |
-| **Size** | {size or '{{Startup / Scale-up / Enterprise}}'} |
-| **Stage** | {stage} |
-| **Domains** | {domains_str} |
-
----
-
-## Key Contacts
-
-<!-- Auto-populated from People pages with company: {name} -->
-
-| Name | Role | Last Interaction |
-|------|------|------------------|
-
-*Run refresh_company to update from People pages*
-
----
-
-## Projects
-
-<!-- Projects involving this company -->
-
----
-
-## Meeting History
-
-<!-- Auto-populated from meetings where attendee emails match domains -->
-
-| Date | Topic | Link |
-|------|-------|------|
-
-*Meetings detected by email domain matching*
-
----
-
-## Related Tasks
-
-<!-- Synced from 03-Tasks/Tasks.md via task MCP -->
-
-*Synced from 03-Tasks/Tasks.md — never*
-
-| Status | Task | Priority |
-|--------|------|----------|
-
----
-
-## Notes
-
-
-
----
-
-*Created: {timestamp}*
-*Updated: {timestamp}*
-"""
-    
     try:
         created = create_page_if_absent(
             filepath,

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -342,7 +342,7 @@ CAPABILITIES: dict[str, dict[str, object]] = {
         "folders": ("05-Areas/Companies",),
         "skills": (),
         "features": ("entity-engine.company-pages",),
-        "default_enabled": False,
+        "default_enabled": True,
     },
     "quarter_goals": {
         "folders": ("01-Quarter_Goals",),
@@ -413,8 +413,48 @@ def update_write_verdict(
     remapped paths back to their semantic defaults before calling, or treat
     them as unclassified. Unclassified paths fail safe: never written.
     """
-    if operation not in ("update", "customization-migration"):
+    if operation not in ("update", "customization-migration", "capability-state"):
         raise ValueError(f"unknown write operation: {operation}")
+
+    if operation == "capability-state":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+        except ContractViolation:
+            return WriteVerdict(
+                str(path),
+                False,
+                "outside-capability-state",
+                None,
+                None,
+            )
+        try:
+            resolution = resolve(candidate)
+        except ContractViolation:
+            resolution = None
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        if candidate == "System/user-profile.yaml":
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-capability-state",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-capability-state",
+            resolution.ownership if resolution is not None else None,
+            resolution.rule_id if resolution is not None else None,
+        )
 
     if operation == "customization-migration":
         try:

--- a/core/provision.cjs
+++ b/core/provision.cjs
@@ -356,9 +356,42 @@ from core.lifecycle import service
 from core.lifecycle.catalog import load_catalog_payload_sources
 
 vault = Path(sys.argv[1])
+preview_only = sys.argv[3] == "preview-only"
+compatibility = (
+    (
+        service._preview_missing_companies_default(vault)
+        if preview_only
+        else service._pin_missing_companies_default(vault)
+    )
+    if sys.argv[2] == "pin-companies"
+    else {"pinned": False, "receipt": None, "preview": None, "states": {}}
+)
+if preview_only:
+    print(json.dumps({
+        "ok": True,
+        "api_version": service.api_version,
+        "previewed": [],
+        "receipt": None,
+        "compatibility_pinned": compatibility["pinned"],
+        "compatibility_receipt": None,
+        "compatibility_preview": compatibility.get("preview"),
+        "compatibility_states": compatibility["states"],
+        "skipped": "dry-run",
+    }))
+    raise SystemExit(0)
 catalog = vault / "System/.release-catalog.json"
 if not catalog.is_file():
-    print(json.dumps({"ok": True, "api_version": service.api_version, "previewed": [], "receipt": None, "skipped": "no-release-catalog"}))
+    print(json.dumps({
+        "ok": True,
+        "api_version": service.api_version,
+        "previewed": [],
+        "receipt": None,
+        "compatibility_pinned": compatibility["pinned"],
+        "compatibility_receipt": compatibility["receipt"],
+        "compatibility_preview": None,
+        "compatibility_states": compatibility["states"],
+        "skipped": "no-release-catalog",
+    }))
     raise SystemExit(0)
 
 inventory = service.build_inventory_and_plan(vault)
@@ -387,17 +420,36 @@ if requested:
         preview["preview"],
         preview["approval_token"],
     )["receipt"]
-print(json.dumps({"ok": True, "api_version": service.api_version, "previewed": requested, "receipt": receipt}))
+print(json.dumps({
+    "ok": True,
+    "api_version": service.api_version,
+    "previewed": requested,
+    "receipt": receipt,
+    "compatibility_pinned": compatibility["pinned"],
+    "compatibility_receipt": compatibility["receipt"],
+    "compatibility_preview": None,
+    "compatibility_states": compatibility["states"],
+}))
 `;
 
-function routeAdoptionThroughLifecycleService(vaultRoot) {
+function routeAdoptionThroughLifecycleService(
+  vaultRoot,
+  { pinCompanies = true, previewOnly = false } = {},
+) {
   const python = process.env.DEX_LIFECYCLE_PYTHON
+    || process.env.DEX_PYTHON
     || (process.platform === 'win32' ? 'python' : 'python3');
   const repoRoot = path.resolve(__dirname, '..');
   const separator = process.platform === 'win32' ? ';' : ':';
   const result = childProcess.spawnSync(
     python,
-    ['-c', LIFECYCLE_ADOPTION, vaultRoot],
+    [
+      '-c',
+      LIFECYCLE_ADOPTION,
+      vaultRoot,
+      pinCompanies ? 'pin-companies' : 'skip-companies',
+      previewOnly ? 'preview-only' : 'execute',
+    ],
     {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -509,15 +561,35 @@ function provision(options) {
       return reporter.summary;
     }
     try {
-      reporter.summary.lifecycle_executor = options.dryRun
-        ? { ok: true, previewed: [], receipt: null, skipped: 'dry-run' }
-        : routeAdoptionThroughLifecycleService(vaultRoot);
-      const lifecycleReceipt = reporter.summary.lifecycle_executor.receipt;
+      reporter.summary.lifecycle_executor = routeAdoptionThroughLifecycleService(
+        vaultRoot,
+        { previewOnly: options.dryRun },
+      );
+      const lifecycleReceipts = [
+        reporter.summary.lifecycle_executor.compatibility_receipt,
+        reporter.summary.lifecycle_executor.receipt,
+      ].filter(Boolean);
+      const lifecycleDeclaredPaths = lifecycleReceipts.flatMap(
+        receipt => receipt.declared_paths
+          || (receipt.files_written || []).map(file => file.path),
+      );
+      const compatibilityPreviewPaths = (
+        reporter.summary.lifecycle_executor.compatibility_preview?.writes || []
+      ).map(write => write.path);
+      const lifecycleTransactionIds = lifecycleReceipts
+        .map(receipt => receipt.transaction_id)
+        .filter(Boolean);
       reporter.summary.mutation_receipt = {
         executor: 'lifecycle-service',
-        declared_paths: (lifecycleReceipt?.files_written || []).map(file => file.path).sort(),
-        lifecycle_transaction_id: lifecycleReceipt?.transaction_id || null,
+        declared_paths: [...lifecycleDeclaredPaths, ...compatibilityPreviewPaths]
+          .filter((file, index, files) => files.indexOf(file) === index)
+          .sort(),
+        lifecycle_transaction_id: lifecycleTransactionIds[0] || null,
+        lifecycle_transaction_ids: lifecycleTransactionIds,
       };
+      reporter.summary.compatibility_pins = reporter.summary.lifecycle_executor.compatibility_pinned
+        ? ['companies']
+        : [];
     } catch (error) {
       reporter.error(error.message);
     }
@@ -525,8 +597,14 @@ function provision(options) {
   }
 
   try {
-    if ((options.adopt || options.onboard) && !options.dryRun) {
-      reporter.summary.lifecycle_executor = routeAdoptionThroughLifecycleService(vaultRoot);
+    if (options.adopt || options.onboard) {
+      reporter.summary.lifecycle_executor = routeAdoptionThroughLifecycleService(
+        vaultRoot,
+        {
+          pinCompanies: options.adopt === true,
+          previewOnly: options.dryRun,
+        },
+      );
     }
     const overlay = loadProfileOverlay(options.profile);
     const templatePath = path.join(vaultRoot, 'System', 'user-profile-template.yaml');
@@ -537,6 +615,15 @@ function provision(options) {
 
     if (fs.existsSync(profilePath)) {
       profile = yaml.load(fs.readFileSync(profilePath, 'utf8')) || {};
+      if (options.adopt && options.dryRun) {
+        profile.capabilities ||= {};
+        for (const [room, enabled] of Object.entries(
+          reporter.summary.lifecycle_executor?.compatibility_states || {},
+        )) {
+          profile.capabilities[room] ||= {};
+          profile.capabilities[room].enabled = enabled;
+        }
+      }
       if (options.onboard) {
         profile = freshProfile;
         writeIfChanged(
@@ -552,8 +639,13 @@ function provision(options) {
         const gapDefaults = structuredClone(freshProfile);
         delete gapDefaults.entity_creation;
         for (const [room, definition] of Object.entries(portableContract.capabilities || {})) {
-          if (!profile.capabilities?.[room] && typeof definition.config === 'string') {
-            gapDefaults.capabilities[room].enabled = capabilityEnabled(profile, room, definition);
+          const explicit = profile.capabilities?.[room]?.enabled;
+          if (typeof explicit === 'boolean') continue;
+          const legacy = typeof definition.config === 'string'
+            ? profile?.[definition.config]?.enabled
+            : undefined;
+          if (typeof legacy === 'boolean') {
+            gapDefaults.capabilities[room].enabled = legacy;
           }
         }
         if (deepFillMissing(profile, gapDefaults)) {
@@ -656,6 +748,17 @@ function provision(options) {
     reporter.error(error.message);
   }
 
+  const lifecycleReceipts = [
+    reporter.summary.lifecycle_executor?.compatibility_receipt,
+    reporter.summary.lifecycle_executor?.receipt,
+  ].filter(Boolean);
+  const lifecycleTransactionIds = lifecycleReceipts
+    .map(receipt => receipt.transaction_id)
+    .filter(Boolean);
+  const lifecycleDeclaredPaths = lifecycleReceipts.flatMap(
+    receipt => receipt.declared_paths
+      || (receipt.files_written || []).map(file => file.path),
+  );
   reporter.summary.mutation_receipt = {
     executor: options.adopt || options.onboard
       ? 'lifecycle-service+provision-contract'
@@ -663,8 +766,10 @@ function provision(options) {
     declared_paths: [...new Set([
       ...reporter.summary.created,
       ...reporter.summary.removed,
+      ...lifecycleDeclaredPaths,
     ])].sort(),
-    lifecycle_transaction_id: reporter.summary.lifecycle_executor?.receipt?.transaction_id || null,
+    lifecycle_transaction_id: lifecycleTransactionIds[0] || null,
+    lifecycle_transaction_ids: lifecycleTransactionIds,
   };
 
   return reporter.summary;

--- a/core/tests/test_capabilities.py
+++ b/core/tests/test_capabilities.py
@@ -103,7 +103,7 @@ def test_room_missing_from_contract_registry_is_unknown(tmp_path: Path) -> None:
         capabilities.surfaces_for("career", contract_path=reduced_contract)
 
 
-def test_all_rooms_default_off_and_legacy_quarterly_planning_is_a_fallback(
+def test_companies_defaults_on_and_legacy_quarterly_planning_is_a_fallback(
     tmp_path: Path,
 ) -> None:
     profile_path = tmp_path / "System/user-profile.yaml"
@@ -115,7 +115,7 @@ def test_all_rooms_default_off_and_legacy_quarterly_planning_is_a_fallback(
     ) is False
     assert capabilities.enabled(
         "companies", profile_path=profile_path, contract_path=CONTRACT_PATH
-    ) is False
+    ) is True
     assert capabilities.enabled(
         "quarter_goals", profile_path=profile_path, contract_path=CONTRACT_PATH
     ) is True
@@ -392,9 +392,9 @@ def test_setup_reconciles_rooms_without_creating_companies_directly() -> None:
     assert "- `05-Areas/Companies/`" not in setup
 
 
-def test_legacy_onboarded_vault_keeps_all_rooms_on(tmp_path):
-    """Review finding #1: a vault onboarded before rooms existed must keep its
-    status quo (everything on) — never be silently reset to fresh defaults."""
+def test_legacy_onboarded_vault_pins_companies_off_and_honors_legacy_state(tmp_path):
+    """An existing vault gets a durable Companies-off opinion before the
+    contract default changes, while its legacy quarter choice remains authoritative."""
     from core import capabilities
 
     vault = _fake_vault(tmp_path)
@@ -407,13 +407,71 @@ def test_legacy_onboarded_vault_keeps_all_rooms_on(tmp_path):
 
     seeded = capabilities.migrate_legacy_room_state(vault)
 
-    assert sorted(seeded) == ["career", "companies", "quarter_goals"]
-    for room in ("career", "companies", "quarter_goals"):
-        assert capabilities.enabled(
-            room, profile_path=vault / "System" / "user-profile.yaml"
-        ) is True
+    assert sorted(seeded) == ["career", "companies"]
+    profile_path = vault / "System" / "user-profile.yaml"
+    assert capabilities.enabled("career", profile_path=profile_path) is True
+    assert capabilities.enabled("companies", profile_path=profile_path) is False
+    assert capabilities.enabled("quarter_goals", profile_path=profile_path) is False
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    assert profile["capabilities"]["companies"]["enabled"] is False
+    assert profile["quarterly_planning"]["enabled"] is False
     # Idempotent: a second run seeds nothing.
     assert capabilities.migrate_legacy_room_state(vault) == []
+
+
+@pytest.mark.parametrize("company_enabled", [True, False])
+def test_legacy_migration_preserves_explicit_company_state(
+    tmp_path: Path,
+    company_enabled: bool,
+) -> None:
+    vault = _fake_vault(tmp_path)
+    profile_path = vault / "System/user-profile.yaml"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    (vault / "System/.onboarding-complete").write_text("{}\n", encoding="utf-8")
+    profile_path.write_text(
+        yaml.safe_dump(
+            {
+                "capabilities": {
+                    "companies": {
+                        "enabled": company_enabled,
+                        "custom": "keep",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    capabilities.migrate_legacy_room_state(vault)
+
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    assert profile["capabilities"]["companies"] == {
+        "enabled": company_enabled,
+        "custom": "keep",
+    }
+
+
+def test_partial_capability_map_only_gains_the_companies_compatibility_pin(
+    tmp_path: Path,
+) -> None:
+    vault = _fake_vault(tmp_path)
+    profile_path = vault / "System/user-profile.yaml"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    (vault / "System/.onboarding-complete").write_text("{}\n", encoding="utf-8")
+    profile_path.write_text(
+        "capabilities:\n  career:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    seeded = capabilities.migrate_legacy_room_state(vault)
+
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    assert seeded == ["companies"]
+    assert profile["capabilities"] == {
+        "career": {"enabled": False},
+        "companies": {"enabled": False},
+    }
 
 
 def test_fresh_unonboarded_vault_is_never_migrated(tmp_path):

--- a/core/tests/test_entity_engine_writers.py
+++ b/core/tests/test_entity_engine_writers.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
-from core.entity_engine import Result
+from core.entity_engine import Result, render_company_page
 from core.mcp import work_server
 from core.ritual_intelligence import contact_promote
 
@@ -114,12 +114,49 @@ def test_work_company_creation_uses_engine_create_primitive(
     result = work_server.create_company_page(
         "Engine Company",
         website="https://engine.example",
+        industry="Software",
+        size="Scale-up",
+        stage="Customer",
     )
 
     assert result["success"] is True
     assert len(calls) == 1
     assert calls[0][0] == companies_dir / "Engine_Company.md"
+    assert calls[0][1] == render_company_page(
+        "Engine Company",
+        domains=["engine.example"],
+        website="https://engine.example",
+        status="Customer",
+    )
     assert calls[0][2] == companies_dir
+
+
+def test_work_company_listing_reads_canonical_company_status(
+    tmp_path: Path, monkeypatch
+) -> None:
+    companies_dir = tmp_path / "Companies"
+    companies_dir.mkdir()
+    (companies_dir / "Engine_Company.md").write_text(
+        render_company_page(
+            "Engine Company",
+            domains=["engine.example"],
+            website="https://engine.example",
+            status="Customer",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "COMPANIES_DIR", companies_dir)
+    monkeypatch.setattr(work_server, "find_people_at_company", lambda _name: [])
+
+    assert work_server.list_companies() == [
+        {
+            "name": "Engine Company",
+            "filepath": str(companies_dir / "Engine_Company.md"),
+            "stage": "Customer",
+            "industry": None,
+            "contacts": 0,
+        }
+    ]
 
 
 def test_work_company_refresh_only_replaces_existing_sections_and_keeps_raw_footer(

--- a/core/tests/test_entity_engine_writers.py
+++ b/core/tests/test_entity_engine_writers.py
@@ -122,12 +122,27 @@ def test_work_company_creation_uses_engine_create_primitive(
     assert result["success"] is True
     assert len(calls) == 1
     assert calls[0][0] == companies_dir / "Engine_Company.md"
-    assert calls[0][1] == render_company_page(
+
+    canonical = render_company_page(
         "Engine Company",
         domains=["engine.example"],
         website="https://engine.example",
         status="Customer",
     )
+    written = calls[0][1]
+
+    # The machine-managed half must stay byte-identical to the canonical
+    # renderer: the entity engine's domain matching depends on that shape.
+    canonical_frontmatter = canonical.split("---", 2)[2].split("## Notes")[0]
+    assert written.split("---", 2)[2].split("## Notes")[0] == canonical_frontmatter
+    assert written.startswith(canonical.split("# Engine Company")[0])
+
+    # industry and size have no canonical frontmatter field, but the tool
+    # accepts them, so they are recorded under Notes rather than discarded.
+    notes = written.split("## Notes", 1)[1].split("## Relationships", 1)[0]
+    assert "**Industry:** Software" in notes
+    assert "**Size:** Scale-up" in notes
+
     assert calls[0][2] == companies_dir
 
 

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -470,10 +470,10 @@ def _write_entity_profile(vault: Path, mode: str) -> None:
     profile = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
     profile["email_domain"] = "dex.test"
     profile["entity_creation"] = {"mode": mode}
+    profile.setdefault("capabilities", {})["companies"] = {"enabled": True}
     profile_path.write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
-    # The entity fixture models an ACTIVE, already-onboarded vault; the marker
-    # engages the legacy capability bridge (rooms keep their pre-rooms status
-    # quo) that background company creation depends on.
+    # The entity fixture opts into company creation explicitly; existing vaults
+    # without a Companies opinion must remain off when the fresh default changes.
     (vault / "System" / ".onboarding-complete").write_text("{}\n", encoding="utf-8")
 
 

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -237,6 +237,24 @@ def test_update_write_verdict_operation_is_keyword_only_with_update_default() ->
     assert parameters["operation"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
+def test_capability_state_operation_only_authorizes_the_live_profile() -> None:
+    allowed = portable_contract.update_write_verdict(
+        "System/user-profile.yaml",
+        exists=True,
+        operation="capability-state",
+    )
+    refused = portable_contract.update_write_verdict(
+        "System/user-profile-template.yaml",
+        exists=True,
+        operation="capability-state",
+    )
+
+    assert allowed.allowed is True
+    assert allowed.action == "write-capability-state"
+    assert refused.allowed is False
+    assert refused.action == "outside-capability-state"
+
+
 @pytest.mark.parametrize(
     "path",
     [
@@ -388,8 +406,9 @@ def test_capability_rooms_cover_gated_regions() -> None:
     assert "meetings" not in capabilities
     assert "people" not in capabilities
     assert "tasks" not in capabilities
-    # Rooms default OFF: a fresh spine-only install is the baseline.
-    assert all(spec["default_enabled"] is False for spec in capabilities.values())
+    assert capabilities["career"]["default_enabled"] is False
+    assert capabilities["companies"]["default_enabled"] is True
+    assert capabilities["quarter_goals"]["default_enabled"] is False
 
 
 def test_committed_dist_matches_source_of_truth() -> None:

--- a/core/tests/test_provision_parity.py
+++ b/core/tests/test_provision_parity.py
@@ -8,10 +8,65 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
+from core import capabilities
 from core.lifecycle import service
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "packages/dex-contracts/dist/portable-vault.contract.json"
+
+
+def _prepare_provision_vault(
+    tmp_path: Path,
+    *,
+    profile_text: str | None = None,
+    companies_default: bool | None = None,
+) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    (vault / "core").mkdir()
+    (vault / ".scripts").mkdir()
+    shutil.copy(REPO_ROOT / "System/.mcp.json.example", vault / "System/.mcp.json.example")
+    shutil.copy(
+        REPO_ROOT / "System/user-profile-template.yaml",
+        vault / "System/user-profile-template.yaml",
+    )
+    if companies_default is not None:
+        template_path = vault / "System/user-profile-template.yaml"
+        template = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+        template["capabilities"]["companies"]["enabled"] = companies_default
+        template_path.write_text(
+            yaml.safe_dump(template, sort_keys=False),
+            encoding="utf-8",
+        )
+    shutil.copy(REPO_ROOT / "core/paths.py", vault / "core/paths.py")
+    shutil.copy(REPO_ROOT / "package.json", vault / "package.json")
+    shutil.copy(REPO_ROOT / "CLAUDE.md", vault / "CLAUDE.md")
+    if profile_text is not None:
+        (vault / "System/user-profile.yaml").write_text(
+            profile_text,
+            encoding="utf-8",
+        )
+    return vault
+
+
+def _run_provision(vault: Path, *options: str) -> dict:
+    completed = subprocess.run(
+        [
+            "node",
+            str(REPO_ROOT / "core/provision.cjs"),
+            "--path",
+            str(vault),
+            *options,
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
 
 
 def test_installer_routes_bootstrap_config_to_sanctioned_provision_contract() -> None:
@@ -24,44 +79,264 @@ def test_installer_routes_bootstrap_config_to_sanctioned_provision_contract() ->
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
 def test_adopt_preserves_existing_content_while_routing_lifecycle(tmp_path: Path) -> None:
-    vault = tmp_path / "existing-vault"
-    (vault / "System").mkdir(parents=True)
-    (vault / "core").mkdir()
-    (vault / ".scripts").mkdir()
-    shutil.copy(REPO_ROOT / "System/.mcp.json.example", vault / "System/.mcp.json.example")
-    shutil.copy(
-        REPO_ROOT / "System/user-profile-template.yaml",
-        vault / "System/user-profile-template.yaml",
-    )
-    shutil.copy(REPO_ROOT / "core/paths.py", vault / "core/paths.py")
-    shutil.copy(REPO_ROOT / "package.json", vault / "package.json")
-    shutil.copy(REPO_ROOT / "CLAUDE.md", vault / "CLAUDE.md")
-    (vault / "System/user-profile.yaml").write_text(
-        "name: Existing User\ncustom: keep\n",
-        encoding="utf-8",
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text="name: Existing User\ncustom: keep\n",
     )
     (vault / "03-Tasks").mkdir()
     tasks = vault / "03-Tasks/Tasks.md"
     tasks.write_text("# My tasks\n", encoding="utf-8")
 
-    completed = subprocess.run(
-        [
-            "node",
-            str(REPO_ROOT / "core/provision.cjs"),
-            "--path",
-            str(vault),
-            "--adopt",
-            "--json",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    summary = _run_provision(vault, "--adopt")
 
-    assert completed.returncode == 0, completed.stderr
-    summary = json.loads(completed.stdout)
     assert summary["lifecycle_executor"]["api_version"] == service.api_version
     assert summary["lifecycle_executor"]["skipped"] == "no-release-catalog"
     assert "name: Existing User" in (vault / "System/user-profile.yaml").read_text()
     assert "custom: keep" in (vault / "System/user-profile.yaml").read_text()
     assert tasks.read_text(encoding="utf-8") == "# My tasks\n"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_fresh_provision_enables_companies_and_creates_its_room(tmp_path: Path) -> None:
+    vault = _prepare_provision_vault(tmp_path)
+
+    _run_provision(vault)
+
+    profile_path = vault / "System/user-profile.yaml"
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    assert profile["capabilities"]["companies"]["enabled"] is True
+    assert capabilities.enabled(
+        "companies",
+        profile_path=profile_path,
+        contract_path=CONTRACT_PATH,
+    ) is True
+    assert (vault / "05-Areas/Companies").is_dir()
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_adopt_pins_an_existing_vault_without_a_company_opinion_off_idempotently(
+    tmp_path: Path,
+) -> None:
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text="name: Existing User\ncustom: keep\n",
+        companies_default=True,
+    )
+    profile_path = vault / "System/user-profile.yaml"
+
+    _run_provision(vault, "--adopt")
+
+    first = profile_path.read_text(encoding="utf-8")
+    profile = yaml.safe_load(first)
+    assert profile["capabilities"]["companies"]["enabled"] is False
+    assert capabilities.enabled(
+        "companies",
+        profile_path=profile_path,
+        contract_path=CONTRACT_PATH,
+    ) is False
+    assert not (vault / "05-Areas/Companies").exists()
+
+    _run_provision(vault, "--adopt")
+
+    assert profile_path.read_text(encoding="utf-8") == first
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_lifecycle_only_update_pins_markerless_existing_vault_transactionally(
+    tmp_path: Path,
+) -> None:
+    original = "# keep this comment\nname: Existing User\ncustom: keep\n"
+    vault = _prepare_provision_vault(tmp_path, profile_text=original)
+    profile_path = vault / "System/user-profile.yaml"
+
+    first_summary = _run_provision(vault, "--adopt", "--lifecycle-only")
+
+    first = profile_path.read_text(encoding="utf-8")
+    profile = yaml.safe_load(first)
+    assert first.startswith(original)
+    assert profile["capabilities"]["career"]["enabled"] is True
+    assert profile["capabilities"]["companies"]["enabled"] is False
+    assert profile["capabilities"]["quarter_goals"]["enabled"] is True
+    assert first_summary["compatibility_pins"] == ["companies"]
+    assert first_summary["mutation_receipt"]["executor"] == "lifecycle-service"
+    assert first_summary["mutation_receipt"]["lifecycle_transaction_id"]
+    transaction_directories = sorted((vault / "System/.dex/tx").iterdir())
+
+    second_summary = _run_provision(vault, "--adopt", "--lifecycle-only")
+
+    assert profile_path.read_text(encoding="utf-8") == first
+    assert second_summary["compatibility_pins"] == []
+    assert sorted((vault / "System/.dex/tx").iterdir()) == transaction_directories
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_lifecycle_only_dry_run_previews_the_exact_compatibility_pin(
+    tmp_path: Path,
+) -> None:
+    original = "# keep this comment\nname: Existing User\n"
+    vault = _prepare_provision_vault(tmp_path, profile_text=original)
+
+    summary = _run_provision(
+        vault,
+        "--adopt",
+        "--lifecycle-only",
+        "--dry-run",
+    )
+
+    assert (vault / "System/user-profile.yaml").read_text(encoding="utf-8") == original
+    assert not (vault / "System/.dex/tx").exists()
+    assert summary["compatibility_pins"] == ["companies"]
+    assert summary["lifecycle_executor"]["compatibility_states"] == {
+        "career": True,
+        "companies": False,
+        "quarter_goals": True,
+    }
+    assert summary["mutation_receipt"]["declared_paths"] == [
+        "System/user-profile.yaml"
+    ]
+    assert summary["mutation_receipt"]["lifecycle_transaction_ids"] == []
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_full_adopt_dry_run_uses_the_transaction_previewed_room_states(
+    tmp_path: Path,
+) -> None:
+    original = "name: Existing User\n"
+    vault = _prepare_provision_vault(tmp_path, profile_text=original)
+
+    summary = _run_provision(vault, "--adopt", "--dry-run")
+
+    assert (vault / "System/user-profile.yaml").read_text(encoding="utf-8") == original
+    assert "05-Areas/Companies" not in summary["created"]
+    assert "05-Areas/Career" in summary["created"]
+    assert "01-Quarter_Goals" in summary["created"]
+    assert summary["lifecycle_executor"]["compatibility_states"] == {
+        "career": True,
+        "companies": False,
+        "quarter_goals": True,
+    }
+
+
+def test_compatibility_pin_recovers_before_inspecting_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text="capabilities:\n  companies:\n    enabled: false\n",
+    )
+    profile_path = vault / "System/user-profile.yaml"
+    calls: list[Path] = []
+
+    def recover(root: Path) -> list[dict]:
+        calls.append(Path(root))
+        profile_path.write_text("name: Rolled Back\n", encoding="utf-8")
+        return []
+
+    monkeypatch.setattr(service.Transaction, "resume", staticmethod(recover))
+
+    result = service._pin_missing_companies_default(vault)
+
+    assert calls == [vault]
+    assert result["pinned"] is True
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    assert profile["capabilities"]["companies"]["enabled"] is False
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_lifecycle_only_update_adds_only_companies_to_a_partial_capability_map(
+    tmp_path: Path,
+) -> None:
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text="capabilities:\n  career:\n    enabled: false\n",
+    )
+
+    _run_provision(vault, "--adopt", "--lifecycle-only")
+
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
+    assert profile["capabilities"] == {
+        "companies": {"enabled": False},
+        "career": {"enabled": False},
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+@pytest.mark.parametrize("company_enabled", [True, False])
+def test_adopt_preserves_an_existing_explicit_company_choice(
+    tmp_path: Path,
+    company_enabled: bool,
+) -> None:
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text=yaml.safe_dump(
+            {
+                "name": "Existing User",
+                "capabilities": {
+                    "companies": {
+                        "enabled": company_enabled,
+                        "custom": "keep",
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        companies_default=True,
+    )
+
+    _run_provision(vault, "--adopt")
+
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
+    assert profile["capabilities"]["companies"] == {
+        "enabled": company_enabled,
+        "custom": "keep",
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+@pytest.mark.parametrize("company_enabled", [True, False])
+def test_lifecycle_only_update_preserves_an_explicit_company_choice(
+    tmp_path: Path,
+    company_enabled: bool,
+) -> None:
+    original = (
+        "# keep this comment\n"
+        "capabilities:\n"
+        "  companies:\n"
+        f"    enabled: {'true' if company_enabled else 'false'}\n"
+        "    custom: keep\n"
+    )
+    vault = _prepare_provision_vault(tmp_path, profile_text=original)
+
+    summary = _run_provision(vault, "--adopt", "--lifecycle-only")
+
+    assert (vault / "System/user-profile.yaml").read_text(encoding="utf-8") == original
+    assert summary["compatibility_pins"] == []
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_adopt_preserves_a_legacy_capability_opinion(tmp_path: Path) -> None:
+    vault = _prepare_provision_vault(
+        tmp_path,
+        profile_text=(
+            "name: Existing User\n"
+            "quarterly_planning:\n"
+            "  enabled: true\n"
+            "  q1_start_month: 4\n"
+        ),
+        companies_default=True,
+    )
+
+    _run_provision(vault, "--adopt")
+
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
+    assert profile["capabilities"]["companies"]["enabled"] is False
+    assert profile["capabilities"]["quarter_goals"]["enabled"] is True
+    assert profile["quarterly_planning"]["enabled"] is True
+    assert profile["quarterly_planning"]["q1_start_month"] == 4

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -829,7 +829,7 @@
       ]
     },
     "companies": {
-      "default_enabled": false,
+      "default_enabled": true,
       "features": [
         "entity-engine.company-pages"
       ],


### PR DESCRIPTION
Most people dealing with customers want company pages, but the room was off by default and had to be found.

## What changes

- **New vaults get the Companies room on.**
- **Existing vaults are explicitly pinned to their current state** during the update, so nobody is silently switched on.
- **Company pages now use one shape instead of two.**

## Why the "existing users" half is the load-bearing part

Capability state resolves in this order: an explicit setting → a legacy key → **the shipped default**. Real vaults that predate this setting have **no value recorded at all** — verified on a genuine 7-month-old vault, which has no `capabilities` block whatsoever.

So simply flipping the default would have silently enabled Companies for every existing user on their next update. That isn't just a folder appearing: the background sync gates company-page creation on this room, so those users would start finding company pages materialising in their vault after an update they thought was routine.

There is already precedent for caring about exactly this — `provision.cjs` deliberately refuses to inject `entity_creation` into an existing vault, with a comment that a vault predating the key must keep the safer default. This follows that spirit.

Guarantees: an explicit `true` or `false` is preserved; a legacy setting is preserved; **only** a vault with no opinion gets pinned; running it twice changes nothing; dry-run previews without writing.

## The two page shapes

There were two renderers producing differently-shaped company pages — one used by direct creation, one by the background engine — and the engine's domain matching relies on its own version. Harmless while the room was off; a real inconsistency once it's on. Direct creation now uses the canonical renderer.

## One thing this review caught

Moving to the canonical renderer silently dropped `industry` and `size`. The tool still **accepted** both arguments and then discarded them with no error — losing whatever the caller passed. They are now recorded under Notes, where the user can see and edit them, while the machine-managed frontmatter stays canonical.

## Incidental fix

`System/user-profile.yaml` and its template had **already drifted apart on main** (the profile was missing a `vault.auto_commit` block). The PII gate only inspects files a change touches, so this was invisible until now. Re-aligned them.

## Verification

- 81 focused tests pass; ruff, PII, portable-contract and architecture-inventory gates all green after committing.
- Verified the canonical renderer keeps Key Contacts and Meeting History as auto-maintained regions, so those sections are not lost — only `industry`/`size` needed rescuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
