### PR TITLE
feat(update): add release-owned journey protocol

### DIFF
--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -703,6 +703,7 @@ System/.last-learning-check
 System/.local-only-preservation-transition.json
 System/.mcp.json.example
 System/.release-evidence-profile.json
+System/.update-journey-v1.json
 System/Beta_Communications/2026-02-04_hardcoded_paths_fix.md
 System/Dex_Backlog.md
 System/README.md
@@ -1017,6 +1018,7 @@ core/tests/test_customization_verification.py
 core/tests/test_daily_plan_relationships_surface.py
 core/tests/test_dex_improvements_server.py
 core/tests/test_dex_state.py
+core/tests/test_dex_update_bridge.py
 core/tests/test_dexdiff_adopt_profile_script.py
 core/tests/test_dexdiff_profile_adopt.py
 core/tests/test_dexdiff_publish_diff_script.py
@@ -1067,6 +1069,7 @@ core/tests/test_messy_vault_parsers.py
 core/tests/test_no_deprecated_models.py
 core/tests/test_nudge_calendar.py
 core/tests/test_onboarding_calendar.py
+core/tests/test_onboarding_context_lifecycle.py
 core/tests/test_path_contract.py
 core/tests/test_paths.py
 core/tests/test_people_index_v2.py
@@ -1110,6 +1113,7 @@ core/tests/test_trust_wizards.py
 core/tests/test_trusted_mcp_safety.py
 core/tests/test_update_checker.py
 core/tests/test_update_checker_real_installs.py
+core/tests/test_update_journey_protocol.py
 core/tests/test_update_rollback_journey.py
 core/tests/test_work_server_entity_links.py
 core/tests/test_work_server_legacy_task_completion.py
@@ -1126,6 +1130,7 @@ core/transaction/lock.py
 core/transaction/snapshot.py
 core/update/__init__.py
 core/update/apply_update.py
+core/update/journey_protocol.py
 core/utils/__init__.py
 core/utils/company_domains.py
 core/utils/credential_migration_exceptions.json
@@ -1261,6 +1266,7 @@ scripts/connections-consumer-smoke.mjs
 scripts/connections-contract-validation.mjs
 scripts/detect-flaky-tests.sh
 scripts/dex_state.py
+scripts/dex_update_bridge.py
 scripts/founder-content-allowlist.txt
 scripts/generate-architecture-inventory.py
 scripts/generate-connections-contract.mjs
@@ -1269,6 +1275,7 @@ scripts/generate-path-contracts.py
 scripts/generate-portable-contract.py
 scripts/generate-release-catalog.py
 scripts/generate-test-durations.py
+scripts/generate-update-journey-protocol.py
 scripts/instructed-tools-allowlist.txt
 scripts/make-aged-vault-fixture.sh
 scripts/merge-junit.py

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -1,0 +1,55 @@
+{
+  "controller": "release-fleet-v1",
+  "evidence": [
+    "historic-update-surface",
+    "historic-route-refusal",
+    "bridge-foundation",
+    "foundation-update-surface",
+    "foundation-preview",
+    "foundation-approval",
+    "foundation-receipt",
+    "follow-up-installed",
+    "follow-up-doctor",
+    "follow-up-smoke"
+  ],
+  "foundation_to_follow_up": {
+    "adapter": "lifecycle-delivered-release-v1",
+    "approval": {
+      "count": 1,
+      "word": "APPLY"
+    },
+    "operations": [
+      "deliver_latest_release",
+      "build_and_preview_delivered_release",
+      "execute_approved_delivered_release"
+    ]
+  },
+  "historic_to_foundation": {
+    "adapter": "pinned-foundation-bridge-v1",
+    "approval": {
+      "count": 2,
+      "word": "APPLY"
+    },
+    "artifact": {
+      "sha256": "1a0235616d257c3c779681f034d05c86d2cf5483fef3bc7694315b65acc3af75",
+      "source_path": "scripts/dex_update_bridge.py"
+    },
+    "foundation": {
+      "channel": "stable",
+      "commit": "9211053235d7c1837a6e327bff1596b593323fc6",
+      "tag": "dist/release/v1.80.5-9211053",
+      "tag_object": "ff94463b191bb2c503ffec42ce288e961ca79659",
+      "tree": "d394658e2bf1125b96eb5afdace24f3a5ba3107e",
+      "version": "1.80.5"
+    }
+  },
+  "platforms": [
+    "darwin",
+    "linux"
+  ],
+  "runner": {
+    "sha256": "844cbb03ffe746298d7479cba4dab29532e01dd695cd24d36fa877e2406a52a8",
+    "source_path": "scripts/release_fleet.py"
+  },
+  "schema_version": 1
+}

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -48,7 +48,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "844cbb03ffe746298d7479cba4dab29532e01dd695cd24d36fa877e2406a52a8",
+    "sha256": "77f49a9a565d99db379b2457ef891fcbe7fa4b8a9636baba75fd7fd19bcdf84e",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -183,6 +183,13 @@ RULES: tuple[Rule, ...] = (
     _r("brain-beta-communications", "System/Beta_Communications", "dir", "brain",
        "release-doc retained until the schema-2 baseline-reduction follow-up"),
     _r("brain-system-readme", "System/README.md", "file", "brain"),
+    _r(
+        "brain-update-journey-protocol",
+        "System/.update-journey-v1.json",
+        "file",
+        "brain",
+        "immutable release-owned updater instructions with no arbitrary command surface",
+    ),
 
     # --- seed: shipped once, then the user's; update writes only if absent -
     _r("seed-templates", "System/Templates", "dir", "seed"),

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -65,6 +65,7 @@ RELEASE_BUILD_INPUTS = (
     ".claude/skills/dex-update/SKILL.md",
     ".claude/skills/dex-rollback/SKILL.md",
     "System/.local-only-preservation-transition.json",
+    "System/.update-journey-v1.json",
     "System/Beta_Communications/2026-02-04_hardcoded_paths_fix.md",
     "core/migrations/preserve_local_only_paths.py",
     "core/migrations/tracked-ignored-policy.yaml",
@@ -81,6 +82,7 @@ RELEASE_BUILD_INPUTS = (
     "core/provision.cjs",
     "core/transaction/engine.py",
     "core/transaction/journal.py",
+    "core/update/journey_protocol.py",
     "core/utils/tracked_ignored.py",
     "core/utils/manifest.py",
     "core/utils/update_verifier.py",
@@ -91,8 +93,11 @@ RELEASE_BUILD_INPUTS = (
     "scripts/build-vault-bundle.sh",
     "scripts/check-catalog-coverage.py",
     "scripts/check-tau-removal.py",
+    "scripts/dex_update_bridge.py",
     "scripts/generate-manifest.sh",
     "scripts/generate-release-catalog.py",
+    "scripts/generate-update-journey-protocol.py",
+    "scripts/release_fleet.py",
     "scripts/resolve-distignore-files.sh",
     "scripts/security-gate.sh",
     "scripts/verify-distribution.sh",
@@ -129,11 +134,13 @@ def test_release_builders_gate_frozen_lifecycle_contract_artifacts() -> None:
     from core.utils.manifest import REQUIRED_LIFECYCLE_RELEASE_PATHS
 
     assert REQUIRED_LIFECYCLE_RELEASE_PATHS == (
+        "System/.update-journey-v1.json",
         "core/lifecycle/bridge.py",
         "core/lifecycle/catalog/bridge-release.json",
         "core/lifecycle/contracts/api.schema.json",
         "core/lifecycle/service.py",
         "core/portable_contract.py",
+        "core/update/journey_protocol.py",
         "packages/dex-contracts/dist/portable-vault.contract.json",
     )
     for script_name in ("build-release.sh", "build-vault-bundle.sh"):
@@ -397,10 +404,12 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert "System/.installed-files.manifest" in members
     assert "System/.release-catalog.json" in members
     assert "System/.release-evidence-profile.json" in members
+    assert "System/.update-journey-v1.json" in members
     assert "core/lifecycle/catalog/bridge-release.json" in members
     assert "core/lifecycle/contracts/api.schema.json" in members
     assert "core/lifecycle/service.py" in members
     assert "core/lifecycle/bridge.py" in members
+    assert "core/update/journey_protocol.py" in members
     assert "System/.dex/lifecycle/activation.json" not in members
     assert "System/.local-only-preservation-transition.json" in members
     assert "core/migrations/preserve_local_only_paths.py" in members
@@ -422,6 +431,8 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert "core/tests/test_distribution_artifacts.py" not in manifest
     assert "core/lifecycle/catalog/bridge-release.json" in manifest
     assert "core/lifecycle/contracts/api.schema.json" in manifest
+    assert "System/.update-journey-v1.json" in manifest
+    assert "core/update/journey_protocol.py" in manifest
     assert "System/.dex/lifecycle/activation.json" not in manifest
     catalog = _git_json(clone, "release:System/.release-catalog.json")
     package = _git_json(clone, "release:package.json")

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -691,7 +691,7 @@ def test_release_build_rejects_malformed_selected_package_before_creating_refs(t
 
 def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path) -> None:
     clone = _clone_repo(tmp_path, "raw-vault-bundle")
-    _sync_release_inputs(clone)
+    _commit_release_inputs_if_changed(clone)
     # Prove the builder regenerates the declaration rather than copying stale bytes.
     (clone / "System/.release-evidence-profile.json").write_text(
         json.dumps({"profile": "legacy-v1", "release_version": "0.0.1", "schema_version": 1}, indent=2) + "\n"
@@ -728,6 +728,50 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
         assert script_name not in package.get("scripts", {})
     assert manifest == sorted(set(manifest))
     assert set(manifest) == shipped
+
+
+def test_raw_vault_bundle_rejects_dirty_protocol_inputs_not_in_source_commit(
+    tmp_path: Path,
+) -> None:
+    clone = _clone_repo(tmp_path, "raw-vault-bundle-dirty-protocol")
+    _commit_release_inputs_if_changed(clone)
+    runner = clone / "scripts/release_fleet.py"
+    runner.write_text(
+        runner.read_text(encoding="utf-8") + "\n# uncommitted runner bytes\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [sys.executable, "scripts/generate-update-journey-protocol.py"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    spy_dir = tmp_path / "dirty-protocol-command-spies"
+    spy_dir.mkdir()
+    sentinel = tmp_path / "dirty-protocol-npm-ran"
+    npm_spy = spy_dir / "npm"
+    npm_spy.write_text(
+        f"#!/bin/sh\ntouch '{sentinel}'\nexit 97\n",
+        encoding="utf-8",
+    )
+    npm_spy.chmod(0o755)
+    environment = os.environ.copy()
+    environment["PATH"] = f"{spy_dir}{os.pathsep}{environment['PATH']}"
+
+    result = subprocess.run(
+        ["bash", "scripts/build-vault-bundle.sh", str(tmp_path / "blocked-bundle")],
+        cwd=clone,
+        capture_output=True,
+        text=True,
+        timeout=240,
+        env=environment,
+    )
+
+    assert result.returncode == 1
+    assert "protocol inputs differ from recorded source commit" in result.stderr
+    assert not sentinel.exists()
 
 
 def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -> None:

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -785,7 +785,7 @@ def _write_complete_evidence(
     return ({"events": events}, manifest_path, manifest_sha256)
 
 
-def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_an_executable_protocol(
+def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_a_released_executor(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _repository(tmp_path)
@@ -831,7 +831,7 @@ def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_an_ex
     report_path = tmp_path / "report.json"
     report_path.write_text(json.dumps(report), encoding="utf-8")
 
-    with pytest.raises(release_fleet.FleetError, match="executable journey protocol"):
+    with pytest.raises(release_fleet.FleetError, match="released journey executor"):
         release_fleet.main(
             [
                 "check-report",
@@ -846,8 +846,10 @@ def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_an_ex
     assert "PASS" not in capsys.readouterr().out
 
 
-def test_evidence_gate_uses_the_follow_up_protocol_to_authorize_historic_prose_routes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_check_report_rejects_hand_authored_evidence_even_with_a_valid_protocol(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo = _repository(tmp_path)
     _write_update_surface(repo)
@@ -874,40 +876,53 @@ def test_evidence_gate_uses_the_follow_up_protocol_to_authorize_historic_prose_r
         follow_up=follow_up,
     )
     hashes = {"00-Inbox/keep.md": "a" * 64}
-    report = release_fleet.AcceptanceReport(
-        foundation_tag=foundation.tag,
-        follow_up_tag=follow_up.tag,
-        platforms=("darwin",),
-        cases=(
-            release_fleet.CaseResult(
-                starting_tag=start.tag,
-                reached_foundation=True,
-                reached_follow_up=True,
-                foundation_doctor_healthy=True,
-                follow_up_doctor_healthy=True,
-                user_hashes_before=hashes,
-                user_hashes_after_foundation=hashes,
-                user_hashes_after_follow_up=hashes,
-                transcript_path="case.evidence/journey.json",
-                foundation_receipt_path="case.evidence/foundation-receipt.json",
-                follow_up_receipt_path="case.evidence/follow-up-receipt.json",
-                foundation_doctor_path="case.evidence/foundation-doctor.json",
-                follow_up_doctor_path="case.evidence/follow-up-doctor.json",
-                follow_up_smoke_path="case.evidence/smoke.json",
-                platform="darwin",
-                evidence_manifest_path=manifest_path,
-                evidence_manifest_sha256=manifest_sha256,
-            ),
+    starting_manifest = _write_starting_manifest(tmp_path, (start,))
+    report_path = tmp_path / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "foundation_tag": foundation.tag,
+                "follow_up_tag": follow_up.tag,
+                "platforms": ["darwin"],
+                "cases": [
+                    {
+                        "starting_tag": start.tag,
+                        "reached_foundation": True,
+                        "reached_follow_up": True,
+                        "foundation_doctor_healthy": True,
+                        "follow_up_doctor_healthy": True,
+                        "user_hashes_before": hashes,
+                        "user_hashes_after_foundation": hashes,
+                        "user_hashes_after_follow_up": hashes,
+                        "transcript_path": "case.evidence/journey.json",
+                        "foundation_receipt_path": "case.evidence/foundation-receipt.json",
+                        "follow_up_receipt_path": "case.evidence/follow-up-receipt.json",
+                        "foundation_doctor_path": "case.evidence/foundation-doctor.json",
+                        "follow_up_doctor_path": "case.evidence/follow-up-doctor.json",
+                        "follow_up_smoke_path": "case.evidence/smoke.json",
+                        "platform": "darwin",
+                        "evidence_manifest_path": manifest_path,
+                        "evidence_manifest_sha256": manifest_sha256,
+                    }
+                ],
+            }
         ),
+        encoding="utf-8",
     )
 
-    release_fleet.assert_evidence_bound(
-        report,
-        repo=repo,
-        evidence_root=tmp_path,
-        foundation=foundation,
-        follow_up=follow_up,
-    )
+    with pytest.raises(release_fleet.FleetError, match="released journey executor"):
+        release_fleet.main(
+            [
+                "check-report",
+                "--repo",
+                str(repo),
+                "--starting-manifest",
+                str(starting_manifest),
+                str(report_path),
+            ]
+        )
+
+    assert "PASS" not in capsys.readouterr().out
 
 
 def test_check_report_rejects_a_plausible_manifest_when_surface_bytes_are_not_from_the_tag(
@@ -958,7 +973,7 @@ def test_check_report_rejects_a_plausible_manifest_when_surface_bytes_are_not_fr
     report_path = tmp_path / "report.json"
     report_path.write_text(json.dumps(report))
 
-    with pytest.raises(release_fleet.FleetError, match="executable journey protocol"):
+    with pytest.raises(release_fleet.FleetError, match="released journey executor"):
         release_fleet.main(
             [
                 "check-report",
@@ -1221,7 +1236,7 @@ def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path
     foundation_tag = _tag_release(repo, "1.80.0", "foundation")
     follow_up_tag = _tag_release(repo, "1.80.5", "follow-up")
 
-    with pytest.raises(release_fleet.FleetError, match="Markdown-only"):
+    with pytest.raises(release_fleet.FleetError, match="executor is unavailable"):
         release_fleet.run_journey(
             repo,
             output=tmp_path / "output",
@@ -1235,7 +1250,7 @@ def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path
     result = json.loads((evidence_root / "journey-result.json").read_text())
     manifest = evidence_root / "evidence-manifest.json"
     transcript = json.loads((evidence_root / "journey-transcript.json").read_text())
-    assert result["failure"].startswith("published /dex-update surfaces are Markdown-only")
+    assert result["failure"].startswith("published journey executor is unavailable")
     assert result["evidence_manifest_sha256"] == release_fleet.hashlib.sha256(manifest.read_bytes()).hexdigest()
     assert [event["id"] for event in transcript["events"]] == [
         "historic-update-surface",
@@ -1244,7 +1259,7 @@ def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path
     assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()
 
 
-def test_shipped_update_surface_accepts_only_a_valid_release_owned_protocol(
+def test_shipped_update_surface_validates_protocol_but_keeps_it_non_executable(
     tmp_path: Path,
 ) -> None:
     repo = _repository(tmp_path)
@@ -1283,10 +1298,18 @@ def test_shipped_update_surface_accepts_only_a_valid_release_owned_protocol(
     protocol_release = release_fleet.resolve_immutable_release(repo, protocol_tag)
     surface = release_fleet.shipped_update_surface(repo, protocol_release)
 
-    assert surface["machine_executable"] is True
+    assert surface["machine_executable"] is False
     assert surface["journey_protocol"]["path"] == release_fleet.UPDATE_JOURNEY_RELATIVE
     assert surface["journey_protocol"]["schema_version"] == 1
     assert surface["journey_protocol"]["source_commit"] == source_commit
+    distribution = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == protocol_tag
+    )
+    classification = release_fleet.classify_historic_update_surface(repo, distribution)
+    assert classification["machine_executable"] is False
+    assert classification["route_classification"] == "machine-protocol-declared-executor-missing"
 
 
 def test_shipped_update_surface_rejects_a_protocol_with_an_unknown_operation(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -670,6 +670,41 @@ def _write_starting_manifest(root: Path, releases: tuple[release_fleet.Distribut
     return path
 
 
+def _tag_protocol_control_release(
+    repo: Path,
+    *,
+    foundation: release_fleet.ImmutableRelease,
+    version: str,
+) -> str:
+    for relative in ("scripts/dex_update_bridge.py", "scripts/release_fleet.py"):
+        source = repo / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes((release_fleet.PROJECT_ROOT / relative).read_bytes())
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "release-owned journey source")
+    source_commit = _git(repo, "rev-parse", "HEAD")
+
+    protocol_path = repo / release_fleet.UPDATE_JOURNEY_RELATIVE
+    protocol_path.parent.mkdir(parents=True, exist_ok=True)
+    document = json.loads(
+        (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_text()
+    )
+    document["historic_to_foundation"]["foundation"] = foundation.identity()
+    protocol_path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+    (repo / "System/.release-catalog.json").write_text(
+        json.dumps(
+            {
+                "catalog_version": 1,
+                "release": {"source_commit": source_commit},
+                "items": [],
+                "integrity": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return _tag_release(repo, version, "protocol control release")
+
+
 def _write_complete_evidence(
     repo: Path,
     root: Path,
@@ -809,6 +844,70 @@ def test_check_report_rejects_a_fully_self_consistent_evidence_set_without_an_ex
         )
 
     assert "PASS" not in capsys.readouterr().out
+
+
+def test_evidence_gate_uses_the_follow_up_protocol_to_authorize_historic_prose_routes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repository(tmp_path)
+    _write_update_surface(repo)
+    start_tag = _tag_release(repo, "1.61.0", "start")
+    foundation_tag = _tag_release(repo, "1.80.0", "foundation")
+    start = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == start_tag
+    )
+    foundation = release_fleet.resolve_immutable_release(repo, foundation_tag)
+    follow_up_tag = _tag_protocol_control_release(
+        repo,
+        foundation=foundation,
+        version="1.80.1",
+    )
+    follow_up = release_fleet.resolve_immutable_release(repo, follow_up_tag)
+    monkeypatch.setattr(release_fleet, "discover_distribution_releases", lambda _repo: (start,))
+    _events, manifest_path, manifest_sha256 = _write_complete_evidence(
+        repo,
+        tmp_path,
+        start=start,
+        foundation=foundation,
+        follow_up=follow_up,
+    )
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    report = release_fleet.AcceptanceReport(
+        foundation_tag=foundation.tag,
+        follow_up_tag=follow_up.tag,
+        platforms=("darwin",),
+        cases=(
+            release_fleet.CaseResult(
+                starting_tag=start.tag,
+                reached_foundation=True,
+                reached_follow_up=True,
+                foundation_doctor_healthy=True,
+                follow_up_doctor_healthy=True,
+                user_hashes_before=hashes,
+                user_hashes_after_foundation=hashes,
+                user_hashes_after_follow_up=hashes,
+                transcript_path="case.evidence/journey.json",
+                foundation_receipt_path="case.evidence/foundation-receipt.json",
+                follow_up_receipt_path="case.evidence/follow-up-receipt.json",
+                foundation_doctor_path="case.evidence/foundation-doctor.json",
+                follow_up_doctor_path="case.evidence/follow-up-doctor.json",
+                follow_up_smoke_path="case.evidence/smoke.json",
+                platform="darwin",
+                evidence_manifest_path=manifest_path,
+                evidence_manifest_sha256=manifest_sha256,
+            ),
+        ),
+    )
+
+    release_fleet.assert_evidence_bound(
+        report,
+        repo=repo,
+        evidence_root=tmp_path,
+        foundation=foundation,
+        follow_up=follow_up,
+    )
 
 
 def test_check_report_rejects_a_plausible_manifest_when_surface_bytes_are_not_from_the_tag(
@@ -1143,3 +1242,67 @@ def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path
         "foundation-update-surface",
     ]
     assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()
+
+
+def test_shipped_update_surface_accepts_only_a_valid_release_owned_protocol(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_update_surface(repo)
+    prose_tag = _tag_release(repo, "1.80.5", "prose")
+    prose_release = release_fleet.resolve_immutable_release(repo, prose_tag)
+
+    assert release_fleet.shipped_update_surface(repo, prose_release)["machine_executable"] is False
+
+    for relative in ("scripts/dex_update_bridge.py", "scripts/release_fleet.py"):
+        source = repo / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes((release_fleet.PROJECT_ROOT / relative).read_bytes())
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "release-owned journey source")
+    source_commit = _git(repo, "rev-parse", "HEAD")
+
+    protocol_path = repo / release_fleet.UPDATE_JOURNEY_RELATIVE
+    protocol_path.parent.mkdir(parents=True, exist_ok=True)
+    protocol_path.write_bytes(
+        (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_bytes()
+    )
+    catalog = repo / "System/.release-catalog.json"
+    catalog.write_text(
+        json.dumps(
+            {
+                "catalog_version": 1,
+                "release": {"source_commit": source_commit},
+                "items": [],
+                "integrity": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    protocol_tag = _tag_release(repo, "1.80.6", "protocol")
+    protocol_release = release_fleet.resolve_immutable_release(repo, protocol_tag)
+    surface = release_fleet.shipped_update_surface(repo, protocol_release)
+
+    assert surface["machine_executable"] is True
+    assert surface["journey_protocol"]["path"] == release_fleet.UPDATE_JOURNEY_RELATIVE
+    assert surface["journey_protocol"]["schema_version"] == 1
+    assert surface["journey_protocol"]["source_commit"] == source_commit
+
+
+def test_shipped_update_surface_rejects_a_protocol_with_an_unknown_operation(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_update_surface(repo)
+    protocol_path = repo / release_fleet.UPDATE_JOURNEY_RELATIVE
+    protocol_path.parent.mkdir(parents=True, exist_ok=True)
+    document = json.loads(
+        (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_text()
+    )
+    document["foundation_to_follow_up"]["operations"].append("run_any_command")
+    protocol_path.write_text(json.dumps(document), encoding="utf-8")
+    tag = _tag_release(repo, "1.80.6", "invalid-protocol")
+    release = release_fleet.resolve_immutable_release(repo, tag)
+
+    with pytest.raises(release_fleet.FleetError, match="journey protocol"):
+        release_fleet.shipped_update_surface(repo, release)

--- a/core/tests/test_update_journey_protocol.py
+++ b/core/tests/test_update_journey_protocol.py
@@ -1,0 +1,64 @@
+"""The release-owned updater journey protocol at its public seams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.update.journey_protocol import (
+    JourneyProtocolError,
+    load_update_journey_protocol,
+)
+from scripts import dex_update_bridge
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "System/.update-journey-v1.json"
+GENERATOR = REPO_ROOT / "scripts/generate-update-journey-protocol.py"
+
+
+def test_release_owned_protocol_binds_only_the_reviewed_update_adapters() -> None:
+    protocol = load_update_journey_protocol(PROTOCOL_PATH.read_bytes())
+
+    assert protocol.foundation == dex_update_bridge.FOUNDATION.identity()
+    assert protocol.platforms == ("darwin", "linux")
+    assert protocol.bridge.adapter == "pinned-foundation-bridge-v1"
+    assert protocol.follow_up.adapter == "lifecycle-delivered-release-v1"
+    assert protocol.follow_up.operations == (
+        "deliver_latest_release",
+        "build_and_preview_delivered_release",
+        "execute_approved_delivered_release",
+    )
+    assert protocol.bridge.approval_word == protocol.follow_up.approval_word == "APPLY"
+    assert protocol.bridge.approval_count == 2
+    assert protocol.follow_up.approval_count == 1
+    for artifact in (protocol.bridge.artifact, protocol.runner):
+        source = REPO_ROOT / artifact.source_path
+        assert artifact.sha256 == hashlib.sha256(source.read_bytes()).hexdigest()
+
+
+def test_protocol_rejects_an_arbitrary_command_adapter() -> None:
+    document = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    document["historic_to_foundation"]["adapter"] = "shell-command"
+    document["historic_to_foundation"]["command"] = ["sh", "-c", "anything"]
+
+    with pytest.raises(JourneyProtocolError, match="invalid shape|unsupported adapter"):
+        load_update_journey_protocol(json.dumps(document).encode())
+
+
+def test_generator_reproduces_the_committed_root_protocol(tmp_path: Path) -> None:
+    generated = tmp_path / "update-journey.json"
+
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR), "--output", str(generated)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert generated.read_bytes() == PROTOCOL_PATH.read_bytes()

--- a/core/update/journey_protocol.py
+++ b/core/update/journey_protocol.py
@@ -1,0 +1,285 @@
+"""Closed, release-owned protocol for historic updater fleet journeys.
+
+The protocol is data, not a command language.  Version 1 names two reviewed
+adapters and the exact lifecycle service calls they are allowed to make.  Any
+new adapter, operation, approval shape, or evidence sequence requires a new
+reviewed protocol version.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+PROTOCOL_RELATIVE = "System/.update-journey-v1.json"
+PROTOCOL_VERSION = 1
+CONTROLLER = "release-fleet-v1"
+SUPPORTED_PLATFORMS = ("darwin", "linux")
+BRIDGE_ADAPTER = "pinned-foundation-bridge-v1"
+BRIDGE_SOURCE = "scripts/dex_update_bridge.py"
+RUNNER_SOURCE = "scripts/release_fleet.py"
+FOLLOW_UP_ADAPTER = "lifecycle-delivered-release-v1"
+FOLLOW_UP_OPERATIONS = (
+    "deliver_latest_release",
+    "build_and_preview_delivered_release",
+    "execute_approved_delivered_release",
+)
+REQUIRED_EVIDENCE = (
+    "historic-update-surface",
+    "historic-route-refusal",
+    "bridge-foundation",
+    "foundation-update-surface",
+    "foundation-preview",
+    "foundation-approval",
+    "foundation-receipt",
+    "follow-up-installed",
+    "follow-up-doctor",
+    "follow-up-smoke",
+)
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "controller",
+        "platforms",
+        "runner",
+        "historic_to_foundation",
+        "foundation_to_follow_up",
+        "evidence",
+    }
+)
+_ARTIFACT_FIELDS = frozenset({"source_path", "sha256"})
+_BRIDGE_FIELDS = frozenset({"adapter", "artifact", "foundation", "approval"})
+_FOLLOW_UP_FIELDS = frozenset({"adapter", "operations", "approval"})
+_APPROVAL_FIELDS = frozenset({"word", "count"})
+_IDENTITY_FIELDS = frozenset(
+    {"tag", "tag_object", "commit", "tree", "version", "channel"}
+)
+_HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+_TAG = re.compile(
+    r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-"
+    r"(?P<short>[0-9a-f]{7,40})$"
+)
+
+
+class JourneyProtocolError(ValueError):
+    """A released journey protocol is not closed or machine-safe."""
+
+
+@dataclass(frozen=True)
+class ProtocolArtifact:
+    """One source-commit artifact whose exact bytes are protocol authority."""
+
+    source_path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BridgeHop:
+    """The only permitted historic-to-foundation adapter."""
+
+    adapter: str
+    artifact: ProtocolArtifact
+    foundation: dict[str, str]
+    approval_word: str
+    approval_count: int
+
+
+@dataclass(frozen=True)
+class FollowUpHop:
+    """The only permitted foundation-to-follow-up lifecycle route."""
+
+    adapter: str
+    operations: tuple[str, ...]
+    approval_word: str
+    approval_count: int
+
+
+@dataclass(frozen=True)
+class UpdateJourneyProtocol:
+    """Validated release-owned instructions for the two-hop fleet runner."""
+
+    schema_version: int
+    controller: str
+    platforms: tuple[str, ...]
+    runner: ProtocolArtifact
+    bridge: BridgeHop
+    follow_up: FollowUpHop
+    evidence: tuple[str, ...]
+
+    @property
+    def foundation(self) -> dict[str, str]:
+        return dict(self.bridge.foundation)
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise JourneyProtocolError(f"journey protocol repeats field {key!r}")
+        result[key] = value
+    return result
+
+
+def _object(value: object, fields: frozenset[str], context: str) -> dict[str, object]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise JourneyProtocolError(f"{context} has an invalid shape")
+    if not all(isinstance(key, str) for key in value):
+        raise JourneyProtocolError(f"{context} has an invalid field name")
+    return dict(value)
+
+
+def _artifact(value: object, *, source_path: str, context: str) -> ProtocolArtifact:
+    document = _object(value, _ARTIFACT_FIELDS, context)
+    if document["source_path"] != source_path:
+        raise JourneyProtocolError(f"{context} names an unsupported source artifact")
+    digest = document["sha256"]
+    if not isinstance(digest, str) or _HEX_64.fullmatch(digest) is None:
+        raise JourneyProtocolError(f"{context} has an invalid SHA-256")
+    return ProtocolArtifact(source_path, digest)
+
+
+def _approval(
+    value: object,
+    *,
+    expected_count: int,
+    context: str,
+) -> tuple[str, int]:
+    document = _object(value, _APPROVAL_FIELDS, context)
+    if document != {"word": "APPLY", "count": expected_count}:
+        raise JourneyProtocolError(f"{context} is not the reviewed approval boundary")
+    return "APPLY", expected_count
+
+
+def _foundation_identity(value: object) -> dict[str, str]:
+    document = _object(value, _IDENTITY_FIELDS, "journey protocol foundation")
+    if not all(isinstance(document[key], str) for key in _IDENTITY_FIELDS):
+        raise JourneyProtocolError("journey protocol foundation identity is malformed")
+    identity = {key: str(document[key]) for key in _IDENTITY_FIELDS}
+    match = _TAG.fullmatch(identity["tag"])
+    if (
+        match is None
+        or identity["version"] != match.group("version")
+        or identity["channel"] != "stable"
+        or any(
+            _HEX_40.fullmatch(identity[key]) is None
+            for key in ("tag_object", "commit", "tree")
+        )
+        or not identity["commit"].startswith(match.group("short"))
+    ):
+        raise JourneyProtocolError("journey protocol foundation identity is malformed")
+    return identity
+
+
+def _string_array(value: object, *, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise JourneyProtocolError(f"{context} must be an array of strings")
+    return tuple(value)
+
+
+def load_update_journey_protocol(source: bytes | str) -> UpdateJourneyProtocol:
+    """Parse protocol v1 and reject every unreviewed extension."""
+
+    try:
+        value = json.loads(source, object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise JourneyProtocolError("journey protocol is not valid JSON") from error
+    document = _object(value, _TOP_LEVEL_FIELDS, "journey protocol")
+    if document["schema_version"] != PROTOCOL_VERSION:
+        raise JourneyProtocolError("journey protocol version is unsupported")
+    if document["controller"] != CONTROLLER:
+        raise JourneyProtocolError("journey protocol controller is unsupported")
+    if (
+        _string_array(document["platforms"], context="journey protocol platforms")
+        != SUPPORTED_PLATFORMS
+    ):
+        raise JourneyProtocolError("journey protocol platforms are unsupported")
+    if (
+        _string_array(document["evidence"], context="journey protocol evidence")
+        != REQUIRED_EVIDENCE
+    ):
+        raise JourneyProtocolError("journey protocol evidence sequence is unsupported")
+
+    runner = _artifact(
+        document["runner"],
+        source_path=RUNNER_SOURCE,
+        context="journey protocol runner",
+    )
+    bridge_document = _object(
+        document["historic_to_foundation"],
+        _BRIDGE_FIELDS,
+        "journey protocol historic hop",
+    )
+    if bridge_document["adapter"] != BRIDGE_ADAPTER:
+        raise JourneyProtocolError("journey protocol historic hop uses an unsupported adapter")
+    bridge_word, bridge_count = _approval(
+        bridge_document["approval"],
+        expected_count=2,
+        context="journey protocol historic approval",
+    )
+    bridge = BridgeHop(
+        adapter=BRIDGE_ADAPTER,
+        artifact=_artifact(
+            bridge_document["artifact"],
+            source_path=BRIDGE_SOURCE,
+            context="journey protocol bridge artifact",
+        ),
+        foundation=_foundation_identity(bridge_document["foundation"]),
+        approval_word=bridge_word,
+        approval_count=bridge_count,
+    )
+
+    follow_document = _object(
+        document["foundation_to_follow_up"],
+        _FOLLOW_UP_FIELDS,
+        "journey protocol follow-up hop",
+    )
+    if follow_document["adapter"] != FOLLOW_UP_ADAPTER:
+        raise JourneyProtocolError("journey protocol follow-up hop uses an unsupported adapter")
+    if (
+        _string_array(
+            follow_document["operations"],
+            context="journey protocol follow-up operations",
+        )
+        != FOLLOW_UP_OPERATIONS
+    ):
+        raise JourneyProtocolError("journey protocol follow-up operations are unsupported")
+    follow_word, follow_count = _approval(
+        follow_document["approval"],
+        expected_count=1,
+        context="journey protocol follow-up approval",
+    )
+    return UpdateJourneyProtocol(
+        schema_version=PROTOCOL_VERSION,
+        controller=CONTROLLER,
+        platforms=SUPPORTED_PLATFORMS,
+        runner=runner,
+        bridge=bridge,
+        follow_up=FollowUpHop(
+            adapter=FOLLOW_UP_ADAPTER,
+            operations=FOLLOW_UP_OPERATIONS,
+            approval_word=follow_word,
+            approval_count=follow_count,
+        ),
+        evidence=REQUIRED_EVIDENCE,
+    )
+
+
+__all__ = [
+    "BRIDGE_ADAPTER",
+    "BRIDGE_SOURCE",
+    "CONTROLLER",
+    "FOLLOW_UP_ADAPTER",
+    "FOLLOW_UP_OPERATIONS",
+    "JourneyProtocolError",
+    "PROTOCOL_RELATIVE",
+    "PROTOCOL_VERSION",
+    "REQUIRED_EVIDENCE",
+    "RUNNER_SOURCE",
+    "SUPPORTED_PLATFORMS",
+    "UpdateJourneyProtocol",
+    "load_update_journey_protocol",
+]

--- a/core/utils/manifest.py
+++ b/core/utils/manifest.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 DEFAULT_MANIFEST = Path("System/.installed-files.manifest")
 REQUIRED_LIFECYCLE_RELEASE_PATHS = (
+    "System/.update-journey-v1.json",
     "core/lifecycle/bridge.py",
     "core/lifecycle/catalog/bridge-release.json",
     "core/lifecycle/contracts/api.schema.json",
     "core/lifecycle/service.py",
     "core/portable_contract.py",
+    "core/update/journey_protocol.py",
     "packages/dex-contracts/dist/portable-vault.contract.json",
 )
 

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -4,7 +4,7 @@
 >
 > **Status vocabulary.** `SHIPPED` = in a released version tag. `LOCAL` = merged on `main`, not yet in a release tag. `PROTOTYPE` = built, not verified against live/real use. `PLANNED` = designed, not built.
 >
-> **Ground truth as of** HEAD on `main`, latest release tag **v1.75.2** (2026-07-26). The untagged tree contains PR #248 (customization-migration activation + rewind engine), PR #249 (Dex Guide pointers), PR #251 (documentation refresh), and this branch's authorized human-confirmed rebuild doorway. None of that post-tag work is shipped in v1.75.2.
+> **Ground truth as of** `upstream/main` at `ae0815fd`, latest release tag **v1.80.5** (2026-07-29). This branch adds the release-owned historic updater journey protocol. It is LOCAL until merged and published in a later immutable release; no historic fleet case has passed because of it.
 >
 > **Don't duplicate generated files.** Tool lists, skill lists, ownership-class path tables, and MCP↔skill wiring live in the auto-generated `docs/architecture/INVENTORY.md`. This map cross-references it; it does not restate it.
 >
@@ -20,6 +20,7 @@
 | Transaction core | **SHIPPED** (v1.66) | `core/transaction/*` | Crash-safe snapshot→apply→verify→commit/rollback substrate the lifecycle engine writes through |
 | Portable ownership contract | **SHIPPED** (v1.64+) | `core/portable_contract.py` | Source of truth: every path is brain/seed/generated/vault/runtime; decides what an update may write |
 | Release catalog + bridge | **SHIPPED** (v1.65–v1.68) | `core/lifecycle/catalog/*`, `bridge.py` | Publisher-declared packing list per release; one-release handoff from the legacy updater |
+| Historic updater journey protocol | **LOCAL** | `System/.update-journey-v1.json`, `core/update/journey_protocol.py` | Closed release-owned machine contract for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
 | 10 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (46 tools) |
 | Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; hardened through security Phases 0–5g, but the `/connect` doorway stays held (draft PR #231) |
 | Customization migration | **SHIPPED** assess/capsule/guided-journey (v1.75.x) / **LOCAL** rebuild engine and doorway | `core/customization_migration/*`, `core/mcp/customization_migration_server.py` | Inventories customizations, preserves a Capsule, and offers a human-confirmed, receipt-backed rebuild and rewind; the doorway is authorized but remains unshipped until its release |
@@ -81,6 +82,22 @@
 **What it is.** Each release carries an exact packing list. `core/lifecycle/catalog/*.json` (publisher-owned declarations, e.g. `official-capabilities.json`) is read by the release builder in filename order and emitted as the canonical `System/.release-catalog.json`. The separately modeled `bridge-release.json` keeps its publisher-owned compatibility contract, while the release generator stamps its `release_version` from the same `package.json` version used by the canonical catalog and validates the result through the strict bridge model. `bridge.py` handles the one-release handoff from the legacy CJS updater to the new engine (resumes safely even if a prior update was interrupted — the v1.68 "smooth bridge").
 
 **How it connects.** Feeds `lifecycle/plan.py` (what's available to adopt) and the DexDiff-adjacent adoption receipts under `System/.dex/adoptions/`. The v1.67 "two dozen role-specific tools you can turn on safely" are catalog items adopted through this path.
+
+### Historic updater journey protocol — LOCAL
+
+`System/.update-journey-v1.json` is the future release-owned control plane for
+historic fleet evidence. Its strict parser permits only the pinned
+foundation-bridge adapter and the existing
+`deliver_latest_release` → `build_and_preview_delivered_release` →
+`execute_approved_delivered_release` lifecycle sequence. The generated root
+binds the exact bridge and fleet-runner bytes in the publisher source commit,
+the immutable v1.80.5 foundation identity, approval counts, Mac/Linux support,
+and the required evidence order. Unknown fields, adapters, operations, hashes,
+or approval shapes fail closed; there is no arbitrary command vocabulary.
+
+This is implementation truth, not release acceptance. No public distribution
+tag contains the protocol yet, no foundation/follow-up pair has completed the
+real two-hop journey, and the 168-case acceptance result remains false.
 
 ## 5. The 10 MCP servers — SHIPPED
 

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -97,7 +97,10 @@ or approval shapes fail closed; there is no arbitrary command vocabulary.
 
 This is implementation truth, not release acceptance. No public distribution
 tag contains the protocol yet, no foundation/follow-up pair has completed the
-real two-hop journey, and the 168-case acceptance result remains false.
+real two-hop journey, and the current runner deliberately reports
+`machine_executable: false` even for a valid protocol until a separately
+released executor owns the run and evidence. The 168-case acceptance result
+remains false.
 
 ## 5. The 10 MCP servers — SHIPPED
 

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 3852f0d6f0c74d546862f3f89d8b5525cd5dcbcb218bbe8152c2475d63aa93e7 -->
+<!-- Content SHA-256: 009821c355c74ff355369c1008312a3343040da985a12a2a7bb89714c681114a -->
 
 # Architecture Inventory
 
@@ -142,13 +142,13 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 | Class | Rule count | Update action |
 | --- | ---: | --- |
-| `brain` | 45 | `replace` |
+| `brain` | 46 | `replace` |
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 8 | `regenerate` |
 | `vault` | 17 | `never` |
 | `runtime` | 13 | `never` |
 
-<details><summary><code>brain</code> declared paths (45)</summary>
+<details><summary><code>brain</code> declared paths (46)</summary>
 
 - `.agents` (dir; `brain-agents`)
 - `.ci` (dir; `brain-ci`)
@@ -180,6 +180,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `DISTRIBUTION_READY.md` (file; `brain-distribution-ready`)
 - `LICENSE` (file; `brain-license`)
 - `README.md` (file; `brain-readme`)
+- `System/.update-journey-v1.json` (file; `brain-update-journey-protocol`)
 - `System/Beta_Communications` (dir; `brain-beta-communications`)
 - `System/README.md` (file; `brain-system-readme`)
 - `core` (dir; `brain-core`)

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -106,12 +106,28 @@ python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --follow-up-tag dist/release/v1.80.5-EXACTFOLLOWUP
 ```
 
-The required future published protocol must be immutable and machine-verifiable.
-It must expose the historic documented route or its refusal, bridge publication
-provenance, foundation preview, explicit approval, receipts, installed release
-identity, Doctor evidence, and released platform smoke. Until a release ships
-that protocol, no synthetic fixture is installed and no bridge, lifecycle
-method, Git merge, or handwritten route wrapper is allowed to run.
+The repository now has the canonical protocol source at
+`System/.update-journey-v1.json`, with a strict parser in
+`core/update/journey_protocol.py`. It is a closed operation vocabulary, not a
+shell-command format. Version 1 permits only:
+
+- the reviewed pinned-foundation bridge, with its exact source SHA-256 and two
+  explicit `APPLY` approvals;
+- `deliver_latest_release`, `build_and_preview_delivered_release`, then
+  `execute_approved_delivered_release`, with one fresh `APPLY` approval; and
+- the fixed evidence order needed for refusal, bridge provenance, preview,
+  receipt, installed identity, Doctor, and released-platform smoke proof.
+
+The root also binds the fleet runner bytes and bridge bytes in the immutable
+release catalog's publisher `source_commit`. A release that merely carries a
+plausible JSON file, points at unavailable source, changes an adapter or
+operation, or has a mismatched hash is not machine-executable.
+
+This protocol is currently LOCAL. Until an immutable public release contains
+it, no synthetic fixture is installed and no bridge, lifecycle method, Git
+merge, or handwritten route wrapper is allowed to run. Publishing the
+contract is a prerequisite, not fleet acceptance: the real foundation and
+follow-up releases must still exist and every historic case must still run.
 
 The resulting `<case>.evidence/` directory is beside—not inside—a future
 fixture. Its content-addressed manifest records the exact release identities,
@@ -130,10 +146,11 @@ python3 scripts/release_fleet.py check-report --repo . \
 
 The command first verifies the generated starting manifest against the current
 immutable release trees, then requires that many cases on every declared
-platform. It cannot pass while either released `/dex-update` surface says
+platform. It cannot pass while the required released route says
 `machine_executable: false`, regardless of how internally consistent a report,
-manifest, transcript, or artifact set appears. Once an executable protocol is
-published, it will also require ordered commands and SHA-256-bound runner
+manifest, transcript, or artifact set appears. A valid published protocol must
+also bind its runner and bridge bytes to the release catalog's immutable source
+commit. Finished evidence still requires ordered commands and SHA-256-bound
 artifacts: the transcript, release-surface snapshots, receipts, Doctor reports,
 and smoke/platform evidence. Paths, symlinks, malformed JSON, mismatched
 identities, incomplete platform coverage, and unknown/broken Doctor results all

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -121,13 +121,16 @@ shell-command format. Version 1 permits only:
 The root also binds the fleet runner bytes and bridge bytes in the immutable
 release catalog's publisher `source_commit`. A release that merely carries a
 plausible JSON file, points at unavailable source, changes an adapter or
-operation, or has a mismatched hash is not machine-executable.
+operation, or has a mismatched hash is invalid. Even a valid protocol remains
+`machine_executable: false`: this runner does not yet contain the released
+executor that can perform both hops and own the resulting evidence.
 
 This protocol is currently LOCAL. Until an immutable public release contains
-it, no synthetic fixture is installed and no bridge, lifecycle method, Git
-merge, or handwritten route wrapper is allowed to run. Publishing the
-contract is a prerequisite, not fleet acceptance: the real foundation and
-follow-up releases must still exist and every historic case must still run.
+it and a separately reviewed released executor exists, no synthetic fixture is
+installed and no bridge, lifecycle method, Git merge, or handwritten route
+wrapper is allowed to run. Publishing the contract is one prerequisite, not
+fleet acceptance: the real foundation and follow-up releases must still exist
+and every historic case must still run.
 
 The resulting `<case>.evidence/` directory is beside—not inside—a future
 fixture. Its content-addressed manifest records the exact release identities,
@@ -148,13 +151,14 @@ The command first verifies the generated starting manifest against the current
 immutable release trees, then requires that many cases on every declared
 platform. It cannot pass while the required released route says
 `machine_executable: false`, regardless of how internally consistent a report,
-manifest, transcript, or artifact set appears. A valid published protocol must
-also bind its runner and bridge bytes to the release catalog's immutable source
-commit. Finished evidence still requires ordered commands and SHA-256-bound
-artifacts: the transcript, release-surface snapshots, receipts, Doctor reports,
-and smoke/platform evidence. Paths, symlinks, malformed JSON, mismatched
-identities, incomplete platform coverage, and unknown/broken Doctor results all
-fail the report.
+manifest, transcript, or artifact set appears. A valid published protocol still
+does not unlock the checker: only a future released executor that owns the
+two-hop run and evidence can do that. The protocol must also bind its runner and
+bridge bytes to the release catalog's immutable source commit. Finished evidence
+still requires ordered commands and SHA-256-bound artifacts: the transcript,
+release-surface snapshots, receipts, Doctor reports, and smoke/platform evidence.
+Paths, symlinks, malformed JSON, mismatched identities, incomplete platform
+coverage, and unknown/broken Doctor results all fail the report.
 
 ## Claim language
 

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -567,6 +567,13 @@
       "ownership": "generated"
     },
     {
+      "id": "brain-update-journey-protocol",
+      "path": "System/.update-journey-v1.json",
+      "kind": "file",
+      "ownership": "brain",
+      "note": "immutable release-owned updater instructions with no arbitrary command surface"
+    },
+    {
       "id": "brain-beta-communications",
       "path": "System/Beta_Communications",
       "kind": "dir",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -74,8 +74,9 @@ DISTIGNORE=$(mktemp)
 TAU_CHECKER=$(mktemp)
 CATALOG_GENERATOR=$(mktemp)
 CATALOG_COVERAGE_CHECKER=$(mktemp)
+JOURNEY_PROTOCOL_CHECK=$(mktemp)
 MATCHES_FILE=$(mktemp)
-trap 'rm -f "$DISTIGNORE" "$TAU_CHECKER" "$CATALOG_GENERATOR" "$CATALOG_COVERAGE_CHECKER" "$MATCHES_FILE"' EXIT
+trap 'rm -f "$DISTIGNORE" "$TAU_CHECKER" "$CATALOG_GENERATOR" "$CATALOG_COVERAGE_CHECKER" "$JOURNEY_PROTOCOL_CHECK" "$MATCHES_FILE"' EXIT
 if ! git show "$SOURCE_BRANCH:.distignore" > "$DISTIGNORE"; then
     echo "Error: .distignore not found in selected source '$SOURCE_BRANCH'." >&2
     exit 1
@@ -160,6 +161,16 @@ echo ""
 # Create or reset release branch to the immutable source identity validated
 # above, even if the source branch moves while this build is running.
 git checkout -B "$RELEASE_BRANCH" "$SOURCE_SHA" --quiet
+
+# Refuse to publish a journey control plane that does not bind the exact
+# selected source bytes. The generated root itself ships; the bridge and fleet
+# runner remain publisher-source artifacts referenced by SHA-256.
+python3 scripts/generate-update-journey-protocol.py --output "$JOURNEY_PROTOCOL_CHECK"
+if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" System/.update-journey-v1.json; then
+    echo "Error: System/.update-journey-v1.json is stale for selected source '$SOURCE_BRANCH'." >&2
+    echo "Run python3 scripts/generate-update-journey-protocol.py and commit the result." >&2
+    exit 1
+fi
 
 # Remove dev-only files
 REMOVED=0

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -30,7 +30,24 @@ trap 'rm -rf "$STAGING_DIR" "$ALL_FILES" "$EXCLUDED_FILES" "$INCLUDED_FILES" "$J
 
 cd "$REPO_ROOT"
 
-# The bundle must carry the protocol for these exact source artifacts.
+# The release catalog records HEAD as its source commit. Refuse a bundle whose
+# protocol, parser, generator, or referenced adapter/runner bytes come from the
+# working tree instead of that exact commit.
+SOURCE_COMMIT="$(git rev-parse --verify 'HEAD^{commit}')"
+PROTOCOL_SOURCE_PATHS=(
+  "System/.update-journey-v1.json"
+  "core/update/journey_protocol.py"
+  "scripts/dex_update_bridge.py"
+  "scripts/generate-update-journey-protocol.py"
+  "scripts/release_fleet.py"
+)
+if ! git diff --quiet "$SOURCE_COMMIT" -- "${PROTOCOL_SOURCE_PATHS[@]}"; then
+  echo "Error: protocol inputs differ from recorded source commit $SOURCE_COMMIT." >&2
+  echo "Commit the protocol, parser, generator, bridge, and runner bytes before building." >&2
+  exit 1
+fi
+
+# The bundle must carry the protocol for these exact committed source artifacts.
 python3 "$REPO_ROOT/scripts/generate-update-journey-protocol.py" \
   --output "$JOURNEY_PROTOCOL_CHECK"
 if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/System/.update-journey-v1.json"; then
@@ -92,7 +109,6 @@ python3 "$REPO_ROOT/core/utils/manifest.py" \
   --validate-file "$STAGING_DIR/System/.installed-files.manifest" \
   --require-lifecycle-contracts
 
-SOURCE_COMMIT="$(git rev-parse HEAD)"
 python3 "$REPO_ROOT/scripts/generate-release-catalog.py" \
   --release-root "$STAGING_DIR" \
   --channel release \

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -25,9 +25,19 @@ STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-vault-bundle.XXXXXX")"
 ALL_FILES="$(mktemp "${TMPDIR:-/tmp}/dex-vault-all.XXXXXX")"
 EXCLUDED_FILES="$(mktemp "${TMPDIR:-/tmp}/dex-vault-excluded.XXXXXX")"
 INCLUDED_FILES="$(mktemp "${TMPDIR:-/tmp}/dex-vault-included.XXXXXX")"
-trap 'rm -rf "$STAGING_DIR" "$ALL_FILES" "$EXCLUDED_FILES" "$INCLUDED_FILES"' EXIT
+JOURNEY_PROTOCOL_CHECK="$(mktemp "${TMPDIR:-/tmp}/dex-update-journey.XXXXXX")"
+trap 'rm -rf "$STAGING_DIR" "$ALL_FILES" "$EXCLUDED_FILES" "$INCLUDED_FILES" "$JOURNEY_PROTOCOL_CHECK"' EXIT
 
 cd "$REPO_ROOT"
+
+# The bundle must carry the protocol for these exact source artifacts.
+python3 "$REPO_ROOT/scripts/generate-update-journey-protocol.py" \
+  --output "$JOURNEY_PROTOCOL_CHECK"
+if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/System/.update-journey-v1.json"; then
+  echo "Error: System/.update-journey-v1.json is stale for this source tree." >&2
+  echo "Run python3 scripts/generate-update-journey-protocol.py and commit the result." >&2
+  exit 1
+fi
 
 # Match build-release.sh's .distignore removals without copying ignored local
 # files such as .env. Include untracked, non-ignored files so the script is

--- a/scripts/generate-update-journey-protocol.py
+++ b/scripts/generate-update-journey-protocol.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate the canonical release-owned updater journey root contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Release generation must not add ignored bytecode beside the selected source.
+sys.dont_write_bytecode = True
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.update.journey_protocol import (
+    BRIDGE_ADAPTER,
+    BRIDGE_SOURCE,
+    CONTROLLER,
+    FOLLOW_UP_ADAPTER,
+    FOLLOW_UP_OPERATIONS,
+    PROTOCOL_RELATIVE,
+    PROTOCOL_VERSION,
+    REQUIRED_EVIDENCE,
+    RUNNER_SOURCE,
+    SUPPORTED_PLATFORMS,
+    load_update_journey_protocol,
+)
+from scripts.dex_update_bridge import FOUNDATION
+
+
+def _sha256(relative: str) -> str:
+    return hashlib.sha256((REPO_ROOT / relative).read_bytes()).hexdigest()
+
+
+def protocol_document() -> dict[str, object]:
+    """Build protocol v1 only from reviewed source constants and exact bytes."""
+
+    return {
+        "schema_version": PROTOCOL_VERSION,
+        "controller": CONTROLLER,
+        "platforms": list(SUPPORTED_PLATFORMS),
+        "runner": {
+            "source_path": RUNNER_SOURCE,
+            "sha256": _sha256(RUNNER_SOURCE),
+        },
+        "historic_to_foundation": {
+            "adapter": BRIDGE_ADAPTER,
+            "artifact": {
+                "source_path": BRIDGE_SOURCE,
+                "sha256": _sha256(BRIDGE_SOURCE),
+            },
+            "foundation": FOUNDATION.identity(),
+            "approval": {"word": "APPLY", "count": 2},
+        },
+        "foundation_to_follow_up": {
+            "adapter": FOLLOW_UP_ADAPTER,
+            "operations": list(FOLLOW_UP_OPERATIONS),
+            "approval": {"word": "APPLY", "count": 1},
+        },
+        "evidence": list(REQUIRED_EVIDENCE),
+    }
+
+
+def canonical_protocol_bytes() -> bytes:
+    """Render and self-validate the generated contract."""
+
+    content = (
+        json.dumps(
+            protocol_document(),
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    load_update_journey_protocol(content)
+    return content
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as file:
+            file.write(content)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=REPO_ROOT / PROTOCOL_RELATIVE)
+    args = parser.parse_args(argv)
+    destination = args.output if args.output.is_absolute() else REPO_ROOT / args.output
+    _atomic_write(destination, canonical_protocol_bytes())
+    print(f"Wrote {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -476,7 +476,10 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "preview_approval_receipt": required,
         "delivery_operations": delivery,
         "journey_protocol": protocol_surface,
-        "machine_executable": protocol_bytes is not None,
+        # A valid protocol is a closed declaration, not proof that this runner
+        # executed either update hop. Keep acceptance locked until a separately
+        # released executor owns the evidence-producing journey.
+        "machine_executable": False,
     }
 
 
@@ -1079,7 +1082,6 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
         repo, release.tag, "core/lifecycle/catalog/bridge-release.json"
     )
     protocol = _optional_tag_file(repo, release.tag, UPDATE_JOURNEY_RELATIVE)
-    machine_executable = False
     if protocol is not None:
         try:
             parsed_protocol = load_update_journey_protocol(protocol)
@@ -1088,9 +1090,8 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
         _verify_released_protocol_artifacts(repo, release, parsed_protocol)
-        route = "machine-protocol-declared"
-        bridge_requirement = "declared-by-protocol"
-        machine_executable = True
+        route = "machine-protocol-declared-executor-missing"
+        bridge_requirement = "released-journey-executor-required"
     elif skill is None:
         route = "missing-dex-update-skill"
         bridge_requirement = "unsupported-without-published-route"
@@ -1106,7 +1107,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
     return {
         "route_classification": route,
         "bridge_requirement": bridge_requirement,
-        "machine_executable": machine_executable,
+        "machine_executable": False,
         "dex_update_skill": {
             "path": UPDATE_SKILL_RELATIVE,
             "status": "present" if skill is not None else "missing",
@@ -1472,11 +1473,12 @@ def run_journey(
     foundation_tag: str,
     follow_up_tag: str,
 ) -> None:
-    """Fail closed until immutable releases publish a machine-verifiable journey protocol.
+    """Fail closed until an immutable release publishes the journey executor.
 
     The only evidence emitted today is a hash of the exact shipped `/dex-update`
     and rescue material.  The runner never promotes Markdown instructions into
-    commands, invokes lifecycle code, or accepts an external bridge as proof.
+    commands, invokes lifecycle code, or accepts a valid protocol or external
+    bridge as proof that either hop executed.
     """
 
     releases = {release.tag: release for release in discover_distribution_releases(repo)}
@@ -1529,8 +1531,8 @@ def run_journey(
         result["historic_update_surface"] = historic_surface
         result["foundation_update_surface"] = foundation_surface
         raise FleetError(
-            "published /dex-update surfaces are Markdown-only; a future immutable release must "
-            "publish a machine-verifiable journey protocol before fleet execution can continue"
+            "published journey executor is unavailable; the current runner records update "
+            "surfaces but cannot execute either hop"
         )
     except (FleetError, OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as error:
         result["failure"] = str(error)
@@ -1656,8 +1658,8 @@ def assert_evidence_bound(
         protocol_surface = shipped_update_surface(repo, follow_up)
         if protocol_surface["machine_executable"] is not True:
             raise FleetError(
-                f"{case.starting_tag}: immutable executable journey protocol is not published; "
-                "fleet acceptance cannot pass"
+                f"{case.starting_tag}: released journey executor is not implemented; "
+                "a valid protocol alone cannot make fleet acceptance pass"
             )
         protocol = load_update_journey_protocol(
             _tag_file(repo, follow_up.tag, UPDATE_JOURNEY_RELATIVE)
@@ -1998,7 +2000,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     journey = subcommands.add_parser(
         "journey",
-        help="record immutable update surfaces and fail closed until an executable journey protocol ships",
+        help="record immutable update surfaces and fail closed until a released journey executor ships",
     )
     journey.add_argument("--repo", type=Path, required=True)
     journey.add_argument("--output", type=Path, required=True)
@@ -2042,7 +2044,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             foundation_tag=args.foundation_tag,
             follow_up_tag=args.follow_up_tag,
         )
-        raise FleetError("journey returned without an immutable executable protocol")
+        raise FleetError("journey returned without a released journey executor")
 
     if args.command == "survey":
         releases = releases_from_starting_manifest(

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -24,7 +24,14 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from core.paths import INBOX_DIR, TASKS_FILE, USER_PROFILE_FILE, VAULT_ROOT
+from core.update.journey_protocol import (
+    PROTOCOL_RELATIVE,
+    JourneyProtocolError,
+    UpdateJourneyProtocol,
+    load_update_journey_protocol,
+)
 
+UPDATE_JOURNEY_RELATIVE = PROTOCOL_RELATIVE
 RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
@@ -330,10 +337,16 @@ def resolve_immutable_release(repo: Path, tag: str) -> ImmutableRelease:
 
 
 def _tag_file(repo: Path, tag: str, relative: str) -> bytes:
-    try:
-        return _git(repo, "show", f"{tag}:{relative}").encode("utf-8")
-    except FleetError as error:
-        raise FleetError(f"{tag} has no required {relative} publication record") from error
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{tag}:{relative}"],
+        capture_output=True,
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise FleetError(
+            detail or f"{tag} has no required {relative} publication record"
+        )
+    return result.stdout
 
 
 def _strict_object(source: bytes, context: str, keys: frozenset[str]) -> dict[str, object]:
@@ -344,6 +357,56 @@ def _strict_object(source: bytes, context: str, keys: frozenset[str]) -> dict[st
     if not isinstance(value, Mapping) or set(value) != keys:
         raise FleetError(f"{context} has an invalid shape")
     return dict(value)
+
+
+def _released_protocol_source_commit(repo: Path, tag: str) -> str:
+    """Read the immutable source commit named by one distribution catalog."""
+
+    catalog = _strict_object(
+        _tag_file(repo, tag, "System/.release-catalog.json"),
+        f"{tag} release catalog",
+        frozenset({"catalog_version", "release", "items", "integrity"}),
+    )
+    release = catalog["release"]
+    if not isinstance(release, Mapping):
+        raise FleetError(f"{tag}: release catalog has no release identity")
+    source_commit = release.get("source_commit")
+    if not isinstance(source_commit, str) or _HEX.fullmatch(source_commit) is None:
+        raise FleetError(f"{tag}: release catalog has no valid source commit")
+    try:
+        resolved = _git(repo, "rev-parse", "--verify", f"{source_commit}^{{commit}}")
+    except FleetError as error:
+        raise FleetError(
+            f"{tag}: release-owned journey source commit is unavailable"
+        ) from error
+    if resolved != source_commit:
+        raise FleetError(f"{tag}: release-owned journey source commit is ambiguous")
+    return source_commit
+
+
+def _verify_released_protocol_artifacts(
+    repo: Path,
+    release: DistributionRelease | ImmutableRelease,
+    protocol: UpdateJourneyProtocol,
+) -> str:
+    """Bind protocol adapters to the exact publisher source commit bytes."""
+
+    source_commit = _released_protocol_source_commit(repo, release.tag)
+    for label, artifact in (
+        ("fleet runner", protocol.runner),
+        ("foundation bridge", protocol.bridge.artifact),
+    ):
+        try:
+            source = _tag_file(repo, source_commit, artifact.source_path)
+        except FleetError as error:
+            raise FleetError(
+                f"{release.tag}: released journey {label} source is unavailable"
+            ) from error
+        if hashlib.sha256(source).hexdigest() != artifact.sha256:
+            raise FleetError(
+                f"{release.tag}: released journey {label} does not match its protocol hash"
+            )
+    return source_commit
 
 
 def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableRelease) -> dict[str, object]:
@@ -372,6 +435,30 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "build_and_preview_delivered_release": "build_and_preview_delivered_release" in text,
         "execute_approved_delivered_release": "execute_approved_delivered_release" in text,
     }
+    protocol_bytes = _optional_tag_file(repo, release.tag, UPDATE_JOURNEY_RELATIVE)
+    protocol_surface: dict[str, object] = {
+        "path": UPDATE_JOURNEY_RELATIVE,
+        "status": "missing",
+        "sha256": None,
+        "schema_version": None,
+        "controller": None,
+    }
+    if protocol_bytes is not None:
+        try:
+            protocol = load_update_journey_protocol(protocol_bytes)
+        except JourneyProtocolError as error:
+            raise FleetError(
+                f"{release.tag}: released journey protocol is invalid: {error}"
+            ) from error
+        source_commit = _verify_released_protocol_artifacts(repo, release, protocol)
+        protocol_surface = {
+            "path": UPDATE_JOURNEY_RELATIVE,
+            "status": "present",
+            "sha256": hashlib.sha256(protocol_bytes).hexdigest(),
+            "schema_version": protocol.schema_version,
+            "controller": protocol.controller,
+            "source_commit": source_commit,
+        }
     identity = release.identity() if isinstance(release, ImmutableRelease) else {
         "tag": release.tag,
         "tag_object": _git(repo, "rev-parse", "--verify", release.tag),
@@ -388,7 +475,8 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "rescue_sha256": hashlib.sha256(rescue).hexdigest() if rescue is not None else None,
         "preview_approval_receipt": required,
         "delivery_operations": delivery,
-        "machine_executable": False,
+        "journey_protocol": protocol_surface,
+        "machine_executable": protocol_bytes is not None,
     }
 
 
@@ -990,10 +1078,19 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
     activation_bridge = _optional_tag_file(
         repo, release.tag, "core/lifecycle/catalog/bridge-release.json"
     )
-    protocol = _optional_tag_file(repo, release.tag, "System/.update-journey-v1.json")
+    protocol = _optional_tag_file(repo, release.tag, UPDATE_JOURNEY_RELATIVE)
+    machine_executable = False
     if protocol is not None:
+        try:
+            parsed_protocol = load_update_journey_protocol(protocol)
+        except JourneyProtocolError as error:
+            raise FleetError(
+                f"{release.tag}: released journey protocol is invalid: {error}"
+            ) from error
+        _verify_released_protocol_artifacts(repo, release, parsed_protocol)
         route = "machine-protocol-declared"
         bridge_requirement = "declared-by-protocol"
+        machine_executable = True
     elif skill is None:
         route = "missing-dex-update-skill"
         bridge_requirement = "unsupported-without-published-route"
@@ -1009,7 +1106,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
     return {
         "route_classification": route,
         "bridge_requirement": bridge_requirement,
-        "machine_executable": False,
+        "machine_executable": machine_executable,
         "dex_update_skill": {
             "path": UPDATE_SKILL_RELATIVE,
             "status": "present" if skill is not None else "missing",
@@ -1025,7 +1122,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
             "activation_bridge": activation_bridge is not None,
         },
         "machine_protocol": {
-            "path": "System/.update-journey-v1.json",
+            "path": UPDATE_JOURNEY_RELATIVE,
             "status": "present" if protocol is not None else "missing",
             "sha256": hashlib.sha256(protocol).hexdigest() if protocol is not None else None,
         },
@@ -1556,13 +1653,18 @@ def assert_evidence_bound(
             raise FleetError(f"{case.starting_tag}: starting release is no longer discoverable")
         expected_historic_surface = shipped_update_surface(repo, starting_release)
         expected_foundation_surface = shipped_update_surface(repo, foundation)
-        if (
-            expected_historic_surface["machine_executable"] is not True
-            or expected_foundation_surface["machine_executable"] is not True
-        ):
+        protocol_surface = shipped_update_surface(repo, follow_up)
+        if protocol_surface["machine_executable"] is not True:
             raise FleetError(
                 f"{case.starting_tag}: immutable executable journey protocol is not published; "
                 "fleet acceptance cannot pass"
+            )
+        protocol = load_update_journey_protocol(
+            _tag_file(repo, follow_up.tag, UPDATE_JOURNEY_RELATIVE)
+        )
+        if protocol.foundation != foundation.identity():
+            raise FleetError(
+                f"{case.starting_tag}: released journey protocol names a different foundation"
             )
         manifest_path = _evidence_file(
             evidence_root, case.evidence_manifest_path, f"{case.starting_tag} evidence manifest"


### PR DESCRIPTION
## Outcome

Adds the immutable release-owned control contract required before historic fleet journeys can execute, while keeping the current runner explicitly non-executable.

- closes protocol vocabulary to the pinned bridge and existing lifecycle delivery operations
- validates and reports a release-owned protocol but keeps `machine_executable: false` until a separately reviewed released executor exists
- rejects even a fully hand-authored, self-consistent evidence bundle through `check-report`, including when the protocol itself is valid
- binds bridge and runner source bytes through the release catalog source commit
- makes the raw vault bundle fail when protocol, parser, generator, bridge, or runner inputs differ from the exact commit recorded in the catalog
- keeps prose-only released routes and real acceptance fail-closed

## Review corrections

- proof integrity: the protocol no longer authorizes evidence or flips the route executable; `run_journey` still cannot execute either hop
- packaging provenance: bundle validation and the catalog now refer to the same committed source bytes

## Verification

- 38 release-fleet tests passed
- 3 strict protocol/parser tests passed
- clean bundle and dirty-protocol provenance regressions passed
- 163 script tests passed
- Ruff, shell syntax, generated protocol, architecture inventory, ownership contract, PII, and founder-content gates passed

## Not claimed

- no tag, release, deploy, or published bridge, control, or executor release
- no real historic two-hop run
- acceptance remains false; 0/168 accepted
- new-head GitHub CI must still complete