### PR TITLE
fix(update): accept pruned legacy tag labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.4] — 🏷️ Historic installs no longer need every old tag label (2026-07-31)
+
+The first formal fleet run passed the oldest supported Dex release, then found
+that later historic installers retained the trusted code history but not the
+old `v1.20.1` tag label. The bridge stopped safely before changing the fixture.
+
+**What this fixes for you:**
+
+* **Later historic Dex versions can reach the bridge.** The updater can prove
+  the exact trusted foundation from its commit and tree even when the old label
+  was pruned by the installer.
+* **The safety boundary remains exact.** A different commit, tree, object type,
+  or unrelated history is still refused before personal files change.
+* **The full Mac fleet can continue.** The fix addresses the shared blocker
+  exposed by 1.49.0 without widening support to unknown repository layouts.
+
 ## [1.81.3] — 🧭 The oldest supported Dex can cross its local-history bridge (2026-07-31)
 
 The full historic Mac journey reached the oldest published starting package,

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.3"
+  "release_version": "1.81.4"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.3",
+  "release_version": "1.81.4",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.3","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.4","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -267,8 +267,12 @@ def test_legacy_topology_requires_exact_tag_commit_tree_and_current_ancestry(
     vault = _vault(tmp_path)
     pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
     values = {
-        ("cat-file", "-t", pin.tag): "tag",
-        ("rev-parse", "--verify", f"refs/tags/{pin.tag}"): pin.tag_object,
+        (
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        ): pin.tag_object,
+        ("cat-file", "-t", pin.tag_object): "tag",
         ("rev-parse", "--verify", f"{pin.tag}^{{commit}}"): pin.commit,
         ("rev-parse", "--verify", f"{pin.tag}^{{tree}}"): pin.tree,
         ("rev-parse", "--verify", "HEAD^{commit}"): "f" * 40,
@@ -283,6 +287,37 @@ def test_legacy_topology_requires_exact_tag_commit_tree_and_current_ancestry(
     assert bridge._supported_legacy_topology(vault) is True
 
     values[("rev-parse", "--verify", f"{pin.tag}^{{tree}}")] = "0" * 40
+    assert bridge._supported_legacy_topology(vault) is False
+
+
+def test_legacy_topology_accepts_exact_pinned_commit_when_old_tag_was_pruned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    head = "f" * 40
+    values = {
+        (
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        ): "",
+        ("cat-file", "-t", pin.commit): "commit",
+        ("rev-parse", "--verify", f"{pin.commit}^{{commit}}"): pin.commit,
+        ("rev-parse", "--verify", f"{pin.commit}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "HEAD^{commit}"): head,
+        ("merge-base", "--is-ancestor", pin.commit, head): "",
+    }
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda _root, *arguments: values[arguments],
+    )
+
+    assert bridge._supported_legacy_topology(vault) is True
+
+    values[("rev-parse", "--verify", f"{pin.commit}^{{tree}}")] = "0" * 40
     assert bridge._supported_legacy_topology(vault) is False
 
 

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "7c464d94a87f43ad49e7782c9b9522341a9c346fc9026fb35630a27793fbb598",
+      "sha256": "58c2ec53f6594d6f912b6e5968d433a6ab75c401982b13c418988e521457f925",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,7 +102,7 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.3-EXACTFOLLOWUP
+  --follow-up-tag dist/release/v1.81.4-EXACTFOLLOWUP
 ```
 
 The repository has the canonical protocol source at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.3",
+  "version": "1.81.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.3",
+      "version": "1.81.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.3",
+  "version": "1.81.4",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -384,13 +384,29 @@ def _supported_legacy_topology(
     ):
         return False
     try:
-        if _run_git(root, "cat-file", "-t", pin.tag) != "tag":
+        tag_object = _run_git(
+            root,
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        )
+        if tag_object:
+            if tag_object != pin.tag_object:
+                return False
+            if _run_git(root, "cat-file", "-t", pin.tag_object) != "tag":
+                return False
+            identity = pin.tag
+        else:
+            # Historic installers retained their own release tag but could
+            # prune older tag labels. The pinned commit remains a safe proof
+            # only when its object type, commit identity, tree, and ancestry
+            # all match the closed v1.20.1 foundation.
+            if _run_git(root, "cat-file", "-t", pin.commit) != "commit":
+                return False
+            identity = pin.commit
+        if _run_git(root, "rev-parse", "--verify", f"{identity}^{{commit}}") != pin.commit:
             return False
-        if _run_git(root, "rev-parse", "--verify", f"refs/tags/{pin.tag}") != pin.tag_object:
-            return False
-        if _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{commit}}") != pin.commit:
-            return False
-        if _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{tree}}") != pin.tree:
+        if _run_git(root, "rev-parse", "--verify", f"{identity}^{{tree}}") != pin.tree:
             return False
         head = _run_git(root, "rev-parse", "--verify", "HEAD^{commit}")
         if _HEX.fullmatch(head) is None:


### PR DESCRIPTION
## What changed
- let historic Mac installs prove the exact pinned v1.20.1 foundation by commit and tree when the old tag label was pruned
- keep the existing exact tag-object proof when the label is present
- prepare v1.81.4 and regenerate the release-owned journey protocol hash

## Why
The formal 170-case public fleet passed v1.20.1, then v1.49.0 stopped safely because its installer retained the trusted commit and ancestry but only its own release tag. All 170 frozen cohort commits descend from the exact pinned foundation.

## Verification
- 150 updater/fleet tests passed
- 163 script tests passed
- 225 integration tests passed
- 170/171 hook tests passed; the one temp-cleanup race passed on immediate isolated rerun
- Ruff, PII, portable contract, founder-content, distribution, and connection-contract gates passed
- full Python suite is still running locally; CI remains authoritative

## Release boundary
Dave has already authorized the production updater release. Merge and publish only after required CI is green.