### PR TITLE
ci: pin mcp below 2.0 — today's 2.0.0 release breaks every MCP server import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp<2" pyyaml python-dateutil requests
       - run: npm ci
       - name: Ensure policy scripts are executable
         run: chmod +x scripts/check-*.sh scripts/check-coverage-threshold.py scripts/check-path-contract-usage.sh scripts/security-gate.sh scripts/benchmark_large_vault.py
@@ -135,7 +135,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp<2" pyyaml python-dateutil requests
       - run: npm ci
       - name: Create vault directories
         run: python -c "from core import paths; from pathlib import Path; [getattr(paths, n).mkdir(parents=True, exist_ok=True) for n in dir(paths) if n.endswith('_DIR') and isinstance(getattr(paths, n), Path)]"
@@ -203,7 +203,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp<2" pyyaml python-dateutil requests
       - name: Download shard results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:

--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp<2" pyyaml python-dateutil requests
           npm ci
 
       - name: Ensure scripts are executable
@@ -72,7 +72,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp<2" pyyaml python-dateutil requests
 
       - name: Messy-vault adoption journey
         run: |


### PR DESCRIPTION
Unblocks ALL red CI repo-wide, urgent.

The `mcp` Python package released 2.0.0 today at 13:45 UTC. It removes the `Server.list_tools` decorator API every Dex MCP server uses. CI installs `mcp` unpinned in five places (ci.yml ×3, nightly-quality.yml ×2), so every run started after 13:45 fails all three test shards with `'Server' object has no attribute 'list_tools'` — regardless of what the PR changes. Main's last green run was 13:38; the first red run was 13:56.

This PR pins `mcp<2` in those five places and nothing else. Local dev environments that installed `mcp` before today are unaffected (1.x). Migrating the servers to the 2.x API is real, separate work — someone should card it.

Evidence: PR #286's run at 13:29 had shards 1–2 green; its 13:56 run (a one-line test-only change) failed all three shards with the same import error on every server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwbM96htMvJwsqpTW11atS