### PR TITLE
Release v1.81.16 with public v1.81.15 fleet foundation

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -7,7 +7,7 @@ on:
         description: Exact public immutable foundation tag
         required: true
         type: string
-        default: dist/release/v1.81.0-6bc490e
+        default: dist/release/v1.81.15-be0e5f3
       follow_up_tag:
         description: Exact public immutable follow-up tag
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.16] — 🧭 Historic updates now aim at the selected public foundation (2026-08-04)
+
+Dex's historic-update bridge previously used the original v1.81.0 foundation,
+even after newer releases had hardened the real two-hop journey. This follow-up
+closes the first hop to the exact public v1.81.15 release instead.
+
+**What this changes for you:**
+
+* **Old installations enter through the selected public foundation.** The bridge
+  verifies the exact annotated tag, commit, and tree before it can preview or
+  change anything.
+* **The second hop stays genuinely separate.** v1.81.16 is the distinct
+  follow-up release used to prove that v1.81.15 can deliver its successor.
+* **Fleet support is not assumed.** Dex will claim historic two-hop support only
+  after the freshly generated public Mac fleet completes with zero failures.
+
 ## [1.81.15] — 🛡️ Temporary GitHub limits no longer stop a safe update (2026-08-04)
 
 During the formal historic Mac run, one healthy update reached its public

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.15"
+  "release_version": "1.81.16"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.15",
+  "release_version": "1.81.16",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.15","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.16","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -203,11 +203,11 @@ def _foundation_topology_adapter(
 
 def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
     assert bridge.FOUNDATION.identity() == {
-        "tag": "dist/release/v1.81.0-6bc490e",
-        "tag_object": "54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
-        "commit": "6bc490e7caec22f60f097c6b54bb563382f542b8",
-        "tree": "dad3e43774e772dfc42df698f8a9818956346d78",
-        "version": "1.81.0",
+        "tag": "dist/release/v1.81.15-be0e5f3",
+        "tag_object": "bd3f25cc51e8fc9677239c656286606b4bc0fe71",
+        "commit": "be0e5f3a615d1f4be827006440cbfb003a17521b",
+        "tree": "f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
+        "version": "1.81.15",
         "channel": "stable",
     }
 

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -25,6 +25,9 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert set(triggers) == {"workflow_dispatch", "pull_request"}
     inputs = triggers["workflow_dispatch"]["inputs"]
     assert inputs["foundation_tag"]["required"] is True
+    assert (
+        inputs["foundation_tag"]["default"] == "dist/release/v1.81.15-be0e5f3"
+    )
     assert inputs["follow_up_tag"]["required"] is True
     assert workflow["permissions"] == {"contents": "read"}
 
@@ -93,7 +96,7 @@ def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
 
 def test_formal_runner_freezes_public_cohort_and_retains_exact_counts() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
-    assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"' in source
+    assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.15-be0e5f3"' in source
     assert 'MAX_DISK_KIB=$((50 * 1024 * 1024))' in source
     assert "release_fleet_acceptance.py cohort" in source
     assert "release_fleet_acceptance.py session" in source

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -56,8 +56,8 @@ def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
         _foundation_release(),
     )
     later = (
-        _release("v1.81.1", "1.81.1", "3"),
-        _release("dist/release/v1.81.2-4444444", "1.81.2", "4"),
+        _release("v1.81.16", "1.81.16", "3"),
+        _release("dist/release/v1.81.17-4444444", "1.81.17", "4"),
     )
 
     manifest = acceptance.frozen_cohort_manifest(
@@ -214,7 +214,7 @@ def test_real_repository_derives_the_current_historic_tree_count() -> None:
 
     assert manifest["case_count"] == len(manifest["cases"]) == len(parsed)
     assert manifest["case_count"] > 0
-    assert manifest["foundation"]["tag"] == "dist/release/v1.81.0-6bc490e"
+    assert manifest["foundation"]["tag"] == "dist/release/v1.81.15-be0e5f3"
 
 
 def _case(tag: str, platform: str) -> release_fleet.CaseResult:

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,16 +35,16 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "596ba0dbdc9d0d8897623fde63f6d01a3edd325b0e767baac0ae50d5b13094a7",
+      "sha256": "fe76a0e7920443bd263baccf89252a856adab32309ad4e5aec127f037b3e5ce5",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
       "channel": "stable",
-      "commit": "6bc490e7caec22f60f097c6b54bb563382f542b8",
-      "tag": "dist/release/v1.81.0-6bc490e",
-      "tag_object": "54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
-      "tree": "dad3e43774e772dfc42df698f8a9818956346d78",
-      "version": "1.81.0"
+      "commit": "be0e5f3a615d1f4be827006440cbfb003a17521b",
+      "tag": "dist/release/v1.81.15-be0e5f3",
+      "tag_object": "bd3f25cc51e8fc9677239c656286606b4bc0fe71",
+      "tree": "f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
+      "version": "1.81.15"
     }
   },
   "platforms": [

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -82,7 +82,7 @@ begin. The bridge is intentionally not a raw Git merge: it fetches only the
 pre-pinned foundation release, proves its annotated tag, commit, and tree, then
 uses that foundation's existing topology and receipt-backed transaction service.
 
-The bridge now pins the exact public v1.81.0 foundation: its annotated
+The bridge now pins the exact public v1.81.15 foundation: its annotated
 distribution tag, tag object, commit, and tree are all closed in the released
 journey contract. That publication is not, by itself, proof that every historic
 route works. Each supported route still needs an installed-fixture rehearsal,
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.15 release,
+Download the versioned bridge and its checksum from the public v1.81.16 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.15/dex-update-bridge-v1.81.15.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.16/dex-update-bridge-v1.81.16.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.15/dex-update-bridge-v1.81.15.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.16/dex-update-bridge-v1.81.16.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.15.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.16.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.15.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -101,10 +101,10 @@ Markdown `/dex-update` instructions into an API.
 ```bash
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
-  --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/v1.81.7-EXACTFOLLOWUP \
-  --bridge-asset /path/to/dex-update-bridge-v1.81.7.py \
-  --bridge-checksum /path/to/dex-update-bridge-v1.81.7.py.sha256
+  --foundation-tag dist/release/v1.81.15-be0e5f3 \
+  --follow-up-tag dist/release/v1.81.16-EXACTFOLLOWUP \
+  --bridge-asset /path/to/dex-update-bridge-v1.81.16.py \
+  --bridge-checksum /path/to/dex-update-bridge-v1.81.16.py.sha256
 ```
 
 The bridge paths must be the separately downloaded GitHub Release asset and
@@ -172,11 +172,11 @@ bounded transport retry does not make the PR canary acceptance evidence.
 ```bash
 python3 scripts/release_fleet_acceptance.py platform --repo . \
   --cohort historic-cohort.json \
-  --foundation-tag dist/release/v1.81.0-EXACTFOUNDATION \
-  --follow-up-tag dist/release/vNEXT-EXACTFOLLOWUP \
+  --foundation-tag dist/release/v1.81.15-be0e5f3 \
+  --follow-up-tag dist/release/v1.81.16-EXACTFOLLOWUP \
   --session acceptance-session.json --key acceptance.key \
-  --bridge-asset /path/to/dex-update-bridge-vNEXT.py \
-  --bridge-checksum /path/to/dex-update-bridge-vNEXT.py.sha256 \
+  --bridge-asset /path/to/dex-update-bridge-v1.81.16.py \
+  --bridge-checksum /path/to/dex-update-bridge-v1.81.16.py.sha256 \
   --output "$fleet_root/darwin"
 ```
 
@@ -214,10 +214,10 @@ constructing the same documents cannot unlock acceptance. The resulting
 content-addressed manifest records the exact executor identity, release
 identities, ordered operations, and artifact hashes.
 
-The protocol and executor were published with the v1.81.0 foundation. That
-publication is one prerequisite, not fleet acceptance: the real follow-up
-release must exist and every historic case must still complete the two-hop
-journey on macOS.
+The v1.81.16 protocol and executor pin the exact public v1.81.15 foundation.
+That publication is one prerequisite, not fleet acceptance: the distinct
+follow-up release must exist and every historic case must still complete the
+two-hop journey on macOS.
 
 ## Validate the finished evidence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.15",
+  "version": "1.81.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.15",
+      "version": "1.81.16",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.15",
+  "version": "1.81.16",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -102,15 +102,15 @@ class ReleasePin:
         }
 
 
-# The first public release with the corrected self-delivery approval boundary
-# and profile-safe package. This pin is intentionally in the bridge source:
+# The exact public release selected as the next first hop for historic installs.
+# This pin is intentionally in the bridge source:
 # discovering a mutable "latest" release would not be a safe bootstrap.
 FOUNDATION = ReleasePin(
-    tag="dist/release/v1.81.0-6bc490e",
-    tag_object="54b1ceef8b1f7ad4f67e4d4d045a134ea443ab53",
-    commit="6bc490e7caec22f60f097c6b54bb563382f542b8",
-    tree="dad3e43774e772dfc42df698f8a9818956346d78",
-    version="1.81.0",
+    tag="dist/release/v1.81.15-be0e5f3",
+    tag_object="bd3f25cc51e8fc9677239c656286606b4bc0fe71",
+    commit="be0e5f3a615d1f4be827006440cbfb003a17521b",
+    tree="f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
+    version="1.81.15",
 )
 
 

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
-PINNED_FOUNDATION_TAG="dist/release/v1.81.0-6bc490e"
+PINNED_FOUNDATION_TAG="dist/release/v1.81.15-be0e5f3"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
 CANARY_STARTS=(
   "v1.51.0"


### PR DESCRIPTION
## Outcome

Prepares the distinct v1.81.16 follow-up release and rotates every formal historic-fleet foundation pin to the exact public v1.81.15 distribution identity.

Exact foundation:
- tag: `dist/release/v1.81.15-be0e5f3`
- tag object: `bd3f25cc51e8fc9677239c656286606b4bc0fe71`
- commit: `be0e5f3a615d1f4be827006440cbfb003a17521b`
- tree: `f1f55abdc7c4e4c54101b3606b162c2cba148f9c`

The journey protocol was regenerated from source. Its new bridge SHA-256 is `fe76a0e7920443bd263baccf89252a856adab32309ad4e5aec127f037b3e5ce5`.

## Verification

- TDD: 4 expected old-pin failures, then 4/4 green
- updater/release selection: 185 passed, 3 Linux-host exclusions for macOS-only authority checks
- Node hook, script, integration, and connection-contract suites: green
- protocol regeneration byte-match, shell syntax, Python compile, diff check: green
- security, PII, portable contract, distribution, path, docs, architecture, founder-content gates: green
- fresh immutable cohort: 200 discovered; 0 started/completed/passed/failed
- independent diff review: approved

## Deliberate non-claims and release blocker

This PR does not claim fleet acceptance and does not merge, tag, publish, or run journeys. The release-tag reachability gate correctly remains blocked before publication: v1.62.0, v1.68.0, and v1.74.0 each have 31 newer active distribution tags. A disposable simulation proves that moving exactly `dist/release/v1.75.1-784fabe` to the absent `dist/archive/v1.75.1-784fabe` makes the gate pass while preserving the 200-case cohort. That external tag action is intentionally not performed by this PR.

The pre-existing release-catalog naming mismatch is recorded separately and untouched.