### PR TITLE
fix(fleet): classify catalog-less semantic protocols safely

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -95,7 +95,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run seven release-shaped macOS journeys
+      - name: Run ten release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -52,12 +52,12 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
-def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run seven release-shaped macOS journeys"
+        step.get("name") == "Run ten release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -74,7 +74,7 @@ def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     canary_starts = tuple(
         re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
     )
-    assert len(canary_starts) == 7
+    assert len(canary_starts) == 10
     assert canary_starts == (
         "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
@@ -83,6 +83,9 @@ def test_seven_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         "dist/archive/v1.63.0-08ce719",
         "dist/archive/v1.65.0-c5ec161",
         "dist/archive/v1.76.0-d0bb932",
+        "v1.81.1",
+        "dist/release/v1.81.1-b17ef02",
+        "v1.81.11",
     )
     assert "build-release.sh --source candidate --target release" in source
     assert "build-vault-bundle.sh" in source

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1086,6 +1086,23 @@ def _write_update_surface(repo: Path) -> None:
     rescue.write_text("# Published rescue\n", encoding="utf-8")
 
 
+def _write_current_protocol_source(repo: Path) -> None:
+    _write_update_surface(repo)
+    for relative in (
+        "scripts/dex_update_bridge.py",
+        "scripts/release_fleet.py",
+        "scripts/release_fleet_executor.py",
+    ):
+        source = repo / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes((release_fleet.PROJECT_ROOT / relative).read_bytes())
+    protocol_path = repo / release_fleet.UPDATE_JOURNEY_RELATIVE
+    protocol_path.parent.mkdir(parents=True, exist_ok=True)
+    protocol_path.write_bytes(
+        (release_fleet.PROJECT_ROOT / release_fleet.UPDATE_JOURNEY_RELATIVE).read_bytes()
+    )
+
+
 def _write_starting_manifest(root: Path, releases: tuple[release_fleet.DistributionRelease, ...]) -> Path:
     path = root / "historic-release-manifest.json"
     path.write_text(json.dumps(release_fleet.starting_release_manifest(releases)), encoding="utf-8")
@@ -2235,6 +2252,172 @@ def test_shipped_update_surface_requires_and_exposes_the_released_executor(
     classification = release_fleet.classify_historic_update_surface(repo, distribution)
     assert classification["machine_executable"] is True
     assert classification["route_classification"] == "machine-protocol-released-executor"
+
+
+def test_shipped_update_surface_records_catalogless_semantic_protocol_as_unbound(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "semantic release source")
+    source_commit = _git(repo, "rev-parse", "HEAD")
+    semantic_tag = "v1.81.1"
+    _git(repo, "tag", semantic_tag)
+    (repo / "release-fix.txt").write_text("packaging fix\n", encoding="utf-8")
+    _git(repo, "add", "release-fix.txt")
+    _git(repo, "commit", "--quiet", "-m", "release-only fix")
+    package_source_commit = _git(repo, "rev-parse", "HEAD")
+
+    catalog = repo / "System/.release-catalog.json"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        json.dumps(
+            {
+                "catalog_version": 1,
+                "release": {"source_commit": package_source_commit},
+                "items": [],
+                "integrity": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _tag_release(repo, "1.81.1", "immutable package")
+    semantic_release = next(
+        release
+        for release in release_fleet.discover_distribution_releases(repo)
+        if release.tag == semantic_tag
+    )
+
+    surface = release_fleet.shipped_update_surface(repo, semantic_release)
+
+    assert surface["release"] == {
+        "tag": semantic_tag,
+        "tag_object": source_commit,
+        "commit": source_commit,
+        "tree": _git(repo, "rev-parse", f"{semantic_tag}^{{tree}}"),
+        "version": "1.81.1",
+        "channel": "stable",
+    }
+    assert surface["machine_executable"] is False
+    assert surface["journey_protocol"]["status"] == "present-unbound"
+    assert surface["journey_protocol"]["source_commit"] == source_commit
+    classification = release_fleet.classify_historic_update_surface(
+        repo, semantic_release
+    )
+    assert classification["machine_executable"] is False
+    assert classification["route_classification"] == "protocol-present-unbound-source"
+
+
+def test_shipped_update_surface_keeps_catalog_strict_for_immutable_release(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    tag = _tag_release(repo, "1.81.1", "catalog-less immutable package")
+    release = release_fleet.resolve_immutable_release(repo, tag)
+
+    with pytest.raises(release_fleet.FleetError, match="release-catalog"):
+        release_fleet.shipped_update_surface(repo, release)
+
+
+def test_shipped_update_surface_rejects_malformed_semantic_catalog(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    catalog = repo / "System/.release-catalog.json"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text("{}\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "semantic release with malformed catalog")
+    tag = "v1.81.2"
+    _git(repo, "tag", tag)
+    release = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == tag
+    )
+
+    with pytest.raises(
+        release_fleet.FleetError, match="release catalog has an invalid shape"
+    ):
+        release_fleet.shipped_update_surface(repo, release)
+
+
+def test_shipped_update_surface_propagates_semantic_catalog_inspection_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "semantic release source")
+    tag = "v1.81.2"
+    _git(repo, "tag", tag)
+    release = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == tag
+    )
+    real_run = release_fleet.subprocess.run
+
+    def fail_catalog_inspection(command: list[str], *args: object, **kwargs: object):
+        if "ls-tree" in command and command[-1] == "System/.release-catalog.json":
+            return release_fleet.subprocess.CompletedProcess(
+                command,
+                128,
+                stdout=b"",
+                stderr=b"fatal: object database read failure\n",
+            )
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(release_fleet.subprocess, "run", fail_catalog_inspection)
+
+    with pytest.raises(release_fleet.FleetError, match="object database read failure"):
+        release_fleet.shipped_update_surface(repo, release)
+
+
+def test_shipped_update_surface_does_not_generalize_mutated_v1810_pin(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "different v1.81.0 source")
+    tag = "v1.81.0"
+    _git(repo, "tag", tag)
+    release = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == tag
+    )
+
+    with pytest.raises(release_fleet.FleetError, match="release-catalog"):
+        release_fleet.shipped_update_surface(repo, release)
+
+
+def test_shipped_update_surface_rejects_catalogless_semantic_protocol_hash_mismatch(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _write_current_protocol_source(repo)
+    executor = repo / "scripts/release_fleet_executor.py"
+    executor.write_bytes(executor.read_bytes() + b"\n# unexpected mutation\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "mutated semantic protocol source")
+    tag = "v1.81.2"
+    _git(repo, "tag", tag)
+    release = next(
+        item
+        for item in release_fleet.discover_distribution_releases(repo)
+        if item.tag == tag
+    )
+
+    with pytest.raises(
+        release_fleet.FleetError, match="does not match its protocol hash"
+    ):
+        release_fleet.shipped_update_surface(repo, release)
 
 
 def test_shipped_update_surface_rejects_a_protocol_with_an_unknown_operation(

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "30943a16337932ce3a65631d4053c3bf47aeb78cf7558b082e529252281eb78d",
+    "sha256": "f2c16da23c777fe2cf09210f53a01e7a1b33e141134fa348f4e5dd37160d626c",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -107,6 +107,18 @@ python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --bridge-checksum /path/to/dex-update-bridge-v1.81.16.py.sha256
 ```
 
+Historic semantic `v*` starting tags have a narrower evidence-only rule. Their
+tag object, commit, tree, version, and channel identity remain exact. When Git
+positively confirms that `System/.release-catalog.json` is absent, the runner
+may record a valid journey protocol only after its runner, executor, and bridge
+hashes match the exact semantic source commit. That surface is labelled
+`present-unbound` and `machine_executable: false`; it cannot grant execution
+authority or substitute a similarly versioned distribution package. A catalog
+that exists but is malformed or unreadable fails closed, as does any source
+hash mismatch. Immutable journey targets, including the foundation and
+follow-up, never receive this evidence exception: their release catalogs and
+publisher-source bindings remain mandatory.
+
 The bridge paths must be the separately downloaded GitHub Release asset and
 its checksum. The runner verifies their exact names, checksum, protocol digest,
 and released source bytes before it creates the fixture. A bridge available

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -380,6 +380,23 @@ def _tag_file(repo: Path, tag: str, relative: str) -> bytes:
     return result.stdout
 
 
+def _tag_file_if_present(repo: Path, tag: str, relative: str) -> bytes | None:
+    """Read one tag path, distinguishing confirmed absence from Git failure."""
+
+    result = subprocess.run(
+        ["git", "-C", str(repo), "ls-tree", "-z", tag, "--", relative],
+        capture_output=True,
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise FleetError(
+            detail or f"{tag}: could not inspect required publication path {relative}"
+        )
+    if not result.stdout:
+        return None
+    return _tag_file(repo, tag, relative)
+
+
 def _strict_object(source: bytes, context: str, keys: frozenset[str]) -> dict[str, object]:
     try:
         value = json.loads(source)
@@ -415,14 +432,15 @@ def _released_protocol_source_commit(repo: Path, tag: str) -> str:
     return source_commit
 
 
-def _verify_released_protocol_artifacts(
+def _verify_protocol_source_artifacts(
     repo: Path,
-    release: DistributionRelease | ImmutableRelease,
+    *,
+    release_tag: str,
+    source_commit: str,
     protocol: UpdateJourneyProtocol,
-) -> str:
-    """Bind protocol adapters to the exact publisher source commit bytes."""
+) -> None:
+    """Prove protocol adapter hashes against one exact source commit."""
 
-    source_commit = _released_protocol_source_commit(repo, release.tag)
     for label, artifact in (
         ("fleet runner", protocol.runner),
         ("journey executor", protocol.executor),
@@ -432,13 +450,55 @@ def _verify_released_protocol_artifacts(
             source = _tag_file(repo, source_commit, artifact.source_path)
         except FleetError as error:
             raise FleetError(
-                f"{release.tag}: released journey {label} source is unavailable"
+                f"{release_tag}: released journey {label} source is unavailable"
             ) from error
         if hashlib.sha256(source).hexdigest() != artifact.sha256:
             raise FleetError(
-                f"{release.tag}: released journey {label} does not match its protocol hash"
+                f"{release_tag}: released journey {label} does not match its protocol hash"
             )
+
+
+def _verify_released_protocol_artifacts(
+    repo: Path,
+    release: DistributionRelease | ImmutableRelease,
+    protocol: UpdateJourneyProtocol,
+) -> str:
+    """Bind protocol adapters to the exact publisher source commit bytes."""
+
+    source_commit = _released_protocol_source_commit(repo, release.tag)
+    _verify_protocol_source_artifacts(
+        repo,
+        release_tag=release.tag,
+        source_commit=source_commit,
+        protocol=protocol,
+    )
     return source_commit
+
+
+def _unbound_semantic_protocol_source(
+    repo: Path,
+    release: DistributionRelease | ImmutableRelease,
+    protocol: UpdateJourneyProtocol,
+) -> str | None:
+    """Prove catalog-less semantic bytes without granting execution authority."""
+
+    pinned = dex_update_bridge.exact_unbound_journey_source(repo, release.tag)
+    if pinned is not None:
+        return pinned
+    if release.tag == dex_update_bridge.V181_UNBOUND_JOURNEY_SOURCE.release.tag:
+        return None
+    if LEGACY_RELEASE_TAG.fullmatch(release.tag) is None:
+        return None
+    catalog = _tag_file_if_present(repo, release.tag, "System/.release-catalog.json")
+    if catalog is not None:
+        return None
+    _verify_protocol_source_artifacts(
+        repo,
+        release_tag=release.tag,
+        source_commit=release.commit,
+        protocol=protocol,
+    )
+    return release.commit
 
 
 def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableRelease) -> dict[str, object]:
@@ -484,8 +544,10 @@ def shipped_update_surface(repo: Path, release: DistributionRelease | ImmutableR
             raise FleetError(
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
-        unbound_source = dex_update_bridge.exact_unbound_journey_source(repo, release.tag)
-        source_commit = unbound_source or _verify_released_protocol_artifacts(repo, release, protocol)
+        unbound_source = _unbound_semantic_protocol_source(repo, release, protocol)
+        source_commit = unbound_source or _verify_released_protocol_artifacts(
+            repo, release, protocol
+        )
         protocol_surface = {
             "path": UPDATE_JOURNEY_RELATIVE,
             "status": "present-unbound" if unbound_source else "present",
@@ -1633,7 +1695,7 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
         repo, release.tag, "core/lifecycle/catalog/bridge-release.json"
     )
     protocol = _optional_tag_file(repo, release.tag, UPDATE_JOURNEY_RELATIVE)
-    unbound_source = dex_update_bridge.exact_unbound_journey_source(repo, release.tag)
+    unbound_source: str | None = None
     if protocol is not None:
         try:
             parsed_protocol = load_update_journey_protocol(protocol)
@@ -1641,6 +1703,9 @@ def classify_historic_update_surface(repo: Path, release: DistributionRelease) -
             raise FleetError(
                 f"{release.tag}: released journey protocol is invalid: {error}"
             ) from error
+        unbound_source = _unbound_semantic_protocol_source(
+            repo, release, parsed_protocol
+        )
         if unbound_source is None:
             _verify_released_protocol_artifacts(repo, release, parsed_protocol)
             route = "machine-protocol-released-executor"

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -15,6 +15,9 @@ CANARY_STARTS=(
   "dist/archive/v1.63.0-08ce719"
   "dist/archive/v1.65.0-c5ec161"
   "dist/archive/v1.76.0-d0bb932"
+  "v1.81.1"
+  "dist/release/v1.81.1-b17ef02"
+  "v1.81.11"
 )
 
 MODE="${1:-}"


### PR DESCRIPTION
## Outcome

Fixes the formal fleet controller stop on semantic `v1.81.1`, whose historical source tag legitimately predates `System/.release-catalog.json`.

Catalog-less semantic tags remain evidence-only: their exact tag/commit/tree identity is preserved, protocol runner/executor/bridge hashes must match that exact semantic source commit, and they cannot grant execution authority or substitute an immutable distribution package. Existing or malformed catalog evidence still fails closed. Immutable foundation/follow-up releases remain catalog-strict.

## Evidence

- Formal run `30942219731`: 200 discovered, 172 started, 171 completed/passed, 1 controller failure, 28 not started.
- All 171 completed journeys reached both public hops, had healthy Doctors, preserved all four protected hashes, and passed retained evidence audit.
- Controller suite: 65/65 passed.
- Independent specification review: 0 findings.
- Independent hard-standards review: 0 hard findings.
- Static current-surface audit: 202/202 passed; this is not Mac fleet acceptance.

## Boundaries

No release, tag move, publication, deployment, or fleet acceptance is performed by this PR.