### PR TITLE
test(fleet): fail closed until immutable update journeys are executable

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -307,6 +307,32 @@ def test_acceptance_report_refuses_when_any_published_start_is_missing() -> None
         )
 
 
+def test_acceptance_report_requires_each_declared_platform_to_cover_each_release() -> None:
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    common = {
+        "starting_tag": "dist/release/v1.61.0-ccccccc",
+        "reached_foundation": True,
+        "reached_follow_up": True,
+        "foundation_doctor_healthy": True,
+        "follow_up_doctor_healthy": True,
+        "user_hashes_before": hashes,
+        "user_hashes_after_foundation": hashes,
+        "user_hashes_after_follow_up": hashes,
+        "transcript_path": "journeys/v1.61.0.md",
+    }
+    report = release_fleet.AcceptanceReport(
+        foundation_tag="dist/release/v1.80.0-aaaaaaa",
+        follow_up_tag="dist/release/v1.80.1-bbbbbbb",
+        cases=(
+            release_fleet.CaseResult(**common, platform="darwin"),
+            release_fleet.CaseResult(**common, platform="linux"),
+        ),
+        platforms=("darwin", "linux"),
+    )
+
+    release_fleet.assert_complete(report, {common["starting_tag"]})
+
+
 def test_build_command_outputs_every_distinct_historic_release(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -340,6 +366,22 @@ def test_manifest_command_lists_every_release_without_building_fixtures(
     assert exit_code == 0
     assert manifest["case_count"] == 2
     assert not output.exists()
+
+
+def test_generated_starting_manifest_supplies_the_required_case_count(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_release(repo, "1.61.0", "one")
+    _tag_release(repo, "1.62.0", "two")
+    releases = release_fleet.discover_distribution_releases(repo)
+    generated = release_fleet.starting_release_manifest(releases)
+
+    assert generated["case_count"] == len(releases) == 2
+    assert release_fleet.releases_from_starting_manifest(
+        json.dumps(generated), current_releases=releases
+    ) == releases
+    generated["case_count"] = 165
+    with pytest.raises(release_fleet.FleetError, match="case count"):
+        release_fleet.releases_from_starting_manifest(json.dumps(generated), current_releases=releases)
 
 
 def test_manifest_cli_runs_from_the_documented_repository_root(tmp_path: Path) -> None:
@@ -383,15 +425,127 @@ def test_build_command_can_construct_one_historic_release_at_a_time(
     assert manifest["cases"][0]["starting"]["tag"] == first
 
 
-def test_check_report_command_requires_all_discovered_starting_releases(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def _write_update_surface(repo: Path) -> None:
+    skill = repo / release_fleet.UPDATE_SKILL_RELATIVE
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(
+        "core.lifecycle.service\npreview\napproval\nApply this exact update?\nreceipt\n"
+        "deliver_latest_release\nbuild_and_preview_delivered_release\n"
+        "execute_approved_delivered_release\n",
+        encoding="utf-8",
+    )
+    rescue = repo / release_fleet.UPDATE_RESCUE_RELATIVE
+    rescue.parent.mkdir(parents=True, exist_ok=True)
+    rescue.write_text("# Published rescue\n", encoding="utf-8")
+
+
+def _write_starting_manifest(root: Path, releases: tuple[release_fleet.DistributionRelease, ...]) -> Path:
+    path = root / "historic-release-manifest.json"
+    path.write_text(json.dumps(release_fleet.starting_release_manifest(releases)), encoding="utf-8")
+    return path
+
+
+def _write_complete_evidence(
+    repo: Path,
+    root: Path,
+    *,
+    start: release_fleet.DistributionRelease,
+    foundation: release_fleet.ImmutableRelease,
+    follow_up: release_fleet.ImmutableRelease,
+) -> tuple[dict[str, object], str, str]:
+    evidence = root / "case.evidence"
+    evidence.mkdir()
+    historic_surface = release_fleet.shipped_update_surface(repo, start)
+    foundation_surface = release_fleet.shipped_update_surface(repo, foundation)
+    (evidence / "historic-update-surface.json").write_text(json.dumps(historic_surface))
+    (evidence / "foundation-update-surface.json").write_text(json.dumps(foundation_surface))
+    (evidence / "foundation-receipt.json").write_text(
+        json.dumps({"release": foundation.identity(), "receipt": {"transaction_id": "foundation"}})
+    )
+    (evidence / "follow-up-receipt.json").write_text(
+        json.dumps({"release": follow_up.identity(), "receipt": {"transaction_id": "follow-up"}})
+    )
+    doctor = json.dumps({"checks": [{"id": "doctor", "verdict": "OK"}]})
+    (evidence / "foundation-doctor.json").write_text(doctor)
+    (evidence / "follow-up-doctor.json").write_text(doctor)
+    (evidence / "smoke.json").write_text(json.dumps({"status": "OK", "platform": "darwin"}))
+    events = [
+        {
+            "id": "historic-update-surface",
+            "command": ["git", "show", f"{start.tag}:{release_fleet.UPDATE_SKILL_RELATIVE}"],
+            "release": historic_surface["release"],
+            "skill_sha256": historic_surface["skill_sha256"],
+            "rescue_sha256": historic_surface["rescue_sha256"],
+        },
+        {"id": "historic-route-refusal", "command": ["/dex-update"], "release": historic_surface["release"]},
+        {"id": "bridge-foundation", "command": ["fleet-journey", "bridge"], "release": foundation.identity()},
+        {
+            "id": "foundation-update-surface",
+            "command": ["git", "show", f"{foundation.tag}:{release_fleet.UPDATE_SKILL_RELATIVE}"],
+            "release": foundation.identity(),
+            "skill_sha256": foundation_surface["skill_sha256"],
+            "rescue_sha256": foundation_surface["rescue_sha256"],
+        },
+        {
+            "id": "foundation-preview",
+            "command": ["/dex-update", "preview"],
+            "from_release": foundation.identity(),
+            "target_release": follow_up.identity(),
+        },
+        {
+            "id": "foundation-approval",
+            "command": ["/dex-update", "approve"],
+            "target_release": follow_up.identity(),
+            "answer": "APPLY",
+        },
+        {"id": "foundation-receipt", "command": ["/dex-update", "receipt"], "release": follow_up.identity()},
+        {"id": "follow-up-installed", "command": ["git", "rev-parse"], "release": follow_up.identity()},
+        {"id": "follow-up-doctor", "command": ["/dex-doctor"]},
+        {"id": "follow-up-smoke", "command": ["dex-smoke"], "platform": "darwin"},
+    ]
+    transcript = evidence / "journey.json"
+    transcript.write_text(json.dumps({"events": events}))
+    manifest_path, manifest_sha256 = release_fleet._write_evidence_manifest(
+        evidence,
+        start=historic_surface["release"],
+        foundation=foundation,
+        follow_up=follow_up,
+        events=events,
+        artifacts={
+            "transcript": transcript,
+            "historic_update_surface": evidence / "historic-update-surface.json",
+            "foundation_update_surface": evidence / "foundation-update-surface.json",
+            "foundation_receipt": evidence / "foundation-receipt.json",
+            "follow_up_receipt": evidence / "follow-up-receipt.json",
+            "foundation_doctor": evidence / "foundation-doctor.json",
+            "follow_up_doctor": evidence / "follow-up-doctor.json",
+            "follow_up_smoke": evidence / "smoke.json",
+        },
+    )
+    return ({"events": events}, manifest_path, manifest_sha256)
+
+
+def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_an_executable_protocol(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _repository(tmp_path)
+    _write_update_surface(repo)
     start_tag = _tag_release(repo, "1.61.0", "one")
     hashes = {"00-Inbox/keep.md": "a" * 64}
+    foundation_tag = _tag_release(repo, "1.80.0", "foundation")
+    follow_up_tag = _tag_release(repo, "1.80.1", "follow-up")
+    start = next(item for item in release_fleet.discover_distribution_releases(repo) if item.tag == start_tag)
+    foundation = release_fleet.resolve_immutable_release(repo, foundation_tag)
+    follow_up = release_fleet.resolve_immutable_release(repo, follow_up_tag)
+    monkeypatch.setattr(release_fleet, "discover_distribution_releases", lambda _repo: (start,))
+    starting_manifest = _write_starting_manifest(tmp_path, (start,))
+    _events, manifest_path, manifest_sha256 = _write_complete_evidence(
+        repo, tmp_path, start=start, foundation=foundation, follow_up=follow_up
+    )
     report = {
-        "foundation_tag": "dist/release/v1.80.0-aaaaaaa",
-        "follow_up_tag": "dist/release/v1.80.1-bbbbbbb",
+        "foundation_tag": foundation_tag,
+        "follow_up_tag": follow_up_tag,
+        "platforms": ["darwin"],
         "cases": [
             {
                 "starting_tag": start_tag,
@@ -402,16 +556,150 @@ def test_check_report_command_requires_all_discovered_starting_releases(
                 "user_hashes_before": hashes,
                 "user_hashes_after_foundation": hashes,
                 "user_hashes_after_follow_up": hashes,
-                "transcript_path": "journeys/v1.61.0.md",
+                "transcript_path": "case.evidence/journey.json",
+                "foundation_receipt_path": "case.evidence/foundation-receipt.json",
+                "follow_up_receipt_path": "case.evidence/follow-up-receipt.json",
+                "foundation_doctor_path": "case.evidence/foundation-doctor.json",
+                "follow_up_doctor_path": "case.evidence/follow-up-doctor.json",
+                "follow_up_smoke_path": "case.evidence/smoke.json",
+                "platform": "darwin",
+                "evidence_manifest_path": manifest_path,
+                "evidence_manifest_sha256": manifest_sha256,
             }
         ],
     }
     report_path = tmp_path / "report.json"
     report_path.write_text(json.dumps(report), encoding="utf-8")
 
-    exit_code = release_fleet.main(
-        ["check-report", "--repo", str(repo), str(report_path)]
-    )
+    with pytest.raises(release_fleet.FleetError, match="executable journey protocol"):
+        release_fleet.main(
+            [
+                "check-report",
+                "--repo",
+                str(repo),
+                "--starting-manifest",
+                str(starting_manifest),
+                str(report_path),
+            ]
+        )
 
-    assert exit_code == 0
-    assert "PASS: 1 historic release trees reached both releases" in capsys.readouterr().out
+    assert "PASS" not in capsys.readouterr().out
+
+
+def test_check_report_rejects_a_plausible_manifest_when_surface_bytes_are_not_from_the_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repository(tmp_path)
+    _write_update_surface(repo)
+    start_tag = _tag_release(repo, "1.61.0", "start")
+    foundation_tag = _tag_release(repo, "1.80.0", "foundation")
+    follow_up_tag = _tag_release(repo, "1.80.1", "follow-up")
+    start = next(item for item in release_fleet.discover_distribution_releases(repo) if item.tag == start_tag)
+    foundation = release_fleet.resolve_immutable_release(repo, foundation_tag)
+    follow_up = release_fleet.resolve_immutable_release(repo, follow_up_tag)
+    monkeypatch.setattr(release_fleet, "discover_distribution_releases", lambda _repo: (start,))
+    starting_manifest = _write_starting_manifest(tmp_path, (start,))
+    _events, manifest_path, manifest_sha256 = _write_complete_evidence(
+        repo, tmp_path, start=start, foundation=foundation, follow_up=follow_up
+    )
+    forged_surface = {"not": "a release surface"}
+    (tmp_path / "case.evidence" / "historic-update-surface.json").write_text(json.dumps(forged_surface))
+    # Rewriting the runner manifest's digest cannot make a hand-authored surface
+    # pass: check-report independently re-reads the immutable tag bytes.
+    manifest = tmp_path / manifest_path
+    value = json.loads(manifest.read_text())
+    value["artifacts"]["historic_update_surface"]["sha256"] = release_fleet.hashlib.sha256(
+        (tmp_path / "case.evidence" / "historic-update-surface.json").read_bytes()
+    ).hexdigest()
+    manifest.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    manifest_sha256 = release_fleet.hashlib.sha256(manifest.read_bytes()).hexdigest()
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    report = {
+        "foundation_tag": foundation_tag,
+        "follow_up_tag": follow_up_tag,
+        "platforms": ["darwin"],
+        "cases": [{
+            "starting_tag": start_tag, "reached_foundation": True, "reached_follow_up": True,
+            "foundation_doctor_healthy": True, "follow_up_doctor_healthy": True,
+            "user_hashes_before": hashes, "user_hashes_after_foundation": hashes,
+            "user_hashes_after_follow_up": hashes, "transcript_path": "case.evidence/journey.json",
+            "foundation_receipt_path": "case.evidence/foundation-receipt.json",
+            "follow_up_receipt_path": "case.evidence/follow-up-receipt.json",
+            "foundation_doctor_path": "case.evidence/foundation-doctor.json",
+            "follow_up_doctor_path": "case.evidence/follow-up-doctor.json",
+            "follow_up_smoke_path": "case.evidence/smoke.json", "platform": "darwin",
+            "evidence_manifest_path": manifest_path, "evidence_manifest_sha256": manifest_sha256,
+        }],
+    }
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report))
+
+    with pytest.raises(release_fleet.FleetError, match="executable journey protocol"):
+        release_fleet.main(
+            [
+                "check-report",
+                "--repo",
+                str(repo),
+                "--starting-manifest",
+                str(starting_manifest),
+                str(report_path),
+            ]
+        )
+
+
+def test_journey_target_must_be_an_immutable_annotated_distribution_tag(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_legacy_release(repo, "1.20.1", "legacy")
+
+    with pytest.raises(release_fleet.FleetError, match="immutable dist/release"):
+        release_fleet.resolve_immutable_release(repo, "v1.20.1")
+
+
+def test_case_environment_is_allowlisted_and_has_an_isolated_home(tmp_path: Path) -> None:
+    environment = release_fleet._case_environment(tmp_path / "vault", tmp_path / "runtime")
+
+    assert set(environment) == {
+        "HOME",
+        "TMPDIR",
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "PYTHONNOUSERSITE",
+        "PYTHONDONTWRITEBYTECODE",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_TERMINAL_PROMPT",
+        "VAULT_PATH",
+    }
+    assert Path(environment["HOME"]).is_dir()
+    assert environment["HOME"] != str(Path.home())
+    assert environment["VAULT_PATH"] == str(tmp_path / "vault")
+
+
+def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _write_update_surface(repo)
+    start_tag = _tag_release(repo, "1.61.0", "start")
+    foundation_tag = _tag_release(repo, "1.80.0", "foundation")
+    follow_up_tag = _tag_release(repo, "1.80.5", "follow-up")
+
+    with pytest.raises(release_fleet.FleetError, match="Markdown-only"):
+        release_fleet.run_journey(
+            repo,
+            output=tmp_path / "output",
+            starting_tag=start_tag,
+            foundation_tag=foundation_tag,
+            follow_up_tag=follow_up_tag,
+        )
+
+    start = next(item for item in release_fleet.discover_distribution_releases(repo) if item.tag == start_tag)
+    evidence_root = tmp_path / "output" / f"{release_fleet.safe_case_name(start)}.evidence"
+    result = json.loads((evidence_root / "journey-result.json").read_text())
+    manifest = evidence_root / "evidence-manifest.json"
+    transcript = json.loads((evidence_root / "journey-transcript.json").read_text())
+    assert result["failure"].startswith("published /dex-update surfaces are Markdown-only")
+    assert result["evidence_manifest_sha256"] == release_fleet.hashlib.sha256(manifest.read_bytes()).hexdigest()
+    assert [event["id"] for event in transcript["events"]] == [
+        "historic-update-surface",
+        "foundation-update-surface",
+    ]
+    assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -44,9 +44,11 @@ run as part of ordinary release preparation.
 python3 scripts/release_fleet.py manifest --repo . > historic-release-manifest.json
 ```
 
-The manifest records each immutable starting tag, commit, and tree. The
-starting source must be a public release tag; never use `main`, a working tree,
-or an untagged release candidate as a historical starting point.
+The manifest records the generated count and every immutable starting tag,
+commit, and tree. It is the source for the required fleet case count—never a
+hand-maintained number. The starting source must be a public release tag; never
+use `main`, a working tree, or an untagged release candidate as a historical
+starting point.
 
 Build and exercise one fixture at a time, retaining only its small report and
 transcript after it passes. The builder never copies a founder's vault and
@@ -62,18 +64,54 @@ Its output records the fixture path and the exact hashes of the synthetic user
 content that must survive. Processing one case at a time keeps the release
 gate bounded rather than storing 120 full repositories on disk.
 
+## Establish the executable-journey prerequisite
+
+The `journey` command currently **does not execute an update**. It reads and
+hashes the exact `/dex-update` skill and rescue material from the historic and
+foundation immutable tags, writes a failed-at-the-boundary transcript, and
+stops. This is intentional: those release surfaces are Markdown instructions,
+not a machine-callable API. Treating them as an API would manufacture a
+successful-looking update path that no released user can actually invoke.
+
+```bash
+python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
+  --starting-tag dist/release/v1.74.0-EXACTSTART \
+  --foundation-tag dist/release/v1.80.0-EXACTFOUNDATION \
+  --follow-up-tag dist/release/v1.80.5-EXACTFOLLOWUP
+```
+
+The required future published protocol must be immutable and machine-verifiable.
+It must expose the historic documented route or its refusal, bridge publication
+provenance, foundation preview, explicit approval, receipts, installed release
+identity, Doctor evidence, and released platform smoke. Until a release ships
+that protocol, no synthetic fixture is installed and no bridge, lifecycle
+method, Git merge, or handwritten route wrapper is allowed to run.
+
+The resulting `<case>.evidence/` directory is beside—not inside—a future
+fixture. Its content-addressed manifest records the exact release identities,
+ordered commands, and artifact hashes. A failed prerequisite attempt is useful
+diagnostic evidence, never fleet acceptance evidence.
+
 ## Validate the finished evidence
 
 After both release tags are public and every case has its journey transcript
 and report entry, validate the report against the full tag set:
 
 ```bash
-python3 scripts/release_fleet.py check-report --repo . REPORT.json
+python3 scripts/release_fleet.py check-report --repo . \
+  --starting-manifest historic-release-manifest.json REPORT.json
 ```
 
-The command passes only when the report covers every discovered starting tree
-and every case has reached both hops, kept its user hashes unchanged, has a
-healthy Doctor result after each hop, and names a user-visible transcript.
+The command first verifies the generated starting manifest against the current
+immutable release trees, then requires that many cases on every declared
+platform. It cannot pass while either released `/dex-update` surface says
+`machine_executable: false`, regardless of how internally consistent a report,
+manifest, transcript, or artifact set appears. Once an executable protocol is
+published, it will also require ordered commands and SHA-256-bound runner
+artifacts: the transcript, release-surface snapshots, receipts, Doctor reports,
+and smoke/platform evidence. Paths, symlinks, malformed JSON, mismatched
+identities, incomplete platform coverage, and unknown/broken Doctor results all
+fail the report.
 
 ## Claim language
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -36,7 +36,9 @@ USER_FIXTURES = {
         b"---\n# User skill\n"
     ),
 }
-REPORT_KEYS = frozenset({"foundation_tag", "follow_up_tag", "cases"})
+REPORT_KEYS = frozenset({"foundation_tag", "follow_up_tag", "platforms", "cases"})
+STARTING_MANIFEST_KEYS = frozenset({"schema_version", "case_count", "cases"})
+STARTING_RELEASE_KEYS = frozenset({"tag", "version", "commit", "tree"})
 CASE_RESULT_KEYS = frozenset(
     {
         "starting_tag",
@@ -48,9 +50,37 @@ CASE_RESULT_KEYS = frozenset(
         "user_hashes_after_foundation",
         "user_hashes_after_follow_up",
         "transcript_path",
+        "foundation_receipt_path",
+        "follow_up_receipt_path",
+        "foundation_doctor_path",
+        "follow_up_doctor_path",
+        "follow_up_smoke_path",
+        "platform",
+        "evidence_manifest_path",
+        "evidence_manifest_sha256",
     }
 )
-
+# Archive tags are historic starting evidence only.  A hop target must be the
+# still-published immutable distribution tag that the release channel can prove.
+IMMUTABLE_TARGET_TAGS = (RELEASE_TAG,)
+_HEX = re.compile(r"^[0-9a-f]{40}$")
+UPDATE_SKILL_RELATIVE = ".claude/skills/dex-update/SKILL.md"
+UPDATE_RESCUE_RELATIVE = "docs/UPDATE-RESCUE.md"
+EVIDENCE_MANIFEST_KEYS = frozenset(
+    {"schema_version", "starting_release", "foundation_release", "follow_up_release", "events", "artifacts"}
+)
+RUNNER_ARTIFACT_KEYS = frozenset(
+    {
+        "transcript",
+        "historic_update_surface",
+        "foundation_update_surface",
+        "foundation_receipt",
+        "follow_up_receipt",
+        "foundation_doctor",
+        "follow_up_doctor",
+        "follow_up_smoke",
+    }
+)
 
 class FleetError(RuntimeError):
     """The historic release fleet could not be built safely."""
@@ -88,6 +118,14 @@ class CaseResult:
     user_hashes_after_foundation: dict[str, str]
     user_hashes_after_follow_up: dict[str, str]
     transcript_path: str
+    foundation_receipt_path: str = ""
+    follow_up_receipt_path: str = ""
+    foundation_doctor_path: str = ""
+    follow_up_doctor_path: str = ""
+    follow_up_smoke_path: str = ""
+    platform: str = ""
+    evidence_manifest_path: str = ""
+    evidence_manifest_sha256: str = ""
 
 
 @dataclass(frozen=True)
@@ -97,13 +135,36 @@ class AcceptanceReport:
     foundation_tag: str
     follow_up_tag: str
     cases: tuple[CaseResult, ...]
+    platforms: tuple[str, ...] = ()
 
 
-def _git(repo: Path, *arguments: str) -> str:
+@dataclass(frozen=True)
+class ImmutableRelease:
+    """A closed tag identity suitable for an explicitly requested journey hop."""
+
+    tag: str
+    tag_object: str
+    commit: str
+    tree: str
+    version: str
+
+    def identity(self) -> dict[str, str]:
+        return {
+            "tag": self.tag,
+            "tag_object": self.tag_object,
+            "commit": self.commit,
+            "tree": self.tree,
+            "version": self.version,
+            "channel": "stable",
+        }
+
+
+def _git(repo: Path, *arguments: str, environment: Mapping[str, str] | None = None) -> str:
     result = subprocess.run(
         ["git", "-C", str(repo), *arguments],
         capture_output=True,
         text=True,
+        env=dict(environment) if environment is not None else None,
     )
     if result.returncode:
         message = result.stderr.strip() or result.stdout.strip() or "Git command failed"
@@ -114,6 +175,163 @@ def _git(repo: Path, *arguments: str) -> str:
 def _git_lines(repo: Path, *arguments: str) -> tuple[str, ...]:
     output = _git(repo, *arguments)
     return tuple(line for line in output.splitlines() if line)
+
+
+def resolve_immutable_release(repo: Path, tag: str) -> ImmutableRelease:
+    """Resolve one annotated immutable release tag, never a moving ref."""
+
+    match = next((pattern.fullmatch(tag) for pattern in IMMUTABLE_TARGET_TAGS if pattern.fullmatch(tag)), None)
+    if match is None:
+        raise FleetError("journey targets must be immutable dist/release tags")
+    tag_object = _git(repo, "rev-parse", "--verify", tag)
+    if _git(repo, "cat-file", "-t", tag) != "tag":
+        raise FleetError(f"{tag}: journey target must be an annotated tag")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
+    if any(_HEX.fullmatch(value) is None for value in (tag_object, commit, tree)):
+        raise FleetError(f"{tag}: journey target identity is malformed")
+    if not commit.startswith(match.group("short")):
+        raise FleetError(f"{tag}: tag suffix does not match its commit")
+    return ImmutableRelease(tag, tag_object, commit, tree, match.group("version"))
+
+
+def _tag_file(repo: Path, tag: str, relative: str) -> bytes:
+    try:
+        return _git(repo, "show", f"{tag}:{relative}").encode("utf-8")
+    except FleetError as error:
+        raise FleetError(f"{tag} has no required {relative} publication record") from error
+
+
+def _strict_object(source: bytes, context: str, keys: frozenset[str]) -> dict[str, object]:
+    try:
+        value = json.loads(source)
+    except json.JSONDecodeError as error:
+        raise FleetError(f"{context} is not valid JSON") from error
+    if not isinstance(value, Mapping) or set(value) != keys:
+        raise FleetError(f"{context} has an invalid shape")
+    return dict(value)
+
+
+def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableRelease) -> dict[str, object]:
+    """Bind the human-facing `/dex-update` contract to exact released bytes.
+
+    Skills are Markdown instructions, not an executable API.  This evidence is
+    deliberately read-only: it proves what the installed release told a person
+    to do, but cannot turn prose into a synthetic update command.
+    """
+
+    skill = _tag_file(repo, release.tag, UPDATE_SKILL_RELATIVE)
+    rescue: bytes | None
+    try:
+        rescue = _tag_file(repo, release.tag, UPDATE_RESCUE_RELATIVE)
+    except FleetError:
+        rescue = None
+    text = skill.decode("utf-8", "strict")
+    required = {
+        "service": "core.lifecycle.service" in text,
+        "preview": "preview" in text.lower(),
+        "approval": "approval" in text.lower() and "Apply this exact update?" in text,
+        "receipt": "receipt" in text.lower(),
+    }
+    delivery = {
+        "deliver_latest_release": "deliver_latest_release" in text,
+        "build_and_preview_delivered_release": "build_and_preview_delivered_release" in text,
+        "execute_approved_delivered_release": "execute_approved_delivered_release" in text,
+    }
+    identity = release.identity() if isinstance(release, ImmutableRelease) else {
+        "tag": release.tag,
+        "tag_object": _git(repo, "rev-parse", "--verify", release.tag),
+        "commit": release.commit,
+        "tree": release.tree,
+        "version": release.version,
+        "channel": "stable",
+    }
+    return {
+        "release": identity,
+        "skill_path": UPDATE_SKILL_RELATIVE,
+        "skill_sha256": hashlib.sha256(skill).hexdigest(),
+        "rescue_path": UPDATE_RESCUE_RELATIVE if rescue is not None else None,
+        "rescue_sha256": hashlib.sha256(rescue).hexdigest() if rescue is not None else None,
+        "preview_approval_receipt": required,
+        "delivery_operations": delivery,
+        "machine_executable": False,
+    }
+
+
+def _has_transaction_receipt(value: object) -> bool:
+    """Recognize the service envelope while rejecting a prose-only success claim."""
+
+    if not isinstance(value, Mapping):
+        return False
+    if isinstance(value.get("transaction_id"), str) and value["transaction_id"]:
+        return True
+    nested = value.get("receipt")
+    return isinstance(nested, Mapping) and isinstance(nested.get("transaction_id"), str) and bool(
+        nested["transaction_id"]
+    )
+
+
+def _case_environment(vault: Path, runtime_root: Path) -> dict[str, str]:
+    """Return the complete, deliberately small environment for one fixture."""
+
+    home = runtime_root / "home"
+    temporary = runtime_root / "tmp"
+    home.mkdir(parents=True, exist_ok=False)
+    temporary.mkdir(parents=True, exist_ok=False)
+    return {
+        "HOME": str(home),
+        "TMPDIR": str(temporary),
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "VAULT_PATH": str(vault),
+    }
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_evidence_manifest(
+    evidence_root: Path,
+    *,
+    start: dict[str, object],
+    foundation: ImmutableRelease,
+    follow_up: ImmutableRelease,
+    events: Sequence[Mapping[str, object]],
+    artifacts: Mapping[str, Path],
+) -> tuple[str, str]:
+    """Write the runner-owned, content-addressed index that report checking consumes."""
+
+    artifact_index: dict[str, dict[str, str]] = {}
+    for name, artifact in artifacts.items():
+        try:
+            relative = artifact.resolve().relative_to(evidence_root.parent.resolve())
+        except ValueError as error:
+            raise FleetError(f"evidence artifact escapes its case directory: {name}") from error
+        if artifact.is_symlink() or not artifact.is_file():
+            raise FleetError(f"evidence artifact is missing or unsafe: {name}")
+        artifact_index[name] = {
+            "path": str(relative),
+            "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+        }
+
+    manifest = {
+        "schema_version": 1,
+        "starting_release": start,
+        "foundation_release": foundation.identity(),
+        "follow_up_release": follow_up.identity(),
+        "events": [dict(event) for event in events],
+        "artifacts": artifact_index,
+    }
+    path = evidence_root / "evidence-manifest.json"
+    _write_json(path, manifest)
+    return f"{evidence_root.name}/evidence-manifest.json", hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _version_key(version: str) -> tuple[int, int, int]:
@@ -188,7 +406,13 @@ def hash_user_owned_files(vault: Path) -> dict[str, str]:
     return hashes
 
 
-def _create_fixture_vault(repo: Path, release: DistributionRelease, output: Path) -> Path:
+def _create_fixture_vault(
+    repo: Path,
+    release: DistributionRelease,
+    output: Path,
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> Path:
     """Clone one historic release without inheriting later release metadata."""
 
     if output.exists() and not output.is_dir():
@@ -207,27 +431,28 @@ def _create_fixture_vault(repo: Path, release: DistributionRelease, output: Path
         "--no-tags",
         str(repo),
         str(vault),
+        environment=environment,
     )
-    _git(vault, "fetch", "--quiet", "--no-tags", "origin", f"refs/tags/{release.tag}:refs/tags/{release.tag}")
-    _git(vault, "checkout", "--quiet", "--detach", release.tag)
-    _git(vault, "remote", "rename", "origin", "upstream")
-    _git(vault, "remote", "set-url", "upstream", PUBLIC_REMOTE)
-    _git(vault, "remote", "set-url", "--push", "upstream", "DISABLED")
+    _git(vault, "fetch", "--quiet", "--no-tags", "origin", f"refs/tags/{release.tag}:refs/tags/{release.tag}", environment=environment)
+    _git(vault, "checkout", "--quiet", "--detach", release.tag, environment=environment)
+    _git(vault, "remote", "rename", "origin", "upstream", environment=environment)
+    _git(vault, "remote", "set-url", "upstream", PUBLIC_REMOTE, environment=environment)
+    _git(vault, "remote", "set-url", "--push", "upstream", "DISABLED", environment=environment)
 
-    _git(vault, "config", "user.name", "Dex Fleet Fixture")
-    _git(vault, "config", "user.email", "fleet@example.com")
+    _git(vault, "config", "user.name", "Dex Fleet Fixture", environment=environment)
+    _git(vault, "config", "user.email", "fleet@example.com", environment=environment)
     return vault
 
 
-def _seed_user_content(vault: Path) -> dict[str, str]:
+def _seed_user_content(vault: Path, environment: Mapping[str, str] | None = None) -> dict[str, str]:
     """Place fixed user-owned content only after the historic install is ready."""
     for relative, content in USER_FIXTURES.items():
         path = vault / relative
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
 
-    _git(vault, "add", "-f", "--", *USER_FIXTURES)
-    _git(vault, "commit", "--quiet", "-m", "test: simulated user content")
+    _git(vault, "add", "-f", "--", *USER_FIXTURES, environment=environment)
+    _git(vault, "commit", "--quiet", "-m", "test: simulated user content", environment=environment)
     return hash_user_owned_files(vault)
 
 
@@ -237,7 +462,7 @@ def build_fixture(repo: Path, release: DistributionRelease, output: Path) -> Fle
     return FleetCase(release=release, vault=vault, user_hashes=_seed_user_content(vault))
 
 
-def _run_historic_installer(vault: Path) -> None:
+def _run_historic_installer(vault: Path, environment: Mapping[str, str] | None = None) -> None:
     """Make the cloned release a realistic installed Dex before adding user data."""
     installer = vault / "install.sh"
     if installer.is_symlink() or not installer.is_file():
@@ -245,6 +470,7 @@ def _run_historic_installer(vault: Path) -> None:
     result = subprocess.run(
         ["bash", "install.sh"],
         cwd=vault,
+        env=dict(environment) if environment is not None else None,
         capture_output=True,
         text=True,
         timeout=15 * 60,
@@ -254,11 +480,107 @@ def _run_historic_installer(vault: Path) -> None:
         raise FleetError(f"historic installer failed for {vault.name}: {detail}")
 
 
-def build_installed_fixture(repo: Path, release: DistributionRelease, output: Path) -> FleetCase:
+def build_installed_fixture(
+    repo: Path,
+    release: DistributionRelease,
+    output: Path,
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> FleetCase:
     """Install the historic release, then add synthetic user-owned data for updating."""
-    vault = _create_fixture_vault(repo, release, output)
-    _run_historic_installer(vault)
-    return FleetCase(release=release, vault=vault, user_hashes=_seed_user_content(vault))
+    vault = _create_fixture_vault(repo, release, output, environment=environment)
+    _run_historic_installer(vault, environment)
+    return FleetCase(release=release, vault=vault, user_hashes=_seed_user_content(vault, environment))
+
+
+def run_journey(
+    repo: Path,
+    *,
+    output: Path,
+    starting_tag: str,
+    foundation_tag: str,
+    follow_up_tag: str,
+) -> None:
+    """Fail closed until immutable releases publish a machine-verifiable journey protocol.
+
+    The only evidence emitted today is a hash of the exact shipped `/dex-update`
+    and rescue material.  The runner never promotes Markdown instructions into
+    commands, invokes lifecycle code, or accepts an external bridge as proof.
+    """
+
+    releases = {release.tag: release for release in discover_distribution_releases(repo)}
+    start = releases.get(starting_tag)
+    if start is None:
+        raise FleetError(f"historic distribution tag was not found: {starting_tag}")
+    foundation = resolve_immutable_release(repo, foundation_tag)
+    follow_up = resolve_immutable_release(repo, follow_up_tag)
+    if foundation.tag == follow_up.tag or foundation.commit == follow_up.commit:
+        raise FleetError("foundation and follow-up must be different immutable releases")
+    # Evidence must not become an untracked vault file that influences either
+    # release preview.  Keep it beside a future disposable fixture.
+    evidence_relative = f"{safe_case_name(start)}.evidence"
+    evidence_root = output / evidence_relative
+    if evidence_root.exists():
+        raise FleetError("journey evidence directory must be empty")
+    transcript_path = evidence_root / "journey-transcript.json"
+    result_path = evidence_root / "journey-result.json"
+    events: list[dict[str, object]] = []
+    result: dict[str, object] = {
+        "starting_tag": start.tag,
+        "foundation_tag": foundation.tag,
+        "follow_up_tag": follow_up.tag,
+        "transcript_path": f"{evidence_relative}/journey-transcript.json",
+    }
+
+    try:
+        historic_surface = shipped_update_surface(repo, start)
+        foundation_surface = shipped_update_surface(repo, foundation)
+        _write_json(evidence_root / "historic-update-surface.json", historic_surface)
+        _write_json(evidence_root / "foundation-update-surface.json", foundation_surface)
+        events.extend(
+            (
+                {
+                    "id": "historic-update-surface",
+                    "command": ["git", "show", f"{start.tag}:{UPDATE_SKILL_RELATIVE}"],
+                    "release": historic_surface["release"],
+                    "skill_sha256": historic_surface["skill_sha256"],
+                    "rescue_sha256": historic_surface["rescue_sha256"],
+                },
+                {
+                    "id": "foundation-update-surface",
+                    "command": ["git", "show", f"{foundation.tag}:{UPDATE_SKILL_RELATIVE}"],
+                    "release": foundation_surface["release"],
+                    "skill_sha256": foundation_surface["skill_sha256"],
+                    "rescue_sha256": foundation_surface["rescue_sha256"],
+                },
+            )
+        )
+        result["historic_update_surface"] = historic_surface
+        result["foundation_update_surface"] = foundation_surface
+        raise FleetError(
+            "published /dex-update surfaces are Markdown-only; a future immutable release must "
+            "publish a machine-verifiable journey protocol before fleet execution can continue"
+        )
+    except (FleetError, OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as error:
+        result["failure"] = str(error)
+        _write_json(transcript_path, {"events": events})
+        artifacts: dict[str, Path] = {"transcript": transcript_path}
+        if (evidence_root / "historic-update-surface.json").is_file():
+            artifacts["historic_update_surface"] = evidence_root / "historic-update-surface.json"
+        if (evidence_root / "foundation-update-surface.json").is_file():
+            artifacts["foundation_update_surface"] = evidence_root / "foundation-update-surface.json"
+        manifest_path, manifest_sha256 = _write_evidence_manifest(
+            evidence_root,
+            start=historic_surface if "historic_surface" in locals() else {"tag": start.tag},
+            foundation=foundation,
+            follow_up=follow_up,
+            events=events,
+            artifacts=artifacts,
+        )
+        result["evidence_manifest_path"] = manifest_path
+        result["evidence_manifest_sha256"] = manifest_sha256
+        _write_json(result_path, result)
+        raise
 
 
 def assert_complete(report: AcceptanceReport, expected_start_tags: set[str]) -> None:
@@ -266,9 +588,9 @@ def assert_complete(report: AcceptanceReport, expected_start_tags: set[str]) -> 
 
     if not report.cases:
         raise FleetError("acceptance report contains no historic releases")
+    if report.platforms and len(set(report.platforms)) != len(report.platforms):
+        raise FleetError("acceptance report has invalid platform coverage")
     actual_tags = {case.starting_tag for case in report.cases}
-    if len(actual_tags) != len(report.cases):
-        raise FleetError("acceptance report contains a duplicate historic release")
     missing = sorted(expected_start_tags - actual_tags)
     if missing:
         raise FleetError("acceptance report is missing historic releases: " + ", ".join(missing))
@@ -293,6 +615,225 @@ def assert_complete(report: AcceptanceReport, expected_start_tags: set[str]) -> 
             raise FleetError(f"{case.starting_tag}: user content changed during follow-up release")
         if not case.transcript_path:
             raise FleetError(f"{case.starting_tag}: user-visible journey transcript is missing")
+        if report.platforms and case.platform not in report.platforms:
+            raise FleetError(f"{case.starting_tag}: platform is not declared in report coverage")
+    if report.platforms:
+        expected_cases = {(tag, platform) for tag in expected_start_tags for platform in report.platforms}
+        actual_cases = {(case.starting_tag, case.platform) for case in report.cases}
+        if len(actual_cases) != len(report.cases):
+            raise FleetError("acceptance report contains a duplicate historic release/platform case")
+        if actual_cases != expected_cases:
+            raise FleetError("acceptance report has incomplete historic release platform coverage")
+    elif len(actual_tags) != len(report.cases):
+        raise FleetError("acceptance report contains a duplicate historic release")
+
+
+def _evidence_file(root: Path, relative: str, context: str) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise FleetError(f"{context} must be a relative evidence path")
+    path = root / candidate
+    if path.is_symlink() or not path.is_file() or path.resolve().parent != path.parent.resolve():
+        raise FleetError(f"{context} is missing or unsafe")
+    return path
+
+
+def _read_evidence_json(root: Path, relative: str, context: str) -> dict[str, object]:
+    path = _evidence_file(root, relative, context)
+    return _strict_object(path.read_bytes(), context, frozenset({"release", "receipt"}))
+
+
+def _manifest_artifact(
+    root: Path,
+    artifacts: Mapping[str, object],
+    name: str,
+    context: str,
+) -> str:
+    """Open one content-addressed runner artifact and return its safe relative path."""
+
+    value = artifacts.get(name)
+    if not isinstance(value, Mapping) or set(value) != {"path", "sha256"}:
+        raise FleetError(f"{context}: runner manifest has no valid {name} artifact")
+    path = value.get("path")
+    digest = value.get("sha256")
+    if not isinstance(path, str) or not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise FleetError(f"{context}: runner manifest has an invalid {name} artifact")
+    artifact = _evidence_file(root, path, f"{context} {name} artifact")
+    if hashlib.sha256(artifact.read_bytes()).hexdigest() != digest:
+        raise FleetError(f"{context}: {name} artifact hash does not match runner manifest")
+    return path
+
+
+def assert_evidence_bound(
+    report: AcceptanceReport,
+    *,
+    repo: Path,
+    evidence_root: Path,
+    foundation: ImmutableRelease,
+    follow_up: ImmutableRelease,
+) -> None:
+    """Open runner-owned evidence and bind it to released source bytes."""
+
+    releases = {release.tag: release for release in discover_distribution_releases(repo)}
+
+    for case in report.cases:
+        starting_release = releases.get(case.starting_tag)
+        if starting_release is None:
+            raise FleetError(f"{case.starting_tag}: starting release is no longer discoverable")
+        expected_historic_surface = shipped_update_surface(repo, starting_release)
+        expected_foundation_surface = shipped_update_surface(repo, foundation)
+        if (
+            expected_historic_surface["machine_executable"] is not True
+            or expected_foundation_surface["machine_executable"] is not True
+        ):
+            raise FleetError(
+                f"{case.starting_tag}: immutable executable journey protocol is not published; "
+                "fleet acceptance cannot pass"
+            )
+        manifest_path = _evidence_file(
+            evidence_root, case.evidence_manifest_path, f"{case.starting_tag} evidence manifest"
+        )
+        if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != case.evidence_manifest_sha256:
+            raise FleetError(f"{case.starting_tag}: evidence manifest hash does not match")
+        manifest = _strict_object(
+            manifest_path.read_bytes(),
+            f"{case.starting_tag} evidence manifest",
+            EVIDENCE_MANIFEST_KEYS,
+        )
+        if (
+            manifest["schema_version"] != 1
+            or not isinstance(manifest["starting_release"], Mapping)
+            or manifest["starting_release"].get("tag") != case.starting_tag
+            or manifest["foundation_release"] != foundation.identity()
+            or manifest["follow_up_release"] != follow_up.identity()
+            or not isinstance(manifest["events"], list)
+            or not isinstance(manifest["artifacts"], Mapping)
+        ):
+            raise FleetError(f"{case.starting_tag}: evidence manifest is not bound to this journey")
+        if any(not isinstance(event, Mapping) for event in manifest["events"]):
+            raise FleetError(f"{case.starting_tag}: evidence manifest contains an invalid event")
+        event_ids = [event.get("id") for event in manifest["events"]]
+        required_order = [
+            "historic-update-surface",
+            "historic-route-refusal",
+            "bridge-foundation",
+            "foundation-update-surface",
+            "foundation-preview",
+            "foundation-approval",
+            "foundation-receipt",
+            "follow-up-installed",
+            "follow-up-doctor",
+            "follow-up-smoke",
+        ]
+        if event_ids != required_order:
+            raise FleetError(f"{case.starting_tag}: evidence manifest has an invalid event order")
+        events = {str(event["id"]): event for event in manifest["events"]}
+        if any(
+            not isinstance(event.get("command"), list)
+            or not event["command"]
+            or any(not isinstance(part, str) or not part for part in event["command"])
+            for event in events.values()
+        ):
+            raise FleetError(f"{case.starting_tag}: evidence manifest contains an invalid command")
+        if (
+            events["historic-update-surface"].get("command")
+            != ["git", "show", f"{case.starting_tag}:{UPDATE_SKILL_RELATIVE}"]
+            or events["historic-update-surface"].get("release") != expected_historic_surface["release"]
+            or events["historic-update-surface"].get("skill_sha256")
+            != expected_historic_surface["skill_sha256"]
+            or events["historic-update-surface"].get("rescue_sha256")
+            != expected_historic_surface["rescue_sha256"]
+            or events["historic-route-refusal"].get("release") != expected_historic_surface["release"]
+            or events["bridge-foundation"].get("release") != foundation.identity()
+            or events["foundation-update-surface"].get("release") != foundation.identity()
+            or events["foundation-update-surface"].get("skill_sha256")
+            != expected_foundation_surface["skill_sha256"]
+            or events["foundation-update-surface"].get("rescue_sha256")
+            != expected_foundation_surface["rescue_sha256"]
+            or events["foundation-preview"].get("from_release") != foundation.identity()
+            or events["foundation-preview"].get("target_release") != follow_up.identity()
+            or events["foundation-approval"].get("target_release") != follow_up.identity()
+            or events["foundation-approval"].get("answer") != "APPLY"
+            or events["foundation-receipt"].get("release") != follow_up.identity()
+            or events["follow-up-installed"].get("release") != follow_up.identity()
+            or events["follow-up-smoke"].get("platform") != case.platform
+        ):
+            raise FleetError(f"{case.starting_tag}: evidence manifest commands or identities are not bound")
+        artifacts = manifest["artifacts"]
+        if set(artifacts) != RUNNER_ARTIFACT_KEYS:
+            raise FleetError(f"{case.starting_tag}: runner manifest has an invalid artifact set")
+        artifact_paths = {
+            name: _manifest_artifact(evidence_root, artifacts, name, case.starting_tag)
+            for name in RUNNER_ARTIFACT_KEYS
+        }
+        if (
+            artifact_paths["transcript"] != case.transcript_path
+            or artifact_paths["foundation_receipt"] != case.foundation_receipt_path
+            or artifact_paths["follow_up_receipt"] != case.follow_up_receipt_path
+            or artifact_paths["foundation_doctor"] != case.foundation_doctor_path
+            or artifact_paths["follow_up_doctor"] != case.follow_up_doctor_path
+            or artifact_paths["follow_up_smoke"] != case.follow_up_smoke_path
+        ):
+            raise FleetError(f"{case.starting_tag}: evidence manifest artifacts are not bound")
+        for artifact_name, expected_surface in (
+            ("historic_update_surface", expected_historic_surface),
+            ("foundation_update_surface", expected_foundation_surface),
+        ):
+            surface = _strict_object(
+                _evidence_file(
+                    evidence_root,
+                    artifact_paths[artifact_name],
+                    f"{case.starting_tag} {artifact_name}",
+                ).read_bytes(),
+                f"{case.starting_tag} {artifact_name}",
+                frozenset(expected_surface),
+            )
+            if surface != expected_surface:
+                raise FleetError(f"{case.starting_tag}: {artifact_name} is not the released update surface")
+        transcript = _evidence_file(evidence_root, case.transcript_path, f"{case.starting_tag} transcript")
+        transcript_value = _strict_object(transcript.read_bytes(), f"{case.starting_tag} transcript", frozenset({"events"}))
+        if not isinstance(transcript_value["events"], list) or transcript_value["events"] != manifest["events"]:
+            raise FleetError(f"{case.starting_tag}: transcript has no journey events")
+        foundation_receipt = _read_evidence_json(
+            evidence_root, case.foundation_receipt_path, f"{case.starting_tag} foundation receipt"
+        )
+        follow_receipt = _read_evidence_json(
+            evidence_root, case.follow_up_receipt_path, f"{case.starting_tag} follow-up receipt"
+        )
+        if foundation_receipt["release"] != foundation.identity() or not _has_transaction_receipt(
+            foundation_receipt["receipt"]
+        ):
+            raise FleetError(f"{case.starting_tag}: foundation receipt is not bound to the supplied release")
+        if follow_receipt["release"] != follow_up.identity() or not _has_transaction_receipt(
+            follow_receipt["receipt"]
+        ):
+            raise FleetError(f"{case.starting_tag}: follow-up receipt is not bound to the supplied release")
+        for label, relative in (
+            ("foundation Doctor", case.foundation_doctor_path),
+            ("follow-up Doctor", case.follow_up_doctor_path),
+        ):
+            doctor = _evidence_file(evidence_root, relative, f"{case.starting_tag} {label}")
+            try:
+                doctor_value = json.loads(doctor.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as error:
+                raise FleetError(f"{case.starting_tag}: {label} is not valid JSON") from error
+            checks = doctor_value.get("checks") if isinstance(doctor_value, Mapping) else None
+            if not isinstance(checks, list) or not checks or any(
+                not isinstance(item, Mapping) or item.get("verdict") not in {"OK", "OFF"}
+                for item in checks
+            ):
+                raise FleetError(f"{case.starting_tag}: {label} is unhealthy or incomplete")
+        smoke = _evidence_file(evidence_root, case.follow_up_smoke_path, f"{case.starting_tag} smoke")
+        try:
+            smoke_value = json.loads(smoke.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise FleetError(f"{case.starting_tag}: smoke evidence is not valid JSON") from error
+        if (
+            not isinstance(smoke_value, Mapping)
+            or smoke_value.get("status") != "OK"
+            or smoke_value.get("platform") != case.platform
+        ):
+            raise FleetError(f"{case.starting_tag}: smoke/platform evidence is not bound")
 
 
 def _required_string(value: Mapping[str, Any], key: str, context: str) -> str:
@@ -329,6 +870,13 @@ def acceptance_report_from_json(source: str) -> AcceptanceReport:
         raise FleetError("acceptance report has an invalid top-level shape")
     foundation_tag = _required_string(raw, "foundation_tag", "acceptance report")
     follow_up_tag = _required_string(raw, "follow_up_tag", "acceptance report")
+    platforms_raw = raw.get("platforms")
+    if (
+        not isinstance(platforms_raw, list)
+        or not platforms_raw
+        or any(not isinstance(platform, str) or not platform for platform in platforms_raw)
+    ):
+        raise FleetError("acceptance report platforms must be a non-empty list of strings")
     cases_raw = raw.get("cases")
     if not isinstance(cases_raw, list):
         raise FleetError("acceptance report cases must be a list")
@@ -361,9 +909,17 @@ def acceptance_report_from_json(source: str) -> AcceptanceReport:
                     case_raw["user_hashes_after_follow_up"], context
                 ),
                 transcript_path=_required_string(case_raw, "transcript_path", context),
+                foundation_receipt_path=_required_string(case_raw, "foundation_receipt_path", context),
+                follow_up_receipt_path=_required_string(case_raw, "follow_up_receipt_path", context),
+                foundation_doctor_path=_required_string(case_raw, "foundation_doctor_path", context),
+                follow_up_doctor_path=_required_string(case_raw, "follow_up_doctor_path", context),
+                follow_up_smoke_path=_required_string(case_raw, "follow_up_smoke_path", context),
+                platform=_required_string(case_raw, "platform", context),
+                evidence_manifest_path=_required_string(case_raw, "evidence_manifest_path", context),
+                evidence_manifest_sha256=_required_string(case_raw, "evidence_manifest_sha256", context),
             )
         )
-    return AcceptanceReport(foundation_tag, follow_up_tag, tuple(cases))
+    return AcceptanceReport(foundation_tag, follow_up_tag, tuple(cases), tuple(platforms_raw))
 
 
 def _case_manifest(case: FleetCase) -> dict[str, object]:
@@ -383,8 +939,55 @@ def _release_manifest(release: DistributionRelease) -> dict[str, str]:
     }
 
 
+def starting_release_manifest(releases: Sequence[DistributionRelease]) -> dict[str, object]:
+    """Return the generated, exact release-tree set that a fleet report must cover."""
+
+    cases = [_release_manifest(release) for release in releases]
+    return {"schema_version": 1, "case_count": len(cases), "cases": cases}
+
+
+def releases_from_starting_manifest(
+    source: str, *, current_releases: Sequence[DistributionRelease]
+) -> tuple[DistributionRelease, ...]:
+    """Parse a generated manifest and reject drift from the current immutable tags."""
+
+    try:
+        raw = json.loads(source)
+    except json.JSONDecodeError as error:
+        raise FleetError("historic release manifest is not valid JSON") from error
+    if not isinstance(raw, Mapping) or set(raw) != STARTING_MANIFEST_KEYS or raw.get("schema_version") != 1:
+        raise FleetError("historic release manifest has an invalid shape")
+    cases = raw.get("cases")
+    count = raw.get("case_count")
+    if not isinstance(cases, list) or not isinstance(count, int) or count != len(cases):
+        raise FleetError("historic release manifest has an invalid case count")
+    parsed: list[DistributionRelease] = []
+    for index, case in enumerate(cases, start=1):
+        if not isinstance(case, Mapping) or set(case) != STARTING_RELEASE_KEYS:
+            raise FleetError(f"historic release manifest case {index} has an invalid shape")
+        values = {name: case[name] for name in STARTING_RELEASE_KEYS}
+        if any(not isinstance(value, str) or not value for value in values.values()):
+            raise FleetError(f"historic release manifest case {index} has invalid values")
+        parsed.append(
+            DistributionRelease(
+                tag=values["tag"],
+                version=values["version"],
+                commit=values["commit"],
+                tree=values["tree"],
+            )
+        )
+    if len({release.tag for release in parsed}) != len(parsed):
+        raise FleetError("historic release manifest contains duplicate tags")
+    expected = tuple(current_releases)
+    if tuple(_release_manifest(release) for release in parsed) != tuple(
+        _release_manifest(release) for release in expected
+    ):
+        raise FleetError("historic release manifest does not match the current immutable release trees")
+    return tuple(parsed)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    """Build the historic fleet or validate a completed two-release report."""
+    """Build, exercise, or validate deterministic historic release journeys."""
 
     parser = argparse.ArgumentParser(description=__doc__)
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -396,14 +999,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     build.add_argument("--starting-tag", help="build only this immutable historic release tag")
     check = subcommands.add_parser("check-report", help="fail closed on incomplete fleet evidence")
     check.add_argument("--repo", type=Path, required=True)
+    check.add_argument(
+        "--starting-manifest",
+        type=Path,
+        required=True,
+        help="generated output from the manifest command for this exact immutable release set",
+    )
     check.add_argument("report", type=Path)
+    journey = subcommands.add_parser(
+        "journey",
+        help="record immutable update surfaces and fail closed until an executable journey protocol ships",
+    )
+    journey.add_argument("--repo", type=Path, required=True)
+    journey.add_argument("--output", type=Path, required=True)
+    journey.add_argument("--starting-tag", required=True)
+    journey.add_argument("--foundation-tag", required=True)
+    journey.add_argument("--follow-up-tag", required=True)
     args = parser.parse_args(argv)
 
     if args.command == "manifest":
         releases = discover_distribution_releases(args.repo)
         print(
             json.dumps(
-                {"case_count": len(releases), "cases": [_release_manifest(release) for release in releases]},
+                starting_release_manifest(releases),
                 indent=2,
                 sort_keys=True,
             )
@@ -426,9 +1044,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 0
 
+    if args.command == "journey":
+        run_journey(
+            args.repo,
+            output=args.output,
+            starting_tag=args.starting_tag,
+            foundation_tag=args.foundation_tag,
+            follow_up_tag=args.follow_up_tag,
+        )
+        raise FleetError("journey returned without an immutable executable protocol")
+
     report = acceptance_report_from_json(args.report.read_text(encoding="utf-8"))
-    expected_start_tags = {release.tag for release in discover_distribution_releases(args.repo)}
+    foundation = resolve_immutable_release(args.repo, report.foundation_tag)
+    follow_up = resolve_immutable_release(args.repo, report.follow_up_tag)
+    if foundation.tag == follow_up.tag or foundation.commit == follow_up.commit:
+        raise FleetError("acceptance report foundation and follow-up are not distinct immutable releases")
+    generated_starting_releases = releases_from_starting_manifest(
+        args.starting_manifest.read_text(encoding="utf-8"),
+        current_releases=discover_distribution_releases(args.repo),
+    )
+    expected_start_tags = {release.tag for release in generated_starting_releases}
     assert_complete(report, expected_start_tags)
+    assert_evidence_bound(
+        report,
+        repo=args.repo,
+        evidence_root=args.report.parent.resolve(),
+        foundation=foundation,
+        follow_up=follow_up,
+    )
     print(f"PASS: {len(report.cases)} historic release trees reached both releases")
     return 0
 


### PR DESCRIPTION
## Status

Draft hardening only. This does **not** run the historic fleet and cannot establish historic update support.

## What it does

- derives the historic starting matrix from a generated, immutable-manifest-bound release set (currently 168 trees)
- binds reported update surfaces back to exact annotated tag bytes
- refuses all acceptance reports, including internally consistent hand-authored evidence, while the released `/dex-update` surface is non-executable Markdown
- documents the future protocol requirements: real historical refusal/rescue, bridge provenance, exact preview and approval, receipts, installed identity, Doctor, and platform smoke

## Verification

- focused fleet tests: 24 passed
- Ruff, compilation, and whitespace checks passed
- independent review confirmed a forged complete evidence bundle is rejected

## Deliberately still absent

No immutable machine-callable journey protocol has been released. No bridge artifact, foundation/follow-up tag pair, 168-case journey, or user-facing acceptance claim exists.