### PR TITLE
fix(updater): preserve v1.63 user profiles

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run five release-shaped macOS journeys
+      - name: Run six release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -49,12 +49,12 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_five_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run five release-shaped macOS journeys"
+        step.get("name") == "Run six release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -62,14 +62,24 @@ def test_five_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         for step in canary["steps"]
     )
     source = RUNNER_PATH.read_text(encoding="utf-8")
-    for start in (
+    canary_block = re.search(
+        r'^CANARY_STARTS=\(\n(?P<body>(?:  "[^"]+"\n)+)\)$',
+        source,
+        re.MULTILINE,
+    )
+    assert canary_block is not None
+    canary_starts = tuple(
+        re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
+    )
+    assert len(canary_starts) == 6
+    assert canary_starts == (
         "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
         "dist/archive/v1.61.0-1ec1387",
         "v1.62.0",
+        "dist/archive/v1.63.0-08ce719",
         "dist/archive/v1.65.0-c5ec161",
-    ):
-        assert source.count(f'  "{start}"') == 1
+    )
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source
     assert source.count("--controlled-approvals") == 1

--- a/core/tests/test_update_bridge_historic_compatibility.py
+++ b/core/tests/test_update_bridge_historic_compatibility.py
@@ -634,6 +634,55 @@ console.log(crypto.createHash('sha256').update(policy).digest('hex'));
     )
 
 
+def _native_topology_command_adapter(
+    tmp_path: Path,
+) -> tuple[bridge._FoundationLifecycleService, ModuleType]:
+    """Bind the bridge around the real native and fixed foundation migrators."""
+
+    source = tmp_path / "foundation-native-source"
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--quiet",
+            "--shared",
+            "--no-checkout",
+            str(Path(__file__).resolve().parents[2]),
+            str(source),
+        ],
+        check=True,
+    )
+    _git(source, "checkout", "--quiet", "--detach", bridge.FOUNDATION.commit)
+
+    engine = ModuleType("native_topology_engine")
+    engine.TOPOLOGY_MIGRATOR_RELATIVE = bridge._TOPOLOGY_MIGRATOR_RELATIVE
+    engine.topology_state = lambda _root: "combined"
+
+    def native_command(vault_root: Path, mode: str) -> list[str]:
+        node = bridge._trusted_executable("node")
+        assert node is not None
+        return [
+            str(node),
+            str((Path(vault_root) / bridge._TOPOLOGY_MIGRATOR_RELATIVE).resolve()),
+            mode,
+        ]
+
+    engine._migrator_command = native_command
+
+    class TopologyService:
+        pass
+
+    return (
+        bridge._FoundationLifecycleService(
+            TopologyService(),
+            engine,
+            apply_update,
+            source,
+        ),
+        engine,
+    )
+
+
 def _commit_nonregular_variant(repository: Path, base: str, mode: str, name: str) -> tuple[str, str]:
     _git(repository, "checkout", "--quiet", "--detach", "--force", base)
     if mode == "120000":
@@ -1128,6 +1177,41 @@ def test_runtime_schema_v2_policy_remains_the_exact_existing_input(
     )
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == pin.inputs.policy_sha256
+
+
+@pytest.mark.parametrize("release_tag", tuple(_NATIVE_MIGRATOR_TRANSPORT))
+def test_native_transport_preserves_the_exact_customer_profile_bytes(
+    tmp_path: Path,
+    release_tag: str,
+) -> None:
+    pin = next(
+        pin
+        for pin in bridge.NATIVE_MIGRATOR_TRANSPORT_RELEASES
+        if pin.tag == release_tag
+    )
+    repository = _historic_checkout(tmp_path, pin)
+    _git(repository, "update-ref", "refs/heads/release", bridge.FOUNDATION.commit)
+    adapter, engine = _native_topology_command_adapter(tmp_path)
+    profile = repository / "System" / "user-profile.yaml"
+    original_profile = profile.read_bytes()
+    original_sha256 = hashlib.sha256(original_profile).hexdigest()
+
+    with adapter._topology_source():
+        assert engine.topology_state(repository) == "combined"
+        command = engine._migrator_command(repository, "--auto")
+
+    completed = subprocess.run(
+        command,
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=bridge._bridge_environment(),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert profile.read_bytes() == original_profile
+    assert hashlib.sha256(profile.read_bytes()).hexdigest() == original_sha256
 
 
 @pytest.mark.parametrize("mode", ("--dry-run", "--auto"))

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "b8ff2d00e80f8e6f2bdae9b2ae3ac2cb4a9364f3dac724332b83c2df56a755aa",
+      "sha256": "596ba0dbdc9d0d8897623fde63f6d01a3edd325b0e767baac0ae50d5b13094a7",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1771,10 +1771,12 @@ class _FoundationLifecycleService:
     """Bind a verified foundation migrator to one legacy lifecycle call.
 
     The foundation service normally launches the migrator shipped inside the
-    vault. v1.20.1 predates that file. For only that exact immutable base, this
-    adapter lets the same lifecycle preview/approval/execute path launch the
-    migrator from the already-verified disposable foundation checkout. No
-    bridge file is copied into the vault and unknown layouts stay fail-closed.
+    vault. v1.20.1 predates that file, while four exact v1.63 release trees
+    shipped a migrator that rewrites a user-owned profile. For only those exact
+    immutable bases, this adapter lets the same lifecycle
+    preview/approval/execute path launch the migrator from the already-verified
+    disposable foundation checkout. No bridge file is copied into the vault
+    and unknown layouts stay fail-closed.
     """
 
     def __init__(
@@ -1961,7 +1963,7 @@ class _FoundationLifecycleService:
                 command[0],
                 "--require",
                 str(self._transport_preload),
-                command[1],
+                str(self._migrator),
                 command[2],
             ]
 

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -12,6 +12,7 @@ CANARY_STARTS=(
   "dist/release/v1.61.0-dc7d332"
   "dist/archive/v1.61.0-1ec1387"
   "v1.62.0"
+  "dist/archive/v1.63.0-08ce719"
   "dist/archive/v1.65.0-c5ec161"
 )
 


### PR DESCRIPTION
## Outcome

The four exact v1.63 release trees that shipped the defective native topology migrator now execute the already-verified v1.81.0 foundation migrator through the same lifecycle approval path. Their exact installed-release, migrator, policy, transition, trusted Node, and file-only transport checks remain in force.

Unknown, altered, modern, and nearby releases remain fail-closed. The bridge does not intercept writes or copy compatibility code into the customer vault.

## TDD proof

Red on current main:
- all 4 exact NATIVE_MIGRATOR_TRANSPORT_RELEASES completed the real native --auto migration
- all 4 changed System/user-profile.yaml by appending vault_schema: 1

Green after this patch:
- all 4 complete the real fixed foundation migration
- exact customer profile bytes and SHA-256 remain unchanged

## Verification

- 346 passed — full historic bridge compatibility contract
- 56 passed — bridge behavior suite
- 6 passed — generated journey protocol suite
- 36 passed — release fleet executor suite
- 163 passed — Node script suite with the declared Python runtime
- Ruff clean on the two changed Python files
- Python compilation clean
- regenerated journey protocol byte-matches a fresh generator output
- git diff --check clean

This PR deliberately does not merge, tag, publish, release, or claim fleet acceptance.
