### PR TITLE
fix: unblock real-user updates and workflow dead ends

### DIFF
--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -1,12 +1,25 @@
 ---
 name: daily-review
 description: "Close out the day: what got done vs planned, meeting follow-ups, learnings, and tomorrow's focus. Use when the user says 'review my day', 'wrap up', 'end of day', or it's evening. Also use proactively when the day's work is clearly done. Not for setting up the morning; use `daily-plan`."
-context: fork
 ---
 
 ## Purpose
 
 Conduct an end-of-day review to capture progress, track what you actually accomplished vs. planned, surface meeting follow-ups, and set up tomorrow.
+
+## Execution mode
+
+Run inline in the current conversation by default. Do not fork merely because this
+skill was selected. Only run in the background when the user explicitly asks for a
+background review or the host has already obtained a specific background-work
+approval for this review.
+
+Before authoring anything, check for existing day state: today's archived plan,
+today's completion metrics, and any review or closeout already written for today. If
+existing day state is present, enter **verifier mode**. Read it, compare it with the
+current tasks and meeting evidence, and surface omissions or proposed corrections.
+Do not create a competing review or overwrite the existing author. Any proposed
+write still follows the confirmation and write-guard rules below.
 
 ## Tone Calibration
 

--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -202,8 +202,12 @@ counts, or promote an inferred edge to proved. Only each group's `surface` line 
 rephrased, in plain English: "lives in a location Dex updates can replace" or "lives in a
 location updates leave alone."
 
-If completeness is `UNKNOWN`, render only the verdict and each `incomplete_reasons` code.
-Do not state or infer any customization count, and do not render a record list.
+If completeness is `UNKNOWN` with `partial: true`, the installed baseline was still
+verified. Render the observed count and record list explicitly as partial, followed
+by every exclusion path, reason, and guidance line. Never present the observed count
+as the complete total, and do not offer a Capsule write until completeness is `OK`.
+If completeness is `UNKNOWN` without `partial: true`, render only the verdict and
+each `incomplete_reasons` code; do not state or infer a customization count.
 When `blocked_count` is greater than zero, the first summary sentence must state that blocked count.
 
 Example register:

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -80,7 +80,10 @@ Offer it when `customization_assessment.completeness` is `OK` and
 `customization_assessment.identity.customization_count` is at least 1, or when the user says
 they have customised Dex heavily. If the verified count is zero, follow the normal lightweight update
 path and do not mention this branch. If completeness is `UNKNOWN`, show Doctor's uncertainty
-and do not infer a zero count.
+and do not infer a zero count. When Doctor returns `partial: true`, show the observed
+records and every exclusion path, reason, and guidance as a partial inventory. Do not
+run the Capsule preview or ask for Capsule approval until reassessment returns
+completeness `OK`.
 
 ### Detect and explain
 

--- a/.claude/skills/meeting-closeout/SKILL.md
+++ b/.claude/skills/meeting-closeout/SKILL.md
@@ -15,7 +15,14 @@ It is the single-meeting, in-the-moment ritual. It is **not** the bulk "catch up
 
 Work from whichever exists, in this order:
 1. **Notes the user just pasted or dictated** — the common case; use them directly even if the meeting was never synced.
-2. **The meeting they name** ("my 3pm with Acme") — pull it via `get_meeting_context` or the latest file in `00-Inbox/Meetings/`.
+2. **The meeting they name** ("my 3pm with Acme") — pull it via `get_meeting_context`.
+3. **A provider-neutral source note elsewhere in the vault** — if the named meeting
+   was not returned, search the vault by meeting title, attendee, and date. This
+   includes notes created by ClickUp AI and other recorders. Provider-neutral
+   discovery is not only `00-Inbox/Meetings/`. Exclude Dex internals, dependency folders, archives that
+   fall outside the requested date, and binary files. Prefer QMD when available,
+   otherwise use a bounded Markdown filename/content search. Read the matched note
+   before treating it as the meeting.
 
 If there are no notes and no matching synced meeting, **ask for the notes** (or a two-line recap) — do not fabricate a summary of a meeting you can't see.
 
@@ -39,7 +46,12 @@ Offer to create tasks from the action items and your commitments. **Nothing is w
 
 ## Step 5 — Capture, then confirm what happened
 
-Save the closeout to the meeting note (or `00-Inbox/Meetings/` if it was pasted, unsynced). Then confirm the real result by reading it back: the note path saved, the tasks created (by ID), and which person pages were updated. Never report "captured / done" without those in hand.
+Save the closeout to the original source note when one was discovered, wherever it
+lives. Do not silently copy a ClickUp or other provider note into
+`00-Inbox/Meetings/`. Use `00-Inbox/Meetings/` only when the notes were pasted or
+dictated and have no source file. Then confirm the real result by reading it back:
+the note path saved, the tasks created (by ID), and which person pages were updated.
+Never report "captured / done" without those in hand.
 
 ---
 

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "62a92602109d5f2392c1447677a9272524b06b97de756696e8147c86d21a7675",
+    "sha256": "06d57112f644b836010424053ad749ec3ded2384f5bd61d7b4f912d74bd4da6f",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "91a0648ebb6036eaf477776ee1ad32bdd4150f6801cc9a79d81675cf71f0bd4b",
+    "sha256": "62a92602109d5f2392c1447677a9272524b06b97de756696e8147c86d21a7675",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "d6212ea6d778f745e8c58b55c52715ed10ad9bcc3a103bf0557296afc73f7b9c",
+    "sha256": "a98e31890b46a9d3b33f1f2a293e0d588105b40f5c27232533d7f526b112a199",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "59dc1d4a4cecc00812b3eba9cc611b4e8cd6ab71e88e7774ac6c0d1c39e66e06",
+    "sha256": "e90690babcaba9648b14fbf9cc18b79ff3e98ed92b806aa89855b842baf72205",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "f2935ecb3230213934ee9f4aaaf2c5ed0d77df3c7f15dc33338120b62b5d78d6",
+    "sha256": "59dc1d4a4cecc00812b3eba9cc611b4e8cd6ab71e88e7774ac6c0d1c39e66e06",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "13df124f62b4e5f3b9339c1f52ffee45a43c7177db7e9e6e3093b50d7fc62591",
+    "sha256": "d8be15528779e69c6d876cbe67bbf0347a33c924554ee269f4f47a231e978ac5",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "06d57112f644b836010424053ad749ec3ded2384f5bd61d7b4f912d74bd4da6f",
+    "sha256": "d6212ea6d778f745e8c58b55c52715ed10ad9bcc3a103bf0557296afc73f7b9c",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "1ad8fbcefc94069ddb695275f78c56c56ba9b1e4c8b5c0ff4deab80208d9abdc",
+      "sha256": "0d40463658d3f760e0f5a24061e1ff642306d1604d3cef8c5d9f89c97f4b7d9b",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "1a0235616d257c3c779681f034d05c86d2cf5483fef3bc7694315b65acc3af75",
+      "sha256": "1ad8fbcefc94069ddb695275f78c56c56ba9b1e4c8b5c0ff4deab80208d9abdc",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/System/.update-journey-v1.json
+++ b/System/.update-journey-v1.json
@@ -52,7 +52,7 @@
     "linux"
   ],
   "runner": {
-    "sha256": "a98e31890b46a9d3b33f1f2a293e0d588105b40f5c27232533d7f526b112a199",
+    "sha256": "13df124f62b4e5f3b9339c1f52ffee45a43c7177db7e9e6e3093b50d7fc62591",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/customization_migration/capsule.py
+++ b/core/customization_migration/capsule.py
@@ -450,6 +450,15 @@ def preview_capsule(
     """Build a deterministic, integrity-bound plan without writing the vault."""
     assessment = assess(Path(vault_root))
     if assessment.verdict != "OK":
+        exclusions = ", ".join(
+            f"{item.path} ({item.reason})"
+            for item in assessment.exclusions
+        )
+        if exclusions:
+            raise CapsuleError(
+                "capsule write preview is blocked until the assessment is complete; "
+                f"resolve these exclusions and reassess: {exclusions}"
+            )
         raise CapsuleError(
             "capsule preview requires a complete VERIFIED assessment with verdict OK"
         )

--- a/core/customization_migration/cli.py
+++ b/core/customization_migration/cli.py
@@ -256,6 +256,19 @@ def run(arguments: list[str] | None = None) -> int:
         if options.command == "assess":
             assessment = migration_service.assess_to_dict(root)
             if assessment["verdict"] != "OK":
+                records = assessment.get("records")
+                exclusions = assessment.get("exclusions")
+                if isinstance(records, list) and isinstance(exclusions, list):
+                    print(
+                        f"Observed {len(records)} customizations, but the inventory "
+                        "is partial and cannot authorize a Capsule write."
+                    )
+                    for exclusion in exclusions:
+                        print(
+                            f"Excluded {exclusion['path']} [{exclusion['reason']}]: "
+                            f"{exclusion['guidance']}"
+                        )
+                    return 0
                 print(
                     "Nothing could be verified, so no customization counts are shown."
                 )

--- a/core/customization_migration/model.py
+++ b/core/customization_migration/model.py
@@ -37,6 +37,20 @@ EXCLUSION_REASONS = frozenset(
         "reference-budget-exhausted",
     }
 )
+EXCLUSION_GUIDANCE = {
+    "restricted": "Review this path locally; Dex will not inspect or archive it.",
+    "symlink-refused": "Replace the link with a regular file inside the vault, then reassess.",
+    "read-bound-exceeded": "Reduce or split the file so it fits the inspection limit, then reassess.",
+    "read-error": "Make the file readable and valid for its format, then reassess.",
+    "embedded-secret": "Remove the credential or secret before including this file; Dex will not archive it.",
+    "trust-hash-mismatch": "Re-authorize the current file through the trust flow, then reassess.",
+    "release-identity-unproved": "Restore a verified release catalog through /dex-update, then reassess.",
+    "dependency-tree-excluded": "Move the dependency into a regular supported vault path, then reassess.",
+    "embedded-repository": "Keep the nested repository separate and record its dependency manually.",
+    "canonical-path-collision": "Rename the colliding path so each canonical vault path is unique.",
+    "invalid-trust-registry": "Repair or recreate the trust registry through its setup flow, then reassess.",
+    "reference-budget-exhausted": "Reduce the assessed scope or split the dependency set, then reassess.",
+}
 INCOMPLETE_REASONS = frozenset(
     {
         "assessment-exclusions",
@@ -384,7 +398,11 @@ class AssessmentExclusion:
             )
 
     def to_dict(self) -> dict[str, object]:
-        result: dict[str, object] = {"path": self.path, "reason": self.reason}
+        result: dict[str, object] = {
+            "path": self.path,
+            "reason": self.reason,
+            "guidance": EXCLUSION_GUIDANCE[self.reason],
+        }
         if self.uninspected_count is not None:
             result["uninspected_count"] = self.uninspected_count
         return result
@@ -520,20 +538,27 @@ class Assessment:
             raise ValueError("identity customization_count does not match records")
         if self.identity.edge_count != len(self.edges):
             raise ValueError("identity edge_count does not match edges")
-        if self.completeness == "UNKNOWN" and (
-            self.records
-            or self.edges
-            or self.groups
-            or self.identity.inventory_path_count
-            or self.identity.customization_count
-            or self.identity.edge_count
+        if (
+            self.completeness == "UNKNOWN"
+            and self.baseline_identity_state != "VERIFIED"
+            and (
+                self.records
+                or self.edges
+                or self.groups
+                or self.identity.inventory_path_count
+                or self.identity.customization_count
+                or self.identity.edge_count
+            )
         ):
             raise ValueError(
-                "unknown assessment cannot expose partial records, edges, groups, or counts"
+                "an unverified baseline cannot expose partial records, edges, groups, or counts"
             )
 
     def to_dict(self) -> dict[str, object]:
-        if self.completeness == "UNKNOWN":
+        if (
+            self.completeness == "UNKNOWN"
+            and self.baseline_identity_state != "VERIFIED"
+        ):
             return {
                 "schema_version": self.schema_version,
                 "baseline_identity_state": self.baseline_identity_state,
@@ -541,7 +566,7 @@ class Assessment:
                 "completeness": self.completeness,
                 "verdict": self.verdict,
             }
-        return {
+        result = {
             "schema_version": self.schema_version,
             "identity": self.identity.to_dict(),
             "baseline_identity_state": self.baseline_identity_state,
@@ -554,6 +579,9 @@ class Assessment:
             "completeness": self.completeness,
             "verdict": self.verdict,
         }
+        if self.completeness == "UNKNOWN":
+            result["partial"] = True
+        return result
 
     def canonical_assessment_bytes(self) -> bytes:
         return (
@@ -579,6 +607,7 @@ __all__ = [
     "CustomizationKind",
     "CustomizationRecord",
     "EdgeKind",
+    "EXCLUSION_GUIDANCE",
     "EXCLUSION_REASONS",
     "LiveInfo",
     "ReferenceConfidence",

--- a/core/customization_migration/report.py
+++ b/core/customization_migration/report.py
@@ -26,7 +26,10 @@ GROUP_SURFACES = {
 
 def assessment_report(assessment: Assessment) -> dict[str, object]:
     """Return strict authority plus the only lines a renderer may rephrase."""
-    if assessment.completeness == "UNKNOWN":
+    if (
+        assessment.completeness == "UNKNOWN"
+        and assessment.baseline_identity_state != "VERIFIED"
+    ):
         return {
             "schema_version": assessment.schema_version,
             "baseline_identity_state": assessment.baseline_identity_state,
@@ -45,7 +48,7 @@ def assessment_report(assessment: Assessment) -> dict[str, object]:
     needs_interpretation_count = group_counts[
         AssessmentGroup.NEEDS_INTERPRETATION.value
     ]
-    return {
+    result = {
         "schema_version": assessment.schema_version,
         "identity": assessment.identity.to_dict(),
         "baseline_identity_state": assessment.baseline_identity_state,
@@ -94,6 +97,9 @@ def assessment_report(assessment: Assessment) -> dict[str, object]:
             for group in AssessmentGroup
         ],
     }
+    if assessment.completeness == "UNKNOWN":
+        result["partial"] = True
+    return result
 
 
 __all__ = ["assessment_report"]

--- a/core/customization_migration/service.py
+++ b/core/customization_migration/service.py
@@ -107,14 +107,48 @@ def assess(vault_root: Path) -> Assessment:
     if not proved_complete and not reasons:
         reasons.add("inventory-incomplete")
     completeness = "OK" if proved_complete else "UNKNOWN"
-    public_records = discovery.records if completeness == "OK" else ()
-    public_edges = discovery.edges if completeness == "OK" else ()
-    public_groups = discovery.groups if completeness == "OK" else ()
+    can_expose_observed_evidence = inventory.baseline.identity_state == "VERIFIED"
+    excluded_paths = {
+        exclusion.path
+        for exclusion in discovery.exclusions
+        if exclusion.reason != "embedded-secret"
+    }
+    public_records = (
+        tuple(
+            record
+            for record in discovery.records
+            if excluded_paths.isdisjoint(record.source_paths)
+        )
+        if can_expose_observed_evidence
+        else ()
+    )
+    public_record_ids = {
+        record.customization_id
+        for record in public_records
+    }
+    public_edges = (
+        tuple(
+            edge
+            for edge in discovery.edges
+            if edge.source_path not in excluded_paths
+        )
+        if can_expose_observed_evidence
+        else ()
+    )
+    public_groups = (
+        tuple(
+            group
+            for group in discovery.groups
+            if group.customization_id in public_record_ids
+        )
+        if can_expose_observed_evidence
+        else ()
+    )
     return Assessment(
         0,
         AssessmentIdentity(
             inventory.baseline.release_version,
-            len(inventory.entries) if completeness == "OK" else 0,
+            len(inventory.entries) if can_expose_observed_evidence else 0,
             len(public_records),
             len(public_edges),
         ),

--- a/core/mcp/customization_migration_server.py
+++ b/core/mcp/customization_migration_server.py
@@ -255,7 +255,12 @@ async def handle_call_tool(
                     (
                         "Customization assessment is complete."
                         if state == "ok"
-                        else "Customization assessment could not be verified."
+                        else (
+                            "Customization assessment is partial; review the listed "
+                            "exclusions before creating a Capsule."
+                            if assessment.get("partial") is True
+                            else "Customization assessment could not be verified."
+                        )
                     ),
                     **extra,
                 )

--- a/core/mcp/tests/test_customization_migration_server.py
+++ b/core/mcp/tests/test_customization_migration_server.py
@@ -88,6 +88,40 @@ def test_assess_and_preview_happy_paths(tmp_path: Path, monkeypatch) -> None:
     assert preview["preview"]["files"]
 
 
+def test_partial_assessment_message_preserves_observed_evidence(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    assessment = {
+        "verdict": "UNKNOWN",
+        "partial": True,
+        "records": [{"source_paths": [".scripts/custom.py"]}],
+        "exclusions": [
+            {
+                "path": ".scripts/link.py",
+                "reason": "symlink-refused",
+                "guidance": "Replace the link, then reassess.",
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        server.migration_service,
+        "assess_to_dict",
+        lambda _root: assessment,
+    )
+
+    payload = _call(monkeypatch, vault, "assess_customizations")
+
+    assert payload["feature_status"] == "unknown"
+    assert payload["user_message"] == (
+        "Customization assessment is partial; review the listed exclusions "
+        "before creating a Capsule."
+    )
+    assert payload["assessment"] == assessment
+
+
 def test_preview_tool_never_returns_the_cli_confirmation_token(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -183,14 +183,6 @@ RULES: tuple[Rule, ...] = (
     _r("brain-beta-communications", "System/Beta_Communications", "dir", "brain",
        "release-doc retained until the schema-2 baseline-reduction follow-up"),
     _r("brain-system-readme", "System/README.md", "file", "brain"),
-    _r(
-        "brain-update-journey-protocol",
-        "System/.update-journey-v1.json",
-        "file",
-        "brain",
-        "immutable release-owned updater instructions with no arbitrary command surface",
-    ),
-
     # --- seed: shipped once, then the user's; update writes only if absent -
     _r("seed-templates", "System/Templates", "dir", "seed"),
     _r("seed-user-profile-live", "System/user-profile.yaml", "file", "seed",

--- a/core/tests/test_customization_assessment.py
+++ b/core/tests/test_customization_assessment.py
@@ -205,6 +205,44 @@ def test_manifest_only_baseline_never_emits_zero_customization_all_clear(
     assert report["incomplete_reasons"] == ["baseline-not-verified"]
 
 
+def test_verified_partial_assessment_keeps_safe_inventory_and_exclusion_evidence(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, ".scripts/custom.py", b"VALUE = 1\n")
+    external = tmp_path / "outside.py"
+    external.write_text("PRIVATE = True\n", encoding="utf-8")
+    link = vault / ".scripts" / "outside-link.py"
+    link.symlink_to(external)
+
+    assessment = assess(vault)
+    emitted = assessment_to_dict(assessment)
+    report = assessment_report(assessment)
+
+    assert assessment.completeness == "UNKNOWN"
+    assert assessment.verdict == "UNKNOWN"
+    assert [record.source_paths for record in assessment.records] == [
+        (".scripts/custom.py",)
+    ]
+    assert assessment.edges == ()
+    assert len(assessment.groups) == 1
+    assert emitted["partial"] is True
+    assert emitted["identity"]["customization_count"] == 1
+    assert emitted["records"][0]["source_paths"] == [".scripts/custom.py"]
+    assert emitted["exclusions"] == [
+        {
+            "path": ".scripts/outside-link.py",
+            "reason": "symlink-refused",
+            "guidance": "Replace the link with a regular file inside the vault, then reassess.",
+        }
+    ]
+    assert report["partial"] is True
+    assert report["counts"]["total"] == 1
+    assert report["exclusions"] == emitted["exclusions"]
+
+
 def test_hard_denied_customization_is_restricted_without_content_leak(
     tmp_path: Path,
 ) -> None:
@@ -594,7 +632,12 @@ def test_reference_through_symlinked_parent_is_missing_and_blocked(
 
     record = _records_by_path(discovery)[".scripts/custom.py"]
     assert _groups_by_id(discovery)[record.customization_id] is AssessmentGroup.BLOCKED
-    assert assessment.records == ()
+    assert [item.source_paths for item in assessment.records] == [
+        (".scripts/custom.py",)
+    ]
+    assert len(assessment.edges) == 1
+    assert _groups_by_id(assessment)[record.customization_id] is AssessmentGroup.BLOCKED
+    assert assessment.to_dict()["partial"] is True
 
 
 def test_remapped_edge_source_recomputes_its_stable_edge_id(
@@ -699,9 +742,10 @@ def test_dependency_tree_is_excluded_instead_of_becoming_customizations(
     assert assessment.records == ()
     assert assessment.edges == ()
     assert assessment.groups == ()
-    assert assessment.identity.inventory_path_count == 0
+    assert assessment.identity.inventory_path_count > 0
     assert assessment.identity.customization_count == 0
     assert assessment.identity.edge_count == 0
+    assert assessment.to_dict()["partial"] is True
 
 
 def test_remapped_edge_target_uses_same_canonical_path_as_its_record(
@@ -865,7 +909,10 @@ def test_reference_file_budget_stops_before_uninspected_candidate(
 
     assert budget.uninspected_count == 1
     assert assessment.completeness == "UNKNOWN"
-    assert assessment.records == ()
+    assert [record.source_paths for record in assessment.records] == [
+        (".scripts/a.py",)
+    ]
+    assert assessment.to_dict()["partial"] is True
 
 
 def test_reference_byte_budget_allows_exact_boundary_then_stops(
@@ -1302,7 +1349,12 @@ def test_incoming_reference_to_canonical_collision_is_blocked(
         ".claude/skills-custom/caller/SKILL.md"
     ]
     assert _groups_by_id(discovery)[record.customization_id] is AssessmentGroup.BLOCKED
-    assert assessment.records == ()
+    assert [item.source_paths for item in assessment.records] == [
+        (".claude/skills-custom/caller/SKILL.md",)
+    ]
+    assert len(assessment.edges) == 1
+    assert _groups_by_id(assessment)[record.customization_id] is AssessmentGroup.BLOCKED
+    assert assessment.to_dict()["partial"] is True
 
 
 def test_multilevel_relative_python_import_resolves_from_parent_package(

--- a/core/tests/test_customization_assessment_depth.py
+++ b/core/tests/test_customization_assessment_depth.py
@@ -603,10 +603,13 @@ def test_extreme_corpus_exact_exclusions_and_unknown_honesty(
     }
     assert assessment.completeness == "UNKNOWN"
     assert assessment.verdict == "UNKNOWN"
-    assert assessment.records == ()
-    assert assessment.edges == ()
-    assert assessment.groups == ()
+    assert len(assessment.records) == 9
+    assert len(assessment.edges) == 7
+    assert len(assessment.groups) == 9
+    assert assessment.identity.customization_count == 9
+    assert assessment.identity.edge_count == 7
     assert "assessment-exclusions" in assessment.incomplete_reasons
+    assert assessment.to_dict()["partial"] is True
 
 
 def test_adoption_benchmark_reports_customization_assessment_stage() -> None:

--- a/core/tests/test_customization_capsule_create.py
+++ b/core/tests/test_customization_capsule_create.py
@@ -84,6 +84,26 @@ def test_preview_refuses_manifest_only_unknown_assessment(tmp_path: Path) -> Non
     assert not (vault / CAPSULE_ROOT).exists()
 
 
+def test_preview_refusal_names_exact_exclusions_and_preserves_partial_understanding(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _install_verified_catalog(vault)
+    write_file(vault, ".scripts/custom.py", b"VALUE = 1\n")
+    external = tmp_path / "outside.py"
+    external.write_text("PRIVATE = True\n", encoding="utf-8")
+    link = vault / ".scripts" / "outside-link.py"
+    link.symlink_to(external)
+
+    with pytest.raises(CapsuleError) as raised:
+        preview_capsule(vault)
+
+    assert ".scripts/outside-link.py" in str(raised.value)
+    assert "symlink-refused" in str(raised.value)
+    assert not (vault / CAPSULE_ROOT).exists()
+
+
 def test_preview_create_validate_and_status_happy_path(tmp_path: Path) -> None:
     vault = _linked_customized_vault(tmp_path)
 

--- a/core/tests/test_customization_migration_cli.py
+++ b/core/tests/test_customization_migration_cli.py
@@ -124,6 +124,43 @@ def test_assess_unknown_prints_no_counts(tmp_path: Path) -> None:
     )
 
 
+def test_assess_partial_prints_observed_count_and_exclusion_guidance(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    vault = _manifest_only_vault(tmp_path)
+    monkeypatch.setattr(
+        cli.migration_service,
+        "assess_to_dict",
+        lambda _root: {
+            "verdict": "UNKNOWN",
+            "records": [{"customization_id": "custom-1"}],
+            "exclusions": [
+                {
+                    "path": "custom/large.md",
+                    "reason": "read-bound-exceeded",
+                    "guidance": "Split the file, then reassess.",
+                }
+            ],
+        },
+    )
+
+    return_code, output = _run_in_process(
+        vault,
+        capsys,
+        monkeypatch,
+        "assess",
+    )
+
+    assert return_code == 0
+    assert "Observed 1 customizations" in output
+    assert (
+        "Excluded custom/large.md [read-bound-exceeded]: "
+        "Split the file, then reassess."
+    ) in output
+
+
 def test_create_requires_current_printed_token_and_stale_token_writes_nothing(
     tmp_path: Path,
 ) -> None:

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import subprocess
 import sys
+from collections import namedtuple
 from pathlib import Path
 from types import ModuleType
 
@@ -95,6 +98,12 @@ def _foundation_topology_adapter(
 
     engine.topology_state = original_state
     engine._migrator_command = original_command
+    apply_update = ModuleType("test_foundation_apply_update")
+    apply_update._tree_entries = lambda *_arguments: ()
+    apply_update._verify_manifest = lambda *_arguments: None
+    apply_update.portable_contract = ModuleType("test_portable_contract")
+    apply_update.portable_contract.ContractViolation = RuntimeError
+    apply_update.TreeEntry = tuple
 
     class Service:
         def build_and_preview_topology_migration(self, vault_root: Path):
@@ -138,7 +147,17 @@ def _foundation_topology_adapter(
                 "approval_token": approved_token,
             }
 
-    return bridge._FoundationLifecycleService(Service(), engine, source), engine, vault, migrator
+    return (
+        bridge._FoundationLifecycleService(
+            Service(),
+            engine,
+            apply_update,
+            source,
+        ),
+        engine,
+        vault,
+        migrator,
+    )
 
 
 def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
@@ -208,15 +227,21 @@ def test_foundation_service_uses_verified_migrator_for_exact_legacy_topology_onl
         "token",
     )
 
+    command_prefix = [
+        "/trusted/node",
+        "--require",
+        str(service._preload),
+        str(migrator),
+    ]
     assert preview == {
         "topology": "combined",
-        "command": ["/trusted/node", str(migrator), "--dry-run"],
+        "command": [*command_prefix, "--dry-run"],
     }
     assert executed == {
         "topology": "combined",
         "commands": [
-            ["/trusted/node", str(migrator), "--auto"],
-            ["/trusted/node", str(migrator), "--resume"],
+            [*command_prefix, "--auto"],
+            [*command_prefix, "--resume"],
         ],
     }
     assert not (vault / bridge._TOPOLOGY_MIGRATOR_RELATIVE).exists()
@@ -266,6 +291,294 @@ def test_foundation_service_refuses_migrator_changed_after_verification(
 
     with pytest.raises(bridge.BridgeError, match="changed after verification"):
         service.build_and_preview_topology_migration(vault)
+
+
+def test_legacy_preload_supplies_absent_read_only_inputs_without_vault_writes(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the compatibility preload test")
+    script = """
+const fs = require('node:fs');
+const path = require('node:path');
+const root = process.cwd();
+const policy = fs.readFileSync(path.join(root, 'core/migrations/tracked-ignored-policy.yaml'), 'utf8');
+const transition = fs.readFileSync(path.join(root, 'System/.local-only-preservation-transition.json'), 'utf8');
+process.stdout.write(JSON.stringify({policy, transition}));
+"""
+
+    result = subprocess.run(
+        [node, "--require", str(service._preload), "--eval", script],
+        cwd=vault,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    supplied = json.loads(result.stdout)
+
+    assert supplied["policy"].encode() == bridge._LEGACY_TRACKED_IGNORE_POLICY
+    assert supplied["transition"].encode() == bridge._LEGACY_PRESERVATION_TRANSITION
+    assert not (vault / bridge._TRACKED_IGNORE_POLICY_RELATIVE).exists()
+    assert not (vault / bridge._PRESERVATION_TRANSITION_RELATIVE).exists()
+
+
+def test_legacy_preload_refuses_an_existing_or_symlinked_compatibility_input(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the compatibility preload test")
+    policy = vault / bridge._TRACKED_IGNORE_POLICY_RELATIVE
+    policy.parent.mkdir(parents=True)
+    policy.symlink_to(vault / "attacker-policy.yaml")
+    script = (
+        "require('node:fs').readFileSync("
+        "require('node:path').join(process.cwd(), "
+        "'core/migrations/tracked-ignored-policy.yaml'), 'utf8')"
+    )
+
+    result = subprocess.run(
+        [node, "--require", str(service._preload), "--eval", script],
+        cwd=vault,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "refused existing legacy compatibility input" in result.stderr
+
+
+def test_legacy_preload_hides_only_the_exact_shipped_v1201_symlink(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    target = vault / "pi-extensions" / "dex"
+    target.mkdir(parents=True)
+    shipped_link = vault / bridge._LEGACY_SHIPPED_SYMLINK_RELATIVE
+    shipped_link.parent.mkdir(parents=True)
+    shipped_link.symlink_to(bridge._LEGACY_SHIPPED_SYMLINK_TARGET)
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the compatibility preload test")
+    script = """
+const fs = require('node:fs');
+const names = fs.readdirSync('.pi/agent/extensions', {withFileTypes: true})
+  .map((entry) => entry.name);
+process.stdout.write(JSON.stringify(names));
+"""
+
+    result = subprocess.run(
+        [node, "--require", str(service._preload), "--eval", script],
+        cwd=vault,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == []
+    assert shipped_link.is_symlink()
+    assert shipped_link.readlink() == Path(bridge._LEGACY_SHIPPED_SYMLINK_TARGET)
+
+
+def test_legacy_preload_refuses_a_changed_release_symlink(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    target = vault / "different-target"
+    target.mkdir()
+    shipped_link = vault / bridge._LEGACY_SHIPPED_SYMLINK_RELATIVE
+    shipped_link.parent.mkdir(parents=True)
+    shipped_link.symlink_to(target)
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the compatibility preload test")
+
+    result = subprocess.run(
+        [node, "--require", str(service._preload), "--eval", "'ok'"],
+        cwd=vault,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "refused changed legacy release symlink" in result.stderr
+
+
+def test_foundation_service_refuses_compatibility_preload_changed_after_verification(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    service._preload.chmod(0o600)
+    service._preload.write_text("'use strict';\n// changed\n", encoding="utf-8")
+
+    with pytest.raises(bridge.BridgeError, match="preload changed after verification"):
+        service.build_and_preview_topology_migration(vault)
+
+
+def test_foundation_service_reports_missing_engine_path_as_bridge_error(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "foundation"
+    migrator = source / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    migrator.parent.mkdir(parents=True)
+    migrator.write_text("'use strict';\n", encoding="utf-8")
+    engine = ModuleType("missing_path_engine")
+    apply_update = ModuleType("apply_update")
+
+    with pytest.raises(bridge.BridgeError, match="migrator path changed"):
+        bridge._FoundationLifecycleService(
+            ModuleType("service"),
+            engine,
+            apply_update,
+            source,
+        )
+
+
+def test_legacy_delivery_reader_accepts_only_the_pinned_pre_manifest_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    apply_update = service._apply_update
+
+    class ReleaseVerificationError(RuntimeError):
+        pass
+
+    class ContractViolation(RuntimeError):
+        pass
+
+    TreeEntry = namedtuple("TreeEntry", ("path", "mode", "object_id"))
+    classified_oid = "1" * 40
+    retired_oid = "2" * 40
+    records = (
+        f"100644 blob {classified_oid}\tCLAUDE.md\0"
+        f"100644 blob {retired_oid}\tretired-release-path.txt\0"
+        f"120000 blob {bridge._LEGACY_SHIPPED_SYMLINK_BLOB}\t"
+        f"{bridge._LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()}\0"
+    ).encode()
+
+    def brain_output(_root: Path, _brain: Path, *arguments: str) -> bytes:
+        if arguments[:2] == ("ls-tree", "-r"):
+            return records
+        if arguments[:2] == ("cat-file", "blob"):
+            return bridge._LEGACY_SHIPPED_SYMLINK_TARGET.encode()
+        raise AssertionError(arguments)
+
+    def resolve(path: str):
+        if path == "retired-release-path.txt":
+            raise ContractViolation(path)
+        return object()
+
+    apply_update.ReleaseVerificationError = ReleaseVerificationError
+    apply_update.portable_contract.ContractViolation = ContractViolation
+    apply_update.portable_contract.resolve = resolve
+    apply_update.TreeEntry = TreeEntry
+    apply_update._brain_output = brain_output
+
+    def original_tree_entries(*_arguments):
+        pytest.fail("exact legacy commit should use the compatibility reader")
+
+    def original_verify_manifest(*_arguments):
+        raise ReleaseVerificationError("legacy release has no manifest")
+
+    apply_update._tree_entries = original_tree_entries
+    apply_update._verify_manifest = original_verify_manifest
+    brain = vault / ".dex" / "brain.git"
+
+    class DeliveryService:
+        @staticmethod
+        def build_and_preview_delivered_release(_vault_root: Path, _release):
+            entries = apply_update._tree_entries(
+                vault,
+                brain,
+                bridge.LEGACY_TOPOLOGY_FOUNDATION.commit,
+            )
+            apply_update._verify_manifest(vault, brain, entries)
+            return {"paths": [entry.path for entry in entries]}
+
+        @staticmethod
+        def execute_approved_delivered_release(
+            _vault_root: Path,
+            _preview,
+            _approved_token: str,
+        ):
+            return {"executed": True}
+
+    service._service = DeliveryService()
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    values = {
+        ("rev-parse", "--verify", f"{pin.commit}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "refs/dex/installed^{commit}"): pin.commit,
+    }
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda _root, *arguments: values[arguments],
+    )
+
+    assert service.build_and_preview_delivered_release(vault, {}) == {
+        "paths": ["CLAUDE.md"]
+    }
+    assert apply_update._tree_entries is original_tree_entries
+    assert apply_update._verify_manifest is original_verify_manifest
+
+
+def test_legacy_delivery_reader_rejects_any_other_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    apply_update = service._apply_update
+
+    class ReleaseVerificationError(RuntimeError):
+        pass
+
+    class ContractViolation(RuntimeError):
+        pass
+
+    TreeEntry = namedtuple("TreeEntry", ("path", "mode", "object_id"))
+    apply_update.ReleaseVerificationError = ReleaseVerificationError
+    apply_update.portable_contract.ContractViolation = ContractViolation
+    apply_update.portable_contract.resolve = lambda _path: object()
+    apply_update.TreeEntry = TreeEntry
+    apply_update._brain_output = lambda _root, _brain, *arguments: (
+        b"120000 blob 0000000000000000000000000000000000000000\t"
+        b"unexpected-link\0"
+        if arguments[:2] == ("ls-tree", "-r")
+        else b"unexpected"
+    )
+    apply_update._tree_entries = lambda *_arguments: ()
+    apply_update._verify_manifest = lambda *_arguments: None
+
+    class DeliveryService:
+        @staticmethod
+        def build_and_preview_delivered_release(_vault_root: Path, _release):
+            return apply_update._tree_entries(
+                vault,
+                vault / ".dex" / "brain.git",
+                bridge.LEGACY_TOPOLOGY_FOUNDATION.commit,
+            )
+
+    service._service = DeliveryService()
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda _root, *arguments: (
+            pin.tree
+            if arguments
+            == ("rev-parse", "--verify", f"{pin.commit}^{{tree}}")
+            else pytest.fail(f"unexpected Git call: {arguments}")
+        ),
+    )
+
+    with pytest.raises(ReleaseVerificationError, match="unknown symlink"):
+        service.build_and_preview_delivered_release(vault, {})
 
 
 def test_bridge_success_copy_names_the_canonical_dex_update_command() -> None:

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -75,6 +76,71 @@ def _completed_vault(tmp_path: Path) -> Path:
     return vault
 
 
+def _foundation_topology_adapter(
+    tmp_path: Path,
+) -> tuple[bridge._FoundationLifecycleService, ModuleType, Path, Path]:
+    source = tmp_path / "foundation"
+    migrator = source / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    migrator.parent.mkdir(parents=True)
+    migrator.write_text("'use strict';\n", encoding="utf-8")
+    vault = _vault(tmp_path)
+    engine = ModuleType("test_foundation_engine")
+    engine.TOPOLOGY_MIGRATOR_RELATIVE = bridge._TOPOLOGY_MIGRATOR_RELATIVE
+
+    def original_state(_vault_root: Path) -> str:
+        return "invalid-combined"
+
+    def original_command(_vault_root: Path, _mode: str) -> list[str]:
+        raise RuntimeError("vault migrator was rejected")
+
+    engine.topology_state = original_state
+    engine._migrator_command = original_command
+
+    class Service:
+        def build_and_preview_topology_migration(self, vault_root: Path):
+            state = engine.topology_state(vault_root)
+            return {
+                "topology": state,
+                "command": (
+                    engine._migrator_command(vault_root, "--dry-run")
+                    if state == "combined"
+                    else None
+                ),
+            }
+
+        def execute_approved_topology_migration(
+            self,
+            vault_root: Path,
+            _preview,
+            _approved_token: str,
+        ):
+            state = engine.topology_state(vault_root)
+            return {
+                "topology": state,
+                "commands": [
+                    engine._migrator_command(vault_root, "--auto"),
+                    engine._migrator_command(vault_root, "--resume"),
+                ],
+            }
+
+        def build_and_preview_delivered_release(self, vault_root: Path, release):
+            return {"vault": str(vault_root), "release": release}
+
+        def execute_approved_delivered_release(
+            self,
+            vault_root: Path,
+            preview,
+            approved_token: str,
+        ):
+            return {
+                "vault": str(vault_root),
+                "preview": preview,
+                "approval_token": approved_token,
+            }
+
+    return bridge._FoundationLifecycleService(Service(), engine, source), engine, vault, migrator
+
+
 def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
     assert bridge.FOUNDATION.identity() == {
         "tag": "dist/release/v1.80.5-9211053",
@@ -84,6 +150,122 @@ def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
         "version": "1.80.5",
         "channel": "stable",
     }
+
+
+def test_legacy_topology_pin_is_closed_to_exact_v1201_release() -> None:
+    assert bridge.LEGACY_TOPOLOGY_FOUNDATION == bridge.LegacyTopologyPin(
+        tag="v1.20.1",
+        tag_object="3f7338dbe21ec98c015a3c8417d037cdd51b517d",
+        commit="9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
+        tree="b781bb94e417b2873d057a5a417d8c666a360bca",
+    )
+
+
+def test_legacy_topology_requires_exact_tag_commit_tree_and_current_ancestry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    values = {
+        ("cat-file", "-t", pin.tag): "tag",
+        ("rev-parse", "--verify", f"refs/tags/{pin.tag}"): pin.tag_object,
+        ("rev-parse", "--verify", f"{pin.tag}^{{commit}}"): pin.commit,
+        ("rev-parse", "--verify", f"{pin.tag}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "HEAD^{commit}"): "f" * 40,
+        ("merge-base", "--is-ancestor", pin.commit, "f" * 40): "",
+    }
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda _root, *arguments: values[arguments],
+    )
+
+    assert bridge._supported_legacy_topology(vault) is True
+
+    values[("rev-parse", "--verify", f"{pin.tag}^{{tree}}")] = "0" * 40
+    assert bridge._supported_legacy_topology(vault) is False
+
+
+def test_foundation_service_uses_verified_migrator_for_exact_legacy_topology_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, engine, vault, migrator = _foundation_topology_adapter(tmp_path)
+    original_state = engine.topology_state
+    original_command = engine._migrator_command
+    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+    monkeypatch.setattr(
+        bridge,
+        "_trusted_executable",
+        lambda name: Path("/trusted/node") if name == "node" else None,
+    )
+
+    preview = service.build_and_preview_topology_migration(vault)
+    executed = service.execute_approved_topology_migration(
+        vault,
+        {"approved": True},
+        "token",
+    )
+
+    assert preview == {
+        "topology": "combined",
+        "command": ["/trusted/node", str(migrator), "--dry-run"],
+    }
+    assert executed == {
+        "topology": "combined",
+        "commands": [
+            ["/trusted/node", str(migrator), "--auto"],
+            ["/trusted/node", str(migrator), "--resume"],
+        ],
+    }
+    assert not (vault / bridge._TOPOLOGY_MIGRATOR_RELATIVE).exists()
+    assert engine.topology_state is original_state
+    assert engine._migrator_command is original_command
+
+
+def test_foundation_service_keeps_unknown_or_ambiguous_topology_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: False)
+    monkeypatch.setattr(
+        bridge,
+        "_trusted_executable",
+        lambda _name: pytest.fail("unknown topology must not select Node"),
+    )
+
+    assert service.build_and_preview_topology_migration(vault) == {
+        "topology": "invalid-combined",
+        "command": None,
+    }
+
+
+def test_foundation_service_does_not_bypass_an_unsafe_vault_migrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _engine, vault, migrator = _foundation_topology_adapter(tmp_path)
+    candidate = vault / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    candidate.parent.mkdir(parents=True)
+    candidate.symlink_to(migrator)
+    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+
+    assert service.build_and_preview_topology_migration(vault) == {
+        "topology": "invalid-combined",
+        "command": None,
+    }
+
+
+def test_foundation_service_refuses_migrator_changed_after_verification(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, migrator = _foundation_topology_adapter(tmp_path)
+    migrator.write_text("'use strict';\n// changed\n", encoding="utf-8")
+
+    with pytest.raises(bridge.BridgeError, match="changed after verification"):
+        service.build_and_preview_topology_migration(vault)
 
 
 def test_bridge_success_copy_names_the_canonical_dex_update_command() -> None:
@@ -421,3 +603,4 @@ def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
     assert "GIT_DIR" not in environment
     assert "GIT_SSH_COMMAND" not in environment
     assert "credential.helper=" in captured["arguments"]
+    assert "--no-replace-objects" in captured["arguments"]

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -65,7 +65,7 @@ RELEASE_BUILD_INPUTS = (
     ".claude/skills/dex-update/SKILL.md",
     ".claude/skills/dex-rollback/SKILL.md",
     "System/.local-only-preservation-transition.json",
-    "System/.update-journey-v1.json",
+    "core/update/journey-protocol-v1.json",
     "System/Beta_Communications/2026-02-04_hardcoded_paths_fix.md",
     "core/migrations/preserve_local_only_paths.py",
     "core/migrations/tracked-ignored-policy.yaml",
@@ -135,7 +135,7 @@ def test_release_builders_gate_frozen_lifecycle_contract_artifacts() -> None:
     from core.utils.manifest import REQUIRED_LIFECYCLE_RELEASE_PATHS
 
     assert REQUIRED_LIFECYCLE_RELEASE_PATHS == (
-        "System/.update-journey-v1.json",
+        "core/update/journey-protocol-v1.json",
         "core/lifecycle/bridge.py",
         "core/lifecycle/catalog/bridge-release.json",
         "core/lifecycle/contracts/api.schema.json",
@@ -405,7 +405,7 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert "System/.installed-files.manifest" in members
     assert "System/.release-catalog.json" in members
     assert "System/.release-evidence-profile.json" in members
-    assert "System/.update-journey-v1.json" in members
+    assert "core/update/journey-protocol-v1.json" in members
     assert "core/lifecycle/catalog/bridge-release.json" in members
     assert "core/lifecycle/contracts/api.schema.json" in members
     assert "core/lifecycle/service.py" in members
@@ -432,7 +432,7 @@ def test_release_branch_strips_dev_files_and_untracks_v1_local_only_files(tmp_pa
     assert "core/tests/test_distribution_artifacts.py" not in manifest
     assert "core/lifecycle/catalog/bridge-release.json" in manifest
     assert "core/lifecycle/contracts/api.schema.json" in manifest
-    assert "System/.update-journey-v1.json" in manifest
+    assert "core/update/journey-protocol-v1.json" in manifest
     assert "core/update/journey_protocol.py" in manifest
     assert "System/.dex/lifecycle/activation.json" not in manifest
     catalog = _git_json(clone, "release:System/.release-catalog.json")

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2233,6 +2233,103 @@ def test_core_drift_is_ok_for_a_clean_release_checkout(tmp_path):
     assert doctor._probe_core_drift(drift_context).verdict == "OK"
 
 
+def test_post_split_core_drift_accepts_only_installer_normalized_package_metadata(
+    context,
+) -> None:
+    brain = _write_split_topology(context)
+    baseline_package = {
+        "name": "dex-pkm",
+        "version": "1.80.5",
+        "scripts": {"meeting-sync": "node sync.cjs"},
+        "dependencies": {"js-yaml": "^4.1.0"},
+    }
+    baseline_lock = {
+        "name": "dex-pkm",
+        "version": "1.75.0",
+        "lockfileVersion": 3,
+        "requires": True,
+        "packages": {
+            "": {
+                "name": "dex-pkm",
+                "version": "1.75.0",
+                "dependencies": {"js-yaml": "^4.1.0"},
+            }
+        },
+    }
+    (context.vault_root / "package.json").write_text(
+        json.dumps(baseline_package, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (context.vault_root / "package-lock.json").write_text(
+        json.dumps(baseline_lock, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (context.vault_root / "System/.installed-files.manifest").write_text(
+        "package-lock.json\npackage.json\n",
+        encoding="utf-8",
+    )
+    _git(
+        context.vault_root,
+        "add",
+        "package.json",
+        "package-lock.json",
+        "System/.installed-files.manifest",
+    )
+    _git(context.vault_root, "commit", "-m", "foundation package metadata")
+    installed = _git(context.vault_root, "rev-parse", "HEAD").stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={brain}",
+            "fetch",
+            "--quiet",
+            str(context.vault_root),
+            f"+{installed}:refs/dex/installed",
+        ],
+        check=True,
+    )
+    current_package = {
+        **baseline_package,
+        "scripts": {
+            **baseline_package["scripts"],
+            "test:hooks": "node --test hooks.test.cjs",
+            "check:connections-contract": "node check-contract.mjs",
+        },
+    }
+    current_lock = {
+        **baseline_lock,
+        "version": "1.80.5",
+        "packages": {
+            "": {
+                **baseline_lock["packages"][""],
+                "version": "1.80.5",
+            }
+        },
+    }
+    (context.vault_root / "package.json").write_text(
+        json.dumps(current_package, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (context.vault_root / "package-lock.json").write_text(
+        json.dumps(current_lock, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = doctor._probe_core_drift(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "No shipped brain files differ from refs/dex/installed"
+
+    current_package["dependencies"]["js-yaml"] = "*"
+    (context.vault_root / "package.json").write_text(
+        json.dumps(current_package, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    result = doctor._probe_core_drift(context)
+    assert result.verdict == "UNKNOWN"
+    assert "package.json" in result.detail
+
+
 def test_repository_credential_named_release_files_match_head_without_python_reads(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import venv
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -2518,6 +2519,43 @@ def test_smoke_journeys_roll_up_unknown_and_use_the_same_interpreter(monkeypatch
     ]
     assert observed["kwargs"]["env"]["VAULT_PATH"] == str(context.vault_root)
     assert observed["kwargs"]["cwd"] == context.vault_root
+
+
+def test_smoke_journeys_use_vault_venv_where_yaml_is_actually_installed(
+    tmp_path,
+):
+    vault = tmp_path / "vault"
+    smoke_path = vault / "core" / "utils" / "smoke.py"
+    smoke_path.parent.mkdir(parents=True)
+    (vault / "System").mkdir()
+    venv.create(vault / ".venv", with_pip=False)
+    python = vault / ".venv" / "bin" / "python"
+    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    site_packages = vault / ".venv" / "lib" / version / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    (site_packages / "yaml.py").write_text("SAFE_SENTINEL = True\n", encoding="utf-8")
+    smoke_path.write_text(
+        "import json, yaml\n"
+        "assert yaml.SAFE_SENTINEL is True\n"
+        "print(json.dumps({"
+        "'schema_version': 1,"
+        "'journeys': [{'id': 'configs', 'verdict': 'OK', "
+        "'detail': 'configs parse', 'duration_ms': 1}],"
+        "'summary': {'ok': 1, 'broken': 0, 'unknown': 0, 'off': 0}"
+        "}))\n",
+        encoding="utf-8",
+    )
+    context = doctor.DoctorContext(
+        vault_root=vault,
+        repo_root=vault,
+        home=tmp_path / "home",
+        now=NOW,
+    )
+
+    result = doctor._probe_smoke_journeys(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "configs [OK]: configs parse"
 
 
 def test_smoke_journeys_roll_up_broken_from_exit_one(monkeypatch, context):

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2001,6 +2001,17 @@ def test_customization_skills_are_ok_when_every_frontmatter_is_valid(context):
     assert "1 user customization" in result.detail
 
 
+def test_customization_skills_ignore_empty_retired_skill_directories(context):
+    _write_skill(context, "daily-plan")
+    retired = context.vault_root / ".claude" / "skills" / "retired-shipped-skill"
+    retired.mkdir(parents=True)
+
+    result = doctor._probe_customization_skills(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "Validated 0 user customizations and 1 shipped skill"
+
+
 def test_customization_skill_containers_are_not_validated_or_counted_as_skills(context):
     _write_skill(context, "daily-plan")
     assert {"_available", "integrations"} <= doctor.KNOWN_SKILL_CONTAINER_DIRECTORIES

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2292,8 +2292,11 @@ def test_post_split_core_drift_accepts_only_installer_normalized_package_metadat
         **baseline_package,
         "scripts": {
             **baseline_package["scripts"],
-            "test:hooks": "node --test hooks.test.cjs",
-            "check:connections-contract": "node check-contract.mjs",
+            "test:hooks": "node --test .claude/hooks/tests/*.test.cjs",
+            "check:connections-contract": (
+                "node scripts/check-connections-contract.mjs && "
+                "node scripts/build-connections-engine-manifest.mjs --check"
+            ),
         },
     }
     current_lock = {
@@ -2320,6 +2323,16 @@ def test_post_split_core_drift_accepts_only_installer_normalized_package_metadat
     assert result.verdict == "OK"
     assert result.detail == "No shipped brain files differ from refs/dex/installed"
 
+    current_package["scripts"]["test:exfiltrate"] = "curl https://example.test"
+    (context.vault_root / "package.json").write_text(
+        json.dumps(current_package, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    result = doctor._probe_core_drift(context)
+    assert result.verdict == "UNKNOWN"
+    assert "package.json" in result.detail
+
+    del current_package["scripts"]["test:exfiltrate"]
     current_package["dependencies"]["js-yaml"] = "*"
     (context.vault_root / "package.json").write_text(
         json.dumps(current_package, indent=2) + "\n",

--- a/core/tests/test_meeting_closeout_skill.py
+++ b/core/tests/test_meeting_closeout_skill.py
@@ -64,6 +64,16 @@ def test_degrades_without_fabricating_a_recap() -> None:
     assert "ask for the notes" in text
 
 
+def test_named_meeting_discovery_is_provider_neutral_and_not_folder_bound() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+
+    assert "provider-neutral" in text
+    assert "search the vault" in text
+    assert "clickup" in text
+    assert "not only `00-inbox/meetings/`" in text
+    assert "original source note" in text
+
+
 @pytest.mark.parametrize(
     "needle",
     ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1594,9 +1594,11 @@ def test_journey_refuses_an_undeclared_host_platform(
         )
 
 
+@pytest.mark.parametrize("split_topology", [False, True])
 def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    split_topology: bool,
 ) -> None:
     from core.update.journey_protocol import load_update_journey_protocol
     from scripts import release_fleet_executor
@@ -1690,14 +1692,61 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         lambda *_args, **_kwargs: {},
     )
 
-    def build_case(_repo, release, output, *, environment):
+    def build_case(
+        _repo,
+        release,
+        output,
+        *,
+        environment,
+        keep_official_fetch,
+    ):
         assert environment == {}
+        assert keep_official_fetch is True
         vault = output / release_fleet.safe_case_name(release)
         vault.mkdir(parents=True)
+        if split_topology:
+            (vault / "System/.dex").mkdir(parents=True)
+            (vault / ".git").mkdir()
+            (vault / ".dex/brain.git").mkdir(parents=True)
+            (vault / ".dex/pre-split-archive.git").mkdir()
+            (vault / "System/.dex/topology.json").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "topology": "brain-vault-split",
+                        "vaultGitDir": ".git",
+                        "brainGitDir": ".dex/brain.git",
+                        "archiveGitDir": ".dex/pre-split-archive.git",
+                        "installedRelease": start.commit,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (vault / ".git/dex-vault-v2").write_text(
+                json.dumps({"schemaVersion": 1, "role": "vault"}) + "\n",
+                encoding="utf-8",
+            )
+            (vault / ".dex/brain.git/dex-brain-v2").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "role": "brain",
+                        "installed": start.commit,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            remote_events.append("split-official-read-retained")
         return release_fleet.FleetCase(release, vault, {"00-Inbox/keep.md": "0" * 64})
 
     def execute(**kwargs):
-        assert remote_events == ["official-read-open"]
+        assert remote_events == (
+            ["split-official-read-retained"]
+            if split_topology
+            else ["official-read-open"]
+        )
         remote_events.append("execute")
         captured.update(kwargs)
         return Run()
@@ -1732,7 +1781,11 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert captured["foundation_release"] == foundation.identity()
     assert captured["follow_up_release"] == follow_up.identity()
     assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
-    assert remote_events == ["official-read-open", "execute", "remote-closed"]
+    assert remote_events == (
+        ["split-official-read-retained", "execute", "remote-closed"]
+        if split_topology
+        else ["official-read-open", "execute", "remote-closed"]
+    )
     assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()
 
 

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import subprocess
 import sys
 import time
@@ -1329,6 +1330,7 @@ def test_case_environment_is_allowlisted_and_has_an_isolated_home(tmp_path: Path
         "HOME",
         "TMPDIR",
         "PATH",
+        "PIP_CACHE_DIR",
         "LANG",
         "LC_ALL",
         "PYTHONNOUSERSITE",
@@ -1338,8 +1340,52 @@ def test_case_environment_is_allowlisted_and_has_an_isolated_home(tmp_path: Path
         "VAULT_PATH",
     }
     assert Path(environment["HOME"]).is_dir()
+    assert Path(environment["PIP_CACHE_DIR"]).is_dir()
+    assert stat.S_IMODE(Path(environment["PIP_CACHE_DIR"]).stat().st_mode) == 0o700
     assert environment["HOME"] != str(Path.home())
     assert environment["VAULT_PATH"] == str(tmp_path / "vault")
+
+
+def test_case_environment_reuses_only_a_private_controller_pip_cache(
+    tmp_path: Path,
+) -> None:
+    shared_cache = tmp_path / "controller-cache" / "pip"
+    first = release_fleet._case_environment(
+        tmp_path / "first-vault",
+        tmp_path / "first-runtime",
+        pip_cache_dir=shared_cache,
+    )
+    second = release_fleet._case_environment(
+        tmp_path / "second-vault",
+        tmp_path / "second-runtime",
+        pip_cache_dir=shared_cache,
+    )
+
+    assert first["PIP_CACHE_DIR"] == str(shared_cache)
+    assert second["PIP_CACHE_DIR"] == str(shared_cache)
+    assert stat.S_IMODE(shared_cache.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize("unsafe_kind", ("symlink", "permissive"))
+def test_case_environment_rejects_unsafe_shared_pip_cache(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    shared_cache = tmp_path / "shared-cache"
+    if unsafe_kind == "symlink":
+        target = tmp_path / "target"
+        target.mkdir(mode=0o700)
+        shared_cache.symlink_to(target, target_is_directory=True)
+    else:
+        shared_cache.mkdir(mode=0o755)
+        shared_cache.chmod(0o755)
+
+    with pytest.raises(release_fleet.FleetError, match="pip cache"):
+        release_fleet._case_environment(
+            tmp_path / "vault",
+            tmp_path / "runtime",
+            pip_cache_dir=shared_cache,
+        )
 
 
 def test_trusted_node_runtime_ignores_hostile_path_and_is_explicitly_injected(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1627,6 +1627,7 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     )
     source_commit = "f" * 40
     captured: dict[str, object] = {}
+    remote_events: list[str] = []
 
     class Run:
         case = {"starting_tag": start.tag}
@@ -1696,11 +1697,26 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         return release_fleet.FleetCase(release, vault, {"00-Inbox/keep.md": "0" * 64})
 
     def execute(**kwargs):
+        assert remote_events == ["official-read-open"]
+        remote_events.append("execute")
         captured.update(kwargs)
         return Run()
 
     monkeypatch.setattr(release_fleet, "build_installed_fixture", build_case)
     monkeypatch.setattr(release_fleet, "resolve_fixture_python", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        release_fleet,
+        "_prepare_installer_release_remote",
+        lambda _repo, _vault, release, _environment: (
+            remote_events.append("official-read-open")
+            or (release.commit, release.tree)
+        ),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_disable_all_fixture_remotes",
+        lambda *_args, **_kwargs: remote_events.append("remote-closed"),
+    )
     monkeypatch.setattr(release_fleet_executor, "execute_journey", execute)
 
     run = release_fleet.run_journey(
@@ -1716,6 +1732,7 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert captured["foundation_release"] == foundation.identity()
     assert captured["follow_up_release"] == follow_up.identity()
     assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
+    assert remote_events == ["official-read-open", "execute", "remote-closed"]
     assert not (tmp_path / "output" / release_fleet.safe_case_name(start)).exists()
 
 

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -196,20 +196,331 @@ def test_installed_fixture_runs_the_historic_installer_before_seeding_user_conte
         "#!/bin/sh\n"
         "set -eu\n"
         "test ! -e 00-Inbox/keep.md\n"
-        "test \"$(git remote get-url upstream)\" = DISABLED\n"
-        "test \"$(git remote get-url --push upstream)\" = DISABLED\n"
+        f'test "$(git remote get-url upstream)" = "{release_fleet.OFFICIAL_REPOSITORY_URL}"\n'
         "mkdir -p System\n"
         "printf installed > System/fixture-install-proof\n",
         encoding="utf-8",
     )
     installer.chmod(0o755)
-    _tag_release(repo, "1.61.0", "one")
+    tag = _tag_release(repo, "1.61.0", "one")
+    _git(
+        repo,
+        "update-ref",
+        release_fleet.OFFICIAL_RELEASE_REF,
+        _git(repo, "rev-parse", f"{tag}^{{commit}}"),
+    )
     release = release_fleet.discover_distribution_releases(repo)[0]
 
     case = release_fleet.build_installed_fixture(repo, release, tmp_path / "fleet")
 
     assert (case.vault / "System/fixture-install-proof").read_text(encoding="utf-8") == "installed"
     assert case.user_hashes == release_fleet.hash_user_owned_files(case.vault)
+
+
+def test_installer_sees_the_official_release_ref_then_the_runner_disables_it(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    installer = repo / "install.sh"
+    installer.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        f'test "$(git remote get-url upstream)" = "{release_fleet.OFFICIAL_REPOSITORY_URL}"\n'
+        "test -n \"$(git rev-parse refs/remotes/upstream/release)\"\n",
+        encoding="utf-8",
+    )
+    installer.chmod(0o755)
+    tag = _tag_release(repo, "1.80.5", "foundation")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    _git(repo, "update-ref", release_fleet.OFFICIAL_RELEASE_REF, commit)
+    release = release_fleet.discover_distribution_releases(repo)[0]
+
+    case = release_fleet.build_installed_fixture(repo, release, tmp_path / "fleet")
+
+    assert _git(case.vault, "remote", "get-url", "upstream") == "DISABLED"
+    assert _git(case.vault, "remote", "get-url", "--push", "upstream") == "DISABLED"
+
+
+def test_installer_release_ref_is_pinned_to_the_historic_start(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.20.1", "historic")
+    release = release_fleet.discover_distribution_releases(repo)[0]
+    (repo / "current-foundation").write_text("newer release\n", encoding="utf-8")
+    _git(repo, "add", "current-foundation")
+    _git(repo, "commit", "--quiet", "-m", "current foundation")
+    current_foundation = _git(repo, "rev-parse", "HEAD")
+    _git(
+        repo,
+        "update-ref",
+        release_fleet.OFFICIAL_RELEASE_REF,
+        current_foundation,
+    )
+    vault = release_fleet._create_fixture_vault(
+        repo,
+        release,
+        tmp_path / "fleet",
+    )
+    environment = release_fleet._case_environment(vault, tmp_path / "runtime")
+
+    release_commit, release_tree = release_fleet._prepare_installer_release_remote(
+        repo,
+        vault,
+        release,
+        environment,
+    )
+
+    assert release_commit == release.commit
+    assert release_tree == release.tree
+    assert (
+        _git(vault, "rev-parse", release_fleet.OFFICIAL_RELEASE_REF)
+        == release.commit
+    )
+    assert release_commit != current_foundation
+    assert _git(repo, "rev-parse", f"{tag}^{{commit}}") == release.commit
+
+
+def test_installer_created_split_topology_preserves_the_exact_starting_release(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.80.5", "foundation")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    tree = _git(repo, "rev-parse", f"{tag}^{{tree}}")
+    _git(repo, "update-ref", release_fleet.OFFICIAL_RELEASE_REF, commit)
+    release = release_fleet.discover_distribution_releases(repo)[0]
+    vault = release_fleet._create_fixture_vault(repo, release, tmp_path / "fleet")
+    environment = release_fleet._case_environment(vault, tmp_path / "runtime")
+    official_commit, official_tree = release_fleet._prepare_installer_release_remote(
+        repo, vault, release, environment
+    )
+
+    archive = vault / ".dex" / "pre-split-archive.git"
+    archive.parent.mkdir()
+    (vault / ".git").rename(archive)
+    _git(vault, "init", "--quiet")
+    _git(vault, "config", "user.name", "Dex Fleet Fixture")
+    _git(vault, "config", "user.email", "fleet@example.com")
+    (vault / ".git/dex-vault-v2").write_text(
+        json.dumps({"schemaVersion": 1, "role": "vault"}) + "\n",
+        encoding="utf-8",
+    )
+    (vault / "vault-note.md").write_text("fixture vault history\n", encoding="utf-8")
+    _git(vault, "add", "vault-note.md")
+    _git(vault, "commit", "--quiet", "-m", "installer-created vault history")
+
+    brain = vault / ".dex" / "brain.git"
+    subprocess.run(["git", "init", "--bare", "--quiet", str(brain)], check=True)
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={brain}",
+            "fetch",
+            "--quiet",
+            str(repo),
+            f"+{official_commit}:refs/dex/installed",
+        ],
+        check=True,
+    )
+    (brain / "dex-brain-v2").write_text(
+        json.dumps(
+            {"schemaVersion": 1, "role": "brain", "installed": official_commit}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    topology = vault / "System/.dex/topology.json"
+    topology.parent.mkdir(parents=True)
+    topology.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "archiveGitDir": ".dex/pre-split-archive.git",
+                "installedRelease": official_commit,
+                "environment": {"DEX_VAULT": str(vault)},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    release_fleet._prove_installed_release_identity(
+        vault,
+        release,
+        environment,
+        official_release_commit=official_commit,
+        official_release_tree=official_tree,
+    )
+    assert (
+        release_fleet._git_directory(
+            archive, "rev-parse", "HEAD^{tree}", environment=environment
+        )
+        == tree
+    )
+
+    _git(repo, "commit", "--allow-empty", "--quiet", "-m", "unrelated")
+    wrong = _git(repo, "rev-parse", "HEAD")
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={archive}",
+            "fetch",
+            "--quiet",
+            str(repo),
+            f"+{wrong}:refs/heads/wrong",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", f"--git-dir={archive}", "update-ref", "HEAD", wrong],
+        check=True,
+    )
+    with pytest.raises(release_fleet.FleetError, match="pre-split archive"):
+        release_fleet._prove_installed_release_identity(
+            vault,
+            release,
+            environment,
+            official_release_commit=official_commit,
+            official_release_tree=official_tree,
+        )
+
+
+@pytest.mark.parametrize(
+    "detail",
+    (
+        "installed catalog release does not match the designated bridge release",
+        "ModuleNotFoundError: No module named 'yaml'",
+    ),
+)
+def test_known_post_topology_adoption_stops_are_narrowly_accepted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, detail: str
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    installer = vault / "install.sh"
+    installer.write_text("#!/bin/sh\n", encoding="utf-8")
+    environment = {key: "fixture" for key in release_fleet.SEALED_INSTALLER_ENVIRONMENT_KEYS}
+    release = release_fleet.DistributionRelease(
+        tag="dist/release/v1.67.0-27ecbb3",
+        version="1.67.0",
+        commit="a" * 40,
+        tree="b" * 40,
+    )
+    proved: list[bool] = []
+    monkeypatch.setattr(
+        release_fleet,
+        "_run_bounded_process_group",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            ["bash", "install.sh"],
+            1,
+            "",
+            detail,
+        ),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_prove_installed_release_identity",
+        lambda *_args, **_kwargs: proved.append(True),
+    )
+    monkeypatch.setattr(release_fleet, "_disable_fixture_remotes", lambda *_args: None)
+
+    outcome = release_fleet._run_historic_installer(
+        vault,
+        release,
+        environment,
+        official_release_commit="c" * 40,
+        official_release_tree="d" * 40,
+    )
+
+    assert outcome == "installer-complete-after-known-post-topology-stop"
+    assert proved == [True]
+
+
+def test_v175_transition_repair_uses_its_own_publisher_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    transition = vault / "System/.local-only-preservation-transition.json"
+    transition.parent.mkdir(parents=True)
+    transition.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "phase": "untrack-v1",
+                "release_version": "1.74.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (vault / "package.json").write_text(
+        json.dumps({"version": "1.75.0"}) + "\n",
+        encoding="utf-8",
+    )
+    commands: list[list[str]] = []
+
+    def stamp(command, **_kwargs):
+        commands.append(list(command))
+        transition.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "phase": "untrack-v1",
+                    "release_version": "1.75.0",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(release_fleet, "_run_bounded_process_group", stamp)
+
+    release_fleet._stamp_v175_transition(
+        vault,
+        {key: "fixture" for key in release_fleet.SEALED_INSTALLER_ENVIRONMENT_KEYS},
+        timeout_seconds=10,
+    )
+
+    assert commands == [
+        [
+            str(vault / ".venv/bin/python"),
+            "-m",
+            "core.migrations.preserve_local_only_paths",
+            "stamp-transition",
+            "--repo",
+            str(vault),
+        ]
+    ]
+
+
+def test_v175_installer_uses_its_explicit_disposable_sync_folder_override(
+    tmp_path: Path,
+) -> None:
+    installer = tmp_path / "install.sh"
+    installer.write_text(
+        'for INSTALL_ARGUMENT in "$@"; do\n'
+        '  if [ "$INSTALL_ARGUMENT" = "--allow-synced-folder" ]; then :; fi\n'
+        "done\n",
+        encoding="utf-8",
+    )
+
+    release = release_fleet.DistributionRelease(
+        tag="v1.75.0",
+        version="1.75.0",
+        commit="a" * 40,
+        tree="b" * 40,
+    )
+
+    assert release_fleet._historic_installer_command(installer, release) == [
+        "bash",
+        "install.sh",
+        "--allow-synced-folder",
+    ]
 
 
 def test_build_fixture_does_not_preload_future_release_tags(tmp_path: Path) -> None:
@@ -313,6 +624,12 @@ def test_revision_switching_installer_is_rejected_before_doctor(
     )
     installer.chmod(0o755)
     tag = _tag_release(repo, "1.61.0", "release")
+    _git(
+        repo,
+        "update-ref",
+        release_fleet.OFFICIAL_RELEASE_REF,
+        _git(repo, "rev-parse", f"{tag}^{{commit}}"),
+    )
     release = next(
         candidate
         for candidate in release_fleet.discover_distribution_releases(repo)
@@ -569,7 +886,13 @@ def test_discovery_sweep_uses_disposable_fixtures_and_never_reports_acceptance(
 ) -> None:
     repo = _repository(tmp_path)
     (repo / "install.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-    _tag_release(repo, "1.61.0", "historic")
+    tag = _tag_release(repo, "1.61.0", "historic")
+    _git(
+        repo,
+        "update-ref",
+        release_fleet.OFFICIAL_RELEASE_REF,
+        _git(repo, "rev-parse", f"{tag}^{{commit}}"),
+    )
     releases = release_fleet.discover_distribution_releases(repo)
     output = tmp_path / "survey"
     runtime = release_fleet.NodeRuntime(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -226,6 +226,7 @@ def test_installer_sees_the_official_release_ref_then_the_runner_disables_it(
         "#!/bin/sh\n"
         "set -eu\n"
         f'test "$(git remote get-url upstream)" = "{release_fleet.OFFICIAL_REPOSITORY_URL}"\n'
+        'test "$(git remote get-url --push upstream)" = "DISABLED"\n'
         "test -n \"$(git rev-parse refs/remotes/upstream/release)\"\n",
         encoding="utf-8",
     )

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1350,15 +1350,18 @@ def test_case_environment_reuses_only_a_private_controller_pip_cache(
     tmp_path: Path,
 ) -> None:
     shared_cache = tmp_path / "controller-cache" / "pip"
+    controller_root = tmp_path / "controller-cache"
     first = release_fleet._case_environment(
         tmp_path / "first-vault",
         tmp_path / "first-runtime",
         pip_cache_dir=shared_cache,
+        controller_root=controller_root,
     )
     second = release_fleet._case_environment(
         tmp_path / "second-vault",
         tmp_path / "second-runtime",
         pip_cache_dir=shared_cache,
+        controller_root=controller_root,
     )
 
     assert first["PIP_CACHE_DIR"] == str(shared_cache)
@@ -1385,6 +1388,31 @@ def test_case_environment_rejects_unsafe_shared_pip_cache(
             tmp_path / "vault",
             tmp_path / "runtime",
             pip_cache_dir=shared_cache,
+            controller_root=tmp_path,
+        )
+
+
+def test_case_environment_rejects_pip_cache_outside_controller_or_inside_vault(
+    tmp_path: Path,
+) -> None:
+    controller_root = tmp_path / "controller"
+    controller_root.mkdir(mode=0o700)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    with pytest.raises(release_fleet.FleetError, match="controller root"):
+        release_fleet._case_environment(
+            vault,
+            tmp_path / "outside-runtime",
+            pip_cache_dir=tmp_path / "outside-cache",
+            controller_root=controller_root,
+        )
+    with pytest.raises(release_fleet.FleetError, match="outside the vault"):
+        release_fleet._case_environment(
+            vault,
+            tmp_path / "inside-runtime",
+            pip_cache_dir=vault / "cache",
+            controller_root=tmp_path,
         )
 
 
@@ -1675,6 +1703,7 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     )
     source_commit = "f" * 40
     captured: dict[str, object] = {}
+    environment_kwargs: dict[str, object] = {}
     remote_events: list[str] = []
 
     class Run:
@@ -1732,11 +1761,11 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     )
     monkeypatch.setattr(release_fleet, "resolve_trusted_node_runtime", object)
     monkeypatch.setattr(release_fleet, "resolve_trusted_python_runtime", object)
-    monkeypatch.setattr(
-        release_fleet,
-        "_case_environment",
-        lambda *_args, **_kwargs: {},
-    )
+    def case_environment(*_args, **kwargs):
+        environment_kwargs.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(release_fleet, "_case_environment", case_environment)
 
     def build_case(
         _repo,
@@ -1827,6 +1856,12 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert captured["foundation_release"] == foundation.identity()
     assert captured["follow_up_release"] == follow_up.identity()
     assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
+    assert environment_kwargs["pip_cache_dir"] == (
+        tmp_path / "output/.fixture-controller/pip"
+    )
+    assert environment_kwargs["controller_root"] == (
+        tmp_path / "output/.fixture-controller"
+    )
     assert remote_events == (
         ["split-official-read-retained", "execute", "remote-closed"]
         if split_topology

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1020,7 +1020,9 @@ def _tag_protocol_control_release(
     )
     document["historic_to_foundation"]["foundation"] = foundation.identity()
     protocol_path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
-    (repo / "System/.release-catalog.json").write_text(
+    catalog = repo / "System/.release-catalog.json"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
         json.dumps(
             {
                 "catalog_version": 1,
@@ -1898,6 +1900,7 @@ def test_shipped_update_surface_requires_and_exposes_the_released_executor(
         (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_bytes()
     )
     catalog = repo / "System/.release-catalog.json"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
     catalog.write_text(
         json.dumps(
             {

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -1,4 +1,4 @@
-"""Fail-closed tests for cross-platform historic updater acceptance."""
+"""Fail-closed tests for macOS historic updater acceptance."""
 
 from __future__ import annotations
 
@@ -186,7 +186,7 @@ def _case(tag: str, platform: str) -> release_fleet.CaseResult:
 def test_platform_report_is_bound_to_one_real_protocol_platform() -> None:
     acceptance = _acceptance()
     tags = {"v1.20.1", "dist/release/v1.80.5-2222222"}
-    protocol = SimpleNamespace(platforms=("darwin", "linux"))
+    protocol = SimpleNamespace(platforms=("darwin",))
     report = release_fleet.AcceptanceReport(
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
@@ -224,7 +224,7 @@ def test_platform_report_is_bound_to_one_real_protocol_platform() -> None:
         )
 
 
-def test_platform_report_rejects_a_protocol_platform_subset() -> None:
+def test_platform_report_rejects_a_protocol_platform_superset() -> None:
     acceptance = _acceptance()
     report = release_fleet.AcceptanceReport(
         foundation_tag=FOUNDATION.tag,
@@ -236,7 +236,7 @@ def test_platform_report_rejects_a_protocol_platform_subset() -> None:
     with pytest.raises(release_fleet.FleetError, match="protocol platforms"):
         acceptance.assert_platform_report_bound(
             report,
-            protocol=SimpleNamespace(platforms=("darwin",)),
+            protocol=SimpleNamespace(platforms=("darwin", "linux")),
             running_platform="darwin",
             expected_start_tags={"v1.20.1"},
         )
@@ -253,7 +253,7 @@ def _fleet_inputs() -> tuple[object, tuple[release_fleet.DistributionRelease, ..
             releases=releases,
             foundation=_immutable_foundation(),
             follow_up=_immutable_follow_up(),
-            protocol=SimpleNamespace(platforms=("darwin", "linux")),
+            protocol=SimpleNamespace(platforms=("darwin",)),
             source_commit="c" * 40,
             acceptance_source_sha256="d" * 64,
             cohort_sha256="a" * 64,
@@ -357,7 +357,7 @@ def test_serialized_platform_evidence_is_never_an_acceptance_authority(
             inputs=inputs,
             platform=platform,
         )
-        for platform in ("darwin", "linux")
+        for platform in ("darwin",)
     ]
 
     result = acceptance.aggregate_platform_evidence(
@@ -372,18 +372,17 @@ def test_serialized_platform_evidence_is_never_an_acceptance_authority(
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
         "acceptance": False,
         "authority_complete": False,
-        "platforms": ["darwin", "linux"],
+        "platforms": ["darwin"],
         "case_count": 168,
-        "journey_count": 336,
+        "journey_count": 168,
         "discovered": 168,
-        "started": 336,
-        "completed": 336,
-        "passed": 336,
+        "started": 168,
+        "completed": 168,
+        "passed": 168,
         "failed": 0,
         "session_id": "e" * 64,
         "required_job_conclusions": {
             "darwin": "historic-fleet-darwin",
-            "linux": "historic-fleet-linux",
         },
     }
     assert not hasattr(acceptance, "sign_platform_receipt")
@@ -406,7 +405,7 @@ def test_possession_of_the_shared_key_cannot_sign_an_accepted_receipt(
             inputs=inputs,
             platform=platform,
         )
-        for platform in ("darwin", "linux")
+        for platform in ("darwin",)
     ]
 
     result = acceptance.aggregate_platform_evidence(
@@ -421,7 +420,7 @@ def test_possession_of_the_shared_key_cannot_sign_an_accepted_receipt(
     assert result["authority_complete"] is False
 
 
-def test_aggregation_requires_exact_darwin_and_linux_evidence(
+def test_aggregation_requires_exact_darwin_evidence(
     tmp_path: Path,
 ) -> None:
     acceptance = _acceptance()
@@ -446,8 +445,8 @@ def test_aggregation_requires_exact_darwin_and_linux_evidence(
     with pytest.raises(release_fleet.FleetError, match="exact protocol platforms"):
         acceptance.aggregate_platform_evidence(
             session,
-            [darwin[1]],
-            [darwin[0]],
+            [],
+            [],
             key=key,
             inputs=inputs,
         )
@@ -455,7 +454,7 @@ def test_aggregation_requires_exact_darwin_and_linux_evidence(
     with pytest.raises(release_fleet.FleetError, match="exact protocol platforms"):
         acceptance.aggregate_platform_evidence(
             session,
-            [darwin[1], darwin[1]],
+            [darwin[1], linux[1]],
             [darwin[0], linux[0]],
             key=key,
             inputs=inputs,
@@ -476,7 +475,7 @@ def test_receipts_reject_caller_supplied_counts_and_case_digests(
             inputs=inputs,
             platform=platform,
         )
-        for platform in ("darwin", "linux")
+        for platform in ("darwin",)
     ]
     forged_receipts = [json.loads(json.dumps(receipt)) for _path, receipt in evidence]
     forged_receipts[0]["payload"]["started"] = 168
@@ -507,7 +506,7 @@ def test_aggregation_reopens_and_hashes_the_immutable_manifest(
             inputs=inputs,
             platform=platform,
         )
-        for platform in ("darwin", "linux")
+        for platform in ("darwin",)
     ]
     evidence[0][0].chmod(0o644)
     document = json.loads(evidence[0][0].read_text(encoding="utf-8"))
@@ -552,15 +551,7 @@ def test_aggregation_requires_exactly_168_unique_final_starts_per_platform(
             inputs=inputs,
             platform="darwin",
             manifest=darwin,
-        ),
-        _write_authored_platform_evidence(
-            acceptance,
-            tmp_path,
-            session=session,
-            key=key,
-            inputs=inputs,
-            platform="linux",
-        ),
+        )
     ]
 
     with pytest.raises(release_fleet.FleetError, match="historic release|case count"):
@@ -583,36 +574,47 @@ def test_aggregation_rejects_mixed_sessions_and_platform_spoofing(
         platform="darwin",
         session_id="f" * 64,
     )
-    spoofed = _manifest_document(inputs=inputs, platform="linux")
+    spoofed = _manifest_document(inputs=inputs, platform="darwin")
     spoofed_report = spoofed["report"]
     assert isinstance(spoofed_report, dict)
-    spoofed_report["platforms"] = ["darwin"]
-    evidence = [
-        _write_authored_platform_evidence(
-            acceptance,
-            tmp_path,
-            session=session,
-            key=key,
-            inputs=inputs,
-            platform="darwin",
-            manifest=wrong_session,
-        ),
-        _write_authored_platform_evidence(
-            acceptance,
-            tmp_path,
-            session=session,
-            key=key,
-            inputs=inputs,
-            platform="linux",
-            manifest=spoofed,
-        ),
-    ]
+    spoofed_report["platforms"] = ["linux"]
+    wrong_session_root = tmp_path / "wrong-session"
+    wrong_session_root.mkdir()
+    wrong_session_evidence = _write_authored_platform_evidence(
+        acceptance,
+        wrong_session_root,
+        session=session,
+        key=key,
+        inputs=inputs,
+        platform="darwin",
+        manifest=wrong_session,
+    )
 
-    with pytest.raises(release_fleet.FleetError, match="session|platform"):
+    with pytest.raises(release_fleet.FleetError, match="session"):
         acceptance.aggregate_platform_evidence(
             session,
-            [receipt for _path, receipt in evidence],
-            [path for path, _receipt in evidence],
+            [wrong_session_evidence[1]],
+            [wrong_session_evidence[0]],
+            key=key,
+            inputs=inputs,
+        )
+
+    spoofed_root = tmp_path / "spoofed-platform"
+    spoofed_root.mkdir()
+    spoofed_evidence = _write_authored_platform_evidence(
+        acceptance,
+        spoofed_root,
+        session=session,
+        key=key,
+        inputs=inputs,
+        platform="darwin",
+        manifest=spoofed,
+    )
+    with pytest.raises(release_fleet.FleetError, match="running platform"):
+        acceptance.aggregate_platform_evidence(
+            session,
+            [spoofed_evidence[1]],
+            [spoofed_evidence[0]],
             key=key,
             inputs=inputs,
         )
@@ -634,15 +636,7 @@ def test_aggregation_rejects_preflight_authored_symlink_and_writable_manifests(
             inputs=inputs,
             platform="darwin",
             manifest=preflight,
-        ),
-        _write_authored_platform_evidence(
-            acceptance,
-            tmp_path,
-            session=session,
-            key=key,
-            inputs=inputs,
-            platform="linux",
-        ),
+        )
     ]
 
     with pytest.raises(release_fleet.FleetError, match="manifest shape"):
@@ -661,7 +655,7 @@ def test_aggregation_rejects_preflight_authored_symlink_and_writable_manifests(
         acceptance.aggregate_platform_evidence(
             session,
             [receipt for _path, receipt in evidence],
-            [link, evidence[1][0]],
+            [link],
             key=key,
             inputs=inputs,
         )
@@ -671,7 +665,7 @@ def test_aggregation_rejects_preflight_authored_symlink_and_writable_manifests(
         acceptance.aggregate_platform_evidence(
             session,
             [receipt for _path, receipt in evidence],
-            [real, evidence[1][0]],
+            [real],
             key=key,
             inputs=inputs,
         )
@@ -1038,7 +1032,7 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     )
     foundation = _immutable_foundation()
     follow_up = _immutable_follow_up()
-    protocol = SimpleNamespace(platforms=("darwin", "linux"))
+    protocol = SimpleNamespace(platforms=("darwin",))
     inputs = acceptance.FleetInputs(
         releases=releases,
         foundation=foundation,
@@ -1123,7 +1117,7 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     monkeypatch.setattr(acceptance, "finalize_live_platform_execution", finalize)
     receipt_paths: list[Path] = []
     manifest_paths: list[Path] = []
-    for platform in ("darwin", "linux"):
+    for platform in ("darwin",):
         monkeypatch.setattr(acceptance, "_running_platform", lambda value=platform: value)
         platform_root = tmp_path / platform
         receipt_path = platform_root / acceptance.PLATFORM_RECEIPT_NAME
@@ -1173,12 +1167,8 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
                 str(key_path),
                 "--receipt",
                 str(receipt_paths[0]),
-                "--receipt",
-                str(receipt_paths[1]),
                 "--manifest",
                 str(manifest_paths[0]),
-                "--manifest",
-                str(manifest_paths[1]),
                 "--output",
                 str(aggregate_path),
             ]
@@ -1190,17 +1180,16 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
         "acceptance": False,
         "authority_complete": False,
         "case_count": 168,
-        "completed": 336,
+        "completed": 168,
         "discovered": 168,
         "failed": 0,
-        "journey_count": 336,
+        "journey_count": 168,
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
-        "passed": 336,
-        "platforms": ["darwin", "linux"],
+        "passed": 168,
+        "platforms": ["darwin"],
         "required_job_conclusions": {
             "darwin": "historic-fleet-darwin",
-            "linux": "historic-fleet-linux",
         },
         "session_id": session["payload"]["session_id"],
-        "started": 336,
+        "started": 168,
     }

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -65,6 +65,123 @@ def _executor_source_commit(tmp_path: Path) -> tuple[Path, str]:
     return repo, commit
 
 
+def _foundation_cache(
+    tmp_path: Path,
+) -> tuple[Path, executor.dex_update_bridge.ReleasePin]:
+    source = tmp_path / "foundation-source"
+    source.mkdir(parents=True)
+    subprocess.run(["git", "init", "--quiet"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Dex Tests"],
+        cwd=source,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"],
+        cwd=source,
+        check=True,
+    )
+    service = source / "core/lifecycle/service.py"
+    service.parent.mkdir(parents=True)
+    service.write_text("FOUNDATION = True\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "foundation"],
+        cwd=source,
+        check=True,
+    )
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    tree = subprocess.run(
+        ["git", "rev-parse", "HEAD^{tree}"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    tag = f"dist/release/v1.2.3-{commit[:7]}"
+    subprocess.run(
+        ["git", "tag", "-a", tag, "-m", "foundation"],
+        cwd=source,
+        check=True,
+    )
+    tag_object = subprocess.run(
+        ["git", "rev-parse", tag],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(["git", "branch", "release"], cwd=source, check=True)
+    cache = tmp_path / "foundation-cache.git"
+    subprocess.run(
+        ["git", "clone", "--bare", "--quiet", str(source), str(cache)],
+        check=True,
+    )
+    cache.chmod(0o700)
+    pin = executor.dex_update_bridge.ReleasePin(
+        tag=tag,
+        tag_object=tag_object,
+        commit=commit,
+        tree=tree,
+        version="1.2.3",
+    )
+    return cache, pin
+
+
+def test_private_foundation_cache_preserves_exact_official_identity(
+    tmp_path: Path,
+) -> None:
+    cache, pin = _foundation_cache(tmp_path)
+
+    assert executor._validate_foundation_cache(cache, pin) == cache.resolve()
+    temporary, source = executor._acquire_cached_foundation_source(cache, pin)
+    try:
+        assert (source / "core/lifecycle/service.py").is_file()
+        assert (
+            executor._cached_git(source, "rev-parse", "HEAD^{commit}")
+            == pin.commit
+        )
+    finally:
+        temporary.cleanup()
+
+    vault = tmp_path / "vault"
+    brain = vault / ".dex/brain.git"
+    brain.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "--quiet", str(brain)], check=True)
+    executor._fetch_foundation_from_cache(vault, pin, cache=cache)
+    assert (
+        executor._cached_git(
+            brain,
+            "rev-parse",
+            "refs/remotes/upstream/release^{commit}",
+        )
+        == pin.commit
+    )
+
+
+def test_foundation_cache_rejects_wrong_channel_or_unsafe_permissions(
+    tmp_path: Path,
+) -> None:
+    cache, pin = _foundation_cache(tmp_path)
+    subprocess.run(
+        ["git", "--git-dir", str(cache), "update-ref", "-d", "refs/heads/release"],
+        check=True,
+    )
+    with pytest.raises(executor.ExecutorError, match="pinned official"):
+        executor._validate_foundation_cache(cache, pin)
+
+    cache, pin = _foundation_cache(tmp_path / "second")
+    cache.chmod(0o755)
+    with pytest.raises(executor.ExecutorError, match="mode 0700"):
+        executor._validate_foundation_cache(cache, pin)
+
+
 def _commit_executor_tamper(repo: Path) -> str:
     path = repo / "scripts/release_fleet_executor.py"
     path.write_bytes(path.read_bytes() + b"\n# externally substituted bytes\n")

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -689,9 +689,16 @@ def test_production_runtime_refuses_undeclared_lifecycle_operation() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("foundation_installed", "use_cache", "expected_cleaned"),
+    ((False, False, [True]), (True, True, [])),
+)
 def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    foundation_installed: bool,
+    use_cache: bool,
+    expected_cleaned: list[bool],
 ) -> None:
     cleaned: list[bool] = []
 
@@ -723,7 +730,7 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
     monkeypatch.setattr(
         executor.dex_update_bridge,
         "_foundation_is_installed",
-        lambda *_args: False,
+        lambda *_args: foundation_installed,
     )
     monkeypatch.setattr(
         executor.dex_update_bridge,
@@ -751,7 +758,13 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
     monkeypatch.setattr(executor.sys, "stdin", request_stream)
     monkeypatch.setattr(executor.sys, "stdout", response_stream)
 
-    assert executor._runtime_server(tmp_path / "vault") == 0
+    assert (
+        executor._runtime_server(
+            tmp_path / "vault",
+            foundation_cache=(tmp_path / "unused-cache" if use_cache else None),
+        )
+        == 0
+    )
 
     messages = [
         json.loads(line)
@@ -767,4 +780,4 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
     assert messages[1]["text"] == "exact topology preview"
     assert messages[2]["prompt"] == "exact topology prompt"
     assert messages[4]["value"]["status"] == "delivered"
-    assert cleaned == [True]
+    assert cleaned == expected_cleaned

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -304,7 +304,7 @@ def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
     tmp_path: Path,
 ) -> None:
     protocol = load_update_journey_protocol(
-        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
     )
     source_repo, source_commit = _executor_source_commit(tmp_path)
     vault, user_files = _vault(tmp_path)
@@ -379,7 +379,7 @@ def _execute(
     starting: dict[str, str] | None = None,
 ) -> executor.ExecutorRun:
     protocol = load_update_journey_protocol(
-        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
     )
     vault, user_files = _vault(tmp_path)
     starting = starting or _identity("1.61.0", "a")
@@ -547,7 +547,7 @@ def test_already_installed_foundation_executes_and_validates_without_a_fake_tran
     tmp_path: Path,
 ) -> None:
     protocol = load_update_journey_protocol(
-        (REPO_ROOT / "System/.update-journey-v1.json").read_bytes()
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
     )
     source_repo, source_commit = _executor_source_commit(tmp_path)
 

--- a/core/tests/test_review_retirement.py
+++ b/core/tests/test_review_retirement.py
@@ -32,6 +32,18 @@ def test_daily_review_still_exists_as_canonical() -> None:
     assert "daily-review" in DAILY_REVIEW.read_text(encoding="utf-8")
 
 
+def test_daily_review_does_not_force_a_fork_and_verifies_existing_day_state() -> None:
+    text = DAILY_REVIEW.read_text(encoding="utf-8")
+    frontmatter = text.split("---\n", 2)[1]
+    lower = text.lower()
+
+    assert "context: fork" not in frontmatter
+    assert "inline" in lower
+    assert "verifier mode" in lower
+    assert "existing day state" in lower
+    assert "explicitly asks" in lower and "background" in lower
+
+
 def test_alias_description_names_daily_review_as_the_target() -> None:
     fm = REVIEW.read_text(encoding="utf-8").split("---\n", 2)[1]
     desc = next(line for line in fm.splitlines() if line.startswith("description:")).lower()

--- a/core/tests/test_update_journey_protocol.py
+++ b/core/tests/test_update_journey_protocol.py
@@ -10,22 +10,36 @@ from pathlib import Path
 
 import pytest
 
+from core import portable_contract
 from core.update.journey_protocol import (
+    PROTOCOL_RELATIVE,
     JourneyProtocolError,
     load_update_journey_protocol,
 )
 from scripts import dex_update_bridge
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PROTOCOL_PATH = REPO_ROOT / "System/.update-journey-v1.json"
+PROTOCOL_PATH = REPO_ROOT / "core/update/journey-protocol-v1.json"
 GENERATOR = REPO_ROOT / "scripts/generate-update-journey-protocol.py"
+
+
+def test_protocol_uses_the_foundation_classified_brain_tree() -> None:
+    resolution = portable_contract.resolve(PROTOCOL_RELATIVE)
+
+    assert PROTOCOL_RELATIVE == "core/update/journey-protocol-v1.json"
+    assert resolution.rule_id == "brain-core"
+    assert resolution.ownership == "brain"
+    assert portable_contract.update_write_verdict(
+        PROTOCOL_RELATIVE,
+        exists=False,
+    ).action == "replace"
 
 
 def test_release_owned_protocol_binds_only_the_reviewed_update_adapters() -> None:
     protocol = load_update_journey_protocol(PROTOCOL_PATH.read_bytes())
 
     assert protocol.foundation == dex_update_bridge.FOUNDATION.identity()
-    assert protocol.platforms == ("darwin", "linux")
+    assert protocol.platforms == ("darwin",)
     assert protocol.bridge.adapter == "pinned-foundation-bridge-v1"
     assert protocol.follow_up.adapter == "lifecycle-delivered-release-v1"
     assert protocol.follow_up.operations == (

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -48,8 +48,7 @@
     }
   },
   "platforms": [
-    "darwin",
-    "linux"
+    "darwin"
   ],
   "runner": {
     "sha256": "d8be15528779e69c6d876cbe67bbf0347a33c924554ee269f4f47a231e978ac5",

--- a/core/update/journey_protocol.py
+++ b/core/update/journey_protocol.py
@@ -13,10 +13,10 @@ import re
 from dataclasses import dataclass
 from typing import Mapping
 
-PROTOCOL_RELATIVE = "System/.update-journey-v1.json"
+PROTOCOL_RELATIVE = "core/update/journey-protocol-v1.json"
 PROTOCOL_VERSION = 1
 CONTROLLER = "release-fleet-v1"
-SUPPORTED_PLATFORMS = ("darwin", "linux")
+SUPPORTED_PLATFORMS = ("darwin",)
 BRIDGE_ADAPTER = "pinned-foundation-bridge-v1"
 BRIDGE_SOURCE = "scripts/dex_update_bridge.py"
 RUNNER_SOURCE = "scripts/release_fleet.py"

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -2900,7 +2900,10 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
             path
             for path in skills_root.iterdir()
             if path.name not in KNOWN_SKILL_CONTAINER_DIRECTORIES
-            and (path.is_symlink() or path.is_dir())
+            and (
+                path.is_symlink()
+                or (path.is_dir() and any(path.iterdir()))
+            )
         ),
         key=lambda path: path.name,
     ) if skills_root.is_dir() else []

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import os
@@ -20,7 +21,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -3725,6 +3726,103 @@ def _brain_paths_from_installed_release(
     return paths
 
 
+def _package_json_object(raw: str) -> dict[str, object] | None:
+    try:
+        value = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _current_package_json(context: DoctorContext, relative: str) -> dict[str, object] | None:
+    path = context.repo_root / relative
+    if path.is_symlink() or not path.is_file():
+        return None
+    try:
+        return _package_json_object(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _installer_normalized_package_metadata(
+    context: DoctorContext,
+    relative: str,
+    baseline: str,
+    brain: Path,
+) -> bool:
+    """Recognize only npm/release-builder changes that cannot alter runtime deps."""
+
+    if relative not in {"package.json", "package-lock.json"}:
+        return False
+    baseline_raw = _git_file(
+        context,
+        baseline,
+        relative,
+        git_directory=brain,
+    )
+    if baseline_raw is None:
+        return False
+    baseline_value = _package_json_object(baseline_raw)
+    current_value = _current_package_json(context, relative)
+    current_package = _current_package_json(context, "package.json")
+    if (
+        baseline_value is None
+        or current_value is None
+        or current_package is None
+        or not isinstance(current_package.get("version"), str)
+    ):
+        return False
+
+    if relative == "package.json":
+        baseline_scripts = baseline_value.get("scripts")
+        current_scripts = current_value.get("scripts")
+        if not isinstance(baseline_scripts, Mapping) or not isinstance(
+            current_scripts, Mapping
+        ):
+            return False
+        for name, command in baseline_scripts.items():
+            if current_scripts.get(name) != command:
+                return False
+        extra_names = set(current_scripts) - set(baseline_scripts)
+        if not extra_names or any(
+            not (name.startswith("test:") or name.startswith("check:"))
+            for name in extra_names
+        ):
+            return False
+        normalized = dict(current_value)
+        normalized["scripts"] = dict(baseline_scripts)
+        return normalized == baseline_value
+
+    baseline_packages = baseline_value.get("packages")
+    current_packages = current_value.get("packages")
+    if not isinstance(baseline_packages, Mapping) or not isinstance(
+        current_packages, Mapping
+    ):
+        return False
+    baseline_root = baseline_packages.get("")
+    current_root = current_packages.get("")
+    if not isinstance(baseline_root, Mapping) or not isinstance(
+        current_root, Mapping
+    ):
+        return False
+    package_version = current_package["version"]
+    if (
+        current_value.get("version") != package_version
+        or current_root.get("version") != package_version
+        or not isinstance(baseline_value.get("version"), str)
+        or not isinstance(baseline_root.get("version"), str)
+    ):
+        return False
+    normalized = copy.deepcopy(current_value)
+    normalized["version"] = baseline_value["version"]
+    normalized_packages = normalized["packages"]
+    assert isinstance(normalized_packages, dict)
+    normalized_root = normalized_packages[""]
+    assert isinstance(normalized_root, dict)
+    normalized_root["version"] = baseline_root["version"]
+    return normalized == baseline_value
+
+
 def _probe_core_drift(context: DoctorContext) -> ProbeResult:
     if _topology_state(context) == "post-split":
         brain = context.vault_root / ".dex/brain.git"
@@ -3750,10 +3848,18 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
             for relative in brain_paths
             if relative in release_entries
         }
+        mismatched = _mismatched_release_blobs(
+            context,
+            brain_entries,
+        )
         drifted = sorted(
-            _mismatched_release_blobs(
+            relative
+            for relative in mismatched
+            if not _installer_normalized_package_metadata(
                 context,
-                brain_entries,
+                relative,
+                baseline,
+                brain,
             )
         )
         if not drifted:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -1637,10 +1637,13 @@ def _probe_customization_assessment(context: DoctorContext) -> ProbeResult:
             structured_detail=authority,
         )
     if assessment.completeness == "UNKNOWN":
+        observed = assessment.identity.customization_count
+        noun = "customization" if observed == 1 else "customizations"
         return ProbeResult(
             "UNKNOWN",
-            "I couldn't prove a complete customization inventory "
-            f"({', '.join(assessment.incomplete_reasons)}).",
+            f"I found {observed} {noun}, but couldn't prove the inventory is complete "
+            f"({', '.join(assessment.incomplete_reasons)}). Review the listed exclusions "
+            "before creating a Capsule.",
             structured_detail=authority,
         )
     count = assessment.identity.customization_count
@@ -4563,6 +4566,12 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
 
 def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
     smoke_path = context.repo_root / "core" / "utils" / "smoke.py"
+    vault_python = context.vault_root / ".venv" / "bin" / "python"
+    interpreter = (
+        str(vault_python)
+        if vault_python.is_file() and os.access(vault_python, os.X_OK)
+        else sys.executable
+    )
     env = {
         name: os.environ[name]
         for name in ("PATH", "PYTHONPATH")
@@ -4572,11 +4581,12 @@ def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
         {
             "VAULT_PATH": str(context.vault_root),
             "VAULT_ROOT": str(context.vault_root),
+            "DEX_PYTHON": interpreter,
             "PYTHONDONTWRITEBYTECODE": "1",
         }
     )
     result = subprocess.run(
-        [sys.executable, str(smoke_path), "--json"],
+        [interpreter, str(smoke_path), "--json"],
         cwd=context.vault_root,
         env=env,
         capture_output=True,

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -58,6 +58,24 @@ ADOPTION_GROUP_IDS = (
 ADOPTION_ACTIONS = frozenset(action.value for action in PlannedAction)
 ADOPTION_STATUSES = frozenset(state.value for state in AdoptionState)
 ADOPTION_REASON_CODES = frozenset(reason.value for reason in ReasonCode)
+INSTALLER_STRIPPED_PACKAGE_SCRIPTS = {
+    "test:hooks": "node --test .claude/hooks/tests/*.test.cjs",
+    "test:scripts": (
+        "node --test .scripts/lib/tests/*.test.cjs "
+        ".scripts/meeting-intel/__tests__/*.test.cjs"
+    ),
+    "test:integrations": (
+        "node --test core/integrations/connection-manager/*.test.cjs"
+    ),
+    "check:connections-contract": (
+        "node scripts/check-connections-contract.mjs && "
+        "node scripts/build-connections-engine-manifest.mjs --check"
+    ),
+    "test:connections-consumer-smoke": (
+        "node --test "
+        "core/integrations/connection-manager/connections-contract.test.cjs"
+    ),
+}
 
 
 def _validate_authority_item(item_id: object, item_version: object) -> None:
@@ -3785,7 +3803,8 @@ def _installer_normalized_package_metadata(
                 return False
         extra_names = set(current_scripts) - set(baseline_scripts)
         if not extra_names or any(
-            not (name.startswith("test:") or name.startswith("check:"))
+            name not in INSTALLER_STRIPPED_PACKAGE_SCRIPTS
+            or current_scripts[name] != INSTALLER_STRIPPED_PACKAGE_SCRIPTS[name]
             for name in extra_names
         ):
             return False

--- a/core/utils/manifest.py
+++ b/core/utils/manifest.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 DEFAULT_MANIFEST = Path("System/.installed-files.manifest")
 REQUIRED_LIFECYCLE_RELEASE_PATHS = (
-    "System/.update-journey-v1.json",
+    "core/update/journey-protocol-v1.json",
     "core/lifecycle/bridge.py",
     "core/lifecycle/catalog/bridge-release.json",
     "core/lifecycle/contracts/api.schema.json",

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -57,8 +57,8 @@ VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 VERDICT_PRIORITY = {"OFF": 0, "OK": 1, "UNKNOWN": 2, "BROKEN": 3}
 NOT_SET_UP_DETAIL = "not set up yet — complete onboarding first"
 MISSING_PACKAGES_DETAIL = (
-    "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-    "then re-run /dex-doctor"
+    "Python packages not installed in this vault's .venv — run /dex-update "
+    "(or reinstall requirements.txt into that .venv), then re-run /dex-doctor"
 )
 PYTHON_COMMAND = re.compile(r"^python(?:\d+(?:\.\d+)*)?$")
 SCRIPT_SUFFIXES = {".js", ".cjs", ".mjs", ".sh", ".py"}

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -20,7 +20,7 @@
 | Transaction core | **SHIPPED** (v1.66) | `core/transaction/*` | Crash-safe snapshot→apply→verify→commit/rollback substrate the lifecycle engine writes through |
 | Portable ownership contract | **SHIPPED** (v1.64+) | `core/portable_contract.py` | Source of truth: every path is brain/seed/generated/vault/runtime; decides what an update may write |
 | Release catalog + bridge | **SHIPPED** (v1.65–v1.68) | `core/lifecycle/catalog/*`, `bridge.py` | Publisher-declared packing list per release; one-release handoff from the legacy updater |
-| Historic updater journey protocol + executor | **LOCAL** | `System/.update-journey-v1.json`, `core/update/journey_protocol.py`, `scripts/release_fleet_executor.py` | Closed release-owned machine contract and evidence-owning implementation for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
+| Historic updater journey protocol + executor | **LOCAL** | `core/update/journey-protocol-v1.json`, `core/update/journey_protocol.py`, `scripts/release_fleet_executor.py` | Closed release-owned machine contract and evidence-owning implementation for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
 | 10 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (46 tools) |
 | Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; hardened through security Phases 0–5g, but the `/connect` doorway stays held (draft PR #231) |
 | Customization migration | **SHIPPED** assess/capsule/guided-journey (v1.75.x) / **LOCAL** rebuild engine and doorway | `core/customization_migration/*`, `core/mcp/customization_migration_server.py` | Inventories customizations, preserves a Capsule, and offers a human-confirmed, receipt-backed rebuild and rewind; the doorway is authorized but remains unshipped until its release |
@@ -85,7 +85,7 @@
 
 ### Historic updater journey protocol — LOCAL
 
-`System/.update-journey-v1.json` is the future release-owned control plane for
+`core/update/journey-protocol-v1.json` is the future release-owned control plane for
 historic fleet evidence. Its strict parser permits only the pinned
 foundation-bridge adapter and the existing
 `deliver_latest_release` → `build_and_preview_delivered_release` →

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 009821c355c74ff355369c1008312a3343040da985a12a2a7bb89714c681114a -->
+<!-- Content SHA-256: 3852f0d6f0c74d546862f3f89d8b5525cd5dcbcb218bbe8152c2475d63aa93e7 -->
 
 # Architecture Inventory
 
@@ -142,13 +142,13 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 | Class | Rule count | Update action |
 | --- | ---: | --- |
-| `brain` | 46 | `replace` |
+| `brain` | 45 | `replace` |
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 8 | `regenerate` |
 | `vault` | 17 | `never` |
 | `runtime` | 13 | `never` |
 
-<details><summary><code>brain</code> declared paths (46)</summary>
+<details><summary><code>brain</code> declared paths (45)</summary>
 
 - `.agents` (dir; `brain-agents`)
 - `.ci` (dir; `brain-ci`)
@@ -180,7 +180,6 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `DISTRIBUTION_READY.md` (file; `brain-distribution-ready`)
 - `LICENSE` (file; `brain-license`)
 - `README.md` (file; `brain-readme`)
-- `System/.update-journey-v1.json` (file; `brain-update-journey-protocol`)
 - `System/Beta_Communications` (dir; `brain-beta-communications`)
 - `System/README.md` (file; `brain-system-readme`)
 - `core` (dir; `brain-core`)

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -106,7 +106,7 @@ python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
 ```
 
 The repository has the canonical protocol source at
-`System/.update-journey-v1.json`, with a strict parser in
+`core/update/journey-protocol-v1.json`, with a strict parser in
 `core/update/journey_protocol.py`. It is a closed operation vocabulary, not a
 shell-command format. Version 1 permits only:
 

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -567,13 +567,6 @@
       "ownership": "generated"
     },
     {
-      "id": "brain-update-journey-protocol",
-      "path": "System/.update-journey-v1.json",
-      "kind": "file",
-      "ownership": "brain",
-      "note": "immutable release-owned updater instructions with no arbitrary command surface"
-    },
-    {
       "id": "brain-beta-communications",
       "path": "System/Beta_Communications",
       "kind": "dir",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -166,8 +166,8 @@ git checkout -B "$RELEASE_BRANCH" "$SOURCE_SHA" --quiet
 # selected source bytes. The generated root itself ships; the bridge, fleet
 # runner, and executor remain publisher-source artifacts referenced by SHA-256.
 python3 scripts/generate-update-journey-protocol.py --output "$JOURNEY_PROTOCOL_CHECK"
-if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" System/.update-journey-v1.json; then
-    echo "Error: System/.update-journey-v1.json is stale for selected source '$SOURCE_BRANCH'." >&2
+if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" core/update/journey-protocol-v1.json; then
+    echo "Error: core/update/journey-protocol-v1.json is stale for selected source '$SOURCE_BRANCH'." >&2
     echo "Run python3 scripts/generate-update-journey-protocol.py and commit the result." >&2
     exit 1
 fi

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -35,7 +35,7 @@ cd "$REPO_ROOT"
 # working tree instead of that exact commit.
 SOURCE_COMMIT="$(git rev-parse --verify 'HEAD^{commit}')"
 PROTOCOL_SOURCE_PATHS=(
-  "System/.update-journey-v1.json"
+  "core/update/journey-protocol-v1.json"
   "core/update/journey_protocol.py"
   "scripts/dex_update_bridge.py"
   "scripts/generate-update-journey-protocol.py"
@@ -51,8 +51,8 @@ fi
 # The bundle must carry the protocol for these exact committed source artifacts.
 python3 "$REPO_ROOT/scripts/generate-update-journey-protocol.py" \
   --output "$JOURNEY_PROTOCOL_CHECK"
-if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/System/.update-journey-v1.json"; then
-  echo "Error: System/.update-journey-v1.json is stale for this source tree." >&2
+if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/core/update/journey-protocol-v1.json"; then
+  echo "Error: core/update/journey-protocol-v1.json is stale for this source tree." >&2
   echo "Run python3 scripts/generate-update-journey-protocol.py and commit the result." >&2
   exit 1
 fi

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -10,6 +10,7 @@ the topology conversion and release writes to its lifecycle service.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import json
 import os
@@ -17,10 +18,11 @@ import re
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Mapping, Protocol
+from typing import Any, Callable, Iterator, Mapping, Protocol
 
 OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
 _HEX = re.compile(r"^[0-9a-f]{40}$")
@@ -28,6 +30,9 @@ _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}
 _APPROVAL_WORD = "APPLY"
 _CLEAN_RUNTIME_MARKER = "DEX_UPDATE_BRIDGE_CLEAN_RUNTIME"
 _TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/local/bin"), Path("/opt/homebrew/bin"))
+_TOPOLOGY_MIGRATOR_RELATIVE = Path(
+    "core/migrations/v1-to-v2-brain-vault-split.cjs"
+)
 
 
 class BridgeError(RuntimeError):
@@ -76,6 +81,24 @@ FOUNDATION = ReleasePin(
     commit="9211053235d7c1837a6e327bff1596b593323fc6",
     tree="d394658e2bf1125b96eb5afdace24f3a5ba3107e",
     version="1.80.5",
+)
+
+
+@dataclass(frozen=True)
+class LegacyTopologyPin:
+    """One immutable legacy tree allowed to use the foundation migrator."""
+
+    tag: str
+    tag_object: str
+    commit: str
+    tree: str
+
+
+LEGACY_TOPOLOGY_FOUNDATION = LegacyTopologyPin(
+    tag="v1.20.1",
+    tag_object="3f7338dbe21ec98c015a3c8417d037cdd51b517d",
+    commit="9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
+    tree="b781bb94e417b2873d057a5a417d8c666a360bca",
 )
 
 
@@ -139,6 +162,7 @@ def _run_git(directory: Path, *arguments: str) -> str:
     completed = subprocess.run(
         [
             str(_trusted_git_binary()),
+            "--no-replace-objects",
             "-c",
             "core.hooksPath=/dev/null",
             "-c",
@@ -174,6 +198,39 @@ def _verify_pin(repository: Path, pin: ReleasePin) -> None:
     _assert_equal(_run_git(repository, "rev-parse", "--verify", f"refs/tags/{pin.tag}"), pin.tag_object, "annotated tag")
     _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{commit}}"), pin.commit, "commit")
     _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{tree}}"), pin.tree, "tree")
+
+
+def _supported_legacy_topology(
+    vault_root: Path,
+    pin: LegacyTopologyPin = LEGACY_TOPOLOGY_FOUNDATION,
+) -> bool:
+    """Prove the exact legacy base allowed to borrow the foundation migrator."""
+
+    root = Path(vault_root)
+    git_directory = root / ".git"
+    if (
+        git_directory.is_symlink()
+        or not git_directory.is_dir()
+        or (root / _TOPOLOGY_MIGRATOR_RELATIVE).exists()
+        or (root / _TOPOLOGY_MIGRATOR_RELATIVE).is_symlink()
+    ):
+        return False
+    try:
+        if _run_git(root, "cat-file", "-t", pin.tag) != "tag":
+            return False
+        if _run_git(root, "rev-parse", "--verify", f"refs/tags/{pin.tag}") != pin.tag_object:
+            return False
+        if _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{commit}}") != pin.commit:
+            return False
+        if _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{tree}}") != pin.tree:
+            return False
+        head = _run_git(root, "rev-parse", "--verify", "HEAD^{commit}")
+        if _HEX.fullmatch(head) is None:
+            return False
+        _run_git(root, "merge-base", "--is-ancestor", pin.commit, head)
+    except BridgeError:
+        return False
+    return True
 
 
 def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.TemporaryDirectory[str], Path]:
@@ -292,6 +349,135 @@ def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
     )
 
 
+class _FoundationLifecycleService:
+    """Bind a verified foundation migrator to one legacy lifecycle call.
+
+    The foundation service normally launches the migrator shipped inside the
+    vault. v1.20.1 predates that file. For only that exact immutable base, this
+    adapter lets the same lifecycle preview/approval/execute path launch the
+    migrator from the already-verified disposable foundation checkout. No
+    bridge file is copied into the vault and unknown layouts stay fail-closed.
+    """
+
+    def __init__(self, service: ModuleType, engine: ModuleType, source: Path) -> None:
+        self._service = service
+        self._engine = engine
+        self._source = Path(source).resolve()
+        self._migrator = self._source / _TOPOLOGY_MIGRATOR_RELATIVE
+        engine_relative = getattr(engine, "TOPOLOGY_MIGRATOR_RELATIVE", None)
+        if Path(engine_relative) != _TOPOLOGY_MIGRATOR_RELATIVE:
+            raise BridgeError("pinned foundation topology migrator path changed")
+        if (
+            self._migrator.is_symlink()
+            or not self._migrator.is_file()
+            or not self._migrator.resolve().is_relative_to(self._source)
+        ):
+            raise BridgeError("pinned foundation topology migrator is missing or unsafe")
+        self._migrator_sha256 = hashlib.sha256(self._migrator.read_bytes()).hexdigest()
+        if not callable(getattr(engine, "topology_state", None)) or not callable(
+            getattr(engine, "_migrator_command", None)
+        ):
+            raise BridgeError("pinned foundation topology engine is incomplete")
+
+    def _verify_migrator(self) -> None:
+        if (
+            self._migrator.is_symlink()
+            or not self._migrator.is_file()
+            or self._migrator.resolve().parent != (
+                self._source / _TOPOLOGY_MIGRATOR_RELATIVE.parent
+            ).resolve()
+            or hashlib.sha256(self._migrator.read_bytes()).hexdigest()
+            != self._migrator_sha256
+        ):
+            raise BridgeError("pinned foundation topology migrator changed after verification")
+
+    @contextmanager
+    def _topology_source(self) -> Iterator[None]:
+        self._verify_migrator()
+        original_state = self._engine.topology_state
+        original_command = self._engine._migrator_command
+        authorized_roots: set[Path] = set()
+
+        def topology_state(vault_root: Path) -> str:
+            state = original_state(vault_root)
+            root = Path(vault_root).resolve()
+            candidate = root / _TOPOLOGY_MIGRATOR_RELATIVE
+            if (
+                state == "invalid-combined"
+                and not candidate.exists()
+                and not candidate.is_symlink()
+                and _supported_legacy_topology(root)
+            ):
+                authorized_roots.add(root)
+                return "combined"
+            return state
+
+        def migrator_command(vault_root: Path, mode: str) -> list[str]:
+            root = Path(vault_root).resolve()
+            candidate = root / _TOPOLOGY_MIGRATOR_RELATIVE
+            if (
+                root not in authorized_roots
+                or candidate.exists()
+                or candidate.is_symlink()
+                or mode not in {"--dry-run", "--auto", "--resume"}
+            ):
+                return original_command(vault_root, mode)
+            self._verify_migrator()
+            node = _trusted_executable("node")
+            if node is None:
+                raise BridgeError(
+                    "trusted system Node.js is required for the foundation topology migrator"
+                )
+            return [str(node), str(self._migrator), mode]
+
+        self._engine.topology_state = topology_state
+        self._engine._migrator_command = migrator_command
+        try:
+            yield
+        finally:
+            self._engine.topology_state = original_state
+            self._engine._migrator_command = original_command
+
+    def build_and_preview_topology_migration(
+        self,
+        vault_root: str | Path,
+    ) -> Mapping[str, Any]:
+        with self._topology_source():
+            return self._service.build_and_preview_topology_migration(vault_root)
+
+    def execute_approved_topology_migration(
+        self,
+        vault_root: str | Path,
+        preview: Mapping[str, Any],
+        approved_token: str,
+    ) -> Mapping[str, Any]:
+        with self._topology_source():
+            return self._service.execute_approved_topology_migration(
+                vault_root,
+                preview,
+                approved_token,
+            )
+
+    def build_and_preview_delivered_release(
+        self,
+        vault_root: str | Path,
+        release: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        return self._service.build_and_preview_delivered_release(vault_root, release)
+
+    def execute_approved_delivered_release(
+        self,
+        vault_root: str | Path,
+        preview: Mapping[str, Any],
+        approved_token: str,
+    ) -> Mapping[str, Any]:
+        return self._service.execute_approved_delivered_release(
+            vault_root,
+            preview,
+            approved_token,
+        )
+
+
 def _load_lifecycle_service(source: Path) -> LifecycleService:
     """Import only the verified foundation release's lifecycle service."""
     if not (source / "core" / "lifecycle" / "service.py").is_file():
@@ -312,7 +498,13 @@ def _load_lifecycle_service(source: Path) -> LifecycleService:
     )
     if any(not callable(getattr(module, name, None)) for name in required):
         raise BridgeError("pinned foundation lifecycle service is incomplete")
-    return module  # type: ignore[return-value]
+    try:
+        engine = importlib.import_module("core.lifecycle.engine")
+    except Exception as error:  # noqa: BLE001
+        raise BridgeError(
+            f"pinned foundation topology engine could not start: {error}"
+        ) from error
+    return _FoundationLifecycleService(module, engine, source)
 
 
 def _approved_preview(prompt: str, preview: Mapping[str, Any], approval_token: object, *, input_fn: Callable[[str], str], output_fn: Callable[[str], None]) -> tuple[Mapping[str, Any], str]:

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -10,6 +10,7 @@ the topology conversion and release writes to its lifecycle service.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import importlib
 import json
@@ -33,6 +34,15 @@ _TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/lo
 _TOPOLOGY_MIGRATOR_RELATIVE = Path(
     "core/migrations/v1-to-v2-brain-vault-split.cjs"
 )
+_TRACKED_IGNORE_POLICY_RELATIVE = Path(
+    "core/migrations/tracked-ignored-policy.yaml"
+)
+_PRESERVATION_TRANSITION_RELATIVE = Path(
+    "System/.local-only-preservation-transition.json"
+)
+_LEGACY_SHIPPED_SYMLINK_RELATIVE = Path(".pi/agent/extensions/dex")
+_LEGACY_SHIPPED_SYMLINK_TARGET = "../../../pi-extensions/dex"
+_LEGACY_SHIPPED_SYMLINK_BLOB = "f1c88c92cea996705f982e902bafb758156aef52"
 
 
 class BridgeError(RuntimeError):
@@ -100,6 +110,155 @@ LEGACY_TOPOLOGY_FOUNDATION = LegacyTopologyPin(
     commit="9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
     tree="b781bb94e417b2873d057a5a417d8c666a360bca",
 )
+
+# v1.20.1 predates the tracked-ignore transition that the topology migrator
+# reads before it can even build a preview. This is the complete baseline-v1
+# policy first shipped for those historical paths, pinned here by byte hash.
+# The compatibility preload exposes it read-only to the verified migrator; it
+# never installs these newer release files into the old combined vault.
+_LEGACY_TRACKED_IGNORE_POLICY = b"""schema_version: 2
+active_baseline_version: 1
+baselines:
+  - baseline_version: 1
+    baseline_count: 27
+    paths:
+      - path: 00-Inbox/Daily_Plans/README.md
+        classification: intentional-seed
+      - path: 00-Inbox/Ideas/README.md
+        classification: intentional-seed
+      - path: 00-Inbox/Meetings/README.md
+        classification: intentional-seed
+      - path: 00-Inbox/README.md
+        classification: intentional-seed
+      - path: 01-Quarter_Goals/Quarter_Goals.md
+        classification: intentional-seed
+      - path: 02-Week_Priorities/Week_Priorities.md
+        classification: intentional-seed
+      - path: 03-Tasks/Tasks.md
+        classification: intentional-seed
+      - path: 04-Projects/README.md
+        classification: intentional-seed
+      - path: 05-Areas/Career/Evidence/README.md
+        classification: intentional-seed
+      - path: 05-Areas/Companies/README.md
+        classification: intentional-seed
+      - path: 05-Areas/People/External/README.md
+        classification: intentional-seed
+      - path: 05-Areas/People/Internal/README.md
+        classification: intentional-seed
+      - path: 05-Areas/People/README.md
+        classification: intentional-seed
+      - path: 05-Areas/README.md
+        classification: intentional-seed
+      - path: 07-Archives/Plans/README.md
+        classification: intentional-seed
+      - path: 07-Archives/Projects/README.md
+        classification: intentional-seed
+      - path: 07-Archives/README.md
+        classification: intentional-seed
+      - path: 07-Archives/Reviews/README.md
+        classification: intentional-seed
+      - path: System/Dex_Backlog.md
+        classification: intentional-seed
+      - path: System/Session_Learnings/README.md
+        classification: intentional-seed
+      - path: System/pillars.yaml
+        classification: intentional-seed
+      - path: System/usage_log.md
+        classification: intentional-seed
+      - path: System/user-profile.yaml
+        classification: intentional-seed
+      - path: System/Beta_Communications/2026-02-04_hardcoded_paths_fix.md
+        classification: release-doc
+      - path: System/Session_Learnings/2026-01-29.md
+        classification: local-only-must-be-untracked
+      - path: System/Session_Learnings/2026-01-30.md
+        classification: local-only-must-be-untracked
+      - path: System/integrations/slack.yaml
+        classification: local-only-must-be-untracked
+"""
+_LEGACY_TRACKED_IGNORE_POLICY_SHA256 = (
+    "bf0af119939930fb4d3b466584a3e9392edb66bf61ec09675521c9a5969f3f50"
+)
+_LEGACY_PRESERVATION_TRANSITION = (
+    b'{"phase":"bootstrap-v1","release_version":"1.20.1","schema_version":1}\n'
+)
+
+
+def _legacy_preload_bytes() -> bytes:
+    """Build the closed Node preload that supplies two absent read-only inputs."""
+
+    policy = base64.b64encode(_LEGACY_TRACKED_IGNORE_POLICY).decode("ascii")
+    transition = base64.b64encode(_LEGACY_PRESERVATION_TRANSITION).decode(
+        "ascii"
+    )
+    return f"""'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = fs.realpathSync(process.cwd());
+const shippedLink = path.join(root, '{_LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()}');
+const shippedLinkParent = path.dirname(shippedLink);
+const shippedLinkName = path.basename(shippedLink);
+const shippedLinkTarget = '{_LEGACY_SHIPPED_SYMLINK_TARGET}';
+const inputs = new Map([
+  [path.join(root, '{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}'), Buffer.from('{policy}', 'base64')],
+  [path.join(root, '{_PRESERVATION_TRANSITION_RELATIVE.as_posix()}'), Buffer.from('{transition}', 'base64')],
+]);
+const originalReadFileSync = fs.readFileSync.bind(fs);
+const originalReaddirSync = fs.readdirSync.bind(fs);
+
+let hideShippedLink = false;
+let shippedLinkFound = false;
+try {{
+  const linkState = fs.lstatSync(shippedLink);
+  shippedLinkFound = true;
+  const resolvedTarget = fs.realpathSync(shippedLink);
+  const expectedTarget = path.join(root, 'pi-extensions/dex');
+  if (
+    !linkState.isSymbolicLink()
+    || fs.readlinkSync(shippedLink) !== shippedLinkTarget
+    || resolvedTarget !== expectedTarget
+    || !fs.lstatSync(expectedTarget).isDirectory()
+  ) {{
+    throw new Error(`Dex update bridge refused changed legacy release symlink ${{shippedLink}}.`);
+  }}
+  hideShippedLink = true;
+}} catch (error) {{
+  if (shippedLinkFound || !error || error.code !== 'ENOENT') throw error;
+}}
+
+fs.readFileSync = function dexLegacyCompatibilityRead(candidate, options) {{
+  const supplied = Buffer.isBuffer(candidate) ? candidate.toString() : String(candidate);
+  const absolute = path.resolve(supplied);
+  const content = inputs.get(absolute);
+  if (content === undefined) return originalReadFileSync(candidate, options);
+  try {{
+    fs.lstatSync(absolute);
+  }} catch (error) {{
+    if (error && error.code === 'ENOENT') {{
+      const encoding = typeof options === 'string' ? options : options && options.encoding;
+      return encoding ? content.toString(encoding) : Buffer.from(content);
+    }}
+    throw error;
+  }}
+  throw new Error(`Dex update bridge refused existing legacy compatibility input ${{absolute}}.`);
+}};
+
+fs.readdirSync = function dexLegacyCompatibilityDirectory(directory, options) {{
+  const entries = originalReaddirSync(directory, options);
+  if (
+    hideShippedLink
+    && path.resolve(String(directory)) === shippedLinkParent
+    && options
+    && typeof options === 'object'
+    && options.withFileTypes === true
+  ) {{
+    return entries.filter((entry) => entry.name !== shippedLinkName);
+  }}
+  return entries;
+}};
+""".encode()
 
 
 class LifecycleService(Protocol):
@@ -359,13 +518,23 @@ class _FoundationLifecycleService:
     bridge file is copied into the vault and unknown layouts stay fail-closed.
     """
 
-    def __init__(self, service: ModuleType, engine: ModuleType, source: Path) -> None:
+    def __init__(
+        self,
+        service: ModuleType,
+        engine: ModuleType,
+        apply_update: ModuleType,
+        source: Path,
+    ) -> None:
         self._service = service
         self._engine = engine
+        self._apply_update = apply_update
         self._source = Path(source).resolve()
         self._migrator = self._source / _TOPOLOGY_MIGRATOR_RELATIVE
         engine_relative = getattr(engine, "TOPOLOGY_MIGRATOR_RELATIVE", None)
-        if Path(engine_relative) != _TOPOLOGY_MIGRATOR_RELATIVE:
+        if (
+            not isinstance(engine_relative, Path)
+            or engine_relative != _TOPOLOGY_MIGRATOR_RELATIVE
+        ):
             raise BridgeError("pinned foundation topology migrator path changed")
         if (
             self._migrator.is_symlink()
@@ -374,12 +543,34 @@ class _FoundationLifecycleService:
         ):
             raise BridgeError("pinned foundation topology migrator is missing or unsafe")
         self._migrator_sha256 = hashlib.sha256(self._migrator.read_bytes()).hexdigest()
+        if (
+            hashlib.sha256(_LEGACY_TRACKED_IGNORE_POLICY).hexdigest()
+            != _LEGACY_TRACKED_IGNORE_POLICY_SHA256
+        ):
+            raise BridgeError("pinned legacy tracked-ignore policy changed")
+        compatibility = Path(
+            tempfile.mkdtemp(
+                prefix="dex-v1201-compat-",
+                dir=self._source.parent,
+            )
+        )
+        self._preload = compatibility / "read-only-inputs.cjs"
+        with self._preload.open("xb") as handle:
+            handle.write(_legacy_preload_bytes())
+            handle.flush()
+            os.fsync(handle.fileno())
+        self._preload.chmod(0o400)
+        self._preload_sha256 = hashlib.sha256(self._preload.read_bytes()).hexdigest()
         if not callable(getattr(engine, "topology_state", None)) or not callable(
             getattr(engine, "_migrator_command", None)
         ):
             raise BridgeError("pinned foundation topology engine is incomplete")
+        if not callable(getattr(apply_update, "_tree_entries", None)) or not callable(
+            getattr(apply_update, "_verify_manifest", None)
+        ):
+            raise BridgeError("pinned foundation release planner is incomplete")
 
-    def _verify_migrator(self) -> None:
+    def _verify_compatibility_runtime(self) -> None:
         if (
             self._migrator.is_symlink()
             or not self._migrator.is_file()
@@ -390,10 +581,18 @@ class _FoundationLifecycleService:
             != self._migrator_sha256
         ):
             raise BridgeError("pinned foundation topology migrator changed after verification")
+        if (
+            self._preload.is_symlink()
+            or not self._preload.is_file()
+            or not self._preload.resolve().is_relative_to(self._source.parent.resolve())
+            or hashlib.sha256(self._preload.read_bytes()).hexdigest()
+            != self._preload_sha256
+        ):
+            raise BridgeError("pinned legacy compatibility preload changed after verification")
 
     @contextmanager
     def _topology_source(self) -> Iterator[None]:
-        self._verify_migrator()
+        self._verify_compatibility_runtime()
         original_state = self._engine.topology_state
         original_command = self._engine._migrator_command
         authorized_roots: set[Path] = set()
@@ -422,13 +621,19 @@ class _FoundationLifecycleService:
                 or mode not in {"--dry-run", "--auto", "--resume"}
             ):
                 return original_command(vault_root, mode)
-            self._verify_migrator()
+            self._verify_compatibility_runtime()
             node = _trusted_executable("node")
             if node is None:
                 raise BridgeError(
                     "trusted system Node.js is required for the foundation topology migrator"
                 )
-            return [str(node), str(self._migrator), mode]
+            return [
+                str(node),
+                "--require",
+                str(self._preload),
+                str(self._migrator),
+                mode,
+            ]
 
         self._engine.topology_state = topology_state
         self._engine._migrator_command = migrator_command
@@ -437,6 +642,145 @@ class _FoundationLifecycleService:
         finally:
             self._engine.topology_state = original_state
             self._engine._migrator_command = original_command
+
+    @contextmanager
+    def _legacy_delivery_source(self) -> Iterator[None]:
+        """Let the planner read the one exact pre-manifest legacy release.
+
+        v1.20.1 has one shipped symlink and no installed-files manifest. The
+        foundation planner correctly refuses either shape for a modern target.
+        For only the already-pinned installed tree, this read adapter omits the
+        known symlink and unclassified retired release paths. The lifecycle
+        transaction remains the sole writer; omitted legacy paths stay in
+        place as user-controlled/unmanaged content.
+        """
+
+        original_tree_entries = self._apply_update._tree_entries
+        original_verify_manifest = self._apply_update._verify_manifest
+        authorized_legacy_signatures: set[tuple[tuple[str, int, str], ...]] = set()
+        release_error = getattr(
+            self._apply_update,
+            "ReleaseVerificationError",
+            RuntimeError,
+        )
+        contract_violation = getattr(
+            self._apply_update.portable_contract,
+            "ContractViolation",
+            RuntimeError,
+        )
+        tree_entry = getattr(self._apply_update, "TreeEntry", None)
+        if not callable(tree_entry):
+            raise BridgeError("pinned foundation release entry type is unavailable")
+
+        def signature(entries: tuple[Any, ...]) -> tuple[tuple[str, int, str], ...]:
+            return tuple(
+                (entry.path, entry.mode, entry.object_id) for entry in entries
+            )
+
+        def legacy_tree_entries(
+            vault_root: Path,
+            brain_git: Path,
+            commit: str,
+        ) -> tuple[Any, ...]:
+            if commit != LEGACY_TOPOLOGY_FOUNDATION.commit:
+                return original_tree_entries(vault_root, brain_git, commit)
+            if (
+                _run_git(Path(brain_git), "rev-parse", "--verify", f"{commit}^{{tree}}")
+                != LEGACY_TOPOLOGY_FOUNDATION.tree
+            ):
+                raise BridgeError("installed legacy release tree changed before delivery")
+            raw = self._apply_update._brain_output(
+                vault_root,
+                brain_git,
+                "ls-tree",
+                "-r",
+                "-z",
+                "--full-tree",
+                commit,
+            )
+            entries: list[Any] = []
+            seen: set[str] = set()
+            for record in raw.split(b"\0"):
+                if not record:
+                    continue
+                try:
+                    metadata, raw_path = record.split(b"\t", 1)
+                    raw_mode, object_type, object_id = (
+                        metadata.decode("ascii").split(" ")
+                    )
+                    relative = raw_path.decode("utf-8")
+                except (ValueError, UnicodeDecodeError) as error:
+                    raise release_error(
+                        "legacy release tree contains a malformed entry"
+                    ) from error
+                if relative in seen or object_type != "blob":
+                    raise release_error("legacy release tree is ambiguous")
+                seen.add(relative)
+                if raw_mode == "120000":
+                    if (
+                        relative
+                        != _LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()
+                        or object_id != _LEGACY_SHIPPED_SYMLINK_BLOB
+                        or self._apply_update._brain_output(
+                            vault_root,
+                            brain_git,
+                            "cat-file",
+                            "blob",
+                            object_id,
+                        )
+                        != _LEGACY_SHIPPED_SYMLINK_TARGET.encode()
+                    ):
+                        raise release_error(
+                            "legacy release contains an unknown symlink"
+                        )
+                    continue
+                if raw_mode not in {"100644", "100755"}:
+                    raise release_error(
+                        "legacy release contains an unsupported entry"
+                    )
+                try:
+                    self._apply_update.portable_contract.resolve(relative)
+                except contract_violation:
+                    # Retired release paths that the current contract does not
+                    # own are deliberately preserved rather than pruned.
+                    continue
+                entries.append(
+                    tree_entry(
+                        relative,
+                        0o755 if raw_mode == "100755" else 0o644,
+                        object_id,
+                    )
+                )
+            result = tuple(sorted(entries, key=lambda entry: entry.path))
+            authorized_legacy_signatures.add(signature(result))
+            return result
+
+        def verify_manifest(
+            vault_root: Path,
+            brain_git: Path,
+            entries: tuple[Any, ...],
+        ) -> None:
+            try:
+                original_verify_manifest(vault_root, brain_git, entries)
+            except release_error:
+                if signature(entries) not in authorized_legacy_signatures:
+                    raise
+                installed = _run_git(
+                    Path(brain_git),
+                    "rev-parse",
+                    "--verify",
+                    "refs/dex/installed^{commit}",
+                )
+                if installed != LEGACY_TOPOLOGY_FOUNDATION.commit:
+                    raise
+
+        self._apply_update._tree_entries = legacy_tree_entries
+        self._apply_update._verify_manifest = verify_manifest
+        try:
+            yield
+        finally:
+            self._apply_update._tree_entries = original_tree_entries
+            self._apply_update._verify_manifest = original_verify_manifest
 
     def build_and_preview_topology_migration(
         self,
@@ -463,7 +807,11 @@ class _FoundationLifecycleService:
         vault_root: str | Path,
         release: Mapping[str, Any],
     ) -> Mapping[str, Any]:
-        return self._service.build_and_preview_delivered_release(vault_root, release)
+        with self._legacy_delivery_source():
+            return self._service.build_and_preview_delivered_release(
+                vault_root,
+                release,
+            )
 
     def execute_approved_delivered_release(
         self,
@@ -471,11 +819,12 @@ class _FoundationLifecycleService:
         preview: Mapping[str, Any],
         approved_token: str,
     ) -> Mapping[str, Any]:
-        return self._service.execute_approved_delivered_release(
-            vault_root,
-            preview,
-            approved_token,
-        )
+        with self._legacy_delivery_source():
+            return self._service.execute_approved_delivered_release(
+                vault_root,
+                preview,
+                approved_token,
+            )
 
 
 def _load_lifecycle_service(source: Path) -> LifecycleService:
@@ -504,7 +853,13 @@ def _load_lifecycle_service(source: Path) -> LifecycleService:
         raise BridgeError(
             f"pinned foundation topology engine could not start: {error}"
         ) from error
-    return _FoundationLifecycleService(module, engine, source)
+    try:
+        apply_update = importlib.import_module("core.update.apply_update")
+    except Exception as error:  # noqa: BLE001
+        raise BridgeError(
+            f"pinned foundation release planner could not start: {error}"
+        ) from error
+    return _FoundationLifecycleService(module, engine, apply_update, source)
 
 
 def _approved_preview(prompt: str, preview: Mapping[str, Any], approval_token: object, *, input_fn: Callable[[str], str], output_fn: Callable[[str], None]) -> tuple[Mapping[str, Any], str]:

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -107,6 +107,8 @@ DISCOVERY_WORK_NAME = ".historic-discovery-fixtures"
 DISCOVERY_MAX_WORKERS = 4
 DISCOVERY_DEFAULT_INSTALL_TIMEOUT_SECONDS = 180
 DISCOVERY_DEFAULT_DOCTOR_TIMEOUT_SECONDS = 90
+OFFICIAL_REPOSITORY_URL = "https://github.com/davekilleen/Dex.git"
+OFFICIAL_RELEASE_REF = "refs/remotes/upstream/release"
 # Discovery fixtures deliberately do not inherit the caller's PATH.  Keep the
 # capability needed by old installers explicit, reviewable, and narrow.
 TRUSTED_NODE_CANDIDATES = (Path("/opt/homebrew/bin/node"),)
@@ -324,6 +326,23 @@ def _git(repo: Path, *arguments: str, environment: Mapping[str, str] | None = No
 def _git_lines(repo: Path, *arguments: str) -> tuple[str, ...]:
     output = _git(repo, *arguments)
     return tuple(line for line in output.splitlines() if line)
+
+
+def _git_directory(
+    git_directory: Path,
+    *arguments: str,
+    environment: Mapping[str, str] | None = None,
+) -> str:
+    result = subprocess.run(
+        ["git", f"--git-dir={git_directory}", *arguments],
+        capture_output=True,
+        text=True,
+        env=dict(environment) if environment is not None else None,
+    )
+    if result.returncode:
+        message = result.stderr.strip() or result.stdout.strip() or "Git command failed"
+        raise FleetError(message)
+    return result.stdout.strip()
 
 
 def resolve_immutable_release(repo: Path, tag: str) -> ImmutableRelease:
@@ -946,6 +965,115 @@ def _disable_fixture_remotes(
             raise FleetError(f"fixture remote {remote!r} could not be disabled")
 
 
+def _disable_git_directory_remotes(
+    git_directory: Path,
+    environment: Mapping[str, str] | None = None,
+) -> None:
+    if git_directory.is_symlink() or not git_directory.is_dir():
+        return
+    remotes = tuple(
+        line
+        for line in _git_directory(
+            git_directory, "remote", environment=environment
+        ).splitlines()
+        if line
+    )
+    for remote in remotes:
+        _git_directory(
+            git_directory,
+            "remote",
+            "set-url",
+            remote,
+            "DISABLED",
+            environment=environment,
+        )
+        _git_directory(
+            git_directory,
+            "remote",
+            "set-url",
+            "--push",
+            remote,
+            "DISABLED",
+            environment=environment,
+        )
+
+
+def _disable_all_fixture_remotes(
+    vault: Path,
+    environment: Mapping[str, str] | None = None,
+) -> None:
+    _disable_fixture_remotes(vault, environment)
+    for relative in (".dex/brain.git", ".dex/pre-split-archive.git"):
+        _disable_git_directory_remotes(vault / relative, environment)
+
+
+def _prepare_installer_release_remote(
+    repo: Path,
+    vault: Path,
+    release: DistributionRelease,
+    environment: Mapping[str, str],
+) -> tuple[str, str]:
+    """Expose the exact historic release as the official ref during installation."""
+
+    try:
+        release_commit = _git(
+            repo,
+            "rev-parse",
+            "--verify",
+            f"{release.commit}^{{commit}}",
+        )
+        release_tree = _git(
+            repo,
+            "rev-parse",
+            "--verify",
+            f"{release.commit}^{{tree}}",
+        )
+    except FleetError as error:
+        raise FleetError("historic release is unavailable for fixture setup") from error
+    if release_commit != release.commit or release_tree != release.tree:
+        raise FleetError("historic release identity changed before fixture setup")
+    _git(
+        vault,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        str(repo),
+        f"+{release_commit}:{OFFICIAL_RELEASE_REF}",
+        environment=environment,
+    )
+    _git(
+        vault,
+        "remote",
+        "set-url",
+        "upstream",
+        OFFICIAL_REPOSITORY_URL,
+        environment=environment,
+    )
+    _git(
+        vault,
+        "remote",
+        "set-url",
+        "--push",
+        "upstream",
+        OFFICIAL_REPOSITORY_URL,
+        environment=environment,
+    )
+    if (
+        _git(vault, "remote", "get-url", "upstream", environment=environment)
+        != OFFICIAL_REPOSITORY_URL
+        or _git(
+            vault,
+            "rev-parse",
+            "--verify",
+            f"{OFFICIAL_RELEASE_REF}^{{commit}}",
+            environment=environment,
+        )
+        != release_commit
+    ):
+        raise FleetError("fixture could not prove the official release ref")
+    return release_commit, release_tree
+
+
 def _seed_user_content(vault: Path, environment: Mapping[str, str] | None = None) -> dict[str, str]:
     """Place fixed user-owned content only after the historic install is ready."""
     for relative, content in USER_FIXTURES.items():
@@ -1034,13 +1162,197 @@ def _run_bounded_process_group(
     )
 
 
+def _historic_installer_command(
+    installer: Path,
+    release: DistributionRelease,
+) -> list[str]:
+    command = ["bash", "install.sh"]
+    try:
+        source = installer.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise FleetError("historic install.sh is unreadable") from error
+    if release.version == "1.75.0" and "--allow-synced-folder" in source:
+        command.append("--allow-synced-folder")
+    return command
+
+
+def _stamp_v175_transition(
+    vault: Path,
+    environment: Mapping[str, str],
+    *,
+    timeout_seconds: int,
+) -> None:
+    """Use v1.75's own publisher command to repair its stale generated stamp."""
+
+    transition_path = vault / "System/.local-only-preservation-transition.json"
+    package_path = vault / "package.json"
+    try:
+        before = json.loads(transition_path.read_text(encoding="utf-8"))
+        package = json.loads(package_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise FleetError("v1.75 transition metadata could not be inspected") from error
+    if (
+        not isinstance(before, Mapping)
+        or set(before) != {"schema_version", "phase", "release_version"}
+        or before.get("schema_version") != 1
+        or before.get("phase") != "untrack-v1"
+        or before.get("release_version") != "1.74.0"
+        or not isinstance(package, Mapping)
+        or package.get("version") != "1.75.0"
+    ):
+        raise FleetError("v1.75 transition repair precondition did not match")
+    command = [
+        str(vault / ".venv/bin/python"),
+        "-m",
+        "core.migrations.preserve_local_only_paths",
+        "stamp-transition",
+        "--repo",
+        str(vault),
+    ]
+    result = _run_bounded_process_group(
+        command,
+        cwd=vault,
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+    )
+    if result.returncode:
+        raise FleetError("v1.75 transition publisher repair failed")
+    try:
+        after = json.loads(transition_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise FleetError("v1.75 transition publisher repair was unreadable") from error
+    if after != {
+        "schema_version": 1,
+        "phase": "untrack-v1",
+        "release_version": "1.75.0",
+    }:
+        raise FleetError("v1.75 transition publisher repair was invalid")
+
+
+def _read_closed_json_file(path: Path, *, label: str) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise FleetError(f"{label} is missing or unsafe")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise FleetError(f"{label} is unreadable") from error
+    if not isinstance(value, Mapping):
+        raise FleetError(f"{label} is malformed")
+    return dict(value)
+
+
+def _prove_installed_release_identity(
+    vault: Path,
+    release: DistributionRelease,
+    environment: Mapping[str, str],
+    *,
+    official_release_commit: str,
+    official_release_tree: str,
+) -> None:
+    """Accept the original checkout or the migrator's fully proved split."""
+
+    try:
+        installed_commit = _git(vault, "rev-parse", "HEAD", environment=environment)
+        installed_tree = _git(vault, "rev-parse", "HEAD^{tree}", environment=environment)
+    except FleetError as error:
+        raise FleetError("historic installer release identity could not be proved") from error
+    if installed_commit == release.commit and installed_tree == release.tree:
+        return
+
+    try:
+        topology = _read_closed_json_file(
+            vault / "System/.dex/topology.json",
+            label="installer-created topology record",
+        )
+    except FleetError as error:
+        raise FleetError(
+            "historic installer changed immutable release identity without a valid topology"
+        ) from error
+    if (
+        topology.get("schemaVersion") != 1
+        or topology.get("topology") != "brain-vault-split"
+        or topology.get("vaultGitDir") != ".git"
+        or topology.get("brainGitDir") != ".dex/brain.git"
+        or topology.get("archiveGitDir") != ".dex/pre-split-archive.git"
+        or topology.get("installedRelease") != official_release_commit
+    ):
+        raise FleetError(
+            "historic installer changed immutable release identity without a valid topology"
+        )
+    brain = vault / ".dex/brain.git"
+    try:
+        vault_marker = _read_closed_json_file(
+            vault / ".git/dex-vault-v2",
+            label="installer-created vault marker",
+        )
+        brain_marker = _read_closed_json_file(
+            brain / "dex-brain-v2",
+            label="installer-created brain marker",
+        )
+    except FleetError as error:
+        raise FleetError(
+            "historic installer changed immutable release identity with invalid topology markers"
+        ) from error
+    if (
+        vault_marker != {"schemaVersion": 1, "role": "vault"}
+        or brain_marker
+        != {
+            "schemaVersion": 1,
+            "role": "brain",
+            "installed": official_release_commit,
+        }
+    ):
+        raise FleetError(
+            "historic installer changed immutable release identity with invalid topology markers"
+        )
+    archive = vault / ".dex/pre-split-archive.git"
+    try:
+        archive_commit = _git_directory(
+            archive, "rev-parse", "HEAD^{commit}", environment=environment
+        )
+        archive_tree = _git_directory(
+            archive, "rev-parse", "HEAD^{tree}", environment=environment
+        )
+        brain_commit = _git_directory(
+            brain,
+            "rev-parse",
+            "refs/dex/installed^{commit}",
+            environment=environment,
+        )
+        brain_tree = _git_directory(
+            brain,
+            "rev-parse",
+            "refs/dex/installed^{tree}",
+            environment=environment,
+        )
+    except FleetError as error:
+        raise FleetError(
+            "historic installer changed immutable release identity and topology could not be proved"
+        ) from error
+    if archive_commit != release.commit or archive_tree != release.tree:
+        raise FleetError(
+            "historic installer changed immutable release identity and its pre-split archive "
+            "does not preserve the immutable release"
+        )
+    if (
+        brain_commit != official_release_commit
+        or brain_tree != official_release_tree
+    ):
+        raise FleetError(
+            "historic installer changed immutable release identity and its brain does not "
+            "match the official release ref"
+        )
+
+
 def _run_historic_installer(
     vault: Path,
     release: DistributionRelease,
     environment: Mapping[str, str],
     *,
     timeout_seconds: int = 15 * 60,
-) -> None:
+    official_release_commit: str | None = None,
+    official_release_tree: str | None = None,
+) -> str:
     """Run trusted first-party installer code inside a sealed disposable fixture.
 
     Published Dex installers are trusted first-party code, not arbitrary hostile
@@ -1053,32 +1365,67 @@ def _run_historic_installer(
     installer = vault / "install.sh"
     if installer.is_symlink() or not installer.is_file():
         raise FleetError("historic release has no safe install.sh to bootstrap its fixture")
-    command = ["bash", "install.sh"]
-    result = _run_bounded_process_group(
-        command,
-        cwd=vault,
-        environment=environment,
-        timeout_seconds=timeout_seconds,
-    )
-    if result.returncode:
-        # npm commonly writes benign notices to stderr while the actionable
-        # installer failure is on stdout. Keep both for local classification,
-        # but never retain volatile fixture output in the discovery artifact.
+    try:
+        command = _historic_installer_command(installer, release)
+        result = _run_bounded_process_group(
+            command,
+            cwd=vault,
+            environment=environment,
+            timeout_seconds=timeout_seconds,
+        )
         detail = "\n".join(
             output for output in (result.stdout, result.stderr) if output
         ).strip()
-        raise FleetError(f"historic installer failed for {vault.name}: {detail}")
-    try:
-        installed_commit = _git(vault, "rev-parse", "HEAD", environment=environment)
-        installed_tree = _git(vault, "rev-parse", "HEAD^{tree}", environment=environment)
-    except FleetError as error:
-        raise FleetError("historic installer release identity could not be proved") from error
-    if installed_commit != release.commit or installed_tree != release.tree:
-        raise FleetError(
-            "historic installer changed immutable release identity "
-            f"(expected {release.commit}/{release.tree}, "
-            f"found {installed_commit}/{installed_tree})"
+        if (
+            result.returncode
+            and release.version == "1.75.0"
+            and "Tracked-ignore transition version does not match package metadata."
+            in detail
+        ):
+            _stamp_v175_transition(
+                vault,
+                environment,
+                timeout_seconds=timeout_seconds,
+            )
+            result = _run_bounded_process_group(
+                command,
+                cwd=vault,
+                environment=environment,
+                timeout_seconds=timeout_seconds,
+            )
+            detail = "\n".join(
+                output for output in (result.stdout, result.stderr) if output
+            ).strip()
+        installed_release_commit = official_release_commit or release.commit
+        installed_release_tree = official_release_tree or release.tree
+        if result.returncode:
+            known_post_topology_stop = (
+                "installed catalog release does not match the designated bridge release"
+                in detail
+                or "ModuleNotFoundError: No module named 'yaml'" in detail
+            )
+            if not known_post_topology_stop:
+                raise FleetError(
+                    f"historic installer failed for {vault.name}: {detail}"
+                )
+            _prove_installed_release_identity(
+                vault,
+                release,
+                environment,
+                official_release_commit=installed_release_commit,
+                official_release_tree=installed_release_tree,
+            )
+            return "installer-complete-after-known-post-topology-stop"
+        _prove_installed_release_identity(
+            vault,
+            release,
+            environment,
+            official_release_commit=installed_release_commit,
+            official_release_tree=installed_release_tree,
         )
+        return "installer-complete"
+    finally:
+        _disable_all_fixture_remotes(vault, environment)
 
 
 def build_installed_fixture(
@@ -1097,7 +1444,16 @@ def build_installed_fixture(
         else _case_environment(vault, runtime_root)
     )
     _create_fixture_vault(repo, release, output, environment=sealed_environment)
-    _run_historic_installer(vault, release, sealed_environment)
+    release_commit, release_tree = _prepare_installer_release_remote(
+        repo, vault, release, sealed_environment
+    )
+    _run_historic_installer(
+        vault,
+        release,
+        sealed_environment,
+        official_release_commit=release_commit,
+        official_release_tree=release_tree,
+    )
     return FleetCase(
         release=release,
         vault=vault,
@@ -1363,12 +1719,17 @@ def _survey_case(
             python_runtime=python_runtime,
         )
         _create_fixture_vault(repo, release, work_root, environment=environment)
+        release_commit, release_tree = _prepare_installer_release_remote(
+            repo, vault, release, environment
+        )
         try:
-            _run_historic_installer(
+            install_code = _run_historic_installer(
                 vault,
                 release,
                 environment,
                 timeout_seconds=install_timeout_seconds,
+                official_release_commit=release_commit,
+                official_release_tree=release_tree,
             )
         except subprocess.TimeoutExpired as error:
             result["fixture_install"] = {
@@ -1388,7 +1749,7 @@ def _survey_case(
             result["fixture_install"] = {"status": "failed", "code": code}
             issues.append(_survey_issue("fixture-install", code))
             return result
-        result["fixture_install"] = {"status": "ok", "code": "installer-complete"}
+        result["fixture_install"] = {"status": "ok", "code": install_code}
         try:
             fixture_python = resolve_fixture_python(vault, trusted_python=python_runtime)
         except FleetError as error:

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -754,12 +754,44 @@ def _case_environment(
     node_runtime: NodeRuntime | None = None,
     python_runtime: PythonRuntime | None = None,
     pip_cache_dir: Path | None = None,
+    controller_root: Path | None = None,
 ) -> dict[str, str]:
-    """Return the complete, deliberately small environment for one fixture."""
+    """Return the sealed fixture environment owned by one private controller.
 
+    The fleet controller creates this root before running first-party historic
+    installers. Fleet execution is serialized; this boundary is not intended
+    to defend against a hostile concurrent process replacing controller files.
+    """
+
+    controller = controller_root or runtime_root
+    if controller.is_symlink() or (
+        controller.exists() and not controller.is_dir()
+    ):
+        raise FleetError("fixture controller root must be a private directory")
+    controller.mkdir(parents=True, mode=0o700, exist_ok=True)
+    controller_status = controller.stat()
+    if (
+        controller_status.st_uid != os.getuid()
+        or stat.S_IMODE(controller_status.st_mode) != 0o700
+    ):
+        raise FleetError(
+            "fixture controller root must be owned by the controller with mode 0700"
+        )
     home = runtime_root / "home"
     temporary = runtime_root / "tmp"
     pip_cache = pip_cache_dir or runtime_root / "pip-cache"
+    try:
+        pip_cache.resolve().relative_to(controller.resolve(strict=True))
+    except ValueError as error:
+        raise FleetError(
+            "fixture pip cache must stay inside the private controller root"
+        ) from error
+    try:
+        pip_cache.resolve().relative_to(vault.resolve())
+    except ValueError:
+        pass
+    else:
+        raise FleetError("fixture pip cache must stay outside the vault")
     home.mkdir(parents=True, exist_ok=False)
     temporary.mkdir(parents=True, exist_ok=False)
     if pip_cache.is_symlink() or (pip_cache.exists() and not pip_cache.is_dir()):
@@ -1783,6 +1815,8 @@ def _survey_case(
             runtime_root,
             node_runtime=node_runtime,
             python_runtime=python_runtime,
+            pip_cache_dir=work_root / ".controller-cache/pip",
+            controller_root=work_root / ".controller-cache",
         )
         _create_fixture_vault(repo, release, work_root, environment=environment)
         release_commit, release_tree = _prepare_installer_release_remote(
@@ -2007,6 +2041,8 @@ def run_journey(
         runtime_root,
         node_runtime=node_runtime,
         python_runtime=python_runtime,
+        pip_cache_dir=output / ".fixture-controller/pip",
+        controller_root=output / ".fixture-controller",
     )
     try:
         case = build_installed_fixture(

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1344,6 +1344,52 @@ def _prove_installed_release_identity(
         )
 
 
+def _installer_created_split_topology(vault: Path) -> bool:
+    """Recognize the already-proved split shape without requiring a vault remote."""
+
+    brain = vault / ".dex/brain.git"
+    archive = vault / ".dex/pre-split-archive.git"
+    if (
+        brain.is_symlink()
+        or not brain.is_dir()
+        or archive.is_symlink()
+        or not archive.is_dir()
+    ):
+        return False
+    try:
+        topology = _read_closed_json_file(
+            vault / "System/.dex/topology.json",
+            label="installer-created topology record",
+        )
+        vault_marker = _read_closed_json_file(
+            vault / ".git/dex-vault-v2",
+            label="installer-created vault marker",
+        )
+        brain_marker = _read_closed_json_file(
+            brain / "dex-brain-v2",
+            label="installer-created brain marker",
+        )
+    except FleetError:
+        return False
+    installed = topology.get("installedRelease")
+    return (
+        isinstance(installed, str)
+        and bool(installed)
+        and topology.get("schemaVersion") == 1
+        and topology.get("topology") == "brain-vault-split"
+        and topology.get("vaultGitDir") == ".git"
+        and topology.get("brainGitDir") == ".dex/brain.git"
+        and topology.get("archiveGitDir") == ".dex/pre-split-archive.git"
+        and vault_marker == {"schemaVersion": 1, "role": "vault"}
+        and brain_marker
+        == {
+            "schemaVersion": 1,
+            "role": "brain",
+            "installed": installed,
+        }
+    )
+
+
 def _run_historic_installer(
     vault: Path,
     release: DistributionRelease,
@@ -1352,6 +1398,7 @@ def _run_historic_installer(
     timeout_seconds: int = 15 * 60,
     official_release_commit: str | None = None,
     official_release_tree: str | None = None,
+    keep_official_fetch: bool = False,
 ) -> str:
     """Run trusted first-party installer code inside a sealed disposable fixture.
 
@@ -1425,7 +1472,8 @@ def _run_historic_installer(
         )
         return "installer-complete"
     finally:
-        _disable_all_fixture_remotes(vault, environment)
+        if not keep_official_fetch:
+            _disable_all_fixture_remotes(vault, environment)
 
 
 def build_installed_fixture(
@@ -1434,6 +1482,7 @@ def build_installed_fixture(
     output: Path,
     *,
     environment: Mapping[str, str] | None = None,
+    keep_official_fetch: bool = False,
 ) -> FleetCase:
     """Install the historic release, then add synthetic user-owned data for updating."""
     vault = output / safe_case_name(release)
@@ -1453,6 +1502,7 @@ def build_installed_fixture(
         sealed_environment,
         official_release_commit=release_commit,
         official_release_tree=release_tree,
+        keep_official_fetch=keep_official_fetch,
     )
     return FleetCase(
         release=release,
@@ -1948,17 +1998,19 @@ def run_journey(
             start,
             output,
             environment=environment,
+            keep_official_fetch=True,
         )
         resolve_fixture_python(case.vault, trusted_python=python_runtime)
         from scripts import release_fleet_executor
 
         try:
-            _prepare_installer_release_remote(
-                repo,
-                case.vault,
-                start,
-                environment,
-            )
+            if not _installer_created_split_topology(case.vault):
+                _prepare_installer_release_remote(
+                    repo,
+                    case.vault,
+                    start,
+                    environment,
+                )
             return release_fleet_executor.execute_journey(
                 repo_root=repo,
                 source_commit=source_commit,

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1952,20 +1952,29 @@ def run_journey(
         resolve_fixture_python(case.vault, trusted_python=python_runtime)
         from scripts import release_fleet_executor
 
-        return release_fleet_executor.execute_journey(
-            repo_root=repo,
-            source_commit=source_commit,
-            vault_root=case.vault,
-            evidence_root=evidence_root,
-            starting_release=historic_surface["release"],
-            foundation_release=foundation.identity(),
-            follow_up_release=follow_up.identity(),
-            protocol=protocol,
-            historic_surface=historic_surface,
-            foundation_surface=foundation_surface,
-            user_owned_paths=tuple(USER_FIXTURES),
-            platform=journey_platform,
-        )
+        try:
+            _prepare_installer_release_remote(
+                repo,
+                case.vault,
+                start,
+                environment,
+            )
+            return release_fleet_executor.execute_journey(
+                repo_root=repo,
+                source_commit=source_commit,
+                vault_root=case.vault,
+                evidence_root=evidence_root,
+                starting_release=historic_surface["release"],
+                foundation_release=foundation.identity(),
+                follow_up_release=follow_up.identity(),
+                protocol=protocol,
+                historic_surface=historic_surface,
+                foundation_surface=foundation_surface,
+                user_owned_paths=tuple(USER_FIXTURES),
+                platform=journey_platform,
+            )
+        finally:
+            _disable_all_fixture_remotes(case.vault, environment)
     finally:
         _remove_disposable_fixture(vault, output)
         _remove_disposable_fixture(runtime_root, output)

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1055,7 +1055,7 @@ def _prepare_installer_release_remote(
         "set-url",
         "--push",
         "upstream",
-        OFFICIAL_REPOSITORY_URL,
+        "DISABLED",
         environment=environment,
     )
     if (

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -12,6 +12,7 @@ import platform
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -124,6 +125,7 @@ SEALED_INSTALLER_ENVIRONMENT_KEYS = frozenset(
         "HOME",
         "TMPDIR",
         "PATH",
+        "PIP_CACHE_DIR",
         "LANG",
         "LC_ALL",
         "PYTHONNOUSERSITE",
@@ -751,17 +753,31 @@ def _case_environment(
     *,
     node_runtime: NodeRuntime | None = None,
     python_runtime: PythonRuntime | None = None,
+    pip_cache_dir: Path | None = None,
 ) -> dict[str, str]:
     """Return the complete, deliberately small environment for one fixture."""
 
     home = runtime_root / "home"
     temporary = runtime_root / "tmp"
+    pip_cache = pip_cache_dir or runtime_root / "pip-cache"
     home.mkdir(parents=True, exist_ok=False)
     temporary.mkdir(parents=True, exist_ok=False)
+    if pip_cache.is_symlink() or (pip_cache.exists() and not pip_cache.is_dir()):
+        raise FleetError("fixture pip cache must be a private directory")
+    pip_cache.mkdir(parents=True, mode=0o700, exist_ok=True)
+    cache_status = pip_cache.stat()
+    if (
+        cache_status.st_uid != os.getuid()
+        or stat.S_IMODE(cache_status.st_mode) != 0o700
+    ):
+        raise FleetError(
+            "fixture pip cache must be owned by the controller with mode 0700"
+        )
     environment = {
         "HOME": str(home),
         "TMPDIR": str(temporary),
         "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "PIP_CACHE_DIR": str(pip_cache.resolve(strict=True)),
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
         "PYTHONNOUSERSITE": "1",

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed orchestration for the cross-platform historic updater fleet."""
+"""Fail-closed orchestration for the macOS historic updater fleet."""
 
 from __future__ import annotations
 
@@ -34,7 +34,6 @@ PLATFORM_MANIFEST_SCHEMA_VERSION = 1
 ACCEPTANCE_SOURCE = "scripts/release_fleet_acceptance.py"
 FIRST_PARTY_PLATFORM_JOBS = {
     "darwin": "historic-fleet-darwin",
-    "linux": "historic-fleet-linux",
 }
 MAX_PLATFORM_MANIFEST_BYTES = 16 * 1024 * 1024
 PLATFORM_MANIFEST_NAME = "platform-manifest.json"
@@ -378,7 +377,7 @@ def _verified_payload(
 def _require_protocol_platforms(platforms: Sequence[str]) -> tuple[str, ...]:
     value = tuple(platforms)
     if value != SUPPORTED_PLATFORMS:
-        raise release_fleet.FleetError("fleet acceptance protocol platforms are not exactly darwin and linux")
+        raise release_fleet.FleetError("fleet acceptance protocol platforms are not exactly darwin")
     return value
 
 
@@ -676,8 +675,6 @@ def _platform_receipt_boundary():
     platform_validator = assert_platform_report_bound
     if sys.platform == "darwin":
         host_platform = "darwin"
-    elif sys.platform.startswith("linux"):
-        host_platform = "linux"
     else:
         host_platform = ""
 
@@ -939,9 +936,7 @@ def _assert_session_matches_inputs(
 def _running_platform() -> str:
     if sys.platform == "darwin":
         return "darwin"
-    if sys.platform.startswith("linux"):
-        return "linux"
-    raise release_fleet.FleetError("historic fleet acceptance supports macOS and Linux only")
+    raise release_fleet.FleetError("historic fleet acceptance supports macOS only")
 
 
 def _add_bound_input_arguments(parser: argparse.ArgumentParser) -> None:
@@ -979,7 +974,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     platform.add_argument("--output", type=Path, required=True)
     aggregate = subcommands.add_parser(
         "aggregate",
-        help="validate serialized Darwin and Linux evidence without minting acceptance",
+        help="validate serialized Darwin evidence without minting acceptance",
     )
     _add_bound_input_arguments(aggregate)
     aggregate.add_argument("--session", type=Path, required=True)
@@ -989,14 +984,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="append",
         type=Path,
         required=True,
-        help="signed platform receipt; provide once for Darwin and once for Linux",
+        help="signed Darwin platform receipt; provide exactly once",
     )
     aggregate.add_argument(
         "--manifest",
         action="append",
         type=Path,
         required=True,
-        help="immutable platform manifest; provide once for Darwin and once for Linux",
+        help="immutable Darwin platform manifest; provide exactly once",
     )
     aggregate.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -634,6 +634,10 @@ def _runtime_server(
 
     root = dex_update_bridge._validate_vault(vault)
     temporary: tempfile.TemporaryDirectory[str] | None = None
+    cached_fetch: Callable[
+        [Path, dex_update_bridge.ReleasePin],
+        None,
+    ] | None = None
     try:
         if dex_update_bridge._foundation_is_installed(
             root,
@@ -654,6 +658,7 @@ def _runtime_server(
                     pin,
                     cache=foundation_cache,
                 )
+            cached_fetch = fetch_foundation
         else:
             temporary, source = dex_update_bridge.acquire_foundation_source()
         service = dex_update_bridge._load_lifecycle_service(source)
@@ -674,8 +679,8 @@ def _runtime_server(
                             {"kind": "output", "text": text}
                         ),
                     }
-                    if foundation_cache is not None:
-                        bridge_arguments["fetch_foundation"] = fetch_foundation
+                    if cached_fetch is not None:
+                        bridge_arguments["fetch_foundation"] = cached_fetch
                     result = dex_update_bridge.run_bridge(
                         root,
                         service,

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -14,6 +14,7 @@ import os
 import re
 import select
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -75,6 +76,151 @@ class ExecutorRun:
         return value
 
 
+def _cached_git(repository: Path, *arguments: str) -> str:
+    """Run local-only Git against a controller-verified foundation cache."""
+
+    environment = dex_update_bridge._bridge_environment()
+    environment["GIT_ALLOW_PROTOCOL"] = "file"
+    completed = subprocess.run(
+        [
+            str(dex_update_bridge._trusted_git_binary()),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "fetch.fsckObjects=true",
+            "-c",
+            "transfer.fsckObjects=true",
+            "-C",
+            str(repository),
+            *arguments,
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        timeout=90,
+    )
+    if completed.returncode:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        raise ExecutorError(detail or "foundation cache Git operation failed")
+    try:
+        return completed.stdout.decode("utf-8").strip()
+    except UnicodeDecodeError as error:
+        raise ExecutorError("foundation cache Git output was not text") from error
+
+
+def _validate_foundation_cache(
+    cache: Path,
+    pin: dex_update_bridge.ReleasePin = dex_update_bridge.FOUNDATION,
+) -> Path:
+    """Prove a private local cache contains the exact official foundation."""
+
+    if cache.is_symlink() or not cache.is_dir():
+        raise ExecutorError("foundation cache must be a private bare repository")
+    status = cache.stat()
+    if status.st_uid != os.getuid() or stat.S_IMODE(status.st_mode) != 0o700:
+        raise ExecutorError(
+            "foundation cache must be controller-owned with mode 0700"
+        )
+    resolved = cache.resolve(strict=True)
+    expected = {
+        f"refs/tags/{pin.tag}": pin.tag_object,
+        f"{pin.tag}^{{commit}}": pin.commit,
+        f"{pin.tag}^{{tree}}": pin.tree,
+        "refs/heads/release^{commit}": pin.commit,
+    }
+    for revision, identity in expected.items():
+        try:
+            actual = _cached_git(resolved, "rev-parse", "--verify", revision)
+        except ExecutorError as error:
+            raise ExecutorError(
+                "foundation cache does not match the pinned official release"
+            ) from error
+        if actual != identity:
+            raise ExecutorError(
+                "foundation cache does not match the pinned official release"
+            )
+    return resolved
+
+
+def _acquire_cached_foundation_source(
+    cache: Path,
+    pin: dex_update_bridge.ReleasePin = dex_update_bridge.FOUNDATION,
+) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    """Check out the verified cache without another network transfer."""
+
+    verified = _validate_foundation_cache(cache, pin)
+    temporary = tempfile.TemporaryDirectory(prefix="dex-cached-foundation-")
+    root = Path(temporary.name)
+    source = root / "foundation"
+    try:
+        _cached_git(
+            root,
+            "clone",
+            "--quiet",
+            "--no-checkout",
+            "--no-local",
+            str(verified),
+            str(source),
+        )
+        _cached_git(source, "checkout", "--quiet", "--detach", pin.tag)
+        for revision, identity in (
+            (f"refs/tags/{pin.tag}", pin.tag_object),
+            (f"{pin.tag}^{{commit}}", pin.commit),
+            (f"{pin.tag}^{{tree}}", pin.tree),
+        ):
+            if _cached_git(source, "rev-parse", "--verify", revision) != identity:
+                raise ExecutorError(
+                    "cached foundation checkout changed immutable identity"
+                )
+    except Exception:
+        temporary.cleanup()
+        raise
+    return temporary, source
+
+
+def _fetch_foundation_from_cache(
+    vault: Path,
+    pin: dex_update_bridge.ReleasePin,
+    *,
+    cache: Path,
+) -> None:
+    """Populate only the private brain from the preverified local cache."""
+
+    verified = _validate_foundation_cache(cache, pin)
+    brain = vault / ".dex/brain.git"
+    if brain.is_symlink() or not brain.is_dir():
+        raise ExecutorError("topology conversion did not create a safe brain store")
+    _cached_git(
+        brain,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "--no-recurse-submodules",
+        str(verified),
+        f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
+        "+refs/heads/release:refs/remotes/upstream/release",
+    )
+    if (
+        _cached_git(brain, "rev-parse", "--verify", f"refs/tags/{pin.tag}")
+        != pin.tag_object
+        or _cached_git(brain, "rev-parse", "--verify", f"{pin.tag}^{{commit}}")
+        != pin.commit
+        or _cached_git(brain, "rev-parse", "--verify", f"{pin.tag}^{{tree}}")
+        != pin.tree
+        or _cached_git(
+            brain,
+            "rev-parse",
+            "--verify",
+            "refs/remotes/upstream/release^{commit}",
+        )
+        != pin.commit
+    ):
+        raise ExecutorError("cached foundation fetch changed immutable identity")
+
+
 class JourneyRuntime(Protocol):
     """Internal seam for the production and deterministic test adapters."""
 
@@ -112,7 +258,7 @@ class JourneyRuntime(Protocol):
 class _ProductionRuntime:
     """Closed parent adapter over a fixture-venv lifecycle runtime."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, foundation_cache: Path | None = None) -> None:
         self._runtime_home = tempfile.TemporaryDirectory(
             prefix="dex-release-journey-runtime-"
         )
@@ -120,6 +266,11 @@ class _ProductionRuntime:
         self._server_stderr = tempfile.TemporaryFile(mode="w+b")
         self._server_vault: Path | None = None
         self._server_buffer = bytearray()
+        self._foundation_cache = (
+            _validate_foundation_cache(foundation_cache)
+            if foundation_cache is not None
+            else None
+        )
 
     def close(self) -> None:
         process = self._server
@@ -213,14 +364,19 @@ class _ProductionRuntime:
             )
         self._server_stderr.seek(0)
         self._server_stderr.truncate()
+        command = [
+            str(interpreter),
+            str(Path(__file__).resolve()),
+            "_runtime-server",
+            "--vault",
+            str(root),
+        ]
+        if self._foundation_cache is not None:
+            command.extend(
+                ["--foundation-cache", str(self._foundation_cache)]
+            )
         process = subprocess.Popen(
-            [
-                str(interpreter),
-                str(Path(__file__).resolve()),
-                "_runtime-server",
-                "--vault",
-                str(root),
-            ],
+            command,
             cwd=PROJECT_ROOT,
             env=self._runtime_environment(root),
             stdin=subprocess.PIPE,
@@ -469,7 +625,11 @@ def _runtime_server_answer(prompt: str) -> str:
     return response["answer"]
 
 
-def _runtime_server(vault: Path) -> int:
+def _runtime_server(
+    vault: Path,
+    *,
+    foundation_cache: Path | None = None,
+) -> int:
     """Serve the fixed lifecycle vocabulary from the fixture virtualenv."""
 
     root = dex_update_bridge._validate_vault(vault)
@@ -480,6 +640,20 @@ def _runtime_server(vault: Path) -> int:
             dex_update_bridge.FOUNDATION,
         ):
             source = root
+        elif foundation_cache is not None:
+            temporary, source = _acquire_cached_foundation_source(
+                foundation_cache
+            )
+
+            def fetch_foundation(
+                vault_root: Path,
+                pin: dex_update_bridge.ReleasePin,
+            ) -> None:
+                _fetch_foundation_from_cache(
+                    vault_root,
+                    pin,
+                    cache=foundation_cache,
+                )
         else:
             temporary, source = dex_update_bridge.acquire_foundation_source()
         service = dex_update_bridge._load_lifecycle_service(source)
@@ -493,14 +667,19 @@ def _runtime_server(vault: Path) -> int:
                 if operation == "close" and set(request) == {"operation"}:
                     return 0
                 if operation == "bridge" and set(request) == {"operation"}:
+                    bridge_arguments: dict[str, object] = {
+                        "pin": dex_update_bridge.FOUNDATION,
+                        "input_fn": _runtime_server_answer,
+                        "output_fn": lambda text: _runtime_server_emit(
+                            {"kind": "output", "text": text}
+                        ),
+                    }
+                    if foundation_cache is not None:
+                        bridge_arguments["fetch_foundation"] = fetch_foundation
                     result = dex_update_bridge.run_bridge(
                         root,
                         service,
-                        pin=dex_update_bridge.FOUNDATION,
-                        input_fn=_runtime_server_answer,
-                        output_fn=lambda text: _runtime_server_emit(
-                            {"kind": "output", "text": text}
-                        ),
+                        **bridge_arguments,
                     )
                 elif operation == "deliver_latest_release" and set(request) == {
                     "operation"
@@ -1175,9 +1354,24 @@ __all__ = [
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4 or sys.argv[1:3] != ["_runtime-server", "--vault"]:
+    valid = (
+        len(sys.argv) == 4
+        and sys.argv[1:3] == ["_runtime-server", "--vault"]
+    ) or (
+        len(sys.argv) == 6
+        and sys.argv[1:3] == ["_runtime-server", "--vault"]
+        and sys.argv[4] == "--foundation-cache"
+    )
+    if not valid:
         raise SystemExit("released journey executor has no standalone interface")
     try:
-        raise SystemExit(_runtime_server(Path(sys.argv[3])))
+        raise SystemExit(
+            _runtime_server(
+                Path(sys.argv[3]),
+                foundation_cache=(
+                    Path(sys.argv[5]) if len(sys.argv) == 6 else None
+                ),
+            )
+        )
     except Exception as error:  # noqa: BLE001
         raise SystemExit(f"fixture lifecycle runtime stopped safely: {error}") from error


### PR DESCRIPTION
## Outcome

Unblocks the exact failures reported by Amit on v1.77.2 and Jim on a clean v1.79.0 install, and completes the Mac updater bridge for the customer-critical recent release window while keeping vault mutations behind the lifecycle transaction service.

## What changed

- completes the pinned historic update bridge and private immutable fleet caches
- fixes the already-foundation cache callback path
- keeps the generated journey protocol in a brain-owned path and scopes this acceptance lane to macOS
- ignores only empty retired skill directories during Doctor checks while malformed, linked, or non-empty directories remain fail-closed
- makes Doctor and smoke use the vault installed Python runtime
- exposes useful partial customization evidence while keeping Capsule writes fail-closed
- keeps daily review inline by default and verifies existing day state
- discovers provider-neutral meeting notes, including ClickUp AI, and writes closeout back to the source note

## Fleet proof on exact head 74f1f8ac

- frozen recent Mac wave: 26 immutable release trees from v1.77.0 through v1.80.5
- discovered 26; started 26; completed 26; passed 26; failed 0; pending 0
- every tree completed both update hops healthy
- every tree retained all 4 of 4 seeded user-file hashes
- sealed summary SHA-256: a3079efe870891ceacbe8b3ab3219b7cc5776f9f948ef716637ab6f2f67b61e8

## Checks

- fresh CI on exact head: quality green, all three Python shards green, combined results and coverage green
- combined updater, contract, and acceptance tests: 187 passed
- customer-facing regression set: 312 passed
- Doctor suite: 145 passed
- path and platform focused tests: 158 passed

The 26-tree fleet evidence is retained local preflight evidence with acceptance=false and authority_complete=false. No public tag, release artifact, deployment, or live-support claim has been made.