### PR TITLE
fix(onboarding): target the open Dex vault for Google

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -50,7 +50,7 @@ Say: "I'll open Google in your browser. Dex asks for one permission — permissi
 Run:
 
 ```bash
-node core/integrations/connection-manager/connect.cjs connect google --scopes calendar.readonly
+DEX_VAULT="$PWD" node core/integrations/connection-manager/connect.cjs connect google --scopes calendar.readonly
 ```
 
 Dex ships its own Google sign-in, so there is nothing for the user to register and no developer console. Do not ask them for a client id or secret, and do not send them to `/google-workspace-setup`.

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -281,6 +281,18 @@ def test_onboarding_confirms_calendar_identity_through_existing_validation() -> 
     assert "Do not bypass either validation call" in calendar_step
 
 
+def test_onboarding_google_connect_targets_the_open_dex_vault() -> None:
+    flow = _read(".claude/flows/onboarding.md")
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
+
+    assert (
+        'DEX_VAULT="$PWD" node core/integrations/connection-manager/connect.cjs '
+        "connect google --scopes calendar.readonly"
+    ) in calendar_step
+
+
 def test_onboarding_keeps_conservative_identity_fallbacks() -> None:
     flow = _read(".claude/flows/onboarding.md")
     calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(


### PR DESCRIPTION
## What changed

The Google Calendar onboarding instruction now sets `DEX_VAULT="$PWD"` before running the connection command.

## Why

The first attempt in the real OAuth demo failed before reaching Google because the connection manager did not know which Dex vault owned the credential store. The retry only worked after Claude inferred and added that setting.

## Verification

- `python -m pytest core/tests/test_instruction_honesty.py -q` — 33 passed
- regenerated architecture inventory; no generated-file drift

Stacked on #320.