### PR TITLE
fix(connect): do not confirm OAuth before token exchange

### DIFF
--- a/core/integrations/connection-manager/connection-manager.phase05.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase05.test.cjs
@@ -267,7 +267,9 @@ test('callback server skips a contended port and completes on the next one', asy
     const pending = cb.waitForCode({ expectedState: 'right-state' });
     const response = harness.request(harness.servers[1], '/callback?code=good-code&state=right-state');
     assert.equal(response.headers['Content-Type'], 'text/html; charset=utf-8');
-    assert.match(response.body, /✅ Connected/);
+    assert.match(response.body, /Approval received/);
+    assert.match(response.body, /Return to Dex to see whether it completed/);
+    assert.doesNotMatch(response.body, /Connected/);
     assert.deepEqual(await pending, { code: 'good-code', state: 'right-state' });
   } finally {
     cb.close();

--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -106,7 +106,11 @@ async function startCallbackServer({
             ? '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Callback not accepted</h2><p>Dex is still waiting for the connection to finish.</p></body></html>'
             : error
             ? `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Connection failed</h2><p>${escapeHtml(error)}</p><p>You can close this tab and return to Dex.</p></body></html>`
-            : `<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>✅ Connected</h2><p>You can close this tab and return to Dex.</p></body></html>`
+            // Receiving Google's redirect only proves that the person approved
+            // the request. Dex still has to exchange that short-lived code and
+            // store the resulting token, so do not claim the connection is
+            // complete until cmdConnect has actually done that work.
+            : '<html><body style="font-family:system-ui;padding:3rem;text-align:center"><h2>Approval received</h2><p>Dex is finishing the secure connection. Return to Dex to see whether it completed.</p></body></html>'
         );
         if (!terminal) return;
         clearTimeout(timeout);

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 239876,
-      "treeHash": "172e23653419cb5a45715ac84365906a449e96e2e8527ed98225bf58dadd94fd",
+      "totalBytes": 240227,
+      "treeHash": "e8283181e7c3a74e5b79fe540208ace69a31f76b0f653b4ca25d58011bbbb12f",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -96,8 +96,8 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 10328,
-          "sha256": "3b4f919bf403656307946c7fbf738edd5c5a5e5505d2ec37ae177c57c35b31b7"
+          "bytes": 10679,
+          "sha256": "9e54745bbf65646de65b6942906436d068fda1f51c3e3b768f4b86ce9c90ee56"
         },
         {
           "path": "pinned-providers.cjs",


### PR DESCRIPTION
Rebased successor to closed PR #323.

The browser now says only “Approval received” after Google returns the authorization code; Dex says “Connected” only after exchange and persistence succeed. This does not enable or release the held /connect doorway.

Verified locally: `npm run check:connections-contract`; `node --test core/integrations/connection-manager/connection-manager.phase05.test.cjs` (24 passing).

No credential, release, deployment, or security-gate change.