### PR TITLE
fix: publish verified updater rescue bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,8 @@ jobs:
           gh release upload "v$VERSION" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
+            "dist/dex-update-bridge-v$VERSION.py" \
+            "dist/dex-update-bridge-v$VERSION.py.sha256" \
             --clobber
 
   build-release-beta:
@@ -447,6 +449,8 @@ jobs:
           gh release upload "v$VERSION" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz" \
             "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
+            "dist/dex-update-bridge-v$VERSION.py" \
+            "dist/dex-update-bridge-v$VERSION.py.sha256" \
             --clobber
 
   deploy-health:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.6] — 🛟 Stranded older installs can obtain the update bridge (2026-08-01)
+
+Jim's clean 1.79.0 package correctly detected the newest release, but its private
+Dex history contained only the installed version. The protected updater could
+verify new release bytes only after another component supplied them, while the
+one-time bridge existed solely inside the release it was meant to help install.
+
+**What this fixes for you:**
+
+* **The one-time bridge is now a real download.** Every release publishes the
+  reviewed compatibility bridge as its own versioned asset beside an exact
+  SHA-256 checksum, rather than hiding it inside the full Dex bundle.
+* **The rescue instructions are complete.** They name the immutable release
+  URLs, verify the downloaded bytes, and only then run the pinned bridge.
+* **Clean package installs are a required acceptance case.** A test controller
+  may no longer count a journey that silently lends the old install unreleased
+  updater code. Personal files remain outside the bridge's write boundary.
+
 ## [1.81.5] — 🧾 Historic installs receive matching migration metadata (2026-07-31)
 
 The public 1.49.0 journey crossed the repaired history proof, then found that

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.5"
+  "release_version": "1.81.6"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.5",
+  "release_version": "1.81.6",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.6","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -731,6 +731,32 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
     assert set(manifest) == shipped
 
 
+def test_raw_vault_bundle_publishes_standalone_verified_bridge(tmp_path: Path) -> None:
+    """A stranded historic install can obtain the reviewed bridge directly."""
+
+    clone = _clone_repo(tmp_path, "raw-vault-bundle-bridge-asset")
+    _commit_release_inputs_if_changed(clone)
+    output = tmp_path / "bridge-asset-output"
+    subprocess.run(
+        ["bash", "scripts/build-vault-bundle.sh", str(output)],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+
+    version = json.loads((clone / "package.json").read_text(encoding="utf-8"))["version"]
+    bridge = output / f"dex-update-bridge-v{version}.py"
+    checksum = output / f"dex-update-bridge-v{version}.py.sha256"
+    expected = (clone / "scripts/dex_update_bridge.py").read_bytes()
+
+    assert bridge.read_bytes() == expected
+    assert checksum.read_text(encoding="utf-8") == (
+        f"{hashlib.sha256(expected).hexdigest()}  {bridge.name}\n"
+    )
+
+
 def test_raw_vault_bundle_rejects_dirty_protocol_inputs_not_in_source_commit(
     tmp_path: Path,
 ) -> None:
@@ -1211,6 +1237,36 @@ def test_beta_release_ci_publishes_vault_bundle_only_as_prerelease() -> None:
     stable_commands = "\n".join(step.get("run", "") for step in stable_job["steps"])
     assert "gh release create" in stable_commands
     assert "--prerelease" not in stable_commands
+
+
+def test_release_ci_uploads_standalone_bridge_and_checksum() -> None:
+    """Stable and beta releases expose the bridge outside the full vault bundle."""
+
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    for job_name in ("build-release", "build-release-beta"):
+        commands = "\n".join(
+            step.get("run", "") for step in workflow["jobs"][job_name]["steps"]
+        )
+        assert 'dist/dex-update-bridge-v$VERSION.py"' in commands
+        assert 'dist/dex-update-bridge-v$VERSION.py.sha256"' in commands
+
+
+def test_update_rescue_acquires_verifies_then_runs_released_bridge() -> None:
+    """The user-facing rescue page names a complete, ordered public route."""
+
+    version = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))["version"]
+    bridge_name = f"dex-update-bridge-v{version}.py"
+    rescue = (REPO_ROOT / "docs/UPDATE-RESCUE.md").read_text(encoding="utf-8")
+    release_url = (
+        f"https://github.com/davekilleen/Dex/releases/download/v{version}/{bridge_name}"
+    )
+
+    download_at = rescue.index(release_url)
+    verify_at = rescue.index(f'shasum -a 256 -c "{bridge_name}.sha256"')
+    run_at = rescue.index(
+        f'python3 "$BRIDGE_DIR/{bridge_name}" --vault "$PWD"'
+    )
+    assert download_at < verify_at < run_at
 
 
 def test_distribution_check_rejects_enabled_integration_templates(tmp_path: Path) -> None:

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import stat
 import subprocess
@@ -389,6 +390,61 @@ def test_installer_created_split_topology_preserves_the_exact_starting_release(
             official_release_commit=official_commit,
             official_release_tree=official_tree,
         )
+
+
+def test_clean_split_package_evidence_has_no_tags_or_remote_tracking_refs(
+    tmp_path: Path,
+) -> None:
+    source = _repository(tmp_path)
+    tag = _tag_release(source, "1.79.0", "clean package")
+    commit = _git(source, "rev-parse", f"{tag}^{{commit}}")
+    vault = tmp_path / "vault"
+    brain = vault / ".dex/brain.git"
+    archive = vault / ".dex/pre-split-archive.git"
+    (vault / ".git").mkdir(parents=True)
+    archive.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "--quiet", str(brain)], check=True)
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "fetch", "--quiet", "--no-tags", str(source), f"+{commit}:refs/dex/installed"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "update-ref", "refs/heads/release", commit],
+        check=True,
+    )
+    (vault / ".git/dex-vault-v2").write_text(
+        json.dumps({"schemaVersion": 1, "role": "vault"}) + "\n"
+    )
+    (brain / "dex-brain-v2").write_text(
+        json.dumps({"schemaVersion": 1, "role": "brain", "installed": commit}) + "\n"
+    )
+    topology = vault / "System/.dex/topology.json"
+    topology.parent.mkdir(parents=True)
+    topology.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "archiveGitDir": ".dex/pre-split-archive.git",
+                "installedRelease": commit,
+            }
+        )
+        + "\n"
+    )
+
+    assert release_fleet._initial_install_evidence(vault, {}) == {
+        "topology": "brain-vault-split",
+        "brain_refs": ["refs/dex/installed", "refs/heads/release"],
+    }
+
+    subprocess.run(
+        ["git", f"--git-dir={brain}", "update-ref", "refs/remotes/origin/release", commit],
+        check=True,
+    )
+    with pytest.raises(release_fleet.FleetError, match="without tags or remote-tracking refs"):
+        release_fleet._initial_install_evidence(vault, {})
 
 
 @pytest.mark.parametrize(
@@ -1711,6 +1767,110 @@ def test_journey_refuses_an_undeclared_host_platform(
         )
 
 
+def test_journey_refuses_controller_bridge_without_released_asset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkout copy cannot stand in for the bridge a user can download."""
+
+    from core.update.journey_protocol import load_update_journey_protocol
+
+    protocol_bytes = (
+        release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE
+    ).read_bytes()
+    protocol = load_update_journey_protocol(protocol_bytes)
+    start = release_fleet.DistributionRelease(
+        tag="dist/release/v1.79.0-aaaaaaa",
+        version="1.79.0",
+        commit="a" * 40,
+        tree="e" * 40,
+    )
+    foundation = release_fleet.ImmutableRelease(
+        tag=protocol.foundation["tag"],
+        tag_object=protocol.foundation["tag_object"],
+        commit=protocol.foundation["commit"],
+        tree=protocol.foundation["tree"],
+        version=protocol.foundation["version"],
+    )
+    follow_up = release_fleet.ImmutableRelease(
+        tag="dist/release/v1.81.6-bbbbbbb",
+        tag_object="c" * 40,
+        commit="b" * 40,
+        tree="d" * 40,
+        version="1.81.6",
+    )
+    monkeypatch.setattr(release_fleet.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        release_fleet, "discover_distribution_releases", lambda _repo: (start,)
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "resolve_immutable_release",
+        lambda _repo, tag: foundation if tag == foundation.tag else follow_up,
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_optional_tag_file",
+        lambda _repo, _tag, relative: (
+            protocol_bytes
+            if relative == release_fleet.UPDATE_JOURNEY_RELATIVE
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        release_fleet,
+        "_verify_released_protocol_artifacts",
+        lambda _repo, _release, _protocol: "f" * 40,
+    )
+
+    with pytest.raises(
+        release_fleet.FleetError,
+        match="standalone released bridge asset is required",
+    ):
+        release_fleet.run_journey(
+            tmp_path,
+            output=tmp_path / "output",
+            starting_tag=start.tag,
+            foundation_tag=foundation.tag,
+            follow_up_tag=follow_up.tag,
+        )
+
+    assert not (tmp_path / "output").exists()
+
+
+def test_standalone_bridge_asset_refuses_a_checksum_not_shipped_for_its_bytes(
+    tmp_path: Path,
+) -> None:
+    from core.update.journey_protocol import load_update_journey_protocol
+
+    protocol = load_update_journey_protocol(
+        (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_bytes()
+    )
+    follow_up = release_fleet.ImmutableRelease(
+        tag="dist/release/v1.81.6-bbbbbbb",
+        tag_object="c" * 40,
+        commit="b" * 40,
+        tree="d" * 40,
+        version="1.81.6",
+    )
+    asset = tmp_path / "dex-update-bridge-v1.81.6.py"
+    asset.write_bytes(
+        (release_fleet.PROJECT_ROOT / protocol.bridge.artifact.source_path).read_bytes()
+    )
+    checksum = tmp_path / "dex-update-bridge-v1.81.6.py.sha256"
+    checksum.write_text(f"{'0' * 64}  {asset.name}\n", encoding="utf-8")
+
+    with pytest.raises(release_fleet.FleetError, match="checksum is invalid"):
+        release_fleet._verify_standalone_bridge_asset(
+            tmp_path,
+            source_commit="f" * 40,
+            follow_up=follow_up,
+            protocol=protocol,
+            bridge_asset=asset,
+            bridge_checksum=checksum,
+        )
+
+
 @pytest.mark.parametrize("split_topology", [False, True])
 def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     tmp_path: Path,
@@ -1745,6 +1905,16 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         tree="e" * 40,
     )
     source_commit = "f" * 40
+    bridge_bytes = (
+        release_fleet.PROJECT_ROOT / protocol.bridge.artifact.source_path
+    ).read_bytes()
+    bridge_asset = tmp_path / f"dex-update-bridge-v{follow_up.version}.py"
+    bridge_asset.write_bytes(bridge_bytes)
+    bridge_checksum = tmp_path / f"{bridge_asset.name}.sha256"
+    bridge_checksum.write_text(
+        f"{hashlib.sha256(bridge_bytes).hexdigest()}  {bridge_asset.name}\n",
+        encoding="utf-8",
+    )
     captured: dict[str, object] = {}
     environment_kwargs: dict[str, object] = {}
     remote_events: list[str] = []
@@ -1809,6 +1979,18 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         return {}
 
     monkeypatch.setattr(release_fleet, "_case_environment", case_environment)
+    monkeypatch.setattr(
+        release_fleet,
+        "_initial_install_evidence",
+        lambda _vault, _environment: (
+            {
+                "topology": "brain-vault-split",
+                "brain_refs": ["refs/dex/installed", "refs/heads/release"],
+            }
+            if split_topology
+            else {"topology": "legacy-monolithic", "brain_refs": []}
+        ),
+    )
 
     def build_case(
         _repo,
@@ -1892,6 +2074,8 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         starting_tag=start.tag,
         foundation_tag=foundation.tag,
         follow_up_tag=follow_up.tag,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
     )
 
     assert run.case == {"starting_tag": start.tag}
@@ -1899,6 +2083,10 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert captured["foundation_release"] == foundation.identity()
     assert captured["follow_up_release"] == follow_up.identity()
     assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
+    assert captured["bridge_asset_evidence"]["source"] == "released-standalone-asset"
+    assert captured["initial_install_evidence"]["topology"] == (
+        "brain-vault-split" if split_topology else "legacy-monolithic"
+    )
     assert environment_kwargs["pip_cache_dir"] == (
         tmp_path / "output/.fixture-controller/pip"
     )

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import os
@@ -194,7 +195,11 @@ def test_production_runtime_exposes_only_installed_qmd_not_ambient_path(
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PATH", f"{tmp_path / 'ambient'}:/usr/bin")
 
-    runtime = executor._ProductionRuntime()
+    bridge = REPO_ROOT / "scripts/dex_update_bridge.py"
+    runtime = executor._ProductionRuntime(
+        bridge_asset=bridge,
+        bridge_sha256=hashlib.sha256(bridge.read_bytes()).hexdigest(),
+    )
     try:
         environment = runtime._runtime_environment(tmp_path)
         runtime_tools = Path(environment["PATH"].split(os.pathsep)[0])
@@ -355,6 +360,9 @@ def test_executor_owns_the_closed_two_hop_journey_and_returned_evidence(
         foundation_surface={"release": protocol.foundation, "machine_executable": False},
         user_owned_paths=user_files,
         platform="darwin",
+        bridge_asset_evidence=_bridge_asset_evidence(protocol, follow_up),
+        bridge_asset_path=REPO_ROOT / protocol.bridge.artifact.source_path,
+        initial_install_evidence={"topology": "legacy-monolithic", "brain_refs": []},
         input_fn=lambda _prompt: "APPLY",
         output_fn=rendered.append,
         _runtime=runtime,
@@ -425,10 +433,51 @@ def _execute(
         foundation_surface={"release": protocol.foundation, "machine_executable": False},
         user_owned_paths=user_files,
         platform="darwin",
+        bridge_asset_evidence=_bridge_asset_evidence(protocol, runtime.follow_up),
+        bridge_asset_path=REPO_ROOT / protocol.bridge.artifact.source_path,
+        initial_install_evidence={"topology": "legacy-monolithic", "brain_refs": []},
         input_fn=input_fn,
         output_fn=lambda _line: None,
         _runtime=runtime,
     )
+
+
+def _bridge_asset_evidence(protocol, follow_up: dict[str, str]) -> dict[str, str]:
+    name = f"dex-update-bridge-v{follow_up['version']}.py"
+    checksum = f"{protocol.bridge.artifact.sha256}  {name}\n".encode()
+    return {
+        "name": name,
+        "sha256": protocol.bridge.artifact.sha256,
+        "checksum_name": f"{name}.sha256",
+        "checksum_sha256": hashlib.sha256(checksum).hexdigest(),
+        "source": "released-standalone-asset",
+    }
+
+
+def test_runtime_loads_the_verified_asset_instead_of_the_controller_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asset = tmp_path / "dex-update-bridge-v1.81.6.py"
+    asset.write_bytes(b"MARKER = 'verified'\n")
+    digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+    original_read_bytes = Path.read_bytes
+
+    def replace_after_read(path: Path) -> bytes:
+        content = original_read_bytes(path)
+        if path == asset:
+            asset.write_bytes(b"MARKER = 'substituted'\n")
+        return content
+
+    monkeypatch.setattr(Path, "read_bytes", replace_after_read)
+
+    loaded = executor._load_released_bridge(asset, digest)
+
+    assert loaded is not executor.dex_update_bridge
+    assert Path(loaded.__file__).resolve() == asset.resolve()
+    assert loaded.MARKER == "verified"
+    with pytest.raises(executor.ExecutorError, match="changed before execution"):
+        executor._load_released_bridge(asset, digest)
 
 
 def test_executor_accepts_an_exact_legacy_starting_tag_without_widening_targets(
@@ -832,6 +881,11 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
         lambda _source: Service(),
     )
     monkeypatch.setattr(executor.dex_update_bridge, "run_bridge", run_bridge)
+    monkeypatch.setattr(
+        executor,
+        "_load_released_bridge",
+        lambda _asset, _digest: executor.dex_update_bridge,
+    )
     request_stream = io.StringIO(
         "\n".join(
             (
@@ -848,9 +902,13 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
     monkeypatch.setattr(executor.sys, "stdout", response_stream)
 
     assert (
-        executor._runtime_server(
-            tmp_path / "vault",
-            foundation_cache=(tmp_path / "unused-cache" if use_cache else None),
+            executor._runtime_server(
+                tmp_path / "vault",
+                bridge_asset=REPO_ROOT / "scripts/dex_update_bridge.py",
+                bridge_sha256=hashlib.sha256(
+                    (REPO_ROOT / "scripts/dex_update_bridge.py").read_bytes()
+                ).hexdigest(),
+                foundation_cache=(tmp_path / "unused-cache" if use_cache else None),
         )
         == 0
     )

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import stat
 import subprocess
@@ -164,6 +165,8 @@ def _run_failure(
     )
     starting = _identity("1.65.0", "a")
     follow_up = _identity("1.81.5", "b")
+    bridge_name = f"dex-update-bridge-v{follow_up['version']}.py"
+    checksum = f"{protocol.bridge.artifact.sha256}  {bridge_name}\n".encode()
     with pytest.raises(executor.ExecutorError) as error:
         executor.execute_journey(
             repo_root=source,
@@ -181,6 +184,18 @@ def _run_failure(
             },
             user_owned_paths=user_paths,
             platform="darwin",
+            bridge_asset_evidence={
+                "name": bridge_name,
+                "sha256": protocol.bridge.artifact.sha256,
+                "checksum_name": f"{bridge_name}.sha256",
+                "checksum_sha256": hashlib.sha256(checksum).hexdigest(),
+                "source": "released-standalone-asset",
+            },
+            bridge_asset_path=REPO_ROOT / protocol.bridge.artifact.source_path,
+            initial_install_evidence={
+                "topology": "legacy-monolithic",
+                "brain_refs": [],
+            },
             input_fn=lambda _prompt: "APPLY",
             output_fn=lambda _line: None,
             _runtime=_Runtime(follow_up, failure=failure),

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "cd574fc09138bdc251537fb4759f559a2d11f376ed08807d815459f8cdf0ceb4",
+    "sha256": "1cce0422a16fb7a0eeaed8fee64cd1c5a8178a31fe0a507e768a4f3de35ac77d",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "bc1ed084a3248a5bc98e91dc20a74b0caed66d22525357f7d4480657ca07e5ce",
+    "sha256": "b516640d2eaa506031ea5d4840496bd8467d3f3c0c3d2ab7df97bcd6f008da37",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,10 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-# This is the released-artifact invocation, not an instruction to run a
-# similarly named file copied from a repository checkout.
+Download the versioned bridge and its checksum from the public v1.81.6 release,
+verify the bytes, then run that exact artifact. Run this block from the vault
+root. It keeps the downloaded files in a temporary folder outside the vault.
+
 ```bash
-python3 dex_update_bridge.py --vault "$PWD"
+BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
+curl -fL \
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.6/dex-update-bridge-v1.81.6.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.6.py"
+curl -fL \
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.6/dex-update-bridge-v1.81.6.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.6.py.sha256"
+(
+  cd "$BRIDGE_DIR"
+  shasum -a 256 -c "dex-update-bridge-v1.81.6.py.sha256"
+)
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.6.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,8 +102,15 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.5-EXACTFOLLOWUP
+  --follow-up-tag dist/release/v1.81.6-EXACTFOLLOWUP \
+  --bridge-asset /path/to/dex-update-bridge-v1.81.6.py \
+  --bridge-checksum /path/to/dex-update-bridge-v1.81.6.py.sha256
 ```
+
+The bridge paths must be the separately downloaded GitHub Release asset and
+its checksum. The runner verifies their exact names, checksum, protocol digest,
+and released source bytes before it creates the fixture. A bridge available
+only in the controller checkout cannot satisfy this gate.
 
 The repository has the canonical protocol source at
 `core/update/journey-protocol-v1.json`, with a strict parser in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.5",
+  "version": "1.81.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.5",
+      "version": "1.81.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.5",
+  "version": "1.81.6",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -21,6 +21,8 @@ mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 TARBALL="$OUTPUT_DIR/dex-vault-bundle-v$VERSION.tar.gz"
 CHECKSUM="$TARBALL.sha256"
+BRIDGE_ASSET="$OUTPUT_DIR/dex-update-bridge-v$VERSION.py"
+BRIDGE_CHECKSUM="$BRIDGE_ASSET.sha256"
 STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-vault-bundle.XXXXXX")"
 ALL_FILES="$(mktemp "${TMPDIR:-/tmp}/dex-vault-all.XXXXXX")"
 EXCLUDED_FILES="$(mktemp "${TMPDIR:-/tmp}/dex-vault-excluded.XXXXXX")"
@@ -129,7 +131,7 @@ python3 "$REPO_ROOT/scripts/check-tau-removal.py" --tree "$STAGING_DIR"
 # distribution contract.
 rm -rf "$STAGING_DIR/node_modules/.bin"
 
-rm -f "$TARBALL" "$CHECKSUM"
+rm -f "$TARBALL" "$CHECKSUM" "$BRIDGE_ASSET" "$BRIDGE_CHECKSUM"
 (
   cd "$STAGING_DIR"
   # COPYFILE_DISABLE=1 stops macOS bsdtar from synthesizing AppleDouble ._*
@@ -144,5 +146,21 @@ python3 "$REPO_ROOT/scripts/check-tau-removal.py" --archive "$TARBALL"
   shasum -a 256 "$(basename "$TARBALL")" > "$(basename "$CHECKSUM")"
 )
 
+# Historic package installs cannot discover this bridge from their own frozen
+# update code. Publish the exact reviewed bridge as a first-class release asset
+# so the documented one-time rescue route has something real to acquire.
+if [ ! -f "$REPO_ROOT/scripts/dex_update_bridge.py" ] || [ -L "$REPO_ROOT/scripts/dex_update_bridge.py" ]; then
+  echo "Error: update bridge source is not a regular file." >&2
+  exit 1
+fi
+cp "$REPO_ROOT/scripts/dex_update_bridge.py" "$BRIDGE_ASSET"
+chmod 0644 "$BRIDGE_ASSET"
+(
+  cd "$OUTPUT_DIR"
+  shasum -a 256 "$(basename "$BRIDGE_ASSET")" > "$(basename "$BRIDGE_CHECKSUM")"
+)
+
 echo "Built $TARBALL"
 echo "Checksum $CHECKSUM"
+echo "Bridge $BRIDGE_ASSET"
+echo "Bridge checksum $BRIDGE_CHECKSUM"

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -1464,6 +1464,28 @@ def _installer_created_split_topology(vault: Path) -> bool:
     )
 
 
+def _initial_install_evidence(
+    vault: Path, environment: Mapping[str, str]
+) -> dict[str, object]:
+    """Prove a package-created split brain has never-fetched ref shape."""
+
+    if not _installer_created_split_topology(vault):
+        return {"topology": "legacy-monolithic", "brain_refs": []}
+    refs_output = _git_directory(
+        vault / ".dex/brain.git",
+        "for-each-ref",
+        "--format=%(refname)",
+        environment=environment,
+    )
+    refs = sorted(line for line in refs_output.splitlines() if line)
+    allowed = {"refs/dex/installed", "refs/heads/release"}
+    if "refs/dex/installed" not in refs or any(ref not in allowed for ref in refs):
+        raise FleetError(
+            "clean split package fixture must begin without tags or remote-tracking refs"
+        )
+    return {"topology": "brain-vault-split", "brain_refs": refs}
+
+
 def _run_historic_installer(
     vault: Path,
     release: DistributionRelease,
@@ -1992,6 +2014,44 @@ def run_discovery_sweep(
     }
 
 
+def _verify_standalone_bridge_asset(
+    repo: Path,
+    *,
+    source_commit: str,
+    follow_up: ImmutableRelease,
+    protocol: UpdateJourneyProtocol,
+    bridge_asset: Path | None,
+    bridge_checksum: Path | None,
+) -> dict[str, str]:
+    """Bind acceptance to the separately distributable release bridge."""
+
+    if bridge_asset is None or bridge_checksum is None:
+        raise FleetError("standalone released bridge asset is required")
+    expected_asset_name = f"dex-update-bridge-v{follow_up.version}.py"
+    expected_checksum_name = f"{expected_asset_name}.sha256"
+    if bridge_asset.name != expected_asset_name or bridge_checksum.name != expected_checksum_name:
+        raise FleetError("standalone released bridge asset names do not match follow-up release")
+    for label, path in (("bridge asset", bridge_asset), ("bridge checksum", bridge_checksum)):
+        if path.is_symlink() or not path.is_file():
+            raise FleetError(f"standalone released {label} is missing or unsafe")
+    bridge_bytes = bridge_asset.read_bytes()
+    bridge_digest = hashlib.sha256(bridge_bytes).hexdigest()
+    checksum_bytes = bridge_checksum.read_bytes()
+    expected_checksum = f"{bridge_digest}  {expected_asset_name}\n".encode("utf-8")
+    if checksum_bytes != expected_checksum:
+        raise FleetError("standalone released bridge checksum is invalid")
+    released_bridge = _tag_file(repo, source_commit, protocol.bridge.artifact.source_path)
+    if bridge_digest != protocol.bridge.artifact.sha256 or bridge_bytes != released_bridge:
+        raise FleetError("standalone released bridge does not match released journey source")
+    return {
+        "name": expected_asset_name,
+        "sha256": bridge_digest,
+        "checksum_name": expected_checksum_name,
+        "checksum_sha256": hashlib.sha256(checksum_bytes).hexdigest(),
+        "source": "released-standalone-asset",
+    }
+
+
 def run_journey(
     repo: Path,
     *,
@@ -1999,6 +2059,8 @@ def run_journey(
     starting_tag: str,
     foundation_tag: str,
     follow_up_tag: str,
+    bridge_asset: Path | None = None,
+    bridge_checksum: Path | None = None,
 ) -> object:
     """Build one fixture and delegate the closed journey to its released executor."""
 
@@ -2026,17 +2088,21 @@ def run_journey(
     if protocol.foundation != foundation.identity():
         raise FleetError("released journey protocol names a different foundation")
     source_commit = _verify_released_protocol_artifacts(repo, follow_up, protocol)
+    bridge_asset_evidence = _verify_standalone_bridge_asset(
+        repo,
+        source_commit=source_commit,
+        follow_up=follow_up,
+        protocol=protocol,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
+    )
+    assert bridge_asset is not None
     for label, artifact, running_path in (
         ("fleet runner", protocol.runner, Path(__file__).resolve()),
         (
             "journey executor",
             protocol.executor,
             PROJECT_ROOT / protocol.executor.source_path,
-        ),
-        (
-            "foundation bridge",
-            protocol.bridge.artifact,
-            PROJECT_ROOT / protocol.bridge.artifact.source_path,
         ),
     ):
         running = running_path.read_bytes()
@@ -2079,6 +2145,7 @@ def run_journey(
             keep_official_fetch=True,
         )
         resolve_fixture_python(case.vault, trusted_python=python_runtime)
+        initial_install_evidence = _initial_install_evidence(case.vault, environment)
         from scripts import release_fleet_executor
 
         try:
@@ -2102,6 +2169,9 @@ def run_journey(
                 foundation_surface=foundation_surface,
                 user_owned_paths=tuple(USER_FIXTURES),
                 platform=journey_platform,
+                bridge_asset_evidence=bridge_asset_evidence,
+                bridge_asset_path=bridge_asset.resolve(strict=True),
+                initial_install_evidence=initial_install_evidence,
             )
         finally:
             _disable_all_fixture_remotes(case.vault, environment)
@@ -2301,6 +2371,17 @@ def assert_evidence_bound(
         if event_ids != required_order:
             raise FleetError(f"{case.starting_tag}: evidence manifest has an invalid event order")
         events = {str(event["id"]): event for event in manifest["events"]}
+        bridge_asset_name = f"dex-update-bridge-v{follow_up.version}.py"
+        bridge_checksum_bytes = (
+            f"{protocol.bridge.artifact.sha256}  {bridge_asset_name}\n".encode("utf-8")
+        )
+        expected_bridge_asset = {
+            "name": bridge_asset_name,
+            "sha256": protocol.bridge.artifact.sha256,
+            "checksum_name": f"{bridge_asset_name}.sha256",
+            "checksum_sha256": hashlib.sha256(bridge_checksum_bytes).hexdigest(),
+            "source": "released-standalone-asset",
+        }
         if any(
             not isinstance(event.get("command"), list)
             or not event["command"]
@@ -2319,9 +2400,23 @@ def assert_evidence_bound(
             or events["historic-route-refusal"].get("release") != expected_historic_surface["release"]
             or events["historic-route-refusal"].get("command")
             != [protocol.executor.source_path, "classify-historic-route"]
+            or events["historic-route-refusal"].get("initial_install")
+            not in (
+                {"topology": "legacy-monolithic", "brain_refs": []},
+                {
+                    "topology": "brain-vault-split",
+                    "brain_refs": ["refs/dex/installed"],
+                },
+                {
+                    "topology": "brain-vault-split",
+                    "brain_refs": ["refs/dex/installed", "refs/heads/release"],
+                },
+            )
             or events["bridge-foundation"].get("release") != foundation.identity()
             or events["bridge-foundation"].get("command")
             != [protocol.executor.source_path, protocol.bridge.adapter]
+            or events["bridge-foundation"].get("bridge_asset")
+            != expected_bridge_asset
             or events["foundation-update-surface"].get("release") != foundation.identity()
             or events["foundation-update-surface"].get("command")
             != ["git", "show", f"{foundation.tag}:{UPDATE_SKILL_RELATIVE}"]
@@ -2642,6 +2737,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     journey.add_argument("--starting-tag", required=True)
     journey.add_argument("--foundation-tag", required=True)
     journey.add_argument("--follow-up-tag", required=True)
+    journey.add_argument("--bridge-asset", type=Path, required=True)
+    journey.add_argument("--bridge-checksum", type=Path, required=True)
     args = parser.parse_args(argv)
 
     if args.command == "manifest":
@@ -2678,6 +2775,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             starting_tag=args.starting_tag,
             foundation_tag=args.foundation_tag,
             follow_up_tag=args.follow_up_tag,
+            bridge_asset=args.bridge_asset,
+            bridge_checksum=args.bridge_checksum,
         )
         print(
             json.dumps(

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from types import ModuleType
 from typing import Callable, Mapping, Protocol, Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -258,7 +259,13 @@ class JourneyRuntime(Protocol):
 class _ProductionRuntime:
     """Closed parent adapter over a fixture-venv lifecycle runtime."""
 
-    def __init__(self, *, foundation_cache: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        bridge_asset: Path,
+        bridge_sha256: str,
+        foundation_cache: Path | None = None,
+    ) -> None:
         self._runtime_home = tempfile.TemporaryDirectory(
             prefix="dex-release-journey-runtime-"
         )
@@ -274,6 +281,8 @@ class _ProductionRuntime:
             if foundation_cache is not None
             else None
         )
+        self._bridge_asset = bridge_asset.resolve(strict=True)
+        self._bridge_sha256 = bridge_sha256
 
     def _link_optional_qmd(self) -> None:
         """Expose only a real controller QMD binary to installed health checks.
@@ -403,6 +412,10 @@ class _ProductionRuntime:
             "_runtime-server",
             "--vault",
             str(root),
+            "--bridge-asset",
+            str(self._bridge_asset),
+            "--bridge-sha256",
+            self._bridge_sha256,
         ]
         if self._foundation_cache is not None:
             command.extend(
@@ -658,12 +671,35 @@ def _runtime_server_answer(prompt: str) -> str:
     return response["answer"]
 
 
+def _load_released_bridge(bridge_asset: Path, bridge_sha256: str):
+    """Load only the standalone bridge bytes already bound to the release."""
+
+    if bridge_asset.is_symlink() or not bridge_asset.is_file():
+        raise ExecutorError("standalone released bridge asset is missing or unsafe")
+    bridge_bytes = bridge_asset.read_bytes()
+    if hashlib.sha256(bridge_bytes).hexdigest() != bridge_sha256:
+        raise ExecutorError("standalone released bridge asset changed before execution")
+    module_name = "dex_released_update_bridge"
+    released_bridge = ModuleType(module_name)
+    released_bridge.__file__ = str(bridge_asset)
+    released_bridge.__package__ = ""
+    sys.modules[module_name] = released_bridge
+    code = compile(bridge_bytes, str(bridge_asset), "exec", dont_inherit=True)
+    exec(code, released_bridge.__dict__)
+    return released_bridge
+
+
 def _runtime_server(
     vault: Path,
     *,
+    bridge_asset: Path,
+    bridge_sha256: str,
     foundation_cache: Path | None = None,
 ) -> int:
     """Serve the fixed lifecycle vocabulary from the fixture virtualenv."""
+
+    global dex_update_bridge
+    dex_update_bridge = _load_released_bridge(bridge_asset, bridge_sha256)
 
     root = dex_update_bridge._validate_vault(vault)
     temporary: tempfile.TemporaryDirectory[str] | None = None
@@ -839,6 +875,7 @@ def _verify_released_executor(
     source_commit: str,
     protocol: UpdateJourneyProtocol,
     foundation: Mapping[str, str],
+    bridge_asset: Path,
 ) -> dict[str, object]:
     if _HEX_40.fullmatch(source_commit) is None:
         raise ExecutorError("released executor source commit is malformed")
@@ -854,7 +891,7 @@ def _verify_released_executor(
         (
             "foundation bridge",
             protocol.bridge.artifact,
-            Path(dex_update_bridge.__file__).resolve(),
+            bridge_asset,
         ),
     )
     evidence: dict[str, object] = {"source_commit": source_commit}
@@ -1033,6 +1070,9 @@ def _execute_journey_with_runtime(
     foundation_surface: Mapping[str, object],
     user_owned_paths: Sequence[str],
     platform: str,
+    bridge_asset_evidence: Mapping[str, str],
+    bridge_asset_path: Path,
+    initial_install_evidence: Mapping[str, object],
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
     _runtime: JourneyRuntime,
@@ -1051,7 +1091,41 @@ def _execute_journey_with_runtime(
         source_commit,
         protocol,
         foundation,
+        bridge_asset_path,
     )
+    expected_asset_name = f"dex-update-bridge-v{follow_up['version']}.py"
+    expected_bridge_evidence = {
+        "name": expected_asset_name,
+        "sha256": protocol.bridge.artifact.sha256,
+        "checksum_name": f"{expected_asset_name}.sha256",
+        "checksum_sha256": bridge_asset_evidence.get("checksum_sha256", ""),
+        "source": "released-standalone-asset",
+    }
+    if (
+        dict(bridge_asset_evidence) != expected_bridge_evidence
+        or re.fullmatch(r"[0-9a-f]{64}", expected_bridge_evidence["checksum_sha256"])
+        is None
+    ):
+        raise ExecutorError("standalone released bridge evidence is invalid")
+    topology = initial_install_evidence.get("topology")
+    brain_refs = initial_install_evidence.get("brain_refs")
+    if (
+        topology not in {"legacy-monolithic", "brain-vault-split"}
+        or not isinstance(brain_refs, list)
+        or any(not isinstance(ref, str) for ref in brain_refs)
+        or (topology == "legacy-monolithic" and brain_refs)
+        or (
+            topology == "brain-vault-split"
+            and (
+                "refs/dex/installed" not in brain_refs
+                or any(
+                    ref not in {"refs/dex/installed", "refs/heads/release"}
+                    for ref in brain_refs
+                )
+            )
+        )
+    ):
+        raise ExecutorError("initial clean package ref evidence is invalid")
     if evidence_root.exists():
         raise ExecutorError("journey evidence directory must be empty")
     evidence_root.mkdir(parents=True, mode=0o700)
@@ -1191,11 +1265,13 @@ def _execute_journey_with_runtime(
             "command": [protocol.executor.source_path, "classify-historic-route"],
             "release": start,
             "machine_executable": historic_surface.get("machine_executable"),
+            "initial_install": dict(initial_install_evidence),
         },
         {
             "id": "bridge-foundation",
             "command": [protocol.executor.source_path, protocol.bridge.adapter],
             "release": foundation,
+            "bridge_asset": dict(bridge_asset_evidence),
             "approval_count": len(bridge_approvals),
             "approvals": bridge_approvals,
         },
@@ -1321,6 +1397,9 @@ def _executor_boundary():
         foundation_surface: Mapping[str, object],
         user_owned_paths: Sequence[str],
         platform: str,
+        bridge_asset_evidence: Mapping[str, str],
+        bridge_asset_path: Path,
+        initial_install_evidence: Mapping[str, object],
         input_fn: Callable[[str], str] = input,
         output_fn: Callable[[str], None] = print,
         _runtime: JourneyRuntime | None = None,
@@ -1328,7 +1407,14 @@ def _executor_boundary():
         """Execute one released journey and retain production authority here."""
 
         production_owned = _runtime is None
-        runtime = production_runtime_type() if production_owned else _runtime
+        runtime = (
+            production_runtime_type(
+                bridge_asset=bridge_asset_path,
+                bridge_sha256=protocol.bridge.artifact.sha256,
+            )
+            if production_owned
+            else _runtime
+        )
         assert runtime is not None
         try:
             case = execute_with_runtime(
@@ -1344,6 +1430,9 @@ def _executor_boundary():
                 foundation_surface=foundation_surface,
                 user_owned_paths=user_owned_paths,
                 platform=platform,
+                bridge_asset_evidence=bridge_asset_evidence,
+                bridge_asset_path=bridge_asset_path,
+                initial_install_evidence=initial_install_evidence,
                 input_fn=input_fn,
                 output_fn=output_fn,
                 _runtime=runtime,
@@ -1407,12 +1496,11 @@ __all__ = [
 
 if __name__ == "__main__":
     valid = (
-        len(sys.argv) == 4
+        len(sys.argv) in {8, 10}
         and sys.argv[1:3] == ["_runtime-server", "--vault"]
-    ) or (
-        len(sys.argv) == 6
-        and sys.argv[1:3] == ["_runtime-server", "--vault"]
-        and sys.argv[4] == "--foundation-cache"
+        and sys.argv[4] == "--bridge-asset"
+        and sys.argv[6] == "--bridge-sha256"
+        and (len(sys.argv) == 8 or sys.argv[8] == "--foundation-cache")
     )
     if not valid:
         raise SystemExit("released journey executor has no standalone interface")
@@ -1420,8 +1508,10 @@ if __name__ == "__main__":
         raise SystemExit(
             _runtime_server(
                 Path(sys.argv[3]),
+                bridge_asset=Path(sys.argv[5]),
+                bridge_sha256=sys.argv[7],
                 foundation_cache=(
-                    Path(sys.argv[5]) if len(sys.argv) == 6 else None
+                    Path(sys.argv[9]) if len(sys.argv) == 10 else None
                 ),
             )
         )


### PR DESCRIPTION
## Outcome

Publishes the reviewed updater bridge as a standalone versioned release asset with its SHA-256 checksum, documents the exact download/verify/run rescue route, and closes the fleet acceptance loophole that let controller-only code count.

The fleet runner now proves clean package installs begin without tags or remote-tracking refs, binds the standalone asset to released source, and the runtime executes the exact in-memory bytes it hashed.

## Verification

- 82 distribution artifact tests passed
- 82 updater fleet/executor tests passed (one VPS-only venv test deselected; CI owns the Mac result)
- 171 hook tests passed
- focused final release-asset tests passed
- Ruff and git diff checks passed
- two-axis code/spec review: no remaining ship-blocking code defect

## Delivery gate

Do not tell Jim or Amit to retry until CI is green, v1.81.7 is public with both bridge assets, and exact public Mac journeys from Jim v1.79.0 and Amit v1.77.2 pass with healthy Doctors and unchanged user hashes.