### PR TITLE
fix: make release changelog insertion portable

### DIFF
--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -757,6 +757,13 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
     package = _git_json(clone, "HEAD:package.json")
     profile = _git_json(clone, "HEAD:System/.release-evidence-profile.json")
     transition = _git_json(clone, "HEAD:System/.local-only-preservation-transition.json")
+    changelog = subprocess.run(
+        ["git", "show", "HEAD:CHANGELOG.md"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
     assert package["version"] == bumped
     assert profile == {"profile": "legacy-v1", "release_version": bumped, "schema_version": 1}
     assert transition == {
@@ -765,6 +772,7 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
         "phase": "untrack-v3",
         "release_version": bumped,
     }
+    assert f"---\n\n## [{bumped}] — (" in changelog
     assert "System/.release-evidence-profile.json" in _release_manifest(clone, "HEAD")
     assert subprocess.run(
         ["git", "rev-parse", f"v{bumped}^{{}}"], cwd=clone, check=True, capture_output=True, text=True

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -110,8 +110,20 @@ fi
 
 # Insert a new section right after the first "---" separator (after the preamble)
 # The CHANGELOG format is:  ## [X.Y.Z] — Title (YYYY-MM-DD)
-sed -i.bak "0,/^---$/s/^---$/---\n\n## [${NEW_VERSION}] — (${TODAY})\n/" CHANGELOG.md
-rm -f CHANGELOG.md.bak
+python3 - "$NEW_VERSION" "$TODAY" <<'CHANGELOG'
+from pathlib import Path
+import sys
+
+path = Path("CHANGELOG.md")
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+for index, line in enumerate(lines):
+    if line.rstrip("\r\n") == "---":
+        lines.insert(index + 1, f"\n## [{sys.argv[1]}] — ({sys.argv[2]})\n")
+        path.write_text("".join(lines), encoding="utf-8")
+        break
+else:
+    raise SystemExit("Error: CHANGELOG.md has no preamble separator")
+CHANGELOG
 
 # --- Generate installed-files manifest -----------------------------------------
 


### PR DESCRIPTION
## Summary
- replace the BSD/GNU sed-dependent changelog insertion with Python standard library code
- cover the committed changelog header in the release-script regression test

## Verification
- `bash -n scripts/release.sh`
- `git diff --check`
- `uv run --python 3.12 --with pytest --with pytest-xdist --with pyyaml python -m pytest core/tests/test_distribution_artifacts.py -k release_script_regenerates_profile_for_bumped_version -q`