### PR TITLE
Session start notices waiting meetings and has them processed in the background

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -47,6 +47,7 @@ These files are not registered as repository-wide lifecycle hooks.
 | File | Caller | Purpose |
 |---|---|---|
 | `meeting-cache-builder.cjs` | Work MCP meeting-cache workflow | Build `System/Memory/meeting-cache.json`. Work MCP exposes `rebuild_meeting_cache`; its missing-cache guidance also names the standalone Node command. |
+| `meeting-queue-check.cjs` | `session-start.sh` | Detect synced-but-unprocessed meetings and inject a one-block notice so the session processes them in the background. |
 | `integration-concierge.cjs` | Onboarding, `/getting-started`, and `/dex-level-up` | Scan the vault for integration signals and return ranked recommendations. |
 | `maintenance.cjs` | Manual: `node .claude/hooks/maintenance.cjs` | Report stale inbox files, broken WikiLinks, orphaned person pages, and old agent memory. |
 

--- a/.claude/hooks/meeting-queue-check.cjs
+++ b/.claude/hooks/meeting-queue-check.cjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { loadPaths } = require('./paths.cjs');
+
+let yaml = null;
+try {
+  yaml = require('js-yaml');
+} catch (error) {
+  // Without a safe parser, meeting notes are skipped.
+}
+
+let getGranolaApiKey = null;
+try {
+  ({ getGranolaApiKey } = require('../../.scripts/meeting-intel/lib/granola-api-key.cjs'));
+} catch (error) {
+  // The prior-sync state remains a valid connection signal without this helper.
+}
+
+let CONTRACT = null;
+try {
+  CONTRACT = loadPaths();
+} catch (error) {
+  // A missing path contract makes the check inapplicable.
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const THROTTLE_SECONDS = 30 * 60;
+
+function emptyResult() {
+  return { count: 0, lines: [] };
+}
+
+function anchoredPaths(vaultRoot) {
+  if (!CONTRACT?.VAULT_ROOT || !CONTRACT?.MEETINGS_DIR || !CONTRACT?.SYSTEM_DIR) {
+    return null;
+  }
+
+  const rel = (contractPath) => path.relative(CONTRACT.VAULT_ROOT, contractPath);
+  const meetingsDir = path.join(vaultRoot, rel(CONTRACT.MEETINGS_DIR));
+  const systemDir = path.join(vaultRoot, rel(CONTRACT.SYSTEM_DIR));
+  return { meetingsDir, systemDir };
+}
+
+function isConnected(vaultRoot, env) {
+  if (typeof getGranolaApiKey === 'function') {
+    try {
+      if (getGranolaApiKey({ vaultRoot, env })) return true;
+    } catch (error) {
+      // Fall through to prior-sync state.
+    }
+  }
+
+  try {
+    return fs.existsSync(
+      path.join(vaultRoot, '.scripts/meeting-intel/processed-meetings.json'),
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
+function isThrottled(markerPath, nowSeconds) {
+  try {
+    if (!fs.existsSync(markerPath)) return false;
+    const value = fs.readFileSync(markerPath, 'utf8').trim();
+    if (!/^\d+$/.test(value)) return false;
+    return nowSeconds - Number(value) < THROTTLE_SECONDS;
+  } catch (error) {
+    return true;
+  }
+}
+
+function parseFrontmatter(source) {
+  const match = source.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---(?:[ \t]*\r?\n|$)/);
+  if (!match || !yaml) return null;
+
+  let document;
+  try {
+    document = yaml.load(match[1]);
+  } catch (error) {
+    return null;
+  }
+  if (!document || typeof document !== 'object' || Array.isArray(document)) return null;
+
+  const fields = {};
+  for (const key of ['date', 'granola_id', 'ai_analyzed']) {
+    if (!Object.hasOwn(document, key) || document[key] === null) continue;
+    fields[key] = document[key] instanceof Date
+      ? document[key].toISOString()
+      : String(document[key]).trim();
+  }
+
+  return {
+    fields,
+    body: source.slice(match[0].length),
+  };
+}
+
+function dayFromValue(value) {
+  if (!value) return null;
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})(?:[T\s].*)?$/);
+  if (!match) return null;
+  const timestamp = Date.parse(`${match[1]}T00:00:00Z`);
+  if (!Number.isFinite(timestamp)) return null;
+  if (new Date(timestamp).toISOString().slice(0, 10) !== match[1]) return null;
+  return { day: match[1], timestamp };
+}
+
+function isRecentDay(value, nowMilliseconds) {
+  const parsed = dayFromValue(value);
+  if (!parsed) return false;
+  const today = new Date(nowMilliseconds).toISOString().slice(0, 10);
+  const todayStart = Date.parse(`${today}T00:00:00Z`);
+  return parsed.day <= today && parsed.timestamp >= todayStart - (7 * DAY_MS);
+}
+
+function hasUncheckedForMeItem(body) {
+  let underForMe = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (/^###\s+For Me\s*$/i.test(line)) {
+      underForMe = true;
+      continue;
+    }
+    if (underForMe && /^#{1,3}\s+/.test(line)) {
+      underForMe = false;
+      continue;
+    }
+    if (underForMe && /^\s*-\s+\[ \](?:\s+|$)/.test(line)) return true;
+  }
+  return false;
+}
+
+function noteIsWaiting(filePath, fallbackDay, nowMilliseconds) {
+  try {
+    const source = fs.readFileSync(filePath, 'utf8');
+    const parsed = parseFrontmatter(source);
+    if (!parsed?.fields.granola_id) return false;
+
+    const day = parsed.fields.date || fallbackDay;
+    if (!isRecentDay(day, nowMilliseconds)) return false;
+
+    if (/<!--\s*tasks-extracted:/.test(source)) return false;
+    if (parsed.fields.ai_analyzed?.toLowerCase() === 'false') return true;
+    return hasUncheckedForMeItem(parsed.body);
+  } catch (error) {
+    return false;
+  }
+}
+
+function countWaitingNotes(meetingsDir, nowMilliseconds) {
+  let dayDirectories;
+  try {
+    dayDirectories = fs.readdirSync(meetingsDir, { withFileTypes: true });
+  } catch (error) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const dayDirectory of dayDirectories) {
+    if (!dayDirectory.isDirectory()) continue;
+    const directoryPath = path.join(meetingsDir, dayDirectory.name);
+    let files;
+    try {
+      files = fs.readdirSync(directoryPath, { withFileTypes: true });
+    } catch (error) {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith('.md')) continue;
+      if (noteIsWaiting(
+        path.join(directoryPath, file.name),
+        dayDirectory.name,
+        nowMilliseconds,
+      )) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+function noticeLines(count) {
+  const noun = count === 1 ? 'meeting' : 'meetings';
+  const verb = count === 1 ? 'has' : 'have';
+  return [
+    `--- 📋 Meetings waiting to be processed (${count}) ---`,
+    `${count} synced ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    "After you finish responding to the user's first message, invoke the",
+    '/process-meetings skill to handle them in the background — it runs forked and',
+    'is idempotent, so do this without being asked. Tell the user in one short line',
+    'that meetings are being processed in the background.',
+    "If the user's first message IS about meetings, just process them as part of it.",
+    '---',
+  ];
+}
+
+function checkMeetingQueue(options = {}) {
+  try {
+    const {
+      vaultRoot = process.cwd(),
+      now = Date.now(),
+      env = process.env,
+    } = options || {};
+    const nowMilliseconds = Number(now);
+    if (typeof vaultRoot !== 'string' || !Number.isFinite(nowMilliseconds)) {
+      return emptyResult();
+    }
+
+    const paths = anchoredPaths(path.resolve(vaultRoot));
+    if (!paths || !isConnected(path.resolve(vaultRoot), env || {})) return emptyResult();
+
+    const markerPath = path.join(paths.systemDir, '.last-meeting-queue-notice');
+    const nowSeconds = Math.floor(nowMilliseconds / 1000);
+    if (isThrottled(markerPath, nowSeconds)) return emptyResult();
+
+    let meetingsDirectory;
+    try {
+      meetingsDirectory = fs.statSync(paths.meetingsDir);
+    } catch (error) {
+      return emptyResult();
+    }
+    if (!meetingsDirectory.isDirectory()) return emptyResult();
+
+    const count = countWaitingNotes(paths.meetingsDir, nowMilliseconds);
+    if (count === 0) return emptyResult();
+
+    try {
+      fs.mkdirSync(paths.systemDir, { recursive: true });
+      fs.writeFileSync(markerPath, `${nowSeconds}\n`);
+    } catch (error) {
+      // A notice still helps even when its throttle marker cannot be persisted.
+    }
+
+    return { count, lines: noticeLines(count) };
+  } catch (error) {
+    return emptyResult();
+  }
+}
+
+module.exports = { checkMeetingQueue };
+
+if (require.main === module) {
+  try {
+    const result = checkMeetingQueue({ vaultRoot: process.argv[2] || process.cwd() });
+    if (result.count > 0) process.stdout.write(`${result.lines.join('\n')}\n`);
+  } catch (error) {
+    // Silent by design.
+  }
+  process.exitCode = 0;
+}

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -339,6 +339,15 @@ except Exception:
     fi
 fi
 
+# 21. Unprocessed synced meetings — detect only; processing happens via /process-meetings.
+if [[ -f "$ONBOARDING_MARKER" ]]; then
+    MEETING_QUEUE_OUTPUT=$(node "$CLAUDE_DIR/.claude/hooks/meeting-queue-check.cjs" "$CLAUDE_DIR" 2>/dev/null || true)
+    if [[ -n "$MEETING_QUEUE_OUTPUT" ]]; then
+        echo "$MEETING_QUEUE_OUTPUT"
+        echo ""
+    fi
+fi
+
 # Background job staleness — keep in sync with core/utils/doctor.py's JOB_FRESHNESS table.
 {
     DEX_LAUNCH_AGENTS_DIR="${DEX_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"

--- a/.claude/hooks/tests/meeting-queue-check.test.cjs
+++ b/.claude/hooks/tests/meeting-queue-check.test.cjs
@@ -1,0 +1,258 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const HOOK_PATH = path.resolve(__dirname, '..', 'meeting-queue-check.cjs');
+const NOW = Date.parse('2026-07-27T12:00:00Z');
+
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-meeting-queue-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function writeMeeting(root, day, fileName, content) {
+  const directory = path.join(root, '00-Inbox', 'Meetings', day);
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, fileName);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+function connectGranola(root) {
+  const statePath = path.join(root, '.scripts', 'meeting-intel', 'processed-meetings.json');
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, '{}\n');
+}
+
+function meetingNote({
+  day = '2026-07-27',
+  granolaId = 'meeting-1',
+  aiAnalyzed,
+  body = '### For Me\n- [ ] Send the proposal\n',
+  tasksExtracted = false,
+} = {}) {
+  const fields = [`date: ${day}`, `granola_id: ${granolaId}`];
+  if (aiAnalyzed !== undefined) fields.push(`ai_analyzed: ${aiAnalyzed}`);
+  const marker = tasksExtracted
+    ? '\n<!-- tasks-extracted: 2026-01-01T00:00:00Z -->\n'
+    : '';
+  return `---\n${fields.join('\n')}\n---\n\n${body}${marker}`;
+}
+
+function expectedLines(count) {
+  const noun = count === 1 ? 'meeting' : 'meetings';
+  const verb = count === 1 ? 'has' : 'have';
+  return [
+    `--- 📋 Meetings waiting to be processed (${count}) ---`,
+    `${count} synced ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    "After you finish responding to the user's first message, invoke the",
+    '/process-meetings skill to handle them in the background — it runs forked and',
+    'is idempotent, so do this without being asked. Tell the user in one short line',
+    'that meetings are being processed in the background.',
+    "If the user's first message IS about meetings, just process them as part of it.",
+    '---',
+  ];
+}
+
+function checkMeetingQueue(options) {
+  assert.equal(fs.existsSync(HOOK_PATH), true, 'meeting queue hook must exist');
+  return require(HOOK_PATH).checkMeetingQueue(options);
+}
+
+test('Granola not connected stays silent even when a meeting is waiting', (t) => {
+  const root = fixture(t);
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'planning.md',
+    [
+      '---',
+      'date: 2026-07-27',
+      'granola_id: meeting-1',
+      '---',
+      '',
+      '### For Me',
+      '- [ ] Send the proposal',
+      '',
+    ].join('\n'),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('connected Granola with an empty queue stays silent', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('detects a recent Granola note with an unchecked For Me item', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.equal(result.count, 1);
+  assert.deepEqual(result.lines, expectedLines(1));
+});
+
+test('does not double-process stamped notes or notes whose For Me items are checked', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'already-stamped.md',
+    meetingNote({
+      granolaId: 'meeting-stamped',
+      aiAnalyzed: false,
+      tasksExtracted: true,
+    }),
+  );
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'already-checked.md',
+    meetingNote({
+      granolaId: 'meeting-checked',
+      body: '### For Me\n- [x] Send the proposal\n',
+    }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('counts an unanalyzed Granola note without a For Me section', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'basic-note.md',
+    meetingNote({ aiAnalyzed: false, body: '# Basic meeting note\n' }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.equal(result.count, 1);
+  assert.deepEqual(result.lines, expectedLines(1));
+});
+
+test('ignores manual-mode queue JSON files', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  const queue = path.join(root, '00-Inbox', 'Meetings', 'queue');
+  fs.mkdirSync(queue, { recursive: true });
+  fs.writeFileSync(path.join(queue, 'old-manual-meeting.json'), '{}\n');
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('excludes meeting notes dated 30 days ago', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(
+    root,
+    '2026-06-27',
+    'old-meeting.md',
+    meetingNote({ day: '2026-06-27', granolaId: 'meeting-old' }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('uses the meeting day directory when date frontmatter is absent', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'fallback-date.md',
+    [
+      '---',
+      'granola_id: meeting-fallback',
+      '---',
+      '',
+      '### For Me',
+      '- [ ] Send the proposal',
+      '',
+    ].join('\n'),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.equal(result.count, 1);
+});
+
+test('a fresh notice marker throttles another session', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
+  const marker = path.join(root, 'System', '.last-meeting-queue-notice');
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  const freshTimestamp = String(Math.floor(NOW / 1000) - 60);
+  fs.writeFileSync(marker, `${freshTimestamp}\n`);
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+  assert.equal(fs.readFileSync(marker, 'utf8'), `${freshTimestamp}\n`);
+});
+
+test('a stale notice marker allows output and is rewritten', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
+  const marker = path.join(root, 'System', '.last-meeting-queue-notice');
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  fs.writeFileSync(marker, `${Math.floor(NOW / 1000) - 3600}\n`);
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+
+  assert.equal(result.count, 1);
+  assert.equal(fs.readFileSync(marker, 'utf8'), `${Math.floor(NOW / 1000)}\n`);
+});
+
+test('malformed meeting frontmatter fails silent and is not counted', (t) => {
+  const root = fixture(t);
+  connectGranola(root);
+  writeMeeting(
+    root,
+    '2026-07-27',
+    'malformed.md',
+    [
+      '---',
+      'date: 2026-07-27',
+      'granola_id: meeting-malformed',
+      'participants: [unterminated',
+      '---',
+      '',
+      '### For Me',
+      '- [ ] This malformed note must not count',
+      '',
+    ].join('\n'),
+  );
+
+  let result;
+  assert.doesNotThrow(() => {
+    result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  });
+  assert.deepEqual(result, { count: 0, lines: [] });
+});

--- a/.claude/reference/meeting-intel.md
+++ b/.claude/reference/meeting-intel.md
@@ -66,6 +66,12 @@ After setup, `/process-meetings` reads synced files and updates your vault:
 
 People qualify after 2+ meetings across 2+ weeks, or after 2+ meetings where at least one has a transcript. An attendee without an email is tracked but never auto-created. In Obsidian mode, auto-linking points names at the person pages' actual vault paths.
 
+## Session-Start Detection
+
+Once Granola is connected, session start checks for synced meetings still waiting for `/process-meetings`: recent notes without a `tasks-extracted` marker that either have `ai_analyzed: false` or an unchecked `### For Me` item. A notice is limited to once every 30 minutes through `System/.last-meeting-queue-notice`, and the check stays silent when Granola is not connected or nothing is waiting.
+
+The detector never processes or edits a meeting. `/process-meetings` still owns that work and continues to respect the vault's `entity_creation` setting.
+
 ## What Gets Extracted
 
 The background sync uses your LLM API to extract:

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -273,6 +273,12 @@ For each meeting with unextracted tasks:
    <!-- tasks-extracted: 2026-02-03T10:30:00Z -->
    ```
 
+   **Also stamp meetings with nothing to extract.** If a meeting note has no
+   action items (or you just added AI analysis to a basic note and found none),
+   add the same `tasks-extracted` comment once processing is complete. The
+   session-start check uses this marker to know a meeting is done — an
+   unstamped note keeps being flagged as waiting.
+
 ### Step 6: Auto-link People in Processed Notes
 
 After finishing edits to each processed meeting note, run this once for every processed note:

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -763,7 +763,7 @@ Tasks use three tag types:
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Just run `/process-meetings` to review and triage.
+**User experience:** Meetings auto-sync. Once Granola is connected, Dex notices waiting meetings at the start of a session and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
 
 ### Why MCP for Integrations?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.79.0] — 📋 Your meetings get dealt with without you asking (2026-07-28)
+
+Once Granola was connected, your meetings did arrive in Dex on their own — but turning them into something useful (updated pages for the people you met, tasks from what you agreed to do, tidy notes) still waited for you to ask. If you never asked, meetings quietly piled up half-done. The docs promised meetings "flow in on their own" — this release makes that promise true.
+
+**What this fixes for you:**
+
+* **Waiting meetings get handled when you start a session.** When you open Dex and there are meetings that haven't been dealt with yet, Dex notices and processes them in the background — person pages updated, tasks pulled out, notes filed — while you get on with whatever you came to do. It tells you in one line that it's happening.
+* **Nothing gets done twice.** A meeting that's already been processed is never picked up again, and if you have several Dex windows open at once they won't trip over each other — the check stands down for half an hour once one of them has taken the job.
+* **Silence when there's nothing to do.** No message when everything's up to date, and nothing at all if you haven't connected Granola — this feature simply doesn't exist for you until you do.
+
 ## [1.78.0] — 📓 Your goals and career pages come back (2026-07-28)
 
 Last week I made Quarter Goals and Career optional — off unless you asked for them — and retired the starter pages that came with each one. That was the wrong call, and one user found out the hard way. They had written a quarter's worth of real goals into the goals page Dex had given them. When that page stopped being part of Dex, their update stopped working. The safety check did its job and refused to run rather than touch the file — but nothing had ever warned them that a page they'd come to rely on was being taken away, and they had to dig their goals out of an old copy themselves.

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -763,7 +763,7 @@ Tasks use three tag types:
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Just run `/process-meetings` to review and triage.
+**User experience:** Meetings auto-sync. Once Granola is connected, Dex notices waiting meetings at the start of a session and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
 
 ### Why MCP for Integrations?
 


### PR DESCRIPTION
## What

The help docs say that once Granola is connected, meetings "flow in on their own." That was only half true: the background sync fetched meetings, but processing them — person pages updated, tasks extracted, notes filed — waited for someone to run `/process-meetings`. If nobody asked, meetings piled up fetched-but-unprocessed.

This adds a **detect-only** session-start step that notices waiting meetings and injects a bounded context block directing the session to run the existing forked `/process-meetings` skill in the background after its first reply. Processing itself is unchanged — same skill, same `entity_creation` settings, same idempotency machinery.

## How

- **`.claude/hooks/meeting-queue-check.cjs`** (new, called from `session-start.sh` §21): counts meeting notes from the last 7 days with a `granola_id`, no `<!-- tasks-extracted: -->` marker, and either unchecked `### For Me` items (same rule `/daily-plan` §5.11 uses) or `ai_analyzed: false`.
  - **Silent** when Granola isn't connected (no key, no sync state) or the queue is empty — zero output, zero nagging.
  - **30-minute throttle** via `System/.last-meeting-queue-notice` so several concurrently opened sessions don't pile on.
  - All vault paths derived through `paths.cjs` (path contract); every failure path fails silent — the hook can never break session start.
  - Manual-mode queue JSONs are deliberately **not** counted: nothing in the repo consumes them, so counting them would nag forever.
- **`/process-meetings` SKILL**: now stamps `tasks-extracted` even when a meeting has nothing to extract, so detection converges instead of re-flagging the same note.
- **Docs**: hooks README, `.claude/reference/meeting-intel.md`, `Dex_Technical_Guide.md`, CHANGELOG 1.78.0.

## Tests

`.claude/hooks/tests/meeting-queue-check.test.cjs` — 11 cases including the two required by the brief: **double-processing** (stamped note, checked items, `ai_analyzed: false` + stamp → all silent) and **Granola-not-connected** (silent even with waiting notes). Plus throttle fresh/stale, 30-day-old notes excluded, day-dir date fallback, malformed frontmatter fails silent, queue JSONs ignored.

Verified end-to-end against a fake vault: notice fires with correct singular grammar; second run throttled; stamped note silent; disconnected vault silent. `input-contract` and `context-injectors` suites still green; `bash -n` clean; path-contract, test-delta, and doc-drift gates run locally against origin/main.

## Follow-up (other repos)

`help/pages/meetings.md` in heydex-website can keep its "meetings flow in on their own" claim once this ships — the owning session will be told what landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUL1VnsCptcRoTLQpty9pT