### PR TITLE
fix(fleet): avoid public metadata rate limit

### DIFF
--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import stat
 import subprocess
+import urllib.error
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
@@ -1245,20 +1246,19 @@ def test_public_bridge_assets_must_match_the_public_stable_release_bytes(
     acceptance = _acceptance()
     release = _immutable_follow_up()
     bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
-    public_metadata = {"tag_name": "v1.81.1", "draft": False, "prerelease": False}
     public_assets = {
         bridge_asset.name: bridge_asset.read_bytes(),
         bridge_checksum.name: bridge_checksum.read_bytes(),
     }
+    stable_releases: list[release_fleet.ImmutableRelease] = []
 
     def public_bytes(url: str, **_kwargs) -> bytes:
-        if url == acceptance.CANONICAL_PUBLIC_RELEASE_API.format(version=release.version):
-            return json.dumps(public_metadata).encode("utf-8")
         for name, content in public_assets.items():
             if url.endswith(name):
                 return content
         pytest.fail(f"unexpected public URL: {url}")
 
+    monkeypatch.setattr(acceptance, "_verify_public_stable_release", stable_releases.append)
     monkeypatch.setattr(acceptance, "_read_public_bytes", public_bytes)
     acceptance._verify_public_bridge_release_asset(
         release,
@@ -1266,6 +1266,7 @@ def test_public_bridge_assets_must_match_the_public_stable_release_bytes(
         bridge_checksum=bridge_checksum,
     )
 
+    assert stable_releases == [release]
     bridge_asset.write_bytes(b"tampered controller copy\n")
     with pytest.raises(release_fleet.FleetError, match="public GitHub release"):
         acceptance._verify_public_bridge_release_asset(
@@ -1274,23 +1275,225 @@ def test_public_bridge_assets_must_match_the_public_stable_release_bytes(
             bridge_checksum=bridge_checksum,
         )
 
-    bridge_asset.write_bytes(public_assets[bridge_asset.name])
-    public_metadata["draft"] = True
-    with pytest.raises(release_fleet.FleetError, match="public stable GitHub release"):
-        acceptance._verify_public_bridge_release_asset(
-            release,
-            bridge_asset=bridge_asset,
-            bridge_checksum=bridge_checksum,
-        )
 
-    public_metadata["draft"] = False
-    public_metadata["prerelease"] = True
-    with pytest.raises(release_fleet.FleetError, match="public stable GitHub release"):
-        acceptance._verify_public_bridge_release_asset(
-            release,
-            bridge_asset=bridge_asset,
-            bridge_checksum=bridge_checksum,
+
+def test_public_stable_release_requires_the_exact_latest_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acceptance = _acceptance()
+    release = _immutable_follow_up()
+
+    class PublicResponse:
+        def __init__(self, final_url: str, status: int = 200) -> None:
+            self._final_url = final_url
+            self._status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def geturl(self) -> str:
+            return self._final_url
+
+        def getcode(self) -> int:
+            return self._status
+
+    class PublicOpener:
+        def __init__(
+            self,
+            handler,
+            *,
+            redirects: tuple[str, ...],
+            final_url: str,
+            status: int = 200,
+        ) -> None:
+            self._handler = handler
+            self._redirects = redirects
+            self._final_url = final_url
+            self._status = status
+
+        def open(self, request, **_kwargs):
+            current = request
+            for redirect in self._redirects:
+                current = self._handler.redirect_request(
+                    current,
+                    None,
+                    302,
+                    "Found",
+                    {},
+                    redirect,
+                )
+            return PublicResponse(self._final_url, self._status)
+
+    expected = acceptance.CANONICAL_PUBLIC_RELEASE_PAGE.format(version=release.version)
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda handler: PublicOpener(handler, redirects=(expected,), final_url=expected),
+    )
+    acceptance._verify_public_stable_release(release)
+
+    hostile_urls = (
+        acceptance.CANONICAL_PUBLIC_LATEST_RELEASE,
+        acceptance.CANONICAL_PUBLIC_RELEASE_PAGE.format(version="1.81.0"),
+        f"https://example.com/davekilleen/Dex/releases/tag/v{release.version}",
+        f"http://github.com/davekilleen/Dex/releases/tag/v{release.version}",
+        f"https://github.com:443/davekilleen/Dex/releases/tag/v{release.version}",
+        f"https://user:@github.com/davekilleen/Dex/releases/tag/v{release.version}",
+        f"https://github.com/DaveKilleen/Dex/releases/tag/v{release.version}",
+        f"https://github.com/davekilleen/dex/releases/tag/v{release.version}",
+        f"https://github.com/davekilleen/Dex/releases/tag/v{release.version}/",
+        f"https://github.com/davekilleen/Dex/releases/tag/v{release.version}?stable=true",
+        f"https://github.com/davekilleen/Dex/releases/tag/v{release.version}#release",
+        "https://github.com/davekilleen/Dex/releases/tag/v%31.81.1",
+        f"https://github.com/davekilleen/Dex/releases/tag/prefix-v{release.version}",
+        f"https://github.com/davekilleen/Dex/releases/tag/v{release.version}-suffix",
+        f"https://github.com/davekilleen/Dex/other/tag/v{release.version}",
+    )
+    for hostile_url in hostile_urls:
+        monkeypatch.setattr(
+            acceptance.urllib.request,
+            "build_opener",
+            lambda handler, _url=hostile_url: PublicOpener(
+                handler,
+                redirects=(_url,),
+                final_url=_url,
+            ),
         )
+        with pytest.raises(release_fleet.FleetError, match="latest public stable"):
+            acceptance._verify_public_stable_release(release)
+
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda handler: PublicOpener(handler, redirects=(), final_url=expected),
+    )
+    with pytest.raises(release_fleet.FleetError, match="latest public stable"):
+        acceptance._verify_public_stable_release(release)
+
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda handler: PublicOpener(
+            handler,
+            redirects=(expected, expected),
+            final_url=expected,
+        ),
+    )
+    with pytest.raises(release_fleet.FleetError, match="latest public stable"):
+        acceptance._verify_public_stable_release(release)
+
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda handler: PublicOpener(
+            handler,
+            redirects=(expected,),
+            final_url=expected,
+            status=204,
+        ),
+    )
+    with pytest.raises(release_fleet.FleetError, match="latest public stable"):
+        acceptance._verify_public_stable_release(release)
+
+    class UnavailableOpener:
+        def open(self, request, **_kwargs):
+            raise urllib.error.HTTPError(
+                request.full_url,
+                403,
+                "forbidden",
+                {},
+                None,
+            )
+
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda _handler: UnavailableOpener(),
+        )
+    with pytest.raises(release_fleet.FleetError, match="public stable GitHub release is unavailable"):
+        acceptance._verify_public_stable_release(release)
+
+
+def test_public_bridge_verification_does_not_depend_on_rate_limited_release_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    release = _immutable_follow_up()
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    public_assets = {
+        bridge_asset.name: bridge_asset.read_bytes(),
+        bridge_checksum.name: bridge_checksum.read_bytes(),
+    }
+    calls: list[str] = []
+
+    class PublicResponse:
+        def __init__(self, *, url: str, content: bytes = b"") -> None:
+            self._url = url
+            self._content = content
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def geturl(self) -> str:
+            return self._url
+
+        def getcode(self) -> int:
+            return 200
+
+        def read(self, _limit: int) -> bytes:
+            return self._content
+
+    def public_urlopen(request, **_kwargs):
+        url = request.full_url
+        calls.append(url)
+        if url.startswith("https://api.github.com/"):
+            raise urllib.error.HTTPError(url, 403, "rate limit exceeded", {}, None)
+        if url == acceptance.CANONICAL_PUBLIC_LATEST_RELEASE:
+            return PublicResponse(
+                url=f"https://github.com/davekilleen/Dex/releases/tag/v{release.version}"
+            )
+        for name, content in public_assets.items():
+            if url.endswith(name):
+                return PublicResponse(url=url, content=content)
+        pytest.fail(f"unexpected public URL: {url}")
+
+    class PublicOpener:
+        def __init__(self, handler) -> None:
+            self._handler = handler
+
+        def open(self, request, **_kwargs):
+            calls.append(request.full_url)
+            expected = acceptance.CANONICAL_PUBLIC_RELEASE_PAGE.format(version=release.version)
+            self._handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                expected,
+            )
+            return PublicResponse(url=expected)
+
+    monkeypatch.setattr(
+        acceptance.urllib.request,
+        "build_opener",
+        lambda handler: PublicOpener(handler),
+    )
+    monkeypatch.setattr(acceptance.urllib.request, "urlopen", public_urlopen)
+    acceptance._verify_public_bridge_release_asset(
+        release,
+        bridge_asset=bridge_asset,
+        bridge_checksum=bridge_checksum,
+    )
+
+    assert not any(url.startswith("https://api.github.com/") for url in calls)
 
 
 def test_platform_cli_preverifies_and_passes_the_bridge_pair_to_every_journey(

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -115,12 +115,19 @@ only in the controller checkout cannot satisfy this gate.
 The formal macOS fleet controller takes that same asset pair explicitly and
 re-proves it against the immutable follow-up protocol before it creates its
 private run directory or starts a journey. The follow-up tag must be the exact
-public stable `dist/release/v*` tag that the foundation updater will deliver;
-the controller proves that the canonical public remote advertises that exact
-annotated tag object, then requires a non-draft, non-prerelease GitHub Release
-for the same version. It downloads the published bridge and checksum from that
-release and compares both byte-for-byte to the submitted pair. Neither a local
-tag nor a controller copy of the bridge can stand in for it.
+public stable `dist/release/v*` tag that the foundation updater will deliver.
+The controller first proves that the canonical public remote advertises that
+exact annotated tag object. It then makes an anonymous GET to GitHub's canonical
+`/davekilleen/Dex/releases/latest` route and accepts exactly one HTTPS redirect
+to the exact canonical `/davekilleen/Dex/releases/tag/v<version>` URL followed
+by HTTP 200. A missing or additional redirect, an off-host or non-HTTPS hop, any
+variation in host, repository, path, case, port, user information, query,
+fragment, encoding, prefix, suffix, or trailing slash, or an unavailable route
+fails closed. This proof uses no API token, local cache, retry-based acceptance,
+or HTML parsing. The controller then downloads the published bridge and
+checksum from that release and compares both byte-for-byte to the submitted
+pair. Neither a local tag nor a controller copy of the bridge can stand in for
+it.
 
 The first-party `historic-fleet-darwin` GitHub Actions workflow is the release
 operator for this gate. Its formal job is manual: after the updater change is

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -38,12 +38,12 @@ FIRST_PARTY_PLATFORM_JOBS = {
     "darwin": "historic-fleet-darwin",
 }
 MAX_PLATFORM_MANIFEST_BYTES = 16 * 1024 * 1024
-MAX_PUBLIC_RELEASE_METADATA_BYTES = 1024 * 1024
 MAX_PUBLIC_RELEASE_ASSET_BYTES = 16 * 1024 * 1024
 PLATFORM_MANIFEST_NAME = "platform-manifest.json"
 PLATFORM_RECEIPT_NAME = "platform-receipt.json"
 CANONICAL_PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
-CANONICAL_PUBLIC_RELEASE_API = "https://api.github.com/repos/davekilleen/Dex/releases/tags/v{version}"
+CANONICAL_PUBLIC_LATEST_RELEASE = "https://github.com/davekilleen/Dex/releases/latest"
+CANONICAL_PUBLIC_RELEASE_PAGE = "https://github.com/davekilleen/Dex/releases/tag/v{version}"
 CANONICAL_PUBLIC_RELEASE_DOWNLOAD = (
     "https://github.com/davekilleen/Dex/releases/download/v{version}/{name}"
 )
@@ -1015,6 +1015,57 @@ def _verify_public_follow_up_release(release: release_fleet.ImmutableRelease) ->
         )
 
 
+class _ExactStableReleaseRedirect(urllib.request.HTTPRedirectHandler):
+    """Allow exactly one canonical redirect to the expected stable tag page."""
+
+    def __init__(self, expected_url: str) -> None:
+        super().__init__()
+        self.expected_url = expected_url
+        self.redirects: list[str] = []
+
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        if (
+            request.full_url != CANONICAL_PUBLIC_LATEST_RELEASE
+            or self.redirects
+            or new_url != self.expected_url
+        ):
+            raise release_fleet.FleetError(
+                "follow-up is not the latest public stable GitHub release"
+            )
+        self.redirects.append(new_url)
+        return super().redirect_request(
+            request,
+            file_pointer,
+            code,
+            message,
+            headers,
+            new_url,
+        )
+
+
+def _verify_public_stable_release(release: release_fleet.ImmutableRelease) -> None:
+    """Prove the public latest-stable route resolves to this exact release."""
+
+    expected_url = CANONICAL_PUBLIC_RELEASE_PAGE.format(version=release.version)
+    redirect_handler = _ExactStableReleaseRedirect(expected_url)
+    opener = urllib.request.build_opener(redirect_handler)
+    request = urllib.request.Request(
+        CANONICAL_PUBLIC_LATEST_RELEASE,
+        headers={"User-Agent": "dex-release-fleet-acceptance"},
+    )
+    try:
+        with opener.open(request, timeout=30) as response:
+            final_url = response.geturl()
+            status = response.getcode()
+    except (OSError, urllib.error.URLError) as error:
+        raise release_fleet.FleetError("public stable GitHub release is unavailable") from error
+
+    if redirect_handler.redirects != [expected_url] or final_url != expected_url or status != 200:
+        raise release_fleet.FleetError(
+            "follow-up is not the latest public stable GitHub release"
+        )
+
+
 def _verify_public_bridge_release_asset(
     release: release_fleet.ImmutableRelease,
     *,
@@ -1023,22 +1074,7 @@ def _verify_public_bridge_release_asset(
 ) -> None:
     """Require the submitted pair to be byte-identical public stable release assets."""
 
-    metadata_bytes = _read_public_bytes(
-        CANONICAL_PUBLIC_RELEASE_API.format(version=release.version),
-        limit=MAX_PUBLIC_RELEASE_METADATA_BYTES,
-        context="stable GitHub release metadata",
-    )
-    try:
-        metadata = json.loads(metadata_bytes)
-    except json.JSONDecodeError as error:
-        raise release_fleet.FleetError("public stable GitHub release metadata is invalid") from error
-    if (
-        not isinstance(metadata, Mapping)
-        or metadata.get("tag_name") != f"v{release.version}"
-        or metadata.get("draft") is not False
-        or metadata.get("prerelease") is not False
-    ):
-        raise release_fleet.FleetError("follow-up is not a public stable GitHub release")
+    _verify_public_stable_release(release)
 
     for path in (bridge_asset, bridge_checksum):
         public_bytes = _read_public_bytes(


### PR DESCRIPTION
## Outcome

The formal Mac fleet no longer depends on the low unauthenticated GitHub API quota when proving that its public follow-up is stable.

## Safety boundary

- Require exactly one HTTPS redirect from the canonical public `/releases/latest` route to the exact canonical `v<version>` release URL.
- Require HTTP 200 after that redirect.
- Reject wrong hosts, schemes, repositories, paths, case, ports, userinfo, query strings, fragments, trailing slashes, encoding variants, prefixes, suffixes, missing redirects, extra redirects, and non-200 responses.
- Keep the anonymous exact annotated-tag proof and byte-identical public bridge/checksum proof unchanged.
- Use no token, local cache, retry-based acceptance, or HTML parsing.

## Root cause

Formal run `30789241346` downloaded the public bridge and checksum, then failed before any journey because the unauthenticated GitHub release-metadata API returned HTTP 403 `rate limit exceeded`.

## Verification

- Exact regression was red before the fix on the retained 403 pattern.
- 3 focused public-release, asset, and rate-limit tests pass.
- 148 updater/fleet control-plane tests pass. Four VPS-only platform/environment tests were deselected; CI supplies macOS and its Python environment.
- 163 script tests pass with the declared Python and dependency paths.
- Ruff passes.
- Generated journey protocol reran without drift.
- Live anonymous GET followed exactly one redirect to `https://github.com/davekilleen/Dex/releases/tag/v1.81.9` and returned HTTP 200.

This PR does not rerun the fleet, tag, publish, deploy, or touch credentials.
