### PR TITLE
fix(profile): the blank template said Career and Quarter Goals were off

### DIFF
--- a/.scripts/lib/tests/provision.test.cjs
+++ b/.scripts/lib/tests/provision.test.cjs
@@ -120,11 +120,11 @@ test('fresh provision creates the full profile, seeds, MCP config, paths, and by
     assert.equal(profile.communication.detail_level, 'concise');
     assert.equal(profile.ignored_key, undefined);
     assert.deepEqual(profile.capabilities, {
-      career: { enabled: false },
+      career: { enabled: true },
       companies: { enabled: true },
-      quarter_goals: { enabled: false },
+      quarter_goals: { enabled: true },
     });
-    assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Career')), false);
+    assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Career')), true);
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), true);
     assert.equal(fs.existsSync(path.join(vault, '01-Quarter_Goals')), true);
 
@@ -197,7 +197,7 @@ test('fresh provision fills omitted capability rooms from template defaults', ()
     assert.deepEqual(profile.capabilities, {
       career: { enabled: true },
       companies: { enabled: true },
-      quarter_goals: { enabled: false },
+      quarter_goals: { enabled: true },
     });
     assert.equal(fs.existsSync(path.join(vault, '05-Areas', 'Companies')), true);
   });

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -129,11 +129,11 @@ journaling:
 # and intentionally have no switch here.
 capabilities:
   career:
-    enabled: false
+    enabled: true
   companies:
     enabled: true
   quarter_goals:
-    enabled: false
+    enabled: true
 
 # Quarterly Planning Configuration
 # Controls whether you use quarterly goal setting

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -18,6 +18,11 @@ email_domain: ""
 # Auto-detected from system if not set. Used for time-of-day greetings and focus time calculations.
 timezone: ""
 
+# Which days you work. Used for daily planning, weekly review timing, and anything
+# that needs to know your weekend. Defaults to Monday-Friday when not set.
+working_week:
+  days: [monday, tuesday, wednesday, thursday, friday]
+
 # Update Channel
 # Additional channels are reserved for a future release.
 updates:

--- a/System/user-profile.yaml
+++ b/System/user-profile.yaml
@@ -124,11 +124,11 @@ journaling:
 # and intentionally have no switch here.
 capabilities:
   career:
-    enabled: false
+    enabled: true
   companies:
     enabled: true
   quarter_goals:
-    enabled: false
+    enabled: true
 
 # Quarterly Planning Configuration
 # Controls whether you use quarterly goal setting


### PR DESCRIPTION
Two places record which rooms a vault starts with, and they disagreed.

| | Career | Companies | Quarter Goals |
|---|---|---|---|
| The contract (the rulebook) | on | on | on |
| `user-profile-template.yaml` | **off** | on | **off** |

## Why it usually doesn't bite

The compatibility step works the rooms out properly and never reads the template. But when that step **can't run** — the broken-Python case fixed in #291 — Dex falls back to the template and hands back the old answer.

Measured on `main` before this change:

```
Python working  → career=true   companies=true  quarter_goals=true
Python broken   → career=false  companies=true  quarter_goals=false
```

Same vault, two different outcomes.

## ⚠️ This also changes what NEW vaults get

Worth saying plainly rather than burying: **Career and Quarter Goals are now on for new vaults.** That matches the contract and the direction already taken for existing vaults, but it is a real product change, not a cosmetic file sync.

**Two tests asserted the older, emptier shape** and now assert the contract:
- `fresh provision creates the full profile, seeds, MCP config, paths, and byte-stable marker`
- `fresh provision fills omitted capability rooms from template defaults`

That those tests broke is the evidence this needed CI rather than a direct push — the change looks like two lines and isn't.

## Verification

- A vault with no recorded opinion gets **all three rooms**, whether or not Python is available.
- A vault that chose off keeps **all three off**, either way.
- 13/13 provisioning tests, 125 Python tests across provisioning parity, capabilities, golden journeys, seed policy, onboarding and calendar. PII gate green (both files kept byte-identical, as that gate requires).

## Note on ownership

Career and Quarter Goals belong to the migration lane, which fixed them earlier today. I flagged this rather than changing it unilaterally, and am proceeding on Dave's explicit go-ahead. Worth a glance from that lane before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
