### PR TITLE
docs(rooms): the changelog, the folder docs, and a setup step with nothing left to ask

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -378,60 +378,33 @@ Then call `validate_and_save_step(step_number=7, step_data={"working_week": {"da
 
 ---
 
-## Step 8: Choose Optional Rooms
+## Step 8: Rooms
 
-Say: "Dex's meetings, people, and tasks spine is always on. I can also add three optional rooms now. Career and Quarter Goals start on by default; say no to leave either one off. Companies remains a separate yes/no choice."
+**Do not ask a question here.** All three rooms are on for a new vault, so there is
+nothing to choose. Onboarding is already long; a question whose answer is always
+"yes" only makes it longer.
 
-Present these three plain yes/no questions using your detected platform tool:
+Say: "Alongside meetings, people, and tasks, you're getting three more rooms:
+**Companies** for the organizations you deal with, **Career** for growth evidence
+and resumes, and **Quarter Goals** for 3-month planning. All three are set up and
+ready — you don't have to use them, and nothing appears in them until you do."
 
-```json
-{
-  "questions": [
-    {
-      "id": "career",
-      "prompt": "Add a Career room for growth evidence, coaching, and resumes?",
-      "allow_multiple": false,
-      "options": [
-        {"id": "yes", "label": "Yes (Recommended)"},
-        {"id": "no", "label": "No"}
-      ]
-    },
-    {
-      "id": "companies",
-      "prompt": "Add a Companies room for organization and account pages?",
-      "allow_multiple": false,
-      "options": [
-        {"id": "yes", "label": "Yes"},
-        {"id": "no", "label": "No"}
-      ]
-    },
-    {
-      "id": "quarter_goals",
-      "prompt": "Add a Quarter Goals room for 3-month planning and reviews?",
-      "allow_multiple": false,
-      "options": [
-        {"id": "yes", "label": "Yes (Recommended)"},
-        {"id": "no", "label": "No"}
-      ]
-    }
-  ]
-}
-```
+Then move straight to Step 9. **Do not call `validate_and_save_step` for step 8.**
+Finalization fills in every room it wasn't given an answer for, using the shipped
+defaults, which turns all three on and creates their folders.
 
-Map each `yes` to `true` and each `no` to `false`. Then call:
+**If the user volunteers that they don't want one** — "skip the career stuff", "I
+don't need quarterly planning" — take them at their word and record only that room:
 
 ```text
 validate_and_save_step(
   step_number=8,
-  step_data={
-    "capabilities": {
-      "career": true/false,
-      "companies": true/false,
-      "quarter_goals": true/false
-    }
-  }
+  step_data={"capabilities": {"career": false}}
 )
 ```
+
+Only name the rooms they actually spoke about. Any room you leave out still follows
+the default, and a recorded answer — on or off — is never overwritten later.
 
 Say: "You can change these later with `/manage-capabilities`. Turning a room off never deletes its notes; it only hides that room's skills and stops new room content from being created."
 

--- a/06-Resources/Dex_System/Folder_Structure.md
+++ b/06-Resources/Dex_System/Folder_Structure.md
@@ -25,7 +25,7 @@ Dex/
 │   │   ├── Internal/         # Colleagues (same email domain)
 │   │   └── External/         # Customers, partners (different domain)
 │   ├── Companies/            # External organizations (universal)
-│   ├── Career/               # Career development (via /career-setup)
+│   ├── Career/               # Career development (set up for you)
 │   └── [Role-specific]/     # Accounts/, Team/, Content/, etc.
 ├── 06-Resources/                # Reference material
 │   ├── Dex_System/           # System documentation
@@ -45,13 +45,13 @@ Dex/
 │   └── Dex_Backlog.md        # System improvement backlog
 ├── 03-Tasks/                    # Task management
 │   └── Tasks.md              # Main task backlog
-├── 01-Quarter_Goals/            # Quarterly planning (optional)
+├── 01-Quarter_Goals/            # Quarterly planning (set up for you)
 │   └── Quarter_Goals.md      # Current quarter's 3-5 goals
-└── 02-Week_Priorities/          # Weekly planning (optional)
+└── 02-Week_Priorities/          # Weekly planning
     └── Week_Priorities.md    # Current week's Top 3
 ```
 
-**Note:** The numbered folders (`01-`, `02-`, `03-`) appear after running the respective planning commands (`/quarter-plan`, `/week-plan`, `/triage`). Before then, you'll just see the PARA folders (04-07) plus 00-Inbox/ and System/.
+**Note:** These folders are all created for you during setup, each with a starter page waiting inside. They stay empty until you run the matching command (`/quarter-plan`, `/week-plan`, `/triage`) or start writing in them yourself.
 
 ---
 
@@ -98,9 +98,10 @@ Eligible external email domains can also become company pages. New vaults start 
 
 Most users only need the universal areas (People and Companies). You can create additional areas as needed for your workflow.
 
-### Career Area (Optional)
+### Career Area
 
-Created via `/career-setup` command:
+Set up for you during onboarding. Run `/career-setup` to fill it in, or `/manage-capabilities` to switch it off — switching it off never deletes anything already written there.
+
 - `Career/` — Career development tracking
   - `Current_Role.md` — Job description and responsibilities
   - `Career_Ladder.md` — Competency framework
@@ -258,7 +259,7 @@ If you enable quarterly and weekly planning, everything connects from pillars �
 5. **Tasks** (`03-Tasks/Tasks.md`)  
    Backlog tagged with `#pillar [Q1-2] [Week-1]` connecting to goals
 
-**Note:** Weekly planning (`02-Week_Priorities/`) is always available. Quarterly planning (`01-Quarter_Goals/`) is optional and created when you run `/quarter-plan`.
+**Note:** Both weekly planning (`02-Week_Priorities/`) and quarterly planning (`01-Quarter_Goals/`) are set up from the start. Quarterly planning can be switched off with `/manage-capabilities` if you don't work that way.
 
 ---
 
@@ -312,7 +313,7 @@ Tasks sync bidirectionally with person pages, company pages, and meeting notes v
 | **00-Inbox/** | Quick captures | Days (until triaged) | Onboarding |
 | **System/** | Configuration | Indefinite | Onboarding |
 | **03-Tasks/** | Task backlog | Indefinite | First `/triage` or `/daily-plan` |
-| **01-Quarter_Goals/** | Quarterly goals | Per quarter | First `/quarter-plan` |
+| **01-Quarter_Goals/** | Quarterly goals | Per quarter | Onboarding |
 | **02-Week_Priorities/** | Weekly priorities | Per week | First `/week-plan` |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.78.0] — 📓 Your goals and career pages come back (2026-07-28)
+
+Last week I made Quarter Goals and Career optional — off unless you asked for them — and retired the starter pages that came with each one. That was the wrong call, and one user found out the hard way. They had written a quarter's worth of real goals into the goals page Dex had given them. When that page stopped being part of Dex, their update stopped working. The safety check did its job and refused to run rather than touch the file — but nothing had ever warned them that a page they'd come to rely on was being taken away, and they had to dig their goals out of an old copy themselves.
+
+**What this fixes for you:**
+
+* **Goals and Career come with Dex again.** Both are set up from the start for a new vault, starter pages included. If you'd never expressed a preference either way, they're switched back on for you too.
+* **A choice you made stays your choice.** If you ever turned either one on or off — during setup or afterwards — that decision stands, and nothing here overrides it in either direction. You can still switch any of them off with `/manage-capabilities`, and switching one off never deletes what you've already written.
+* **Dex recognises its own pages again.** The starter goals page and the career evidence page ship with Dex once more, so when you write into them, an update knows what it's looking at instead of treating your work as a stray file it daren't touch.
+* **Setup stops asking.** It used to put three yes/no questions to you about rooms you hadn't seen yet, right when you were trying to get started. All three now simply come with Dex, and setup tells you so in a sentence.
+
+Thanks to Amit, who reported this and worked out exactly what had happened.
+
 ## [1.77.2] — 🔔 Dex can tell you about updates again (2026-07-27)
 
 Yesterday's fix was half the story. Chasing it properly — by testing against the real thing rather than a stand-in — turned up something considerably worse: **Dex had stopped telling almost anyone that updates existed.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,13 +518,13 @@ Dex uses the PARA method: Projects (time-bound), Areas (ongoing), Resources (ref
 - `04-Projects/` - Active projects
 - `05-Areas/People/` - Person pages (Internal/ and External/)
 - `05-Areas/Companies/` - External organizations
-- `05-Areas/Career/` - Career development (optional, via `/career-setup`)
+- `05-Areas/Career/` - Career development (set up by default; fill in with `/career-setup`)
 - `06-Resources/` - Reference material
 - `07-Archives/` - Completed work
 - `00-Inbox/` - Capture zone (meetings, ideas)
 - `System/` - Configuration (pillars.yaml, user-profile.yaml)
 - `03-Tasks/Tasks.md` - Task backlog
-- `01-Quarter_Goals/Quarter_Goals.md` - Quarterly goals (optional)
+- `01-Quarter_Goals/Quarter_Goals.md` - Quarterly goals (set up by default)
 - `02-Week_Priorities/Week_Priorities.md` - Weekly priorities
 
 **Planning hierarchy:** Pillars → Quarter Goals → Week Priorities → Daily Plans → Tasks

--- a/core/mcp/tests/test_onboarding_server.py
+++ b/core/mcp/tests/test_onboarding_server.py
@@ -934,11 +934,23 @@ class TestCapabilityStep:
             "quarter_goals": {"enabled": True},
         }
 
-    def test_onboarding_flow_recommends_the_two_protected_default_on_rooms(self):
-        flow = (REPO_ROOT / ".claude/flows/onboarding.md").read_text(encoding="utf-8")
+    def test_onboarding_step_8_asks_nothing_now_that_every_room_is_on(self):
+        """All three rooms default on, so step 8 has no question left to ask.
 
-        assert "Career and Quarter Goals start on by default" in flow
-        assert flow.count('"label": "Yes (Recommended)"') == 2
+        It states what the user is getting and moves on. The step must not put a
+        yes/no choice to someone whose answer is always yes, and must not force
+        an answer — an unanswered step 8 is what lets finalization fill every
+        room from the shipped defaults.
+        """
+        flow = (REPO_ROOT / ".claude/flows/onboarding.md").read_text(encoding="utf-8")
+        step = flow.split("## Step 8:", 1)[1].split("## Step 9:", 1)[0]
+
+        assert '"options"' not in step
+        assert "Recommended" not in step
+        assert "**Do not ask a question here.**" in step
+        assert "Do not call `validate_and_save_step` for step 8." in step
+        for room in ("Companies", "Career", "Quarter Goals"):
+            assert room in step
 
     def test_finalize_with_default_answers_provisions_protected_room_seeds(
         self, tmp_path, monkeypatch

--- a/core/tests/test_capabilities.py
+++ b/core/tests/test_capabilities.py
@@ -135,6 +135,35 @@ def test_no_opinion_rooms_default_on_and_legacy_quarterly_planning_is_a_fallback
     ) is True
 
 
+def test_flipped_rooms_default_on_but_a_recorded_answer_always_wins(
+    tmp_path: Path,
+) -> None:
+    """Career and Quarter Goals default on (Dave's 2026-07-28 rooms decision).
+
+    The default is the *fallback*, never an override: a recorded answer outranks
+    it in both directions, so flipping the default can never switch a room on for
+    someone who said no, nor off for someone who said yes.
+    """
+    profile_path = tmp_path / "System/user-profile.yaml"
+
+    for room in ("career", "quarter_goals"):
+        _profile(profile_path, **{room: False})
+        assert capabilities.enabled(
+            room, profile_path=profile_path, contract_path=CONTRACT_PATH
+        ) is False
+
+        _profile(profile_path, **{room: True})
+        assert capabilities.enabled(
+            room, profile_path=profile_path, contract_path=CONTRACT_PATH
+        ) is True
+
+    # A map that names one room leaves the other on the contract default.
+    _profile(profile_path, quarter_goals=False)
+    assert capabilities.enabled(
+        "career", profile_path=profile_path, contract_path=CONTRACT_PATH
+    ) is True
+
+
 def test_off_rooms_stay_dormant_and_leave_the_spine_intact(tmp_path: Path) -> None:
     vault = _fake_vault(tmp_path)
     profile_path = _profile(

--- a/docs/Dex_System/Folder_Structure.md
+++ b/docs/Dex_System/Folder_Structure.md
@@ -25,7 +25,7 @@ Dex/
 │   │   ├── Internal/         # Colleagues (same email domain)
 │   │   └── External/         # Customers, partners (different domain)
 │   ├── Companies/            # External organizations (universal)
-│   ├── Career/               # Career development (via /career-setup)
+│   ├── Career/               # Career development (set up for you)
 │   └── [Role-specific]/     # Accounts/, Team/, Content/, etc.
 ├── 06-Resources/                # Reference material
 │   ├── Dex_System/           # System documentation
@@ -45,13 +45,13 @@ Dex/
 │   └── Dex_Backlog.md        # System improvement backlog
 ├── 03-Tasks/                    # Task management
 │   └── Tasks.md              # Main task backlog
-├── 01-Quarter_Goals/            # Quarterly planning (optional)
+├── 01-Quarter_Goals/            # Quarterly planning (set up for you)
 │   └── Quarter_Goals.md      # Current quarter's 3-5 goals
-└── 02-Week_Priorities/          # Weekly planning (optional)
+└── 02-Week_Priorities/          # Weekly planning
     └── Week_Priorities.md    # Current week's Top 3
 ```
 
-**Note:** The numbered folders (`01-`, `02-`, `03-`) appear after running the respective planning commands (`/quarter-plan`, `/week-plan`, `/triage`). Before then, you'll just see the PARA folders (04-07) plus 00-Inbox/ and System/.
+**Note:** These folders are all created for you during setup, each with a starter page waiting inside. They stay empty until you run the matching command (`/quarter-plan`, `/week-plan`, `/triage`) or start writing in them yourself.
 
 ---
 
@@ -98,9 +98,10 @@ Eligible external email domains can also become company pages. New vaults start 
 
 Most users only need the universal areas (People and Companies). You can create additional areas as needed for your workflow.
 
-### Career Area (Optional)
+### Career Area
 
-Created via `/career-setup` command:
+Set up for you during onboarding. Run `/career-setup` to fill it in, or `/manage-capabilities` to switch it off — switching it off never deletes anything already written there.
+
 - `Career/` — Career development tracking
   - `Current_Role.md` — Job description and responsibilities
   - `Career_Ladder.md` — Competency framework
@@ -258,7 +259,7 @@ If you enable quarterly and weekly planning, everything connects from pillars �
 5. **Tasks** (`03-Tasks/Tasks.md`)  
    Backlog tagged with `#pillar [Q1-2] [Week-1]` connecting to goals
 
-**Note:** Weekly planning (`02-Week_Priorities/`) is always available. Quarterly planning (`01-Quarter_Goals/`) is optional and created when you run `/quarter-plan`.
+**Note:** Both weekly planning (`02-Week_Priorities/`) and quarterly planning (`01-Quarter_Goals/`) are set up from the start. Quarterly planning can be switched off with `/manage-capabilities` if you don't work that way.
 
 ---
 
@@ -312,7 +313,7 @@ Tasks sync bidirectionally with person pages, company pages, and meeting notes v
 | **00-Inbox/** | Quick captures | Days (until triaged) | Onboarding |
 | **System/** | Configuration | Indefinite | Onboarding |
 | **03-Tasks/** | Task backlog | Indefinite | First `/triage` or `/daily-plan` |
-| **01-Quarter_Goals/** | Quarterly goals | Per quarter | First `/quarter-plan` |
+| **01-Quarter_Goals/** | Quarterly goals | Per quarter | Onboarding |
 | **02-Week_Priorities/** | Weekly priorities | Per week | First `/week-plan` |
 
 ---


### PR DESCRIPTION
Stacked on #288 (Quarter Goals and Career back on by default). **Review #288 first — this targets its branch, not `main`.** #288 changed the behavior; this finishes the user-facing half of it.

## What

**CHANGELOG v1.78.0.** Written for the person deciding whether to update: what was taken away last week, what it cost the one user who hit it, what is back now. Credits Amit.

**Folder docs.** `06-Resources/Dex_System/Folder_Structure.md` and its `docs/` twin (byte-identical, verified with `cmp`) plus the CLAUDE.md folder list no longer describe Career and Quarter Goals as optional extras you create on demand. They ship set up, with their starter pages in place.

**Onboarding Step 8 shrinks to nothing.** It asked three yes/no questions whose answer is now always yes — at the exact moment someone is trying to get started, about rooms they haven't seen. Replaced with one informational sentence naming all three, plus an explicit instruction *not* to call `validate_and_save_step` for step 8. That omission is what lets finalization fill every room from the shipped defaults. A user who volunteers "skip the career stuff" is still recorded, one room at a time — partial answers were already supported by `_capability_states`.

## Verification

- **Full suite: 2541 passed, 69 skipped, 0 failed** (`core/tests core/mcp/tests core/migrations/tests`, not-fuzz, xdist loadgroup). No flakes this run.
- **PR gates green against `origin/main`:** `check-test-delta`, `check-path-contract-usage`, `check-doc-drift`. Also `check-portable-contract` (dist in sync) and `ruff`.
- Doc twins confirmed byte-identical.

## Two things worth a reviewer's attention

**1. I changed a test #288 added.** `test_onboarding_flow_recommends_the_two_protected_default_on_rooms` asserted the flow shows exactly two `"Yes (Recommended)"` labels. Shrinking the step removes them, so that assertion encoded the intermediate state. It is now `test_onboarding_step_8_asks_nothing_now_that_every_room_is_on`, which locks the stronger contract: no options block, no "Recommended", the step must say not to call `validate_and_save_step`, and all three rooms must be named. The behavior it protects was already proven independently by `test_dry_run_uses_contract_defaults_when_capabilities_are_omitted` — an unanswered step 8 yields all three rooms on, with folders created.

**2. New test on the property the whole reversal rests on.** `test_flipped_rooms_default_on_but_a_recorded_answer_always_wins` asserts the flipped default is a *fallback*, never an override: a recorded answer wins in both directions, for both rooms. Nobody who said no gets a room switched on; nobody who said yes gets one switched off. I verified this by reading `capabilities.enabled` rather than trusting the summary — the explicit check short-circuits ahead of the legacy switch, which short-circuits ahead of the default — but under the old default-off it was only vacuously true for these two rooms, so it was worth pinning.

## Out of scope, flagged not fixed

`scripts/check-tracked-ignored.py` still reports one stale row: `05-Areas/Companies/README.md` is declared a shipped starter but isn't tracked at the vault root — it lives in the room pack instead. This is pre-existing on `main`, not introduced here, and #288 improved the count from 21/24 to 23/24 by restoring the other two. Fixing it means choosing between the two placement conventions now in play, which belongs with whoever settles that question. Note the guard is not currently wired into CI, so nothing catches this class automatically — same class as the defect that started all this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT3RWB6BjtkgAkArjgJDsC