### PR TITLE
release: v1.81.0 updater bridge foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.0] — 🛟 Older Dex installations have a safe way forward again (2026-07-31)
+
+Some people on recent older versions of Dex could see that an update existed but
+still could not reach it through the normal guided route. Amit hit this on 1.77.2;
+Jim hit it on a clean 1.79.0 install. Both stopped safely, but neither should have
+needed a technical rescue.
+
+**What this fixes for you:**
+
+* **Recent older Dex versions can cross the update bridge.** Dex now has the
+  missing, pinned handoff that lets those installations reach the protected
+  self-updating foundation without asking you to use Git or replace files by hand.
+* **Your files remain the hard boundary.** I exercised every distinct Mac release
+  tree from 1.77.0 through 1.80.5 through two complete update hops. All 26 finished
+  healthy, with every seeded user file unchanged.
+* **The checkup uses the environment Dex actually installed.** Doctor and smoke
+  now inspect the vault's own Python environment, so an installed dependency is
+  no longer reported missing just because a different system Python was found
+  first.
+* **Retired empty skill folders stop looking broken.** If an update correctly
+  removes an old built-in skill and leaves an empty folder behind, Doctor ignores
+  that harmless shell. Linked, malformed, custom, or non-empty folders still fail
+  closed.
+* **Customized setups get useful, honest guidance.** Dex can show the safe evidence
+  it verified and explain each excluded item separately, while still refusing to
+  write a Capsule when the full safety contract is not met.
+* **Daily review stays in the conversation you started.** It no longer forces a
+  second thread, and it recognises a review that already exists for the day.
+* **Meeting closeout can find notes from more than one provider.** Notes such as
+  ClickUp AI are found wherever they legitimately live, and the closeout is written
+  back to that source note rather than copied into a competing record.
+
+This is the bridge foundation. The immediately following release is deliberately
+separate so this version can prove it can fetch and deliver its own successor
+through the same public route.
+
 ## [1.80.5] — 🔒 Your personal profile never ships in Dex (2026-07-29)
 
 Dex's download package used to include a default profile file. It was not your

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -703,7 +703,6 @@ System/.last-learning-check
 System/.local-only-preservation-transition.json
 System/.mcp.json.example
 System/.release-evidence-profile.json
-System/.update-journey-v1.json
 System/Beta_Communications/2026-02-04_hardcoded_paths_fix.md
 System/Dex_Backlog.md
 System/README.md
@@ -1086,6 +1085,7 @@ core/tests/test_release_catalog.py
 core/tests/test_release_catalog_generation.py
 core/tests/test_release_channel.py
 core/tests/test_release_fleet.py
+core/tests/test_release_fleet_acceptance.py
 core/tests/test_release_fleet_executor.py
 core/tests/test_release_tag_uniqueness.py
 core/tests/test_review_retirement.py
@@ -1131,6 +1131,7 @@ core/transaction/lock.py
 core/transaction/snapshot.py
 core/update/__init__.py
 core/update/apply_update.py
+core/update/journey-protocol-v1.json
 core/update/journey_protocol.py
 core/utils/__init__.py
 core/utils/company_domains.py
@@ -1285,6 +1286,7 @@ scripts/pii_gate.py
 scripts/pr_report.py
 scripts/release.sh
 scripts/release_fleet.py
+scripts/release_fleet_acceptance.py
 scripts/release_fleet_executor.py
 scripts/render-health-page.py
 scripts/resolve-distignore-files.sh

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.80.5"
+  "release_version": "1.81.0"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.80.5",
+  "release_version": "1.81.0",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.80.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.0","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "d8be15528779e69c6d876cbe67bbf0347a33c924554ee269f4f47a231e978ac5",
+    "sha256": "6f44f9a718a066e3964a7a502f8ef0f2fb193214ccc58874f0059bc5af033a19",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -7,14 +7,52 @@ A compact snapshot of released, local, and planned Dex Core work.
 
 SHIPPED/LOCAL are computed live — run `/dex-orient` or `python3 scripts/dex_state.py` for current truth.
 
-Released: v1.75.2 (2026-07-26)
+Released: v1.80.5 (2026-07-29)
 
-### LOCAL — on main, not yet released (4)
+### LOCAL — on main, not yet released (42)
 
-- #251 docs: full documentation refresh to v1.75.2 ground truth
-- #248 feat(customization-migration): activation + rewind — make a verified rebuild live, reversibly (Lane G)
-- #249 docs: point new users at the Dex Guide (heydex.ai/help)
-- docs(changelog): v1.75.2 — one honest entry: proven vault move + guided customization journey + security groundwork
+- #336 fix: unblock real-user updates and workflow dead ends
+- Merge pull request #335 from davekilleen/codex/fleet-acceptance-aggregation
+- fix: keep fleet evidence aggregation non-authoritative
+- feat: add authenticated historic fleet aggregation
+- Merge pull request #334 from davekilleen/codex/release-owned-journey-executor
+- fix(update): close fleet proof gaps
+- feat(update): add release-owned journey executor
+- Merge pull request #333 from davekilleen/codex/release-owned-journey-protocol
+- fix(update): keep journey proof fail closed
+- feat(update): add release-owned journey protocol
+- Merge pull request #331 from davekilleen/codex/fleet-journey-runner
+- fix(fleet): kill timed-out process descendants
+- Merge remote-tracking branch 'upstream/main' into codex/fleet-journey-runner
+- fix(fleet): harden historic installer fixtures
+- Merge pull request #332 from davekilleen/codex/onboarding-context-lifecycle
+- fix(onboarding): close lifecycle approval gaps
+- feat(fleet): survey historic update readiness
+- feat(onboarding): persist confirmed context through lifecycle
+- Merge pull request #328 from davekilleen/codex/updater-bridge-resume-safety
+- fix(update): bind bridge marker to vault runtime
+- fix(update): seal bridge runtime environment
+- Merge remote-tracking branch 'upstream/main' into codex/updater-bridge-resume-safety
+- Merge pull request #329 from davekilleen/codex/fleet-journey-runner
+- Merge remote-tracking branch 'upstream/main' into codex/updater-bridge-resume-safety
+- feat(fleet): execute one pinned historic update journey
+- fix(capabilities): align legacy company defaults
+- fix(update): harden bridge resume safety
+- test(doctor): expect enabled companies recovery
+- fix(capabilities): align legacy company defaults
+- fix(update): harden bridge resume boundary
+- feat(update): add lifecycle-era bridge bootstrap
+- fix(lifecycle): register MCP from delivered definition
+- fix(lifecycle): register MCP from delivered definition
+- fix: make release changelog insertion portable
+- fix: make release changelog insertion portable
+- fix(doctor): isolate launch agents by vault
+- fix: surface unattributable doctor jobs
+- fix: scope doctor launch agents to vault paths
+- fix(connect): do not confirm OAuth before token exchange
+- fix(connect): do not confirm OAuth before token exchange
+- fix: discover archived release fleet trees
+- fix: discover archived release fleet trees
 <!-- GENERATED:END -->
 
 <!-- PLANNED:START -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.75.0",
+  "version": "1.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.75.0",
+      "version": "1.81.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.80.5",
+  "version": "1.81.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1182,6 +1182,8 @@ def _run_bounded_process_group(
             process.poll()
             if not _process_group_exists(process.pid):
                 break
+            if process.returncode is not None:
+                break
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break


### PR DESCRIPTION
## Outcome

Publishes the authorized Mac updater bridge foundation for recent older Dex installations, including the exact Amit v1.77.2 and Jim v1.79.0 failure generations fixed by PR #336.

## Release proof

- based on merged main commit `31425ce261e66a739ffcd49c64f7107c3f0c5a15`
- retained recent Mac wave: 26/26 immutable trees passed, 0 failed
- every journey completed two healthy hops and preserved 4/4 seeded user-file hashes
- sealed evidence SHA-256: `a3079efe870891ceacbe8b3ab3219b7cc5776f9f948ef716637ab6f2f67b61e8`
- clean local release gate: 117 focused updater/release tests passed
- distribution, PII, founder-content, portable ownership, Tau-removal, and security gates passed

## Release sequence

This is the first authorized release in the two-step proof. After CI publishes v1.81.0, the v1.81.1 follow-up will pin this exact immutable distribution tag and prove v1.81.0 can deliver its successor through the public route.

Nothing is called live until the served artifacts and public consumer route are verified.