### PR TITLE
fix: keep the updater bridge valid after release advances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.2] — 🔗 The update bridge stays valid when a newer release goes live (2026-07-31)
+
+The first public journey from Amit's 1.77.2 release found that the bridge still
+compared its exact 1.81.0 foundation with the moving public release pointer.
+Once 1.81.1 went live, that extra comparison stopped the journey even though the
+verified foundation package itself was unchanged.
+
+**What this fixes for you:**
+
+* **A newer release no longer breaks the first hop.** Dex now verifies the exact
+  immutable foundation package and gives that verified commit to the protected
+  update lifecycle, without requiring the public “latest” pointer to stay frozen.
+* **The safety boundary is unchanged.** The tag object, commit, and tree must all
+  match the declared foundation before Dex creates the private update pointer.
+* **Failures still stop before your files are changed.** The public journey that
+  exposed this issue failed closed; this patch changes only how the already
+  verified foundation is handed into the lifecycle.
+
 ## [1.81.1] — ✅ The update bridge proves it can deliver its own follow-up (2026-07-31)
 
 Dex 1.81.0 gave recent older installations a safe bridge back onto the protected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ verified foundation package itself was unchanged.
 * **A newer release no longer breaks the first hop.** Dex now verifies the exact
   immutable foundation package and gives that verified commit to the protected
   update lifecycle, without requiring the public “latest” pointer to stay frozen.
+* **The bridge can continue to the second hop.** Its compatibility adapter now
+  exposes the foundation's verified “fetch the next release” operation instead
+  of stopping after the first healthy install.
 * **The safety boundary is unchanged.** The tag object, commit, and tree must all
   match the declared foundation before Dex creates the private update pointer.
 * **Failures still stop before your files are changed.** The public journey that

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.1"
+  "release_version": "1.81.2"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.1",
+  "release_version": "1.81.2",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.1","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.2","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -171,6 +171,55 @@ def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
     }
 
 
+def test_foundation_fetch_survives_public_release_channel_advancing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The immutable first hop must still work after its follow-up is public."""
+
+    vault = _vault(tmp_path)
+    pin = bridge.FOUNDATION
+    follow_up_commit = "b17ef028ce3fa8ec3ea3973688b9d392e4166a17"
+    calls: list[tuple[str, ...]] = []
+    private_release_ref = follow_up_commit
+
+    def run_git(_directory: Path, *arguments: str) -> str:
+        nonlocal private_release_ref
+        calls.append(arguments)
+        if arguments == (
+            "update-ref",
+            "refs/remotes/upstream/release",
+            pin.commit,
+        ):
+            private_release_ref = pin.commit
+            return ""
+        if arguments == ("rev-parse", "--verify", f"refs/tags/{pin.tag}"):
+            return pin.tag_object
+        if arguments == ("rev-parse", "--verify", f"{pin.tag}^{{commit}}"):
+            return pin.commit
+        if arguments == ("rev-parse", "--verify", f"{pin.tag}^{{tree}}"):
+            return pin.tree
+        if arguments == (
+            "rev-parse",
+            "--verify",
+            "refs/remotes/upstream/release^{commit}",
+        ):
+            return private_release_ref
+        return ""
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+
+    bridge._fetch_foundation_into_brain(vault, pin)
+
+    fetch = next(arguments for arguments in calls if arguments[0] == "fetch")
+    assert "+refs/heads/release:refs/remotes/upstream/release" not in fetch
+    assert (
+        "update-ref",
+        "refs/remotes/upstream/release",
+        pin.commit,
+    ) in calls
+
+
 def test_legacy_topology_pin_is_closed_to_exact_v1201_release() -> None:
     assert bridge.LEGACY_TOPOLOGY_FOUNDATION == bridge.LegacyTopologyPin(
         tag="v1.20.1",

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -135,6 +135,9 @@ def _foundation_topology_adapter(
         def build_and_preview_delivered_release(self, vault_root: Path, release):
             return {"vault": str(vault_root), "release": release}
 
+        def deliver_latest_release(self, vault_root: Path):
+            return {"status": "delivered", "vault": str(vault_root)}
+
         def execute_approved_delivered_release(
             self,
             vault_root: Path,
@@ -467,6 +470,15 @@ def test_foundation_service_refuses_compatibility_preload_changed_after_verifica
 
     with pytest.raises(bridge.BridgeError, match="preload changed after verification"):
         service.build_and_preview_topology_migration(vault)
+
+
+def test_foundation_service_exposes_release_delivery(tmp_path: Path) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+
+    assert service.deliver_latest_release(vault) == {
+        "status": "delivered",
+        "vault": str(vault),
+    }
 
 
 def test_foundation_service_reports_missing_engine_path_as_bridge_error(

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "cdcb48271503abab4a15f07af3809700ef05aa442e85933418230bd8a394eac9",
+      "sha256": "f4c00924e5de29de1d5eeed0c1ddeae567fc4a5f52136887b3473202ed5056d2",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "8a6f9edac91ec1bf78b89256ab985feb868c1ace883da1c86cbb7ad36ce86bf9",
+      "sha256": "cdcb48271503abab4a15f07af3809700ef05aa442e85933418230bd8a394eac9",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,7 +102,7 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.1-EXACTFOLLOWUP
+  --follow-up-tag dist/release/v1.81.2-EXACTFOLLOWUP
 ```
 
 The repository has the canonical protocol source at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.1",
+  "version": "1.81.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.1",
+      "version": "1.81.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.1",
+  "version": "1.81.2",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -872,7 +872,12 @@ def _approved_preview(prompt: str, preview: Mapping[str, Any], approval_token: o
 
 
 def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
-    """Fetch one pinned release into the private brain; no vault file is written."""
+    """Fetch one pinned release into the private brain; no vault file is written.
+
+    The public release branch is allowed to advance after the foundation ships.
+    Only the closed immutable tag identifies the first hop.  Once verified, its
+    exact commit becomes the private release ref consumed by lifecycle.
+    """
     brain = vault_root / ".dex" / "brain.git"
     if brain.is_symlink() or not brain.is_dir():
         raise BridgeError("topology conversion did not create a safe Dex brain store")
@@ -885,13 +890,18 @@ def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
         "--no-recurse-submodules",
         OFFICIAL_REMOTE,
         f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
-        "+refs/heads/release:refs/remotes/upstream/release",
     )
     _verify_pin(brain, pin)
+    _run_git(
+        brain,
+        "update-ref",
+        "refs/remotes/upstream/release",
+        pin.commit,
+    )
     _assert_equal(
         _run_git(brain, "rev-parse", "--verify", "refs/remotes/upstream/release^{commit}"),
         pin.commit,
-        "stable release-channel target",
+        "private foundation release ref",
     )
 
 

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -802,6 +802,12 @@ class _FoundationLifecycleService:
                 approved_token,
             )
 
+    def deliver_latest_release(
+        self,
+        vault_root: str | Path,
+    ) -> Mapping[str, Any]:
+        return self._service.deliver_latest_release(vault_root)
+
     def build_and_preview_delivered_release(
         self,
         vault_root: str | Path,
@@ -842,6 +848,7 @@ def _load_lifecycle_service(source: Path) -> LifecycleService:
     required = (
         "build_and_preview_topology_migration",
         "execute_approved_topology_migration",
+        "deliver_latest_release",
         "build_and_preview_delivered_release",
         "execute_approved_delivered_release",
     )


### PR DESCRIPTION
## Outcome

Fixes the two failures found by the first public Amit v1.77.2 journey:

- verify the immutable v1.81.0 foundation without requiring the moving public release branch to remain pinned to it
- expose the foundation release-delivery operation through the compatibility adapter so the journey can continue to the second hop
- prepare v1.81.2 as the immutable hotfix and regenerate the journey protocol digest

## Proof

- 88 focused updater, executor, protocol, and acceptance tests passed
- release-shaped v1.77.2 preflight reached the healthy v1.81.0 foundation and continued into follow-up discovery
- the preflight then stopped at the expected local/public identity boundary because v1.81.2 is not public yet
- Ruff, security, PII, founder-content, portable-contract, architecture-inventory, and distribution gates passed locally

## Current external blocker

The live release-tag reachability gate needs one more approved historical label move before v1.81.2 can publish. A disposable simulation proves moving dist/release/v1.66.0-06e32f6 to dist/archive/v1.66.0-06e32f6 restores the gate while preserving the same tag object, commit, and tree. No live tag move is included in this PR.