### PR TITLE
feat: deliver verified Dex releases through updater

### DIFF
--- a/.claude/hooks/tests/data-safety-instructions.test.cjs
+++ b/.claude/hooks/tests/data-safety-instructions.test.cjs
@@ -63,7 +63,9 @@ const UPDATE_SERVICE_OPERATIONS = new Set([
   'build_and_preview_topology_migration',
   'execute_approved_topology_migration',
   'read_lifecycle_state',
-  'deliver_and_apply_latest_release',
+  'deliver_latest_release',
+  'build_and_preview_delivered_release',
+  'execute_approved_delivered_release',
   // Capsule journey (Lane H): read-only customization-migration operations and the
   // authority fields the skill must reproduce verbatim. The CLI create/abandon writes
   // are human-confirmed and capsule-scoped; they never touch vault user files.
@@ -229,14 +231,16 @@ test('update mutation follows the immutable preview, approval, execute service r
   assertOnlyServiceOperations(UPDATE_SKILL, UPDATE_SERVICE_OPERATIONS, 'dex-update');
   assert.match(
     UPDATE_SKILL,
-    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.3\.0\./,
+    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.4\.0\./,
   );
   assert.match(UPDATE_SKILL, /Execution requires an explicit yes to that exact preview\./);
   // execute is gated on an UNCHANGED preview + token for BOTH the adoption route and the
   // conflict-resolution route (the #205 keep-both/take-theirs branch) — assert both.
   assert.match(UPDATE_SKILL, /Pass unchanged adoption previews and tokens to `execute_approved_adoption`/);
   assert.match(UPDATE_SKILL, /unchanged resolution previews and tokens to `execute_approved_conflict_resolution`/);
-  assert.match(UPDATE_SKILL, /ask `deliver_and_apply_latest_release` through `core\.lifecycle\.service`/);
+  assert.match(UPDATE_SKILL, /ask `deliver_latest_release`\s+through `core\.lifecycle\.service`/);
+  assert.match(UPDATE_SKILL, /ask\s+`build_and_preview_delivered_release` through `core\.lifecycle\.service`/);
+  assert.match(UPDATE_SKILL, /`execute_approved_delivered_release` with the same preview and approval token/);
   assert.match(UPDATE_SKILL, /The lifecycle service owns every mutation\./);
 
   assertInOrder(UPDATE_SKILL, [

--- a/.claude/hooks/tests/data-safety-instructions.test.cjs
+++ b/.claude/hooks/tests/data-safety-instructions.test.cjs
@@ -63,6 +63,7 @@ const UPDATE_SERVICE_OPERATIONS = new Set([
   'build_and_preview_topology_migration',
   'execute_approved_topology_migration',
   'read_lifecycle_state',
+  'deliver_and_apply_latest_release',
   // Capsule journey (Lane H): read-only customization-migration operations and the
   // authority fields the skill must reproduce verbatim. The CLI create/abandon writes
   // are human-confirmed and capsule-scoped; they never touch vault user files.
@@ -228,13 +229,14 @@ test('update mutation follows the immutable preview, approval, execute service r
   assertOnlyServiceOperations(UPDATE_SKILL, UPDATE_SERVICE_OPERATIONS, 'dex-update');
   assert.match(
     UPDATE_SKILL,
-    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.1\.0\./,
+    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.3\.0\./,
   );
   assert.match(UPDATE_SKILL, /Execution requires an explicit yes to that exact preview\./);
   // execute is gated on an UNCHANGED preview + token for BOTH the adoption route and the
   // conflict-resolution route (the #205 keep-both/take-theirs branch) — assert both.
   assert.match(UPDATE_SKILL, /Pass unchanged adoption previews and tokens to `execute_approved_adoption`/);
   assert.match(UPDATE_SKILL, /unchanged resolution previews and tokens to `execute_approved_conflict_resolution`/);
+  assert.match(UPDATE_SKILL, /ask `deliver_and_apply_latest_release` through `core\.lifecycle\.service`/);
   assert.match(UPDATE_SKILL, /The lifecycle service owns every mutation\./);
 
   assertInOrder(UPDATE_SKILL, [

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when someone wants the latest Dex capabilities or asks what an up
 
 ## The one route
 
-Every lifecycle operation goes through `core.lifecycle.service` version 1.3.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
+Every lifecycle operation goes through `core.lifecycle.service` version 1.4.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
 
 Use the service operations in this order:
 
@@ -23,14 +23,20 @@ Use the service operations in this order:
 8. Pass unchanged adoption previews and tokens to `execute_approved_adoption`, and unchanged resolution previews and tokens to `execute_approved_conflict_resolution`.
 9. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render every receipt.
 
-For a split vault whose approved update needs new release bytes, never ask the
-user to run Git. After the user has explicitly approved the displayed update,
-ask `deliver_and_apply_latest_release` through `core.lifecycle.service`. That
-service proves the newest immutable release in an isolated cache, fetches only
-that pinned tag and its release-channel ref into Dex's private brain store,
-re-proves the fetched bytes, and only then enters the existing transaction-backed
-apply path. Render its returned delivery evidence and transaction result. If it
-returns `not-delivered` or an error, stop; no vault-content change was made.
+For a split vault whose update needs new release bytes, never ask the user to
+run Git. Before presenting a delivery update, ask `deliver_latest_release`
+through `core.lifecycle.service`. It proves the newest immutable release in an
+isolated cache, fetches only that pinned tag and its release-channel ref into
+Dex's private brain store, then proves the fetched bytes again. This delivery
+step does not change vault content.
+
+Only when delivery returns its exact release identity, ask
+`build_and_preview_delivered_release` through `core.lifecycle.service` with
+that identity. Show every returned write and ask: “Apply this exact update?”
+Only a fresh explicit yes to that unchanged preview permits
+`execute_approved_delivered_release` with the same preview and approval token.
+Render its lifecycle receipt. If delivery, preview, or execution refuses, stop;
+no vault-content change was made.
 
 If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a rejected transaction, stop. Explain the refusal in ordinary language and leave the vault untouched. A refusal is a safety result, not an invitation to work around the engine.
 

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -23,6 +23,15 @@ Use the service operations in this order:
 8. Pass unchanged adoption previews and tokens to `execute_approved_adoption`, and unchanged resolution previews and tokens to `execute_approved_conflict_resolution`.
 9. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render every receipt.
 
+For a split vault whose approved update needs new release bytes, never ask the
+user to run Git. After the user has explicitly approved the displayed update,
+run `python3 -m core.update.apply_update --vault VAULT_ROOT --deliver-latest`.
+That command proves the newest immutable release in an isolated cache, fetches
+only that pinned tag and its release-channel ref into Dex's private brain store,
+re-proves the fetched bytes, and only then enters the existing transaction-backed
+apply path. Render its returned delivery evidence and transaction result. If it
+returns `not-delivered` or an error, stop; no vault-content change was made.
+
 If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a rejected transaction, stop. Explain the refusal in ordinary language and leave the vault untouched. A refusal is a safety result, not an invitation to work around the engine.
 
 ## One-time brain and vault upgrade

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -23,14 +23,15 @@ Use the service operations in this order:
 8. Pass unchanged adoption previews and tokens to `execute_approved_adoption`, and unchanged resolution previews and tokens to `execute_approved_conflict_resolution`.
 9. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render every receipt.
 
-For a split vault whose approved update needs new release bytes, never ask the
-user to run Git. After the user has explicitly approved the displayed update,
-run `python3 -m core.update.apply_update --vault VAULT_ROOT --deliver-latest`.
-That command proves the newest immutable release in an isolated cache, fetches
-only that pinned tag and its release-channel ref into Dex's private brain store,
-re-proves the fetched bytes, and only then enters the existing transaction-backed
-apply path. Render its returned delivery evidence and transaction result. If it
-returns `not-delivered` or an error, stop; no vault-content change was made.
+For a split vault whose update needs new release bytes, never ask the user to
+run Git. Before building the adoption preview, use Dex's delivery component to
+prove the newest immutable release in an isolated cache, fetch only that pinned
+tag and its release-channel ref into Dex's private brain store, and prove the
+fetched bytes again. Give that verified release source to the lifecycle service
+when it builds the preview. After the user has explicitly approved the displayed
+preview, make the change only through the existing `execute_approved_adoption`
+step above. Render the delivery evidence and lifecycle receipt. If delivery or
+the lifecycle service refuses, stop; no vault-content change was made.
 
 If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a rejected transaction, stop. Explain the refusal in ordinary language and leave the vault untouched. A refusal is a safety result, not an invitation to work around the engine.
 

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when someone wants the latest Dex capabilities or asks what an up
 
 ## The one route
 
-Every lifecycle operation goes through `core.lifecycle.service` version 1.1.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
+Every lifecycle operation goes through `core.lifecycle.service` version 1.3.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
 
 Use the service operations in this order:
 
@@ -23,15 +23,14 @@ Use the service operations in this order:
 8. Pass unchanged adoption previews and tokens to `execute_approved_adoption`, and unchanged resolution previews and tokens to `execute_approved_conflict_resolution`.
 9. Ask `read_lifecycle_state` for the verified post-update state and retention warning, then render every receipt.
 
-For a split vault whose update needs new release bytes, never ask the user to
-run Git. Before building the adoption preview, use Dex's delivery component to
-prove the newest immutable release in an isolated cache, fetch only that pinned
-tag and its release-channel ref into Dex's private brain store, and prove the
-fetched bytes again. Give that verified release source to the lifecycle service
-when it builds the preview. After the user has explicitly approved the displayed
-preview, make the change only through the existing `execute_approved_adoption`
-step above. Render the delivery evidence and lifecycle receipt. If delivery or
-the lifecycle service refuses, stop; no vault-content change was made.
+For a split vault whose approved update needs new release bytes, never ask the
+user to run Git. After the user has explicitly approved the displayed update,
+ask `deliver_and_apply_latest_release` through `core.lifecycle.service`. That
+service proves the newest immutable release in an isolated cache, fetches only
+that pinned tag and its release-channel ref into Dex's private brain store,
+re-proves the fetched bytes, and only then enters the existing transaction-backed
+apply path. Render its returned delivery evidence and transaction result. If it
+returns `not-delivered` or an error, stop; no vault-content change was made.
 
 If the service reports UNKNOWN, conflict, changed evidence, an unsafe path, or a rejected transaction, stop. Explain the refusal in ordinary language and leave the vault untouched. A refusal is a safety result, not an invitation to work around the engine.
 

--- a/core/lifecycle/bridge.py
+++ b/core/lifecycle/bridge.py
@@ -23,7 +23,7 @@ ACTIVATION_VERSION = 1
 BRIDGE_RELEASE_RELATIVE = Path("core/lifecycle/catalog/bridge-release.json")
 ACTIVATION_RELATIVE = Path("System/.dex/lifecycle/activation.json")
 CATALOG_RELATIVE = Path("System/.release-catalog.json")
-COMPATIBLE_ACTIVATION_API_VERSIONS = frozenset({"1.2.0"})
+COMPATIBLE_ACTIVATION_API_VERSIONS = frozenset({"1.2.0", "1.3.0"})
 
 
 class BridgeError(RuntimeError):

--- a/core/lifecycle/bridge.py
+++ b/core/lifecycle/bridge.py
@@ -23,6 +23,7 @@ ACTIVATION_VERSION = 1
 BRIDGE_RELEASE_RELATIVE = Path("core/lifecycle/catalog/bridge-release.json")
 ACTIVATION_RELATIVE = Path("System/.dex/lifecycle/activation.json")
 CATALOG_RELATIVE = Path("System/.release-catalog.json")
+COMPATIBLE_ACTIVATION_API_VERSIONS = frozenset({"1.2.0"})
 
 
 class BridgeError(RuntimeError):
@@ -169,7 +170,10 @@ def _validate_activation(raw: bytes, bridge: BridgeRelease) -> dict[str, object]
 
         if type(value["activation_version"]) is not int or value["activation_version"] != 1:
             raise BridgeActivationError("existing activation has an unsupported version")
-        if value["api_version"] != api_version:
+        if value["api_version"] not in {
+            api_version,
+            *COMPATIBLE_ACTIVATION_API_VERSIONS,
+        }:
             raise BridgeActivationError("existing activation belongs to another lifecycle API")
         if value["bridge_release_version"] != bridge.release_version:
             raise BridgeActivationError("existing activation belongs to another bridge release")

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["api_version", "x-operations"],
   "properties": {
-    "api_version": {"const": "1.3.0"},
+    "api_version": {"const": "1.4.0"},
     "x-operations": {"type": "object"}
   },
   "x-operations": {
@@ -34,6 +34,18 @@
     "deliver_and_apply_latest_release": {
       "request": {"$ref": "#/$defs/vaultRequest"},
       "response": {"$ref": "#/$defs/releaseDeliveryResponse"}
+    },
+    "deliver_latest_release": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/releaseDeliveryResponse"}
+    },
+    "build_and_preview_delivered_release": {
+      "request": {"$ref": "#/$defs/deliveredReleasePreviewRequest"},
+      "response": {"$ref": "#/$defs/deliveredReleasePreviewResponse"}
+    },
+    "execute_approved_delivered_release": {
+      "request": {"$ref": "#/$defs/deliveredReleaseExecuteRequest"},
+      "response": {"$ref": "#/$defs/deliveredReleaseExecuteResponse"}
     },
     "build_and_preview_conflict_resolution": {
       "request": {"$ref": "#/$defs/resolutionsRequest"},
@@ -103,7 +115,7 @@
     "apiEnvelope": {
       "type": "object",
       "required": ["api_version"],
-      "properties": {"api_version": {"const": "1.3.0"}}
+      "properties": {"api_version": {"const": "1.4.0"}}
     },
     "vaultRequest": {
       "type": "object",
@@ -118,7 +130,7 @@
           "additionalProperties": false,
           "required": ["api_version", "status", "evidence"],
           "properties": {
-            "api_version": {"const": "1.3.0"},
+            "api_version": {"const": "1.4.0"},
             "status": {"const": "not-delivered"},
             "evidence": {"type": "object"}
           }
@@ -126,12 +138,96 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["api_version", "status", "delivery", "update"],
+          "required": ["api_version", "status", "release"],
           "properties": {
-            "api_version": {"const": "1.3.0"},
-            "status": {"const": "updated"},
-            "delivery": {"type": "object"},
-            "update": {"type": "object"}
+            "api_version": {"const": "1.4.0"},
+            "status": {"const": "delivered"},
+            "release": {"$ref": "#/$defs/releaseIdentity"}
+          }
+        }
+      ]
+    },
+    "releaseIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tag", "tag_object", "commit", "tree", "version", "channel"],
+      "properties": {
+        "tag": {"type": "string", "minLength": 1},
+        "tag_object": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "tree": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "channel": {"type": "string", "enum": ["stable", "beta"]}
+      }
+    },
+    "deliveredReleaseWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "action", "sha256", "byte_size", "mode", "current"],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "action": {"type": "string", "enum": ["write", "delete"]},
+        "sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "byte_size": {"type": "integer", "minimum": 0},
+        "mode": {"type": "integer", "minimum": 0, "maximum": 511},
+        "current": {"type": "object"}
+      }
+    },
+    "deliveredReleasePreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["release", "previous_commit", "writes"],
+      "properties": {
+        "release": {"$ref": "#/$defs/releaseIdentity"},
+        "previous_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "writes": {"type": "array", "items": {"$ref": "#/$defs/deliveredReleaseWrite"}}
+      }
+    },
+    "deliveredReleasePreviewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release": {"$ref": "#/$defs/releaseIdentity"}
+      }
+    },
+    "deliveredReleasePreviewResponse": {
+      "allOf": [
+        {"$ref": "#/$defs/apiEnvelope"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "preview", "approval_token"],
+          "properties": {
+            "api_version": {"const": "1.4.0"},
+            "preview": {"$ref": "#/$defs/deliveredReleasePreview"},
+            "approval_token": {"$ref": "#/$defs/sha256"}
+          }
+        }
+      ]
+    },
+    "deliveredReleaseExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/deliveredReleasePreview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "deliveredReleaseExecuteResponse": {
+      "allOf": [
+        {"$ref": "#/$defs/apiEnvelope"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "receipt", "release"],
+          "properties": {
+            "api_version": {"const": "1.4.0"},
+            "receipt": {"type": "object"},
+            "release": {"$ref": "#/$defs/releaseIdentity"}
           }
         }
       ]
@@ -181,7 +277,7 @@
           "additionalProperties": false,
           "required": ["api_version", "inventory", "plan"],
           "properties": {
-            "api_version": {"const": "1.3.0"},
+            "api_version": {"const": "1.4.0"},
             "inventory": {"$ref": "#/$defs/inventory"},
             "plan": {"$ref": "#/$defs/plan"}
           }
@@ -228,7 +324,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "preview": {"$ref": "#/$defs/preview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -313,7 +409,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -360,7 +456,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "rewind_acknowledgement_token"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/adoptionReceipt"},
         "rewind_acknowledgement_token": {"$ref": "#/$defs/sha256"}
       }
@@ -406,7 +502,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "rewind_receipt": {"$ref": "#/$defs/rewindReceipt"}
       }
     },
@@ -451,7 +547,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "preview": {"$ref": "#/$defs/archivePreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -486,7 +582,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/archiveReceipt"}
       }
     },
@@ -495,7 +591,7 @@
       "additionalProperties": false,
       "required": ["api_version", "ledger_state", "retention"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "ledger_state": {"$ref": "#/$defs/ledgerState"},
         "retention": {"$ref": "#/$defs/retention"}
       }
@@ -544,7 +640,7 @@
       "additionalProperties": false,
       "required": ["api_version", "topology", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "topology": {"type": "string", "minLength": 1},
         "preview": {"$ref": "#/$defs/topologyPreview"},
         "approval_token": {
@@ -626,7 +722,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "receipt_path"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/topologyReceipt"},
         "receipt_path": {"$ref": "#/$defs/path"}
       }
@@ -674,7 +770,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/rebuildCapsuleReceipt"}
       }
     },
@@ -705,7 +801,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/rebuildStagingReceipt"}
       }
     },
@@ -752,7 +848,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/rebuildVerificationReceipt"}
       }
     },
@@ -808,7 +904,7 @@
         "rewind_acknowledgement_token"
       ],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "receipt": {"$ref": "#/$defs/rebuildActivationReceipt"},
         "rewind_acknowledgement_token": {
           "anyOf": [
@@ -905,7 +1001,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "rewind_receipt": {"$ref": "#/$defs/rebuildRewindReceipt"}
       }
     },
@@ -923,7 +1019,7 @@
       "additionalProperties": false,
       "required": ["api_version", "capsule_id", "abandoned"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "capsule_id": {"$ref": "#/$defs/capsuleId"},
         "abandoned": {"const": true}
       }
@@ -933,7 +1029,7 @@
       "additionalProperties": false,
       "required": ["api_version", "outcomes"],
       "properties": {
-        "api_version": {"const": "1.3.0"},
+        "api_version": {"const": "1.4.0"},
         "outcomes": {
           "type": "array",
           "items": {"type": "object"}

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["api_version", "x-operations"],
   "properties": {
-    "api_version": {"const": "1.2.0"},
+    "api_version": {"const": "1.3.0"},
     "x-operations": {"type": "object"}
   },
   "x-operations": {
@@ -30,6 +30,10 @@
     "read_lifecycle_state": {
       "request": {"$ref": "#/$defs/vaultRequest"},
       "response": {"$ref": "#/$defs/stateResponse"}
+    },
+    "deliver_and_apply_latest_release": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/releaseDeliveryResponse"}
     },
     "build_and_preview_conflict_resolution": {
       "request": {"$ref": "#/$defs/resolutionsRequest"},
@@ -99,13 +103,38 @@
     "apiEnvelope": {
       "type": "object",
       "required": ["api_version"],
-      "properties": {"api_version": {"const": "1.2.0"}}
+      "properties": {"api_version": {"const": "1.3.0"}}
     },
     "vaultRequest": {
       "type": "object",
       "additionalProperties": false,
       "required": ["vault_root"],
       "properties": {"vault_root": {"$ref": "#/$defs/path"}}
+    },
+    "releaseDeliveryResponse": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "status", "evidence"],
+          "properties": {
+            "api_version": {"const": "1.3.0"},
+            "status": {"const": "not-delivered"},
+            "evidence": {"type": "object"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "status", "delivery", "update"],
+          "properties": {
+            "api_version": {"const": "1.3.0"},
+            "status": {"const": "updated"},
+            "delivery": {"type": "object"},
+            "update": {"type": "object"}
+          }
+        }
+      ]
     },
     "previewRequest": {
       "type": "object",
@@ -152,7 +181,7 @@
           "additionalProperties": false,
           "required": ["api_version", "inventory", "plan"],
           "properties": {
-            "api_version": {"const": "1.2.0"},
+            "api_version": {"const": "1.3.0"},
             "inventory": {"$ref": "#/$defs/inventory"},
             "plan": {"$ref": "#/$defs/plan"}
           }
@@ -199,7 +228,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "preview": {"$ref": "#/$defs/preview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -284,7 +313,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -331,7 +360,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "rewind_acknowledgement_token"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/adoptionReceipt"},
         "rewind_acknowledgement_token": {"$ref": "#/$defs/sha256"}
       }
@@ -377,7 +406,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "rewind_receipt": {"$ref": "#/$defs/rewindReceipt"}
       }
     },
@@ -422,7 +451,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "preview": {"$ref": "#/$defs/archivePreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -457,7 +486,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/archiveReceipt"}
       }
     },
@@ -466,7 +495,7 @@
       "additionalProperties": false,
       "required": ["api_version", "ledger_state", "retention"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "ledger_state": {"$ref": "#/$defs/ledgerState"},
         "retention": {"$ref": "#/$defs/retention"}
       }
@@ -515,7 +544,7 @@
       "additionalProperties": false,
       "required": ["api_version", "topology", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "topology": {"type": "string", "minLength": 1},
         "preview": {"$ref": "#/$defs/topologyPreview"},
         "approval_token": {
@@ -597,7 +626,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "receipt_path"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/topologyReceipt"},
         "receipt_path": {"$ref": "#/$defs/path"}
       }
@@ -645,7 +674,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/rebuildCapsuleReceipt"}
       }
     },
@@ -676,7 +705,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/rebuildStagingReceipt"}
       }
     },
@@ -723,7 +752,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/rebuildVerificationReceipt"}
       }
     },
@@ -779,7 +808,7 @@
         "rewind_acknowledgement_token"
       ],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "receipt": {"$ref": "#/$defs/rebuildActivationReceipt"},
         "rewind_acknowledgement_token": {
           "anyOf": [
@@ -876,7 +905,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "rewind_receipt": {"$ref": "#/$defs/rebuildRewindReceipt"}
       }
     },
@@ -894,7 +923,7 @@
       "additionalProperties": false,
       "required": ["api_version", "capsule_id", "abandoned"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "capsule_id": {"$ref": "#/$defs/capsuleId"},
         "abandoned": {"const": true}
       }
@@ -904,7 +933,7 @@
       "additionalProperties": false,
       "required": ["api_version", "outcomes"],
       "properties": {
-        "api_version": {"const": "1.2.0"},
+        "api_version": {"const": "1.3.0"},
         "outcomes": {
           "type": "array",
           "items": {"type": "object"}

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -47,7 +47,7 @@ from core.lifecycle.retention import compute_retention_report
 from core.path_safety import unsafe_existing_parent
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction
 
-api_version = "1.2.0"
+api_version = "1.3.0"
 
 _CATALOG_RELATIVE = "System/.release-catalog.json"
 _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -557,6 +557,13 @@ def read_lifecycle_state(vault_root: str | Path) -> dict[str, object]:
     )
 
 
+def deliver_and_apply_latest_release(vault_root: str | Path) -> dict[str, object]:
+    """Deliver an evidence-pinned release through the transactional updater."""
+    from core.update.apply_update import deliver_and_apply_latest_release as deliver
+
+    return _envelope(**deliver(Path(vault_root)))
+
+
 def build_and_preview_conflict_resolution(
     vault_root: str | Path,
     release_root: str | Path,
@@ -816,6 +823,7 @@ __all__ = [
     "execute_approved_adoption",
     "rewind_adoption_by_receipt",
     "read_lifecycle_state",
+    "deliver_and_apply_latest_release",
     "build_and_preview_conflict_resolution",
     "execute_approved_conflict_resolution",
     "build_archive_removal_preview",

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -18,7 +18,7 @@ import json
 import os
 import re
 import shutil
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 from core import portable_contract
@@ -47,7 +47,7 @@ from core.lifecycle.retention import compute_retention_report
 from core.path_safety import unsafe_existing_parent
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction
 
-api_version = "1.3.0"
+api_version = "1.4.0"
 
 _CATALOG_RELATIVE = "System/.release-catalog.json"
 _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -100,8 +100,8 @@ def _transaction_preview_document(
     writes: list[dict[str, object]] = []
     seen: set[str] = set()
     for entry in plan:
-        if not isinstance(entry, PlanEntry) or entry.content is None:
-            raise ValueError("private lifecycle transactions currently accept writes only")
+        if not isinstance(entry, PlanEntry):
+            raise ValueError("private lifecycle transactions require PlanEntry values")
         if entry.relative in seen:
             raise ValueError(f"transaction preview repeats path {entry.relative}")
         seen.add(entry.relative)
@@ -133,8 +133,9 @@ def _transaction_preview_document(
         writes.append(
             {
                 "path": entry.relative,
+                "action": entry.operation,
                 "sha256": entry.sha256(),
-                "byte_size": len(entry.content),
+                "byte_size": len(entry.content) if entry.content is not None else 0,
                 "mode": entry.mode,
                 "current": current,
             }
@@ -196,6 +197,7 @@ def _execute_approved_transaction(
     purpose: str,
     approved_token: str,
     operation: str = "update",
+    before_commit: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Execute an exact private preview through the one Transaction engine."""
     root = Path(vault_root)
@@ -219,7 +221,9 @@ def _execute_approved_transaction(
     )
     tx_root_relative = Path("System/.dex/tx")
     tx_paths_before = _tree_paths(root, tx_root_relative)
-    result = Transaction.begin(root, list(plan), operation=operation).run()
+    result = Transaction.begin(root, list(plan), operation=operation).run(
+        before_commit=before_commit
+    )
     tx_paths_after = _tree_paths(root, tx_root_relative)
     declared_paths = (
         set(targets)
@@ -557,11 +561,154 @@ def read_lifecycle_state(vault_root: str | Path) -> dict[str, object]:
     )
 
 
-def deliver_and_apply_latest_release(vault_root: str | Path) -> dict[str, object]:
-    """Deliver an evidence-pinned release through the transactional updater."""
-    from core.update.apply_update import deliver_and_apply_latest_release as deliver
+def _bound_release_plan(root: Path, entries: Sequence[PlanEntry]) -> list[PlanEntry]:
+    """Bind every delivered-release write to the bytes the user previewed."""
+    bound: list[PlanEntry] = []
+    for entry in entries:
+        target = root / entry.relative
+        if target.exists() or target.is_symlink():
+            if target.is_symlink() or not target.is_file():
+                raise PlanRejected(f"{entry.relative}: existing target is not a regular file")
+            raw = target.read_bytes()
+            bound.append(
+                PlanEntry(
+                    entry.relative,
+                    entry.content,
+                    entry.mode,
+                    expected_current_sha256=hashlib.sha256(raw).hexdigest(),
+                )
+            )
+            continue
+        if entry.content is None:
+            raise PlanRejected(f"{entry.relative}: delivered-release deletion target disappeared")
+        bound.append(
+            PlanEntry(
+                entry.relative,
+                entry.content,
+                entry.mode,
+                expected_absent=True,
+            )
+        )
+    return bound
+
+
+def _closed_release_identity(value: Mapping[str, object]) -> dict[str, str]:
+    required = {"tag", "tag_object", "commit", "tree", "version", "channel"}
+    if set(value) != required or not all(isinstance(value[key], str) for key in required):
+        raise PlanRejected("delivered release identity is malformed")
+    return {key: str(value[key]) for key in sorted(required)}
+
+
+def _delivered_release_preview(
+    vault_root: str | Path,
+    release_identity: Mapping[str, object],
+) -> tuple[dict[str, object], list[PlanEntry], object, str]:
+    """Rebuild the exact delivery preview from immutable fetched bytes."""
+    from core.update import apply_update
+
+    root = Path(vault_root).resolve()
+    identity = _closed_release_identity(release_identity)
+    release = apply_update.verify_release_ref(
+        root,
+        tag=identity["tag"],
+        tag_object=identity["tag_object"],
+        commit=identity["commit"],
+        tree=identity["tree"],
+    )
+    if apply_update._release_identity(release) != identity:
+        raise PlanRejected("delivered release identity changed during verification")
+    previous_commit = apply_update.validated_release_apply_context(root, release)
+    plan = _bound_release_plan(root, apply_update.build_update_plan(root, release).entries)
+    transaction = _transaction_preview_document(
+        root,
+        plan,
+        purpose="delivered-release",
+    )
+    preview: dict[str, object] = {
+        "release": identity,
+        "previous_commit": previous_commit,
+        "writes": transaction["writes"],
+    }
+    return preview, plan, release, previous_commit
+
+
+def deliver_latest_release(vault_root: str | Path) -> dict[str, object]:
+    """Fetch and re-prove a release, without a vault-content transaction."""
+    from core.update.apply_update import deliver_latest_release as deliver
 
     return _envelope(**deliver(Path(vault_root)))
+
+
+def build_and_preview_delivered_release(
+    vault_root: str | Path,
+    release: Mapping[str, object],
+) -> dict[str, object]:
+    """Render the exact immutable delivered release before asking for approval."""
+    preview, _plan, _verified, _previous = _delivered_release_preview(vault_root, release)
+    return _envelope(
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def execute_approved_delivered_release(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Apply only the unchanged delivered-release preview through Transaction."""
+    from core.update import apply_update
+
+    if not isinstance(preview, Mapping) or set(preview) != {
+        "release",
+        "previous_commit",
+        "writes",
+    }:
+        raise PlanRejected("delivered-release preview is malformed")
+    if not isinstance(preview["release"], Mapping):
+        raise PlanRejected("delivered-release preview is missing its release identity")
+    try:
+        expected_preview, plan, release, previous_commit = _delivered_release_preview(
+            vault_root,
+            preview["release"],
+        )
+        supplied_bytes = _canonical(dict(preview))
+    except (TypeError, ValueError) as error:
+        raise PlanRejected("delivered-release preview is not canonical JSON") from error
+    expected_bytes = _canonical(expected_preview)
+    expected_token = hashlib.sha256(expected_bytes).hexdigest()
+    if not hmac.compare_digest(supplied_bytes, expected_bytes) or not isinstance(
+        approved_token, str
+    ) or not hmac.compare_digest(approved_token, expected_token):
+        raise PlanRejected("delivered-release approval does not match the current exact preview")
+
+    transaction_token = _preview_transaction(
+        vault_root,
+        plan,
+        purpose="delivered-release",
+    )["approval_token"]
+    executed = _execute_approved_transaction(
+        vault_root,
+        plan,
+        purpose="delivered-release",
+        approved_token=str(transaction_token),
+        before_commit=lambda: apply_update._finalize_release_metadata(
+            Path(vault_root).resolve(), release, previous_commit
+        ),
+    )
+    return _envelope(receipt=executed["receipt"], release=expected_preview["release"])
+
+
+def deliver_and_apply_latest_release(vault_root: str | Path) -> dict[str, object]:
+    """Safe v1.3 bridge: never apply a release that was not previewed."""
+    del vault_root
+    return _envelope(
+        status="not-delivered",
+        evidence={
+            "status": "deprecated",
+            "reason": "use-deliver-preview-execute",
+        },
+    )
 
 
 def build_and_preview_conflict_resolution(
@@ -823,6 +970,9 @@ __all__ = [
     "execute_approved_adoption",
     "rewind_adoption_by_receipt",
     "read_lifecycle_state",
+    "deliver_latest_release",
+    "build_and_preview_delivered_release",
+    "execute_approved_delivered_release",
     "deliver_and_apply_latest_release",
     "build_and_preview_conflict_resolution",
     "execute_approved_conflict_resolution",

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from core.lifecycle import service
+from core.transaction.engine import PlanRejected
 from core.update import apply_update
 from core.utils.update_verifier import legacy_profile_bytes
 
@@ -246,9 +248,10 @@ def test_apply_update_replaces_brain_prunes_unchanged_and_preserves_user_owned_p
     )
 
 
-def test_delivery_fetches_a_pinned_release_before_the_transactional_apply(
+def test_delivery_previews_and_applies_only_the_exact_pinned_release(
     split_release_fixture: dict[str, object],
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vault = split_release_fixture["vault"]
     release = split_release_fixture["release"]
@@ -271,7 +274,7 @@ def test_delivery_fetches_a_pinned_release_before_the_transactional_apply(
         != 0
     )
 
-    result = apply_update.deliver_and_apply_latest_release(
+    delivered = apply_update.deliver_latest_release(
         vault,
         state_root=tmp_path / "evidence-state",
         remote_url=str(release),
@@ -279,12 +282,70 @@ def test_delivery_fetches_a_pinned_release_before_the_transactional_apply(
         wall_clock_seconds=60.0,
     )
 
-    assert result["status"] == "updated"
-    assert result["delivery"]["tag"] == target_tag
-    assert result["update"]["committed"] is True
+    assert delivered["status"] == "delivered"
+    assert delivered["release"]["tag"] == target_tag
     assert _git(brain, "rev-parse", f"refs/tags/{target_tag}")
+    assert _git(brain, "rev-parse", "refs/dex/installed") == old_commit
+    assert (vault / "README.md").read_bytes() == b"old brain\n"
+
+    previewed = service.build_and_preview_delivered_release(vault, delivered["release"])
+    assert previewed["preview"]["release"] == delivered["release"]
+    assert {entry["path"] for entry in previewed["preview"]["writes"]} >= {"README.md", "core/obsolete.py"}
+
+    def direct_apply_must_not_run(*_args, **_kwargs):
+        raise AssertionError("delivery execution bypassed core.lifecycle.service")
+
+    monkeypatch.setattr(apply_update, "apply_verified_release", direct_apply_must_not_run)
+    executed = service.execute_approved_delivered_release(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    assert executed["release"] == delivered["release"]
+    assert executed["receipt"]["transaction_id"]
     assert _git(brain, "rev-parse", "refs/dex/installed") == target_commit
     assert (vault / "README.md").read_bytes() == b"new brain\n"
+
+
+def test_delivered_release_refuses_any_preview_drift_before_writing(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    vault = split_release_fixture["vault"]
+    release = split_release_fixture["release"]
+    brain = split_release_fixture["brain"]
+    old_tag, _old_tag_object, old_commit, _old_tree = split_release_fixture["old"]
+    del old_tag
+
+    _write(release, "System/.release-evidence-profile.json", legacy_profile_bytes("1.65.0"))
+    target_tag, _target_tag_object, target_commit, _target_tree = _commit_release(release, "1.65.0")
+    _git(release, "branch", "-f", "release", target_commit)
+    _write(vault, "package.json", b'{"name":"dex-test","version":"1.63.0"}\n')
+    _write(vault, "System/.release-evidence-profile.json", legacy_profile_bytes("1.63.0"))
+    _git(brain, "update-ref", "refs/remotes/upstream/release", old_commit)
+
+    delivered = apply_update.deliver_latest_release(
+        vault,
+        state_root=tmp_path / "evidence-state",
+        remote_url=str(release),
+        allow_test_transport=True,
+        wall_clock_seconds=60.0,
+    )
+    assert delivered["status"] == "delivered"
+    assert delivered["release"]["tag"] == target_tag
+    previewed = service.build_and_preview_delivered_release(vault, delivered["release"])
+    _write(vault, "README.md", b"user changed this after preview\n")
+
+    with pytest.raises(PlanRejected, match="approval does not match"):
+        service.execute_approved_delivered_release(
+            vault,
+            previewed["preview"],
+            previewed["approval_token"],
+        )
+
+    assert (vault / "README.md").read_bytes() == b"user changed this after preview\n"
+    assert _git(brain, "rev-parse", "refs/dex/installed") == old_commit
 
 
 def test_apply_update_keeps_personal_instructions_when_release_template_changes(

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from core.update import apply_update
+from core.utils.update_verifier import legacy_profile_bytes
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -243,6 +244,47 @@ def test_apply_update_replaces_brain_prunes_unchanged_and_preserves_user_owned_p
         ).stdout.strip()
         == target_commit
     )
+
+
+def test_delivery_fetches_a_pinned_release_before_the_transactional_apply(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    vault = split_release_fixture["vault"]
+    release = split_release_fixture["release"]
+    brain = split_release_fixture["brain"]
+    old_tag, _old_tag_object, old_commit, _old_tree = split_release_fixture["old"]
+    del old_tag
+
+    _write(release, "System/.release-evidence-profile.json", legacy_profile_bytes("1.65.0"))
+    target_tag, target_tag_object, target_commit, target_tree = _commit_release(release, "1.65.0")
+    del target_tag_object, target_tree
+    _git(release, "branch", "-f", "release", target_commit)
+    _write(vault, "package.json", b'{"name":"dex-test","version":"1.63.0"}\n')
+    _write(vault, "System/.release-evidence-profile.json", legacy_profile_bytes("1.63.0"))
+    _git(brain, "update-ref", "refs/remotes/upstream/release", old_commit)
+    assert (
+        subprocess.run(
+            ["git", f"--git-dir={brain}", "rev-parse", "--verify", f"refs/tags/{target_tag}"],
+            capture_output=True,
+        ).returncode
+        != 0
+    )
+
+    result = apply_update.deliver_and_apply_latest_release(
+        vault,
+        state_root=tmp_path / "evidence-state",
+        remote_url=str(release),
+        allow_test_transport=True,
+        wall_clock_seconds=60.0,
+    )
+
+    assert result["status"] == "updated"
+    assert result["delivery"]["tag"] == target_tag
+    assert result["update"]["committed"] is True
+    assert _git(brain, "rev-parse", f"refs/tags/{target_tag}")
+    assert _git(brain, "rev-parse", "refs/dex/installed") == target_commit
+    assert (vault / "README.md").read_bytes() == b"new brain\n"
 
 
 def test_apply_update_keeps_personal_instructions_when_release_template_changes(

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -124,6 +124,10 @@ def test_reactivation_is_idempotent_but_invalid_existing_record_is_refused(
     assert activation_path.read_bytes() == before_bytes
     assert activation_path.stat().st_mtime_ns == before_mtime
 
+    previous_api = {**first, "api_version": "1.2.0"}
+    activation_path.write_bytes(_canonical(previous_api))
+    assert activate_vault(vault) == previous_api
+
     activation_path.write_text('{"activation_version":999}\n', encoding="utf-8")
     with pytest.raises(BridgeActivationError, match="existing activation"):
         activate_vault(vault)
@@ -302,8 +306,8 @@ def test_shipped_bridge_release_matches_transaction_resume_window() -> None:
     assert bridge.transaction_journal.incompatible_action == "rollback-only"
 
 
-def test_lifecycle_1_1_callers_resolve_unchanged_operations() -> None:
-    """The 1.2 surface is additive: every 1.1 operation keeps its exact call shape."""
+def test_lifecycle_1_2_callers_resolve_unchanged_operations() -> None:
+    """The 1.3 surface is additive: every 1.2 operation keeps its exact call shape."""
     expected_signatures = {
         "build_inventory_and_plan": "(vault_root: 'str | Path') -> 'dict[str, object]'",
         "build_and_preview_adoption": (
@@ -346,7 +350,7 @@ def test_lifecycle_1_1_callers_resolve_unchanged_operations() -> None:
         ),
     }
 
-    assert service.api_version == "1.2.0"
+    assert service.api_version == "1.3.0"
     assert {
         name: str(inspect.signature(getattr(service, name)))
         for name in expected_signatures

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -128,6 +128,10 @@ def test_reactivation_is_idempotent_but_invalid_existing_record_is_refused(
     activation_path.write_bytes(_canonical(previous_api))
     assert activate_vault(vault) == previous_api
 
+    previous_api = {**first, "api_version": "1.3.0"}
+    activation_path.write_bytes(_canonical(previous_api))
+    assert activate_vault(vault) == previous_api
+
     activation_path.write_text('{"activation_version":999}\n', encoding="utf-8")
     with pytest.raises(BridgeActivationError, match="existing activation"):
         activate_vault(vault)
@@ -350,7 +354,7 @@ def test_lifecycle_1_2_callers_resolve_unchanged_operations() -> None:
         ),
     }
 
-    assert service.api_version == "1.3.0"
+    assert service.api_version == "1.4.0"
     assert {
         name: str(inspect.signature(getattr(service, name)))
         for name in expected_signatures

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -14,6 +14,7 @@ from core.lifecycle.bridge import ACTIVATION_RELATIVE
 from core.lifecycle.engine import rewind_acknowledgement_token
 from core.tests.test_adoption_transaction import _setup
 from core.tests.test_lifecycle_bridge import _write_bridge_release
+from core.update import apply_update
 
 SCHEMA_PATH = (
     Path(__file__).resolve().parents[1]
@@ -238,7 +239,7 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 def test_api_version_is_present_and_frozen_in_schema() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
-    assert service.api_version == "1.2.0"
+    assert service.api_version == "1.3.0"
     assert schema["properties"]["api_version"] == {"const": service.api_version}
 
 
@@ -250,6 +251,7 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
         "execute_approved_adoption",
         "rewind_adoption_by_receipt",
         "read_lifecycle_state",
+        "deliver_and_apply_latest_release",
         "build_and_preview_conflict_resolution",
         "execute_approved_conflict_resolution",
         "build_archive_removal_preview",
@@ -279,6 +281,33 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
     assert "bridge" in service.__doc__.lower()
 
 
+def test_release_delivery_is_exposed_only_through_the_lifecycle_service(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    expected = {"status": "not-delivered", "evidence": {"status": "UNKNOWN"}}
+    called_with: list[Path] = []
+
+    def fake_delivery(vault_root: Path) -> dict[str, object]:
+        called_with.append(vault_root)
+        return expected
+
+    monkeypatch.setattr(apply_update, "deliver_and_apply_latest_release", fake_delivery)
+
+    response = service.deliver_and_apply_latest_release(vault)
+
+    assert called_with == [vault]
+    assert response == {"api_version": service.api_version, **expected}
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    _assert_conforms(
+        schema,
+        "deliver_and_apply_latest_release",
+        {"vault_root": str(vault)},
+        response,
+    )
+
+
 def test_archive_removal_is_previewed_approved_and_receipted(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     archive = vault / ".dex/pre-split-archive.git"
@@ -289,7 +318,7 @@ def test_archive_removal_is_previewed_approved_and_receipted(tmp_path: Path) -> 
 
     preview = service.build_archive_removal_preview(vault)
 
-    assert preview["api_version"] == "1.2.0"
+    assert preview["api_version"] == "1.3.0"
     assert preview["preview"]["archive_relative"] == ".dex/pre-split-archive.git"
     assert preview["preview"]["size_bytes"] == len(b"ref: refs/heads/main\narchive bytes")
     assert preview["preview"]["retention"] == "one full release cycle after conversion"

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -239,7 +239,7 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 def test_api_version_is_present_and_frozen_in_schema() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
-    assert service.api_version == "1.3.0"
+    assert service.api_version == "1.4.0"
     assert schema["properties"]["api_version"] == {"const": service.api_version}
 
 
@@ -251,6 +251,9 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
         "execute_approved_adoption",
         "rewind_adoption_by_receipt",
         "read_lifecycle_state",
+        "deliver_latest_release",
+        "build_and_preview_delivered_release",
+        "execute_approved_delivered_release",
         "deliver_and_apply_latest_release",
         "build_and_preview_conflict_resolution",
         "execute_approved_conflict_resolution",
@@ -281,30 +284,104 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
     assert "bridge" in service.__doc__.lower()
 
 
-def test_release_delivery_is_exposed_only_through_the_lifecycle_service(
+def test_release_delivery_is_non_mutating_and_exposed_only_through_the_lifecycle_service(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     vault = tmp_path / "vault"
-    expected = {"status": "not-delivered", "evidence": {"status": "UNKNOWN"}}
+    expected = {
+        "status": "delivered",
+        "release": {
+            "tag": "dist/release/v1.65.0-0123456789abcdef0123456789abcdef01234567",
+            "tag_object": "0123456789abcdef0123456789abcdef01234567",
+            "commit": "0123456789abcdef0123456789abcdef01234567",
+            "tree": "0123456789abcdef0123456789abcdef01234567",
+            "version": "1.65.0",
+            "channel": "stable",
+        },
+    }
     called_with: list[Path] = []
 
     def fake_delivery(vault_root: Path) -> dict[str, object]:
         called_with.append(vault_root)
         return expected
 
-    monkeypatch.setattr(apply_update, "deliver_and_apply_latest_release", fake_delivery)
+    monkeypatch.setattr(apply_update, "deliver_latest_release", fake_delivery)
 
-    response = service.deliver_and_apply_latest_release(vault)
+    response = service.deliver_latest_release(vault)
 
     assert called_with == [vault]
     assert response == {"api_version": service.api_version, **expected}
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     _assert_conforms(
         schema,
-        "deliver_and_apply_latest_release",
+        "deliver_latest_release",
         {"vault_root": str(vault)},
         response,
+    )
+
+
+def test_legacy_release_delivery_operation_is_a_non_mutating_bridge(tmp_path: Path) -> None:
+    response = service.deliver_and_apply_latest_release(tmp_path / "vault")
+
+    assert response == {
+        "api_version": service.api_version,
+        "status": "not-delivered",
+        "evidence": {
+            "status": "deprecated",
+            "reason": "use-deliver-preview-execute",
+        },
+    }
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    _assert_conforms(
+        schema,
+        "deliver_and_apply_latest_release",
+        {"vault_root": str(tmp_path / "vault")},
+        response,
+    )
+
+
+def test_delivered_release_preview_and_execute_contracts_bind_one_identity() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    identity = {
+        "tag": "dist/release/v1.65.0-0123456789abcdef0123456789abcdef01234567",
+        "tag_object": "0123456789abcdef0123456789abcdef01234567",
+        "commit": "0123456789abcdef0123456789abcdef01234567",
+        "tree": "0123456789abcdef0123456789abcdef01234567",
+        "version": "1.65.0",
+        "channel": "stable",
+    }
+    preview = {
+        "release": identity,
+        "previous_commit": "89abcdef0123456789abcdef0123456789abcdef",
+        "writes": [
+            {
+                "path": "README.md",
+                "action": "write",
+                "sha256": "a" * 64,
+                "byte_size": 10,
+                "mode": 420,
+                "current": {"exists": True},
+            }
+        ],
+    }
+    token = "b" * 64
+    preview_response = {
+        "api_version": service.api_version,
+        "preview": preview,
+        "approval_token": token,
+    }
+    _assert_conforms(
+        schema,
+        "build_and_preview_delivered_release",
+        {"vault_root": "/tmp/vault", "release": identity},
+        preview_response,
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_delivered_release",
+        {"vault_root": "/tmp/vault", "preview": preview, "approved_token": token},
+        {"api_version": service.api_version, "receipt": {}, "release": identity},
     )
 
 
@@ -318,7 +395,7 @@ def test_archive_removal_is_previewed_approved_and_receipted(tmp_path: Path) -> 
 
     preview = service.build_archive_removal_preview(vault)
 
-    assert preview["api_version"] == "1.3.0"
+    assert preview["api_version"] == "1.4.0"
     assert preview["preview"]["archive_relative"] == ".dex/pre-split-archive.git"
     assert preview["preview"]["size_bytes"] == len(b"ref: refs/heads/main\narchive bytes")
     assert preview["preview"]["retention"] == "one full release cycle after conversion"

--- a/core/tests/test_lifecycle_topology_migration.py
+++ b/core/tests/test_lifecycle_topology_migration.py
@@ -101,7 +101,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
 
     previewed = service.build_and_preview_topology_migration(vault)
 
-    assert previewed["api_version"] == "1.2.0"
+    assert previewed["api_version"] == "1.3.0"
     assert previewed["topology"] == "combined"
     assert previewed["preview"]["operation"] == "brain-vault-topology-migration"
     assert [
@@ -125,7 +125,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
     )
 
     assert (vault / "System/.dex/topology.json").is_file()
-    assert executed["api_version"] == "1.2.0"
+    assert executed["api_version"] == "1.3.0"
     assert executed["receipt"]["operation"] == "brain-vault-topology-migration"
     assert executed["receipt"]["topology_before"] == "combined"
     assert executed["receipt"]["topology_after"] == "post-split"
@@ -221,7 +221,7 @@ def test_dex_update_skill_routes_the_guided_migration_through_service() -> None:
         REPO_ROOT / ".claude/skills/dex-update/SKILL.md"
     ).read_text(encoding="utf-8")
 
-    assert "version 1.1.0" in instructions
+    assert "version 1.3.0" in instructions
     assert "build_and_preview_topology_migration" in instructions
     assert "execute_approved_topology_migration" in instructions
     assert "dry-run" in instructions

--- a/core/tests/test_lifecycle_topology_migration.py
+++ b/core/tests/test_lifecycle_topology_migration.py
@@ -101,7 +101,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
 
     previewed = service.build_and_preview_topology_migration(vault)
 
-    assert previewed["api_version"] == "1.3.0"
+    assert previewed["api_version"] == "1.4.0"
     assert previewed["topology"] == "combined"
     assert previewed["preview"]["operation"] == "brain-vault-topology-migration"
     assert [
@@ -125,7 +125,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
     )
 
     assert (vault / "System/.dex/topology.json").is_file()
-    assert executed["api_version"] == "1.3.0"
+    assert executed["api_version"] == "1.4.0"
     assert executed["receipt"]["operation"] == "brain-vault-topology-migration"
     assert executed["receipt"]["topology_before"] == "combined"
     assert executed["receipt"]["topology_after"] == "post-split"
@@ -221,7 +221,7 @@ def test_dex_update_skill_routes_the_guided_migration_through_service() -> None:
         REPO_ROOT / ".claude/skills/dex-update/SKILL.md"
     ).read_text(encoding="utf-8")
 
-    assert "version 1.3.0" in instructions
+    assert "version 1.4.0" in instructions
     assert "build_and_preview_topology_migration" in instructions
     assert "execute_approved_topology_migration" in instructions
     assert "dry-run" in instructions

--- a/core/tests/test_update_checker.py
+++ b/core/tests/test_update_checker.py
@@ -21,11 +21,13 @@ from core.utils.update_verifier import (
     CATALOG_PATH,
     MANIFEST_PATH,
     PROFILE_PATH,
+    STATUS_IDENTITY,
     STATUS_NONE,
     STATUS_OFFLINE,
     STATUS_RELEASE,
     STATUS_SKIPPED,
     STATUS_UNKNOWN,
+    STATUS_UP_TO_DATE,
     CancelledError,
     CompatibilityArtifact,
     GitRunner,
@@ -1075,3 +1077,79 @@ def test_session_start_settings_are_fetch_only_and_do_not_claim_sync() -> None:
     assert "git pull" not in all_commands
     assert "pulled latest" not in all_commands
     assert "synced with github" not in all_commands
+
+
+def test_latest_release_identity_proof_is_exact_and_does_not_persist_notice_state(
+    tmp_path: Path,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "1.62.0")
+    tag, commit = _release(remote, "1.63.0")
+    state = tmp_path / "state"
+
+    result = update_verifier_module.prove_latest_release(
+        vault,
+        "stable",
+        state_root=state,
+        remote_url=str(remote),
+        allow_test_transport=True,
+        wall_clock_seconds=60.0,
+    )
+
+    assert result == {
+        "status": STATUS_IDENTITY,
+        "version": "1.63.0",
+        "tag": tag,
+        "tag_object": _tag_object(remote, tag),
+        "commit": commit,
+        "tree": _git(remote, "rev-parse", f"{commit}^{{tree}}"),
+    }
+    assert not state.exists()
+
+
+def test_release_identity_proof_refuses_unknown_or_ambiguous_versions(tmp_path: Path) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "1.62.0")
+    commit = _git(remote, "rev-parse", "HEAD")
+    _git(remote, "tag", "-a", f"dist/release/v1.62.0-{commit[:8]}", "-m", "duplicate")
+    kwargs = {
+        "state_root": tmp_path / "state",
+        "remote_url": str(remote),
+        "allow_test_transport": True,
+        "wall_clock_seconds": 60.0,
+    }
+
+    assert update_verifier_module.prove_release_identity(vault, "stable", "1.62.0", **kwargs) == {
+        "status": STATUS_UNKNOWN,
+        "reason": "release-ambiguous",
+    }
+    assert update_verifier_module.prove_release_identity(vault, "stable", "9.9.9", **kwargs) == {
+        "status": STATUS_UNKNOWN,
+        "reason": "release-not-found",
+    }
+
+
+def test_latest_release_identity_proof_reports_up_to_date(tmp_path: Path) -> None:
+    vault = _installed_vault(tmp_path / "vault", "1.63.0")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "1.63.0")
+
+    result = update_verifier_module.prove_latest_release(
+        vault,
+        "stable",
+        state_root=tmp_path / "state",
+        remote_url=str(remote),
+        allow_test_transport=True,
+        wall_clock_seconds=60.0,
+    )
+
+    assert result == {
+        "status": STATUS_UP_TO_DATE,
+        "current_version": "1.63.0",
+        "latest_version": "1.63.0",
+    }

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -523,23 +523,111 @@ def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dic
     }
 
 
+def deliver_and_apply_latest_release(
+    vault_root: Path,
+    *,
+    state_root: Path | None = None,
+    remote_url: str | None = None,
+    allow_test_transport: bool = False,
+    git_runner: Any | None = None,
+    wall_clock_seconds: float = 10.0,
+) -> dict[str, Any]:
+    """Fetch an evidence-pinned release into the brain store, then apply it safely.
+
+    The download is deliberately separate from the vault mutation: first prove an
+    immutable release in a disposable evidence cache, then fetch that exact tag
+    and release-channel ref into the split brain Git store, and finally prove the
+    fetched bytes again before the existing transaction-backed apply path runs.
+    """
+    from core.utils.update_verifier import (
+        CANONICAL_REMOTE_URL,
+        STATUS_IDENTITY,
+        GitRunner,
+        prove_latest_release,
+    )
+
+    root = Path(vault_root).resolve()
+    channel = release_channel.read_channel(root)
+    effective_remote = remote_url or CANONICAL_REMOTE_URL
+    evidence = prove_latest_release(
+        root,
+        channel,
+        state_root=state_root,
+        remote_url=effective_remote,
+        allow_test_transport=allow_test_transport,
+        git_runner=git_runner,
+        wall_clock_seconds=wall_clock_seconds,
+    )
+    if evidence.get("status") != STATUS_IDENTITY:
+        return {"status": "not-delivered", "evidence": evidence}
+
+    tag = evidence["tag"]
+    tag_object = evidence["tag_object"]
+    commit = evidence["commit"]
+    tree = evidence["tree"]
+    if not all(isinstance(value, str) for value in (tag, tag_object, commit, tree)):
+        return {"status": "not-delivered", "evidence": {"status": "UNKNOWN", "reason": "identity-malformed"}}
+
+    brain_git, _topology_value, _brain_marker = _topology(root)
+    _verify_official_origin(root, brain_git)
+    branch = release_channel.release_branch(channel)
+    if branch is None:
+        return {"status": "not-delivered", "evidence": {"status": "UNKNOWN", "reason": "channel-invalid"}}
+    transport = git_runner or GitRunner(
+        allowed_protocol="file" if allow_test_transport else "https"
+    )
+    transport.run(
+        brain_git,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "--no-recurse-submodules",
+        effective_remote,
+        f"refs/tags/{tag}:refs/tags/{tag}",
+        f"+refs/heads/{branch}:refs/remotes/upstream/{branch}",
+        network=True,
+        max_output_bytes=1024,
+    )
+    release = verify_release_ref(
+        root,
+        tag=tag,
+        tag_object=tag_object,
+        commit=commit,
+        tree=tree,
+    )
+    return {
+        "status": "updated",
+        "delivery": evidence,
+        "update": apply_verified_release(root, release),
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--vault", type=Path, default=Path.cwd())
-    parser.add_argument("--tag", required=True)
-    parser.add_argument("--tag-object", required=True)
-    parser.add_argument("--commit", required=True)
-    parser.add_argument("--tree", required=True)
+    parser.add_argument("--deliver-latest", action="store_true")
+    parser.add_argument("--tag")
+    parser.add_argument("--tag-object")
+    parser.add_argument("--commit")
+    parser.add_argument("--tree")
     args = parser.parse_args(argv)
     try:
-        release = verify_release_ref(
-            args.vault,
-            tag=args.tag,
-            tag_object=args.tag_object,
-            commit=args.commit,
-            tree=args.tree,
-        )
-        result = apply_verified_release(args.vault, release)
+        if args.deliver_latest:
+            if any(value is not None for value in (args.tag, args.tag_object, args.commit, args.tree)):
+                parser.error("--deliver-latest cannot be combined with an explicit release identity")
+            result = deliver_and_apply_latest_release(args.vault)
+        else:
+            if any(value is None for value in (args.tag, args.tag_object, args.commit, args.tree)):
+                parser.error("--tag, --tag-object, --commit, and --tree are required without --deliver-latest")
+            release = verify_release_ref(
+                args.vault,
+                tag=args.tag,
+                tag_object=args.tag_object,
+                commit=args.commit,
+                tree=args.tree,
+            )
+            result = apply_verified_release(args.vault, release)
     except (OSError, RuntimeError) as error:
         print(json.dumps({"ok": False, "error": str(error)}, sort_keys=True))
         return 1

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -486,10 +486,17 @@ def _finalize_release_metadata(
         raise
 
 
-def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dict[str, Any]:
-    """Apply a verified immutable release through the shared transaction core."""
+def validated_release_apply_context(
+    vault_root: Path,
+    release: VerifiedReleaseRef,
+) -> str:
+    """Return the installed commit after proving a release can replace it.
+
+    This read-only guard is shared by the lifecycle preview and execute routes.
+    It deliberately contains no mutation so an approval preview can bind both
+    the installed state and the exact immutable target before execution.
+    """
     root = Path(vault_root).resolve()
-    Transaction.resume(root)
     brain_git, topology, marker = _topology(root)
     if brain_git != release.brain_git:
         raise UpdateError("verified release belongs to a different split brain store")
@@ -498,6 +505,14 @@ def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dic
         raise UpdateError("installed release identity disagrees across the split topology markers")
     if previous_commit == release.commit:
         raise UpdateError("that immutable release is already installed")
+    return previous_commit
+
+
+def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dict[str, Any]:
+    """Apply a verified immutable release through the shared transaction core."""
+    root = Path(vault_root).resolve()
+    Transaction.resume(root)
+    previous_commit = validated_release_apply_context(root, release)
     plan = build_update_plan(root, release)
     transaction = Transaction.begin(root, list(plan.entries), allow_empty=True)
     transaction_result = transaction.run(
@@ -523,7 +538,19 @@ def apply_verified_release(vault_root: Path, release: VerifiedReleaseRef) -> dic
     }
 
 
-def deliver_and_apply_latest_release(
+def _release_identity(release: VerifiedReleaseRef) -> dict[str, str]:
+    """Return the closed identity a lifecycle preview must bind to."""
+    return {
+        "tag": release.tag,
+        "tag_object": release.tag_object,
+        "commit": release.commit,
+        "tree": release.tree,
+        "version": release.version,
+        "channel": release.channel,
+    }
+
+
+def deliver_latest_release(
     vault_root: Path,
     *,
     state_root: Path | None = None,
@@ -532,12 +559,13 @@ def deliver_and_apply_latest_release(
     git_runner: Any | None = None,
     wall_clock_seconds: float = 10.0,
 ) -> dict[str, Any]:
-    """Fetch an evidence-pinned release into the brain store, then apply it safely.
+    """Fetch and re-verify one evidence-pinned release without changing vault content.
 
-    The download is deliberately separate from the vault mutation: first prove an
-    immutable release in a disposable evidence cache, then fetch that exact tag
-    and release-channel ref into the split brain Git store, and finally prove the
-    fetched bytes again before the existing transaction-backed apply path runs.
+    This is the read side of delivery. It proves an immutable release in a
+    disposable evidence cache, fetches only that exact tag and channel ref into
+    Dex's private brain store, then re-proves the fetched bytes. It deliberately
+    does not build a transaction or mutate a vault file; the lifecycle service
+    must turn this returned identity into the exact user-visible preview.
     """
     from core.utils.update_verifier import (
         CANONICAL_REMOTE_URL,
@@ -596,10 +624,26 @@ def deliver_and_apply_latest_release(
         commit=commit,
         tree=tree,
     )
+    return {"status": "delivered", "release": _release_identity(release)}
+
+
+def deliver_and_apply_latest_release(
+    vault_root: Path,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Compatibility shim for the withdrawn unsafe one-step delivery API.
+
+    Version 1.3 exposed this name before its approval-boundary flaw was found.
+    Preserve its call shape, but never apply an unseen release: callers receive
+    a safe refusal and must use the lifecycle deliver-preview-execute route.
+    """
+    del vault_root, kwargs
     return {
-        "status": "updated",
-        "delivery": evidence,
-        "update": apply_verified_release(root, release),
+        "status": "not-delivered",
+        "evidence": {
+            "status": "deprecated",
+            "reason": "use-lifecycle-deliver-preview-execute",
+        },
     }
 
 
@@ -616,18 +660,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.deliver_latest:
             if any(value is not None for value in (args.tag, args.tag_object, args.commit, args.tree)):
                 parser.error("--deliver-latest cannot be combined with an explicit release identity")
-            result = deliver_and_apply_latest_release(args.vault)
+            result = deliver_latest_release(args.vault)
         else:
             if any(value is None for value in (args.tag, args.tag_object, args.commit, args.tree)):
                 parser.error("--tag, --tag-object, --commit, and --tree are required without --deliver-latest")
-            release = verify_release_ref(
-                args.vault,
-                tag=args.tag,
-                tag_object=args.tag_object,
-                commit=args.commit,
-                tree=args.tree,
+            parser.error(
+                "direct release application is retired; core.lifecycle.service "
+                "must build and execute the approved preview"
             )
-            result = apply_verified_release(args.vault, release)
     except (OSError, RuntimeError) as error:
         print(json.dumps({"ok": False, "error": str(error)}, sort_keys=True))
         return 1

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -36,6 +36,9 @@ STATUS_NONE = "no-newer-release-observed-unverified"
 STATUS_OFFLINE = "offline"
 STATUS_UNKNOWN = "UNKNOWN"
 STATUS_SKIPPED = "skipped"
+STATUS_IDENTITY = "release-identity-proved"
+STATUS_UP_TO_DATE = "up-to-date"
+_VALID_CHANNELS = frozenset({"stable", "beta"})
 
 _SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 _TAG_RE = re.compile(
@@ -721,7 +724,10 @@ class UpdateVerifier:
             raise EvidenceError("isolated release cache contains alternate object storage")
         GitRunner._bounded_directory_usage(self.cache_path)
 
-    def _remote_release_tags(self) -> RemoteReleaseTagEnumeration:
+    def _remote_release_tags(
+        self,
+        exact_version: SemVer | None = None,
+    ) -> RemoteReleaseTagEnumeration:
         raw = self.git.run_plain(
             "-c",
             "credential.helper=",
@@ -768,10 +774,13 @@ class UpdateVerifier:
                 tag_object=object_id.decode("ascii"),
             )
             version = SemVer.parse(match.group("version"))
-            if highest_version is None or version > highest_version:
+            if exact_version is not None:
+                if version == exact_version:
+                    selected.append(evidence)
+            elif highest_version is None or version > highest_version:
                 highest_version = version
                 selected = [evidence]
-            elif version == highest_version:
+            elif exact_version is None and version == highest_version:
                 selected.append(evidence)
         if len(selected) > MAX_RELEASE_TAGS:
             raise EvidenceError("higher release candidate count exceeded its bound")
@@ -993,6 +1002,82 @@ class UpdateVerifier:
             self._verify_catalog(profile, entries)
         return CandidateEvidence(expected_version, tag, fetched_tag_object, commit, tree, profile.profile)
 
+    @staticmethod
+    def _identity_result(candidate: CandidateEvidence) -> dict[str, object]:
+        return {
+            "status": STATUS_IDENTITY,
+            "version": candidate.version,
+            "tag": candidate.tag,
+            "tag_object": candidate.tag_object,
+            "commit": candidate.commit,
+            "tree": candidate.tree,
+        }
+
+    def _prove_release(
+        self,
+        channel: str,
+        *,
+        exact_version: str | None,
+    ) -> dict[str, object]:
+        """Prove a release identity without changing notice or cache state."""
+        self._budget = ExecutionBudget.start(self.wall_clock_seconds)
+        self.git.use_budget(self._budget)
+        try:
+            if channel not in _VALID_CHANNELS:
+                return {"status": STATUS_UNKNOWN, "reason": "channel-invalid"}
+            if channel != "stable":
+                return {"status": STATUS_UNKNOWN, "reason": "channel-unsupported"}
+            requested: SemVer | None = None
+            if exact_version is not None:
+                try:
+                    requested = SemVer.parse(exact_version)
+                except EvidenceError:
+                    return {"status": STATUS_UNKNOWN, "reason": "version-invalid"}
+            current_version = self._current_version() if exact_version is None else None
+            remote_tags = self._remote_release_tags(requested).selected
+            if not remote_tags:
+                return {
+                    "status": STATUS_UNKNOWN,
+                    "reason": "release-not-found" if exact_version is not None else "no-published-release",
+                }
+            if len(remote_tags) != 1:
+                return {"status": STATUS_UNKNOWN, "reason": "release-ambiguous"}
+            remote_tag = remote_tags[0]
+            match = _TAG_RE.fullmatch(remote_tag.tag)
+            if match is None:
+                return {"status": STATUS_UNKNOWN, "reason": "release-not-found"}
+            with self._quarantined_cache(use_state_root=False):
+                self._fetch((remote_tag,))
+                candidate = self._verify_candidate(
+                    remote_tag.tag,
+                    remote_tag.tag_object,
+                    match.group("version"),
+                    match.group("short"),
+                )
+            if current_version is not None and SemVer.parse(candidate.version) <= SemVer.parse(current_version):
+                return {
+                    "status": STATUS_UP_TO_DATE,
+                    "current_version": current_version,
+                    "latest_version": candidate.version,
+                }
+            return self._identity_result(candidate)
+        except OfflineError:
+            return {"status": STATUS_OFFLINE, "reason": "network-unavailable"}
+        except (CancelledError, EvidenceError, OSError, UnicodeError, subprocess.SubprocessError) as error:
+            reason = {
+                CancelledError: "cancelled",
+                TagObjectMovedError: "tag-object-moved",
+                TagObjectMismatchError: "tag-object-mismatch",
+                EvidenceError: "evidence-invalid",
+                OSError: "io-error",
+                UnicodeError: "encoding-invalid",
+                subprocess.SubprocessError: "subprocess-failed",
+            }.get(type(error), "evidence-invalid")
+            return {"status": STATUS_UNKNOWN, "reason": reason}
+        finally:
+            self._budget = None
+            self.git.budget = None
+
     def _legacy_notice_matches(self, candidate: CandidateEvidence, state: dict[str, object]) -> bool:
         if state.get("legacy_notice_migrated") is True:
             return False
@@ -1017,9 +1102,13 @@ class UpdateVerifier:
         )
 
     @contextmanager
-    def _quarantined_cache(self):
-        self.state_root.mkdir(parents=True, exist_ok=True, mode=0o700)
-        quarantine = Path(tempfile.mkdtemp(prefix="objects-quarantine.", dir=self.state_root)) / "objects.git"
+    def _quarantined_cache(self, *, use_state_root: bool = True):
+        if use_state_root:
+            self.state_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            parent = Path(tempfile.mkdtemp(prefix="objects-quarantine.", dir=self.state_root))
+        else:
+            parent = Path(tempfile.mkdtemp(prefix="dex-release-evidence."))
+        quarantine = parent / "objects.git"
         original_cache = self._evidence_cache
         self._evidence_cache = quarantine
         if self._budget is not None:
@@ -1031,7 +1120,7 @@ class UpdateVerifier:
             self._evidence_cache = original_cache
             if self._budget is not None:
                 self._budget.monitored_path = None
-            shutil.rmtree(quarantine.parent, ignore_errors=True)
+            shutil.rmtree(parent, ignore_errors=True)
 
     def _promote_quarantine(self) -> None:
         quarantine = self.cache_path
@@ -1295,6 +1384,84 @@ class UpdateVerifier:
         finally:
             self._budget = None
             self.git.budget = None
+
+
+def _run_release_identity_query(
+    vault: str | Path,
+    channel: str,
+    *,
+    version: str | None,
+    state_root: Path | None,
+    remote_url: str,
+    allow_test_transport: bool,
+    git_runner: GitRunner | None,
+    fetch_override: Callable[[GitRunner, Path, str], None] | None,
+    wall_clock_seconds: float,
+) -> dict[str, object]:
+    try:
+        verifier = UpdateVerifier(
+            Path(vault),
+            state_root=state_root,
+            remote_url=remote_url,
+            allow_test_transport=allow_test_transport,
+            git_runner=git_runner,
+            fetch_override=fetch_override,
+            wall_clock_seconds=wall_clock_seconds,
+        )
+    except (EvidenceError, OSError, UnicodeError, subprocess.SubprocessError):
+        return {"status": STATUS_UNKNOWN, "reason": "query-setup-invalid"}
+    return verifier._prove_release(channel, exact_version=version)
+
+
+def prove_latest_release(
+    vault: str | Path,
+    channel: str,
+    *,
+    state_root: Path | None = None,
+    remote_url: str = CANONICAL_REMOTE_URL,
+    allow_test_transport: bool = False,
+    git_runner: GitRunner | None = None,
+    fetch_override: Callable[[GitRunner, Path, str], None] | None = None,
+    wall_clock_seconds: float = SESSION_WALL_CLOCK_SECONDS,
+) -> dict[str, object]:
+    """Prove the newest published release without changing notice state."""
+    return _run_release_identity_query(
+        vault,
+        channel,
+        version=None,
+        state_root=state_root,
+        remote_url=remote_url,
+        allow_test_transport=allow_test_transport,
+        git_runner=git_runner,
+        fetch_override=fetch_override,
+        wall_clock_seconds=wall_clock_seconds,
+    )
+
+
+def prove_release_identity(
+    vault: str | Path,
+    channel: str,
+    version: str,
+    *,
+    state_root: Path | None = None,
+    remote_url: str = CANONICAL_REMOTE_URL,
+    allow_test_transport: bool = False,
+    git_runner: GitRunner | None = None,
+    fetch_override: Callable[[GitRunner, Path, str], None] | None = None,
+    wall_clock_seconds: float = SESSION_WALL_CLOCK_SECONDS,
+) -> dict[str, object]:
+    """Prove one exact published release without changing notice state."""
+    return _run_release_identity_query(
+        vault,
+        channel,
+        version=version,
+        state_root=state_root,
+        remote_url=remote_url,
+        allow_test_transport=allow_test_transport,
+        git_runner=git_runner,
+        fetch_override=fetch_override,
+        wall_clock_seconds=wall_clock_seconds,
+    )
 
 
 def _session_start_output(result: dict[str, object]) -> None:

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -62,13 +62,13 @@ the assistant drives, the user approves.
 
 Once a vault has the delivered update route, `/dex-update` does not ask a person
 to fetch or merge anything. After it has shown the exact update and received a
-fresh yes, it uses `core.update.apply_update --deliver-latest`: Dex proves the
-newest published release in a disposable cache, fetches only that pinned release
-into its private brain store, proves the fetched bytes again, then hands the
-existing transaction-backed updater the exact identity. The transaction and
-ownership contract still decide every vault-content write and keep the receipt
-and rewind evidence. If delivery cannot be proved, it stops before that apply
-step; do not substitute a manual Git command.
+fresh yes, it asks `deliver_and_apply_latest_release` through
+`core.lifecycle.service`. Dex proves the newest published release in a disposable
+cache, fetches only that pinned release into its private brain store, proves the
+fetched bytes again, then enters the existing transaction-backed apply path. The
+transaction and ownership contract still decide every vault-content write and
+keep the receipt and rewind evidence. If delivery cannot be proved, it stops
+before that apply step; do not substitute a manual Git command.
 
 ## Special case: v1.62.0 refuses before the merge
 

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -58,6 +58,18 @@ the new version's guided route (topology check, adoption plan, receipts) now wor
 and completes the update properly. Then run `/dex-doctor`. Both are conversational;
 the assistant drives, the user approves.
 
+## Current guided route — no Git workaround
+
+Once a vault has the delivered update route, `/dex-update` does not ask a person
+to fetch or merge anything. After it has shown the exact update and received a
+fresh yes, it uses `core.update.apply_update --deliver-latest`: Dex proves the
+newest published release in a disposable cache, fetches only that pinned release
+into its private brain store, proves the fetched bytes again, then hands the
+existing transaction-backed updater the exact identity. The transaction and
+ownership contract still decide every vault-content write and keep the receipt
+and rewind evidence. If delivery cannot be proved, it stops before that apply
+step; do not substitute a manual Git command.
+
 ## Special case: v1.62.0 refuses before the merge
 
 Six of the seven published copies of v1.62.0 shipped a self-contradictory metadata

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -61,14 +61,17 @@ the assistant drives, the user approves.
 ## Current guided route — no Git workaround
 
 Once a vault has the delivered update route, `/dex-update` does not ask a person
-to fetch or merge anything. After it has shown the exact update and received a
-fresh yes, it asks `deliver_and_apply_latest_release` through
-`core.lifecycle.service`. Dex proves the newest published release in a disposable
-cache, fetches only that pinned release into its private brain store, proves the
-fetched bytes again, then enters the existing transaction-backed apply path. The
-transaction and ownership contract still decide every vault-content write and
-keep the receipt and rewind evidence. If delivery cannot be proved, it stops
-before that apply step; do not substitute a manual Git command.
+to fetch or merge anything. First, `deliver_latest_release` through
+`core.lifecycle.service` proves the newest published release in a disposable
+cache, fetches only that pinned release into Dex's private brain store, and
+proves the fetched bytes again. It does not change vault content.
+
+Dex then asks `build_and_preview_delivered_release` through the same service
+with that exact release identity, shows every write, and waits for a fresh yes.
+Only `execute_approved_delivered_release` with the unchanged preview and token
+can write. The transaction and ownership contract decide every vault-content
+write and keep the receipt and rewind evidence. If delivery, preview, or
+execution cannot be proved, it stops; do not substitute a manual Git command.
 
 ## Special case: v1.62.0 refuses before the merge
 


### PR DESCRIPTION
## What changed\n- makes /dex-update prove, fetch, re-prove, and apply the exact newest stable release\n- keeps fetched payload separate from vault writes; the existing transaction-backed apply path remains the only content mutation path\n- adds focused proof and end-to-end delivery tests\n\n## Verification\n- /tmp/dex-delivery-venv.JZJYsf/bin/python -m pytest -q core/tests/test_apply_update.py core/tests/test_update_checker.py::test_latest_release_identity_proof_is_exact_and_does_not_persist_notice_state core/tests/test_update_checker.py::test_release_identity_proof_refuses_unknown_or_ambiguous_versions core/tests/test_update_checker.py::test_latest_release_identity_proof_reports_up_to_date\n- ruff check for changed Python files\n- compileall for delivery modules