### PR TITLE
fix(release): keep package lock versions aligned

### DIFF
--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -801,7 +801,7 @@ def test_raw_vault_bundle_rejects_dirty_protocol_inputs_not_in_source_commit(
     assert not sentinel.exists()
 
 
-def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -> None:
+def test_release_script_synchronizes_all_bumped_version_metadata(tmp_path: Path) -> None:
     clone = _clone_repo(tmp_path, "release-script-profile")
     _sync_release_inputs(clone)
     for relative_path in (
@@ -837,6 +837,7 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
     )
 
     package = _git_json(clone, "HEAD:package.json")
+    package_lock = _git_json(clone, "HEAD:package-lock.json")
     profile = _git_json(clone, "HEAD:System/.release-evidence-profile.json")
     transition = _git_json(clone, "HEAD:System/.local-only-preservation-transition.json")
     changelog = subprocess.run(
@@ -854,6 +855,8 @@ def test_release_script_regenerates_profile_for_bumped_version(tmp_path: Path) -
         text=True,
     ).stdout
     assert package["version"] == bumped
+    assert package_lock["version"] == bumped
+    assert package_lock["packages"][""]["version"] == bumped
     assert profile == {"profile": "legacy-v1", "release_version": bumped, "schema_version": 1}
     assert transition == {
         "schema_version": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.10",
+      "version": "1.81.13",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -102,8 +102,17 @@ rm -f package.json.bak
 
 # Keep package-lock.json in sync (if it exists)
 if [ -f package-lock.json ]; then
-  sed -i.bak "0,/\"version\": \"${CURRENT_VERSION}\"/s/\"version\": \"${CURRENT_VERSION}\"/\"version\": \"${NEW_VERSION}\"/" package-lock.json
-  rm -f package-lock.json.bak
+  python3 - "$NEW_VERSION" <<'LOCK'
+import json
+from pathlib import Path
+import sys
+
+path = Path("package-lock.json")
+document = json.loads(path.read_text(encoding="utf-8"))
+document["version"] = sys.argv[1]
+document["packages"][""]["version"] = sys.argv[1]
+path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+LOCK
 fi
 
 # --- Insert CHANGELOG header --------------------------------------------------


### PR DESCRIPTION
## Outcome

Keeps both npm lockfile version fields aligned with package.json during every future Dex release, and corrects the one stale inner field left on main after v1.81.13.

## Why

The release script updated only the first top-level version in package-lock.json. Its packages[""] root metadata remained at v1.81.10 even after package.json and the lockfile top-level version reached v1.81.13. npm repairs that one line automatically, but it creates avoidable local drift and the existing release regression did not detect it.

## Changes

- align the current package-lock root metadata to v1.81.13
- update scripts/release.sh to write both lockfile version fields deterministically
- extend the real release-script regression to assert package.json plus both lockfile versions
- preserve the already-published v1.81.13 CHANGELOG wording from PR #384

## Verification

- red proof: the expanded regression failed with packages[""].version = 1.81.10 instead of the expected 1.81.14
- green proof: 2 focused release tests passed
- Ruff passed
- bash syntax passed
- final version contract: package.json = package-lock top-level = package-lock packages[""] = 1.81.13
- git diff check passed

## Publication boundary

This is a maintenance follow-up to merged PR #384 and supersedes duplicate release PR #385. It does not change package.json, CHANGELOG, any published tag, release asset, release branch, or updater route. v1.81.13 remains immutable.