### PR TITLE
fix: discover archived release fleet trees

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -58,6 +58,14 @@ def _tag_legacy_release(repo: Path, version: str, content: str) -> str:
     return tag
 
 
+def _archive_release_tag(repo: Path, tag: str) -> str:
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    version, short = tag.removeprefix("dist/release/v").split("-", maxsplit=1)
+    archive_tag = f"dist/archive/v{version}-{short}"
+    _git(repo, "tag", "-a", archive_tag, commit, "-m", archive_tag)
+    return archive_tag
+
+
 def test_discovers_each_distinct_distribution_tree_once(tmp_path: Path) -> None:
     repo = _repository(tmp_path)
     first = _tag_release(repo, "1.61.0", "one")
@@ -75,6 +83,84 @@ def test_rejects_distribution_tag_that_does_not_name_its_commit(tmp_path: Path) 
 
     with pytest.raises(release_fleet.FleetError, match="does not match"):
         release_fleet.discover_distribution_releases(repo)
+
+
+def test_discovers_archived_distribution_tree_when_the_canonical_tag_is_absent(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.64.0", "historic release")
+    archive_tag = _archive_release_tag(repo, tag)
+    _git(repo, "tag", "-d", tag)
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == [archive_tag]
+
+
+def test_discovers_exact_v164_archived_starting_tree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tag = "dist/archive/v1.64.0-366c168"
+    commit = "366c168af61c50ee7157976a9eb8a154ca0fd7f4"
+    tree = "0bf7e30785d511e4b3774358f73ce569167f3f60"
+
+    def fake_git(_repo: Path, *arguments: str) -> str:
+        if arguments == ("tag", "--list"):
+            return tag
+        if arguments == ("rev-parse", f"{tag}^{{commit}}"):
+            return commit
+        if arguments == ("rev-parse", f"{tag}^{{tree}}"):
+            return tree
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(release_fleet, "_git", fake_git)
+
+    assert release_fleet.discover_distribution_releases(tmp_path) == (
+        release_fleet.DistributionRelease(
+            tag=tag,
+            version="1.64.0",
+            commit=commit,
+            tree=tree,
+        ),
+    )
+
+
+def test_prefers_canonical_tag_when_archive_tag_has_the_same_tree(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.64.0", "historic release")
+    _archive_release_tag(repo, tag)
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == [tag]
+
+
+def test_rejects_colliding_immutable_distribution_identities(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    canonical_tag = "dist/release/v1.64.0-366c168"
+    archive_tag = "dist/archive/v1.64.0-366c168"
+    commits = {
+        canonical_tag: "366c168af61c50ee7157976a9eb8a154ca0fd7f4",
+        archive_tag: "366c168dddddddddddddddddddddddddddddddddd",
+    }
+    trees = {
+        canonical_tag: "0bf7e30785d511e4b3774358f73ce569167f3f60",
+        archive_tag: "ad5c7be7f2075bc3de74d4d0b168bb29e72c2d4e",
+    }
+
+    def fake_git(_repo: Path, *arguments: str) -> str:
+        if arguments == ("tag", "--list"):
+            return "\n".join((canonical_tag, archive_tag))
+        for suffix, values in (("^{commit}", commits), ("^{tree}", trees)):
+            tag = arguments[1].removesuffix(suffix)
+            if arguments == ("rev-parse", f"{tag}{suffix}"):
+                return values[tag]
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(release_fleet, "_git", fake_git)
+
+    with pytest.raises(release_fleet.FleetError, match="ambiguous immutable distribution identity"):
+        release_fleet.discover_distribution_releases(tmp_path)
 
 
 def test_discovers_legacy_published_release_trees_too(tmp_path: Path) -> None:

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -8,10 +8,14 @@ published Dex can reach it.
 ## What must pass
 
 Every distinct tree behind a published release tag is a starting case. This
-means the `dist/release/v*` packages as well as the older public `v*` release
-tags that predate that format. If two tags point at different trees—even when
-they share the same version number—they are separate cases. Byte-identical
-trees are one case.
+means the `dist/release/v*` packages, historic `dist/archive/v*` distribution
+tags, and the older public `v*` release tags that predate that format. Archive
+tags preserve an immutable historic starting tree after its canonical
+distribution ref is retired; their version-and-commit suffix must still match
+the tagged commit. If two tags point at different trees—even when they share
+the same version number—they are separate cases. Byte-identical trees are one
+case. A canonical and archive tag that claim the same version-and-commit
+identity but resolve to different commits are rejected as ambiguous.
 
 Each case must complete two real update hops:
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -22,6 +22,9 @@ from core.paths import INBOX_DIR, TASKS_FILE, USER_PROFILE_FILE, VAULT_ROOT
 RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
+ARCHIVE_RELEASE_TAG = re.compile(
+    r"^dist/archive/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
+)
 LEGACY_RELEASE_TAG = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
 USER_FIXTURES = {
@@ -121,9 +124,10 @@ def _version_key(version: str) -> tuple[int, int, int]:
 
 
 def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...]:
-    """Return every distinct tree behind public distribution and legacy release tags."""
+    """Return every distinct tree behind immutable and legacy public release tags."""
 
     seen_trees: set[str] = set()
+    immutable_identities: dict[tuple[str, str], str] = {}
     discovered: list[DistributionRelease] = []
     candidates: list[tuple[int, str, re.Match[str]]] = []
     for tag in _git_lines(repo, "tag", "--list"):
@@ -131,14 +135,26 @@ def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...
         if distribution_match is not None:
             candidates.append((0, tag, distribution_match))
             continue
+        archive_match = ARCHIVE_RELEASE_TAG.fullmatch(tag)
+        if archive_match is not None:
+            candidates.append((1, tag, archive_match))
+            continue
         legacy_match = LEGACY_RELEASE_TAG.fullmatch(tag)
         if legacy_match is not None:
-            candidates.append((1, tag, legacy_match))
+            candidates.append((2, tag, legacy_match))
 
     for priority, tag, match in sorted(candidates, key=lambda item: (item[0], item[1])):
         commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
-        if priority == 0 and not commit.startswith(match.group("short")):
+        if priority < 2 and not commit.startswith(match.group("short")):
             raise FleetError(f"{tag}: tag suffix does not match its commit")
+        if priority < 2:
+            identity = (match.group("version"), match.group("short"))
+            existing_commit = immutable_identities.setdefault(identity, commit)
+            if existing_commit != commit:
+                raise FleetError(
+                    f"{tag}: ambiguous immutable distribution identity "
+                    f"v{identity[0]}-{identity[1]}"
+                )
         tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
         if tree in seen_trees:
             continue


### PR DESCRIPTION
## Summary
- Discover immutable dist/archive/v* tags as historic release-fleet starts.
- Preserve canonical-tag priority and reject colliding immutable identities.
- Cover the exact archived v1.64.0-366c168 tree.

## Verification
- uv run --python 3.12 --with pytest --with pyyaml python -m pytest core/tests/test_release_fleet.py -q
- uv run --python 3.12 --with ruff ruff check scripts/release_fleet.py core/tests/test_release_fleet.py
- python3 -m py_compile scripts/release_fleet.py
- git diff --check

No tags, releases, assets, or remote release refs were changed.