### PR TITLE
ci: stop duplicate release tags from silently deafening old installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         run: bash scripts/check-doc-drift.sh
       - name: Release-tag uniqueness gate
         run: bash scripts/check-release-tag-uniqueness.sh
+      - name: Old-version release-tag reachability gate
+        run: bash scripts/check-release-tag-reachability.sh
       - name: Architecture inventory drift gate
         run: bash scripts/check-architecture-inventory.sh
       - name: Instructed-tool existence gate

--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GATE = REPO_ROOT / "scripts/check-release-tag-uniqueness.sh"
+REACHABILITY_GATE = REPO_ROOT / "scripts/check-release-tag-reachability.sh"
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -64,15 +66,13 @@ def test_gate_accepts_one_annotated_tag_per_version(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_gate_allows_historical_duplicates_at_or_below_threshold(
+def test_gate_rejects_duplicate_at_old_version(
     tmp_path: Path,
 ) -> None:
     repository = _repository_with_remote_tags(
         tmp_path,
         "dist/release/v1.76.0-1111111",
         "dist/release/v1.76.0-2222222",
-        "dist/release/v1.77.1-3333333",
-        "dist/release/v1.77.1-4444444",
     )
 
     result = subprocess.run(
@@ -83,13 +83,14 @@ def test_gate_allows_historical_duplicates_at_or_below_threshold(
         text=True,
     )
 
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "Historical exception: v1.76.0" in result.stdout
-    assert "Historical exception: v1.77.1" in result.stdout
-    assert "at or below v1.77.1" in result.stdout
+    assert result.returncode == 1
+    assert "v1.76.0 has 2 dist/release tags" in result.stderr
+    assert "dist/archive/*" in result.stderr
+    assert "git push --tags" in result.stderr
+    assert "stale local tags" in result.stderr
     gate_source = GATE.read_text(encoding="utf-8")
-    assert 'HISTORICAL_VERSION_THRESHOLD="1.77.1"' in gate_source
-    assert "1.77.0|1.77.1" not in gate_source
+    assert "HISTORICAL_VERSION_THRESHOLD" not in gate_source
+    assert "version_is_at_or_below_threshold" not in gate_source
 
 
 def test_gate_reports_every_new_version_with_duplicate_tags(tmp_path: Path) -> None:
@@ -114,6 +115,104 @@ def test_gate_reports_every_new_version_with_duplicate_tags(tmp_path: Path) -> N
     assert "v1.79.0" in result.stderr
 
 
+def _newer_release_tags(count: int) -> tuple[str, ...]:
+    return tuple(
+        f"dist/release/v1.{minor}.0-{minor:07x}"
+        for minor in range(75, 75 + count)
+    )
+
+
+def test_reachability_gate_passes_below_safety_margin(tmp_path: Path) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        *_newer_release_tags(25),
+    )
+
+    result = subprocess.run(
+        ["bash", str(REACHABILITY_GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Release-tag reachability gate passed." in result.stdout
+
+
+@pytest.mark.parametrize("newer_count", (26, 27))
+def test_reachability_gate_fails_at_or_above_safety_margin(
+    tmp_path: Path,
+    newer_count: int,
+) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        *_newer_release_tags(newer_count),
+    )
+
+    result = subprocess.run(
+        ["bash", str(REACHABILITY_GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    for sentinel in ("1.62.0", "1.68.0", "1.74.0"):
+        assert (
+            f"v{sentinel} has {newer_count} newer dist/release tags"
+            in result.stderr
+        )
+    assert "dist/archive/*" in result.stderr
+
+
+def test_reachability_gate_fails_loudly_when_remote_tags_are_unreadable(
+    tmp_path: Path,
+) -> None:
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.79.0-1111111",
+    )
+    _git(
+        repository,
+        "remote",
+        "set-url",
+        "origin",
+        str(tmp_path / "missing.git"),
+    )
+
+    result = subprocess.run(
+        ["bash", str(REACHABILITY_GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "could not read dist/release tags from origin" in result.stderr
+    assert "git ls-remote failed" in result.stderr
+
+
+def test_reachability_gate_fails_loudly_when_remote_has_no_release_tags(
+    tmp_path: Path,
+) -> None:
+    repository = _repository_with_remote_tags(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(REACHABILITY_GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "origin returned no readable dist/release tags" in result.stderr
+    assert "old-version reachability cannot be verified" in result.stderr
+
+
 def test_stable_release_ci_publishes_each_version_at_most_once() -> None:
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
@@ -121,6 +220,10 @@ def test_stable_release_ci_publishes_each_version_at_most_once() -> None:
     quality_steps = workflow["jobs"]["quality"]["steps"]
     assert any(
         step.get("run") == "bash scripts/check-release-tag-uniqueness.sh"
+        for step in quality_steps
+    )
+    assert any(
+        step.get("run") == "bash scripts/check-release-tag-reachability.sh"
         for step in quality_steps
     )
 

--- a/scripts/check-release-tag-reachability.sh
+++ b/scripts/check-release-tag-reachability.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+SENTINEL_VERSIONS=("1.62.0" "1.68.0" "1.74.0")
+SAFETY_MARGIN=26
+SHIPPED_TAG_BOUND=32
+
+if ! REMOTE_TAGS="$(
+  git ls-remote --tags origin 'refs/tags/dist/release/v*'
+)"; then
+  echo "❌ Release-tag reachability gate failed: could not read dist/release tags from origin; git ls-remote failed." >&2
+  exit 1
+fi
+
+# Annotated tags also produce a peeled ^{} ref; count only the tag ref itself.
+RELEASE_VERSIONS="$(
+  printf '%s\n' "$REMOTE_TAGS" |
+    awk '
+      $2 !~ /\^\{\}$/ &&
+      $2 ~ /^refs\/tags\/dist\/release\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/ {
+        version = $2
+        sub(/^refs\/tags\/dist\/release\/v/, "", version)
+        sub(/-[0-9a-f]+$/, "", version)
+        print version
+      }
+    '
+)"
+
+if [ -z "$RELEASE_VERSIONS" ]; then
+  echo "❌ Release-tag reachability gate failed: origin returned no readable dist/release tags, so old-version reachability cannot be verified." >&2
+  exit 1
+fi
+
+FAILED=0
+for SENTINEL in "${SENTINEL_VERSIONS[@]}"; do
+  NEWER_COUNT="$(
+    printf '%s\n' "$RELEASE_VERSIONS" |
+      awk -F. -v sentinel="$SENTINEL" '
+        BEGIN {
+          split(sentinel, sentinel_parts, ".")
+        }
+        ($1 + 0) > (sentinel_parts[1] + 0) ||
+        (($1 + 0) == (sentinel_parts[1] + 0) &&
+          ($2 + 0) > (sentinel_parts[2] + 0)) ||
+        (($1 + 0) == (sentinel_parts[1] + 0) &&
+          ($2 + 0) == (sentinel_parts[2] + 0) &&
+          ($3 + 0) > (sentinel_parts[3] + 0)) {
+            count++
+        }
+        END {
+          print count + 0
+        }
+      '
+  )"
+
+  if [ "$NEWER_COUNT" -ge "$SAFETY_MARGIN" ]; then
+    echo "❌ v$SENTINEL has $NEWER_COUNT newer dist/release tags; the safety margin is $SAFETY_MARGIN before the shipped $SHIPPED_TAG_BOUND-tag bound." >&2
+    echo "Archive older duplicates to dist/archive/* before old installs go silent." >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "❌ Release-tag reachability gate failed." >&2
+  exit 1
+fi
+
+echo "Release-tag reachability gate passed."

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -1,33 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Every release at or below this version was published before this uniqueness
-# guard existed, so duplicate tags there are history rather than a CI failure.
-HISTORICAL_VERSION_THRESHOLD="1.77.1"
-
 REMOTE_TAGS="$(
   git ls-remote --tags origin 'refs/tags/dist/release/v*'
 )"
-
-version_is_at_or_below_threshold() {
-  local version="$1"
-  local threshold="$2"
-  local version_major version_minor version_patch
-  local threshold_major threshold_minor threshold_patch
-
-  IFS=. read -r version_major version_minor version_patch <<<"$version"
-  IFS=. read -r threshold_major threshold_minor threshold_patch <<<"$threshold"
-
-  if ((version_major != threshold_major)); then
-    ((version_major < threshold_major))
-    return
-  fi
-  if ((version_minor != threshold_minor)); then
-    ((version_minor < threshold_minor))
-    return
-  fi
-  ((version_patch <= threshold_patch))
-}
 
 # Annotated tags also produce a peeled ^{} ref; count only the tag ref itself.
 DUPLICATE_VERSIONS="$(
@@ -54,18 +30,15 @@ DUPLICATE_VERSIONS="$(
 FAILED=0
 while read -r VERSION COUNT; do
   [ -n "${VERSION:-}" ] || continue
-  if version_is_at_or_below_threshold "$VERSION" "$HISTORICAL_VERSION_THRESHOLD"; then
-    echo "Historical exception: v$VERSION has $COUNT release tags; it is at or below v$HISTORICAL_VERSION_THRESHOLD and predates the uniqueness guard."
-  else
-    echo "❌ v$VERSION has $COUNT dist/release tags; each version may publish exactly one artifact." >&2
-    FAILED=1
-  fi
+  echo "❌ v$VERSION has $COUNT dist/release tags; each version may publish exactly one artifact." >&2
+  FAILED=1
 done <<EOF
 $DUPLICATE_VERSIONS
 EOF
 
 if [ "$FAILED" -ne 0 ]; then
-  echo "❌ Release-tag uniqueness gate failed. Bump the version before publishing another artifact." >&2
+  echo "❌ Release-tag uniqueness gate failed: one or more versions have duplicate dist/release tags." >&2
+  echo "Archive the duplicates under dist/archive/*. The likely cause is a git push --tags from a clone holding stale local tags." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why

This morning's duplicate-tag cleanup restored update notices for every install on v1.74 and older. This afternoon it was **undone** — all 99 duplicate `dist/release` tags reappeared (most likely a `git push --tags` from a clone holding stale local tags) and every one of those installs went silent again. Nothing detected it; a manual re-test found it.

The existing uniqueness gate could not have caught it: it grandfathered every version at or below `1.77.1`, which is precisely where the duplicates live.

## What changes

- **The uniqueness gate becomes absolute.** Every version now has exactly one canonical tag, so the historical exemption is obsolete and is removed. Any version with more than one `dist/release` tag now fails CI, and the message names the likely cause (stale clone pushing all tags) and the remedy (duplicates belong under `dist/archive/*`).
- **A new reachability tripwire.** For sentinels 1.62.0 / 1.68.0 / 1.74.0 it counts release tags newer than each and fails at 26 — 80% of the 32-tag bound those shipped versions enforce — so we find out *before* old installs go deaf, not after. Fails loudly rather than skipping if the tag list can't be read.

## Verification

- Both gates run green against the live repository (post re-archive).
- 9 tests: clean list passes; a resurrected duplicate at an old version now fails (the regression that was missed); 25/26/27 boundary cases; unreadable and empty tag sources fail loudly; CI wiring asserted.

Built by Codex (gpt-5.6-sol); reviewed and independently verified by the orchestrating session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYVtjfpeWhhnVAT8wBDmyU