### PR TITLE
test(updater): isolate v1.76 follow-up failure

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run six release-shaped macOS journeys
+      - name: Run five release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -49,12 +49,12 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_five_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run six release-shaped macOS journeys"
+        step.get("name") == "Run five release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -71,14 +71,13 @@ def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     canary_starts = tuple(
         re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
     )
-    assert len(canary_starts) == 6
+    assert len(canary_starts) == 5
     assert canary_starts == (
-        "v1.51.0",
-        "dist/release/v1.61.0-dc7d332",
-        "dist/archive/v1.61.0-1ec1387",
-        "v1.62.0",
-        "dist/archive/v1.63.0-08ce719",
-        "dist/archive/v1.65.0-c5ec161",
+        "v1.75.2",
+        "dist/archive/v1.76.0-d0bb932",
+        "dist/archive/v1.76.0-f482229",
+        "dist/release/v1.76.0-be28050",
+        "v1.76.0",
     )
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -8,12 +8,11 @@ CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
 PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
 CANARY_STARTS=(
-  "v1.51.0"
-  "dist/release/v1.61.0-dc7d332"
-  "dist/archive/v1.61.0-1ec1387"
-  "v1.62.0"
-  "dist/archive/v1.63.0-08ce719"
-  "dist/archive/v1.65.0-c5ec161"
+  "v1.75.2"
+  "dist/archive/v1.76.0-d0bb932"
+  "dist/archive/v1.76.0-f482229"
+  "dist/release/v1.76.0-be28050"
+  "v1.76.0"
 )
 
 MODE="${1:-}"


### PR DESCRIPTION
## Purpose
Run the smallest release-shaped Mac slice around the sole attempt-2 fleet failure before inventing a compatibility exception.

## Exact cases
- `v1.75.2` predecessor boundary
- `dist/archive/v1.76.0-d0bb932` passing neighbour
- `dist/archive/v1.76.0-f482229` exact failure
- `dist/release/v1.76.0-be28050` strongest near-match / next unreached
- `v1.76.0` semantic boundary

## Safety
This PR changes only the non-publishing PR canary and its static contract. It does not alter updater production code, public tags, releases, or the formal cohort. If all five pass, the prior generic `evidence-invalid` result is treated as transient and no historic pin is added.

## Local checks
- all four static workflow contract functions passed
- Bash syntax passed
- Python compilation passed
- `git diff --check` passed

Formal attempt 2 evidence: 170 discovered / 133 started / 132 completed / 132 passed / 1 failed at exact `f482229`; 132 successful journeys and 1,056 artifact hashes independently verified.