### PR TITLE
Fix historic Mac updater bridge across the frozen fleet

### DIFF
--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -328,7 +328,17 @@ def test_foundation_service_uses_verified_migrator_for_exact_legacy_topology_onl
     service, engine, vault, migrator = _foundation_topology_adapter(tmp_path)
     original_state = engine.topology_state
     original_command = engine._migrator_command
-    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+    authorization = bridge.LegacyTopologyAuthorization(
+        "absent-inputs",
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        None,
+        "absent",
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_legacy_topology_authorization",
+        lambda _root: authorization,
+    )
     monkeypatch.setattr(
         bridge,
         "_trusted_executable",
@@ -345,7 +355,7 @@ def test_foundation_service_uses_verified_migrator_for_exact_legacy_topology_onl
     command_prefix = [
         "/trusted/node",
         "--require",
-        str(service._preload),
+        str(service._preload_for_authorization(authorization)),
         str(migrator),
     ]
     assert preview == {
@@ -419,7 +429,17 @@ if (
             return engine._run_topology_migrator(vault_root, "--dry-run")
 
     service._service = RunningService()
-    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+    authorization = bridge.LegacyTopologyAuthorization(
+        "absent-inputs",
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        None,
+        "absent",
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_legacy_topology_authorization",
+        lambda _root: authorization,
+    )
     monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "https")
     parent_environment = bridge._bridge_environment()
     parent_attempt = subprocess.run(
@@ -455,7 +475,7 @@ def test_foundation_service_keeps_unknown_or_ambiguous_topology_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
-    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: False)
+    monkeypatch.setattr(bridge, "_legacy_topology_authorization", lambda _root: None)
     monkeypatch.setattr(
         bridge,
         "_trusted_executable",
@@ -476,7 +496,11 @@ def test_foundation_service_does_not_bypass_an_unsafe_vault_migrator(
     candidate = vault / bridge._TOPOLOGY_MIGRATOR_RELATIVE
     candidate.parent.mkdir(parents=True)
     candidate.symlink_to(migrator)
-    monkeypatch.setattr(bridge, "_supported_legacy_topology", lambda _root: True)
+    monkeypatch.setattr(
+        bridge,
+        "_legacy_topology_authorization",
+        lambda _root: pytest.fail("unsafe migrator must be rejected before authorization"),
+    )
 
     assert service.build_and_preview_topology_migration(vault) == {
         "topology": "invalid-combined",

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -711,9 +711,13 @@ def test_legacy_delivery_reader_accepts_only_the_pinned_pre_manifest_tree(
     TreeEntry = namedtuple("TreeEntry", ("path", "mode", "object_id"))
     classified_oid = "1" * 40
     retired_oid = "2" * 40
+    omission_a_oid = "3" * 40
+    omission_b_oid = "4" * 40
     records = (
         f"100644 blob {classified_oid}\tCLAUDE.md\0"
         f"100644 blob {retired_oid}\tretired-release-path.txt\0"
+        f"100644 blob {omission_a_oid}\tclosed-omission-a\0"
+        f"100644 blob {omission_b_oid}\tclosed-omission-b\0"
         f"120000 blob {bridge._LEGACY_SHIPPED_SYMLINK_BLOB}\t"
         f"{bridge._LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()}\0"
     ).encode()
@@ -735,6 +739,20 @@ def test_legacy_delivery_reader_accepts_only_the_pinned_pre_manifest_tree(
     apply_update.portable_contract.resolve = resolve
     apply_update.TreeEntry = TreeEntry
     apply_update._brain_output = brain_output
+    original_omission_identity = bridge._manifestless_omission_identity
+    omission_identities = {
+        "closed-omission-a": "af78f3d480b78b5bb558d873b98638c91d532de98f84f8f50e73448a1404b37d",
+        "closed-omission-b": "50a3e65dc2d65e6f6b28b30b630e06656d95ddd82f4a68a7152017119b110f90",
+    }
+
+    def omission_identity(relative: str, raw_mode: str, object_id: str) -> str:
+        if relative in omission_identities:
+            assert raw_mode == "100644"
+            assert object_id in {omission_a_oid, omission_b_oid}
+            return omission_identities[relative]
+        return original_omission_identity(relative, raw_mode, object_id)
+
+    monkeypatch.setattr(bridge, "_manifestless_omission_identity", omission_identity)
 
     def original_tree_entries(*_arguments):
         pytest.fail("exact legacy commit should use the compatibility reader")

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2244,6 +2244,43 @@ def test_core_drift_is_ok_for_a_clean_release_checkout(tmp_path):
     assert doctor._probe_core_drift(drift_context).verdict == "OK"
 
 
+def test_worktree_blob_ids_hash_large_release_trees_in_pipe_safe_batches(
+    context,
+    monkeypatch,
+) -> None:
+    relatives = [f"core/release-file-{index:04d}.py" for index in range(600)]
+    expected = {
+        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest()
+        for relative in relatives
+    }
+    observed_batches: list[list[str]] = []
+
+    def pipe_limited_git_result(
+        _context,
+        *arguments,
+        git_directory=None,
+        input_text=None,
+    ) -> subprocess.CompletedProcess[str]:
+        assert arguments == ("hash-object", "--no-filters", "--stdin-paths")
+        assert git_directory is None
+        batch = input_text.splitlines()
+        observed_batches.append(batch)
+        if len(batch) > 128:
+            return subprocess.CompletedProcess(arguments, 1, "", "simulated pipe saturation")
+        return subprocess.CompletedProcess(
+            arguments,
+            0,
+            "".join(f"{expected[relative]}\n" for relative in batch),
+            "",
+        )
+
+    monkeypatch.setattr(doctor, "_git_result", pipe_limited_git_result)
+
+    assert doctor._worktree_blob_ids(context, relatives) == expected
+    assert len(observed_batches) > 1
+    assert max(map(len, observed_batches)) <= 128
+
+
 def test_post_split_core_drift_accepts_only_installer_normalized_package_metadata(
     context,
 ) -> None:

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -219,6 +219,7 @@ def test_production_runtime_retries_exact_installed_doctor_after_transport_timeo
         "checks": [{"id": "core.drift", "verdict": "OK"}],
     }
     processes = []
+    killed_process_groups: list[int] = []
 
     class FakeProcess:
         returncode = 0
@@ -250,11 +251,18 @@ def test_production_runtime_retries_exact_installed_doctor_after_transport_timeo
         lambda _root: interpreter,
     )
     monkeypatch.setattr(executor.subprocess, "Popen", popen)
-    monkeypatch.setattr(executor.os, "killpg", lambda _pid, _signal: None)
+    monkeypatch.setattr(
+        executor.os,
+        "killpg",
+        lambda pid, _signal: killed_process_groups.append(pid),
+    )
 
     runtime = executor._ProductionRuntime()
     try:
-        assert runtime.doctor(vault) == report
+        assert runtime.doctor(vault) == {
+            **report,
+            "journey_transport": {"attempt_count": 2},
+        }
     finally:
         runtime.close()
 
@@ -265,6 +273,168 @@ def test_production_runtime_retries_exact_installed_doctor_after_transport_timeo
     )
     assert processes[0].commands == [60, None]
     assert processes[1].commands == [60]
+    assert killed_process_groups == [processes[0].pid]
+    assert all(process.kwargs["start_new_session"] is True for process in processes)
+
+
+def test_production_runtime_fails_after_two_doctor_transport_timeouts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    processes = []
+    killed_process_groups: list[int] = []
+
+    class TimedOutProcess:
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.pid = 44000 + len(processes)
+            self.commands: list[float | int | None] = []
+
+        def communicate(self, timeout=None):
+            self.commands.append(timeout)
+            if timeout is not None:
+                raise subprocess.TimeoutExpired("doctor", timeout)
+            return b"", b""
+
+    def popen(_command, **kwargs):
+        process = TimedOutProcess()
+        process.kwargs = kwargs
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(executor.dex_update_bridge, "_validate_vault", lambda root: root)
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_installed_python",
+        lambda _root: interpreter,
+    )
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+    monkeypatch.setattr(
+        executor.os,
+        "killpg",
+        lambda pid, _signal: killed_process_groups.append(pid),
+    )
+
+    runtime = executor._ProductionRuntime()
+    try:
+        with pytest.raises(
+            executor.ExecutorError,
+            match="installed core.utils.doctor timed out",
+        ):
+            runtime.doctor(vault)
+    finally:
+        runtime.close()
+
+    assert len(processes) == 2
+    assert killed_process_groups == [process.pid for process in processes]
+    assert all(process.commands == [60, None] for process in processes)
+    assert all(process.kwargs["start_new_session"] is True for process in processes)
+
+
+@pytest.mark.parametrize(
+    ("stdout", "stderr", "returncode", "error"),
+    (
+        (b"{}", b"doctor failed", 1, "doctor failed"),
+        (b"not-json", b"", 0, "malformed JSON"),
+    ),
+)
+def test_production_runtime_does_not_retry_non_timeout_doctor_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: bytes,
+    stderr: bytes,
+    returncode: int,
+    error: str,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    processes = []
+
+    class FakeProcess:
+        pid = 42000
+
+        def __init__(self) -> None:
+            self.returncode = returncode
+
+        def communicate(self, timeout=None):
+            return stdout, stderr
+
+    def popen(_command, **_kwargs):
+        process = FakeProcess()
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(executor.dex_update_bridge, "_validate_vault", lambda root: root)
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_installed_python",
+        lambda _root: interpreter,
+    )
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+
+    runtime = executor._ProductionRuntime()
+    try:
+        with pytest.raises(executor.ExecutorError, match=error):
+            runtime.doctor(vault)
+    finally:
+        runtime.close()
+
+    assert len(processes) == 1
+
+
+def test_production_runtime_does_not_retry_an_unhealthy_doctor_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    report = {
+        "summary": {"broken": 1, "unknown": 0},
+        "checks": [{"id": "core.drift", "verdict": "BROKEN"}],
+    }
+    processes = []
+
+    class FakeProcess:
+        pid = 43000
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return json.dumps(report).encode("utf-8"), b""
+
+    def popen(_command, **_kwargs):
+        process = FakeProcess()
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(executor.dex_update_bridge, "_validate_vault", lambda root: root)
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_installed_python",
+        lambda _root: interpreter,
+    )
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+
+    runtime = executor._ProductionRuntime()
+    try:
+        observed = runtime.doctor(vault)
+    finally:
+        runtime.close()
+
+    assert observed == {
+        **report,
+        "journey_transport": {"attempt_count": 1},
+    }
+    assert executor._doctor_healthy(observed) is False
+    assert len(processes) == 1
 
 
 def _commit_executor_tamper(repo: Path) -> str:

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -206,6 +206,67 @@ def test_production_runtime_exposes_only_installed_qmd_not_ambient_path(
         runtime.close()
 
 
+def test_production_runtime_retries_exact_installed_doctor_after_transport_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    interpreter = tmp_path / "python"
+    interpreter.touch()
+    report = {
+        "summary": {"broken": 0, "unknown": 0},
+        "checks": [{"id": "core.drift", "verdict": "OK"}],
+    }
+    processes = []
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, *, times_out: bool) -> None:
+            self.pid = 41000 + len(processes)
+            self.times_out = times_out
+            self.commands: list[float | int | None] = []
+
+        def communicate(self, timeout=None):
+            self.commands.append(timeout)
+            if self.times_out and timeout is not None:
+                raise subprocess.TimeoutExpired("doctor", timeout)
+            if timeout is None:
+                return b"", b""
+            return json.dumps(report).encode("utf-8"), b""
+
+    def popen(command, **kwargs):
+        process = FakeProcess(times_out=not processes)
+        process.command = command
+        process.kwargs = kwargs
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(executor.dex_update_bridge, "_validate_vault", lambda root: root)
+    monkeypatch.setattr(
+        executor.dex_update_bridge,
+        "_installed_python",
+        lambda _root: interpreter,
+    )
+    monkeypatch.setattr(executor.subprocess, "Popen", popen)
+    monkeypatch.setattr(executor.os, "killpg", lambda _pid, _signal: None)
+
+    runtime = executor._ProductionRuntime()
+    try:
+        assert runtime.doctor(vault) == report
+    finally:
+        runtime.close()
+
+    assert len(processes) == 2
+    assert all(
+        process.command == [str(interpreter), "-m", "core.utils.doctor"]
+        for process in processes
+    )
+    assert processes[0].commands == [60, None]
+    assert processes[1].commands == [60]
+
+
 def _commit_executor_tamper(repo: Path) -> str:
     path = repo / "scripts/release_fleet_executor.py"
     path.write_bytes(path.read_bytes() + b"\n# externally substituted bytes\n")

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -275,6 +275,59 @@ def test_failure_diagnostic_is_atomic_and_never_overwrites_existing_file(
     assert list(evidence.glob("*.tmp")) == []
 
 
+def test_failure_diagnostic_never_removes_a_preexisting_temporary_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = tmp_path / "case.evidence"
+    evidence.mkdir(mode=0o700)
+    evidence.chmod(0o700)
+    name = "foundation-doctor-failure.diagnostic.json"
+    timestamp = 123456
+    monkeypatch.setattr(executor.time, "time_ns", lambda: timestamp)
+    temporary = evidence / f".{name}.{executor.os.getpid()}.{timestamp}.tmp"
+    temporary.write_text("another process owns this\n", encoding="utf-8")
+
+    with pytest.raises(executor.ExecutorError, match="could not be retained safely"):
+        executor._write_failure_diagnostic(
+            evidence,
+            name,
+            {"acceptance": False, "kind": "local-failure-diagnostic"},
+        )
+
+    assert temporary.read_text(encoding="utf-8") == "another process owns this\n"
+
+
+def test_safe_metadata_does_not_follow_a_symlink_swapped_after_lstat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault, _ = _vault(tmp_path)
+    relative = "System/.release-catalog.json"
+    candidate = vault / relative
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP-SECRET-NOT-FOR-DIAGNOSTICS\n", encoding="utf-8")
+    original_open = executor.os.open
+    swapped = False
+
+    def swap_before_open(path, *args, **kwargs):
+        nonlocal swapped
+        if Path(path) == candidate and not swapped:
+            swapped = True
+            candidate.unlink()
+            candidate.symlink_to(secret)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(executor.os, "open", swap_before_open)
+
+    metadata = executor._safe_file_metadata(vault, relative)
+
+    assert swapped
+    assert metadata["state"] in {"unreadable", "changed"}
+    assert "sha256" not in metadata
+    assert "TOP-SECRET-NOT-FOR-DIAGNOSTICS" not in json.dumps(metadata)
+
+
 def test_failure_diagnostic_cleans_temporary_file_when_file_fsync_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -1,0 +1,269 @@
+"""Failure-only diagnostics for the closed historic update executor."""
+
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.update.journey_protocol import load_update_journey_protocol
+from scripts import release_fleet_executor as executor
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _identity(version: str, fill: str) -> dict[str, str]:
+    commit = fill * 40
+    return {
+        "tag": f"dist/release/v{version}-{commit[:7]}",
+        "tag_object": ("f" if fill != "f" else "e") * 40,
+        "commit": commit,
+        "tree": ("d" if fill != "d" else "c") * 40,
+        "version": version,
+        "channel": "stable",
+    }
+
+
+def _released_executor_source(tmp_path: Path) -> tuple[Path, str]:
+    source = tmp_path / "released-source"
+    source.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=source, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"], cwd=source, check=True
+    )
+    for relative in (
+        "scripts/dex_update_bridge.py",
+        "scripts/release_fleet.py",
+        "scripts/release_fleet_executor.py",
+    ):
+        destination = source / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes((REPO_ROOT / relative).read_bytes())
+    subprocess.run(["git", "add", "-A"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "released executor"],
+        cwd=source,
+        check=True,
+    )
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return source, commit
+
+
+def _vault(tmp_path: Path) -> tuple[Path, tuple[str, ...]]:
+    vault = tmp_path / "vault"
+    user_paths = (
+        "00-Inbox/keep.md",
+        "03-Tasks/Tasks.md",
+        "System/user-profile.yaml",
+        ".claude/skills/my-weekly-review/SKILL.md",
+    )
+    for relative in user_paths:
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"user-owned:{relative}\n", encoding="utf-8")
+    # This deliberately looks like a sensitive user config.  Diagnostics may
+    # retain a digest but must never serialize its contents.
+    (vault / ".mcp.json").write_text(
+        '{"token":"TOP-SECRET-NOT-FOR-DIAGNOSTICS"}\n', encoding="utf-8"
+    )
+    (vault / "System/.release-catalog.json").write_text("{}\n", encoding="utf-8")
+    (vault / "System/.installed-files.manifest").write_text("{}\n", encoding="utf-8")
+    return vault, user_paths
+
+
+class _Runtime:
+    def __init__(self, follow_up: dict[str, str], *, failure: str) -> None:
+        self.follow_up = follow_up
+        self.failure = failure
+        self.installed = ""
+        self.doctor_calls = 0
+
+    def bridge_to_foundation(self, vault, foundation, *, input_fn, output_fn):
+        for prompt in ("topology", "foundation", "mcp"):
+            assert input_fn(prompt) == "APPLY"
+        self.installed = foundation["commit"]
+        return {
+            "foundation": dict(foundation),
+            "topology_receipt": {"receipt": {"transaction_id": "topology"}},
+            "delivery_receipt": {"receipt": {"transaction_id": "foundation"}},
+            "mcp_registration_receipt": {"receipt": {"transaction_id": "mcp"}},
+        }
+
+    def installed_release(self, vault):
+        return self.installed
+
+    def doctor(self, vault):
+        self.doctor_calls += 1
+        broken = (self.failure == "foundation-doctor" and self.doctor_calls == 1) or (
+            self.failure == "follow-up-doctor" and self.doctor_calls == 2
+        )
+        verdict = "BROKEN" if broken else "OK"
+        return {
+            "checks": [
+                {
+                    "id": "doctor.dependency",
+                    "verdict": verdict,
+                    "detail": "TOP-SECRET-NOT-FOR-DIAGNOSTICS",
+                }
+            ]
+        }
+
+    def deliver_latest_release(self, vault):
+        if self.failure == "follow-up-delivery":
+            return {
+                "status": "unexpected: TOP-SECRET-NOT-FOR-DIAGNOSTICS",
+                "release": {"opaque": "TOP-SECRET-NOT-FOR-DIAGNOSTICS"},
+            }
+        return {"status": "delivered", "release": self.follow_up}
+
+    def build_and_preview_delivered_release(self, vault, release):
+        return {
+            "preview": {"release": dict(release), "writes": []},
+            "approval_token": "exact-token",
+        }
+
+    def execute_approved_delivered_release(self, vault, preview, approved_token):
+        assert approved_token == "exact-token"
+        self.installed = self.follow_up["commit"]
+        return {
+            "receipt": {"transaction_id": "follow-up"},
+            "release": self.follow_up,
+        }
+
+    def smoke(self, vault):
+        return {
+            "journeys": [{"id": "topology", "verdict": "OK"}],
+            "summary": {"broken": 0, "unknown": 0},
+        }
+
+
+def _run_failure(
+    tmp_path: Path,
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    source, source_commit = _released_executor_source(tmp_path)
+    monkeypatch.setattr(
+        executor,
+        "_verify_released_executor",
+        lambda *_args, **_kwargs: {"source_commit": "test-only"},
+    )
+    vault, user_paths = _vault(tmp_path)
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
+    )
+    starting = _identity("1.65.0", "a")
+    follow_up = _identity("1.81.5", "b")
+    with pytest.raises(executor.ExecutorError) as error:
+        executor.execute_journey(
+            repo_root=source,
+            source_commit=source_commit,
+            vault_root=vault,
+            evidence_root=tmp_path / "case.evidence",
+            starting_release=starting,
+            foundation_release=protocol.foundation,
+            follow_up_release=follow_up,
+            protocol=protocol,
+            historic_surface={"release": starting, "machine_executable": False},
+            foundation_surface={
+                "release": protocol.foundation,
+                "machine_executable": False,
+            },
+            user_owned_paths=user_paths,
+            platform="darwin",
+            input_fn=lambda _prompt: "APPLY",
+            output_fn=lambda _line: None,
+            _runtime=_Runtime(follow_up, failure=failure),
+        )
+    assert "failure diagnostic could not be retained safely" not in str(error.value)
+    expected = {
+        "foundation-doctor": "foundation Doctor is unhealthy",
+        "follow-up-delivery": "lifecycle delivery did not prove",
+        "follow-up-doctor": "follow-up Doctor is unhealthy",
+    }[failure]
+    assert expected in str(error.value)
+    return tmp_path / "case.evidence"
+
+
+@pytest.mark.parametrize(
+    ("failure", "artifact", "phase"),
+    (
+        (
+            "foundation-doctor",
+            "foundation-doctor-failure.diagnostic.json",
+            "foundation-doctor",
+        ),
+        (
+            "follow-up-delivery",
+            "follow-up-delivery-failure.diagnostic.json",
+            "follow-up-delivery",
+        ),
+        (
+            "follow-up-doctor",
+            "follow-up-doctor-failure.diagnostic.json",
+            "follow-up-doctor",
+        ),
+    ),
+)
+def test_failed_journey_retains_only_private_sanitized_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    artifact: str,
+    phase: str,
+) -> None:
+    evidence = _run_failure(tmp_path, failure, monkeypatch)
+    diagnostic = evidence / artifact
+    document = json.loads(diagnostic.read_text(encoding="utf-8"))
+
+    assert document["acceptance"] is False
+    assert document["kind"] == "local-failure-diagnostic"
+    assert document["phase"] == phase
+    assert "TOP-SECRET-NOT-FOR-DIAGNOSTICS" not in diagnostic.read_text()
+    assert stat.S_IMODE(evidence.stat().st_mode) == 0o700
+    assert stat.S_IMODE(diagnostic.stat().st_mode) == 0o600
+    assert not (evidence / "journey-result.json").exists()
+    assert not (evidence / "evidence-manifest.json").exists()
+    assert not (evidence / "journey-transcript.json").exists()
+    if "doctor" in failure:
+        assert document["doctor"] == {
+            "check_count": 1,
+            "checks": [{"id": "doctor.dependency", "verdict": "BROKEN"}],
+            "details": "redacted",
+        }
+    else:
+        assert document["delivery"] == {
+            "status": "not-delivered",
+            "release_matches_expected": False,
+        }
+
+
+def test_failure_diagnostic_is_atomic_and_never_overwrites_existing_file(
+    tmp_path: Path,
+) -> None:
+    evidence = tmp_path / "case.evidence"
+    evidence.mkdir(mode=0o700)
+    evidence.chmod(0o700)
+    destination = evidence / "foundation-doctor-failure.diagnostic.json"
+    destination.write_text("original diagnostic\n", encoding="utf-8")
+    destination.chmod(0o600)
+
+    with pytest.raises(executor.ExecutorError, match="could not be retained safely"):
+        executor._write_failure_diagnostic(
+            evidence,
+            destination.name,
+            {"acceptance": False, "kind": "local-failure-diagnostic"},
+        )
+
+    assert destination.read_text(encoding="utf-8") == "original diagnostic\n"
+    assert list(evidence.glob("*.tmp")) == []

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -71,8 +71,8 @@ def _vault(tmp_path: Path) -> tuple[Path, tuple[str, ...]]:
         target = vault / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(f"user-owned:{relative}\n", encoding="utf-8")
-    # This deliberately looks like a sensitive user config.  Diagnostics may
-    # retain a digest but must never serialize its contents.
+    # This deliberately looks like a sensitive user config. Diagnostics must
+    # neither read nor serialize it.
     (vault / ".mcp.json").write_text(
         '{"token":"TOP-SECRET-NOT-FOR-DIAGNOSTICS"}\n', encoding="utf-8"
     )
@@ -229,7 +229,13 @@ def test_failed_journey_retains_only_private_sanitized_diagnostic(
     assert document["acceptance"] is False
     assert document["kind"] == "local-failure-diagnostic"
     assert document["phase"] == phase
-    assert "TOP-SECRET-NOT-FOR-DIAGNOSTICS" not in diagnostic.read_text()
+    serialized = diagnostic.read_text(encoding="utf-8")
+    assert "TOP-SECRET-NOT-FOR-DIAGNOSTICS" not in serialized
+    assert ".mcp.json" not in serialized
+    assert set(document["runtime_metadata"]) == {
+        "System/.installed-files.manifest",
+        "System/.release-catalog.json",
+    }
     assert stat.S_IMODE(evidence.stat().st_mode) == 0o700
     assert stat.S_IMODE(diagnostic.stat().st_mode) == 0o600
     assert not (evidence / "journey-result.json").exists()
@@ -266,4 +272,34 @@ def test_failure_diagnostic_is_atomic_and_never_overwrites_existing_file(
         )
 
     assert destination.read_text(encoding="utf-8") == "original diagnostic\n"
+    assert list(evidence.glob("*.tmp")) == []
+
+
+def test_failure_diagnostic_cleans_temporary_file_when_file_fsync_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = tmp_path / "case.evidence"
+    evidence.mkdir(mode=0o700)
+    evidence.chmod(0o700)
+    original_fsync = executor.os.fsync
+    calls = 0
+
+    def fail_first_fsync(descriptor: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("injected fsync failure")
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(executor.os, "fsync", fail_first_fsync)
+
+    with pytest.raises(executor.ExecutorError, match="could not be retained safely"):
+        executor._write_failure_diagnostic(
+            evidence,
+            "foundation-doctor-failure.diagnostic.json",
+            {"acceptance": False, "kind": "local-failure-diagnostic"},
+        )
+
+    assert not (evidence / "foundation-doctor-failure.diagnostic.json").exists()
     assert list(evidence.glob("*.tmp")) == []

--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -122,10 +122,14 @@ def _newer_release_tags(count: int) -> tuple[str, ...]:
     )
 
 
-def test_reachability_gate_passes_below_safety_margin(tmp_path: Path) -> None:
+@pytest.mark.parametrize("newer_count", (26, 30))
+def test_reachability_gate_passes_with_at_least_two_shipped_slots_remaining(
+    tmp_path: Path,
+    newer_count: int,
+) -> None:
     repository = _repository_with_remote_tags(
         tmp_path,
-        *_newer_release_tags(25),
+        *_newer_release_tags(newer_count),
     )
 
     result = subprocess.run(
@@ -140,8 +144,8 @@ def test_reachability_gate_passes_below_safety_margin(tmp_path: Path) -> None:
     assert "Release-tag reachability gate passed." in result.stdout
 
 
-@pytest.mark.parametrize("newer_count", (26, 27))
-def test_reachability_gate_fails_at_or_above_safety_margin(
+@pytest.mark.parametrize("newer_count", (31, 32))
+def test_reachability_gate_fails_before_the_last_shipped_slot_is_consumed(
     tmp_path: Path,
     newer_count: int,
 ) -> None:
@@ -164,7 +168,8 @@ def test_reachability_gate_fails_at_or_above_safety_margin(
             f"v{sentinel} has {newer_count} newer dist/release tags"
             in result.stderr
         )
-    assert "dist/archive/*" in result.stderr
+    assert "Do not move immutable release labels blindly" in result.stderr
+    assert "verified bridge-and-archive procedure" in result.stderr
 
 
 def test_reachability_gate_fails_loudly_when_remote_tags_are_unreadable(

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -24,7 +24,6 @@ import pytest
 
 from scripts import dex_update_bridge as bridge
 
-
 # These are independent historical Git identities.  A ``None`` value is part
 # of the identity: it means that the historical tree did *not* ship that
 # input, not that a nearby release may supply it.

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -534,6 +534,47 @@ def _delivery_adapter(
     return bridge._FoundationLifecycleService(service, engine, apply_update, source), service
 
 
+def _topology_command_adapter(
+    tmp_path: Path,
+) -> tuple[bridge._FoundationLifecycleService, ModuleType]:
+    """Build the real bridge command adapter around a disposable migrator."""
+
+    source = tmp_path / "foundation-topology-source"
+    migrator = source / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    migrator.parent.mkdir(parents=True)
+    migrator.write_text(
+        """'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+fs.readFileSync(path.join(process.cwd(), 'core/migrations/tracked-ignored-policy.yaml'));
+fs.readFileSync(path.join(process.cwd(), 'System/.local-only-preservation-transition.json'));
+""",
+        encoding="utf-8",
+    )
+
+    engine = ModuleType("historic_topology_engine")
+    engine.TOPOLOGY_MIGRATOR_RELATIVE = bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    engine.topology_state = lambda _root: "invalid-combined"
+
+    def rejected_command(_root: Path, _mode: str) -> list[str]:
+        raise RuntimeError("historic vault migrator was rejected")
+
+    engine._migrator_command = rejected_command
+
+    class TopologyService:
+        pass
+
+    return (
+        bridge._FoundationLifecycleService(
+            TopologyService(),
+            engine,
+            apply_update,
+            source,
+        ),
+        engine,
+    )
+
+
 def _commit_nonregular_variant(repository: Path, base: str, mode: str, name: str) -> tuple[str, str]:
     _git(repository, "checkout", "--quiet", "--detach", "--force", base)
     if mode == "120000":
@@ -909,6 +950,125 @@ def test_runtime_legacy_topology_refuses_cross_borrowed_existing_inputs(
         )
 
     assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+
+def test_runtime_legacy_command_reproves_unchanged_existing_input_tuple(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.MISSING_MIGRATOR_RELEASES[3]
+    repository = _historic_checkout(tmp_path, pin.release)
+    adapter, engine = _topology_command_adapter(tmp_path)
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        command = engine._migrator_command(repository, "--dry-run")
+
+    assert command[-2:] == [str(adapter._migrator), "--dry-run"]
+    completed = subprocess.run(
+        command,
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=bridge._bridge_environment(),
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize("mode", ("--dry-run", "--auto"))
+def test_runtime_legacy_command_refuses_exact_cross_borrow_after_authorization(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    pin = bridge.MISSING_MIGRATOR_RELEASES[3]
+    borrowed = bridge.MISSING_MIGRATOR_RELEASES[8]
+    assert pin.release.version == borrowed.release.version
+    assert pin.release.package_blob == borrowed.release.package_blob
+    assert pin.inputs != borrowed.inputs
+
+    repository = _historic_checkout(tmp_path, pin.release)
+    adapter, engine = _topology_command_adapter(tmp_path)
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        for relative, blob in (
+            (bridge._TRACKED_IGNORE_POLICY_RELATIVE, borrowed.inputs.policy_blob),
+            (bridge._PRESERVATION_TRANSITION_RELATIVE, borrowed.inputs.transition_blob),
+        ):
+            (repository / relative).write_bytes(
+                subprocess.run(
+                    ["git", "-C", str(repository), "cat-file", "blob", blob],
+                    check=True,
+                    capture_output=True,
+                ).stdout
+            )
+
+        with pytest.raises(bridge.BridgeError, match="identity changed after authorization"):
+            engine._migrator_command(repository, mode)
+
+
+def test_runtime_legacy_command_refuses_existing_inputs_added_to_absent_class(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.MANIFESTLESS_SEMANTIC_RELEASES[1]
+    borrowed = bridge.MISSING_MIGRATOR_RELEASES[8]
+    repository = _historic_checkout(tmp_path, pin)
+    adapter, engine = _topology_command_adapter(tmp_path)
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        for relative, blob in (
+            (bridge._TRACKED_IGNORE_POLICY_RELATIVE, borrowed.inputs.policy_blob),
+            (bridge._PRESERVATION_TRANSITION_RELATIVE, borrowed.inputs.transition_blob),
+        ):
+            candidate = repository / relative
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            candidate.write_bytes(
+                subprocess.run(
+                    ["git", "-C", str(repository), "cat-file", "blob", blob],
+                    check=True,
+                    capture_output=True,
+                ).stdout
+            )
+
+        with pytest.raises(bridge.BridgeError, match="identity changed after authorization"):
+            engine._migrator_command(repository, "--dry-run")
+
+
+def test_bound_legacy_preload_refuses_cross_borrow_after_command_creation(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.MISSING_MIGRATOR_RELEASES[3]
+    borrowed = bridge.MISSING_MIGRATOR_RELEASES[8]
+    repository = _historic_checkout(tmp_path, pin.release)
+    adapter, engine = _topology_command_adapter(tmp_path)
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        command = engine._migrator_command(repository, "--dry-run")
+
+    for relative, blob in (
+        (bridge._TRACKED_IGNORE_POLICY_RELATIVE, borrowed.inputs.policy_blob),
+        (bridge._PRESERVATION_TRANSITION_RELATIVE, borrowed.inputs.transition_blob),
+    ):
+        (repository / relative).write_bytes(
+            subprocess.run(
+                ["git", "-C", str(repository), "cat-file", "blob", blob],
+                check=True,
+                capture_output=True,
+            ).stdout
+        )
+
+    completed = subprocess.run(
+        command,
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=bridge._bridge_environment(),
+    )
+    assert completed.returncode != 0
+    assert "refused an unknown legacy compatibility tuple" in completed.stderr
 
 
 def test_runtime_retired_manifest_topology_requires_exact_git_and_absent_inputs(

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -1,0 +1,319 @@
+"""Adversarial contract for the closed historic updater bridge allow-list.
+
+The bridge implementation exposes two deliberately small, data-only seams:
+
+``historic_compatibility_pins()`` returns the immutable, JSON-like pin ledger
+and ``historic_compatibility_for(evidence)`` returns a pin name only for a
+complete *installed-source* identity.  The latter must return ``None`` for
+every near miss; it is not an ancestry, version, or best-effort compatibility
+detector.  Filesystem/Git collection belongs to the bridge, while this module
+keeps the authorization policy independently frozen and easy to audit.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from scripts import dex_update_bridge as bridge
+
+
+# These are independent historical Git identities.  A ``None`` value is part
+# of the identity: it means that the historical tree did *not* ship that
+# input, not that a nearby release may supply it.
+_MANIFESTLESS_MISSING_MIGRATOR = {
+    "v1.20.1": {
+        "tag_object": "3f7338dbe21ec98c015a3c8417d037cdd51b517d",
+        "commit": "9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
+        "tree": "b781bb94e417b2873d057a5a417d8c666a360bca",
+        "package_blob": "524e4fc38b6ef0b266776fd52023e41e603fa4a1",
+    },
+    "v1.49.0": {
+        "tag_object": None,
+        "commit": "930adabf3e88b6534b3c90a9ad386151c1e291e4",
+        "tree": "0a153375382907fd25a68d7c1845851d0d1f9946",
+        "package_blob": "32c22a6a13f1444beb8ce62a30ce6309b70244be",
+    },
+    "v1.51.0": {
+        "tag_object": None,
+        "commit": "c8069c90c1715bc7a10aced19ef95e3657089bfd",
+        "tree": "8129f1a2d66a6a9d412cb6a3d919af725b160e6f",
+        "package_blob": "887ddacba2ff3e99b4293c50b522b112e8e7b8e0",
+    },
+    "v1.52.0": {
+        "tag_object": None,
+        "commit": "0b843163815dab2bd9d0d4797a70f7c59864e76f",
+        "tree": "faebf21f5c14dc10a2ac9b28856040425e6a24a8",
+        "package_blob": "34227d365e65fde32a61830c0b77cd6331fb3e7b",
+    },
+    "v1.53.0": {
+        "tag_object": None,
+        "commit": "a0bbd82d4a7c825b94c2e5467d3d34f8f2129280",
+        "tree": "59a50aba122ef8213544dc99ba36fd19cc78b5c1",
+        "package_blob": "d21587d1eb2e23562428fa72d4d7fb9e0a586b97",
+    },
+    "v1.54.0": {
+        "tag_object": None,
+        "commit": "3956d3710645492975d66f8f481c806c72533453",
+        "tree": "ce724d55e677ef126a5f1ed4aa03f48236379327",
+        "package_blob": "113903345c57bf43ad4c2f991af866f0e1183da9",
+    },
+    "v1.55.0": {
+        "tag_object": None,
+        "commit": "a023581a86b56ef97577513092001ea565832e17",
+        "tree": "754789c0721bcb9bd82f43055afa8f09be0fda28",
+        "package_blob": "2b1c2330ad98ca6ca85fb3319a59d7b6835f8368",
+    },
+    "v1.56.0": {
+        "tag_object": None,
+        "commit": "69505741999ab493f4f23733e33a9ffb2395c4bf",
+        "tree": "255083281de057f9dd07bdfe2c3e94be1e1de5ce",
+        "package_blob": "90bbdde25254fd3a9ceb3c4221337d9b3b39008f",
+    },
+    "v1.57.0": {
+        "tag_object": None,
+        "commit": "e5220bf72689e4434697aaa06978cac31cc9d5ee",
+        "tree": "68af3dbebc0cbac8699dfa6d9fecf41b11852785",
+        "package_blob": "f6e66582be2bd845ebc6bdf3e7166ada6a4c0d1b",
+    },
+    "v1.58.0": {
+        "tag_object": None,
+        "commit": "b001eb4048d413e1c68213f83b2c3ca2ad818a17",
+        "tree": "da2ee15b6490452d85eaf8a7fd883f92b743bea9",
+        "package_blob": "d25d36733053bd92f7f6d86fae9e0a887adb0bbc",
+    },
+    "v1.59.0": {
+        "tag_object": None,
+        "commit": "f3a4413d6a1bc245250e23b4f5868953620b7237",
+        "tree": "9ecb0a55dd44c16b82a06ac1a02a1ee1a872607e",
+        "package_blob": "5cf1c327e9eec8c42d578c3da9bb6520f7b5fe18",
+    },
+    "v1.60.0": {
+        "tag_object": None,
+        "commit": "6c986d80280e15af26b9cc4412c4578461b916db",
+        "tree": "6906f751bbb058db9bd4aee01e745459661c7131",
+        "package_blob": "7bbc92cdcfc2fd023861fb30d474e129f885913a",
+    },
+    "v1.61.0": {
+        "tag_object": None,
+        "commit": "b7c74d877b2aca4cb70ab343173f444feca612d0",
+        "tree": "0dda073b96be4955312445a089c625cc902738ca",
+        "package_blob": "884cf4421e2c3d74a8717f707fd3ac83c4bbc8fb",
+    },
+}
+
+_V175_OMISSIONS = (
+    "core/customization_migration/__init__.py",
+    "core/customization_migration/inventory.py",
+    "core/customization_migration/model.py",
+    "core/customization_migration/planning.py",
+    "core/customization_migration/references.py",
+    "core/customization_migration/report.py",
+    "core/customization_migration/service.py",
+    "core/tests/test_customization_assessment.py",
+    "core/tests/test_customization_assessment_doctor.py",
+    "core/tests/test_customization_assessment_planning.py",
+    "core/tests/test_lifecycle_topology_migration.py",
+    "docs/customization-migration-threat-model.md",
+    "docs/plans/2026-07-24-customization-migration-mcp.md",
+)
+
+_NATIVE_MIGRATOR_TRANSPORT = {
+    "dist/release/v1.63.0-08ce719": {
+        "tag_object": "492b56c53dbe469dcac93c7d9a85081026f04132",
+        "commit": "08ce719d595809808e202fa4a7a5fbc68c1b5257",
+        "tree": "87467beec1c11e91ff1bc27223d310b32b9b4978",
+    },
+    "dist/release/v1.63.0-2f006c9": {
+        "tag_object": "25e579ea946e8b493fcec0d2e49aec5cdb9c1141",
+        "commit": "2f006c95adcb566ee6ce881ffb534628ade49d02",
+        "tree": "cfe29096d001d08ba77a9a649c9999d40f250c6e",
+    },
+    "dist/release/v1.63.0-9a0660f": {
+        "tag_object": "d5123c4438c97b5c0e630dddad049f66389d3bc7",
+        "commit": "9a0660f785b4f6d0c15ab3a77b346bb522e80eb7",
+        "tree": "d4bc25fed1798db4e362506b60627da4b4fa97ad",
+    },
+    "dist/release/v1.63.0-9dc6e3d": {
+        "tag_object": "05553ca6f04a2b89a3efbbea9d4901c63b74ae1f",
+        "commit": "9dc6e3dfafd75b23c40607171787bd028099f6d1",
+        "tree": "582bef8eebf62d171c63354b5cf4c618f2ac5593",
+    },
+}
+
+_COMMON_NATIVE_MIGRATOR = {
+    "package_blob": "036655ee0687f89a309b6ac18e763996e719695c",
+    "policy_blob": "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+    "transition_blob": "91069155a2b5d14409d927af8708556f424740bd",
+    "migrator_blob": "57da3fa834ed1f9069f0187dd19b3e3e6f5b5580",
+    "install_blob": "f1ce82fa657786a3b9cae0526a8a8757531f6f39",
+}
+
+
+def _expected_pins() -> dict[str, dict[str, object]]:
+    pins: dict[str, dict[str, object]] = {}
+    for tag, identity in _MANIFESTLESS_MISSING_MIGRATOR.items():
+        pins[tag] = {
+            "kind": "manifestless-missing-migrator",
+            "role": "installed-source",
+            "tag": tag,
+            **identity,
+            "manifest_blob": None,
+            "policy_blob": None,
+            "transition_blob": None,
+            "migrator_blob": None,
+            "unexpected_nonregular_paths": (),
+        }
+    pins["v1.20.1"].update(
+        {
+            "shipped_symlink": {
+                "path": ".pi/agent/extensions/dex",
+                "blob": "f1c88c92cea996705f982e902bafb758156aef52",
+                "target": "../../../pi-extensions/dex",
+            },
+        }
+    )
+    pins["v1.75.0"] = {
+        "kind": "incomplete-manifest",
+        "role": "installed-source",
+        "tag": "v1.75.0",
+        "tag_object": None,
+        "commit": "5e73481519ee9b5fe9a6c3196ee7cabaa0446ee8",
+        "tree": "382b92df5b3a14da90e9122956353f589f2fc0b7",
+        "package_blob": "1cacd5c174cfc309e855bd54ae96bcf04afa4079",
+        "manifest_blob": "6d2105eb1e33bd007ef8b4e2e77b927508a150f7",
+        "manifest_sha256": "6a065ef3bcce45ac8e42d8143a4eb9e3516ea633fd0cbe8c3d2aff10a137ec34",
+        "manifest_path_count": 1201,
+        "omitted_paths": _V175_OMISSIONS,
+        "omitted_paths_sha256": "b476b6a35ac869339e93f6451f13f6a09c6622b7be6ba73ee6e82bc404cc567d",
+        "policy_blob": "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "transition_blob": "2a016eafa4f2712343c3eea206b5be22259e3362",
+        "migrator_blob": "559a870762bd8feb68aac7b6a9f93ec2f99d1efd",
+        "unexpected_nonregular_paths": (),
+    }
+    pins["v1.81.0"] = {
+        "kind": "semantic-no-catalog",
+        "role": "installed-source",
+        "tag": "v1.81.0",
+        "tag_object": None,
+        "commit": "0f23787a22aa52afb40878df05e4819f77d179e6",
+        "tree": "03e1832add6a27bc6c6dc833bfdba2b6cf7fd524",
+        "package_blob": "f54091ab0c0d543c848bb1344b8a0048c067b89f",
+        "catalog_blob": None,
+        "manifest_blob": "1264aba3b8f1cff516caeb277380c09be1973e99",
+        "manifest_sha256": "fdd28af603f7575efcfe358472a60d0513b08d2f0f7aecf8395f7a0da27ea8ca",
+        "manifest_path_count": 1297,
+        "policy_blob": "7d1f2b3ace56e12fce2ff01fafe6435cd1b59e59",
+        "transition_blob": "4b7ad8ff59d95a5e0af7106cb40f3aafa699400c",
+        "migrator_blob": "c73fe7e186abbcd8dc588fa5c94d6244bf156662",
+        "unexpected_nonregular_paths": (),
+    }
+    for tag, identity in _NATIVE_MIGRATOR_TRANSPORT.items():
+        pins[tag] = {
+            "kind": "native-migrator-file-transport",
+            "role": "installed-source",
+            "tag": tag,
+            **identity,
+            **_COMMON_NATIVE_MIGRATOR,
+            "unexpected_nonregular_paths": (),
+        }
+    return pins
+
+
+def _ledger() -> dict[str, dict[str, object]]:
+    """Normalize the bridge's read-only ledger without sharing test objects."""
+
+    return {name: dict(pin) for name, pin in bridge.historic_compatibility_pins().items()}
+
+
+def _authorize(evidence: dict[str, object]) -> str | None:
+    return bridge.historic_compatibility_for(evidence)
+
+
+def test_historic_ledger_is_exactly_the_closed_frozen_set() -> None:
+    """No range, prefix, or latest-version fallback may enter this ledger."""
+
+    assert _ledger() == _expected_pins()
+    assert len(_MANIFESTLESS_MISSING_MIGRATOR) == 13
+    assert len(_V175_OMISSIONS) == 13
+    assert len(_NATIVE_MIGRATOR_TRANSPORT) == 4
+
+
+@pytest.mark.parametrize("name", tuple(_expected_pins()))
+def test_each_frozen_historic_identity_authorizes_only_as_installed_source(name: str) -> None:
+    evidence = deepcopy(_expected_pins()[name])
+
+    assert _authorize(evidence) == name
+
+    modern_target = deepcopy(evidence)
+    modern_target["role"] = "delivery-target"
+    assert _authorize(modern_target) is None
+
+
+@pytest.mark.parametrize("name", tuple(_expected_pins()))
+def test_one_tampered_identity_field_never_inherits_historic_authorization(name: str) -> None:
+    evidence = deepcopy(_expected_pins()[name])
+    evidence["package_blob"] = "0" * 40
+
+    assert _authorize(evidence) is None
+
+
+def test_cross_pairing_a_real_tree_and_a_real_package_is_not_compatibility() -> None:
+    evidence = deepcopy(_expected_pins()["v1.57.0"])
+    evidence["tree"] = _expected_pins()["v1.58.0"]["tree"]
+
+    assert _authorize(evidence) is None
+
+
+def test_v120_tau_symlink_is_exact_and_another_symlink_is_not_allowed() -> None:
+    evidence = deepcopy(_expected_pins()["v1.20.1"])
+    assert _authorize(evidence) == "v1.20.1"
+
+    evidence["shipped_symlink"] = {
+        **evidence["shipped_symlink"],
+        "target": "../../../../outside-the-vault",
+    }
+    assert _authorize(evidence) is None
+
+
+@pytest.mark.parametrize("name", ("v1.75.0", "v1.81.0", "dist/release/v1.63.0-08ce719"))
+def test_unexpected_nonregular_entry_is_not_hidden_by_a_known_historic_shape(name: str) -> None:
+    evidence = deepcopy(_expected_pins()[name])
+    evidence["unexpected_nonregular_paths"] = ("System/unsafe-link",)
+
+    assert _authorize(evidence) is None
+
+
+def test_missing_migrator_policy_transition_and_package_are_a_closed_tuple() -> None:
+    evidence = deepcopy(_expected_pins()["v1.61.0"])
+    assert _authorize(evidence) == "v1.61.0"
+
+    # The empty historical tuple is not permission to borrow newer inputs.
+    evidence["policy_blob"] = _COMMON_NATIVE_MIGRATOR["policy_blob"]
+    evidence["transition_blob"] = _COMMON_NATIVE_MIGRATOR["transition_blob"]
+    assert _authorize(evidence) is None
+
+
+def test_native_file_transport_permission_is_not_reused_by_a_nearby_release() -> None:
+    evidence = deepcopy(_expected_pins()["dist/release/v1.63.0-08ce719"])
+    assert _authorize(evidence) == "dist/release/v1.63.0-08ce719"
+
+    evidence["tag"] = "dist/release/v1.63.0-f2f288e"
+    assert _authorize(evidence) is None
+
+
+def test_modern_foundation_is_not_granted_any_historic_escape_hatch() -> None:
+    """A current target is handled by normal validation, never this ledger."""
+
+    assert _authorize(
+        {
+            "role": "delivery-target",
+            "tag": bridge.FOUNDATION.tag,
+            "tag_object": bridge.FOUNDATION.tag_object,
+            "commit": bridge.FOUNDATION.commit,
+            "tree": bridge.FOUNDATION.tree,
+            "package_blob": "not-a-historic-package",
+            "unexpected_nonregular_paths": (),
+        }
+    ) is None

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -529,6 +529,25 @@ def test_v120_tau_symlink_is_exact_and_another_symlink_is_not_allowed() -> None:
     assert _authorize(evidence) is None
 
 
+def test_v120_manifestless_omission_identities_are_closed() -> None:
+    evidence = deepcopy(_expected_pins()["v1.20.1"])
+    assert _authorize(evidence) == "v1.20.1"
+
+    exact = frozenset(
+        {
+            "af78f3d480b78b5bb558d873b98638c91d532de98f84f8f50e73448a1404b37d",
+            "50a3e65dc2d65e6f6b28b30b630e06656d95ddd82f4a68a7152017119b110f90",
+        }
+    )
+    assert bridge._manifestless_omission_identities_match(exact)
+
+    omitted = next(iter(exact))
+    tampered = frozenset((exact - {omitted}) | {"0" + omitted[1:]})
+    assert not bridge._manifestless_omission_identities_match(tampered)
+    assert not bridge._manifestless_omission_identities_match(exact - {omitted})
+    assert not bridge._manifestless_omission_identities_match(exact | {"f" * 64})
+
+
 @pytest.mark.parametrize("name", ("v1.75.0", "v1.81.0", "dist/release/v1.63.0-08ce719"))
 def test_unexpected_nonregular_entry_is_not_hidden_by_a_known_historic_shape(name: str) -> None:
     evidence = deepcopy(_expected_pins()[name])

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -176,7 +176,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.61.0-a010533", "6ecc9ea45be51d6040466072eeedef9a26dda15f",
@@ -186,7 +186,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.61.0-dc7d332", "113ea147d484da0c2eb3bd80e35fa934388b095e",
@@ -196,7 +196,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-5a4fc2a", "e031be627ae35606770cee498f1101f050e75ef6",
@@ -206,7 +206,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-6de410c", "5e954b3e10e52a48024b6030d3125d35d4699fb3",
@@ -216,7 +216,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-ba4862f", "7157ae8defde2e8698e5b6900bf4c6d9394b16d3",
@@ -226,7 +226,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-cebe07b", "6b5f8f663c08613d5c8c49308bc1d08326e02a8f",
@@ -236,7 +236,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-d1ff64c", "ff0cd2c781a9689e26b0ba207e408649bf02fff1",
@@ -246,7 +246,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "dist/release/v1.62.0-d5bd522", "2abdc01c6a78b1a69eb7484dae151f646c603adc",
@@ -275,8 +275,8 @@ _MISSING_MIGRATOR_FAILURES = (
         "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
         "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
         "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
-        "8cec307895b102363a85992f5f3f5a2c7b0d3730",
-        "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+        "cffb865aafcda0d20e66082f9c5eab4323f7b664",
+        "d4fe097c6be47b5ca6198fbca412959c9777da2e6cafb863235be73c71a376a9",
     ),
     (
         "v1.62.0", "4913a778452003fcf8dc71a10222d5275ff28d5c",
@@ -286,7 +286,7 @@ _MISSING_MIGRATOR_FAILURES = (
         "35fa3d86020fe7b22768c199379508ddb4cef992",
         "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
         "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
-        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
     ),
     (
         "v1.63.0", "eff2f060455f186fcd27f5e680825051baf037b7",
@@ -295,8 +295,8 @@ _MISSING_MIGRATOR_FAILURES = (
         "2f13e9f4f765dbe18a68a6fbe4b58f211eccecd50deba60e45647fdef0b9f6cf",
         "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
         "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
-        "8cec307895b102363a85992f5f3f5a2c7b0d3730",
-        "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+        "cffb865aafcda0d20e66082f9c5eab4323f7b664",
+        "d4fe097c6be47b5ca6198fbca412959c9777da2e6cafb863235be73c71a376a9",
     ),
 )
 

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -369,6 +369,28 @@ def _expected_pins() -> dict[str, dict[str, object]]:
             },
         }
     )
+    pins["dist/release/v1.61.0-774437a"] = {
+        "kind": "complete-manifest-retired-paths",
+        "role": "installed-source",
+        "tag": "dist/release/v1.61.0-774437a",
+        "tag_object": "d1325426421fc0228865b2a64c8e780f2b8056ed",
+        "commit": "774437aadfdb85bf834e2c2e1eacca6488364c18",
+        "tree": "c3a71ece867e43c88dd30b8166c6087da2b344f2",
+        "version": "1.61.0",
+        "package_blob": "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+        "package_sha256": "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        "manifest_blob": "feef2bb3dd6756c7c54d76bdfd6128904c87f679",
+        "manifest_sha256": "edf6e98bc16063c47b362280cfa33fd10f075a5d240d5884d5ded5d894cbcc63",
+        "manifest_path_count": 768,
+        "policy_blob": None,
+        "transition_blob": None,
+        "migrator_blob": None,
+        "omission_identities": (
+            "50a3e65dc2d65e6f6b28b30b630e06656d95ddd82f4a68a7152017119b110f90",
+            "af78f3d480b78b5bb558d873b98638c91d532de98f84f8f50e73448a1404b37d",
+        ),
+        "unexpected_nonregular_paths": (),
+    }
     pins["v1.75.0"] = {
         "kind": "incomplete-manifest",
         "role": "installed-source",
@@ -710,6 +732,27 @@ def test_cross_pairing_a_real_tree_and_a_real_package_is_not_compatibility() -> 
     assert _authorize(evidence) is None
 
 
+@pytest.mark.parametrize(
+    "field",
+    tuple(_expected_pins()["dist/release/v1.61.0-774437a"]),
+)
+def test_retired_manifest_one_field_near_miss_is_refused(field: str) -> None:
+    evidence = deepcopy(_expected_pins()["dist/release/v1.61.0-774437a"])
+    actual = evidence[field]
+    if isinstance(actual, str):
+        evidence[field] = ("0" * len(actual)) if actual else "changed"
+    elif actual is None:
+        evidence[field] = "unexpected-present-input"
+    elif isinstance(actual, int):
+        evidence[field] = actual + 1
+    elif isinstance(actual, tuple):
+        evidence[field] = (("0" * 64), *actual[1:]) if actual else ("unexpected",)
+    else:  # pragma: no cover - fixed literal table guards the supported shapes.
+        raise AssertionError(f"retired-manifest test has unsupported field: {field}")
+
+    assert _authorize(evidence) is None
+
+
 def test_v120_tau_symlink_is_exact_and_another_symlink_is_not_allowed() -> None:
     evidence = deepcopy(_expected_pins()["v1.20.1"])
     assert _authorize(evidence) == "v1.20.1"
@@ -868,6 +911,62 @@ def test_runtime_legacy_topology_refuses_cross_borrowed_existing_inputs(
     assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
 
 
+def test_runtime_retired_manifest_topology_requires_exact_git_and_absent_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.V161_RETIRED_MANIFEST_RELEASE
+    nearby = bridge.MANIFESTLESS_SEMANTIC_RELEASES[-1]
+    repository = _historic_checkout(tmp_path, pin)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", ())
+    monkeypatch.setattr(bridge, "MISSING_MIGRATOR_RELEASES", ())
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is True
+
+    mutations = (
+        replace(pin, tag_object=nearby.tag_object),
+        replace(pin, tag_object_type="commit"),
+        replace(pin, commit=nearby.commit),
+        replace(pin, tree=nearby.tree),
+        replace(pin, package_blob=nearby.package_blob),
+        replace(pin, package_sha256="0" * 64),
+    )
+    for mutation in mutations:
+        monkeypatch.setattr(bridge, "V161_RETIRED_MANIFEST_RELEASE", mutation)
+        assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+    monkeypatch.setattr(bridge, "V161_RETIRED_MANIFEST_RELEASE", pin)
+
+    absent_inputs = (
+        bridge._TRACKED_IGNORE_POLICY_RELATIVE,
+        bridge._PRESERVATION_TRANSITION_RELATIVE,
+        bridge._TOPOLOGY_MIGRATOR_RELATIVE,
+    )
+    for relative in absent_inputs:
+        candidate = repository / relative
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text("unexpected compatibility input\n", encoding="utf-8")
+        assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+        candidate.unlink()
+
+    symlink = repository / bridge._TRACKED_IGNORE_POLICY_RELATIVE
+    symlink.symlink_to(repository / "CLAUDE.md")
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _restore_checkout(repository, pin)
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", nearby.commit)
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _restore_checkout(repository, pin)
+    _git(repository, "checkout", "--quiet", "--detach", "--force", bridge.FOUNDATION.commit)
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+
 def test_runtime_native_transport_matches_only_exact_git_and_regular_files(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -940,6 +1039,19 @@ def test_runtime_retired_manifest_adapter_accepts_exact_public_git_tree(
 ) -> None:
     pin = _V161_RETIRED_MANIFEST_RELEASE
     repository = _historic_checkout(tmp_path, pin)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is True
+
+    # The split migration moves the original Git store into the pre-split
+    # archive, then brain.git fetches the installed commit with --no-tags.
+    # Delivery must rely on the already-proven installed identity, not expect
+    # the annotated release tag to be present in the new brain store.
+    _git(repository, "update-ref", "-d", f"refs/tags/{pin.tag}")
     adapter, service = _delivery_adapter(tmp_path, repository)
     service.commit = pin.commit
     _git(repository, "update-ref", "refs/dex/installed", pin.commit)

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -18,10 +18,15 @@ must be proven exact before the bridge can use an in-memory compatibility view.
 
 from __future__ import annotations
 
+import subprocess
 from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from types import ModuleType
 
 import pytest
 
+from core.update import apply_update
 from scripts import dex_update_bridge as bridge
 
 # These are independent historical Git identities.  A ``None`` value is part
@@ -420,6 +425,93 @@ def _authorize_missing_migrator(evidence: dict[str, object]) -> str | None:
     return bridge.historic_missing_migrator_for(evidence)
 
 
+def _git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "user.name=Dex Updater Test",
+            "-c",
+            "user.email=updater-test@example.invalid",
+            "-C",
+            str(repository),
+            *arguments,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return completed.stdout.decode("utf-8").strip()
+
+
+def _historic_checkout(tmp_path: Path, pin: bridge.HistoricReleasePin) -> Path:
+    """Make a disposable checkout backed by the test runner's real Git objects."""
+
+    repository = tmp_path / "historic-vault"
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--quiet",
+            "--shared",
+            "--no-checkout",
+            str(Path(__file__).resolve().parents[2]),
+            str(repository),
+        ],
+        check=True,
+    )
+    _git(repository, "checkout", "--quiet", "--detach", pin.commit)
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", pin.tag_object)
+    return repository
+
+
+def _restore_checkout(repository: Path, pin: bridge.HistoricReleasePin) -> None:
+    _git(repository, "checkout", "--quiet", "--detach", "--force", pin.commit)
+    _git(repository, "clean", "-dffx")
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", pin.tag_object)
+
+
+def _delivery_adapter(
+    tmp_path: Path,
+    repository: Path,
+) -> tuple[bridge._FoundationLifecycleService, object]:
+    source = tmp_path / "foundation-source"
+    migrator = source / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    migrator.parent.mkdir(parents=True)
+    migrator.write_text("'use strict';\n", encoding="utf-8")
+
+    engine = ModuleType("historic_delivery_engine")
+    engine.TOPOLOGY_MIGRATOR_RELATIVE = bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    engine.topology_state = lambda _root: "invalid-combined"
+    engine._migrator_command = lambda _root, _mode: []
+
+    class DeliveryService:
+        commit = ""
+
+        def build_and_preview_delivered_release(self, _vault_root: Path, _release: object):
+            entries = apply_update._tree_entries(repository, repository / ".git", self.commit)
+            apply_update._verify_manifest(repository, repository / ".git", entries)
+            return entries
+
+    service = DeliveryService()
+    return bridge._FoundationLifecycleService(service, engine, apply_update, source), service
+
+
+def _commit_nonregular_variant(repository: Path, base: str, mode: str, name: str) -> tuple[str, str]:
+    _git(repository, "checkout", "--quiet", "--detach", "--force", base)
+    if mode == "120000":
+        target = repository / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to("CLAUDE.md")
+        _git(repository, "add", "--", name)
+    else:
+        _git(repository, "update-index", "--add", "--cacheinfo", f"160000,{base},{name}")
+    _git(repository, "commit", "--quiet", "-m", f"test {mode} entry")
+    commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    return commit, _git(repository, "rev-parse", "HEAD^{tree}")
+
+
 def test_historic_ledger_is_exactly_the_closed_frozen_set() -> None:
     """No range, prefix, or latest-version fallback may enter this ledger."""
 
@@ -588,3 +680,270 @@ def test_modern_foundation_is_not_granted_any_historic_escape_hatch() -> None:
             "unexpected_nonregular_paths": (),
         }
     ) is None
+
+
+def test_runtime_legacy_topology_matches_real_git_and_regular_files_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.MANIFESTLESS_SEMANTIC_RELEASES[1]
+    nearby = bridge.MANIFESTLESS_SEMANTIC_RELEASES[2]
+    repository = _historic_checkout(tmp_path, pin)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", (pin,))
+    monkeypatch.setattr(bridge, "MISSING_MIGRATOR_RELEASES", ())
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is True
+
+    mutations = (
+        replace(pin, tag_object=nearby.tag_object),
+        replace(pin, tag_object_type="tag"),
+        replace(pin, commit=nearby.commit),
+        replace(pin, tree=nearby.tree),
+        replace(pin, package_blob=nearby.package_blob),
+        replace(pin, package_sha256="0" * 64),
+    )
+    for mutation in mutations:
+        monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", (mutation,))
+        assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", (pin,))
+
+    package = repository / bridge._PACKAGE_RELATIVE
+    package.write_text('{"version":"1.49.0","tampered":true}\n', encoding="utf-8")
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _restore_checkout(repository, pin)
+    package.unlink()
+    package.symlink_to("CLAUDE.md")
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _restore_checkout(repository, pin)
+    package.unlink()
+    package.mkdir()
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _restore_checkout(repository, pin)
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", nearby.commit)
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+    _git(repository, "checkout", "--quiet", "--detach", "--force", bridge.FOUNDATION.commit)
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+
+def test_runtime_legacy_topology_refuses_cross_borrowed_existing_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.MISSING_MIGRATOR_RELEASES[0]
+    borrowed = bridge.MISSING_MIGRATOR_RELEASES[8]
+    repository = _historic_checkout(tmp_path, pin.release)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", ())
+    monkeypatch.setattr(bridge, "MISSING_MIGRATOR_RELEASES", (pin,))
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is True
+
+    for relative, blob in (
+        (bridge._TRACKED_IGNORE_POLICY_RELATIVE, borrowed.inputs.policy_blob),
+        (bridge._PRESERVATION_TRANSITION_RELATIVE, borrowed.inputs.transition_blob),
+    ):
+        (repository / relative).write_bytes(
+            subprocess.run(
+                ["git", "-C", str(repository), "cat-file", "blob", blob],
+                check=True,
+                capture_output=True,
+            ).stdout
+        )
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+
+def test_runtime_native_transport_matches_only_exact_git_and_regular_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.NATIVE_MIGRATOR_TRANSPORT_RELEASES[0]
+    nearby = bridge.NATIVE_MIGRATOR_TRANSPORT_RELEASES[1]
+    repository = _historic_checkout(tmp_path, pin)
+
+    assert bridge._native_transport_release(repository) == pin
+    monkeypatch.setattr(bridge, "NATIVE_MIGRATOR_TRANSPORT_RELEASES", (pin,))
+
+    package = repository / bridge._PACKAGE_RELATIVE
+    package.write_text('{"version":"1.63.0","tampered":true}\n', encoding="utf-8")
+    assert bridge._native_transport_release(repository) is None
+
+    _restore_checkout(repository, pin)
+    candidate = repository / bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    candidate.unlink()
+    candidate.symlink_to(repository / "CLAUDE.md")
+    assert bridge._native_transport_release(repository) is None
+
+    _restore_checkout(repository, pin)
+    candidate = repository / bridge._TRACKED_IGNORE_POLICY_RELATIVE
+    candidate.unlink()
+    candidate.mkdir()
+    assert bridge._native_transport_release(repository) is None
+
+    _restore_checkout(repository, pin)
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", nearby.tag_object)
+    assert bridge._native_transport_release(repository) is None
+
+    _git(repository, "checkout", "--quiet", "--detach", "--force", bridge.FOUNDATION.commit)
+    assert bridge._native_transport_release(repository) is None
+
+
+def test_runtime_manifest_omission_adapter_accepts_only_exact_historic_trees(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifestless = bridge.MANIFESTLESS_SEMANTIC_RELEASES[0]
+    repository = _historic_checkout(tmp_path, manifestless)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+
+    service.commit = manifestless.commit
+    _git(repository, "update-ref", "refs/dex/installed", manifestless.commit)
+    entries = adapter.build_and_preview_delivered_release(repository, {})
+    assert bridge._LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix() not in {
+        entry.path for entry in entries
+    }
+    assert "System/.installed-files.manifest" not in {entry.path for entry in entries}
+
+    defective = bridge.V175_DEFECTIVE_MANIFEST_RELEASE
+    _restore_checkout(repository, defective)
+    service.commit = defective.commit
+    _git(repository, "update-ref", "refs/dex/installed", defective.commit)
+    entries = adapter.build_and_preview_delivered_release(repository, {})
+    paths = {entry.path for entry in entries}
+    assert len(entries) == 1201
+    assert paths.isdisjoint(bridge._V175_DEFECTIVE_MANIFEST_OMISSIONS)
+
+    changed = dict(bridge._V175_DEFECTIVE_MANIFEST_OMISSIONS)
+    changed[next(iter(changed))] = "0" * 40
+    monkeypatch.setattr(bridge, "_V175_DEFECTIVE_MANIFEST_OMISSIONS", changed)
+    with pytest.raises(apply_update.ReleaseVerificationError, match="omission changed"):
+        adapter.build_and_preview_delivered_release(repository, {})
+
+
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    (("120000", "unknown symlink"), ("160000", "ambiguous")),
+)
+def test_runtime_manifest_omission_adapter_refuses_real_unknown_nonregular_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    message: str,
+) -> None:
+    defective = bridge.V175_DEFECTIVE_MANIFEST_RELEASE
+    repository = _historic_checkout(tmp_path, defective)
+    commit, tree = _commit_nonregular_variant(
+        repository,
+        defective.commit,
+        mode,
+        "System/unexpected-nonregular",
+    )
+    mutation = replace(
+        defective,
+        tag_object=commit,
+        tag_object_type="commit",
+        commit=commit,
+        tree=tree,
+    )
+    monkeypatch.setattr(bridge, "V175_DEFECTIVE_MANIFEST_RELEASE", mutation)
+    _git(repository, "update-ref", "refs/dex/installed", commit)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = commit
+
+    with pytest.raises(apply_update.ReleaseVerificationError, match=message):
+        adapter.build_and_preview_delivered_release(repository, {})
+
+
+def test_runtime_manifest_adapter_binds_entries_to_installed_commit_and_keeps_unknown_modern_strict(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.MANIFESTLESS_SEMANTIC_RELEASES[1]
+    nearby = bridge.MANIFESTLESS_SEMANTIC_RELEASES[2]
+    repository = _historic_checkout(tmp_path, pin)
+    adapter, _service = _delivery_adapter(tmp_path, repository)
+    _git(repository, "update-ref", "refs/dex/installed", pin.commit)
+
+    with adapter._legacy_delivery_source():
+        entries = apply_update._tree_entries(repository, repository / ".git", pin.commit)
+        _git(repository, "update-ref", "refs/dex/installed", nearby.commit)
+        with pytest.raises(apply_update.ReleaseVerificationError, match="identity changed"):
+            apply_update._verify_manifest(repository, repository / ".git", entries)
+
+    modern = bridge.V181_UNBOUND_JOURNEY_SOURCE.release
+    _restore_checkout(repository, modern)
+    _git(repository, "rm", "--quiet", "System/.installed-files.manifest")
+    _git(repository, "commit", "--quiet", "-m", "test unknown manifestless modern tree")
+    unknown_commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    _git(repository, "update-ref", "refs/dex/installed", unknown_commit)
+    with adapter._legacy_delivery_source():
+        entries = apply_update._tree_entries(repository, repository / ".git", unknown_commit)
+        with pytest.raises(apply_update.ReleaseVerificationError, match="missing its installed-files manifest"):
+            apply_update._verify_manifest(repository, repository / ".git", entries)
+
+
+def test_exact_unbound_journey_source_uses_real_git_identity_and_artifact_blobs(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.V181_UNBOUND_JOURNEY_SOURCE
+    repository = _historic_checkout(tmp_path, pin.release)
+
+    assert bridge.exact_unbound_journey_source(repository, pin.release.tag) == pin.release.commit
+
+    nearby = bridge.MANIFESTLESS_SEMANTIC_RELEASES[-1]
+    release_mutations = (
+        replace(pin.release, tag_object=nearby.tag_object),
+        replace(pin.release, commit=nearby.commit),
+        replace(pin.release, tree=nearby.tree),
+    )
+    for release in release_mutations:
+        assert bridge.exact_unbound_journey_source(
+            repository,
+            pin.release.tag,
+            replace(pin, release=release),
+        ) is None
+
+    first_artifact = pin.artifacts[0]
+    changed_artifacts = ((first_artifact[0], "0" * 40, first_artifact[2]), *pin.artifacts[1:])
+    assert bridge.exact_unbound_journey_source(
+        repository,
+        pin.release.tag,
+        replace(pin, artifacts=changed_artifacts),
+    ) is None
+
+    _git(repository, "update-ref", f"refs/tags/{pin.release.tag}", nearby.commit)
+    assert bridge.exact_unbound_journey_source(repository, pin.release.tag) is None
+    assert bridge.exact_unbound_journey_source(repository, bridge.FOUNDATION.tag) is None
+
+    _restore_checkout(repository, pin.release)
+    catalog = repository / "System/.release-catalog.json"
+    catalog.write_text("{}\n", encoding="utf-8")
+    _git(repository, "add", "--", catalog.relative_to(repository).as_posix())
+    _git(repository, "commit", "--quiet", "-m", "test catalog-bearing source")
+    catalog_commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    catalog_tree = _git(repository, "rev-parse", "HEAD^{tree}")
+    _git(repository, "update-ref", f"refs/tags/{pin.release.tag}", catalog_commit)
+    catalog_pin = replace(
+        pin,
+        release=replace(
+            pin.release,
+            tag_object=catalog_commit,
+            commit=catalog_commit,
+            tree=catalog_tree,
+        ),
+    )
+    assert bridge.exact_unbound_journey_source(repository, pin.release.tag, catalog_pin) is None

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -18,6 +18,7 @@ must be proven exact before the bridge can use an in-memory compatibility view.
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from copy import deepcopy
 from dataclasses import replace
@@ -151,6 +152,17 @@ _NATIVE_MIGRATOR_TRANSPORT = {
         "tree": "582bef8eebf62d171c63354b5cf4c618f2ac5593",
     },
 }
+
+_V161_RETIRED_MANIFEST_RELEASE = bridge.HistoricReleasePin(
+    "dist/release/v1.61.0-774437a",
+    "d1325426421fc0228865b2a64c8e780f2b8056ed",
+    "tag",
+    "774437aadfdb85bf834e2c2e1eacca6488364c18",
+    "c3a71ece867e43c88dd30b8166c6087da2b344f2",
+    "1.61.0",
+    "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+    "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+)
 
 _COMMON_NATIVE_MIGRATOR = {
     "package_blob": "036655ee0687f89a309b6ac18e763996e719695c",
@@ -492,6 +504,8 @@ def _delivery_adapter(
         def build_and_preview_delivered_release(self, _vault_root: Path, _release: object):
             entries = apply_update._tree_entries(repository, repository / ".git", self.commit)
             apply_update._verify_manifest(repository, repository / ".git", entries)
+            for entry in entries:
+                apply_update.portable_contract.resolve(entry.path)
             return entries
 
     service = DeliveryService()
@@ -551,6 +565,51 @@ def _commit_manifestless_omission_variant(
     )
     commit = _git(repository, "rev-parse", "HEAD^{commit}")
     return commit, _git(repository, "rev-parse", "HEAD^{tree}")
+
+
+def _commit_retired_manifest_variant(
+    repository: Path,
+    base: str,
+    mutation: str,
+) -> tuple[str, str, str, str]:
+    """Create a manifest-consistent real Git near-miss around the retired pair."""
+
+    readme = "extensions/tau-mirror/README-TAU-MIRROR.md"
+    unexpected = "extensions/tau-mirror/unexpected.md"
+    manifest = repository / "System/.installed-files.manifest"
+    _git(repository, "checkout", "--quiet", "--detach", "--force", base)
+    paths = manifest.read_text(encoding="utf-8").splitlines()
+    if mutation == "missing":
+        _git(repository, "rm", "--quiet", "--", readme)
+        paths.remove(readme)
+    elif mutation == "extra":
+        target = repository / unexpected
+        target.write_text("unexpected retired content\n", encoding="utf-8")
+        _git(repository, "add", "--", unexpected)
+        paths.append(unexpected)
+    elif mutation == "tampered-blob":
+        (repository / readme).write_text("tampered historic bytes\n", encoding="utf-8")
+        _git(repository, "add", "--", readme)
+    elif mutation == "altered-mode":
+        _git(repository, "update-index", "--chmod=+x", "--", readme)
+    elif mutation == "renamed-path":
+        _git(repository, "mv", "--", readme, unexpected)
+        paths[paths.index(readme)] = unexpected
+    else:  # pragma: no cover - the parametrization below is deliberately closed
+        raise AssertionError(f"unknown test mutation: {mutation}")
+    if mutation in {"missing", "extra", "renamed-path"}:
+        manifest.write_text("\n".join(sorted(paths)) + "\n", encoding="utf-8")
+        _git(repository, "add", "--", "System/.installed-files.manifest")
+    _git(repository, "commit", "--quiet", "-m", f"test retired manifest {mutation}")
+    commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    tree = _git(repository, "rev-parse", "HEAD^{tree}")
+    manifest_blob = _git(repository, "rev-parse", f"{commit}:System/.installed-files.manifest")
+    manifest_sha256 = subprocess.run(
+        ["git", "-C", str(repository), "cat-file", "blob", manifest_blob],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return commit, tree, manifest_blob, hashlib.sha256(manifest_sha256).hexdigest()
 
 
 def test_historic_ledger_is_exactly_the_closed_frozen_set() -> None:
@@ -873,6 +932,87 @@ def test_runtime_manifest_omission_adapter_accepts_only_exact_historic_trees(
     changed[next(iter(changed))] = "0" * 40
     monkeypatch.setattr(bridge, "_V175_DEFECTIVE_MANIFEST_OMISSIONS", changed)
     with pytest.raises(apply_update.ReleaseVerificationError, match="omission changed"):
+        adapter.build_and_preview_delivered_release(repository, {})
+
+
+def test_runtime_retired_manifest_adapter_accepts_exact_public_git_tree(
+    tmp_path: Path,
+) -> None:
+    pin = _V161_RETIRED_MANIFEST_RELEASE
+    repository = _historic_checkout(tmp_path, pin)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = pin.commit
+    _git(repository, "update-ref", "refs/dex/installed", pin.commit)
+    retired_bytes = {
+        relative: (repository / relative).read_bytes()
+        for relative in (
+            "extensions/tau-mirror/README-TAU-MIRROR.md",
+            "extensions/tau-mirror/tau-mirror-integration.ts",
+        )
+    }
+
+    entries = adapter.build_and_preview_delivered_release(repository, {})
+
+    assert bridge.V161_RETIRED_MANIFEST_RELEASE == pin
+    assert bridge._V161_RETIRED_MANIFEST_BLOB == "feef2bb3dd6756c7c54d76bdfd6128904c87f679"
+    assert (
+        bridge._V161_RETIRED_MANIFEST_SHA256
+        == "edf6e98bc16063c47b362280cfa33fd10f075a5d240d5884d5ded5d894cbcc63"
+    )
+    assert len(entries) == 766
+    assert {
+        "extensions/tau-mirror/README-TAU-MIRROR.md",
+        "extensions/tau-mirror/tau-mirror-integration.ts",
+    }.isdisjoint(entry.path for entry in entries)
+    assert {
+        relative: (repository / relative).read_bytes() for relative in retired_bytes
+    } == retired_bytes
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("missing", "omission set changed"),
+        ("extra", "unknown unclassified path"),
+        ("tampered-blob", "unknown unclassified path"),
+        ("altered-mode", "unknown unclassified path"),
+        ("renamed-path", "unknown unclassified path"),
+    ),
+)
+def test_runtime_retired_manifest_adapter_refuses_real_git_identity_near_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+    message: str,
+) -> None:
+    pin = _V161_RETIRED_MANIFEST_RELEASE
+    repository = _historic_checkout(tmp_path, pin)
+    commit, tree, manifest_blob, manifest_sha256 = _commit_retired_manifest_variant(
+        repository,
+        pin.commit,
+        mutation,
+    )
+    mutated_pin = replace(
+        pin,
+        tag_object=commit,
+        tag_object_type="commit",
+        commit=commit,
+        tree=tree,
+    )
+    _git(repository, "update-ref", f"refs/tags/{pin.tag}", commit)
+    _git(repository, "update-ref", "refs/dex/installed", commit)
+    monkeypatch.setattr(bridge, "V161_RETIRED_MANIFEST_RELEASE", mutated_pin, raising=False)
+    monkeypatch.setattr(bridge, "_V161_RETIRED_MANIFEST_BLOB", manifest_blob, raising=False)
+    monkeypatch.setattr(
+        bridge,
+        "_V161_RETIRED_MANIFEST_SHA256",
+        manifest_sha256,
+        raising=False,
+    )
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = commit
+
+    with pytest.raises(apply_update.ReleaseVerificationError, match=message):
         adapter.build_and_preview_delivered_release(repository, {})
 
 

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -434,7 +434,7 @@ def _git(repository: Path, *arguments: str) -> str:
             "-c",
             "user.name=Dex Updater Test",
             "-c",
-            "user.email=updater-test@example.invalid",
+            "user.email=updater-test@example.com",
             "-C",
             str(repository),
             *arguments,
@@ -508,6 +508,47 @@ def _commit_nonregular_variant(repository: Path, base: str, mode: str, name: str
     else:
         _git(repository, "update-index", "--add", "--cacheinfo", f"160000,{base},{name}")
     _git(repository, "commit", "--quiet", "-m", f"test {mode} entry")
+    commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    return commit, _git(repository, "rev-parse", "HEAD^{tree}")
+
+
+def _commit_manifestless_omission_variant(
+    repository: Path,
+    base: str,
+    mutation: str,
+) -> tuple[str, str]:
+    """Create one real Git near-miss around the closed legacy omission pair."""
+
+    readme = "extensions/tau-mirror/README-TAU-MIRROR.md"
+    unexpected = "extensions/tau-mirror/unexpected.md"
+    _git(repository, "checkout", "--quiet", "--detach", "--force", base)
+    if mutation == "missing":
+        _git(repository, "rm", "--quiet", "--", readme)
+    elif mutation == "extra":
+        blob = _git(repository, "rev-parse", f"{base}:{readme}")
+        _git(
+            repository,
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"100644,{blob},{unexpected}",
+        )
+    elif mutation == "tampered-blob":
+        (repository / readme).write_text("tampered historic bytes\n", encoding="utf-8")
+        _git(repository, "add", "--", readme)
+    elif mutation == "altered-mode":
+        _git(repository, "update-index", "--chmod=+x", "--", readme)
+    elif mutation == "renamed-path":
+        _git(repository, "mv", "--", readme, unexpected)
+    else:  # pragma: no cover - the parametrization below is deliberately closed
+        raise AssertionError(f"unknown test mutation: {mutation}")
+    _git(
+        repository,
+        "commit",
+        "--quiet",
+        "-m",
+        f"test manifestless omission {mutation}",
+    )
     commit = _git(repository, "rev-parse", "HEAD^{commit}")
     return commit, _git(repository, "rev-parse", "HEAD^{tree}")
 
@@ -832,6 +873,42 @@ def test_runtime_manifest_omission_adapter_accepts_only_exact_historic_trees(
     changed[next(iter(changed))] = "0" * 40
     monkeypatch.setattr(bridge, "_V175_DEFECTIVE_MANIFEST_OMISSIONS", changed)
     with pytest.raises(apply_update.ReleaseVerificationError, match="omission changed"):
+        adapter.build_and_preview_delivered_release(repository, {})
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("missing", "omission set changed"),
+        ("extra", "unknown unclassified path"),
+        ("tampered-blob", "unknown unclassified path"),
+        ("altered-mode", "unknown unclassified path"),
+        ("renamed-path", "unknown unclassified path"),
+    ),
+)
+def test_runtime_manifest_omission_adapter_refuses_real_git_identity_near_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+    message: str,
+) -> None:
+    pin = bridge.MANIFESTLESS_SEMANTIC_RELEASES[1]
+    repository = _historic_checkout(tmp_path, pin)
+    commit, tree = _commit_manifestless_omission_variant(
+        repository,
+        pin.commit,
+        mutation,
+    )
+    # Rebind only the immutable outer tree pin so this near-miss reaches the
+    # production omission matcher; neither its identity function nor its
+    # closed expected set is replaced here.
+    mutated_pin = replace(pin, commit=commit, tree=tree)
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", (mutated_pin,))
+    _git(repository, "update-ref", "refs/dex/installed", commit)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = commit
+
+    with pytest.raises(apply_update.ReleaseVerificationError, match=message):
         adapter.build_and_preview_delivered_release(repository, {})
 
 

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -8,6 +8,12 @@ complete *installed-source* identity.  The latter must return ``None`` for
 every near miss; it is not an ancestry, version, or best-effort compatibility
 detector.  Filesystem/Git collection belongs to the bridge, while this module
 keeps the authorization policy independently frozen and easy to audit.
+
+The separate existing-inputs cohort uses the equivalent
+``historic_missing_migrator_pins()`` and
+``historic_missing_migrator_for(evidence)`` seams.  It must not be folded into
+the manifestless ledger: its policy and transition inputs already exist and
+must be proven exact before the bridge can use an in-memory compatibility view.
 """
 
 from __future__ import annotations
@@ -151,6 +157,179 @@ _COMMON_NATIVE_MIGRATOR = {
 }
 
 
+# This is intentionally a *separate* failure class from the 13 manifestless
+# semantic releases above.  These are the precise 13 historic installations
+# that retained policy + transition inputs but not the topology migrator.  The
+# table comes from the sealed 170-case breadth summary and the production
+# bridge's closed ``MissingMigratorPin`` tuples.  A release must match its own
+# release identity *and* its own existing-input tuple; no tuple is a generic
+# migration permission.
+_MISSING_MIGRATOR_FAILURES = (
+    (
+        "dist/release/v1.61.0-03c33d3",
+        "b278bc51278c5b141dd65883fec920c8cb92d17a",
+        "03c33d3c956557d1077ae2606168732a2c05bfb0",
+        "f4e950f8266bd770ff99ce59f4b0de02ae8f2e19",
+        "1.61.0",
+        "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+        "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.61.0-a010533", "6ecc9ea45be51d6040466072eeedef9a26dda15f",
+        "a010533278912f092e6920447846f2c7b3402abe", "3cd446661d70a9f2bc5f9fcd58083efbd2f4b436",
+        "1.61.0", "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+        "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.61.0-dc7d332", "113ea147d484da0c2eb3bd80e35fa934388b095e",
+        "dc7d332bed63589982664eca493da925cd1da6ce", "75f5fd9ae7baa05ee775093661e258746a18b0fb",
+        "1.61.0", "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+        "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-5a4fc2a", "e031be627ae35606770cee498f1101f050e75ef6",
+        "5a4fc2a5a00f8523c231d840cbe9b2decb9b101e", "d51076f79dfac62020f83fa9430defe2ca605201",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-6de410c", "5e954b3e10e52a48024b6030d3125d35d4699fb3",
+        "6de410cce1b7bb80a4195940092bd5e82d7c32cf", "c0d5374d8e0494df461f012458b937fae797d007",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-ba4862f", "7157ae8defde2e8698e5b6900bf4c6d9394b16d3",
+        "ba4862f55813d34ab7ec6970507dc40e3ef8027f", "235168077df9621db3fcddfb677633bdcc946723",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-cebe07b", "6b5f8f663c08613d5c8c49308bc1d08326e02a8f",
+        "cebe07b23d6ceabf286ad31a24ce1aed23321c29", "4ec6aad8d9d162ccc489fbf7a9ff4b37f3e83b95",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-d1ff64c", "ff0cd2c781a9689e26b0ba207e408649bf02fff1",
+        "d1ff64c7f8938cb81b548bc7238c4cc9dc398a64", "feba9f46177dd802b698d5acd60896282b1508ff",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "dist/release/v1.62.0-d5bd522", "2abdc01c6a78b1a69eb7484dae151f646c603adc",
+        "d5bd522bccc3d17498d3c0c1e437ca0909c975a4", "3de9d2ec9884d4c97c471ecbf32236572fb8d496",
+        "1.62.0", "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+        "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+        "8cec307895b102363a85992f5f3f5a2c7b0d3730",
+        "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+    ),
+    (
+        "dist/release/v1.63.0-6167d6e", "041d65c0e5706b191eea172fbe59762f66cbf3c9",
+        "6167d6ef82d1607ed65b7b795538eb4ccdb23cbe", "c3e961ac5cbef45d762962ecd50b4fafbdece958",
+        "1.63.0", "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+        "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+        "91069155a2b5d14409d927af8708556f424740bd",
+        "afd7f6338561ecd3597f32552e594f14630028f9ced64755f6dc11249b43d7a4",
+    ),
+    (
+        "dist/release/v1.63.0-d1050f4", "d4a49d6be2e5bdccf6ceee3cc6f016524e4d02bc",
+        "d1050f47598a1625205dc571313dc3d4d08cfcd3", "b18cee1e7f61d4873c0748bd48396d7aa9ccd985",
+        "1.63.0", "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+        "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+        "8cec307895b102363a85992f5f3f5a2c7b0d3730",
+        "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+    ),
+    (
+        "v1.62.0", "4913a778452003fcf8dc71a10222d5275ff28d5c",
+        "77c4a15a7884080e48b095c8de2c384d01a87883", "1bf30a86c151890024040f0e4e1a533be17c5686",
+        "1.62.0", "2d7f21a72798d4189f042e955e62ee799e90a90c",
+        "75bef63d563a7e5062db6ad664ccb65a7581dbfd3d466655d1b3709bbad7ffa5",
+        "35fa3d86020fe7b22768c199379508ddb4cef992",
+        "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+        "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+        "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e",
+    ),
+    (
+        "v1.63.0", "eff2f060455f186fcd27f5e680825051baf037b7",
+        "b5ee55366f3600b79748a9b56e063a9825172a45", "a418102a6d8254a14c81575d1d86aea7d28bd6f8",
+        "1.63.0", "846e23a1dd09c7096784268b234fde7139915575",
+        "2f13e9f4f765dbe18a68a6fbe4b58f211eccecd50deba60e45647fdef0b9f6cf",
+        "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+        "8cec307895b102363a85992f5f3f5a2c7b0d3730",
+        "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+    ),
+)
+
+
+def _missing_migrator_ledger() -> dict[str, dict[str, object]]:
+    """Independent expected public seam for exact existing-input authorizations."""
+
+    fields = (
+        "tag",
+        "tag_object",
+        "commit",
+        "tree",
+        "version",
+        "package_blob",
+        "package_sha256",
+        "policy_blob",
+        "policy_sha256",
+        "transition_blob",
+        "transition_sha256",
+    )
+    return {
+        values[0]: {
+            "kind": "existing-inputs-missing-migrator",
+            "role": "installed-source",
+            **dict(zip(fields, values, strict=True)),
+            "migrator_blob": None,
+            "migrator_state": "absent",
+            "overwrite_existing_inputs": False,
+        }
+        for values in _MISSING_MIGRATOR_FAILURES
+    }
+
+
 def _expected_pins() -> dict[str, dict[str, object]]:
     pins: dict[str, dict[str, object]] = {}
     for tag, identity in _MANIFESTLESS_MISSING_MIGRATOR.items():
@@ -231,6 +410,17 @@ def _authorize(evidence: dict[str, object]) -> str | None:
     return bridge.historic_compatibility_for(evidence)
 
 
+def _missing_migrator_pins() -> dict[str, dict[str, object]]:
+    return {
+        name: dict(pin)
+        for name, pin in bridge.historic_missing_migrator_pins().items()
+    }
+
+
+def _authorize_missing_migrator(evidence: dict[str, object]) -> str | None:
+    return bridge.historic_missing_migrator_for(evidence)
+
+
 def test_historic_ledger_is_exactly_the_closed_frozen_set() -> None:
     """No range, prefix, or latest-version fallback may enter this ledger."""
 
@@ -238,6 +428,69 @@ def test_historic_ledger_is_exactly_the_closed_frozen_set() -> None:
     assert len(_MANIFESTLESS_MISSING_MIGRATOR) == 13
     assert len(_V175_OMISSIONS) == 13
     assert len(_NATIVE_MIGRATOR_TRANSPORT) == 4
+
+
+def test_missing_migrator_ledger_is_the_exact_13_case_failure_group() -> None:
+    """The old existing-inputs problem cannot grow into a version-range rule."""
+
+    assert _missing_migrator_pins() == _missing_migrator_ledger()
+    assert len(_MISSING_MIGRATOR_FAILURES) == 13
+
+
+@pytest.mark.parametrize("name", tuple(_missing_migrator_ledger()))
+def test_each_missing_migrator_tuple_is_authorized_only_when_complete(name: str) -> None:
+    evidence = deepcopy(_missing_migrator_ledger()[name])
+    assert _authorize_missing_migrator(evidence) == name
+
+
+@pytest.mark.parametrize("name", tuple(_missing_migrator_ledger()))
+@pytest.mark.parametrize(
+    "field",
+    (
+        "tag",
+        "tag_object",
+        "commit",
+        "tree",
+        "version",
+        "package_blob",
+        "package_sha256",
+        "policy_blob",
+        "policy_sha256",
+        "transition_blob",
+        "transition_sha256",
+        "migrator_blob",
+        "migrator_state",
+        "overwrite_existing_inputs",
+        "role",
+    ),
+)
+def test_missing_migrator_one_field_near_miss_is_refused(
+    name: str,
+    field: str,
+) -> None:
+    evidence = deepcopy(_missing_migrator_ledger()[name])
+    actual = evidence[field]
+    if isinstance(actual, str):
+        evidence[field] = ("0" * len(actual)) if actual else "changed"
+    elif actual is None:
+        evidence[field] = "unexpected-present-migrator"
+    elif isinstance(actual, bool):
+        evidence[field] = not actual
+    else:  # pragma: no cover - fixed literal table guards the supported shapes.
+        raise AssertionError(f"missing-migrator test has unsupported field: {field}")
+
+    assert _authorize_missing_migrator(evidence) is None
+
+
+def test_missing_migrator_tuple_cannot_borrow_a_nearby_release_inputs() -> None:
+    source = deepcopy(_missing_migrator_ledger()["dist/release/v1.62.0-d5bd522"])
+    nearby = _missing_migrator_ledger()["dist/release/v1.62.0-5a4fc2a"]
+    source["policy_blob"] = nearby["policy_blob"]
+    source["policy_sha256"] = nearby["policy_sha256"]
+    source["transition_blob"] = nearby["transition_blob"]
+    source["transition_sha256"] = nearby["transition_sha256"]
+
+    assert _authorize_missing_migrator(source) is None
 
 
 @pytest.mark.parametrize("name", tuple(_expected_pins()))

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "a061e10a92ae724dc3d49409cc235b060082e2a38e9e043a255f92525d570567",
+    "sha256": "74043a814c261ce401cf07dbd06e8d2779bfb95b09fcee5d76f5f7ce15e0417d",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "2df8dd343c8fa067a60752e46bab2b7c8ea7ad886b2bfd5f1b010f7fc68c30fb",
+      "sha256": "c0958baa48e6c0e128ec73aa0abfad8c19cb6f9b5758bd631e4b76cf0412a0cc",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "ae8d80fa335325624adc181367ec7a8cce52a45c68cc1b65285c04e2b9522a44",
+      "sha256": "18e8f0397e14cc5a79ed45887f5dc6989a2b65dc561fbba66c837bacb8f44095",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "c0958baa48e6c0e128ec73aa0abfad8c19cb6f9b5758bd631e4b76cf0412a0cc",
+      "sha256": "ae8d80fa335325624adc181367ec7a8cce52a45c68cc1b65285c04e2b9522a44",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "cd574fc09138bdc251537fb4759f559a2d11f376ed08807d815459f8cdf0ceb4",
+    "sha256": "a061e10a92ae724dc3d49409cc235b060082e2a38e9e043a255f92525d570567",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "c17e0372f78aa38904f18e60831651d4b37613bd6376fc18bb4cb49e20e29715",
+      "sha256": "89d5810643b0aff4bcb0a0a30debede34f3e1cfc2464691fb1bd815f0b0ab4b0",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "bc1ed084a3248a5bc98e91dc20a74b0caed66d22525357f7d4480657ca07e5ce",
+    "sha256": "f67ff3cc8f35f14750479085982e73c7ea27b45a001ac93689ce8e8d46767f74",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "74043a814c261ce401cf07dbd06e8d2779bfb95b09fcee5d76f5f7ce15e0417d",
+    "sha256": "f93d0079dfea67db17f86a6ab24694b16d81d5e72adeef6e70885cfba050d9f4",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "89d5810643b0aff4bcb0a0a30debede34f3e1cfc2464691fb1bd815f0b0ab4b0",
+      "sha256": "2df8dd343c8fa067a60752e46bab2b7c8ea7ad886b2bfd5f1b010f7fc68c30fb",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -3637,19 +3637,23 @@ def _worktree_blob_ids(
 ) -> dict[str, str]:
     if not relatives:
         return {}
-    hashed = _git_result(
-        context,
-        "hash-object",
-        "--no-filters",
-        "--stdin-paths",
-        input_text="".join(f"{relative}\n" for relative in relatives),
-    )
-    if hashed.returncode != 0:
-        return {}
-    object_ids = hashed.stdout.splitlines()
-    if len(object_ids) != len(relatives):
-        return {}
-    return dict(zip(relatives, object_ids, strict=True))
+    worktree_ids: dict[str, str] = {}
+    for offset in range(0, len(relatives), 128):
+        batch = relatives[offset : offset + 128]
+        hashed = _git_result(
+            context,
+            "hash-object",
+            "--no-filters",
+            "--stdin-paths",
+            input_text="".join(f"{relative}\n" for relative in batch),
+        )
+        if hashed.returncode != 0:
+            return {}
+        object_ids = hashed.stdout.splitlines()
+        if len(object_ids) != len(batch):
+            return {}
+        worktree_ids.update(zip(batch, object_ids, strict=True))
+    return worktree_ids
 
 
 def _symlink_matches_release_blob(path: Path, object_id: str) -> bool:

--- a/scripts/check-release-tag-reachability.sh
+++ b/scripts/check-release-tag-reachability.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 SENTINEL_VERSIONS=("1.62.0" "1.68.0" "1.74.0")
-SAFETY_MARGIN=26
+# The shipped verifier accepts at most 32 newer candidates. Stop while two
+# slots remain: the current CI run may publish one release, leaving one final
+# recovery slot rather than forcing a risky early label move.
+SAFETY_MARGIN=31
 SHIPPED_TAG_BOUND=32
 
 if ! REMOTE_TAGS="$(
@@ -55,7 +58,7 @@ for SENTINEL in "${SENTINEL_VERSIONS[@]}"; do
 
   if [ "$NEWER_COUNT" -ge "$SAFETY_MARGIN" ]; then
     echo "❌ v$SENTINEL has $NEWER_COUNT newer dist/release tags; the safety margin is $SAFETY_MARGIN before the shipped $SHIPPED_TAG_BOUND-tag bound." >&2
-    echo "Archive older duplicates to dist/archive/* before old installs go silent." >&2
+    echo "Do not move immutable release labels blindly; use the verified bridge-and-archive procedure before old installs go silent." >&2
     FAILED=1
   fi
 done

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -31,18 +31,17 @@ _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}
 _APPROVAL_WORD = "APPLY"
 _CLEAN_RUNTIME_MARKER = "DEX_UPDATE_BRIDGE_CLEAN_RUNTIME"
 _TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/local/bin"), Path("/opt/homebrew/bin"))
-_TOPOLOGY_MIGRATOR_RELATIVE = Path(
-    "core/migrations/v1-to-v2-brain-vault-split.cjs"
-)
-_TRACKED_IGNORE_POLICY_RELATIVE = Path(
-    "core/migrations/tracked-ignored-policy.yaml"
-)
-_PRESERVATION_TRANSITION_RELATIVE = Path(
-    "System/.local-only-preservation-transition.json"
-)
+_TOPOLOGY_MIGRATOR_RELATIVE = Path("core/migrations/v1-to-v2-brain-vault-split.cjs")
+_TRACKED_IGNORE_POLICY_RELATIVE = Path("core/migrations/tracked-ignored-policy.yaml")
+_PRESERVATION_TRANSITION_RELATIVE = Path("System/.local-only-preservation-transition.json")
 _LEGACY_SHIPPED_SYMLINK_RELATIVE = Path(".pi/agent/extensions/dex")
 _LEGACY_SHIPPED_SYMLINK_TARGET = "../../../pi-extensions/dex"
 _LEGACY_SHIPPED_SYMLINK_BLOB = "f1c88c92cea996705f982e902bafb758156aef52"
+_PACKAGE_RELATIVE = Path("package.json")
+_TAU_MIRROR_OMISSIONS = {
+    "extensions/tau-mirror/README-TAU-MIRROR.md": "c19e4fafa1adeb1d1232299ff7be68c448cab498",
+    "extensions/tau-mirror/tau-mirror-integration.ts": "fff2a52e50070545ad46760100d9cedab5dc1ecd",
+}
 
 
 class BridgeError(RuntimeError):
@@ -110,6 +109,631 @@ LEGACY_TOPOLOGY_FOUNDATION = LegacyTopologyPin(
     commit="9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
     tree="b781bb94e417b2873d057a5a417d8c666a360bca",
 )
+_LEGACY_V1201_PACKAGE_SHA256 = "d0f3908ba0f6268d23c182acc1b3ef5b7557b92791635ff315eb6e324529f7ec"
+
+
+@dataclass(frozen=True)
+class HistoricReleasePin:
+    """One exact published historical tree used by a read-only adapter."""
+
+    tag: str
+    tag_object: str
+    tag_object_type: str
+    commit: str
+    tree: str
+    version: str
+    package_blob: str
+    package_sha256: str
+
+    def __post_init__(self) -> None:
+        semantic = re.fullmatch(r"v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)", self.tag)
+        distribution = _RELEASE_TAG.fullmatch(self.tag)
+        if semantic is None and distribution is None:
+            raise BridgeError("historic release tag is malformed")
+        if semantic is not None and semantic.group("version") != self.version:
+            raise BridgeError("historic semantic tag and version disagree")
+        if distribution is not None and not self.tag.startswith(f"dist/release/v{self.version}-"):
+            raise BridgeError("historic distribution tag and version disagree")
+        if self.tag_object_type not in {"commit", "tag"}:
+            raise BridgeError("historic tag object type is malformed")
+        if any(_HEX.fullmatch(value) is None for value in (self.tag_object, self.commit, self.tree, self.package_blob)):
+            raise BridgeError("historic release identity is malformed")
+        if not re.fullmatch(r"[0-9a-f]{64}", self.package_sha256):
+            raise BridgeError("historic package identity is malformed")
+
+
+MANIFESTLESS_SEMANTIC_RELEASES = (
+    HistoricReleasePin(
+        "v1.20.1",
+        "3f7338dbe21ec98c015a3c8417d037cdd51b517d",
+        "tag",
+        "9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
+        "b781bb94e417b2873d057a5a417d8c666a360bca",
+        "1.20.1",
+        "524e4fc38b6ef0b266776fd52023e41e603fa4a1",
+        _LEGACY_V1201_PACKAGE_SHA256,
+    ),
+    HistoricReleasePin(
+        "v1.49.0",
+        "930adabf3e88b6534b3c90a9ad386151c1e291e4",
+        "commit",
+        "930adabf3e88b6534b3c90a9ad386151c1e291e4",
+        "0a153375382907fd25a68d7c1845851d0d1f9946",
+        "1.49.0",
+        "32c22a6a13f1444beb8ce62a30ce6309b70244be",
+        "acb472fb40dfb883c32b67fb07834de384154fd19697e90689cf16dfbf47621e",
+    ),
+    HistoricReleasePin(
+        "v1.51.0",
+        "c8069c90c1715bc7a10aced19ef95e3657089bfd",
+        "commit",
+        "c8069c90c1715bc7a10aced19ef95e3657089bfd",
+        "8129f1a2d66a6a9d412cb6a3d919af725b160e6f",
+        "1.51.0",
+        "887ddacba2ff3e99b4293c50b522b112e8e7b8e0",
+        "9518a9e1c162dd6ca8cdea484fc8081be2097edeeec2d3807b7b3d77b0283ebb",
+    ),
+    HistoricReleasePin(
+        "v1.52.0",
+        "0b843163815dab2bd9d0d4797a70f7c59864e76f",
+        "commit",
+        "0b843163815dab2bd9d0d4797a70f7c59864e76f",
+        "faebf21f5c14dc10a2ac9b28856040425e6a24a8",
+        "1.52.0",
+        "34227d365e65fde32a61830c0b77cd6331fb3e7b",
+        "64faaa5fcc8e1e77c12ed27d1b5f0c4ed5033d3d68029e94d7d9e9bdfc294cce",
+    ),
+    HistoricReleasePin(
+        "v1.53.0",
+        "a0bbd82d4a7c825b94c2e5467d3d34f8f2129280",
+        "commit",
+        "a0bbd82d4a7c825b94c2e5467d3d34f8f2129280",
+        "59a50aba122ef8213544dc99ba36fd19cc78b5c1",
+        "1.53.0",
+        "d21587d1eb2e23562428fa72d4d7fb9e0a586b97",
+        "1387699217fcc824db0a24517cc30fbe55ccbb4b24af9fce8eabb7ea886485e3",
+    ),
+    HistoricReleasePin(
+        "v1.54.0",
+        "3956d3710645492975d66f8f481c806c72533453",
+        "commit",
+        "3956d3710645492975d66f8f481c806c72533453",
+        "ce724d55e677ef126a5f1ed4aa03f48236379327",
+        "1.54.0",
+        "113903345c57bf43ad4c2f991af866f0e1183da9",
+        "64c64e97a995e7d0570d32b6e5dcb7743ef5394f6eefac09102aea8fe9e45b5d",
+    ),
+    HistoricReleasePin(
+        "v1.55.0",
+        "a023581a86b56ef97577513092001ea565832e17",
+        "commit",
+        "a023581a86b56ef97577513092001ea565832e17",
+        "754789c0721bcb9bd82f43055afa8f09be0fda28",
+        "1.55.0",
+        "2b1c2330ad98ca6ca85fb3319a59d7b6835f8368",
+        "ef626306a279cbef8f288f9ffd922d4fdb02c4095efc805df04348229f98cb12",
+    ),
+    HistoricReleasePin(
+        "v1.56.0",
+        "69505741999ab493f4f23733e33a9ffb2395c4bf",
+        "commit",
+        "69505741999ab493f4f23733e33a9ffb2395c4bf",
+        "255083281de057f9dd07bdfe2c3e94be1e1de5ce",
+        "1.56.0",
+        "90bbdde25254fd3a9ceb3c4221337d9b3b39008f",
+        "510a898356a7cad6b0efcd07ad49411a9881ae11e9ab3f2e06e08513b672dee0",
+    ),
+    HistoricReleasePin(
+        "v1.57.0",
+        "e5220bf72689e4434697aaa06978cac31cc9d5ee",
+        "commit",
+        "e5220bf72689e4434697aaa06978cac31cc9d5ee",
+        "68af3dbebc0cbac8699dfa6d9fecf41b11852785",
+        "1.57.0",
+        "f6e66582be2bd845ebc6bdf3e7166ada6a4c0d1b",
+        "c7478d3a64f1bf05ba6a29d2473fd72fe745d59029e943a267db329976fe09ff",
+    ),
+    HistoricReleasePin(
+        "v1.58.0",
+        "b001eb4048d413e1c68213f83b2c3ca2ad818a17",
+        "commit",
+        "b001eb4048d413e1c68213f83b2c3ca2ad818a17",
+        "da2ee15b6490452d85eaf8a7fd883f92b743bea9",
+        "1.58.0",
+        "d25d36733053bd92f7f6d86fae9e0a887adb0bbc",
+        "3e70ba4f05ed921f9015a610348ee6886fed19832b43a9cced2982088b206234",
+    ),
+    HistoricReleasePin(
+        "v1.59.0",
+        "f3a4413d6a1bc245250e23b4f5868953620b7237",
+        "commit",
+        "f3a4413d6a1bc245250e23b4f5868953620b7237",
+        "9ecb0a55dd44c16b82a06ac1a02a1ee1a872607e",
+        "1.59.0",
+        "5cf1c327e9eec8c42d578c3da9bb6520f7b5fe18",
+        "3ae65b8c0bdeea9e1c483459f9b902b484f01e04f32cc667fbd6300a8e87cebb",
+    ),
+    HistoricReleasePin(
+        "v1.60.0",
+        "6c986d80280e15af26b9cc4412c4578461b916db",
+        "commit",
+        "6c986d80280e15af26b9cc4412c4578461b916db",
+        "6906f751bbb058db9bd4aee01e745459661c7131",
+        "1.60.0",
+        "7bbc92cdcfc2fd023861fb30d474e129f885913a",
+        "c63aab865609555c3904879b4793245b5b67713e250add31273a505dd990c946",
+    ),
+    HistoricReleasePin(
+        "v1.61.0",
+        "b7c74d877b2aca4cb70ab343173f444feca612d0",
+        "commit",
+        "b7c74d877b2aca4cb70ab343173f444feca612d0",
+        "0dda073b96be4955312445a089c625cc902738ca",
+        "1.61.0",
+        "884cf4421e2c3d74a8717f707fd3ac83c4bbc8fb",
+        "30056d4dcf5a32208bc12e001b8f5b8c81b38f9499704ed47149569e7a6cdf38",
+    ),
+)
+
+V175_DEFECTIVE_MANIFEST_RELEASE = HistoricReleasePin(
+    "v1.75.0",
+    "5e73481519ee9b5fe9a6c3196ee7cabaa0446ee8",
+    "commit",
+    "5e73481519ee9b5fe9a6c3196ee7cabaa0446ee8",
+    "382b92df5b3a14da90e9122956353f589f2fc0b7",
+    "1.75.0",
+    "1cacd5c174cfc309e855bd54ae96bcf04afa4079",
+    "fec3b6816d52f4f08c45f41e19b264b5d7dbc3844defc76186791a7f1d850308",
+)
+_V175_DEFECTIVE_MANIFEST_OMISSIONS = {
+    "core/customization_migration/__init__.py": "9fae2734c7f4e1b42c569f6df73a43ef90fb253e",
+    "core/customization_migration/inventory.py": "e96ae8a94544291aa28b37446655df65b76e7741",
+    "core/customization_migration/model.py": "ce26945a12d1e68e50ac4d7693b38c3aadb218dc",
+    "core/customization_migration/planning.py": "134f4707644842831731042308cba7fc30db55aa",
+    "core/customization_migration/references.py": "f4269d559a53d009e69f8f2d0b83293e43105bb4",
+    "core/customization_migration/report.py": "6ffee5daffea929af450245f49f75b16293b0f09",
+    "core/customization_migration/service.py": "fba73a430cfe6a4537f390f1f5b6423c64c1a074",
+    "core/tests/test_customization_assessment.py": "8a339e39e646fccb9f6c9babe64d9b62ccc5b0c6",
+    "core/tests/test_customization_assessment_doctor.py": "b15ce6ebff890fa04ea60be3564848c8d4e252b9",
+    "core/tests/test_customization_assessment_planning.py": "e29f5d97a506912af85e1c107237faad85f8b44d",
+    "core/tests/test_lifecycle_topology_migration.py": "5cb2ae955cc575498284d4a96eb675b33ea3a4ba",
+    "docs/customization-migration-threat-model.md": "f8fad1a1b5b5e249f66240fc32fa6c592ebd964f",
+    "docs/plans/2026-07-24-customization-migration-mcp.md": "27ec0f3ff56c32bcc7960021f3b534414589272a",
+}
+
+
+@dataclass(frozen=True)
+class UnboundJourneySourcePin:
+    """One exact semantic source whose journey files predate the catalog bind."""
+
+    release: HistoricReleasePin
+    artifacts: tuple[tuple[str, str, str], ...]
+
+
+V181_UNBOUND_JOURNEY_SOURCE = UnboundJourneySourcePin(
+    release=HistoricReleasePin(
+        "v1.81.0",
+        "0f23787a22aa52afb40878df05e4819f77d179e6",
+        "commit",
+        "0f23787a22aa52afb40878df05e4819f77d179e6",
+        "03e1832add6a27bc6c6dc833bfdba2b6cf7fd524",
+        "1.81.0",
+        "f54091ab0c0d543c848bb1344b8a0048c067b89f",
+        "c4a8d1f0ebab0fb73656027812457f2c8f948e39be13b1eeca4bbcb33742a1bb",
+    ),
+    artifacts=(
+        (
+            "System/.installed-files.manifest",
+            "1264aba3b8f1cff516caeb277380c09be1973e99",
+            "fdd28af603f7575efcfe358472a60d0513b08d2f0f7aecf8395f7a0da27ea8ca",
+        ),
+        (
+            "core/update/journey-protocol-v1.json",
+            "d707e5d251a38333bcd2e8c658f543eac5cd75bf",
+            "a8a99cc5766f83e9ed4daaac2d3173175736805b486cd028da04ae98b2dc15c0",
+        ),
+        (
+            "scripts/release_fleet.py",
+            "4da97ce6837d24a4b837bc3fcc29a30236b71b49",
+            "6f44f9a718a066e3964a7a502f8ef0f2fb193214ccc58874f0059bc5af033a19",
+        ),
+        (
+            "scripts/release_fleet_executor.py",
+            "b97af897a3be095463ea7c3627b1b46ed0d5931f",
+            "e90690babcaba9648b14fbf9cc18b79ff3e98ed92b806aa89855b842baf72205",
+        ),
+        (
+            "scripts/dex_update_bridge.py",
+            "16a95863f5ece67c9b700f243451e6b3f18b6dfa",
+            "0d40463658d3f760e0f5a24061e1ff642306d1604d3cef8c5d9f89c97f4b7d9b",
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ExistingInputTuple:
+    """Exact existing inputs that may be replaced in-memory for one child."""
+
+    policy_blob: str
+    policy_sha256: str
+    transition_blob: str
+    transition_sha256: str
+
+
+_INPUT_A_STALE_BOOTSTRAP = ExistingInputTuple(
+    "35fa3d86020fe7b22768c199379508ddb4cef992",
+    "4d7d0b4940afd1e0b0891801f75db2dce925ea6893cde82176aa0abe5b4c1872",
+    "f76bf2a54600dd4ee8553664c9b9f36c4111e489",
+    "f7073cf418c2ea7504f2bf1030d84d5a85be1b90f42f14895959e8318ff34e4e",
+)
+_INPUT_B_V162_BOOTSTRAP = ExistingInputTuple(
+    "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+    "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+    "8cec307895b102363a85992f5f3f5a2c7b0d3730",
+    "31f90404e5898913b14d61a470489ac307abfd6877e313d2d714e2204b3037f7",
+)
+_INPUT_B_V163_BOOTSTRAP = ExistingInputTuple(
+    "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+    "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+    "cffb865aafcda0d20e66082f9c5eab4323f7b664",
+    "d4fe097c6be47b5ca6198fbca412959c9777da2e6cafb863235be73c71a376a9",
+)
+_INPUT_B_V163_UNTRACK = ExistingInputTuple(
+    "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+    "caf6c54e8172ecc3d8f92a13fb6a739dddb8e9965e24bfa5a6e29d08f412aa5d",
+    "91069155a2b5d14409d927af8708556f424740bd",
+    "afd7f6338561ecd3597f32552e594f14630028f9ced64755f6dc11249b43d7a4",
+)
+
+
+@dataclass(frozen=True)
+class MissingMigratorPin:
+    release: HistoricReleasePin
+    inputs: ExistingInputTuple
+
+
+def _historic_pin(
+    tag: str,
+    tag_object: str,
+    commit: str,
+    tree: str,
+    version: str,
+    package_blob: str,
+    package_sha256: str,
+) -> HistoricReleasePin:
+    return HistoricReleasePin(tag, tag_object, "tag", commit, tree, version, package_blob, package_sha256)
+
+
+MISSING_MIGRATOR_RELEASES = (
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.61.0-03c33d3",
+            "b278bc51278c5b141dd65883fec920c8cb92d17a",
+            "03c33d3c956557d1077ae2606168732a2c05bfb0",
+            "f4e950f8266bd770ff99ce59f4b0de02ae8f2e19",
+            "1.61.0",
+            "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+            "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.61.0-a010533",
+            "6ecc9ea45be51d6040466072eeedef9a26dda15f",
+            "a010533278912f092e6920447846f2c7b3402abe",
+            "3cd446661d70a9f2bc5f9fcd58083efbd2f4b436",
+            "1.61.0",
+            "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+            "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.61.0-dc7d332",
+            "113ea147d484da0c2eb3bd80e35fa934388b095e",
+            "dc7d332bed63589982664eca493da925cd1da6ce",
+            "75f5fd9ae7baa05ee775093661e258746a18b0fb",
+            "1.61.0",
+            "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+            "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-5a4fc2a",
+            "e031be627ae35606770cee498f1101f050e75ef6",
+            "5a4fc2a5a00f8523c231d840cbe9b2decb9b101e",
+            "d51076f79dfac62020f83fa9430defe2ca605201",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-6de410c",
+            "5e954b3e10e52a48024b6030d3125d35d4699fb3",
+            "6de410cce1b7bb80a4195940092bd5e82d7c32cf",
+            "c0d5374d8e0494df461f012458b937fae797d007",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-ba4862f",
+            "7157ae8defde2e8698e5b6900bf4c6d9394b16d3",
+            "ba4862f55813d34ab7ec6970507dc40e3ef8027f",
+            "235168077df9621db3fcddfb677633bdcc946723",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-cebe07b",
+            "6b5f8f663c08613d5c8c49308bc1d08326e02a8f",
+            "cebe07b23d6ceabf286ad31a24ce1aed23321c29",
+            "4ec6aad8d9d162ccc489fbf7a9ff4b37f3e83b95",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-d1ff64c",
+            "ff0cd2c781a9689e26b0ba207e408649bf02fff1",
+            "d1ff64c7f8938cb81b548bc7238c4cc9dc398a64",
+            "feba9f46177dd802b698d5acd60896282b1508ff",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.62.0-d5bd522",
+            "2abdc01c6a78b1a69eb7484dae151f646c603adc",
+            "d5bd522bccc3d17498d3c0c1e437ca0909c975a4",
+            "3de9d2ec9884d4c97c471ecbf32236572fb8d496",
+            "1.62.0",
+            "eefff9e671693d8eba2a1bb97a4f146923542ddf",
+            "0d9912852060bae981c74dff56d24d1b12cdc5125a73b2c4c87d61bf51c787a4",
+        ),
+        _INPUT_B_V162_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.63.0-6167d6e",
+            "041d65c0e5706b191eea172fbe59762f66cbf3c9",
+            "6167d6ef82d1607ed65b7b795538eb4ccdb23cbe",
+            "c3e961ac5cbef45d762962ecd50b4fafbdece958",
+            "1.63.0",
+            "036655ee0687f89a309b6ac18e763996e719695c",
+            "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+        ),
+        _INPUT_B_V163_UNTRACK,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "dist/release/v1.63.0-d1050f4",
+            "d4a49d6be2e5bdccf6ceee3cc6f016524e4d02bc",
+            "d1050f47598a1625205dc571313dc3d4d08cfcd3",
+            "b18cee1e7f61d4873c0748bd48396d7aa9ccd985",
+            "1.63.0",
+            "036655ee0687f89a309b6ac18e763996e719695c",
+            "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+        ),
+        _INPUT_B_V163_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "v1.62.0",
+            "4913a778452003fcf8dc71a10222d5275ff28d5c",
+            "77c4a15a7884080e48b095c8de2c384d01a87883",
+            "1bf30a86c151890024040f0e4e1a533be17c5686",
+            "1.62.0",
+            "2d7f21a72798d4189f042e955e62ee799e90a90c",
+            "75bef63d563a7e5062db6ad664ccb65a7581dbfd3d466655d1b3709bbad7ffa5",
+        ),
+        _INPUT_A_STALE_BOOTSTRAP,
+    ),
+    MissingMigratorPin(
+        _historic_pin(
+            "v1.63.0",
+            "eff2f060455f186fcd27f5e680825051baf037b7",
+            "b5ee55366f3600b79748a9b56e063a9825172a45",
+            "a418102a6d8254a14c81575d1d86aea7d28bd6f8",
+            "1.63.0",
+            "846e23a1dd09c7096784268b234fde7139915575",
+            "2f13e9f4f765dbe18a68a6fbe4b58f211eccecd50deba60e45647fdef0b9f6cf",
+        ),
+        _INPUT_B_V163_BOOTSTRAP,
+    ),
+)
+
+
+def historic_missing_migrator_pins() -> dict[str, dict[str, object]]:
+    """Return the exact existing-input, missing-migrator failure cohort."""
+
+    return {
+        compatibility.release.tag: {
+            "kind": "existing-inputs-missing-migrator",
+            "role": "installed-source",
+            "tag": compatibility.release.tag,
+            "tag_object": compatibility.release.tag_object,
+            "commit": compatibility.release.commit,
+            "tree": compatibility.release.tree,
+            "version": compatibility.release.version,
+            "package_blob": compatibility.release.package_blob,
+            "package_sha256": compatibility.release.package_sha256,
+            "policy_blob": compatibility.inputs.policy_blob,
+            "policy_sha256": compatibility.inputs.policy_sha256,
+            "transition_blob": compatibility.inputs.transition_blob,
+            "transition_sha256": compatibility.inputs.transition_sha256,
+            "migrator_blob": None,
+            "migrator_state": "absent",
+            "overwrite_existing_inputs": False,
+        }
+        for compatibility in MISSING_MIGRATOR_RELEASES
+    }
+
+
+def historic_missing_migrator_for(evidence: Mapping[str, object]) -> str | None:
+    """Authorize only one complete exact existing-input failure identity."""
+
+    if not isinstance(evidence, Mapping):
+        return None
+    supplied = dict(evidence)
+    for name, pin in historic_missing_migrator_pins().items():
+        if supplied == pin:
+            return name
+    return None
+
+_NATIVE_MIGRATOR_BLOB = "57da3fa834ed1f9069f0187dd19b3e3e6f5b5580"
+_NATIVE_MIGRATOR_SHA256 = "7c825da3c2cb38c7327431f237c3bf95c08f9e47b907555afa37b85cda7ec19f"
+_NATIVE_INSTALL_BLOB = "f1ce82fa657786a3b9cae0526a8a8757531f6f39"
+NATIVE_MIGRATOR_TRANSPORT_RELEASES = (
+    _historic_pin(
+        "dist/release/v1.63.0-08ce719",
+        "492b56c53dbe469dcac93c7d9a85081026f04132",
+        "08ce719d595809808e202fa4a7a5fbc68c1b5257",
+        "87467beec1c11e91ff1bc27223d310b32b9b4978",
+        "1.63.0",
+        "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+    ),
+    _historic_pin(
+        "dist/release/v1.63.0-2f006c9",
+        "25e579ea946e8b493fcec0d2e49aec5cdb9c1141",
+        "2f006c95adcb566ee6ce881ffb534628ade49d02",
+        "cfe29096d001d08ba77a9a649c9999d40f250c6e",
+        "1.63.0",
+        "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+    ),
+    _historic_pin(
+        "dist/release/v1.63.0-9a0660f",
+        "d5123c4438c97b5c0e630dddad049f66389d3bc7",
+        "9a0660f785b4f6d0c15ab3a77b346bb522e80eb7",
+        "d4bc25fed1798db4e362506b60627da4b4fa97ad",
+        "1.63.0",
+        "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+    ),
+    _historic_pin(
+        "dist/release/v1.63.0-9dc6e3d",
+        "05553ca6f04a2b89a3efbbea9d4901c63b74ae1f",
+        "9dc6e3dfafd75b23c40607171787bd028099f6d1",
+        "582bef8eebf62d171c63354b5cf4c618f2ac5593",
+        "1.63.0",
+        "036655ee0687f89a309b6ac18e763996e719695c",
+        "c7d1e58bfcf635af6703dc519546b12ed7538a34ee298d493b3db373cb495c98",
+    ),
+)
+
+
+def historic_compatibility_pins() -> dict[str, dict[str, object]]:
+    """Return the closed installed-source compatibility ledger."""
+
+    pins: dict[str, dict[str, object]] = {}
+    for release in MANIFESTLESS_SEMANTIC_RELEASES:
+        pins[release.tag] = {
+            "kind": "manifestless-missing-migrator",
+            "role": "installed-source",
+            "tag": release.tag,
+            "tag_object": release.tag_object if release.tag_object_type == "tag" else None,
+            "commit": release.commit,
+            "tree": release.tree,
+            "package_blob": release.package_blob,
+            "manifest_blob": None,
+            "policy_blob": None,
+            "transition_blob": None,
+            "migrator_blob": None,
+            "unexpected_nonregular_paths": (),
+        }
+    pins["v1.20.1"]["shipped_symlink"] = {
+        "path": _LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix(),
+        "blob": _LEGACY_SHIPPED_SYMLINK_BLOB,
+        "target": _LEGACY_SHIPPED_SYMLINK_TARGET,
+    }
+    pins[V175_DEFECTIVE_MANIFEST_RELEASE.tag] = {
+        "kind": "incomplete-manifest",
+        "role": "installed-source",
+        "tag": V175_DEFECTIVE_MANIFEST_RELEASE.tag,
+        "tag_object": None,
+        "commit": V175_DEFECTIVE_MANIFEST_RELEASE.commit,
+        "tree": V175_DEFECTIVE_MANIFEST_RELEASE.tree,
+        "package_blob": V175_DEFECTIVE_MANIFEST_RELEASE.package_blob,
+        "manifest_blob": "6d2105eb1e33bd007ef8b4e2e77b927508a150f7",
+        "manifest_sha256": "6a065ef3bcce45ac8e42d8143a4eb9e3516ea633fd0cbe8c3d2aff10a137ec34",
+        "manifest_path_count": 1201,
+        "omitted_paths": tuple(_V175_DEFECTIVE_MANIFEST_OMISSIONS),
+        "omitted_paths_sha256": "b476b6a35ac869339e93f6451f13f6a09c6622b7be6ba73ee6e82bc404cc567d",
+        "policy_blob": "b2dfd209e83ecfed1d1f7fcc90be4e3444f08b2e",
+        "transition_blob": "2a016eafa4f2712343c3eea206b5be22259e3362",
+        "migrator_blob": "559a870762bd8feb68aac7b6a9f93ec2f99d1efd",
+        "unexpected_nonregular_paths": (),
+    }
+    source = V181_UNBOUND_JOURNEY_SOURCE.release
+    pins[source.tag] = {
+        "kind": "semantic-no-catalog",
+        "role": "installed-source",
+        "tag": source.tag,
+        "tag_object": None,
+        "commit": source.commit,
+        "tree": source.tree,
+        "package_blob": source.package_blob,
+        "catalog_blob": None,
+        "manifest_blob": "1264aba3b8f1cff516caeb277380c09be1973e99",
+        "manifest_sha256": "fdd28af603f7575efcfe358472a60d0513b08d2f0f7aecf8395f7a0da27ea8ca",
+        "manifest_path_count": 1297,
+        "policy_blob": "7d1f2b3ace56e12fce2ff01fafe6435cd1b59e59",
+        "transition_blob": "4b7ad8ff59d95a5e0af7106cb40f3aafa699400c",
+        "migrator_blob": "c73fe7e186abbcd8dc588fa5c94d6244bf156662",
+        "unexpected_nonregular_paths": (),
+    }
+    for release in NATIVE_MIGRATOR_TRANSPORT_RELEASES:
+        pins[release.tag] = {
+            "kind": "native-migrator-file-transport",
+            "role": "installed-source",
+            "tag": release.tag,
+            "tag_object": release.tag_object,
+            "commit": release.commit,
+            "tree": release.tree,
+            "package_blob": release.package_blob,
+            "policy_blob": _INPUT_B_V163_UNTRACK.policy_blob,
+            "transition_blob": _INPUT_B_V163_UNTRACK.transition_blob,
+            "migrator_blob": _NATIVE_MIGRATOR_BLOB,
+            "install_blob": _NATIVE_INSTALL_BLOB,
+            "unexpected_nonregular_paths": (),
+        }
+    return pins
+
+
+def historic_compatibility_for(evidence: Mapping[str, object]) -> str | None:
+    """Authorize only a complete exact installed-source ledger entry."""
+
+    if not isinstance(evidence, Mapping):
+        return None
+    supplied = dict(evidence)
+    for name, pin in historic_compatibility_pins().items():
+        if supplied == pin:
+            return name
+    return None
+
 
 # v1.20.1 predates the tracked-ignore transition that the topology migrator
 # reads before it can even build a preview. This is the complete baseline-v1
@@ -177,16 +801,29 @@ baselines:
       - path: System/integrations/slack.yaml
         classification: local-only-must-be-untracked
 """
-_LEGACY_TRACKED_IGNORE_POLICY_SHA256 = (
-    "bf0af119939930fb4d3b466584a3e9392edb66bf61ec09675521c9a5969f3f50"
-)
+_LEGACY_TRACKED_IGNORE_POLICY_SHA256 = "bf0af119939930fb4d3b466584a3e9392edb66bf61ec09675521c9a5969f3f50"
 
 
 def _legacy_preload_bytes() -> bytes:
-    """Build the closed Node preload that supplies two absent read-only inputs."""
+    """Build the closed preload for absent or exact defective legacy inputs."""
 
     policy = base64.b64encode(_LEGACY_TRACKED_IGNORE_POLICY).decode("ascii")
+    allowed_existing = json.dumps(
+        sorted(
+            {
+                (
+                    pin.release.version,
+                    pin.release.package_sha256,
+                    pin.inputs.policy_sha256,
+                    pin.inputs.transition_sha256,
+                )
+                for pin in MISSING_MIGRATOR_RELEASES
+            }
+        ),
+        separators=(",", ":"),
+    )
     return f"""'use strict';
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -207,8 +844,21 @@ const packagePath = path.join(root, 'package.json');
 const inputs = new Map([
   [path.join(root, '{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}'), Buffer.from('{policy}', 'base64')],
 ]);
+const allowedExisting = new Set({allowed_existing}.map((values) => values.join(':')));
 const originalReadFileSync = fs.readFileSync.bind(fs);
 const originalReaddirSync = fs.readdirSync.bind(fs);
+
+function regularBytes(candidate, description) {{
+  const state = fs.lstatSync(candidate);
+  if (!state.isFile() || state.isSymbolicLink()) {{
+    throw new Error(`Dex update bridge refused existing legacy compatibility input ${{candidate}} (${{description}} is unsafe).`);
+  }}
+  return originalReadFileSync(candidate);
+}}
+
+function digest(content) {{
+  return crypto.createHash('sha256').update(content).digest('hex');
+}}
 
 function legacyTransition() {{
   const packageState = fs.lstatSync(packagePath);
@@ -230,6 +880,61 @@ function legacyTransition() {{
     release_version: packageJson.version,
     schema_version: 1,
   }})}}\\n`, 'utf8');
+}}
+
+function optionalState(candidate) {{
+  try {{ return fs.lstatSync(candidate); }} catch (error) {{
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }}
+}}
+
+function compatibilityInputs() {{
+  const policyPath = [...inputs.keys()][0];
+  const suppliedPolicy = [...inputs.values()][0];
+  const policyState = optionalState(policyPath);
+  const transitionState = optionalState(transitionPath);
+  if (!policyState && !transitionState) {{
+    return {{policy: suppliedPolicy, transition: legacyTransition()}};
+  }}
+  if (!policyState || !transitionState) {{
+    throw new Error('Dex update bridge refused existing legacy compatibility input: partial tuple.');
+  }}
+  const packageBytes = regularBytes(packagePath, 'package metadata');
+  let packageJson;
+  try {{ packageJson = JSON.parse(packageBytes.toString('utf8')); }} catch (error) {{
+    throw new Error(`Dex update bridge refused invalid legacy package metadata ${{packagePath}}.`);
+  }}
+  if (!packageJson || typeof packageJson.version !== 'string') {{
+    throw new Error(`Dex update bridge refused invalid legacy package version ${{packagePath}}.`);
+  }}
+  const policyBytes = regularBytes(policyPath, 'tracked-ignore policy');
+  const transitionBytes = regularBytes(transitionPath, 'preservation transition');
+  const tuple = [
+    packageJson.version,
+    digest(packageBytes),
+    digest(policyBytes),
+    digest(transitionBytes),
+  ].join(':');
+  if (!allowedExisting.has(tuple)) {{
+    throw new Error('Dex update bridge refused an unknown legacy compatibility tuple.');
+  }}
+  let transitionJson;
+  try {{ transitionJson = JSON.parse(transitionBytes.toString('utf8')); }} catch (error) {{
+    throw new Error('Dex update bridge refused invalid legacy transition metadata.');
+  }}
+  if (
+    !transitionJson
+    || transitionJson.schema_version !== 1
+    || !['bootstrap-v1', 'untrack-v1'].includes(transitionJson.phase)
+    || typeof transitionJson.release_version !== 'string'
+  ) {{
+    throw new Error('Dex update bridge refused invalid legacy transition metadata.');
+  }}
+  const virtualTransition = transitionJson.release_version === packageJson.version
+    ? transitionBytes
+    : legacyTransition();
+  return {{policy: policyBytes, transition: virtualTransition}};
 }}
 
 let hideShippedLink = false;
@@ -257,19 +962,12 @@ fs.readFileSync = function dexLegacyCompatibilityRead(candidate, options) {{
   const absolute = path.resolve(supplied);
   const suppliedInput = inputs.has(absolute) || absolute === transitionPath;
   if (!suppliedInput) return originalReadFileSync(candidate, options);
-  try {{
-    fs.lstatSync(absolute);
-  }} catch (error) {{
-    if (error && error.code === 'ENOENT') {{
-      const content = absolute === transitionPath
-        ? legacyTransition()
-        : inputs.get(absolute);
-      const encoding = typeof options === 'string' ? options : options && options.encoding;
-      return encoding ? content.toString(encoding) : Buffer.from(content);
-    }}
-    throw error;
-  }}
-  throw new Error(`Dex update bridge refused existing legacy compatibility input ${{absolute}}.`);
+  const suppliedInputs = compatibilityInputs();
+  const content = absolute === transitionPath
+    ? suppliedInputs.transition
+    : suppliedInputs.policy;
+  const encoding = typeof options === 'string' ? options : options && options.encoding;
+  return encoding ? content.toString(encoding) : Buffer.from(content);
 }};
 
 fs.readdirSync = function dexLegacyCompatibilityDirectory(directory, options) {{
@@ -288,13 +986,32 @@ fs.readdirSync = function dexLegacyCompatibilityDirectory(directory, options) {{
 """.encode()
 
 
+def _transport_preload_bytes() -> bytes:
+    """Build a child-only protocol switch with no filesystem interception."""
+
+    return b"""'use strict';
+if (process.env.GIT_ALLOW_PROTOCOL !== 'https') {
+  throw new Error('Dex update bridge refused an unsafe inherited Git protocol policy.');
+}
+process.env.GIT_ALLOW_PROTOCOL = 'file';
+"""
+
+
 class LifecycleService(Protocol):
     def build_and_preview_topology_migration(self, vault_root: str | Path) -> Mapping[str, Any]: ...
-    def execute_approved_topology_migration(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
-    def build_and_preview_delivered_release(self, vault_root: str | Path, release: Mapping[str, Any]) -> Mapping[str, Any]: ...
-    def execute_approved_delivered_release(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
+    def execute_approved_topology_migration(
+        self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str
+    ) -> Mapping[str, Any]: ...
+    def build_and_preview_delivered_release(
+        self, vault_root: str | Path, release: Mapping[str, Any]
+    ) -> Mapping[str, Any]: ...
+    def execute_approved_delivered_release(
+        self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str
+    ) -> Mapping[str, Any]: ...
     def build_and_preview_mcp_registration(self, vault_root: str | Path) -> Mapping[str, Any]: ...
-    def execute_approved_mcp_registration(self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str) -> Mapping[str, Any]: ...
+    def execute_approved_mcp_registration(
+        self, vault_root: str | Path, preview: Mapping[str, Any], approved_token: str
+    ) -> Mapping[str, Any]: ...
 
 
 def _trusted_executable(name: str) -> Path | None:
@@ -383,9 +1100,153 @@ def _assert_equal(actual: str, expected: str, description: str) -> None:
 
 
 def _verify_pin(repository: Path, pin: ReleasePin) -> None:
-    _assert_equal(_run_git(repository, "rev-parse", "--verify", f"refs/tags/{pin.tag}"), pin.tag_object, "annotated tag")
+    _assert_equal(
+        _run_git(repository, "rev-parse", "--verify", f"refs/tags/{pin.tag}"), pin.tag_object, "annotated tag"
+    )
     _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{commit}}"), pin.commit, "commit")
     _assert_equal(_run_git(repository, "rev-parse", "--verify", f"{pin.tag}^{{tree}}"), pin.tree, "tree")
+
+
+def _regular_sha256(path: Path) -> str | None:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _matches_historic_release(vault_root: Path, pin: HistoricReleasePin) -> bool:
+    """Prove an exact tagged base plus its unchanged working package."""
+
+    root = Path(vault_root)
+    try:
+        if (
+            _run_git(
+                root,
+                "for-each-ref",
+                "--format=%(objectname)",
+                f"refs/tags/{pin.tag}",
+            )
+            != pin.tag_object
+            or _run_git(root, "cat-file", "-t", pin.tag_object) != pin.tag_object_type
+            or _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{commit}}") != pin.commit
+            or _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{tree}}") != pin.tree
+            or _run_git(
+                root,
+                "rev-parse",
+                "--verify",
+                f"{pin.commit}:{_PACKAGE_RELATIVE.as_posix()}",
+            )
+            != pin.package_blob
+            or _regular_sha256(root / _PACKAGE_RELATIVE) != pin.package_sha256
+        ):
+            return False
+        head = _run_git(root, "rev-parse", "--verify", "HEAD^{commit}")
+        if _HEX.fullmatch(head) is None:
+            return False
+        _run_git(root, "merge-base", "--is-ancestor", pin.commit, head)
+    except BridgeError:
+        return False
+    return True
+
+
+def _matches_existing_inputs(vault_root: Path, pin: MissingMigratorPin) -> bool:
+    root = Path(vault_root)
+    try:
+        if (
+            _run_git(
+                root,
+                "rev-parse",
+                "--verify",
+                f"{pin.release.commit}:{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}",
+            )
+            != pin.inputs.policy_blob
+            or _run_git(
+                root,
+                "rev-parse",
+                "--verify",
+                f"{pin.release.commit}:{_PRESERVATION_TRANSITION_RELATIVE.as_posix()}",
+            )
+            != pin.inputs.transition_blob
+        ):
+            return False
+    except BridgeError:
+        return False
+    return (
+        _regular_sha256(root / _TRACKED_IGNORE_POLICY_RELATIVE) == pin.inputs.policy_sha256
+        and _regular_sha256(root / _PRESERVATION_TRANSITION_RELATIVE) == pin.inputs.transition_sha256
+    )
+
+
+def _native_transport_release(vault_root: Path) -> HistoricReleasePin | None:
+    """Return one of four exact native-migrator transport pins, or nothing."""
+
+    root = Path(vault_root)
+    for pin in NATIVE_MIGRATOR_TRANSPORT_RELEASES:
+        if not _matches_historic_release(root, pin):
+            continue
+        try:
+            if (
+                _run_git(
+                    root,
+                    "rev-parse",
+                    "--verify",
+                    f"{pin.commit}:{_TOPOLOGY_MIGRATOR_RELATIVE.as_posix()}",
+                )
+                != _NATIVE_MIGRATOR_BLOB
+                or _run_git(
+                    root,
+                    "rev-parse",
+                    "--verify",
+                    f"{pin.commit}:{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}",
+                )
+                != _INPUT_B_V163_UNTRACK.policy_blob
+                or _run_git(
+                    root,
+                    "rev-parse",
+                    "--verify",
+                    f"{pin.commit}:{_PRESERVATION_TRANSITION_RELATIVE.as_posix()}",
+                )
+                != _INPUT_B_V163_UNTRACK.transition_blob
+            ):
+                continue
+        except BridgeError:
+            continue
+        if (
+            _regular_sha256(root / _TOPOLOGY_MIGRATOR_RELATIVE) == _NATIVE_MIGRATOR_SHA256
+            and _regular_sha256(root / _TRACKED_IGNORE_POLICY_RELATIVE) == _INPUT_B_V163_UNTRACK.policy_sha256
+            and _regular_sha256(root / _PRESERVATION_TRANSITION_RELATIVE) == _INPUT_B_V163_UNTRACK.transition_sha256
+        ):
+            return pin
+    return None
+
+
+def exact_unbound_journey_source(
+    repository: Path,
+    tag: str,
+    pin: UnboundJourneySourcePin = V181_UNBOUND_JOURNEY_SOURCE,
+) -> str | None:
+    """Resolve only the exact catalog-less v1.81 semantic source commit."""
+
+    if tag != pin.release.tag:
+        return None
+    root = Path(repository)
+    try:
+        if (
+            _run_git(root, "rev-parse", "--verify", f"refs/tags/{tag}") != pin.release.tag_object
+            or _run_git(root, "cat-file", "-t", pin.release.tag_object) != "commit"
+            or _run_git(root, "rev-parse", "--verify", f"{tag}^{{commit}}") != pin.release.commit
+            or _run_git(root, "rev-parse", "--verify", f"{tag}^{{tree}}") != pin.release.tree
+            or _run_git(root, "ls-tree", "-z", tag, "--", "System/.release-catalog.json")
+        ):
+            return None
+        for relative, blob, _sha256 in pin.artifacts:
+            if _run_git(root, "rev-parse", "--verify", f"{tag}:{relative}") != blob:
+                return None
+    except BridgeError:
+        return None
+    return pin.release.commit
 
 
 def _supported_legacy_topology(
@@ -403,6 +1264,21 @@ def _supported_legacy_topology(
         or (root / _TOPOLOGY_MIGRATOR_RELATIVE).is_symlink()
     ):
         return False
+    package = root / _PACKAGE_RELATIVE
+    if package.exists() or package.is_symlink():
+        absent_inputs = (
+            _TRACKED_IGNORE_POLICY_RELATIVE,
+            _PRESERVATION_TRANSITION_RELATIVE,
+            _TOPOLOGY_MIGRATOR_RELATIVE,
+        )
+        for release in MANIFESTLESS_SEMANTIC_RELEASES:
+            if _matches_historic_release(root, release) and all(
+                not (root / relative).exists() and not (root / relative).is_symlink() for relative in absent_inputs
+            ):
+                return True
+        for compatibility in MISSING_MIGRATOR_RELEASES:
+            if _matches_historic_release(root, compatibility.release) and _matches_existing_inputs(root, compatibility):
+                return True
     try:
         tag_object = _run_git(
             root,
@@ -434,6 +1310,8 @@ def _supported_legacy_topology(
         _run_git(root, "merge-base", "--is-ancestor", pin.commit, head)
     except BridgeError:
         return False
+    if package.exists() or package.is_symlink():
+        return _regular_sha256(package) == _LEGACY_V1201_PACKAGE_SHA256
     return True
 
 
@@ -445,7 +1323,16 @@ def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.Te
     source = root / "foundation"
     try:
         _run_git(root, "init", "--bare", "--quiet", str(bare))
-        _run_git(bare, "fetch", "--quiet", "--no-tags", "--no-write-fetch-head", "--no-recurse-submodules", OFFICIAL_REMOTE, f"refs/tags/{pin.tag}:refs/tags/{pin.tag}")
+        _run_git(
+            bare,
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "--no-recurse-submodules",
+            OFFICIAL_REMOTE,
+            f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
+        )
         _verify_pin(bare, pin)
         # A linked worktree keeps the verified objects in the disposable bare
         # evidence store. It avoids opening the local ``file`` transport, which
@@ -576,10 +1463,7 @@ class _FoundationLifecycleService:
         self._source = Path(source).resolve()
         self._migrator = self._source / _TOPOLOGY_MIGRATOR_RELATIVE
         engine_relative = getattr(engine, "TOPOLOGY_MIGRATOR_RELATIVE", None)
-        if (
-            not isinstance(engine_relative, Path)
-            or engine_relative != _TOPOLOGY_MIGRATOR_RELATIVE
-        ):
+        if not isinstance(engine_relative, Path) or engine_relative != _TOPOLOGY_MIGRATOR_RELATIVE:
             raise BridgeError("pinned foundation topology migrator path changed")
         if (
             self._migrator.is_symlink()
@@ -588,10 +1472,7 @@ class _FoundationLifecycleService:
         ):
             raise BridgeError("pinned foundation topology migrator is missing or unsafe")
         self._migrator_sha256 = hashlib.sha256(self._migrator.read_bytes()).hexdigest()
-        if (
-            hashlib.sha256(_LEGACY_TRACKED_IGNORE_POLICY).hexdigest()
-            != _LEGACY_TRACKED_IGNORE_POLICY_SHA256
-        ):
+        if hashlib.sha256(_LEGACY_TRACKED_IGNORE_POLICY).hexdigest() != _LEGACY_TRACKED_IGNORE_POLICY_SHA256:
             raise BridgeError("pinned legacy tracked-ignore policy changed")
         compatibility = Path(
             tempfile.mkdtemp(
@@ -606,6 +1487,13 @@ class _FoundationLifecycleService:
             os.fsync(handle.fileno())
         self._preload.chmod(0o400)
         self._preload_sha256 = hashlib.sha256(self._preload.read_bytes()).hexdigest()
+        self._transport_preload = compatibility / "file-transport-only.cjs"
+        with self._transport_preload.open("xb") as handle:
+            handle.write(_transport_preload_bytes())
+            handle.flush()
+            os.fsync(handle.fileno())
+        self._transport_preload.chmod(0o400)
+        self._transport_preload_sha256 = hashlib.sha256(self._transport_preload.read_bytes()).hexdigest()
         if not callable(getattr(engine, "topology_state", None)) or not callable(
             getattr(engine, "_migrator_command", None)
         ):
@@ -619,21 +1507,24 @@ class _FoundationLifecycleService:
         if (
             self._migrator.is_symlink()
             or not self._migrator.is_file()
-            or self._migrator.resolve().parent != (
-                self._source / _TOPOLOGY_MIGRATOR_RELATIVE.parent
-            ).resolve()
-            or hashlib.sha256(self._migrator.read_bytes()).hexdigest()
-            != self._migrator_sha256
+            or self._migrator.resolve().parent != (self._source / _TOPOLOGY_MIGRATOR_RELATIVE.parent).resolve()
+            or hashlib.sha256(self._migrator.read_bytes()).hexdigest() != self._migrator_sha256
         ):
             raise BridgeError("pinned foundation topology migrator changed after verification")
         if (
             self._preload.is_symlink()
             or not self._preload.is_file()
             or not self._preload.resolve().is_relative_to(self._source.parent.resolve())
-            or hashlib.sha256(self._preload.read_bytes()).hexdigest()
-            != self._preload_sha256
+            or hashlib.sha256(self._preload.read_bytes()).hexdigest() != self._preload_sha256
         ):
             raise BridgeError("pinned legacy compatibility preload changed after verification")
+        if (
+            self._transport_preload.is_symlink()
+            or not self._transport_preload.is_file()
+            or not self._transport_preload.resolve().is_relative_to(self._source.parent.resolve())
+            or hashlib.sha256(self._transport_preload.read_bytes()).hexdigest() != self._transport_preload_sha256
+        ):
+            raise BridgeError("pinned transport compatibility preload changed after verification")
 
     @contextmanager
     def _topology_source(self) -> Iterator[None]:
@@ -641,11 +1532,14 @@ class _FoundationLifecycleService:
         original_state = self._engine.topology_state
         original_command = self._engine._migrator_command
         authorized_roots: set[Path] = set()
+        transport_roots: set[Path] = set()
 
         def topology_state(vault_root: Path) -> str:
             state = original_state(vault_root)
             root = Path(vault_root).resolve()
             candidate = root / _TOPOLOGY_MIGRATOR_RELATIVE
+            if state == "combined" and _native_transport_release(root) is not None:
+                transport_roots.add(root)
             if (
                 state == "invalid-combined"
                 and not candidate.exists()
@@ -660,24 +1554,43 @@ class _FoundationLifecycleService:
             root = Path(vault_root).resolve()
             candidate = root / _TOPOLOGY_MIGRATOR_RELATIVE
             if (
-                root not in authorized_roots
-                or candidate.exists()
-                or candidate.is_symlink()
-                or mode not in {"--dry-run", "--auto", "--resume"}
+                root in authorized_roots
+                and not candidate.exists()
+                and not candidate.is_symlink()
+                and mode in {"--dry-run", "--auto", "--resume"}
             ):
-                return original_command(vault_root, mode)
+                self._verify_compatibility_runtime()
+                node = _trusted_executable("node")
+                if node is None:
+                    raise BridgeError("trusted system Node.js is required for the foundation topology migrator")
+                return [
+                    str(node),
+                    "--require",
+                    str(self._preload),
+                    str(self._migrator),
+                    mode,
+                ]
+            command = original_command(vault_root, mode)
+            if root not in transport_roots:
+                return command
+            if (
+                mode not in {"--dry-run", "--auto", "--resume"}
+                or _native_transport_release(root) is None
+                or len(command) != 3
+                or Path(command[1]).resolve() != candidate.resolve()
+                or command[2] != mode
+            ):
+                raise BridgeError("pinned native migrator transport identity changed")
+            trusted_node = _trusted_executable("node")
+            if trusted_node is None or Path(command[0]).resolve() != trusted_node:
+                raise BridgeError("pinned native migrator selected an untrusted Node.js")
             self._verify_compatibility_runtime()
-            node = _trusted_executable("node")
-            if node is None:
-                raise BridgeError(
-                    "trusted system Node.js is required for the foundation topology migrator"
-                )
             return [
-                str(node),
+                command[0],
                 "--require",
-                str(self._preload),
-                str(self._migrator),
-                mode,
+                str(self._transport_preload),
+                command[1],
+                command[2],
             ]
 
         self._engine.topology_state = topology_state
@@ -702,7 +1615,8 @@ class _FoundationLifecycleService:
 
         original_tree_entries = self._apply_update._tree_entries
         original_verify_manifest = self._apply_update._verify_manifest
-        authorized_legacy_signatures: set[tuple[tuple[str, int, str], ...]] = set()
+        authorized_legacy_signatures: dict[tuple[tuple[str, int, str], ...], tuple[str, str]] = {}
+        manifestless_by_commit = {pin.commit: pin for pin in MANIFESTLESS_SEMANTIC_RELEASES}
         release_error = getattr(
             self._apply_update,
             "ReleaseVerificationError",
@@ -718,22 +1632,20 @@ class _FoundationLifecycleService:
             raise BridgeError("pinned foundation release entry type is unavailable")
 
         def signature(entries: tuple[Any, ...]) -> tuple[tuple[str, int, str], ...]:
-            return tuple(
-                (entry.path, entry.mode, entry.object_id) for entry in entries
-            )
+            return tuple((entry.path, entry.mode, entry.object_id) for entry in entries)
 
         def legacy_tree_entries(
             vault_root: Path,
             brain_git: Path,
             commit: str,
         ) -> tuple[Any, ...]:
-            if commit != LEGACY_TOPOLOGY_FOUNDATION.commit:
+            manifestless = manifestless_by_commit.get(commit)
+            defective = V175_DEFECTIVE_MANIFEST_RELEASE if commit == V175_DEFECTIVE_MANIFEST_RELEASE.commit else None
+            pin = manifestless or defective
+            if pin is None:
                 return original_tree_entries(vault_root, brain_git, commit)
-            if (
-                _run_git(Path(brain_git), "rev-parse", "--verify", f"{commit}^{{tree}}")
-                != LEGACY_TOPOLOGY_FOUNDATION.tree
-            ):
-                raise BridgeError("installed legacy release tree changed before delivery")
+            if _run_git(Path(brain_git), "rev-parse", "--verify", f"{commit}^{{tree}}") != pin.tree:
+                raise BridgeError("installed historic release tree changed before delivery")
             raw = self._apply_update._brain_output(
                 vault_root,
                 brain_git,
@@ -745,26 +1657,24 @@ class _FoundationLifecycleService:
             )
             entries: list[Any] = []
             seen: set[str] = set()
+            omitted: set[str] = set()
             for record in raw.split(b"\0"):
                 if not record:
                     continue
                 try:
                     metadata, raw_path = record.split(b"\t", 1)
-                    raw_mode, object_type, object_id = (
-                        metadata.decode("ascii").split(" ")
-                    )
+                    raw_mode, object_type, object_id = metadata.decode("ascii").split(" ")
                     relative = raw_path.decode("utf-8")
                 except (ValueError, UnicodeDecodeError) as error:
-                    raise release_error(
-                        "legacy release tree contains a malformed entry"
-                    ) from error
+                    raise release_error("legacy release tree contains a malformed entry") from error
                 if relative in seen or object_type != "blob":
                     raise release_error("legacy release tree is ambiguous")
                 seen.add(relative)
                 if raw_mode == "120000":
                     if (
-                        relative
-                        != _LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()
+                        manifestless is None
+                        or manifestless.commit != LEGACY_TOPOLOGY_FOUNDATION.commit
+                        or relative != _LEGACY_SHIPPED_SYMLINK_RELATIVE.as_posix()
                         or object_id != _LEGACY_SHIPPED_SYMLINK_BLOB
                         or self._apply_update._brain_output(
                             vault_root,
@@ -775,20 +1685,38 @@ class _FoundationLifecycleService:
                         )
                         != _LEGACY_SHIPPED_SYMLINK_TARGET.encode()
                     ):
-                        raise release_error(
-                            "legacy release contains an unknown symlink"
-                        )
+                        raise release_error("historic release contains an unknown symlink")
                     continue
                 if raw_mode not in {"100644", "100755"}:
-                    raise release_error(
-                        "legacy release contains an unsupported entry"
+                    raise release_error("historic release contains an unsupported entry")
+                if defective is not None and relative in _V175_DEFECTIVE_MANIFEST_OMISSIONS:
+                    if raw_mode != "100644" or object_id != _V175_DEFECTIVE_MANIFEST_OMISSIONS[relative]:
+                        raise release_error("historic defective-manifest omission changed")
+                    omitted.add(relative)
+                    continue
+                if manifestless is not None and relative in _TAU_MIRROR_OMISSIONS:
+                    if object_id != _TAU_MIRROR_OMISSIONS[relative]:
+                        raise release_error("historic tau-mirror omission changed")
+                    omitted.add(relative)
+                    continue
+                if manifestless is None:
+                    entries.append(
+                        tree_entry(
+                            relative,
+                            0o755 if raw_mode == "100755" else 0o644,
+                            object_id,
+                        )
                     )
+                    continue
                 try:
                     self._apply_update.portable_contract.resolve(relative)
-                except contract_violation:
+                except contract_violation as error:
                     # Retired release paths that the current contract does not
-                    # own are deliberately preserved rather than pruned.
-                    continue
+                    # own are preserved only for the already-shipped v1.20.1
+                    # exception. Later pins have only the exact tau omissions.
+                    if manifestless.commit == LEGACY_TOPOLOGY_FOUNDATION.commit:
+                        continue
+                    raise release_error("historic release contains an unknown unclassified path") from error
                 entries.append(
                     tree_entry(
                         relative,
@@ -796,8 +1724,13 @@ class _FoundationLifecycleService:
                         object_id,
                     )
                 )
+            if defective is not None and omitted != set(_V175_DEFECTIVE_MANIFEST_OMISSIONS):
+                raise release_error("historic release omission set changed")
             result = tuple(sorted(entries, key=lambda entry: entry.path))
-            authorized_legacy_signatures.add(signature(result))
+            authorized_legacy_signatures[signature(result)] = (
+                pin.commit,
+                "manifestless" if manifestless is not None else "incomplete-manifest",
+            )
             return result
 
         def verify_manifest(
@@ -805,18 +1738,22 @@ class _FoundationLifecycleService:
             brain_git: Path,
             entries: tuple[Any, ...],
         ) -> None:
+            authorization = authorized_legacy_signatures.get(signature(entries))
+            if authorization is None:
+                original_verify_manifest(vault_root, brain_git, entries)
+                return
+            installed = _run_git(
+                Path(brain_git),
+                "rev-parse",
+                "--verify",
+                "refs/dex/installed^{commit}",
+            )
+            if installed != authorization[0]:
+                raise release_error("historic installed release identity changed")
             try:
                 original_verify_manifest(vault_root, brain_git, entries)
             except release_error:
-                if signature(entries) not in authorized_legacy_signatures:
-                    raise
-                installed = _run_git(
-                    Path(brain_git),
-                    "rev-parse",
-                    "--verify",
-                    "refs/dex/installed^{commit}",
-                )
-                if installed != LEGACY_TOPOLOGY_FOUNDATION.commit:
+                if authorization[1] != "manifestless":
                     raise
 
         self._apply_update._tree_entries = legacy_tree_entries
@@ -922,19 +1859,22 @@ def _load_lifecycle_service(source: Path) -> LifecycleService:
     try:
         engine = importlib.import_module("core.lifecycle.engine")
     except Exception as error:  # noqa: BLE001
-        raise BridgeError(
-            f"pinned foundation topology engine could not start: {error}"
-        ) from error
+        raise BridgeError(f"pinned foundation topology engine could not start: {error}") from error
     try:
         apply_update = importlib.import_module("core.update.apply_update")
     except Exception as error:  # noqa: BLE001
-        raise BridgeError(
-            f"pinned foundation release planner could not start: {error}"
-        ) from error
+        raise BridgeError(f"pinned foundation release planner could not start: {error}") from error
     return _FoundationLifecycleService(module, engine, apply_update, source)
 
 
-def _approved_preview(prompt: str, preview: Mapping[str, Any], approval_token: object, *, input_fn: Callable[[str], str], output_fn: Callable[[str], None]) -> tuple[Mapping[str, Any], str]:
+def _approved_preview(
+    prompt: str,
+    preview: Mapping[str, Any],
+    approval_token: object,
+    *,
+    input_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+) -> tuple[Mapping[str, Any], str]:
     if not isinstance(approval_token, str) or not approval_token:
         raise BridgeError("lifecycle preview did not return an approval token")
     output_fn(json.dumps(preview, indent=2, sort_keys=True))
@@ -1070,10 +2010,7 @@ def _complete_mcp_registration(
 ) -> Mapping[str, Any]:
     registration = service.build_and_preview_mcp_registration(vault_root)
     if registration.get("needed") is False:
-        if (
-            registration.get("preview") is not None
-            or registration.get("approval_token") is not None
-        ):
+        if registration.get("preview") is not None or registration.get("approval_token") is not None:
             raise BridgeError("foundation returned a malformed completed MCP registration")
         return {"skipped": "mcp-already-registered"}
 
@@ -1097,7 +2034,15 @@ def _complete_mcp_registration(
     )
 
 
-def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin = FOUNDATION, fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain, input_fn: Callable[[str], str] = input, output_fn: Callable[[str], None] = print) -> Mapping[str, Any]:
+def run_bridge(
+    vault_root: Path,
+    service: LifecycleService,
+    *,
+    pin: ReleasePin = FOUNDATION,
+    fetch_foundation: Callable[[Path, ReleasePin], None] = _fetch_foundation_into_brain,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> Mapping[str, Any]:
     """Run up to three fresh approval boundaries through the foundation service."""
     root = _validate_vault(vault_root)
     # This local ref is the authoritative resume marker. Check it before
@@ -1121,15 +2066,18 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     # returns a read-only status document. Older service shapes used
     # ``brain-vault-split`` with no preview. Neither has an approval token, so
     # neither is an operation the bridge may repeat.
-    if (
-        topology.get("topology") in {"brain-vault-split", "post-split"}
-        and topology.get("approval_token") is None
-    ):
+    if topology.get("topology") in {"brain-vault-split", "post-split"} and topology.get("approval_token") is None:
         topology_receipt: Mapping[str, Any] = {"skipped": "already-brain-vault-split"}
     else:
         if not isinstance(preview, Mapping):
             raise BridgeError("foundation could not produce a topology preview")
-        preview, token = _approved_preview("Dex will first separate its code from your notes.", preview, topology.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
+        preview, token = _approved_preview(
+            "Dex will first separate its code from your notes.",
+            preview,
+            topology.get("approval_token"),
+            input_fn=input_fn,
+            output_fn=output_fn,
+        )
         topology_receipt = service.execute_approved_topology_migration(root, preview, token)
 
     # This fetch touches only Dex's private code store. The following preview is
@@ -1139,7 +2087,13 @@ def run_bridge(vault_root: Path, service: LifecycleService, *, pin: ReleasePin =
     release_preview = delivery.get("preview")
     if not isinstance(release_preview, Mapping):
         raise BridgeError("foundation could not produce a delivered-release preview")
-    release_preview, release_token = _approved_preview(f"Dex will now install verified foundation v{pin.version}.", release_preview, delivery.get("approval_token"), input_fn=input_fn, output_fn=output_fn)
+    release_preview, release_token = _approved_preview(
+        f"Dex will now install verified foundation v{pin.version}.",
+        release_preview,
+        delivery.get("approval_token"),
+        input_fn=input_fn,
+        output_fn=output_fn,
+    )
     delivery_receipt = service.execute_approved_delivered_release(root, release_preview, release_token)
 
     mcp_registration_receipt = _complete_mcp_registration(

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -290,6 +290,20 @@ MANIFESTLESS_SEMANTIC_RELEASES = (
     ),
 )
 
+V161_RETIRED_MANIFEST_RELEASE = HistoricReleasePin(
+    "dist/release/v1.61.0-774437a",
+    "d1325426421fc0228865b2a64c8e780f2b8056ed",
+    "tag",
+    "774437aadfdb85bf834e2c2e1eacca6488364c18",
+    "c3a71ece867e43c88dd30b8166c6087da2b344f2",
+    "1.61.0",
+    "b5e268bfd8bfe62e3efbe5a141e8dbb020d73609",
+    "20d095aedcad0a13bd6b25ea183afcd5d367c438adb082b1044c582fb5c2ebf9",
+)
+_V161_RETIRED_MANIFEST_BLOB = "feef2bb3dd6756c7c54d76bdfd6128904c87f679"
+_V161_RETIRED_MANIFEST_SHA256 = "edf6e98bc16063c47b362280cfa33fd10f075a5d240d5884d5ded5d894cbcc63"
+_V161_RETIRED_MANIFEST_PATH_COUNT = 768
+
 V175_DEFECTIVE_MANIFEST_RELEASE = HistoricReleasePin(
     "v1.75.0",
     "5e73481519ee9b5fe9a6c3196ee7cabaa0446ee8",
@@ -1620,12 +1634,13 @@ class _FoundationLifecycleService:
     def _legacy_delivery_source(self) -> Iterator[None]:
         """Let the planner read the one exact pre-manifest legacy release.
 
-        v1.20.1 has one shipped symlink and no installed-files manifest. The
-        foundation planner correctly refuses either shape for a modern target.
-        For only the already-pinned installed tree, this read adapter omits the
-        known symlink and unclassified retired release paths. The lifecycle
-        transaction remains the sole writer; omitted legacy paths stay in
-        place as user-controlled/unmanaged content.
+        Historic sources can have no manifest, one incomplete manifest, or one
+        exact early manifest that still names two retired entries. The
+        foundation planner correctly refuses those shapes for a modern target.
+        For only the already-pinned installed trees, this read adapter omits
+        closed entry identities. The lifecycle transaction remains the sole
+        writer; omitted legacy paths stay in place as user-controlled/unmanaged
+        content.
         """
 
         original_tree_entries = self._apply_update._tree_entries
@@ -1656,11 +1671,53 @@ class _FoundationLifecycleService:
         ) -> tuple[Any, ...]:
             manifestless = manifestless_by_commit.get(commit)
             defective = V175_DEFECTIVE_MANIFEST_RELEASE if commit == V175_DEFECTIVE_MANIFEST_RELEASE.commit else None
-            pin = manifestless or defective
+            retired_manifest = (
+                V161_RETIRED_MANIFEST_RELEASE
+                if commit == V161_RETIRED_MANIFEST_RELEASE.commit
+                else None
+            )
+            pin = manifestless or defective or retired_manifest
             if pin is None:
                 return original_tree_entries(vault_root, brain_git, commit)
             if _run_git(Path(brain_git), "rev-parse", "--verify", f"{commit}^{{tree}}") != pin.tree:
                 raise BridgeError("installed historic release tree changed before delivery")
+            if retired_manifest is not None:
+                try:
+                    if (
+                        _run_git(
+                            Path(brain_git),
+                            "for-each-ref",
+                            "--format=%(objectname)",
+                            f"refs/tags/{retired_manifest.tag}",
+                        )
+                        != retired_manifest.tag_object
+                        or _run_git(Path(brain_git), "cat-file", "-t", retired_manifest.tag_object)
+                        != retired_manifest.tag_object_type
+                        or _run_git(
+                            Path(brain_git),
+                            "rev-parse",
+                            "--verify",
+                            f"{retired_manifest.tag}^{{commit}}",
+                        )
+                        != retired_manifest.commit
+                        or _run_git(
+                            Path(brain_git),
+                            "rev-parse",
+                            "--verify",
+                            f"{retired_manifest.commit}:{_PACKAGE_RELATIVE.as_posix()}",
+                        )
+                        != retired_manifest.package_blob
+                        or _run_git(
+                            Path(brain_git),
+                            "rev-parse",
+                            "--verify",
+                            f"{retired_manifest.commit}:System/.installed-files.manifest",
+                        )
+                        != _V161_RETIRED_MANIFEST_BLOB
+                    ):
+                        raise release_error("historic retired-manifest identity changed")
+                except BridgeError as error:
+                    raise release_error("historic retired-manifest identity changed") from error
             raw = self._apply_update._brain_output(
                 vault_root,
                 brain_git,
@@ -1710,10 +1767,28 @@ class _FoundationLifecycleService:
                     omitted.add(relative)
                     continue
                 omission_identity = _manifestless_omission_identity(relative, raw_mode, object_id)
-                if manifestless is not None and omission_identity in _MANIFESTLESS_OMISSION_IDENTITIES:
+                if (
+                    (manifestless is not None or retired_manifest is not None)
+                    and omission_identity in _MANIFESTLESS_OMISSION_IDENTITIES
+                ):
                     omitted.add(omission_identity)
                     continue
-                if manifestless is None:
+                if manifestless is None and retired_manifest is None:
+                    entries.append(
+                        tree_entry(
+                            relative,
+                            0o755 if raw_mode == "100755" else 0o644,
+                            object_id,
+                        )
+                    )
+                    continue
+                if retired_manifest is not None:
+                    try:
+                        self._apply_update.portable_contract.resolve(relative)
+                    except contract_violation as error:
+                        raise release_error(
+                            "historic release contains an unknown unclassified path"
+                        ) from error
                     entries.append(
                         tree_entry(
                             relative,
@@ -1742,10 +1817,39 @@ class _FoundationLifecycleService:
                 raise release_error("historic release omission set changed")
             if manifestless is not None and not _manifestless_omission_identities_match(omitted):
                 raise release_error("historic manifestless omission set changed")
+            if retired_manifest is not None:
+                if not _manifestless_omission_identities_match(omitted):
+                    raise release_error("historic retired-manifest omission set changed")
+                complete = original_tree_entries(vault_root, brain_git, commit)
+                original_verify_manifest(vault_root, brain_git, complete)
+                by_path = {entry.path: entry for entry in complete}
+                manifest_entry = by_path.get("System/.installed-files.manifest")
+                if (
+                    len(complete) != _V161_RETIRED_MANIFEST_PATH_COUNT
+                    or manifest_entry is None
+                    or manifest_entry.object_id != _V161_RETIRED_MANIFEST_BLOB
+                    or hashlib.sha256(
+                        self._apply_update._brain_output(
+                            vault_root,
+                            brain_git,
+                            "cat-file",
+                            "blob",
+                            manifest_entry.object_id,
+                        )
+                    ).hexdigest()
+                    != _V161_RETIRED_MANIFEST_SHA256
+                ):
+                    raise release_error("historic retired-manifest identity changed")
             result = tuple(sorted(entries, key=lambda entry: entry.path))
             authorized_legacy_signatures[signature(result)] = (
                 pin.commit,
-                "manifestless" if manifestless is not None else "incomplete-manifest",
+                (
+                    "manifestless"
+                    if manifestless is not None
+                    else "retired-manifest"
+                    if retired_manifest is not None
+                    else "incomplete-manifest"
+                ),
             )
             return result
 
@@ -1769,7 +1873,7 @@ class _FoundationLifecycleService:
             try:
                 original_verify_manifest(vault_root, brain_git, entries)
             except release_error:
-                if authorization[1] != "manifestless":
+                if authorization[1] not in {"manifestless", "retired-manifest"}:
                     raise
 
         self._apply_update._tree_entries = legacy_tree_entries

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -38,10 +38,25 @@ _LEGACY_SHIPPED_SYMLINK_RELATIVE = Path(".pi/agent/extensions/dex")
 _LEGACY_SHIPPED_SYMLINK_TARGET = "../../../pi-extensions/dex"
 _LEGACY_SHIPPED_SYMLINK_BLOB = "f1c88c92cea996705f982e902bafb758156aef52"
 _PACKAGE_RELATIVE = Path("package.json")
-_TAU_MIRROR_OMISSIONS = {
-    "extensions/tau-mirror/README-TAU-MIRROR.md": "c19e4fafa1adeb1d1232299ff7be68c448cab498",
-    "extensions/tau-mirror/tau-mirror-integration.ts": "fff2a52e50070545ad46760100d9cedab5dc1ecd",
-}
+_MANIFESTLESS_OMISSION_IDENTITIES = frozenset(
+    {
+        "af78f3d480b78b5bb558d873b98638c91d532de98f84f8f50e73448a1404b37d",
+        "50a3e65dc2d65e6f6b28b30b630e06656d95ddd82f4a68a7152017119b110f90",
+    }
+)
+
+
+def _manifestless_omission_identity(relative: str, raw_mode: str, object_id: str) -> str:
+    """Return an opaque identity for one exact historical tree entry."""
+
+    record = f"{raw_mode} blob {object_id}\t{relative}".encode()
+    return hashlib.sha256(record).hexdigest()
+
+
+def _manifestless_omission_identities_match(identities: set[str] | frozenset[str]) -> bool:
+    """Accept only the complete closed omission set shipped by the pinned trees."""
+
+    return frozenset(identities) == _MANIFESTLESS_OMISSION_IDENTITIES
 
 
 class BridgeError(RuntimeError):
@@ -1694,10 +1709,9 @@ class _FoundationLifecycleService:
                         raise release_error("historic defective-manifest omission changed")
                     omitted.add(relative)
                     continue
-                if manifestless is not None and relative in _TAU_MIRROR_OMISSIONS:
-                    if object_id != _TAU_MIRROR_OMISSIONS[relative]:
-                        raise release_error("historic tau-mirror omission changed")
-                    omitted.add(relative)
+                omission_identity = _manifestless_omission_identity(relative, raw_mode, object_id)
+                if manifestless is not None and omission_identity in _MANIFESTLESS_OMISSION_IDENTITIES:
+                    omitted.add(omission_identity)
                     continue
                 if manifestless is None:
                     entries.append(
@@ -1713,7 +1727,7 @@ class _FoundationLifecycleService:
                 except contract_violation as error:
                     # Retired release paths that the current contract does not
                     # own are preserved only for the already-shipped v1.20.1
-                    # exception. Later pins have only the exact tau omissions.
+                    # exception. Later pins have only the two closed omissions.
                     if manifestless.commit == LEGACY_TOPOLOGY_FOUNDATION.commit:
                         continue
                     raise release_error("historic release contains an unknown unclassified path") from error
@@ -1726,6 +1740,8 @@ class _FoundationLifecycleService:
                 )
             if defective is not None and omitted != set(_V175_DEFECTIVE_MANIFEST_OMISSIONS):
                 raise release_error("historic release omission set changed")
+            if manifestless is not None and not _manifestless_omission_identities_match(omitted):
+                raise release_error("historic manifestless omission set changed")
             result = tuple(sorted(entries, key=lambda entry: entry.path))
             authorized_legacy_signatures[signature(result)] = (
                 pin.commit,

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -422,6 +422,16 @@ class MissingMigratorPin:
     inputs: ExistingInputTuple
 
 
+@dataclass(frozen=True)
+class LegacyTopologyAuthorization:
+    """Exact release and input class proven before borrowing the migrator."""
+
+    kind: str
+    release: HistoricReleasePin | LegacyTopologyPin
+    inputs: ExistingInputTuple | None
+    package_state: str
+
+
 def _historic_pin(
     tag: str,
     tag_object: str,
@@ -853,10 +863,36 @@ baselines:
 _LEGACY_TRACKED_IGNORE_POLICY_SHA256 = "bf0af119939930fb4d3b466584a3e9392edb66bf61ec09675521c9a5969f3f50"
 
 
-def _legacy_preload_bytes() -> bytes:
+def _legacy_preload_bytes(
+    authorization: LegacyTopologyAuthorization | None = None,
+) -> bytes:
     """Build the closed preload for absent or exact defective legacy inputs."""
 
     policy = base64.b64encode(_LEGACY_TRACKED_IGNORE_POLICY).decode("ascii")
+    if authorization is None:
+        allowed_pins = MISSING_MIGRATOR_RELEASES
+        expected_package_version = None
+        expected_package_sha256 = None
+        expected_package_state = None
+    else:
+        allowed_pins = tuple(
+            pin
+            for pin in MISSING_MIGRATOR_RELEASES
+            if authorization.inputs is not None
+            and pin.release == authorization.release
+            and pin.inputs == authorization.inputs
+        )
+        if isinstance(authorization.release, HistoricReleasePin):
+            expected_package_version = authorization.release.version
+            expected_package_sha256 = authorization.release.package_sha256
+        else:
+            expected_package_version = "1.20.1"
+            expected_package_sha256 = (
+                _LEGACY_V1201_PACKAGE_SHA256
+                if authorization.package_state == "present"
+                else None
+            )
+        expected_package_state = authorization.package_state
     allowed_existing = json.dumps(
         sorted(
             {
@@ -866,7 +902,7 @@ def _legacy_preload_bytes() -> bytes:
                     pin.inputs.policy_sha256,
                     pin.inputs.transition_sha256,
                 )
-                for pin in MISSING_MIGRATOR_RELEASES
+                for pin in allowed_pins
             }
         ),
         separators=(",", ":"),
@@ -894,6 +930,9 @@ const inputs = new Map([
   [path.join(root, '{_TRACKED_IGNORE_POLICY_RELATIVE.as_posix()}'), Buffer.from('{policy}', 'base64')],
 ]);
 const allowedExisting = new Set({allowed_existing}.map((values) => values.join(':')));
+const expectedPackageVersion = {json.dumps(expected_package_version)};
+const expectedPackageDigest = {json.dumps(expected_package_sha256)};
+const expectedPackageState = {json.dumps(expected_package_state)};
 const originalReadFileSync = fs.readFileSync.bind(fs);
 const originalReaddirSync = fs.readdirSync.bind(fs);
 
@@ -923,6 +962,13 @@ function legacyTransition() {{
     || !/^[0-9]+\\.[0-9]+\\.[0-9]+$/.test(packageJson.version)
   ) {{
     throw new Error(`Dex update bridge refused invalid legacy package version ${{packagePath}}.`);
+  }}
+  if (
+    (expectedPackageState && expectedPackageState !== 'present')
+    || (expectedPackageVersion && packageJson.version !== expectedPackageVersion)
+    || (expectedPackageDigest && digest(originalReadFileSync(packagePath)) !== expectedPackageDigest)
+  ) {{
+    throw new Error('Dex update bridge refused changed legacy package identity.');
   }}
   return Buffer.from(`${{JSON.stringify({{
     phase: 'bootstrap-v1',
@@ -956,6 +1002,13 @@ function compatibilityInputs() {{
   }}
   if (!packageJson || typeof packageJson.version !== 'string') {{
     throw new Error(`Dex update bridge refused invalid legacy package version ${{packagePath}}.`);
+  }}
+  if (
+    (expectedPackageState && expectedPackageState !== 'present')
+    || (expectedPackageVersion && packageJson.version !== expectedPackageVersion)
+    || (expectedPackageDigest && digest(packageBytes) !== expectedPackageDigest)
+  ) {{
+    throw new Error('Dex update bridge refused changed legacy package identity.');
   }}
   const policyBytes = regularBytes(policyPath, 'tracked-ignore policy');
   const transitionBytes = regularBytes(transitionPath, 'preservation transition');
@@ -1298,11 +1351,11 @@ def exact_unbound_journey_source(
     return pin.release.commit
 
 
-def _supported_legacy_topology(
+def _legacy_topology_authorization(
     vault_root: Path,
     pin: LegacyTopologyPin = LEGACY_TOPOLOGY_FOUNDATION,
-) -> bool:
-    """Prove the exact legacy base allowed to borrow the foundation migrator."""
+) -> LegacyTopologyAuthorization | None:
+    """Return the exact legacy release and input class proved at this instant."""
 
     root = Path(vault_root)
     git_directory = root / ".git"
@@ -1312,7 +1365,7 @@ def _supported_legacy_topology(
         or (root / _TOPOLOGY_MIGRATOR_RELATIVE).exists()
         or (root / _TOPOLOGY_MIGRATOR_RELATIVE).is_symlink()
     ):
-        return False
+        return None
     package = root / _PACKAGE_RELATIVE
     if package.exists() or package.is_symlink():
         absent_inputs = (
@@ -1324,15 +1377,30 @@ def _supported_legacy_topology(
             if _matches_historic_release(root, release) and all(
                 not (root / relative).exists() and not (root / relative).is_symlink() for relative in absent_inputs
             ):
-                return True
+                return LegacyTopologyAuthorization(
+                    "absent-inputs",
+                    release,
+                    None,
+                    "present",
+                )
         if _matches_historic_release(root, V161_RETIRED_MANIFEST_RELEASE) and all(
             not (root / relative).exists() and not (root / relative).is_symlink()
             for relative in absent_inputs
         ):
-            return True
+            return LegacyTopologyAuthorization(
+                "absent-inputs",
+                V161_RETIRED_MANIFEST_RELEASE,
+                None,
+                "present",
+            )
         for compatibility in MISSING_MIGRATOR_RELEASES:
             if _matches_historic_release(root, compatibility.release) and _matches_existing_inputs(root, compatibility):
-                return True
+                return LegacyTopologyAuthorization(
+                    "existing-inputs",
+                    compatibility.release,
+                    compatibility.inputs,
+                    "present",
+                )
     try:
         tag_object = _run_git(
             root,
@@ -1342,9 +1410,9 @@ def _supported_legacy_topology(
         )
         if tag_object:
             if tag_object != pin.tag_object:
-                return False
+                return None
             if _run_git(root, "cat-file", "-t", pin.tag_object) != "tag":
-                return False
+                return None
             identity = pin.tag
         else:
             # Historic installers retained their own release tag but could
@@ -1352,21 +1420,39 @@ def _supported_legacy_topology(
             # only when its object type, commit identity, tree, and ancestry
             # all match the closed v1.20.1 foundation.
             if _run_git(root, "cat-file", "-t", pin.commit) != "commit":
-                return False
+                return None
             identity = pin.commit
         if _run_git(root, "rev-parse", "--verify", f"{identity}^{{commit}}") != pin.commit:
-            return False
+            return None
         if _run_git(root, "rev-parse", "--verify", f"{identity}^{{tree}}") != pin.tree:
-            return False
+            return None
         head = _run_git(root, "rev-parse", "--verify", "HEAD^{commit}")
         if _HEX.fullmatch(head) is None:
-            return False
+            return None
         _run_git(root, "merge-base", "--is-ancestor", pin.commit, head)
     except BridgeError:
-        return False
+        return None
     if package.exists() or package.is_symlink():
-        return _regular_sha256(package) == _LEGACY_V1201_PACKAGE_SHA256
-    return True
+        if _regular_sha256(package) != _LEGACY_V1201_PACKAGE_SHA256:
+            return None
+        package_state = "present"
+    else:
+        package_state = "absent"
+    return LegacyTopologyAuthorization(
+        "absent-inputs",
+        pin,
+        None,
+        package_state,
+    )
+
+
+def _supported_legacy_topology(
+    vault_root: Path,
+    pin: LegacyTopologyPin = LEGACY_TOPOLOGY_FOUNDATION,
+) -> bool:
+    """Prove the exact legacy base allowed to borrow the foundation migrator."""
+
+    return _legacy_topology_authorization(vault_root, pin) is not None
 
 
 def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.TemporaryDirectory[str], Path]:
@@ -1541,6 +1627,10 @@ class _FoundationLifecycleService:
             os.fsync(handle.fileno())
         self._preload.chmod(0o400)
         self._preload_sha256 = hashlib.sha256(self._preload.read_bytes()).hexdigest()
+        self._authorization_preloads: dict[
+            LegacyTopologyAuthorization,
+            tuple[Path, str],
+        ] = {}
         self._transport_preload = compatibility / "file-transport-only.cjs"
         with self._transport_preload.open("xb") as handle:
             handle.write(_transport_preload_bytes())
@@ -1572,6 +1662,15 @@ class _FoundationLifecycleService:
             or hashlib.sha256(self._preload.read_bytes()).hexdigest() != self._preload_sha256
         ):
             raise BridgeError("pinned legacy compatibility preload changed after verification")
+        for authorization_preload, expected_sha256 in self._authorization_preloads.values():
+            if (
+                authorization_preload.is_symlink()
+                or not authorization_preload.is_file()
+                or not authorization_preload.resolve().is_relative_to(self._source.parent.resolve())
+                or hashlib.sha256(authorization_preload.read_bytes()).hexdigest()
+                != expected_sha256
+            ):
+                raise BridgeError("bound legacy compatibility preload changed after verification")
         if (
             self._transport_preload.is_symlink()
             or not self._transport_preload.is_file()
@@ -1580,12 +1679,39 @@ class _FoundationLifecycleService:
         ):
             raise BridgeError("pinned transport compatibility preload changed after verification")
 
+    def _preload_for_authorization(
+        self,
+        authorization: LegacyTopologyAuthorization,
+    ) -> Path:
+        existing = self._authorization_preloads.get(authorization)
+        if existing is not None:
+            return existing[0]
+        content = _legacy_preload_bytes(authorization)
+        sha256 = hashlib.sha256(content).hexdigest()
+        preload = self._preload.parent / f"read-only-inputs-{sha256[:16]}.cjs"
+        try:
+            with preload.open("xb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            preload.chmod(0o400)
+        except FileExistsError as error:
+            if (
+                preload.is_symlink()
+                or not preload.is_file()
+                or hashlib.sha256(preload.read_bytes()).hexdigest() != sha256
+            ):
+                raise BridgeError("bound legacy compatibility preload identity collided") from error
+        self._authorization_preloads[authorization] = (preload, sha256)
+        self._verify_compatibility_runtime()
+        return preload
+
     @contextmanager
     def _topology_source(self) -> Iterator[None]:
         self._verify_compatibility_runtime()
         original_state = self._engine.topology_state
         original_command = self._engine._migrator_command
-        authorized_roots: set[Path] = set()
+        authorized_roots: dict[Path, LegacyTopologyAuthorization] = {}
         transport_roots: set[Path] = set()
 
         def topology_state(vault_root: Path) -> str:
@@ -1598,29 +1724,34 @@ class _FoundationLifecycleService:
                 state == "invalid-combined"
                 and not candidate.exists()
                 and not candidate.is_symlink()
-                and _supported_legacy_topology(root)
             ):
-                authorized_roots.add(root)
-                return "combined"
+                authorization = _legacy_topology_authorization(root)
+                if authorization is not None:
+                    authorized_roots[root] = authorization
+                    return "combined"
             return state
 
         def migrator_command(vault_root: Path, mode: str) -> list[str]:
             root = Path(vault_root).resolve()
             candidate = root / _TOPOLOGY_MIGRATOR_RELATIVE
-            if (
-                root in authorized_roots
-                and not candidate.exists()
-                and not candidate.is_symlink()
-                and mode in {"--dry-run", "--auto", "--resume"}
-            ):
+            authorization = authorized_roots.get(root)
+            if authorization is not None:
+                if (
+                    candidate.exists()
+                    or candidate.is_symlink()
+                    or mode not in {"--dry-run", "--auto", "--resume"}
+                    or _legacy_topology_authorization(root) != authorization
+                ):
+                    raise BridgeError("pinned legacy topology identity changed after authorization")
                 self._verify_compatibility_runtime()
                 node = _trusted_executable("node")
                 if node is None:
                     raise BridgeError("trusted system Node.js is required for the foundation topology migrator")
+                preload = self._preload_for_authorization(authorization)
                 return [
                     str(node),
                     "--require",
-                    str(self._preload),
+                    str(preload),
                     str(self._migrator),
                     mode,
                 ]

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -698,6 +698,26 @@ def historic_compatibility_pins() -> dict[str, dict[str, object]]:
         "blob": _LEGACY_SHIPPED_SYMLINK_BLOB,
         "target": _LEGACY_SHIPPED_SYMLINK_TARGET,
     }
+    retired_manifest = V161_RETIRED_MANIFEST_RELEASE
+    pins[retired_manifest.tag] = {
+        "kind": "complete-manifest-retired-paths",
+        "role": "installed-source",
+        "tag": retired_manifest.tag,
+        "tag_object": retired_manifest.tag_object,
+        "commit": retired_manifest.commit,
+        "tree": retired_manifest.tree,
+        "version": retired_manifest.version,
+        "package_blob": retired_manifest.package_blob,
+        "package_sha256": retired_manifest.package_sha256,
+        "manifest_blob": _V161_RETIRED_MANIFEST_BLOB,
+        "manifest_sha256": _V161_RETIRED_MANIFEST_SHA256,
+        "manifest_path_count": _V161_RETIRED_MANIFEST_PATH_COUNT,
+        "policy_blob": None,
+        "transition_blob": None,
+        "migrator_blob": None,
+        "omission_identities": tuple(sorted(_MANIFESTLESS_OMISSION_IDENTITIES)),
+        "unexpected_nonregular_paths": (),
+    }
     pins[V175_DEFECTIVE_MANIFEST_RELEASE.tag] = {
         "kind": "incomplete-manifest",
         "role": "installed-source",
@@ -1305,6 +1325,11 @@ def _supported_legacy_topology(
                 not (root / relative).exists() and not (root / relative).is_symlink() for relative in absent_inputs
             ):
                 return True
+        if _matches_historic_release(root, V161_RETIRED_MANIFEST_RELEASE) and all(
+            not (root / relative).exists() and not (root / relative).is_symlink()
+            for relative in absent_inputs
+        ):
+            return True
         for compatibility in MISSING_MIGRATOR_RELEASES:
             if _matches_historic_release(root, compatibility.release) and _matches_existing_inputs(root, compatibility):
                 return True
@@ -1686,20 +1711,13 @@ class _FoundationLifecycleService:
                     if (
                         _run_git(
                             Path(brain_git),
-                            "for-each-ref",
-                            "--format=%(objectname)",
-                            f"refs/tags/{retired_manifest.tag}",
-                        )
-                        != retired_manifest.tag_object
-                        or _run_git(Path(brain_git), "cat-file", "-t", retired_manifest.tag_object)
-                        != retired_manifest.tag_object_type
-                        or _run_git(
-                            Path(brain_git),
                             "rev-parse",
                             "--verify",
-                            f"{retired_manifest.tag}^{{commit}}",
+                            "refs/dex/installed^{commit}",
                         )
                         != retired_manifest.commit
+                        or _run_git(Path(brain_git), "cat-file", "-t", retired_manifest.commit)
+                        != "commit"
                         or _run_git(
                             Path(brain_git),
                             "rev-parse",

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -31,6 +31,7 @@ from core.update.journey_protocol import (
     UpdateJourneyProtocol,
     load_update_journey_protocol,
 )
+from scripts import dex_update_bridge
 
 UPDATE_JOURNEY_RELATIVE = PROTOCOL_RELATIVE
 RELEASE_TAG = re.compile(
@@ -474,6 +475,7 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "controller": None,
         "executor": None,
     }
+    unbound_source: str | None = None
     if protocol_bytes is not None:
         try:
             protocol = load_update_journey_protocol(protocol_bytes)
@@ -481,10 +483,11 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
             raise FleetError(
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
-        source_commit = _verify_released_protocol_artifacts(repo, release, protocol)
+        unbound_source = dex_update_bridge.exact_unbound_journey_source(repo, release.tag)
+        source_commit = unbound_source or _verify_released_protocol_artifacts(repo, release, protocol)
         protocol_surface = {
             "path": UPDATE_JOURNEY_RELATIVE,
-            "status": "present",
+            "status": "present-unbound" if unbound_source else "present",
             "sha256": hashlib.sha256(protocol_bytes).hexdigest(),
             "schema_version": protocol.schema_version,
             "controller": protocol.controller,
@@ -513,7 +516,7 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
         "journey_protocol": protocol_surface,
         # This describes released capability, not successful execution.
         # Acceptance still requires a live, process-local ExecutorRun.
-        "machine_executable": protocol_bytes is not None,
+        "machine_executable": protocol_bytes is not None and unbound_source is None,
     }
 
 
@@ -1602,6 +1605,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
         repo, release.tag, "core/lifecycle/catalog/bridge-release.json"
     )
     protocol = _optional_tag_file(repo, release.tag, UPDATE_JOURNEY_RELATIVE)
+    unbound_source = dex_update_bridge.exact_unbound_journey_source(repo, release.tag)
     if protocol is not None:
         try:
             parsed_protocol = load_update_journey_protocol(protocol)
@@ -1609,9 +1613,13 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
             raise FleetError(
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
-        _verify_released_protocol_artifacts(repo, release, parsed_protocol)
-        route = "machine-protocol-released-executor"
-        bridge_requirement = "released-journey-executor"
+        if unbound_source is None:
+            _verify_released_protocol_artifacts(repo, release, parsed_protocol)
+            route = "machine-protocol-released-executor"
+            bridge_requirement = "released-journey-executor"
+        else:
+            route = "protocol-present-unbound-source"
+            bridge_requirement = "versioned-delivery-bridge-required"
     elif skill is None:
         route = "missing-dex-update-skill"
         bridge_requirement = "unsupported-without-published-route"
@@ -1627,7 +1635,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
     return {
         "route_classification": route,
         "bridge_requirement": bridge_requirement,
-        "machine_executable": protocol is not None,
+        "machine_executable": protocol is not None and unbound_source is None,
         "dex_update_skill": {
             "path": UPDATE_SKILL_RELATIVE,
             "status": "present" if skill is not None else "missing",

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -1024,19 +1024,19 @@ def _write_failure_diagnostic(
         + "\n"
     ).encode("utf-8")
     temporary = evidence_root / f".{name}.{os.getpid()}.{time.time_ns()}.tmp"
-    descriptor = os.open(
-        temporary,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-        0o600,
-    )
     try:
-        view = memoryview(content)
-        while view:
-            view = view[os.write(descriptor, view) :]
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        try:
+            view = memoryview(content)
+            while view:
+                view = view[os.write(descriptor, view) :]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
         # link(2) is atomic and fails rather than replacing a pre-existing path.
         os.link(temporary, destination, follow_symlinks=False)
         directory = os.open(evidence_root, os.O_RDONLY)
@@ -1060,7 +1060,6 @@ def _failure_runtime_metadata(vault: Path) -> dict[str, dict[str, object]]:
     return {
         relative: _safe_file_metadata(vault, relative)
         for relative in (
-            ".mcp.json",
             "System/.release-catalog.json",
             "System/.installed-files.manifest",
         )

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -556,6 +556,8 @@ class _ProductionRuntime:
         vault: Path,
         module: str,
         *arguments: str,
+        timeout_seconds: int = 600,
+        timeout_attempts: int = 1,
     ) -> Mapping[str, object]:
         root = dex_update_bridge._validate_vault(vault)
         interpreter = dex_update_bridge._installed_python(root)
@@ -572,13 +574,21 @@ class _ProductionRuntime:
             start_new_session=True,
         )
         try:
-            stdout, stderr = process.communicate(timeout=600)
+            stdout, stderr = process.communicate(timeout=timeout_seconds)
         except subprocess.TimeoutExpired as error:
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
             process.communicate()
+            if timeout_attempts > 1:
+                return self._installed_json(
+                    vault,
+                    module,
+                    *arguments,
+                    timeout_seconds=timeout_seconds,
+                    timeout_attempts=timeout_attempts - 1,
+                )
             raise ExecutorError(f"installed {module} timed out") from error
         if len(stdout) > 16 * 1024 * 1024 or len(stderr) > 1024 * 1024:
             raise ExecutorError(f"installed {module} output exceeded its bound")
@@ -594,7 +604,12 @@ class _ProductionRuntime:
         return report
 
     def doctor(self, vault: Path) -> Mapping[str, object]:
-        return self._installed_json(vault, "core.utils.doctor")
+        return self._installed_json(
+            vault,
+            "core.utils.doctor",
+            timeout_seconds=60,
+            timeout_attempts=2,
+        )
 
     def deliver_latest_release(self, vault: Path) -> Mapping[str, object]:
         return self._server_call(vault, "deliver_latest_release")

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -558,6 +558,8 @@ class _ProductionRuntime:
         *arguments: str,
         timeout_seconds: int = 600,
         timeout_attempts: int = 1,
+        attempt_number: int = 1,
+        retain_attempt_count: bool = False,
     ) -> Mapping[str, object]:
         root = dex_update_bridge._validate_vault(vault)
         interpreter = dex_update_bridge._installed_python(root)
@@ -588,6 +590,8 @@ class _ProductionRuntime:
                     *arguments,
                     timeout_seconds=timeout_seconds,
                     timeout_attempts=timeout_attempts - 1,
+                    attempt_number=attempt_number + 1,
+                    retain_attempt_count=retain_attempt_count,
                 )
             raise ExecutorError(f"installed {module} timed out") from error
         if len(stdout) > 16 * 1024 * 1024 or len(stderr) > 1024 * 1024:
@@ -601,6 +605,15 @@ class _ProductionRuntime:
             raise ExecutorError(f"installed {module} returned malformed JSON") from error
         if not isinstance(report, Mapping):
             raise ExecutorError(f"installed {module} returned malformed JSON")
+        if retain_attempt_count:
+            if "journey_transport" in report:
+                raise ExecutorError(
+                    f"installed {module} returned reserved journey transport evidence"
+                )
+            return {
+                **report,
+                "journey_transport": {"attempt_count": attempt_number},
+            }
         return report
 
     def doctor(self, vault: Path) -> Mapping[str, object]:
@@ -609,6 +622,7 @@ class _ProductionRuntime:
             "core.utils.doctor",
             timeout_seconds=60,
             timeout_attempts=2,
+            retain_attempt_count=True,
         )
 
     def deliver_latest_release(self, vault: Path) -> Mapping[str, object]:

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -951,11 +951,41 @@ def _safe_file_metadata(vault: Path, relative: str) -> dict[str, object]:
         return {"state": "not-regular"}
     if status.st_size > _FAILURE_DIAGNOSTIC_MAX_FILE_BYTES:
         return {"state": "too-large", "byte_size": status.st_size}
-    return {
-        "state": "regular",
-        "byte_size": status.st_size,
-        "sha256": hashlib.sha256(candidate.read_bytes()).hexdigest(),
-    }
+    try:
+        descriptor = os.open(
+            candidate,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except FileNotFoundError:
+        return {"state": "missing"}
+    except OSError:
+        # Do not include operating-system errors: they can embed user paths.
+        return {"state": "unreadable"}
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            return {"state": "not-regular"}
+        if (opened.st_dev, opened.st_ino) != (status.st_dev, status.st_ino):
+            return {"state": "changed"}
+        if opened.st_size > _FAILURE_DIAGNOSTIC_MAX_FILE_BYTES:
+            return {"state": "too-large", "byte_size": opened.st_size}
+        digest = hashlib.sha256()
+        byte_size = 0
+        while True:
+            chunk = os.read(descriptor, min(64 * 1024, _FAILURE_DIAGNOSTIC_MAX_FILE_BYTES + 1 - byte_size))
+            if not chunk:
+                break
+            byte_size += len(chunk)
+            if byte_size > _FAILURE_DIAGNOSTIC_MAX_FILE_BYTES:
+                return {"state": "too-large", "byte_size": byte_size}
+            digest.update(chunk)
+        return {
+            "state": "regular",
+            "byte_size": byte_size,
+            "sha256": digest.hexdigest(),
+        }
+    finally:
+        os.close(descriptor)
 
 
 def _sanitized_doctor_report(report: Mapping[str, object]) -> dict[str, object]:
@@ -1024,12 +1054,14 @@ def _write_failure_diagnostic(
         + "\n"
     ).encode("utf-8")
     temporary = evidence_root / f".{name}.{os.getpid()}.{time.time_ns()}.tmp"
+    created = False
     try:
         descriptor = os.open(
             temporary,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
             0o600,
         )
+        created = True
         try:
             view = memoryview(content)
             while view:
@@ -1047,10 +1079,11 @@ def _write_failure_diagnostic(
     except OSError as error:
         raise ExecutorError("failure diagnostic could not be retained safely") from error
     finally:
-        try:
-            temporary.unlink()
-        except FileNotFoundError:
-            pass
+        if created:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
     return destination
 
 

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -925,6 +925,178 @@ def _doctor_healthy(report: Mapping[str, object]) -> bool:
     )
 
 
+_FAILURE_DIAGNOSTIC_FILES = frozenset(
+    {
+        "foundation-doctor-failure.diagnostic.json",
+        "follow-up-delivery-failure.diagnostic.json",
+        "follow-up-doctor-failure.diagnostic.json",
+    }
+)
+_FAILURE_DIAGNOSTIC_MAX_FILE_BYTES = 1024 * 1024
+_DOCTOR_DIAGNOSTIC_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+_DOCTOR_DIAGNOSTIC_VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
+
+
+def _safe_file_metadata(vault: Path, relative: str) -> dict[str, object]:
+    """Return non-content metadata for one fixed Dex-owned runtime file."""
+
+    candidate = vault / relative
+    try:
+        status = candidate.lstat()
+    except FileNotFoundError:
+        return {"state": "missing"}
+    if stat.S_ISLNK(status.st_mode):
+        return {"state": "symlink"}
+    if not stat.S_ISREG(status.st_mode):
+        return {"state": "not-regular"}
+    if status.st_size > _FAILURE_DIAGNOSTIC_MAX_FILE_BYTES:
+        return {"state": "too-large", "byte_size": status.st_size}
+    return {
+        "state": "regular",
+        "byte_size": status.st_size,
+        "sha256": hashlib.sha256(candidate.read_bytes()).hexdigest(),
+    }
+
+
+def _sanitized_doctor_report(report: Mapping[str, object]) -> dict[str, object]:
+    """Keep Doctor verdicts while deliberately excluding free-form details."""
+
+    checks = report.get("checks")
+    if not isinstance(checks, list):
+        return {"checks_state": "malformed"}
+    sanitized: list[dict[str, str]] = []
+    for check in checks[:200]:
+        if not isinstance(check, Mapping):
+            sanitized.append({"id": "<malformed>", "verdict": "<malformed>"})
+            continue
+        identifier = check.get("id")
+        verdict = check.get("verdict")
+        sanitized.append(
+            {
+                "id": (
+                    identifier
+                    if isinstance(identifier, str)
+                    and _DOCTOR_DIAGNOSTIC_ID.fullmatch(identifier)
+                    else "<redacted>"
+                ),
+                "verdict": (
+                    verdict
+                    if isinstance(verdict, str) and verdict in _DOCTOR_DIAGNOSTIC_VERDICTS
+                    else "<redacted>"
+                ),
+            }
+        )
+    return {
+        "checks": sanitized,
+        "check_count": len(checks),
+        "details": "redacted",
+    }
+
+
+def _write_failure_diagnostic(
+    evidence_root: Path,
+    name: str,
+    value: Mapping[str, object],
+) -> Path:
+    """Atomically retain one private, non-acceptance failure diagnostic.
+
+    The success evidence bundle deliberately remains all-or-nothing.  These
+    diagnostics are a separate, local-only seam for a failed journey and are
+    neither indexed nor referenced by a journey result or evidence manifest.
+    """
+
+    if name not in _FAILURE_DIAGNOSTIC_FILES:
+        raise ExecutorError("failure diagnostic name is not declared")
+    try:
+        root_status = evidence_root.lstat()
+    except FileNotFoundError as error:
+        raise ExecutorError("failure diagnostic root is missing") from error
+    if not stat.S_ISDIR(root_status.st_mode) or stat.S_ISLNK(root_status.st_mode):
+        raise ExecutorError("failure diagnostic root is unsafe")
+    if stat.S_IMODE(root_status.st_mode) != 0o700:
+        raise ExecutorError("failure diagnostic root must have mode 0700")
+
+    destination = evidence_root / name
+    if destination.parent != evidence_root:
+        raise ExecutorError("failure diagnostic path is unsafe")
+    content = (
+        json.dumps(value, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+    temporary = evidence_root / f".{name}.{os.getpid()}.{time.time_ns()}.tmp"
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        view = memoryview(content)
+        while view:
+            view = view[os.write(descriptor, view) :]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        # link(2) is atomic and fails rather than replacing a pre-existing path.
+        os.link(temporary, destination, follow_symlinks=False)
+        directory = os.open(evidence_root, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except OSError as error:
+        raise ExecutorError("failure diagnostic could not be retained safely") from error
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+    return destination
+
+
+def _failure_runtime_metadata(vault: Path) -> dict[str, dict[str, object]]:
+    """Digest only fixed Dex-owned files; never serialize their contents."""
+
+    return {
+        relative: _safe_file_metadata(vault, relative)
+        for relative in (
+            ".mcp.json",
+            "System/.release-catalog.json",
+            "System/.installed-files.manifest",
+        )
+    }
+
+
+def _failure_diagnostic(
+    *,
+    phase: str,
+    vault: Path,
+    foundation: Mapping[str, str],
+    follow_up: Mapping[str, str],
+    doctor: Mapping[str, object] | None = None,
+    delivery: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    document: dict[str, object] = {
+        "acceptance": False,
+        "kind": "local-failure-diagnostic",
+        "phase": phase,
+        "schema_version": 1,
+        "expected_foundation": dict(foundation),
+        "expected_follow_up": dict(follow_up),
+        "runtime_metadata": _failure_runtime_metadata(vault),
+    }
+    if doctor is not None:
+        document["doctor"] = _sanitized_doctor_report(doctor)
+    if delivery is not None:
+        document["delivery"] = {
+            "status": (
+                "delivered" if delivery.get("status") == "delivered" else "not-delivered"
+            ),
+            "release_matches_expected": delivery.get("release") == dict(follow_up),
+        }
+    return document
+
+
 def _smoke_healthy(report: Mapping[str, object]) -> bool:
     journeys = report.get("journeys")
     summary = report.get("summary")
@@ -1096,6 +1268,17 @@ def _execute_journey_with_runtime(
         raise ExecutorError("user-owned content changed during foundation delivery")
     foundation_doctor = dict(_runtime.doctor(vault))
     if not _doctor_healthy(foundation_doctor):
+        _write_failure_diagnostic(
+            evidence_root,
+            "foundation-doctor-failure.diagnostic.json",
+            _failure_diagnostic(
+                phase="foundation-doctor",
+                vault=vault,
+                foundation=foundation,
+                follow_up=follow_up,
+                doctor=foundation_doctor,
+            ),
+        )
         raise ExecutorError("foundation Doctor is unhealthy or incomplete")
     after_foundation = _hash_user_owned(vault, user_owned_paths)
     if after_foundation != before:
@@ -1106,6 +1289,17 @@ def _execute_journey_with_runtime(
         delivered.get("status") != "delivered"
         or delivered.get("release") != follow_up
     ):
+        _write_failure_diagnostic(
+            evidence_root,
+            "follow-up-delivery-failure.diagnostic.json",
+            _failure_diagnostic(
+                phase="follow-up-delivery",
+                vault=vault,
+                foundation=foundation,
+                follow_up=follow_up,
+                delivery=delivered,
+            ),
+        )
         raise ExecutorError("lifecycle delivery did not prove the requested follow-up release")
     preview_response = dict(
         _runtime.build_and_preview_delivered_release(vault, follow_up)
@@ -1142,6 +1336,17 @@ def _execute_journey_with_runtime(
         raise ExecutorError("user-owned content changed during follow-up delivery")
     follow_doctor = dict(_runtime.doctor(vault))
     if not _doctor_healthy(follow_doctor):
+        _write_failure_diagnostic(
+            evidence_root,
+            "follow-up-doctor-failure.diagnostic.json",
+            _failure_diagnostic(
+                phase="follow-up-doctor",
+                vault=vault,
+                foundation=foundation,
+                follow_up=follow_up,
+                doctor=follow_doctor,
+            ),
+        )
         raise ExecutorError("follow-up Doctor is unhealthy or incomplete")
     smoke_report = dict(_runtime.smoke(vault))
     if not _smoke_healthy(smoke_report):


### PR DESCRIPTION
## Summary

- binds the universal bridge to the exact immutable historic release and exact compatibility inputs
- adds closed repair coverage for 32 of the 34 sealed breadth failures; the two v1.65 singleton failures passed fresh local-current-route reruns
- hardens Mac Doctor transport against the observed pipe deadlock with one bounded retry and process-group cleanup
- adds exact v1.61 retired-manifest and tagless brain topology support
- improves fleet failure diagnostics and rebinds the generated journey protocol to the current bridge, runner, and executor

## Evidence before this PR

- frozen cohort: 170 discovered, 170 started, 170 completed, 136 passed, 34 failed
- singleton diagnostic reruns: 2 started, 2 completed, 2 passed, 0 failed
- supplemental public starts outside the frozen cohort: 10 discovered, 0 started
- repair merged: 0; released: 0; live: 0

The singleton reruns are local-current-route diagnostics, not public fleet acceptance.

## Candidate verification

- 611 focused Python updater, fleet, protocol, and Doctor tests passed
- 163 script tests passed with the vault Python explicitly bound
- release-shaped dry run passed
- deterministic protocol regeneration passed
- Ruff, PII, founder-content, security, Tau removal, and diff checks passed
- two independent final reviews approved the integrated head

## After merge and a public follow-up release

1. rerun the exact failed 34 through the public two-hop route
2. if green, run the formal sequential 170-case acceptance fleet
3. run the 10 supplemental public starting trees

This PR does not claim merge, publication, live support, or fleet acceptance.