### PR TITLE
fix: accept verified historic fleet starts

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run three release-shaped macOS journeys
+      - name: Run four release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -1,0 +1,109 @@
+name: historic-fleet-darwin
+
+on:
+  workflow_dispatch:
+    inputs:
+      foundation_tag:
+        description: Exact public immutable foundation tag
+        required: true
+        type: string
+        default: dist/release/v1.81.0-6bc490e
+      follow_up_tag:
+        description: Exact public immutable follow-up tag
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - .github/workflows/historic-fleet-darwin.yml
+      - core/update/journey-protocol-v1.json
+      - scripts/build-release.sh
+      - scripts/build-vault-bundle.sh
+      - scripts/dex_update_bridge.py
+      - scripts/release_fleet.py
+      - scripts/release_fleet_acceptance.py
+      - scripts/release_fleet_executor.py
+      - scripts/run-historic-fleet-darwin.sh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: historic-fleet-darwin-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  historic-fleet-darwin:
+    if: github.event_name == 'workflow_dispatch'
+    name: historic-fleet-darwin
+    runs-on: macos-14
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install controller dependencies
+        run: |
+          python3 -m pip install -r requirements-dev.txt
+          python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
+          npm ci
+      - name: Run the public macOS historic fleet
+        env:
+          FOUNDATION_TAG: ${{ inputs.foundation_tag }}
+          FOLLOW_UP_TAG: ${{ inputs.follow_up_tag }}
+          FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin
+        run: bash scripts/run-historic-fleet-darwin.sh formal
+      - name: Retain formal fleet evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: historic-fleet-darwin-${{ github.run_id }}
+          path: ${{ runner.temp }}/historic-fleet-darwin
+          if-no-files-found: warn
+          retention-days: 14
+
+  historic-fleet-darwin-pr-canary:
+    if: github.event_name == 'pull_request'
+    name: historic-fleet-darwin-pr-canary
+    runs-on: macos-14
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install canary dependencies
+        run: |
+          python3 -m pip install -r requirements-dev.txt
+          python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
+          npm ci
+      - name: Run three release-shaped macOS journeys
+        env:
+          FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
+        run: bash scripts/run-historic-fleet-darwin.sh canary
+      - name: Retain PR canary evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: historic-fleet-darwin-pr-canary-${{ github.run_id }}
+          path: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
+          if-no-files-found: warn
+          retention-days: 7

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -700,6 +700,37 @@ def test_foundation_service_exposes_release_delivery(tmp_path: Path) -> None:
     }
 
 
+def test_foundation_service_routes_only_explicit_test_delivery_to_local_cache(
+    tmp_path: Path,
+) -> None:
+    service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    calls: list[tuple[Path, dict[str, object]]] = []
+
+    def deliver(vault_root: Path, **kwargs: object) -> dict[str, object]:
+        calls.append((vault_root, kwargs))
+        return {"status": "delivered-from-cache"}
+
+    service._apply_update.deliver_latest_release = deliver
+    cache = tmp_path / "candidate-release.git"
+
+    assert service.deliver_latest_release(
+        vault,
+        remote_url=str(cache),
+        allow_test_transport=True,
+    ) == {"status": "delivered-from-cache"}
+    assert calls == [
+        (
+            vault,
+            {
+                "remote_url": str(cache),
+                "allow_test_transport": True,
+            },
+        )
+    ]
+    with pytest.raises(bridge.BridgeError, match="explicit local cache"):
+        service.deliver_latest_release(vault, remote_url=str(cache))
+
+
 def test_foundation_service_reports_missing_engine_path_as_bridge_error(
     tmp_path: Path,
 ) -> None:

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -71,6 +71,7 @@ def test_four_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         assert f'"{start}"' in source
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source
+    assert source.count("--controlled-approvals") == 1
     assert "git push" not in source
     assert "gh release" not in source
     assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -1,0 +1,89 @@
+"""Static safety contract for the first-party macOS historic fleet workflow."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/historic-fleet-darwin.yml"
+RUNNER_PATH = REPO_ROOT / "scripts/run-historic-fleet-darwin.sh"
+PINNED_ACTION = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def _workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
+    workflow = _workflow()
+    triggers = workflow.get("on", workflow.get(True))
+    assert workflow["name"] == "historic-fleet-darwin"
+    assert set(triggers) == {"workflow_dispatch", "pull_request"}
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["foundation_tag"]["required"] is True
+    assert inputs["follow_up_tag"]["required"] is True
+    assert workflow["permissions"] == {"contents": "read"}
+
+    for job in workflow["jobs"].values():
+        assert job["runs-on"] == "macos-14"
+        assert 1 <= job["timeout-minutes"] <= 360
+        for step in job["steps"]:
+            if "uses" in step:
+                assert PINNED_ACTION.fullmatch(step["uses"])
+            if step.get("uses", "").startswith("actions/checkout@"):
+                assert step["with"]["persist-credentials"] is False
+
+    formal = workflow["jobs"]["historic-fleet-darwin"]
+    assert formal["name"] == "historic-fleet-darwin"
+    assert formal["if"] == "github.event_name == 'workflow_dispatch'"
+    assert any(
+        step.get("run") == "bash scripts/run-historic-fleet-darwin.sh formal"
+        for step in formal["steps"]
+    )
+    upload = formal["steps"][-1]
+    assert upload["if"] == "always()"
+    assert upload["with"]["if-no-files-found"] == "warn"
+
+
+def test_pr_canary_is_separate_release_shaped_and_cannot_publish() -> None:
+    workflow = _workflow()
+    canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
+    assert canary["if"] == "github.event_name == 'pull_request'"
+    assert any(
+        step.get("run") == "bash scripts/run-historic-fleet-darwin.sh canary"
+        for step in canary["steps"]
+    )
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    for start in (
+        "dist/release/v1.61.0-dc7d332",
+        "v1.62.0",
+        "dist/archive/v1.65.0-c5ec161",
+    ):
+        assert f'"{start}"' in source
+    assert "build-release.sh --source candidate --target release" in source
+    assert "build-vault-bundle.sh" in source
+    assert "git push" not in source
+    assert "gh release" not in source
+    assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_formal_runner_freezes_public_cohort_and_retains_exact_counts() -> None:
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"' in source
+    assert 'MAX_DISK_KIB=$((50 * 1024 * 1024))' in source
+    assert "release_fleet_acceptance.py cohort" in source
+    assert "release_fleet_acceptance.py session" in source
+    assert '"platform"' in source
+    assert "release_fleet_acceptance.py aggregate" in source
+    assert "CANONICAL_PUBLIC_REMOTE" in source
+    assert "shasum -a 256 -c" in source
+    for count in ("discovered", "started", "completed", "passed", "failed"):
+        assert f'"{count}"' in source
+
+
+def test_runner_has_valid_bash_syntax() -> None:
+    subprocess.run(["bash", "-n", str(RUNNER_PATH)], check=True)

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -49,16 +49,21 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_pr_canary_is_separate_release_shaped_and_cannot_publish() -> None:
+def test_four_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
+    assert any(
+        step.get("name") == "Run four release-shaped macOS journeys"
+        for step in canary["steps"]
+    )
     assert any(
         step.get("run") == "bash scripts/run-historic-fleet-darwin.sh canary"
         for step in canary["steps"]
     )
     source = RUNNER_PATH.read_text(encoding="utf-8")
     for start in (
+        "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
         "v1.62.0",
         "dist/archive/v1.65.0-c5ec161",
@@ -69,6 +74,7 @@ def test_pr_canary_is_separate_release_shaped_and_cannot_publish() -> None:
     assert "git push" not in source
     assert "gh release" not in source
     assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert source.count('  "v1.51.0"') == 1
 
 
 def test_formal_runner_freezes_public_cohort_and_retains_exact_counts() -> None:

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -72,6 +72,8 @@ def test_four_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source
     assert source.count("--controlled-approvals") == 1
+    assert source.count("--follow-up-cache") == 1
+    assert "--follow-up-cache" not in source.split("run_canary()", 1)[0]
     assert "git push" not in source
     assert "gh release" not in source
     assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1917,10 +1917,12 @@ def test_standalone_bridge_asset_refuses_a_checksum_not_shipped_for_its_bytes(
 
 
 @pytest.mark.parametrize("split_topology", [False, True])
+@pytest.mark.parametrize("controlled_approvals", [False, True])
 def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     split_topology: bool,
+    controlled_approvals: bool,
 ) -> None:
     from core.update.journey_protocol import load_update_journey_protocol
     from scripts import release_fleet_executor
@@ -2131,6 +2133,7 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         follow_up_tag=follow_up.tag,
         bridge_asset=bridge_asset,
         bridge_checksum=bridge_checksum,
+        controlled_approvals=controlled_approvals,
     )
 
     assert run.case == {"starting_tag": start.tag}
@@ -2142,6 +2145,12 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert captured["initial_install_evidence"]["topology"] == (
         "brain-vault-split" if split_topology else "legacy-monolithic"
     )
+    if controlled_approvals:
+        approval_input = captured["input_fn"]
+        assert callable(approval_input)
+        assert approval_input("exact controlled prompt") == protocol.bridge.approval_word
+    else:
+        assert "input_fn" not in captured
     assert environment_kwargs["pip_cache_dir"] == (
         tmp_path / "output/.fixture-controller/pip"
     )

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -2134,12 +2134,14 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         bridge_asset=bridge_asset,
         bridge_checksum=bridge_checksum,
         controlled_approvals=controlled_approvals,
+        follow_up_cache=tmp_path / "candidate-release.git",
     )
 
     assert run.case == {"starting_tag": start.tag}
     assert captured["source_commit"] == source_commit
     assert captured["foundation_release"] == foundation.identity()
     assert captured["follow_up_release"] == follow_up.identity()
+    assert captured["follow_up_cache"] == tmp_path / "candidate-release.git"
     assert captured["user_owned_paths"] == tuple(release_fleet.USER_FIXTURES)
     assert captured["bridge_asset_evidence"]["source"] == "released-standalone-asset"
     assert captured["initial_install_evidence"]["topology"] == (

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1730,6 +1730,51 @@ def test_fixture_python_proves_real_venv_and_local_dependencies_before_doctor(
     assert not marker.exists()
 
 
+def test_fixture_python_pre_bridge_proof_does_not_require_modern_mcp(
+    tmp_path: Path,
+) -> None:
+    runtime = _current_base_python_runtime()
+    vault = tmp_path / "vault"
+    fixture_root = vault / ".venv"
+    fixture_bin = fixture_root / "bin"
+    fixture_bin.mkdir(parents=True)
+    (fixture_bin / "python").symlink_to(runtime.resolved_python)
+    (fixture_root / "pyvenv.cfg").write_text(
+        "\n".join(
+            (
+                f"home = {runtime.resolved_python.parent}",
+                "include-system-site-packages = false",
+                f"version = {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    site_packages = (
+        fixture_root
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    yaml_package = site_packages / "yaml"
+    yaml_package.mkdir(parents=True)
+    yaml_origin = yaml_package / "__init__.py"
+    yaml_origin.write_text("# fixture-local PyYAML\n", encoding="utf-8")
+
+    fixture_python = release_fleet.resolve_fixture_python(
+        vault,
+        trusted_python=runtime,
+        required_dependencies=release_fleet.PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES,
+    )
+
+    assert fixture_python.dependency_origins == (("yaml", str(yaml_origin)),)
+    with pytest.raises(
+        release_fleet.FleetError,
+        match="fixture venv dependency is unavailable: mcp",
+    ):
+        release_fleet.resolve_fixture_python(vault, trusted_python=runtime)
+
+
 def test_journey_fails_closed_before_building_when_release_has_no_executor(
     tmp_path: Path,
 ) -> None:
@@ -1973,7 +2018,11 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         },
     )
     monkeypatch.setattr(release_fleet, "resolve_trusted_node_runtime", object)
-    monkeypatch.setattr(release_fleet, "resolve_trusted_python_runtime", object)
+    trusted_python = object()
+    monkeypatch.setattr(
+        release_fleet, "resolve_trusted_python_runtime", lambda: trusted_python
+    )
+
     def case_environment(*_args, **kwargs):
         environment_kwargs.update(kwargs)
         return {}
@@ -2052,7 +2101,13 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         return Run()
 
     monkeypatch.setattr(release_fleet, "build_installed_fixture", build_case)
-    monkeypatch.setattr(release_fleet, "resolve_fixture_python", lambda *_args, **_kwargs: object())
+    fixture_python_calls: list[dict[str, object]] = []
+
+    def resolve_fixture(*_args, **kwargs):
+        fixture_python_calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(release_fleet, "resolve_fixture_python", resolve_fixture)
     monkeypatch.setattr(
         release_fleet,
         "_prepare_installer_release_remote",
@@ -2093,6 +2148,12 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     assert environment_kwargs["controller_root"] == (
         tmp_path / "output/.fixture-controller"
     )
+    assert fixture_python_calls == [
+        {
+            "trusted_python": trusted_python,
+            "required_dependencies": release_fleet.PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES,
+        }
+    ]
     assert remote_events == (
         ["split-official-read-retained", "execute", "remote-closed"]
         if split_topology

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -764,12 +764,14 @@ def test_platform_collector_retains_every_live_run_and_exact_counts(
         follow_up_tag: str,
         bridge_asset: Path,
         bridge_checksum: Path,
+        controlled_approvals: bool,
     ) -> object:
         assert output == tmp_path
         assert foundation_tag == FOUNDATION.tag
         assert follow_up_tag == "dist/release/v1.81.1-3333333"
         assert bridge_asset == asset_path
         assert bridge_checksum == checksum_path
+        assert controlled_approvals is True
         run = SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
         created.append(run)
         return run
@@ -817,8 +819,10 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
         follow_up_tag: str,
         bridge_asset: Path,
         bridge_checksum: Path,
+        controlled_approvals: bool,
     ) -> object:
         del output, foundation_tag, follow_up_tag, bridge_asset, bridge_checksum
+        assert controlled_approvals is True
         if starting_tag == releases[1].tag:
             raise release_fleet.FleetError("synthetic journey failed")
         return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -62,18 +62,44 @@ def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
     manifest = acceptance.frozen_cohort_manifest(
         historic + later,
         foundation=_foundation(),
-        expected_count=2,
     )
     parsed = acceptance.releases_from_frozen_cohort(
         json.dumps(manifest),
         current_releases=historic + later,
         foundation=_foundation(),
-        expected_count=2,
     )
 
     assert parsed == historic
     assert manifest["case_count"] == 2
     assert manifest["foundation"] == _foundation()
+
+
+def test_frozen_cohort_derives_and_binds_its_current_public_case_count() -> None:
+    acceptance = _acceptance()
+    historic = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _foundation_release(),
+    )
+
+    manifest = acceptance.frozen_cohort_manifest(historic)
+    parsed = acceptance.releases_from_frozen_cohort(
+        json.dumps(manifest),
+        current_releases=historic,
+    )
+    session = acceptance.create_acceptance_session(
+        cohort_sha256="a" * 64,
+        foundation=_foundation(),
+        follow_up_tag="dist/release/v1.81.7-3333333",
+        source_commit="c" * 40,
+        acceptance_source_sha256="d" * 64,
+        protocol_platforms=("darwin",),
+        case_count=len(parsed),
+        key=bytes(range(32)),
+        session_id="e" * 64,
+    )
+
+    assert manifest["case_count"] == session["payload"]["case_count"] == 2
+    assert session["payload"]["journey_count"] == 2
 
 
 def test_frozen_cohort_rejects_a_new_release_at_or_before_the_foundation() -> None:
@@ -85,7 +111,6 @@ def test_frozen_cohort_rejects_a_new_release_at_or_before_the_foundation() -> No
     manifest = acceptance.frozen_cohort_manifest(
         historic,
         foundation=_foundation(),
-        expected_count=2,
     )
     unexpected = _release("dist/release/v1.79.0-5555555", "1.79.0", "5")
 
@@ -94,7 +119,37 @@ def test_frozen_cohort_rejects_a_new_release_at_or_before_the_foundation() -> No
             json.dumps(manifest),
             current_releases=historic + (unexpected,),
             foundation=_foundation(),
-            expected_count=2,
+        )
+
+
+def test_frozen_cohort_rejects_missing_duplicate_and_miscounted_starts() -> None:
+    acceptance = _acceptance()
+    historic = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _foundation_release(),
+    )
+    manifest = acceptance.frozen_cohort_manifest(historic)
+
+    with pytest.raises(release_fleet.FleetError, match="identity drift"):
+        acceptance.releases_from_frozen_cohort(
+            json.dumps(manifest),
+            current_releases=historic[1:],
+        )
+
+    duplicate = release_fleet.DistributionRelease(
+        tag=historic[0].tag,
+        version=historic[0].version,
+        commit="9" * 40,
+        tree="8" * 40,
+    )
+    with pytest.raises(release_fleet.FleetError, match="repeats a release tag"):
+        acceptance.frozen_cohort_manifest(historic + (duplicate,))
+
+    miscounted = dict(manifest, case_count=3)
+    with pytest.raises(release_fleet.FleetError, match="invalid case count"):
+        acceptance.releases_from_frozen_cohort(
+            json.dumps(miscounted),
+            current_releases=historic,
         )
 
 
@@ -107,7 +162,6 @@ def test_frozen_cohort_rejects_identity_drift_and_wrong_foundation() -> None:
     manifest = acceptance.frozen_cohort_manifest(
         historic,
         foundation=_foundation(),
-        expected_count=2,
     )
     changed = release_fleet.DistributionRelease(
         tag=historic[0].tag,
@@ -121,7 +175,6 @@ def test_frozen_cohort_rejects_identity_drift_and_wrong_foundation() -> None:
             json.dumps(manifest),
             current_releases=(changed, historic[1]),
             foundation=_foundation(),
-            expected_count=2,
         )
 
     other_foundation = dict(_foundation(), tree="e" * 40)
@@ -130,7 +183,6 @@ def test_frozen_cohort_rejects_identity_drift_and_wrong_foundation() -> None:
             json.dumps(manifest),
             current_releases=historic,
             foundation=other_foundation,
-            expected_count=2,
         )
 
 
@@ -145,18 +197,22 @@ def test_frozen_cohort_requires_the_exact_foundation_release() -> None:
         acceptance.frozen_cohort_manifest(
             without_foundation,
             foundation=_foundation(),
-            expected_count=2,
         )
 
 
-def test_real_repository_freezes_exactly_170_historic_trees() -> None:
+def test_real_repository_derives_the_current_historic_tree_count() -> None:
     acceptance = _acceptance()
     repository = Path(__file__).resolve().parents[2]
     current = release_fleet.discover_distribution_releases(repository)
 
     manifest = acceptance.frozen_cohort_manifest(current)
+    parsed = acceptance.releases_from_frozen_cohort(
+        json.dumps(manifest),
+        current_releases=current,
+    )
 
-    assert manifest["case_count"] == acceptance.EXPECTED_HISTORIC_CASES == 170
+    assert manifest["case_count"] == len(manifest["cases"]) == len(parsed)
+    assert manifest["case_count"] > 0
     assert manifest["foundation"]["tag"] == "dist/release/v1.81.0-6bc490e"
 
 
@@ -243,11 +299,11 @@ def test_platform_report_rejects_a_protocol_platform_superset() -> None:
 
 
 def _fleet_inputs() -> tuple[object, tuple[release_fleet.DistributionRelease, ...]]:
-    acceptance = _acceptance()
     releases = tuple(
         _release(f"v1.0.{index}", f"1.0.{index}", f"{index % 10}")
-        for index in range(1, acceptance.EXPECTED_HISTORIC_CASES + 1)
+        for index in range(1, 4)
     )
+    acceptance = _acceptance()
     return (
         acceptance.FleetInputs(
             releases=releases,
@@ -272,6 +328,7 @@ def _signed_session(acceptance):
         source_commit=inputs.source_commit,
         acceptance_source_sha256=inputs.acceptance_source_sha256,
         protocol_platforms=inputs.protocol.platforms,
+        case_count=len(inputs.releases),
         key=key,
         session_id="e" * 64,
     )
@@ -367,18 +424,19 @@ def test_serialized_platform_evidence_is_never_an_acceptance_authority(
         key=key,
         inputs=inputs,
     )
+    case_count = len(inputs.releases)
 
     assert result == {
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
         "acceptance": False,
         "authority_complete": False,
         "platforms": ["darwin"],
-        "case_count": 170,
-        "journey_count": 170,
-        "discovered": 170,
-        "started": 170,
-        "completed": 170,
-        "passed": 170,
+        "case_count": case_count,
+        "journey_count": case_count,
+        "discovered": case_count,
+        "started": case_count,
+        "completed": case_count,
+        "passed": case_count,
         "failed": 0,
         "session_id": "e" * 64,
         "required_job_conclusions": {
@@ -524,8 +582,8 @@ def test_aggregation_reopens_and_hashes_the_immutable_manifest(
         )
 
 
-@pytest.mark.parametrize("mutation", ("169", "171", "substitution", "duplicate"))
-def test_aggregation_requires_exactly_170_unique_final_starts_per_platform(
+@pytest.mark.parametrize("mutation", ("missing", "extra", "substitution", "duplicate"))
+def test_aggregation_requires_the_frozen_unique_final_starts_per_platform(
     mutation: str,
     tmp_path: Path,
 ) -> None:
@@ -534,9 +592,9 @@ def test_aggregation_requires_exactly_170_unique_final_starts_per_platform(
     darwin = _manifest_document(inputs=inputs, platform="darwin")
     cases = darwin["report"]["cases"]
     assert isinstance(cases, list)
-    if mutation == "169":
+    if mutation == "missing":
         cases.pop()
-    elif mutation == "171":
+    elif mutation == "extra":
         cases.append(_case_document(_case("v9.9.9", "darwin")))
     elif mutation == "substitution":
         cases[0] = _case_document(_case("v9.9.9", "darwin"))
@@ -910,10 +968,10 @@ def test_live_finalization_rejects_a_spoofed_host_platform(
         ),
         (),
         {
-            "discovered": 170,
-            "started": 170,
-            "completed": 170,
-            "passed": 170,
+            "discovered": len(inputs.releases),
+            "started": len(inputs.releases),
+            "completed": len(inputs.releases),
+            "passed": len(inputs.releases),
             "failed": 0,
         },
     )
@@ -1255,13 +1313,14 @@ def test_platform_cli_preverifies_and_passes_the_bridge_pair_to_every_journey(
 
     def collect(*args, **kwargs):
         captured["collect"] = (args, kwargs)
+        case_count = len(inputs.releases)
         return SimpleNamespace(
             report=SimpleNamespace(platforms=("darwin",)),
             counts={
-                "discovered": 170,
-                "started": 170,
-                "completed": 170,
-                "passed": 170,
+                "discovered": case_count,
+                "started": case_count,
+                "completed": case_count,
+                "passed": case_count,
                 "failed": 0,
             },
         )
@@ -1328,7 +1387,7 @@ def test_session_key_file_is_private_and_rejects_symlinks(tmp_path: Path) -> Non
         acceptance.read_session_key(key_path)
 
 
-def test_cohort_cli_writes_the_exact_170_tree_manifest(
+def test_cohort_cli_writes_the_current_public_tree_manifest(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -1340,15 +1399,16 @@ def test_cohort_cli_writes_the_exact_170_tree_manifest(
 
     result = json.loads(capsys.readouterr().out)
     manifest = json.loads(output.read_text(encoding="utf-8"))
+    case_count = len(manifest["cases"])
     assert exit_code == 0
     assert result == {
         "acceptance": False,
-        "case_count": 170,
+        "case_count": case_count,
         "foundation_tag": FOUNDATION.tag,
         "outcome": "HISTORIC_COHORT_FROZEN",
         "output": str(output),
     }
-    assert manifest["case_count"] == 170
+    assert manifest["case_count"] == case_count
 
 
 def test_acceptance_source_is_bound_to_exact_publisher_commit_bytes(
@@ -1414,7 +1474,7 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     acceptance = _acceptance()
     releases = tuple(
         _release(f"v1.0.{index}", f"1.0.{index}", f"{index % 10}")
-        for index in range(1, acceptance.EXPECTED_HISTORIC_CASES + 1)
+        for index in range(1, 4)
     )
     foundation = _immutable_foundation()
     follow_up = _immutable_follow_up()
@@ -1458,13 +1518,14 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
 
     def collect(*args, running_platform: str, **kwargs):
         del args, kwargs
+        case_count = len(inputs.releases)
         return SimpleNamespace(
             report=SimpleNamespace(platforms=(running_platform,)),
             counts={
-                "discovered": 170,
-                "started": 170,
-                "completed": 170,
-                "passed": 170,
+                "discovered": case_count,
+                "started": case_count,
+                "completed": case_count,
+                "passed": case_count,
                 "failed": 0,
             },
         )
@@ -1579,20 +1640,21 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
         == 0
     )
     result = json.loads(aggregate_path.read_text(encoding="utf-8"))
+    case_count = len(inputs.releases)
     assert result == {
         "acceptance": False,
         "authority_complete": False,
-        "case_count": 170,
-        "completed": 170,
-        "discovered": 170,
+        "case_count": case_count,
+        "completed": case_count,
+        "discovered": case_count,
         "failed": 0,
-        "journey_count": 170,
+        "journey_count": case_count,
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
-        "passed": 170,
+        "passed": case_count,
         "platforms": ["darwin"],
         "required_job_conclusions": {
             "darwin": "historic-fleet-darwin",
         },
         "session_id": session["payload"]["session_id"],
-        "started": 170,
+        "started": case_count,
     }

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -675,6 +675,17 @@ def _case_document(case: release_fleet.CaseResult) -> dict[str, object]:
     return {field.name: getattr(case, field.name) for field in fields(case)}
 
 
+def _bridge_pair(root: Path) -> tuple[Path, Path]:
+    asset = root / "dex-update-bridge-v1.81.1.py"
+    checksum = root / f"{asset.name}.sha256"
+    asset.write_bytes(b"released bridge bytes\n")
+    checksum.write_text(
+        f"{hashlib.sha256(asset.read_bytes()).hexdigest()}  {asset.name}\n",
+        encoding="utf-8",
+    )
+    return asset, checksum
+
+
 def test_platform_collector_retains_every_live_run_and_exact_counts(
     tmp_path: Path,
 ) -> None:
@@ -684,6 +695,7 @@ def test_platform_collector_retains_every_live_run_and_exact_counts(
         _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
     )
     created: list[object] = []
+    asset_path, checksum_path = _bridge_pair(tmp_path)
 
     def journey_runner(
         _repo: Path,
@@ -692,10 +704,14 @@ def test_platform_collector_retains_every_live_run_and_exact_counts(
         starting_tag: str,
         foundation_tag: str,
         follow_up_tag: str,
+        bridge_asset: Path,
+        bridge_checksum: Path,
     ) -> object:
         assert output == tmp_path
         assert foundation_tag == FOUNDATION.tag
         assert follow_up_tag == "dist/release/v1.81.1-3333333"
+        assert bridge_asset == asset_path
+        assert bridge_checksum == checksum_path
         run = SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
         created.append(run)
         return run
@@ -707,6 +723,8 @@ def test_platform_collector_retains_every_live_run_and_exact_counts(
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
         running_platform="darwin",
+        bridge_asset=asset_path,
+        bridge_checksum=checksum_path,
         journey_runner=journey_runner,
     )
 
@@ -730,6 +748,7 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
         _release("v1.20.1", "1.20.1", "1"),
         _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
     )
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
 
     def journey_runner(
         _repo: Path,
@@ -738,8 +757,10 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
         starting_tag: str,
         foundation_tag: str,
         follow_up_tag: str,
+        bridge_asset: Path,
+        bridge_checksum: Path,
     ) -> object:
-        del output, foundation_tag, follow_up_tag
+        del output, foundation_tag, follow_up_tag, bridge_asset, bridge_checksum
         if starting_tag == releases[1].tag:
             raise release_fleet.FleetError("synthetic journey failed")
         return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
@@ -752,6 +773,8 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
             foundation_tag=FOUNDATION.tag,
             follow_up_tag="dist/release/v1.81.1-3333333",
             running_platform="darwin",
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
             journey_runner=journey_runner,
         )
 
@@ -791,6 +814,7 @@ def test_forged_executor_runs_cannot_mint_a_platform_receipt(
     acceptance = _acceptance()
     key, session, inputs = _signed_session(acceptance)
     running_platform = acceptance._running_platform()
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
     execution = acceptance.collect_platform_runs(
         tmp_path,
         output=tmp_path,
@@ -798,6 +822,8 @@ def test_forged_executor_runs_cannot_mint_a_platform_receipt(
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
         running_platform=running_platform,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
         journey_runner=lambda _repo, **kwargs: SimpleNamespace(
             case=_case_document(_case(str(kwargs["starting_tag"]), running_platform))
         ),
@@ -836,6 +862,7 @@ def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
     acceptance = _acceptance()
     key, session, inputs = _signed_session(acceptance)
     running_platform = acceptance._running_platform()
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
     releases = (
         _release("v1.20.1", "1.20.1", "1"),
         _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
@@ -847,6 +874,8 @@ def test_changed_evidence_validator_cannot_mint_a_platform_receipt(
         foundation_tag=FOUNDATION.tag,
         follow_up_tag="dist/release/v1.81.1-3333333",
         running_platform=running_platform,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
         journey_runner=lambda _repo, **kwargs: SimpleNamespace(
             case=_case_document(_case(str(kwargs["starting_tag"]), running_platform))
         ),
@@ -920,6 +949,363 @@ def test_platform_controller_creates_one_private_non_resumable_run_root(
     unsafe_parent.symlink_to(real_parent, target_is_directory=True)
     with pytest.raises(release_fleet.FleetError, match="parent is unsafe"):
         acceptance._create_private_run_root(unsafe_parent / "run")
+
+
+def _platform_cli_arguments(
+    root: Path,
+    *,
+    foundation: release_fleet.ImmutableRelease,
+    follow_up: release_fleet.ImmutableRelease,
+    session_path: Path,
+    key_path: Path,
+    output: Path,
+) -> list[str]:
+    return [
+        "platform",
+        "--repo",
+        str(root),
+        "--cohort",
+        str(root / "cohort.json"),
+        "--foundation-tag",
+        foundation.tag,
+        "--follow-up-tag",
+        follow_up.tag,
+        "--session",
+        str(session_path),
+        "--key",
+        str(key_path),
+        "--output",
+        str(output),
+    ]
+
+
+def _write_platform_session(
+    root: Path,
+    *,
+    acceptance,
+) -> tuple[Path, Path, object]:
+    key, session, inputs = _signed_session(acceptance)
+    session_path = root / "session.json"
+    key_path = root / "session.key"
+    session_path.write_bytes(acceptance._json_bytes(session))
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    return session_path, key_path, inputs
+
+
+def test_platform_cli_requires_a_bridge_asset_and_checksum(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    session_path, key_path, inputs = _write_platform_session(tmp_path, acceptance=acceptance)
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+
+    with pytest.raises(SystemExit):
+        acceptance.main(
+            _platform_cli_arguments(
+                tmp_path,
+                foundation=inputs.foundation,
+                follow_up=inputs.follow_up,
+                session_path=session_path,
+                key_path=key_path,
+                output=tmp_path / "run",
+            )
+        )
+
+
+def test_platform_cli_rejects_a_tampered_bridge_pair_before_starting_a_journey(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    session_path, key_path, inputs = _write_platform_session(tmp_path, acceptance=acceptance)
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    run_root = tmp_path / "run"
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+    monkeypatch.setattr(acceptance, "_running_platform", lambda: "darwin")
+    monkeypatch.setattr(acceptance, "_verify_public_follow_up_release", lambda _release: None, raising=False)
+    monkeypatch.setattr(
+        release_fleet,
+        "_verify_standalone_bridge_asset",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            release_fleet.FleetError("standalone released bridge checksum is invalid")
+        ),
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "collect_platform_runs",
+        lambda *args, **kwargs: pytest.fail("journey collector must not start"),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="checksum is invalid"):
+        acceptance.main(
+            _platform_cli_arguments(
+                tmp_path,
+                foundation=inputs.foundation,
+                follow_up=inputs.follow_up,
+                session_path=session_path,
+                key_path=key_path,
+                output=run_root,
+            )
+            + [
+                "--bridge-asset",
+                str(bridge_asset),
+                "--bridge-checksum",
+                str(bridge_checksum),
+            ]
+        )
+
+    assert not run_root.exists()
+
+
+def test_platform_cli_rejects_a_follow_up_not_advertised_by_the_public_remote(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    session_path, key_path, inputs = _write_platform_session(tmp_path, acceptance=acceptance)
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+    monkeypatch.setattr(acceptance, "_running_platform", lambda: "darwin")
+    monkeypatch.setattr(release_fleet, "_verify_standalone_bridge_asset", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        acceptance,
+        "_verify_public_follow_up_release",
+        lambda _release: (_ for _ in ()).throw(
+            release_fleet.FleetError("follow-up release is not advertised by the public stable remote")
+        ),
+        raising=False,
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="not advertised"):
+        acceptance.main(
+            _platform_cli_arguments(
+                tmp_path,
+                foundation=inputs.foundation,
+                follow_up=inputs.follow_up,
+                session_path=session_path,
+                key_path=key_path,
+                output=tmp_path / "run",
+            )
+            + ["--bridge-asset", str(bridge_asset), "--bridge-checksum", str(bridge_checksum)]
+        )
+    assert not (tmp_path / "run").exists()
+
+
+def test_platform_cli_rejects_a_bridge_pair_not_matching_the_public_release(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    session_path, key_path, inputs = _write_platform_session(tmp_path, acceptance=acceptance)
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    run_root = tmp_path / "run"
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+    monkeypatch.setattr(acceptance, "_running_platform", lambda: "darwin")
+    monkeypatch.setattr(acceptance, "_verify_public_follow_up_release", lambda _release: None, raising=False)
+    monkeypatch.setattr(release_fleet, "_verify_standalone_bridge_asset", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        acceptance,
+        "_verify_public_bridge_release_asset",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            release_fleet.FleetError("bridge asset does not match the public GitHub release")
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "collect_platform_runs",
+        lambda *args, **kwargs: pytest.fail("journey collector must not start"),
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="public GitHub release"):
+        acceptance.main(
+            _platform_cli_arguments(
+                tmp_path,
+                foundation=inputs.foundation,
+                follow_up=inputs.follow_up,
+                session_path=session_path,
+                key_path=key_path,
+                output=run_root,
+            )
+            + ["--bridge-asset", str(bridge_asset), "--bridge-checksum", str(bridge_checksum)]
+        )
+
+    assert not run_root.exists()
+
+
+def test_public_follow_up_release_requires_the_exact_canonical_remote_tag_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acceptance = _acceptance()
+    release = _immutable_follow_up()
+    calls: list[list[str]] = []
+
+    def advertised(arguments, **_kwargs):
+        calls.append(arguments)
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"{release.tag_object}\trefs/tags/{release.tag}\n",
+        )
+
+    monkeypatch.setattr(acceptance.subprocess, "run", advertised)
+    acceptance._verify_public_follow_up_release(release)
+
+    assert calls == [
+        [
+            "git",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "protocol.file.allow=never",
+            "ls-remote",
+            "--refs",
+            "--tags",
+            acceptance.CANONICAL_PUBLIC_REMOTE,
+            f"refs/tags/{release.tag}",
+        ]
+    ]
+
+    monkeypatch.setattr(
+        acceptance.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout=f"{'0' * 40}\trefs/tags/{release.tag}\n"),
+    )
+    with pytest.raises(release_fleet.FleetError, match="not advertised"):
+        acceptance._verify_public_follow_up_release(release)
+
+
+def test_public_bridge_assets_must_match_the_public_stable_release_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    release = _immutable_follow_up()
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    public_metadata = {"tag_name": "v1.81.1", "draft": False, "prerelease": False}
+    public_assets = {
+        bridge_asset.name: bridge_asset.read_bytes(),
+        bridge_checksum.name: bridge_checksum.read_bytes(),
+    }
+
+    def public_bytes(url: str, **_kwargs) -> bytes:
+        if url == acceptance.CANONICAL_PUBLIC_RELEASE_API.format(version=release.version):
+            return json.dumps(public_metadata).encode("utf-8")
+        for name, content in public_assets.items():
+            if url.endswith(name):
+                return content
+        pytest.fail(f"unexpected public URL: {url}")
+
+    monkeypatch.setattr(acceptance, "_read_public_bytes", public_bytes)
+    acceptance._verify_public_bridge_release_asset(
+        release,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
+    )
+
+    bridge_asset.write_bytes(b"tampered controller copy\n")
+    with pytest.raises(release_fleet.FleetError, match="public GitHub release"):
+        acceptance._verify_public_bridge_release_asset(
+            release,
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
+        )
+
+    bridge_asset.write_bytes(public_assets[bridge_asset.name])
+    public_metadata["draft"] = True
+    with pytest.raises(release_fleet.FleetError, match="public stable GitHub release"):
+        acceptance._verify_public_bridge_release_asset(
+            release,
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
+        )
+
+    public_metadata["draft"] = False
+    public_metadata["prerelease"] = True
+    with pytest.raises(release_fleet.FleetError, match="public stable GitHub release"):
+        acceptance._verify_public_bridge_release_asset(
+            release,
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
+        )
+
+
+def test_platform_cli_preverifies_and_passes_the_bridge_pair_to_every_journey(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    session_path, key_path, inputs = _write_platform_session(tmp_path, acceptance=acceptance)
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(acceptance, "load_fleet_inputs", lambda *args, **kwargs: inputs)
+    monkeypatch.setattr(acceptance, "_running_platform", lambda: "darwin")
+    monkeypatch.setattr(acceptance, "_verify_public_follow_up_release", lambda _release: None, raising=False)
+    monkeypatch.setattr(
+        acceptance,
+        "_verify_public_bridge_release_asset",
+        lambda *_args, **_kwargs: None,
+        raising=False,
+    )
+
+    def verify_asset(*args, **kwargs):
+        captured["verified"] = (args, kwargs)
+        return {"source": "released-standalone-asset"}
+
+    def collect(*args, **kwargs):
+        captured["collect"] = (args, kwargs)
+        return SimpleNamespace(
+            report=SimpleNamespace(platforms=("darwin",)),
+            counts={
+                "discovered": 170,
+                "started": 170,
+                "completed": 170,
+                "passed": 170,
+                "failed": 0,
+            },
+        )
+
+    monkeypatch.setattr(release_fleet, "_verify_standalone_bridge_asset", verify_asset)
+    monkeypatch.setattr(acceptance, "collect_platform_runs", collect)
+    monkeypatch.setattr(
+        acceptance,
+        "finalize_live_platform_execution",
+        lambda *_args, **_kwargs: {
+            "manifest_output": "platform-manifest.json",
+            "receipt_output": "platform-receipt.json",
+            "manifest_sha256": "a" * 64,
+        },
+    )
+
+    assert (
+        acceptance.main(
+            _platform_cli_arguments(
+                tmp_path,
+                foundation=inputs.foundation,
+                follow_up=inputs.follow_up,
+                session_path=session_path,
+                key_path=key_path,
+                output=tmp_path / "run",
+            )
+            + [
+                "--bridge-asset",
+                str(bridge_asset),
+                "--bridge-checksum",
+                str(bridge_checksum),
+            ]
+        )
+        == 0
+    )
+    assert captured["verified"][1] == {
+        "source_commit": inputs.source_commit,
+        "follow_up": inputs.follow_up,
+        "protocol": inputs.protocol,
+        "bridge_asset": bridge_asset,
+        "bridge_checksum": bridge_checksum,
+    }
+    assert captured["collect"][1]["bridge_asset"] == bridge_asset
+    assert captured["collect"][1]["bridge_checksum"] == bridge_checksum
 
 
 def test_session_key_file_is_private_and_rejects_symlinks(tmp_path: Path) -> None:
@@ -1068,6 +1454,7 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
     )
     session = json.loads(session_path.read_text(encoding="utf-8"))
     capsys.readouterr()
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
 
     def collect(*args, running_platform: str, **kwargs):
         del args, kwargs
@@ -1115,6 +1502,18 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
 
     monkeypatch.setattr(acceptance, "collect_platform_runs", collect)
     monkeypatch.setattr(acceptance, "finalize_live_platform_execution", finalize)
+    monkeypatch.setattr(
+        release_fleet,
+        "_verify_standalone_bridge_asset",
+        lambda *args, **kwargs: {"source": "released-standalone-asset"},
+    )
+    monkeypatch.setattr(acceptance, "_verify_public_follow_up_release", lambda _release: None, raising=False)
+    monkeypatch.setattr(
+        acceptance,
+        "_verify_public_bridge_release_asset",
+        lambda *_args, **_kwargs: None,
+        raising=False,
+    )
     receipt_paths: list[Path] = []
     manifest_paths: list[Path] = []
     for platform in ("darwin",):
@@ -1140,6 +1539,10 @@ def test_full_command_surface_aggregates_evidence_without_minting_acceptance(
                     str(session_path),
                     "--key",
                     str(key_path),
+                    "--bridge-asset",
+                    str(bridge_asset),
+                    "--bridge-checksum",
+                    str(bridge_checksum),
                     "--output",
                     str(platform_root),
                 ]

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -891,6 +891,33 @@ def test_executor_records_the_bridge_approval_count_that_actually_occurred(
     ]
 
 
+def test_controlled_fleet_approval_still_rejects_excess_bridge_prompts(
+    tmp_path: Path,
+) -> None:
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
+    )
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+
+    class ExcessApprovalRuntime(_Runtime):
+        def bridge_to_foundation(
+            self, vault: Path, foundation, *, input_fn, output_fn
+        ):
+            del vault, foundation, output_fn
+            for index in range(protocol.bridge.approval_count + 1):
+                input_fn(f"controlled approval {index + 1}")
+            pytest.fail("the executor must reject an excess controlled approval")
+
+    with pytest.raises(executor.ExecutorError, match="approval was not exact"):
+        _execute(
+            tmp_path,
+            ExcessApprovalRuntime(_identity("1.81.0", "b")),
+            source_repo=source_repo,
+            source_commit=source_commit,
+            input_fn=lambda _prompt: protocol.bridge.approval_word,
+        )
+
+
 def test_already_installed_foundation_executes_and_validates_without_a_fake_transaction(
     tmp_path: Path,
 ) -> None:

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -86,7 +86,9 @@ def _foundation_cache(
 ) -> tuple[Path, executor.dex_update_bridge.ReleasePin]:
     source = tmp_path / "foundation-source"
     source.mkdir(parents=True)
-    subprocess.run(["git", "init", "--quiet"], cwd=source, check=True)
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch=main"], cwd=source, check=True
+    )
     subprocess.run(
         ["git", "config", "user.name", "Dex Tests"],
         cwd=source,

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -150,6 +150,17 @@ def _foundation_cache(
     return cache, pin
 
 
+def _follow_up_cache(
+    tmp_path: Path,
+) -> tuple[Path, executor.dex_update_bridge.ReleasePin]:
+    cache, pin = _foundation_cache(tmp_path)
+    subprocess.run(
+        ["git", "--git-dir", str(cache), "update-ref", "-d", "refs/heads/main"],
+        check=True,
+    )
+    return cache, pin
+
+
 def test_private_foundation_cache_preserves_exact_official_identity(
     tmp_path: Path,
 ) -> None:
@@ -196,6 +207,79 @@ def test_foundation_cache_rejects_wrong_channel_or_unsafe_permissions(
     cache.chmod(0o755)
     with pytest.raises(executor.ExecutorError, match="mode 0700"):
         executor._validate_foundation_cache(cache, pin)
+
+
+def test_private_follow_up_cache_is_exact_and_rejects_ref_tampering(
+    tmp_path: Path,
+) -> None:
+    cache, pin = _follow_up_cache(tmp_path)
+    release = pin.identity()
+
+    assert executor._validate_follow_up_cache(cache, release) == cache.resolve()
+
+    subprocess.run(
+        ["git", "--git-dir", str(cache), "update-ref", "-d", "refs/heads/release"],
+        check=True,
+    )
+    with pytest.raises(executor.ExecutorError, match="follow-up cache"):
+        executor._validate_follow_up_cache(cache, release)
+
+    cache, pin = _follow_up_cache(tmp_path / "extra-ref")
+    subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(cache),
+            "update-ref",
+            "refs/heads/unreviewed",
+            pin.commit,
+        ],
+        check=True,
+    )
+    with pytest.raises(executor.ExecutorError, match="outside the requested"):
+        executor._validate_follow_up_cache(cache, pin.identity())
+
+    cache, pin = _follow_up_cache(tmp_path / "alternates")
+    alternates = cache / "objects/info/alternates"
+    alternates.write_text(str(tmp_path / "other-objects") + "\n", encoding="utf-8")
+    with pytest.raises(executor.ExecutorError, match="alternate object stores"):
+        executor._validate_follow_up_cache(cache, pin.identity())
+
+
+def test_only_canonical_public_transport_is_eligible_for_executor_authority(
+    tmp_path: Path,
+) -> None:
+    runtime = _production_runtime()
+    methods = {
+        name: getattr(executor._ProductionRuntime, name)
+        for name in (
+            "bridge_to_foundation",
+            "installed_release",
+            "doctor",
+            "deliver_latest_release",
+            "build_and_preview_delivered_release",
+            "execute_approved_delivered_release",
+            "smoke",
+            "close",
+        )
+    }
+    try:
+        assert executor._production_authority_intact(
+            runtime,
+            production_owned=True,
+            follow_up_cache=None,
+            production_runtime_type=executor._ProductionRuntime,
+            production_methods=methods,
+        )
+        assert not executor._production_authority_intact(
+            runtime,
+            production_owned=True,
+            follow_up_cache=tmp_path / "candidate-release.git",
+            production_runtime_type=executor._ProductionRuntime,
+            production_methods=methods,
+        )
+    finally:
+        runtime.close()
 
 
 def test_production_runtime_exposes_only_installed_qmd_not_ambient_path(
@@ -659,6 +743,7 @@ def _execute(
     source_commit: str,
     input_fn=lambda _prompt: "APPLY",
     starting: dict[str, str] | None = None,
+    follow_up_cache: Path | None = None,
 ) -> executor.ExecutorRun:
     protocol = load_update_journey_protocol(
         (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
@@ -681,10 +766,59 @@ def _execute(
         bridge_asset_evidence=_bridge_asset_evidence(protocol, runtime.follow_up),
         bridge_asset_path=REPO_ROOT / protocol.bridge.artifact.source_path,
         initial_install_evidence={"topology": "legacy-monolithic", "brain_refs": []},
+        follow_up_cache=follow_up_cache,
         input_fn=input_fn,
         output_fn=lambda _line: None,
         _runtime=runtime,
     )
+
+
+def test_cache_backed_run_cannot_satisfy_formal_acceptance_authority(
+    tmp_path: Path,
+) -> None:
+    protocol = load_update_journey_protocol(
+        (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
+    )
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    follow_up = _identity("1.81.8", "b")
+    run = _execute(
+        tmp_path,
+        _Runtime(follow_up),
+        source_repo=source_repo,
+        source_commit=source_commit,
+        follow_up_cache=tmp_path / "candidate-release.git",
+    )
+    report = release_fleet.AcceptanceReport(
+        foundation_tag=protocol.foundation["tag"],
+        follow_up_tag=follow_up["tag"],
+        cases=(release_fleet.CaseResult(**run.case),),
+        platforms=("darwin",),
+    )
+    foundation = release_fleet.ImmutableRelease(
+        tag=protocol.foundation["tag"],
+        tag_object=protocol.foundation["tag_object"],
+        commit=protocol.foundation["commit"],
+        tree=protocol.foundation["tree"],
+        version=protocol.foundation["version"],
+    )
+    target = release_fleet.ImmutableRelease(
+        tag=follow_up["tag"],
+        tag_object=follow_up["tag_object"],
+        commit=follow_up["commit"],
+        tree=follow_up["tree"],
+        version=follow_up["version"],
+    )
+
+    assert executor.is_authoritative_executor_run(run) is False
+    with pytest.raises(release_fleet.FleetError, match="executor authority"):
+        release_fleet.assert_evidence_bound(
+            report,
+            repo=tmp_path,
+            evidence_root=tmp_path / "case.evidence",
+            foundation=foundation,
+            follow_up=target,
+            executor_runs=(run,),
+        )
 
 
 def _bridge_asset_evidence(protocol, follow_up: dict[str, str]) -> dict[str, str]:
@@ -1119,17 +1253,28 @@ def test_production_runtime_refuses_undeclared_lifecycle_operation() -> None:
 
 
 @pytest.mark.parametrize(
-    ("foundation_installed", "use_cache", "expected_cleaned"),
-    ((False, False, [True]), (True, True, [])),
+    (
+        "foundation_installed",
+        "use_foundation_cache",
+        "use_follow_up_cache",
+        "expected_cleaned",
+    ),
+    (
+        (False, False, False, [True]),
+        (True, True, False, []),
+        (True, False, True, []),
+    ),
 )
 def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     foundation_installed: bool,
-    use_cache: bool,
+    use_foundation_cache: bool,
+    use_follow_up_cache: bool,
     expected_cleaned: list[bool],
 ) -> None:
     cleaned: list[bool] = []
+    delivery_arguments: list[dict[str, object]] = []
 
     class Temporary:
         def cleanup(self) -> None:
@@ -1137,7 +1282,11 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
 
     class Service:
         @staticmethod
-        def deliver_latest_release(vault: Path) -> dict[str, object]:
+        def deliver_latest_release(
+            vault: Path,
+            **kwargs: object,
+        ) -> dict[str, object]:
+            delivery_arguments.append(kwargs)
             return {"status": "delivered", "vault": str(vault)}
 
     def run_bridge(vault, service, *, pin, input_fn, output_fn):
@@ -1180,6 +1329,11 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
         "_load_released_bridge",
         lambda _asset, _digest: executor.dex_update_bridge,
     )
+    monkeypatch.setattr(
+        executor,
+        "_validate_follow_up_cache",
+        lambda cache, _release: cache.resolve(),
+    )
     request_stream = io.StringIO(
         "\n".join(
             (
@@ -1202,7 +1356,19 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
                 bridge_sha256=hashlib.sha256(
                     (REPO_ROOT / "scripts/dex_update_bridge.py").read_bytes()
                 ).hexdigest(),
-                foundation_cache=(tmp_path / "unused-cache" if use_cache else None),
+                foundation_cache=(
+                    tmp_path / "unused-cache"
+                    if use_foundation_cache
+                    else None
+                ),
+                follow_up_cache=(
+                    tmp_path / "candidate-release.git"
+                    if use_follow_up_cache
+                    else None
+                ),
+                follow_up_release=(
+                    _identity("1.81.8", "b") if use_follow_up_cache else None
+                ),
         )
         == 0
     )
@@ -1221,4 +1387,16 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
     assert messages[1]["text"] == "exact topology preview"
     assert messages[2]["prompt"] == "exact topology prompt"
     assert messages[4]["value"]["status"] == "delivered"
+    assert delivery_arguments == (
+        [
+            {
+                "remote_url": str(
+                    (tmp_path / "candidate-release.git").resolve()
+                ),
+                "allow_test_transport": True,
+            }
+        ]
+        if use_follow_up_cache
+        else [{}]
+    )
     assert cleaned == expected_cleaned

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -45,6 +45,12 @@ def _legacy_identity(version: str, fill: str) -> dict[str, str]:
     return identity
 
 
+def _archive_identity(version: str, fill: str) -> dict[str, str]:
+    identity = _identity(version, fill)
+    identity["tag"] = identity["tag"].replace("dist/release/", "dist/archive/", 1)
+    return identity
+
+
 def _executor_source_commit(tmp_path: Path) -> tuple[Path, str]:
     repo = tmp_path / "source"
     repo.mkdir()
@@ -738,6 +744,25 @@ def test_executor_accepts_an_exact_legacy_starting_tag_without_widening_targets(
     assert executor.is_authoritative_executor_run(run) is False
 
 
+def test_executor_accepts_an_exact_archive_start_without_widening_targets(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    runtime = _Runtime(_identity("1.81.0", "b"))
+    starting = _archive_identity("1.65.0", "a")
+
+    run = _execute(
+        tmp_path,
+        runtime,
+        source_repo=source_repo,
+        source_commit=source_commit,
+        starting=starting,
+    )
+
+    assert run.case["starting_tag"] == "dist/archive/v1.65.0-aaaaaaa"
+    assert executor.is_authoritative_executor_run(run) is False
+
+
 @pytest.mark.parametrize(
     "tag",
     (
@@ -745,6 +770,9 @@ def test_executor_accepts_an_exact_legacy_starting_tag_without_widening_targets(
         "v01.20.1",
         "v1.20",
         "legacy/v1.20.1",
+        "dist/archive/v1.20.1-not-a-commit",
+        "dist/archive/v1.20.1-aaaaaaaa",
+        "dist/archives/v1.20.1-aaaaaaa",
     ),
 )
 def test_executor_rejects_malformed_or_arbitrary_starting_refs(

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -246,40 +246,9 @@ def test_private_follow_up_cache_is_exact_and_rejects_ref_tampering(
         executor._validate_follow_up_cache(cache, pin.identity())
 
 
-def test_only_canonical_public_transport_is_eligible_for_executor_authority(
-    tmp_path: Path,
-) -> None:
-    runtime = _production_runtime()
-    methods = {
-        name: getattr(executor._ProductionRuntime, name)
-        for name in (
-            "bridge_to_foundation",
-            "installed_release",
-            "doctor",
-            "deliver_latest_release",
-            "build_and_preview_delivered_release",
-            "execute_approved_delivered_release",
-            "smoke",
-            "close",
-        )
-    }
-    try:
-        assert executor._production_authority_intact(
-            runtime,
-            production_owned=True,
-            follow_up_cache=None,
-            production_runtime_type=executor._ProductionRuntime,
-            production_methods=methods,
-        )
-        assert not executor._production_authority_intact(
-            runtime,
-            production_owned=True,
-            follow_up_cache=tmp_path / "candidate-release.git",
-            production_runtime_type=executor._ProductionRuntime,
-            production_methods=methods,
-        )
-    finally:
-        runtime.close()
+def test_production_authority_predicate_is_sealed_inside_executor_boundary() -> None:
+    assert not hasattr(executor, "_production_authority_intact")
+    assert "_production_authority_intact" not in executor.execute_journey.__code__.co_names
 
 
 def test_production_runtime_exposes_only_installed_qmd_not_ambient_path(
@@ -775,12 +744,19 @@ def _execute(
 
 def test_cache_backed_run_cannot_satisfy_formal_acceptance_authority(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     protocol = load_update_journey_protocol(
         (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
     )
     source_repo, source_commit = _executor_source_commit(tmp_path)
     follow_up = _identity("1.81.8", "b")
+    monkeypatch.setattr(
+        executor,
+        "_production_authority_intact",
+        lambda *_args, **_kwargs: True,
+        raising=False,
+    )
     run = _execute(
         tmp_path,
         _Runtime(follow_up),

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -952,6 +952,55 @@ def test_runtime_legacy_topology_refuses_cross_borrowed_existing_inputs(
     assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
 
 
+@pytest.mark.parametrize(
+    "pin",
+    (
+        bridge.MISSING_MIGRATOR_RELEASES[2],
+        bridge.MISSING_MIGRATOR_RELEASES[-2],
+    ),
+    ids=("dist-v1.61.0-dc7d332", "semantic-v1.62.0"),
+)
+def test_runtime_legacy_topology_accepts_an_exact_pin_after_its_label_is_pruned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pin: bridge.MissingMigratorPin,
+) -> None:
+    repository = _historic_checkout(tmp_path, pin.release)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", ())
+    monkeypatch.setattr(bridge, "MISSING_MIGRATOR_RELEASES", (pin,))
+
+    _git(repository, "update-ref", "-d", f"refs/tags/{pin.release.tag}")
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is True
+
+
+def test_runtime_legacy_topology_refuses_a_wrong_object_at_a_pruned_pin_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.MISSING_MIGRATOR_RELEASES[2]
+    nearby = bridge.MISSING_MIGRATOR_RELEASES[1]
+    repository = _historic_checkout(tmp_path, pin.release)
+    impossible_fallback = replace(
+        bridge.LEGACY_TOPOLOGY_FOUNDATION,
+        tag="v9.9.9",
+        commit="0" * 40,
+        tree="0" * 40,
+    )
+    monkeypatch.setattr(bridge, "MANIFESTLESS_SEMANTIC_RELEASES", ())
+    monkeypatch.setattr(bridge, "MISSING_MIGRATOR_RELEASES", (pin,))
+
+    _git(repository, "update-ref", f"refs/tags/{pin.release.tag}", nearby.release.commit)
+
+    assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
+
+
 def test_runtime_legacy_command_reproves_unchanged_existing_input_tuple(
     tmp_path: Path,
 ) -> None:

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -546,8 +546,19 @@ def _topology_command_adapter(
         """'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
-fs.readFileSync(path.join(process.cwd(), 'core/migrations/tracked-ignored-policy.yaml'));
+const crypto = require('node:crypto');
+const policy = fs.readFileSync(
+  path.join(process.cwd(), 'core/migrations/tracked-ignored-policy.yaml'),
+  'utf8',
+);
+if (
+  !/^schema_version:\\s*\\d+\\s*$/m.test(policy)
+  || !/^active_baseline_version:\\s*\\d+\\s*$/m.test(policy)
+) {
+  throw new Error('Tracked-ignore policy is missing schema or active baseline.');
+}
 fs.readFileSync(path.join(process.cwd(), 'System/.local-only-preservation-transition.json'));
+console.log(crypto.createHash('sha256').update(policy).digest('hex'));
 """,
         encoding="utf-8",
     )
@@ -1001,12 +1012,24 @@ def test_runtime_legacy_topology_refuses_a_wrong_object_at_a_pruned_pin_label(
     assert bridge._supported_legacy_topology(repository, impossible_fallback) is False
 
 
-def test_runtime_legacy_command_reproves_unchanged_existing_input_tuple(
+@pytest.mark.parametrize(
+    "release_tag",
+    (
+        "dist/release/v1.61.0-dc7d332",
+        "v1.62.0",
+    ),
+)
+def test_runtime_schema_v1_policy_uses_read_only_foundation_compatibility(
     tmp_path: Path,
+    release_tag: str,
 ) -> None:
-    pin = bridge.MISSING_MIGRATOR_RELEASES[3]
+    pin = next(pin for pin in bridge.MISSING_MIGRATOR_RELEASES if pin.release.tag == release_tag)
     repository = _historic_checkout(tmp_path, pin.release)
     adapter, engine = _topology_command_adapter(tmp_path)
+    policy_path = repository / bridge._TRACKED_IGNORE_POLICY_RELATIVE
+    transition_path = repository / bridge._PRESERVATION_TRANSITION_RELATIVE
+    original_policy = policy_path.read_bytes()
+    original_transition = transition_path.read_bytes()
 
     with adapter._topology_source():
         assert engine.topology_state(repository) == "combined"
@@ -1022,6 +1045,36 @@ def test_runtime_legacy_command_reproves_unchanged_existing_input_tuple(
         env=bridge._bridge_environment(),
     )
     assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == bridge._LEGACY_TRACKED_IGNORE_POLICY_SHA256
+    assert policy_path.read_bytes() == original_policy
+    assert transition_path.read_bytes() == original_transition
+
+
+def test_runtime_schema_v2_policy_remains_the_exact_existing_input(
+    tmp_path: Path,
+) -> None:
+    pin = next(
+        pin
+        for pin in bridge.MISSING_MIGRATOR_RELEASES
+        if pin.release.tag == "dist/release/v1.62.0-d5bd522"
+    )
+    repository = _historic_checkout(tmp_path, pin.release)
+    adapter, engine = _topology_command_adapter(tmp_path)
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        command = engine._migrator_command(repository, "--dry-run")
+
+    completed = subprocess.run(
+        command,
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=bridge._bridge_environment(),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == pin.inputs.policy_sha256
 
 
 @pytest.mark.parametrize("mode", ("--dry-run", "--auto"))

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -391,6 +391,25 @@ def _expected_pins() -> dict[str, dict[str, object]]:
         ),
         "unexpected_nonregular_paths": (),
     }
+    pins["v1.62.0"] = {
+        "kind": "self-omitting-manifest",
+        "role": "installed-source",
+        "tag": "v1.62.0",
+        "tag_object": "4913a778452003fcf8dc71a10222d5275ff28d5c",
+        "commit": "77c4a15a7884080e48b095c8de2c384d01a87883",
+        "tree": "1bf30a86c151890024040f0e4e1a533be17c5686",
+        "version": "1.62.0",
+        "package_blob": "2d7f21a72798d4189f042e955e62ee799e90a90c",
+        "package_sha256": "75bef63d563a7e5062db6ad664ccb65a7581dbfd3d466655d1b3709bbad7ffa5",
+        "manifest_blob": "eb3ac8f377abc98199eaf49c02b638fce5aad69f",
+        "manifest_sha256": "29dd6a9eccd8d358eda08506ac7d6b574cca78c1dec09c64ad24dd0ec359161d",
+        "manifest_path_count": 987,
+        "omitted_paths": ("System/.installed-files.manifest",),
+        "policy_blob": None,
+        "transition_blob": None,
+        "migrator_blob": None,
+        "unexpected_nonregular_paths": (),
+    }
     pins["v1.75.0"] = {
         "kind": "incomplete-manifest",
         "role": "installed-source",
@@ -1293,6 +1312,71 @@ def test_runtime_manifest_omission_adapter_accepts_only_exact_historic_trees(
     changed[next(iter(changed))] = "0" * 40
     monkeypatch.setattr(bridge, "_V175_DEFECTIVE_MANIFEST_OMISSIONS", changed)
     with pytest.raises(apply_update.ReleaseVerificationError, match="omission changed"):
+        adapter.build_and_preview_delivered_release(repository, {})
+
+
+def test_runtime_self_omitting_manifest_adapter_accepts_exact_semantic_v162_tree(
+    tmp_path: Path,
+) -> None:
+    pin = bridge.V162_SELF_OMITTING_MANIFEST_RELEASE
+    repository = _historic_checkout(tmp_path, pin)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = pin.commit
+    _git(repository, "update-ref", "refs/dex/installed", pin.commit)
+
+    entries = adapter.build_and_preview_delivered_release(repository, {})
+
+    assert len(entries) == 988
+    assert "System/.installed-files.manifest" in {entry.path for entry in entries}
+
+
+def test_runtime_self_omitting_manifest_adapter_refuses_an_extra_omission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pin = bridge.V162_SELF_OMITTING_MANIFEST_RELEASE
+    repository = _historic_checkout(tmp_path, pin)
+    manifest = repository / "System/.installed-files.manifest"
+    paths = manifest.read_text(encoding="utf-8").splitlines()
+    paths.remove("CLAUDE.md")
+    manifest.write_text("\n".join(paths) + "\n", encoding="utf-8")
+    _git(repository, "add", "--", "System/.installed-files.manifest")
+    _git(repository, "commit", "--quiet", "-m", "test extra manifest omission")
+    commit = _git(repository, "rev-parse", "HEAD^{commit}")
+    tree = _git(repository, "rev-parse", "HEAD^{tree}")
+    manifest_blob = _git(
+        repository,
+        "rev-parse",
+        "HEAD:System/.installed-files.manifest",
+    )
+    manifest_bytes = manifest.read_bytes()
+    mutated_pin = replace(
+        pin,
+        tag_object=commit,
+        tag_object_type="commit",
+        commit=commit,
+        tree=tree,
+    )
+    monkeypatch.setattr(bridge, "V162_SELF_OMITTING_MANIFEST_RELEASE", mutated_pin)
+    monkeypatch.setattr(bridge, "_V162_SELF_OMITTING_MANIFEST_BLOB", manifest_blob)
+    monkeypatch.setattr(
+        bridge,
+        "_V162_SELF_OMITTING_MANIFEST_SHA256",
+        hashlib.sha256(manifest_bytes).hexdigest(),
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_V162_SELF_OMITTING_MANIFEST_PATH_COUNT",
+        len(paths),
+    )
+    _git(repository, "update-ref", "refs/dex/installed", commit)
+    adapter, service = _delivery_adapter(tmp_path, repository)
+    service.commit = commit
+
+    with pytest.raises(
+        apply_update.ReleaseVerificationError,
+        match="self-omitting manifest identity changed",
+    ):
         adapter.build_and_preview_delivered_release(repository, {})
 
 

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "4cb05019c1f58e869af670cb1ebac153f8269b85f6a7601aabc2a9aeec1380cd",
+    "sha256": "e747892139a25137fa328f47e2e025d74eed7c86344bf26a01e9369a73d9e733",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "5ca65e1bf0d9f7f3e6ece522109f07ca700e8bd0a332ca88f5515071fb25c6d3",
+    "sha256": "4cb05019c1f58e869af670cb1ebac153f8269b85f6a7601aabc2a9aeec1380cd",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "e4da481f90470cc516b2c27b1a3f7a138b95ca0866268d6982b460047a14f131",
+      "sha256": "64fd13b9c24d715755f8426d082b904e08f88d1660564d38fc70339b325f012d",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "8339b473edd5e21b1489c441fd89ddb0a8421c4115146e29df2a76d02454390c",
+    "sha256": "30943a16337932ce3a65631d4053c3bf47aeb78cf7558b082e529252281eb78d",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "64fd13b9c24d715755f8426d082b904e08f88d1660564d38fc70339b325f012d",
+      "sha256": "4828f2ddfbc020282a8a95c7642b525c18e08a78ddfe0632cdd6e72231a5dba9",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "9d023c097eef7039ce37973d3d910553cdef5c5c289951705533eceb62034499",
+    "sha256": "8339b473edd5e21b1489c441fd89ddb0a8421c4115146e29df2a76d02454390c",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "f874eb2fc5211d698208281adf5ef5ae21c43365dfdf8ae83cca30694a2ee396",
+    "sha256": "5ca65e1bf0d9f7f3e6ece522109f07ca700e8bd0a332ca88f5515071fb25c6d3",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "18e8f0397e14cc5a79ed45887f5dc6989a2b65dc561fbba66c837bacb8f44095",
+      "sha256": "a8bd7782d645302127a4e85bbfd570fc126bac5bfa01d5c51f54030d64aa517d",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "1ee86c46c6d626241f51c4e071b7aa7af4eaf043a13b67cc9375c2d190d10ace",
+    "sha256": "9d023c097eef7039ce37973d3d910553cdef5c5c289951705533eceb62034499",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "a8bd7782d645302127a4e85bbfd570fc126bac5bfa01d5c51f54030d64aa517d",
+      "sha256": "e4da481f90470cc516b2c27b1a3f7a138b95ca0866268d6982b460047a14f131",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -112,6 +112,27 @@ its checksum. The runner verifies their exact names, checksum, protocol digest,
 and released source bytes before it creates the fixture. A bridge available
 only in the controller checkout cannot satisfy this gate.
 
+The formal macOS fleet controller takes that same asset pair explicitly and
+re-proves it against the immutable follow-up protocol before it creates its
+private run directory or starts a journey. The follow-up tag must be the exact
+public stable `dist/release/v*` tag that the foundation updater will deliver;
+the controller proves that the canonical public remote advertises that exact
+annotated tag object, then requires a non-draft, non-prerelease GitHub Release
+for the same version. It downloads the published bridge and checksum from that
+release and compares both byte-for-byte to the submitted pair. Neither a local
+tag nor a controller copy of the bridge can stand in for it.
+
+```bash
+python3 scripts/release_fleet_acceptance.py platform --repo . \
+  --cohort historic-cohort.json \
+  --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
+  --follow-up-tag dist/release/vNEXT-EXACTFOLLOWUP \
+  --session acceptance-session.json --key acceptance.key \
+  --bridge-asset /path/to/dex-update-bridge-vNEXT.py \
+  --bridge-checksum /path/to/dex-update-bridge-vNEXT.py.sha256 \
+  --output "$fleet_root/darwin"
+```
+
 The repository has the canonical protocol source at
 `core/update/journey-protocol-v1.json`, with a strict parser in
 `core/update/journey_protocol.py`. It is a closed operation vocabulary, not a

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -122,6 +122,22 @@ for the same version. It downloads the published bridge and checksum from that
 release and compares both byte-for-byte to the submitted pair. Neither a local
 tag nor a controller copy of the bridge can stand in for it.
 
+The first-party `historic-fleet-darwin` GitHub Actions workflow is the release
+operator for this gate. Its formal job is manual: after the updater change is
+merged and the follow-up GitHub Release is public, provide the exact immutable
+foundation and follow-up tags. The job refreshes the public tags, freezes the
+cohort, downloads and verifies the public bridge pair, and runs all starts
+sequentially on macOS. It retains the evidence and exact
+discovered/started/completed/passed/failed counts on both success and failure.
+The job is time-bounded to six hours and monitors a 50 GiB working-set limit.
+
+Pull requests that touch the updater route get a separate non-publishing
+macOS canary. It builds a local release-shaped candidate and runs real journeys
+from `dist/release/v1.61.0-dc7d332`, semantic `v1.62.0`, and an archived
+v1.65.0 start. Those three journeys can catch packaging and compatibility
+regressions before merge, but they are explicitly non-acceptance evidence and
+cannot weaken or replace the manual freshly generated public fleet gate.
+
 ```bash
 python3 scripts/release_fleet_acceptance.py platform --repo . \
   --cohort historic-cohort.json \

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -133,10 +133,10 @@ The job is time-bounded to six hours and monitors a 50 GiB working-set limit.
 
 Pull requests that touch the updater route get a separate non-publishing
 macOS canary. It builds a local release-shaped candidate and runs real journeys
-from `dist/release/v1.61.0-dc7d332`, semantic `v1.62.0`, and an archived
-v1.65.0 start. Those three journeys can catch packaging and compatibility
-regressions before merge, but they are explicitly non-acceptance evidence and
-cannot weaken or replace the manual freshly generated public fleet gate.
+from semantic `v1.51.0`, `dist/release/v1.61.0-dc7d332`, semantic `v1.62.0`,
+and an archived v1.65.0 start. Those four journeys catch the old dependency
+fixture, topology, and archive paths before merge, but remain explicitly
+non-acceptance evidence and cannot replace the freshly generated public fleet.
 
 ```bash
 python3 scripts/release_fleet_acceptance.py platform --repo . \

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -304,6 +304,22 @@ _V161_RETIRED_MANIFEST_BLOB = "feef2bb3dd6756c7c54d76bdfd6128904c87f679"
 _V161_RETIRED_MANIFEST_SHA256 = "edf6e98bc16063c47b362280cfa33fd10f075a5d240d5884d5ded5d894cbcc63"
 _V161_RETIRED_MANIFEST_PATH_COUNT = 768
 
+V162_SELF_OMITTING_MANIFEST_RELEASE = HistoricReleasePin(
+    "v1.62.0",
+    "4913a778452003fcf8dc71a10222d5275ff28d5c",
+    "tag",
+    "77c4a15a7884080e48b095c8de2c384d01a87883",
+    "1bf30a86c151890024040f0e4e1a533be17c5686",
+    "1.62.0",
+    "2d7f21a72798d4189f042e955e62ee799e90a90c",
+    "75bef63d563a7e5062db6ad664ccb65a7581dbfd3d466655d1b3709bbad7ffa5",
+)
+_V162_SELF_OMITTING_MANIFEST_BLOB = "eb3ac8f377abc98199eaf49c02b638fce5aad69f"
+_V162_SELF_OMITTING_MANIFEST_SHA256 = (
+    "29dd6a9eccd8d358eda08506ac7d6b574cca78c1dec09c64ad24dd0ec359161d"
+)
+_V162_SELF_OMITTING_MANIFEST_PATH_COUNT = 987
+
 V175_DEFECTIVE_MANIFEST_RELEASE = HistoricReleasePin(
     "v1.75.0",
     "5e73481519ee9b5fe9a6c3196ee7cabaa0446ee8",
@@ -578,15 +594,7 @@ MISSING_MIGRATOR_RELEASES = (
         _INPUT_B_V163_BOOTSTRAP,
     ),
     MissingMigratorPin(
-        _historic_pin(
-            "v1.62.0",
-            "4913a778452003fcf8dc71a10222d5275ff28d5c",
-            "77c4a15a7884080e48b095c8de2c384d01a87883",
-            "1bf30a86c151890024040f0e4e1a533be17c5686",
-            "1.62.0",
-            "2d7f21a72798d4189f042e955e62ee799e90a90c",
-            "75bef63d563a7e5062db6ad664ccb65a7581dbfd3d466655d1b3709bbad7ffa5",
-        ),
+        V162_SELF_OMITTING_MANIFEST_RELEASE,
         _INPUT_A_STALE_BOOTSTRAP,
     ),
     MissingMigratorPin(
@@ -726,6 +734,26 @@ def historic_compatibility_pins() -> dict[str, dict[str, object]]:
         "transition_blob": None,
         "migrator_blob": None,
         "omission_identities": tuple(sorted(_MANIFESTLESS_OMISSION_IDENTITIES)),
+        "unexpected_nonregular_paths": (),
+    }
+    self_omitting = V162_SELF_OMITTING_MANIFEST_RELEASE
+    pins[self_omitting.tag] = {
+        "kind": "self-omitting-manifest",
+        "role": "installed-source",
+        "tag": self_omitting.tag,
+        "tag_object": self_omitting.tag_object,
+        "commit": self_omitting.commit,
+        "tree": self_omitting.tree,
+        "version": self_omitting.version,
+        "package_blob": self_omitting.package_blob,
+        "package_sha256": self_omitting.package_sha256,
+        "manifest_blob": _V162_SELF_OMITTING_MANIFEST_BLOB,
+        "manifest_sha256": _V162_SELF_OMITTING_MANIFEST_SHA256,
+        "manifest_path_count": _V162_SELF_OMITTING_MANIFEST_PATH_COUNT,
+        "omitted_paths": ("System/.installed-files.manifest",),
+        "policy_blob": None,
+        "transition_blob": None,
+        "migrator_blob": None,
         "unexpected_nonregular_paths": (),
     }
     pins[V175_DEFECTIVE_MANIFEST_RELEASE.tag] = {
@@ -1852,7 +1880,12 @@ class _FoundationLifecycleService:
                 if commit == V161_RETIRED_MANIFEST_RELEASE.commit
                 else None
             )
-            pin = manifestless or defective or retired_manifest
+            self_omitting = (
+                V162_SELF_OMITTING_MANIFEST_RELEASE
+                if commit == V162_SELF_OMITTING_MANIFEST_RELEASE.commit
+                else None
+            )
+            pin = manifestless or defective or retired_manifest or self_omitting
             if pin is None:
                 return original_tree_entries(vault_root, brain_git, commit)
             if _run_git(Path(brain_git), "rev-parse", "--verify", f"{commit}^{{tree}}") != pin.tree:
@@ -1887,6 +1920,29 @@ class _FoundationLifecycleService:
                         raise release_error("historic retired-manifest identity changed")
                 except BridgeError as error:
                     raise release_error("historic retired-manifest identity changed") from error
+            if self_omitting is not None:
+                try:
+                    if (
+                        _run_git(
+                            Path(brain_git),
+                            "rev-parse",
+                            "--verify",
+                            "refs/dex/installed^{commit}",
+                        )
+                        != self_omitting.commit
+                        or _run_git(
+                            Path(brain_git),
+                            "rev-parse",
+                            "--verify",
+                            f"{self_omitting.commit}:System/.installed-files.manifest",
+                        )
+                        != _V162_SELF_OMITTING_MANIFEST_BLOB
+                    ):
+                        raise release_error("historic self-omitting manifest identity changed")
+                except BridgeError as error:
+                    raise release_error(
+                        "historic self-omitting manifest identity changed"
+                    ) from error
             raw = self._apply_update._brain_output(
                 vault_root,
                 brain_git,
@@ -2010,6 +2066,38 @@ class _FoundationLifecycleService:
                 ):
                     raise release_error("historic retired-manifest identity changed")
             result = tuple(sorted(entries, key=lambda entry: entry.path))
+            if self_omitting is not None:
+                by_path = {entry.path: entry for entry in result}
+                manifest_entry = by_path.get("System/.installed-files.manifest")
+                if manifest_entry is None:
+                    raise release_error("historic self-omitting manifest identity changed")
+                manifest_bytes = self._apply_update._brain_output(
+                    vault_root,
+                    brain_git,
+                    "cat-file",
+                    "blob",
+                    manifest_entry.object_id,
+                )
+                try:
+                    manifest_text = manifest_bytes.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise release_error(
+                        "historic self-omitting manifest identity changed"
+                    ) from error
+                manifest_paths = manifest_text.splitlines()
+                expected_paths = set(by_path) - {"System/.installed-files.manifest"}
+                if (
+                    len(result) != _V162_SELF_OMITTING_MANIFEST_PATH_COUNT + 1
+                    or manifest_entry.object_id != _V162_SELF_OMITTING_MANIFEST_BLOB
+                    or hashlib.sha256(manifest_bytes).hexdigest()
+                    != _V162_SELF_OMITTING_MANIFEST_SHA256
+                    or not manifest_text.endswith("\n")
+                    or "\r" in manifest_text
+                    or manifest_paths != sorted(set(manifest_paths))
+                    or len(manifest_paths) != _V162_SELF_OMITTING_MANIFEST_PATH_COUNT
+                    or set(manifest_paths) != expected_paths
+                ):
+                    raise release_error("historic self-omitting manifest identity changed")
             authorized_legacy_signatures[signature(result)] = (
                 pin.commit,
                 (
@@ -2017,6 +2105,8 @@ class _FoundationLifecycleService:
                     if manifestless is not None
                     else "retired-manifest"
                     if retired_manifest is not None
+                    else "self-omitting-manifest"
+                    if self_omitting is not None
                     else "incomplete-manifest"
                 ),
             )
@@ -2042,7 +2132,11 @@ class _FoundationLifecycleService:
             try:
                 original_verify_manifest(vault_root, brain_git, entries)
             except release_error:
-                if authorization[1] not in {"manifestless", "retired-manifest"}:
+                if authorization[1] not in {
+                    "manifestless",
+                    "retired-manifest",
+                    "self-omitting-manifest",
+                }:
                     raise
 
         self._apply_update._tree_entries = legacy_tree_entries

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1219,21 +1219,36 @@ def _regular_sha256(path: Path) -> str | None:
 
 
 def _matches_historic_release(vault_root: Path, pin: HistoricReleasePin) -> bool:
-    """Prove an exact tagged base plus its unchanged working package."""
+    """Prove an exact historic base plus its unchanged working package."""
 
     root = Path(vault_root)
     try:
+        tag_object = _run_git(
+            root,
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        )
+        if tag_object:
+            if (
+                tag_object != pin.tag_object
+                or _run_git(root, "cat-file", "-t", pin.tag_object)
+                != pin.tag_object_type
+            ):
+                return False
+            identity = pin.tag
+        else:
+            # Historic installations can retain the exact pinned commit while
+            # their own old label is pruned. A present but different label is
+            # refused above; without one, the closed commit is the identity.
+            if _run_git(root, "cat-file", "-t", pin.commit) != "commit":
+                return False
+            identity = pin.commit
         if (
-            _run_git(
-                root,
-                "for-each-ref",
-                "--format=%(objectname)",
-                f"refs/tags/{pin.tag}",
-            )
-            != pin.tag_object
-            or _run_git(root, "cat-file", "-t", pin.tag_object) != pin.tag_object_type
-            or _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{commit}}") != pin.commit
-            or _run_git(root, "rev-parse", "--verify", f"{pin.tag}^{{tree}}") != pin.tree
+            _run_git(root, "rev-parse", "--verify", f"{identity}^{{commit}}")
+            != pin.commit
+            or _run_git(root, "rev-parse", "--verify", f"{identity}^{{tree}}")
+            != pin.tree
             or _run_git(
                 root,
                 "rev-parse",

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -869,6 +869,7 @@ def _legacy_preload_bytes(
     """Build the closed preload for absent or exact defective legacy inputs."""
 
     policy = base64.b64encode(_LEGACY_TRACKED_IGNORE_POLICY).decode("ascii")
+    replace_legacy_policy = authorization is not None and authorization.inputs == _INPUT_A_STALE_BOOTSTRAP
     if authorization is None:
         allowed_pins = MISSING_MIGRATOR_RELEASES
         expected_package_version = None
@@ -933,6 +934,7 @@ const allowedExisting = new Set({allowed_existing}.map((values) => values.join('
 const expectedPackageVersion = {json.dumps(expected_package_version)};
 const expectedPackageDigest = {json.dumps(expected_package_sha256)};
 const expectedPackageState = {json.dumps(expected_package_state)};
+const replaceLegacyPolicy = {json.dumps(replace_legacy_policy)};
 const originalReadFileSync = fs.readFileSync.bind(fs);
 const originalReaddirSync = fs.readdirSync.bind(fs);
 
@@ -1036,7 +1038,10 @@ function compatibilityInputs() {{
   const virtualTransition = transitionJson.release_version === packageJson.version
     ? transitionBytes
     : legacyTransition();
-  return {{policy: policyBytes, transition: virtualTransition}};
+  return {{
+    policy: replaceLegacyPolicy ? suppliedPolicy : policyBytes,
+    transition: virtualTransition,
+  }};
 }}
 
 let hideShippedLink = false;

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -2076,7 +2076,20 @@ class _FoundationLifecycleService:
     def deliver_latest_release(
         self,
         vault_root: str | Path,
+        *,
+        remote_url: str | None = None,
+        allow_test_transport: bool = False,
     ) -> Mapping[str, Any]:
+        if remote_url is not None or allow_test_transport:
+            if remote_url is None or not allow_test_transport:
+                raise BridgeError(
+                    "test release transport requires an explicit local cache"
+                )
+            return self._apply_update.deliver_latest_release(
+                Path(vault_root),
+                remote_url=remote_url,
+                allow_test_transport=True,
+            )
         return self._service.deliver_latest_release(vault_root)
 
     def build_and_preview_delivered_release(

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -121,6 +121,7 @@ TRUSTED_PYTHON_ROOTS = (Path("/opt/homebrew"),)
 MINIMUM_SUPPORTED_PYTHON = (3, 10)
 PROCESS_GROUP_TERMINATION_GRACE_SECONDS = 1.0
 FIXTURE_REQUIRED_PYTHON_DEPENDENCIES = ("mcp", "yaml")
+PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES = ("yaml",)
 SEALED_INSTALLER_ENVIRONMENT_KEYS = frozenset(
     {
         "HOME",
@@ -672,8 +673,13 @@ def resolve_trusted_python_runtime() -> PythonRuntime:
     raise FleetError("no trusted supported Python runtime is available: " + "; ".join(errors))
 
 
-def resolve_fixture_python(vault: Path, *, trusted_python: PythonRuntime) -> FixturePython:
-    """Prove Doctor's interpreter and dependencies belong to one real fixture venv."""
+def resolve_fixture_python(
+    vault: Path,
+    *,
+    trusted_python: PythonRuntime,
+    required_dependencies: Sequence[str] = FIXTURE_REQUIRED_PYTHON_DEPENDENCIES,
+) -> FixturePython:
+    """Prove a fixture interpreter and the phase-required dependencies are local."""
 
     venv_root = vault / ".venv"
     requested_python = venv_root / "bin" / "python"
@@ -739,7 +745,7 @@ def resolve_fixture_python(vault: Path, *, trusted_python: PythonRuntime) -> Fix
     if not isinstance(raw_dependencies, Mapping):
         raise FleetError("fixture venv dependency provenance was malformed")
     dependency_origins: list[tuple[str, str]] = []
-    for dependency in FIXTURE_REQUIRED_PYTHON_DEPENDENCIES:
+    for dependency in required_dependencies:
         origin = raw_dependencies.get(dependency)
         if not isinstance(origin, str) or not origin:
             raise FleetError(f"fixture venv dependency is unavailable: {dependency}")
@@ -2152,7 +2158,11 @@ def run_journey(
             environment=environment,
             keep_official_fetch=True,
         )
-        resolve_fixture_python(case.vault, trusted_python=python_runtime)
+        resolve_fixture_python(
+            case.vault,
+            trusted_python=python_runtime,
+            required_dependencies=PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES,
+        )
         initial_install_evidence = _initial_install_evidence(case.vault, environment)
         from scripts import release_fleet_executor
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -2076,6 +2076,7 @@ def run_journey(
     bridge_asset: Path | None = None,
     bridge_checksum: Path | None = None,
     controlled_approvals: bool = False,
+    follow_up_cache: Path | None = None,
 ) -> object:
     """Build one fixture and delegate the closed journey to its released executor."""
 
@@ -2204,6 +2205,7 @@ def run_journey(
                 bridge_asset_evidence=bridge_asset_evidence,
                 bridge_asset_path=bridge_asset.resolve(strict=True),
                 initial_install_evidence=initial_install_evidence,
+                follow_up_cache=follow_up_cache,
                 **({"input_fn": approval_input} if approval_input is not None else {}),
             )
         finally:
@@ -2772,6 +2774,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     journey.add_argument("--follow-up-tag", required=True)
     journey.add_argument("--bridge-asset", type=Path, required=True)
     journey.add_argument("--bridge-checksum", type=Path, required=True)
+    journey.add_argument("--follow-up-cache", type=Path)
     journey.add_argument(
         "--controlled-approvals",
         action="store_true",
@@ -2816,6 +2819,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             bridge_asset=args.bridge_asset,
             bridge_checksum=args.bridge_checksum,
             controlled_approvals=args.controlled_approvals,
+            follow_up_cache=args.follow_up_cache,
         )
         print(
             json.dumps(

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -18,7 +18,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -2075,6 +2075,7 @@ def run_journey(
     follow_up_tag: str,
     bridge_asset: Path | None = None,
     bridge_checksum: Path | None = None,
+    controlled_approvals: bool = False,
 ) -> object:
     """Build one fixture and delegate the closed journey to its released executor."""
 
@@ -2101,6 +2102,19 @@ def run_journey(
         raise FleetError(f"follow-up released journey protocol is invalid: {error}") from error
     if protocol.foundation != foundation.identity():
         raise FleetError("released journey protocol names a different foundation")
+    approval_input: Callable[[str], str] | None = None
+    if controlled_approvals:
+        bridge_word = protocol.bridge.approval_word
+        follow_up_word = protocol.follow_up.approval_word
+        if bridge_word != follow_up_word:
+            raise FleetError("controlled fleet approvals require one exact protocol word")
+
+        def approve_disposable_fixture(prompt: str) -> str:
+            if not isinstance(prompt, str) or not prompt:
+                raise FleetError("controlled fleet approval prompt is invalid")
+            return bridge_word
+
+        approval_input = approve_disposable_fixture
     source_commit = _verify_released_protocol_artifacts(repo, follow_up, protocol)
     bridge_asset_evidence = _verify_standalone_bridge_asset(
         repo,
@@ -2190,6 +2204,7 @@ def run_journey(
                 bridge_asset_evidence=bridge_asset_evidence,
                 bridge_asset_path=bridge_asset.resolve(strict=True),
                 initial_install_evidence=initial_install_evidence,
+                **({"input_fn": approval_input} if approval_input is not None else {}),
             )
         finally:
             _disable_all_fixture_remotes(case.vault, environment)
@@ -2757,6 +2772,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     journey.add_argument("--follow-up-tag", required=True)
     journey.add_argument("--bridge-asset", type=Path, required=True)
     journey.add_argument("--bridge-checksum", type=Path, required=True)
+    journey.add_argument(
+        "--controlled-approvals",
+        action="store_true",
+        help="approve only the disposable fixture used by a controlled fleet run",
+    )
     args = parser.parse_args(argv)
 
     if args.command == "manifest":
@@ -2795,6 +2815,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             follow_up_tag=args.follow_up_tag,
             bridge_asset=args.bridge_asset,
             bridge_checksum=args.bridge_checksum,
+            controlled_approvals=args.controlled_approvals,
         )
         print(
             json.dumps(

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -31,7 +31,6 @@ from core.update.journey_protocol import (
 from scripts import release_fleet
 from scripts.dex_update_bridge import FOUNDATION
 
-EXPECTED_HISTORIC_CASES = 170
 COHORT_SCHEMA_VERSION = 1
 PLATFORM_MANIFEST_SCHEMA_VERSION = 1
 ACCEPTANCE_SOURCE = "scripts/release_fleet_acceptance.py"
@@ -127,6 +126,15 @@ class PlatformFleetFailure(release_fleet.FleetError):
         self.counts = dict(counts)
 
 
+def _fleet_case_count(inputs: FleetInputs) -> int:
+    """Return the frozen cohort count only when every starting tag is unique."""
+
+    count = len(inputs.releases)
+    if count < 1 or len({release.tag for release in inputs.releases}) != count:
+        raise release_fleet.FleetError("fleet inputs do not contain the exact historic cohort")
+    return count
+
+
 def _version_tuple(value: str) -> tuple[int, int, int]:
     match = _SEMVER.fullmatch(value)
     if match is None:
@@ -168,14 +176,13 @@ def frozen_cohort_manifest(
     releases: Sequence[release_fleet.DistributionRelease],
     *,
     foundation: Mapping[str, str] | None = None,
-    expected_count: int = EXPECTED_HISTORIC_CASES,
 ) -> dict[str, object]:
     """Freeze the accepted historic trees through the immutable foundation."""
 
     foundation_identity = _foundation_document(foundation)
     historic = _historic_releases(releases, foundation=foundation_identity)
-    if len(historic) != expected_count:
-        raise release_fleet.FleetError(f"historic cohort has {len(historic)} trees; expected {expected_count}")
+    if len({release.tag for release in historic}) != len(historic):
+        raise release_fleet.FleetError("historic cohort repeats a release tag")
     return {
         "schema_version": COHORT_SCHEMA_VERSION,
         "foundation": foundation_identity,
@@ -189,7 +196,6 @@ def releases_from_frozen_cohort(
     *,
     current_releases: Sequence[release_fleet.DistributionRelease],
     foundation: Mapping[str, str] | None = None,
-    expected_count: int = EXPECTED_HISTORIC_CASES,
 ) -> tuple[release_fleet.DistributionRelease, ...]:
     """Validate a frozen cohort while allowing only post-foundation releases."""
 
@@ -207,7 +213,13 @@ def releases_from_frozen_cohort(
         raise release_fleet.FleetError("historic cohort manifest has an invalid foundation identity or shape")
     cases = document.get("cases")
     count = document.get("case_count")
-    if not isinstance(cases, list) or not isinstance(count, int) or count != expected_count or count != len(cases):
+    if (
+        not isinstance(cases, list)
+        or not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 1
+        or count != len(cases)
+    ):
         raise release_fleet.FleetError("historic cohort manifest has an invalid case count")
 
     parsed: list[release_fleet.DistributionRelease] = []
@@ -399,6 +411,7 @@ def create_acceptance_session(
     source_commit: str,
     acceptance_source_sha256: str,
     protocol_platforms: Sequence[str],
+    case_count: int,
     key: bytes,
     session_id: str,
 ) -> dict[str, object]:
@@ -412,6 +425,9 @@ def create_acceptance_session(
         or _HEX_64.fullmatch(session_id) is None
         or _HEX_40.fullmatch(source_commit) is None
         or release_fleet.RELEASE_TAG.fullmatch(follow_up_tag) is None
+        or not isinstance(case_count, int)
+        or isinstance(case_count, bool)
+        or case_count < 1
     ):
         raise release_fleet.FleetError("fleet acceptance session identity is invalid")
     return _sign(
@@ -424,8 +440,8 @@ def create_acceptance_session(
             "source_commit": source_commit,
             "acceptance_source_sha256": acceptance_source_sha256,
             "platforms": list(platforms),
-            "case_count": EXPECTED_HISTORIC_CASES,
-            "journey_count": EXPECTED_HISTORIC_CASES * len(platforms),
+            "case_count": case_count,
+            "journey_count": case_count * len(platforms),
         },
         key,
     )
@@ -531,9 +547,8 @@ def aggregate_platform_evidence(
         key=key,
         inputs=inputs,
     )
+    case_count = _fleet_case_count(inputs)
     expected_tags = {release.tag for release in inputs.releases}
-    if len(inputs.releases) != EXPECTED_HISTORIC_CASES or len(expected_tags) != EXPECTED_HISTORIC_CASES:
-        raise release_fleet.FleetError("fleet inputs do not contain the exact historic cohort")
 
     receipts_by_platform: dict[str, dict[str, object]] = {}
     for signed in receipts:
@@ -589,18 +604,18 @@ def aggregate_platform_evidence(
             running_platform=platform,
             expected_start_tags=expected_tags,
         )
-        if len(report.cases) != EXPECTED_HISTORIC_CASES:
+        if len(report.cases) != case_count:
             raise release_fleet.FleetError(f"{platform}: platform manifest has an invalid case count")
 
-    total = EXPECTED_HISTORIC_CASES * len(platforms)
+    total = case_count * len(platforms)
     return {
         "outcome": "HISTORIC_FLEET_EVIDENCE_AGGREGATED",
         "acceptance": False,
         "authority_complete": False,
         "platforms": list(platforms),
-        "case_count": EXPECTED_HISTORIC_CASES,
+        "case_count": case_count,
         "journey_count": total,
-        "discovered": EXPECTED_HISTORIC_CASES,
+        "discovered": case_count,
         "started": total,
         "completed": total,
         "passed": total,
@@ -709,12 +724,8 @@ def _platform_receipt_boundary():
             or globals().get("assert_platform_report_bound") is not platform_validator
         ):
             raise release_fleet.FleetError("fleet acceptance validator changed during the live process")
+        case_count = _fleet_case_count(inputs)
         expected_start_tags = {release.tag for release in inputs.releases}
-        if (
-            len(inputs.releases) != EXPECTED_HISTORIC_CASES
-            or len(expected_start_tags) != EXPECTED_HISTORIC_CASES
-        ):
-            raise release_fleet.FleetError("fleet inputs do not contain the exact historic cohort")
         platform_validator(
             execution.report,
             protocol=inputs.protocol,
@@ -732,10 +743,10 @@ def _platform_receipt_boundary():
 
         counts = execution.counts
         if counts != {
-            "discovered": EXPECTED_HISTORIC_CASES,
-            "started": EXPECTED_HISTORIC_CASES,
-            "completed": EXPECTED_HISTORIC_CASES,
-            "passed": EXPECTED_HISTORIC_CASES,
+            "discovered": case_count,
+            "started": case_count,
+            "completed": case_count,
+            "passed": case_count,
             "failed": 0,
         }:
             raise release_fleet.FleetError("live platform execution is incomplete or failed")
@@ -749,9 +760,9 @@ def _platform_receipt_boundary():
             or execution.report.follow_up_tag != inputs.follow_up.tag
         ):
             raise release_fleet.FleetError("live platform execution is not bound to the immutable releases")
-        if len(execution.report.cases) != EXPECTED_HISTORIC_CASES:
+        if len(execution.report.cases) != case_count:
             raise release_fleet.FleetError(
-                f"live platform execution does not have exactly {EXPECTED_HISTORIC_CASES} final starts"
+                f"live platform execution does not have exactly {case_count} final starts"
             )
         cases: list[dict[str, object]] = [
             {field: getattr(case, field) for field in sorted(release_fleet.CASE_RESULT_KEYS)}
@@ -924,6 +935,7 @@ def _assert_session_matches_inputs(
     key: bytes,
     inputs: FleetInputs,
 ) -> dict[str, object]:
+    case_count = _fleet_case_count(inputs)
     payload = _verified_payload(
         session,
         key=key,
@@ -938,8 +950,8 @@ def _assert_session_matches_inputs(
         "source_commit": inputs.source_commit,
         "acceptance_source_sha256": inputs.acceptance_source_sha256,
         "platforms": list(_require_protocol_platforms(inputs.protocol.platforms)),
-        "case_count": EXPECTED_HISTORIC_CASES,
-        "journey_count": EXPECTED_HISTORIC_CASES * len(SUPPORTED_PLATFORMS),
+        "case_count": case_count,
+        "journey_count": case_count * len(SUPPORTED_PLATFORMS),
     }
     if any(payload.get(field) != value for field, value in expected.items()):
         raise release_fleet.FleetError("fleet acceptance session does not match the immutable fleet inputs")
@@ -1136,6 +1148,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_commit=inputs.source_commit,
             acceptance_source_sha256=inputs.acceptance_source_sha256,
             protocol_platforms=inputs.protocol.platforms,
+            case_count=_fleet_case_count(inputs),
             key=key,
             session_id=secrets.token_hex(32),
         )

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -11,7 +11,10 @@ import os
 import re
 import secrets
 import stat
+import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,8 +39,15 @@ FIRST_PARTY_PLATFORM_JOBS = {
     "darwin": "historic-fleet-darwin",
 }
 MAX_PLATFORM_MANIFEST_BYTES = 16 * 1024 * 1024
+MAX_PUBLIC_RELEASE_METADATA_BYTES = 1024 * 1024
+MAX_PUBLIC_RELEASE_ASSET_BYTES = 16 * 1024 * 1024
 PLATFORM_MANIFEST_NAME = "platform-manifest.json"
 PLATFORM_RECEIPT_NAME = "platform-receipt.json"
+CANONICAL_PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
+CANONICAL_PUBLIC_RELEASE_API = "https://api.github.com/repos/davekilleen/Dex/releases/tags/v{version}"
+CANONICAL_PUBLIC_RELEASE_DOWNLOAD = (
+    "https://github.com/davekilleen/Dex/releases/download/v{version}/{name}"
+)
 _COHORT_FIELDS = frozenset({"schema_version", "foundation", "case_count", "cases"})
 _RELEASE_FIELDS = frozenset({"tag", "version", "commit", "tree"})
 _SEMVER = re.compile(
@@ -608,6 +618,8 @@ def collect_platform_runs(
     foundation_tag: str,
     follow_up_tag: str,
     running_platform: str,
+    bridge_asset: Path,
+    bridge_checksum: Path,
     journey_runner: Callable[..., object] = release_fleet.run_journey,
 ) -> PlatformExecution:
     """Run one platform sequentially and retain every live executor result."""
@@ -630,6 +642,8 @@ def collect_platform_runs(
                 starting_tag=release.tag,
                 foundation_tag=foundation_tag,
                 follow_up_tag=follow_up_tag,
+                bridge_asset=bridge_asset,
+                bridge_checksum=bridge_checksum,
             )
             case = getattr(run, "case", None)
             if not isinstance(case, Mapping):
@@ -941,6 +955,92 @@ def _running_platform() -> str:
     raise release_fleet.FleetError("historic fleet acceptance supports macOS only")
 
 
+def _read_public_bytes(url: str, *, limit: int, context: str) -> bytes:
+    """Read one bounded canonical GitHub response or fail the acceptance closed."""
+
+    request = urllib.request.Request(url, headers={"User-Agent": "dex-release-fleet-acceptance"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            content = response.read(limit + 1)
+    except (OSError, urllib.error.URLError) as error:
+        raise release_fleet.FleetError(f"public {context} is unavailable") from error
+    if len(content) > limit:
+        raise release_fleet.FleetError(f"public {context} is too large")
+    return content
+
+
+def _verify_public_follow_up_release(release: release_fleet.ImmutableRelease) -> None:
+    """Prove the immutable release tag is advertised by the canonical remote."""
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                "credential.helper=",
+                "-c",
+                "protocol.file.allow=never",
+                "ls-remote",
+                "--refs",
+                "--tags",
+                CANONICAL_PUBLIC_REMOTE,
+                f"refs/tags/{release.tag}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise release_fleet.FleetError(
+            "follow-up release cannot be verified against the public stable remote"
+        ) from error
+    expected = f"{release.tag_object}\trefs/tags/{release.tag}"
+    if result.returncode != 0 or result.stdout.strip() != expected:
+        raise release_fleet.FleetError(
+            "follow-up release is not advertised by the public stable remote"
+        )
+
+
+def _verify_public_bridge_release_asset(
+    release: release_fleet.ImmutableRelease,
+    *,
+    bridge_asset: Path,
+    bridge_checksum: Path,
+) -> None:
+    """Require the submitted pair to be byte-identical public stable release assets."""
+
+    metadata_bytes = _read_public_bytes(
+        CANONICAL_PUBLIC_RELEASE_API.format(version=release.version),
+        limit=MAX_PUBLIC_RELEASE_METADATA_BYTES,
+        context="stable GitHub release metadata",
+    )
+    try:
+        metadata = json.loads(metadata_bytes)
+    except json.JSONDecodeError as error:
+        raise release_fleet.FleetError("public stable GitHub release metadata is invalid") from error
+    if (
+        not isinstance(metadata, Mapping)
+        or metadata.get("tag_name") != f"v{release.version}"
+        or metadata.get("draft") is not False
+        or metadata.get("prerelease") is not False
+    ):
+        raise release_fleet.FleetError("follow-up is not a public stable GitHub release")
+
+    for path in (bridge_asset, bridge_checksum):
+        public_bytes = _read_public_bytes(
+            CANONICAL_PUBLIC_RELEASE_DOWNLOAD.format(version=release.version, name=path.name),
+            limit=MAX_PUBLIC_RELEASE_ASSET_BYTES,
+            context="stable GitHub release bridge asset",
+        )
+        try:
+            supplied_bytes = path.read_bytes()
+        except OSError as error:
+            raise release_fleet.FleetError("submitted bridge asset is unavailable") from error
+        if public_bytes != supplied_bytes:
+            raise release_fleet.FleetError("bridge asset does not match the public GitHub release")
+
+
 def _add_bound_input_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--repo", type=Path, required=True)
     parser.add_argument("--cohort", type=Path, required=True)
@@ -973,6 +1073,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     _add_bound_input_arguments(platform)
     platform.add_argument("--session", type=Path, required=True)
     platform.add_argument("--key", type=Path, required=True)
+    platform.add_argument("--bridge-asset", type=Path, required=True)
+    platform.add_argument("--bridge-checksum", type=Path, required=True)
     platform.add_argument("--output", type=Path, required=True)
     aggregate = subcommands.add_parser(
         "aggregate",
@@ -1069,6 +1171,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     _assert_session_matches_inputs(signed_session, key=key, inputs=inputs)
 
     if args.command == "platform":
+        _verify_public_follow_up_release(inputs.follow_up)
+        release_fleet._verify_standalone_bridge_asset(
+            args.repo,
+            source_commit=inputs.source_commit,
+            follow_up=inputs.follow_up,
+            protocol=inputs.protocol,
+            bridge_asset=args.bridge_asset,
+            bridge_checksum=args.bridge_checksum,
+        )
+        _verify_public_bridge_release_asset(
+            inputs.follow_up,
+            bridge_asset=args.bridge_asset,
+            bridge_checksum=args.bridge_checksum,
+        )
         _create_private_run_root(args.output)
         running_platform = _running_platform()
         execution = collect_platform_runs(
@@ -1078,6 +1194,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             foundation_tag=inputs.foundation.tag,
             follow_up_tag=inputs.follow_up.tag,
             running_platform=running_platform,
+            bridge_asset=args.bridge_asset,
+            bridge_checksum=args.bridge_checksum,
         )
         finalized = finalize_live_platform_execution(
             execution,

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -659,6 +659,7 @@ def collect_platform_runs(
                 follow_up_tag=follow_up_tag,
                 bridge_asset=bridge_asset,
                 bridge_checksum=bridge_checksum,
+                controlled_approvals=True,
             )
             case = getattr(run, "case", None)
             if not isinstance(case, Mapping):

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -39,6 +39,10 @@ _RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,40})$"
 )
+_ARCHIVE_RELEASE_TAG = re.compile(
+    r"^dist/archive/v(?P<version>(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7})$"
+)
 _LEGACY_RELEASE_TAG = re.compile(
     r"^v(?P<version>(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))$"
@@ -841,6 +845,7 @@ def _strict_identity(
     value: Mapping[str, object],
     context: str,
     *,
+    allow_archive: bool = False,
     allow_legacy: bool = False,
 ) -> dict[str, str]:
     if set(value) != _IDENTITY_FIELDS or not all(
@@ -849,12 +854,16 @@ def _strict_identity(
         raise ExecutorError(f"{context} release identity is malformed")
     identity = {field: str(value[field]) for field in _IDENTITY_FIELDS}
     tag_match = _RELEASE_TAG.fullmatch(identity["tag"])
+    archive_match = (
+        _ARCHIVE_RELEASE_TAG.fullmatch(identity["tag"]) if allow_archive else None
+    )
     legacy_match = (
         _LEGACY_RELEASE_TAG.fullmatch(identity["tag"]) if allow_legacy else None
     )
+    immutable_match = tag_match if tag_match is not None else archive_match
     version = (
-        tag_match.group("version")
-        if tag_match is not None
+        immutable_match.group("version")
+        if immutable_match is not None
         else legacy_match.group("version") if legacy_match is not None else None
     )
     if (
@@ -862,8 +871,8 @@ def _strict_identity(
         or version is None
         or version != identity["version"]
         or (
-            tag_match is not None
-            and not identity["commit"].startswith(tag_match.group("short"))
+            immutable_match is not None
+            and not identity["commit"].startswith(immutable_match.group("short"))
         )
         or identity["channel"] != "stable"
     ):
@@ -1314,7 +1323,12 @@ def _execute_journey_with_runtime(
 
     if platform not in protocol.platforms:
         raise ExecutorError(f"journey platform is not declared by the protocol: {platform}")
-    start = _strict_identity(starting_release, "starting", allow_legacy=True)
+    start = _strict_identity(
+        starting_release,
+        "starting",
+        allow_archive=True,
+        allow_legacy=True,
+    )
     foundation = _strict_identity(foundation_release, "foundation")
     follow_up = _strict_identity(follow_up_release, "follow-up")
     if foundation == follow_up:

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -149,6 +149,51 @@ def _validate_foundation_cache(
     return resolved
 
 
+def _validate_follow_up_cache(
+    cache: Path,
+    release: Mapping[str, object],
+) -> Path:
+    """Prove a closed private cache contains the requested canary identity."""
+
+    identity = _strict_identity(release, "follow-up")
+    if cache.is_symlink() or not cache.is_dir():
+        raise ExecutorError("follow-up cache must be a private bare repository")
+    status = cache.stat()
+    if status.st_uid != os.getuid() or stat.S_IMODE(status.st_mode) != 0o700:
+        raise ExecutorError("follow-up cache must be controller-owned with mode 0700")
+    resolved = cache.resolve(strict=True)
+    if _cached_git(resolved, "rev-parse", "--is-bare-repository") != "true":
+        raise ExecutorError("follow-up cache must be a private bare repository")
+    alternates = resolved / "objects" / "info" / "alternates"
+    if alternates.is_symlink() or alternates.exists():
+        raise ExecutorError("follow-up cache must not use alternate object stores")
+    expected = {
+        f"refs/tags/{identity['tag']}": identity["tag_object"],
+        f"{identity['tag']}^{{commit}}": identity["commit"],
+        f"{identity['tag']}^{{tree}}": identity["tree"],
+        "refs/heads/release^{commit}": identity["commit"],
+    }
+    for revision, expected_object in expected.items():
+        try:
+            actual = _cached_git(resolved, "rev-parse", "--verify", revision)
+        except ExecutorError as error:
+            raise ExecutorError(
+                "follow-up cache does not match the requested canary release"
+            ) from error
+        if actual != expected_object:
+            raise ExecutorError(
+                "follow-up cache does not match the requested canary release"
+            )
+    refs = set(
+        _cached_git(resolved, "for-each-ref", "--format=%(refname)").splitlines()
+    )
+    if refs != {f"refs/tags/{identity['tag']}", "refs/heads/release"}:
+        raise ExecutorError(
+            "follow-up cache contains refs outside the requested canary release"
+        )
+    return resolved
+
+
 def _acquire_cached_foundation_source(
     cache: Path,
     pin: dex_update_bridge.ReleasePin = dex_update_bridge.FOUNDATION,
@@ -269,6 +314,8 @@ class _ProductionRuntime:
         bridge_asset: Path,
         bridge_sha256: str,
         foundation_cache: Path | None = None,
+        follow_up_cache: Path | None = None,
+        follow_up_release: Mapping[str, object] | None = None,
     ) -> None:
         self._runtime_home = tempfile.TemporaryDirectory(
             prefix="dex-release-journey-runtime-"
@@ -283,6 +330,20 @@ class _ProductionRuntime:
         self._foundation_cache = (
             _validate_foundation_cache(foundation_cache)
             if foundation_cache is not None
+            else None
+        )
+        if (follow_up_cache is None) != (follow_up_release is None):
+            raise ExecutorError(
+                "follow-up cache and release identity must be supplied together"
+            )
+        self._follow_up_release = (
+            _strict_identity(follow_up_release, "follow-up")
+            if follow_up_release is not None
+            else None
+        )
+        self._follow_up_cache = (
+            _validate_follow_up_cache(follow_up_cache, self._follow_up_release)
+            if follow_up_cache is not None and self._follow_up_release is not None
             else None
         )
         self._bridge_asset = bridge_asset.resolve(strict=True)
@@ -425,6 +486,20 @@ class _ProductionRuntime:
             command.extend(
                 ["--foundation-cache", str(self._foundation_cache)]
             )
+        if self._follow_up_cache is not None:
+            assert self._follow_up_release is not None
+            command.extend(
+                [
+                    "--follow-up-cache",
+                    str(self._follow_up_cache),
+                    "--follow-up-release",
+                    json.dumps(
+                        self._follow_up_release,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                ]
+            )
         process = subprocess.Popen(
             command,
             cwd=PROJECT_ROOT,
@@ -521,6 +596,29 @@ class _ProductionRuntime:
         if not isinstance(response, Mapping):
             raise ExecutorError(
                 f"released foundation lifecycle operation {operation} "
+                "returned malformed evidence"
+            )
+        return response
+
+    @staticmethod
+    def _test_delivery_call(
+        service: object,
+        vault: Path,
+        follow_up_cache: Path,
+    ) -> Mapping[str, object]:
+        function = getattr(service, "deliver_latest_release", None)
+        if not callable(function):
+            raise ExecutorError(
+                "released foundation lifecycle service lacks deliver_latest_release"
+            )
+        response = function(
+            vault,
+            remote_url=str(follow_up_cache),
+            allow_test_transport=True,
+        )
+        if not isinstance(response, Mapping):
+            raise ExecutorError(
+                "released foundation lifecycle operation deliver_latest_release "
                 "returned malformed evidence"
             )
         return response
@@ -728,11 +826,23 @@ def _runtime_server(
     bridge_asset: Path,
     bridge_sha256: str,
     foundation_cache: Path | None = None,
+    follow_up_cache: Path | None = None,
+    follow_up_release: Mapping[str, object] | None = None,
 ) -> int:
     """Serve the fixed lifecycle vocabulary from the fixture virtualenv."""
 
     global dex_update_bridge
     dex_update_bridge = _load_released_bridge(bridge_asset, bridge_sha256)
+
+    if (follow_up_cache is None) != (follow_up_release is None):
+        raise ExecutorError(
+            "follow-up cache and release identity must be supplied together"
+        )
+    verified_follow_up_cache = (
+        _validate_follow_up_cache(follow_up_cache, follow_up_release)
+        if follow_up_cache is not None and follow_up_release is not None
+        else None
+    )
 
     root = dex_update_bridge._validate_vault(vault)
     temporary: tempfile.TemporaryDirectory[str] | None = None
@@ -791,11 +901,18 @@ def _runtime_server(
                 elif operation == "deliver_latest_release" and set(request) == {
                     "operation"
                 }:
-                    result = _ProductionRuntime._service_call(
-                        service,
-                        operation,
-                        root,
-                    )
+                    if verified_follow_up_cache is None:
+                        result = _ProductionRuntime._service_call(
+                            service,
+                            operation,
+                            root,
+                        )
+                    else:
+                        result = _ProductionRuntime._test_delivery_call(
+                            service,
+                            root,
+                            verified_follow_up_cache,
+                        )
                 elif operation == "build_and_preview_delivered_release":
                     payload = request.get("payload")
                     if (
@@ -1643,6 +1760,27 @@ def _execute_journey_with_runtime(
     return case
 
 
+def _production_authority_intact(
+    runtime: object,
+    *,
+    production_owned: bool,
+    follow_up_cache: Path | None,
+    production_runtime_type: type,
+    production_methods: Mapping[str, object],
+) -> bool:
+    """Keep acceptance authority on the canonical public transport only."""
+
+    return (
+        production_owned
+        and follow_up_cache is None
+        and type(runtime) is production_runtime_type
+        and all(
+            getattr(production_runtime_type, name) is function
+            for name, function in production_methods.items()
+        )
+    )
+
+
 def _executor_boundary():
     """Create the sole production entrypoint without exporting a proof mint."""
 
@@ -1680,6 +1818,7 @@ def _executor_boundary():
         bridge_asset_evidence: Mapping[str, str],
         bridge_asset_path: Path,
         initial_install_evidence: Mapping[str, object],
+        follow_up_cache: Path | None = None,
         input_fn: Callable[[str], str] = input,
         output_fn: Callable[[str], None] = print,
         _runtime: JourneyRuntime | None = None,
@@ -1691,6 +1830,8 @@ def _executor_boundary():
             production_runtime_type(
                 bridge_asset=bridge_asset_path,
                 bridge_sha256=protocol.bridge.artifact.sha256,
+                follow_up_cache=follow_up_cache,
+                follow_up_release=follow_up_release if follow_up_cache is not None else None,
             )
             if production_owned
             else _runtime
@@ -1727,13 +1868,12 @@ def _executor_boundary():
         ).encode("utf-8")
         run = object.__new__(ExecutorRun)
         object.__setattr__(run, "_case_json", case_json)
-        production_intact = (
-            production_owned
-            and type(runtime) is production_runtime_type
-            and all(
-                getattr(production_runtime_type, name) is function
-                for name, function in production_methods.items()
-            )
+        production_intact = _production_authority_intact(
+            runtime,
+            production_owned=production_owned,
+            follow_up_cache=follow_up_cache,
+            production_runtime_type=production_runtime_type,
+            production_methods=production_methods,
         )
         seal = (
             (authority, hashlib.sha256(case_json).digest())
@@ -1776,23 +1916,60 @@ __all__ = [
 
 if __name__ == "__main__":
     valid = (
-        len(sys.argv) in {8, 10}
+        len(sys.argv) >= 8
+        and len(sys.argv) % 2 == 0
         and sys.argv[1:3] == ["_runtime-server", "--vault"]
         and sys.argv[4] == "--bridge-asset"
         and sys.argv[6] == "--bridge-sha256"
-        and (len(sys.argv) == 8 or sys.argv[8] == "--foundation-cache")
     )
+    extra_arguments: dict[str, str] = {}
+    if valid:
+        for index in range(8, len(sys.argv), 2):
+            option = sys.argv[index]
+            if (
+                option not in {
+                    "--foundation-cache",
+                    "--follow-up-cache",
+                    "--follow-up-release",
+                }
+                or option in extra_arguments
+            ):
+                valid = False
+                break
+            extra_arguments[option] = sys.argv[index + 1]
+    if (
+        ("--follow-up-cache" in extra_arguments)
+        != ("--follow-up-release" in extra_arguments)
+    ):
+        valid = False
     if not valid:
         raise SystemExit("released journey executor has no standalone interface")
     try:
+        follow_up_release = (
+            json.loads(extra_arguments["--follow-up-release"])
+            if "--follow-up-release" in extra_arguments
+            else None
+        )
+        if follow_up_release is not None and not isinstance(
+            follow_up_release, Mapping
+        ):
+            raise ExecutorError("follow-up release identity is malformed")
         raise SystemExit(
             _runtime_server(
                 Path(sys.argv[3]),
                 bridge_asset=Path(sys.argv[5]),
                 bridge_sha256=sys.argv[7],
                 foundation_cache=(
-                    Path(sys.argv[9]) if len(sys.argv) == 10 else None
+                    Path(extra_arguments["--foundation-cache"])
+                    if "--foundation-cache" in extra_arguments
+                    else None
                 ),
+                follow_up_cache=(
+                    Path(extra_arguments["--follow-up-cache"])
+                    if "--follow-up-cache" in extra_arguments
+                    else None
+                ),
+                follow_up_release=follow_up_release,
             )
         )
     except Exception as error:  # noqa: BLE001

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -1760,27 +1760,6 @@ def _execute_journey_with_runtime(
     return case
 
 
-def _production_authority_intact(
-    runtime: object,
-    *,
-    production_owned: bool,
-    follow_up_cache: Path | None,
-    production_runtime_type: type,
-    production_methods: Mapping[str, object],
-) -> bool:
-    """Keep acceptance authority on the canonical public transport only."""
-
-    return (
-        production_owned
-        and follow_up_cache is None
-        and type(runtime) is production_runtime_type
-        and all(
-            getattr(production_runtime_type, name) is function
-            for name, function in production_methods.items()
-        )
-    )
-
-
 def _executor_boundary():
     """Create the sole production entrypoint without exporting a proof mint."""
 
@@ -1800,6 +1779,24 @@ def _executor_boundary():
             "close",
         )
     }
+
+    def production_authority_intact(
+        runtime: object,
+        *,
+        production_owned: bool,
+        follow_up_cache: Path | None,
+    ) -> bool:
+        """Keep acceptance authority on the canonical public transport only."""
+
+        return (
+            production_owned
+            and follow_up_cache is None
+            and type(runtime) is production_runtime_type
+            and all(
+                getattr(production_runtime_type, name) is function
+                for name, function in production_methods.items()
+            )
+        )
 
     def execute_journey(
         *,
@@ -1868,12 +1865,10 @@ def _executor_boundary():
         ).encode("utf-8")
         run = object.__new__(ExecutorRun)
         object.__setattr__(run, "_case_json", case_json)
-        production_intact = _production_authority_intact(
+        production_intact = production_authority_intact(
             runtime,
             production_owned=production_owned,
             follow_up_cache=follow_up_cache,
-            production_runtime_type=production_runtime_type,
-            production_methods=production_methods,
         )
         seal = (
             (authority, hashlib.sha256(case_json).digest())

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -400,7 +400,8 @@ run_canary() {
       --foundation-tag "$PINNED_FOUNDATION_TAG" \
       --follow-up-tag "$CANDIDATE_TAG" \
       --bridge-asset "$BRIDGE_ASSET" \
-      --bridge-checksum "$BRIDGE_CHECKSUM"
+      --bridge-checksum "$BRIDGE_CHECKSUM" \
+      --controlled-approvals
     then
       journey_status=0
     else

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -8,6 +8,7 @@ CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
 PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
 CANARY_STARTS=(
+  "v1.51.0"
   "dist/release/v1.61.0-dc7d332"
   "v1.62.0"
   "dist/archive/v1.65.0-c5ec161"

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -380,6 +380,13 @@ run_canary() {
     return 1
   fi
   CANDIDATE_TAG="${candidate_tags[0]}"
+  FOLLOW_UP_CACHE="$WORK_ROOT/candidate-release.git"
+  git init --bare --quiet "$FOLLOW_UP_CACHE"
+  chmod 700 "$FOLLOW_UP_CACHE"
+  git -c credential.helper= -c protocol.file.allow=always \
+    --git-dir="$FOLLOW_UP_CACHE" fetch --quiet --no-tags . \
+    "refs/tags/$CANDIDATE_TAG:refs/tags/$CANDIDATE_TAG" \
+    "+refs/heads/release:refs/heads/release"
   CANDIDATE_VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
   ASSET_ROOT="$WORK_ROOT/candidate-assets"
   mkdir -m 700 "$ASSET_ROOT"
@@ -401,6 +408,7 @@ run_canary() {
       --follow-up-tag "$CANDIDATE_TAG" \
       --bridge-asset "$BRIDGE_ASSET" \
       --bridge-checksum "$BRIDGE_CHECKSUM" \
+      --follow-up-cache "$FOLLOW_UP_CACHE" \
       --controlled-approvals
     then
       journey_status=0

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -1,0 +1,424 @@
+#!/bin/bash
+# Run the first-party macOS historic fleet without carrying CI credentials.
+# Formal mode accepts exact public releases; canary mode creates local refs only.
+
+set -euo pipefail
+
+CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
+PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"
+MAX_DISK_KIB=$((50 * 1024 * 1024))
+CANARY_STARTS=(
+  "dist/release/v1.61.0-dc7d332"
+  "v1.62.0"
+  "dist/archive/v1.65.0-c5ec161"
+)
+
+MODE="${1:-}"
+case "$MODE" in
+  formal|canary) ;;
+  *) echo "Usage: $0 formal|canary" >&2; exit 64 ;;
+esac
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "historic-fleet-darwin requires a macOS runner" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+RUNNER_TEMP_ROOT="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+WORK_ROOT="${FLEET_WORK_ROOT:?FLEET_WORK_ROOT is required}"
+case "$WORK_ROOT" in
+  "$RUNNER_TEMP_ROOT"/*) ;;
+  *) echo "FLEET_WORK_ROOT must be beneath RUNNER_TEMP" >&2; exit 1 ;;
+esac
+if [ -e "$WORK_ROOT" ] || [ -L "$WORK_ROOT" ]; then
+  echo "fleet work root already exists: $WORK_ROOT" >&2
+  exit 1
+fi
+mkdir -m 700 "$WORK_ROOT"
+
+COUNTS_FILE="$WORK_ROOT/counts.json"
+SUMMARY_FILE="$WORK_ROOT/summary.md"
+LOG_FILE="$WORK_ROOT/controller.log"
+SESSION_KEY="$WORK_ROOT/acceptance.key"
+DISCOVERED=0
+STARTED=0
+COMPLETED=0
+PASSED=0
+FAILED=0
+
+write_counts() {
+  python3 - "$COUNTS_FILE" "$DISCOVERED" "$STARTED" "$COMPLETED" "$PASSED" "$FAILED" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+document = {
+    "discovered": int(sys.argv[2]),
+    "started": int(sys.argv[3]),
+    "completed": int(sys.argv[4]),
+    "passed": int(sys.argv[5]),
+    "failed": int(sys.argv[6]),
+}
+temporary = path.with_suffix(".tmp")
+temporary.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+os.replace(temporary, path)
+PY
+}
+
+write_summary() {
+  write_counts
+  {
+    echo "## $MODE historic-fleet-darwin"
+    echo
+    echo "| discovered | started | completed | passed | failed |"
+    echo "|---:|---:|---:|---:|---:|"
+    echo "| $DISCOVERED | $STARTED | $COMPLETED | $PASSED | $FAILED |"
+    echo
+    if [ "$MODE" = "formal" ]; then
+      echo "Foundation: \`${FOUNDATION_TAG:-unset}\`"
+      echo
+      echo "Follow-up: \`${FOLLOW_UP_TAG:-unset}\`"
+    else
+      echo "This PR canary is release-shaped non-acceptance evidence. It cannot publish."
+    fi
+  } > "$SUMMARY_FILE"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+finish() {
+  status=$?
+  rm -f "$SESSION_KEY"
+  write_summary || true
+  return "$status"
+}
+trap finish EXIT
+
+refresh_public_tags() {
+  while IFS= read -r tag; do
+    [ -n "$tag" ] && git update-ref -d "refs/tags/$tag"
+  done < <(git tag --list)
+  git -c credential.helper= -c protocol.file.allow=never fetch \
+    --force --prune --no-tags "$CANONICAL_PUBLIC_REMOTE" \
+    '+refs/tags/*:refs/tags/*'
+}
+
+assert_public_annotated_tag() {
+  local tag local_object advertised short commit
+  tag="$1"
+  if [ "$(git cat-file -t "$tag" 2>/dev/null || true)" != "tag" ]; then
+    echo "public immutable tag is missing or is not annotated: $tag" >&2
+    return 1
+  fi
+  local_object="$(git rev-parse --verify "$tag")"
+  advertised="$(git -c credential.helper= -c protocol.file.allow=never ls-remote \
+    --refs --tags "$CANONICAL_PUBLIC_REMOTE" "refs/tags/$tag")"
+  if [ "$advertised" != "$local_object"$'\t'"refs/tags/$tag" ]; then
+    echo "public immutable tag identity does not match: $tag" >&2
+    return 1
+  fi
+  short="${tag##*-}"
+  commit="$(git rev-parse --verify "$tag^{commit}")"
+  case "$commit" in
+    "$short"*) ;;
+    *) echo "immutable tag suffix does not match its commit: $tag" >&2; return 1 ;;
+  esac
+}
+
+disk_kib() {
+  du -sk "$WORK_ROOT" | awk '{print $1}'
+}
+
+run_bounded() {
+  budget_marker="$WORK_ROOT/disk-budget-exceeded"
+  rm -f "$budget_marker"
+  "$@" >> "$LOG_FILE" 2>&1 &
+  command_pid=$!
+  (
+    while kill -0 "$command_pid" 2>/dev/null; do
+      used="$(disk_kib)"
+      if [ "$used" -gt "$MAX_DISK_KIB" ]; then
+        printf 'historic fleet exceeded %s KiB (used %s KiB)\n' \
+          "$MAX_DISK_KIB" "$used" > "$budget_marker"
+        pkill -TERM -P "$command_pid" 2>/dev/null || true
+        kill -TERM "$command_pid" 2>/dev/null || true
+        exit 0
+      fi
+      sleep 30
+    done
+  ) &
+  monitor_pid=$!
+  if wait "$command_pid"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
+  kill "$monitor_pid" 2>/dev/null || true
+  wait "$monitor_pid" 2>/dev/null || true
+  if [ -f "$budget_marker" ]; then
+    cat "$budget_marker" >&2
+    return 75
+  fi
+  return "$command_status"
+}
+
+run_formal() {
+  FOUNDATION_TAG="${FOUNDATION_TAG:?FOUNDATION_TAG is required}"
+  FOLLOW_UP_TAG="${FOLLOW_UP_TAG:?FOLLOW_UP_TAG is required}"
+  if [ "$FOUNDATION_TAG" != "$PINNED_FOUNDATION_TAG" ]; then
+    echo "foundation must be the exact pinned public identity $PINNED_FOUNDATION_TAG" >&2
+    return 1
+  fi
+  if ! [[ "$FOLLOW_UP_TAG" =~ ^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$ ]]; then
+    echo "follow-up must be an exact immutable dist/release tag" >&2
+    return 1
+  fi
+  if [ "$FOLLOW_UP_TAG" = "$FOUNDATION_TAG" ]; then
+    echo "foundation and follow-up must differ" >&2
+    return 1
+  fi
+
+  refresh_public_tags
+  assert_public_annotated_tag "$FOUNDATION_TAG"
+  assert_public_annotated_tag "$FOLLOW_UP_TAG"
+
+  SOURCE_COMMIT="$(git show "$FOLLOW_UP_TAG:System/.release-catalog.json" | python3 -c '
+import json, re, sys
+document = json.load(sys.stdin)
+value = document.get("release", {}).get("source_commit")
+if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{40}", value) is None:
+    raise SystemExit("follow-up release has no canonical source commit")
+print(value)
+')"
+  if [ "$(git rev-parse --verify "$SOURCE_COMMIT^{commit}")" != "$SOURCE_COMMIT" ]; then
+    echo "follow-up publisher source commit is unavailable" >&2
+    return 1
+  fi
+  git checkout --detach "$SOURCE_COMMIT"
+
+  COHORT="$WORK_ROOT/historic-cohort.json"
+  SESSION="$WORK_ROOT/acceptance-session.json"
+  PLATFORM_ROOT="$WORK_ROOT/platform"
+  ASSET_ROOT="$WORK_ROOT/public-assets"
+  mkdir -m 700 "$ASSET_ROOT"
+
+  python3 scripts/release_fleet_acceptance.py cohort \
+    --repo . --output "$COHORT" | tee "$WORK_ROOT/cohort-result.json"
+  DISCOVERED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["case_count"])' "$COHORT")"
+  if [ "$DISCOVERED" -lt 1 ]; then
+    echo "fresh public cohort is empty" >&2
+    return 1
+  fi
+
+  python3 scripts/release_fleet_acceptance.py session \
+    --repo . --cohort "$COHORT" \
+    --foundation-tag "$FOUNDATION_TAG" --follow-up-tag "$FOLLOW_UP_TAG" \
+    --session-output "$SESSION" --key-output "$SESSION_KEY" \
+    | tee "$WORK_ROOT/session-result.json"
+
+  FOLLOW_UP_VERSION="$(printf '%s\n' "$FOLLOW_UP_TAG" | sed -E 's#^dist/release/v([0-9]+\.[0-9]+\.[0-9]+)-[0-9a-f]+$#\1#')"
+  BRIDGE_ASSET="$ASSET_ROOT/dex-update-bridge-v$FOLLOW_UP_VERSION.py"
+  BRIDGE_CHECKSUM="$BRIDGE_ASSET.sha256"
+  PUBLIC_RELEASE="https://github.com/davekilleen/Dex/releases/download/v$FOLLOW_UP_VERSION"
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 --fail --location \
+    --retry 3 --retry-all-errors --max-time 120 \
+    "$PUBLIC_RELEASE/$(basename "$BRIDGE_ASSET")" --output "$BRIDGE_ASSET"
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 --fail --location \
+    --retry 3 --retry-all-errors --max-time 120 \
+    "$PUBLIC_RELEASE/$(basename "$BRIDGE_CHECKSUM")" --output "$BRIDGE_CHECKSUM"
+  if [ "$(wc -c < "$BRIDGE_ASSET")" -gt $((16 * 1024 * 1024)) ] \
+    || [ "$(wc -c < "$BRIDGE_CHECKSUM")" -gt 4096 ]; then
+    echo "public bridge asset exceeds its bounded size" >&2
+    return 1
+  fi
+  (cd "$ASSET_ROOT" && shasum -a 256 -c "$(basename "$BRIDGE_CHECKSUM")")
+
+  export DEX_COUNTS_FILE="$COUNTS_FILE"
+  export DEX_COHORT_FILE="$COHORT"
+  export DEX_PLATFORM_ROOT="$PLATFORM_ROOT"
+  export DEX_FOUNDATION_TAG="$FOUNDATION_TAG"
+  export DEX_FOLLOW_UP_TAG="$FOLLOW_UP_TAG"
+  export DEX_SESSION_FILE="$SESSION"
+  export DEX_SESSION_KEY="$SESSION_KEY"
+  export DEX_BRIDGE_ASSET="$BRIDGE_ASSET"
+  export DEX_BRIDGE_CHECKSUM="$BRIDGE_CHECKSUM"
+
+  if run_bounded python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from scripts import release_fleet_acceptance as acceptance
+
+counts_path = Path(os.environ["DEX_COUNTS_FILE"])
+platform_root = Path(os.environ["DEX_PLATFORM_ROOT"])
+cohort = json.loads(Path(os.environ["DEX_COHORT_FILE"]).read_text(encoding="utf-8"))
+discovered = int(cohort["case_count"])
+
+def write(counts):
+    counts_path.write_text(json.dumps(dict(counts), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+arguments = [
+    "platform",
+    "--repo", ".",
+    "--cohort", os.environ["DEX_COHORT_FILE"],
+    "--foundation-tag", os.environ["DEX_FOUNDATION_TAG"],
+    "--follow-up-tag", os.environ["DEX_FOLLOW_UP_TAG"],
+    "--session", os.environ["DEX_SESSION_FILE"],
+    "--key", os.environ["DEX_SESSION_KEY"],
+    "--bridge-asset", os.environ["DEX_BRIDGE_ASSET"],
+    "--bridge-checksum", os.environ["DEX_BRIDGE_CHECKSUM"],
+    "--output", os.environ["DEX_PLATFORM_ROOT"],
+]
+try:
+    result = acceptance.main(arguments)
+except acceptance.PlatformFleetFailure as error:
+    write(error.counts)
+    raise
+except Exception:
+    completed = sum(1 for _ in platform_root.glob("*.evidence/evidence-manifest.json"))
+    write({
+        "discovered": discovered,
+        "started": completed,
+        "completed": completed,
+        "passed": completed,
+        "failed": 0,
+    })
+    raise
+else:
+    write({
+        "discovered": discovered,
+        "started": discovered,
+        "completed": discovered,
+        "passed": discovered,
+        "failed": 0,
+    })
+    raise SystemExit(result)
+PY
+  then
+    platform_status=0
+  else
+    platform_status=$?
+  fi
+
+  if [ ! -f "$COUNTS_FILE" ]; then
+    completed_evidence=0
+    if [ -d "$PLATFORM_ROOT" ]; then
+      completed_evidence="$(find "$PLATFORM_ROOT" -type f -name evidence-manifest.json | wc -l | tr -d ' ')"
+      if [ "$completed_evidence" -lt "$DISCOVERED" ]; then
+        STARTED=$((completed_evidence + 1))
+        FAILED=1
+      else
+        STARTED="$completed_evidence"
+      fi
+    fi
+    COMPLETED="$completed_evidence"
+    PASSED="$completed_evidence"
+    write_counts
+  fi
+  if [ -f "$COUNTS_FILE" ]; then
+    read -r DISCOVERED STARTED COMPLETED PASSED FAILED < <(
+      python3 - "$COUNTS_FILE" <<'PY'
+import json, sys
+value = json.load(open(sys.argv[1]))
+print(*(value[name] for name in ("discovered", "started", "completed", "passed", "failed")))
+PY
+    )
+  fi
+  if [ "$platform_status" -ne 0 ]; then
+    tail -200 "$LOG_FILE" >&2 || true
+    return "$platform_status"
+  fi
+
+  python3 scripts/release_fleet_acceptance.py aggregate \
+    --repo . --cohort "$COHORT" \
+    --foundation-tag "$FOUNDATION_TAG" --follow-up-tag "$FOLLOW_UP_TAG" \
+    --session "$SESSION" --key "$SESSION_KEY" \
+    --receipt "$PLATFORM_ROOT/platform-receipt.json" \
+    --manifest "$PLATFORM_ROOT/platform-manifest.json" \
+    --output "$WORK_ROOT/aggregate.json" | tee "$WORK_ROOT/aggregate-result.json"
+  [ "$(disk_kib)" -le "$MAX_DISK_KIB" ]
+}
+
+run_canary() {
+  if [ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]; then
+    echo "the local release-shaped canary runs only for pull requests" >&2
+    return 1
+  fi
+  if ! [[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "GITHUB_SHA must identify the exact pull-request candidate" >&2
+    return 1
+  fi
+
+  refresh_public_tags
+  assert_public_annotated_tag "$PINNED_FOUNDATION_TAG"
+  for start in "${CANARY_STARTS[@]}"; do
+    if ! git rev-parse --verify "$start^{commit}" >/dev/null 2>&1; then
+      echo "public canary start is unavailable: $start" >&2
+      return 1
+    fi
+  done
+
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git branch -f candidate "$GITHUB_SHA"
+  bash scripts/build-release.sh --source candidate --target release \
+    | tee "$WORK_ROOT/candidate-release-build.log"
+  CANDIDATE_COMMIT="$(git rev-parse --verify release^{commit})"
+  candidate_tags=()
+  while IFS= read -r tag; do
+    [ -n "$tag" ] && candidate_tags+=("$tag")
+  done < <(git tag --points-at "$CANDIDATE_COMMIT" --list 'dist/release/v*')
+  if [ "${#candidate_tags[@]}" -ne 1 ]; then
+    echo "candidate build did not create exactly one immutable release tag" >&2
+    return 1
+  fi
+  CANDIDATE_TAG="${candidate_tags[0]}"
+  CANDIDATE_VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
+  ASSET_ROOT="$WORK_ROOT/candidate-assets"
+  mkdir -m 700 "$ASSET_ROOT"
+  bash scripts/build-vault-bundle.sh "$ASSET_ROOT" \
+    | tee "$WORK_ROOT/candidate-assets-build.log"
+  BRIDGE_ASSET="$ASSET_ROOT/dex-update-bridge-v$CANDIDATE_VERSION.py"
+  BRIDGE_CHECKSUM="$BRIDGE_ASSET.sha256"
+  (cd "$ASSET_ROOT" && shasum -a 256 -c "$(basename "$BRIDGE_CHECKSUM")")
+
+  JOURNEY_ROOT="$WORK_ROOT/journeys"
+  mkdir -m 700 "$JOURNEY_ROOT"
+  DISCOVERED="${#CANARY_STARTS[@]}"
+  for start in "${CANARY_STARTS[@]}"; do
+    STARTED=$((STARTED + 1))
+    if run_bounded python3 scripts/release_fleet.py journey \
+      --repo . --output "$JOURNEY_ROOT" \
+      --starting-tag "$start" \
+      --foundation-tag "$PINNED_FOUNDATION_TAG" \
+      --follow-up-tag "$CANDIDATE_TAG" \
+      --bridge-asset "$BRIDGE_ASSET" \
+      --bridge-checksum "$BRIDGE_CHECKSUM"
+    then
+      journey_status=0
+    else
+      journey_status=$?
+    fi
+    if [ "$journey_status" -ne 0 ]; then
+      FAILED=$((FAILED + 1))
+      tail -200 "$LOG_FILE" >&2 || true
+      return "$journey_status"
+    fi
+    COMPLETED=$((COMPLETED + 1))
+    PASSED=$((PASSED + 1))
+    write_counts
+  done
+  [ "$(disk_kib)" -le "$MAX_DISK_KIB" ]
+}
+
+if [ "$MODE" = "formal" ]; then
+  run_formal
+else
+  run_canary
+fi


### PR DESCRIPTION
## What changed\n\n- accepts historic starts only through closed, verified identities; modern releases keep their existing strict policy\n- restores exact compatibility for the v1.51, v1.61, and v1.62 published shapes without weakening current updater checks\n- derives the frozen immutable historic count from the public manifest instead of trusting a fixed number\n- adds a real macOS-14 PR canary covering four published start shapes: v1.51 semantic, v1.61 dist, v1.62 semantic, and archived v1.65\n- adds the formal sequential Mac fleet workflow with a 50GB disk guard, public release/tag/bridge verification, first-failure stop, and retained evidence\n- regenerates the journey protocol and restores direct topology regressions\n\n## Verification\n\n- combined Python fleet/update suites: 446 passed, 4 Linux-host-only tests deselected (three Mac-only formal acceptance checks and one VPS system-venv limitation)\n- script tests: 163 passed\n- historic bridge + protocol suite: 317 passed\n- release executor suite: 36 passed\n- exact v1.61/v1.62 regressions and hostile near-miss checks: passed\n- Ruff, diff checks, and deterministic journey-protocol generation: passed\n- freshly generated immutable public cohort: 170 discovered starts (104 archive, 23 active release, 43 semantic)\n- PR Mac canary run 30777856425: 4 discovered, 4 started, 4 completed, 4 passed, 0 failed\n- all four starts reached the foundation and follow-up; both Doctors were healthy; protected user hashes were unchanged\n\n## Delivery boundary\n\nThe PR Mac canary is green using local, nonpublishing release-shaped artifacts.\n\nThis PR does **not** claim formal fleet acceptance. After merge and a new public follow-up release, the formal sequential Mac workflow must freshly derive and complete the entire public historic cohort before acceptance can be claimed.