### PR TITLE
Preserve user profile bytes during Dex migration

### DIFF
--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -1712,13 +1712,6 @@ function phase5Swap(root, state) {
   writeTopologySentinel(root, state.preflight.releaseCommit);
 }
 
-function stampVaultSchema(source) {
-  if (/^vault_schema:\s*/m.test(source)) {
-    return source.replace(/^vault_schema:\s*.*$/m, 'vault_schema: 1');
-  }
-  return `${source.replace(/\s*$/, '')}\n\nvault_schema: 1\n`;
-}
-
 function mergedCustomInstructions(existingCustom, inlineExtensions) {
   if (existingCustom === inlineExtensions) {
     return { content: existingCustom, appended: false };
@@ -1775,10 +1768,6 @@ function phase6Rematerialize(root, state = {}) {
     throw new Error('Stopped safely inside P6 after preserving the lifted instructions. Run --resume to continue.');
   }
 
-  const profilePath = path.join(root, 'System', 'user-profile.yaml');
-  if (exists(profilePath)) {
-    writeMigrationFile(root, profilePath, stampVaultSchema(fs.readFileSync(profilePath, 'utf8')), 0o644);
-  }
 }
 
 function phase7ReportOnly(state) {

--- a/core/tests/brain-vault-migrator-integration.test.cjs
+++ b/core/tests/brain-vault-migrator-integration.test.cjs
@@ -359,7 +359,11 @@ test('real migration preserves user bytes and creates two isolated histories', (
   assert.equal(fs.readFileSync(path.join(vault, 'CLAUDE-custom.md'), 'utf8'), expectedExtensions);
   assert.match(fs.readFileSync(path.join(vault, 'CLAUDE.md'), 'utf8'), /fixture sentinel: café/);
   assert.doesNotMatch(fs.readFileSync(path.join(vault, 'CLAUDE.md'), 'utf8'), /USER_EXTENSIONS_/);
-  assert.match(fs.readFileSync(path.join(vault, 'System', 'user-profile.yaml'), 'utf8'), /^vault_schema: 1$/m);
+  assert.equal(
+    fs.readFileSync(path.join(vault, 'System', 'user-profile.yaml'))
+      .compare(userBytes.get('System/user-profile.yaml')),
+    0,
+  );
   const reportAndBackupText = [
     fs.readFileSync(path.join(vault, 'System', 'migration-report-v2.md'), 'utf8'),
     ...[...snapshotFiles(path.join(vault, 'System', 'backups', 'pre-split')).keys()]

--- a/core/tests/brain-vault-migrator-unit.test.cjs
+++ b/core/tests/brain-vault-migrator-unit.test.cjs
@@ -588,7 +588,7 @@ test('P6 treats a markerless CLAUDE.md as nothing to lift', () => {
   assert.equal(fs.existsSync(path.join(root, 'CLAUDE-custom.md')), false);
   assert.equal(state.p6.liftComplete, true);
   assert.equal(state.p6.customSha256, null);
-  assert.match(fs.readFileSync(path.join(root, 'System', 'user-profile.yaml'), 'utf8'), /^vault_schema: 1$/m);
+  assert.equal(fs.readFileSync(path.join(root, 'System', 'user-profile.yaml'), 'utf8'), 'name: Test\n');
 });
 
 test('the pre-split snapshot restores a pre-existing migration report', () => {

--- a/docs/portable-vault-contract-design.md
+++ b/docs/portable-vault-contract-design.md
@@ -66,10 +66,11 @@ the portability audit — reusing the existing `quarterly_planning.enabled` prec
 Contract rule: an absent room is VALID (repair/convergence must not recreate it).
 
 ## vault_schema
-Declared in `System/user-profile.yaml` (`vault_schema: 1`); the contract JSON carries
-`vault_schema_supported: ">=1 <2"`. Boot comparison semantics per Vault_Contract §6
-(older → offer migrator; newer → refuse writes) — enforcement lands with the engine
-PRs, the contract just carries the declaration.
+The contract JSON carries `vault_schema_supported: ">=1 <2"`. The migration must
+not stamp or rewrite `System/user-profile.yaml` to record this: that file belongs to
+the user. Boot comparison semantics per Vault_Contract §6 (older → offer migrator;
+newer → refuse writes) remain an engine concern; the contract only carries the
+supported range.
 
 ## The CI gate (red-when-removed)
 `scripts/check-portable-contract.sh` fails when:


### PR DESCRIPTION
Fixes the fleet finding: the brain/vault migration must not stamp `System/user-profile.yaml`. Adds regression coverage requiring the profile bytes to remain unchanged.