### PR TITLE
fix(capabilities): align legacy company defaults

### DIFF
--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -142,7 +142,7 @@ capabilities:
 # key and keep this legacy switch aligned; the migration never runs in reverse.
 quarterly_planning:
   # Whether quarterly planning is enabled
-  enabled: false
+  enabled: true
   
   # Has user been asked about quarterly planning during onboarding?
   prompted: false

--- a/core/capabilities.py
+++ b/core/capabilities.py
@@ -368,11 +368,11 @@ def migrate_legacy_room_state(
     """One-time bridge for vaults onboarded before capability rooms existed.
 
     Preserve each room's pre-migration behavior without overriding an explicit
-    capability value or a legacy config value. Companies is pinned off because
-    its fresh-vault default is now on; Career and Quarter Goals keep the earlier
-    bridge's on default when they have no prior opinion. Fresh installs write
-    explicit room answers at onboarding and are never touched here. Returns the
-    rooms seeded (empty when no migration was needed).
+    capability value or a legacy config value. A room with no recorded opinion
+    is restored to its current default, so the legacy and lifecycle-only paths
+    agree. Fresh installs write explicit room answers at onboarding and are
+    never touched here. Returns the rooms seeded (empty when no migration was
+    needed).
     """
     root = Path(vault_root).resolve()
     profile_file = Path(profile_path or root / "System/user-profile.yaml")
@@ -385,11 +385,11 @@ def migrate_legacy_room_state(
     profile = _read_profile(profile_file, strict=True)
     capability_state = profile.get("capabilities")
     room_defaults = (
-        {"companies": False}
+        {"companies": True}
         if isinstance(capability_state, Mapping)
         else {
             "career": True,
-            "companies": False,
+            "companies": True,
             "quarter_goals": True,
         }
     )
@@ -538,7 +538,7 @@ def render_missing_companies_compatibility_pin(
     *,
     contract_path: Path | str | None = None,
 ) -> str | None:
-    """Render the one-time Companies-off pin without rewriting profile prose.
+    """Render the one-time Companies compatibility pin without rewriting profile prose.
 
     ``None`` means the profile already has an explicit or legacy opinion.
     Invalid state fails closed so an update cannot fall through to the new

--- a/core/tests/test_capabilities.py
+++ b/core/tests/test_capabilities.py
@@ -136,6 +136,15 @@ def test_no_opinion_rooms_default_on_and_legacy_quarterly_planning_is_a_fallback
     ) is True
 
 
+def test_profile_template_keeps_quarter_goal_defaults_aligned() -> None:
+    profile = yaml.safe_load(
+        (REPO_ROOT / "System/user-profile-template.yaml").read_text(encoding="utf-8")
+    )
+
+    assert profile["capabilities"]["quarter_goals"]["enabled"] is True
+    assert profile["quarterly_planning"]["enabled"] is True
+
+
 def test_flipped_rooms_default_on_but_a_recorded_answer_always_wins(
     tmp_path: Path,
 ) -> None:
@@ -433,9 +442,9 @@ def test_setup_defers_rooms_to_the_onboarding_flow_and_creates_nothing_itself() 
     assert "- `05-Areas/Companies/`" not in setup
 
 
-def test_legacy_onboarded_vault_pins_companies_off_and_honors_legacy_state(tmp_path):
-    """An existing vault gets a durable Companies-off opinion before the
-    contract default changes, while its legacy quarter choice remains authoritative."""
+def test_legacy_onboarded_vault_restores_companies_and_honors_legacy_state(tmp_path):
+    """An existing vault with no Companies opinion gets the current default,
+    while its explicit legacy quarter choice remains authoritative."""
     from core import capabilities
 
     vault = _fake_vault(tmp_path)
@@ -451,10 +460,10 @@ def test_legacy_onboarded_vault_pins_companies_off_and_honors_legacy_state(tmp_p
     assert sorted(seeded) == ["career", "companies"]
     profile_path = vault / "System" / "user-profile.yaml"
     assert capabilities.enabled("career", profile_path=profile_path) is True
-    assert capabilities.enabled("companies", profile_path=profile_path) is False
+    assert capabilities.enabled("companies", profile_path=profile_path) is True
     assert capabilities.enabled("quarter_goals", profile_path=profile_path) is False
     profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
-    assert profile["capabilities"]["companies"]["enabled"] is False
+    assert profile["capabilities"]["companies"]["enabled"] is True
     assert profile["quarterly_planning"]["enabled"] is False
     # Idempotent: a second run seeds nothing.
     assert capabilities.migrate_legacy_room_state(vault) == []
@@ -475,7 +484,7 @@ def test_pre_engine_identity_without_marker_gets_legacy_room_pins(
 
     assert sorted(seeded) == ["career", "companies", "quarter_goals"]
     assert capabilities.enabled("career", profile_path=profile_path) is True
-    assert capabilities.enabled("companies", profile_path=profile_path) is False
+    assert capabilities.enabled("companies", profile_path=profile_path) is True
     assert capabilities.enabled("quarter_goals", profile_path=profile_path) is True
 
 
@@ -493,7 +502,7 @@ def test_real_room_content_without_marker_counts_as_onboarding_evidence(
     seeded = capabilities.migrate_legacy_room_state(vault)
 
     assert sorted(seeded) == ["career", "companies", "quarter_goals"]
-    assert capabilities.enabled("companies", profile_path=profile_path) is False
+    assert capabilities.enabled("companies", profile_path=profile_path) is True
 
 
 def test_shipped_room_seed_without_identity_is_not_onboarding_evidence(
@@ -603,7 +612,7 @@ def test_legacy_migration_preserves_explicit_company_state(
     }
 
 
-def test_partial_capability_map_only_gains_the_companies_compatibility_pin(
+def test_partial_capability_map_gains_the_enabled_companies_compatibility_pin(
     tmp_path: Path,
 ) -> None:
     vault = _fake_vault(tmp_path)
@@ -621,7 +630,7 @@ def test_partial_capability_map_only_gains_the_companies_compatibility_pin(
     assert seeded == ["companies"]
     assert profile["capabilities"] == {
         "career": {"enabled": False},
-        "companies": {"enabled": False},
+        "companies": {"enabled": True},
     }
     assert capabilities.enabled(
         "quarter_goals",

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1362,7 +1362,7 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     profile = (
         context.vault_root / "System/user-profile.yaml"
     ).read_text(encoding="utf-8")
-    assert "companies:\n    enabled: false" in profile
+    assert "companies:\n    enabled: true" in profile
 
 
 def test_mcp_registered_distinguishes_never_onboarded_from_missing_after_onboarding(context):


### PR DESCRIPTION
## What changed

The two current migration paths disagreed for an existing vault with no recorded Companies choice: lifecycle-only provisioning restored Companies on, while the legacy room-state migrator wrote it off. This successor makes the legacy path use the same enabled default while preserving every explicit capability or legacy setting.

It also aligns the shipped quarterly-planning template flag with the already-enabled Quarter Goals capability, with a regression test.

## Scope

- No CHANGELOG or release edits
- No first-run or onboarding-flow changes
- No changes to explicit user choices

## Verification

- Focused capabilities and provision-parity suite: 40 passed
- Full Node script suite: 163 passed
- Ruff, portable-contract, PII, and whitespace checks passed

Supersedes only the room-migration parity portion of stale PR #286.