### PR TITLE
ci(seeds): make the shipped-starter guard binding, and ship the last missing starter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
         run: bash scripts/check-architecture-inventory.sh
       - name: Instructed-tool existence gate
         run: python scripts/check-instructed-tools.py
+      - name: Shipped-seed tracking gate
+        # A starter page Dex ships can silently stop shipping — the file is
+        # covered by .gitignore, so dropping it from the index looks like
+        # nothing. A user who had written real work into that page then finds
+        # their update refusing to run. This gate fails the build instead.
+        run: python scripts/check-tracked-ignored.py
       - name: Create vault directories
         run: python -c "from core import paths; from pathlib import Path; [getattr(paths, n).mkdir(parents=True, exist_ok=True) for n in dir(paths) if n.endswith('_DIR') and isinstance(getattr(paths, n), Path)]"
       - name: Generate paths.json

--- a/05-Areas/Companies/README.md
+++ b/05-Areas/Companies/README.md
@@ -1,0 +1,10 @@
+# Companies
+
+Organization-level notes and account context.
+
+Use this directory for:
+- company profiles
+- account strategy notes
+- relationship and opportunity context
+
+This directory is part of the core vault path contract and must exist.

--- a/core/tests/test_shipped_seed_policy.py
+++ b/core/tests/test_shipped_seed_policy.py
@@ -1,0 +1,127 @@
+"""The starter pages Dex ships must actually ship, and must stay ship-checked.
+
+Dex hands the user starter pages — a goals page, a career evidence page, a
+companies page — and users write real work into them. Those paths are covered by
+.gitignore (they are user PARA folders), so each one is tracked only because it
+was force-added. Dropping one from the index is therefore invisible: no diff
+noise, no warning, nothing red. It has happened, and it cost a user their
+quarter's goals — their update refused to run rather than touch a file Dex no
+longer recognised as its own.
+
+The policy in ``core/migrations/tracked-ignored-policy.yaml`` already declares
+what must ship. These tests make the declaration binding.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts/check-tracked-ignored.py"
+POLICY = REPO_ROOT / "core/migrations/tracked-ignored-policy.yaml"
+WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_tracked_ignored", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_tracked_ignored"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_every_declared_seed_is_actually_tracked() -> None:
+    """The real repository satisfies its own shipped-seed policy.
+
+    This is the check that would have caught the original defect. It runs
+    against the working repository, not a fixture, because a fixture cannot
+    decay the way the real index did.
+    """
+    checker = _load_checker()
+
+    result = checker.check(REPO_ROOT, POLICY)
+
+    assert result["ok"], (
+        "Shipped-seed policy is not satisfied. "
+        f"errors={result['errors']} "
+        f"(expected {result['expected_tracked']} tracked, "
+        f"found {result['actual_tracked_ignored']}). "
+        "A declared seed must be tracked at its real vault path via `git add -f`; "
+        "a copy under .claude/skills/_available/capabilities/ does not count."
+    )
+
+
+def test_the_gate_runs_in_ci_on_every_build() -> None:
+    """The guard is only worth anything if it is not optional.
+
+    It must run unconditionally in the quality job — not behind an `if`, and
+    not only on pull requests, so a direct push to main cannot drop a seed.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["quality"]["steps"]
+
+    matching = [
+        step
+        for step in steps
+        if "check-tracked-ignored.py" in str(step.get("run", ""))
+    ]
+
+    assert len(matching) == 1, "CI must run the shipped-seed gate exactly once"
+    assert "if" not in matching[0], "the shipped-seed gate must not be conditional"
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["stale-policy-row", "unknown-tracked-ignored", "local-only-still-tracked"],
+)
+def test_failure_output_states_the_convention(code: str) -> None:
+    """A bare error code leaves the next person guessing which copy counts.
+
+    Two placement conventions exist side by side — the vault-root seed and the
+    dormant room-pack copy — and only one satisfies the policy. The failure
+    message has to say so.
+    """
+    checker = _load_checker()
+
+    explanation = "\n".join(checker._explain([{"code": code, "paths": ["some/path.md"]}]))
+
+    assert code in explanation
+    assert "some/path.md" in explanation
+    assert len(checker.CONVENTIONS[code]) > 80
+
+
+def test_stale_row_message_names_both_placements() -> None:
+    checker = _load_checker()
+
+    message = checker.CONVENTIONS["stale-policy-row"]
+
+    assert "git add -f" in message
+    assert ".claude/skills/_available/capabilities" in message
+    assert "does NOT satisfy" in message
+
+
+def test_policy_declares_the_three_room_starters() -> None:
+    """The pages this whole guard exists to protect are the ones declared."""
+    policy = yaml.safe_load(POLICY.read_text(encoding="utf-8"))
+    active = next(
+        baseline
+        for baseline in policy["baselines"]
+        if baseline["baseline_version"] == policy["active_baseline_version"]
+    )
+    declared = {
+        row["path"]
+        for row in active["paths"]
+        if row["classification"] == "intentional-seed"
+    }
+
+    for seed in (
+        "01-Quarter_Goals/Quarter_Goals.md",
+        "05-Areas/Career/Evidence/README.md",
+        "05-Areas/Companies/README.md",
+    ):
+        assert seed in declared

--- a/scripts/check-tracked-ignored.py
+++ b/scripts/check-tracked-ignored.py
@@ -26,6 +26,46 @@ def load_policy(path: Path) -> tuple[PolicyRow, ...]:
     return load_exact_policy(path).rows
 
 
+CONVENTIONS: dict[str, str] = {
+    "stale-policy-row": (
+        "Declared seed is missing from the repository. A seed must be tracked at its "
+        "real vault path (the path in the policy), force-added with `git add -f` "
+        "because .gitignore covers the user PARA folders. A copy under "
+        ".claude/skills/_available/capabilities/<room>/folders/ is the dormant "
+        "room-pack placeholder — it is copied in only when a room is switched on "
+        "later, and it does NOT satisfy this policy. Ship both: the vault-root seed "
+        "is what users get, the room-pack copy is the fallback."
+    ),
+    "unknown-tracked-ignored": (
+        "Tracked despite being ignored, but not declared in the policy. Either add a "
+        "row to core/migrations/tracked-ignored-policy.yaml (if this is a seed Dex "
+        "ships on purpose) or untrack it with `git rm --cached`."
+    ),
+    "local-only-still-tracked": (
+        "Declared local-only, but still tracked. These must be untracked with "
+        "`git rm --cached` so they never ship to users."
+    ),
+    "bootstrap-state-mismatch": (
+        "Transition metadata says bootstrap, but the tracked set does not match the "
+        "declared local-only set. Reconcile before advancing the baseline."
+    ),
+    "check-failed": "The policy could not be read or did not agree with transition metadata.",
+}
+
+
+def _explain(errors: list[dict[str, object]]) -> list[str]:
+    """Human-readable lines for CI logs — the JSON alone reads as an opaque code."""
+    lines: list[str] = []
+    for error in errors:
+        code = str(error.get("code", ""))
+        lines.append(f"{code}: {CONVENTIONS.get(code, '')}".rstrip(": "))
+        for path in error.get("paths", []) or []:
+            lines.append(f"  - {path}")
+        if detail := error.get("detail"):
+            lines.append(f"  {detail}")
+    return lines
+
+
 def check(repo: Path, policy_path: Path) -> dict[str, object]:
     policy = load_exact_policy(policy_path)
     rows = policy.rows
@@ -72,8 +112,18 @@ def main(argv: list[str] | None = None) -> int:
         result = check(args.repo.resolve(), args.policy.resolve())
     except TrackedIgnoredError as error:
         result = {"ok": False, "errors": [{"code": "check-failed", "detail": str(error)}]}
-    print(json.dumps(result, sort_keys=True))
-    return 0 if result["ok"] else 1
+    print(json.dumps(result, sort_keys=True), flush=True)
+    if result["ok"]:
+        return 0
+    errors = result.get("errors") or []
+    print("\nShipped-seed policy check FAILED.", file=sys.stderr)
+    for line in _explain(errors):
+        print(line, file=sys.stderr)
+    print(
+        "\nPolicy: core/migrations/tracked-ignored-policy.yaml (active baseline).",
+        file=sys.stderr,
+    )
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #288/#289. The guard that would have caught today's defect already existed and was already correct — it was simply never wired to anything.

## The problem

`scripts/check-tracked-ignored.py` is referenced by no workflow and no npm script. Nothing ran it, so nothing failed when a declared starter page stopped shipping.

That silence is the whole defect. The starter pages live under user PARA folders, which `.gitignore` covers, so each one is tracked *only* because it was force-added. Dropping one from the index produces no diff noise, no warning, nothing red — and the first person to find out is a user who had written a quarter of real goals into that page and whose update then refused to run rather than touch a file Dex no longer recognised as its own.

## What this does

**1. The gate runs in CI, unconditionally.** Added to the `quality` job. Deliberately *not* behind `if: github.event_name == 'pull_request'` like the diff-aware gates — a direct push to `main` must not be able to drop a starter either. A test asserts both properties, so the wiring can't quietly be removed or made conditional later.

**2. Ships `05-Areas/Companies/README.md`,** the last declared-but-missing starter. Placement per the ruling: the real vault path, same convention as the two restored in #288. The count goes 23/24 → **24/24, status `clean`**.

**3. The failure output now states the convention.** Two placements exist side by side and only one satisfies the policy — that ambiguity cost time in this lane and would have cost the next person the same. Each error code now gets a plain explanation on stderr with the offending paths:

```
Shipped-seed policy check FAILED.
stale-policy-row: Declared seed is missing from the repository. A seed must be
tracked at its real vault path (the path in the policy), force-added with
`git add -f` because .gitignore covers the user PARA folders. A copy under
.claude/skills/_available/capabilities/<room>/folders/ is the dormant room-pack
placeholder — it is copied in only when a room is switched on later, and it does
NOT satisfy this policy. Ship both: the vault-root seed is what users get, the
room-pack copy is the fallback.
  - 01-Quarter_Goals/Quarter_Goals.md
```

## On the two copies

Worth stating explicitly, since it caused the #286-vs-#288 divergence. Both copies are intentional and they are not duplicates:

- **Vault-root seed** (`05-Areas/Companies/README.md`) — ships in the distributable vault. This is what a user actually gets, and it is what the policy counts.
- **Room-pack copy** (`.claude/skills/_available/capabilities/companies/folders/...`) — a placeholder copied in by `_copy_missing` *only if absent*, for when a room is switched on later in a vault that never had the folder. It never overwrites the real page.

## Verification

- **Guard now passes on the real repo:** `{"actual_tracked_ignored": 24, "expected_tracked": 24, "ok": true, "status": "clean"}`, exit 0. Verified it still exits 1 on a missing seed before adding the file.
- **Full suite: 2548 passed, 69 skipped, 0 failed** (not-fuzz, xdist loadgroup).
- **Gates green against `origin/main`:** `check-test-delta`, `check-path-contract-usage`, `check-doc-drift`, `check-portable-contract`, `ruff`.
- Workflow YAML parses.

## Correction to an earlier note of mine

I reported yesterday that the checker "exits 0 despite `ok: false`". That was wrong — it always returned 1 correctly. I had read the exit code of a shell pipeline rather than the script's. The wiring gap was real; the exit-code bug was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT3RWB6BjtkgAkArjgJDsC