### PR TITLE
fix: clarify first-run chat restart

### DIFF
--- a/core/tests/test_install_convergence.py
+++ b/core/tests/test_install_convergence.py
@@ -130,6 +130,9 @@ def test_fresh_git_install_routes_bounded_migration_through_auto_then_resume(tmp
     assert "Separating the Dex brain from your vault" in result.stdout
     assert "separate Git histories" in result.stdout
     assert "Dex installation complete" in result.stdout
+    assert "Start a new Claude Code or Cursor chat in this folder" in result.stdout
+    assert "a new chat loads Dex's MCP servers" in result.stdout
+    assert "In Cursor chat" not in result.stdout
 
 
 def test_synced_folder_install_carries_explicit_override_into_resume(tmp_path: Path) -> None:

--- a/install.sh
+++ b/install.sh
@@ -324,7 +324,9 @@ if [[ "$WORK_MCP_STATUS" == *"Needs"* ]]; then
 fi
 echo ""
 echo "Next steps:"
-echo "  1. In Cursor chat, type: /setup"
-echo "  2. Answer the setup questions (~5 minutes)"
-echo "  3. Start using Dex!"
+echo "  1. Start a new Claude Code or Cursor chat in this folder"
+echo "     (a new chat loads Dex's MCP servers)"
+echo "  2. Type: /setup"
+echo "  3. Answer the setup questions (~5 minutes)"
+echo "  4. Start using Dex!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary
- make final installer guidance work for Claude Code and Cursor
- explain that a new chat is required to load Dex MCP servers
- retain `/setup` as the explicit first-run command

## Verification
- `bash -n install.sh`
- `python -m pytest -q core/tests/test_install_convergence.py` (5 passed)

No merge, release, deployment, or Google sign-in is included.