### PR TITLE
ci(fleet): diagnose public semantic v1.73 first on macOS

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run seven release-shaped macOS journeys
+      - name: Run public v1.73 diagnostic then seven release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -49,12 +49,13 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_pr_canary_runs_exact_public_v173_first_then_preserves_seven_candidate_starts() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run seven release-shaped macOS journeys"
+        step.get("name")
+        == "Run public v1.73 diagnostic then seven release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -72,6 +73,21 @@ def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
     )
     assert len(canary_starts) == 7
+    assert 'DIAGNOSTIC_START_TAG="v1.73.0"' in source
+    assert (
+        'DIAGNOSTIC_START_OBJECT="9ce09979a61ddfea726041b83e952924b378ce96"'
+        in source
+    )
+    assert (
+        'DIAGNOSTIC_START_COMMIT="c316cd9f318dbcd51f24f43b4f9239045cba6c5c"'
+        in source
+    )
+    assert (
+        'DIAGNOSTIC_FOLLOW_UP_TAG="dist/release/v1.81.14-31a6bb8"' in source
+    )
+    assert source.index('--starting-tag "$DIAGNOSTIC_START_TAG"') < source.index(
+        '--starting-tag "$start"', source.index("run_canary()")
+    )
     assert canary_starts == (
         "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
@@ -83,9 +99,15 @@ def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     )
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source
-    assert source.count("--controlled-approvals") == 1
+    assert source.count("--controlled-approvals") == 2
     assert source.count("--follow-up-cache") == 1
     assert "--follow-up-cache" not in source.split("run_canary()", 1)[0]
+    diagnostic_call = source.split(
+        '--starting-tag "$DIAGNOSTIC_START_TAG"', 1
+    )[1].split("then", 1)[0]
+    assert '--foundation-tag "$PINNED_FOUNDATION_TAG"' in diagnostic_call
+    assert '--follow-up-tag "$DIAGNOSTIC_FOLLOW_UP_TAG"' in diagnostic_call
+    assert "--follow-up-cache" not in diagnostic_call
     assert "git push" not in source
     assert "gh release" not in source
     assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 
 CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
 PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"
+DIAGNOSTIC_START_TAG="v1.73.0"
+DIAGNOSTIC_START_OBJECT="9ce09979a61ddfea726041b83e952924b378ce96"
+DIAGNOSTIC_START_COMMIT="c316cd9f318dbcd51f24f43b4f9239045cba6c5c"
+DIAGNOSTIC_FOLLOW_UP_TAG="dist/release/v1.81.14-31a6bb8"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
 CANARY_STARTS=(
   "v1.51.0"
@@ -361,12 +365,70 @@ run_canary() {
 
   refresh_public_tags
   assert_public_annotated_tag "$PINNED_FOUNDATION_TAG"
+  assert_public_annotated_tag "$DIAGNOSTIC_FOLLOW_UP_TAG"
+  if [ "$(git cat-file -t "$DIAGNOSTIC_START_TAG" 2>/dev/null || true)" != "tag" ] \
+    || [ "$(git rev-parse --verify "$DIAGNOSTIC_START_TAG")" != "$DIAGNOSTIC_START_OBJECT" ] \
+    || [ "$(git rev-parse --verify "$DIAGNOSTIC_START_TAG^{commit}")" != "$DIAGNOSTIC_START_COMMIT" ]; then
+    echo "public diagnostic start identity does not match: $DIAGNOSTIC_START_TAG" >&2
+    return 1
+  fi
+  diagnostic_advertised="$(git -c credential.helper= -c protocol.file.allow=never ls-remote \
+    --refs --tags "$CANONICAL_PUBLIC_REMOTE" "refs/tags/$DIAGNOSTIC_START_TAG")"
+  if [ "$diagnostic_advertised" != "$DIAGNOSTIC_START_OBJECT"$'\t'"refs/tags/$DIAGNOSTIC_START_TAG" ]; then
+    echo "public diagnostic start is not the exact advertised tag: $DIAGNOSTIC_START_TAG" >&2
+    return 1
+  fi
   for start in "${CANARY_STARTS[@]}"; do
     if ! git rev-parse --verify "$start^{commit}" >/dev/null 2>&1; then
       echo "public canary start is unavailable: $start" >&2
       return 1
     fi
   done
+
+  JOURNEY_ROOT="$WORK_ROOT/journeys"
+  mkdir -m 700 "$JOURNEY_ROOT"
+  DISCOVERED=$((${#CANARY_STARTS[@]} + 1))
+
+  DIAGNOSTIC_VERSION="1.81.14"
+  DIAGNOSTIC_ASSET_ROOT="$WORK_ROOT/public-diagnostic-assets"
+  mkdir -m 700 "$DIAGNOSTIC_ASSET_ROOT"
+  DIAGNOSTIC_BRIDGE_ASSET="$DIAGNOSTIC_ASSET_ROOT/dex-update-bridge-v$DIAGNOSTIC_VERSION.py"
+  DIAGNOSTIC_BRIDGE_CHECKSUM="$DIAGNOSTIC_BRIDGE_ASSET.sha256"
+  DIAGNOSTIC_PUBLIC_RELEASE="https://github.com/davekilleen/Dex/releases/download/v$DIAGNOSTIC_VERSION"
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 --fail --location \
+    --retry 3 --retry-all-errors --max-time 120 \
+    "$DIAGNOSTIC_PUBLIC_RELEASE/$(basename "$DIAGNOSTIC_BRIDGE_ASSET")" \
+    --output "$DIAGNOSTIC_BRIDGE_ASSET"
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 --fail --location \
+    --retry 3 --retry-all-errors --max-time 120 \
+    "$DIAGNOSTIC_PUBLIC_RELEASE/$(basename "$DIAGNOSTIC_BRIDGE_CHECKSUM")" \
+    --output "$DIAGNOSTIC_BRIDGE_CHECKSUM"
+  if [ "$(wc -c < "$DIAGNOSTIC_BRIDGE_ASSET")" -gt $((16 * 1024 * 1024)) ] \
+    || [ "$(wc -c < "$DIAGNOSTIC_BRIDGE_CHECKSUM")" -gt 4096 ]; then
+    echo "public diagnostic bridge asset exceeds its bounded size" >&2
+    return 1
+  fi
+  (cd "$DIAGNOSTIC_ASSET_ROOT" && shasum -a 256 -c "$(basename "$DIAGNOSTIC_BRIDGE_CHECKSUM")")
+
+  STARTED=$((STARTED + 1))
+  if run_bounded python3 scripts/release_fleet.py journey \
+    --repo . --output "$JOURNEY_ROOT" \
+    --starting-tag "$DIAGNOSTIC_START_TAG" \
+    --foundation-tag "$PINNED_FOUNDATION_TAG" \
+    --follow-up-tag "$DIAGNOSTIC_FOLLOW_UP_TAG" \
+    --bridge-asset "$DIAGNOSTIC_BRIDGE_ASSET" \
+    --bridge-checksum "$DIAGNOSTIC_BRIDGE_CHECKSUM" \
+    --controlled-approvals
+  then
+    COMPLETED=$((COMPLETED + 1))
+    PASSED=$((PASSED + 1))
+    write_counts
+  else
+    journey_status=$?
+    FAILED=$((FAILED + 1))
+    tail -200 "$LOG_FILE" >&2 || true
+    return "$journey_status"
+  fi
 
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -399,9 +461,6 @@ run_canary() {
   BRIDGE_CHECKSUM="$BRIDGE_ASSET.sha256"
   (cd "$ASSET_ROOT" && shasum -a 256 -c "$(basename "$BRIDGE_CHECKSUM")")
 
-  JOURNEY_ROOT="$WORK_ROOT/journeys"
-  mkdir -m 700 "$JOURNEY_ROOT"
-  DISCOVERED="${#CANARY_STARTS[@]}"
   for start in "${CANARY_STARTS[@]}"; do
     STARTED=$((STARTED + 1))
     if run_bounded python3 scripts/release_fleet.py journey \


### PR DESCRIPTION
## Linked Issue
- Mission Control: historic two-hop updater fleet diagnostic

## What Changed
- Runs the exact public semantic `v1.73.0` identity first on the macOS PR canary.
- Sends that first journey through released `v1.81.0` and the public `v1.81.14` bridge before the existing seven candidate journeys.
- Pins the semantic tag object and commit and fails closed if the advertised public identity differs.
- Retains the existing candidate-build checks, journey evidence, count tracking, disk limit, and no-publish boundary.

This is a temporary diagnostic PR. Its purpose is to distinguish a release-specific v1.73 failure from the transient public-route failure observed only after 95 successful journeys in the formal fleet. It is not an acceptance or release claim.

## Test Plan
- Unit/integration tests added or updated: exact route/order and immutable identities are pinned in `core/tests/test_historic_fleet_darwin_workflow.py`.
- Negative/error-path tests added or updated: the runner refuses a missing, non-annotated, locally mismatched, or publicly mismatched v1.73 tag.
- Commands run locally:
  - `.venv/bin/python -m pytest -q core/tests/test_historic_fleet_darwin_workflow.py` — 4 passed
  - `.venv/bin/ruff check core/tests/test_historic_fleet_darwin_workflow.py` — passed
  - `bash -n scripts/run-historic-fleet-darwin.sh` — passed
  - `git diff --check` — passed
  - `bash scripts/check-pii.sh` — passed
  - `bash scripts/check-founder-content.sh` — passed
  - Public v1.81.14 bridge checksum verification — passed

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low; draft diagnostic only, no merge or release intended.
- Rollback plan: close the draft PR and delete its branch after the retained Mac evidence is classified.

## Docs Impact
- Files updated: none.
- If none, reason: this is temporary diagnostic orchestration, not a product behavior change.
