### PR TITLE
Release v1.81.8 verified historic Mac updater route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.8] — 🧭 Historic Mac installs enter a verified update route (2026-08-03)
+
+The historic updater sweep found real published Mac installs whose trustworthy
+release shapes predated today's metadata. Dex correctly stopped rather than
+guessing, but those known installs still needed an exact route into the protected
+two-step updater and a real Mac gate to prove it.
+
+**What this fixes for you:**
+
+* **Known historic releases are recognised by their exact identities.** Dex can
+  accept the verified v1.51, v1.61, v1.62, and archived v1.65 shapes used by the
+  release fleet, while unfamiliar or altered installs still stop safely.
+* **Each update hop is exercised on a real Mac.** The release gate runs the
+  foundation and follow-up updates, checks Doctor and smoke health, and confirms
+  protected personal-file hashes did not change.
+* **Fleet acceptance is counted from public history, never assumed.** The formal
+  controller freshly derives every immutable starting case, retains evidence,
+  and stops on failure. This release enables that public run; it does not claim
+  the full fleet has passed before those journeys complete.
+
 ## [1.81.7] — 🛟 Stranded older installs can obtain the update bridge (2026-08-01)
 
 Jim's clean 1.79.0 package correctly detected the newest release, but its private

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -598,6 +598,7 @@
 .github/dependabot.yml
 .github/pull_request_template.md
 .github/workflows/ci.yml
+.github/workflows/historic-fleet-darwin.yml
 .github/workflows/nightly-quality.yml
 .github/workflows/release.yml
 .gitignore
@@ -1043,6 +1044,7 @@ core/tests/test_health_page_scripts.py
 core/tests/test_health_telemetry.py
 core/tests/test_health_telemetry_consent_ux.py
 core/tests/test_health_telemetry_privacy.py
+core/tests/test_historic_fleet_darwin_workflow.py
 core/tests/test_history_hygiene.py
 core/tests/test_initiative_kickoff_skill.py
 core/tests/test_install_adoption_python.py
@@ -1292,6 +1294,7 @@ scripts/release_fleet_acceptance.py
 scripts/release_fleet_executor.py
 scripts/render-health-page.py
 scripts/resolve-distignore-files.sh
+scripts/run-historic-fleet-darwin.sh
 scripts/security-allowlist.txt
 scripts/security-gate.sh
 scripts/security-scan.py

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.7"
+  "release_version": "1.81.8"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.7",
+  "release_version": "1.81.8",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.7","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.8","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.7 release,
+Download the versioned bridge and its checksum from the public v1.81.8 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.7/dex-update-bridge-v1.81.7.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.7.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.8/dex-update-bridge-v1.81.8.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.7/dex-update-bridge-v1.81.7.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.7.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.8/dex-update-bridge-v1.81.8.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.7.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.8.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.7.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.7",
+  "version": "1.81.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.7",
+      "version": "1.81.8",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.7",
+  "version": "1.81.8",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Outcome

Prepares v1.81.8 as the public follow-up release for the historic Mac updater route merged in PR #368.

## Included

- bumps all release metadata from v1.81.7 to v1.81.8
- documents the exact v1.51, v1.61, v1.62, and archived v1.65 compatibility routes proven by the PR Mac canary
- keeps unfamiliar or altered install shapes fail-closed
- documents the real Mac two-hop health and protected-file checks
- explicitly records that formal fleet acceptance still requires the freshly generated public run
- regenerates the installed-files manifest from merged commit `4f90c717954c795094fd596408eb156e551ffbdc`

## Verification before PR

- release metadata: 7/7 aligned
- focused release/catalog tests: 3 passed
- release-tag safety tests: 10 passed
- live release-tag uniqueness gate: passed
- live old-version reachability gate: passed
- updater journey protocol generation: deterministic
- installed-files manifest regeneration: deterministic
- release build dry-run: passed from commit `c06a51aef0567159636682d4e38ace69ed39c15e`
- HeyDex release-notes baseline: v1.81.7 confirmed public
- diff check and worktree status: clean

## Honest state

PR #368 is merged at `4f90c717954c795094fd596408eb156e551ffbdc`. Public latest remains v1.81.7. No v1.81.8 semantic tag, distribution tag, bundle, checksum, bridge asset, or GitHub Release exists yet. This PR has not tagged, published, deployed, or touched secrets.

After publication, the formal macOS fleet controller must freshly derive and complete the entire public historic cohort before acceptance can be claimed.
