### PR TITLE
fix(lifecycle): register MCP from delivered definition

### DIFF
--- a/core/customization_migration/registration.py
+++ b/core/customization_migration/registration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 def mcp_registration_snippet() -> dict[str, object]:
     return {
         "customization-migration-mcp": {
+            "type": "stdio",
             "command": "{{VAULT_PATH}}/.venv/bin/python",
             "args": [
                 "{{VAULT_PATH}}/core/mcp/customization_migration_server.py"

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -22,6 +22,7 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 from core import portable_contract
+from core.customization_migration.registration import mcp_registration_snippet
 from core.lifecycle.catalog import load_catalog, load_catalog_payload_sources
 from core.lifecycle.conflict import (
     ConflictResolutionPreview,
@@ -54,7 +55,6 @@ _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _ARCHIVE_RELATIVE = ".dex/pre-split-archive.git"
 _ARCHIVE_RECEIPTS_RELATIVE = "System/.dex/archive-removals"
 _MCP_CONFIG_RELATIVE = ".mcp.json"
-_MCP_TEMPLATE_RELATIVE = "System/.mcp.json.example"
 _MCP_REGISTRATION_NAME = "customization-migration-mcp"
 _REBUILD_TRANSACTION_PATH = re.compile(
     r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
@@ -708,25 +708,20 @@ def _mcp_registration_preview(
     """Build the one explicitly approved, add-only MCP registration write."""
     root = Path(vault_root).resolve()
     target = root / _MCP_CONFIG_RELATIVE
-    template = root / _MCP_TEMPLATE_RELATIVE
     if target.is_symlink() or (target.exists() and not target.is_file()):
         raise PlanRejected(".mcp.json must be a regular file")
-    if template.is_symlink() or not template.is_file():
-        raise PlanRejected("System/.mcp.json.example must be a regular file")
     try:
         existing = json.loads(target.read_text(encoding="utf-8")) if target.exists() else {}
-        generated = json.loads(template.read_text(encoding="utf-8"))
     except json.JSONDecodeError as error:
         raise PlanRejected("MCP configuration must contain valid JSON") from error
-    if not isinstance(existing, dict) or not isinstance(generated, dict):
+    if not isinstance(existing, dict):
         raise PlanRejected("MCP configuration must contain a JSON object")
     servers = existing.get("mcpServers")
-    generated_servers = generated.get("mcpServers")
     if servers is None:
         servers = {}
-    if not isinstance(servers, dict) or not isinstance(generated_servers, dict):
+    if not isinstance(servers, dict):
         raise PlanRejected("MCP configuration must contain an mcpServers object")
-    registration = generated_servers.get(_MCP_REGISTRATION_NAME)
+    registration = mcp_registration_snippet().get(_MCP_REGISTRATION_NAME)
     if not isinstance(registration, dict):
         raise PlanRejected("the shipped MCP registration is missing or malformed")
     if _MCP_REGISTRATION_NAME in servers:

--- a/core/tests/test_customization_migration_cli.py
+++ b/core/tests/test_customization_migration_cli.py
@@ -218,6 +218,7 @@ def test_registration_snippet_shape_is_pinned() -> None:
 
     assert mcp_registration_snippet() == {
         "customization-migration-mcp": {
+            "type": "stdio",
             "command": "{{VAULT_PATH}}/.venv/bin/python",
             "args": [
                 "{{VAULT_PATH}}/core/mcp/customization_migration_server.py"

--- a/core/tests/test_mcp_registration_lifecycle.py
+++ b/core/tests/test_mcp_registration_lifecycle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from core import portable_contract
+from core.customization_migration.registration import mcp_registration_snippet
 from core.lifecycle import service
 from core.transaction.engine import PlanRejected
 
@@ -98,3 +99,34 @@ def test_mcp_registration_refuses_if_user_configuration_changes_after_preview(
     after = json.loads(config.read_text(encoding="utf-8"))
     assert SERVER_NAME not in after["mcpServers"]
     assert after["unrelated_user_setting"]["changed_after_preview"] is True
+
+
+def test_mcp_registration_uses_the_delivered_definition_not_a_preserved_seed(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    stale_seed = json.loads((vault / "System/.mcp.json.example").read_text(encoding="utf-8"))
+    stale_seed["mcpServers"].pop(SERVER_NAME, None)
+    (vault / "System/.mcp.json.example").write_text(
+        json.dumps(stale_seed, indent=2) + "\n", encoding="utf-8"
+    )
+
+    previewed = service.build_and_preview_mcp_registration(vault)
+    service.execute_approved_mcp_registration(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    configured = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+    assert configured["mcpServers"][SERVER_NAME] == {
+        "type": "stdio",
+        "command": f"{vault}/.venv/bin/python",
+        "args": [f"{vault}/core/mcp/customization_migration_server.py"],
+        "env": {"VAULT_PATH": str(vault)},
+    }
+
+
+def test_shipped_registration_definition_matches_the_fresh_install_template() -> None:
+    template = json.loads((REPO_ROOT / "System/.mcp.json.example").read_text(encoding="utf-8"))
+    assert mcp_registration_snippet()[SERVER_NAME] == template["mcpServers"][SERVER_NAME]


### PR DESCRIPTION
## What changed\nAn old preserved seed template could omit a Dex-owned MCP registration, leaving the lifecycle service unable to restore it after an update. The lifecycle preview now derives that registration from the delivered Core definition, while retaining the existing add-only preview, explicit approval, and transaction path.\n\n## Proof\n- Final branch: 5 focused MCP-registration tests passed; relevant lifecycle-contract cases were deselected by the narrow filter.\n- Ruff passed on every changed Python file.\n- Two independent reviews approved the four-file diff.\n- Source/template parity regression prevents the delivered definition drifting from a fresh install.\n\nThis is a future-foundation repair only. It does not publish the updater bridge or make a historical-update claim.