### PR TITLE
fix(doctor): isolate launch agents by vault

### DIFF
--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1653,6 +1653,23 @@ def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypa
     assert fresh.verdict == "OFF"
 
 
+def test_corrupt_dex_plist_is_unknown_not_foreign(monkeypatch, context):
+    """A malformed plist has no trustworthy ownership evidence either way."""
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    plist = agents / "com.dex.meeting-intel.plist"
+    plist.write_bytes(b"not a plist")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    loaded = doctor._probe_jobs_loaded(context)
+    fresh = doctor._probe_jobs_fresh(context)
+
+    assert loaded.verdict == "UNKNOWN"
+    assert fresh.verdict == "UNKNOWN"
+    assert plist.name in loaded.detail
+    assert plist.name in fresh.detail
+
+
 def test_jobs_loaded_owns_unshipped_label_with_program_path_inside_vault(monkeypatch, context):
     plist = _write_plist(context, "com.dex.local-job")
     missing_script = context.vault_root / ".scripts" / "local-job.py"

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -145,9 +145,16 @@ def _write_mcp_config(context, servers):
 def _write_plist(context, label):
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
+    script = context.vault_root / ".scripts" / f"{label}.sh"
+    script.parent.mkdir(exist_ok=True)
+    script.write_text("#!/bin/bash\n")
+    script.chmod(0o755)
     plist = agents / f"{label}.plist"
     with plist.open("wb") as handle:
-        plistlib.dump({"Label": label, "ProgramArguments": ["/bin/bash"]}, handle)
+        plistlib.dump(
+            {"Label": label, "ProgramArguments": ["/bin/bash", str(script)]},
+            handle,
+        )
     return plist
 
 
@@ -1617,6 +1624,35 @@ def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_
     assert "research-scan.py" not in result.detail
 
 
+def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypatch, context):
+    """A shipped label alone must not make a disposable fixture own a host job."""
+    plist = _write_plist(context, "com.dex.meeting-intel")
+    foreign_vault = context.home.parent / "Dex-Google-OAuth-Verification-Working"
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.dex.meeting-intel",
+                "ProgramArguments": [
+                    "/bin/bash",
+                    str(foreign_vault / ".scripts" / "dex-launcher.sh"),
+                ],
+                "WorkingDirectory": str(foreign_vault),
+            },
+            handle,
+        )
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    loaded = doctor._probe_jobs_loaded(context)
+    fresh = doctor._probe_jobs_fresh(context)
+
+    assert loaded.verdict == "OFF"
+    assert loaded.detail == (
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
+    )
+    assert fresh.verdict == "OFF"
+
+
 def test_jobs_loaded_owns_unshipped_label_with_program_path_inside_vault(monkeypatch, context):
     plist = _write_plist(context, "com.dex.local-job")
     missing_script = context.vault_root / ".scripts" / "local-job.py"
@@ -1635,11 +1671,12 @@ def test_jobs_loaded_owns_unshipped_label_with_program_path_inside_vault(monkeyp
 
 def test_jobs_loaded_owns_repo_shipped_obsidian_agent(monkeypatch, context):
     plist = _write_plist(context, "com.dex.obsidian-sync")
+    missing_script = context.vault_root / "core" / "obsidian" / "missing-sync-daemon.py"
     with plist.open("wb") as handle:
         plistlib.dump(
             {
                 "Label": "com.dex.obsidian-sync",
-                "ProgramArguments": ["/bin/bash", "core/obsidian/missing-sync-daemon.py"],
+                "ProgramArguments": ["/bin/bash", str(missing_script)],
             },
             handle,
         )
@@ -1696,7 +1733,11 @@ def test_jobs_loaded_maps_invalid_or_unsubstituted_plist_to_broken_t2(monkeypatc
         plistlib.dump(
             {
                 "Label": "com.dex.meeting-intel",
-                "ProgramArguments": ["/bin/bash", "{{VAULT_PATH}}/.scripts/dex-launcher.sh"],
+                "ProgramArguments": [
+                    "/bin/bash",
+                    str(context.vault_root / ".scripts" / "dex-launcher.sh"),
+                    "{{VAULT_PATH}}/.scripts/dex-launcher.sh",
+                ],
             },
             handle,
         )

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -589,18 +589,6 @@ JOB_FRESHNESS = {
     ),
 }
 
-# Ownership includes every launch agent this repo can install; only some emit freshness logs.
-SHIPPED_LAUNCH_AGENT_LABELS = frozenset(
-    {
-        "com.dex.changelog-checker",
-        "com.dex.learning-review",
-        "com.dex.meeting-intel",
-        "com.dex.obsidian-sync",
-        "com.dex.smoke-nightly",
-    }
-)
-
-
 QUICK_CHECKS = (
     CheckDefinition("vault.structure", "Vault structure", "_probe_vault_structure"),
     CheckDefinition("vault.configs", "Vault configuration", "_probe_vault_configs"),
@@ -2261,9 +2249,13 @@ def _plist_strings(value: object) -> Iterator[str]:
 
 
 def _plist_owned_by_vault(plist: Path, data: dict[str, Any], context: DoctorContext) -> bool:
-    label = str(data.get("Label") or plist.stem)
-    if label in SHIPPED_LAUNCH_AGENT_LABELS:
-        return True
+    """Return whether a launch agent explicitly points into this vault.
+
+    Labels are shared between Dex installs, so they are not ownership evidence.
+    A known ``com.dex.*`` label can still belong to another Dex vault on the
+    same Mac; only an absolute ProgramArguments path beneath this vault makes
+    it this vault's responsibility.
+    """
     arguments = data.get("ProgramArguments")
     if not isinstance(arguments, list):
         return False
@@ -2390,11 +2382,9 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     for plist in plists:
         try:
             data = _plist_data(plist)
-        except RuntimeError as error:
-            if plist.stem in SHIPPED_LAUNCH_AGENT_LABELS:
-                issues.append((2, _one_line(error)))
-            else:
-                skipped_count += 1
+        except RuntimeError:
+            # A corrupt plist cannot be safely attributed from its filename.
+            skipped_count += 1
             continue
         if not _plist_owned_by_vault(plist, data, context):
             skipped_count += 1
@@ -2469,7 +2459,14 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
 
 
 def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
-    installed = {_plist_label(plist) for plist in _installed_launch_agents(context)}
+    installed = set()
+    for plist in _installed_launch_agents(context):
+        try:
+            data = _plist_data(plist)
+        except RuntimeError:
+            continue
+        if _plist_owned_by_vault(plist, data, context):
+            installed.add(str(data.get("Label") or plist.stem))
     monitored = [label for label in JOB_FRESHNESS if label in installed]
     if not monitored:
         return ProbeResult("OFF", "No monitored Dex freshness jobs are installed")

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -2285,6 +2285,13 @@ def _with_skipped_launch_agents(detail: str, skipped_count: int) -> str:
     return f"{detail}; {note}"
 
 
+def _unattributable_launch_agent_detail(plist: Path, error: Exception) -> str:
+    return (
+        f"Could not determine whether {plist.name} belongs to this vault "
+        f"({_one_line(error)})"
+    )
+
+
 def _plist_configuration_issue(plist: Path, data: dict[str, Any], context: DoctorContext) -> str | None:
     arguments = data.get("ProgramArguments")
     if not isinstance(arguments, list) or not arguments or not isinstance(arguments[0], str):
@@ -2379,16 +2386,20 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     unknowns = []
     runtime_labels = []
     skipped_count = 0
+    owned_count = 0
     for plist in plists:
         try:
             data = _plist_data(plist)
-        except RuntimeError:
-            # A corrupt plist cannot be safely attributed from its filename.
-            skipped_count += 1
+        except RuntimeError as error:
+            # A corrupt plist could belong to this vault, but a filename alone
+            # cannot establish that safely. Surface the uncertainty instead of
+            # falsely treating it as a foreign Dex installation.
+            unknowns.append(_unattributable_launch_agent_detail(plist, error))
             continue
         if not _plist_owned_by_vault(plist, data, context):
             skipped_count += 1
             continue
+        owned_count += 1
         label = str(data.get("Label") or plist.stem)
         configuration_issue = _plist_configuration_issue(plist, data, context)
         if configuration_issue:
@@ -2424,8 +2435,12 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
                     unknowns.append(f"{label} is loaded but has no observable LastExitStatus")
                 elif status["last_exit_status"] != 0:
                     issues.append((2, f"{label} last exited with status {status['last_exit_status']}"))
-    owned_count = len(plists) - skipped_count
     if not owned_count:
+        if unknowns:
+            return ProbeResult(
+                "UNKNOWN",
+                _with_skipped_launch_agents("; ".join(unknowns), skipped_count),
+            )
         return ProbeResult(
             "OFF",
             _with_skipped_launch_agents("No launch agents for this vault are installed", skipped_count),
@@ -2460,15 +2475,19 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
 
 def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     installed = set()
+    unknowns = []
     for plist in _installed_launch_agents(context):
         try:
             data = _plist_data(plist)
-        except RuntimeError:
+        except RuntimeError as error:
+            unknowns.append(_unattributable_launch_agent_detail(plist, error))
             continue
         if _plist_owned_by_vault(plist, data, context):
             installed.add(str(data.get("Label") or plist.stem))
     monitored = [label for label in JOB_FRESHNESS if label in installed]
     if not monitored:
+        if unknowns:
+            return ProbeResult("UNKNOWN", "; ".join(unknowns))
         return ProbeResult("OFF", "No monitored Dex freshness jobs are installed")
 
     stale = []
@@ -2484,9 +2503,11 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     if stale:
         return ProbeResult(
             "BROKEN",
-            "; ".join(stale),
+            "; ".join([*stale, *unknowns]),
             Heal(tier=2, action="Run the stale job once and inspect its application log.", applied=False),
         )
+    if unknowns:
+        return ProbeResult("UNKNOWN", "; ".join(unknowns))
     return ProbeResult("OK", f"All {len(monitored)} installed job logs are within their freshness thresholds")
 
 

--- a/docs/dex-doctor-spec.md
+++ b/docs/dex-doctor-spec.md
@@ -106,8 +106,8 @@ repointed to `/dex-doctor`.
 | mcp.orphans | every `core/mcp/*_server.py` present in `.mcp.json` | — | orphaned server (T2 add) |
 | python.env | `.venv` python exists; `mcp`, `yaml`, `dateutil`, `requests` importable | — | missing (T2: pip install into venv) |
 | hooks.wired | every hook command in `settings.json` points at an existing file | — | dangling hook (T2) |
-| jobs.loaded | for each `~/Library/LaunchAgents/com.dex.*.plist`: `launchctl list` state, interpreter exists+executable (ProgramArguments[0]) | plist not installed | installed but unloaded (T2 load) / interpreter missing (T3 install node) |
-| jobs.fresh | log mtime vs cadence: meeting-intel >48 h, changelog-checker >7 d, learning-review >7 d — only when the job is installed | job not installed | stale beyond threshold (detail says last-run date) |
+| jobs.loaded | for each `~/Library/LaunchAgents/com.dex.*.plist` that has an absolute `ProgramArguments` path under the checked vault: `launchctl list` state, interpreter exists+executable (ProgramArguments[0]). Same-label agents for another vault are skipped; an unreadable plist is `UNKNOWN`, not assumed foreign. | no attributable plist installed | installed but unloaded (T2 load) / interpreter missing (T3 install node) |
+| jobs.fresh | log mtime vs cadence: meeting-intel >48 h, changelog-checker >7 d, learning-review >7 d — only for an attributable job in the checked vault. Same-label foreign jobs are ignored; an unreadable plist is `UNKNOWN`. | no attributable job installed | stale beyond threshold (detail says last-run date) |
 | preflight.queue | `run_preflight()` result + queued errors | — | per preflight |
 | doctor.self | instruments counter; last-run file writable | — | any probe raised (UNKNOWN with error) |
 


### PR DESCRIPTION
## What changed\nDoctor now attributes a `com.dex.*` launch agent only when its absolute `ProgramArguments` path belongs to the vault being checked. A same-label agent for another Dex vault no longer contaminates a historic-fixture check. Corrupt or unattributable matching plists are surfaced as **UNKNOWN**, not silently dismissed as foreign.\n\n## Proof\n- 16 focused Doctor job/freshness tests passed on the final rebased branch.\n- Independent review approved the ownership, foreign-agent, and corrupt-plist behaviours.\n- 138 broader Doctor tests passed in the implementation worktree; four environment-dependent tests could not run there because its venv lacked `js-yaml`/`mcp`, so this is not represented as a full-suite green result.\n\nNo host jobs, real vaults, tags, releases, or credentials were changed.