### PR TITLE
release: v1.81.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.14] — (2026-08-04)
+
 ## [1.81.13] — 🧷 v1.63 updates keep your saved profile intact (2026-08-03)
 
 The formal historic Mac fleet reached an exact v1.63 installation, then stopped

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.13"
+  "release_version": "1.81.14"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.13",
+  "release_version": "1.81.14",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.13","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.14","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.13 release,
+Download the versioned bridge and its checksum from the public v1.81.14 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.14/dex-update-bridge-v1.81.14.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.13/dex-update-bridge-v1.81.13.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.14/dex-update-bridge-v1.81.14.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.13.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.14.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.13.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.13",
+  "version": "1.81.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.13",
+      "version": "1.81.14",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.13",
+  "version": "1.81.14",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Candidate

Prepares v1.81.14 from green main commit 443ea669. This release carries the bounded final offline-fetch retry from merged PR #388.

## Verification

- v1.81.13 remains the current published release
- v1.81.14 tag was created locally only and has not been pushed
- release metadata diff is limited to the expected version/evidence/catalog/changelog files
- git diff --check passes
- main CI run 30883871307 attempt 2 passed all required gates

## Delivery boundary

Do not merge or publish until explicitly approved. After publication, rerun the formal 170-journey Mac fleet against the new public release.