### PR TITLE
release: v1.81.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.9] — 🧹 Oldest Dex installs clear one dormant search registration (2026-08-03)
+
+The formal Mac fleet began with v1.20.1 and reached the public foundation with
+personal files unchanged. Doctor then found that this oldest release still
+advertised the optional qmd search server even though qmd was not installed, so
+the updater correctly stopped before claiming a healthy result.
+
+**What this fixes for you:**
+
+* **The exact dormant qmd entry is removed during the protected bridge.** A proven
+  v1.20.1 install can replace that obsolete registration while adding Dex's current
+  lifecycle server, using the normal preview, approval, transaction, and receipt.
+* **Your other connections and settings stay untouched.** The compatibility route
+  removes only the exact legacy qmd shape; every unrelated MCP server and top-level
+  setting is preserved.
+* **The exception remains narrowly closed.** Dex requires the exact oldest-release
+  origin, the exact dormant registration, and an absent qmd executable. Any altered
+  or unfamiliar state still stops safely.
+* **Fleet acceptance is still earned by journeys.** This release repairs the first
+  formal failure; the freshly generated public 170-case run must restart and finish
+  before Dex claims universal historic support.
+
 ## [1.81.8] — 🧭 Historic Mac installs enter a verified update route (2026-08-03)
 
 The historic updater sweep found real published Mac installs whose trustworthy

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.8"
+  "release_version": "1.81.9"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.8",
+  "release_version": "1.81.9",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.8","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.9","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.8 release,
+Download the versioned bridge and its checksum from the public v1.81.9 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.8/dex-update-bridge-v1.81.8.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.9/dex-update-bridge-v1.81.9.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.8/dex-update-bridge-v1.81.8.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.9/dex-update-bridge-v1.81.9.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.8.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.9.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.8.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.8",
+  "version": "1.81.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.8",
+      "version": "1.81.9",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.8",
+  "version": "1.81.9",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Outcome

Prepares v1.81.9 as the public follow-up for the exact v1.20.1 dormant-qmd repair merged in PR #371.

## Included

- bumps all seven canonical release metadata references from v1.81.8 to v1.81.9
- updates the rescue bridge download, checksum, and execution commands to v1.81.9
- explains the exact oldest-install failure and its narrowly closed repair in the changelog
- preserves every unrelated MCP server and setting and keeps unfamiliar states fail-closed
- explicitly records that formal 170-case acceptance still requires a fresh public rerun
- regenerates the release evidence profile, local-only transition stamp, and installed-files manifest from merged commit `95a0f5ba01b6599330530ed622d6e9770ea1059b`

## Verification before PR

- release metadata: 7/7 aligned to v1.81.9
- exact rescue route test: passed
- focused release/catalog tests: 3 passed
- release-tag safety tests: 10 passed
- live release-tag uniqueness gate: passed
- live old-version reachability gate: passed
- updater journey protocol generation: deterministic
- installed-files manifest regeneration: deterministic
- package lock regeneration: deterministic
- release build dry-run: passed from commit `7f225541a078bd52bf3bf779f19760a7259f771a`
- previous release baseline: public v1.81.8 confirmed with all four updater assets
- diff check and worktree status: clean

## Honest state

PR #371 is merged at `95a0f5ba01b6599330530ed622d6e9770ea1059b`. Public latest remains v1.81.8. No v1.81.9 semantic tag, distribution tag, bundle, checksum, bridge asset, or GitHub Release exists yet. This PR has not tagged, published, deployed, or touched secrets.

After publication, formal run 30785160310 remains a failed first attempt at 170 discovered, 1 started, 0 completed, 0 passed, and 1 failed. The freshly generated public 170-case fleet must restart and finish before acceptance can be claimed.
