### PR TITLE
The meeting sweep watches the landing zone — any meeting note counts, no Granola required

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -47,7 +47,7 @@ These files are not registered as repository-wide lifecycle hooks.
 | File | Caller | Purpose |
 |---|---|---|
 | `meeting-cache-builder.cjs` | Work MCP meeting-cache workflow | Build `System/Memory/meeting-cache.json`. Work MCP exposes `rebuild_meeting_cache`; its missing-cache guidance also names the standalone Node command. |
-| `meeting-queue-check.cjs` | `session-start.sh` | Detect synced-but-unprocessed meetings and inject a one-block notice so the session processes them in the background. |
+| `meeting-queue-check.cjs` | `session-start.sh` | Detect unprocessed meetings in the landing zone (synced, manually captured, or queued) and inject a one-block notice so the session processes them in the background. |
 | `integration-concierge.cjs` | Onboarding, `/getting-started`, and `/dex-level-up` | Scan the vault for integration signals and return ranked recommendations. |
 | `maintenance.cjs` | Manual: `node .claude/hooks/maintenance.cjs` | Report stale inbox files, broken WikiLinks, orphaned person pages, and old agent memory. |
 

--- a/.claude/hooks/meeting-queue-check.cjs
+++ b/.claude/hooks/meeting-queue-check.cjs
@@ -9,14 +9,7 @@ let yaml = null;
 try {
   yaml = require('js-yaml');
 } catch (error) {
-  // Without a safe parser, meeting notes are skipped.
-}
-
-let getGranolaApiKey = null;
-try {
-  ({ getGranolaApiKey } = require('../../.scripts/meeting-intel/lib/granola-api-key.cjs'));
-} catch (error) {
-  // The prior-sync state remains a valid connection signal without this helper.
+  // Filename, day-directory, and text signals remain available without YAML.
 }
 
 let CONTRACT = null;
@@ -44,24 +37,6 @@ function anchoredPaths(vaultRoot) {
   return { meetingsDir, systemDir };
 }
 
-function isConnected(vaultRoot, env) {
-  if (typeof getGranolaApiKey === 'function') {
-    try {
-      if (getGranolaApiKey({ vaultRoot, env })) return true;
-    } catch (error) {
-      // Fall through to prior-sync state.
-    }
-  }
-
-  try {
-    return fs.existsSync(
-      path.join(vaultRoot, '.scripts/meeting-intel/processed-meetings.json'),
-    );
-  } catch (error) {
-    return false;
-  }
-}
-
 function isThrottled(markerPath, nowSeconds) {
   try {
     if (!fs.existsSync(markerPath)) return false;
@@ -86,7 +61,7 @@ function parseFrontmatter(source) {
   if (!document || typeof document !== 'object' || Array.isArray(document)) return null;
 
   const fields = {};
-  for (const key of ['date', 'granola_id', 'ai_analyzed']) {
+  for (const key of ['date', 'ai_analyzed']) {
     if (!Object.hasOwn(document, key) || document[key] === null) continue;
     fields[key] = document[key] instanceof Date
       ? document[key].toISOString()
@@ -117,9 +92,26 @@ function isRecentDay(value, nowMilliseconds) {
   return parsed.day <= today && parsed.timestamp >= todayStart - (7 * DAY_MS);
 }
 
-function hasUncheckedForMeItem(body) {
+function datePrefixFromFilename(filePath) {
+  const match = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2})(?:\b|_)/);
+  return match?.[1] || null;
+}
+
+function resolveNoteDay(filePath, frontmatterDate, fallbackDay) {
+  for (const candidate of [
+    frontmatterDate,
+    datePrefixFromFilename(filePath),
+    fallbackDay,
+  ]) {
+    const parsed = dayFromValue(candidate);
+    if (parsed) return parsed.day;
+  }
+  return null;
+}
+
+function hasUncheckedForMeItem(source) {
   let underForMe = false;
-  for (const line of body.split(/\r?\n/)) {
+  for (const line of source.split(/\r?\n/)) {
     if (/^###\s+For Me\s*$/i.test(line)) {
       underForMe = true;
       continue;
@@ -137,29 +129,44 @@ function noteIsWaiting(filePath, fallbackDay, nowMilliseconds) {
   try {
     const source = fs.readFileSync(filePath, 'utf8');
     const parsed = parseFrontmatter(source);
-    if (!parsed?.fields.granola_id) return false;
 
-    const day = parsed.fields.date || fallbackDay;
+    const day = resolveNoteDay(filePath, parsed?.fields.date, fallbackDay);
     if (!isRecentDay(day, nowMilliseconds)) return false;
 
-    if (/<!--\s*tasks-extracted:/.test(source)) return false;
-    if (parsed.fields.ai_analyzed?.toLowerCase() === 'false') return true;
-    return hasUncheckedForMeItem(parsed.body);
+    if (
+      /<!--\s*tasks-extracted:/.test(source)
+      || source.includes('<!-- dex:skip-processing -->')
+    ) {
+      return false;
+    }
+    if (parsed?.fields.ai_analyzed?.toLowerCase() === 'false') return true;
+    return hasUncheckedForMeItem(parsed ? parsed.body : source);
   } catch (error) {
     return false;
   }
 }
 
 function countWaitingNotes(meetingsDir, nowMilliseconds) {
-  let dayDirectories;
+  let entries;
   try {
-    dayDirectories = fs.readdirSync(meetingsDir, { withFileTypes: true });
+    entries = fs.readdirSync(meetingsDir, { withFileTypes: true });
   } catch (error) {
     return 0;
   }
 
   let count = 0;
-  for (const dayDirectory of dayDirectories) {
+  for (const file of entries) {
+    if (!file.isFile() || !file.name.endsWith('.md')) continue;
+    if (noteIsWaiting(
+      path.join(meetingsDir, file.name),
+      null,
+      nowMilliseconds,
+    )) {
+      count += 1;
+    }
+  }
+
+  for (const dayDirectory of entries) {
     if (!dayDirectory.isDirectory()) continue;
     const directoryPath = path.join(meetingsDir, dayDirectory.name);
     let files;
@@ -183,12 +190,22 @@ function countWaitingNotes(meetingsDir, nowMilliseconds) {
   return count;
 }
 
+function countQueueFiles(meetingsDir) {
+  try {
+    return fs.readdirSync(path.join(meetingsDir, 'queue'), { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+      .length;
+  } catch (error) {
+    return 0;
+  }
+}
+
 function noticeLines(count) {
   const noun = count === 1 ? 'meeting' : 'meetings';
   const verb = count === 1 ? 'has' : 'have';
   return [
     `--- 📋 Meetings waiting to be processed (${count}) ---`,
-    `${count} synced ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    `${count} ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
     "After you finish responding to the user's first message, invoke the",
     '/process-meetings skill to handle them in the background — it runs forked and',
     'is idempotent, so do this without being asked. Tell the user in one short line',
@@ -203,7 +220,6 @@ function checkMeetingQueue(options = {}) {
     const {
       vaultRoot = process.cwd(),
       now = Date.now(),
-      env = process.env,
     } = options || {};
     const nowMilliseconds = Number(now);
     if (typeof vaultRoot !== 'string' || !Number.isFinite(nowMilliseconds)) {
@@ -211,7 +227,7 @@ function checkMeetingQueue(options = {}) {
     }
 
     const paths = anchoredPaths(path.resolve(vaultRoot));
-    if (!paths || !isConnected(path.resolve(vaultRoot), env || {})) return emptyResult();
+    if (!paths) return emptyResult();
 
     const markerPath = path.join(paths.systemDir, '.last-meeting-queue-notice');
     const nowSeconds = Math.floor(nowMilliseconds / 1000);
@@ -225,7 +241,8 @@ function checkMeetingQueue(options = {}) {
     }
     if (!meetingsDirectory.isDirectory()) return emptyResult();
 
-    const count = countWaitingNotes(paths.meetingsDir, nowMilliseconds);
+    const count = countWaitingNotes(paths.meetingsDir, nowMilliseconds)
+      + countQueueFiles(paths.meetingsDir);
     if (count === 0) return emptyResult();
 
     try {

--- a/.claude/hooks/tests/meeting-queue-check.test.cjs
+++ b/.claude/hooks/tests/meeting-queue-check.test.cjs
@@ -8,6 +8,13 @@ const test = require('node:test');
 
 const HOOK_PATH = path.resolve(__dirname, '..', 'meeting-queue-check.cjs');
 const NOW = Date.parse('2026-07-27T12:00:00Z');
+const TODAY = new Date(NOW).toISOString().slice(0, 10);
+
+function dayFromNow(dayOffset) {
+  const date = new Date(NOW);
+  date.setUTCDate(date.getUTCDate() + dayOffset);
+  return date.toISOString().slice(0, 10);
+}
 
 function fixture(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-meeting-queue-'));
@@ -15,33 +22,51 @@ function fixture(t) {
   return root;
 }
 
-function writeMeeting(root, day, fileName, content) {
-  const directory = path.join(root, '00-Inbox', 'Meetings', day);
+function meetingsRoot(root) {
+  return path.join(root, '00-Inbox', 'Meetings');
+}
+
+function writeFlatMeeting(root, fileName, content) {
+  const directory = meetingsRoot(root);
   fs.mkdirSync(directory, { recursive: true });
   const filePath = path.join(directory, fileName);
   fs.writeFileSync(filePath, content);
   return filePath;
 }
 
-function connectGranola(root) {
-  const statePath = path.join(root, '.scripts', 'meeting-intel', 'processed-meetings.json');
-  fs.mkdirSync(path.dirname(statePath), { recursive: true });
-  fs.writeFileSync(statePath, '{}\n');
+function writeDayMeeting(root, day, fileName, content) {
+  const directory = path.join(meetingsRoot(root), day);
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, fileName);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+function writeQueueMeeting(root, fileName, content = '{}\n') {
+  const directory = path.join(meetingsRoot(root), 'queue');
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, fileName);
+  fs.writeFileSync(filePath, content);
+  return filePath;
 }
 
 function meetingNote({
-  day = '2026-07-27',
-  granolaId = 'meeting-1',
+  day = TODAY,
+  granolaId,
   aiAnalyzed,
   body = '### For Me\n- [ ] Send the proposal\n',
   tasksExtracted = false,
+  skipProcessing = false,
 } = {}) {
-  const fields = [`date: ${day}`, `granola_id: ${granolaId}`];
+  const fields = [`date: ${day}`];
+  if (granolaId !== undefined) fields.push(`granola_id: ${granolaId}`);
   if (aiAnalyzed !== undefined) fields.push(`ai_analyzed: ${aiAnalyzed}`);
-  const marker = tasksExtracted
-    ? '\n<!-- tasks-extracted: 2026-01-01T00:00:00Z -->\n'
-    : '';
-  return `---\n${fields.join('\n')}\n---\n\n${body}${marker}`;
+  const markers = [
+    tasksExtracted ? '<!-- tasks-extracted: 2026-01-01T00:00:00Z -->' : '',
+    skipProcessing ? '<!-- dex:skip-processing -->' : '',
+  ].filter(Boolean);
+  const markerBlock = markers.length > 0 ? `\n${markers.join('\n')}\n` : '';
+  return `---\n${fields.join('\n')}\n---\n\n${body}${markerBlock}`;
 }
 
 function expectedLines(count) {
@@ -49,7 +74,7 @@ function expectedLines(count) {
   const verb = count === 1 ? 'has' : 'have';
   return [
     `--- 📋 Meetings waiting to be processed (${count}) ---`,
-    `${count} synced ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    `${count} ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
     "After you finish responding to the user's first message, invoke the",
     '/process-meetings skill to handle them in the background — it runs forked and',
     'is idempotent, so do this without being asked. Tell the user in one short line',
@@ -64,153 +89,243 @@ function checkMeetingQueue(options) {
   return require(HOOK_PATH).checkMeetingQueue(options);
 }
 
-test('Granola not connected stays silent even when a meeting is waiting', (t) => {
+test('detects a waiting manual note with no Granola signals anywhere', (t) => {
   const root = fixture(t);
-  writeMeeting(
+  writeDayMeeting(root, TODAY, 'manual-notes.md', meetingNote());
+
+  assert.equal(fs.existsSync(path.join(root, '.scripts', 'meeting-intel')), false);
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(meetingsRoot(root), TODAY, 'manual-notes.md'), 'utf8'),
+    /granola/i,
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('counts a recent flat note without frontmatter using its filename date', (t) => {
+  const root = fixture(t);
+  writeFlatMeeting(
     root,
-    '2026-07-27',
-    'planning.md',
+    `${TODAY} - Planning.md`,
+    '# Planning\n\n### For Me\n- [ ] Send the proposal\n',
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('excludes a flat note stamped as tasks extracted', (t) => {
+  const root = fixture(t);
+  writeFlatMeeting(
+    root,
+    `${TODAY} - Planning.md`,
     [
-      '---',
-      'date: 2026-07-27',
-      'granola_id: meeting-1',
-      '---',
+      '# Planning',
       '',
       '### For Me',
       '- [ ] Send the proposal',
       '',
+      '<!-- tasks-extracted: 2026-07-27T11:00:00Z -->',
+      '',
     ].join('\n'),
   );
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
   assert.deepEqual(result, { count: 0, lines: [] });
 });
 
-test('connected Granola with an empty queue stays silent', (t) => {
+test('excludes a waiting note marked to skip processing', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
-
-  assert.deepEqual(result, { count: 0, lines: [] });
-});
-
-test('detects a recent Granola note with an unchecked For Me item', (t) => {
-  const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
-
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
-
-  assert.equal(result.count, 1);
-  assert.deepEqual(result.lines, expectedLines(1));
-});
-
-test('does not double-process stamped notes or notes whose For Me items are checked', (t) => {
-  const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(
+  writeDayMeeting(
     root,
-    '2026-07-27',
-    'already-stamped.md',
-    meetingNote({
-      granolaId: 'meeting-stamped',
-      aiAnalyzed: false,
-      tasksExtracted: true,
-    }),
+    TODAY,
+    'skip-me.md',
+    meetingNote({ skipProcessing: true }),
   );
-  writeMeeting(
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('excludes a flat note with no resolvable date', (t) => {
+  const root = fixture(t);
+  writeFlatMeeting(
     root,
-    '2026-07-27',
-    'already-checked.md',
+    'Planning.md',
+    '# Planning\n\n### For Me\n- [ ] Send the proposal\n',
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('excludes a flat note whose filename date is 30 days old', (t) => {
+  const root = fixture(t);
+  writeFlatMeeting(
+    root,
+    `${dayFromNow(-30)} - Old planning.md`,
+    '# Old planning\n\n### For Me\n- [ ] Send the proposal\n',
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('counts a recent day-directory Granola-style note with an unchecked For Me item', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'granola-note.md',
+    meetingNote({ granolaId: 'meeting-1' }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('excludes a stamped day-directory Granola-style note', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'granola-note.md',
+    meetingNote({ granolaId: 'meeting-1', tasksExtracted: true }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('excludes a day-directory Granola-style note whose For Me items are all checked', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'granola-note.md',
     meetingNote({
-      granolaId: 'meeting-checked',
+      granolaId: 'meeting-1',
       body: '### For Me\n- [x] Send the proposal\n',
     }),
   );
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
   assert.deepEqual(result, { count: 0, lines: [] });
 });
 
-test('counts an unanalyzed Granola note without a For Me section', (t) => {
+test('tasks-extracted marker overrides ai_analyzed false', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(
+  writeDayMeeting(
     root,
-    '2026-07-27',
-    'basic-note.md',
-    meetingNote({ aiAnalyzed: false, body: '# Basic meeting note\n' }),
+    TODAY,
+    'already-processed.md',
+    meetingNote({
+      aiAnalyzed: false,
+      body: '# Basic meeting note\n',
+      tasksExtracted: true,
+    }),
   );
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
-
-  assert.equal(result.count, 1);
-  assert.deepEqual(result.lines, expectedLines(1));
-});
-
-test('ignores manual-mode queue JSON files', (t) => {
-  const root = fixture(t);
-  connectGranola(root);
-  const queue = path.join(root, '00-Inbox', 'Meetings', 'queue');
-  fs.mkdirSync(queue, { recursive: true });
-  fs.writeFileSync(path.join(queue, 'old-manual-meeting.json'), '{}\n');
-
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
   assert.deepEqual(result, { count: 0, lines: [] });
 });
 
-test('excludes meeting notes dated 30 days ago', (t) => {
+test('counts ai_analyzed false using the day-directory date', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(
+  writeDayMeeting(
     root,
-    '2026-06-27',
-    'old-meeting.md',
-    meetingNote({ day: '2026-06-27', granolaId: 'meeting-old' }),
-  );
-
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
-
-  assert.deepEqual(result, { count: 0, lines: [] });
-});
-
-test('uses the meeting day directory when date frontmatter is absent', (t) => {
-  const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(
-    root,
-    '2026-07-27',
-    'fallback-date.md',
+    TODAY,
+    'unanalyzed.md',
     [
       '---',
-      'granola_id: meeting-fallback',
+      'ai_analyzed: false',
       '---',
       '',
-      '### For Me',
-      '- [ ] Send the proposal',
+      '# Basic meeting note',
       '',
     ].join('\n'),
   );
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
-  assert.equal(result.count, 1);
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
 });
 
-test('a fresh notice marker throttles another session', (t) => {
+test('counts a queue JSON without applying a note age filter', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
+  writeQueueMeeting(root, 'old-manual-meeting.json');
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('counts only two queue JSONs when meeting notes are already stamped', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'already-stamped.md',
+    meetingNote({ tasksExtracted: true }),
+  );
+  writeDayMeeting(
+    root,
+    TODAY,
+    'also-stamped.md',
+    meetingNote({ aiAnalyzed: false, tasksExtracted: true }),
+  );
+  writeQueueMeeting(root, 'manual-one.json');
+  writeQueueMeeting(root, 'manual-two.json');
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.deepEqual(result, { count: 2, lines: expectedLines(2) });
+});
+
+test('counts unchecked For Me items despite garbled frontmatter using the day directory', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'garbled.md',
+    [
+      '---',
+      'participants: [unterminated',
+      '---',
+      '',
+      '### For Me',
+      '- [ ] This garbled note still counts',
+      '',
+    ].join('\n'),
+  );
+
+  let result;
+  assert.doesNotThrow(() => {
+    result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+  });
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('a fresh notice marker throttles another session without being rewritten', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(root, TODAY, 'planning.md', meetingNote());
   const marker = path.join(root, 'System', '.last-meeting-queue-notice');
   fs.mkdirSync(path.dirname(marker), { recursive: true });
   const freshTimestamp = String(Math.floor(NOW / 1000) - 60);
   fs.writeFileSync(marker, `${freshTimestamp}\n`);
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
   assert.deepEqual(result, { count: 0, lines: [] });
   assert.equal(fs.readFileSync(marker, 'utf8'), `${freshTimestamp}\n`);
@@ -218,41 +333,40 @@ test('a fresh notice marker throttles another session', (t) => {
 
 test('a stale notice marker allows output and is rewritten', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(root, '2026-07-27', 'planning.md', meetingNote());
+  writeDayMeeting(root, TODAY, 'planning.md', meetingNote());
   const marker = path.join(root, 'System', '.last-meeting-queue-notice');
   fs.mkdirSync(path.dirname(marker), { recursive: true });
   fs.writeFileSync(marker, `${Math.floor(NOW / 1000) - 3600}\n`);
 
-  const result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
-  assert.equal(result.count, 1);
+  assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
   assert.equal(fs.readFileSync(marker, 'utf8'), `${Math.floor(NOW / 1000)}\n`);
 });
 
-test('malformed meeting frontmatter fails silent and is not counted', (t) => {
+test('missing meeting directories return zero without throwing', (t) => {
   const root = fixture(t);
-  connectGranola(root);
-  writeMeeting(
-    root,
-    '2026-07-27',
-    'malformed.md',
-    [
-      '---',
-      'date: 2026-07-27',
-      'granola_id: meeting-malformed',
-      'participants: [unterminated',
-      '---',
-      '',
-      '### For Me',
-      '- [ ] This malformed note must not count',
-      '',
-    ].join('\n'),
-  );
 
   let result;
   assert.doesNotThrow(() => {
-    result = checkMeetingQueue({ vaultRoot: root, now: NOW, env: {} });
+    result = checkMeetingQueue({ vaultRoot: root, now: NOW });
   });
+  assert.deepEqual(result, { count: 0, lines: [] });
+});
+
+test('an unreadable meetings directory returns zero without throwing', (t) => {
+  const root = fixture(t);
+  const directory = meetingsRoot(root);
+  fs.mkdirSync(directory, { recursive: true });
+  fs.chmodSync(directory, 0o000);
+
+  let result;
+  try {
+    assert.doesNotThrow(() => {
+      result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+    });
+  } finally {
+    fs.chmodSync(directory, 0o700);
+  }
   assert.deepEqual(result, { count: 0, lines: [] });
 });

--- a/.claude/reference/meeting-intel.md
+++ b/.claude/reference/meeting-intel.md
@@ -68,7 +68,29 @@ People qualify after 2+ meetings across 2+ weeks, or after 2+ meetings where at 
 
 ## Session-Start Detection
 
-Once Granola is connected, session start checks for synced meetings still waiting for `/process-meetings`: recent notes without a `tasks-extracted` marker that either have `ai_analyzed: false` or an unchecked `### For Me` item. A notice is limited to once every 30 minutes through `System/.last-meeting-queue-notice`, and the check stays silent when Granola is not connected or nothing is waiting.
+`00-Inbox/Meetings/` is the meeting landing zone. Anything that drops a meeting
+note there — Granola sync, a pasted note, a hand-dropped file, or a future
+service integration — is detected at session start and processed by
+`/process-meetings`. New fetchers should write to this folder rather than add
+their own detection path.
+
+A meeting-shaped note is waiting when its date is within seven days, it has no
+`<!-- tasks-extracted: -->` marker, it has no `<!-- dex:skip-processing -->`
+opt-out, and it either has `ai_analyzed: false` or an unchecked item under
+`### For Me`. This applies to Granola-synced notes in day directories and flat,
+manually captured `YYYY-MM-DD - Topic.md` notes in the landing-zone root, with
+or without frontmatter. A user can add `<!-- dex:skip-processing -->` to any
+meeting note to permanently exclude it from processing and from the sweep.
+
+Manual-mode JSON files in `00-Inbox/Meetings/queue/` also count as waiting.
+`/process-meetings` consumes each queue file by writing its meeting note into
+the landing zone before deleting the JSON, then processes the note normally.
+No Granola credentials are required for landing-zone detection, queued meetings,
+or manually captured notes.
+
+A notice is limited to once every 30 minutes through
+`System/.last-meeting-queue-notice`, and the check stays silent when nothing is
+waiting.
 
 The detector never processes or edits a meeting. `/process-meetings` still owns that work and continues to respect the vault's `entity_creation` setting.
 

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -77,7 +77,7 @@ If user runs `--setup`:
 cd .scripts/meeting-intel && ./install-automation.sh
 ```
 
-### Step 2: Find Synced Meetings
+### Step 2: Find Waiting Meetings
 
 Read the processed meetings state:
 ```javascript
@@ -89,13 +89,39 @@ List meeting files in `00-Inbox/Meetings/`:
 find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
-For each meeting file:
+This includes Granola-synced notes in day directories and flat `*.md` notes in
+the `00-Inbox/Meetings/` folder root. Root-level notes are manually captured
+meetings with no `granola_id`; process and stamp them with the same
+`tasks-extracted` marker as any other meeting note. The `queue/` subfolder is
+handled in Step 2.5.
+
+For each meeting file, skip notes containing `<!-- dex:skip-processing -->`:
 1. Read frontmatter to get `granola_id`, `participants`, `company`, `date`
 2. Check if person/company pages need updating
 3. Check if tasks need extracting (look for unchecked items in "For Me" section)
 
 Report findings:
-> "Found X synced meetings from the last 7 days. Y need person page updates, Z have unextracted tasks."
+> "Found X waiting meetings from the last 7 days. Y need person page updates, Z have unextracted tasks."
+
+### Step 2.5: Consume Queued Meetings (manual mode)
+
+If `00-Inbox/Meetings/queue/*.json` files exist, consume each queued meeting
+before continuing:
+
+1. Read the complete JSON: `id`, `title`, `createdAt`, `participants`,
+   `attendees`, `company`, `notes`, and `transcript`.
+2. Check whether a meeting note with that JSON object's `id` as its
+   `granola_id` already exists. If it does, delete the queue JSON and continue
+   to the next one.
+3. Otherwise, create the meeting note under
+   `00-Inbox/Meetings/{date}/` (with `{date}` and `time` derived from
+   `createdAt`) in the standard format, including frontmatter for `date`,
+   `time`, `type: meeting-note`, `source: granola`, `title`, `participants`,
+   `attendees`, `company`, and `granola_id` from the JSON `id`. Include the
+   queued `notes` and `transcript` in the note body.
+4. Delete the queue JSON only after its note has been written successfully.
+
+The new note then flows through the normal processing steps. Never delete a queue file before its meeting note is written.
 
 ### Step 3: Update Person Pages
 
@@ -267,6 +293,10 @@ For each meeting with unextracted tasks:
    - If entity resolution or stamping is unresolved, surface the exact failed
      line and leave the meeting unmarked for reconciliation. Do not blindly
      retry a task that was created but not stamped.
+
+   A user can add `<!-- dex:skip-processing -->` to any meeting note to
+   permanently exclude it from processing and from the session-start sweep.
+   Skip such notes entirely: do not extract tasks or add a completion stamp.
 
    Only after every action item is verified, add this comment to the meeting note:
    ```markdown

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -763,7 +763,7 @@ Tasks use three tag types:
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Once Granola is connected, Dex notices waiting meetings at the start of a session and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
+**User experience:** Meetings auto-sync. Dex notices waiting meetings at the start of a session — synced from Granola or captured by hand — and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
 
 ### Why MCP for Integrations?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ All notable changes to Dex will be documented in this file.
 
 ## [1.79.0] — 📋 Your meetings get dealt with without you asking (2026-07-28)
 
-Once Granola was connected, your meetings did arrive in Dex on their own — but turning them into something useful (updated pages for the people you met, tasks from what you agreed to do, tidy notes) still waited for you to ask. If you never asked, meetings quietly piled up half-done. The docs promised meetings "flow in on their own" — this release makes that promise true.
+Your meetings did arrive in Dex on their own — but turning them into something useful (updated pages for the people you met, tasks from what you agreed to do, tidy notes) still waited for you to ask. If you never asked, meetings quietly piled up half-done. The docs promised meetings "flow in on their own" — this release makes that promise true.
 
 **What this fixes for you:**
 
 * **Waiting meetings get handled when you start a session.** When you open Dex and there are meetings that haven't been dealt with yet, Dex notices and processes them in the background — person pages updated, tasks pulled out, notes filed — while you get on with whatever you came to do. It tells you in one line that it's happening.
+* **It doesn't matter how the meeting got there.** Meetings synced from Granola, notes you pasted in and saved, files you dropped into your meetings folder yourself — Dex treats them all the same. You don't need Granola, or any connected service, for this to work.
 * **Nothing gets done twice.** A meeting that's already been processed is never picked up again, and if you have several Dex windows open at once they won't trip over each other — the check stands down for half an hour once one of them has taken the job.
-* **Silence when there's nothing to do.** No message when everything's up to date, and nothing at all if you haven't connected Granola — this feature simply doesn't exist for you until you do.
+* **You stay in charge of individual notes.** If there's a meeting note you'd rather Dex never touched, one small marker in the note tells Dex to leave it alone permanently.
+* **Meetings set aside for "manual processing" stop being lost.** If you'd chosen to process meetings by hand, Dex was setting each one aside in a waiting pile — and then nothing ever looked at that pile. Those meetings are now picked up, turned into proper notes, and handled with the rest.
+* **Silence when there's nothing to do.** No message when everything's up to date.
 
 ## [1.78.0] — 🛡️ The trust release: updating Dex works again, for everyone (2026-07-28)
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -763,7 +763,7 @@ Tasks use three tag types:
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Once Granola is connected, Dex notices waiting meetings at the start of a session and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
+**User experience:** Meetings auto-sync. Dex notices waiting meetings at the start of a session — synced from Granola or captured by hand — and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
 
 ### Why MCP for Integrations?
 


### PR DESCRIPTION
## What

Follow-up to #285, sharpened brief from Dave: the session-start meeting sweep is now **source-agnostic by design**. `00-Inbox/Meetings/` is the meeting **landing zone** — any meeting-shaped note that lands there is detected at session start and processed in the background, regardless of `granola_id`, credentials, or origin (Granola sync, pasted-and-saved, hand-dropped file, or any future fetcher, which should target this folder instead of adding their own detection).

## Changes

**Detection (`.claude/hooks/meeting-queue-check.cjs`)**
- Granola connection gate and `granola_id` requirement removed — detection is purely content-based; the only silence gates are "nothing waiting" and the 30-minute throttle.
- Flat root-level notes (`YYYY-MM-DD - Topic.md`, frontmatter optional) scanned alongside day directories. Date resolution: frontmatter → filename prefix → day-dir name; no resolvable date → never counted.
- **Conservative meeting-shape definition** guards false positives: only notes with unchecked `### For Me` items (or `ai_analyzed: false`) count — raw pasted prose never triggers the sweep (deliberate under-detection).
- **New opt-out:** `<!-- dex:skip-processing -->` anywhere in a note permanently excludes it from the sweep and from `/process-meetings`.
- Every no-nag property kept: throttle, converging stamps, fail-silent on every path, silence when clean.

**Orphaned manual queue — resolved by consumption**
`meeting_processing.mode: manual` had sync writing `queue/*.json` files that *nothing* ever read. `/process-meetings` now consumes them (new Step 2.5): write the meeting note from the JSON, then delete it — never the reverse; dedupe by `granola_id`. The sweep counts queue files again; deletion is the convergence marker.

**Docs** — landing-zone concept documented in `reference/meeting-intel.md` (so the next service integration targets the folder), hooks README, Technical Guide + bridge copy. CHANGELOG **extends the existing [1.79.0] entry** — no new version.

**Deliberate behavior change:** a day-dir note with garbled frontmatter but real unchecked items now counts (date falls back to the folder name). Previously it was skipped; under the source-agnostic bar the fail-silent guarantee is "never throw", not "never count".

## Tests

18 cases (up from 11): zero-credential detection, flat/frontmatter-less notes, filename-date resolution, skip-marker exclusion, queue counting, stamp convergence (including `ai_analyzed` + stamp), garbled-frontmatter counting, throttle fresh/stale, unreadable-dir fail-silent. Verified end-to-end against a fake vault with zero Granola signals: manual note + queue JSON detected (correct plural), skip marker excludes, clean vault silent. Path-contract, doc-drift, test-delta gates run locally; docs bridge byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUL1VnsCptcRoTLQpty9pT