### PR TITLE
fix(connect): do not confirm OAuth before token exchange

### DIFF
--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -267,7 +267,9 @@ test('callback server skips a contended port and completes on the next one', asy
     const pending = cb.waitForCode({ expectedState: 'right-state' });
     const response = harness.request(harness.servers[1], '/callback?code=good-code&state=right-state');
     assert.equal(response.headers['Content-Type'], 'text/html; charset=utf-8');
-    assert.match(response.body, /✅ Connected/);
+    assert.match(response.body, /Approval received/);
+    assert.match(response.body, /Return to Dex to see whether it completed/);
+    assert.doesNotMatch(response.body, /Connected/);
     assert.deepEqual(await pending, { code: 'good-code', state: 'right-state' });
   } finally {
     cb.close();

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -106,7 +106,11 @@ async function startCallbackServer({
             ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Callback not accepted</h2><p>Dex is still waiting for the connection to finish.</p></body></html>'
             : error
             ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${escapeHtml(error)}</p><p>You can close this tab and return to Dex.</p></body></html>`
-            : `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>✅ Connected</h2><p>You can close this tab and return to Dex.</p></body></html>`
+            // Receiving Google's redirect only proves that the person approved
+            // the request. Dex still has to exchange that short-lived code and
+            // store the resulting token, so do not claim the connection is
+            // complete until cmdConnect has actually done that work.
+            : '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Approval received</h2><p>Dex is finishing the secure connection. Return to Dex to see whether it completed.</p></body></html>'
         );
         if (!terminal) return;
         clearTimeout(timeout);

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 241229,
-      "treeHash": "c341bac2558671b9334b6c1fdc61cc504385dd13bac38e8c3bafe4d998e11b20",
+      "totalBytes": 241580,
+      "treeHash": "b29fa8597a37798396b376847b90b49fcf5bbbe12b75c845cde89c101c61b34a",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -96,8 +96,8 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 10328,
-          "sha256": "3b4f919bf403656307946c7fbf738edd5c5a5e5505d2ec37ae177c57c35b31b7"
+          "bytes": 10679,
+          "sha256": "9e54745bbf65646de65b6942906436d068fda1f51c3e3b768f4b86ce9c90ee56"
         },
         {
           "path": "pinned-providers.cjs",


### PR DESCRIPTION
## What changed

The localhost callback page now says **Approval received** rather than **Connected**. Google returning an authorization code is not the completed connection: Dex must still exchange that code for a token and securely store it.

## Why

The Google Calendar onboarding demo showed the real failure mode: the browser said Connected, while the subsequent token exchange failed. This change prevents that misleading confirmation.

## Verification

- `node --test core/integrations/connection-manager/connection-manager.phase05.test.cjs core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs` (33 passing)
- `npm run test:integrations` (227 passing)
- regenerated and verified the checked-in connections engine manifest

Stacked on #320 because it fixes the user-facing behaviour of that new Google onboarding path.