### PR TITLE
test: gate Dex updates across every public release

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -64,3 +64,29 @@ def test_rejects_distribution_tag_that_does_not_name_its_commit(tmp_path: Path) 
 
     with pytest.raises(release_fleet.FleetError, match="does not match"):
         release_fleet.discover_distribution_releases(repo)
+
+
+def test_build_fixture_uses_requested_release_and_preserves_user_hashes(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    release = release_fleet.discover_distribution_releases(repo)[0]
+
+    case = release_fleet.build_fixture(repo, release, tmp_path / "fleet")
+
+    assert _git(case.vault, "rev-parse", "HEAD^") == release.commit
+    assert _git(case.vault, "remote", "get-url", "upstream") == release_fleet.PUBLIC_REMOTE
+    assert _git(case.vault, "remote", "get-url", "--push", "upstream") == "DISABLED"
+    assert case.user_hashes == release_fleet.hash_user_owned_files(case.vault)
+
+
+def test_build_fixture_refuses_to_overwrite_an_existing_case(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    release = release_fleet.discover_distribution_releases(repo)[0]
+    output = tmp_path / "fleet"
+    case = output / release_fleet.safe_case_name(release)
+    case.mkdir(parents=True)
+    (case / "keep-me").write_text("do not delete", encoding="utf-8")
+
+    with pytest.raises(release_fleet.FleetError, match="case directory"):
+        release_fleet.build_fixture(repo, release, output)

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -24,7 +24,7 @@ def _repository(tmp_path: Path) -> Path:
     repo = tmp_path / "releases"
     _git(tmp_path, "init", "--quiet", str(repo))
     _git(repo, "config", "user.name", "Dex Fleet Tests")
-    _git(repo, "config", "user.email", "fleet-tests@example.invalid")
+    _git(repo, "config", "user.email", "fleet-tests@example.com")
     return repo
 
 

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -48,6 +48,15 @@ def _tag_release(
     return tag
 
 
+def _tag_legacy_release(repo: Path, version: str, content: str) -> str:
+    (repo / "README.md").write_text(content + "\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", f"legacy release {version}")
+    tag = f"v{version}"
+    _git(repo, "tag", "-a", tag, "-m", tag)
+    return tag
+
+
 def test_discovers_each_distinct_distribution_tree_once(tmp_path: Path) -> None:
     repo = _repository(tmp_path)
     first = _tag_release(repo, "1.61.0", "one")
@@ -65,6 +74,16 @@ def test_rejects_distribution_tag_that_does_not_name_its_commit(tmp_path: Path) 
 
     with pytest.raises(release_fleet.FleetError, match="does not match"):
         release_fleet.discover_distribution_releases(repo)
+
+
+def test_discovers_legacy_published_release_trees_too(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    legacy = _tag_legacy_release(repo, "1.20.1", "legacy")
+    distribution = _tag_release(repo, "1.61.0", "distribution")
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == [legacy, distribution]
 
 
 def test_build_fixture_uses_requested_release_and_preserves_user_hashes(tmp_path: Path) -> None:
@@ -181,6 +200,47 @@ def test_build_command_outputs_every_distinct_historic_release(
     assert [case["starting"]["tag"] for case in manifest["cases"]] == [
         release.tag for release in release_fleet.discover_distribution_releases(repo)
     ]
+
+
+def test_manifest_command_lists_every_release_without_building_fixtures(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    _tag_release(repo, "1.62.0", "two")
+    output = tmp_path / "fleet"
+
+    exit_code = release_fleet.main(["manifest", "--repo", str(repo)])
+
+    manifest = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert manifest["case_count"] == 2
+    assert not output.exists()
+
+
+def test_build_command_can_construct_one_historic_release_at_a_time(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repository(tmp_path)
+    first = _tag_release(repo, "1.61.0", "one")
+    _tag_release(repo, "1.62.0", "two")
+
+    exit_code = release_fleet.main(
+        [
+            "build",
+            "--repo",
+            str(repo),
+            "--output",
+            str(tmp_path / "fleet"),
+            "--starting-tag",
+            first,
+        ]
+    )
+
+    manifest = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert manifest["case_count"] == 1
+    assert manifest["cases"][0]["starting"]["tag"] == first
 
 
 def test_check_report_command_requires_all_discovered_starting_releases(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1,0 +1,66 @@
+"""Tests for the historic-release acceptance fleet builder."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import release_fleet
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _repository(tmp_path: Path) -> Path:
+    repo = tmp_path / "releases"
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.name", "Dex Fleet Tests")
+    _git(repo, "config", "user.email", "fleet-tests@example.invalid")
+    return repo
+
+
+def _tag_release(
+    repo: Path,
+    version: str,
+    content: str,
+    *,
+    allow_empty: bool = False,
+    suffix: str | None = None,
+) -> str:
+    (repo / "README.md").write_text(content + "\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    commit_args = ["commit", "--quiet", "-m", f"release {version}"]
+    if allow_empty:
+        commit_args.insert(1, "--allow-empty")
+    _git(repo, *commit_args)
+    commit = _git(repo, "rev-parse", "HEAD")
+    tag = f"dist/release/v{version}-{suffix or commit[:7]}"
+    _git(repo, "tag", "-a", tag, "-m", tag)
+    return tag
+
+
+def test_discovers_each_distinct_distribution_tree_once(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    first = _tag_release(repo, "1.61.0", "one")
+    second = _tag_release(repo, "1.61.0", "two")
+    _tag_release(repo, "1.62.0", "two", allow_empty=True)
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == sorted([first, second])
+
+
+def test_rejects_distribution_tag_that_does_not_name_its_commit(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "actual", suffix="deadbee")
+
+    with pytest.raises(release_fleet.FleetError, match="does not match"):
+        release_fleet.discover_distribution_releases(repo)

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -90,3 +91,127 @@ def test_build_fixture_refuses_to_overwrite_an_existing_case(tmp_path: Path) -> 
 
     with pytest.raises(release_fleet.FleetError, match="case directory"):
         release_fleet.build_fixture(repo, release, output)
+
+
+def test_acceptance_report_requires_both_hops_and_unchanged_user_hashes() -> None:
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    report = release_fleet.AcceptanceReport(
+        foundation_tag="dist/release/v1.80.0-aaaaaaa",
+        follow_up_tag="dist/release/v1.80.1-bbbbbbb",
+        cases=(
+            release_fleet.CaseResult(
+                starting_tag="dist/release/v1.61.0-ccccccc",
+                reached_foundation=True,
+                reached_follow_up=True,
+                foundation_doctor_healthy=True,
+                follow_up_doctor_healthy=True,
+                user_hashes_before=hashes,
+                user_hashes_after_foundation=hashes,
+                user_hashes_after_follow_up=hashes,
+                transcript_path="journeys/v1.61.0.md",
+            ),
+            release_fleet.CaseResult(
+                starting_tag="dist/release/v1.62.0-ddddddd",
+                reached_foundation=True,
+                reached_follow_up=False,
+                foundation_doctor_healthy=True,
+                follow_up_doctor_healthy=True,
+                user_hashes_before=hashes,
+                user_hashes_after_foundation=hashes,
+                user_hashes_after_follow_up=hashes,
+                transcript_path="journeys/v1.62.0.md",
+            ),
+        ),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="follow-up"):
+        release_fleet.assert_complete(
+            report,
+            {
+                "dist/release/v1.61.0-ccccccc",
+                "dist/release/v1.62.0-ddddddd",
+            },
+        )
+
+
+def test_acceptance_report_refuses_when_any_published_start_is_missing() -> None:
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    report = release_fleet.AcceptanceReport(
+        foundation_tag="dist/release/v1.80.0-aaaaaaa",
+        follow_up_tag="dist/release/v1.80.1-bbbbbbb",
+        cases=(
+            release_fleet.CaseResult(
+                starting_tag="dist/release/v1.61.0-ccccccc",
+                reached_foundation=True,
+                reached_follow_up=True,
+                foundation_doctor_healthy=True,
+                follow_up_doctor_healthy=True,
+                user_hashes_before=hashes,
+                user_hashes_after_foundation=hashes,
+                user_hashes_after_follow_up=hashes,
+                transcript_path="journeys/v1.61.0.md",
+            ),
+        ),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="missing"):
+        release_fleet.assert_complete(
+            report,
+            {
+                "dist/release/v1.61.0-ccccccc",
+                "dist/release/v1.62.0-ddddddd",
+            },
+        )
+
+
+def test_build_command_outputs_every_distinct_historic_release(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    _tag_release(repo, "1.62.0", "two")
+
+    exit_code = release_fleet.main(
+        ["build", "--repo", str(repo), "--output", str(tmp_path / "fleet")]
+    )
+
+    manifest = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert manifest["case_count"] == 2
+    assert [case["starting"]["tag"] for case in manifest["cases"]] == [
+        release.tag for release in release_fleet.discover_distribution_releases(repo)
+    ]
+
+
+def test_check_report_command_requires_all_discovered_starting_releases(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repository(tmp_path)
+    start_tag = _tag_release(repo, "1.61.0", "one")
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    report = {
+        "foundation_tag": "dist/release/v1.80.0-aaaaaaa",
+        "follow_up_tag": "dist/release/v1.80.1-bbbbbbb",
+        "cases": [
+            {
+                "starting_tag": start_tag,
+                "reached_foundation": True,
+                "reached_follow_up": True,
+                "foundation_doctor_healthy": True,
+                "follow_up_doctor_healthy": True,
+                "user_hashes_before": hashes,
+                "user_hashes_after_foundation": hashes,
+                "user_hashes_after_follow_up": hashes,
+                "transcript_path": "journeys/v1.61.0.md",
+            }
+        ],
+    }
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    exit_code = release_fleet.main(
+        ["check-report", "--repo", str(repo), str(report_path)]
+    )
+
+    assert exit_code == 0
+    assert "PASS: 1 historic release trees reached both releases" in capsys.readouterr().out

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -1,0 +1,66 @@
+# Release-fleet acceptance for Dex updates
+
+This is the release gate for the promise that no existing Dex installation is
+left behind. It is deliberately stricter than the normal unit tests: a green
+test of the updater source does not prove that a person running an old,
+published Dex can reach it.
+
+## What must pass
+
+Every distinct tree behind the published `dist/release/v*` tags is a starting
+case. If two tags point at different trees—even when they share the same
+version number—they are separate cases. Byte-identical trees are one case.
+
+Each case must complete two real update hops:
+
+1. **Historic release to the foundation release.** The foundation is the first
+   public release containing the self-delivering updater. Use the old vault's
+   own `/dex-update` instructions. If that old route safely refuses, follow
+   only its documented one-time rescue route. Record the user-visible wording,
+   approval prompts, final release identity, and `/dex-doctor` verdict.
+2. **Foundation release to a follow-up release.** From the same fixture, run
+   `/dex-update` again. This hop must use the foundation release's delivery
+   path: fetch the exact verified release, show the exact preview, collect a
+   fresh approval, and commit the receipt-backed update. Record the same
+   evidence.
+
+For both hops, the fixture's user-owned hashes must be identical before and
+after. A changed hash, an unknown result, a missing transcript, a missing
+receipt, or an unhealthy Doctor result is a failure—not something to explain
+away.
+
+## Build the historic fixtures
+
+Use a fresh temporary directory. The builder never copies a founder's vault
+and refuses to overwrite an existing case.
+
+```bash
+fleet_root=$(mktemp -d /private/tmp/dex-release-fleet.XXXXXX)
+python3 scripts/release_fleet.py build --repo . --output "$fleet_root" \
+  > "$fleet_root/manifest.json"
+```
+
+`manifest.json` records each immutable starting tag, commit, tree, fixture
+path, and the exact hashes of the synthetic user content that must survive.
+The starting source must be public distribution tags; never use `main`, a
+working tree, or an untagged release candidate as a historical starting point.
+
+## Validate the finished evidence
+
+After both release tags are public and every case has its journey transcript
+and report entry, validate the report against the full tag set:
+
+```bash
+python3 scripts/release_fleet.py check-report --repo . REPORT.json
+```
+
+The command passes only when the report covers every discovered starting tree
+and every case has reached both hops, kept its user hashes unchanged, has a
+healthy Doctor result after each hop, and names a user-visible transcript.
+
+## Claim language
+
+Before this check passes, say only that the updater is implemented and locally
+tested. After it passes against the two actual public tags on every supported
+platform, it is accurate to say that historical Dex installations have a
+proven path to the normal `/dex-update` experience.

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -7,9 +7,11 @@ published Dex can reach it.
 
 ## What must pass
 
-Every distinct tree behind the published `dist/release/v*` tags is a starting
-case. If two tags point at different trees—even when they share the same
-version number—they are separate cases. Byte-identical trees are one case.
+Every distinct tree behind a published release tag is a starting case. This
+means the `dist/release/v*` packages as well as the older public `v*` release
+tags that predate that format. If two tags point at different trees—even when
+they share the same version number—they are separate cases. Byte-identical
+trees are one case.
 
 Each case must complete two real update hops:
 
@@ -29,21 +31,32 @@ after. A changed hash, an unknown result, a missing transcript, a missing
 receipt, or an unhealthy Doctor result is a failure—not something to explain
 away.
 
-## Build the historic fixtures
+## Discover and build the historic fixtures
 
-Use a fresh temporary directory. The builder never copies a founder's vault
-and refuses to overwrite an existing case.
+Discover the whole historic set first. This creates no copies, so it is safe to
+run as part of ordinary release preparation.
+
+```bash
+python3 scripts/release_fleet.py manifest --repo . > historic-release-manifest.json
+```
+
+The manifest records each immutable starting tag, commit, and tree. The
+starting source must be a public release tag; never use `main`, a working tree,
+or an untagged release candidate as a historical starting point.
+
+Build and exercise one fixture at a time, retaining only its small report and
+transcript after it passes. The builder never copies a founder's vault and
+refuses to overwrite an existing case.
 
 ```bash
 fleet_root=$(mktemp -d /private/tmp/dex-release-fleet.XXXXXX)
 python3 scripts/release_fleet.py build --repo . --output "$fleet_root" \
-  > "$fleet_root/manifest.json"
+  --starting-tag dist/release/v1.61.0-EXACTTAG
 ```
 
-`manifest.json` records each immutable starting tag, commit, tree, fixture
-path, and the exact hashes of the synthetic user content that must survive.
-The starting source must be public distribution tags; never use `main`, a
-working tree, or an untagged release candidate as a historical starting point.
+Its output records the fixture path and the exact hashes of the synthetic user
+content that must survive. Processing one case at a time keeps the release
+gate bounded rather than storing 120 full repositories on disk.
 
 ## Validate the finished evidence
 

--- a/docs/superpowers/plans/2026-07-29-updater-bridge-fleet.md
+++ b/docs/superpowers/plans/2026-07-29-updater-bridge-fleet.md
@@ -1,0 +1,335 @@
+# Updater Bridge Fleet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make “no released Dex installation is left behind” a repeatable, evidence-backed release gate: every distinct published release tree must reach a foundation release safely, then reach a subsequent release through `/dex-update` alone.
+
+**Architecture:** Keep the acceptance tool in the repository so its behaviour is reviewed and tested, but create every aged installation in a fresh temporary directory outside the repository. The tool will discover every distinct public release tree (`dist/release/v*` plus older public `v*` tags that predate that format), construct a realistic old vault with non-personal fixture data and recorded ownership hashes, and emit a machine-readable case manifest. A separate journey runner will consume only an immutable, published foundation tag and follow-up tag, record the before/after evidence, and refuse to call the fleet complete unless every case has both receipts and unchanged user-owned hashes.
+
+**Tech Stack:** Python 3 standard library, Git command line, existing lifecycle delivery service, pytest, shell release scripts.
+
+---
+
+## Release contract
+
+The gate has two irreversible truth rules:
+
+1. The foundation and follow-up inputs are annotated `dist/release/v*` tags that exist on the public release remote. A local branch, a source checkout, or an untagged `main` commit is not an input.
+2. A case passes only after its own installed release identity resolves to the foundation tag, its user-owned fixture hashes match exactly, `/dex-doctor` is healthy, then the same installation resolves to the follow-up tag through the release-delivery service and still preserves those hashes.
+
+There are currently 156 distinct trees across the public release tags. The test set must retain different trees that share a semantic version, because they are different packages a real person might have installed. It may collapse only byte-identical trees.
+
+### Task 1: Add the release-tree discovery contract
+
+**Files:**
+- Create: `scripts/release_fleet.py`
+- Create: `core/tests/test_release_fleet.py`
+
+- [ ] **Step 1: Write the failing discovery tests**
+
+```python
+def test_discovers_each_distinct_distribution_tree_once(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    first = _tag_release(repo, "1.61.0", "one")
+    second = _tag_release(repo, "1.61.0", "two")
+    _same_tree = _tag_release(repo, "1.62.0", "two", allow_empty=True)
+    releases = release_fleet.discover_distribution_releases(repo)
+    assert [release.tag for release in releases] == [
+        first,
+        second,
+    ]
+
+
+def test_rejects_distribution_tag_that_does_not_name_its_commit(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "actual", suffix="deadbee")
+    with pytest.raises(release_fleet.FleetError, match="does not match"):
+        release_fleet.discover_distribution_releases(repo)
+```
+
+- [ ] **Step 2: Run the discovery tests and verify they fail because `release_fleet` does not exist**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'scripts.release_fleet'`.
+
+- [ ] **Step 3: Implement only the immutable-release discovery surface**
+
+```python
+@dataclass(frozen=True)
+class DistributionRelease:
+    tag: str
+    version: str
+    commit: str
+    tree: str
+
+
+def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...]:
+    seen_trees: set[str] = set()
+    discovered: list[DistributionRelease] = []
+    for tag in _git_lines(repo, "tag", "--list", "dist/release/v*"):
+        match = RELEASE_TAG.fullmatch(tag)
+        if match is None:
+            continue
+        commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+        if not commit.startswith(match.group("short")):
+            raise FleetError(f"{tag}: tag suffix does not match its commit")
+        tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
+        if tree in seen_trees:
+            continue
+        seen_trees.add(tree)
+        discovered.append(DistributionRelease(tag, match.group("version"), commit, tree))
+    return tuple(sorted(discovered, key=lambda item: (_version_key(item.version), item.tag)))
+```
+
+`_git` must invoke Git with `check=True`, capture text output, and raise `FleetError` with the command’s stderr on failure. `_version_key` must return `tuple(int(part) for part in version.split("."))`.
+
+- [ ] **Step 4: Run the discovery tests and verify they pass**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: `2 passed`.
+
+- [ ] **Step 5: Commit the tested discovery contract**
+
+```bash
+git add scripts/release_fleet.py core/tests/test_release_fleet.py
+git commit -m "test: discover every distinct published Dex release tree"
+```
+
+### Task 2: Build clean, non-personal aged-vault fixtures
+
+**Files:**
+- Modify: `scripts/release_fleet.py`
+- Modify: `core/tests/test_release_fleet.py`
+
+- [ ] **Step 1: Write the failing fixture tests**
+
+```python
+def test_build_fixture_uses_the_requested_release_and_preserves_user_hashes(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    release = release_fleet.discover_distribution_releases(repo)[0]
+    case = release_fleet.build_fixture(repo, release, tmp_path / "fleet")
+    assert _git(case.vault, "rev-parse", "HEAD^") == release.commit
+    assert _git(case.vault, "remote", "get-url", "upstream") == release_fleet.PUBLIC_REMOTE
+    assert _git(case.vault, "remote", "get-url", "--push", "upstream") == "DISABLED"
+    assert case.user_hashes == release_fleet.hash_user_owned_files(case.vault)
+
+
+def test_build_fixture_refuses_a_nonempty_output_directory(tmp_path: Path) -> None:
+    output = tmp_path / "fleet"
+    output.mkdir()
+    release = _release()
+    case = output / release_fleet.safe_case_name(release)
+    case.mkdir()
+    (case / "keep-me").write_text("do not delete", encoding="utf-8")
+    with pytest.raises(release_fleet.FleetError, match="empty"):
+        release_fleet.build_fixture(tmp_path, release, output)
+```
+
+- [ ] **Step 2: Run the fixture tests and verify they fail because `build_fixture` does not exist**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: failure naming `build_fixture`.
+
+- [ ] **Step 3: Implement fresh fixture creation without copying founder data or deleting an existing directory**
+
+```python
+USER_FIXTURES = {
+    "00-Inbox/keep.md": b"# User note\\nThis must survive updates.\\n",
+    "03-Tasks/Tasks.md": b"# My task\\n- Keep this task exactly.\\n",
+    "System/user-profile.yaml": b"updates:\\n  channel: stable\\n",
+    ".claude/skills/my-weekly-review/SKILL.md": b"---\\nname: my-weekly-review\\n---\\n# User skill\\n",
+}
+
+
+def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> FleetCase:
+    output.mkdir(parents=True, exist_ok=True)
+    vault = output / safe_case_name(release)
+    if vault.exists():
+        raise FleetError(f"fleet case directory must be empty: {vault}")
+    _run(repo, "clone", "--no-checkout", "--no-local", str(repo), str(vault))
+    _run(vault, "checkout", "--detach", release.tag)
+    _run(vault, "remote", "rename", "origin", "upstream")
+    _run(vault, "remote", "set-url", "upstream", PUBLIC_REMOTE)
+    _run(vault, "remote", "set-url", "--push", "upstream", "DISABLED")
+    for relative, content in USER_FIXTURES.items():
+        path = vault / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    _run(vault, "config", "user.name", "Dex Fleet Fixture")
+    _run(vault, "config", "user.email", "fleet@example.invalid")
+    _run(vault, "add", "-A")
+    _run(vault, "commit", "-m", "test: simulated user content")
+    return FleetCase(release=release, vault=vault, user_hashes=hash_user_owned_files(vault))
+```
+
+`hash_user_owned_files` must hash only `USER_FIXTURES` paths using SHA-256 and must fail when any expected fixture path is missing, a directory, or a symlink.
+
+- [ ] **Step 4: Run the fixture tests and verify they pass**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: all release-fleet tests pass.
+
+- [ ] **Step 5: Commit the fixture builder**
+
+```bash
+git add scripts/release_fleet.py core/tests/test_release_fleet.py
+git commit -m "test: build disposable historic Dex update fixtures"
+```
+
+### Task 3: Define the two-release acceptance report and fail-closed checker
+
+**Files:**
+- Modify: `scripts/release_fleet.py`
+- Modify: `core/tests/test_release_fleet.py`
+- Create: `docs/release-fleet-acceptance.md`
+
+- [ ] **Step 1: Write the failing report tests**
+
+```python
+def test_acceptance_report_requires_both_release_hops_and_unchanged_user_hashes() -> None:
+    report = release_fleet.AcceptanceReport(
+        foundation_tag="dist/release/v1.80.0-aaaaaaa",
+        follow_up_tag="dist/release/v1.80.1-bbbbbbb",
+        cases=(
+            release_fleet.CaseResult("dist/release/v1.61.0-ccccccc", True, True, True),
+            release_fleet.CaseResult("dist/release/v1.62.0-ddddddd", True, False, True),
+        ),
+    )
+    with pytest.raises(release_fleet.FleetError, match="follow-up"):
+        release_fleet.assert_complete(report)
+```
+
+- [ ] **Step 2: Run the report test and verify it fails because the report classes do not exist**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: failure naming `AcceptanceReport` or `assert_complete`.
+
+- [ ] **Step 3: Implement the fail-closed report contract and CLI**
+
+```python
+def assert_complete(report: AcceptanceReport) -> None:
+    if not report.cases:
+        raise FleetError("acceptance report contains no historic releases")
+    failures = [
+        result.tag for result in report.cases
+        if not (result.reached_foundation and result.reached_follow_up and result.user_hashes_preserved)
+    ]
+    if failures:
+        raise FleetError("release fleet acceptance failed: " + ", ".join(failures))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    build = subcommands.add_parser("build")
+    build.add_argument("--repo", type=Path, required=True)
+    build.add_argument("--output", type=Path, required=True)
+    check = subcommands.add_parser("check-report")
+    check.add_argument("report", type=Path)
+    args = parser.parse_args(argv)
+    if args.command == "build":
+        cases = [build_fixture(args.repo, release, args.output) for release in discover_distribution_releases(args.repo)]
+        print(json.dumps({"case_count": len(cases), "cases": [case.to_dict() for case in cases]}, indent=2))
+        return 0
+    report = AcceptanceReport.from_json(args.report.read_text(encoding="utf-8"))
+    assert_complete(report)
+    print(f"PASS: {len(report.cases)} historic release trees reached both releases")
+    return 0
+```
+
+The JSON report must include the full starting tag, foundation tag, follow-up tag, exact installed identity after each hop, before/after user hash maps, Doctor verdict, timestamp, and the path to the user-visible journey transcript. Missing fields, unknown versions, or a changed user hash must make `check-report` fail.
+
+- [ ] **Step 4: Document the only acceptable live rehearsal**
+
+`docs/release-fleet-acceptance.md` must say:
+
+```markdown
+1. Build fixtures from the public `dist/release/v*` tags; never from `main`.
+2. Publish the foundation tag before starting the first hop.
+3. Run each fixture's own `/dex-update` journey. A refusal is a finding; do not repair around it.
+4. Run `/dex-doctor` and record the receipt and user-hash comparison.
+5. Publish a follow-up tag, then repeat `/dex-update` from the same fixture.
+6. Run `python3 scripts/release_fleet.py check-report REPORT.json`.
+7. Do not describe the update promise as proven unless this command passes for every distinct published release tree on every supported platform.
+```
+
+- [ ] **Step 5: Run the full release-fleet unit suite and verify it passes**
+
+Run: `.venv/bin/python -m pytest core/tests/test_release_fleet.py -q`
+
+Expected: all tests pass with no network access or mutation outside pytest’s temporary directory.
+
+- [ ] **Step 6: Commit the gate and its operating instructions**
+
+```bash
+git add scripts/release_fleet.py core/tests/test_release_fleet.py docs/release-fleet-acceptance.md
+git commit -m "feat: add all-version Dex update acceptance gate"
+```
+
+### Task 4: Rehearse the gate before any production release
+
+**Files:**
+- Modify: `core/tests/test_release_fleet.py` only if rehearsal exposes a contract gap
+- Create outside the repository: a temporary fleet directory created with `mktemp -d`
+
+- [ ] **Step 1: Install the isolated test dependencies**
+
+Run:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements-dev.txt
+npm ci
+```
+
+Expected: test interpreter and Node dependencies are available in this worktree only.
+
+- [ ] **Step 2: Run the focused unit suite and the existing delivery contracts**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest \
+  core/tests/test_release_fleet.py \
+  core/tests/test_apply_update.py \
+  core/tests/test_lifecycle_service_contract.py -q
+npm run test:hooks
+```
+
+Expected: all selected Python tests and hooks pass.
+
+- [ ] **Step 3: Discover the complete current historic matrix without building duplicate repositories**
+
+Run:
+
+```bash
+.venv/bin/python scripts/release_fleet.py manifest --repo . > /private/tmp/dex-release-fleet-manifest.json
+```
+
+Expected: the manifest reports 156 distinct starting trees; no path under `~/dex/artifacts/migration-fleet/` is changed. Build and exercise one starting tag at a time with `build --starting-tag TAG` so the final run never stores 156 full repositories concurrently.
+
+- [ ] **Step 4: Record the release blocker honestly**
+
+The current public tag is v1.79.0. There is no published foundation tag containing self-delivery and no subsequent public follow-up tag. Therefore no command can truthfully complete live two-hop acceptance yet. Record the prepared matrix count and unit verification, but do not call it release proof.
+
+- [ ] **Step 5: Commit only a regression exposed by the rehearsal, otherwise leave the completed implementation commit unchanged**
+
+```bash
+git status --short
+```
+
+Expected: clean tree after the committed implementation; temporary fleet is not tracked.
+
+## Plan self-review
+
+- Every distinct published distribution tree is discovered from immutable annotated tags (Task 1).
+- No fixture reads Dave’s vault or copies personal content; every user-owned byte is synthetic and hash-checked (Task 2).
+- The release report requires both historical-to-foundation and foundation-to-follow-up evidence, not merely a passing unit test (Task 3).
+- The final proof is intentionally blocked until two actual public tags exist; Task 4 distinguishes prepared infrastructure from release acceptance.
+- No step deletes an existing directory or uses a mutable working tree as a historic release fixture.

--- a/docs/superpowers/plans/2026-07-29-updater-bridge-fleet.md
+++ b/docs/superpowers/plans/2026-07-29-updater-bridge-fleet.md
@@ -160,7 +160,7 @@ def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> Fle
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
     _run(vault, "config", "user.name", "Dex Fleet Fixture")
-    _run(vault, "config", "user.email", "fleet@example.invalid")
+    _run(vault, "config", "user.email", "fleet@example.com")
     _run(vault, "add", "-A")
     _run(vault, "commit", "-m", "test: simulated user content")
     return FleetCase(release=release, vault=vault, user_hashes=hash_user_owned_files(vault))

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -187,7 +187,7 @@ def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> Fle
         path.write_bytes(content)
 
     _git(vault, "config", "user.name", "Dex Fleet Fixture")
-    _git(vault, "config", "user.email", "fleet@example.invalid")
+    _git(vault, "config", "user.email", "fleet@example.com")
     _git(vault, "add", "-f", "--", *USER_FIXTURES)
     _git(vault, "commit", "--quiet", "-m", "test: simulated user content")
     return FleetCase(release=release, vault=vault, user_hashes=hash_user_owned_files(vault))

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
+import json
 import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Mapping, Sequence
 
 RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
@@ -22,6 +25,20 @@ USER_FIXTURES = {
         b"---\n# User skill\n"
     ),
 }
+REPORT_KEYS = frozenset({"foundation_tag", "follow_up_tag", "cases"})
+CASE_RESULT_KEYS = frozenset(
+    {
+        "starting_tag",
+        "reached_foundation",
+        "reached_follow_up",
+        "foundation_doctor_healthy",
+        "follow_up_doctor_healthy",
+        "user_hashes_before",
+        "user_hashes_after_foundation",
+        "user_hashes_after_follow_up",
+        "transcript_path",
+    }
+)
 
 
 class FleetError(RuntimeError):
@@ -45,6 +62,30 @@ class FleetCase:
     release: DistributionRelease
     vault: Path
     user_hashes: dict[str, str]
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """Evidence from one historic installation's two-release journey."""
+
+    starting_tag: str
+    reached_foundation: bool
+    reached_follow_up: bool
+    foundation_doctor_healthy: bool
+    follow_up_doctor_healthy: bool
+    user_hashes_before: dict[str, str]
+    user_hashes_after_foundation: dict[str, str]
+    user_hashes_after_follow_up: dict[str, str]
+    transcript_path: str
+
+
+@dataclass(frozen=True)
+class AcceptanceReport:
+    """The complete evidence set required before claiming fleet acceptance."""
+
+    foundation_tag: str
+    follow_up_tag: str
+    cases: tuple[CaseResult, ...]
 
 
 def _git(repo: Path, *arguments: str) -> str:
@@ -142,3 +183,160 @@ def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> Fle
     _git(vault, "add", "-f", "--", *USER_FIXTURES)
     _git(vault, "commit", "--quiet", "-m", "test: simulated user content")
     return FleetCase(release=release, vault=vault, user_hashes=hash_user_owned_files(vault))
+
+
+def assert_complete(report: AcceptanceReport, expected_start_tags: set[str]) -> None:
+    """Refuse a release claim unless every historic package completed both hops."""
+
+    if not report.cases:
+        raise FleetError("acceptance report contains no historic releases")
+    actual_tags = {case.starting_tag for case in report.cases}
+    if len(actual_tags) != len(report.cases):
+        raise FleetError("acceptance report contains a duplicate historic release")
+    missing = sorted(expected_start_tags - actual_tags)
+    if missing:
+        raise FleetError("acceptance report is missing historic releases: " + ", ".join(missing))
+    unexpected = sorted(actual_tags - expected_start_tags)
+    if unexpected:
+        raise FleetError("acceptance report contains unknown historic releases: " + ", ".join(unexpected))
+
+    for case in report.cases:
+        if not case.reached_foundation:
+            raise FleetError(f"{case.starting_tag}: foundation release was not reached")
+        if not case.reached_follow_up:
+            raise FleetError(f"{case.starting_tag}: follow-up release was not reached")
+        if not case.foundation_doctor_healthy:
+            raise FleetError(f"{case.starting_tag}: Doctor was unhealthy after foundation release")
+        if not case.follow_up_doctor_healthy:
+            raise FleetError(f"{case.starting_tag}: Doctor was unhealthy after follow-up release")
+        if not case.user_hashes_before:
+            raise FleetError(f"{case.starting_tag}: user-content evidence is missing")
+        if case.user_hashes_before != case.user_hashes_after_foundation:
+            raise FleetError(f"{case.starting_tag}: user content changed during foundation release")
+        if case.user_hashes_before != case.user_hashes_after_follow_up:
+            raise FleetError(f"{case.starting_tag}: user content changed during follow-up release")
+        if not case.transcript_path:
+            raise FleetError(f"{case.starting_tag}: user-visible journey transcript is missing")
+
+
+def _required_string(value: Mapping[str, Any], key: str, context: str) -> str:
+    candidate = value.get(key)
+    if not isinstance(candidate, str) or not candidate:
+        raise FleetError(f"{context} has no valid {key}")
+    return candidate
+
+
+def _hash_map(value: object, context: str) -> dict[str, str]:
+    if not isinstance(value, Mapping) or not value:
+        raise FleetError(f"{context} must be a non-empty object")
+    hashes: dict[str, str] = {}
+    for relative, digest in value.items():
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or not isinstance(digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        ):
+            raise FleetError(f"{context} contains an invalid user-content hash")
+        hashes[relative] = digest
+    return hashes
+
+
+def acceptance_report_from_json(source: str) -> AcceptanceReport:
+    """Parse a strict, machine-readable two-release acceptance report."""
+
+    try:
+        raw = json.loads(source)
+    except json.JSONDecodeError as error:
+        raise FleetError("acceptance report is not valid JSON") from error
+    if not isinstance(raw, Mapping) or set(raw) != REPORT_KEYS:
+        raise FleetError("acceptance report has an invalid top-level shape")
+    foundation_tag = _required_string(raw, "foundation_tag", "acceptance report")
+    follow_up_tag = _required_string(raw, "follow_up_tag", "acceptance report")
+    cases_raw = raw.get("cases")
+    if not isinstance(cases_raw, list):
+        raise FleetError("acceptance report cases must be a list")
+
+    cases: list[CaseResult] = []
+    for index, case_raw in enumerate(cases_raw, start=1):
+        context = f"acceptance case {index}"
+        if not isinstance(case_raw, Mapping) or set(case_raw) != CASE_RESULT_KEYS:
+            raise FleetError(f"{context} has an invalid shape")
+        boolean_keys = (
+            "reached_foundation",
+            "reached_follow_up",
+            "foundation_doctor_healthy",
+            "follow_up_doctor_healthy",
+        )
+        if any(not isinstance(case_raw[key], bool) for key in boolean_keys):
+            raise FleetError(f"{context} has an invalid boolean verdict")
+        cases.append(
+            CaseResult(
+                starting_tag=_required_string(case_raw, "starting_tag", context),
+                reached_foundation=bool(case_raw["reached_foundation"]),
+                reached_follow_up=bool(case_raw["reached_follow_up"]),
+                foundation_doctor_healthy=bool(case_raw["foundation_doctor_healthy"]),
+                follow_up_doctor_healthy=bool(case_raw["follow_up_doctor_healthy"]),
+                user_hashes_before=_hash_map(case_raw["user_hashes_before"], context),
+                user_hashes_after_foundation=_hash_map(
+                    case_raw["user_hashes_after_foundation"], context
+                ),
+                user_hashes_after_follow_up=_hash_map(
+                    case_raw["user_hashes_after_follow_up"], context
+                ),
+                transcript_path=_required_string(case_raw, "transcript_path", context),
+            )
+        )
+    return AcceptanceReport(foundation_tag, follow_up_tag, tuple(cases))
+
+
+def _case_manifest(case: FleetCase) -> dict[str, object]:
+    return {
+        "starting": {
+            "tag": case.release.tag,
+            "version": case.release.version,
+            "commit": case.release.commit,
+            "tree": case.release.tree,
+        },
+        "vault": str(case.vault),
+        "user_hashes": case.user_hashes,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build the historic fleet or validate a completed two-release report."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    build = subcommands.add_parser("build", help="build clean historic-release fixtures")
+    build.add_argument("--repo", type=Path, required=True)
+    build.add_argument("--output", type=Path, required=True)
+    check = subcommands.add_parser("check-report", help="fail closed on incomplete fleet evidence")
+    check.add_argument("--repo", type=Path, required=True)
+    check.add_argument("report", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.command == "build":
+        releases = discover_distribution_releases(args.repo)
+        cases = [build_fixture(args.repo, release, args.output) for release in releases]
+        print(
+            json.dumps(
+                {"case_count": len(cases), "cases": [_case_manifest(case) for case in cases]},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    report = acceptance_report_from_json(args.report.read_text(encoding="utf-8"))
+    expected_start_tags = {release.tag for release in discover_distribution_releases(args.repo)}
+    assert_complete(report, expected_start_tags)
+    print(f"PASS: {len(report.cases)} historic release trees reached both releases")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FleetError as error:
+        raise SystemExit(f"FAIL: {error}") from error

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Discover immutable historic Dex release trees for fleet acceptance."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+RELEASE_TAG = re.compile(
+    r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
+)
+
+
+class FleetError(RuntimeError):
+    """The historic release fleet could not be built safely."""
+
+
+@dataclass(frozen=True)
+class DistributionRelease:
+    """One immutable published release tree that a user may be running."""
+
+    tag: str
+    version: str
+    commit: str
+    tree: str
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *arguments],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        message = result.stderr.strip() or result.stdout.strip() or "Git command failed"
+        raise FleetError(message)
+    return result.stdout.strip()
+
+
+def _git_lines(repo: Path, *arguments: str) -> tuple[str, ...]:
+    output = _git(repo, *arguments)
+    return tuple(line for line in output.splitlines() if line)
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    parts = tuple(int(part) for part in version.split("."))
+    if len(parts) != 3:
+        raise FleetError(f"distribution tag has an invalid semantic version: {version}")
+    return parts  # type: ignore[return-value]
+
+
+def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...]:
+    """Return every distinct immutable tree behind the public distribution tags."""
+
+    seen_trees: set[str] = set()
+    discovered: list[DistributionRelease] = []
+    for tag in _git_lines(repo, "tag", "--list", "dist/release/v*"):
+        match = RELEASE_TAG.fullmatch(tag)
+        if match is None:
+            continue
+        commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+        if not commit.startswith(match.group("short")):
+            raise FleetError(f"{tag}: tag suffix does not match its commit")
+        tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
+        if tree in seen_trees:
+            continue
+        seen_trees.add(tree)
+        discovered.append(
+            DistributionRelease(
+                tag=tag,
+                version=match.group("version"),
+                commit=commit,
+                tree=tree,
+            )
+        )
+    return tuple(sorted(discovered, key=lambda item: (_version_key(item.version), item.tag)))

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 import subprocess
 from dataclasses import dataclass
@@ -11,6 +12,16 @@ from pathlib import Path
 RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
+PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
+USER_FIXTURES = {
+    "00-Inbox/keep.md": b"# User note\nThis must survive updates.\n",
+    "03-Tasks/Tasks.md": b"# My task\n- Keep this task exactly.\n",
+    "System/user-profile.yaml": b"updates:\n  channel: stable\n",
+    ".claude/skills/my-weekly-review/SKILL.md": (
+        b"---\nname: my-weekly-review\ndescription: User-authored weekly review.\n"
+        b"---\n# User skill\n"
+    ),
+}
 
 
 class FleetError(RuntimeError):
@@ -25,6 +36,15 @@ class DistributionRelease:
     version: str
     commit: str
     tree: str
+
+
+@dataclass(frozen=True)
+class FleetCase:
+    """A fresh historic install plus the user content that must survive it."""
+
+    release: DistributionRelease
+    vault: Path
+    user_hashes: dict[str, str]
 
 
 def _git(repo: Path, *arguments: str) -> str:
@@ -76,3 +96,49 @@ def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...
             )
         )
     return tuple(sorted(discovered, key=lambda item: (_version_key(item.version), item.tag)))
+
+
+def safe_case_name(release: DistributionRelease) -> str:
+    """Return a filesystem-safe, immutable name for one historic release case."""
+
+    return f"v{release.version}-{release.commit[:12]}"
+
+
+def hash_user_owned_files(vault: Path) -> dict[str, str]:
+    """Hash the fixture files whose bytes an update may never change."""
+
+    hashes: dict[str, str] = {}
+    for relative in USER_FIXTURES:
+        path = vault / relative
+        if path.is_symlink() or not path.is_file():
+            raise FleetError(f"user fixture is not a regular file: {relative}")
+        hashes[relative] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> FleetCase:
+    """Create a disposable old install without overwriting any existing case."""
+
+    if output.exists() and not output.is_dir():
+        raise FleetError(f"fleet output is not a directory: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    vault = output / safe_case_name(release)
+    if vault.exists():
+        raise FleetError(f"fleet case directory must be empty: {vault}")
+
+    _git(repo, "clone", "--quiet", "--no-checkout", "--no-local", str(repo), str(vault))
+    _git(vault, "checkout", "--quiet", "--detach", release.tag)
+    _git(vault, "remote", "rename", "origin", "upstream")
+    _git(vault, "remote", "set-url", "upstream", PUBLIC_REMOTE)
+    _git(vault, "remote", "set-url", "--push", "upstream", "DISABLED")
+
+    for relative, content in USER_FIXTURES.items():
+        path = vault / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+    _git(vault, "config", "user.name", "Dex Fleet Fixture")
+    _git(vault, "config", "user.email", "fleet@example.invalid")
+    _git(vault, "add", "-f", "--", *USER_FIXTURES)
+    _git(vault, "commit", "--quiet", "-m", "test: simulated user content")
+    return FleetCase(release=release, vault=vault, user_hashes=hash_user_owned_files(vault))

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -15,6 +15,7 @@ from typing import Any, Mapping, Sequence
 RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
+LEGACY_RELEASE_TAG = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
 USER_FIXTURES = {
     "00-Inbox/keep.md": b"# User note\nThis must survive updates.\n",
@@ -113,16 +114,23 @@ def _version_key(version: str) -> tuple[int, int, int]:
 
 
 def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...]:
-    """Return every distinct immutable tree behind the public distribution tags."""
+    """Return every distinct tree behind public distribution and legacy release tags."""
 
     seen_trees: set[str] = set()
     discovered: list[DistributionRelease] = []
-    for tag in _git_lines(repo, "tag", "--list", "dist/release/v*"):
-        match = RELEASE_TAG.fullmatch(tag)
-        if match is None:
+    candidates: list[tuple[int, str, re.Match[str]]] = []
+    for tag in _git_lines(repo, "tag", "--list"):
+        distribution_match = RELEASE_TAG.fullmatch(tag)
+        if distribution_match is not None:
+            candidates.append((0, tag, distribution_match))
             continue
+        legacy_match = LEGACY_RELEASE_TAG.fullmatch(tag)
+        if legacy_match is not None:
+            candidates.append((1, tag, legacy_match))
+
+    for priority, tag, match in sorted(candidates, key=lambda item: (item[0], item[1])):
         commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
-        if not commit.startswith(match.group("short")):
+        if priority == 0 and not commit.startswith(match.group("short")):
             raise FleetError(f"{tag}: tag suffix does not match its commit")
         tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
         if tree in seen_trees:
@@ -292,14 +300,18 @@ def acceptance_report_from_json(source: str) -> AcceptanceReport:
 
 def _case_manifest(case: FleetCase) -> dict[str, object]:
     return {
-        "starting": {
-            "tag": case.release.tag,
-            "version": case.release.version,
-            "commit": case.release.commit,
-            "tree": case.release.tree,
-        },
+        "starting": _release_manifest(case.release),
         "vault": str(case.vault),
         "user_hashes": case.user_hashes,
+    }
+
+
+def _release_manifest(release: DistributionRelease) -> dict[str, str]:
+    return {
+        "tag": release.tag,
+        "version": release.version,
+        "commit": release.commit,
+        "tree": release.tree,
     }
 
 
@@ -308,16 +320,34 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description=__doc__)
     subcommands = parser.add_subparsers(dest="command", required=True)
+    manifest = subcommands.add_parser("manifest", help="list historic releases without cloning them")
+    manifest.add_argument("--repo", type=Path, required=True)
     build = subcommands.add_parser("build", help="build clean historic-release fixtures")
     build.add_argument("--repo", type=Path, required=True)
     build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--starting-tag", help="build only this immutable historic release tag")
     check = subcommands.add_parser("check-report", help="fail closed on incomplete fleet evidence")
     check.add_argument("--repo", type=Path, required=True)
     check.add_argument("report", type=Path)
     args = parser.parse_args(argv)
 
+    if args.command == "manifest":
+        releases = discover_distribution_releases(args.repo)
+        print(
+            json.dumps(
+                {"case_count": len(releases), "cases": [_release_manifest(release) for release in releases]},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
     if args.command == "build":
         releases = discover_distribution_releases(args.repo)
+        if args.starting_tag:
+            releases = tuple(release for release in releases if release.tag == args.starting_tag)
+            if not releases:
+                raise FleetError(f"historic distribution tag was not found: {args.starting_tag}")
         cases = [build_fixture(args.repo, release, args.output) for release in releases]
         print(
             json.dumps(


### PR DESCRIPTION
## What this adds
- Discovers every distinct public Dex release tree, including legacy releases before distribution tags.
- Builds disposable, non-personal historic vault fixtures with disabled push remotes and protected user-content hashes.
- Requires a two-hop acceptance report: historic to foundation, then foundation to follow-up, with healthy Doctor results and unchanged user bytes.
- Documents the release gate and its honest claim boundary.

## Evidence
- 156 real historic fixtures built and structurally verified locally.
- 41 focused Python tests and 171 hook tests passed.

## Deliberate boundary
This prepares the real acceptance run. It does not claim the old-user update journey has passed; that requires two actual published release tags.