### PR TITLE
Fix missing Dex MCP registration during update

### DIFF
--- a/.claude/hooks/tests/data-safety-instructions.test.cjs
+++ b/.claude/hooks/tests/data-safety-instructions.test.cjs
@@ -66,6 +66,8 @@ const UPDATE_SERVICE_OPERATIONS = new Set([
   'deliver_latest_release',
   'build_and_preview_delivered_release',
   'execute_approved_delivered_release',
+  'build_and_preview_mcp_registration',
+  'execute_approved_mcp_registration',
   // Capsule journey (Lane H): read-only customization-migration operations and the
   // authority fields the skill must reproduce verbatim. The CLI create/abandon writes
   // are human-confirmed and capsule-scoped; they never touch vault user files.
@@ -241,6 +243,7 @@ test('update mutation follows the immutable preview, approval, execute service r
   assert.match(UPDATE_SKILL, /ask `deliver_latest_release`\s+through `core\.lifecycle\.service`/);
   assert.match(UPDATE_SKILL, /ask\s+`build_and_preview_delivered_release` through `core\.lifecycle\.service`/);
   assert.match(UPDATE_SKILL, /`execute_approved_delivered_release` with the same preview and approval token/);
+  assert.match(UPDATE_SKILL, /Only after a fresh explicit yes, pass the unchanged preview and approval token to `execute_approved_mcp_registration`/);
   assert.match(UPDATE_SKILL, /The lifecycle service owns every mutation\./);
 
   assertInOrder(UPDATE_SKILL, [

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -59,6 +59,20 @@ After success, show the topology receipt, including its transaction identifier, 
 
 If the dry-run fails, the report changes before approval, approval is missing, conversion stops, or the final split cannot be proved, show the service refusal and stop. Do not improvise a repair.
 
+## One-time local connection refresh
+
+After the topology branch (or at the start of a split-vault update), ask
+`build_and_preview_mcp_registration`. This checks whether Dex's own
+Customization Migration connection is missing from an older local setup.
+
+- If `needed` is `false`, say that Dex's local connections are already current and continue.
+- If `needed` is `true`, show the returned server name and the complete write preview. Explain: “Dex will add this one Dex-owned local connection. It will not replace, remove, or alter any of your existing connections or their settings.” Ask: “Add this exact Dex connection?”
+- Only after a fresh explicit yes, pass the unchanged preview and approval token to `execute_approved_mcp_registration`. Render its transaction receipt, including the saved recovery snapshot.
+
+This is the only update route allowed to add this missing Dex-owned registration.
+Never edit `.mcp.json` directly, replace an existing server entry, or treat the
+earlier update approval as approval for this connection change.
+
 ## Deeply customised setup
 
 Before applying an update, use the deep Doctor report to decide whether to offer this branch.

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -47,6 +47,14 @@
       "request": {"$ref": "#/$defs/deliveredReleaseExecuteRequest"},
       "response": {"$ref": "#/$defs/deliveredReleaseExecuteResponse"}
     },
+    "build_and_preview_mcp_registration": {
+      "request": {"$ref": "#/$defs/vaultRequest"},
+      "response": {"$ref": "#/$defs/mcpRegistrationPreviewResponse"}
+    },
+    "execute_approved_mcp_registration": {
+      "request": {"$ref": "#/$defs/mcpRegistrationExecuteRequest"},
+      "response": {"$ref": "#/$defs/mcpRegistrationExecuteResponse"}
+    },
     "build_and_preview_conflict_resolution": {
       "request": {"$ref": "#/$defs/resolutionsRequest"},
       "response": {"$ref": "#/$defs/conflictPreviewResponse"}
@@ -231,6 +239,69 @@
           }
         }
       ]
+    },
+    "mcpRegistrationPreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registration", "writes"],
+      "properties": {
+        "registration": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["config_path", "server_name", "action"],
+          "properties": {
+            "config_path": {"const": ".mcp.json"},
+            "server_name": {"const": "customization-migration-mcp"},
+            "action": {"const": "add-only"}
+          }
+        },
+        "writes": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+      }
+    },
+    "mcpRegistrationPreviewResponse": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "needed", "preview", "approval_token"],
+          "properties": {
+            "api_version": {"const": "1.4.0"},
+            "needed": {"const": true},
+            "preview": {"$ref": "#/$defs/mcpRegistrationPreview"},
+            "approval_token": {"$ref": "#/$defs/sha256"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "needed", "preview", "approval_token"],
+          "properties": {
+            "api_version": {"const": "1.4.0"},
+            "needed": {"const": false},
+            "preview": {"type": "null"},
+            "approval_token": {"type": "null"}
+          }
+        }
+      ]
+    },
+    "mcpRegistrationExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/mcpRegistrationPreview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "mcpRegistrationExecuteResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.4.0"},
+        "receipt": {"type": "object"}
+      }
     },
     "previewRequest": {
       "type": "object",

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -53,6 +53,9 @@ _CATALOG_RELATIVE = "System/.release-catalog.json"
 _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _ARCHIVE_RELATIVE = ".dex/pre-split-archive.git"
 _ARCHIVE_RECEIPTS_RELATIVE = "System/.dex/archive-removals"
+_MCP_CONFIG_RELATIVE = ".mcp.json"
+_MCP_TEMPLATE_RELATIVE = "System/.mcp.json.example"
+_MCP_REGISTRATION_NAME = "customization-migration-mcp"
 _REBUILD_TRANSACTION_PATH = re.compile(
     r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
     r"receipts/(?:capsule|activation|rewind)\.json|"
@@ -699,6 +702,118 @@ def execute_approved_delivered_release(
     return _envelope(receipt=executed["receipt"], release=expected_preview["release"])
 
 
+def _mcp_registration_preview(
+    vault_root: str | Path,
+) -> tuple[dict[str, object] | None, list[PlanEntry]]:
+    """Build the one explicitly approved, add-only MCP registration write."""
+    root = Path(vault_root).resolve()
+    target = root / _MCP_CONFIG_RELATIVE
+    template = root / _MCP_TEMPLATE_RELATIVE
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise PlanRejected(".mcp.json must be a regular file")
+    if template.is_symlink() or not template.is_file():
+        raise PlanRejected("System/.mcp.json.example must be a regular file")
+    try:
+        existing = json.loads(target.read_text(encoding="utf-8")) if target.exists() else {}
+        generated = json.loads(template.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise PlanRejected("MCP configuration must contain valid JSON") from error
+    if not isinstance(existing, dict) or not isinstance(generated, dict):
+        raise PlanRejected("MCP configuration must contain a JSON object")
+    servers = existing.get("mcpServers")
+    generated_servers = generated.get("mcpServers")
+    if servers is None:
+        servers = {}
+    if not isinstance(servers, dict) or not isinstance(generated_servers, dict):
+        raise PlanRejected("MCP configuration must contain an mcpServers object")
+    registration = generated_servers.get(_MCP_REGISTRATION_NAME)
+    if not isinstance(registration, dict):
+        raise PlanRejected("the shipped MCP registration is missing or malformed")
+    if _MCP_REGISTRATION_NAME in servers:
+        return None, []
+
+    rendered = json.loads(json.dumps(registration).replace("{{VAULT_PATH}}", str(root)))
+    if os.name == "nt":
+        rendered = json.loads(
+            json.dumps(rendered).replace(".venv/bin/python", ".venv/Scripts/python.exe")
+        )
+    updated = dict(existing)
+    updated_servers = dict(servers)
+    updated_servers[_MCP_REGISTRATION_NAME] = rendered
+    updated["mcpServers"] = updated_servers
+    content = (json.dumps(updated, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    current = target.read_bytes() if target.exists() else None
+    plan = [
+        PlanEntry(
+            _MCP_CONFIG_RELATIVE,
+            content,
+            mode=(target.stat().st_mode & 0o777) if target.exists() else 0o600,
+            expected_current_sha256=(hashlib.sha256(current).hexdigest() if current else None),
+            expected_absent=not target.exists(),
+        )
+    ]
+    transaction = _transaction_preview_document(
+        root,
+        plan,
+        purpose="mcp-registration",
+        operation="mcp-registration",
+    )
+    preview = {
+        "registration": {
+            "config_path": _MCP_CONFIG_RELATIVE,
+            "server_name": _MCP_REGISTRATION_NAME,
+            "action": "add-only",
+        },
+        "writes": transaction["writes"],
+    }
+    return preview, plan
+
+
+def build_and_preview_mcp_registration(vault_root: str | Path) -> dict[str, object]:
+    """Show the exact missing Dex MCP registration before any configuration write."""
+    preview, _plan = _mcp_registration_preview(vault_root)
+    if preview is None:
+        return _envelope(needed=False, preview=None, approval_token=None)
+    return _envelope(
+        needed=True,
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def execute_approved_mcp_registration(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Add only the exact previewed Dex registration through one transaction."""
+    try:
+        expected_preview, plan = _mcp_registration_preview(vault_root)
+        supplied = _canonical(dict(preview))
+    except (TypeError, ValueError) as error:
+        raise PlanRejected("MCP registration preview is not canonical JSON") from error
+    if expected_preview is None:
+        raise PlanRejected("the customization migration MCP registration is already present")
+    expected = _canonical(expected_preview)
+    token = hashlib.sha256(expected).hexdigest()
+    if not isinstance(approved_token, str) or not hmac.compare_digest(supplied, expected) or not hmac.compare_digest(approved_token, token):
+        raise PlanRejected("MCP registration approval does not match the current exact preview")
+    transaction = _preview_transaction(
+        vault_root,
+        plan,
+        purpose="mcp-registration",
+        operation="mcp-registration",
+    )
+    executed = _execute_approved_transaction(
+        vault_root,
+        plan,
+        purpose="mcp-registration",
+        operation="mcp-registration",
+        approved_token=str(transaction["approval_token"]),
+    )
+    return _envelope(receipt=executed["receipt"])
+
+
 def deliver_and_apply_latest_release(vault_root: str | Path) -> dict[str, object]:
     """Safe v1.3 bridge: never apply a release that was not previewed."""
     del vault_root
@@ -973,6 +1088,8 @@ __all__ = [
     "deliver_latest_release",
     "build_and_preview_delivered_release",
     "execute_approved_delivered_release",
+    "build_and_preview_mcp_registration",
+    "execute_approved_mcp_registration",
     "deliver_and_apply_latest_release",
     "build_and_preview_conflict_resolution",
     "execute_approved_conflict_resolution",

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -311,8 +311,8 @@ RULES: tuple[Rule, ...] = (
     _r("vault-env", ".env", "file", "vault", "raw secret authority (SR1 #150 model)"),
     _r("vault-credentials", "System/credentials", "dir", "vault", "secrets; hard-denied"),
     _r("vault-mcp-json", ".mcp.json", "file", "vault",
-       "REPORT-ONLY: SR1 #150's structural residual detector owns it; no engine "
-       "may rewrite it"),
+       "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
+       "mcp-registration lifecycle transaction"),
     _r("vault-claude-custom", "CLAUDE-custom.md", "file", "vault",
        "the one canonical home for user instructions (Vault_Contract §5)"),
     _r("vault-skills-custom", ".claude/skills-custom", "dir", "vault"),
@@ -413,7 +413,12 @@ def update_write_verdict(
     remapped paths back to their semantic defaults before calling, or treat
     them as unclassified. Unclassified paths fail safe: never written.
     """
-    if operation not in ("update", "customization-migration", "capability-state"):
+    if operation not in (
+        "update",
+        "customization-migration",
+        "capability-state",
+        "mcp-registration",
+    ):
         raise ValueError(f"unknown write operation: {operation}")
 
     if operation == "capability-state":
@@ -454,6 +459,37 @@ def update_write_verdict(
             "outside-capability-state",
             resolution.ownership if resolution is not None else None,
             resolution.rule_id if resolution is not None else None,
+        )
+
+    if operation == "mcp-registration":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+            resolution = resolve(candidate)
+        except ContractViolation:
+            return WriteVerdict(str(path), False, "outside-mcp-registration", None, None)
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership,
+                resolution.rule_id,
+            )
+        if candidate == ".mcp.json":
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-explicitly-approved-registration",
+                resolution.ownership,
+                resolution.rule_id,
+            )
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-mcp-registration",
+            resolution.ownership,
+            resolution.rule_id,
         )
 
     if operation == "customization-migration":

--- a/core/tests/test_instructed_tools_gate.py
+++ b/core/tests/test_instructed_tools_gate.py
@@ -73,6 +73,22 @@ def plain_helper() -> None:
     }
 
 
+def test_public_lifecycle_operation_extraction_uses_the_explicit_public_surface() -> None:
+    checker = _load_checker()
+    source = '''
+__all__ = [
+    "build_and_preview_mcp_registration",
+    "execute_approved_mcp_registration",
+    "not an operation",
+]
+'''
+
+    assert checker.extract_public_lifecycle_operations(source) == {
+        "build_and_preview_mcp_registration",
+        "execute_approved_mcp_registration",
+    }
+
+
 def test_unknown_call_reference_is_detected() -> None:
     findings = _find_unknown("First line.\nCall `missing_tool()` now.\n")
 

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -118,13 +118,15 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         inventory_response,
     )
 
+    mcp_vault = tmp_path / "mcp-vault"
+    (mcp_vault / "System").mkdir(parents=True)
     shutil.copy2(
         REPO_ROOT / "System/.mcp.json.example",
-        vault / "System/.mcp.json.example",
+        mcp_vault / "System/.mcp.json.example",
     )
-    (vault / ".mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
-    mcp_preview_request = {"vault_root": str(vault)}
-    mcp_preview_response = service.build_and_preview_mcp_registration(vault)
+    (mcp_vault / ".mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    mcp_preview_request = {"vault_root": str(mcp_vault)}
+    mcp_preview_response = service.build_and_preview_mcp_registration(mcp_vault)
     _assert_conforms(
         schema,
         "build_and_preview_mcp_registration",
@@ -132,12 +134,12 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         mcp_preview_response,
     )
     mcp_execute_request = {
-        "vault_root": str(vault),
+        "vault_root": str(mcp_vault),
         "preview": mcp_preview_response["preview"],
         "approved_token": mcp_preview_response["approval_token"],
     }
     mcp_execute_response = service.execute_approved_mcp_registration(
-        vault,
+        mcp_vault,
         mcp_preview_response["preview"],
         mcp_preview_response["approval_token"],
     )

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -22,6 +22,7 @@ SCHEMA_PATH = (
     / "contracts"
     / "api.schema.json"
 )
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _json_type(value: object, expected: str) -> bool:
@@ -115,6 +116,36 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         "build_inventory_and_plan",
         inventory_request,
         inventory_response,
+    )
+
+    shutil.copy2(
+        REPO_ROOT / "System/.mcp.json.example",
+        vault / "System/.mcp.json.example",
+    )
+    (vault / ".mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    mcp_preview_request = {"vault_root": str(vault)}
+    mcp_preview_response = service.build_and_preview_mcp_registration(vault)
+    _assert_conforms(
+        schema,
+        "build_and_preview_mcp_registration",
+        mcp_preview_request,
+        mcp_preview_response,
+    )
+    mcp_execute_request = {
+        "vault_root": str(vault),
+        "preview": mcp_preview_response["preview"],
+        "approved_token": mcp_preview_response["approval_token"],
+    }
+    mcp_execute_response = service.execute_approved_mcp_registration(
+        vault,
+        mcp_preview_response["preview"],
+        mcp_preview_response["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_mcp_registration",
+        mcp_execute_request,
+        mcp_execute_response,
     )
 
     preview_request = {
@@ -254,6 +285,8 @@ def test_public_surface_requires_a_version_bump_and_bridge_to_change() -> None:
         "deliver_latest_release",
         "build_and_preview_delivered_release",
         "execute_approved_delivered_release",
+        "build_and_preview_mcp_registration",
+        "execute_approved_mcp_registration",
         "deliver_and_apply_latest_release",
         "build_and_preview_conflict_resolution",
         "execute_approved_conflict_resolution",

--- a/core/tests/test_mcp_registration_lifecycle.py
+++ b/core/tests/test_mcp_registration_lifecycle.py
@@ -1,0 +1,100 @@
+"""Receipt-backed repair of one missing Dex-owned MCP registration."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle import service
+from core.transaction.engine import PlanRejected
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_NAME = "customization-migration-mcp"
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "System/.mcp.json.example", vault / "System/.mcp.json.example")
+    (vault / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "user-owned": {
+                        "command": "user-mcp",
+                        "args": ["--keep-this-exactly"],
+                        "env": {"USER_TOKEN": "synthetic-user-secret"},
+                    }
+                },
+                "unrelated_user_setting": {"preserve": True},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def test_mcp_registration_is_previewed_and_adds_only_the_missing_dex_entry(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    before = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+
+    previewed = service.build_and_preview_mcp_registration(vault)
+    executed = service.execute_approved_mcp_registration(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    after = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+    assert previewed["preview"]["registration"]["server_name"] == SERVER_NAME
+    assert after["mcpServers"]["user-owned"] == before["mcpServers"]["user-owned"]
+    assert after["unrelated_user_setting"] == before["unrelated_user_setting"]
+    assert SERVER_NAME in after["mcpServers"]
+    assert executed["receipt"]["purpose"] == "mcp-registration"
+
+    already_current = service.build_and_preview_mcp_registration(vault)
+    assert already_current == {
+        "api_version": service.api_version,
+        "needed": False,
+        "preview": None,
+        "approval_token": None,
+    }
+
+
+def test_mcp_registration_contract_allows_only_the_explicit_user_approved_file() -> None:
+    assert portable_contract.update_write_verdict(
+        ".mcp.json", exists=True, operation="mcp-registration"
+    ).allowed
+    assert not portable_contract.update_write_verdict(
+        "System/user-profile.yaml", exists=True, operation="mcp-registration"
+    ).allowed
+
+
+def test_mcp_registration_refuses_if_user_configuration_changes_after_preview(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    previewed = service.build_and_preview_mcp_registration(vault)
+    config = vault / ".mcp.json"
+    changed = json.loads(config.read_text(encoding="utf-8"))
+    changed["unrelated_user_setting"]["changed_after_preview"] = True
+    config.write_text(json.dumps(changed, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(PlanRejected, match="approval does not match"):
+        service.execute_approved_mcp_registration(
+            vault,
+            previewed["preview"],
+            previewed["approval_token"],
+        )
+
+    after = json.loads(config.read_text(encoding="utf-8"))
+    assert SERVER_NAME not in after["mcpServers"]
+    assert after["unrelated_user_setting"]["changed_after_preview"] is True

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -122,7 +122,7 @@
       "path": ".mcp.json",
       "kind": "file",
       "ownership": "vault",
-      "note": "REPORT-ONLY: SR1 #150's structural residual detector owns it; no engine may rewrite it"
+      "note": "REPORT-ONLY except the explicitly previewed, user-approved, add-only mcp-registration lifecycle transaction"
     },
     {
       "id": "brain-obsidian",

--- a/scripts/check-instructed-tools.py
+++ b/scripts/check-instructed-tools.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import difflib
 import re
 import sys
@@ -40,6 +41,27 @@ def extract_defined_tool_names(source: str) -> set[str]:
     return set(TOOL_DECLARATION.findall(source)) | set(
         FASTMCP_TOOL_DECLARATION.findall(source)
     )
+
+
+def extract_public_lifecycle_operations(source: str) -> set[str]:
+    """Return the statically declared public lifecycle-service operations."""
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple)):
+            return set()
+        return {
+            item.value
+            for item in node.value.elts
+            if isinstance(item, ast.Constant)
+            and isinstance(item.value, str)
+            and re.fullmatch(TOOL_NAME_PATTERN, item.value) is not None
+        }
+    return set()
 
 
 def parse_allowlist(source: str) -> set[str]:
@@ -115,10 +137,14 @@ def is_instruction_surface(path: Path, repo_root: Path = REPO_ROOT) -> bool:
 
 
 def collect_defined_tools(repo_root: Path = REPO_ROOT) -> set[str]:
-    """Collect every statically declared top-level MCP tool."""
+    """Collect statically declared MCP tools and public lifecycle operations."""
     defined_tools: set[str] = set()
     for path in sorted((repo_root / "core" / "mcp").glob("*.py")):
         defined_tools.update(extract_defined_tool_names(path.read_text(encoding="utf-8")))
+    lifecycle_service = repo_root / "core" / "lifecycle" / "service.py"
+    defined_tools.update(
+        extract_public_lifecycle_operations(lifecycle_service.read_text(encoding="utf-8"))
+    )
     return defined_tools
 
 


### PR DESCRIPTION
Why: Older installed Dex releases can safely reach the current package but may retain an older MCP config without the Dex Customization Migration registration. Doctor then reports that one missing Dex-owned connection.

What: Adds a lifecycle-owned, previewed, explicitly approved add-only registration repair. It preserves existing MCP servers and unrelated settings, refuses if configuration changes after preview, and records a transaction recovery snapshot. Dex update offers this separate one-time connection refresh after delivery.

Verification: test scripts 163 passing; hook safety 171 passing; connection contract check; lifecycle, MCP, and migration Python suite; focused bridge tests and Ruff; real v1.20.1 installed fixture reaches Doctor with 0 broken checks after this registration.

No production release is cut by this PR.