### PR TITLE
release: v1.81.1 updater bridge follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.1] — ✅ The update bridge proves it can deliver its own follow-up (2026-07-31)
+
+Dex 1.81.0 gave recent older installations a safe bridge back onto the protected
+update route. This deliberately separate follow-up proves that the bridge
+foundation can recognise, fetch, and deliver its own successor from the public
+release channel.
+
+**What this means for you:**
+
+* **The bridge is a real route, not a one-off repair.** Recent older Dex versions
+  can move through the 1.81.0 foundation and continue to this release using the
+  same guided update journey.
+* **Every handoff is pinned to one exact release.** Dex verifies the immutable
+  public identity of the bridge before trusting it, so a similarly named tag or
+  changed package cannot silently replace the tested foundation.
+* **Your own files remain outside the release.** Both update hops use Dex's
+  protected transaction boundary, with Doctor checking the result before the
+  journey is allowed to count as complete.
+
 ## [1.81.0] — 🛟 Older Dex installations have a safe way forward again (2026-07-31)
 
 Some people on recent older versions of Dex could see that an update existed but

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.0"
+  "release_version": "1.81.1"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.0",
+  "release_version": "1.81.1",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.0","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.1","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -162,11 +162,11 @@ def _foundation_topology_adapter(
 
 def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
     assert bridge.FOUNDATION.identity() == {
-        "tag": "dist/release/v1.80.5-9211053",
-        "tag_object": "ff94463b191bb2c503ffec42ce288e961ca79659",
-        "commit": "9211053235d7c1837a6e327bff1596b593323fc6",
-        "tree": "d394658e2bf1125b96eb5afdace24f3a5ba3107e",
-        "version": "1.80.5",
+        "tag": "dist/release/v1.81.0-6bc490e",
+        "tag_object": "54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
+        "commit": "6bc490e7caec22f60f097c6b54bb563382f542b8",
+        "tree": "dad3e43774e772dfc42df698f8a9818956346d78",
+        "version": "1.81.0",
         "channel": "stable",
     }
 

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -612,6 +612,47 @@ def test_installer_timeout_kills_detached_term_ignoring_child_after_leader_exits
     assert not (vault / "child-finished").exists()
 
 
+def test_timeout_retries_transient_permission_error_while_group_is_reaped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker = tmp_path / "child-finished"
+    real_killpg = release_fleet.os.killpg
+    kill_attempts = 0
+
+    def transient_killpg(process_group_id: int, requested_signal: int) -> None:
+        nonlocal kill_attempts
+        if requested_signal == release_fleet.signal.SIGKILL:
+            kill_attempts += 1
+            if kill_attempts == 1:
+                raise PermissionError("macOS is still reaping the exited process group")
+        real_killpg(process_group_id, requested_signal)
+
+    monkeypatch.setattr(release_fleet.os, "killpg", transient_killpg)
+    command = [
+        "/bin/sh",
+        "-c",
+        (
+            "trap 'exit 0' TERM; "
+            "(trap '' TERM; exec >/dev/null 2>&1; "
+            f"sleep 1.25; printf escaped > {marker!s}) & "
+            "while :; do sleep 10; done"
+        ),
+    ]
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        release_fleet._run_bounded_process_group(
+            command,
+            cwd=tmp_path,
+            environment=release_fleet.os.environ,
+            timeout_seconds=0.2,
+        )
+
+    assert kill_attempts >= 2
+    time.sleep(2.0)
+    assert not marker.exists()
+
+
 def test_revision_switching_installer_is_rejected_before_doctor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -55,8 +55,8 @@ def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
         _foundation_release(),
     )
     later = (
-        _release("v1.81.0", "1.81.0", "3"),
-        _release("dist/release/v1.81.1-4444444", "1.81.1", "4"),
+        _release("v1.81.1", "1.81.1", "3"),
+        _release("dist/release/v1.81.2-4444444", "1.81.2", "4"),
     )
 
     manifest = acceptance.frozen_cohort_manifest(
@@ -149,15 +149,15 @@ def test_frozen_cohort_requires_the_exact_foundation_release() -> None:
         )
 
 
-def test_real_repository_freezes_exactly_168_historic_trees() -> None:
+def test_real_repository_freezes_exactly_170_historic_trees() -> None:
     acceptance = _acceptance()
     repository = Path(__file__).resolve().parents[2]
     current = release_fleet.discover_distribution_releases(repository)
 
     manifest = acceptance.frozen_cohort_manifest(current)
 
-    assert manifest["case_count"] == acceptance.EXPECTED_HISTORIC_CASES == 168
-    assert manifest["foundation"]["tag"] == "dist/release/v1.80.5-9211053"
+    assert manifest["case_count"] == acceptance.EXPECTED_HISTORIC_CASES == 170
+    assert manifest["foundation"]["tag"] == "dist/release/v1.81.0-6bc490e"
 
 
 def _case(tag: str, platform: str) -> release_fleet.CaseResult:
@@ -373,12 +373,12 @@ def test_serialized_platform_evidence_is_never_an_acceptance_authority(
         "acceptance": False,
         "authority_complete": False,
         "platforms": ["darwin"],
-        "case_count": 168,
-        "journey_count": 168,
-        "discovered": 168,
-        "started": 168,
-        "completed": 168,
-        "passed": 168,
+        "case_count": 170,
+        "journey_count": 170,
+        "discovered": 170,
+        "started": 170,
+        "completed": 170,
+        "passed": 170,
         "failed": 0,
         "session_id": "e" * 64,
         "required_job_conclusions": {
@@ -524,8 +524,8 @@ def test_aggregation_reopens_and_hashes_the_immutable_manifest(
         )
 
 
-@pytest.mark.parametrize("mutation", ("167", "169", "substitution", "duplicate"))
-def test_aggregation_requires_exactly_168_unique_final_starts_per_platform(
+@pytest.mark.parametrize("mutation", ("169", "171", "substitution", "duplicate"))
+def test_aggregation_requires_exactly_170_unique_final_starts_per_platform(
     mutation: str,
     tmp_path: Path,
 ) -> None:
@@ -534,9 +534,9 @@ def test_aggregation_requires_exactly_168_unique_final_starts_per_platform(
     darwin = _manifest_document(inputs=inputs, platform="darwin")
     cases = darwin["report"]["cases"]
     assert isinstance(cases, list)
-    if mutation == "167":
+    if mutation == "169":
         cases.pop()
-    elif mutation == "169":
+    elif mutation == "171":
         cases.append(_case_document(_case("v9.9.9", "darwin")))
     elif mutation == "substitution":
         cases[0] = _case_document(_case("v9.9.9", "darwin"))
@@ -881,10 +881,10 @@ def test_live_finalization_rejects_a_spoofed_host_platform(
         ),
         (),
         {
-            "discovered": 168,
-            "started": 168,
-            "completed": 168,
-            "passed": 168,
+            "discovered": 170,
+            "started": 170,
+            "completed": 170,
+            "passed": 170,
             "failed": 0,
         },
     )
@@ -942,13 +942,13 @@ def test_session_key_file_is_private_and_rejects_symlinks(tmp_path: Path) -> Non
         acceptance.read_session_key(key_path)
 
 
-def test_cohort_cli_writes_the_exact_168_tree_manifest(
+def test_cohort_cli_writes_the_exact_170_tree_manifest(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     acceptance = _acceptance()
     repository = Path(__file__).resolve().parents[2]
-    output = tmp_path / "historic-through-v1.80.5.json"
+    output = tmp_path / "historic-through-v1.81.0.json"
 
     exit_code = acceptance.main(["cohort", "--repo", str(repository), "--output", str(output)])
 
@@ -957,12 +957,12 @@ def test_cohort_cli_writes_the_exact_168_tree_manifest(
     assert exit_code == 0
     assert result == {
         "acceptance": False,
-        "case_count": 168,
+        "case_count": 170,
         "foundation_tag": FOUNDATION.tag,
         "outcome": "HISTORIC_COHORT_FROZEN",
         "output": str(output),
     }
-    assert manifest["case_count"] == 168
+    assert manifest["case_count"] == 170
 
 
 def test_acceptance_source_is_bound_to_exact_publisher_commit_bytes(
@@ -1074,10 +1074,10 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
         return SimpleNamespace(
             report=SimpleNamespace(platforms=(running_platform,)),
             counts={
-                "discovered": 168,
-                "started": 168,
-                "completed": 168,
-                "passed": 168,
+                "discovered": 170,
+                "started": 170,
+                "completed": 170,
+                "passed": 170,
                 "failed": 0,
             },
         )
@@ -1179,17 +1179,17 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     assert result == {
         "acceptance": False,
         "authority_complete": False,
-        "case_count": 168,
-        "completed": 168,
-        "discovered": 168,
+        "case_count": 170,
+        "completed": 170,
+        "discovered": 170,
         "failed": 0,
-        "journey_count": 168,
+        "journey_count": 170,
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
-        "passed": 168,
+        "passed": 170,
         "platforms": ["darwin"],
         "required_job_conclusions": {
             "darwin": "historic-fleet-darwin",
         },
         "session_id": session["payload"]["session_id"],
-        "started": 168,
+        "started": 170,
     }

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,16 +35,16 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "0d40463658d3f760e0f5a24061e1ff642306d1604d3cef8c5d9f89c97f4b7d9b",
+      "sha256": "8a6f9edac91ec1bf78b89256ab985feb868c1ace883da1c86cbb7ad36ce86bf9",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
       "channel": "stable",
-      "commit": "9211053235d7c1837a6e327bff1596b593323fc6",
-      "tag": "dist/release/v1.80.5-9211053",
-      "tag_object": "ff94463b191bb2c503ffec42ce288e961ca79659",
-      "tree": "d394658e2bf1125b96eb5afdace24f3a5ba3107e",
-      "version": "1.80.5"
+      "commit": "6bc490e7caec22f60f097c6b54bb563382f542b8",
+      "tag": "dist/release/v1.81.0-6bc490e",
+      "tag_object": "54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
+      "tree": "dad3e43774e772dfc42df698f8a9818956346d78",
+      "version": "1.81.0"
     }
   },
   "platforms": [

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "6f44f9a718a066e3964a7a502f8ef0f2fb193214ccc58874f0059bc5af033a19",
+    "sha256": "c6c94344cf4974dea70aa718a81f55a7ae4bfabbf33357a76ffce97c8d91a181",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -82,23 +82,21 @@ begin. The bridge is intentionally not a raw Git merge: it fetches only the
 pre-pinned foundation release, proves its annotated tag, commit, and tree, then
 uses that foundation's existing topology and receipt-backed transaction service.
 
-This source is not yet a published historical-support promise. Its pinned
-foundation is exactly v1.80.5; it cannot include repairs introduced in later
-source commits. In particular, do not treat a later MCP-registration repair as
-evidence that a v1.74–v1.79 bridge journey is complete. Each historical route
-needs an installed-fixture rehearsal, preserved-user-file hashes, Doctor output,
-and path evidence before it can be offered as supported recovery.
+The bridge now pins the exact public v1.81.0 foundation: its annotated
+distribution tag, tag object, commit, and tree are all closed in the released
+journey contract. That publication is not, by itself, proof that every historic
+route works. Each supported route still needs an installed-fixture rehearsal,
+preserved-user-file hashes, Doctor output, and path evidence before it counts as
+accepted recovery.
 
-Do not run this unpublished source as a rescue command. When a later immutable
-foundation includes the repair and the full fixture evidence is green, publish a
-separately versioned bridge file with its SHA-256 and the exact annotated
-distribution tag, tag object, commit, and tree it pins. That bridge source and
-artifact must name that same future foundation identity; rebasing this file onto
-`main` is not a substitute for a released tag. An older bridge must refuse
-rather than silently substituting a newer release.
+Do not run repository source as a substitute for the released bridge. The
+released artifact and journey contract must name the same immutable foundation
+identity. A newer source commit, a mutable branch, or a similarly named tag is
+not equivalent, and an older bridge must refuse rather than silently
+substituting a newer release.
 
-# This is the eventual published-artifact invocation, not an instruction to
-# run this repository source before that release exists.
+# This is the released-artifact invocation, not an instruction to run a
+# similarly named file copied from a repository checkout.
 ```bash
 python3 dex_update_bridge.py --vault "$PWD"
 ```

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -4,7 +4,7 @@
 >
 > **Status vocabulary.** `SHIPPED` = in a released version tag. `LOCAL` = merged on `main`, not yet in a release tag. `PROTOTYPE` = built, not verified against live/real use. `PLANNED` = designed, not built.
 >
-> **Ground truth as of** `upstream/main` at `7edae25df`, latest release tag **v1.80.5** (2026-07-29). This branch adds the release-owned historic updater journey executor to the already-merged protocol. It remains LOCAL until merged and both pieces remain unpublished until a later immutable release; no historic fleet case has passed because of them.
+> **Ground truth as of** `upstream/main` at `0f23787a`, latest release tag **v1.81.0** (2026-07-31). The updater bridge, journey protocol, and executor are published. The separate v1.81.1 follow-up and full macOS fleet acceptance are still in progress.
 >
 > **Don't duplicate generated files.** Tool lists, skill lists, ownership-class path tables, and MCP↔skill wiring live in the auto-generated `docs/architecture/INVENTORY.md`. This map cross-references it; it does not restate it.
 >
@@ -20,7 +20,7 @@
 | Transaction core | **SHIPPED** (v1.66) | `core/transaction/*` | Crash-safe snapshot→apply→verify→commit/rollback substrate the lifecycle engine writes through |
 | Portable ownership contract | **SHIPPED** (v1.64+) | `core/portable_contract.py` | Source of truth: every path is brain/seed/generated/vault/runtime; decides what an update may write |
 | Release catalog + bridge | **SHIPPED** (v1.65–v1.68) | `core/lifecycle/catalog/*`, `bridge.py` | Publisher-declared packing list per release; one-release handoff from the legacy updater |
-| Historic updater journey protocol + executor | **LOCAL** | `core/update/journey-protocol-v1.json`, `core/update/journey_protocol.py`, `scripts/release_fleet_executor.py` | Closed release-owned machine contract and evidence-owning implementation for the pinned bridge and lifecycle delivery route; not yet published or fleet-executed |
+| Historic updater journey protocol + executor | **SHIPPED** (v1.81.0), acceptance pending | `core/update/journey-protocol-v1.json`, `core/update/journey_protocol.py`, `scripts/release_fleet_executor.py` | Closed release-owned machine contract and evidence-owning implementation for the pinned bridge and lifecycle delivery route |
 | 10 MCP servers | **SHIPPED** (mixed ages) | `core/mcp/*_server.py` | The tool surface Dex acts through; Work MCP is the giant (46 tools) |
 | Connection Manager (OAuth/token) | **SHIPPED ENGINE, `/connect` HELD** | `core/integrations/connection-manager/` | Local-first OAuth via Nango catalog-as-data; encrypted on-device tokens; hardened through security Phases 0–5g, but the `/connect` doorway stays held (draft PR #231) |
 | Customization migration | **SHIPPED** assess/capsule/guided-journey (v1.75.x) / **LOCAL** rebuild engine and doorway | `core/customization_migration/*`, `core/mcp/customization_migration_server.py` | Inventories customizations, preserves a Capsule, and offers a human-confirmed, receipt-backed rebuild and rewind; the doorway is authorized but remains unshipped until its release |
@@ -83,16 +83,16 @@
 
 **How it connects.** Feeds `lifecycle/plan.py` (what's available to adopt) and the DexDiff-adjacent adoption receipts under `System/.dex/adoptions/`. The v1.67 "two dozen role-specific tools you can turn on safely" are catalog items adopted through this path.
 
-### Historic updater journey protocol — LOCAL
+### Historic updater journey protocol — SHIPPED CONTROL PLANE, ACCEPTANCE PENDING
 
-`core/update/journey-protocol-v1.json` is the future release-owned control plane for
+`core/update/journey-protocol-v1.json` is the release-owned control plane for
 historic fleet evidence. Its strict parser permits only the pinned
 foundation-bridge adapter and the existing
 `deliver_latest_release` → `build_and_preview_delivered_release` →
 `execute_approved_delivered_release` lifecycle sequence. The generated root
 binds the exact bridge, fleet-runner, and executor bytes in the publisher
-source commit, the immutable v1.80.5 foundation identity, maximum conditional
-approval counts, Mac/Linux support, and the required evidence order. Unknown
+source commit, the immutable v1.81.0 foundation identity, maximum conditional
+approval counts, macOS support, and the required evidence order. Unknown
 fields, adapters, operations, hashes, or approval shapes fail closed; there is
 no arbitrary command vocabulary.
 
@@ -104,10 +104,10 @@ user-owned files, and writes receipts and the transcript itself. Its successful
 result carries process-local authority that serialized JSON cannot recreate;
 `check-report` therefore stays closed to externally authored substitutes.
 
-This is implementation truth, not release acceptance. No public distribution
-tag contains the protocol or executor yet, no foundation/follow-up pair has
-completed the real two-hop journey, and the public v1.80.5 surface remains
-`machine_executable: false`. The 168-case acceptance result remains false.
+This is implementation truth, not release acceptance. Public v1.81.0 contains
+the foundation and closed journey contract, but the separate follow-up and full
+170-tree macOS journey have not yet completed. The fleet-acceptance result
+therefore remains false.
 
 ## 5. The 10 MCP servers — SHIPPED
 

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -7,52 +7,11 @@ A compact snapshot of released, local, and planned Dex Core work.
 
 SHIPPED/LOCAL are computed live — run `/dex-orient` or `python3 scripts/dex_state.py` for current truth.
 
-Released: v1.80.5 (2026-07-29)
+Released: v1.81.0 (2026-07-31)
 
-### LOCAL — on main, not yet released (42)
+### LOCAL — on main, not yet released (0)
 
-- #336 fix: unblock real-user updates and workflow dead ends
-- Merge pull request #335 from davekilleen/codex/fleet-acceptance-aggregation
-- fix: keep fleet evidence aggregation non-authoritative
-- feat: add authenticated historic fleet aggregation
-- Merge pull request #334 from davekilleen/codex/release-owned-journey-executor
-- fix(update): close fleet proof gaps
-- feat(update): add release-owned journey executor
-- Merge pull request #333 from davekilleen/codex/release-owned-journey-protocol
-- fix(update): keep journey proof fail closed
-- feat(update): add release-owned journey protocol
-- Merge pull request #331 from davekilleen/codex/fleet-journey-runner
-- fix(fleet): kill timed-out process descendants
-- Merge remote-tracking branch 'upstream/main' into codex/fleet-journey-runner
-- fix(fleet): harden historic installer fixtures
-- Merge pull request #332 from davekilleen/codex/onboarding-context-lifecycle
-- fix(onboarding): close lifecycle approval gaps
-- feat(fleet): survey historic update readiness
-- feat(onboarding): persist confirmed context through lifecycle
-- Merge pull request #328 from davekilleen/codex/updater-bridge-resume-safety
-- fix(update): bind bridge marker to vault runtime
-- fix(update): seal bridge runtime environment
-- Merge remote-tracking branch 'upstream/main' into codex/updater-bridge-resume-safety
-- Merge pull request #329 from davekilleen/codex/fleet-journey-runner
-- Merge remote-tracking branch 'upstream/main' into codex/updater-bridge-resume-safety
-- feat(fleet): execute one pinned historic update journey
-- fix(capabilities): align legacy company defaults
-- fix(update): harden bridge resume safety
-- test(doctor): expect enabled companies recovery
-- fix(capabilities): align legacy company defaults
-- fix(update): harden bridge resume boundary
-- feat(update): add lifecycle-era bridge bootstrap
-- fix(lifecycle): register MCP from delivered definition
-- fix(lifecycle): register MCP from delivered definition
-- fix: make release changelog insertion portable
-- fix: make release changelog insertion portable
-- fix(doctor): isolate launch agents by vault
-- fix: surface unattributable doctor jobs
-- fix: scope doctor launch agents to vault paths
-- fix(connect): do not confirm OAuth before token exchange
-- fix(connect): do not confirm OAuth before token exchange
-- fix: discover archived release fleet trees
-- fix: discover archived release fleet trees
+- none
 <!-- GENERATED:END -->
 
 <!-- PLANNED:START -->

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -101,8 +101,8 @@ Markdown `/dex-update` instructions into an API.
 ```bash
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
-  --foundation-tag dist/release/v1.80.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.80.5-EXACTFOLLOWUP
+  --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
+  --follow-up-tag dist/release/v1.81.1-EXACTFOLLOWUP
 ```
 
 The repository has the canonical protocol source at
@@ -138,10 +138,10 @@ constructing the same documents cannot unlock acceptance. The resulting
 content-addressed manifest records the exact executor identity, release
 identities, ordered operations, and artifact hashes.
 
-The protocol and executor are currently LOCAL. Public v1.80.5 contains neither,
-so its surface remains `machine_executable: false`. Publishing both is one
-prerequisite, not fleet acceptance: the real follow-up release must exist and
-every historic case must still run on every declared platform.
+The protocol and executor were published with the v1.81.0 foundation. That
+publication is one prerequisite, not fleet acceptance: the real follow-up
+release must exist and every historic case must still complete the two-hop
+journey on macOS.
 
 ## Validate the finished evidence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.0",
+      "version": "1.81.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -86,11 +86,11 @@ class ReleasePin:
 # and profile-safe package. This pin is intentionally in the bridge source:
 # discovering a mutable "latest" release would not be a safe bootstrap.
 FOUNDATION = ReleasePin(
-    tag="dist/release/v1.80.5-9211053",
-    tag_object="ff94463b191bb2c503ffec42ce288e961ca79659",
-    commit="9211053235d7c1837a6e327bff1596b593323fc6",
-    tree="d394658e2bf1125b96eb5afdace24f3a5ba3107e",
-    version="1.80.5",
+    tag="dist/release/v1.81.0-6bc490e",
+    tag_object="54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
+    commit="6bc490e7caec22f60f097c6b54bb563382f542b8",
+    tree="dad3e43774e772dfc42df698f8a9818956346d78",
+    version="1.81.0",
 )
 
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1189,14 +1189,24 @@ def _run_bounded_process_group(
                 break
             time.sleep(min(0.02, remaining))
         if _process_group_exists(process.pid):
-            try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            except PermissionError as error:
-                raise FleetError(
-                    "timed-out fixture process group could not be killed"
-                ) from error
+            kill_deadline = time.monotonic() + PROCESS_GROUP_TERMINATION_GRACE_SECONDS
+            permission_error: PermissionError | None = None
+            while _process_group_exists(process.pid):
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    permission_error = None
+                except ProcessLookupError:
+                    break
+                except PermissionError as error:
+                    permission_error = error
+                remaining = kill_deadline - time.monotonic()
+                if remaining <= 0:
+                    if _process_group_exists(process.pid):
+                        raise FleetError(
+                            "timed-out fixture process group could not be killed"
+                        ) from permission_error
+                    break
+                time.sleep(min(0.02, remaining))
         stdout, stderr = process.communicate()
         raise subprocess.TimeoutExpired(
             list(command),

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -28,7 +28,7 @@ from core.update.journey_protocol import (
 from scripts import release_fleet
 from scripts.dex_update_bridge import FOUNDATION
 
-EXPECTED_HISTORIC_CASES = 168
+EXPECTED_HISTORIC_CASES = 170
 COHORT_SCHEMA_VERSION = 1
 PLATFORM_MANIFEST_SCHEMA_VERSION = 1
 ACCEPTANCE_SOURCE = "scripts/release_fleet_acceptance.py"
@@ -293,7 +293,7 @@ def load_fleet_inputs(
     foundation = release_fleet.resolve_immutable_release(repo, foundation_tag)
     follow_up = release_fleet.resolve_immutable_release(repo, follow_up_tag)
     if foundation.identity() != FOUNDATION.identity():
-        raise release_fleet.FleetError("fleet acceptance foundation is not the pinned v1.80.5 identity")
+        raise release_fleet.FleetError("fleet acceptance foundation is not the pinned bridge identity")
     if foundation.tag == follow_up.tag or foundation.commit == follow_up.commit:
         raise release_fleet.FleetError("foundation and follow-up must be different immutable releases")
     try:
@@ -736,7 +736,9 @@ def _platform_receipt_boundary():
         ):
             raise release_fleet.FleetError("live platform execution is not bound to the immutable releases")
         if len(execution.report.cases) != EXPECTED_HISTORIC_CASES:
-            raise release_fleet.FleetError("live platform execution does not have exactly 168 final starts")
+            raise release_fleet.FleetError(
+                f"live platform execution does not have exactly {EXPECTED_HISTORIC_CASES} final starts"
+            )
         cases: list[dict[str, object]] = [
             {field: getattr(case, field) for field in sorted(release_fleet.CASE_RESULT_KEYS)}
             for case in execution.report.cases


### PR DESCRIPTION
## Outcome

Publishes the deliberately separate follow-up to the v1.81.0 updater foundation.

- Pins the bridge to the exact public v1.81.0 annotated tag, tag object, release commit, and tree.
- Advances the frozen historic boundary from 168 to the newly re-derived 170 immutable release trees.
- Regenerates the release and journey contracts for v1.81.1.
- Updates release guidance so published control-plane truth is not confused with full-fleet acceptance.

## Verified locally

- `138 passed` across bridge, fleet, acceptance, executor, and journey-protocol tests.
- `163 passed` in the script suite with the project Python bound via `DEX_PYTHON`.
- Ruff clean for changed Python.
- Distribution safety gate: 0 errors; 8 pre-existing historical/example warnings.
- v1.81.0 public bundle: HTTP 200, 8,485,239 bytes, SHA-256 `d8b6f7bd67a5d0c303b90e0b450e8c27f97f3ab2d3e13dce37b5c9e23b486358`.

## Release truth

v1.81.0 is published and verified. This PR is not released until merged and the main release job publishes and verifies v1.81.1.
