### PR TITLE
fix(update): retry final offline fetch once

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run six release-shaped macOS journeys
+      - name: Run seven release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -215,6 +215,14 @@ def _stub_latest_identity(
     return evidence
 
 
+def _visible_vault_content(root: Path) -> dict[str, bytes]:
+    return {
+        candidate.relative_to(root).as_posix(): candidate.read_bytes()
+        for candidate in root.rglob("*")
+        if candidate.is_file() and candidate.relative_to(root).parts[0] not in {".dex", ".git"}
+    }
+
+
 def _retarget_release(
     fixture: dict[str, object],
     relative: str,
@@ -361,15 +369,19 @@ def test_default_delivery_budget_remains_ten_seconds_and_evidence_failure_is_not
         return {"status": "UNKNOWN", "reason": "evidence-invalid"}
 
     monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+    runner = _ScriptedDeliveryFetch(())
 
     assert apply_update.deliver_latest_release(
         vault,
         state_root=tmp_path / "evidence-state",
+        git_runner=runner,
     ) == {
         "status": "not-delivered",
         "evidence": {"status": "UNKNOWN", "reason": "evidence-invalid"},
     }
     assert calls == [10.0]
+    assert runner.calls == []
+    assert runner.budgets == []
 
 
 def test_final_delivery_fetch_retries_one_transient_offline_failure_with_fresh_budget(
@@ -415,13 +427,7 @@ def test_final_delivery_fetch_stops_after_two_offline_attempts_without_vault_mut
 ) -> None:
     vault = split_release_fixture["vault"]
     _stub_latest_identity(split_release_fixture, monkeypatch)
-    protected_paths = (
-        "README.md",
-        "03-Tasks/Tasks.md",
-        "04-Projects/private.md",
-        "System/user-profile.yaml",
-    )
-    before = {relative: (vault / relative).read_bytes() for relative in protected_paths}
+    before = _visible_vault_content(vault)
     sleeps: list[float] = []
     monkeypatch.setattr(apply_update.time, "sleep", sleeps.append)
     runner = _ScriptedDeliveryFetch(
@@ -446,13 +452,15 @@ def test_final_delivery_fetch_stops_after_two_offline_attempts_without_vault_mut
     assert runner.calls[0] == runner.calls[1]
     assert len(runner.budgets) == 2
     assert runner.budgets[0] is not runner.budgets[1]
-    assert runner.budgets[1].deadline == runner.budgets[0].deadline
+    assert runner.budgets[1].deadline > runner.budgets[0].deadline
     assert all(
-        0 < budget.deadline - apply_update.time.monotonic() <= apply_update.FINAL_FETCH_BUDGET_SECONDS
+        0
+        < budget.deadline - apply_update.time.monotonic()
+        <= apply_update.FINAL_FETCH_ATTEMPT_BUDGET_SECONDS
         for budget in runner.budgets
     )
     assert sleeps == [apply_update.FINAL_FETCH_RETRY_BACKOFF_SECONDS]
-    assert {relative: (vault / relative).read_bytes() for relative in protected_paths} == before
+    assert _visible_vault_content(vault) == before
 
 
 def test_final_delivery_fetch_does_not_retry_evidence_failure(
@@ -468,6 +476,76 @@ def test_final_delivery_fetch_does_not_retry_evidence_failure(
     )
 
     with pytest.raises(update_verifier.EvidenceError, match="release identity contradicted"):
+        apply_update.deliver_latest_release(
+            split_release_fixture["vault"],
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+        )
+
+    assert len(runner.calls) == 1
+    assert len(runner.budgets) == 1
+    assert sleeps == []
+
+
+def test_final_delivery_does_not_fetch_when_origin_verification_fails(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_latest_identity(split_release_fixture, monkeypatch)
+    _git(
+        split_release_fixture["brain"],
+        "remote",
+        "set-url",
+        "origin",
+        "https://example.com/not-dex.git",
+    )
+    runner = _ScriptedDeliveryFetch((None,))
+
+    with pytest.raises(apply_update.ReleaseVerificationError, match="official Dex repository"):
+        apply_update.deliver_latest_release(
+            split_release_fixture["vault"],
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+        )
+
+    assert runner.calls == []
+    assert runner.budgets == []
+
+
+def test_final_delivery_does_not_fetch_when_topology_verification_fails(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    _stub_latest_identity(split_release_fixture, monkeypatch)
+    _write(vault, "System/.dex/topology.json", b"{}\n")
+    runner = _ScriptedDeliveryFetch((None,))
+
+    with pytest.raises(apply_update.UpdateError, match="topology is incomplete"):
+        apply_update.deliver_latest_release(
+            vault,
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+        )
+
+    assert runner.calls == []
+    assert runner.budgets == []
+
+
+def test_final_delivery_does_not_retry_post_fetch_identity_failure(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = _stub_latest_identity(split_release_fixture, monkeypatch)
+    evidence["tag_object"] = "0" * 40
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update.time, "sleep", sleeps.append)
+    runner = _ScriptedDeliveryFetch((None,))
+
+    with pytest.raises(apply_update.ReleaseVerificationError, match="tag object"):
         apply_update.deliver_latest_release(
             split_release_fixture["vault"],
             state_root=tmp_path / "evidence-state",

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -178,6 +178,43 @@ def _verified(fixture: dict[str, object]) -> apply_update.VerifiedReleaseRef:
     )
 
 
+class _ScriptedDeliveryFetch:
+    def __init__(self, outcomes: tuple[BaseException | None, ...]) -> None:
+        self.outcomes = outcomes
+        self.calls: list[tuple[Path, tuple[str, ...], dict[str, object]]] = []
+        self.budgets: list[update_verifier.ExecutionBudget] = []
+
+    def use_budget(self, budget: update_verifier.ExecutionBudget) -> None:
+        self.budgets.append(budget)
+
+    def run(self, git_dir: Path, *arguments: str, **kwargs: object) -> bytes:
+        self.calls.append((git_dir, arguments, kwargs))
+        outcome = self.outcomes[len(self.calls) - 1]
+        if outcome is not None:
+            raise outcome
+        return b""
+
+
+def _stub_latest_identity(
+    fixture: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, object]:
+    tag, tag_object, commit, tree = fixture["target"]
+    evidence = {
+        "status": update_verifier.STATUS_IDENTITY,
+        "tag": tag,
+        "tag_object": tag_object,
+        "commit": commit,
+        "tree": tree,
+    }
+    monkeypatch.setattr(
+        update_verifier,
+        "prove_latest_release",
+        lambda *_args, **_kwargs: evidence,
+    )
+    return evidence
+
+
 def _retarget_release(
     fixture: dict[str, object],
     relative: str,
@@ -333,6 +370,113 @@ def test_default_delivery_budget_remains_ten_seconds_and_evidence_failure_is_not
         "evidence": {"status": "UNKNOWN", "reason": "evidence-invalid"},
     }
     assert calls == [10.0]
+
+
+def test_final_delivery_fetch_retries_one_transient_offline_failure_with_fresh_budget(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = _stub_latest_identity(split_release_fixture, monkeypatch)
+    runner = _ScriptedDeliveryFetch(
+        (update_verifier.OfflineError("temporary network loss"), None)
+    )
+
+    result = apply_update.deliver_latest_release(
+        split_release_fixture["vault"],
+        state_root=tmp_path / "evidence-state",
+        git_runner=runner,
+    )
+
+    assert result["status"] == "delivered"
+    assert result["release"] == {
+        "tag": evidence["tag"],
+        "tag_object": evidence["tag_object"],
+        "commit": evidence["commit"],
+        "tree": evidence["tree"],
+        "version": "1.64.0",
+        "channel": "stable",
+    }
+    assert len(runner.calls) == 2
+    assert runner.calls[0] == runner.calls[1]
+    assert runner.calls[0][1][-2:] == (
+        f"refs/tags/{evidence['tag']}:refs/tags/{evidence['tag']}",
+        "+refs/heads/release:refs/remotes/upstream/release",
+    )
+    assert runner.calls[0][2] == {"network": True, "max_output_bytes": 1024}
+    assert len(runner.budgets) == 2
+    assert runner.budgets[0] is not runner.budgets[1]
+
+
+def test_final_delivery_fetch_stops_after_two_offline_attempts_without_vault_mutation(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    _stub_latest_identity(split_release_fixture, monkeypatch)
+    protected_paths = (
+        "README.md",
+        "03-Tasks/Tasks.md",
+        "04-Projects/private.md",
+        "System/user-profile.yaml",
+    )
+    before = {relative: (vault / relative).read_bytes() for relative in protected_paths}
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update.time, "sleep", sleeps.append)
+    runner = _ScriptedDeliveryFetch(
+        (
+            update_verifier.OfflineError("first untrusted detail"),
+            update_verifier.OfflineError("second untrusted detail"),
+        )
+    )
+
+    with pytest.raises(
+        update_verifier.OfflineError,
+        match="^final release delivery fetch was unavailable after attempt 2$",
+    ):
+        apply_update.deliver_latest_release(
+            vault,
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+            wall_clock_seconds=60.0,
+        )
+
+    assert len(runner.calls) == 2
+    assert runner.calls[0] == runner.calls[1]
+    assert len(runner.budgets) == 2
+    assert runner.budgets[0] is not runner.budgets[1]
+    assert runner.budgets[1].deadline == runner.budgets[0].deadline
+    assert all(
+        0 < budget.deadline - apply_update.time.monotonic() <= apply_update.FINAL_FETCH_BUDGET_SECONDS
+        for budget in runner.budgets
+    )
+    assert sleeps == [apply_update.FINAL_FETCH_RETRY_BACKOFF_SECONDS]
+    assert {relative: (vault / relative).read_bytes() for relative in protected_paths} == before
+
+
+def test_final_delivery_fetch_does_not_retry_evidence_failure(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_latest_identity(split_release_fixture, monkeypatch)
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update.time, "sleep", sleeps.append)
+    runner = _ScriptedDeliveryFetch(
+        (update_verifier.EvidenceError("release identity contradicted"),)
+    )
+
+    with pytest.raises(update_verifier.EvidenceError, match="release identity contradicted"):
+        apply_update.deliver_latest_release(
+            split_release_fixture["vault"],
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+        )
+
+    assert len(runner.calls) == 1
+    assert len(runner.budgets) == 1
+    assert sleeps == []
 
 
 def test_delivered_release_refuses_any_preview_drift_before_writing(

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -49,12 +49,12 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run six release-shaped macOS journeys"
+        step.get("name") == "Run seven release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -71,7 +71,7 @@ def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     canary_starts = tuple(
         re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
     )
-    assert len(canary_starts) == 6
+    assert len(canary_starts) == 7
     assert canary_starts == (
         "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
@@ -79,6 +79,7 @@ def test_six_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         "v1.62.0",
         "dist/archive/v1.63.0-08ce719",
         "dist/archive/v1.65.0-c5ec161",
+        "dist/archive/v1.76.0-d0bb932",
     )
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import os
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -38,6 +39,8 @@ RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,64})$"
 )
+FINAL_FETCH_BUDGET_SECONDS = 10.0
+FINAL_FETCH_RETRY_BACKOFF_SECONDS = 0.1
 START_MARKER = re.compile(
     rb"^## USER_EXTENSIONS_START[^\r\n]*(?:\r?\n|$)",
     re.MULTILINE,
@@ -570,7 +573,9 @@ def deliver_latest_release(
     from core.utils.update_verifier import (
         CANONICAL_REMOTE_URL,
         STATUS_IDENTITY,
+        ExecutionBudget,
         GitRunner,
+        OfflineError,
         prove_latest_release,
     )
 
@@ -601,22 +606,37 @@ def deliver_latest_release(
     branch = release_channel.release_branch(channel)
     if branch is None:
         return {"status": "not-delivered", "evidence": {"status": "UNKNOWN", "reason": "channel-invalid"}}
-    transport = git_runner or GitRunner(
-        allowed_protocol="file" if allow_test_transport else "https"
+    transport = git_runner or GitRunner(allowed_protocol="file" if allow_test_transport else "https")
+    final_fetch_deadline = time.monotonic() + max(
+        0.0,
+        min(wall_clock_seconds, FINAL_FETCH_BUDGET_SECONDS),
     )
-    transport.run(
-        brain_git,
-        "fetch",
-        "--quiet",
-        "--no-tags",
-        "--no-write-fetch-head",
-        "--no-recurse-submodules",
-        effective_remote,
-        f"refs/tags/{tag}:refs/tags/{tag}",
-        f"+refs/heads/{branch}:refs/remotes/upstream/{branch}",
-        network=True,
-        max_output_bytes=1024,
-    )
+    for attempt in (1, 2):
+        transport.use_budget(ExecutionBudget(final_fetch_deadline))
+        try:
+            transport.run(
+                brain_git,
+                "fetch",
+                "--quiet",
+                "--no-tags",
+                "--no-write-fetch-head",
+                "--no-recurse-submodules",
+                effective_remote,
+                f"refs/tags/{tag}:refs/tags/{tag}",
+                f"+refs/heads/{branch}:refs/remotes/upstream/{branch}",
+                network=True,
+                max_output_bytes=1024,
+            )
+            break
+        except OfflineError as error:
+            if attempt == 2:
+                raise OfflineError("final release delivery fetch was unavailable after attempt 2") from error
+            time.sleep(
+                min(
+                    FINAL_FETCH_RETRY_BACKOFF_SECONDS,
+                    max(0.0, final_fetch_deadline - time.monotonic()),
+                )
+            )
     release = verify_release_ref(
         root,
         tag=tag,

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -39,7 +39,7 @@ RELEASE_TAG = re.compile(
     r"^dist/release/v(?P<version>(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*))-(?P<short>[0-9a-f]{7,64})$"
 )
-FINAL_FETCH_BUDGET_SECONDS = 10.0
+FINAL_FETCH_ATTEMPT_BUDGET_SECONDS = 5.0
 FINAL_FETCH_RETRY_BACKOFF_SECONDS = 0.1
 START_MARKER = re.compile(
     rb"^## USER_EXTENSIONS_START[^\r\n]*(?:\r?\n|$)",
@@ -607,12 +607,12 @@ def deliver_latest_release(
     if branch is None:
         return {"status": "not-delivered", "evidence": {"status": "UNKNOWN", "reason": "channel-invalid"}}
     transport = git_runner or GitRunner(allowed_protocol="file" if allow_test_transport else "https")
-    final_fetch_deadline = time.monotonic() + max(
-        0.0,
-        min(wall_clock_seconds, FINAL_FETCH_BUDGET_SECONDS),
-    )
     for attempt in (1, 2):
-        transport.use_budget(ExecutionBudget(final_fetch_deadline))
+        attempt_seconds = min(
+            max(0.0, wall_clock_seconds),
+            FINAL_FETCH_ATTEMPT_BUDGET_SECONDS,
+        )
+        transport.use_budget(ExecutionBudget.start(attempt_seconds))
         try:
             transport.run(
                 brain_git,
@@ -631,12 +631,7 @@ def deliver_latest_release(
         except OfflineError as error:
             if attempt == 2:
                 raise OfflineError("final release delivery fetch was unavailable after attempt 2") from error
-            time.sleep(
-                min(
-                    FINAL_FETCH_RETRY_BACKOFF_SECONDS,
-                    max(0.0, final_fetch_deadline - time.monotonic()),
-                )
-            )
+            time.sleep(FINAL_FETCH_RETRY_BACKOFF_SECONDS)
     release = verify_release_ref(
         root,
         tag=tag,

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -14,6 +14,7 @@ CANARY_STARTS=(
   "v1.62.0"
   "dist/archive/v1.63.0-08ce719"
   "dist/archive/v1.65.0-c5ec161"
+  "dist/archive/v1.76.0-d0bb932"
 )
 
 MODE="${1:-}"


### PR DESCRIPTION
## Outcome

Retries the final post-proof release fetch exactly once when and only when it fails with `OfflineError`.

## Safety boundaries

- Reuses the exact proved immutable tag and release-branch refspec.
- Keeps canonical HTTPS and official-origin verification unchanged.
- Gives each attempt a fresh capped 5-second time/output budget, keeping the pair near the previous 10-second ceiling, plus one capped 100ms backoff.
- Re-runs the existing exact release identity verification after a successful fetch.
- Does not retry evidence, tag/identity, origin, topology, product, cancellation, or filesystem failures.
- Permanent offline failure raises a sanitized final-fetch/attempt diagnostic and leaves the whole visible vault content tree unchanged.

## TDD evidence

RED before implementation:

- `test_final_delivery_fetch_retries_one_transient_offline_failure_with_fresh_budget` failed on the first `OfflineError`; one fetch attempt only.

GREEN:

- `7 passed, 23 deselected` for final-delivery/default-budget contracts.
- `80 passed` for `core/tests/test_apply_update.py` + `core/tests/test_update_checker.py`.
- Ruff, Python compilation, and `git diff --check` passed.

## Not done

No merge, tag, release, fleet run, or deployment.
