### PR TITLE
feat(rooms): Quarter Goals and Career on by default again — the shipped seeds return

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -380,7 +380,7 @@ Then call `validate_and_save_step(step_number=7, step_data={"working_week": {"da
 
 ## Step 8: Choose Optional Rooms
 
-Say: "Dex's meetings, people, and tasks spine is always on. I can also add three optional rooms now. All three start off unless you say yes."
+Say: "Dex's meetings, people, and tasks spine is always on. I can also add three optional rooms now. Career and Quarter Goals start on by default; say no to leave either one off. Companies remains a separate yes/no choice."
 
 Present these three plain yes/no questions using your detected platform tool:
 
@@ -392,7 +392,7 @@ Present these three plain yes/no questions using your detected platform tool:
       "prompt": "Add a Career room for growth evidence, coaching, and resumes?",
       "allow_multiple": false,
       "options": [
-        {"id": "yes", "label": "Yes"},
+        {"id": "yes", "label": "Yes (Recommended)"},
         {"id": "no", "label": "No"}
       ]
     },
@@ -410,7 +410,7 @@ Present these three plain yes/no questions using your detected platform tool:
       "prompt": "Add a Quarter Goals room for 3-month planning and reviews?",
       "allow_multiple": false,
       "options": [
-        {"id": "yes", "label": "Yes"},
+        {"id": "yes", "label": "Yes (Recommended)"},
         {"id": "no", "label": "No"}
       ]
     }

--- a/.scripts/lib/tests/provision.test.cjs
+++ b/.scripts/lib/tests/provision.test.cjs
@@ -126,7 +126,7 @@ test('fresh provision creates the full profile, seeds, MCP config, paths, and by
     });
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Career')), false);
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), true);
-    assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), false);
+    assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), true);
 
     const pillars = yaml.load(fs.readFileSync(path.join(vault, 'System', 'pillars.yaml'), 'utf8'));
     assert.deepEqual(pillars.pillars[0], {
@@ -172,8 +172,15 @@ test('fresh provision surfaces only the selected capability rooms', () => {
       assert.equal(fs.existsSync(path.join(vault, '.claude', 'skills', skill, 'SKILL.md')), true);
     }
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), false);
-    assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), false);
+    assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), true);
+    assert.equal(fs.existsSync(path.join(vault, '.claude', 'skills', 'quarter-plan')), false);
+    assert.equal(fs.existsSync(path.join(vault, '.claude', 'skills', 'quarter-review')), false);
   });
+});
+
+test('provision contract restores Quarter Goals without changing Companies baseline', () => {
+  assert.equal(contract.para_directories.includes('01-Quarter_Goals'), true);
+  assert.equal(contract.para_directories.includes('05-Areas/Companies'), false);
 });
 
 test('fresh provision fills omitted capability rooms from template defaults', () => {

--- a/01-Quarter_Goals/Quarter_Goals.md
+++ b/01-Quarter_Goals/Quarter_Goals.md
@@ -1,0 +1,15 @@
+# Quarter Goals
+
+Your 2–4 most important outcomes for this quarter. Everything you plan weekly and
+daily should trace back to something here.
+
+Run `/quarter-plan` and Dex will build this page with you — or just start writing.
+This file is yours: updates never overwrite it.
+
+---
+
+## 🎯 This Quarter
+
+1.
+2.
+3.

--- a/05-Areas/Career/Evidence/README.md
+++ b/05-Areas/Career/Evidence/README.md
@@ -1,0 +1,11 @@
+# Evidence
+
+Artifacts that support career outcomes over time.
+
+Examples:
+- impact snapshots
+- wins and outcomes
+- customer/team feedback
+- performance evidence
+
+This directory is part of the core vault path contract and must exist.

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -1575,8 +1575,8 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 result = create_error_response("No active session", suggestion="Call start_onboarding_session first")
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
             
-            # Step 8 (optional rooms) is skippable: every room defaults OFF, so an
-            # unanswered step means the safe default, never a blocker.
+            # Step 8 is skippable: omitted answers resolve from the portable
+            # contract defaults and are persisted explicitly at finalization.
             required_steps = [s for s in range(1, ONBOARDING_STEPS + 1) if s != 8]
             completed = session['completed_steps']
             missing = [s for s in required_steps if s not in completed]
@@ -1660,8 +1660,8 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
             # Verify all required steps completed
-            # Step 8 (optional rooms) is skippable: every room defaults OFF, so an
-            # unanswered step means the safe default, never a blocker.
+            # Step 8 is skippable: omitted answers resolve from the portable
+            # contract defaults and are persisted explicitly at finalization.
             required_steps = [s for s in range(1, ONBOARDING_STEPS + 1) if s != 8]
             completed = session['completed_steps']
             missing = [s for s in required_steps if s not in completed]

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -9,6 +9,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 import pytest
+import yaml
 
 # core/mcp/tests -> repo root (for `core.paths`) and core/mcp (for the module).
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -801,7 +802,7 @@ class TestCapabilityStep:
         assert onboarding_server.load_session()["data"]["capabilities"] == {
             "career": True,
             "companies": True,
-            "quarter_goals": False,
+            "quarter_goals": True,
         }
 
     def test_rejects_non_boolean_room_answers(self, tmp_path, monkeypatch):
@@ -886,7 +887,7 @@ class TestCapabilityStep:
         preview = payload["data"]
         assert "05-Areas/Career" in preview["would_create_folders"]
         assert "05-Areas/Companies" not in preview["would_create_folders"]
-        assert "01-Quarter_Goals" not in preview["would_create_folders"]
+        assert "01-Quarter_Goals" in preview["would_create_folders"]
         assert preview["preview_user_profile"]["capabilities"] == {
             "career": {"enabled": True},
             "companies": {"enabled": False},
@@ -924,9 +925,84 @@ class TestCapabilityStep:
         )
 
         preview = payload["data"]
+        assert "05-Areas/Career" in preview["would_create_folders"]
         assert "05-Areas/Companies" in preview["would_create_folders"]
-        assert preview["preview_user_profile"]["capabilities"]["companies"] == {
-            "enabled": True
+        assert "01-Quarter_Goals" in preview["would_create_folders"]
+        assert preview["preview_user_profile"]["capabilities"] == {
+            "career": {"enabled": True},
+            "companies": {"enabled": True},
+            "quarter_goals": {"enabled": True},
+        }
+
+    def test_onboarding_flow_recommends_the_two_protected_default_on_rooms(self):
+        flow = (REPO_ROOT / ".claude/flows/onboarding.md").read_text(encoding="utf-8")
+
+        assert "Career and Quarter Goals start on by default" in flow
+        assert flow.count('"label": "Yes (Recommended)"') == 2
+
+    def test_finalize_with_default_answers_provisions_protected_room_seeds(
+        self, tmp_path, monkeypatch
+    ):
+        system = tmp_path / "System"
+        system.mkdir()
+        shutil.copy(
+            REPO_ROOT / "System/user-profile-template.yaml",
+            system / "user-profile-template.yaml",
+        )
+        shutil.copytree(
+            REPO_ROOT / ".claude/skills/_available/capabilities",
+            tmp_path / ".claude/skills/_available/capabilities",
+        )
+        (tmp_path / "core").mkdir()
+        shutil.copy(REPO_ROOT / "core/paths.py", tmp_path / "core/paths.py")
+        (tmp_path / ".scripts").mkdir()
+        mcp_example = system / ".mcp.json.example"
+        mcp_example.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+        (tmp_path / "CLAUDE.md").write_text(
+            "## User Profile\n\n---\n",
+            encoding="utf-8",
+        )
+
+        paths = {
+            "BASE_DIR": tmp_path,
+            "SESSION_FILE": system / ".onboarding-session.json",
+            "MCP_CONFIG_EXAMPLE": mcp_example,
+            "MARKER_FILE": system / ".onboarding-complete",
+        }
+        for name, value in paths.items():
+            monkeypatch.setattr(onboarding_server, name, value)
+
+        session = onboarding_server.create_new_session()
+        session["completed_steps"] = [1, 2, 3, 4, 5, 6, 7]
+        session["current_step"] = 8
+        session["data"] = {
+            "name": "Default User",
+            "role": "Founder",
+            "role_group": "leadership",
+            "company_size": "startup",
+            "email_domain": "example.com",
+            "pillars": ["Build", "Learn"],
+            "communication": {},
+            "working_week": {
+                "days": ["monday", "tuesday", "wednesday", "thursday", "friday"]
+            },
+        }
+        onboarding_server.save_session(session)
+
+        payload = _decode_tool_result(
+            asyncio.run(onboarding_server.handle_call_tool("finalize_onboarding", {}))
+        )
+
+        assert payload["success"] is True, payload
+        assert (tmp_path / "05-Areas/Career/Evidence/README.md").is_file()
+        assert (tmp_path / "01-Quarter_Goals/Quarter_Goals.md").is_file()
+        profile = yaml.safe_load(
+            (tmp_path / "System/user-profile.yaml").read_text(encoding="utf-8")
+        )
+        assert profile["capabilities"] == {
+            "career": {"enabled": True},
+            "companies": {"enabled": True},
+            "quarter_goals": {"enabled": True},
         }
 
     def test_finalize_provisions_only_selected_room_assets(self, tmp_path, monkeypatch):
@@ -985,7 +1061,9 @@ class TestCapabilityStep:
         assert (tmp_path / "05-Areas/Career/Evidence/README.md").is_file()
         assert (tmp_path / ".claude/skills/career-setup/SKILL.md").is_file()
         assert not (tmp_path / "05-Areas/Companies").exists()
-        assert not (tmp_path / "01-Quarter_Goals").exists()
+        assert (tmp_path / "01-Quarter_Goals").is_dir()
+        assert not (tmp_path / ".claude/skills/quarter-plan").exists()
+        assert not (tmp_path / ".claude/skills/quarter-review").exists()
         assert (tmp_path / "03-Tasks/Tasks.md").is_file()
         assert (tmp_path / "05-Areas/People/Internal").is_dir()
         profile = (tmp_path / "System/user-profile.yaml").read_text(encoding="utf-8")

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -336,7 +336,7 @@ CAPABILITIES: dict[str, dict[str, object]] = {
         "folders": ("05-Areas/Career",),
         "skills": ("career-setup", "career-coach", "resume-builder"),
         "mcp": ("career_server", "resume_server"),
-        "default_enabled": False,
+        "default_enabled": True,
     },
     "companies": {
         "folders": ("05-Areas/Companies",),
@@ -348,7 +348,7 @@ CAPABILITIES: dict[str, dict[str, object]] = {
         "folders": ("01-Quarter_Goals",),
         "skills": ("quarter-plan", "quarter-review"),
         "config": "quarterly_planning",
-        "default_enabled": False,
+        "default_enabled": True,
     },
 }
 

--- a/core/provision-contract.json
+++ b/core/provision-contract.json
@@ -75,6 +75,7 @@
     "07-Archives/Plans",
     "07-Archives/Reviews",
     "System/Templates",
+    "01-Quarter_Goals",
     "03-Tasks",
     "02-Week_Priorities"
   ],

--- a/core/tests/test_capabilities.py
+++ b/core/tests/test_capabilities.py
@@ -103,7 +103,7 @@ def test_room_missing_from_contract_registry_is_unknown(tmp_path: Path) -> None:
         capabilities.surfaces_for("career", contract_path=reduced_contract)
 
 
-def test_companies_defaults_on_and_legacy_quarterly_planning_is_a_fallback(
+def test_no_opinion_rooms_default_on_and_legacy_quarterly_planning_is_a_fallback(
     tmp_path: Path,
 ) -> None:
     profile_path = tmp_path / "System/user-profile.yaml"
@@ -112,7 +112,7 @@ def test_companies_defaults_on_and_legacy_quarterly_planning_is_a_fallback(
 
     assert capabilities.enabled(
         "career", profile_path=profile_path, contract_path=CONTRACT_PATH
-    ) is False
+    ) is True
     assert capabilities.enabled(
         "companies", profile_path=profile_path, contract_path=CONTRACT_PATH
     ) is True
@@ -132,7 +132,7 @@ def test_companies_defaults_on_and_legacy_quarterly_planning_is_a_fallback(
     profile_path.write_text("capabilities: malformed\n", encoding="utf-8")
     assert capabilities.enabled(
         "career", profile_path=profile_path, contract_path=CONTRACT_PATH
-    ) is False
+    ) is True
 
 
 def test_off_rooms_stay_dormant_and_leave_the_spine_intact(tmp_path: Path) -> None:
@@ -472,6 +472,11 @@ def test_partial_capability_map_only_gains_the_companies_compatibility_pin(
         "career": {"enabled": False},
         "companies": {"enabled": False},
     }
+    assert capabilities.enabled(
+        "quarter_goals",
+        profile_path=profile_path,
+        contract_path=CONTRACT_PATH,
+    ) is True
 
 
 def test_fresh_unonboarded_vault_is_never_migrated(tmp_path):

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -138,6 +138,30 @@ def test_update_write_verdict(path: str, exists: bool, allowed: bool, action: st
 
 
 @pytest.mark.parametrize(
+    "relative_path",
+    [
+        "01-Quarter_Goals/Quarter_Goals.md",
+        "05-Areas/Career/Evidence/README.md",
+    ],
+)
+def test_protected_capability_seeds_ship_with_write_if_absent_policy(
+    relative_path: str,
+) -> None:
+    seed = REPO_ROOT / relative_path
+    assert seed.is_file(), (
+        f"{relative_path} is a protected shipped seed. If retirement is deliberate, "
+        "declare it explicitly and update this regression with the migration proof."
+    )
+
+    absent = portable_contract.update_write_verdict(relative_path, exists=False)
+    existing = portable_contract.update_write_verdict(relative_path, exists=True)
+    assert absent.allowed is True
+    assert absent.action == "write-if-absent"
+    assert existing.allowed is False
+    assert existing.action == "write-if-absent"
+
+
+@pytest.mark.parametrize(
     ("path", "exists"),
     [
         ("04-Projects/My_Project/notes.md", True),
@@ -406,9 +430,9 @@ def test_capability_rooms_cover_gated_regions() -> None:
     assert "meetings" not in capabilities
     assert "people" not in capabilities
     assert "tasks" not in capabilities
-    assert capabilities["career"]["default_enabled"] is False
+    assert capabilities["career"]["default_enabled"] is True
     assert capabilities["companies"]["default_enabled"] is True
-    assert capabilities["quarter_goals"]["default_enabled"] is False
+    assert capabilities["quarter_goals"]["default_enabled"] is True
 
 
 def test_committed_dist_matches_source_of_truth() -> None:

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -814,7 +814,7 @@
   ],
   "capabilities": {
     "career": {
-      "default_enabled": false,
+      "default_enabled": true,
       "folders": [
         "05-Areas/Career"
       ],
@@ -840,7 +840,7 @@
     },
     "quarter_goals": {
       "config": "quarterly_planning",
-      "default_enabled": false,
+      "default_enabled": true,
       "folders": [
         "01-Quarter_Goals"
       ],


### PR DESCRIPTION
Reverses the default-off half of #155 per Dave's 2026-07-28 decision (ratified as the base for the defaults reversal; a follow-up lane stacks CHANGELOG + doc twins + onboarding wording on this base).

## Why
A real user (Amit) had real quarterly data in `01-Quarter_Goals/Quarter_Goals.md`. When #155 retired the shipped seeds, the product's protection around that data silently ended — the update engine then (correctly) hard-blocked his update, but nothing ever told him a template he wrote in had stopped shipping. Dave's call: these rooms are on by default; risk of data harm outweighs tidiness.

## What changes
- `career` and `quarter_goals` `default_enabled: false → true` in the portable contract (companies untouched — #284 already handled it). Explicit user choices, on or off, are never overwritten; legacy `quarterly_planning.enabled` still honored.
- The two retired seeds ship again: `01-Quarter_Goals/Quarter_Goals.md` (now with a small starter template — it had shipped 0-byte since the initial commit) and `05-Areas/Career/Evidence/README.md` (byte-identical to v1.62.0). Both are seed-class / write-if-absent: an existing user file always wins; updates never overwrite them.
- `01-Quarter_Goals` registered as a PARA directory in the provision contract; JS contract twin regenerated (schema twin unchanged).
- Onboarding Step 8 stays skippable; omitted room answers now resolve from the contract defaults and are persisted explicitly at finalization.
- Regression: retiring either seed now fails a test unless the retirement is declared with its migration story.

## Verification
- 97 contract+capabilities tests green after review; Codex's full run: 270 focused Python + 13 provisioning + 163 script-suite tests green; portable-contract drift, PII, and founder-content gates green.
- Local PR gates (path-contract, test-delta, portable-contract) green against origin/main.

Built by Codex (gpt-5.6-sol); reviewed, seed content authored, and invariants adjusted by the orchestrating session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYVtjfpeWhhnVAT8wBDmyU