### PR TITLE
fix(update): let the verified legacy bridge read local history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.3] — 🧭 The oldest supported Dex can cross its local-history bridge (2026-07-31)
+
+The full historic Mac journey reached the oldest published starting package,
+1.20.1, and found that its one-time migration was blocked from reading its own
+verified local Git history. It stopped safely before changing the fixture.
+
+**What this fixes for you:**
+
+* **The legacy bridge can build its private update history.** Only the exact,
+  verified 1.20.1 migration process may read the vault's existing local Git
+  store during the split.
+* **The exception cannot reach the network.** The migration child switches from
+  HTTPS-only to local-file-only access; it does not widen the bridge to accept
+  both.
+* **Machine-wide Git security remains untouched.** No global setting is written,
+  and every other bridge operation keeps the existing HTTPS-only boundary.
+* **Failures still stop before personal files change.** The original fleet
+  attempt failed closed, and the journey continues to verify every protected
+  user-file hash across both update hops.
+
 ## [1.81.2] — 🔗 The update bridge stays valid when a newer release goes live (2026-07-31)
 
 The first public journey from Amit's 1.77.2 release found that the bridge still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ verified local Git history. It stopped safely before changing the fixture.
   both.
 * **Machine-wide Git security remains untouched.** No global setting is written,
   and every other bridge operation keeps the existing HTTPS-only boundary.
+* **Interrupted upgrades finish their health setup on retry.** If the foundation
+  is already installed but Dex's current customization connection is still
+  missing, the bridge shows the exact add-only change and asks before adding it.
+* **Health checks see QMD only when it is really installed.** The sealed fleet
+  journey exposes that one optional executable without inheriting other ambient
+  machine commands.
 * **Failures still stop before personal files change.** The original fleet
   attempt failed closed, and the journey continues to verify every protected
   user-file hash across both update hops.

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.2"
+  "release_version": "1.81.3"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.2",
+  "release_version": "1.81.3",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.2","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.3","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -970,7 +970,16 @@ def test_bridge_does_not_repeat_a_completed_topology_conversion(tmp_path: Path) 
 def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_channel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    service = _SplitService()
+    class CurrentMcpService(_SplitService):
+        def build_and_preview_mcp_registration(self, vault_root: Path):
+            self.calls.append("mcp-preview")
+            return {
+                "needed": False,
+                "preview": None,
+                "approval_token": None,
+            }
+
+    service = CurrentMcpService()
     monkeypatch.setattr(bridge, "_foundation_is_installed", lambda _vault, _pin: True)
 
     result = bridge.run_bridge(
@@ -984,9 +993,29 @@ def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_cha
     assert result["topology_receipt"] == {"skipped": "foundation-already-installed"}
     assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
     assert result["mcp_registration_receipt"] == {
-        "skipped": "foundation-already-installed"
+        "skipped": "mcp-already-registered"
     }
-    assert service.calls == []
+    assert service.calls == ["mcp-preview"]
+
+
+def test_bridge_retry_finishes_missing_mcp_registration_without_repeating_update_hops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _SplitService()
+    monkeypatch.setattr(bridge, "_foundation_is_installed", lambda _vault, _pin: True)
+
+    result = bridge.run_bridge(
+        _vault(tmp_path),
+        service,
+        fetch_foundation=lambda _vault, _pin: pytest.fail("completed bridge must not fetch"),
+        input_fn=lambda _prompt: "APPLY",
+        output_fn=lambda _line: None,
+    )
+
+    assert result["topology_receipt"] == {"skipped": "foundation-already-installed"}
+    assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
+    assert result["mcp_registration_receipt"] == {"receipt": "mcp-registration"}
+    assert service.calls == ["mcp-preview", "mcp-execute:mcp-token"]
 
 
 def test_completed_foundation_requires_all_durable_split_markers(
@@ -1003,25 +1032,40 @@ def test_completed_foundation_requires_all_durable_split_markers(
         bridge._foundation_is_installed(vault, bridge.FOUNDATION)
 
 
-def test_main_resumes_completed_foundation_before_runtime_or_source_download(
+def test_main_resumes_completed_foundation_from_installed_service_without_download(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    class CurrentMcpService(_SplitService):
+        def build_and_preview_mcp_registration(self, vault_root: Path):
+            self.calls.append("mcp-preview")
+            return {
+                "needed": False,
+                "preview": None,
+                "approval_token": None,
+            }
+
     vault = _completed_vault(tmp_path)
+    service = CurrentMcpService()
+    reexec_calls: list[tuple[Path, list[str]]] = []
     monkeypatch.setattr(bridge, "_run_git", lambda *_arguments: bridge.FOUNDATION.commit)
     monkeypatch.setattr(
         bridge,
         "_reexec_in_installed_runtime",
-        lambda *_arguments: pytest.fail("completed bridge must not re-exec"),
+        lambda root, arguments: reexec_calls.append((root, list(arguments))),
     )
     monkeypatch.setattr(
         bridge,
         "acquire_foundation_source",
         lambda: pytest.fail("completed bridge must not download source"),
     )
+    monkeypatch.setattr(bridge, "_load_lifecycle_service", lambda source: service)
 
     assert bridge.main(["--vault", str(vault)]) == 0
     output = capsys.readouterr().out
     assert '"foundation-already-installed"' in output
+    assert '"mcp-already-registered"' in output
+    assert service.calls == ["mcp-preview"]
+    assert reexec_calls == [(vault, ["--vault", str(vault)])]
 
 
 def test_runtime_reexec_cleans_a_hostile_same_interpreter_and_preset_marker(

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -96,8 +96,18 @@ def _foundation_topology_adapter(
     def original_command(_vault_root: Path, _mode: str) -> list[str]:
         raise RuntimeError("vault migrator was rejected")
 
+    def original_run(vault_root: Path, mode: str):
+        return subprocess.run(
+            engine._migrator_command(vault_root, mode),
+            cwd=vault_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     engine.topology_state = original_state
     engine._migrator_command = original_command
+    engine._run_topology_migrator = original_run
     apply_update = ModuleType("test_foundation_apply_update")
     apply_update._tree_entries = lambda *_arguments: ()
     apply_update._verify_manifest = lambda *_arguments: None
@@ -301,6 +311,92 @@ def test_foundation_service_uses_verified_migrator_for_exact_legacy_topology_onl
     assert engine._migrator_command is original_command
 
 
+def test_verified_legacy_migrator_gets_only_scoped_local_git_transport(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, engine, vault, migrator = _foundation_topology_adapter(tmp_path)
+    subprocess.run(["git", "init", "--quiet", str(vault)], check=True)
+    migrator.write_text(
+        """'use strict';
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const result = spawnSync(
+  'git',
+  [
+    '-c',
+    'protocol.file.allow=always',
+    'clone',
+    '--bare',
+    path.join(process.cwd(), '.git'),
+    path.join(process.cwd(), '.dex', 'transport-proof.git'),
+  ],
+  { encoding: 'utf8' },
+);
+if (result.status !== 0) {
+  process.stderr.write(result.stderr || result.stdout);
+  process.exit(result.status || 1);
+}
+const network = spawnSync(
+  'git',
+  ['ls-remote', 'https://example.invalid/dex.git'],
+  { encoding: 'utf8' },
+);
+if (
+  network.status === 0
+  || !String(network.stderr).includes("transport 'https' not allowed")
+) {
+  process.stderr.write(network.stderr || network.stdout || 'HTTPS was not blocked');
+  process.exit(network.status || 1);
+}
+""",
+        encoding="utf-8",
+    )
+    service = bridge._FoundationLifecycleService(
+        service._service,
+        engine,
+        service._apply_update,
+        service._source,
+    )
+
+    class RunningService:
+        @staticmethod
+        def build_and_preview_topology_migration(vault_root: Path):
+            assert engine.topology_state(vault_root) == "combined"
+            return engine._run_topology_migrator(vault_root, "--dry-run")
+
+    service._service = RunningService()
+    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "https")
+    parent_environment = bridge._bridge_environment()
+    parent_attempt = subprocess.run(
+        [
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "clone",
+            "--bare",
+            str(vault / ".git"),
+            str(vault / ".dex" / "parent-transport-proof.git"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=parent_environment,
+    )
+
+    assert parent_attempt.returncode != 0
+    assert "transport 'file' not allowed" in parent_attempt.stderr
+    assert parent_environment["GIT_ALLOW_PROTOCOL"] == "https"
+    assert parent_environment["GIT_CONFIG_GLOBAL"] == os.devnull
+
+    result = service.build_and_preview_topology_migration(vault)
+
+    assert result.returncode == 0, result.stderr
+    assert (vault / ".dex" / "transport-proof.git").is_dir()
+    assert os.environ["GIT_ALLOW_PROTOCOL"] == "https"
+
+
 def test_foundation_service_keeps_unknown_or_ambiguous_topology_fail_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -367,6 +463,7 @@ process.stdout.write(JSON.stringify({policy, transition}));
         check=True,
         capture_output=True,
         text=True,
+        env=bridge._bridge_environment(),
     )
     supplied = json.loads(result.stdout)
 
@@ -398,6 +495,7 @@ def test_legacy_preload_refuses_an_existing_or_symlinked_compatibility_input(
         check=False,
         capture_output=True,
         text=True,
+        env=bridge._bridge_environment(),
     )
 
     assert result.returncode != 0
@@ -429,6 +527,7 @@ process.stdout.write(JSON.stringify(names));
         check=True,
         capture_output=True,
         text=True,
+        env=bridge._bridge_environment(),
     )
 
     assert json.loads(result.stdout) == []
@@ -455,6 +554,7 @@ def test_legacy_preload_refuses_a_changed_release_symlink(
         check=False,
         capture_output=True,
         text=True,
+        env=bridge._bridge_environment(),
     )
 
     assert result.returncode != 0

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -39,6 +39,24 @@ class _Service:
         assert preview == {"step": "release"}
         return {"receipt": "release"}
 
+    def build_and_preview_mcp_registration(self, vault_root: Path):
+        self.calls.append("mcp-preview")
+        return {
+            "needed": True,
+            "preview": {"step": "mcp-registration"},
+            "approval_token": "mcp-token",
+        }
+
+    def execute_approved_mcp_registration(
+        self,
+        vault_root: Path,
+        preview,
+        approved_token: str,
+    ):
+        self.calls.append(f"mcp-execute:{approved_token}")
+        assert preview == {"step": "mcp-registration"}
+        return {"receipt": "mcp-registration"}
+
 
 
 class _SplitService(_Service):
@@ -755,9 +773,9 @@ def test_release_pin_rejects_a_mutable_or_incomplete_identity() -> None:
         bridge.ReleasePin("dist/release/v1.80.5-aaaaaaa", "not-a-hash", "b" * 40, "c" * 40, "1.80.5")
 
 
-def test_bridge_requires_two_new_approvals_and_routes_writes_through_foundation_service(tmp_path: Path) -> None:
+def test_bridge_requires_three_new_approvals_and_routes_writes_through_foundation_service(tmp_path: Path) -> None:
     service = _Service()
-    answers = iter(("APPLY", "APPLY"))
+    answers = iter(("APPLY", "APPLY", "APPLY"))
     fetched: list[Path] = []
     vault = _vault(tmp_path)
 
@@ -775,6 +793,8 @@ def test_bridge_requires_two_new_approvals_and_routes_writes_through_foundation_
         "topology-execute:topology-token",
         "release-preview",
         "release-execute:release-token",
+        "mcp-preview",
+        "mcp-execute:mcp-token",
     ]
     assert fetched == [vault]
 
@@ -865,10 +885,69 @@ def test_bridge_stops_before_delivered_release_execution_when_second_preview_is_
     assert service.calls == ["topology-preview", "topology-execute:topology-token", "release-preview"]
 
 
+def test_bridge_stops_before_mcp_registration_when_third_preview_is_not_approved(
+    tmp_path: Path,
+) -> None:
+    service = _Service()
+    answers = iter(("APPLY", "APPLY", "no"))
+
+    with pytest.raises(bridge.BridgeError, match="no change"):
+        bridge.run_bridge(
+            _vault(tmp_path),
+            service,
+            fetch_foundation=lambda _vault, _pin: None,
+            input_fn=lambda _prompt: next(answers),
+            output_fn=lambda _line: None,
+        )
+
+    assert service.calls == [
+        "topology-preview",
+        "topology-execute:topology-token",
+        "release-preview",
+        "release-execute:release-token",
+        "mcp-preview",
+    ]
+
+
+def test_bridge_does_not_request_mcp_approval_when_registration_is_current(
+    tmp_path: Path,
+) -> None:
+    class CurrentMcpService(_Service):
+        def build_and_preview_mcp_registration(self, vault_root: Path):
+            self.calls.append("mcp-preview")
+            return {
+                "needed": False,
+                "preview": None,
+                "approval_token": None,
+            }
+
+    service = CurrentMcpService()
+    answers = iter(("APPLY", "APPLY"))
+
+    result = bridge.run_bridge(
+        _vault(tmp_path),
+        service,
+        fetch_foundation=lambda _vault, _pin: None,
+        input_fn=lambda _prompt: next(answers),
+        output_fn=lambda _line: None,
+    )
+
+    assert result["mcp_registration_receipt"] == {
+        "skipped": "mcp-already-registered"
+    }
+    assert service.calls == [
+        "topology-preview",
+        "topology-execute:topology-token",
+        "release-preview",
+        "release-execute:release-token",
+        "mcp-preview",
+    ]
+
+
 def test_bridge_does_not_repeat_a_completed_topology_conversion(tmp_path: Path) -> None:
     service = _SplitService()
     vault = _vault(tmp_path)
-    answers = iter(("APPLY",))
+    answers = iter(("APPLY", "APPLY"))
 
     result = bridge.run_bridge(
         vault,
@@ -879,7 +958,13 @@ def test_bridge_does_not_repeat_a_completed_topology_conversion(tmp_path: Path) 
     )
 
     assert result["topology_receipt"] == {"skipped": "already-brain-vault-split"}
-    assert service.calls == ["topology-preview", "release-preview", "release-execute:release-token"]
+    assert service.calls == [
+        "topology-preview",
+        "release-preview",
+        "release-execute:release-token",
+        "mcp-preview",
+        "mcp-execute:mcp-token",
+    ]
 
 
 def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_channel(
@@ -898,6 +983,9 @@ def test_bridge_resumes_offline_without_fetching_or_revalidating_an_advanced_cha
 
     assert result["topology_receipt"] == {"skipped": "foundation-already-installed"}
     assert result["delivery_receipt"] == {"skipped": "foundation-already-installed"}
+    assert result["mcp_registration_receipt"] == {
+        "skipped": "foundation-already-installed"
+    }
     assert service.calls == []
 
 

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -598,7 +598,7 @@ def test_already_installed_foundation_executes_and_validates_without_a_fake_tran
                     "skipped": "foundation-already-installed"
                 },
                 "mcp_registration_receipt": {
-                    "skipped": "foundation-already-installed"
+                    "skipped": "mcp-already-registered"
                 },
             }
 
@@ -623,6 +623,53 @@ def test_already_installed_foundation_executes_and_validates_without_a_fake_tran
         foundation_receipt["receipt"],
         expected_foundation=protocol.foundation,
         approval_count=0,
+    )
+
+
+def test_already_installed_foundation_can_finish_one_approved_mcp_registration(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class ResumeRegistrationRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            self.calls.append("bridge")
+            output_fn(json.dumps({"preview": "mcp-registration"}))
+            assert input_fn("mcp approval") == "APPLY"
+            self.installed = foundation["commit"]
+            return {
+                "foundation": dict(foundation),
+                "topology_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+                "delivery_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+                "mcp_registration_receipt": {
+                    "receipt": {"transaction_id": "mcp-registration-tx"}
+                },
+            }
+
+    run = _execute(
+        tmp_path,
+        ResumeRegistrationRuntime(_identity("1.81.0", "b")),
+        source_repo=source_repo,
+        source_commit=source_commit,
+    )
+    evidence = tmp_path / "case.evidence"
+    transcript = json.loads((evidence / "journey-transcript.json").read_text())
+    foundation_receipt = json.loads(
+        (evidence / "foundation-receipt.json").read_text()
+    )
+
+    assert run.case["reached_foundation"] is True
+    assert transcript["events"][2]["approval_count"] == 1
+    assert release_fleet._valid_foundation_bridge_receipt(
+        foundation_receipt["receipt"],
+        expected_foundation=foundation_receipt["release"],
+        approval_count=1,
     )
 
 

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -182,6 +183,29 @@ def test_foundation_cache_rejects_wrong_channel_or_unsafe_permissions(
         executor._validate_foundation_cache(cache, pin)
 
 
+def test_production_runtime_exposes_only_installed_qmd_not_ambient_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qmd = tmp_path / ".bun" / "bin" / "qmd"
+    qmd.parent.mkdir(parents=True)
+    qmd.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    qmd.chmod(0o755)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", f"{tmp_path / 'ambient'}:/usr/bin")
+
+    runtime = executor._ProductionRuntime()
+    try:
+        environment = runtime._runtime_environment(tmp_path)
+        runtime_tools = Path(environment["PATH"].split(os.pathsep)[0])
+
+        assert (runtime_tools / "qmd").resolve() == qmd.resolve()
+        assert str(qmd.parent) not in environment["PATH"].split(os.pathsep)
+        assert str(tmp_path / "ambient") not in environment["PATH"]
+    finally:
+        runtime.close()
+
+
 def _commit_executor_tamper(repo: Path) -> str:
     path = repo / "scripts/release_fleet_executor.py"
     path.write_bytes(path.read_bytes() + b"\n# externally substituted bytes\n")
@@ -227,11 +251,16 @@ class _Runtime:
         assert input_fn("topology approval") == "APPLY"
         output_fn(json.dumps({"preview": "foundation"}))
         assert input_fn("foundation approval") == "APPLY"
+        output_fn(json.dumps({"preview": "mcp-registration"}))
+        assert input_fn("mcp approval") == "APPLY"
         self.installed = foundation["commit"]
         return {
             "foundation": dict(foundation),
             "topology_receipt": {"receipt": {"transaction_id": "topology-tx"}},
             "delivery_receipt": {"receipt": {"transaction_id": "foundation-tx"}},
+            "mcp_registration_receipt": {
+                "receipt": {"transaction_id": "mcp-registration-tx"}
+            },
         }
 
     def installed_release(self, vault: Path) -> str:
@@ -355,11 +384,11 @@ def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
     assert release_fleet._valid_foundation_bridge_receipt(
         foundation_receipt["receipt"],
         expected_foundation=protocol.foundation,
-        approval_count=2,
+        approval_count=3,
     )
     assert follow_up_receipt["receipt"]["receipt"]["transaction_id"] == "follow-up-tx"
     assert [event["id"] for event in transcript["events"]] == list(protocol.evidence)
-    assert transcript["events"][2]["approval_count"] == 2
+    assert transcript["events"][2]["approval_count"] == 3
     assert rendered
 
     mutable_copy = run.case
@@ -519,6 +548,9 @@ def test_executor_records_the_bridge_approval_count_that_actually_occurred(
                 "delivery_receipt": {
                     "receipt": {"transaction_id": "foundation-tx"}
                 },
+                "mcp_registration_receipt": {
+                    "skipped": "mcp-already-registered"
+                },
             }
 
     runtime = OneApprovalRuntime(_identity("1.81.0", "b"))
@@ -565,6 +597,9 @@ def test_already_installed_foundation_executes_and_validates_without_a_fake_tran
                 "delivery_receipt": {
                     "skipped": "foundation-already-installed"
                 },
+                "mcp_registration_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
             }
 
     runtime = AlreadyInstalledRuntime(_identity("1.81.0", "b"))
@@ -597,6 +632,7 @@ def test_mutating_foundation_bridge_still_requires_a_real_delivery_receipt() -> 
         "foundation": foundation,
         "topology_receipt": {"skipped": "already-brain-vault-split"},
         "delivery_receipt": {"status": "claimed-complete"},
+        "mcp_registration_receipt": {"skipped": "mcp-already-registered"},
     }
 
     assert not release_fleet._valid_foundation_bridge_receipt(
@@ -621,6 +657,9 @@ def test_executor_rejects_a_partial_already_installed_claim(
                 "foundation": dict(foundation),
                 "topology_receipt": {"status": "claimed-complete"},
                 "delivery_receipt": {
+                    "skipped": "foundation-already-installed"
+                },
+                "mcp_registration_receipt": {
                     "skipped": "foundation-already-installed"
                 },
             }
@@ -720,6 +759,9 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
             "foundation": pin.identity(),
             "topology_receipt": {"receipt": {"transaction_id": "topology"}},
             "delivery_receipt": {"receipt": {"transaction_id": "foundation"}},
+            "mcp_registration_receipt": {
+                "receipt": {"transaction_id": "mcp-registration"}
+            },
         }
 
     monkeypatch.setattr(

--- a/core/tests/test_update_journey_protocol.py
+++ b/core/tests/test_update_journey_protocol.py
@@ -65,6 +65,23 @@ def test_protocol_rejects_an_arbitrary_command_adapter() -> None:
         load_update_journey_protocol(json.dumps(document).encode())
 
 
+def test_protocol_reader_keeps_the_published_two_approval_bridge_compatible() -> None:
+    document = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    document["historic_to_foundation"]["approval"]["count"] = 2
+
+    protocol = load_update_journey_protocol(json.dumps(document).encode())
+
+    assert protocol.bridge.approval_count == 2
+
+
+def test_protocol_rejects_an_unreviewed_bridge_approval_count() -> None:
+    document = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    document["historic_to_foundation"]["approval"]["count"] = 4
+
+    with pytest.raises(JourneyProtocolError, match="reviewed approval boundary"):
+        load_update_journey_protocol(json.dumps(document).encode())
+
+
 def test_generator_reproduces_the_committed_root_protocol(tmp_path: Path) -> None:
     generated = tmp_path / "update-journey.json"
 

--- a/core/tests/test_update_journey_protocol.py
+++ b/core/tests/test_update_journey_protocol.py
@@ -48,7 +48,7 @@ def test_release_owned_protocol_binds_only_the_reviewed_update_adapters() -> Non
         "execute_approved_delivered_release",
     )
     assert protocol.bridge.approval_word == protocol.follow_up.approval_word == "APPLY"
-    assert protocol.bridge.approval_count == 2
+    assert protocol.bridge.approval_count == 3
     assert protocol.follow_up.approval_count == 1
     assert protocol.executor.source_path == "scripts/release_fleet_executor.py"
     for artifact in (protocol.bridge.artifact, protocol.runner, protocol.executor):

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "e90690babcaba9648b14fbf9cc18b79ff3e98ed92b806aa89855b842baf72205",
+    "sha256": "28b3320f05905f28a6362d8d32da2d1752d8d58e0746d58e5887d9f7d640099e",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -31,11 +31,11 @@
   "historic_to_foundation": {
     "adapter": "pinned-foundation-bridge-v1",
     "approval": {
-      "count": 2,
+      "count": 3,
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "2202010f0085f4972396c1fea4d9a9fd8eeb44f98e75e3a94e4610480f5e53ab",
+      "sha256": "a0cf51c25283fc7e746a5945afe32dc276c3bea7323489683930c2a567c5de22",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "c6c94344cf4974dea70aa718a81f55a7ae4bfabbf33357a76ffce97c8d91a181",
+    "sha256": "af5fbf72df5e66b04e80bf5b80fbcf7eee73d5cfd0d4fe74c303772936878953",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "28b3320f05905f28a6362d8d32da2d1752d8d58e0746d58e5887d9f7d640099e",
+    "sha256": "cd574fc09138bdc251537fb4759f559a2d11f376ed08807d815459f8cdf0ceb4",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "a0cf51c25283fc7e746a5945afe32dc276c3bea7323489683930c2a567c5de22",
+      "sha256": "7c464d94a87f43ad49e7782c9b9522341a9c346fc9026fb35630a27793fbb598",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "af5fbf72df5e66b04e80bf5b80fbcf7eee73d5cfd0d4fe74c303772936878953",
+    "sha256": "bc1ed084a3248a5bc98e91dc20a74b0caed66d22525357f7d4480657ca07e5ce",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "f4c00924e5de29de1d5eeed0c1ddeae567fc4a5f52136887b3473202ed5056d2",
+      "sha256": "2202010f0085f4972396c1fea4d9a9fd8eeb44f98e75e3a94e4610480f5e53ab",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey_protocol.py
+++ b/core/update/journey_protocol.py
@@ -148,13 +148,22 @@ def _artifact(value: object, *, source_path: str, context: str) -> ProtocolArtif
 def _approval(
     value: object,
     *,
-    expected_count: int,
+    expected_count: int | tuple[int, ...],
     context: str,
 ) -> tuple[str, int]:
     document = _object(value, _APPROVAL_FIELDS, context)
-    if document != {"word": "APPLY", "count": expected_count}:
+    expected_counts = (
+        (expected_count,) if isinstance(expected_count, int) else expected_count
+    )
+    count = document.get("count")
+    if (
+        document.get("word") != "APPLY"
+        or not isinstance(count, int)
+        or isinstance(count, bool)
+        or count not in expected_counts
+    ):
         raise JourneyProtocolError(f"{context} is not the reviewed approval boundary")
-    return "APPLY", expected_count
+    return "APPLY", count
 
 
 def _foundation_identity(value: object) -> dict[str, str]:
@@ -225,7 +234,7 @@ def load_update_journey_protocol(source: bytes | str) -> UpdateJourneyProtocol:
         raise JourneyProtocolError("journey protocol historic hop uses an unsupported adapter")
     bridge_word, bridge_count = _approval(
         bridge_document["approval"],
-        expected_count=3,
+        expected_count=(2, 3),
         context="journey protocol historic approval",
     )
     bridge = BridgeHop(

--- a/core/update/journey_protocol.py
+++ b/core/update/journey_protocol.py
@@ -225,7 +225,7 @@ def load_update_journey_protocol(source: bytes | str) -> UpdateJourneyProtocol:
         raise JourneyProtocolError("journey protocol historic hop uses an unsupported adapter")
     bridge_word, bridge_count = _approval(
         bridge_document["approval"],
-        expected_count=2,
+        expected_count=3,
         context="journey protocol historic approval",
     )
     bridge = BridgeHop(

--- a/docs/portable-vault-contract-design.md
+++ b/docs/portable-vault-contract-design.md
@@ -50,7 +50,10 @@ path traversal. (From #141 ownership.cjs deny set + Vault_Contract §3 secrets r
 - `System/integrations/config.yaml` = `seed` (shipped reference-schema template;
   install-if-absent; never overwritten once user-owned).
 - `.mcp.json` = `vault` + `report_only: true` (SR1's structural residual detector owns
-  it; no engine may rewrite it).
+  it; release updates and migration engines never rewrite it). The one narrow
+  exception is the later-ratified lifecycle registration repair: after showing
+  the exact preview and receiving explicit approval, it may add Dex's own missing
+  Customization Migration entry. It cannot replace or remove any user entry.
 - Raw secret authority = vault-root `.env` (hard-deny).
 
 ## Capability registry (Decision C, Option 2)

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,7 +102,7 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.2-EXACTFOLLOWUP
+  --follow-up-tag dist/release/v1.81.3-EXACTFOLLOWUP
 ```
 
 The repository has the canonical protocol source at

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -111,8 +111,9 @@ The repository has the canonical protocol source at
 shell-command format. Version 1 permits only:
 
 - the reviewed pinned-foundation bridge, with its exact source SHA-256 and up
-  to two conditional `APPLY` approvals (topology and delivery previews are
-  requested only when the actual fixture state requires them);
+  to three conditional `APPLY` approvals (topology, delivery, and a missing
+  current MCP registration are requested only when the fixture state requires
+  them);
 - `deliver_latest_release`, `build_and_preview_delivered_release`, then
   `execute_approved_delivered_release`, with one fresh `APPLY` approval; and
 - the fixed evidence order needed for refusal, bridge provenance, preview,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.2",
+  "version": "1.81.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.2",
+      "version": "1.81.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.2",
+  "version": "1.81.3",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -273,6 +273,8 @@ class LifecycleService(Protocol):
     def execute_approved_topology_migration(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
     def build_and_preview_delivered_release(self, vault_root: str | Path, release: Mapping[str, Any]) -> Mapping[str, Any]: ...
     def execute_approved_delivered_release(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
+    def build_and_preview_mcp_registration(self, vault_root: str | Path) -> Mapping[str, Any]: ...
+    def execute_approved_mcp_registration(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
 
 
 def _trusted_executable(name: str) -> Path | None:
@@ -839,6 +841,24 @@ class _FoundationLifecycleService:
                 approved_token,
             )
 
+    def build_and_preview_mcp_registration(
+        self,
+        vault_root: str | Path,
+    ) -> Mapping[str, Any]:
+        return self._service.build_and_preview_mcp_registration(vault_root)
+
+    def execute_approved_mcp_registration(
+        self,
+        vault_root: str | Path,
+        preview: Mapping[str, Any],
+        approved_token: str,
+    ) -> Mapping[str, Any]:
+        return self._service.execute_approved_mcp_registration(
+            vault_root,
+            preview,
+            approved_token,
+        )
+
 
 def _load_lifecycle_service(source: Path) -> LifecycleService:
     """Import only the verified foundation release's lifecycle service."""
@@ -858,6 +878,8 @@ def _load_lifecycle_service(source: Path) -> LifecycleService:
         "deliver_latest_release",
         "build_and_preview_delivered_release",
         "execute_approved_delivered_release",
+        "build_and_preview_mcp_registration",
+        "execute_approved_mcp_registration",
     )
     if any(not callable(getattr(module, name, None)) for name in required):
         raise BridgeError("pinned foundation lifecycle service is incomplete")
@@ -996,11 +1018,12 @@ def _completed_bridge_result(pin: ReleasePin) -> dict[str, object]:
         "foundation": pin.identity(),
         "topology_receipt": {"skipped": "foundation-already-installed"},
         "delivery_receipt": {"skipped": "foundation-already-installed"},
+        "mcp_registration_receipt": {"skipped": "foundation-already-installed"},
     }
 
 
 def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
-    """Run two fresh approval boundaries using the verified foundation service."""
+    """Run up to three fresh approval boundaries through the foundation service."""
     root = _validate_vault(vault_root)
     # This local ref is the authoritative resume marker. Check it before
     # importing/calling lifecycle code or attempting any network operation: a
@@ -1036,10 +1059,41 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
     delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
 
+    registration = service.build_and_preview_mcp_registration(root)
+    if registration.get("needed") is False:
+        if (
+            registration.get("preview") is not None
+            or registration.get("approval_token") is not None
+        ):
+            raise BridgeError("foundation returned a malformed completed MCP registration")
+        mcp_registration_receipt: Mapping[str, Any] = {
+            "skipped": "mcp-already-registered"
+        }
+    else:
+        registration_preview = registration.get("preview")
+        if registration.get("needed") is not True or not isinstance(
+            registration_preview,
+            Mapping,
+        ):
+            raise BridgeError("foundation could not produce an MCP registration preview")
+        registration_preview, registration_token = _approved_preview(
+            "Dex will add the current customization migration server to your MCP configuration.",
+            registration_preview,
+            registration.get("approval_token"),
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
+        mcp_registration_receipt = service.execute_approved_mcp_registration(
+            root,
+            registration_preview,
+            registration_token,
+        )
+
     return {
         "foundation": pin.identity(),
         "topology_receipt": dict(topology_receipt),
         "delivery_receipt": dict(delivery_receipt),
+        "mcp_registration_receipt": dict(mcp_registration_receipt),
     }
 
 

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1013,13 +1013,52 @@ def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
     return True
 
 
-def _completed_bridge_result(pin: ReleasePin) -> dict[str, object]:
+def _completed_bridge_result(
+    pin: ReleasePin,
+    mcp_registration_receipt: Mapping[str, Any],
+) -> dict[str, object]:
     return {
         "foundation": pin.identity(),
         "topology_receipt": {"skipped": "foundation-already-installed"},
         "delivery_receipt": {"skipped": "foundation-already-installed"},
-        "mcp_registration_receipt": {"skipped": "foundation-already-installed"},
+        "mcp_registration_receipt": dict(mcp_registration_receipt),
     }
+
+
+def _complete_mcp_registration(
+    vault_root: Path,
+    service: LifecycleService,
+    *,
+    input_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+) -> Mapping[str, Any]:
+    registration = service.build_and_preview_mcp_registration(vault_root)
+    if registration.get("needed") is False:
+        if (
+            registration.get("preview") is not None
+            or registration.get("approval_token") is not None
+        ):
+            raise BridgeError("foundation returned a malformed completed MCP registration")
+        return {"skipped": "mcp-already-registered"}
+
+    registration_preview = registration.get("preview")
+    if registration.get("needed") is not True or not isinstance(
+        registration_preview,
+        Mapping,
+    ):
+        raise BridgeError("foundation could not produce an MCP registration preview")
+    registration_preview, registration_token = _approved_preview(
+        "Dex will add the current customization migration server to your MCP configuration.",
+        registration_preview,
+        registration.get("approval_token"),
+        input_fn=input_fn,
+        output_fn=output_fn,
+    )
+    return service.execute_approved_mcp_registration(
+        vault_root,
+        registration_preview,
+        registration_token,
+    )
 
 
 def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
@@ -1030,7 +1069,15 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     # completed bridge must work offline and must not be disturbed merely
     # because the stable channel has subsequently advanced.
     if _foundation_is_installed(root, pin):
-        return _completed_bridge_result(pin)
+        return _completed_bridge_result(
+            pin,
+            _complete_mcp_registration(
+                root,
+                service,
+                input_fn=input_fn,
+                output_fn=output_fn,
+            ),
+        )
 
     topology = service.build_and_preview_topology_migration(root)
     preview = topology.get("preview")
@@ -1059,35 +1106,12 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
     delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
 
-    registration = service.build_and_preview_mcp_registration(root)
-    if registration.get("needed") is False:
-        if (
-            registration.get("preview") is not None
-            or registration.get("approval_token") is not None
-        ):
-            raise BridgeError("foundation returned a malformed completed MCP registration")
-        mcp_registration_receipt: Mapping[str, Any] = {
-            "skipped": "mcp-already-registered"
-        }
-    else:
-        registration_preview = registration.get("preview")
-        if registration.get("needed") is not True or not isinstance(
-            registration_preview,
-            Mapping,
-        ):
-            raise BridgeError("foundation could not produce an MCP registration preview")
-        registration_preview, registration_token = _approved_preview(
-            "Dex will add the current customization migration server to your MCP configuration.",
-            registration_preview,
-            registration.get("approval_token"),
-            input_fn=input_fn,
-            output_fn=output_fn,
-        )
-        mcp_registration_receipt = service.execute_approved_mcp_registration(
-            root,
-            registration_preview,
-            registration_token,
-        )
+    mcp_registration_receipt = _complete_mcp_registration(
+        root,
+        service,
+        input_fn=input_fn,
+        output_fn=output_fn,
+    )
 
     return {
         "foundation": pin.identity(),
@@ -1110,7 +1134,14 @@ def main(argv: list[str] | None = None) -> int:
         # selecting the old virtualenv or downloading source so resuming it is
         # genuinely offline and independent of a later stable-channel change.
         if _foundation_is_installed(vault, FOUNDATION):
-            result = _completed_bridge_result(FOUNDATION)
+            _reexec_in_installed_runtime(
+                vault,
+                sys.argv[1:] if argv is None else argv,
+            )
+            result = run_bridge(
+                vault,
+                _load_lifecycle_service(vault),
+            )
         else:
             _reexec_in_installed_runtime(vault, sys.argv[1:] if argv is None else argv)
             temporary, source = acquire_foundation_source()

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -196,6 +196,13 @@ def _legacy_preload_bytes() -> bytes:
 const fs = require('node:fs');
 const path = require('node:path');
 
+if (process.env.GIT_ALLOW_PROTOCOL !== 'https') {{
+  throw new Error('Dex update bridge refused an unsafe inherited Git protocol policy.');
+}}
+// The pinned topology migrator uses only the vault's existing local Git store.
+// Replace, rather than widen, the bridge's HTTPS policy inside this one child.
+process.env.GIT_ALLOW_PROTOCOL = 'file';
+
 const root = fs.realpathSync(process.cwd());
 const shippedLink = path.join(root, '{_LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()}');
 const shippedLinkParent = path.dirname(shippedLink);

--- a/scripts/generate-update-journey-protocol.py
+++ b/scripts/generate-update-journey-protocol.py
@@ -61,7 +61,7 @@ def protocol_document() -> dict[str, object]:
                 "sha256": _sha256(BRIDGE_SOURCE),
             },
             "foundation": FOUNDATION.identity(),
-            "approval": {"word": "APPLY", "count": 2},
+            "approval": {"word": "APPLY", "count": 3},
         },
         "foundation_to_follow_up": {
             "adapter": FOLLOW_UP_ADAPTER,

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -542,7 +542,12 @@ def _valid_foundation_bridge_receipt(
     if (
         not isinstance(value, Mapping)
         or set(value)
-        != {"foundation", "topology_receipt", "delivery_receipt"}
+        != {
+            "foundation",
+            "topology_receipt",
+            "delivery_receipt",
+            "mcp_registration_receipt",
+        }
         or value["foundation"] != expected_foundation
     ):
         return False
@@ -550,10 +555,17 @@ def _valid_foundation_bridge_receipt(
     if (
         value["topology_receipt"] == already_installed
         and value["delivery_receipt"] == already_installed
+        and value["mcp_registration_receipt"] == already_installed
     ):
         return approval_count == 0
-    return approval_count > 0 and _has_transaction_receipt(
-        value["delivery_receipt"]
+    registration = value["mcp_registration_receipt"]
+    return (
+        approval_count > 0
+        and _has_transaction_receipt(value["delivery_receipt"])
+        and (
+            registration == {"skipped": "mcp-already-registered"}
+            or _has_transaction_receipt(registration)
+        )
     )
 
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -552,20 +552,22 @@ def _valid_foundation_bridge_receipt(
     ):
         return False
     already_installed = {"skipped": "foundation-already-installed"}
-    if (
+    foundation_completed = (
         value["topology_receipt"] == already_installed
         and value["delivery_receipt"] == already_installed
-        and value["mcp_registration_receipt"] == already_installed
-    ):
-        return approval_count == 0
+    )
     registration = value["mcp_registration_receipt"]
+    registration_current = registration == {"skipped": "mcp-already-registered"}
+    registration_completed = _has_transaction_receipt(registration)
+    if foundation_completed:
+        return (
+            (registration_current and approval_count == 0)
+            or (registration_completed and approval_count == 1)
+        )
     return (
         approval_count > 0
         and _has_transaction_receipt(value["delivery_receipt"])
-        and (
-            registration == {"skipped": "mcp-already-registered"}
-            or _has_transaction_receipt(registration)
-        )
+        and (registration_current or registration_completed)
     )
 
 

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -980,27 +980,26 @@ def _validate_bridge_result(
         raise ExecutorError("foundation bridge returned a different release identity")
     delivery = value["delivery_receipt"]
     already_installed = {"skipped": "foundation-already-installed"}
-    completed = (
+    foundation_completed = (
         value["topology_receipt"] == already_installed
         and delivery == already_installed
-        and value["mcp_registration_receipt"] == already_installed
     )
-    if not _contains_transaction_receipt(delivery) and not completed:
+    if not _contains_transaction_receipt(delivery) and not foundation_completed:
         raise ExecutorError(
             "foundation bridge did not return a lifecycle transaction receipt"
         )
-    if completed and approval_count != 0:
-        raise ExecutorError("completed foundation bridge requested an approval")
-    if not completed and approval_count == 0:
+    if not foundation_completed and approval_count == 0:
         raise ExecutorError("foundation delivery completed without an approval")
     registration = value["mcp_registration_receipt"]
-    if (
-        not completed
-        and registration != {"skipped": "mcp-already-registered"}
-        and not _contains_transaction_receipt(registration)
-    ):
+    registration_current = registration == {"skipped": "mcp-already-registered"}
+    registration_completed = _contains_transaction_receipt(registration)
+    if not registration_current and not registration_completed:
         raise ExecutorError(
             "foundation bridge did not return an MCP registration transaction receipt"
+        )
+    if foundation_completed and approval_count != int(registration_completed):
+        raise ExecutorError(
+            "completed foundation bridge approval did not match MCP registration"
         )
     return dict(value)
 

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -266,11 +266,41 @@ class _ProductionRuntime:
         self._server_stderr = tempfile.TemporaryFile(mode="w+b")
         self._server_vault: Path | None = None
         self._server_buffer = bytearray()
+        self._runtime_tools = Path(self._runtime_home.name) / "tools"
+        self._runtime_tools.mkdir(mode=0o700)
+        self._link_optional_qmd()
         self._foundation_cache = (
             _validate_foundation_cache(foundation_cache)
             if foundation_cache is not None
             else None
         )
+
+    def _link_optional_qmd(self) -> None:
+        """Expose only a real controller QMD binary to installed health checks.
+
+        The bridge environment deliberately ignores caller PATH. Very old Dex
+        releases nevertheless registered optional QMD by default, so hiding a
+        QMD binary that is genuinely installed on the fleet controller creates
+        a false Doctor failure. Link only that exact executable into the closed
+        runtime tool directory; no other ambient command becomes available.
+        """
+
+        home = Path.home()
+        candidates = (
+            home / ".bun" / "bin" / "qmd",
+            home / ".local" / "bin" / "qmd",
+            Path("/usr/local/bin/qmd"),
+            Path("/opt/homebrew/bin/qmd"),
+        )
+        for candidate in candidates:
+            try:
+                resolved = candidate.resolve(strict=True)
+            except OSError:
+                continue
+            if not resolved.is_file() or not os.access(resolved, os.X_OK):
+                continue
+            (self._runtime_tools / "qmd").symlink_to(resolved)
+            return
 
     def close(self) -> None:
         process = self._server
@@ -293,6 +323,9 @@ class _ProductionRuntime:
     def _runtime_environment(self, vault: Path) -> dict[str, str]:
         runtime_root = Path(self._runtime_home.name)
         environment = dex_update_bridge._bridge_environment()
+        environment["PATH"] = os.pathsep.join(
+            (str(self._runtime_tools), environment["PATH"])
+        )
         environment.update(
             {
                 "DEX_VAULT": str(vault),
@@ -936,7 +969,12 @@ def _validate_bridge_result(
     foundation: Mapping[str, str],
     approval_count: int,
 ) -> dict[str, object]:
-    if set(value) != {"foundation", "topology_receipt", "delivery_receipt"}:
+    if set(value) != {
+        "foundation",
+        "topology_receipt",
+        "delivery_receipt",
+        "mcp_registration_receipt",
+    }:
         raise ExecutorError("foundation bridge returned malformed evidence")
     if value["foundation"] != foundation:
         raise ExecutorError("foundation bridge returned a different release identity")
@@ -945,6 +983,7 @@ def _validate_bridge_result(
     completed = (
         value["topology_receipt"] == already_installed
         and delivery == already_installed
+        and value["mcp_registration_receipt"] == already_installed
     )
     if not _contains_transaction_receipt(delivery) and not completed:
         raise ExecutorError(
@@ -954,6 +993,15 @@ def _validate_bridge_result(
         raise ExecutorError("completed foundation bridge requested an approval")
     if not completed and approval_count == 0:
         raise ExecutorError("foundation delivery completed without an approval")
+    registration = value["mcp_registration_receipt"]
+    if (
+        not completed
+        and registration != {"skipped": "mcp-already-registered"}
+        and not _contains_transaction_receipt(registration)
+    ):
+        raise ExecutorError(
+            "foundation bridge did not return an MCP registration transaction receipt"
+        )
     return dict(value)
 
 


### PR DESCRIPTION
## Outcome

The exact v1.20.1 bridge migration can read its already-verified local Git history without weakening the network-facing updater boundary. The verified migration child replaces HTTPS access with file-only access; it does not enable both.

The bridge also finishes a missing current Dex MCP registration through the existing add-only lifecycle preview and approval, including after an interrupted foundation install.

## Safety

- machine-wide Git configuration is untouched
- parent bridge remains HTTPS-only
- migration child is file-only and rejects HTTPS
- wrong/unknown topology and changed migrator bytes still fail closed
- MCP registration is previewed, explicitly approved, and cannot replace user entries
- old published two-approval protocols remain accepted; unreviewed counts are rejected
- journey protocol hashes are regenerated from the exact released bytes

## Verification

- 72 focused bridge, executor, protocol, and MCP lifecycle tests passed locally
- full PR quality gate, all three Python shards, combined coverage, touched-file coverage, JUnit merge, and shard completeness passed
- release-shaped v1.81.3 candidate `dist/release/v1.81.3-6e117d21` built successfully
- real v1.20.1 Mac rehearsal completed the foundation hop, added the missing registration, passed foundation Doctor, and stopped at the designed public-release boundary because v1.81.3 is not published yet
- the genuine public two-hop v1.20.1 journey will run immediately after main publishes v1.81.3

## Root cause

The bridge correctly restricted network Git to HTTPS, but that environment whitelist overrode the pinned topology migrator’s command-scoped permission to fetch from the vault’s existing local repository. This patch moves the protocol switch into the verified v1.20.1 preload only.