### PR TITLE
fix(update): match legacy transition metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.5] — 🧾 Historic installs receive matching migration metadata (2026-07-31)
+
+The public 1.49.0 journey crossed the repaired history proof, then found that
+the read-only migration marker still named 1.20.1. The foundation migrator
+correctly refused that mismatch before changing the fixture.
+
+**What this fixes for you:**
+
+* **Each historic install receives its own version marker.** The compatibility
+  layer derives the read-only transition metadata from the installed package.
+* **Malformed metadata still stops safely.** Missing, symlinked, or invalid
+  package versions are refused before the migration can begin.
+* **No compatibility file is written into the old vault.** The marker exists
+  only inside the verified migration process and personal files remain guarded.
+
 ## [1.81.4] — 🏷️ Historic installs no longer need every old tag label (2026-07-31)
 
 The first formal fleet run passed the oldest supported Dex release, then found

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.4"
+  "release_version": "1.81.5"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.4",
+  "release_version": "1.81.5",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.4","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -501,6 +501,10 @@ def test_legacy_preload_supplies_absent_read_only_inputs_without_vault_writes(
     node = shutil.which("node")
     if node is None:
         pytest.skip("Node.js is required for the compatibility preload test")
+    (vault / "package.json").write_text(
+        '{"name":"dex-pkm","version":"1.49.0"}\n',
+        encoding="utf-8",
+    )
     script = """
 const fs = require('node:fs');
 const path = require('node:path');
@@ -521,8 +525,46 @@ process.stdout.write(JSON.stringify({policy, transition}));
     supplied = json.loads(result.stdout)
 
     assert supplied["policy"].encode() == bridge._LEGACY_TRACKED_IGNORE_POLICY
-    assert supplied["transition"].encode() == bridge._LEGACY_PRESERVATION_TRANSITION
+    assert json.loads(supplied["transition"]) == {
+        "phase": "bootstrap-v1",
+        "release_version": "1.49.0",
+        "schema_version": 1,
+    }
     assert not (vault / bridge._TRACKED_IGNORE_POLICY_RELATIVE).exists()
+    assert not (vault / bridge._PRESERVATION_TRANSITION_RELATIVE).exists()
+
+
+def test_legacy_preload_refuses_an_invalid_package_version(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the compatibility preload test")
+    (vault / "package.json").write_text(
+        '{"name":"dex-pkm","version":"../../changed"}\n',
+        encoding="utf-8",
+    )
+    script = """
+const fs = require('node:fs');
+const path = require('node:path');
+fs.readFileSync(
+  path.join(process.cwd(), 'System/.local-only-preservation-transition.json'),
+  'utf8',
+);
+"""
+
+    result = subprocess.run(
+        [node, "--require", str(service._preload), "--eval", script],
+        cwd=vault,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=bridge._bridge_environment(),
+    )
+
+    assert result.returncode != 0
+    assert "Dex update bridge refused invalid legacy package version" in result.stderr
     assert not (vault / bridge._PRESERVATION_TRANSITION_RELATIVE).exists()
 
 

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "58c2ec53f6594d6f912b6e5968d433a6ab75c401982b13c418988e521457f925",
+      "sha256": "c17e0372f78aa38904f18e60831651d4b37613bd6376fc18bb4cb49e20e29715",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,7 +102,7 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.4-EXACTFOLLOWUP
+  --follow-up-tag dist/release/v1.81.5-EXACTFOLLOWUP
 ```
 
 The repository has the canonical protocol source at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.4",
+  "version": "1.81.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.4",
+      "version": "1.81.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.4",
+  "version": "1.81.5",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -180,18 +180,12 @@ baselines:
 _LEGACY_TRACKED_IGNORE_POLICY_SHA256 = (
     "bf0af119939930fb4d3b466584a3e9392edb66bf61ec09675521c9a5969f3f50"
 )
-_LEGACY_PRESERVATION_TRANSITION = (
-    b'{"phase":"bootstrap-v1","release_version":"1.20.1","schema_version":1}\n'
-)
 
 
 def _legacy_preload_bytes() -> bytes:
     """Build the closed Node preload that supplies two absent read-only inputs."""
 
     policy = base64.b64encode(_LEGACY_TRACKED_IGNORE_POLICY).decode("ascii")
-    transition = base64.b64encode(_LEGACY_PRESERVATION_TRANSITION).decode(
-        "ascii"
-    )
     return f"""'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
@@ -208,12 +202,35 @@ const shippedLink = path.join(root, '{_LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix(
 const shippedLinkParent = path.dirname(shippedLink);
 const shippedLinkName = path.basename(shippedLink);
 const shippedLinkTarget = '{_LEGACY_SHIPPED_SYMLINK_TARGET}';
+const transitionPath = path.join(root, '{_PRESERVATION_TRANSITION_RELATIVE.as_posix()}');
+const packagePath = path.join(root, 'package.json');
 const inputs = new Map([
   [path.join(root, '{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}'), Buffer.from('{policy}', 'base64')],
-  [path.join(root, '{_PRESERVATION_TRANSITION_RELATIVE.as_posix()}'), Buffer.from('{transition}', 'base64')],
 ]);
 const originalReadFileSync = fs.readFileSync.bind(fs);
 const originalReaddirSync = fs.readdirSync.bind(fs);
+
+function legacyTransition() {{
+  const packageState = fs.lstatSync(packagePath);
+  if (!packageState.isFile() || packageState.isSymbolicLink()) {{
+    throw new Error(`Dex update bridge refused unsafe legacy package metadata ${{packagePath}}.`);
+  }}
+  const packageJson = JSON.parse(originalReadFileSync(packagePath, 'utf8'));
+  if (
+    !packageJson
+    || typeof packageJson !== 'object'
+    || Array.isArray(packageJson)
+    || typeof packageJson.version !== 'string'
+    || !/^[0-9]+\\.[0-9]+\\.[0-9]+$/.test(packageJson.version)
+  ) {{
+    throw new Error(`Dex update bridge refused invalid legacy package version ${{packagePath}}.`);
+  }}
+  return Buffer.from(`${{JSON.stringify({{
+    phase: 'bootstrap-v1',
+    release_version: packageJson.version,
+    schema_version: 1,
+  }})}}\\n`, 'utf8');
+}}
 
 let hideShippedLink = false;
 let shippedLinkFound = false;
@@ -238,12 +255,15 @@ try {{
 fs.readFileSync = function dexLegacyCompatibilityRead(candidate, options) {{
   const supplied = Buffer.isBuffer(candidate) ? candidate.toString() : String(candidate);
   const absolute = path.resolve(supplied);
-  const content = inputs.get(absolute);
-  if (content === undefined) return originalReadFileSync(candidate, options);
+  const suppliedInput = inputs.has(absolute) || absolute === transitionPath;
+  if (!suppliedInput) return originalReadFileSync(candidate, options);
   try {{
     fs.lstatSync(absolute);
   }} catch (error) {{
     if (error && error.code === 'ENOENT') {{
+      const content = absolute === transitionPath
+        ? legacyTransition()
+        : inputs.get(absolute);
       const encoding = typeof options === 'string' ? options : options && options.encoding;
       return encoding ? content.toString(encoding) : Buffer.from(content);
     }}


### PR DESCRIPTION
## Outcome

The public v1.49.0 Mac journey now receives read-only migration metadata matching its installed package version instead of the fixed v1.20.1 marker.

## Why

v1.81.4 correctly repaired legacy topology proof, then the real public v1.49.0 journey stopped safely because the compatibility marker said v1.20.1 while package metadata said v1.49.0.

## Change

- derive the compatibility-only transition version from the installed `package.json`
- require a regular, non-symlink package file with a strict `X.Y.Z` version
- fail closed on invalid metadata
- keep the compatibility marker process-local; no file is written into the historic vault
- bump release metadata to v1.81.5 and regenerate the journey protocol

## Proof

- 116 focused updater/fleet tests passed
- 163 script tests passed with the project Python binding
- 225 integration tests passed
- 171 hook tests passed except one unrelated temporary-directory cleanup flake; its exact file passed 12/12 on immediate rerun
- PII, portable-vault, founder-content, distribution, connection-contract, Ruff, and release-tag reachability gates passed

The v1.69 distribution label was moved atomically from `dist/release` to `dist/archive` at the identical annotated object to restore the release safety margin. The public v1.69 release, bundle, checksum, commit, and tree remain unchanged.

Existing production updater authorization applies. Merge and release when CI is green; no additional Dave approval is required.
