### PR TITLE
release: v1.81.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.13] — 🛡️ v1.63 upgrades preserve your profile (2026-08-03)
+
+The formal Mac fleet reached one exact v1.63 package whose original migrator
+tried to add release metadata to `System/user-profile.yaml`. That file belongs
+to the person, so Dex stopped before accepting the update rather than silently
+changing it.
+
+**What this fixes for you:**
+
+* **Known v1.63 packages use the corrected migration path.** The four exact
+  immutable v1.63 release identities now run the verified foundation migrator
+  instead of their older embedded copy.
+* **Your profile remains your file.** The exact failed package completed both
+  update hops with its profile, tasks, inbox note, and customised weekly-review
+  skill byte-for-byte unchanged.
+* **Unknown installs still stop safely.** The compatibility route remains closed
+  to the four published identities; altered or unfamiliar packages do not gain
+  a broader exception.
+* **Fleet acceptance is still earned by journeys.** The release-shaped six-case
+  Mac canary passed, including the exact v1.63 failure, but the freshly generated
+  170-case public fleet must restart and finish before Dex claims full historic
+  support.
+
 ## [1.81.12] — (2026-08-03)
 
 ## [1.81.11] — (2026-08-03)

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.12"
+  "release_version": "1.81.13"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.12",
+  "release_version": "1.81.13",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.12","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.13","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.12 release,
+Download the versioned bridge and its checksum from the public v1.81.13 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.12/dex-update-bridge-v1.81.12.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.12/dex-update-bridge-v1.81.12.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.12.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.13.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.12.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.12",
+  "version": "1.81.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.10",
+      "version": "1.81.13",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.12",
+  "version": "1.81.13",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Outcome

Prepares v1.81.13 so the exact v1.63 profile-preservation repair in PR #383 can reach the public updater route without changing the immutable v1.81.12 release.

## User impact

- routes only the four exact published v1.63 identities through the corrected foundation migrator
- keeps `System/user-profile.yaml` and the other protected canary files byte-for-byte unchanged
- advances the versioned rescue bridge to v1.81.13
- makes no full-fleet acceptance claim before the fresh 170-case public Mac run completes

## Release preparation

- package and both package-lock root versions: `1.81.13`
- CHANGELOG entry in house voice
- UPDATE-RESCUE bridge URLs: `v1.81.13`
- regenerated release evidence/profile and local-only transition
- bridge release metadata: `1.81.13`
- installed-files manifest regenerated with no byte change

## Evidence

- PR #383 Mac canary run 30835166016: 6 discovered, 6 started, 6 completed, 6 passed, 0 failed
- exact `dist/archive/v1.63.0-08ce719` reached both hops; both Doctors healthy; protected profile SHA-256 remained `0a0392ee54ac35e4538c631747c005ab5408f13883e60a1fbbe23bf33c96722b`
- update journey protocol regeneration comparison passed
- installed-files manifest validation passed (1,302 paths)
- release metadata alignment passed
- release-tag uniqueness and prepublication reachability gates passed
- distribution release dry-run passed against exact source `f1320c3`

## Publication boundary

This PR does not merge, tag, publish, deploy, alter v1.81.12, or claim fleet acceptance. After green CI and merge, the release lane must verify the one immutable `dist/release/v1.81.13-*` tag, semantic release, exactly four anonymous assets and checksums, latest-release redirect, then start a fresh 170-case public Mac fleet.
