### PR TITLE
fix(fleet): prove bounded public follow-up delivery

### DIFF
--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -14,6 +14,7 @@ import pytest
 from core.lifecycle import service
 from core.transaction.engine import PlanRejected
 from core.update import apply_update
+from core.utils import update_verifier
 from core.utils.update_verifier import legacy_profile_bytes
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -306,6 +307,32 @@ def test_delivery_previews_and_applies_only_the_exact_pinned_release(
     assert executed["receipt"]["transaction_id"]
     assert _git(brain, "rev-parse", "refs/dex/installed") == target_commit
     assert (vault / "README.md").read_bytes() == b"new brain\n"
+
+
+def test_default_delivery_budget_remains_ten_seconds_and_evidence_failure_is_not_retried(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    calls: list[float] = []
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        calls.append(wall_clock_seconds)
+        return {"status": "UNKNOWN", "reason": "evidence-invalid"}
+
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+
+    assert apply_update.deliver_latest_release(
+        vault,
+        state_root=tmp_path / "evidence-state",
+    ) == {
+        "status": "not-delivered",
+        "evidence": {"status": "UNKNOWN", "reason": "evidence-invalid"},
+    }
+    assert calls == [10.0]
 
 
 def test_delivered_release_refuses_any_preview_drift_before_writing(

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -134,8 +134,16 @@ def _foundation_topology_adapter(
     apply_update.portable_contract = ModuleType("test_portable_contract")
     apply_update.portable_contract.ContractViolation = RuntimeError
     apply_update.TreeEntry = tuple
+    apply_update.deliver_latest_release = lambda vault_root, **_kwargs: {
+        "status": "delivered",
+        "vault": str(vault_root),
+    }
 
     class Service:
+        @staticmethod
+        def _envelope(**values: object) -> dict[str, object]:
+            return {"api_version": "1.0.0", **values}
+
         def build_and_preview_topology_migration(self, vault_root: Path):
             state = engine.topology_state(vault_root)
             return {
@@ -1134,13 +1142,29 @@ def test_foundation_service_refuses_compatibility_preload_changed_after_verifica
         service.build_and_preview_topology_migration(vault)
 
 
-def test_foundation_service_exposes_release_delivery(tmp_path: Path) -> None:
+def test_foundation_service_exposes_enveloped_release_delivery_with_formal_budget(
+    tmp_path: Path,
+) -> None:
     service, _engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    calls: list[tuple[Path, dict[str, object]]] = []
+
+    def deliver(vault_root: Path, **kwargs: object) -> dict[str, object]:
+        calls.append((vault_root, kwargs))
+        return {
+            "status": "not-delivered",
+            "evidence": {"status": "UNKNOWN", "reason": "evidence-invalid"},
+        }
+
+    service._apply_update.deliver_latest_release = deliver
 
     assert service.deliver_latest_release(vault) == {
-        "status": "delivered",
-        "vault": str(vault),
+        "api_version": "1.0.0",
+        "status": "not-delivered",
+        "evidence": {"status": "UNKNOWN", "reason": "evidence-invalid"},
     }
+    assert calls == [
+        (vault, {"wall_clock_seconds": 60.0}),
+    ]
 
 
 def test_foundation_service_routes_only_explicit_test_delivery_to_local_cache(
@@ -1167,11 +1191,14 @@ def test_foundation_service_routes_only_explicit_test_delivery_to_local_cache(
             {
                 "remote_url": str(cache),
                 "allow_test_transport": True,
+                "wall_clock_seconds": 60.0,
             },
         )
     ]
     with pytest.raises(bridge.BridgeError, match="explicit local cache"):
         service.deliver_latest_release(vault, remote_url=str(cache))
+    with pytest.raises(bridge.BridgeError, match="explicit local cache"):
+        service.deliver_latest_release(vault, allow_test_transport=True)
 
 
 def test_foundation_service_reports_missing_engine_path_as_bridge_error(

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -124,6 +124,9 @@ class _Runtime:
             return {
                 "status": "unexpected: TOP-SECRET-NOT-FOR-DIAGNOSTICS",
                 "release": {"opaque": "TOP-SECRET-NOT-FOR-DIAGNOSTICS"},
+                "evidence": {
+                    "reason": "TOP-SECRET-NOT-FOR-DIAGNOSTICS",
+                },
             }
         return {"status": "delivered", "release": self.follow_up}
 
@@ -264,9 +267,48 @@ def test_failed_journey_retains_only_private_sanitized_diagnostic(
         }
     else:
         assert document["delivery"] == {
-            "status": "not-delivered",
+            "elapsed_ms": document["delivery"]["elapsed_ms"],
+            "failure_reason": "unclassified",
             "release_matches_expected": False,
+            "status": "not-delivered",
         }
+        assert isinstance(document["delivery"]["elapsed_ms"], int)
+        assert 0 <= document["delivery"]["elapsed_ms"] <= 900_000
+
+
+def test_failure_diagnostic_retains_only_allowlisted_delivery_reason(
+    tmp_path: Path,
+) -> None:
+    vault, _user_paths = _vault(tmp_path)
+    document = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={
+            "status": "not-delivered",
+            "evidence": {"reason": "evidence-invalid"},
+        },
+        delivery_elapsed_ms=1_000_000,
+    )
+
+    assert document["delivery"] == {
+        "elapsed_ms": 900_000,
+        "failure_reason": "evidence-invalid",
+        "release_matches_expected": False,
+        "status": "not-delivered",
+    }
+
+    unclassified = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={"status": "not-delivered", "evidence": {"reason": ["unsafe"]}},
+        delivery_elapsed_ms=-1,
+    )
+    assert unclassified["delivery"]["failure_reason"] == "unclassified"
+    assert unclassified["delivery"]["elapsed_ms"] == 0
 
 
 def test_failure_diagnostic_is_atomic_and_never_overwrites_existing_file(

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "e747892139a25137fa328f47e2e025d74eed7c86344bf26a01e9369a73d9e733",
+    "sha256": "ac25db8ebbc3f56e5a173ef9429ae16a31a0a834fa17f6a9327ca193f80182eb",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "90986a037e53db1dc238082fec559c5709bfd7899ad7cbd4290cfe2d8a5f3953",
+      "sha256": "a766b2d31e9f98036c9e5557f39080fe98453a409499c228f8e14db00579d295",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -29,6 +29,7 @@ from types import ModuleType
 from typing import Any, Callable, Iterator, Mapping, Protocol
 
 OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
+_FLEET_FOLLOW_UP_DELIVERY_WALL_CLOCK_SECONDS = 60.0
 _HEX = re.compile(r"^[0-9a-f]{40}$")
 _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$")
 _APPROVAL_WORD = "APPLY"
@@ -2273,8 +2274,14 @@ class _FoundationLifecycleService:
                 Path(vault_root),
                 remote_url=remote_url,
                 allow_test_transport=True,
+                wall_clock_seconds=_FLEET_FOLLOW_UP_DELIVERY_WALL_CLOCK_SECONDS,
             )
-        return self._service.deliver_latest_release(vault_root)
+        return self._service._envelope(
+            **self._apply_update.deliver_latest_release(
+                Path(vault_root),
+                wall_clock_seconds=_FLEET_FOLLOW_UP_DELIVERY_WALL_CLOCK_SECONDS,
+            )
+        )
 
     def build_and_preview_delivered_release(
         self,

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -54,6 +54,23 @@ _DECLARED_LIFECYCLE_OPERATIONS = frozenset(
         "execute_approved_delivered_release",
     }
 )
+_SAFE_DELIVERY_FAILURE_REASONS = frozenset(
+    {
+        "cancelled",
+        "channel-invalid",
+        "encoding-invalid",
+        "evidence-invalid",
+        "identity-malformed",
+        "io-error",
+        "network-unavailable",
+        "query-setup-invalid",
+        "state-write-failed",
+        "subprocess-failed",
+        "tag-object-mismatch",
+        "tag-object-moved",
+    }
+)
+_MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS = 900_000
 
 
 class ExecutorError(RuntimeError):
@@ -1299,6 +1316,7 @@ def _failure_diagnostic(
     follow_up: Mapping[str, str],
     doctor: Mapping[str, object] | None = None,
     delivery: Mapping[str, object] | None = None,
+    delivery_elapsed_ms: int | None = None,
 ) -> dict[str, object]:
     document: dict[str, object] = {
         "acceptance": False,
@@ -1312,11 +1330,23 @@ def _failure_diagnostic(
     if doctor is not None:
         document["doctor"] = _sanitized_doctor_report(doctor)
     if delivery is not None:
+        evidence = delivery.get("evidence")
+        reason = evidence.get("reason") if isinstance(evidence, Mapping) else None
         document["delivery"] = {
             "status": (
                 "delivered" if delivery.get("status") == "delivered" else "not-delivered"
             ),
             "release_matches_expected": delivery.get("release") == dict(follow_up),
+            "failure_reason": (
+                reason
+                if isinstance(reason, str)
+                and reason in _SAFE_DELIVERY_FAILURE_REASONS
+                else "unclassified"
+            ),
+            "elapsed_ms": min(
+                max(delivery_elapsed_ms or 0, 0),
+                _MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS,
+            ),
         }
     return document
 
@@ -1550,7 +1580,9 @@ def _execute_journey_with_runtime(
     if after_foundation != before:
         raise ExecutorError("user-owned content changed during foundation health proof")
 
+    delivery_started = time.monotonic_ns()
     delivered = dict(_runtime.deliver_latest_release(vault))
+    delivery_elapsed_ms = (time.monotonic_ns() - delivery_started) // 1_000_000
     if (
         delivered.get("status") != "delivered"
         or delivered.get("release") != follow_up
@@ -1564,6 +1596,7 @@ def _execute_journey_with_runtime(
                 foundation=foundation,
                 follow_up=follow_up,
                 delivery=delivered,
+                delivery_elapsed_ms=delivery_elapsed_ms,
             ),
         )
         raise ExecutorError("lifecycle delivery did not prove the requested follow-up release")


### PR DESCRIPTION
## Summary

- route historic fleet follow-up delivery through the verified updater rather than the foundation's retired bridge API
- retain exact release identity, explicit approval, and fail-closed evidence
- bound public delivery proof to 60 seconds and retain only safe failure diagnostics

## Verification

- `88 passed`: focused apply-update, bridge, and failure-diagnostic tests
- `141 passed, 4 deselected`: Linux-capable fleet, acceptance, executor, and rollback tests
- macOS-only acceptance checks are intentionally left to the required PR canary

## Fleet status

The prior retained formal run stopped at v1.53.0 because the second-hop delivery invoked the safe retired API from v1.81.0. This PR fixes that runner defect but does not claim fleet acceptance; the retained macOS canary and fresh 170-case formal run remain required.