### PR TITLE
feat: add authenticated historic fleet aggregation

### DIFF
--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -1,0 +1,808 @@
+"""Fail-closed tests for cross-platform historic updater acceptance."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import stat
+import subprocess
+from dataclasses import fields
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import release_fleet
+from scripts.dex_update_bridge import FOUNDATION
+
+
+def _acceptance():
+    try:
+        return importlib.import_module("scripts.release_fleet_acceptance")
+    except ModuleNotFoundError:
+        pytest.fail("release_fleet_acceptance is not implemented")
+
+
+def _release(tag: str, version: str, suffix: str) -> release_fleet.DistributionRelease:
+    return release_fleet.DistributionRelease(
+        tag=tag,
+        version=version,
+        commit=(suffix * 40)[:40],
+        tree=((chr(ord(suffix) + 1)) * 40)[:40],
+    )
+
+
+def _foundation() -> dict[str, str]:
+    return FOUNDATION.identity()
+
+
+def _foundation_release() -> release_fleet.DistributionRelease:
+    identity = FOUNDATION.identity()
+    return release_fleet.DistributionRelease(
+        tag=identity["tag"],
+        version=identity["version"],
+        commit=identity["commit"],
+        tree=identity["tree"],
+    )
+
+
+def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
+    acceptance = _acceptance()
+    historic = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _foundation_release(),
+    )
+    later = (
+        _release("v1.81.0", "1.81.0", "3"),
+        _release("dist/release/v1.81.1-4444444", "1.81.1", "4"),
+    )
+
+    manifest = acceptance.frozen_cohort_manifest(
+        historic + later,
+        foundation=_foundation(),
+        expected_count=2,
+    )
+    parsed = acceptance.releases_from_frozen_cohort(
+        json.dumps(manifest),
+        current_releases=historic + later,
+        foundation=_foundation(),
+        expected_count=2,
+    )
+
+    assert parsed == historic
+    assert manifest["case_count"] == 2
+    assert manifest["foundation"] == _foundation()
+
+
+def test_frozen_cohort_rejects_a_new_release_at_or_before_the_foundation() -> None:
+    acceptance = _acceptance()
+    historic = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _foundation_release(),
+    )
+    manifest = acceptance.frozen_cohort_manifest(
+        historic,
+        foundation=_foundation(),
+        expected_count=2,
+    )
+    unexpected = _release("dist/release/v1.79.0-5555555", "1.79.0", "5")
+
+    with pytest.raises(release_fleet.FleetError, match="unexpected historical release"):
+        acceptance.releases_from_frozen_cohort(
+            json.dumps(manifest),
+            current_releases=historic + (unexpected,),
+            foundation=_foundation(),
+            expected_count=2,
+        )
+
+
+def test_frozen_cohort_rejects_identity_drift_and_wrong_foundation() -> None:
+    acceptance = _acceptance()
+    historic = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _foundation_release(),
+    )
+    manifest = acceptance.frozen_cohort_manifest(
+        historic,
+        foundation=_foundation(),
+        expected_count=2,
+    )
+    changed = release_fleet.DistributionRelease(
+        tag=historic[0].tag,
+        version=historic[0].version,
+        commit="9" * 40,
+        tree=historic[0].tree,
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="historic cohort identity drift"):
+        acceptance.releases_from_frozen_cohort(
+            json.dumps(manifest),
+            current_releases=(changed, historic[1]),
+            foundation=_foundation(),
+            expected_count=2,
+        )
+
+    other_foundation = dict(_foundation(), tree="e" * 40)
+    with pytest.raises(release_fleet.FleetError, match="foundation identity"):
+        acceptance.releases_from_frozen_cohort(
+            json.dumps(manifest),
+            current_releases=historic,
+            foundation=other_foundation,
+            expected_count=2,
+        )
+
+
+def test_frozen_cohort_requires_the_exact_foundation_release() -> None:
+    acceptance = _acceptance()
+    without_foundation = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="foundation release"):
+        acceptance.frozen_cohort_manifest(
+            without_foundation,
+            foundation=_foundation(),
+            expected_count=2,
+        )
+
+
+def test_real_repository_freezes_exactly_168_historic_trees() -> None:
+    acceptance = _acceptance()
+    repository = Path(__file__).resolve().parents[2]
+    current = release_fleet.discover_distribution_releases(repository)
+
+    manifest = acceptance.frozen_cohort_manifest(current)
+
+    assert manifest["case_count"] == acceptance.EXPECTED_HISTORIC_CASES == 168
+    assert manifest["foundation"]["tag"] == "dist/release/v1.80.5-9211053"
+
+
+def _case(tag: str, platform: str) -> release_fleet.CaseResult:
+    hashes = {"00-Inbox/keep.md": "a" * 64}
+    return release_fleet.CaseResult(
+        starting_tag=tag,
+        reached_foundation=True,
+        reached_follow_up=True,
+        foundation_doctor_healthy=True,
+        follow_up_doctor_healthy=True,
+        user_hashes_before=hashes,
+        user_hashes_after_foundation=hashes,
+        user_hashes_after_follow_up=hashes,
+        transcript_path=f"{tag}.evidence/transcript.json",
+        foundation_receipt_path=f"{tag}.evidence/foundation.json",
+        follow_up_receipt_path=f"{tag}.evidence/follow-up.json",
+        foundation_doctor_path=f"{tag}.evidence/foundation-doctor.json",
+        follow_up_doctor_path=f"{tag}.evidence/follow-up-doctor.json",
+        follow_up_smoke_path=f"{tag}.evidence/smoke.json",
+        platform=platform,
+        evidence_manifest_path=f"{tag}.evidence/manifest.json",
+        evidence_manifest_sha256="b" * 64,
+    )
+
+
+def test_platform_report_is_bound_to_one_real_protocol_platform() -> None:
+    acceptance = _acceptance()
+    tags = {"v1.20.1", "dist/release/v1.80.5-2222222"}
+    protocol = SimpleNamespace(platforms=("darwin", "linux"))
+    report = release_fleet.AcceptanceReport(
+        foundation_tag=FOUNDATION.tag,
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        cases=tuple(_case(tag, "darwin") for tag in sorted(tags)),
+        platforms=("darwin",),
+    )
+
+    acceptance.assert_platform_report_bound(
+        report,
+        protocol=protocol,
+        running_platform="darwin",
+        expected_start_tags=tags,
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="running platform"):
+        acceptance.assert_platform_report_bound(
+            report,
+            protocol=protocol,
+            running_platform="linux",
+            expected_start_tags=tags,
+        )
+
+    broad_report = release_fleet.AcceptanceReport(
+        report.foundation_tag,
+        report.follow_up_tag,
+        report.cases,
+        ("darwin", "linux"),
+    )
+    with pytest.raises(release_fleet.FleetError, match="exactly one"):
+        acceptance.assert_platform_report_bound(
+            broad_report,
+            protocol=protocol,
+            running_platform="darwin",
+            expected_start_tags=tags,
+        )
+
+
+def test_platform_report_rejects_a_protocol_platform_subset() -> None:
+    acceptance = _acceptance()
+    report = release_fleet.AcceptanceReport(
+        foundation_tag=FOUNDATION.tag,
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        cases=(_case("v1.20.1", "darwin"),),
+        platforms=("darwin",),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="protocol platforms"):
+        acceptance.assert_platform_report_bound(
+            report,
+            protocol=SimpleNamespace(platforms=("darwin",)),
+            running_platform="darwin",
+            expected_start_tags={"v1.20.1"},
+        )
+
+
+def _signed_session_and_receipts(acceptance, *, expected_count: int = 2):
+    key = bytes(range(32))
+    session = acceptance.create_acceptance_session(
+        cohort_sha256="a" * 64,
+        foundation=_foundation(),
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        source_commit="c" * 40,
+        acceptance_source_sha256="d" * 64,
+        protocol_platforms=("darwin", "linux"),
+        key=key,
+        expected_count=expected_count,
+        session_id="e" * 64,
+    )
+    receipts = [
+        acceptance.sign_platform_receipt(
+            session,
+            platform=platform,
+            case_result_sha256=digest * 64,
+            key=key,
+            started=expected_count,
+            completed=expected_count,
+            passed=expected_count,
+            failed=0,
+        )
+        for platform, digest in (("darwin", "1"), ("linux", "2"))
+    ]
+    return key, session, receipts
+
+
+def test_signed_aggregation_requires_exact_darwin_and_linux_receipts() -> None:
+    acceptance = _acceptance()
+    key, session, receipts = _signed_session_and_receipts(acceptance)
+
+    result = acceptance.aggregate_signed_platform_receipts(
+        session,
+        receipts,
+        key=key,
+        protocol_platforms=("darwin", "linux"),
+        expected_count=2,
+    )
+
+    assert result == {
+        "outcome": "HISTORIC_FLEET_ACCEPTED",
+        "acceptance": True,
+        "platforms": ["darwin", "linux"],
+        "case_count": 2,
+        "journey_count": 4,
+        "discovered": 2,
+        "started": 4,
+        "completed": 4,
+        "passed": 4,
+        "failed": 0,
+        "session_id": "e" * 64,
+    }
+
+    with pytest.raises(release_fleet.FleetError, match="exact protocol platforms"):
+        acceptance.aggregate_signed_platform_receipts(
+            session,
+            [receipts[0]],
+            key=key,
+            protocol_platforms=("darwin", "linux"),
+            expected_count=2,
+        )
+
+    with pytest.raises(release_fleet.FleetError, match="protocol platforms"):
+        acceptance.aggregate_signed_platform_receipts(
+            session,
+            receipts,
+            key=key,
+            protocol_platforms=("darwin",),
+            expected_count=2,
+        )
+
+
+def test_signed_aggregation_rejects_tampering_and_incomplete_counts() -> None:
+    acceptance = _acceptance()
+    key, session, receipts = _signed_session_and_receipts(acceptance)
+    unsigned = [receipt["payload"] for receipt in receipts]
+    with pytest.raises(release_fleet.FleetError, match="signed shape"):
+        acceptance.aggregate_signed_platform_receipts(
+            session,
+            unsigned,
+            key=key,
+            protocol_platforms=("darwin", "linux"),
+            expected_count=2,
+        )
+
+    tampered = json.loads(json.dumps(receipts))
+    tampered[0]["payload"]["passed"] = 1
+
+    with pytest.raises(release_fleet.FleetError, match="signature"):
+        acceptance.aggregate_signed_platform_receipts(
+            session,
+            tampered,
+            key=key,
+            protocol_platforms=("darwin", "linux"),
+            expected_count=2,
+        )
+
+    incomplete = acceptance.sign_platform_receipt(
+        session,
+        platform="darwin",
+        case_result_sha256="1" * 64,
+        key=key,
+        started=2,
+        completed=1,
+        passed=1,
+        failed=1,
+    )
+    with pytest.raises(release_fleet.FleetError, match="incomplete or failed"):
+        acceptance.aggregate_signed_platform_receipts(
+            session,
+            [incomplete, receipts[1]],
+            key=key,
+            protocol_platforms=("darwin", "linux"),
+            expected_count=2,
+        )
+
+
+def _case_document(case: release_fleet.CaseResult) -> dict[str, object]:
+    return {field.name: getattr(case, field.name) for field in fields(case)}
+
+
+def test_platform_collector_retains_every_live_run_and_exact_counts(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+    )
+    created: list[object] = []
+
+    def journey_runner(
+        _repo: Path,
+        *,
+        output: Path,
+        starting_tag: str,
+        foundation_tag: str,
+        follow_up_tag: str,
+    ) -> object:
+        assert output == tmp_path
+        assert foundation_tag == FOUNDATION.tag
+        assert follow_up_tag == "dist/release/v1.81.1-3333333"
+        run = SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
+        created.append(run)
+        return run
+
+    execution = acceptance.collect_platform_runs(
+        tmp_path,
+        output=tmp_path,
+        releases=releases,
+        foundation_tag=FOUNDATION.tag,
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        running_platform="darwin",
+        journey_runner=journey_runner,
+    )
+
+    assert execution.executor_runs == tuple(created)
+    assert [case.starting_tag for case in execution.report.cases] == [release.tag for release in releases]
+    assert execution.report.platforms == ("darwin",)
+    assert execution.counts == {
+        "discovered": 2,
+        "started": 2,
+        "completed": 2,
+        "passed": 2,
+        "failed": 0,
+    }
+
+
+def test_platform_collector_stops_on_first_failure_with_honest_counts(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+    )
+
+    def journey_runner(
+        _repo: Path,
+        *,
+        output: Path,
+        starting_tag: str,
+        foundation_tag: str,
+        follow_up_tag: str,
+    ) -> object:
+        del output, foundation_tag, follow_up_tag
+        if starting_tag == releases[1].tag:
+            raise release_fleet.FleetError("synthetic journey failed")
+        return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
+
+    with pytest.raises(acceptance.PlatformFleetFailure) as failure:
+        acceptance.collect_platform_runs(
+            tmp_path,
+            output=tmp_path,
+            releases=releases,
+            foundation_tag=FOUNDATION.tag,
+            follow_up_tag="dist/release/v1.81.1-3333333",
+            running_platform="darwin",
+            journey_runner=journey_runner,
+        )
+
+    assert failure.value.counts == {
+        "discovered": 2,
+        "started": 2,
+        "completed": 1,
+        "passed": 1,
+        "failed": 1,
+    }
+
+
+def _immutable_foundation() -> release_fleet.ImmutableRelease:
+    identity = FOUNDATION.identity()
+    return release_fleet.ImmutableRelease(
+        identity["tag"],
+        identity["tag_object"],
+        identity["commit"],
+        identity["tree"],
+        identity["version"],
+    )
+
+
+def _immutable_follow_up() -> release_fleet.ImmutableRelease:
+    return release_fleet.ImmutableRelease(
+        "dist/release/v1.81.1-3333333",
+        "3" * 40,
+        "3333333" + "4" * 33,
+        "5" * 40,
+        "1.81.1",
+    )
+
+
+def test_forged_executor_runs_cannot_mint_a_platform_receipt(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, _receipts = _signed_session_and_receipts(
+        acceptance,
+        expected_count=2,
+    )
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+    )
+    execution = acceptance.collect_platform_runs(
+        tmp_path,
+        output=tmp_path,
+        releases=releases,
+        foundation_tag=FOUNDATION.tag,
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        running_platform="darwin",
+        journey_runner=lambda _repo, **kwargs: SimpleNamespace(
+            case=_case_document(_case(str(kwargs["starting_tag"]), "darwin"))
+        ),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="executor authority"):
+        acceptance.finalize_live_platform_execution(
+            execution,
+            repo=tmp_path,
+            evidence_root=tmp_path,
+            foundation=_immutable_foundation(),
+            follow_up=_immutable_follow_up(),
+            protocol=SimpleNamespace(platforms=("darwin", "linux")),
+            expected_start_tags={release.tag for release in releases},
+            session=session,
+            key=key,
+            cohort_sha256="a" * 64,
+            source_commit="c" * 40,
+            acceptance_source_sha256="d" * 64,
+            expected_count=2,
+        )
+
+
+def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, _receipts = _signed_session_and_receipts(
+        acceptance,
+        expected_count=2,
+    )
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+    )
+    execution = acceptance.collect_platform_runs(
+        tmp_path,
+        output=tmp_path,
+        releases=releases,
+        foundation_tag=FOUNDATION.tag,
+        follow_up_tag="dist/release/v1.81.1-3333333",
+        running_platform="darwin",
+        journey_runner=lambda _repo, **kwargs: SimpleNamespace(
+            case=_case_document(_case(str(kwargs["starting_tag"]), "darwin"))
+        ),
+    )
+    monkeypatch.setattr(release_fleet, "assert_evidence_bound", lambda *args, **kwargs: None)
+
+    with pytest.raises(release_fleet.FleetError, match="validator changed"):
+        acceptance.finalize_live_platform_execution(
+            execution,
+            repo=tmp_path,
+            evidence_root=tmp_path,
+            foundation=_immutable_foundation(),
+            follow_up=_immutable_follow_up(),
+            protocol=SimpleNamespace(platforms=("darwin", "linux")),
+            expected_start_tags={release.tag for release in releases},
+            session=session,
+            key=key,
+            cohort_sha256="a" * 64,
+            source_commit="c" * 40,
+            acceptance_source_sha256="d" * 64,
+            expected_count=2,
+        )
+
+
+def test_session_key_file_is_private_and_rejects_symlinks(tmp_path: Path) -> None:
+    acceptance = _acceptance()
+    key_path = tmp_path / "acceptance.key"
+    key = bytes(range(32))
+
+    acceptance.write_session_key(key_path, key=key)
+
+    assert acceptance.read_session_key(key_path) == key
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    with pytest.raises(release_fleet.FleetError, match="already exists"):
+        acceptance.write_session_key(key_path, key=key)
+
+    key_path.unlink()
+    target = tmp_path / "target.key"
+    target.write_bytes(key)
+    key_path.symlink_to(target)
+    with pytest.raises(release_fleet.FleetError, match="unsafe"):
+        acceptance.read_session_key(key_path)
+
+
+def test_cohort_cli_writes_the_exact_168_tree_manifest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    acceptance = _acceptance()
+    repository = Path(__file__).resolve().parents[2]
+    output = tmp_path / "historic-through-v1.80.5.json"
+
+    exit_code = acceptance.main(["cohort", "--repo", str(repository), "--output", str(output)])
+
+    result = json.loads(capsys.readouterr().out)
+    manifest = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert result == {
+        "acceptance": False,
+        "case_count": 168,
+        "foundation_tag": FOUNDATION.tag,
+        "outcome": "HISTORIC_COHORT_FROZEN",
+        "output": str(output),
+    }
+    assert manifest["case_count"] == 168
+
+
+def test_acceptance_source_is_bound_to_exact_publisher_commit_bytes(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    repository = tmp_path / "publisher"
+    source = repository / "scripts" / "release_fleet_acceptance.py"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(Path(acceptance.__file__).read_bytes())
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "Dex Fleet Test"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "config",
+            "user.email",
+            "fleet@example.com",
+        ],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repository), "add", str(source)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", "exact publisher source"],
+        check=True,
+    )
+    exact_commit = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    digest = acceptance.verify_acceptance_source_bound(repository, exact_commit)
+
+    assert digest == hashlib.sha256(source.read_bytes()).hexdigest()
+    source.write_text("# changed publisher source\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", str(source)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", "changed publisher source"],
+        check=True,
+    )
+    changed_commit = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    with pytest.raises(release_fleet.FleetError, match="acceptance orchestrator bytes"):
+        acceptance.verify_acceptance_source_bound(repository, changed_commit)
+
+
+def test_full_command_surface_aggregates_two_live_platform_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    acceptance = _acceptance()
+    releases = tuple(
+        _release(f"v1.0.{index}", f"1.0.{index}", f"{index % 10}")
+        for index in range(1, acceptance.EXPECTED_HISTORIC_CASES + 1)
+    )
+    foundation = _immutable_foundation()
+    follow_up = _immutable_follow_up()
+    protocol = SimpleNamespace(platforms=("darwin", "linux"))
+    inputs = acceptance.FleetInputs(
+        releases=releases,
+        foundation=foundation,
+        follow_up=follow_up,
+        protocol=protocol,
+        source_commit="c" * 40,
+        acceptance_source_sha256="d" * 64,
+        cohort_sha256="a" * 64,
+    )
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+    session_path = tmp_path / "session.json"
+    key_path = tmp_path / "session.key"
+
+    assert (
+        acceptance.main(
+            [
+                "session",
+                "--repo",
+                str(tmp_path),
+                "--cohort",
+                str(tmp_path / "cohort.json"),
+                "--foundation-tag",
+                foundation.tag,
+                "--follow-up-tag",
+                follow_up.tag,
+                "--session-output",
+                str(session_path),
+                "--key-output",
+                str(key_path),
+            ]
+        )
+        == 0
+    )
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    capsys.readouterr()
+
+    def collect(*args, running_platform: str, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(
+            report=SimpleNamespace(platforms=(running_platform,)),
+            counts={
+                "discovered": 168,
+                "started": 168,
+                "completed": 168,
+                "passed": 168,
+                "failed": 0,
+            },
+        )
+
+    def finalize(execution, **kwargs):
+        return acceptance.sign_platform_receipt(
+            kwargs["session"],
+            platform=execution.report.platforms[0],
+            case_result_sha256=("1" if execution.report.platforms[0] == "darwin" else "2") * 64,
+            key=kwargs["key"],
+            started=168,
+            completed=168,
+            passed=168,
+            failed=0,
+        )
+
+    monkeypatch.setattr(acceptance, "collect_platform_runs", collect)
+    monkeypatch.setattr(acceptance, "finalize_live_platform_execution", finalize)
+    receipt_paths: list[Path] = []
+    for platform in ("darwin", "linux"):
+        monkeypatch.setattr(acceptance, "_running_platform", lambda value=platform: value)
+        receipt_path = tmp_path / f"{platform}.receipt.json"
+        receipt_paths.append(receipt_path)
+        assert (
+            acceptance.main(
+                [
+                    "platform",
+                    "--repo",
+                    str(tmp_path),
+                    "--cohort",
+                    str(tmp_path / "cohort.json"),
+                    "--foundation-tag",
+                    foundation.tag,
+                    "--follow-up-tag",
+                    follow_up.tag,
+                    "--session",
+                    str(session_path),
+                    "--key",
+                    str(key_path),
+                    "--output",
+                    str(tmp_path / platform),
+                    "--receipt-output",
+                    str(receipt_path),
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+    aggregate_path = tmp_path / "aggregate.json"
+    assert (
+        acceptance.main(
+            [
+                "aggregate",
+                "--repo",
+                str(tmp_path),
+                "--cohort",
+                str(tmp_path / "cohort.json"),
+                "--foundation-tag",
+                foundation.tag,
+                "--follow-up-tag",
+                follow_up.tag,
+                "--session",
+                str(session_path),
+                "--key",
+                str(key_path),
+                "--receipt",
+                str(receipt_paths[0]),
+                "--receipt",
+                str(receipt_paths[1]),
+                "--output",
+                str(aggregate_path),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(aggregate_path.read_text(encoding="utf-8"))
+    assert result == {
+        "acceptance": True,
+        "case_count": 168,
+        "completed": 336,
+        "discovered": 168,
+        "failed": 0,
+        "journey_count": 336,
+        "outcome": "HISTORIC_FLEET_ACCEPTED",
+        "passed": 336,
+        "platforms": ["darwin", "linux"],
+        "session_id": session["payload"]["session_id"],
+        "started": 336,
+    }

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import inspect
 import json
 import stat
 import subprocess
@@ -241,122 +242,438 @@ def test_platform_report_rejects_a_protocol_platform_subset() -> None:
         )
 
 
-def _signed_session_and_receipts(acceptance, *, expected_count: int = 2):
+def _fleet_inputs() -> tuple[object, tuple[release_fleet.DistributionRelease, ...]]:
+    acceptance = _acceptance()
+    releases = tuple(
+        _release(f"v1.0.{index}", f"1.0.{index}", f"{index % 10}")
+        for index in range(1, acceptance.EXPECTED_HISTORIC_CASES + 1)
+    )
+    return (
+        acceptance.FleetInputs(
+            releases=releases,
+            foundation=_immutable_foundation(),
+            follow_up=_immutable_follow_up(),
+            protocol=SimpleNamespace(platforms=("darwin", "linux")),
+            source_commit="c" * 40,
+            acceptance_source_sha256="d" * 64,
+            cohort_sha256="a" * 64,
+        ),
+        releases,
+    )
+
+
+def _signed_session(acceptance):
+    inputs, _releases = _fleet_inputs()
     key = bytes(range(32))
     session = acceptance.create_acceptance_session(
-        cohort_sha256="a" * 64,
-        foundation=_foundation(),
-        follow_up_tag="dist/release/v1.81.1-3333333",
-        source_commit="c" * 40,
-        acceptance_source_sha256="d" * 64,
-        protocol_platforms=("darwin", "linux"),
+        cohort_sha256=inputs.cohort_sha256,
+        foundation=inputs.foundation.identity(),
+        follow_up_tag=inputs.follow_up.tag,
+        source_commit=inputs.source_commit,
+        acceptance_source_sha256=inputs.acceptance_source_sha256,
+        protocol_platforms=inputs.protocol.platforms,
         key=key,
-        expected_count=expected_count,
         session_id="e" * 64,
     )
-    receipts = [
-        acceptance.sign_platform_receipt(
-            session,
-            platform=platform,
-            case_result_sha256=digest * 64,
-            key=key,
-            started=expected_count,
-            completed=expected_count,
-            passed=expected_count,
-            failed=0,
-        )
-        for platform, digest in (("darwin", "1"), ("linux", "2"))
-    ]
-    return key, session, receipts
+    return key, session, inputs
 
 
-def test_signed_aggregation_requires_exact_darwin_and_linux_receipts() -> None:
+def _manifest_document(
+    *,
+    inputs: object,
+    platform: str,
+    session_id: str = "e" * 64,
+    cases: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
     acceptance = _acceptance()
-    key, session, receipts = _signed_session_and_receipts(acceptance)
+    if cases is None:
+        cases = [
+            _case_document(_case(release.tag, platform))
+            for release in inputs.releases
+        ]
+    return {
+        "schema_version": acceptance.PLATFORM_MANIFEST_SCHEMA_VERSION,
+        "outcome": "HISTORIC_PLATFORM_EVIDENCE",
+        "acceptance": False,
+        "session_id": session_id,
+        "platform": platform,
+        "cohort_sha256": inputs.cohort_sha256,
+        "foundation": inputs.foundation.identity(),
+        "follow_up_tag": inputs.follow_up.tag,
+        "source_commit": inputs.source_commit,
+        "acceptance_source_sha256": inputs.acceptance_source_sha256,
+        "report": {
+            "foundation_tag": inputs.foundation.tag,
+            "follow_up_tag": inputs.follow_up.tag,
+            "platforms": [platform],
+            "cases": cases,
+        },
+    }
 
-    result = acceptance.aggregate_signed_platform_receipts(
+
+def _write_authored_platform_evidence(
+    acceptance,
+    root: Path,
+    *,
+    session: object,
+    key: bytes,
+    inputs: object,
+    platform: str,
+    manifest: dict[str, object] | None = None,
+) -> tuple[Path, dict[str, object]]:
+    document = (
+        _manifest_document(inputs=inputs, platform=platform)
+        if manifest is None
+        else manifest
+    )
+    manifest_path = root / f"{platform}.manifest.json"
+    manifest_bytes = acceptance._json_bytes(document)
+    manifest_path.write_bytes(manifest_bytes)
+    manifest_path.chmod(0o444)
+    session_id = session["payload"]["session_id"]
+    receipt = acceptance._sign(
+        {
+            "schema_version": 1,
+            "session_id": session_id,
+            "platform": platform,
+            "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        },
+        key,
+    )
+    return manifest_path, receipt
+
+
+def test_serialized_platform_evidence_is_never_an_acceptance_authority(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform=platform,
+        )
+        for platform in ("darwin", "linux")
+    ]
+
+    result = acceptance.aggregate_platform_evidence(
         session,
-        receipts,
+        [receipt for _manifest, receipt in evidence],
+        [manifest for manifest, _receipt in evidence],
         key=key,
-        protocol_platforms=("darwin", "linux"),
-        expected_count=2,
+        inputs=inputs,
     )
 
     assert result == {
-        "outcome": "HISTORIC_FLEET_ACCEPTED",
-        "acceptance": True,
+        "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
+        "acceptance": False,
+        "authority_complete": False,
         "platforms": ["darwin", "linux"],
-        "case_count": 2,
-        "journey_count": 4,
-        "discovered": 2,
-        "started": 4,
-        "completed": 4,
-        "passed": 4,
+        "case_count": 168,
+        "journey_count": 336,
+        "discovered": 168,
+        "started": 336,
+        "completed": 336,
+        "passed": 336,
         "failed": 0,
         "session_id": "e" * 64,
+        "required_job_conclusions": {
+            "darwin": "historic-fleet-darwin",
+            "linux": "historic-fleet-linux",
+        },
     }
+    assert not hasattr(acceptance, "sign_platform_receipt")
+    source = Path(acceptance.__file__).read_text(encoding="utf-8")
+    assert '"acceptance": True' not in source
+    assert "HISTORIC_FLEET_ACCEPTED" not in source
+
+
+def test_possession_of_the_shared_key_cannot_sign_an_accepted_receipt(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform=platform,
+        )
+        for platform in ("darwin", "linux")
+    ]
+
+    result = acceptance.aggregate_platform_evidence(
+        session,
+        [receipt for _manifest, receipt in evidence],
+        [manifest for manifest, _receipt in evidence],
+        key=key,
+        inputs=inputs,
+    )
+
+    assert result["acceptance"] is False
+    assert result["authority_complete"] is False
+
+
+def test_aggregation_requires_exact_darwin_and_linux_evidence(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    darwin = _write_authored_platform_evidence(
+        acceptance,
+        tmp_path,
+        session=session,
+        key=key,
+        inputs=inputs,
+        platform="darwin",
+    )
+    linux = _write_authored_platform_evidence(
+        acceptance,
+        tmp_path,
+        session=session,
+        key=key,
+        inputs=inputs,
+        platform="linux",
+    )
 
     with pytest.raises(release_fleet.FleetError, match="exact protocol platforms"):
-        acceptance.aggregate_signed_platform_receipts(
+        acceptance.aggregate_platform_evidence(
             session,
-            [receipts[0]],
+            [darwin[1]],
+            [darwin[0]],
             key=key,
-            protocol_platforms=("darwin", "linux"),
-            expected_count=2,
+            inputs=inputs,
         )
 
-    with pytest.raises(release_fleet.FleetError, match="protocol platforms"):
-        acceptance.aggregate_signed_platform_receipts(
+    with pytest.raises(release_fleet.FleetError, match="exact protocol platforms"):
+        acceptance.aggregate_platform_evidence(
             session,
-            receipts,
+            [darwin[1], darwin[1]],
+            [darwin[0], linux[0]],
             key=key,
-            protocol_platforms=("darwin",),
-            expected_count=2,
+            inputs=inputs,
         )
 
 
-def test_signed_aggregation_rejects_tampering_and_incomplete_counts() -> None:
+def test_receipts_reject_caller_supplied_counts_and_case_digests(
+    tmp_path: Path,
+) -> None:
     acceptance = _acceptance()
-    key, session, receipts = _signed_session_and_receipts(acceptance)
-    unsigned = [receipt["payload"] for receipt in receipts]
+    key, session, inputs = _signed_session(acceptance)
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform=platform,
+        )
+        for platform in ("darwin", "linux")
+    ]
+    forged_receipts = [json.loads(json.dumps(receipt)) for _path, receipt in evidence]
+    forged_receipts[0]["payload"]["started"] = 168
+    forged_receipts[0]["payload"]["case_result_sha256"] = "f" * 64
+    forged_receipts[0] = acceptance._sign(forged_receipts[0]["payload"], key)
+
     with pytest.raises(release_fleet.FleetError, match="signed shape"):
-        acceptance.aggregate_signed_platform_receipts(
+        acceptance.aggregate_platform_evidence(
             session,
-            unsigned,
+            forged_receipts,
+            [path for path, _receipt in evidence],
             key=key,
-            protocol_platforms=("darwin", "linux"),
-            expected_count=2,
+            inputs=inputs,
         )
 
-    tampered = json.loads(json.dumps(receipts))
-    tampered[0]["payload"]["passed"] = 1
 
-    with pytest.raises(release_fleet.FleetError, match="signature"):
-        acceptance.aggregate_signed_platform_receipts(
-            session,
-            tampered,
+def test_aggregation_reopens_and_hashes_the_immutable_manifest(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
             key=key,
-            protocol_platforms=("darwin", "linux"),
-            expected_count=2,
+            inputs=inputs,
+            platform=platform,
+        )
+        for platform in ("darwin", "linux")
+    ]
+    evidence[0][0].chmod(0o644)
+    document = json.loads(evidence[0][0].read_text(encoding="utf-8"))
+    document["session_id"] = "f" * 64
+    evidence[0][0].write_text(json.dumps(document), encoding="utf-8")
+    evidence[0][0].chmod(0o444)
+
+    with pytest.raises(release_fleet.FleetError, match="manifest hash"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [path for path, _receipt in evidence],
+            key=key,
+            inputs=inputs,
         )
 
-    incomplete = acceptance.sign_platform_receipt(
-        session,
+
+@pytest.mark.parametrize("mutation", ("167", "169", "substitution", "duplicate"))
+def test_aggregation_requires_exactly_168_unique_final_starts_per_platform(
+    mutation: str,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    darwin = _manifest_document(inputs=inputs, platform="darwin")
+    cases = darwin["report"]["cases"]
+    assert isinstance(cases, list)
+    if mutation == "167":
+        cases.pop()
+    elif mutation == "169":
+        cases.append(_case_document(_case("v9.9.9", "darwin")))
+    elif mutation == "substitution":
+        cases[0] = _case_document(_case("v9.9.9", "darwin"))
+    else:
+        cases[0] = dict(cases[1])
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform="darwin",
+            manifest=darwin,
+        ),
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform="linux",
+        ),
+    ]
+
+    with pytest.raises(release_fleet.FleetError, match="historic release|case count"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [path for path, _receipt in evidence],
+            key=key,
+            inputs=inputs,
+        )
+
+
+def test_aggregation_rejects_mixed_sessions_and_platform_spoofing(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    wrong_session = _manifest_document(
+        inputs=inputs,
         platform="darwin",
-        case_result_sha256="1" * 64,
-        key=key,
-        started=2,
-        completed=1,
-        passed=1,
-        failed=1,
+        session_id="f" * 64,
     )
-    with pytest.raises(release_fleet.FleetError, match="incomplete or failed"):
-        acceptance.aggregate_signed_platform_receipts(
-            session,
-            [incomplete, receipts[1]],
+    spoofed = _manifest_document(inputs=inputs, platform="linux")
+    spoofed_report = spoofed["report"]
+    assert isinstance(spoofed_report, dict)
+    spoofed_report["platforms"] = ["darwin"]
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
             key=key,
-            protocol_platforms=("darwin", "linux"),
-            expected_count=2,
+            inputs=inputs,
+            platform="darwin",
+            manifest=wrong_session,
+        ),
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform="linux",
+            manifest=spoofed,
+        ),
+    ]
+
+    with pytest.raises(release_fleet.FleetError, match="session|platform"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [path for path, _receipt in evidence],
+            key=key,
+            inputs=inputs,
+        )
+
+
+def test_aggregation_rejects_preflight_authored_symlink_and_writable_manifests(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    preflight = _manifest_document(inputs=inputs, platform="darwin")
+    preflight["authoritative_executor_run"] = False
+    evidence = [
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform="darwin",
+            manifest=preflight,
+        ),
+        _write_authored_platform_evidence(
+            acceptance,
+            tmp_path,
+            session=session,
+            key=key,
+            inputs=inputs,
+            platform="linux",
+        ),
+    ]
+
+    with pytest.raises(release_fleet.FleetError, match="manifest shape"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [path for path, _receipt in evidence],
+            key=key,
+            inputs=inputs,
+        )
+
+    real = evidence[0][0]
+    link = tmp_path / "linked.manifest.json"
+    link.symlink_to(real)
+    with pytest.raises(release_fleet.FleetError, match="immutable"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [link, evidence[1][0]],
+            key=key,
+            inputs=inputs,
+        )
+
+    real.chmod(0o644)
+    with pytest.raises(release_fleet.FleetError, match="immutable"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [receipt for _path, receipt in evidence],
+            [real, evidence[1][0]],
+            key=key,
+            inputs=inputs,
         )
 
 
@@ -478,23 +795,17 @@ def test_forged_executor_runs_cannot_mint_a_platform_receipt(
     tmp_path: Path,
 ) -> None:
     acceptance = _acceptance()
-    key, session, _receipts = _signed_session_and_receipts(
-        acceptance,
-        expected_count=2,
-    )
-    releases = (
-        _release("v1.20.1", "1.20.1", "1"),
-        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
-    )
+    key, session, inputs = _signed_session(acceptance)
+    running_platform = acceptance._running_platform()
     execution = acceptance.collect_platform_runs(
         tmp_path,
         output=tmp_path,
-        releases=releases,
+        releases=inputs.releases,
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
-        running_platform="darwin",
+        running_platform=running_platform,
         journey_runner=lambda _repo, **kwargs: SimpleNamespace(
-            case=_case_document(_case(str(kwargs["starting_tag"]), "darwin"))
+            case=_case_document(_case(str(kwargs["starting_tag"]), running_platform))
         ),
     )
 
@@ -503,17 +814,25 @@ def test_forged_executor_runs_cannot_mint_a_platform_receipt(
             execution,
             repo=tmp_path,
             evidence_root=tmp_path,
-            foundation=_immutable_foundation(),
-            follow_up=_immutable_follow_up(),
-            protocol=SimpleNamespace(platforms=("darwin", "linux")),
-            expected_start_tags={release.tag for release in releases},
+            inputs=inputs,
             session=session,
             key=key,
-            cohort_sha256="a" * 64,
-            source_commit="c" * 40,
-            acceptance_source_sha256="d" * 64,
-            expected_count=2,
         )
+    assert not (tmp_path / "platform-manifest.json").exists()
+    assert not (tmp_path / "platform-receipt.json").exists()
+
+
+def test_live_finalizer_does_not_accept_caller_counts_digests_or_start_tags() -> None:
+    acceptance = _acceptance()
+
+    assert set(inspect.signature(acceptance.finalize_live_platform_execution).parameters) == {
+        "execution",
+        "repo",
+        "evidence_root",
+        "inputs",
+        "session",
+        "key",
+    }
 
 
 def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
@@ -521,10 +840,8 @@ def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
     tmp_path: Path,
 ) -> None:
     acceptance = _acceptance()
-    key, session, _receipts = _signed_session_and_receipts(
-        acceptance,
-        expected_count=2,
-    )
+    key, session, inputs = _signed_session(acceptance)
+    running_platform = acceptance._running_platform()
     releases = (
         _release("v1.20.1", "1.20.1", "1"),
         _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
@@ -535,9 +852,9 @@ def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
         releases=releases,
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
-        running_platform="darwin",
+        running_platform=running_platform,
         journey_runner=lambda _repo, **kwargs: SimpleNamespace(
-            case=_case_document(_case(str(kwargs["starting_tag"]), "darwin"))
+            case=_case_document(_case(str(kwargs["starting_tag"]), running_platform))
         ),
     )
     monkeypatch.setattr(release_fleet, "assert_evidence_bound", lambda *args, **kwargs: None)
@@ -547,17 +864,68 @@ def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
             execution,
             repo=tmp_path,
             evidence_root=tmp_path,
-            foundation=_immutable_foundation(),
-            follow_up=_immutable_follow_up(),
-            protocol=SimpleNamespace(platforms=("darwin", "linux")),
-            expected_start_tags={release.tag for release in releases},
+            inputs=inputs,
             session=session,
             key=key,
-            cohort_sha256="a" * 64,
-            source_commit="c" * 40,
-            acceptance_source_sha256="d" * 64,
-            expected_count=2,
         )
+
+
+def test_live_finalization_rejects_a_spoofed_host_platform(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    key, session, inputs = _signed_session(acceptance)
+    running_platform = acceptance._running_platform()
+    spoofed_platform = "linux" if running_platform == "darwin" else "darwin"
+    tag = "v1.20.1"
+    execution = acceptance.PlatformExecution(
+        release_fleet.AcceptanceReport(
+            foundation_tag=FOUNDATION.tag,
+            follow_up_tag="dist/release/v1.81.1-3333333",
+            cases=(_case(tag, spoofed_platform),),
+            platforms=(spoofed_platform,),
+        ),
+        (),
+        {
+            "discovered": 168,
+            "started": 168,
+            "completed": 168,
+            "passed": 168,
+            "failed": 0,
+        },
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="running platform"):
+        acceptance.finalize_live_platform_execution(
+            execution,
+            repo=tmp_path,
+            evidence_root=tmp_path,
+            inputs=inputs,
+            session=session,
+            key=key,
+        )
+    assert not (tmp_path / "platform-manifest.json").exists()
+    assert not (tmp_path / "platform-receipt.json").exists()
+
+
+def test_platform_controller_creates_one_private_non_resumable_run_root(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    root = tmp_path / "run"
+
+    acceptance._create_private_run_root(root)
+
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    with pytest.raises(release_fleet.FleetError, match="already exists"):
+        acceptance._create_private_run_root(root)
+
+    unsafe_parent = tmp_path / "linked-parent"
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    unsafe_parent.symlink_to(real_parent, target_is_directory=True)
+    with pytest.raises(release_fleet.FleetError, match="parent is unsafe"):
+        acceptance._create_private_run_root(unsafe_parent / "run")
 
 
 def test_session_key_file_is_private_and_rejects_symlinks(tmp_path: Path) -> None:
@@ -658,7 +1026,7 @@ def test_acceptance_source_is_bound_to_exact_publisher_commit_bytes(
         acceptance.verify_acceptance_source_bound(repository, changed_commit)
 
 
-def test_full_command_surface_aggregates_two_live_platform_receipts(
+def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -721,24 +1089,47 @@ def test_full_command_surface_aggregates_two_live_platform_receipts(
         )
 
     def finalize(execution, **kwargs):
-        return acceptance.sign_platform_receipt(
-            kwargs["session"],
-            platform=execution.report.platforms[0],
-            case_result_sha256=("1" if execution.report.platforms[0] == "darwin" else "2") * 64,
-            key=kwargs["key"],
-            started=168,
-            completed=168,
-            passed=168,
-            failed=0,
+        platform = execution.report.platforms[0]
+        manifest = _manifest_document(
+            inputs=inputs,
+            platform=platform,
+            session_id=kwargs["session"]["payload"]["session_id"],
         )
+        manifest_bytes = acceptance._json_bytes(manifest)
+        manifest_output = kwargs["evidence_root"] / acceptance.PLATFORM_MANIFEST_NAME
+        receipt_output = kwargs["evidence_root"] / acceptance.PLATFORM_RECEIPT_NAME
+        manifest_output.write_bytes(manifest_bytes)
+        manifest_output.chmod(0o444)
+        receipt = acceptance._sign(
+            {
+                "schema_version": 1,
+                "session_id": kwargs["session"]["payload"]["session_id"],
+                "platform": platform,
+                "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+            },
+            kwargs["key"],
+        )
+        receipt_output.write_bytes(acceptance._json_bytes(receipt))
+        receipt_output.chmod(0o444)
+        return {
+            "acceptance": False,
+            "platform": platform,
+            "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+            "manifest_output": str(manifest_output),
+            "receipt_output": str(receipt_output),
+        }
 
     monkeypatch.setattr(acceptance, "collect_platform_runs", collect)
     monkeypatch.setattr(acceptance, "finalize_live_platform_execution", finalize)
     receipt_paths: list[Path] = []
+    manifest_paths: list[Path] = []
     for platform in ("darwin", "linux"):
         monkeypatch.setattr(acceptance, "_running_platform", lambda value=platform: value)
-        receipt_path = tmp_path / f"{platform}.receipt.json"
+        platform_root = tmp_path / platform
+        receipt_path = platform_root / acceptance.PLATFORM_RECEIPT_NAME
+        manifest_path = platform_root / acceptance.PLATFORM_MANIFEST_NAME
         receipt_paths.append(receipt_path)
+        manifest_paths.append(manifest_path)
         assert (
             acceptance.main(
                 [
@@ -756,9 +1147,7 @@ def test_full_command_surface_aggregates_two_live_platform_receipts(
                     "--key",
                     str(key_path),
                     "--output",
-                    str(tmp_path / platform),
-                    "--receipt-output",
-                    str(receipt_path),
+                    str(platform_root),
                 ]
             )
             == 0
@@ -786,6 +1175,10 @@ def test_full_command_surface_aggregates_two_live_platform_receipts(
                 str(receipt_paths[0]),
                 "--receipt",
                 str(receipt_paths[1]),
+                "--manifest",
+                str(manifest_paths[0]),
+                "--manifest",
+                str(manifest_paths[1]),
                 "--output",
                 str(aggregate_path),
             ]
@@ -794,15 +1187,20 @@ def test_full_command_surface_aggregates_two_live_platform_receipts(
     )
     result = json.loads(aggregate_path.read_text(encoding="utf-8"))
     assert result == {
-        "acceptance": True,
+        "acceptance": False,
+        "authority_complete": False,
         "case_count": 168,
         "completed": 336,
         "discovered": 168,
         "failed": 0,
         "journey_count": 336,
-        "outcome": "HISTORIC_FLEET_ACCEPTED",
+        "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
         "passed": 336,
         "platforms": ["darwin", "linux"],
+        "required_job_conclusions": {
+            "darwin": "historic-fleet-darwin",
+            "linux": "historic-fleet-linux",
+        },
         "session_id": session["payload"]["session_id"],
         "started": 336,
     }

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -1,0 +1,1008 @@
+#!/usr/bin/env python3
+"""Fail-closed orchestration for the cross-platform historic updater fleet."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.update.journey_protocol import (
+    SUPPORTED_PLATFORMS,
+    JourneyProtocolError,
+    load_update_journey_protocol,
+)
+from scripts import release_fleet
+from scripts.dex_update_bridge import FOUNDATION
+
+EXPECTED_HISTORIC_CASES = 168
+COHORT_SCHEMA_VERSION = 1
+ACCEPTANCE_SOURCE = "scripts/release_fleet_acceptance.py"
+_COHORT_FIELDS = frozenset({"schema_version", "foundation", "case_count", "cases"})
+_RELEASE_FIELDS = frozenset({"tag", "version", "commit", "tree"})
+_SEMVER = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)$"
+)
+_HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+_SIGNED_FIELDS = frozenset({"payload", "signature"})
+_SESSION_FIELDS = frozenset(
+    {
+        "schema_version",
+        "session_id",
+        "cohort_sha256",
+        "foundation",
+        "follow_up_tag",
+        "source_commit",
+        "acceptance_source_sha256",
+        "platforms",
+        "case_count",
+        "journey_count",
+    }
+)
+_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "session_id",
+        "platform",
+        "cohort_sha256",
+        "foundation_tag",
+        "follow_up_tag",
+        "source_commit",
+        "acceptance_source_sha256",
+        "case_count",
+        "started",
+        "completed",
+        "passed",
+        "failed",
+        "case_result_sha256",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PlatformExecution:
+    """One process's in-memory report and still-live executor capabilities."""
+
+    report: release_fleet.AcceptanceReport
+    executor_runs: tuple[object, ...]
+    counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class FleetInputs:
+    """All immutable identities shared by one acceptance session."""
+
+    releases: tuple[release_fleet.DistributionRelease, ...]
+    foundation: release_fleet.ImmutableRelease
+    follow_up: release_fleet.ImmutableRelease
+    protocol: object
+    source_commit: str
+    acceptance_source_sha256: str
+    cohort_sha256: str
+
+
+class PlatformFleetFailure(release_fleet.FleetError):
+    """One platform stopped before its complete live verdict."""
+
+    def __init__(self, message: str, counts: Mapping[str, int]) -> None:
+        super().__init__(message)
+        self.counts = dict(counts)
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    match = _SEMVER.fullmatch(value)
+    if match is None:
+        raise release_fleet.FleetError(f"historic release has invalid version: {value}")
+    return tuple(int(match[name]) for name in ("major", "minor", "patch"))
+
+
+def _release_document(release: release_fleet.DistributionRelease) -> dict[str, str]:
+    return {
+        "tag": release.tag,
+        "version": release.version,
+        "commit": release.commit,
+        "tree": release.tree,
+    }
+
+
+def _foundation_document(foundation: Mapping[str, str] | None) -> dict[str, str]:
+    expected = FOUNDATION.identity()
+    supplied = dict(foundation) if foundation is not None else expected
+    if supplied != expected:
+        raise release_fleet.FleetError("historic cohort foundation identity does not match the pinned bridge")
+    return expected
+
+
+def _historic_releases(
+    releases: Sequence[release_fleet.DistributionRelease],
+    *,
+    foundation: Mapping[str, str],
+) -> tuple[release_fleet.DistributionRelease, ...]:
+    boundary = _version_tuple(foundation["version"])
+    historic = tuple(release for release in releases if _version_tuple(release.version) <= boundary)
+    expected_foundation = {field: foundation[field] for field in ("tag", "version", "commit", "tree")}
+    if sum(_release_document(release) == expected_foundation for release in historic) != 1:
+        raise release_fleet.FleetError("historic cohort does not contain the exact pinned foundation release")
+    return historic
+
+
+def frozen_cohort_manifest(
+    releases: Sequence[release_fleet.DistributionRelease],
+    *,
+    foundation: Mapping[str, str] | None = None,
+    expected_count: int = EXPECTED_HISTORIC_CASES,
+) -> dict[str, object]:
+    """Freeze the accepted historic trees through the immutable foundation."""
+
+    foundation_identity = _foundation_document(foundation)
+    historic = _historic_releases(releases, foundation=foundation_identity)
+    if len(historic) != expected_count:
+        raise release_fleet.FleetError(f"historic cohort has {len(historic)} trees; expected {expected_count}")
+    return {
+        "schema_version": COHORT_SCHEMA_VERSION,
+        "foundation": foundation_identity,
+        "case_count": len(historic),
+        "cases": [_release_document(release) for release in historic],
+    }
+
+
+def releases_from_frozen_cohort(
+    source: str,
+    *,
+    current_releases: Sequence[release_fleet.DistributionRelease],
+    foundation: Mapping[str, str] | None = None,
+    expected_count: int = EXPECTED_HISTORIC_CASES,
+) -> tuple[release_fleet.DistributionRelease, ...]:
+    """Validate a frozen cohort while allowing only post-foundation releases."""
+
+    foundation_identity = _foundation_document(foundation)
+    try:
+        document = json.loads(source)
+    except json.JSONDecodeError as error:
+        raise release_fleet.FleetError("historic cohort manifest is not valid JSON") from error
+    if (
+        not isinstance(document, Mapping)
+        or set(document) != _COHORT_FIELDS
+        or document.get("schema_version") != COHORT_SCHEMA_VERSION
+        or document.get("foundation") != foundation_identity
+    ):
+        raise release_fleet.FleetError("historic cohort manifest has an invalid foundation identity or shape")
+    cases = document.get("cases")
+    count = document.get("case_count")
+    if not isinstance(cases, list) or not isinstance(count, int) or count != expected_count or count != len(cases):
+        raise release_fleet.FleetError("historic cohort manifest has an invalid case count")
+
+    parsed: list[release_fleet.DistributionRelease] = []
+    for index, case in enumerate(cases, start=1):
+        if (
+            not isinstance(case, Mapping)
+            or set(case) != _RELEASE_FIELDS
+            or any(not isinstance(case[field], str) or not case[field] for field in _RELEASE_FIELDS)
+        ):
+            raise release_fleet.FleetError(f"historic cohort manifest case {index} is invalid")
+        parsed.append(
+            release_fleet.DistributionRelease(
+                tag=str(case["tag"]),
+                version=str(case["version"]),
+                commit=str(case["commit"]),
+                tree=str(case["tree"]),
+            )
+        )
+    if len({release.tag for release in parsed}) != len(parsed):
+        raise release_fleet.FleetError("historic cohort manifest repeats a release tag")
+
+    current_historic = _historic_releases(
+        current_releases,
+        foundation=foundation_identity,
+    )
+    parsed_by_tag = {release.tag: release for release in parsed}
+    current_by_tag = {release.tag: release for release in current_historic}
+    unexpected = sorted(current_by_tag.keys() - parsed_by_tag.keys())
+    if unexpected:
+        raise release_fleet.FleetError(
+            "unexpected historical release appeared at or before the foundation: " + ", ".join(unexpected)
+        )
+    if parsed_by_tag != current_by_tag or tuple(parsed) != current_historic:
+        raise release_fleet.FleetError("historic cohort identity drift")
+    return tuple(parsed)
+
+
+def assert_platform_report_bound(
+    report: release_fleet.AcceptanceReport,
+    *,
+    protocol: object,
+    running_platform: str,
+    expected_start_tags: set[str],
+) -> None:
+    """Bind one live-process report to one member of the exact protocol set."""
+
+    protocol_platforms = tuple(getattr(protocol, "platforms", ()))
+    if protocol_platforms != SUPPORTED_PLATFORMS:
+        raise release_fleet.FleetError("released journey protocol platforms are not the exact supported set")
+    if running_platform not in protocol_platforms:
+        raise release_fleet.FleetError("running platform is not declared by the protocol")
+    if report.platforms != (running_platform,):
+        raise release_fleet.FleetError("a live platform report must declare exactly one running platform")
+    release_fleet.assert_complete(report, expected_start_tags)
+
+
+def verify_acceptance_source_bound(repo: Path, source_commit: str) -> str:
+    """Require this running orchestrator to equal its publisher-commit bytes."""
+
+    if _HEX_40.fullmatch(source_commit) is None:
+        raise release_fleet.FleetError("acceptance orchestrator source commit is invalid")
+    try:
+        released = release_fleet._tag_file(repo, source_commit, ACCEPTANCE_SOURCE)
+    except release_fleet.FleetError as error:
+        raise release_fleet.FleetError("released acceptance orchestrator source is unavailable") from error
+    running = Path(__file__).resolve().read_bytes()
+    if running != released:
+        raise release_fleet.FleetError("running acceptance orchestrator bytes do not match the publisher commit")
+    return hashlib.sha256(running).hexdigest()
+
+
+def load_fleet_inputs(
+    repo: Path,
+    cohort_path: Path,
+    *,
+    foundation_tag: str,
+    follow_up_tag: str,
+) -> FleetInputs:
+    """Resolve and bind every immutable input before any journey can start."""
+
+    try:
+        cohort_bytes = cohort_path.read_bytes()
+    except OSError as error:
+        raise release_fleet.FleetError("historic cohort manifest is unavailable") from error
+    try:
+        cohort_source = cohort_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise release_fleet.FleetError("historic cohort manifest is not valid UTF-8") from error
+    releases = releases_from_frozen_cohort(
+        cohort_source,
+        current_releases=release_fleet.discover_distribution_releases(repo),
+    )
+    foundation = release_fleet.resolve_immutable_release(repo, foundation_tag)
+    follow_up = release_fleet.resolve_immutable_release(repo, follow_up_tag)
+    if foundation.identity() != FOUNDATION.identity():
+        raise release_fleet.FleetError("fleet acceptance foundation is not the pinned v1.80.5 identity")
+    if foundation.tag == follow_up.tag or foundation.commit == follow_up.commit:
+        raise release_fleet.FleetError("foundation and follow-up must be different immutable releases")
+    try:
+        protocol = load_update_journey_protocol(
+            release_fleet._tag_file(
+                repo,
+                follow_up.tag,
+                release_fleet.UPDATE_JOURNEY_RELATIVE,
+            )
+        )
+    except (release_fleet.FleetError, JourneyProtocolError) as error:
+        raise release_fleet.FleetError("follow-up released journey protocol is unavailable or invalid") from error
+    _require_protocol_platforms(protocol.platforms)
+    if protocol.foundation != foundation.identity():
+        raise release_fleet.FleetError("released journey protocol names a different foundation")
+    source_commit = release_fleet._verify_released_protocol_artifacts(
+        repo,
+        follow_up,
+        protocol,
+    )
+    acceptance_source_sha256 = verify_acceptance_source_bound(repo, source_commit)
+    return FleetInputs(
+        releases=releases,
+        foundation=foundation,
+        follow_up=follow_up,
+        protocol=protocol,
+        source_commit=source_commit,
+        acceptance_source_sha256=acceptance_source_sha256,
+        cohort_sha256=hashlib.sha256(cohort_bytes).hexdigest(),
+    )
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sign(payload: Mapping[str, object], key: bytes) -> dict[str, object]:
+    if not isinstance(key, bytes) or len(key) != 32:
+        raise release_fleet.FleetError("fleet acceptance session key must be exactly 32 bytes")
+    return {
+        "payload": dict(payload),
+        "signature": hmac.new(
+            key,
+            _canonical_bytes(payload),
+            hashlib.sha256,
+        ).hexdigest(),
+    }
+
+
+def _verified_payload(
+    signed: object,
+    *,
+    key: bytes,
+    fields: frozenset[str],
+    context: str,
+) -> dict[str, object]:
+    if not isinstance(signed, Mapping) or set(signed) != _SIGNED_FIELDS:
+        raise release_fleet.FleetError(f"{context} has an invalid signed shape")
+    payload = signed.get("payload")
+    signature = signed.get("signature")
+    if (
+        not isinstance(payload, Mapping)
+        or set(payload) != fields
+        or not isinstance(signature, str)
+        or _HEX_64.fullmatch(signature) is None
+    ):
+        raise release_fleet.FleetError(f"{context} has an invalid signed shape")
+    expected = _sign(dict(payload), key)["signature"]
+    assert isinstance(expected, str)
+    if not hmac.compare_digest(signature, expected):
+        raise release_fleet.FleetError(f"{context} signature is invalid")
+    return dict(payload)
+
+
+def _require_protocol_platforms(platforms: Sequence[str]) -> tuple[str, ...]:
+    value = tuple(platforms)
+    if value != SUPPORTED_PLATFORMS:
+        raise release_fleet.FleetError("fleet acceptance protocol platforms are not exactly darwin and linux")
+    return value
+
+
+def create_acceptance_session(
+    *,
+    cohort_sha256: str,
+    foundation: Mapping[str, str] | None,
+    follow_up_tag: str,
+    source_commit: str,
+    acceptance_source_sha256: str,
+    protocol_platforms: Sequence[str],
+    key: bytes,
+    expected_count: int = EXPECTED_HISTORIC_CASES,
+    session_id: str,
+) -> dict[str, object]:
+    """Create one authenticated session shared by both platform processes."""
+
+    platforms = _require_protocol_platforms(protocol_platforms)
+    foundation_identity = _foundation_document(foundation)
+    if (
+        _HEX_64.fullmatch(cohort_sha256) is None
+        or _HEX_64.fullmatch(acceptance_source_sha256) is None
+        or _HEX_64.fullmatch(session_id) is None
+        or _HEX_40.fullmatch(source_commit) is None
+        or release_fleet.RELEASE_TAG.fullmatch(follow_up_tag) is None
+        or expected_count < 1
+    ):
+        raise release_fleet.FleetError("fleet acceptance session identity is invalid")
+    return _sign(
+        {
+            "schema_version": 1,
+            "session_id": session_id,
+            "cohort_sha256": cohort_sha256,
+            "foundation": foundation_identity,
+            "follow_up_tag": follow_up_tag,
+            "source_commit": source_commit,
+            "acceptance_source_sha256": acceptance_source_sha256,
+            "platforms": list(platforms),
+            "case_count": expected_count,
+            "journey_count": expected_count * len(platforms),
+        },
+        key,
+    )
+
+
+def sign_platform_receipt(
+    session: object,
+    *,
+    platform: str,
+    case_result_sha256: str,
+    key: bytes,
+    started: int,
+    completed: int,
+    passed: int,
+    failed: int,
+) -> dict[str, object]:
+    """Authenticate a live platform verdict for later cross-process aggregation."""
+
+    session_payload = _verified_payload(
+        session,
+        key=key,
+        fields=_SESSION_FIELDS,
+        context="fleet acceptance session",
+    )
+    platforms = _require_protocol_platforms(
+        session_payload.get("platforms", ())  # type: ignore[arg-type]
+    )
+    if (
+        platform not in platforms
+        or _HEX_64.fullmatch(case_result_sha256) is None
+        or any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in (started, completed, passed, failed)
+        )
+    ):
+        raise release_fleet.FleetError("platform fleet receipt identity is invalid")
+    foundation = session_payload["foundation"]
+    assert isinstance(foundation, Mapping)
+    return _sign(
+        {
+            "schema_version": 1,
+            "session_id": session_payload["session_id"],
+            "platform": platform,
+            "cohort_sha256": session_payload["cohort_sha256"],
+            "foundation_tag": foundation["tag"],
+            "follow_up_tag": session_payload["follow_up_tag"],
+            "source_commit": session_payload["source_commit"],
+            "acceptance_source_sha256": session_payload["acceptance_source_sha256"],
+            "case_count": session_payload["case_count"],
+            "started": started,
+            "completed": completed,
+            "passed": passed,
+            "failed": failed,
+            "case_result_sha256": case_result_sha256,
+        },
+        key,
+    )
+
+
+def aggregate_signed_platform_receipts(
+    session: object,
+    receipts: Sequence[object],
+    *,
+    key: bytes,
+    protocol_platforms: Sequence[str],
+    expected_count: int = EXPECTED_HISTORIC_CASES,
+) -> dict[str, object]:
+    """Produce one verdict from exact signed Darwin and Linux process receipts."""
+
+    platforms = _require_protocol_platforms(protocol_platforms)
+    session_payload = _verified_payload(
+        session,
+        key=key,
+        fields=_SESSION_FIELDS,
+        context="fleet acceptance session",
+    )
+    if (
+        tuple(session_payload.get("platforms", ())) != platforms
+        or session_payload.get("case_count") != expected_count
+        or session_payload.get("journey_count") != expected_count * len(platforms)
+    ):
+        raise release_fleet.FleetError("fleet acceptance session is not bound to the protocol platforms and cohort")
+
+    by_platform: dict[str, dict[str, object]] = {}
+    for signed in receipts:
+        receipt = _verified_payload(
+            signed,
+            key=key,
+            fields=_RECEIPT_FIELDS,
+            context="platform fleet receipt",
+        )
+        platform = receipt.get("platform")
+        if not isinstance(platform, str) or platform in by_platform:
+            raise release_fleet.FleetError("platform receipts do not cover the exact protocol platforms")
+        by_platform[platform] = receipt
+    if set(by_platform) != set(platforms) or len(by_platform) != len(platforms):
+        raise release_fleet.FleetError("platform receipts do not cover the exact protocol platforms")
+
+    for platform in platforms:
+        receipt = by_platform[platform]
+        foundation = session_payload["foundation"]
+        assert isinstance(foundation, Mapping)
+        identity_fields = (
+            receipt.get("session_id") == session_payload["session_id"],
+            receipt.get("cohort_sha256") == session_payload["cohort_sha256"],
+            receipt.get("foundation_tag") == foundation["tag"],
+            receipt.get("follow_up_tag") == session_payload["follow_up_tag"],
+            receipt.get("source_commit") == session_payload["source_commit"],
+            receipt.get("acceptance_source_sha256") == session_payload["acceptance_source_sha256"],
+            receipt.get("case_count") == expected_count,
+            isinstance(receipt.get("case_result_sha256"), str)
+            and _HEX_64.fullmatch(str(receipt["case_result_sha256"])) is not None,
+        )
+        if not all(identity_fields):
+            raise release_fleet.FleetError(f"{platform}: platform fleet receipt is not bound to the session")
+        counts = tuple(receipt.get(field) for field in ("started", "completed", "passed", "failed"))
+        if counts != (expected_count, expected_count, expected_count, 0):
+            raise release_fleet.FleetError(f"{platform}: platform fleet receipt is incomplete or failed")
+
+    total = expected_count * len(platforms)
+    return {
+        "outcome": "HISTORIC_FLEET_ACCEPTED",
+        "acceptance": True,
+        "platforms": list(platforms),
+        "case_count": expected_count,
+        "journey_count": total,
+        "discovered": expected_count,
+        "started": total,
+        "completed": total,
+        "passed": total,
+        "failed": 0,
+        "session_id": session_payload["session_id"],
+    }
+
+
+def collect_platform_runs(
+    repo: Path,
+    *,
+    output: Path,
+    releases: Sequence[release_fleet.DistributionRelease],
+    foundation_tag: str,
+    follow_up_tag: str,
+    running_platform: str,
+    journey_runner: Callable[..., object] = release_fleet.run_journey,
+) -> PlatformExecution:
+    """Run one platform sequentially and retain every live executor result."""
+
+    counts = {
+        "discovered": len(releases),
+        "started": 0,
+        "completed": 0,
+        "passed": 0,
+        "failed": 0,
+    }
+    executor_runs: list[object] = []
+    case_documents: list[dict[str, object]] = []
+    for release in releases:
+        counts["started"] += 1
+        try:
+            run = journey_runner(
+                repo,
+                output=output,
+                starting_tag=release.tag,
+                foundation_tag=foundation_tag,
+                follow_up_tag=follow_up_tag,
+            )
+            case = getattr(run, "case", None)
+            if not isinstance(case, Mapping):
+                raise release_fleet.FleetError(f"{release.tag}: journey returned no live case evidence")
+            case_documents.append(dict(case))
+            executor_runs.append(run)
+            counts["completed"] += 1
+            counts["passed"] += 1
+        except Exception as error:
+            counts["failed"] += 1
+            raise PlatformFleetFailure(
+                f"{release.tag}: platform journey failed: {error}",
+                counts,
+            ) from error
+
+    try:
+        report = release_fleet.acceptance_report_from_json(
+            json.dumps(
+                {
+                    "foundation_tag": foundation_tag,
+                    "follow_up_tag": follow_up_tag,
+                    "platforms": [running_platform],
+                    "cases": case_documents,
+                },
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    except Exception as error:
+        counts["failed"] += 1
+        raise PlatformFleetFailure(
+            f"platform journey report is malformed: {error}",
+            counts,
+        ) from error
+    return PlatformExecution(report, tuple(executor_runs), counts)
+
+
+def _platform_receipt_boundary():
+    evidence_validator = release_fleet.assert_evidence_bound
+    complete_validator = release_fleet.assert_complete
+    platform_validator = assert_platform_report_bound
+
+    def finalize_live_platform_execution(
+        execution: PlatformExecution,
+        *,
+        repo: Path,
+        evidence_root: Path,
+        foundation: release_fleet.ImmutableRelease,
+        follow_up: release_fleet.ImmutableRelease,
+        protocol: object,
+        expected_start_tags: set[str],
+        session: object,
+        key: bytes,
+        cohort_sha256: str,
+        source_commit: str,
+        acceptance_source_sha256: str,
+        expected_count: int = EXPECTED_HISTORIC_CASES,
+    ) -> dict[str, object]:
+        """Validate live authority, then and only then authenticate one receipt."""
+
+        if (
+            release_fleet.assert_evidence_bound is not evidence_validator
+            or release_fleet.assert_complete is not complete_validator
+            or globals().get("assert_platform_report_bound") is not platform_validator
+        ):
+            raise release_fleet.FleetError("fleet acceptance validator changed during the live process")
+        platform_validator(
+            execution.report,
+            protocol=protocol,
+            running_platform=execution.report.platforms[0] if len(execution.report.platforms) == 1 else "",
+            expected_start_tags=expected_start_tags,
+        )
+        evidence_validator(
+            execution.report,
+            repo=repo,
+            evidence_root=evidence_root,
+            foundation=foundation,
+            follow_up=follow_up,
+            executor_runs=execution.executor_runs,
+        )
+
+        counts = execution.counts
+        if counts != {
+            "discovered": expected_count,
+            "started": expected_count,
+            "completed": expected_count,
+            "passed": expected_count,
+            "failed": 0,
+        }:
+            raise release_fleet.FleetError("live platform execution is incomplete or failed")
+        session_payload = _verified_payload(
+            session,
+            key=key,
+            fields=_SESSION_FIELDS,
+            context="fleet acceptance session",
+        )
+        if (
+            session_payload.get("cohort_sha256") != cohort_sha256
+            or session_payload.get("foundation") != foundation.identity()
+            or session_payload.get("follow_up_tag") != follow_up.tag
+            or session_payload.get("source_commit") != source_commit
+            or session_payload.get("acceptance_source_sha256") != acceptance_source_sha256
+            or session_payload.get("case_count") != expected_count
+            or tuple(session_payload.get("platforms", ())) != tuple(getattr(protocol, "platforms", ()))
+        ):
+            raise release_fleet.FleetError("live platform execution is not bound to the acceptance session")
+        cases = [
+            {field: getattr(case, field) for field in sorted(release_fleet.CASE_RESULT_KEYS)}
+            for case in execution.report.cases
+        ]
+        return sign_platform_receipt(
+            session,
+            platform=execution.report.platforms[0],
+            case_result_sha256=hashlib.sha256(_canonical_bytes(cases)).hexdigest(),
+            key=key,
+            started=counts["started"],
+            completed=counts["completed"],
+            passed=counts["passed"],
+            failed=counts["failed"],
+        )
+
+    return finalize_live_platform_execution
+
+
+finalize_live_platform_execution = _platform_receipt_boundary()
+del _platform_receipt_boundary
+
+
+def _write_exclusive(path: Path, content: bytes, *, mode: int) -> None:
+    if not path.parent.is_dir():
+        raise release_fleet.FleetError(f"acceptance output parent does not exist: {path.parent}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags, mode)
+    except FileExistsError as error:
+        raise release_fleet.FleetError(f"acceptance output already exists: {path}") from error
+    try:
+        view = memoryview(content)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def write_session_key(path: Path, *, key: bytes | None = None) -> bytes:
+    """Create one private, non-reusable acceptance-session key."""
+
+    value = secrets.token_bytes(32) if key is None else key
+    if not isinstance(value, bytes) or len(value) != 32:
+        raise release_fleet.FleetError("fleet acceptance session key must be exactly 32 bytes")
+    _write_exclusive(path, value, mode=0o600)
+    return value
+
+
+def read_session_key(path: Path) -> bytes:
+    """Open one private key without following links or accepting loose modes."""
+
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise release_fleet.FleetError("fleet acceptance session key is missing") from error
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or path.is_symlink()
+        or metadata.st_size != 32
+    ):
+        raise release_fleet.FleetError("fleet acceptance session key is unsafe")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        try:
+            value = os.read(descriptor, 33)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        raise release_fleet.FleetError("fleet acceptance session key is unsafe") from error
+    if len(value) != 32:
+        raise release_fleet.FleetError("fleet acceptance session key is unsafe")
+    return value
+
+
+def _read_json(path: Path, *, context: str) -> object:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise OSError("not a regular file")
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise release_fleet.FleetError(f"{context} is unavailable or invalid") from error
+
+
+def _assert_session_matches_inputs(
+    session: object,
+    *,
+    key: bytes,
+    inputs: FleetInputs,
+) -> dict[str, object]:
+    payload = _verified_payload(
+        session,
+        key=key,
+        fields=_SESSION_FIELDS,
+        context="fleet acceptance session",
+    )
+    expected = {
+        "schema_version": 1,
+        "cohort_sha256": inputs.cohort_sha256,
+        "foundation": inputs.foundation.identity(),
+        "follow_up_tag": inputs.follow_up.tag,
+        "source_commit": inputs.source_commit,
+        "acceptance_source_sha256": inputs.acceptance_source_sha256,
+        "platforms": list(_require_protocol_platforms(inputs.protocol.platforms)),
+        "case_count": EXPECTED_HISTORIC_CASES,
+        "journey_count": EXPECTED_HISTORIC_CASES * len(SUPPORTED_PLATFORMS),
+    }
+    if any(payload.get(field) != value for field, value in expected.items()):
+        raise release_fleet.FleetError("fleet acceptance session does not match the immutable fleet inputs")
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or _HEX_64.fullmatch(session_id) is None:
+        raise release_fleet.FleetError("fleet acceptance session identity is invalid")
+    return payload
+
+
+def _running_platform() -> str:
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    raise release_fleet.FleetError("historic fleet acceptance supports macOS and Linux only")
+
+
+def _add_bound_input_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--cohort", type=Path, required=True)
+    parser.add_argument("--foundation-tag", required=True)
+    parser.add_argument("--follow-up-tag", required=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Freeze, execute, or aggregate the formal historic release fleet."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    cohort = subcommands.add_parser(
+        "cohort",
+        help="freeze all immutable historic trees through the pinned foundation",
+    )
+    cohort.add_argument("--repo", type=Path, required=True)
+    cohort.add_argument("--output", type=Path, required=True)
+    session = subcommands.add_parser(
+        "session",
+        help="bind one authenticated acceptance session to immutable release inputs",
+    )
+    _add_bound_input_arguments(session)
+    session.add_argument("--session-output", type=Path, required=True)
+    session.add_argument("--key-output", type=Path, required=True)
+    platform = subcommands.add_parser(
+        "platform",
+        help="run all frozen starts on this platform and mint one live-bound receipt",
+    )
+    _add_bound_input_arguments(platform)
+    platform.add_argument("--session", type=Path, required=True)
+    platform.add_argument("--key", type=Path, required=True)
+    platform.add_argument("--output", type=Path, required=True)
+    platform.add_argument("--receipt-output", type=Path, required=True)
+    aggregate = subcommands.add_parser(
+        "aggregate",
+        help="verify exact Darwin and Linux receipts and produce one fleet verdict",
+    )
+    _add_bound_input_arguments(aggregate)
+    aggregate.add_argument("--session", type=Path, required=True)
+    aggregate.add_argument("--key", type=Path, required=True)
+    aggregate.add_argument(
+        "--receipt",
+        action="append",
+        type=Path,
+        required=True,
+        help="signed platform receipt; provide once for Darwin and once for Linux",
+    )
+    aggregate.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    if args.command == "cohort":
+        manifest = frozen_cohort_manifest(release_fleet.discover_distribution_releases(args.repo))
+        _write_exclusive(args.output, _json_bytes(manifest), mode=0o644)
+        print(
+            json.dumps(
+                {
+                    "outcome": "HISTORIC_COHORT_FROZEN",
+                    "acceptance": False,
+                    "foundation_tag": FOUNDATION.tag,
+                    "case_count": manifest["case_count"],
+                    "output": str(args.output),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    inputs = load_fleet_inputs(
+        args.repo,
+        args.cohort,
+        foundation_tag=args.foundation_tag,
+        follow_up_tag=args.follow_up_tag,
+    )
+    if args.command == "session":
+        for output in (args.session_output, args.key_output):
+            if output.exists() or output.is_symlink():
+                raise release_fleet.FleetError(f"acceptance output already exists: {output}")
+        key = write_session_key(args.key_output)
+        signed_session = create_acceptance_session(
+            cohort_sha256=inputs.cohort_sha256,
+            foundation=inputs.foundation.identity(),
+            follow_up_tag=inputs.follow_up.tag,
+            source_commit=inputs.source_commit,
+            acceptance_source_sha256=inputs.acceptance_source_sha256,
+            protocol_platforms=inputs.protocol.platforms,
+            key=key,
+            session_id=secrets.token_hex(32),
+        )
+        _write_exclusive(
+            args.session_output,
+            _json_bytes(signed_session),
+            mode=0o644,
+        )
+        print(
+            json.dumps(
+                {
+                    "outcome": "HISTORIC_FLEET_SESSION_CREATED",
+                    "acceptance": False,
+                    "discovered": len(inputs.releases),
+                    "started": 0,
+                    "completed": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "session_output": str(args.session_output),
+                    "key_output": str(args.key_output),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    key = read_session_key(args.key)
+    signed_session = _read_json(
+        args.session,
+        context="fleet acceptance session",
+    )
+    _assert_session_matches_inputs(signed_session, key=key, inputs=inputs)
+
+    if args.command == "platform":
+        if args.output.exists() or args.output.is_symlink():
+            raise release_fleet.FleetError(f"platform fleet output already exists: {args.output}")
+        try:
+            args.output.mkdir(mode=0o700)
+        except OSError as error:
+            raise release_fleet.FleetError(f"platform fleet output cannot be created: {args.output}") from error
+        running_platform = _running_platform()
+        execution = collect_platform_runs(
+            args.repo,
+            output=args.output,
+            releases=inputs.releases,
+            foundation_tag=inputs.foundation.tag,
+            follow_up_tag=inputs.follow_up.tag,
+            running_platform=running_platform,
+        )
+        receipt = finalize_live_platform_execution(
+            execution,
+            repo=args.repo,
+            evidence_root=args.output.resolve(),
+            foundation=inputs.foundation,
+            follow_up=inputs.follow_up,
+            protocol=inputs.protocol,
+            expected_start_tags={release.tag for release in inputs.releases},
+            session=signed_session,
+            key=key,
+            cohort_sha256=inputs.cohort_sha256,
+            source_commit=inputs.source_commit,
+            acceptance_source_sha256=inputs.acceptance_source_sha256,
+        )
+        _write_exclusive(
+            args.receipt_output,
+            _json_bytes(receipt),
+            mode=0o644,
+        )
+        print(
+            json.dumps(
+                {
+                    "outcome": "HISTORIC_PLATFORM_ACCEPTED",
+                    "acceptance": False,
+                    "platform": running_platform,
+                    **execution.counts,
+                    "receipt_output": str(args.receipt_output),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    receipts = [_read_json(path, context=f"platform fleet receipt {path}") for path in args.receipt]
+    result = aggregate_signed_platform_receipts(
+        signed_session,
+        receipts,
+        key=key,
+        protocol_platforms=inputs.protocol.platforms,
+    )
+    _write_exclusive(args.output, _json_bytes(result), mode=0o644)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except release_fleet.FleetError as error:
+        raise SystemExit(f"FAIL: {error}") from error

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -30,7 +30,15 @@ from scripts.dex_update_bridge import FOUNDATION
 
 EXPECTED_HISTORIC_CASES = 168
 COHORT_SCHEMA_VERSION = 1
+PLATFORM_MANIFEST_SCHEMA_VERSION = 1
 ACCEPTANCE_SOURCE = "scripts/release_fleet_acceptance.py"
+FIRST_PARTY_PLATFORM_JOBS = {
+    "darwin": "historic-fleet-darwin",
+    "linux": "historic-fleet-linux",
+}
+MAX_PLATFORM_MANIFEST_BYTES = 16 * 1024 * 1024
+PLATFORM_MANIFEST_NAME = "platform-manifest.json"
+PLATFORM_RECEIPT_NAME = "platform-receipt.json"
 _COHORT_FIELDS = frozenset({"schema_version", "foundation", "case_count", "cases"})
 _RELEASE_FIELDS = frozenset({"tag", "version", "commit", "tree"})
 _SEMVER = re.compile(
@@ -60,17 +68,22 @@ _RECEIPT_FIELDS = frozenset(
         "schema_version",
         "session_id",
         "platform",
+        "manifest_sha256",
+    }
+)
+_PLATFORM_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "outcome",
+        "acceptance",
+        "session_id",
+        "platform",
         "cohort_sha256",
-        "foundation_tag",
+        "foundation",
         "follow_up_tag",
         "source_commit",
         "acceptance_source_sha256",
-        "case_count",
-        "started",
-        "completed",
-        "passed",
-        "failed",
-        "case_result_sha256",
+        "report",
     }
 )
 
@@ -378,7 +391,6 @@ def create_acceptance_session(
     acceptance_source_sha256: str,
     protocol_platforms: Sequence[str],
     key: bytes,
-    expected_count: int = EXPECTED_HISTORIC_CASES,
     session_id: str,
 ) -> dict[str, object]:
     """Create one authenticated session shared by both platform processes."""
@@ -391,7 +403,6 @@ def create_acceptance_session(
         or _HEX_64.fullmatch(session_id) is None
         or _HEX_40.fullmatch(source_commit) is None
         or release_fleet.RELEASE_TAG.fullmatch(follow_up_tag) is None
-        or expected_count < 1
     ):
         raise release_fleet.FleetError("fleet acceptance session identity is invalid")
     return _sign(
@@ -404,92 +415,118 @@ def create_acceptance_session(
             "source_commit": source_commit,
             "acceptance_source_sha256": acceptance_source_sha256,
             "platforms": list(platforms),
-            "case_count": expected_count,
-            "journey_count": expected_count * len(platforms),
+            "case_count": EXPECTED_HISTORIC_CASES,
+            "journey_count": EXPECTED_HISTORIC_CASES * len(platforms),
         },
         key,
     )
 
 
-def sign_platform_receipt(
-    session: object,
-    *,
-    platform: str,
-    case_result_sha256: str,
-    key: bytes,
-    started: int,
-    completed: int,
-    passed: int,
-    failed: int,
-) -> dict[str, object]:
-    """Authenticate a live platform verdict for later cross-process aggregation."""
+def _immutable_manifest_bytes(path: Path) -> bytes:
+    """Reopen one write-closed regular file without following aliases."""
 
-    session_payload = _verified_payload(
-        session,
-        key=key,
-        fields=_SESSION_FIELDS,
-        context="fleet acceptance session",
-    )
-    platforms = _require_protocol_platforms(
-        session_payload.get("platforms", ())  # type: ignore[arg-type]
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise release_fleet.FleetError("platform fleet manifest is not immutable") from error
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) & 0o222
+        or metadata.st_nlink != 1
+        or metadata.st_size < 1
+        or metadata.st_size > MAX_PLATFORM_MANIFEST_BYTES
+    ):
+        raise release_fleet.FleetError("platform fleet manifest is not immutable")
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        try:
+            before = os.fstat(descriptor)
+            chunks: list[bytes] = []
+            remaining = before.st_size
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 1024 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            content = b"".join(chunks)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        raise release_fleet.FleetError("platform fleet manifest is not immutable") from error
+    identity = (
+        "st_dev",
+        "st_ino",
+        "st_mode",
+        "st_nlink",
+        "st_size",
+        "st_mtime_ns",
+        "st_ctime_ns",
     )
     if (
-        platform not in platforms
-        or _HEX_64.fullmatch(case_result_sha256) is None
-        or any(
-            isinstance(value, bool) or not isinstance(value, int) or value < 0
-            for value in (started, completed, passed, failed)
-        )
+        any(getattr(metadata, field) != getattr(before, field) for field in identity)
+        or stat.S_IMODE(before.st_mode) & 0o222
+        or len(content) != before.st_size
+        or any(getattr(before, field) != getattr(after, field) for field in identity)
     ):
-        raise release_fleet.FleetError("platform fleet receipt identity is invalid")
-    foundation = session_payload["foundation"]
-    assert isinstance(foundation, Mapping)
-    return _sign(
-        {
-            "schema_version": 1,
-            "session_id": session_payload["session_id"],
-            "platform": platform,
-            "cohort_sha256": session_payload["cohort_sha256"],
-            "foundation_tag": foundation["tag"],
-            "follow_up_tag": session_payload["follow_up_tag"],
-            "source_commit": session_payload["source_commit"],
-            "acceptance_source_sha256": session_payload["acceptance_source_sha256"],
-            "case_count": session_payload["case_count"],
-            "started": started,
-            "completed": completed,
-            "passed": passed,
-            "failed": failed,
-            "case_result_sha256": case_result_sha256,
-        },
-        key,
+        raise release_fleet.FleetError("platform fleet manifest changed while it was read")
+    return content
+
+
+def _parse_platform_manifest(
+    path: Path,
+) -> tuple[bytes, dict[str, object], release_fleet.AcceptanceReport]:
+    content = _immutable_manifest_bytes(path)
+    try:
+        document = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise release_fleet.FleetError("platform fleet manifest is invalid") from error
+    if (
+        not isinstance(document, Mapping)
+        or set(document) != _PLATFORM_MANIFEST_FIELDS
+        or document.get("schema_version") != PLATFORM_MANIFEST_SCHEMA_VERSION
+        or document.get("outcome") != "HISTORIC_PLATFORM_EVIDENCE"
+        or document.get("acceptance") is not False
+        or not isinstance(document.get("report"), Mapping)
+    ):
+        raise release_fleet.FleetError("platform fleet manifest shape is invalid")
+    report = release_fleet.acceptance_report_from_json(
+        json.dumps(
+            document["report"],
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
     )
+    return content, dict(document), report
 
 
-def aggregate_signed_platform_receipts(
+def aggregate_platform_evidence(
     session: object,
     receipts: Sequence[object],
+    manifest_paths: Sequence[Path],
     *,
     key: bytes,
-    protocol_platforms: Sequence[str],
-    expected_count: int = EXPECTED_HISTORIC_CASES,
+    inputs: FleetInputs,
 ) -> dict[str, object]:
-    """Produce one verdict from exact signed Darwin and Linux process receipts."""
+    """Validate serialized evidence while refusing to treat it as execution authority."""
 
-    platforms = _require_protocol_platforms(protocol_platforms)
-    session_payload = _verified_payload(
+    platforms = _require_protocol_platforms(inputs.protocol.platforms)
+    session_payload = _assert_session_matches_inputs(
         session,
         key=key,
-        fields=_SESSION_FIELDS,
-        context="fleet acceptance session",
+        inputs=inputs,
     )
-    if (
-        tuple(session_payload.get("platforms", ())) != platforms
-        or session_payload.get("case_count") != expected_count
-        or session_payload.get("journey_count") != expected_count * len(platforms)
-    ):
-        raise release_fleet.FleetError("fleet acceptance session is not bound to the protocol platforms and cohort")
+    expected_tags = {release.tag for release in inputs.releases}
+    if len(inputs.releases) != EXPECTED_HISTORIC_CASES or len(expected_tags) != EXPECTED_HISTORIC_CASES:
+        raise release_fleet.FleetError("fleet inputs do not contain the exact historic cohort")
 
-    by_platform: dict[str, dict[str, object]] = {}
+    receipts_by_platform: dict[str, dict[str, object]] = {}
     for signed in receipts:
         receipt = _verified_payload(
             signed,
@@ -498,46 +535,69 @@ def aggregate_signed_platform_receipts(
             context="platform fleet receipt",
         )
         platform = receipt.get("platform")
-        if not isinstance(platform, str) or platform in by_platform:
-            raise release_fleet.FleetError("platform receipts do not cover the exact protocol platforms")
-        by_platform[platform] = receipt
-    if set(by_platform) != set(platforms) or len(by_platform) != len(platforms):
-        raise release_fleet.FleetError("platform receipts do not cover the exact protocol platforms")
+        if not isinstance(platform, str) or platform in receipts_by_platform:
+            raise release_fleet.FleetError("platform evidence does not cover the exact protocol platforms")
+        receipts_by_platform[platform] = receipt
+
+    manifests_by_platform: dict[str, tuple[bytes, dict[str, object], release_fleet.AcceptanceReport]] = {}
+    for path in manifest_paths:
+        content, manifest, report = _parse_platform_manifest(path)
+        platform = manifest.get("platform")
+        if not isinstance(platform, str) or platform in manifests_by_platform:
+            raise release_fleet.FleetError("platform evidence does not cover the exact protocol platforms")
+        manifests_by_platform[platform] = (content, manifest, report)
+
+    if (
+        set(receipts_by_platform) != set(platforms)
+        or set(manifests_by_platform) != set(platforms)
+        or len(receipts_by_platform) != len(platforms)
+        or len(manifests_by_platform) != len(platforms)
+    ):
+        raise release_fleet.FleetError("platform evidence does not cover the exact protocol platforms")
 
     for platform in platforms:
-        receipt = by_platform[platform]
-        foundation = session_payload["foundation"]
-        assert isinstance(foundation, Mapping)
-        identity_fields = (
-            receipt.get("session_id") == session_payload["session_id"],
-            receipt.get("cohort_sha256") == session_payload["cohort_sha256"],
-            receipt.get("foundation_tag") == foundation["tag"],
-            receipt.get("follow_up_tag") == session_payload["follow_up_tag"],
-            receipt.get("source_commit") == session_payload["source_commit"],
-            receipt.get("acceptance_source_sha256") == session_payload["acceptance_source_sha256"],
-            receipt.get("case_count") == expected_count,
-            isinstance(receipt.get("case_result_sha256"), str)
-            and _HEX_64.fullmatch(str(receipt["case_result_sha256"])) is not None,
+        receipt = receipts_by_platform[platform]
+        content, manifest, report = manifests_by_platform[platform]
+        if (
+            receipt.get("schema_version") != 1
+            or receipt.get("session_id") != session_payload["session_id"]
+            or receipt.get("manifest_sha256") != hashlib.sha256(content).hexdigest()
+        ):
+            raise release_fleet.FleetError(f"{platform}: platform manifest hash is not bound to its receipt")
+        if (
+            manifest.get("session_id") != session_payload["session_id"]
+            or manifest.get("platform") != platform
+            or manifest.get("cohort_sha256") != inputs.cohort_sha256
+            or manifest.get("foundation") != inputs.foundation.identity()
+            or manifest.get("follow_up_tag") != inputs.follow_up.tag
+            or manifest.get("source_commit") != inputs.source_commit
+            or manifest.get("acceptance_source_sha256") != inputs.acceptance_source_sha256
+        ):
+            raise release_fleet.FleetError(f"{platform}: platform manifest is not bound to the session")
+        assert_platform_report_bound(
+            report,
+            protocol=inputs.protocol,
+            running_platform=platform,
+            expected_start_tags=expected_tags,
         )
-        if not all(identity_fields):
-            raise release_fleet.FleetError(f"{platform}: platform fleet receipt is not bound to the session")
-        counts = tuple(receipt.get(field) for field in ("started", "completed", "passed", "failed"))
-        if counts != (expected_count, expected_count, expected_count, 0):
-            raise release_fleet.FleetError(f"{platform}: platform fleet receipt is incomplete or failed")
+        if len(report.cases) != EXPECTED_HISTORIC_CASES:
+            raise release_fleet.FleetError(f"{platform}: platform manifest has an invalid case count")
 
-    total = expected_count * len(platforms)
+    total = EXPECTED_HISTORIC_CASES * len(platforms)
     return {
-        "outcome": "HISTORIC_FLEET_ACCEPTED",
-        "acceptance": True,
+        "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
+        "acceptance": False,
+        "authority_complete": False,
         "platforms": list(platforms),
-        "case_count": expected_count,
+        "case_count": EXPECTED_HISTORIC_CASES,
         "journey_count": total,
-        "discovered": expected_count,
+        "discovered": EXPECTED_HISTORIC_CASES,
         "started": total,
         "completed": total,
         "passed": total,
         "failed": 0,
         "session_id": session_payload["session_id"],
+        "required_job_conclusions": dict(FIRST_PARTY_PLATFORM_JOBS),
     }
 
 
@@ -614,24 +674,23 @@ def _platform_receipt_boundary():
     evidence_validator = release_fleet.assert_evidence_bound
     complete_validator = release_fleet.assert_complete
     platform_validator = assert_platform_report_bound
+    if sys.platform == "darwin":
+        host_platform = "darwin"
+    elif sys.platform.startswith("linux"):
+        host_platform = "linux"
+    else:
+        host_platform = ""
 
     def finalize_live_platform_execution(
         execution: PlatformExecution,
         *,
         repo: Path,
         evidence_root: Path,
-        foundation: release_fleet.ImmutableRelease,
-        follow_up: release_fleet.ImmutableRelease,
-        protocol: object,
-        expected_start_tags: set[str],
+        inputs: FleetInputs,
         session: object,
         key: bytes,
-        cohort_sha256: str,
-        source_commit: str,
-        acceptance_source_sha256: str,
-        expected_count: int = EXPECTED_HISTORIC_CASES,
     ) -> dict[str, object]:
-        """Validate live authority, then and only then authenticate one receipt."""
+        """Validate live authority, then write one immutable evidence pair."""
 
         if (
             release_fleet.assert_evidence_bound is not evidence_validator
@@ -639,60 +698,105 @@ def _platform_receipt_boundary():
             or globals().get("assert_platform_report_bound") is not platform_validator
         ):
             raise release_fleet.FleetError("fleet acceptance validator changed during the live process")
+        expected_start_tags = {release.tag for release in inputs.releases}
+        if (
+            len(inputs.releases) != EXPECTED_HISTORIC_CASES
+            or len(expected_start_tags) != EXPECTED_HISTORIC_CASES
+        ):
+            raise release_fleet.FleetError("fleet inputs do not contain the exact historic cohort")
         platform_validator(
             execution.report,
-            protocol=protocol,
-            running_platform=execution.report.platforms[0] if len(execution.report.platforms) == 1 else "",
+            protocol=inputs.protocol,
+            running_platform=host_platform,
             expected_start_tags=expected_start_tags,
         )
         evidence_validator(
             execution.report,
             repo=repo,
             evidence_root=evidence_root,
-            foundation=foundation,
-            follow_up=follow_up,
+            foundation=inputs.foundation,
+            follow_up=inputs.follow_up,
             executor_runs=execution.executor_runs,
         )
 
         counts = execution.counts
         if counts != {
-            "discovered": expected_count,
-            "started": expected_count,
-            "completed": expected_count,
-            "passed": expected_count,
+            "discovered": EXPECTED_HISTORIC_CASES,
+            "started": EXPECTED_HISTORIC_CASES,
+            "completed": EXPECTED_HISTORIC_CASES,
+            "passed": EXPECTED_HISTORIC_CASES,
             "failed": 0,
         }:
             raise release_fleet.FleetError("live platform execution is incomplete or failed")
-        session_payload = _verified_payload(
+        session_payload = _assert_session_matches_inputs(
             session,
             key=key,
-            fields=_SESSION_FIELDS,
-            context="fleet acceptance session",
+            inputs=inputs,
         )
         if (
-            session_payload.get("cohort_sha256") != cohort_sha256
-            or session_payload.get("foundation") != foundation.identity()
-            or session_payload.get("follow_up_tag") != follow_up.tag
-            or session_payload.get("source_commit") != source_commit
-            or session_payload.get("acceptance_source_sha256") != acceptance_source_sha256
-            or session_payload.get("case_count") != expected_count
-            or tuple(session_payload.get("platforms", ())) != tuple(getattr(protocol, "platforms", ()))
+            execution.report.foundation_tag != inputs.foundation.tag
+            or execution.report.follow_up_tag != inputs.follow_up.tag
         ):
-            raise release_fleet.FleetError("live platform execution is not bound to the acceptance session")
-        cases = [
+            raise release_fleet.FleetError("live platform execution is not bound to the immutable releases")
+        if len(execution.report.cases) != EXPECTED_HISTORIC_CASES:
+            raise release_fleet.FleetError("live platform execution does not have exactly 168 final starts")
+        cases: list[dict[str, object]] = [
             {field: getattr(case, field) for field in sorted(release_fleet.CASE_RESULT_KEYS)}
             for case in execution.report.cases
         ]
-        return sign_platform_receipt(
-            session,
-            platform=execution.report.platforms[0],
-            case_result_sha256=hashlib.sha256(_canonical_bytes(cases)).hexdigest(),
-            key=key,
-            started=counts["started"],
-            completed=counts["completed"],
-            passed=counts["passed"],
-            failed=counts["failed"],
+        manifest = {
+            "schema_version": PLATFORM_MANIFEST_SCHEMA_VERSION,
+            "outcome": "HISTORIC_PLATFORM_EVIDENCE",
+            "acceptance": False,
+            "session_id": session_payload["session_id"],
+            "platform": host_platform,
+            "cohort_sha256": inputs.cohort_sha256,
+            "foundation": inputs.foundation.identity(),
+            "follow_up_tag": inputs.follow_up.tag,
+            "source_commit": inputs.source_commit,
+            "acceptance_source_sha256": inputs.acceptance_source_sha256,
+            "report": {
+                "foundation_tag": execution.report.foundation_tag,
+                "follow_up_tag": execution.report.follow_up_tag,
+                "platforms": list(execution.report.platforms),
+                "cases": cases,
+            },
+        }
+        try:
+            root_metadata = evidence_root.lstat()
+        except OSError as error:
+            raise release_fleet.FleetError("platform fleet output is unsafe") from error
+        if (
+            evidence_root.is_symlink()
+            or not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_IMODE(root_metadata.st_mode) != 0o700
+        ):
+            raise release_fleet.FleetError("platform fleet output is unsafe")
+        manifest_output = evidence_root / PLATFORM_MANIFEST_NAME
+        receipt_output = evidence_root / PLATFORM_RECEIPT_NAME
+        manifest_bytes = _json_bytes(manifest)
+        for output in (manifest_output, receipt_output):
+            if output.exists() or output.is_symlink():
+                raise release_fleet.FleetError(f"acceptance output already exists: {output}")
+        _write_exclusive(manifest_output, manifest_bytes, mode=0o444)
+        manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+        receipt = _sign(
+            {
+                "schema_version": 1,
+                "session_id": session_payload["session_id"],
+                "platform": host_platform,
+                "manifest_sha256": manifest_sha256,
+            },
+            key,
         )
+        _write_exclusive(receipt_output, _json_bytes(receipt), mode=0o444)
+        return {
+            "acceptance": False,
+            "platform": host_platform,
+            "manifest_sha256": manifest_sha256,
+            "manifest_output": str(manifest_output),
+            "receipt_output": str(receipt_output),
+        }
 
     return finalize_live_platform_execution
 
@@ -779,6 +883,28 @@ def _read_json(path: Path, *, context: str) -> object:
         raise release_fleet.FleetError(f"{context} is unavailable or invalid") from error
 
 
+def _create_private_run_root(path: Path) -> None:
+    """Create the controller-owned root that may contain disposable fixtures."""
+
+    if path.exists() or path.is_symlink():
+        raise release_fleet.FleetError(f"platform fleet output already exists: {path}")
+    parent = path.parent
+    try:
+        parent_metadata = parent.lstat()
+    except OSError as error:
+        raise release_fleet.FleetError(f"platform fleet output parent is unavailable: {parent}") from error
+    if parent.is_symlink() or not stat.S_ISDIR(parent_metadata.st_mode):
+        raise release_fleet.FleetError(f"platform fleet output parent is unsafe: {parent}")
+    try:
+        path.mkdir(mode=0o700)
+        path.chmod(0o700)
+        metadata = path.lstat()
+    except OSError as error:
+        raise release_fleet.FleetError(f"platform fleet output cannot be created: {path}") from error
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise release_fleet.FleetError(f"platform fleet output is unsafe: {path}")
+
+
 def _assert_session_matches_inputs(
     session: object,
     *,
@@ -845,16 +971,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     session.add_argument("--key-output", type=Path, required=True)
     platform = subcommands.add_parser(
         "platform",
-        help="run all frozen starts on this platform and mint one live-bound receipt",
+        help="run all frozen starts in one process and write live-validated platform evidence",
     )
     _add_bound_input_arguments(platform)
     platform.add_argument("--session", type=Path, required=True)
     platform.add_argument("--key", type=Path, required=True)
     platform.add_argument("--output", type=Path, required=True)
-    platform.add_argument("--receipt-output", type=Path, required=True)
     aggregate = subcommands.add_parser(
         "aggregate",
-        help="verify exact Darwin and Linux receipts and produce one fleet verdict",
+        help="validate serialized Darwin and Linux evidence without minting acceptance",
     )
     _add_bound_input_arguments(aggregate)
     aggregate.add_argument("--session", type=Path, required=True)
@@ -865,6 +990,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         type=Path,
         required=True,
         help="signed platform receipt; provide once for Darwin and once for Linux",
+    )
+    aggregate.add_argument(
+        "--manifest",
+        action="append",
+        type=Path,
+        required=True,
+        help="immutable platform manifest; provide once for Darwin and once for Linux",
     )
     aggregate.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
@@ -940,12 +1072,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     _assert_session_matches_inputs(signed_session, key=key, inputs=inputs)
 
     if args.command == "platform":
-        if args.output.exists() or args.output.is_symlink():
-            raise release_fleet.FleetError(f"platform fleet output already exists: {args.output}")
-        try:
-            args.output.mkdir(mode=0o700)
-        except OSError as error:
-            raise release_fleet.FleetError(f"platform fleet output cannot be created: {args.output}") from error
+        _create_private_run_root(args.output)
         running_platform = _running_platform()
         execution = collect_platform_runs(
             args.repo,
@@ -955,33 +1082,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             follow_up_tag=inputs.follow_up.tag,
             running_platform=running_platform,
         )
-        receipt = finalize_live_platform_execution(
+        finalized = finalize_live_platform_execution(
             execution,
             repo=args.repo,
             evidence_root=args.output.resolve(),
-            foundation=inputs.foundation,
-            follow_up=inputs.follow_up,
-            protocol=inputs.protocol,
-            expected_start_tags={release.tag for release in inputs.releases},
+            inputs=inputs,
             session=signed_session,
             key=key,
-            cohort_sha256=inputs.cohort_sha256,
-            source_commit=inputs.source_commit,
-            acceptance_source_sha256=inputs.acceptance_source_sha256,
-        )
-        _write_exclusive(
-            args.receipt_output,
-            _json_bytes(receipt),
-            mode=0o644,
         )
         print(
             json.dumps(
                 {
-                    "outcome": "HISTORIC_PLATFORM_ACCEPTED",
+                    "outcome": "HISTORIC_PLATFORM_EVIDENCE",
                     "acceptance": False,
                     "platform": running_platform,
                     **execution.counts,
-                    "receipt_output": str(args.receipt_output),
+                    "manifest_output": finalized["manifest_output"],
+                    "receipt_output": finalized["receipt_output"],
+                    "manifest_sha256": finalized["manifest_sha256"],
                 },
                 indent=2,
                 sort_keys=True,
@@ -990,13 +1108,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     receipts = [_read_json(path, context=f"platform fleet receipt {path}") for path in args.receipt]
-    result = aggregate_signed_platform_receipts(
+    result = aggregate_platform_evidence(
         signed_session,
         receipts,
+        args.manifest,
         key=key,
-        protocol_platforms=inputs.protocol.platforms,
+        inputs=inputs,
     )
-    _write_exclusive(args.output, _json_bytes(result), mode=0o644)
+    _write_exclusive(args.output, _json_bytes(result), mode=0o444)
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 


### PR DESCRIPTION
## Summary

- freeze the accepted historic cohort at exactly 168 immutable trees through pinned v1.80.5
- run each platform in one process on its real host and retain all live ExecutorRun capabilities through final validation
- derive the exact 168 counts, start identities, and manifest digest inside the controller; no public receipt signer or caller counts, digests, or start-tag inputs remain
- write the platform manifest and transport receipt only after live validation, inside the new mode-0700 non-resumable run root, with exclusive mode-0444 files
- reopen and hash strict Darwin and Linux manifests during aggregation; duplicate, substituted, 167, 169, mixed-session, spoofed-platform, writable, symlinked, tampered, authored/preflight-shaped, and arbitrary receipt fields fail closed

## Authority boundary

HMAC now binds transport bytes only. Serialized receipts and local aggregation are never execution authority and always return `acceptance: false` plus `authority_complete: false`.

A future parent CI gate must require both fixed first-party jobs, `historic-fleet-darwin` and `historic-fleet-linux`, to run their platform controller successfully before any acceptance claim can exist. That parent-job gate is not implemented in these two PR-owned files, so this PR remains draft.

The closed synthetic-fixture approval responder is also an explicit follow-up outside PR #335: the current runner interface does not expose a safe prompt responder seam, and changing executor defaults here would weaken the authority boundary.

## Verification

- focused fleet, acceptance, and executor suite: 85 passed
- independent acceptance-only reproduction: 29 passed
- broad Python suite: 2,747 passed, 69 skipped, 2 deselected; the only two failures are deep-JSON assessment failures reproduced identically on pristine `85ed9657`
- Ruff, Python bytecode compilation, diff check, PII gate, and founder-content gate passed

## Deliberately not run

No real 168 x 2 fleet, tag, release, deploy, secret operation, or acceptance claim was performed.