### PR TITLE
fix(deps): pin mcp below 2.0 — it just shipped a breaking major and CI is red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
       - run: npm ci
       - name: Ensure policy scripts are executable
         run: chmod +x scripts/check-*.sh scripts/check-coverage-threshold.py scripts/check-path-contract-usage.sh scripts/security-gate.sh scripts/benchmark_large_vault.py
@@ -135,7 +135,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
       - run: npm ci
       - name: Create vault directories
         run: python -c "from core import paths; from pathlib import Path; [getattr(paths, n).mkdir(parents=True, exist_ok=True) for n in dir(paths) if n.endswith('_DIR') and isinstance(getattr(paths, n), Path)]"
@@ -203,7 +203,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
       - name: Download shard results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:

--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
 
       - name: Ensure scripts are executable
@@ -72,7 +72,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install mcp pyyaml python-dateutil requests
+          pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
 
       - name: Messy-vault adoption journey
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements.txt
 
 # Core MCP functionality
-mcp>=1.0.0
+mcp>=1.0.0,<2.0.0
 
 # Configuration and data handling
 pyyaml>=6.0


### PR DESCRIPTION
The `mcp` library published **2.0.0**, a breaking major that removes the decorator API and the `fastmcp` module every Dex server uses. Servers fail at import:

```
AttributeError: 'Server' object has no attribute 'list_tools'
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Impact

**CI is red for everyone.** It installed `mcp` unpinned, so every run since 2.0.0 was published fails on any test that merely starts a server — calendar, work, onboarding, update-checker.

The failures land on whichever PR runs next and look like that PR's fault. The first one I saw was initially blamed on an unrelated onboarding change; the giveaway was that the failing files were ones that PR never touched.

## What is NOT affected

**The installer.** `core/mcp/requirements.txt`, which `install.sh` uses, was already pinned to `<2.0.0`. Real installs are fine. Worth stating plainly because the unpinned root `requirements.txt` makes it look worse than it is.

## The fix

Pins the two places that were not:
- root `requirements.txt` (plugin requirements)
- `ci.yml` (3 occurrences) and `nightly-quality.yml` (2)

## Verification

Ran the same import against both majors:

```
mcp 1.x → onboarding_server imports fine ✅
mcp 2.x → AttributeError: 'Server' object has no attribute 'list_tools' ❌
```

## Follow-up worth considering

`mcp>=1.0.0` with no upper bound is how this happened. Other unpinned dependencies carry the same risk — a dependency audit would be worth someone's time, separately from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUDRVR3TyM66X5V3JnzqKR
