### PR TITLE
fix(update): harden bridge resume safety

### DIFF
--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -1,0 +1,184 @@
+"""Focused contracts for the one-time lifecycle-era updater bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import dex_update_bridge as bridge
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def build_and_preview_topology_migration(self, vault_root: Path):
+        self.calls.append("topology-preview")
+        return {"preview": {"step": "topology"}, "approval_token": "topology-token"}
+
+    def execute_approved_topology_migration(self, vault_root: Path, preview, approved_token: str):
+        self.calls.append(f"topology-execute:{approved_token}")
+        assert preview == {"step": "topology"}
+        return {"receipt": "topology"}
+
+    def build_and_preview_delivered_release(self, vault_root: Path, release):
+        self.calls.append("release-preview")
+        assert release == bridge.FOUNDATION.identity()
+        return {"preview": {"step": "release"}, "approval_token": "release-token"}
+
+    def execute_approved_delivered_release(self, vault_root: Path, preview, approved_token: str):
+        self.calls.append(f"release-execute:{approved_token}")
+        assert preview == {"step": "release"}
+        return {"receipt": "release"}
+
+
+
+class _SplitService(_Service):
+    def build_and_preview_topology_migration(self, vault_root: Path):
+        self.calls.append("topology-preview")
+        return {
+            "topology": "post-split",
+            "preview": {"status": "already complete"},
+            "approval_token": None,
+        }
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / ".git").mkdir(parents=True)
+    (vault / ".dex" / "brain.git").mkdir(parents=True)
+    (vault / "System").mkdir()
+    return vault
+
+
+def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
+    assert bridge.FOUNDATION.identity() == {
+        "tag": "dist/release/v1.80.5-9211053",
+        "tag_object": "ff94463b191bb2c503ffec42ce288e961ca79659",
+        "commit": "9211053235d7c1837a6e327bff1596b593323fc6",
+        "tree": "d394658e2bf1125b96eb5afdace24f3a5ba3107e",
+        "version": "1.80.5",
+        "channel": "stable",
+    }
+
+
+def test_bridge_success_copy_names_the_canonical_dex_update_command() -> None:
+    source = Path(bridge.__file__).read_text(encoding="utf-8")
+    assert "Future updates use dex-update." in source
+    assert "Future updates use /dex update." not in source
+
+
+def test_release_pin_rejects_a_mutable_or_incomplete_identity() -> None:
+    with pytest.raises(bridge.BridgeError, match="immutable distribution"):
+        bridge.ReleasePin("release", "a" * 40, "b" * 40, "c" * 40, "1.80.5")
+    with pytest.raises(bridge.BridgeError, match="malformed"):
+        bridge.ReleasePin("dist/release/v1.80.5-aaaaaaa", "not-a-hash", "b" * 40, "c" * 40, "1.80.5")
+
+
+def test_bridge_requires_two_new_approvals_and_routes_writes_through_foundation_service(tmp_path: Path) -> None:
+    service = _Service()
+    answers = iter(("APPLY", "APPLY"))
+    fetched: list[Path] = []
+    vault = _vault(tmp_path)
+
+    result = bridge.run_bridge(
+        vault,
+        service,
+        fetch_foundation=lambda root, _pin: fetched.append(root),
+        input_fn=lambda _prompt: next(answers),
+        output_fn=lambda _line: None,
+    )
+
+    assert result["foundation"] == bridge.FOUNDATION.identity()
+    assert service.calls == [
+        "topology-preview",
+        "topology-execute:topology-token",
+        "release-preview",
+        "release-execute:release-token",
+    ]
+    assert fetched == [vault]
+
+
+def test_bridge_stops_before_any_release_fetch_when_topology_preview_is_not_approved(tmp_path: Path) -> None:
+    service = _Service()
+
+    with pytest.raises(bridge.BridgeError, match="no change"):
+        bridge.run_bridge(
+            _vault(tmp_path),
+            service,
+            fetch_foundation=lambda _vault, _pin: pytest.fail("release fetch must not happen"),
+            input_fn=lambda _prompt: "no",
+            output_fn=lambda _line: None,
+        )
+
+    assert service.calls == ["topology-preview"]
+
+
+def test_bridge_rejects_a_symlinked_vault_before_calling_the_service_or_fetching(tmp_path: Path) -> None:
+    service = _Service()
+    target = _vault(tmp_path)
+    linked = tmp_path / "linked-vault"
+    linked.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(bridge.BridgeError, match="contains a symlink"):
+        bridge.run_bridge(
+            linked,
+            service,
+            fetch_foundation=lambda _vault, _pin: pytest.fail("release fetch must not happen"),
+            input_fn=lambda _prompt: pytest.fail("approval must not be requested"),
+            output_fn=lambda _line: pytest.fail("preview must not be rendered"),
+        )
+
+    assert service.calls == []
+
+
+def test_bridge_stops_before_delivered_release_execution_when_second_preview_is_not_approved(tmp_path: Path) -> None:
+    service = _Service()
+    answers = iter(("APPLY", "no"))
+
+    with pytest.raises(bridge.BridgeError, match="no change"):
+        bridge.run_bridge(
+            _vault(tmp_path),
+            service,
+            fetch_foundation=lambda _vault, _pin: None,
+            input_fn=lambda _prompt: next(answers),
+            output_fn=lambda _line: None,
+        )
+
+    assert service.calls == ["topology-preview", "topology-execute:topology-token", "release-preview"]
+
+
+def test_bridge_does_not_repeat_a_completed_topology_conversion(tmp_path: Path) -> None:
+    service = _SplitService()
+    vault = _vault(tmp_path)
+    answers = iter(("APPLY",))
+
+    result = bridge.run_bridge(
+        vault,
+        service,
+        fetch_foundation=lambda _vault, _pin: None,
+        input_fn=lambda _prompt: next(answers),
+        output_fn=lambda _line: None,
+    )
+
+    assert result["topology_receipt"] == {"skipped": "already-brain-vault-split"}
+    assert service.calls == ["topology-preview", "release-preview", "release-execute:release-token"]
+
+
+def test_bridge_can_resume_after_the_foundation_was_installed_before_a_later_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _SplitService()
+    monkeypatch.setattr(bridge, "_foundation_is_installed", lambda _vault, _pin: True)
+
+    result = bridge.run_bridge(
+        _vault(tmp_path),
+        service,
+        fetch_foundation=lambda _vault, _pin: None,
+        input_fn=lambda _prompt: pytest.fail("already-installed bridge must not request approval"),
+        output_fn=lambda _line: pytest.fail("already-installed bridge must not render a preview"),
+    )
+
+    assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
+    assert service.calls == ["topology-preview"]

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -65,7 +66,7 @@ def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
 
 def test_bridge_success_copy_names_the_canonical_dex_update_command() -> None:
     source = Path(bridge.__file__).read_text(encoding="utf-8")
-    assert "Future updates use dex-update." in source
+    assert "future updates use /dex-update." in source
     assert "Future updates use /dex update." not in source
 
 
@@ -133,6 +134,43 @@ def test_bridge_rejects_a_symlinked_vault_before_calling_the_service_or_fetching
     assert service.calls == []
 
 
+@pytest.mark.parametrize("private_parent", (".venv", ".dex"))
+def test_bridge_rejects_a_symlinked_private_parent_before_service_or_fetch(
+    tmp_path: Path, private_parent: str
+) -> None:
+    service = _Service()
+    vault = _vault(tmp_path)
+    target = tmp_path / f"{private_parent.removeprefix('.')}target"
+    private_path = vault / private_parent
+    if private_path.exists():
+        private_path.rename(target)
+    else:
+        target.mkdir()
+    (vault / private_parent).symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(bridge.BridgeError, match=rf"{private_parent} must not be a symlink"):
+        bridge.run_bridge(
+            vault,
+            service,
+            fetch_foundation=lambda _vault, _pin: pytest.fail("release fetch must not happen"),
+            input_fn=lambda _prompt: pytest.fail("approval must not be requested"),
+            output_fn=lambda _line: pytest.fail("preview must not be rendered"),
+        )
+
+    assert service.calls == []
+
+
+def test_normal_virtualenv_python_symlink_remains_accepted(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    venv = vault / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("home = /synthetic\n", encoding="utf-8")
+    (venv / "bin" / "python").symlink_to(Path(sys.executable))
+
+    assert bridge._validate_vault(vault) == vault
+    assert bridge._installed_python(vault) == venv / "bin" / "python"
+
+
 def test_bridge_stops_before_delivered_release_execution_when_second_preview_is_not_approved(tmp_path: Path) -> None:
     service = _Service()
     answers = iter(("APPLY", "no"))
@@ -166,7 +204,7 @@ def test_bridge_does_not_repeat_a_completed_topology_conversion(tmp_path: Path) 
     assert service.calls == ["topology-preview", "release-preview", "release-execute:release-token"]
 
 
-def test_bridge_can_resume_after_the_foundation_was_installed_before_a_later_step(
+def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_channel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     service = _SplitService()
@@ -175,10 +213,11 @@ def test_bridge_can_resume_after_the_foundation_was_installed_before_a_later_ste
     result = bridge.run_bridge(
         _vault(tmp_path),
         service,
-        fetch_foundation=lambda _vault, _pin: None,
+        fetch_foundation=lambda _vault, _pin: pytest.fail("completed bridge must not fetch"),
         input_fn=lambda _prompt: pytest.fail("already-installed bridge must not request approval"),
         output_fn=lambda _line: pytest.fail("already-installed bridge must not render a preview"),
     )
 
+    assert result["topology_receipt"] == {"skipped": "foundation-already-installed"}
     assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
-    assert service.calls == ["topology-preview"]
+    assert service.calls == []

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -318,6 +318,68 @@ def test_runtime_reexec_cleans_a_hostile_same_interpreter_and_preset_marker(
         assert name not in environment
 
 
+def test_runtime_reexec_rejects_a_forged_exact_clean_environment_from_host_python(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+    vault = _vault(tmp_path)
+    selected_interpreter = vault / ".venv" / "bin" / "python"
+    clean_environment = bridge._bridge_environment()
+    clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+
+    def fake_execve(interpreter: str, argv: list[str], environment: dict[str, str]) -> None:
+        captured["interpreter"] = interpreter
+        captured["argv"] = argv
+        captured["environment"] = environment
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
+    monkeypatch.setattr(bridge.os, "execve", fake_execve)
+    monkeypatch.setattr(bridge.os, "environ", clean_environment)
+
+    bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+
+    assert captured["interpreter"] == str(selected_interpreter)
+    assert captured["argv"] == [
+        str(selected_interpreter),
+        str(Path(bridge.__file__).resolve()),
+        "--vault",
+        "/safe/vault",
+    ]
+    assert captured["environment"] == clean_environment
+
+
+def test_runtime_marker_accepts_only_the_selected_virtualenv_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path)
+    selected_interpreter = vault / ".venv" / "bin" / "python"
+    selected_prefix = selected_interpreter.parent.parent
+    clean_environment = bridge._bridge_environment()
+    clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
+    monkeypatch.setattr(bridge.os, "environ", clean_environment)
+    monkeypatch.setattr(bridge.sys, "executable", str(selected_interpreter))
+    monkeypatch.setattr(bridge.sys, "prefix", str(selected_prefix))
+    monkeypatch.setattr(bridge.sys, "exec_prefix", str(selected_prefix))
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("selected clean virtualenv must not re-exec"),
+    )
+
+    bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+
+
+def test_runtime_refuses_to_fall_back_to_host_python_without_vault_virtualenv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: None)
+
+    with pytest.raises(bridge.BridgeError, match="installed virtualenv"):
+        bridge._reexec_in_installed_runtime(_vault(tmp_path), ["--vault", "/safe/vault"])
+
+
 def test_trusted_executable_does_not_consult_caller_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     attacker_git = tmp_path / "git"
     attacker_git.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -50,6 +52,26 @@ def _vault(tmp_path: Path) -> Path:
     (vault / ".git").mkdir(parents=True)
     (vault / ".dex" / "brain.git").mkdir(parents=True)
     (vault / "System").mkdir()
+    return vault
+
+
+def _completed_vault(tmp_path: Path) -> Path:
+    vault = _vault(tmp_path)
+    (vault / "System" / ".dex").mkdir()
+    (vault / "System" / ".dex" / "topology.json").write_text(
+        '{"topology":"brain-vault-split","vaultGitDir":".git",'
+        '"brainGitDir":".dex/brain.git","installedRelease":"'
+        + bridge.FOUNDATION.commit
+        + '","environment":{"DEX_VAULT":"'
+        + str(vault)
+        + '"}}\n',
+        encoding="utf-8",
+    )
+    (vault / ".git" / "dex-vault-v2").write_text('{"role":"vault"}\n', encoding="utf-8")
+    (vault / ".dex" / "brain.git" / "dex-brain-v2").write_text(
+        '{"role":"brain","installed":"' + bridge.FOUNDATION.commit + '"}\n',
+        encoding="utf-8",
+    )
     return vault
 
 
@@ -221,3 +243,69 @@ def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_cha
     assert result["topology_receipt"] == {"skipped": "foundation-already-installed"}
     assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
     assert service.calls == []
+
+
+def test_completed_foundation_requires_all_durable_split_markers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _completed_vault(tmp_path)
+    monkeypatch.setattr(bridge, "_run_git", lambda *_arguments: bridge.FOUNDATION.commit)
+
+    assert bridge._foundation_is_installed(vault, bridge.FOUNDATION) is True
+
+    topology = vault / "System" / ".dex" / "topology.json"
+    topology.write_text('{"topology":"brain-vault-split"}\n', encoding="utf-8")
+    with pytest.raises(bridge.BridgeError, match="markers do not agree"):
+        bridge._foundation_is_installed(vault, bridge.FOUNDATION)
+
+
+def test_main_resumes_completed_foundation_before_runtime_or_source_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault = _completed_vault(tmp_path)
+    monkeypatch.setattr(bridge, "_run_git", lambda *_arguments: bridge.FOUNDATION.commit)
+    monkeypatch.setattr(
+        bridge,
+        "_reexec_in_installed_runtime",
+        lambda *_arguments: pytest.fail("completed bridge must not re-exec"),
+    )
+    monkeypatch.setattr(
+        bridge,
+        "acquire_foundation_source",
+        lambda: pytest.fail("completed bridge must not download source"),
+    )
+
+    assert bridge.main(["--vault", str(vault)]) == 0
+    output = capsys.readouterr().out
+    assert '"foundation-already-installed"' in output
+
+
+def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(arguments, **kwargs):
+        captured["arguments"] = arguments
+        captured["environment"] = kwargs["env"]
+        return subprocess.CompletedProcess(arguments, 0, stdout=b"ok\n", stderr=b"")
+
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/private/attacker-config")
+    monkeypatch.setenv("GIT_DIR", "/private/attacker-repository")
+    monkeypatch.setenv("GIT_SSH_COMMAND", "attacker-command")
+    monkeypatch.setenv("HOME", "/private/credential-home")
+    monkeypatch.setenv("PYTHONPATH", "/private/attacker-python")
+    monkeypatch.setattr(bridge.subprocess, "run", fake_run)
+
+    assert bridge._run_git(tmp_path, "rev-parse", "HEAD") == "ok"
+
+    environment = captured["environment"]
+    assert isinstance(environment, dict)
+    assert environment["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert environment["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert environment["GIT_TERMINAL_PROMPT"] == "0"
+    assert "HOME" not in environment
+    assert "PYTHONPATH" not in environment
+    assert "GIT_DIR" not in environment
+    assert "GIT_SSH_COMMAND" not in environment
+    assert "credential.helper=" in captured["arguments"]

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -280,6 +280,54 @@ def test_main_resumes_completed_foundation_before_runtime_or_source_download(
     assert '"foundation-already-installed"' in output
 
 
+def test_runtime_reexec_cleans_a_hostile_same_interpreter_and_preset_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_execve(interpreter: str, argv: list[str], environment: dict[str, str]) -> None:
+        captured["interpreter"] = interpreter
+        captured["argv"] = argv
+        captured["environment"] = environment
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: Path(sys.executable))
+    monkeypatch.setattr(bridge.os, "execve", fake_execve)
+    monkeypatch.setenv(bridge._CLEAN_RUNTIME_MARKER, "1")
+    monkeypatch.setenv("PATH", "/private/attacker-bin")
+    monkeypatch.setenv("GIT_DIR", "/private/attacker-repository")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/private/attacker-config")
+    monkeypatch.setenv("GIT_SSH_COMMAND", "attacker-command")
+    monkeypatch.setenv("PYTHONPATH", "/private/attacker-python")
+    monkeypatch.setenv("NODE_OPTIONS", "--require=/private/attacker-node")
+
+    bridge._reexec_in_installed_runtime(_vault(tmp_path), ["--vault", "/safe/vault"])
+
+    assert captured["interpreter"] == str(Path(sys.executable))
+    assert captured["argv"] == [
+        str(Path(sys.executable)),
+        str(Path(bridge.__file__).resolve()),
+        "--vault",
+        "/safe/vault",
+    ]
+    environment = captured["environment"]
+    assert isinstance(environment, dict)
+    assert environment[bridge._CLEAN_RUNTIME_MARKER] == "1"
+    assert "/private/attacker-bin" not in environment["PATH"]
+    assert environment["GIT_CONFIG_GLOBAL"] == os.devnull
+    for name in ("GIT_DIR", "GIT_SSH_COMMAND", "PYTHONPATH", "NODE_OPTIONS"):
+        assert name not in environment
+
+
+def test_trusted_executable_does_not_consult_caller_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    attacker_git = tmp_path / "git"
+    attacker_git.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    attacker_git.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setattr(bridge, "_TRUSTED_EXECUTABLE_DIRECTORIES", (tmp_path / "system-bin",))
+
+    assert bridge._trusted_executable("git") is None
+
+
 def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -294,6 +342,7 @@ def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
     monkeypatch.setenv("GIT_DIR", "/private/attacker-repository")
     monkeypatch.setenv("GIT_SSH_COMMAND", "attacker-command")
     monkeypatch.setenv("HOME", "/private/credential-home")
+    monkeypatch.setenv("PATH", "/private/attacker-bin")
     monkeypatch.setenv("PYTHONPATH", "/private/attacker-python")
     monkeypatch.setattr(bridge.subprocess, "run", fake_run)
 
@@ -304,6 +353,7 @@ def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
     assert environment["GIT_CONFIG_GLOBAL"] == os.devnull
     assert environment["GIT_CONFIG_NOSYSTEM"] == "1"
     assert environment["GIT_TERMINAL_PROMPT"] == "0"
+    assert "/private/attacker-bin" not in environment["PATH"]
     assert "HOME" not in environment
     assert "PYTHONPATH" not in environment
     assert "GIT_DIR" not in environment

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -91,9 +91,11 @@ and path evidence before it can be offered as supported recovery.
 
 Do not run this unpublished source as a rescue command. When a later immutable
 foundation includes the repair and the full fixture evidence is green, publish a
-separately versioned bridge file with its SHA-256, then use the file matched to
-that foundation. An older bridge must refuse rather than silently substituting a
-newer release.
+separately versioned bridge file with its SHA-256 and the exact annotated
+distribution tag, tag object, commit, and tree it pins. That bridge source and
+artifact must name that same future foundation identity; rebasing this file onto
+`main` is not a substitute for a released tag. An older bridge must refuse
+rather than silently substituting a newer release.
 
 # This is the eventual published-artifact invocation, not an instruction to
 # run this repository source before that release exists.

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -73,6 +73,35 @@ can write. The transaction and ownership contract decide every vault-content
 write and keep the receipt and rewind evidence. If delivery, preview, or
 execution cannot be proved, it stops; do not substitute a manual Git command.
 
+## Lifecycle-era bridge — v1.74 through v1.79
+
+Those releases can safely update the Dex files they already have, but they do
+not contain the later delivery mechanism that fetches a new Dex release. They
+need one **one-time bridge** before their normal `dex-update` experience can
+begin. The bridge is intentionally not a raw Git merge: it fetches only the
+pre-pinned foundation release, proves its annotated tag, commit, and tree, then
+uses that foundation's existing topology and receipt-backed transaction service.
+
+On macOS or Linux, from the old Dex folder, download the separately published,
+versioned bridge file and verify the SHA-256 printed beside that exact file
+before running it. Use the bridge file matched to the currently published
+stable foundation; an older bridge refuses rather than silently substituting a
+newer release.
+
+```bash
+python3 dex_update_bridge.py --vault "$PWD"
+```
+
+It shows two independent previews and requires `APPLY` for each: first the
+one-time separation of Dex code from the user's notes, then the exact files for
+the verified foundation release. It never pushes, never uses a branch, and
+stops before a user-file change if either proof or approval is missing. Once it
+finishes, all later updates are the ordinary `dex-update` route.
+
+Windows is not part of this P0 bridge. Do not substitute an unverified PowerShell
+or Git command; use the supported rescue path until a Windows bridge is
+published.
+
 ## Special case: v1.62.0 refuses before the merge
 
 Six of the seven published copies of v1.62.0 shipped a self-contradictory metadata

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -82,12 +82,21 @@ begin. The bridge is intentionally not a raw Git merge: it fetches only the
 pre-pinned foundation release, proves its annotated tag, commit, and tree, then
 uses that foundation's existing topology and receipt-backed transaction service.
 
-On macOS or Linux, from the old Dex folder, download the separately published,
-versioned bridge file and verify the SHA-256 printed beside that exact file
-before running it. Use the bridge file matched to the currently published
-stable foundation; an older bridge refuses rather than silently substituting a
+This source is not yet a published historical-support promise. Its pinned
+foundation is exactly v1.80.5; it cannot include repairs introduced in later
+source commits. In particular, do not treat a later MCP-registration repair as
+evidence that a v1.74–v1.79 bridge journey is complete. Each historical route
+needs an installed-fixture rehearsal, preserved-user-file hashes, Doctor output,
+and path evidence before it can be offered as supported recovery.
+
+Do not run this unpublished source as a rescue command. When a later immutable
+foundation includes the repair and the full fixture evidence is green, publish a
+separately versioned bridge file with its SHA-256, then use the file matched to
+that foundation. An older bridge must refuse rather than silently substituting a
 newer release.
 
+# This is the eventual published-artifact invocation, not an instruction to
+# run this repository source before that release exists.
 ```bash
 python3 dex_update_bridge.py --vault "$PWD"
 ```
@@ -95,8 +104,9 @@ python3 dex_update_bridge.py --vault "$PWD"
 It shows two independent previews and requires `APPLY` for each: first the
 one-time separation of Dex code from the user's notes, then the exact files for
 the verified foundation release. It never pushes, never uses a branch, and
-stops before a user-file change if either proof or approval is missing. Once it
-finishes, all later updates are the ordinary `dex-update` route.
+stops before a user-file change if either proof or approval is missing. Only a
+published bridge whose historical fixture proof is green may say that later
+updates are the ordinary `/dex-update` route.
 
 Windows is not part of this P0 bridge. Do not substitute an unverified PowerShell
 or Git command; use the supported rescue path until a Windows bridge is

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""One-time, pinned bootstrap for Dex lifecycle-era installations.
+
+This is deliberately separate from an installed old Dex's update instructions.
+Those releases can safely update the code they already contain, but cannot fetch
+new Dex code. The bridge proves one predeclared foundation release and delegates
+the topology conversion and release writes to its lifecycle service.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, Mapping, Protocol
+
+OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
+_HEX = re.compile(r"^[0-9a-f]{40}$")
+_RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$")
+_APPROVAL_WORD = "APPLY"
+
+
+class BridgeError(RuntimeError):
+    """The bridge could not prove it is safe to continue."""
+
+
+@dataclass(frozen=True)
+class ReleasePin:
+    """The closed immutable identity of the one bridge foundation release."""
+
+    tag: str
+    tag_object: str
+    commit: str
+    tree: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if _RELEASE_TAG.fullmatch(self.tag) is None:
+            raise BridgeError("foundation tag is not an immutable distribution tag")
+        if any(_HEX.fullmatch(value) is None for value in (self.tag_object, self.commit, self.tree)):
+            raise BridgeError("foundation release identity is malformed")
+        if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", self.version):
+            raise BridgeError("foundation release version is malformed")
+        if not self.tag.startswith(f"dist/release/v{self.version}-"):
+            raise BridgeError("foundation tag and version disagree")
+
+    def identity(self) -> dict[str, str]:
+        return {
+            "tag": self.tag,
+            "tag_object": self.tag_object,
+            "commit": self.commit,
+            "tree": self.tree,
+            "version": self.version,
+            # ``release`` is the Git ref name; lifecycle identities name the
+            # user-facing channel as ``stable``.
+            "channel": "stable",
+        }
+
+
+# The first public release with the corrected self-delivery approval boundary
+# and profile-safe package. This pin is intentionally in the bridge source:
+# discovering a mutable "latest" release would not be a safe bootstrap.
+FOUNDATION = ReleasePin(
+    tag="dist/release/v1.80.5-9211053",
+    tag_object="ff94463b191bb2c503ffec42ce288e961ca79659",
+    commit="9211053235d7c1837a6e327bff1596b593323fc6",
+    tree="d394658e2bf1125b96eb5afdace24f3a5ba3107e",
+    version="1.80.5",
+)
+
+
+class LifecycleService(Protocol):
+    def build_and_preview_topology_migration(self, vault_root: str | Path) -> Mapping[str, Any]: ...
+    def execute_approved_topology_migration(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
+    def build_and_preview_delivered_release(self, vault_root: str | Path, release: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def execute_approved_delivered_release(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
+
+
+def _run_git(directory: Path, *arguments: str) -> str:
+    """Run a non-interactive Git operation with hooks and non-HTTPS blocked."""
+    completed = subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", "-c", "fetch.fsckObjects=true", "-c", "transfer.fsckObjects=true", "-C", str(directory), *arguments],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GIT_ALLOW_PROTOCOL": "https", "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0"},
+        timeout=90,
+    )
+    if completed.returncode:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        raise BridgeError(detail or "Git could not retrieve the pinned Dex release")
+    try:
+        return completed.stdout.decode("utf-8").strip()
+    except UnicodeDecodeError as error:
+        raise BridgeError("Git returned non-text release metadata") from error
+
+
+def _assert_equal(actual: str, expected: str, description: str) -> None:
+    if actual != expected:
+        raise BridgeError(f"pinned foundation {description} did not match")
+
+
+def _verify_pin(repository: Path, pin: ReleasePin) -> None:
+    _assert_equal(_run_git(repository, "rev-parse", "--verify", f"refs/tags/{pin.tag}"), pin.tag_object, "annotated tag")
+    _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{commit}}"), pin.commit, "commit")
+    _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{tree}}"), pin.tree, "tree")
+
+
+def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    """Fetch only the pinned foundation tag into a disposable source checkout."""
+    temporary = tempfile.TemporaryDirectory(prefix="dex-update-bridge-")
+    root = Path(temporary.name)
+    bare = root / "evidence.git"
+    source = root / "foundation"
+    try:
+        _run_git(root, "init", "--bare", "--quiet", str(bare))
+        _run_git(bare, "fetch", "--quiet", "--no-tags", "--no-write-fetch-head", "--no-recurse-submodules", OFFICIAL_REMOTE, f"refs/tags/{pin.tag}:refs/tags/{pin.tag}")
+        _verify_pin(bare, pin)
+        # A linked worktree keeps the verified objects in the disposable bare
+        # evidence store. It avoids opening the local ``file`` transport, which
+        # this bridge deliberately blocks for every network-facing Git call.
+        _run_git(bare, "worktree", "add", "--quiet", "--detach", str(source), pin.tag)
+        _verify_pin(source, pin)
+    except Exception:
+        temporary.cleanup()
+        raise
+    return temporary, source
+
+
+def _validate_vault(vault_root: Path) -> Path:
+    supplied = Path(vault_root).expanduser()
+    if ".." in supplied.parts:
+        raise BridgeError("Dex vault path must not contain parent-directory traversal")
+    # ``resolve()`` follows links, so it is only safe after every component of
+    # the path supplied by the caller has been checked.  Otherwise a symlinked
+    # root would appear to be an ordinary target directory by the time the
+    # lifecycle service sees it.
+    lexical = Path(os.path.abspath(supplied))
+    path_component = Path(lexical.anchor)
+    for component in lexical.parts[1:]:
+        path_component /= component
+        if path_component.is_symlink():
+            raise BridgeError("Dex vault path contains a symlink")
+    root = lexical.resolve()
+    if not root.is_dir():
+        raise BridgeError("Dex vault is not a safe directory")
+    if (root / ".git").is_symlink() or not (root / ".git").exists():
+        raise BridgeError("Dex vault does not have a safe Git history")
+    if (root / "System").is_symlink() or not (root / "System").is_dir():
+        raise BridgeError("Dex vault does not have a safe System directory")
+    return root
+
+
+def _installed_python(vault_root: Path) -> Path | None:
+    """Return Dex's already-created POSIX virtualenv interpreter, if present.
+
+    The foundation lifecycle service needs the same runtime dependencies that
+    the historical Dex installer already put in ``.venv``.  The bridge never
+    downloads Python packages at update time.  This is deliberately a POSIX
+    seam; Windows gets its own reviewed bridge rather than guessed paths.
+    """
+    candidate = vault_root / ".venv" / "bin" / "python"
+    config = vault_root / ".venv" / "pyvenv.cfg"
+    # POSIX venvs normally expose Python as a symlink to the system interpreter;
+    # executing that entrypoint is what makes its dependency site-packages
+    # available, so reject only a missing/non-executable resolved target.
+    if not candidate.exists() or not candidate.resolve().is_file() or not os.access(candidate, os.X_OK):
+        return None
+    if config.is_symlink() or not config.is_file():
+        return None
+    return candidate
+
+
+def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
+    """Restart once in the install's existing dependency runtime, if needed."""
+    if os.environ.get("DEX_UPDATE_BRIDGE_RUNTIME") == "1":
+        return
+    interpreter = _installed_python(vault_root)
+    if interpreter is None or interpreter.resolve() == Path(sys.executable).resolve():
+        return
+    environment = {**os.environ, "DEX_UPDATE_BRIDGE_RUNTIME": "1"}
+    os.execve(
+        str(interpreter),
+        [str(interpreter), str(Path(__file__).resolve()), *argv],
+        environment,
+    )
+
+
+def _load_lifecycle_service(source: Path) -> LifecycleService:
+    """Import only the verified foundation release's lifecycle service."""
+    if not (source / "core" / "lifecycle" / "service.py").is_file():
+        raise BridgeError("pinned foundation release has no lifecycle service")
+    for name in tuple(sys.modules):
+        if name == "core" or name.startswith("core."):
+            del sys.modules[name]
+    sys.path.insert(0, str(source))
+    try:
+        module: ModuleType = importlib.import_module("core.lifecycle.service")
+    except Exception as error:  # noqa: BLE001
+        raise BridgeError(f"pinned foundation lifecycle service could not start: {error}") from error
+    required = (
+        "build_and_preview_topology_migration",
+        "execute_approved_topology_migration",
+        "build_and_preview_delivered_release",
+        "execute_approved_delivered_release",
+    )
+    if any(not callable(getattr(module, name, None)) for name in required):
+        raise BridgeError("pinned foundation lifecycle service is incomplete")
+    return module  # type: ignore[return-value]
+
+
+def _approved_preview(prompt: str, preview: Mapping[str, Any], approval_token: object, *, input_fn: Callable[[str], str], output_fn: Callable[[str], None]) -> tuple[Mapping[str, Any], str]:
+    if not isinstance(approval_token, str) or not approval_token:
+        raise BridgeError("lifecycle preview did not return an approval token")
+    output_fn(json.dumps(preview, indent=2, sort_keys=True))
+    if input_fn(f"{prompt} Type {_APPROVAL_WORD} to continue: ") != _APPROVAL_WORD:
+        raise BridgeError("no change was made because the displayed preview was not approved")
+    return preview, approval_token
+
+
+def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
+    """Fetch one pinned release into the private brain; no vault file is written."""
+    brain = vault_root / ".dex" / "brain.git"
+    if brain.is_symlink() or not brain.is_dir():
+        raise BridgeError("topology conversion did not create a safe Dex brain store")
+    _run_git(
+        brain,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "--no-recurse-submodules",
+        OFFICIAL_REMOTE,
+        f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
+        "+refs/heads/release:refs/remotes/upstream/release",
+    )
+    _verify_pin(brain, pin)
+    _assert_equal(
+        _run_git(brain, "rev-parse", "--verify", "refs/remotes/upstream/release^{commit}"),
+        pin.commit,
+        "stable release-channel target",
+    )
+
+
+def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
+    brain = vault_root / ".dex" / "brain.git"
+    if brain.is_symlink() or not brain.is_dir():
+        raise BridgeError("topology conversion did not create a safe Dex brain store")
+    try:
+        installed = _run_git(brain, "rev-parse", "--verify", "refs/dex/installed^{commit}")
+    except BridgeError:
+        return False
+    return installed == pin.commit
+
+
+def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
+    """Run two fresh approval boundaries using the verified foundation service."""
+    root = _validate_vault(vault_root)
+    topology = service.build_and_preview_topology_migration(root)
+    preview = topology.get("preview")
+    # Foundation v1.80.5 calls a completed conversion ``post-split`` and still
+    # returns a read-only status document. Older service shapes used
+    # ``brain-vault-split`` with no preview. Neither has an approval token, so
+    # neither is an operation the bridge may repeat.
+    if (
+        topology.get("topology") in {"brain-vault-split", "post-split"}
+        and topology.get("approval_token") is None
+    ):
+        topology_receipt: Mapping[str, Any] = {"skipped": "already-brain-vault-split"}
+    else:
+        if not isinstance(preview, Mapping):
+            raise BridgeError("foundation could not produce a topology preview")
+        preview, token = _approved_preview("Dex will first separate its code from your notes.", preview, topology.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
+        topology_receipt = service.execute_approved_topology_migration(root, preview, token)
+
+    # This fetch touches only Dex's private code store. The following preview is
+    # still the sole authority for every vault-content write.
+    fetch_foundation(root, pin)
+    if _foundation_is_installed(root, pin):
+        delivery_receipt: Mapping[str, Any] = {"skipped": "foundation-already-installed"}
+    else:
+        delivery = service.build_and_preview_delivered_release(root, pin.identity())
+        release_preview = delivery.get("preview")
+        if not isinstance(release_preview, Mapping):
+            raise BridgeError("foundation could not produce a delivered-release preview")
+        release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
+        delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
+
+    return {
+        "foundation": pin.identity(),
+        "topology_receipt": dict(topology_receipt),
+        "delivery_receipt": dict(delivery_receipt),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, default=Path.cwd(), help="old Dex vault (defaults to current directory)")
+    args = parser.parse_args(argv)
+    if sys.platform.startswith("win"):
+        parser.error("this P0 bridge supports macOS and Linux only")
+    if shutil.which("git") is None:
+        parser.error("Git is required for the one-time Dex update bridge")
+    try:
+        vault = _validate_vault(args.vault)
+        _reexec_in_installed_runtime(vault, sys.argv[1:] if argv is None else argv)
+        temporary, source = acquire_foundation_source()
+        try:
+            result = run_bridge(vault, _load_lifecycle_service(source))
+        finally:
+            temporary.cleanup()
+    except (BridgeError, OSError, RuntimeError) as error:
+        print(f"Dex update bridge stopped safely: {error}", file=sys.stderr)
+        return 1
+    print("Dex is now on the self-delivering updater. Future updates use dex-update.")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -27,6 +27,7 @@ OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
 _HEX = re.compile(r"^[0-9a-f]{40}$")
 _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$")
 _APPROVAL_WORD = "APPLY"
+_SUBPROCESS_ENVIRONMENT = ("PATH", "TMPDIR", "TMP", "TEMP", "SYSTEMROOT", "WINDIR")
 
 
 class BridgeError(RuntimeError):
@@ -85,13 +86,54 @@ class LifecycleService(Protocol):
     def execute_approved_delivered_release(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
 
 
+def _bridge_environment() -> dict[str, str]:
+    """Return the small, non-interactive environment used by the bridge.
+
+    The bridge fetches one public, pinned release; it must never inherit a
+    caller's Git repository selection, configuration, credential helpers, or
+    Python import path.  Keep only the platform variables needed to locate
+    executables and temporary files, then explicitly disable all Git config
+    sources that could alter retrieval.
+    """
+    environment = {
+        name: value
+        for name in _SUBPROCESS_ENVIRONMENT
+        if (value := os.environ.get(name))
+    }
+    environment.update(
+        {
+            "GCM_INTERACTIVE": "Never",
+            "GIT_ALLOW_PROTOCOL": "https",
+            "GIT_ASKPASS": "false",
+            "GIT_ATTR_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    return environment
+
+
 def _run_git(directory: Path, *arguments: str) -> str:
     """Run a non-interactive Git operation with hooks and non-HTTPS blocked."""
     completed = subprocess.run(
-        ["git", "-c", "core.hooksPath=/dev/null", "-c", "fetch.fsckObjects=true", "-c", "transfer.fsckObjects=true", "-C", str(directory), *arguments],
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "fetch.fsckObjects=true",
+            "-c",
+            "transfer.fsckObjects=true",
+            "-C",
+            str(directory),
+            *arguments,
+        ],
         check=False,
         capture_output=True,
-        env={**os.environ, "GIT_ALLOW_PROTOCOL": "https", "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0"},
+        env=_bridge_environment(),
         timeout=90,
     )
     if completed.returncode:
@@ -195,7 +237,8 @@ def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
     interpreter = _installed_python(vault_root)
     if interpreter is None or interpreter.resolve() == Path(sys.executable).resolve():
         return
-    environment = {**os.environ, "DEX_UPDATE_BRIDGE_RUNTIME": "1"}
+    environment = _bridge_environment()
+    environment["DEX_UPDATE_BRIDGE_RUNTIME"] = "1"
     os.execve(
         str(interpreter),
         [str(interpreter), str(Path(__file__).resolve()), *argv],
@@ -259,6 +302,53 @@ def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
     )
 
 
+def _regular_json(path: Path, description: str) -> dict[str, Any]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise BridgeError(f"{description} is not a regular file")
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BridgeError(f"{description} is unreadable") from error
+    if not isinstance(value, dict):
+        raise BridgeError(f"{description} is not an object")
+    return value
+
+
+def _validate_completed_foundation(vault_root: Path, pin: ReleasePin) -> None:
+    """Prove every durable split marker agrees with the installed pin."""
+    brain = vault_root / ".dex" / "brain.git"
+    paths = {
+        ".git": vault_root / ".git",
+        ".dex": vault_root / ".dex",
+        ".dex/brain.git": brain,
+        "System/.dex": vault_root / "System" / ".dex",
+    }
+    for relative, path in paths.items():
+        if path.is_symlink() or not path.is_dir():
+            raise BridgeError(f"completed bridge has an unsafe {relative} directory")
+
+    topology = _regular_json(vault_root / "System" / ".dex" / "topology.json", "split topology marker")
+    vault_marker = _regular_json(vault_root / ".git" / "dex-vault-v2", "vault Git marker")
+    brain_marker = _regular_json(brain / "dex-brain-v2", "brain Git marker")
+    environment = topology.get("environment")
+    wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
+    try:
+        wiring_matches = isinstance(wired_vault, str) and Path(wired_vault).resolve() == vault_root
+    except (OSError, RuntimeError):
+        wiring_matches = False
+    if (
+        topology.get("topology") != "brain-vault-split"
+        or topology.get("vaultGitDir") != ".git"
+        or topology.get("brainGitDir") != ".dex/brain.git"
+        or not wiring_matches
+        or topology.get("installedRelease") != pin.commit
+        or vault_marker.get("role") != "vault"
+        or brain_marker.get("role") != "brain"
+        or brain_marker.get("installed") != pin.commit
+    ):
+        raise BridgeError("completed bridge markers do not agree with the pinned foundation")
+
+
 def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
     """Check the local installed ref without fetching or consulting a channel.
 
@@ -278,7 +368,18 @@ def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
         installed = _run_git(brain, "rev-parse", "--verify", "refs/dex/installed^{commit}")
     except BridgeError:
         return False
-    return installed == pin.commit
+    if installed != pin.commit:
+        return False
+    _validate_completed_foundation(vault_root, pin)
+    return True
+
+
+def _completed_bridge_result(pin: ReleasePin) -> dict[str, object]:
+    return {
+        "foundation": pin.identity(),
+        "topology_receipt": {"skipped": "foundation-already-installed"},
+        "delivery_receipt": {"skipped": "foundation-already-installed"},
+    }
 
 
 def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
@@ -289,11 +390,7 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     # completed bridge must work offline and must not be disturbed merely
     # because the stable channel has subsequently advanced.
     if _foundation_is_installed(root, pin):
-        return {
-            "foundation": pin.identity(),
-            "topology_receipt": {"skipped": "foundation-already-installed"},
-            "delivery_receipt": {"skipped": "foundation-already-installed"},
-        }
+        return _completed_bridge_result(pin)
 
     topology = service.build_and_preview_topology_migration(root)
     preview = topology.get("preview")
@@ -339,12 +436,18 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("Git is required for the one-time Dex update bridge")
     try:
         vault = _validate_vault(args.vault)
-        _reexec_in_installed_runtime(vault, sys.argv[1:] if argv is None else argv)
-        temporary, source = acquire_foundation_source()
-        try:
-            result = run_bridge(vault, _load_lifecycle_service(source))
-        finally:
-            temporary.cleanup()
+        # A completed bridge has all durable state locally.  Check before
+        # selecting the old virtualenv or downloading source so resuming it is
+        # genuinely offline and independent of a later stable-channel change.
+        if _foundation_is_installed(vault, FOUNDATION):
+            result = _completed_bridge_result(FOUNDATION)
+        else:
+            _reexec_in_installed_runtime(vault, sys.argv[1:] if argv is None else argv)
+            temporary, source = acquire_foundation_source()
+            try:
+                result = run_bridge(vault, _load_lifecycle_service(source))
+            finally:
+                temporary.cleanup()
     except (BridgeError, OSError, RuntimeError) as error:
         print(f"Dex update bridge stopped safely: {error}", file=sys.stderr)
         return 1

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -156,6 +156,12 @@ def _validate_vault(vault_root: Path) -> Path:
         raise BridgeError("Dex vault does not have a safe Git history")
     if (root / "System").is_symlink() or not (root / "System").is_dir():
         raise BridgeError("Dex vault does not have a safe System directory")
+    for private_parent in (".venv", ".dex"):
+        candidate = root / private_parent
+        if candidate.is_symlink():
+            raise BridgeError(f"Dex vault {private_parent} must not be a symlink")
+        if candidate.exists() and not candidate.is_dir():
+            raise BridgeError(f"Dex vault {private_parent} must be a directory")
     return root
 
 
@@ -167,8 +173,11 @@ def _installed_python(vault_root: Path) -> Path | None:
     downloads Python packages at update time.  This is deliberately a POSIX
     seam; Windows gets its own reviewed bridge rather than guessed paths.
     """
-    candidate = vault_root / ".venv" / "bin" / "python"
-    config = vault_root / ".venv" / "pyvenv.cfg"
+    venv = vault_root / ".venv"
+    if venv.is_symlink() or (venv.exists() and not venv.is_dir()):
+        return None
+    candidate = venv / "bin" / "python"
+    config = venv / "pyvenv.cfg"
     # POSIX venvs normally expose Python as a symlink to the system interpreter;
     # executing that entrypoint is what makes its dependency site-packages
     # available, so reject only a missing/non-executable resolved target.
@@ -251,9 +260,20 @@ def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
 
 
 def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
+    """Check the local installed ref without fetching or consulting a channel.
+
+    This is deliberately safe to call before topology conversion: an old vault
+    simply has no private brain store yet, whereas a completed bridge can
+    resume offline even if the public stable channel has advanced.
+    """
     brain = vault_root / ".dex" / "brain.git"
-    if brain.is_symlink() or not brain.is_dir():
-        raise BridgeError("topology conversion did not create a safe Dex brain store")
+    dex_root = vault_root / ".dex"
+    if dex_root.is_symlink() or brain.is_symlink():
+        raise BridgeError("Dex private code store must not contain a symlink")
+    if not dex_root.exists() or not brain.exists():
+        return False
+    if not dex_root.is_dir() or not brain.is_dir():
+        raise BridgeError("Dex private code store is not a safe directory")
     try:
         installed = _run_git(brain, "rev-parse", "--verify", "refs/dex/installed^{commit}")
     except BridgeError:
@@ -264,6 +284,17 @@ def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
 def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
     """Run two fresh approval boundaries using the verified foundation service."""
     root = _validate_vault(vault_root)
+    # This local ref is the authoritative resume marker. Check it before
+    # importing/calling lifecycle code or attempting any network operation: a
+    # completed bridge must work offline and must not be disturbed merely
+    # because the stable channel has subsequently advanced.
+    if _foundation_is_installed(root, pin):
+        return {
+            "foundation": pin.identity(),
+            "topology_receipt": {"skipped": "foundation-already-installed"},
+            "delivery_receipt": {"skipped": "foundation-already-installed"},
+        }
+
     topology = service.build_and_preview_topology_migration(root)
     preview = topology.get("preview")
     # Foundation v1.80.5 calls a completed conversion ``post-split`` and still
@@ -284,15 +315,12 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     # This fetch touches only Dex's private code store. The following preview is
     # still the sole authority for every vault-content write.
     fetch_foundation(root, pin)
-    if _foundation_is_installed(root, pin):
-        delivery_receipt: Mapping[str, Any] = {"skipped": "foundation-already-installed"}
-    else:
-        delivery = service.build_and_preview_delivered_release(root, pin.identity())
-        release_preview = delivery.get("preview")
-        if not isinstance(release_preview, Mapping):
-            raise BridgeError("foundation could not produce a delivered-release preview")
-        release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
-        delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
+    delivery = service.build_and_preview_delivered_release(root, pin.identity())
+    release_preview = delivery.get("preview")
+    if not isinstance(release_preview, Mapping):
+        raise BridgeError("foundation could not produce a delivered-release preview")
+    release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
+    delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
 
     return {
         "foundation": pin.identity(),
@@ -320,7 +348,7 @@ def main(argv: list[str] | None = None) -> int:
     except (BridgeError, OSError, RuntimeError) as error:
         print(f"Dex update bridge stopped safely: {error}", file=sys.stderr)
         return 1
-    print("Dex is now on the self-delivering updater. Future updates use dex-update.")
+    print("Foundation delivery is complete. Once historical support is verified, future updates use /dex-update.")
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -250,19 +250,41 @@ def _installed_python(vault_root: Path) -> Path | None:
     return candidate
 
 
+def _running_in_selected_runtime(interpreter: Path) -> bool:
+    """Prove this process was launched through the selected vault virtualenv.
+
+    Virtualenv Python binaries may be symlinks to the host binary, so comparing
+    resolved executables would accept a host-Python invocation.  Preserve the
+    invocation path and require the virtualenv's runtime prefixes as well.
+    """
+    selected_prefix = interpreter.parent.parent
+    return (
+        os.path.abspath(sys.executable) == str(interpreter)
+        and os.path.abspath(sys.prefix) == str(selected_prefix)
+        and os.path.abspath(sys.exec_prefix) == str(selected_prefix)
+    )
+
+
 def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
     """Enter one clean process before loading any foundation code.
 
     The installed venv can resolve to the same binary as the invoking Python,
     but running it by its venv path still selects the installed dependencies.
     Never trust a caller-supplied runtime marker: it is accepted only when the
-    complete environment already equals the closed runtime environment.
+    complete environment already equals the closed runtime environment and the
+    running Python identifies as the selected vault virtualenv.
     """
+    interpreter = _installed_python(vault_root)
+    if interpreter is None:
+        raise BridgeError("Dex's installed virtualenv is required for the one-time update bridge")
     environment = _bridge_environment()
     environment[_CLEAN_RUNTIME_MARKER] = "1"
-    if os.environ.get(_CLEAN_RUNTIME_MARKER) == "1" and dict(os.environ) == environment:
+    if (
+        os.environ.get(_CLEAN_RUNTIME_MARKER) == "1"
+        and dict(os.environ) == environment
+        and _running_in_selected_runtime(interpreter)
+    ):
         return
-    interpreter = _installed_python(vault_root) or Path(sys.executable).resolve()
     os.execve(
         str(interpreter),
         [str(interpreter), str(Path(__file__).resolve()), *argv],

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -14,7 +14,6 @@ import importlib
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -27,7 +26,8 @@ OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
 _HEX = re.compile(r"^[0-9a-f]{40}$")
 _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$")
 _APPROVAL_WORD = "APPLY"
-_SUBPROCESS_ENVIRONMENT = ("PATH", "TMPDIR", "TMP", "TEMP", "SYSTEMROOT", "WINDIR")
+_CLEAN_RUNTIME_MARKER = "DEX_UPDATE_BRIDGE_CLEAN_RUNTIME"
+_TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/local/bin"), Path("/opt/homebrew/bin"))
 
 
 class BridgeError(RuntimeError):
@@ -86,39 +86,59 @@ class LifecycleService(Protocol):
     def execute_approved_delivered_release(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
 
 
+def _trusted_executable(name: str) -> Path | None:
+    """Find a system-installed executable without consulting caller PATH."""
+    for directory in _TRUSTED_EXECUTABLE_DIRECTORIES:
+        candidate = directory / name
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return resolved
+    return None
+
+
+def _trusted_git_binary() -> Path:
+    git = _trusted_executable("git")
+    if git is None:
+        raise BridgeError("trusted system Git is required for the one-time Dex update bridge")
+    return git
+
+
 def _bridge_environment() -> dict[str, str]:
     """Return the small, non-interactive environment used by the bridge.
 
     The bridge fetches one public, pinned release; it must never inherit a
-    caller's Git repository selection, configuration, credential helpers, or
-    Python import path.  Keep only the platform variables needed to locate
-    executables and temporary files, then explicitly disable all Git config
-    sources that could alter retrieval.
+    caller's Git repository selection, configuration, credential helpers,
+    Python import path, or executable lookup.  The foundation's Node migrator
+    inherits this exact environment, so its Git children receive the same
+    boundary.
     """
-    environment = {
-        name: value
-        for name in _SUBPROCESS_ENVIRONMENT
-        if (value := os.environ.get(name))
+    executable_directories = [str(_trusted_git_binary().parent)]
+    node = _trusted_executable("node")
+    if node is not None:
+        executable_directories.append(str(node.parent))
+    executable_directories.extend(str(directory) for directory in _TRUSTED_EXECUTABLE_DIRECTORIES)
+    return {
+        "PATH": os.pathsep.join(dict.fromkeys(executable_directories)),
+        "GCM_INTERACTIVE": "Never",
+        "GIT_ALLOW_PROTOCOL": "https",
+        "GIT_ASKPASS": "false",
+        "GIT_ATTR_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
     }
-    environment.update(
-        {
-            "GCM_INTERACTIVE": "Never",
-            "GIT_ALLOW_PROTOCOL": "https",
-            "GIT_ASKPASS": "false",
-            "GIT_ATTR_NOSYSTEM": "1",
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_TERMINAL_PROMPT": "0",
-        }
-    )
-    return environment
 
 
 def _run_git(directory: Path, *arguments: str) -> str:
     """Run a non-interactive Git operation with hooks and non-HTTPS blocked."""
     completed = subprocess.run(
         [
-            "git",
+            str(_trusted_git_binary()),
             "-c",
             "core.hooksPath=/dev/null",
             "-c",
@@ -231,14 +251,18 @@ def _installed_python(vault_root: Path) -> Path | None:
 
 
 def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
-    """Restart once in the install's existing dependency runtime, if needed."""
-    if os.environ.get("DEX_UPDATE_BRIDGE_RUNTIME") == "1":
-        return
-    interpreter = _installed_python(vault_root)
-    if interpreter is None or interpreter.resolve() == Path(sys.executable).resolve():
-        return
+    """Enter one clean process before loading any foundation code.
+
+    The installed venv can resolve to the same binary as the invoking Python,
+    but running it by its venv path still selects the installed dependencies.
+    Never trust a caller-supplied runtime marker: it is accepted only when the
+    complete environment already equals the closed runtime environment.
+    """
     environment = _bridge_environment()
-    environment["DEX_UPDATE_BRIDGE_RUNTIME"] = "1"
+    environment[_CLEAN_RUNTIME_MARKER] = "1"
+    if os.environ.get(_CLEAN_RUNTIME_MARKER) == "1" and dict(os.environ) == environment:
+        return
+    interpreter = _installed_python(vault_root) or Path(sys.executable).resolve()
     os.execve(
         str(interpreter),
         [str(interpreter), str(Path(__file__).resolve()), *argv],
@@ -432,9 +456,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if sys.platform.startswith("win"):
         parser.error("this P0 bridge supports macOS and Linux only")
-    if shutil.which("git") is None:
-        parser.error("Git is required for the one-time Dex update bridge")
     try:
+        _trusted_git_binary()
         vault = _validate_vault(args.vault)
         # A completed bridge has all durable state locally.  Check before
         # selecting the old virtualenv or downloading source so resuming it is


### PR DESCRIPTION
## Status

Draft-only, non-release hardening for the lifecycle-era update bridge. It does **not** claim historic-user support, publish a bridge artifact, cut a tag, or authorize a fleet run.

## What changes

- completed bridge resumes locally before it re-execs or downloads source; durable split, wiring, and installed-ref markers must agree
- Git and re-exec use a scrubbed non-interactive environment with credential helpers and inherited Git/Python state excluded
- rescue documentation now requires a future exact annotated foundation identity plus a matching versioned bridge artifact; rebasing on `main` is explicitly insufficient

## Evidence

- focused bridge suite: 15 passed (worker run)
- Ruff passed (worker run)
- independent diff/whitespace review completed

## Still deliberately absent

1. a future published foundation tag containing the registration repair
2. a versioned, hash-published bridge artifact matching that exact tag
3. real historic `/dex-update` journey execution and the 165-case two-hop evidence

No credential, release, tag, deployment, or user vault was changed.