### PR TITLE
release: prepare v1.81.15 updater foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.15] — 🛡️ Temporary GitHub limits no longer stop a safe update (2026-08-04)
+
+During the formal historic Mac run, one healthy update reached its public
+foundation and then GitHub temporarily refused the second release proof. Dex
+stopped safely before previewing or writing anything, but the route had to be
+run again after the temporary limit cleared.
+
+**What this fixes for you:**
+
+* **One explicit GitHub rate-limit response gets one bounded retry.** Dex uses
+  only the time left inside the existing ten-second proof window; it does not
+  extend or loop the check.
+* **Every safety boundary stays closed.** Wrong release identities, invalid or
+  generic evidence, other HTTP failures, and a final download rejection still
+  stop immediately without previewing or changing your files.
+* **Fleet acceptance still requires the complete public run.** This release
+  hardens the exact transient seam that stopped the previous run, but Dex will
+  not claim historic two-hop support until a fresh retained 170-case Mac run
+  completes with zero failures.
+
 ## [1.81.14] — (2026-08-04)
 
 ## [1.81.13] — 🧷 v1.63 updates keep your saved profile intact (2026-08-03)

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.14"
+  "release_version": "1.81.15"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.14",
+  "release_version": "1.81.15",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.14","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.15","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.14 release,
+Download the versioned bridge and its checksum from the public v1.81.15 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.14/dex-update-bridge-v1.81.14.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.15/dex-update-bridge-v1.81.15.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.14/dex-update-bridge-v1.81.14.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.15/dex-update-bridge-v1.81.15.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.14.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.15.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.14.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.14",
+  "version": "1.81.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.14",
+      "version": "1.81.15",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.14",
+  "version": "1.81.15",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- advance Dex release metadata from 1.81.14 to 1.81.15
- publish truthful release notes for the merged explicit HTTP 429 proof retry from PR #407
- advance the versioned update-rescue bridge references and regenerate release evidence metadata

This is Foundation A only. It prepares the first public release containing the bounded retry; it does not tag, publish, merge, or claim 170-case fleet acceptance.

## Verification
- post-merge CI for source commit 2aa1a433: fully green (run 30912133856)
- generated installed-files manifest rerun: 1,302 paths, no diff
- focused release/updater Python suite: 214 passed
- hook tests: 171 passed
- script tests: 163 passed
- integration tests: 224 passed, 1 skipped
- connections contract: green, 8 fixtures and 21-file engine manifest verified
- security, PII, founder-content, portable contract, architecture inventory, path consistency, release-tag uniqueness, and distribution safety gates: green
- final staged/committed diff: 7 files, +33/-13, diff check clean

## Known release-safety gate
The old-version reachability gate intentionally remains red for an unpublished 1.81.15: v1.62.0 and v1.68.0 each currently have 31 newer dist/release refs. This PR must not merge until the verified bridge-and-archive procedure safely moves one eligible active distribution ref. No tag was moved or safety check weakened in this branch.

Exact candidate identified by the release lane: dist/release/v1.74.0-eb50463 to dist/archive/v1.74.0-eb50463. The destination was absent at preflight. The tag-move owner must independently preserve and verify the same annotated object, commit, tree, semantic release, assets, and reversibility before CI is rerun.
