### PR TITLE
release: v1.81.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.10] — 🛡️ Fleet proof no longer spends GitHub's shared API allowance (2026-08-03)
+
+The formal Mac fleet re-derived all 170 public starting cases, then GitHub refused
+the controller's unauthenticated release-metadata request because the shared public
+API allowance had been exhausted. The bridge and its checksum were already public
+and valid, but the gate correctly stopped before starting any journeys.
+
+**What this fixes for you:**
+
+* **Stable-release proof uses GitHub's public latest-release route.** The controller
+  requires one exact redirect to this version's canonical release page instead of
+  consuming the rate-limited metadata API.
+* **The updater assets remain independently verified.** Dex still downloads the
+  public bridge and checksum anonymously and requires their bytes to match the
+  submitted release artifacts exactly.
+* **Unexpected release routes still stop safely.** A missing redirect, extra hop,
+  different host, different version, query, fragment, or non-success response is
+  rejected before a historic installation starts.
+* **Fleet acceptance is still earned by journeys.** This release removes the
+  controller blocker; the freshly generated 170-case Mac run must still complete
+  before Dex claims historic two-hop acceptance.
+
 ## [1.81.9] — 🧹 Oldest Dex installs clear one dormant search registration (2026-08-03)
 
 The formal Mac fleet began with v1.20.1 and reached the public foundation with

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.9"
+  "release_version": "1.81.10"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.9",
+  "release_version": "1.81.10",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.9","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.10","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.9 release,
+Download the versioned bridge and its checksum from the public v1.81.10 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.9/dex-update-bridge-v1.81.9.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.10/dex-update-bridge-v1.81.10.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.9/dex-update-bridge-v1.81.9.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.10/dex-update-bridge-v1.81.10.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.9.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.10.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.9.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.9",
+  "version": "1.81.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.9",
+      "version": "1.81.10",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.9",
+  "version": "1.81.10",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Outcome

Prepares the minimal v1.81.10 follow-up release from exact merged main 261b34fcfe701d9068d9ff2a807ae42bad4761c1.

This release carries the formal-fleet controller fix from PR #373: public stable-release verification now uses one exact canonical GitHub latest-release redirect instead of the shared unauthenticated metadata API allowance. The public bridge and checksum remain anonymously downloaded and byte-verified, and hostile or unexpected redirect shapes still fail closed.

The freshly generated 170-case Mac two-hop acceptance run remains outstanding. This PR does not claim fleet acceptance, merge, tag, publish, deploy, or alter older tags.

## Release-only changes

- bump canonical package and lockfile version to 1.81.10
- stamp the release evidence, preservation transition, and lifecycle bridge metadata
- move rescue instructions to versioned v1.81.10 bridge URLs
- add an honest changelog entry that keeps 170-case acceptance pending
- regenerate System/.installed-files.manifest with repo tooling; it remained byte-identical at 1,302 tracked paths

## Verification

- exact base: 261b34fcfe701d9068d9ff2a807ae42bad4761c1
- release commit: 7f09cba0d019edf0e65362a0faf5ffe1e8ce7478
- update journey protocol generator: byte-identical
- installed-files manifest generator: 1,302 paths, byte-identical
- release dry-run: passed from the committed release branch
- release-shaped bundle: built; bundle and bridge SHA-256 checks passed
- release metadata focused tests: 3 passed
- broader release-focused Linux run: 159 passed; 3 macOS-only receipt tests refused Linux as designed
- script tests: 163 passed
- PII, founder content, portable contract, doc drift, test delta, distribution, architecture inventory, tracked-ignore, path consistency, connection contract, release-tag uniqueness, and historic-tag reachability gates: passed
- full PR CI and the Mac release canary remain required before merge
