### PR TITLE
fix(update): retry explicit public proof 429

### DIFF
--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -471,6 +471,47 @@ def test_pre_delivery_proof_does_not_retry_when_429_exhausts_original_deadline(
     assert sleeps == []
 
 
+def test_pre_delivery_proof_stops_after_two_http_429_results_without_mutation(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    before = _visible_vault_content(vault)
+    state_root = tmp_path / "evidence-state"
+    proof_budgets: list[float] = []
+    transient = {
+        "status": "UNKNOWN",
+        "reason": "transient-http-rejection",
+        "diagnostic": {"classification": "http-429"},
+    }
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        proof_budgets.append(wall_clock_seconds)
+        return transient
+
+    moments = iter((100.0, 100.2, 100.3))
+    monkeypatch.setattr(apply_update, "_monotonic", lambda: next(moments))
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update, "time", SimpleNamespace(sleep=sleeps.append))
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+    runner = _ScriptedDeliveryFetch(())
+
+    assert apply_update.deliver_latest_release(
+        vault,
+        state_root=state_root,
+        git_runner=runner,
+        wall_clock_seconds=10.0,
+    ) == {"status": "not-delivered", "evidence": transient}
+    assert proof_budgets == [10.0, pytest.approx(9.7)]
+    assert sleeps == [apply_update.PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS]
+    assert runner.calls == []
+    assert _visible_vault_content(vault) == before
+    assert not state_root.exists()
+
+
 def test_pre_delivery_proof_does_not_retry_unclassified_http_5xx(
     split_release_fixture: dict[str, object],
     tmp_path: Path,
@@ -497,6 +538,33 @@ def test_pre_delivery_proof_does_not_retry_unclassified_http_5xx(
         git_runner=_ScriptedDeliveryFetch(()),
     ) == {"status": "not-delivered", "evidence": evidence}
     assert calls == [10.0]
+
+
+def test_final_delivery_fetch_does_not_retry_http_429_classification(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    _stub_latest_identity(split_release_fixture, monkeypatch)
+    before = _visible_vault_content(vault)
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update, "time", SimpleNamespace(sleep=sleeps.append))
+    runner = _ScriptedDeliveryFetch(
+        (update_verifier.TransientHttpRejectionError(),)
+    )
+
+    with pytest.raises(update_verifier.TransientHttpRejectionError):
+        apply_update.deliver_latest_release(
+            vault,
+            state_root=tmp_path / "evidence-state",
+            git_runner=runner,
+        )
+
+    assert len(runner.calls) == 1
+    assert len(runner.budgets) == 1
+    assert sleeps == []
+    assert _visible_vault_content(vault) == before
 
 
 def test_final_delivery_fetch_retries_one_transient_offline_failure_with_fresh_budget(

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -386,6 +386,119 @@ def test_default_delivery_budget_remains_ten_seconds_and_evidence_failure_is_not
     assert runner.budgets == []
 
 
+def test_pre_delivery_proof_retries_one_sanitized_http_429_within_original_deadline(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    tag, tag_object, commit, tree = split_release_fixture["target"]
+    evidence = {
+        "status": update_verifier.STATUS_IDENTITY,
+        "tag": tag,
+        "tag_object": tag_object,
+        "commit": commit,
+        "tree": tree,
+    }
+    proof_budgets: list[float] = []
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        proof_budgets.append(wall_clock_seconds)
+        if len(proof_budgets) == 1:
+            return {
+                "status": "UNKNOWN",
+                "reason": "transient-http-rejection",
+                "diagnostic": {"classification": "http-429"},
+            }
+        return evidence
+
+    moments = iter((100.0, 100.2, 100.3))
+    monkeypatch.setattr(apply_update, "_monotonic", lambda: next(moments), raising=False)
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update, "time", SimpleNamespace(sleep=sleeps.append))
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+    runner = _ScriptedDeliveryFetch((None,))
+
+    result = apply_update.deliver_latest_release(
+        vault,
+        state_root=tmp_path / "evidence-state",
+        git_runner=runner,
+        wall_clock_seconds=10.0,
+    )
+
+    assert result["status"] == "delivered"
+    assert result["release"]["tag_object"] == tag_object
+    assert result["release"]["commit"] == commit
+    assert result["release"]["tree"] == tree
+    assert proof_budgets == [10.0, pytest.approx(9.7)]
+    assert sleeps == [apply_update.PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS]
+    assert len(runner.calls) == 1
+
+
+def test_pre_delivery_proof_does_not_retry_when_429_exhausts_original_deadline(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proof_budgets: list[float] = []
+    transient = {
+        "status": "UNKNOWN",
+        "reason": "transient-http-rejection",
+        "diagnostic": {"classification": "http-429"},
+    }
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        proof_budgets.append(wall_clock_seconds)
+        return transient
+
+    moments = iter((100.0, 109.95))
+    monkeypatch.setattr(apply_update, "_monotonic", lambda: next(moments), raising=False)
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update, "time", SimpleNamespace(sleep=sleeps.append))
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+
+    assert apply_update.deliver_latest_release(
+        split_release_fixture["vault"],
+        state_root=tmp_path / "evidence-state",
+        git_runner=_ScriptedDeliveryFetch(()),
+        wall_clock_seconds=10.0,
+    ) == {"status": "not-delivered", "evidence": transient}
+    assert proof_budgets == [10.0]
+    assert sleeps == []
+
+
+def test_pre_delivery_proof_does_not_retry_unclassified_http_5xx(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[float] = []
+    evidence = {
+        "status": "UNKNOWN",
+        "reason": "evidence-invalid",
+        "diagnostic": {"classification": "http-503"},
+    }
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        calls.append(wall_clock_seconds)
+        return evidence
+
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+
+    assert apply_update.deliver_latest_release(
+        split_release_fixture["vault"],
+        state_root=tmp_path / "evidence-state",
+        git_runner=_ScriptedDeliveryFetch(()),
+    ) == {"status": "not-delivered", "evidence": evidence}
+    assert calls == [10.0]
+
+
 def test_final_delivery_fetch_retries_one_transient_offline_failure_with_fresh_budget(
     split_release_fixture: dict[str, object],
     tmp_path: Path,

--- a/core/tests/test_update_checker.py
+++ b/core/tests/test_update_checker.py
@@ -30,9 +30,11 @@ from core.utils.update_verifier import (
     STATUS_UP_TO_DATE,
     CancelledError,
     CompatibilityArtifact,
+    EvidenceError,
     GitRunner,
     OfflineError,
     ReleaseEvidenceProfile,
+    TransientHttpRejectionError,
     UpdateVerifier,
     canonical_profile_bytes,
     legacy_profile_bytes,
@@ -222,6 +224,79 @@ def _verifier(vault: Path, remote: Path, state: Path, **kwargs) -> UpdateVerifie
         now=lambda: datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc),
         **kwargs,
     )
+
+
+@pytest.mark.parametrize(
+    "detail",
+    (
+        "fatal: unable to access release endpoint: The requested URL returned error: 429 /private/customer/path",
+        "error: RPC failed; HTTP 429 curl 22 release endpoint /private/customer/path",
+    ),
+)
+def test_network_git_classifies_only_explicit_http_429_without_retaining_stderr(
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    fake_git = tmp_path / "git"
+    _write(
+        fake_git,
+        f'#!/bin/sh\necho "{detail}" >&2\nexit 128\n'.encode(),
+    )
+    fake_git.chmod(0o755)
+    runner = GitRunner(git_path=fake_git)
+
+    with pytest.raises(TransientHttpRejectionError) as error_info:
+        runner.run_plain("ls-remote", network=True)
+
+    assert error_info.value.classification == "http-429"
+    assert str(error_info.value) == "canonical Git endpoint returned a transient HTTP rejection"
+    assert "customer" not in str(error_info.value)
+    assert "429" not in str(error_info.value)
+
+
+def test_release_identity_proof_retains_only_sanitized_http_429_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+
+    def reject(*_args, **_kwargs):
+        raise TransientHttpRejectionError
+
+    monkeypatch.setattr(UpdateVerifier, "_remote_release_tags", reject)
+
+    assert update_verifier_module.prove_latest_release(
+        vault,
+        "stable",
+        state_root=tmp_path / "state",
+        wall_clock_seconds=10.0,
+    ) == {
+        "status": STATUS_UNKNOWN,
+        "reason": "transient-http-rejection",
+        "diagnostic": {"classification": "http-429"},
+    }
+
+
+@pytest.mark.parametrize(
+    "detail",
+    (
+        "fatal: unable to access release endpoint: The requested URL returned error: 503",
+        "fatal: generic evidence-invalid",
+    ),
+)
+def test_network_git_does_not_classify_other_rejections_as_transient_http(
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    fake_git = tmp_path / "git"
+    _write(fake_git, f'#!/bin/sh\necho "{detail}" >&2\nexit 128\n'.encode())
+    fake_git.chmod(0o755)
+    runner = GitRunner(git_path=fake_git)
+
+    with pytest.raises(EvidenceError) as error_info:
+        runner.run_plain("ls-remote", network=True)
+
+    assert type(error_info.value) is EvidenceError
 
 
 def test_legacy_release_notice_is_readable_and_keeps_technical_evidence_out_of_user_copy(

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -18,6 +18,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from time import monotonic as _monotonic
 from typing import Any, Callable
 
 from core import portable_contract
@@ -41,6 +42,7 @@ RELEASE_TAG = re.compile(
 )
 FINAL_FETCH_ATTEMPT_BUDGET_SECONDS = 5.0
 FINAL_FETCH_RETRY_BACKOFF_SECONDS = 0.1
+PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS = 0.1
 START_MARKER = re.compile(
     rb"^## USER_EXTENSIONS_START[^\r\n]*(?:\r?\n|$)",
     re.MULTILINE,
@@ -553,6 +555,55 @@ def _release_identity(release: VerifiedReleaseRef) -> dict[str, str]:
     }
 
 
+def _is_retryable_public_proof_rejection(evidence: dict[str, object]) -> bool:
+    """Accept only the verifier's closed, sanitized HTTP 429 classification."""
+    return set(evidence) == {"status", "reason", "diagnostic"} and evidence == {
+        "status": "UNKNOWN",
+        "reason": "transient-http-rejection",
+        "diagnostic": {"classification": "http-429"},
+    }
+
+
+def _prove_latest_release_with_bounded_retry(
+    root: Path,
+    channel: str,
+    *,
+    state_root: Path | None,
+    remote_url: str,
+    allow_test_transport: bool,
+    git_runner: Any | None,
+    wall_clock_seconds: float,
+) -> dict[str, object]:
+    """Retry one explicit HTTP 429 without extending the original proof deadline."""
+    from core.utils.update_verifier import prove_latest_release
+
+    initial_budget = max(0.0, wall_clock_seconds)
+    proof_deadline = _monotonic() + initial_budget
+    evidence: dict[str, object]
+    for attempt in (1, 2):
+        remaining = (
+            initial_budget
+            if attempt == 1
+            else max(0.0, proof_deadline - _monotonic())
+        )
+        evidence = prove_latest_release(
+            root,
+            channel,
+            state_root=state_root,
+            remote_url=remote_url,
+            allow_test_transport=allow_test_transport,
+            git_runner=git_runner,
+            wall_clock_seconds=remaining,
+        )
+        if attempt == 2 or not _is_retryable_public_proof_rejection(evidence):
+            return evidence
+        remaining = max(0.0, proof_deadline - _monotonic())
+        if remaining <= PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS:
+            return evidence
+        time.sleep(PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS)
+    raise AssertionError("bounded proof retry loop did not return")
+
+
 def deliver_latest_release(
     vault_root: Path,
     *,
@@ -576,13 +627,12 @@ def deliver_latest_release(
         ExecutionBudget,
         GitRunner,
         OfflineError,
-        prove_latest_release,
     )
 
     root = Path(vault_root).resolve()
     channel = release_channel.read_channel(root)
     effective_remote = remote_url or CANONICAL_REMOTE_URL
-    evidence = prove_latest_release(
+    evidence = _prove_latest_release_with_bounded_retry(
         root,
         channel,
         state_root=state_root,

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -55,6 +55,10 @@ _OFFLINE_MARKERS = (
     "couldn't connect to server",
     "temporary failure in name resolution",
 )
+_TRANSIENT_HTTP_REJECTION_RE = re.compile(
+    r"(?:\bHTTP(?:/[0-9.]+)?\s+429\b|\brequested URL returned error:\s*429\b)",
+    re.IGNORECASE,
+)
 _FORBIDDEN_GIT_ENV_NAMES = {
     "ALL_PROXY",
     "HTTP_PROXY",
@@ -96,6 +100,15 @@ class EvidenceError(RuntimeError):
 
 class OfflineError(RuntimeError):
     """The bounded canonical network operation could not complete."""
+
+
+class TransientHttpRejectionError(EvidenceError):
+    """The canonical Git endpoint explicitly reported one retryable rejection."""
+
+    classification = "http-429"
+
+    def __init__(self) -> None:
+        super().__init__("canonical Git endpoint returned a transient HTTP rejection")
 
 
 class CancelledError(RuntimeError):
@@ -491,6 +504,8 @@ class GitRunner:
             budget.consume_output(stdout_size + len(stderr))
             if process.returncode != 0:
                 detail = stderr[: 64 * 1024].decode("utf-8", errors="replace").strip()
+                if network and _TRANSIENT_HTTP_REJECTION_RE.search(detail):
+                    raise TransientHttpRejectionError
                 if network and any(marker in detail.lower() for marker in _OFFLINE_MARKERS):
                     raise OfflineError("bounded canonical fetch was unavailable")
                 raise EvidenceError(detail or "Git evidence command failed")
@@ -1061,6 +1076,12 @@ class UpdateVerifier:
                     "latest_version": candidate.version,
                 }
             return self._identity_result(candidate)
+        except TransientHttpRejectionError as error:
+            return {
+                "status": STATUS_UNKNOWN,
+                "reason": "transient-http-rejection",
+                "diagnostic": {"classification": error.classification},
+            }
         except OfflineError:
             return {"status": STATUS_OFFLINE, "reason": "network-unavailable"}
         except (CancelledError, EvidenceError, OSError, UnicodeError, subprocess.SubprocessError) as error:


### PR DESCRIPTION
## Linked Issue
- Mission Control: existing historic updater fleet card (non-closing hardening)

## What Changed
- A fast public GitHub rate-limit rejection could previously look identical to malformed release evidence, stopping an otherwise valid update before delivery. The pre-delivery proof now retries one explicitly classified HTTP 429, while malformed identity, tag, tree, signature-equivalent evidence, generic failures, and unclassified 5xx responses still fail immediately.
- The retry shares the original ten-second proof deadline: the second attempt receives only the remaining time after a capped 0.1-second backoff. Raw Git output is discarded; retained diagnostics contain only the closed `http-429` classification.
- A successful retry still goes through the existing exact tag-object, commit, tree, channel, manifest, and post-fetch re-verification before any release can be delivered.

## Test Plan
- Unit/integration tests added or updated:
  - Real bounded Git-runner tests for both known HTTP 429 stderr shapes and sanitized classification.
  - Delivery tests for one retry, shared deadline accounting, exhausted-deadline refusal, the two-attempt ceiling, exact identity re-verification, and non-retry of unclassified 5xx/evidence or final-fetch 429 failures.
- Negative/error-path tests added or updated:
  - HTTP 503 and generic Git rejection remain plain evidence failures.
  - Existing malformed evidence, post-fetch identity mismatch, origin mismatch, and topology refusal tests remain green.
- Commands run locally:
  - `.venv/bin/python -m pytest -q core/tests/test_update_checker.py core/tests/test_apply_update.py` — 90 passed
  - `.venv/bin/python -m pytest -q core/tests/test_dex_update_bridge.py core/tests/test_update_bridge_historic_compatibility.py core/tests/test_release_fleet_failure_diagnostics.py` — 410 passed
  - `.venv/bin/ruff check core/utils/update_verifier.py core/update/apply_update.py core/tests/test_update_checker.py core/tests/test_apply_update.py` — passed
  - `.venv/bin/python -m py_compile core/utils/update_verifier.py core/update/apply_update.py` — passed
  - `git diff --check`, PII gate, and founder-content gate — passed

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: medium; this changes only pre-delivery handling of one explicit network response and never bypasses evidence verification.
- Rollback plan: revert this single commit; the prior fail-closed no-retry behavior returns.

## Docs Impact
- Files updated: none.
- If none, reason: the user-facing updater contract is unchanged; this is bounded transport hardening beneath the existing proof boundary.
