### PR TITLE
feat(update): add release-owned journey executor

### DIFF
--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -1086,6 +1086,7 @@ core/tests/test_release_catalog.py
 core/tests/test_release_catalog_generation.py
 core/tests/test_release_channel.py
 core/tests/test_release_fleet.py
+core/tests/test_release_fleet_executor.py
 core/tests/test_release_tag_uniqueness.py
 core/tests/test_review_retirement.py
 core/tests/test_ritual_intelligence_entrypoints.py
@@ -1284,6 +1285,7 @@ scripts/pii_gate.py
 scripts/pr_report.py
 scripts/release.sh
 scripts/release_fleet.py
+scripts/release_fleet_executor.py
 scripts/render-health-page.py
 scripts/resolve-distignore-files.sh
 scripts/security-allowlist.txt

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -12,6 +12,10 @@
     "follow-up-doctor",
     "follow-up-smoke"
   ],
+  "executor": {
+    "sha256": "6fb224abb7715d2cc98f1ce68a5844e5fc9a5a05491f866b9b5b71a37b7c6a15",
+    "source_path": "scripts/release_fleet_executor.py"
+  },
   "foundation_to_follow_up": {
     "adapter": "lifecycle-delivered-release-v1",
     "approval": {
@@ -48,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "77f49a9a565d99db379b2457ef891fcbe7fa4b8a9636baba75fd7fd19bcdf84e",
+    "sha256": "e07c5b5ff5ef69e04575b75c2f9d9b8407f8f933fbc6fecebe1b9d505d6c0e21",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "6fb224abb7715d2cc98f1ce68a5844e5fc9a5a05491f866b9b5b71a37b7c6a15",
+    "sha256": "f2935ecb3230213934ee9f4aaaf2c5ed0d77df3c7f15dc33338120b62b5d78d6",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "e07c5b5ff5ef69e04575b75c2f9d9b8407f8f933fbc6fecebe1b9d505d6c0e21",
+    "sha256": "91a0648ebb6036eaf477776ee1ad32bdd4150f6801cc9a79d81675cf71f0bd4b",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -98,6 +98,7 @@ RELEASE_BUILD_INPUTS = (
     "scripts/generate-release-catalog.py",
     "scripts/generate-update-journey-protocol.py",
     "scripts/release_fleet.py",
+    "scripts/release_fleet_executor.py",
     "scripts/resolve-distignore-files.sh",
     "scripts/security-gate.sh",
     "scripts/verify-distribution.sh",
@@ -735,9 +736,9 @@ def test_raw_vault_bundle_rejects_dirty_protocol_inputs_not_in_source_commit(
 ) -> None:
     clone = _clone_repo(tmp_path, "raw-vault-bundle-dirty-protocol")
     _commit_release_inputs_if_changed(clone)
-    runner = clone / "scripts/release_fleet.py"
-    runner.write_text(
-        runner.read_text(encoding="utf-8") + "\n# uncommitted runner bytes\n",
+    executor = clone / "scripts/release_fleet_executor.py"
+    executor.write_text(
+        executor.read_text(encoding="utf-8") + "\n# uncommitted executor bytes\n",
         encoding="utf-8",
     )
     subprocess.run(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -676,7 +676,11 @@ def _tag_protocol_control_release(
     foundation: release_fleet.ImmutableRelease,
     version: str,
 ) -> str:
-    for relative in ("scripts/dex_update_bridge.py", "scripts/release_fleet.py"):
+    for relative in (
+        "scripts/dex_update_bridge.py",
+        "scripts/release_fleet.py",
+        "scripts/release_fleet_executor.py",
+    ):
         source = repo / relative
         source.parent.mkdir(parents=True, exist_ok=True)
         source.write_bytes((release_fleet.PROJECT_ROOT / relative).read_bytes())
@@ -1229,14 +1233,16 @@ def test_fixture_python_proves_real_venv_and_local_dependencies_before_doctor(
     assert not marker.exists()
 
 
-def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path: Path) -> None:
+def test_journey_fails_closed_before_building_when_release_has_no_executor(
+    tmp_path: Path,
+) -> None:
     repo = _repository(tmp_path)
     _write_update_surface(repo)
     start_tag = _tag_release(repo, "1.61.0", "start")
     foundation_tag = _tag_release(repo, "1.80.0", "foundation")
     follow_up_tag = _tag_release(repo, "1.80.5", "follow-up")
 
-    with pytest.raises(release_fleet.FleetError, match="executor is unavailable"):
+    with pytest.raises(release_fleet.FleetError, match="released journey executor"):
         release_fleet.run_journey(
             repo,
             output=tmp_path / "output",
@@ -1245,21 +1251,151 @@ def test_journey_fails_closed_after_recording_immutable_update_surfaces(tmp_path
             follow_up_tag=follow_up_tag,
         )
 
-    start = next(item for item in release_fleet.discover_distribution_releases(repo) if item.tag == start_tag)
-    evidence_root = tmp_path / "output" / f"{release_fleet.safe_case_name(start)}.evidence"
-    result = json.loads((evidence_root / "journey-result.json").read_text())
-    manifest = evidence_root / "evidence-manifest.json"
-    transcript = json.loads((evidence_root / "journey-transcript.json").read_text())
-    assert result["failure"].startswith("published journey executor is unavailable")
-    assert result["evidence_manifest_sha256"] == release_fleet.hashlib.sha256(manifest.read_bytes()).hexdigest()
-    assert [event["id"] for event in transcript["events"]] == [
-        "historic-update-surface",
-        "foundation-update-surface",
-    ]
+    assert not (tmp_path / "output").exists()
+
+
+def test_journey_refuses_an_undeclared_host_platform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(release_fleet.sys, "platform", "win32")
+
+    with pytest.raises(release_fleet.FleetError, match="macOS and Linux only"):
+        release_fleet.run_journey(
+            tmp_path,
+            output=tmp_path / "output",
+            starting_tag="unused",
+            foundation_tag="unused",
+            follow_up_tag="unused",
+        )
+
+
+def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.update.journey_protocol import load_update_journey_protocol
+    from scripts import release_fleet_executor
+
+    protocol_bytes = (
+        release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE
+    ).read_bytes()
+    protocol = load_update_journey_protocol(protocol_bytes)
+    foundation = release_fleet.ImmutableRelease(
+        tag=protocol.foundation["tag"],
+        tag_object=protocol.foundation["tag_object"],
+        commit=protocol.foundation["commit"],
+        tree=protocol.foundation["tree"],
+        version=protocol.foundation["version"],
+    )
+    follow_up = release_fleet.ImmutableRelease(
+        tag="dist/release/v1.81.0-bbbbbbb",
+        tag_object="c" * 40,
+        commit="b" * 40,
+        tree="d" * 40,
+        version="1.81.0",
+    )
+    start = release_fleet.DistributionRelease(
+        tag="dist/release/v1.61.0-aaaaaaa",
+        version="1.61.0",
+        commit="a" * 40,
+        tree="e" * 40,
+    )
+    source_commit = "f" * 40
+    captured: dict[str, object] = {}
+
+    class Run:
+        case = {"starting_tag": start.tag}
+
+    monkeypatch.setattr(
+        release_fleet,
+        "discover_distribution_releases",
+        lambda _repo: (start,),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "resolve_immutable_release",
+        lambda _repo, tag: foundation if tag == foundation.tag else follow_up,
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_optional_tag_file",
+        lambda _repo, _tag, relative: (
+            protocol_bytes
+            if relative == release_fleet.UPDATE_JOURNEY_RELATIVE
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_verify_released_protocol_artifacts",
+        lambda _repo, _release, _protocol: source_commit,
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_tag_file",
+        lambda _repo, _commit, relative: (
+            release_fleet.PROJECT_ROOT / relative
+        ).read_bytes(),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "shipped_update_surface",
+        lambda _repo, release: {
+            "release": (
+                release.identity()
+                if isinstance(release, release_fleet.ImmutableRelease)
+                else {
+                    "tag": release.tag,
+                    "tag_object": "9" * 40,
+                    "commit": release.commit,
+                    "tree": release.tree,
+                    "version": release.version,
+                    "channel": "stable",
+                }
+            ),
+            "machine_executable": False,
+        },
+    )
+    monkeypatch.setattr(release_fleet, "resolve_trusted_node_runtime", object)
+    monkeypatch.setattr(release_fleet, "resolve_trusted_python_runtime", object)
+    monkeypatch.setattr(
+        release_fleet,
+        "_case_environment",
+        lambda *_args, **_kwargs: {},
+    )
+
+    def build_case(_repo, release, output, *, environment):
+        assert environment == {}
+        vault = output / release_fleet.safe_case_name(release)
+        vault.mkdir(parents=True)
+        return release_fleet.FleetCase(release, vault, {"00-Inbox/keep.md": "0" * 64})
+
+    def execute(**kwargs):
+        captured.update(kwargs)
+        return Run()
+
+    monkeypatch.setattr(release_fleet, "build_installed_fixture", build_case)
+    monkeypatch.setattr(release_fleet, "resolve_fixture_python", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(release_fleet_executor, "execute_journey", execute)
+
+    run = release_fleet.run_journey(
+        tmp_path,
+        output=tmp_path / "output",
+        starting_tag=start.tag,
+        foundation_tag=foundation.tag,
+        follow_up_tag=follow_up.tag,
+    )
+
+    assert run.case == {"starting_tag": start.tag}
+    assert captured["source_commit"] == source_commit
+    assert captured["foundation_release"] == foundation.identity()
+    assert captured["follow_up_release"] == follow_up.identity()
+    assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
     assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()
 
 
-def test_shipped_update_surface_validates_protocol_but_keeps_it_non_executable(
+def test_shipped_update_surface_requires_and_exposes_the_released_executor(
     tmp_path: Path,
 ) -> None:
     repo = _repository(tmp_path)
@@ -1269,7 +1405,11 @@ def test_shipped_update_surface_validates_protocol_but_keeps_it_non_executable(
 
     assert release_fleet.shipped_update_surface(repo, prose_release)["machine_executable"] is False
 
-    for relative in ("scripts/dex_update_bridge.py", "scripts/release_fleet.py"):
+    for relative in (
+        "scripts/dex_update_bridge.py",
+        "scripts/release_fleet.py",
+        "scripts/release_fleet_executor.py",
+    ):
         source = repo / relative
         source.parent.mkdir(parents=True, exist_ok=True)
         source.write_bytes((release_fleet.PROJECT_ROOT / relative).read_bytes())
@@ -1298,18 +1438,24 @@ def test_shipped_update_surface_validates_protocol_but_keeps_it_non_executable(
     protocol_release = release_fleet.resolve_immutable_release(repo, protocol_tag)
     surface = release_fleet.shipped_update_surface(repo, protocol_release)
 
-    assert surface["machine_executable"] is False
+    assert surface["machine_executable"] is True
     assert surface["journey_protocol"]["path"] == release_fleet.UPDATE_JOURNEY_RELATIVE
     assert surface["journey_protocol"]["schema_version"] == 1
     assert surface["journey_protocol"]["source_commit"] == source_commit
+    assert surface["journey_protocol"]["executor"] == {
+        "source_path": "scripts/release_fleet_executor.py",
+        "sha256": release_fleet.hashlib.sha256(
+            (release_fleet.PROJECT_ROOT / "scripts/release_fleet_executor.py").read_bytes()
+        ).hexdigest(),
+    }
     distribution = next(
         item
         for item in release_fleet.discover_distribution_releases(repo)
         if item.tag == protocol_tag
     )
     classification = release_fleet.classify_historic_update_surface(repo, distribution)
-    assert classification["machine_executable"] is False
-    assert classification["route_classification"] == "machine-protocol-declared-executor-missing"
+    assert classification["machine_executable"] is True
+    assert classification["route_classification"] == "machine-protocol-released-executor"
 
 
 def test_shipped_update_surface_rejects_a_protocol_with_an_unknown_operation(

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -1,0 +1,484 @@
+"""Integration and adversarial contracts for the released journey executor."""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.update.journey_protocol import load_update_journey_protocol
+from scripts import release_fleet_executor as executor
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _identity(version: str, fill: str) -> dict[str, str]:
+    commit = fill * 40
+    return {
+        "tag": f"dist/release/v{version}-{commit[:7]}",
+        "tag_object": ("f" if fill != "f" else "e") * 40,
+        "commit": commit,
+        "tree": ("d" if fill != "d" else "c") * 40,
+        "version": version,
+        "channel": "stable",
+    }
+
+
+def _executor_source_commit(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "tests@example.com"], cwd=repo, check=True)
+    for relative in (
+        "scripts/dex_update_bridge.py",
+        "scripts/release_fleet.py",
+        "scripts/release_fleet_executor.py",
+    ):
+        target = repo / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative, target)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "released executor source"],
+        cwd=repo,
+        check=True,
+    )
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return repo, commit
+
+
+def _commit_executor_tamper(repo: Path) -> str:
+    path = repo / "scripts/release_fleet_executor.py"
+    path.write_bytes(path.read_bytes() + b"\n# externally substituted bytes\n")
+    subprocess.run(["git", "add", str(path)], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "substitute executor"],
+        cwd=repo,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _vault(tmp_path: Path) -> tuple[Path, tuple[str, ...]]:
+    root = tmp_path / "vault"
+    user_files = (
+        "00-Inbox/keep.md",
+        "03-Tasks/Tasks.md",
+        "System/user-profile.yaml",
+        ".claude/skills/my-weekly-review/SKILL.md",
+    )
+    for relative in user_files:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"user-owned:{relative}\n", encoding="utf-8")
+    return root, user_files
+
+
+class _Runtime:
+    def __init__(self, follow_up: dict[str, str]) -> None:
+        self.follow_up = follow_up
+        self.installed = ""
+        self.calls: list[str] = []
+
+    def bridge_to_foundation(self, vault: Path, foundation, *, input_fn, output_fn):
+        self.calls.append("bridge")
+        output_fn(json.dumps({"preview": "topology"}))
+        assert input_fn("topology approval") == "APPLY"
+        output_fn(json.dumps({"preview": "foundation"}))
+        assert input_fn("foundation approval") == "APPLY"
+        self.installed = foundation["commit"]
+        return {
+            "foundation": dict(foundation),
+            "topology_receipt": {"receipt": {"transaction_id": "topology-tx"}},
+            "delivery_receipt": {"receipt": {"transaction_id": "foundation-tx"}},
+        }
+
+    def installed_release(self, vault: Path) -> str:
+        self.calls.append("installed")
+        return self.installed
+
+    def doctor(self, vault: Path) -> dict[str, object]:
+        self.calls.append("doctor")
+        return {"checks": [{"id": "doctor.self", "verdict": "OK"}]}
+
+    def deliver_latest_release(self, vault: Path) -> dict[str, object]:
+        self.calls.append("deliver_latest_release")
+        return {"api_version": "1.4.0", "status": "delivered", "release": self.follow_up}
+
+    def build_and_preview_delivered_release(
+        self, vault: Path, release
+    ) -> dict[str, object]:
+        self.calls.append("build_and_preview_delivered_release")
+        return {
+            "api_version": "1.4.0",
+            "preview": {
+                "release": dict(release),
+                "previous_commit": self.installed,
+                "writes": [{"path": "core/released.py"}],
+            },
+            "approval_token": "exact-preview-token",
+        }
+
+    def execute_approved_delivered_release(
+        self, vault: Path, preview, approved_token: str
+    ) -> dict[str, object]:
+        self.calls.append("execute_approved_delivered_release")
+        assert approved_token == "exact-preview-token"
+        self.installed = self.follow_up["commit"]
+        return {
+            "api_version": "1.4.0",
+            "receipt": {"transaction_id": "follow-up-tx"},
+            "release": self.follow_up,
+        }
+
+    def smoke(self, vault: Path) -> dict[str, object]:
+        self.calls.append("smoke")
+        return {
+            "schema_version": 1,
+            "journeys": [{"id": "topology", "verdict": "OK", "detail": "healthy"}],
+            "summary": {"ok": 1, "broken": 0, "unknown": 0, "off": 0},
+        }
+
+
+def test_serialized_or_directly_constructed_run_cannot_gain_executor_authority() -> None:
+    authored = {"case": {"starting_tag": "dist/release/v1.0.0-deadbee"}}
+
+    assert executor.is_authoritative_executor_run(authored) is False
+    assert not hasattr(executor, "_EXECUTOR_AUTHORITY")
+    with pytest.raises(executor.ExecutorError, match="live executor"):
+        executor.ExecutorRun(authored["case"])
+
+
+def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
+    tmp_path: Path,
+) -> None:
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+    )
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    vault, user_files = _vault(tmp_path)
+    starting = _identity("1.61.0", "a")
+    follow_up = _identity("1.81.0", "b")
+    runtime = _Runtime(follow_up)
+    rendered: list[str] = []
+
+    run = executor.execute_journey(
+        repo_root=source_repo,
+        source_commit=source_commit,
+        vault_root=vault,
+        evidence_root=tmp_path / "case.evidence",
+        starting_release=starting,
+        foundation_release=protocol.foundation,
+        follow_up_release=follow_up,
+        protocol=protocol,
+        historic_surface={"release": starting, "machine_executable": False},
+        foundation_surface={"release": protocol.foundation, "machine_executable": False},
+        user_owned_paths=user_files,
+        platform="darwin",
+        input_fn=lambda _prompt: "APPLY",
+        output_fn=rendered.append,
+        _runtime=runtime,
+    )
+
+    assert executor.is_authoritative_executor_run(run)
+    assert run.case["reached_foundation"] is True
+    assert run.case["reached_follow_up"] is True
+    assert run.case["user_hashes_before"] == run.case["user_hashes_after_foundation"]
+    assert run.case["user_hashes_before"] == run.case["user_hashes_after_follow_up"]
+    assert runtime.calls == [
+        "bridge",
+        "installed",
+        "doctor",
+        "deliver_latest_release",
+        "build_and_preview_delivered_release",
+        "execute_approved_delivered_release",
+        "installed",
+        "doctor",
+        "smoke",
+    ]
+    evidence = tmp_path / "case.evidence"
+    foundation_receipt = json.loads((evidence / "foundation-receipt.json").read_text())
+    follow_up_receipt = json.loads((evidence / "follow-up-receipt.json").read_text())
+    transcript = json.loads((evidence / "journey-transcript.json").read_text())
+    assert foundation_receipt["receipt"]["delivery_receipt"]["receipt"]["transaction_id"] == "foundation-tx"
+    assert follow_up_receipt["receipt"]["receipt"]["transaction_id"] == "follow-up-tx"
+    assert [event["id"] for event in transcript["events"]] == list(protocol.evidence)
+    assert transcript["events"][2]["approval_count"] == 2
+    assert rendered
+
+
+def _execute(
+    tmp_path: Path,
+    runtime: _Runtime,
+    *,
+    source_repo: Path,
+    source_commit: str,
+    input_fn=lambda _prompt: "APPLY",
+) -> executor.ExecutorRun:
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+    )
+    vault, user_files = _vault(tmp_path)
+    starting = _identity("1.61.0", "a")
+    return executor.execute_journey(
+        repo_root=source_repo,
+        source_commit=source_commit,
+        vault_root=vault,
+        evidence_root=tmp_path / "case.evidence",
+        starting_release=starting,
+        foundation_release=protocol.foundation,
+        follow_up_release=runtime.follow_up,
+        protocol=protocol,
+        historic_surface={"release": starting, "machine_executable": False},
+        foundation_surface={"release": protocol.foundation, "machine_executable": False},
+        user_owned_paths=user_files,
+        platform="darwin",
+        input_fn=input_fn,
+        output_fn=lambda _line: None,
+        _runtime=runtime,
+    )
+
+
+def test_executor_refuses_released_source_with_substituted_executor_bytes(
+    tmp_path: Path,
+) -> None:
+    source_repo, _source_commit = _executor_source_commit(tmp_path)
+    substituted_commit = _commit_executor_tamper(source_repo)
+    runtime = _Runtime(_identity("1.81.0", "b"))
+
+    with pytest.raises(executor.ExecutorError, match="released protocol source"):
+        _execute(
+            tmp_path,
+            runtime,
+            source_repo=source_repo,
+            source_commit=substituted_commit,
+        )
+
+    assert runtime.calls == []
+
+
+def test_executor_refuses_a_bridge_without_a_real_or_resumed_receipt(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class MissingReceiptRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            result = dict(
+                super().bridge_to_foundation(
+                    vault,
+                    foundation,
+                    input_fn=input_fn,
+                    output_fn=output_fn,
+                )
+            )
+            result["delivery_receipt"] = {"status": "claimed-complete"}
+            return result
+
+    runtime = MissingReceiptRuntime(_identity("1.81.0", "b"))
+
+    with pytest.raises(executor.ExecutorError, match="transaction receipt"):
+        _execute(
+            tmp_path,
+            runtime,
+            source_repo=source_repo,
+            source_commit=source_commit,
+        )
+
+
+def test_executor_records_the_bridge_approval_count_that_actually_occurred(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class OneApprovalRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            self.calls.append("bridge")
+            output_fn(json.dumps({"preview": "foundation"}))
+            assert input_fn("foundation approval") == "APPLY"
+            self.installed = foundation["commit"]
+            return {
+                "foundation": dict(foundation),
+                "topology_receipt": {"skipped": "already-brain-vault-split"},
+                "delivery_receipt": {
+                    "receipt": {"transaction_id": "foundation-tx"}
+                },
+            }
+
+    runtime = OneApprovalRuntime(_identity("1.81.0", "b"))
+    run = _execute(
+        tmp_path,
+        runtime,
+        source_repo=source_repo,
+        source_commit=source_commit,
+    )
+
+    transcript = json.loads(
+        (
+            tmp_path
+            / "case.evidence"
+            / "journey-transcript.json"
+        ).read_text()
+    )
+    assert executor.is_authoritative_executor_run(run)
+    assert transcript["events"][2]["approval_count"] == 1
+    assert transcript["events"][2]["approvals"] == [
+        {"prompt": "foundation approval", "answer": "APPLY"}
+    ]
+
+
+def test_executor_refuses_user_content_mutation_and_unhealthy_proof(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class MutatingRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            result = super().bridge_to_foundation(
+                vault,
+                foundation,
+                input_fn=input_fn,
+                output_fn=output_fn,
+            )
+            (vault / "00-Inbox/keep.md").write_text(
+                "mutated by update\n",
+                encoding="utf-8",
+            )
+            return result
+
+    with pytest.raises(executor.ExecutorError, match="user-owned content changed"):
+        _execute(
+            tmp_path,
+            MutatingRuntime(_identity("1.81.0", "b")),
+            source_repo=source_repo,
+            source_commit=source_commit,
+        )
+
+    healthy_root = tmp_path / "unhealthy"
+    healthy_root.mkdir()
+    source_repo_2, source_commit_2 = _executor_source_commit(healthy_root)
+
+    class UnhealthyRuntime(_Runtime):
+        def doctor(self, vault: Path) -> dict[str, object]:
+            self.calls.append("doctor")
+            return {"checks": [{"id": "doctor.self", "verdict": "BROKEN"}]}
+
+    with pytest.raises(executor.ExecutorError, match="Doctor is unhealthy"):
+        _execute(
+            healthy_root,
+            UnhealthyRuntime(_identity("1.81.0", "b")),
+            source_repo=source_repo_2,
+            source_commit=source_commit_2,
+        )
+
+
+def test_production_runtime_refuses_undeclared_lifecycle_operation() -> None:
+    with pytest.raises(executor.ExecutorError, match="not declared"):
+        executor._ProductionRuntime._service_call(
+            object(),
+            "run_any_command",
+        )
+
+
+def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleaned: list[bool] = []
+
+    class Temporary:
+        def cleanup(self) -> None:
+            cleaned.append(True)
+
+    class Service:
+        @staticmethod
+        def deliver_latest_release(vault: Path) -> dict[str, object]:
+            return {"status": "delivered", "vault": str(vault)}
+
+    def run_bridge(vault, service, *, pin, input_fn, output_fn):
+        assert service.__class__ is Service
+        assert pin is executor.dex_update_bridge.FOUNDATION
+        output_fn("exact topology preview")
+        assert input_fn("exact topology prompt") == "APPLY"
+        return {
+            "foundation": pin.identity(),
+            "topology_receipt": {"receipt": {"transaction_id": "topology"}},
+            "delivery_receipt": {"receipt": {"transaction_id": "foundation"}},
+        }
+
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_validate_vault",
+        lambda vault: vault,
+    )
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_foundation_is_installed",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "acquire_foundation_source",
+        lambda: (Temporary(), tmp_path / "foundation"),
+    )
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_load_lifecycle_service",
+        lambda _source: Service(),
+    )
+    monkeypatch.setattr(executor.dex_update_bridge, "run_bridge", run_bridge)
+    request_stream = io.StringIO(
+        "\n".join(
+            (
+                '{"operation":"bridge"}',
+                '{"answer":"APPLY"}',
+                '{"operation":"deliver_latest_release"}',
+                '{"operation":"close"}',
+                "",
+            )
+        )
+    )
+    response_stream = io.StringIO()
+    monkeypatch.setattr(executor.sys, "stdin", request_stream)
+    monkeypatch.setattr(executor.sys, "stdout", response_stream)
+
+    assert executor._runtime_server(tmp_path / "vault") == 0
+
+    messages = [
+        json.loads(line)
+        for line in response_stream.getvalue().splitlines()
+    ]
+    assert [message["kind"] for message in messages] == [
+        "ready",
+        "output",
+        "prompt",
+        "result",
+        "result",
+    ]
+    assert messages[1]["text"] == "exact topology preview"
+    assert messages[2]["prompt"] == "exact topology prompt"
+    assert messages[4]["value"]["status"] == "delivered"
+    assert cleaned == [True]

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from core.update.journey_protocol import load_update_journey_protocol
+from scripts import release_fleet
 from scripts import release_fleet_executor as executor
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -26,6 +27,12 @@ def _identity(version: str, fill: str) -> dict[str, str]:
         "version": version,
         "channel": "stable",
     }
+
+
+def _legacy_identity(version: str, fill: str) -> dict[str, str]:
+    identity = _identity(version, fill)
+    identity["tag"] = f"v{version}"
+    return identity
 
 
 def _executor_source_commit(tmp_path: Path) -> tuple[Path, str]:
@@ -162,8 +169,18 @@ def test_serialized_or_directly_constructed_run_cannot_gain_executor_authority()
 
     assert executor.is_authoritative_executor_run(authored) is False
     assert not hasattr(executor, "_EXECUTOR_AUTHORITY")
+    assert not hasattr(executor, "_authoritative_run")
     with pytest.raises(executor.ExecutorError, match="live executor"):
         executor.ExecutorRun(authored["case"])
+    forged = object.__new__(executor.ExecutorRun)
+    assert executor.is_authoritative_executor_run(forged) is False
+    object.__setattr__(forged, "_authority", object())
+    object.__setattr__(
+        forged,
+        "_case_json",
+        json.dumps(authored["case"]).encode("utf-8"),
+    )
+    assert executor.is_authoritative_executor_run(forged) is False
 
 
 def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
@@ -197,7 +214,7 @@ def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
         _runtime=runtime,
     )
 
-    assert executor.is_authoritative_executor_run(run)
+    assert executor.is_authoritative_executor_run(run) is False
     assert run.case["reached_foundation"] is True
     assert run.case["reached_follow_up"] is True
     assert run.case["user_hashes_before"] == run.case["user_hashes_after_foundation"]
@@ -218,10 +235,21 @@ def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
     follow_up_receipt = json.loads((evidence / "follow-up-receipt.json").read_text())
     transcript = json.loads((evidence / "journey-transcript.json").read_text())
     assert foundation_receipt["receipt"]["delivery_receipt"]["receipt"]["transaction_id"] == "foundation-tx"
+    assert release_fleet._valid_foundation_bridge_receipt(
+        foundation_receipt["receipt"],
+        expected_foundation=protocol.foundation,
+        approval_count=2,
+    )
     assert follow_up_receipt["receipt"]["receipt"]["transaction_id"] == "follow-up-tx"
     assert [event["id"] for event in transcript["events"]] == list(protocol.evidence)
     assert transcript["events"][2]["approval_count"] == 2
     assert rendered
+
+    mutable_copy = run.case
+    mutable_copy["user_hashes_before"]["00-Inbox/keep.md"] = "0" * 64
+    assert run.case["user_hashes_before"]["00-Inbox/keep.md"] != "0" * 64
+    with pytest.raises(executor.ExecutorError, match="immutable"):
+        run._case_json = b"{}"
 
 
 def _execute(
@@ -231,12 +259,13 @@ def _execute(
     source_repo: Path,
     source_commit: str,
     input_fn=lambda _prompt: "APPLY",
+    starting: dict[str, str] | None = None,
 ) -> executor.ExecutorRun:
     protocol = load_update_journey_protocol(
         (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
     )
     vault, user_files = _vault(tmp_path)
-    starting = _identity("1.61.0", "a")
+    starting = starting or _identity("1.61.0", "a")
     return executor.execute_journey(
         repo_root=source_repo,
         source_commit=source_commit,
@@ -254,6 +283,55 @@ def _execute(
         output_fn=lambda _line: None,
         _runtime=runtime,
     )
+
+
+def test_executor_accepts_an_exact_legacy_starting_tag_without_widening_targets(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    runtime = _Runtime(_identity("1.81.0", "b"))
+    starting = _legacy_identity("1.20.1", "a")
+
+    run = _execute(
+        tmp_path,
+        runtime,
+        source_repo=source_repo,
+        source_commit=source_commit,
+        starting=starting,
+    )
+
+    assert run.case["starting_tag"] == "v1.20.1"
+    assert executor.is_authoritative_executor_run(run) is False
+
+
+@pytest.mark.parametrize(
+    "tag",
+    (
+        "refs/tags/v1.20.1",
+        "v01.20.1",
+        "v1.20",
+        "legacy/v1.20.1",
+    ),
+)
+def test_executor_rejects_malformed_or_arbitrary_starting_refs(
+    tmp_path: Path,
+    tag: str,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    runtime = _Runtime(_identity("1.81.0", "b"))
+    starting = _legacy_identity("1.20.1", "a")
+    starting["tag"] = tag
+
+    with pytest.raises(executor.ExecutorError, match="starting release identity"):
+        _execute(
+            tmp_path,
+            runtime,
+            source_repo=source_repo,
+            source_commit=source_commit,
+            starting=starting,
+        )
+
+    assert runtime.calls == []
 
 
 def test_executor_refuses_released_source_with_substituted_executor_bytes(
@@ -341,11 +419,102 @@ def test_executor_records_the_bridge_approval_count_that_actually_occurred(
             / "journey-transcript.json"
         ).read_text()
     )
-    assert executor.is_authoritative_executor_run(run)
+    assert executor.is_authoritative_executor_run(run) is False
     assert transcript["events"][2]["approval_count"] == 1
     assert transcript["events"][2]["approvals"] == [
         {"prompt": "foundation approval", "answer": "APPLY"}
     ]
+
+
+def test_already_installed_foundation_executes_and_validates_without_a_fake_transaction(
+    tmp_path: Path,
+) -> None:
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+    )
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class AlreadyInstalledRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            self.calls.append("bridge")
+            self.installed = foundation["commit"]
+            return {
+                "foundation": dict(foundation),
+                "topology_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+                "delivery_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+            }
+
+    runtime = AlreadyInstalledRuntime(_identity("1.81.0", "b"))
+    run = _execute(
+        tmp_path,
+        runtime,
+        source_repo=source_repo,
+        source_commit=source_commit,
+    )
+    evidence = tmp_path / "case.evidence"
+    transcript = json.loads((evidence / "journey-transcript.json").read_text())
+    foundation_receipt = json.loads(
+        (evidence / "foundation-receipt.json").read_text()
+    )
+
+    assert run.case["reached_foundation"] is True
+    assert transcript["events"][2]["approval_count"] == 0
+    assert "transaction_id" not in json.dumps(foundation_receipt)
+    assert foundation_receipt["release"] == protocol.foundation
+    assert release_fleet._valid_foundation_bridge_receipt(
+        foundation_receipt["receipt"],
+        expected_foundation=protocol.foundation,
+        approval_count=0,
+    )
+
+
+def test_mutating_foundation_bridge_still_requires_a_real_delivery_receipt() -> None:
+    foundation = _identity("1.80.5", "c")
+    claimed_mutation = {
+        "foundation": foundation,
+        "topology_receipt": {"skipped": "already-brain-vault-split"},
+        "delivery_receipt": {"status": "claimed-complete"},
+    }
+
+    assert not release_fleet._valid_foundation_bridge_receipt(
+        claimed_mutation,
+        expected_foundation=foundation,
+        approval_count=1,
+    )
+
+
+def test_executor_rejects_a_partial_already_installed_claim(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class PartialResumeRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            self.calls.append("bridge")
+            self.installed = foundation["commit"]
+            return {
+                "foundation": dict(foundation),
+                "topology_receipt": {"status": "claimed-complete"},
+                "delivery_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+            }
+
+    with pytest.raises(executor.ExecutorError, match="transaction receipt"):
+        _execute(
+            tmp_path,
+            PartialResumeRuntime(_identity("1.81.0", "b")),
+            source_repo=source_repo,
+            source_commit=source_commit,
+        )
 
 
 def test_executor_refuses_user_content_mutation_and_unhealthy_proof(

--- a/core/tests/test_update_journey_protocol.py
+++ b/core/tests/test_update_journey_protocol.py
@@ -36,7 +36,8 @@ def test_release_owned_protocol_binds_only_the_reviewed_update_adapters() -> Non
     assert protocol.bridge.approval_word == protocol.follow_up.approval_word == "APPLY"
     assert protocol.bridge.approval_count == 2
     assert protocol.follow_up.approval_count == 1
-    for artifact in (protocol.bridge.artifact, protocol.runner):
+    assert protocol.executor.source_path == "scripts/release_fleet_executor.py"
+    for artifact in (protocol.bridge.artifact, protocol.runner, protocol.executor):
         source = REPO_ROOT / artifact.source_path
         assert artifact.sha256 == hashlib.sha256(source.read_bytes()).hexdigest()
 

--- a/core/update/journey_protocol.py
+++ b/core/update/journey_protocol.py
@@ -20,6 +20,7 @@ SUPPORTED_PLATFORMS = ("darwin", "linux")
 BRIDGE_ADAPTER = "pinned-foundation-bridge-v1"
 BRIDGE_SOURCE = "scripts/dex_update_bridge.py"
 RUNNER_SOURCE = "scripts/release_fleet.py"
+EXECUTOR_SOURCE = "scripts/release_fleet_executor.py"
 FOLLOW_UP_ADAPTER = "lifecycle-delivered-release-v1"
 FOLLOW_UP_OPERATIONS = (
     "deliver_latest_release",
@@ -45,6 +46,7 @@ _TOP_LEVEL_FIELDS = frozenset(
         "controller",
         "platforms",
         "runner",
+        "executor",
         "historic_to_foundation",
         "foundation_to_follow_up",
         "evidence",
@@ -106,6 +108,7 @@ class UpdateJourneyProtocol:
     controller: str
     platforms: tuple[str, ...]
     runner: ProtocolArtifact
+    executor: ProtocolArtifact
     bridge: BridgeHop
     follow_up: FollowUpHop
     evidence: tuple[str, ...]
@@ -208,6 +211,11 @@ def load_update_journey_protocol(source: bytes | str) -> UpdateJourneyProtocol:
         source_path=RUNNER_SOURCE,
         context="journey protocol runner",
     )
+    executor = _artifact(
+        document["executor"],
+        source_path=EXECUTOR_SOURCE,
+        context="journey protocol executor",
+    )
     bridge_document = _object(
         document["historic_to_foundation"],
         _BRIDGE_FIELDS,
@@ -257,6 +265,7 @@ def load_update_journey_protocol(source: bytes | str) -> UpdateJourneyProtocol:
         controller=CONTROLLER,
         platforms=SUPPORTED_PLATFORMS,
         runner=runner,
+        executor=executor,
         bridge=bridge,
         follow_up=FollowUpHop(
             adapter=FOLLOW_UP_ADAPTER,
@@ -272,6 +281,7 @@ __all__ = [
     "BRIDGE_ADAPTER",
     "BRIDGE_SOURCE",
     "CONTROLLER",
+    "EXECUTOR_SOURCE",
     "FOLLOW_UP_ADAPTER",
     "FOLLOW_UP_OPERATIONS",
     "JourneyProtocolError",

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -4,7 +4,7 @@
 >
 > **Status vocabulary.** `SHIPPED` = in a released version tag. `LOCAL` = merged on `main`, not yet in a release tag. `PROTOTYPE` = built, not verified against live/real use. `PLANNED` = designed, not built.
 >
-> **Ground truth as of** `upstream/main` at `ae0815fd`, latest release tag **v1.80.5** (2026-07-29). This branch adds the release-owned historic updater journey protocol. It is LOCAL until merged and published in a later immutable release; no historic fleet case has passed because of it.
+> **Ground truth as of** `upstream/main` at `7edae25df`, latest release tag **v1.80.5** (2026-07-29). This branch adds the release-owned historic updater journey executor to the already-merged protocol. It remains LOCAL until merged and both pieces remain unpublished until a later immutable release; no historic fleet case has passed because of them.
 >
 > **Don't duplicate generated files.** Tool lists, skill lists, ownership-class path tables, and MCP↔skill wiring live in the auto-generated `docs/architecture/INVENTORY.md`. This map cross-references it; it does not restate it.
 >
@@ -20,7 +20,7 @@
 | Transaction core | **SHIPPED** (v1.66) | `core/transaction/*` | Crash-safe snapshot→apply→verify→commit/rollback substrate the lifecycle engine writes through |
 | Portable ownership contract | **SHIPPED** (v1.64+) | `core/portable_contract.py` | Source of truth: every path is brain/seed/generated/vault/runtime; decides what an update may write |
 | Release catalog + bridge | **SHIPPED** (v1.65–v1.68) | `core/lifecycle/catalog/*`, `bridge.py` | Publisher-declared packing list per release; one-release handoff from the legacy updater |
-| Historic updater journey protocol | **LOCAL** | `System/.update-journey-v1.json`, `core/update/journey_protocol.py` | Closed release-owned machine contract for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
+| Historic updater journey protocol + executor | **LOCAL** | `System/.update-journey-v1.json`, `core/update/journey_protocol.py`, `scripts/release_fleet_executor.py` | Closed release-owned machine contract and evidence-owning implementation for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
 | 10 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (46 tools) |
 | Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; hardened through security Phases 0–5g, but the `/connect` doorway stays held (draft PR #231) |
 | Customization migration | **SHIPPED** assess/capsule/guided-journey (v1.75.x) / **LOCAL** rebuild engine and doorway | `core/customization_migration/*`, `core/mcp/customization_migration_server.py` | Inventories customizations, preserves a Capsule, and offers a human-confirmed, receipt-backed rebuild and rewind; the doorway is authorized but remains unshipped until its release |
@@ -90,17 +90,24 @@ historic fleet evidence. Its strict parser permits only the pinned
 foundation-bridge adapter and the existing
 `deliver_latest_release` → `build_and_preview_delivered_release` →
 `execute_approved_delivered_release` lifecycle sequence. The generated root
-binds the exact bridge and fleet-runner bytes in the publisher source commit,
-the immutable v1.80.5 foundation identity, approval counts, Mac/Linux support,
-and the required evidence order. Unknown fields, adapters, operations, hashes,
-or approval shapes fail closed; there is no arbitrary command vocabulary.
+binds the exact bridge, fleet-runner, and executor bytes in the publisher
+source commit, the immutable v1.80.5 foundation identity, maximum conditional
+approval counts, Mac/Linux support, and the required evidence order. Unknown
+fields, adapters, operations, hashes, or approval shapes fail closed; there is
+no arbitrary command vocabulary.
+
+`scripts/release_fleet_executor.py` owns one real journey: it verifies its
+released source identity, invokes the pinned bridge and only the three declared
+lifecycle operations, records the approval prompts that actually occurred,
+checks installed refs, runs the installed Doctor and smoke suite, hashes
+user-owned files, and writes receipts and the transcript itself. Its successful
+result carries process-local authority that serialized JSON cannot recreate;
+`check-report` therefore stays closed to externally authored substitutes.
 
 This is implementation truth, not release acceptance. No public distribution
-tag contains the protocol yet, no foundation/follow-up pair has completed the
-real two-hop journey, and the current runner deliberately reports
-`machine_executable: false` even for a valid protocol until a separately
-released executor owns the run and evidence. The 168-case acceptance result
-remains false.
+tag contains the protocol or executor yet, no foundation/follow-up pair has
+completed the real two-hop journey, and the public v1.80.5 surface remains
+`machine_executable: false`. The 168-case acceptance result remains false.
 
 ## 5. The 10 MCP servers — SHIPPED
 

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -92,12 +92,11 @@ gate bounded rather than storing 120 full repositories on disk.
 
 ## Establish the executable-journey prerequisite
 
-The `journey` command currently **does not execute an update**. It reads and
-hashes the exact `/dex-update` skill and rescue material from the historic and
-foundation immutable tags, writes a failed-at-the-boundary transcript, and
-stops. This is intentional: those release surfaces are Markdown instructions,
-not a machine-callable API. Treating them as an API would manufacture a
-successful-looking update path that no released user can actually invoke.
+The `journey` command executes one case only when the follow-up distribution
+publishes the closed protocol and its catalog points to exact source bytes for
+the runner, executor, and pinned bridge. A release missing any of those pieces
+fails before a fixture is built. The command never promotes the historic
+Markdown `/dex-update` instructions into an API.
 
 ```bash
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
@@ -106,36 +105,43 @@ python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --follow-up-tag dist/release/v1.80.5-EXACTFOLLOWUP
 ```
 
-The repository now has the canonical protocol source at
+The repository has the canonical protocol source at
 `System/.update-journey-v1.json`, with a strict parser in
 `core/update/journey_protocol.py`. It is a closed operation vocabulary, not a
 shell-command format. Version 1 permits only:
 
-- the reviewed pinned-foundation bridge, with its exact source SHA-256 and two
-  explicit `APPLY` approvals;
+- the reviewed pinned-foundation bridge, with its exact source SHA-256 and up
+  to two conditional `APPLY` approvals (topology and delivery previews are
+  requested only when the actual fixture state requires them);
 - `deliver_latest_release`, `build_and_preview_delivered_release`, then
   `execute_approved_delivered_release`, with one fresh `APPLY` approval; and
 - the fixed evidence order needed for refusal, bridge provenance, preview,
   receipt, installed identity, Doctor, and released-platform smoke proof.
 
-The root also binds the fleet runner bytes and bridge bytes in the immutable
+The root binds the fleet runner, executor, and bridge bytes in the immutable
 release catalog's publisher `source_commit`. A release that merely carries a
 plausible JSON file, points at unavailable source, changes an adapter or
-operation, or has a mismatched hash is invalid. Even a valid protocol remains
-`machine_executable: false`: this runner does not yet contain the released
-executor that can perform both hops and own the resulting evidence.
+operation, or has a mismatched hash is invalid.
 
-This protocol is currently LOCAL. Until an immutable public release contains
-it and a separately reviewed released executor exists, no synthetic fixture is
-installed and no bridge, lifecycle method, Git merge, or handwritten route
-wrapper is allowed to run. Publishing the contract is one prerequisite, not
-fleet acceptance: the real foundation and follow-up releases must still exist
-and every historic case must still run.
+The executor at `scripts/release_fleet_executor.py` verifies those released
+bytes before calling the pinned bridge. It then invokes only the three declared
+lifecycle operations, captures their real previews and receipts, verifies the
+installed release markers after each hop, runs the installed Doctor and smoke
+suite, and hashes user-owned content before and after. It writes the evidence
+files and transcript itself. The bridge approval count in the transcript is the
+number of prompts that actually occurred, never a fixed or inferred claim.
 
-The resulting `<case>.evidence/` directory is beside—not inside—a future
-fixture. Its content-addressed manifest records the exact release identities,
-ordered commands, and artifact hashes. A failed prerequisite attempt is useful
-diagnostic evidence, never fleet acceptance evidence.
+The executor returns a process-local authority object. Its JSON artifacts are
+review material, not authority: reserializing, editing, or independently
+constructing the same documents cannot unlock acceptance. The resulting
+`<case>.evidence/` directory is beside—not inside—the disposable fixture. Its
+content-addressed manifest records the exact executor identity, release
+identities, ordered operations, and artifact hashes.
+
+The protocol and executor are currently LOCAL. Public v1.80.5 contains neither,
+so its surface remains `machine_executable: false`. Publishing both is one
+prerequisite, not fleet acceptance: the real follow-up release must exist and
+every historic case must still run on every declared platform.
 
 ## Validate the finished evidence
 
@@ -149,16 +155,15 @@ python3 scripts/release_fleet.py check-report --repo . \
 
 The command first verifies the generated starting manifest against the current
 immutable release trees, then requires that many cases on every declared
-platform. It cannot pass while the required released route says
-`machine_executable: false`, regardless of how internally consistent a report,
-manifest, transcript, or artifact set appears. A valid published protocol still
-does not unlock the checker: only a future released executor that owns the
-two-hop run and evidence can do that. The protocol must also bind its runner and
-bridge bytes to the release catalog's immutable source commit. Finished evidence
-still requires ordered commands and SHA-256-bound artifacts: the transcript,
-release-surface snapshots, receipts, Doctor reports, and smoke/platform evidence.
-Paths, symlinks, malformed JSON, mismatched identities, incomplete platform
-coverage, and unknown/broken Doctor results all fail the report.
+platform. It remains fail-closed for a report read from disk: no internally
+consistent report, manifest, transcript, receipt, or artifact set can recreate
+the executor's live process authority. Fleet orchestration must keep each
+`ExecutorRun` in the process that performs the corresponding journey and pass
+those live results into the validator. Finished evidence still requires ordered
+operations and SHA-256-bound artifacts: the transcript, release-surface
+snapshots, receipts, Doctor reports, and smoke/platform evidence. Paths,
+symlinks, malformed JSON, mismatched identities, incomplete platform coverage,
+and unknown/broken Doctor results all fail the report.
 
 ## Claim language
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -163,8 +163,8 @@ echo ""
 git checkout -B "$RELEASE_BRANCH" "$SOURCE_SHA" --quiet
 
 # Refuse to publish a journey control plane that does not bind the exact
-# selected source bytes. The generated root itself ships; the bridge and fleet
-# runner remain publisher-source artifacts referenced by SHA-256.
+# selected source bytes. The generated root itself ships; the bridge, fleet
+# runner, and executor remain publisher-source artifacts referenced by SHA-256.
 python3 scripts/generate-update-journey-protocol.py --output "$JOURNEY_PROTOCOL_CHECK"
 if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" System/.update-journey-v1.json; then
     echo "Error: System/.update-journey-v1.json is stale for selected source '$SOURCE_BRANCH'." >&2

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -40,10 +40,11 @@ PROTOCOL_SOURCE_PATHS=(
   "scripts/dex_update_bridge.py"
   "scripts/generate-update-journey-protocol.py"
   "scripts/release_fleet.py"
+  "scripts/release_fleet_executor.py"
 )
 if ! git diff --quiet "$SOURCE_COMMIT" -- "${PROTOCOL_SOURCE_PATHS[@]}"; then
   echo "Error: protocol inputs differ from recorded source commit $SOURCE_COMMIT." >&2
-  echo "Commit the protocol, parser, generator, bridge, and runner bytes before building." >&2
+  echo "Commit the protocol, parser, generator, bridge, runner, and executor bytes before building." >&2
   exit 1
 fi
 

--- a/scripts/generate-update-journey-protocol.py
+++ b/scripts/generate-update-journey-protocol.py
@@ -22,6 +22,7 @@ from core.update.journey_protocol import (
     BRIDGE_ADAPTER,
     BRIDGE_SOURCE,
     CONTROLLER,
+    EXECUTOR_SOURCE,
     FOLLOW_UP_ADAPTER,
     FOLLOW_UP_OPERATIONS,
     PROTOCOL_RELATIVE,
@@ -48,6 +49,10 @@ def protocol_document() -> dict[str, object]:
         "runner": {
             "source_path": RUNNER_SOURCE,
             "sha256": _sha256(RUNNER_SOURCE),
+        },
+        "executor": {
+            "source_path": EXECUTOR_SOURCE,
+            "sha256": _sha256(EXECUTOR_SOURCE),
         },
         "historic_to_foundation": {
             "adapter": BRIDGE_ADAPTER,

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -79,7 +79,15 @@ _HEX = re.compile(r"^[0-9a-f]{40}$")
 UPDATE_SKILL_RELATIVE = ".claude/skills/dex-update/SKILL.md"
 UPDATE_RESCUE_RELATIVE = "docs/UPDATE-RESCUE.md"
 EVIDENCE_MANIFEST_KEYS = frozenset(
-    {"schema_version", "starting_release", "foundation_release", "follow_up_release", "events", "artifacts"}
+    {
+        "schema_version",
+        "executor",
+        "starting_release",
+        "foundation_release",
+        "follow_up_release",
+        "events",
+        "artifacts",
+    }
 )
 RUNNER_ARTIFACT_KEYS = frozenset(
     {
@@ -394,6 +402,7 @@ def _verify_released_protocol_artifacts(
     source_commit = _released_protocol_source_commit(repo, release.tag)
     for label, artifact in (
         ("fleet runner", protocol.runner),
+        ("journey executor", protocol.executor),
         ("foundation bridge", protocol.bridge.artifact),
     ):
         try:
@@ -442,6 +451,7 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "sha256": None,
         "schema_version": None,
         "controller": None,
+        "executor": None,
     }
     if protocol_bytes is not None:
         try:
@@ -457,6 +467,10 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
             "sha256": hashlib.sha256(protocol_bytes).hexdigest(),
             "schema_version": protocol.schema_version,
             "controller": protocol.controller,
+            "executor": {
+                "source_path": protocol.executor.source_path,
+                "sha256": protocol.executor.sha256,
+            },
             "source_commit": source_commit,
         }
     identity = release.identity() if isinstance(release, ImmutableRelease) else {
@@ -476,10 +490,9 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "preview_approval_receipt": required,
         "delivery_operations": delivery,
         "journey_protocol": protocol_surface,
-        # A valid protocol is a closed declaration, not proof that this runner
-        # executed either update hop. Keep acceptance locked until a separately
-        # released executor owns the evidence-producing journey.
-        "machine_executable": False,
+        # This describes released capability, not successful execution.
+        # Acceptance still requires a live, process-local ExecutorRun.
+        "machine_executable": protocol_bytes is not None,
     }
 
 
@@ -490,9 +503,10 @@ def _has_transaction_receipt(value: object) -> bool:
         return False
     if isinstance(value.get("transaction_id"), str) and value["transaction_id"]:
         return True
-    nested = value.get("receipt")
-    return isinstance(nested, Mapping) and isinstance(nested.get("transaction_id"), str) and bool(
-        nested["transaction_id"]
+    return any(
+        _has_transaction_receipt(nested)
+        for nested in value.values()
+        if isinstance(nested, Mapping)
     )
 
 
@@ -1090,8 +1104,8 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
         _verify_released_protocol_artifacts(repo, release, parsed_protocol)
-        route = "machine-protocol-declared-executor-missing"
-        bridge_requirement = "released-journey-executor-required"
+        route = "machine-protocol-released-executor"
+        bridge_requirement = "released-journey-executor"
     elif skill is None:
         route = "missing-dex-update-skill"
         bridge_requirement = "unsupported-without-published-route"
@@ -1107,7 +1121,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
     return {
         "route_classification": route,
         "bridge_requirement": bridge_requirement,
-        "machine_executable": False,
+        "machine_executable": protocol is not None,
         "dex_update_skill": {
             "path": UPDATE_SKILL_RELATIVE,
             "status": "present" if skill is not None else "missing",
@@ -1472,15 +1486,15 @@ def run_journey(
     starting_tag: str,
     foundation_tag: str,
     follow_up_tag: str,
-) -> None:
-    """Fail closed until an immutable release publishes the journey executor.
+) -> object:
+    """Build one fixture and delegate the closed journey to its released executor."""
 
-    The only evidence emitted today is a hash of the exact shipped `/dex-update`
-    and rescue material.  The runner never promotes Markdown instructions into
-    commands, invokes lifecycle code, or accepts a valid protocol or external
-    bridge as proof that either hop executed.
-    """
-
+    if sys.platform == "darwin":
+        journey_platform = "darwin"
+    elif sys.platform.startswith("linux"):
+        journey_platform = "linux"
+    else:
+        raise FleetError("released journey executor supports macOS and Linux only")
     releases = {release.tag: release for release in discover_distribution_releases(repo)}
     start = releases.get(starting_tag)
     if start is None:
@@ -1489,71 +1503,85 @@ def run_journey(
     follow_up = resolve_immutable_release(repo, follow_up_tag)
     if foundation.tag == follow_up.tag or foundation.commit == follow_up.commit:
         raise FleetError("foundation and follow-up must be different immutable releases")
+    protocol_bytes = _optional_tag_file(repo, follow_up.tag, UPDATE_JOURNEY_RELATIVE)
+    if protocol_bytes is None:
+        raise FleetError("follow-up release has no released journey executor")
+    try:
+        protocol = load_update_journey_protocol(protocol_bytes)
+    except JourneyProtocolError as error:
+        raise FleetError(f"follow-up released journey protocol is invalid: {error}") from error
+    if protocol.foundation != foundation.identity():
+        raise FleetError("released journey protocol names a different foundation")
+    source_commit = _verify_released_protocol_artifacts(repo, follow_up, protocol)
+    for label, artifact, running_path in (
+        ("fleet runner", protocol.runner, Path(__file__).resolve()),
+        (
+            "journey executor",
+            protocol.executor,
+            PROJECT_ROOT / protocol.executor.source_path,
+        ),
+        (
+            "foundation bridge",
+            protocol.bridge.artifact,
+            PROJECT_ROOT / protocol.bridge.artifact.source_path,
+        ),
+    ):
+        running = running_path.read_bytes()
+        released = _tag_file(repo, source_commit, artifact.source_path)
+        if (
+            hashlib.sha256(running).hexdigest() != artifact.sha256
+            or running != released
+        ):
+            raise FleetError(
+                f"running {label} bytes do not match the released journey source"
+            )
+
     # Evidence must not become an untracked vault file that influences either
-    # release preview.  Keep it beside a future disposable fixture.
+    # release preview. Keep it beside the disposable fixture.
     evidence_relative = f"{safe_case_name(start)}.evidence"
     evidence_root = output / evidence_relative
     if evidence_root.exists():
         raise FleetError("journey evidence directory must be empty")
-    transcript_path = evidence_root / "journey-transcript.json"
-    result_path = evidence_root / "journey-result.json"
-    events: list[dict[str, object]] = []
-    result: dict[str, object] = {
-        "starting_tag": start.tag,
-        "foundation_tag": foundation.tag,
-        "follow_up_tag": follow_up.tag,
-        "transcript_path": f"{evidence_relative}/journey-transcript.json",
-    }
-
+    case_name = safe_case_name(start)
+    vault = output / case_name
+    runtime_root = output / f"{case_name}.runtime"
+    historic_surface = shipped_update_surface(repo, start)
+    foundation_surface = shipped_update_surface(repo, foundation)
+    node_runtime = resolve_trusted_node_runtime()
+    python_runtime = resolve_trusted_python_runtime()
+    environment = _case_environment(
+        vault,
+        runtime_root,
+        node_runtime=node_runtime,
+        python_runtime=python_runtime,
+    )
     try:
-        historic_surface = shipped_update_surface(repo, start)
-        foundation_surface = shipped_update_surface(repo, foundation)
-        _write_json(evidence_root / "historic-update-surface.json", historic_surface)
-        _write_json(evidence_root / "foundation-update-surface.json", foundation_surface)
-        events.extend(
-            (
-                {
-                    "id": "historic-update-surface",
-                    "command": ["git", "show", f"{start.tag}:{UPDATE_SKILL_RELATIVE}"],
-                    "release": historic_surface["release"],
-                    "skill_sha256": historic_surface["skill_sha256"],
-                    "rescue_sha256": historic_surface["rescue_sha256"],
-                },
-                {
-                    "id": "foundation-update-surface",
-                    "command": ["git", "show", f"{foundation.tag}:{UPDATE_SKILL_RELATIVE}"],
-                    "release": foundation_surface["release"],
-                    "skill_sha256": foundation_surface["skill_sha256"],
-                    "rescue_sha256": foundation_surface["rescue_sha256"],
-                },
-            )
+        case = build_installed_fixture(
+            repo,
+            start,
+            output,
+            environment=environment,
         )
-        result["historic_update_surface"] = historic_surface
-        result["foundation_update_surface"] = foundation_surface
-        raise FleetError(
-            "published journey executor is unavailable; the current runner records update "
-            "surfaces but cannot execute either hop"
+        resolve_fixture_python(case.vault, trusted_python=python_runtime)
+        from scripts import release_fleet_executor
+
+        return release_fleet_executor.execute_journey(
+            repo_root=repo,
+            source_commit=source_commit,
+            vault_root=case.vault,
+            evidence_root=evidence_root,
+            starting_release=historic_surface["release"],
+            foundation_release=foundation.identity(),
+            follow_up_release=follow_up.identity(),
+            protocol=protocol,
+            historic_surface=historic_surface,
+            foundation_surface=foundation_surface,
+            user_owned_paths=tuple(USER_FIXTURES),
+            platform=journey_platform,
         )
-    except (FleetError, OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as error:
-        result["failure"] = str(error)
-        _write_json(transcript_path, {"events": events})
-        artifacts: dict[str, Path] = {"transcript": transcript_path}
-        if (evidence_root / "historic-update-surface.json").is_file():
-            artifacts["historic_update_surface"] = evidence_root / "historic-update-surface.json"
-        if (evidence_root / "foundation-update-surface.json").is_file():
-            artifacts["foundation_update_surface"] = evidence_root / "foundation-update-surface.json"
-        manifest_path, manifest_sha256 = _write_evidence_manifest(
-            evidence_root,
-            start=historic_surface if "historic_surface" in locals() else {"tag": start.tag},
-            foundation=foundation,
-            follow_up=follow_up,
-            events=events,
-            artifacts=artifacts,
-        )
-        result["evidence_manifest_path"] = manifest_path
-        result["evidence_manifest_sha256"] = manifest_sha256
-        _write_json(result_path, result)
-        raise
+    finally:
+        _remove_disposable_fixture(vault, output)
+        _remove_disposable_fixture(runtime_root, output)
 
 
 def assert_complete(report: AcceptanceReport, expected_start_tags: set[str]) -> None:
@@ -1644,8 +1672,32 @@ def assert_evidence_bound(
     evidence_root: Path,
     foundation: ImmutableRelease,
     follow_up: ImmutableRelease,
+    executor_runs: Sequence[object] = (),
 ) -> None:
     """Open runner-owned evidence and bind it to released source bytes."""
+
+    from scripts import release_fleet_executor
+
+    if len(executor_runs) != len(report.cases) or any(
+        not release_fleet_executor.is_authoritative_executor_run(run)
+        for run in executor_runs
+    ):
+        raise FleetError(
+            "released journey executor authority is required in this live process; "
+            "serialized evidence cannot substitute for execution"
+        )
+    authoritative_cases = [run.case for run in executor_runs]  # type: ignore[attr-defined]
+    expected_cases = [
+        {
+            field: getattr(case, field)
+            for field in CASE_RESULT_KEYS
+        }
+        for case in report.cases
+    ]
+    if authoritative_cases != expected_cases:
+        raise FleetError(
+            "released journey executor authority does not match the acceptance report"
+        )
 
     releases = {release.tag: release for release in discover_distribution_releases(repo)}
 
@@ -1664,6 +1716,7 @@ def assert_evidence_bound(
         protocol = load_update_journey_protocol(
             _tag_file(repo, follow_up.tag, UPDATE_JOURNEY_RELATIVE)
         )
+        source_commit = _verify_released_protocol_artifacts(repo, follow_up, protocol)
         if protocol.foundation != foundation.identity():
             raise FleetError(
                 f"{case.starting_tag}: released journey protocol names a different foundation"
@@ -1680,6 +1733,22 @@ def assert_evidence_bound(
         )
         if (
             manifest["schema_version"] != 1
+            or manifest["executor"]
+            != {
+                "source_commit": source_commit,
+                "executor": {
+                    "source_path": protocol.executor.source_path,
+                    "sha256": protocol.executor.sha256,
+                },
+                "fleet_runner": {
+                    "source_path": protocol.runner.source_path,
+                    "sha256": protocol.runner.sha256,
+                },
+                "foundation_bridge": {
+                    "source_path": protocol.bridge.artifact.source_path,
+                    "sha256": protocol.bridge.artifact.sha256,
+                },
+            }
             or not isinstance(manifest["starting_release"], Mapping)
             or manifest["starting_release"].get("tag") != case.starting_tag
             or manifest["foundation_release"] != foundation.identity()
@@ -1722,21 +1791,56 @@ def assert_evidence_bound(
             or events["historic-update-surface"].get("rescue_sha256")
             != expected_historic_surface["rescue_sha256"]
             or events["historic-route-refusal"].get("release") != expected_historic_surface["release"]
+            or events["historic-route-refusal"].get("command")
+            != [protocol.executor.source_path, "classify-historic-route"]
             or events["bridge-foundation"].get("release") != foundation.identity()
+            or events["bridge-foundation"].get("command")
+            != [protocol.executor.source_path, protocol.bridge.adapter]
             or events["foundation-update-surface"].get("release") != foundation.identity()
+            or events["foundation-update-surface"].get("command")
+            != ["git", "show", f"{foundation.tag}:{UPDATE_SKILL_RELATIVE}"]
             or events["foundation-update-surface"].get("skill_sha256")
             != expected_foundation_surface["skill_sha256"]
             or events["foundation-update-surface"].get("rescue_sha256")
             != expected_foundation_surface["rescue_sha256"]
             or events["foundation-preview"].get("from_release") != foundation.identity()
             or events["foundation-preview"].get("target_release") != follow_up.identity()
+            or events["foundation-preview"].get("command")
+            != list(protocol.follow_up.operations[:2])
             or events["foundation-approval"].get("target_release") != follow_up.identity()
             or events["foundation-approval"].get("answer") != "APPLY"
+            or events["foundation-approval"].get("command")
+            != [protocol.executor.source_path, "approve-follow-up"]
             or events["foundation-receipt"].get("release") != follow_up.identity()
+            or events["foundation-receipt"].get("command")
+            != [protocol.follow_up.operations[2]]
             or events["follow-up-installed"].get("release") != follow_up.identity()
+            or events["follow-up-installed"].get("command")
+            != [protocol.executor.source_path, "verify-installed-release"]
+            or events["follow-up-doctor"].get("command")
+            != [protocol.executor.source_path, "doctor"]
+            or events["follow-up-smoke"].get("command")
+            != [protocol.executor.source_path, "smoke"]
             or events["follow-up-smoke"].get("platform") != case.platform
         ):
             raise FleetError(f"{case.starting_tag}: evidence manifest commands or identities are not bound")
+        bridge_approvals = events["bridge-foundation"].get("approvals")
+        approval_count = events["bridge-foundation"].get("approval_count")
+        if (
+            not isinstance(approval_count, int)
+            or approval_count < 0
+            or approval_count > protocol.bridge.approval_count
+            or not isinstance(bridge_approvals, list)
+            or approval_count != len(bridge_approvals)
+            or any(
+                not isinstance(approval, Mapping)
+                or set(approval) != {"prompt", "answer"}
+                or not isinstance(approval["prompt"], str)
+                or approval["answer"] != protocol.bridge.approval_word
+                for approval in bridge_approvals
+            )
+        ):
+            raise FleetError(f"{case.starting_tag}: bridge approvals are not exact")
         artifacts = manifest["artifacts"]
         if set(artifacts) != RUNNER_ARTIFACT_KEYS:
             raise FleetError(f"{case.starting_tag}: runner manifest has an invalid artifact set")
@@ -2000,7 +2104,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     journey = subcommands.add_parser(
         "journey",
-        help="record immutable update surfaces and fail closed until a released journey executor ships",
+        help="run one released, closed historic update journey",
     )
     journey.add_argument("--repo", type=Path, required=True)
     journey.add_argument("--output", type=Path, required=True)
@@ -2037,14 +2141,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "journey":
-        run_journey(
+        run = run_journey(
             args.repo,
             output=args.output,
             starting_tag=args.starting_tag,
             foundation_tag=args.foundation_tag,
             follow_up_tag=args.follow_up_tag,
         )
-        raise FleetError("journey returned without a released journey executor")
+        print(
+            json.dumps(
+                {
+                    "outcome": "JOURNEY_COMPLETE_NON_ACCEPTANCE",
+                    "acceptance": False,
+                    "case": run.case,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
 
     if args.command == "survey":
         releases = releases_from_starting_manifest(

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -510,6 +510,32 @@ def _has_transaction_receipt(value: object) -> bool:
     )
 
 
+def _valid_foundation_bridge_receipt(
+    value: object,
+    *,
+    expected_foundation: Mapping[str, object],
+    approval_count: int,
+) -> bool:
+    """Accept either the exact resume receipt or an approved lifecycle mutation."""
+
+    if (
+        not isinstance(value, Mapping)
+        or set(value)
+        != {"foundation", "topology_receipt", "delivery_receipt"}
+        or value["foundation"] != expected_foundation
+    ):
+        return False
+    already_installed = {"skipped": "foundation-already-installed"}
+    if (
+        value["topology_receipt"] == already_installed
+        and value["delivery_receipt"] == already_installed
+    ):
+        return approval_count == 0
+    return approval_count > 0 and _has_transaction_receipt(
+        value["delivery_receipt"]
+    )
+
+
 def _trusted_runtime_path(path: Path, *, label: str, roots: Sequence[Path]) -> Path:
     """Resolve an allowlisted runtime file without accepting an ambient executable."""
 
@@ -1882,8 +1908,13 @@ def assert_evidence_bound(
         follow_receipt = _read_evidence_json(
             evidence_root, case.follow_up_receipt_path, f"{case.starting_tag} follow-up receipt"
         )
-        if foundation_receipt["release"] != foundation.identity() or not _has_transaction_receipt(
-            foundation_receipt["receipt"]
+        if (
+            foundation_receipt["release"] != foundation.identity()
+            or not _valid_foundation_bridge_receipt(
+                foundation_receipt["receipt"],
+                expected_foundation=foundation.identity(),
+                approval_count=approval_count,
+            )
         ):
             raise FleetError(f"{case.starting_tag}: foundation receipt is not bound to the supplied release")
         if follow_receipt["release"] != follow_up.identity() or not _has_transaction_receipt(

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -37,6 +37,10 @@ _RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,40})$"
 )
+_LEGACY_RELEASE_TAG = re.compile(
+    r"^v(?P<version>(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))$"
+)
 _DECLARED_LIFECYCLE_OPERATIONS = frozenset(
     {
         "deliver_latest_release",
@@ -53,37 +57,22 @@ class ExecutorError(RuntimeError):
 class ExecutorRun:
     """One live executor result that cannot be reconstructed from JSON."""
 
-    __slots__ = ("_authority", "_case")
+    __slots__ = ("_authority", "_case_json")
 
     def __init__(self, case: Mapping[str, object]) -> None:
         raise ExecutorError(
             "only the live executor can create an authoritative journey run"
         )
 
+    def __setattr__(self, name: str, value: object) -> None:
+        raise ExecutorError("executor run proof is immutable")
+
     @property
     def case(self) -> dict[str, object]:
-        return dict(self._case)
-
-
-def _authority_boundary():
-    """Keep the live capability outside the module namespace."""
-
-    authority = object()
-
-    def create(case: Mapping[str, object]) -> ExecutorRun:
-        run = object.__new__(ExecutorRun)
-        run._case = dict(case)
-        run._authority = authority
-        return run
-
-    def check(value: object) -> bool:
-        return isinstance(value, ExecutorRun) and value._authority is authority
-
-    return create, check
-
-
-_authoritative_run, is_authoritative_executor_run = _authority_boundary()
-del _authority_boundary
+        value = json.loads(self._case_json)
+        if not isinstance(value, dict):
+            raise ExecutorError("executor run proof is malformed")
+        return value
 
 
 class JourneyRuntime(Protocol):
@@ -566,18 +555,34 @@ def _runtime_server(vault: Path) -> int:
     return 1
 
 
-def _strict_identity(value: Mapping[str, object], context: str) -> dict[str, str]:
+def _strict_identity(
+    value: Mapping[str, object],
+    context: str,
+    *,
+    allow_legacy: bool = False,
+) -> dict[str, str]:
     if set(value) != _IDENTITY_FIELDS or not all(
         isinstance(value[field], str) for field in _IDENTITY_FIELDS
     ):
         raise ExecutorError(f"{context} release identity is malformed")
     identity = {field: str(value[field]) for field in _IDENTITY_FIELDS}
     tag_match = _RELEASE_TAG.fullmatch(identity["tag"])
+    legacy_match = (
+        _LEGACY_RELEASE_TAG.fullmatch(identity["tag"]) if allow_legacy else None
+    )
+    version = (
+        tag_match.group("version")
+        if tag_match is not None
+        else legacy_match.group("version") if legacy_match is not None else None
+    )
     if (
         any(_HEX_40.fullmatch(identity[field]) is None for field in ("tag_object", "commit", "tree"))
-        or tag_match is None
-        or tag_match.group("version") != identity["version"]
-        or not identity["commit"].startswith(tag_match.group("short"))
+        or version is None
+        or version != identity["version"]
+        or (
+            tag_match is not None
+            and not identity["commit"].startswith(tag_match.group("short"))
+        )
         or identity["channel"] != "stable"
     ):
         raise ExecutorError(f"{context} release identity is malformed")
@@ -752,7 +757,11 @@ def _validate_bridge_result(
     if value["foundation"] != foundation:
         raise ExecutorError("foundation bridge returned a different release identity")
     delivery = value["delivery_receipt"]
-    completed = delivery == {"skipped": "foundation-already-installed"}
+    already_installed = {"skipped": "foundation-already-installed"}
+    completed = (
+        value["topology_receipt"] == already_installed
+        and delivery == already_installed
+    )
     if not _contains_transaction_receipt(delivery) and not completed:
         raise ExecutorError(
             "foundation bridge did not return a lifecycle transaction receipt"
@@ -796,12 +805,12 @@ def _execute_journey_with_runtime(
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
     _runtime: JourneyRuntime,
-) -> ExecutorRun:
+) -> dict[str, object]:
     """Execute and own one closed two-hop journey in the current process."""
 
     if platform not in protocol.platforms:
         raise ExecutorError(f"journey platform is not declared by the protocol: {platform}")
-    start = _strict_identity(starting_release, "starting")
+    start = _strict_identity(starting_release, "starting", allow_legacy=True)
     foundation = _strict_identity(foundation_release, "foundation")
     follow_up = _strict_identity(follow_up_release, "follow-up")
     if foundation == follow_up:
@@ -1044,52 +1053,115 @@ def _execute_journey_with_runtime(
         "evidence_manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
     }
     _write_json(evidence_root / "journey-result.json", case)
-    return _authoritative_run(case)
+    return case
 
 
-def execute_journey(
-    *,
-    repo_root: Path,
-    source_commit: str,
-    vault_root: Path,
-    evidence_root: Path,
-    starting_release: Mapping[str, object],
-    foundation_release: Mapping[str, object],
-    follow_up_release: Mapping[str, object],
-    protocol: UpdateJourneyProtocol,
-    historic_surface: Mapping[str, object],
-    foundation_surface: Mapping[str, object],
-    user_owned_paths: Sequence[str],
-    platform: str,
-    input_fn: Callable[[str], str] = input,
-    output_fn: Callable[[str], None] = print,
-    _runtime: JourneyRuntime | None = None,
-) -> ExecutorRun:
-    """Execute one released journey and retain authority in this process."""
+def _executor_boundary():
+    """Create the sole production entrypoint without exporting a proof mint."""
 
-    owned_runtime = _runtime is None
-    runtime = _runtime or _ProductionRuntime()
-    try:
-        return _execute_journey_with_runtime(
-            repo_root=repo_root,
-            source_commit=source_commit,
-            vault_root=vault_root,
-            evidence_root=evidence_root,
-            starting_release=starting_release,
-            foundation_release=foundation_release,
-            follow_up_release=follow_up_release,
-            protocol=protocol,
-            historic_surface=historic_surface,
-            foundation_surface=foundation_surface,
-            user_owned_paths=user_owned_paths,
-            platform=platform,
-            input_fn=input_fn,
-            output_fn=output_fn,
-            _runtime=runtime,
+    authority = object()
+    production_runtime_type = _ProductionRuntime
+    execute_with_runtime = _execute_journey_with_runtime
+    production_methods = {
+        name: getattr(production_runtime_type, name)
+        for name in (
+            "bridge_to_foundation",
+            "installed_release",
+            "doctor",
+            "deliver_latest_release",
+            "build_and_preview_delivered_release",
+            "execute_approved_delivered_release",
+            "smoke",
+            "close",
         )
-    finally:
-        if owned_runtime:
-            runtime.close()  # type: ignore[attr-defined]
+    }
+
+    def execute_journey(
+        *,
+        repo_root: Path,
+        source_commit: str,
+        vault_root: Path,
+        evidence_root: Path,
+        starting_release: Mapping[str, object],
+        foundation_release: Mapping[str, object],
+        follow_up_release: Mapping[str, object],
+        protocol: UpdateJourneyProtocol,
+        historic_surface: Mapping[str, object],
+        foundation_surface: Mapping[str, object],
+        user_owned_paths: Sequence[str],
+        platform: str,
+        input_fn: Callable[[str], str] = input,
+        output_fn: Callable[[str], None] = print,
+        _runtime: JourneyRuntime | None = None,
+    ) -> ExecutorRun:
+        """Execute one released journey and retain production authority here."""
+
+        production_owned = _runtime is None
+        runtime = production_runtime_type() if production_owned else _runtime
+        assert runtime is not None
+        try:
+            case = execute_with_runtime(
+                repo_root=repo_root,
+                source_commit=source_commit,
+                vault_root=vault_root,
+                evidence_root=evidence_root,
+                starting_release=starting_release,
+                foundation_release=foundation_release,
+                follow_up_release=follow_up_release,
+                protocol=protocol,
+                historic_surface=historic_surface,
+                foundation_surface=foundation_surface,
+                user_owned_paths=user_owned_paths,
+                platform=platform,
+                input_fn=input_fn,
+                output_fn=output_fn,
+                _runtime=runtime,
+            )
+        finally:
+            if production_owned:
+                runtime.close()  # type: ignore[attr-defined]
+        case_json = json.dumps(
+            case,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        run = object.__new__(ExecutorRun)
+        object.__setattr__(run, "_case_json", case_json)
+        production_intact = (
+            production_owned
+            and type(runtime) is production_runtime_type
+            and all(
+                getattr(production_runtime_type, name) is function
+                for name, function in production_methods.items()
+            )
+        )
+        seal = (
+            (authority, hashlib.sha256(case_json).digest())
+            if production_intact
+            else None
+        )
+        object.__setattr__(run, "_authority", seal)
+        return run
+
+    def is_authoritative_executor_run(value: object) -> bool:
+        if not isinstance(value, ExecutorRun):
+            return False
+        seal = getattr(value, "_authority", None)
+        case_json = getattr(value, "_case_json", None)
+        return (
+            isinstance(seal, tuple)
+            and len(seal) == 2
+            and seal[0] is authority
+            and isinstance(seal[1], bytes)
+            and isinstance(case_json, bytes)
+            and seal[1] == hashlib.sha256(case_json).digest()
+        )
+
+    return execute_journey, is_authoritative_executor_run
+
+
+execute_journey, is_authoritative_executor_run = _executor_boundary()
+del _executor_boundary
 
 
 __all__ = [

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -1,0 +1,1111 @@
+#!/usr/bin/env python3
+"""Release-owned executor for one verified historic Dex update journey.
+
+This module is the only implementation allowed to turn the closed journey
+protocol into bridge and lifecycle calls. Serialized evidence is output for
+review; authority stays in the live ``ExecutorRun`` returned by this process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import select
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.update.journey_protocol import UpdateJourneyProtocol
+from scripts import dex_update_bridge
+
+EXECUTOR_INTERFACE_VERSION = 1
+_IDENTITY_FIELDS = frozenset(
+    {"tag", "tag_object", "commit", "tree", "version", "channel"}
+)
+_HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+_RELEASE_TAG = re.compile(
+    r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,40})$"
+)
+_DECLARED_LIFECYCLE_OPERATIONS = frozenset(
+    {
+        "deliver_latest_release",
+        "build_and_preview_delivered_release",
+        "execute_approved_delivered_release",
+    }
+)
+
+
+class ExecutorError(RuntimeError):
+    """The released journey executor could not prove a safe completed run."""
+
+
+class ExecutorRun:
+    """One live executor result that cannot be reconstructed from JSON."""
+
+    __slots__ = ("_authority", "_case")
+
+    def __init__(self, case: Mapping[str, object]) -> None:
+        raise ExecutorError(
+            "only the live executor can create an authoritative journey run"
+        )
+
+    @property
+    def case(self) -> dict[str, object]:
+        return dict(self._case)
+
+
+def _authority_boundary():
+    """Keep the live capability outside the module namespace."""
+
+    authority = object()
+
+    def create(case: Mapping[str, object]) -> ExecutorRun:
+        run = object.__new__(ExecutorRun)
+        run._case = dict(case)
+        run._authority = authority
+        return run
+
+    def check(value: object) -> bool:
+        return isinstance(value, ExecutorRun) and value._authority is authority
+
+    return create, check
+
+
+_authoritative_run, is_authoritative_executor_run = _authority_boundary()
+del _authority_boundary
+
+
+class JourneyRuntime(Protocol):
+    """Internal seam for the production and deterministic test adapters."""
+
+    def bridge_to_foundation(
+        self,
+        vault: Path,
+        foundation: Mapping[str, str],
+        *,
+        input_fn: Callable[[str], str],
+        output_fn: Callable[[str], None],
+    ) -> Mapping[str, object]: ...
+
+    def installed_release(self, vault: Path) -> str: ...
+
+    def doctor(self, vault: Path) -> Mapping[str, object]: ...
+
+    def deliver_latest_release(self, vault: Path) -> Mapping[str, object]: ...
+
+    def build_and_preview_delivered_release(
+        self,
+        vault: Path,
+        release: Mapping[str, str],
+    ) -> Mapping[str, object]: ...
+
+    def execute_approved_delivered_release(
+        self,
+        vault: Path,
+        preview: Mapping[str, object],
+        approved_token: str,
+    ) -> Mapping[str, object]: ...
+
+    def smoke(self, vault: Path) -> Mapping[str, object]: ...
+
+
+class _ProductionRuntime:
+    """Closed parent adapter over a fixture-venv lifecycle runtime."""
+
+    def __init__(self) -> None:
+        self._runtime_home = tempfile.TemporaryDirectory(
+            prefix="dex-release-journey-runtime-"
+        )
+        self._server: subprocess.Popen[bytes] | None = None
+        self._server_stderr = tempfile.TemporaryFile(mode="w+b")
+        self._server_vault: Path | None = None
+        self._server_buffer = bytearray()
+
+    def close(self) -> None:
+        process = self._server
+        if process is not None and process.poll() is None:
+            try:
+                assert process.stdin is not None
+                process.stdin.write(b'{"operation":"close"}\n')
+                process.stdin.flush()
+                process.wait(timeout=10)
+            except (BrokenPipeError, OSError, subprocess.TimeoutExpired):
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait()
+        self._server = None
+        self._server_stderr.close()
+        self._runtime_home.cleanup()
+
+    def _runtime_environment(self, vault: Path) -> dict[str, str]:
+        runtime_root = Path(self._runtime_home.name)
+        environment = dex_update_bridge._bridge_environment()
+        environment.update(
+            {
+                "DEX_VAULT": str(vault),
+                "HOME": str(runtime_root),
+                "TMPDIR": str(runtime_root),
+                "VAULT_PATH": str(vault),
+                "VAULT_ROOT": str(vault),
+            }
+        )
+        return environment
+
+    def _server_error(self, fallback: str) -> ExecutorError:
+        self._server_stderr.flush()
+        self._server_stderr.seek(0)
+        detail = self._server_stderr.read(64 * 1024).decode(
+            "utf-8",
+            "replace",
+        ).strip()
+        return ExecutorError(detail or fallback)
+
+    def _read_server_message(self, *, deadline: float) -> dict[str, object]:
+        process = self._server
+        if process is None or process.stdout is None:
+            raise ExecutorError("fixture lifecycle runtime is not running")
+        while b"\n" not in self._server_buffer:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ExecutorError("fixture lifecycle runtime timed out")
+            ready, _, _ = select.select([process.stdout], [], [], remaining)
+            if not ready:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait()
+                raise ExecutorError("fixture lifecycle runtime timed out")
+            chunk = os.read(process.stdout.fileno(), 64 * 1024)
+            if not chunk:
+                raise self._server_error("fixture lifecycle runtime stopped")
+            self._server_buffer.extend(chunk)
+            if len(self._server_buffer) > 16 * 1024 * 1024:
+                raise ExecutorError(
+                    "fixture lifecycle runtime message exceeded its bound"
+                )
+        line, _, remainder = self._server_buffer.partition(b"\n")
+        self._server_buffer = bytearray(remainder)
+        try:
+            message = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ExecutorError(
+                "fixture lifecycle runtime returned malformed JSON"
+            ) from error
+        if not isinstance(message, dict):
+            raise ExecutorError("fixture lifecycle runtime returned malformed JSON")
+        return message
+
+    def _ensure_server(self, vault: Path) -> None:
+        root = dex_update_bridge._validate_vault(vault)
+        if self._server is not None:
+            if root != self._server_vault:
+                raise ExecutorError("fixture lifecycle runtime changed vaults")
+            if self._server.poll() is not None:
+                raise self._server_error("fixture lifecycle runtime stopped")
+            return
+        interpreter = dex_update_bridge._installed_python(root)
+        if interpreter is None:
+            raise ExecutorError(
+                "Dex's installed virtualenv is required for the journey runtime"
+            )
+        self._server_stderr.seek(0)
+        self._server_stderr.truncate()
+        process = subprocess.Popen(
+            [
+                str(interpreter),
+                str(Path(__file__).resolve()),
+                "_runtime-server",
+                "--vault",
+                str(root),
+            ],
+            cwd=PROJECT_ROOT,
+            env=self._runtime_environment(root),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=self._server_stderr,
+            bufsize=0,
+            start_new_session=True,
+        )
+        self._server = process
+        self._server_vault = root
+        message = self._read_server_message(deadline=time.monotonic() + 180)
+        if message != {"kind": "ready"}:
+            raise self._server_error("fixture lifecycle runtime did not become ready")
+
+    def _server_call(
+        self,
+        vault: Path,
+        operation: str,
+        payload: Mapping[str, object] | None = None,
+        *,
+        input_fn: Callable[[str], str] | None = None,
+        output_fn: Callable[[str], None] | None = None,
+    ) -> Mapping[str, object]:
+        if operation != "bridge" and operation not in _DECLARED_LIFECYCLE_OPERATIONS:
+            raise ExecutorError(
+                f"lifecycle operation is not declared by the journey: {operation}"
+            )
+        self._ensure_server(vault)
+        process = self._server
+        assert process is not None and process.stdin is not None
+        request = {"operation": operation}
+        if payload is not None:
+            request["payload"] = dict(payload)
+        process.stdin.write(
+            (
+                json.dumps(request, separators=(",", ":"), sort_keys=True)
+                + "\n"
+            ).encode("utf-8")
+        )
+        process.stdin.flush()
+        deadline = time.monotonic() + 900
+        while True:
+            message = self._read_server_message(deadline=deadline)
+            kind = message.get("kind")
+            if kind == "output" and set(message) == {"kind", "text"}:
+                text = message["text"]
+                if not isinstance(text, str) or output_fn is None:
+                    raise ExecutorError("fixture lifecycle output event is malformed")
+                output_fn(text)
+                continue
+            if kind == "prompt" and set(message) == {"kind", "prompt"}:
+                prompt = message["prompt"]
+                if not isinstance(prompt, str) or input_fn is None:
+                    raise ExecutorError("fixture lifecycle prompt event is malformed")
+                answer = input_fn(prompt)
+                process.stdin.write(
+                    (
+                        json.dumps({"answer": answer}, separators=(",", ":"))
+                        + "\n"
+                    ).encode("utf-8")
+                )
+                process.stdin.flush()
+                continue
+            if kind == "error" and set(message) == {"kind", "message"}:
+                detail = message["message"]
+                raise ExecutorError(
+                    detail if isinstance(detail, str) and detail else "fixture runtime failed"
+                )
+            if kind == "result" and set(message) == {"kind", "value"}:
+                value = message["value"]
+                if not isinstance(value, Mapping):
+                    raise ExecutorError("fixture lifecycle result is malformed")
+                return value
+            raise ExecutorError("fixture lifecycle runtime event is malformed")
+
+    @staticmethod
+    def _service_call(
+        service: object,
+        operation: str,
+        *arguments: object,
+    ) -> Mapping[str, object]:
+        if operation not in _DECLARED_LIFECYCLE_OPERATIONS:
+            raise ExecutorError(
+                f"lifecycle operation is not declared by the journey: {operation}"
+            )
+        function = getattr(service, operation, None)
+        if not callable(function):
+            raise ExecutorError(
+                f"released foundation lifecycle service lacks {operation}"
+            )
+        response = function(*arguments)
+        if not isinstance(response, Mapping):
+            raise ExecutorError(
+                f"released foundation lifecycle operation {operation} "
+                "returned malformed evidence"
+            )
+        return response
+
+    def bridge_to_foundation(
+        self,
+        vault: Path,
+        foundation: Mapping[str, str],
+        *,
+        input_fn: Callable[[str], str],
+        output_fn: Callable[[str], None],
+    ) -> Mapping[str, object]:
+        if foundation != dex_update_bridge.FOUNDATION.identity():
+            raise ExecutorError("executor foundation does not match the pinned bridge")
+        return self._server_call(
+            vault,
+            "bridge",
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+
+    def installed_release(self, vault: Path) -> str:
+        root = dex_update_bridge._validate_vault(vault)
+        brain = root / ".dex" / "brain.git"
+        topology = dex_update_bridge._regular_json(
+            root / "System" / ".dex" / "topology.json",
+            "split topology marker",
+        )
+        brain_marker = dex_update_bridge._regular_json(
+            brain / "dex-brain-v2",
+            "brain Git marker",
+        )
+        installed = dex_update_bridge._run_git(
+            brain,
+            "rev-parse",
+            "--verify",
+            "refs/dex/installed^{commit}",
+        )
+        if (
+            topology.get("installedRelease") != installed
+            or brain_marker.get("installed") != installed
+        ):
+            raise ExecutorError(
+                "installed release identity disagrees across topology markers"
+            )
+        return installed
+
+    def _installed_json(
+        self,
+        vault: Path,
+        module: str,
+        *arguments: str,
+    ) -> Mapping[str, object]:
+        root = dex_update_bridge._validate_vault(vault)
+        interpreter = dex_update_bridge._installed_python(root)
+        if interpreter is None:
+            raise ExecutorError(
+                "Dex's installed virtualenv is required for journey health proof"
+            )
+        process = subprocess.Popen(
+            [str(interpreter), "-m", module, *arguments],
+            cwd=root,
+            env=self._runtime_environment(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=600)
+        except subprocess.TimeoutExpired as error:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.communicate()
+            raise ExecutorError(f"installed {module} timed out") from error
+        if len(stdout) > 16 * 1024 * 1024 or len(stderr) > 1024 * 1024:
+            raise ExecutorError(f"installed {module} output exceeded its bound")
+        if process.returncode:
+            detail = stderr.decode("utf-8", "replace").strip()
+            raise ExecutorError(detail or f"installed {module} failed")
+        try:
+            report = json.loads(stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ExecutorError(f"installed {module} returned malformed JSON") from error
+        if not isinstance(report, Mapping):
+            raise ExecutorError(f"installed {module} returned malformed JSON")
+        return report
+
+    def doctor(self, vault: Path) -> Mapping[str, object]:
+        return self._installed_json(vault, "core.utils.doctor")
+
+    def deliver_latest_release(self, vault: Path) -> Mapping[str, object]:
+        return self._server_call(vault, "deliver_latest_release")
+
+    def build_and_preview_delivered_release(
+        self,
+        vault: Path,
+        release: Mapping[str, str],
+    ) -> Mapping[str, object]:
+        return self._server_call(
+            vault,
+            "build_and_preview_delivered_release",
+            {"release": dict(release)},
+        )
+
+    def execute_approved_delivered_release(
+        self,
+        vault: Path,
+        preview: Mapping[str, object],
+        approved_token: str,
+    ) -> Mapping[str, object]:
+        return self._server_call(
+            vault,
+            "execute_approved_delivered_release",
+            {
+                "preview": dict(preview),
+                "approval_token": approved_token,
+            },
+        )
+
+    def smoke(self, vault: Path) -> Mapping[str, object]:
+        return self._installed_json(vault, "core.utils.smoke", "--json")
+
+
+def _runtime_server_emit(value: Mapping[str, object]) -> None:
+    print(
+        json.dumps(
+            dict(value),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+
+def _runtime_server_answer(prompt: str) -> str:
+    _runtime_server_emit({"kind": "prompt", "prompt": prompt})
+    line = sys.stdin.readline()
+    try:
+        response = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise ExecutorError("journey approval response is malformed") from error
+    if (
+        not isinstance(response, Mapping)
+        or set(response) != {"answer"}
+        or not isinstance(response["answer"], str)
+    ):
+        raise ExecutorError("journey approval response is malformed")
+    return response["answer"]
+
+
+def _runtime_server(vault: Path) -> int:
+    """Serve the fixed lifecycle vocabulary from the fixture virtualenv."""
+
+    root = dex_update_bridge._validate_vault(vault)
+    temporary: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if dex_update_bridge._foundation_is_installed(
+            root,
+            dex_update_bridge.FOUNDATION,
+        ):
+            source = root
+        else:
+            temporary, source = dex_update_bridge.acquire_foundation_source()
+        service = dex_update_bridge._load_lifecycle_service(source)
+        _runtime_server_emit({"kind": "ready"})
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+                if not isinstance(request, Mapping):
+                    raise ExecutorError("fixture lifecycle request is malformed")
+                operation = request.get("operation")
+                if operation == "close" and set(request) == {"operation"}:
+                    return 0
+                if operation == "bridge" and set(request) == {"operation"}:
+                    result = dex_update_bridge.run_bridge(
+                        root,
+                        service,
+                        pin=dex_update_bridge.FOUNDATION,
+                        input_fn=_runtime_server_answer,
+                        output_fn=lambda text: _runtime_server_emit(
+                            {"kind": "output", "text": text}
+                        ),
+                    )
+                elif operation == "deliver_latest_release" and set(request) == {
+                    "operation"
+                }:
+                    result = _ProductionRuntime._service_call(
+                        service,
+                        operation,
+                        root,
+                    )
+                elif operation == "build_and_preview_delivered_release":
+                    payload = request.get("payload")
+                    if (
+                        set(request) != {"operation", "payload"}
+                        or not isinstance(payload, Mapping)
+                        or set(payload) != {"release"}
+                        or not isinstance(payload["release"], Mapping)
+                    ):
+                        raise ExecutorError("fixture lifecycle request is malformed")
+                    result = _ProductionRuntime._service_call(
+                        service,
+                        operation,
+                        root,
+                        payload["release"],
+                    )
+                elif operation == "execute_approved_delivered_release":
+                    payload = request.get("payload")
+                    if (
+                        set(request) != {"operation", "payload"}
+                        or not isinstance(payload, Mapping)
+                        or set(payload) != {"preview", "approval_token"}
+                        or not isinstance(payload["preview"], Mapping)
+                        or not isinstance(payload["approval_token"], str)
+                    ):
+                        raise ExecutorError("fixture lifecycle request is malformed")
+                    result = _ProductionRuntime._service_call(
+                        service,
+                        operation,
+                        root,
+                        payload["preview"],
+                        payload["approval_token"],
+                    )
+                else:
+                    raise ExecutorError(
+                        f"lifecycle operation is not declared by the journey: {operation}"
+                    )
+                _runtime_server_emit({"kind": "result", "value": dict(result)})
+            except Exception as error:  # noqa: BLE001
+                _runtime_server_emit({"kind": "error", "message": str(error)})
+    finally:
+        if temporary is not None:
+            temporary.cleanup()
+    return 1
+
+
+def _strict_identity(value: Mapping[str, object], context: str) -> dict[str, str]:
+    if set(value) != _IDENTITY_FIELDS or not all(
+        isinstance(value[field], str) for field in _IDENTITY_FIELDS
+    ):
+        raise ExecutorError(f"{context} release identity is malformed")
+    identity = {field: str(value[field]) for field in _IDENTITY_FIELDS}
+    tag_match = _RELEASE_TAG.fullmatch(identity["tag"])
+    if (
+        any(_HEX_40.fullmatch(identity[field]) is None for field in ("tag_object", "commit", "tree"))
+        or tag_match is None
+        or tag_match.group("version") != identity["version"]
+        or not identity["commit"].startswith(tag_match.group("short"))
+        or identity["channel"] != "stable"
+    ):
+        raise ExecutorError(f"{context} release identity is malformed")
+    return identity
+
+
+def _git_show(repo_root: Path, commit: str, relative: str) -> bytes:
+    result = subprocess.run(
+        [
+            str(dex_update_bridge._trusted_git_binary()),
+            "--no-replace-objects",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "credential.helper=",
+            "-C",
+            str(repo_root),
+            "show",
+            f"{commit}:{relative}",
+        ],
+        capture_output=True,
+        env=dex_update_bridge._bridge_environment(),
+        timeout=90,
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise ExecutorError(
+            detail or f"released executor source is unavailable: {relative}"
+        )
+    if len(result.stdout) > 16 * 1024 * 1024:
+        raise ExecutorError(f"released source exceeds the executor bound: {relative}")
+    return result.stdout
+
+
+def _verify_released_executor(
+    repo_root: Path,
+    source_commit: str,
+    protocol: UpdateJourneyProtocol,
+    foundation: Mapping[str, str],
+) -> dict[str, object]:
+    if _HEX_40.fullmatch(source_commit) is None:
+        raise ExecutorError("released executor source commit is malformed")
+    if protocol.foundation != dict(foundation):
+        raise ExecutorError("journey protocol names a different foundation release")
+    artifacts = (
+        (
+            "fleet runner",
+            protocol.runner,
+            PROJECT_ROOT / protocol.runner.source_path,
+        ),
+        ("executor", protocol.executor, Path(__file__).resolve()),
+        (
+            "foundation bridge",
+            protocol.bridge.artifact,
+            Path(dex_update_bridge.__file__).resolve(),
+        ),
+    )
+    evidence: dict[str, object] = {"source_commit": source_commit}
+    for label, artifact, running_path in artifacts:
+        running = running_path.read_bytes()
+        released = _git_show(repo_root, source_commit, artifact.source_path)
+        digest = hashlib.sha256(running).hexdigest()
+        if digest != artifact.sha256 or running != released:
+            raise ExecutorError(
+                f"running {label} bytes do not match the released protocol source"
+            )
+        evidence[label.replace(" ", "_")] = {
+            "source_path": artifact.source_path,
+            "sha256": digest,
+        }
+    return evidence
+
+
+def _write_json(path: Path, value: object) -> None:
+    content = (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        view = memoryview(content)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _hash_user_owned(vault: Path, relatives: Sequence[str]) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for relative in relatives:
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ExecutorError(f"user-owned evidence path is unsafe: {relative}")
+        path = vault / candidate
+        if path.is_symlink() or not path.is_file():
+            raise ExecutorError(f"user-owned evidence file is missing: {relative}")
+        hashes[relative] = hashlib.sha256(path.read_bytes()).hexdigest()
+    if not hashes:
+        raise ExecutorError("journey has no user-owned hash evidence")
+    return hashes
+
+
+def _doctor_healthy(report: Mapping[str, object]) -> bool:
+    checks = report.get("checks")
+    return (
+        isinstance(checks, list)
+        and bool(checks)
+        and all(
+            isinstance(check, Mapping) and check.get("verdict") in {"OK", "OFF"}
+            for check in checks
+        )
+    )
+
+
+def _smoke_healthy(report: Mapping[str, object]) -> bool:
+    journeys = report.get("journeys")
+    summary = report.get("summary")
+    return (
+        isinstance(journeys, list)
+        and bool(journeys)
+        and all(
+            isinstance(journey, Mapping) and journey.get("verdict") in {"OK", "OFF"}
+            for journey in journeys
+        )
+        and isinstance(summary, Mapping)
+        and summary.get("broken") == 0
+        and summary.get("unknown") == 0
+    )
+
+
+def _transaction_receipt(value: Mapping[str, object], context: str) -> dict[str, object]:
+    receipt = value.get("receipt")
+    if (
+        not isinstance(receipt, Mapping)
+        or not isinstance(receipt.get("transaction_id"), str)
+        or not receipt["transaction_id"]
+    ):
+        raise ExecutorError(f"{context} did not return a lifecycle transaction receipt")
+    return dict(value)
+
+
+def _contains_transaction_receipt(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    if isinstance(value.get("transaction_id"), str) and value["transaction_id"]:
+        return True
+    return any(
+        _contains_transaction_receipt(nested)
+        for nested in value.values()
+        if isinstance(nested, Mapping)
+    )
+
+
+def _validate_bridge_result(
+    value: Mapping[str, object],
+    foundation: Mapping[str, str],
+    approval_count: int,
+) -> dict[str, object]:
+    if set(value) != {"foundation", "topology_receipt", "delivery_receipt"}:
+        raise ExecutorError("foundation bridge returned malformed evidence")
+    if value["foundation"] != foundation:
+        raise ExecutorError("foundation bridge returned a different release identity")
+    delivery = value["delivery_receipt"]
+    completed = delivery == {"skipped": "foundation-already-installed"}
+    if not _contains_transaction_receipt(delivery) and not completed:
+        raise ExecutorError(
+            "foundation bridge did not return a lifecycle transaction receipt"
+        )
+    if completed and approval_count != 0:
+        raise ExecutorError("completed foundation bridge requested an approval")
+    if not completed and approval_count == 0:
+        raise ExecutorError("foundation delivery completed without an approval")
+    return dict(value)
+
+
+def _artifact_index(
+    evidence_root: Path,
+    artifacts: Mapping[str, Path],
+) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for name, path in artifacts.items():
+        if path.is_symlink() or not path.is_file() or path.parent != evidence_root:
+            raise ExecutorError(f"executor evidence artifact is missing or unsafe: {name}")
+        result[name] = {
+            "path": f"{evidence_root.name}/{path.name}",
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+    return result
+
+
+def _execute_journey_with_runtime(
+    *,
+    repo_root: Path,
+    source_commit: str,
+    vault_root: Path,
+    evidence_root: Path,
+    starting_release: Mapping[str, object],
+    foundation_release: Mapping[str, object],
+    follow_up_release: Mapping[str, object],
+    protocol: UpdateJourneyProtocol,
+    historic_surface: Mapping[str, object],
+    foundation_surface: Mapping[str, object],
+    user_owned_paths: Sequence[str],
+    platform: str,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+    _runtime: JourneyRuntime,
+) -> ExecutorRun:
+    """Execute and own one closed two-hop journey in the current process."""
+
+    if platform not in protocol.platforms:
+        raise ExecutorError(f"journey platform is not declared by the protocol: {platform}")
+    start = _strict_identity(starting_release, "starting")
+    foundation = _strict_identity(foundation_release, "foundation")
+    follow_up = _strict_identity(follow_up_release, "follow-up")
+    if foundation == follow_up:
+        raise ExecutorError("foundation and follow-up releases must be different")
+    executor_identity = _verify_released_executor(
+        repo_root.resolve(),
+        source_commit,
+        protocol,
+        foundation,
+    )
+    if evidence_root.exists():
+        raise ExecutorError("journey evidence directory must be empty")
+    evidence_root.mkdir(parents=True, mode=0o700)
+    vault = vault_root.resolve(strict=True)
+    before = _hash_user_owned(vault, user_owned_paths)
+    if historic_surface.get("release") != start:
+        raise ExecutorError("historic update surface is not bound to the starting release")
+    if foundation_surface.get("release") != foundation:
+        raise ExecutorError("foundation update surface is not bound to the foundation release")
+
+    bridge_approvals: list[dict[str, str]] = []
+
+    def bridge_input(prompt: str) -> str:
+        answer = input_fn(prompt)
+        bridge_approvals.append({"prompt": prompt, "answer": answer})
+        if (
+            answer != protocol.bridge.approval_word
+            or len(bridge_approvals) > protocol.bridge.approval_count
+        ):
+            raise ExecutorError("foundation bridge approval was not exact")
+        return answer
+
+    bridge_response = dict(
+        _runtime.bridge_to_foundation(
+            vault,
+            foundation,
+            input_fn=bridge_input,
+            output_fn=output_fn,
+        )
+    )
+    if len(bridge_approvals) > protocol.bridge.approval_count:
+        raise ExecutorError("foundation bridge requested too many approvals")
+    bridge_result = _validate_bridge_result(
+        bridge_response,
+        foundation,
+        len(bridge_approvals),
+    )
+    if _runtime.installed_release(vault) != foundation["commit"]:
+        raise ExecutorError("foundation release was not installed exactly")
+    after_foundation = _hash_user_owned(vault, user_owned_paths)
+    if after_foundation != before:
+        raise ExecutorError("user-owned content changed during foundation delivery")
+    foundation_doctor = dict(_runtime.doctor(vault))
+    if not _doctor_healthy(foundation_doctor):
+        raise ExecutorError("foundation Doctor is unhealthy or incomplete")
+    after_foundation = _hash_user_owned(vault, user_owned_paths)
+    if after_foundation != before:
+        raise ExecutorError("user-owned content changed during foundation health proof")
+
+    delivered = dict(_runtime.deliver_latest_release(vault))
+    if (
+        delivered.get("status") != "delivered"
+        or delivered.get("release") != follow_up
+    ):
+        raise ExecutorError("lifecycle delivery did not prove the requested follow-up release")
+    preview_response = dict(
+        _runtime.build_and_preview_delivered_release(vault, follow_up)
+    )
+    preview = preview_response.get("preview")
+    approval_token = preview_response.get("approval_token")
+    if not isinstance(preview, Mapping) or not isinstance(approval_token, str) or not approval_token:
+        raise ExecutorError("follow-up lifecycle preview is incomplete")
+    output_fn(json.dumps(preview, indent=2, sort_keys=True))
+    follow_prompt = (
+        f"Dex will install verified follow-up v{follow_up['version']}. "
+        f"Type {protocol.follow_up.approval_word} to continue: "
+    )
+    follow_answer = input_fn(follow_prompt)
+    if follow_answer != protocol.follow_up.approval_word:
+        raise ExecutorError("follow-up lifecycle preview was not approved exactly")
+    follow_receipt = _transaction_receipt(
+        dict(
+            _runtime.execute_approved_delivered_release(
+                vault,
+                preview,
+                approval_token,
+            )
+        ),
+        "follow-up lifecycle execution",
+    )
+    if (
+        follow_receipt.get("release") != follow_up
+        or _runtime.installed_release(vault) != follow_up["commit"]
+    ):
+        raise ExecutorError("follow-up release was not installed exactly")
+    after_follow_up = _hash_user_owned(vault, user_owned_paths)
+    if after_follow_up != before:
+        raise ExecutorError("user-owned content changed during follow-up delivery")
+    follow_doctor = dict(_runtime.doctor(vault))
+    if not _doctor_healthy(follow_doctor):
+        raise ExecutorError("follow-up Doctor is unhealthy or incomplete")
+    smoke_report = dict(_runtime.smoke(vault))
+    if not _smoke_healthy(smoke_report):
+        raise ExecutorError("follow-up smoke proof is unhealthy or incomplete")
+    after_follow_up = _hash_user_owned(vault, user_owned_paths)
+    if after_follow_up != before:
+        raise ExecutorError("user-owned content changed during follow-up health proof")
+
+    historic_surface_path = evidence_root / "historic-update-surface.json"
+    foundation_surface_path = evidence_root / "foundation-update-surface.json"
+    foundation_receipt_path = evidence_root / "foundation-receipt.json"
+    follow_receipt_path = evidence_root / "follow-up-receipt.json"
+    foundation_doctor_path = evidence_root / "foundation-doctor.json"
+    follow_doctor_path = evidence_root / "follow-up-doctor.json"
+    smoke_path = evidence_root / "follow-up-smoke.json"
+    transcript_path = evidence_root / "journey-transcript.json"
+    for path, value in (
+        (historic_surface_path, dict(historic_surface)),
+        (foundation_surface_path, dict(foundation_surface)),
+        (
+            foundation_receipt_path,
+            {"release": foundation, "receipt": bridge_result},
+        ),
+        (follow_receipt_path, {"release": follow_up, "receipt": follow_receipt}),
+        (foundation_doctor_path, foundation_doctor),
+        (follow_doctor_path, follow_doctor),
+        (
+            smoke_path,
+            {"status": "OK", "platform": platform, "report": smoke_report},
+        ),
+    ):
+        _write_json(path, value)
+
+    preview_sha256 = hashlib.sha256(
+        (json.dumps(dict(preview), sort_keys=True, separators=(",", ":")) + "\n").encode()
+    ).hexdigest()
+    events = [
+        {
+            "id": "historic-update-surface",
+            "command": ["git", "show", f"{start['tag']}:.claude/skills/dex-update/SKILL.md"],
+            "release": start,
+            "skill_sha256": historic_surface.get("skill_sha256"),
+            "rescue_sha256": historic_surface.get("rescue_sha256"),
+        },
+        {
+            "id": "historic-route-refusal",
+            "command": [protocol.executor.source_path, "classify-historic-route"],
+            "release": start,
+            "machine_executable": historic_surface.get("machine_executable"),
+        },
+        {
+            "id": "bridge-foundation",
+            "command": [protocol.executor.source_path, protocol.bridge.adapter],
+            "release": foundation,
+            "approval_count": len(bridge_approvals),
+            "approvals": bridge_approvals,
+        },
+        {
+            "id": "foundation-update-surface",
+            "command": ["git", "show", f"{foundation['tag']}:.claude/skills/dex-update/SKILL.md"],
+            "release": foundation,
+            "skill_sha256": foundation_surface.get("skill_sha256"),
+            "rescue_sha256": foundation_surface.get("rescue_sha256"),
+        },
+        {
+            "id": "foundation-preview",
+            "command": list(protocol.follow_up.operations[:2]),
+            "from_release": foundation,
+            "target_release": follow_up,
+            "preview_sha256": preview_sha256,
+        },
+        {
+            "id": "foundation-approval",
+            "command": [protocol.executor.source_path, "approve-follow-up"],
+            "target_release": follow_up,
+            "answer": follow_answer,
+        },
+        {
+            "id": "foundation-receipt",
+            "command": [protocol.follow_up.operations[2]],
+            "release": follow_up,
+        },
+        {
+            "id": "follow-up-installed",
+            "command": [protocol.executor.source_path, "verify-installed-release"],
+            "release": follow_up,
+        },
+        {
+            "id": "follow-up-doctor",
+            "command": [protocol.executor.source_path, "doctor"],
+        },
+        {
+            "id": "follow-up-smoke",
+            "command": [protocol.executor.source_path, "smoke"],
+            "platform": platform,
+        },
+    ]
+    if tuple(str(event["id"]) for event in events) != protocol.evidence:
+        raise ExecutorError("executor evidence order does not match the closed protocol")
+    _write_json(transcript_path, {"events": events})
+
+    artifacts = {
+        "transcript": transcript_path,
+        "historic_update_surface": historic_surface_path,
+        "foundation_update_surface": foundation_surface_path,
+        "foundation_receipt": foundation_receipt_path,
+        "follow_up_receipt": follow_receipt_path,
+        "foundation_doctor": foundation_doctor_path,
+        "follow_up_doctor": follow_doctor_path,
+        "follow_up_smoke": smoke_path,
+    }
+    manifest = {
+        "schema_version": 1,
+        "executor": executor_identity,
+        "starting_release": start,
+        "foundation_release": foundation,
+        "follow_up_release": follow_up,
+        "events": events,
+        "artifacts": _artifact_index(evidence_root, artifacts),
+    }
+    manifest_path = evidence_root / "evidence-manifest.json"
+    _write_json(manifest_path, manifest)
+    case = {
+        "starting_tag": start["tag"],
+        "reached_foundation": True,
+        "reached_follow_up": True,
+        "foundation_doctor_healthy": True,
+        "follow_up_doctor_healthy": True,
+        "user_hashes_before": before,
+        "user_hashes_after_foundation": after_foundation,
+        "user_hashes_after_follow_up": after_follow_up,
+        "transcript_path": f"{evidence_root.name}/{transcript_path.name}",
+        "foundation_receipt_path": f"{evidence_root.name}/{foundation_receipt_path.name}",
+        "follow_up_receipt_path": f"{evidence_root.name}/{follow_receipt_path.name}",
+        "foundation_doctor_path": f"{evidence_root.name}/{foundation_doctor_path.name}",
+        "follow_up_doctor_path": f"{evidence_root.name}/{follow_doctor_path.name}",
+        "follow_up_smoke_path": f"{evidence_root.name}/{smoke_path.name}",
+        "platform": platform,
+        "evidence_manifest_path": f"{evidence_root.name}/{manifest_path.name}",
+        "evidence_manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+    }
+    _write_json(evidence_root / "journey-result.json", case)
+    return _authoritative_run(case)
+
+
+def execute_journey(
+    *,
+    repo_root: Path,
+    source_commit: str,
+    vault_root: Path,
+    evidence_root: Path,
+    starting_release: Mapping[str, object],
+    foundation_release: Mapping[str, object],
+    follow_up_release: Mapping[str, object],
+    protocol: UpdateJourneyProtocol,
+    historic_surface: Mapping[str, object],
+    foundation_surface: Mapping[str, object],
+    user_owned_paths: Sequence[str],
+    platform: str,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+    _runtime: JourneyRuntime | None = None,
+) -> ExecutorRun:
+    """Execute one released journey and retain authority in this process."""
+
+    owned_runtime = _runtime is None
+    runtime = _runtime or _ProductionRuntime()
+    try:
+        return _execute_journey_with_runtime(
+            repo_root=repo_root,
+            source_commit=source_commit,
+            vault_root=vault_root,
+            evidence_root=evidence_root,
+            starting_release=starting_release,
+            foundation_release=foundation_release,
+            follow_up_release=follow_up_release,
+            protocol=protocol,
+            historic_surface=historic_surface,
+            foundation_surface=foundation_surface,
+            user_owned_paths=user_owned_paths,
+            platform=platform,
+            input_fn=input_fn,
+            output_fn=output_fn,
+            _runtime=runtime,
+        )
+    finally:
+        if owned_runtime:
+            runtime.close()  # type: ignore[attr-defined]
+
+
+__all__ = [
+    "EXECUTOR_INTERFACE_VERSION",
+    "ExecutorError",
+    "ExecutorRun",
+    "JourneyRuntime",
+    "execute_journey",
+    "is_authoritative_executor_run",
+]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4 or sys.argv[1:3] != ["_runtime-server", "--vault"]:
+        raise SystemExit("released journey executor has no standalone interface")
+    try:
+        raise SystemExit(_runtime_server(Path(sys.argv[3])))
+    except Exception as error:  # noqa: BLE001
+        raise SystemExit(f"fixture lifecycle runtime stopped safely: {error}") from error


### PR DESCRIPTION
## Outcome

Adds the release-owned executor for one historic Dex update journey. A published follow-up release must bind the exact runner, executor, and pinned bridge bytes before any fixture is built.

The executor:
- accepts the generated immutable historic set: 126 exact `dist/release/v…` starts and 42 exact legacy `v…` starts, while rejecting arbitrary or malformed refs
- runs the pinned bridge and only the three declared lifecycle operations inside the verified fixture virtualenv
- records the approvals that actually occur, exact installed identities, lifecycle receipts, Doctor, smoke, user-content hashes, transcript, and content-addressed manifest
- seals process-local authority only on the production-owned runtime path; injected runtimes remain non-authoritative, direct construction cannot mint authority, and nested case data is defensively immutable
- validates the real zero-approval `foundation-already-installed` resume receipt without inventing a transaction ID, while mutating foundation delivery still requires a lifecycle receipt
- keeps the standalone check-report path fail-closed for external evidence

The generated installed-files manifest now includes both the executor and its regression suite.

## Truth boundary

- no 168-case fleet run was performed
- acceptance remains 0/168
- public v1.80.5 has no protocol or executor and remains `machine_executable=false`
- no release, tag, merge, deployment, secret, or fleet acceptance claim is included

## Verification

- current release inventory: 168 cases = 126 `dist/release/v…` + 42 legacy `v…`, no other ref forms
- 59 focused updater protocol/executor/fleet tests pass
- 138 release-fleet, protocol, manifest, package, and distribution tests pass
- all 163 script tests pass with the required project Python runtime
- release build and raw bundle protocol/package tests pass
- real release-shaped vault bundle build passes
- Ruff, Python syntax, generated protocol/manifest drift, PII, and founder-content gates pass
