### PR TITLE
release: v1.81.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.13] — 🧷 v1.63 updates keep your saved profile intact (2026-08-03)
+
+The formal historic Mac fleet reached an exact v1.63 installation, then stopped
+because that release's built-in split helper rewrote its saved user profile while
+entering the protected update foundation. Dex's preservation guard caught the
+change and refused to continue, so no unsafe result was accepted.
+
+**What this fixes for you:**
+
+* **Exact affected v1.63 releases use the verified foundation migrator.** The
+  updater replaces only the known faulty helper for four immutable historic
+  release identities; unfamiliar or altered installations still stop safely.
+* **Your profile and other protected content remain byte-for-byte unchanged.** A
+  retained macOS canary proved the saved profile, notes, tasks, and custom skill
+  survive both update hops exactly.
+* **Fleet acceptance still requires the complete public run.** This release fixes
+  the v1.63 blocker, but Dex will not claim every historic release is upgradeable
+  until a fresh retained 170-case Mac run completes with zero failures.
+
 ## [1.81.12] — (2026-08-03)
 
 ## [1.81.11] — (2026-08-03)

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.12"
+  "release_version": "1.81.13"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.12",
+  "release_version": "1.81.13",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.12","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.13","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.12 release,
+Download the versioned bridge and its checksum from the public v1.81.13 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.12/dex-update-bridge-v1.81.12.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.12/dex-update-bridge-v1.81.12.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.12.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.13.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.12",
+  "version": "1.81.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.12",
+  "version": "1.81.13",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- publish the verified v1.63 profile-preservation repair as v1.81.13
- retain exact Mac canary coverage for the affected historic v1.63 release
- keep universal historic-fleet acceptance explicitly pending the fresh public 170-case run

## Verification before PR
- PR #383 CI and six-case macOS canary green
- v1.63 protected profile, notes, tasks, and custom skill hashes unchanged across both hops
- distribution verification: 0 errors
- release-tag reachability and uniqueness gates green after exact archive retention

## Release hold
This PR prepares the release candidate only. Do not publish or claim the Historic Mac Fleet closed until the public v1.81.13 assets exist and a fresh retained macOS run records 170 discovered, 170 started, 170 completed, 170 passed, 0 failed.