### PR TITLE
Release v1.81.6 historic Mac updater repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.6] — 🪜 Historic Mac upgrades recognise every known release shape (2026-07-31)
+
+The full historic sweep found eight exact older Mac release shapes where the
+updater stopped safely. This release teaches the bridge those verified layouts
+without turning unknown installations into guesses.
+
+**What this fixes for you:**
+
+* **The eight known historic layouts have a supported route forward.** Dex
+  recognises their exact release identities and can move them onto the protected
+  two-step update path.
+* **Unknown layouts still stop before personal files change.** Compatibility is
+  granted only to the old release shapes proven by the fleet evidence.
+* **The release safety gate keeps a recovery slot available.** It now blocks the
+  release history one step before an older updater would run out of room to
+  discover its bridge.
+* **Fleet acceptance remains evidence-led.** The published journeys must still
+  pass before Dex claims these repairs are live for every historic starting point.
+
 ## [1.81.5] — 🧾 Historic installs receive matching migration metadata (2026-07-31)
 
 The public 1.49.0 journey crossed the repaired history proof, then found that

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -1087,6 +1087,7 @@ core/tests/test_release_channel.py
 core/tests/test_release_fleet.py
 core/tests/test_release_fleet_acceptance.py
 core/tests/test_release_fleet_executor.py
+core/tests/test_release_fleet_failure_diagnostics.py
 core/tests/test_release_tag_uniqueness.py
 core/tests/test_review_retirement.py
 core/tests/test_ritual_intelligence_entrypoints.py
@@ -1112,6 +1113,7 @@ core/tests/test_transcript_ingest.py
 core/tests/test_transcript_reconcile.py
 core/tests/test_trust_wizards.py
 core/tests/test_trusted_mcp_safety.py
+core/tests/test_update_bridge_historic_compatibility.py
 core/tests/test_update_checker.py
 core/tests/test_update_checker_real_installs.py
 core/tests/test_update_journey_protocol.py

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.5"
+  "release_version": "1.81.6"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.5",
+  "release_version": "1.81.6",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.6","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.5",
+  "version": "1.81.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.5",
+      "version": "1.81.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.5",
+  "version": "1.81.6",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Outcome

Publishes the merged historic Mac updater repair as v1.81.6 after this release-only change passes CI and merges.

## Included

- bumps all release metadata from v1.81.5 to v1.81.6
- documents the eight exact historic Mac compatibility shapes addressed by PR #358
- keeps unknown layouts fail-closed
- records that formal fleet acceptance still requires published journeys
- regenerates the installed-files manifest from the merged repair tree

## Verification before PR

- release metadata: 6/6 aligned
- focused release/catalog tests: 3 passed
- reachability tests: 10 passed
- live reachability gate: passed
- release build dry-run: passed
- manifest regeneration: deterministic
- diff check: clean

## Honest state

PR #358 is merged at `94f8b839c57e75adf95867aaa60d61afad82285d`. Public latest remains v1.81.5. No v1.81.6 tag, distribution tag, bundle, checksum, or GitHub Release exists yet. After publication, acceptance runs in order: failed 34, formal 170, then 10 supplemental starts.