### PR TITLE
fix(release): keep rescue bridge version current

### DIFF
--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -846,6 +846,13 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
         capture_output=True,
         text=True,
     ).stdout
+    rescue = subprocess.run(
+        ["git", "show", "HEAD:docs/UPDATE-RESCUE.md"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
     assert package["version"] == bumped
     assert profile == {"profile": "legacy-v1", "release_version": bumped, "schema_version": 1}
     assert transition == {
@@ -855,6 +862,13 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
         "release_version": bumped,
     }
     assert f"---\n\n## [{bumped}] — (" in changelog
+    bridge_name = f"dex-update-bridge-v{bumped}.py"
+    assert (
+        f"https://github.com/davekilleen/Dex/releases/download/v{bumped}/{bridge_name}"
+        in rescue
+    )
+    assert f'shasum -a 256 -c "{bridge_name}.sha256"' in rescue
+    assert f'python3 "$BRIDGE_DIR/{bridge_name}" --vault "$PWD"' in rescue
     assert "System/.release-evidence-profile.json" in _release_manifest(clone, "HEAD")
     assert subprocess.run(
         ["git", "rev-parse", f"v{bumped}^{{}}"], cwd=clone, check=True, capture_output=True, text=True

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.10 release,
+Download the versioned bridge and its checksum from the public v1.81.11 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.10/dex-update-bridge-v1.81.10.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.11/dex-update-bridge-v1.81.11.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.11.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.10/dex-update-bridge-v1.81.10.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.11/dex-update-bridge-v1.81.11.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.11.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.10.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.11.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.10.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.11.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -125,6 +125,27 @@ else:
     raise SystemExit("Error: CHANGELOG.md has no preamble separator")
 CHANGELOG
 
+# --- Advance the versioned update-rescue bridge --------------------------------
+
+# The rescue instructions name the released bridge itself, so they must move with
+# every release. Refuse to cut a release if the guide is already out of sync:
+# publishing another tag would otherwise leave a broken public recovery command.
+python3 - "$CURRENT_VERSION" "$NEW_VERSION" <<'UPDATE_RESCUE'
+from pathlib import Path
+import sys
+
+current_version, new_version = sys.argv[1:]
+path = Path("docs/UPDATE-RESCUE.md")
+text = path.read_text(encoding="utf-8")
+current_marker = f"v{current_version}"
+if current_marker not in text:
+    raise SystemExit(
+        f"Error: {path} does not name the current public bridge {current_marker}; "
+        "repair the rescue guide before cutting another release"
+    )
+path.write_text(text.replace(current_marker, f"v{new_version}"), encoding="utf-8")
+UPDATE_RESCUE
+
 # --- Generate installed-files manifest -----------------------------------------
 
 python3 core/utils/update_verifier.py \
@@ -145,7 +166,7 @@ bash scripts/generate-manifest.sh
 
 # --- Commit, tag, push --------------------------------------------------------
 
-git add package.json package-lock.json CHANGELOG.md \
+git add package.json package-lock.json CHANGELOG.md docs/UPDATE-RESCUE.md \
   core/lifecycle/catalog/bridge-release.json \
   System/.release-evidence-profile.json \
   System/.local-only-preservation-transition.json \


### PR DESCRIPTION
Why: the v1.81.11 release check exposed an out-of-date rescue bridge command. This updates the current guide and makes scripts/release.sh advance the bridge version with each release, refusing a stale guide before publication.

Verification: git diff --check; bash -n scripts/release.sh; end-to-end patch release in a disposable local clone, producing matching v1.81.12 rescue URLs, checksum, and command. CI runs the permanent regression test.

No release is published by this PR.