### PR TITLE
fix(release): the cut stamps the engine's version label too

### DIFF
--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.77.2","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.78.0","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -120,11 +120,21 @@ python3 core/utils/update_verifier.py \
   --release-version "$NEW_VERSION"
 VAULT_PATH="$PWD" python3 -m core.migrations.preserve_local_only_paths stamp-transition \
   --repo "$PWD"
+python3 - "$NEW_VERSION" <<'STAMP'
+import json, sys
+path = "core/lifecycle/catalog/bridge-release.json"
+data = json.load(open(path))
+data["release_version"] = sys.argv[1]
+open(path, "w").write(
+    json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+)
+STAMP
 bash scripts/generate-manifest.sh
 
 # --- Commit, tag, push --------------------------------------------------------
 
 git add package.json package-lock.json CHANGELOG.md \
+  core/lifecycle/catalog/bridge-release.json \
   System/.release-evidence-profile.json \
   System/.local-only-preservation-transition.json \
   System/.installed-files.manifest


### PR DESCRIPTION
The v1.78.0 cut went red on main because our own new bridge-pin guard (from #292) caught real drift: the cut bumps package.json but nothing bumped the in-repo bridge-release.json. This stamps the label as part of scripts/release.sh (alongside the evidence profile and transition stamps) and syncs it to 1.78.0 now. Verified: full bridge suite + the failing distribution test green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYVtjfpeWhhnVAT8wBDmyU