### PR TITLE
fix(update): reconcile dormant v1.20 qmd registration

### DIFF
--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -311,7 +311,10 @@ RULES: tuple[Rule, ...] = (
     _r("vault-credentials", "System/credentials", "dir", "vault", "secrets; hard-denied"),
     _r("vault-mcp-json", ".mcp.json", "file", "vault",
        "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
-       "mcp-registration lifecycle transaction"),
+       "mcp-registration lifecycle transaction and the sole bridge-only "
+       "legacy-qmd-reconciliation exception for an exact v1.20-compatible "
+       "install, exact dormant qmd entry, absent qmd executable, and explicit "
+       "removal approval"),
     _r("vault-claude-custom", "CLAUDE-custom.md", "file", "vault",
        "the one canonical home for user instructions (Vault_Contract §5)"),
     _r("vault-skills-custom", ".claude/skills-custom", "dir", "vault"),
@@ -417,6 +420,7 @@ def update_write_verdict(
         "customization-migration",
         "capability-state",
         "mcp-registration",
+        "legacy-qmd-reconciliation",
         "onboarding-context",
     ):
         raise ValueError(f"unknown write operation: {operation}")
@@ -501,13 +505,18 @@ def update_write_verdict(
             resolution.rule_id if resolution is not None else None,
         )
 
-    if operation == "mcp-registration":
+    if operation in ("mcp-registration", "legacy-qmd-reconciliation"):
+        outside_reason = (
+            "outside-legacy-qmd-reconciliation"
+            if operation == "legacy-qmd-reconciliation"
+            else "outside-mcp-registration"
+        )
         try:
             denied = is_denied(path)
             candidate = _normalize(path)
             resolution = resolve(candidate)
         except ContractViolation:
-            return WriteVerdict(str(path), False, "outside-mcp-registration", None, None)
+            return WriteVerdict(str(path), False, outside_reason, None, None)
         if denied:
             return WriteVerdict(
                 candidate,
@@ -520,14 +529,18 @@ def update_write_verdict(
             return WriteVerdict(
                 candidate,
                 True,
-                "write-explicitly-approved-registration",
+                (
+                    "write-explicitly-approved-legacy-qmd-reconciliation"
+                    if operation == "legacy-qmd-reconciliation"
+                    else "write-explicitly-approved-registration"
+                ),
                 resolution.ownership,
                 resolution.rule_id,
             )
         return WriteVerdict(
             candidate,
             False,
-            "outside-mcp-registration",
+            outside_reason,
             resolution.ownership,
             resolution.rule_id,
         )

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -14,6 +14,7 @@ from types import ModuleType
 import pytest
 
 from core.lifecycle import service as lifecycle_service
+from core.transaction.engine import PlanRejected
 from scripts import dex_update_bridge as bridge
 
 
@@ -261,6 +262,25 @@ def test_legacy_topology_pin_is_closed_to_exact_v1201_release() -> None:
     )
 
 
+def _write_v1201_archive_marker(
+    archive: Path,
+    pin: bridge.LegacyTopologyPin,
+    head: str,
+) -> None:
+    (archive / bridge._PRE_SPLIT_ARCHIVE_MARKER).write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "migrationId": "2026-08-03T00:00:00.000Z",
+                "preSplitHead": head,
+                "releaseCommit": pin.commit,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_completed_split_proves_v1201_only_from_exact_archive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -270,6 +290,7 @@ def test_completed_split_proves_v1201_only_from_exact_archive(
     archive.mkdir()
     pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
     head = "f" * 40
+    _write_v1201_archive_marker(archive, pin, head)
     values = {
         (
             "for-each-ref",
@@ -282,19 +303,75 @@ def test_completed_split_proves_v1201_only_from_exact_archive(
         ("rev-parse", "--verify", "HEAD^{commit}"): head,
         ("merge-base", "--is-ancestor", pin.commit, head): "",
     }
-    monkeypatch.setattr(
-        bridge,
-        "_run_git",
-        lambda root, *arguments: (
-            values[arguments]
-            if root == archive
-            else pytest.fail("only the verified archive may be inspected")
-        ),
-    )
+    ancestry_ok = True
+
+    def run_git(root: Path, *arguments: str) -> str:
+        if root != archive:
+            pytest.fail("only the verified archive may be inspected")
+        if arguments[0] == "merge-base" and not ancestry_ok:
+            raise bridge.BridgeError("not an ancestor")
+        return values[arguments]
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
 
     assert bridge._archive_has_exact_v1201_origin(vault) is True
 
     values[("rev-parse", "--verify", f"{pin.tag}^{{tree}}")] = "0" * 40
+    assert bridge._archive_has_exact_v1201_origin(vault) is False
+
+
+def test_completed_split_accepts_exact_pinned_commit_when_archive_tag_was_pruned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    archive = vault / ".dex" / "pre-split-archive.git"
+    archive.mkdir()
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    head = "f" * 40
+    _write_v1201_archive_marker(archive, pin, head)
+    values = {
+        (
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        ): "",
+        ("cat-file", "-t", pin.commit): "commit",
+        ("rev-parse", "--verify", f"{pin.commit}^{{commit}}"): pin.commit,
+        ("rev-parse", "--verify", f"{pin.commit}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "HEAD^{commit}"): head,
+        ("merge-base", "--is-ancestor", pin.commit, head): "",
+    }
+    ancestry_ok = True
+
+    def run_git(root: Path, *arguments: str) -> str:
+        if root != archive:
+            pytest.fail("only the verified archive may be inspected")
+        if arguments[0] == "merge-base" and not ancestry_ok:
+            raise bridge.BridgeError("not an ancestor")
+        return values[arguments]
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+
+    assert bridge._archive_has_exact_v1201_origin(vault) is True
+
+    values[("rev-parse", "--verify", f"{pin.commit}^{{tree}}")] = "0" * 40
+    assert bridge._archive_has_exact_v1201_origin(vault) is False
+    values[("rev-parse", "--verify", f"{pin.commit}^{{tree}}")] = pin.tree
+    values[("cat-file", "-t", pin.commit)] = "blob"
+    assert bridge._archive_has_exact_v1201_origin(vault) is False
+    values[("cat-file", "-t", pin.commit)] = "commit"
+    ancestry_ok = False
+    assert bridge._archive_has_exact_v1201_origin(vault) is False
+
+    marker = json.loads(
+        (archive / bridge._PRE_SPLIT_ARCHIVE_MARKER).read_text(encoding="utf-8")
+    )
+    marker["releaseCommit"] = "0" * 40
+    (archive / bridge._PRE_SPLIT_ARCHIVE_MARKER).write_text(
+        json.dumps(marker) + "\n",
+        encoding="utf-8",
+    )
     assert bridge._archive_has_exact_v1201_origin(vault) is False
 
 
@@ -350,6 +427,7 @@ def test_exact_v1201_bridge_reconciles_dormant_qmd_in_approved_mcp_transaction(
     assert registration["preview"]["registration"]["action"] == (
         "add-current-and-remove-dormant-qmd"
     )
+    assert registration["preview"]["purpose"] == "legacy-qmd-reconciliation"
     assert registration["preview"]["compatibility"] == {
         "action": "remove-dormant-legacy-registration",
         "server_name": "qmd",
@@ -359,12 +437,171 @@ def test_exact_v1201_bridge_reconciles_dormant_qmd_in_approved_mcp_transaction(
         registration["preview"],
         registration["approval_token"],
     )
-    assert receipt["receipt"]["purpose"] == "mcp-registration"
+    assert receipt["receipt"]["purpose"] == "legacy-qmd-reconciliation"
     updated = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
     assert "qmd" not in updated["mcpServers"]
     assert "customization-migration-mcp" in updated["mcpServers"]
     assert updated["mcpServers"]["user-server"] == original["mcpServers"]["user-server"]
     assert updated["userSetting"] == original["userSetting"]
+
+
+def _configured_v1201_compatibility_adapter(
+    tmp_path: Path,
+) -> tuple[bridge._FoundationLifecycleService, Path, dict[str, object]]:
+    adapter, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    adapter._service = lifecycle_service
+    subprocess.run(["git", "init", "--quiet"], cwd=vault, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"],
+        cwd=vault,
+        check=True,
+    )
+    original: dict[str, object] = {
+        "mcpServers": {
+            "qmd": {"command": "qmd", "args": ["mcp"]},
+            "user-server": {"type": "http", "url": "https://example.com/mcp"},
+        },
+        "userSetting": {"preserve": True},
+    }
+    (vault / ".mcp.json").write_text(
+        json.dumps(original, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".mcp.json"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "legacy MCP config"],
+        cwd=vault,
+        check=True,
+    )
+    return adapter, vault, original
+
+
+def test_completed_split_archive_proof_builds_v1201_compatibility_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, vault, _original = _configured_v1201_compatibility_adapter(tmp_path)
+    archive = vault / ".dex" / "pre-split-archive.git"
+    archive.mkdir()
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    head = "f" * 40
+    _write_v1201_archive_marker(archive, pin, head)
+    values = {
+        (
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        ): "",
+        ("cat-file", "-t", pin.commit): "commit",
+        ("rev-parse", "--verify", f"{pin.commit}^{{commit}}"): pin.commit,
+        ("rev-parse", "--verify", f"{pin.commit}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "HEAD^{commit}"): head,
+        ("merge-base", "--is-ancestor", pin.commit, head): "",
+    }
+    monkeypatch.setattr(bridge, "_legacy_topology_authorization", lambda _root: None)
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda root, *arguments: (
+            values[arguments]
+            if root == archive
+            else pytest.fail("only the verified archive may be inspected")
+        ),
+    )
+    monkeypatch.setattr(bridge, "_optional_qmd_executable", lambda: None)
+
+    registration = adapter.build_and_preview_mcp_registration(vault)
+
+    assert registration["needed"] is True
+    assert registration["preview"]["registration"]["action"] == (
+        "add-current-and-remove-dormant-qmd"
+    )
+    assert registration["preview"]["compatibility"]["action"] == (
+        "remove-dormant-legacy-registration"
+    )
+
+
+@pytest.mark.parametrize("mutation", ["unrelated", "qmd-changed", "qmd-removed"])
+def test_v1201_compatibility_refuses_configuration_changed_after_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    adapter, vault, _original = _configured_v1201_compatibility_adapter(tmp_path)
+    monkeypatch.setattr(adapter, "_v1201_origin_is_proven", lambda _root: True)
+    monkeypatch.setattr(bridge, "_optional_qmd_executable", lambda: None)
+    registration = adapter.build_and_preview_mcp_registration(vault)
+    config = vault / ".mcp.json"
+    changed = json.loads(config.read_text(encoding="utf-8"))
+    if mutation == "unrelated":
+        changed["userSetting"]["changed_after_preview"] = True
+    elif mutation == "qmd-changed":
+        changed["mcpServers"]["qmd"]["args"] = ["serve"]
+    else:
+        del changed["mcpServers"]["qmd"]
+    config.write_text(json.dumps(changed, indent=2) + "\n", encoding="utf-8")
+    changed_bytes = config.read_bytes()
+
+    with pytest.raises(
+        (bridge.BridgeError, PlanRejected),
+        match="approval does not match",
+    ):
+        adapter.execute_approved_mcp_registration(
+            vault,
+            registration["preview"],
+            registration["approval_token"],
+        )
+
+    assert config.read_bytes() == changed_bytes
+
+
+@pytest.mark.parametrize("tamper", ["compatibility", "writes", "token"])
+def test_v1201_compatibility_refuses_tampered_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tamper: str,
+) -> None:
+    adapter, vault, _original = _configured_v1201_compatibility_adapter(tmp_path)
+    monkeypatch.setattr(adapter, "_v1201_origin_is_proven", lambda _root: True)
+    monkeypatch.setattr(bridge, "_optional_qmd_executable", lambda: None)
+    registration = adapter.build_and_preview_mcp_registration(vault)
+    preview = json.loads(json.dumps(registration["preview"]))
+    token = registration["approval_token"]
+    if tamper == "compatibility":
+        preview["compatibility"]["action"] = "keep-registration"
+    elif tamper == "writes":
+        preview["writes"][0]["sha256"] = "0" * 64
+    else:
+        token = "0" * 64
+    config = vault / ".mcp.json"
+    before = config.read_bytes()
+
+    with pytest.raises(bridge.BridgeError, match="approval does not match"):
+        adapter.execute_approved_mcp_registration(vault, preview, token)
+
+    assert config.read_bytes() == before
+
+
+def test_v1201_compatibility_refuses_changed_private_foundation_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, vault, _original = _configured_v1201_compatibility_adapter(tmp_path)
+    monkeypatch.setattr(adapter, "_v1201_origin_is_proven", lambda _root: True)
+    monkeypatch.setattr(bridge, "_optional_qmd_executable", lambda: None)
+    monkeypatch.setattr(
+        lifecycle_service,
+        "_canonical",
+        lambda value, unexpected=None: b"changed private signature",
+    )
+    config = vault / ".mcp.json"
+    before = config.read_bytes()
+
+    with pytest.raises(bridge.BridgeError, match="transaction API changed"):
+        adapter.build_and_preview_mcp_registration(vault)
+
+    assert config.read_bytes() == before
 
 
 def test_v1201_bridge_keeps_changed_qmd_registration_fail_closed(

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -13,6 +13,7 @@ from types import ModuleType
 
 import pytest
 
+from core.lifecycle import service as lifecycle_service
 from scripts import dex_update_bridge as bridge
 
 
@@ -258,6 +259,211 @@ def test_legacy_topology_pin_is_closed_to_exact_v1201_release() -> None:
         commit="9e6f35d3282cb354008a4e7372b1cdb1d469ad3d",
         tree="b781bb94e417b2873d057a5a417d8c666a360bca",
     )
+
+
+def test_completed_split_proves_v1201_only_from_exact_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    archive = vault / ".dex" / "pre-split-archive.git"
+    archive.mkdir()
+    pin = bridge.LEGACY_TOPOLOGY_FOUNDATION
+    head = "f" * 40
+    values = {
+        (
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        ): pin.tag_object,
+        ("cat-file", "-t", pin.tag_object): "tag",
+        ("rev-parse", "--verify", f"{pin.tag}^{{commit}}"): pin.commit,
+        ("rev-parse", "--verify", f"{pin.tag}^{{tree}}"): pin.tree,
+        ("rev-parse", "--verify", "HEAD^{commit}"): head,
+        ("merge-base", "--is-ancestor", pin.commit, head): "",
+    }
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda root, *arguments: (
+            values[arguments]
+            if root == archive
+            else pytest.fail("only the verified archive may be inspected")
+        ),
+    )
+
+    assert bridge._archive_has_exact_v1201_origin(vault) is True
+
+    values[("rev-parse", "--verify", f"{pin.tag}^{{tree}}")] = "0" * 40
+    assert bridge._archive_has_exact_v1201_origin(vault) is False
+
+
+def test_exact_v1201_bridge_reconciles_dormant_qmd_in_approved_mcp_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    adapter._service = lifecycle_service
+    subprocess.run(["git", "init", "--quiet"], cwd=vault, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"],
+        cwd=vault,
+        check=True,
+    )
+    original = {
+        "mcpServers": {
+            "qmd": {"command": "qmd", "args": ["mcp"]},
+            "user-server": {
+                "type": "http",
+                "url": "https://example.com/mcp",
+            },
+        },
+        "userSetting": {"preserve": True},
+    }
+    (vault / ".mcp.json").write_text(
+        json.dumps(original, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".mcp.json"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "legacy MCP config"],
+        cwd=vault,
+        check=True,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_v1201_origin_is_proven",
+        lambda _root: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_optional_qmd_executable",
+        lambda: None,
+        raising=False,
+    )
+
+    registration = adapter.build_and_preview_mcp_registration(vault)
+
+    assert registration["needed"] is True
+    assert registration["preview"]["registration"]["action"] == (
+        "add-current-and-remove-dormant-qmd"
+    )
+    assert registration["preview"]["compatibility"] == {
+        "action": "remove-dormant-legacy-registration",
+        "server_name": "qmd",
+    }
+    receipt = adapter.execute_approved_mcp_registration(
+        vault,
+        registration["preview"],
+        registration["approval_token"],
+    )
+    assert receipt["receipt"]["purpose"] == "mcp-registration"
+    updated = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+    assert "qmd" not in updated["mcpServers"]
+    assert "customization-migration-mcp" in updated["mcpServers"]
+    assert updated["mcpServers"]["user-server"] == original["mcpServers"]["user-server"]
+    assert updated["userSetting"] == original["userSetting"]
+
+
+def test_v1201_bridge_keeps_changed_qmd_registration_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    adapter._service = lifecycle_service
+    subprocess.run(["git", "init", "--quiet"], cwd=vault, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"],
+        cwd=vault,
+        check=True,
+    )
+    changed_qmd = {"command": "qmd", "args": ["serve", "--changed"]}
+    (vault / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"qmd": changed_qmd}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".mcp.json"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "changed MCP config"],
+        cwd=vault,
+        check=True,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_v1201_origin_is_proven",
+        lambda _root: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_optional_qmd_executable",
+        lambda: None,
+        raising=False,
+    )
+
+    registration = adapter.build_and_preview_mcp_registration(vault)
+    assert registration["preview"]["registration"]["action"] == "add-only"
+    assert "compatibility" not in registration["preview"]
+
+    adapter.execute_approved_mcp_registration(
+        vault,
+        registration["preview"],
+        registration["approval_token"],
+    )
+    updated = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+    assert updated["mcpServers"]["qmd"] == changed_qmd
+
+
+def test_v1201_bridge_preserves_exact_qmd_registration_when_qmd_is_installed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    adapter._service = lifecycle_service
+    subprocess.run(["git", "init", "--quiet"], cwd=vault, check=True)
+    subprocess.run(["git", "config", "user.name", "Dex Tests"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.com"],
+        cwd=vault,
+        check=True,
+    )
+    qmd = tmp_path / "bin" / "qmd"
+    qmd.parent.mkdir()
+    qmd.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    qmd.chmod(0o755)
+    exact_qmd = {"command": "qmd", "args": ["mcp"]}
+    (vault / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"qmd": exact_qmd}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".mcp.json"], cwd=vault, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "working qmd config"],
+        cwd=vault,
+        check=True,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_v1201_origin_is_proven",
+        lambda _root: True,
+        raising=False,
+    )
+    monkeypatch.setattr(bridge, "_optional_qmd_executable", lambda: qmd)
+
+    registration = adapter.build_and_preview_mcp_registration(vault)
+    assert registration["preview"]["registration"]["action"] == "add-only"
+    assert "compatibility" not in registration["preview"]
+
+    adapter.execute_approved_mcp_registration(
+        vault,
+        registration["preview"],
+        registration["approval_token"],
+    )
+    updated = json.loads((vault / ".mcp.json").read_text(encoding="utf-8"))
+    assert updated["mcpServers"]["qmd"] == exact_qmd
 
 
 def test_legacy_topology_requires_exact_tag_commit_tree_and_current_ancestry(

--- a/core/tests/test_mcp_registration_lifecycle.py
+++ b/core/tests/test_mcp_registration_lifecycle.py
@@ -79,6 +79,21 @@ def test_mcp_registration_contract_allows_only_the_explicit_user_approved_file()
     ).allowed
 
 
+def test_legacy_qmd_reconciliation_contract_is_a_separate_single_file_exception() -> None:
+    verdict = portable_contract.update_write_verdict(
+        ".mcp.json",
+        exists=True,
+        operation="legacy-qmd-reconciliation",
+    )
+    assert verdict.allowed
+    assert verdict.action == "write-explicitly-approved-legacy-qmd-reconciliation"
+    assert not portable_contract.update_write_verdict(
+        "System/user-profile.yaml",
+        exists=True,
+        operation="legacy-qmd-reconciliation",
+    ).allowed
+
+
 def test_mcp_registration_refuses_if_user_configuration_changes_after_preview(
     tmp_path: Path,
 ) -> None:

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "4828f2ddfbc020282a8a95c7642b525c18e08a78ddfe0632cdd6e72231a5dba9",
+      "sha256": "e09a71d1f3fc98eb9d663cbaf6e937596db19616a454f1fa33005d25f60fd119",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "e09a71d1f3fc98eb9d663cbaf6e937596db19616a454f1fa33005d25f60fd119",
+      "sha256": "90986a037e53db1dc238082fec559c5709bfd7899ad7cbd4290cfe2d8a5f3953",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/portable-vault-contract-design.md
+++ b/docs/portable-vault-contract-design.md
@@ -53,7 +53,15 @@ path traversal. (From #141 ownership.cjs deny set + Vault_Contract §3 secrets r
   it; release updates and migration engines never rewrite it). The one narrow
   exception is the later-ratified lifecycle registration repair: after showing
   the exact preview and receiving explicit approval, it may add Dex's own missing
-  Customization Migration entry. It cannot replace or remove any user entry.
+  Customization Migration entry. The normal public lifecycle service remains
+  add-only and cannot replace or remove any user entry. There is one bridge-only
+  legacy exception: an exact v1.20-compatible install may remove only the exact
+  dormant `qmd` registration (`{"command":"qmd","args":["mcp"]}`) when no real
+  `qmd` executable exists, the removal is shown in the exact preview, and the user
+  explicitly approves it. The immutable v1.81.0 transaction engine carries that
+  write under its older `mcp-registration` path gate, but the logical transaction
+  and receipt purpose is `legacy-qmd-reconciliation`; all other MCP configuration
+  remains user-owned and unchanged.
 - Raw secret authority = vault-root `.env` (hard-deny).
 
 ## Capability registry (Decision C, Option 2)

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -122,7 +122,7 @@
       "path": ".mcp.json",
       "kind": "file",
       "ownership": "vault",
-      "note": "REPORT-ONLY except the explicitly previewed, user-approved, add-only mcp-registration lifecycle transaction"
+      "note": "REPORT-ONLY except the explicitly previewed, user-approved, add-only mcp-registration lifecycle transaction and the sole bridge-only legacy-qmd-reconciliation exception for an exact v1.20-compatible install, exact dormant qmd entry, absent qmd executable, and explicit removal approval"
     },
     {
       "id": "brain-obsidian",

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import hmac
 import importlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -125,6 +127,7 @@ LEGACY_TOPOLOGY_FOUNDATION = LegacyTopologyPin(
     tree="b781bb94e417b2873d057a5a417d8c666a360bca",
 )
 _LEGACY_V1201_PACKAGE_SHA256 = "d0f3908ba0f6268d23c182acc1b3ef5b7557b92791635ff315eb6e324529f7ec"
+_LEGACY_DORMANT_QMD_ENTRY = {"command": "qmd", "args": ["mcp"]}
 
 
 @dataclass(frozen=True)
@@ -1149,6 +1152,29 @@ class LifecycleService(Protocol):
     ) -> Mapping[str, Any]: ...
 
 
+def _optional_qmd_executable() -> Path | None:
+    """Return a real optional qmd command without trusting arbitrary locations."""
+
+    discovered = shutil.which("qmd")
+    candidates = (
+        Path(discovered) if discovered else None,
+        Path.home() / ".bun" / "bin" / "qmd",
+        Path.home() / ".local" / "bin" / "qmd",
+        Path("/usr/local/bin/qmd"),
+        Path("/opt/homebrew/bin/qmd"),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return resolved
+    return None
+
+
 def _trusted_executable(name: str) -> Path | None:
     """Find a system-installed executable without consulting caller PATH."""
     for directory in _TRUSTED_EXECUTABLE_DIRECTORIES:
@@ -1501,6 +1527,40 @@ def _supported_legacy_topology(
     """Prove the exact legacy base allowed to borrow the foundation migrator."""
 
     return _legacy_topology_authorization(vault_root, pin) is not None
+
+
+def _archive_has_exact_v1201_origin(
+    vault_root: Path,
+    pin: LegacyTopologyPin = LEGACY_TOPOLOGY_FOUNDATION,
+) -> bool:
+    """Prove a completed split still originated at the exact v1.20.1 tree."""
+
+    archive = Path(vault_root) / ".dex" / "pre-split-archive.git"
+    if archive.is_symlink() or not archive.is_dir():
+        return False
+    try:
+        if (
+            _run_git(
+                archive,
+                "for-each-ref",
+                "--format=%(objectname)",
+                f"refs/tags/{pin.tag}",
+            )
+            != pin.tag_object
+            or _run_git(archive, "cat-file", "-t", pin.tag_object) != "tag"
+            or _run_git(archive, "rev-parse", "--verify", f"{pin.tag}^{{commit}}")
+            != pin.commit
+            or _run_git(archive, "rev-parse", "--verify", f"{pin.tag}^{{tree}}")
+            != pin.tree
+        ):
+            return False
+        head = _run_git(archive, "rev-parse", "--verify", "HEAD^{commit}")
+        if _HEX.fullmatch(head) is None:
+            return False
+        _run_git(archive, "merge-base", "--is-ancestor", pin.commit, head)
+    except BridgeError:
+        return False
+    return True
 
 
 def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.TemporaryDirectory[str], Path]:
@@ -2210,10 +2270,124 @@ class _FoundationLifecycleService:
                 approved_token,
             )
 
+    def _v1201_origin_is_proven(self, vault_root: Path) -> bool:
+        root = Path(vault_root).resolve()
+        authorization = _legacy_topology_authorization(root)
+        return (
+            authorization is not None
+            and authorization.release == LEGACY_TOPOLOGY_FOUNDATION
+        ) or _archive_has_exact_v1201_origin(root)
+
+    def _compatibility_mcp_registration(
+        self,
+        vault_root: Path,
+    ) -> tuple[Mapping[str, Any], list[Any]] | None:
+        """Build one exact approved transaction for v1.20.1's dormant qmd entry."""
+
+        root = Path(vault_root).resolve()
+        if not self._v1201_origin_is_proven(root) or _optional_qmd_executable() is not None:
+            return None
+        target = root / ".mcp.json"
+        if target.is_symlink() or not target.is_file():
+            return None
+        try:
+            current = target.read_bytes()
+            existing = json.loads(current.decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(existing, dict):
+            return None
+        servers = existing.get("mcpServers")
+        if (
+            not isinstance(servers, dict)
+            or servers.get("qmd") != _LEGACY_DORMANT_QMD_ENTRY
+        ):
+            return None
+
+        required = (
+            "_mcp_registration_preview",
+            "_transaction_preview_document",
+            "_preview_transaction",
+            "_execute_approved_transaction",
+            "_canonical",
+            "_envelope",
+            "PlanEntry",
+        )
+        if any(getattr(self._service, name, None) is None for name in required):
+            raise BridgeError(
+                "pinned foundation MCP compatibility transaction API is incomplete"
+            )
+        normal_preview, normal_plan = self._service._mcp_registration_preview(root)
+        if normal_preview is None:
+            updated = dict(existing)
+            action = "remove-dormant-qmd"
+        else:
+            if len(normal_plan) != 1 or normal_plan[0].content is None:
+                raise BridgeError("pinned foundation MCP registration plan is malformed")
+            try:
+                updated = json.loads(normal_plan[0].content.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise BridgeError(
+                    "pinned foundation MCP registration plan is malformed"
+                ) from error
+            action = "add-current-and-remove-dormant-qmd"
+        updated_servers = updated.get("mcpServers")
+        if (
+            not isinstance(updated_servers, dict)
+            or updated_servers.get("qmd") != _LEGACY_DORMANT_QMD_ENTRY
+        ):
+            raise BridgeError("dormant qmd registration changed during preview")
+        updated_servers = dict(updated_servers)
+        del updated_servers["qmd"]
+        updated = dict(updated)
+        updated["mcpServers"] = updated_servers
+        content = (json.dumps(updated, indent=2, ensure_ascii=False) + "\n").encode(
+            "utf-8"
+        )
+        plan = [
+            self._service.PlanEntry(
+                ".mcp.json",
+                content,
+                mode=target.stat().st_mode & 0o777,
+                expected_current_sha256=hashlib.sha256(current).hexdigest(),
+            )
+        ]
+        transaction = self._service._transaction_preview_document(
+            root,
+            plan,
+            purpose="mcp-registration",
+            operation="mcp-registration",
+        )
+        preview = {
+            "registration": {
+                "config_path": ".mcp.json",
+                "server_name": "customization-migration-mcp",
+                "action": action,
+            },
+            "compatibility": {
+                "server_name": "qmd",
+                "action": "remove-dormant-legacy-registration",
+            },
+            "writes": transaction["writes"],
+        }
+        return (
+            self._service._envelope(
+                needed=True,
+                preview=preview,
+                approval_token=hashlib.sha256(
+                    self._service._canonical(preview)
+                ).hexdigest(),
+            ),
+            plan,
+        )
+
     def build_and_preview_mcp_registration(
         self,
         vault_root: str | Path,
     ) -> Mapping[str, Any]:
+        compatibility = self._compatibility_mcp_registration(Path(vault_root))
+        if compatibility is not None:
+            return compatibility[0]
         return self._service.build_and_preview_mcp_registration(vault_root)
 
     def execute_approved_mcp_registration(
@@ -2222,6 +2396,41 @@ class _FoundationLifecycleService:
         preview: Mapping[str, Any],
         approved_token: str,
     ) -> Mapping[str, Any]:
+        compatibility = self._compatibility_mcp_registration(Path(vault_root))
+        if compatibility is not None:
+            expected, plan = compatibility
+            expected_preview = expected.get("preview")
+            expected_token = expected.get("approval_token")
+            try:
+                supplied = self._service._canonical(dict(preview))
+                canonical_expected = self._service._canonical(expected_preview)
+            except (TypeError, ValueError) as error:
+                raise BridgeError(
+                    "legacy MCP compatibility preview is not canonical JSON"
+                ) from error
+            if (
+                not isinstance(approved_token, str)
+                or not isinstance(expected_token, str)
+                or not hmac.compare_digest(supplied, canonical_expected)
+                or not hmac.compare_digest(approved_token, expected_token)
+            ):
+                raise BridgeError(
+                    "legacy MCP compatibility approval does not match the current exact preview"
+                )
+            transaction = self._service._preview_transaction(
+                vault_root,
+                plan,
+                purpose="mcp-registration",
+                operation="mcp-registration",
+            )
+            executed = self._service._execute_approved_transaction(
+                vault_root,
+                plan,
+                purpose="mcp-registration",
+                operation="mcp-registration",
+                approved_token=str(transaction["approval_token"]),
+            )
+            return self._service._envelope(receipt=executed["receipt"])
         return self._service.execute_approved_mcp_registration(
             vault_root,
             preview,
@@ -2416,8 +2625,18 @@ def _complete_mcp_registration(
         Mapping,
     ):
         raise BridgeError("foundation could not produce an MCP registration preview")
+    compatibility = registration_preview.get("compatibility")
+    prompt = (
+        "Dex will remove the dormant optional qmd entry left by v1.20.1 while keeping the current customization migration server registered."
+        if compatibility
+        == {
+            "server_name": "qmd",
+            "action": "remove-dormant-legacy-registration",
+        }
+        else "Dex will add the current customization migration server to your MCP configuration."
+    )
     registration_preview, registration_token = _approved_preview(
-        "Dex will add the current customization migration server to your MCP configuration.",
+        prompt,
         registration_preview,
         registration.get("approval_token"),
         input_fn=input_fn,

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -14,6 +14,7 @@ import base64
 import hashlib
 import hmac
 import importlib
+import inspect
 import json
 import os
 import re
@@ -34,6 +35,8 @@ _APPROVAL_WORD = "APPLY"
 _CLEAN_RUNTIME_MARKER = "DEX_UPDATE_BRIDGE_CLEAN_RUNTIME"
 _TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/local/bin"), Path("/opt/homebrew/bin"))
 _TOPOLOGY_MIGRATOR_RELATIVE = Path("core/migrations/v1-to-v2-brain-vault-split.cjs")
+_PRE_SPLIT_ARCHIVE_MARKER = "dex-pre-split-v2-archive.json"
+_LEGACY_QMD_RECONCILIATION_PURPOSE = "legacy-qmd-reconciliation"
 _TRACKED_IGNORE_POLICY_RELATIVE = Path("core/migrations/tracked-ignored-policy.yaml")
 _PRESERVATION_TRANSITION_RELATIVE = Path("System/.local-only-preservation-transition.json")
 _LEGACY_SHIPPED_SYMLINK_RELATIVE = Path(".pi/agent/extensions/dex")
@@ -1539,23 +1542,50 @@ def _archive_has_exact_v1201_origin(
     if archive.is_symlink() or not archive.is_dir():
         return False
     try:
+        marker = _regular_json(
+            archive / _PRE_SPLIT_ARCHIVE_MARKER,
+            "pre-split archive marker",
+        )
         if (
-            _run_git(
-                archive,
-                "for-each-ref",
-                "--format=%(objectname)",
-                f"refs/tags/{pin.tag}",
-            )
-            != pin.tag_object
-            or _run_git(archive, "cat-file", "-t", pin.tag_object) != "tag"
-            or _run_git(archive, "rev-parse", "--verify", f"{pin.tag}^{{commit}}")
+            set(marker)
+            != {"schemaVersion", "migrationId", "preSplitHead", "releaseCommit"}
+            or marker.get("schemaVersion") != 1
+            or not isinstance(marker.get("migrationId"), str)
+            or not marker["migrationId"]
+            or marker.get("releaseCommit") != pin.commit
+        ):
+            return False
+        pre_split_head = marker.get("preSplitHead")
+        if not isinstance(pre_split_head, str) or _HEX.fullmatch(pre_split_head) is None:
+            return False
+        tag_object = _run_git(
+            archive,
+            "for-each-ref",
+            "--format=%(objectname)",
+            f"refs/tags/{pin.tag}",
+        )
+        if tag_object:
+            if tag_object != pin.tag_object:
+                return False
+            if _run_git(archive, "cat-file", "-t", pin.tag_object) != "tag":
+                return False
+            identity = pin.tag
+        else:
+            # A completed split may preserve the exact release commit while
+            # pruning its old label. Accept only the same closed object, tree,
+            # and ancestry proof used before the split.
+            if _run_git(archive, "cat-file", "-t", pin.commit) != "commit":
+                return False
+            identity = pin.commit
+        if (
+            _run_git(archive, "rev-parse", "--verify", f"{identity}^{{commit}}")
             != pin.commit
-            or _run_git(archive, "rev-parse", "--verify", f"{pin.tag}^{{tree}}")
+            or _run_git(archive, "rev-parse", "--verify", f"{identity}^{{tree}}")
             != pin.tree
         ):
             return False
         head = _run_git(archive, "rev-parse", "--verify", "HEAD^{commit}")
-        if _HEX.fullmatch(head) is None:
+        if head != pre_split_head:
             return False
         _run_git(archive, "merge-base", "--is-ancestor", pin.commit, head)
     except BridgeError:
@@ -2317,6 +2347,49 @@ class _FoundationLifecycleService:
             raise BridgeError(
                 "pinned foundation MCP compatibility transaction API is incomplete"
             )
+        expected_parameters = {
+            "_mcp_registration_preview": ("vault_root",),
+            "_transaction_preview_document": (
+                "vault_root",
+                "plan",
+                "purpose",
+                "operation",
+            ),
+            "_preview_transaction": (
+                "vault_root",
+                "plan",
+                "purpose",
+                "operation",
+            ),
+            "_execute_approved_transaction": (
+                "vault_root",
+                "plan",
+                "purpose",
+                "approved_token",
+                "operation",
+                "before_commit",
+            ),
+            "_canonical": ("value",),
+            "_envelope": ("values",),
+            "PlanEntry": (
+                "relative",
+                "content",
+                "mode",
+                "expected_current_sha256",
+                "expected_absent",
+            ),
+        }
+        for name, parameters in expected_parameters.items():
+            try:
+                actual = tuple(inspect.signature(getattr(self._service, name)).parameters)
+            except (TypeError, ValueError) as error:
+                raise BridgeError(
+                    "pinned foundation MCP compatibility transaction API is unreadable"
+                ) from error
+            if actual != parameters:
+                raise BridgeError(
+                    "pinned foundation MCP compatibility transaction API changed"
+                )
         normal_preview, normal_plan = self._service._mcp_registration_preview(root)
         if normal_preview is None:
             updated = dict(existing)
@@ -2355,10 +2428,14 @@ class _FoundationLifecycleService:
         transaction = self._service._transaction_preview_document(
             root,
             plan,
-            purpose="mcp-registration",
+            purpose=_LEGACY_QMD_RECONCILIATION_PURPOSE,
+            # Immutable v1.81.0 recognizes only this path-level transport
+            # operation. The narrower logical purpose and bridge eligibility
+            # gates enforce the separately ratified legacy exception.
             operation="mcp-registration",
         )
         preview = {
+            "purpose": _LEGACY_QMD_RECONCILIATION_PURPOSE,
             "registration": {
                 "config_path": ".mcp.json",
                 "server_name": "customization-migration-mcp",
@@ -2420,13 +2497,13 @@ class _FoundationLifecycleService:
             transaction = self._service._preview_transaction(
                 vault_root,
                 plan,
-                purpose="mcp-registration",
+                purpose=_LEGACY_QMD_RECONCILIATION_PURPOSE,
                 operation="mcp-registration",
             )
             executed = self._service._execute_approved_transaction(
                 vault_root,
                 plan,
-                purpose="mcp-registration",
+                purpose=_LEGACY_QMD_RECONCILIATION_PURPOSE,
                 operation="mcp-registration",
                 approved_token=str(transaction["approval_token"]),
             )
@@ -2627,7 +2704,7 @@ def _complete_mcp_registration(
         raise BridgeError("foundation could not produce an MCP registration preview")
     compatibility = registration_preview.get("compatibility")
     prompt = (
-        "Dex will remove the dormant optional qmd entry left by v1.20.1 while keeping the current customization migration server registered."
+        "Dex will remove the dormant optional qmd entry associated with this v1.20-compatible install while keeping the current customization migration server registered."
         if compatibility
         == {
             "server_name": "qmd",


### PR DESCRIPTION
## What changed

- Bind the compatibility path to the exact immutable v1.20.1 lineage, including the migration archive marker, exact release commit/tree/ancestry, and safe pruned-label resume.
- Ratify one bridge-only legacy-qmd-reconciliation exception while keeping the normal public MCP lifecycle service add-only.
- When the exact dormant qmd registration is present and no real qmd executable exists, combine removal with the current MCP registration in one explicit preview, APPLY approval, and receipt-backed lifecycle transaction. Altered qmd entries, other releases, installed qmd, and all user-added configuration remain untouched.
- Fail closed if the pinned v1.81.0 private transaction API signatures change, then regenerate the contract and journey protocol artifacts.

## Why

Formal run 30785160310 reached exact foundation v1.81.0, preserved user hashes, then failed its first Doctor because the v1.20.1-compatible configuration still contained an optional qmd registration while the binary was absent.

## Verification

- 500 focused updater, bridge, portable-contract, and protocol tests passed
- Direct post-preview config changes and preview/write/token tampering reject without changing bytes
- Ruff passed
- Generated portable contract and journey protocol reproduced
- Git diff check passed

## Acceptance state

This PR repairs the first classified failure. It does not claim a rerun or fleet acceptance. Formal counts remain discovered 170, started 1, completed 0, passed 0, failed 1.