### PR TITLE
Release v1.81.17 fleet failure collector

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/historic-fleet-darwin.yml
+      - package.json
       - core/update/journey-protocol-v1.json
       - scripts/build-release.sh
       - scripts/build-vault-bundle.sh

--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -7,7 +7,7 @@ on:
         description: Exact public immutable foundation tag
         required: true
         type: string
-        default: dist/release/v1.81.15-be0e5f3
+        default: dist/release/v1.81.16-281202d
       follow_up_tag:
         description: Exact public immutable follow-up tag
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ than the customer update path.
   an exact historic release genuinely predates the catalogue, Dex can use its
   verified updater files as evidence instead of requiring a file that never
   existed.
+* **The newest public release joins the historic proof set.** Both v1.81.16
+  identities are tested through the exact immutable v1.81.16 first hop before
+  the distinct v1.81.17 follow-up.
 * **Missing or altered proof still stops safely.** An unreadable or malformed
   catalogue, changed updater files, or a mismatched release identity is still
   rejected before a journey starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.17] — 🧭 Historic checks now recognise what older releases actually shipped (2026-08-05)
+
+The final public Mac fleet stopped before testing one old semantic release because
+that release predates Dex's release catalogue. The adjacent immutable package
+completed both update hops, showing that the stop was in the fleet proof rather
+than the customer update path.
+
+**What this fixes for you:**
+
+* **Older semantic releases are judged by the files they actually shipped.** When
+  an exact historic release genuinely predates the catalogue, Dex can use its
+  verified updater files as evidence instead of requiring a file that never
+  existed.
+* **Missing or altered proof still stops safely.** An unreadable or malformed
+  catalogue, changed updater files, or a mismatched release identity is still
+  rejected before a journey starts.
+* **Historic support still has to be earned.** This release removes the narrow
+  proof-controller blocker, but Dex will claim support only after the freshly
+  generated public Mac fleet completes with zero failures.
+
 ## [1.81.16] — 🧭 Historic updates now aim at the selected public foundation (2026-08-04)
 
 Dex's historic-update bridge previously used the original v1.81.0 foundation,

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.16"
+  "release_version": "1.81.17"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.16",
+  "release_version": "1.81.17",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.16","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.17","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -203,11 +203,11 @@ def _foundation_topology_adapter(
 
 def test_foundation_pin_is_closed_and_uses_only_the_release_channel() -> None:
     assert bridge.FOUNDATION.identity() == {
-        "tag": "dist/release/v1.81.15-be0e5f3",
-        "tag_object": "bd3f25cc51e8fc9677239c656286606b4bc0fe71",
-        "commit": "be0e5f3a615d1f4be827006440cbfb003a17521b",
-        "tree": "f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
-        "version": "1.81.15",
+        "tag": "dist/release/v1.81.16-281202d",
+        "tag_object": "6abd259c87bf88519fd8b0bfa863cb99b959660f",
+        "commit": "281202dcc10a41540c5f72bd6b47bd7d7dcc776d",
+        "tree": "6725b11a8756b04ba7d6b26399ab90eb75f43af0",
+        "version": "1.81.16",
         "channel": "stable",
     }
 

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -52,6 +52,14 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     assert upload["with"]["if-no-files-found"] == "warn"
 
 
+def test_release_version_bump_triggers_the_pr_canary() -> None:
+    workflow = _workflow()
+    triggers = workflow.get("on", workflow.get(True))
+    pull_request_paths = set(triggers["pull_request"]["paths"])
+
+    assert "package.json" in pull_request_paths
+
+
 def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -26,7 +26,7 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     inputs = triggers["workflow_dispatch"]["inputs"]
     assert inputs["foundation_tag"]["required"] is True
     assert (
-        inputs["foundation_tag"]["default"] == "dist/release/v1.81.15-be0e5f3"
+        inputs["foundation_tag"]["default"] == "dist/release/v1.81.16-281202d"
     )
     assert inputs["follow_up_tag"]["required"] is True
     assert workflow["permissions"] == {"contents": "read"}
@@ -107,7 +107,7 @@ def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
 
 def test_formal_runner_freezes_public_cohort_and_retains_exact_counts() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
-    assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.15-be0e5f3"' in source
+    assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.16-281202d"' in source
     assert 'MAX_DISK_KIB=$((50 * 1024 * 1024))' in source
     assert "release_fleet_acceptance.py cohort" in source
     assert "release_fleet_acceptance.py session" in source

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1933,6 +1933,29 @@ def test_standalone_bridge_asset_refuses_a_checksum_not_shipped_for_its_bytes(
         )
 
 
+def test_case_executor_collects_only_failures_after_case_execution_starts() -> None:
+    from scripts import release_fleet_executor
+
+    def case_failure(*, _case_started, **_kwargs):
+        _case_started()
+        raise release_fleet_executor.ExecutorError("foundation Doctor is unhealthy")
+
+    with pytest.raises(
+        release_fleet.CaseJourneyFailure,
+        match="foundation Doctor is unhealthy",
+    ):
+        release_fleet.run_case_executor("v1.61.0", case_failure)
+
+    def integrity_failure(**_kwargs):
+        raise release_fleet_executor.ExecutorError("released executor identity changed")
+
+    with pytest.raises(
+        release_fleet_executor.ExecutorError,
+        match="released executor identity changed",
+    ):
+        release_fleet.run_case_executor("v1.61.0", integrity_failure)
+
+
 @pytest.mark.parametrize("split_topology", [False, True])
 @pytest.mark.parametrize("controlled_approvals", [False, True])
 def test_journey_delegates_only_after_released_source_and_fixture_are_bound(

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1958,11 +1958,13 @@ def test_case_executor_collects_only_failures_after_case_execution_starts() -> N
 
 @pytest.mark.parametrize("split_topology", [False, True])
 @pytest.mark.parametrize("controlled_approvals", [False, True])
+@pytest.mark.parametrize("fixture_failure", [False, True])
 def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     split_topology: bool,
     controlled_approvals: bool,
+    fixture_failure: bool,
 ) -> None:
     from core.update.journey_protocol import load_update_journey_protocol
     from scripts import release_fleet_executor
@@ -2091,6 +2093,8 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         environment,
         keep_official_fetch,
     ):
+        if fixture_failure:
+            raise release_fleet.FleetError("fixture provenance changed")
         assert environment == {}
         assert keep_official_fetch is True
         vault = output / release_fleet.safe_case_name(release)
@@ -2164,6 +2168,23 @@ def test_journey_delegates_only_after_released_source_and_fixture_are_bound(
         lambda *_args, **_kwargs: remote_events.append("remote-closed"),
     )
     monkeypatch.setattr(release_fleet_executor, "execute_journey", execute)
+
+    if fixture_failure:
+        with pytest.raises(release_fleet.FleetError) as failure:
+            release_fleet.run_journey(
+                tmp_path,
+                output=tmp_path / "output",
+                starting_tag=start.tag,
+                foundation_tag=foundation.tag,
+                follow_up_tag=follow_up.tag,
+                bridge_asset=bridge_asset,
+                bridge_checksum=bridge_checksum,
+                controlled_approvals=controlled_approvals,
+                follow_up_cache=tmp_path / "candidate-release.git",
+            )
+        assert type(failure.value) is release_fleet.FleetError
+        assert str(failure.value) == "fixture provenance changed"
+        return
 
     run = release_fleet.run_journey(
         tmp_path,

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -53,11 +53,12 @@ def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
     acceptance = _acceptance()
     historic = (
         _release("v1.20.1", "1.20.1", "1"),
+        _release("v1.81.16", "1.81.16", "3"),
         _foundation_release(),
     )
     later = (
-        _release("v1.81.16", "1.81.16", "3"),
-        _release("dist/release/v1.81.17-4444444", "1.81.17", "4"),
+        _release("v1.81.17", "1.81.17", "4"),
+        _release("dist/release/v1.81.18-5555555", "1.81.18", "5"),
     )
 
     manifest = acceptance.frozen_cohort_manifest(
@@ -71,7 +72,7 @@ def test_frozen_cohort_excludes_later_control_and_follow_up_releases() -> None:
     )
 
     assert parsed == historic
-    assert manifest["case_count"] == 2
+    assert manifest["case_count"] == 3
     assert manifest["foundation"] == _foundation()
 
 
@@ -214,7 +215,7 @@ def test_real_repository_derives_the_current_historic_tree_count() -> None:
 
     assert manifest["case_count"] == len(manifest["cases"]) == len(parsed)
     assert manifest["case_count"] > 0
-    assert manifest["foundation"]["tag"] == "dist/release/v1.81.15-be0e5f3"
+    assert manifest["foundation"]["tag"] == "dist/release/v1.81.16-281202d"
 
 
 def _case(tag: str, platform: str) -> release_fleet.CaseResult:

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -802,15 +802,17 @@ def test_platform_collector_retains_every_live_run_and_exact_counts(
     }
 
 
-def test_platform_collector_stops_on_first_failure_with_honest_counts(
+def test_platform_collector_collects_every_case_failure_before_failing_closed(
     tmp_path: Path,
 ) -> None:
     acceptance = _acceptance()
     releases = (
         _release("v1.20.1", "1.20.1", "1"),
         _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+        _release("v1.81.1", "1.81.1", "3"),
     )
     bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    attempted: list[str] = []
 
     def journey_runner(
         _repo: Path,
@@ -825,8 +827,12 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
     ) -> object:
         del output, foundation_tag, follow_up_tag, bridge_asset, bridge_checksum
         assert controlled_approvals is True
-        if starting_tag == releases[1].tag:
-            raise release_fleet.FleetError("synthetic journey failed")
+        attempted.append(starting_tag)
+        if starting_tag in {releases[0].tag, releases[2].tag}:
+            raise release_fleet.CaseJourneyFailure(
+                starting_tag,
+                "synthetic journey failed",
+            )
         return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
 
     with pytest.raises(acceptance.PlatformFleetFailure) as failure:
@@ -843,12 +849,74 @@ def test_platform_collector_stops_on_first_failure_with_honest_counts(
         )
 
     assert failure.value.counts == {
-        "discovered": 2,
+        "discovered": 3,
+        "started": 3,
+        "completed": 1,
+        "passed": 1,
+        "failed": 2,
+    }
+    assert attempted == [release.tag for release in releases]
+    assert [item.starting_tag for item in failure.value.failures] == [
+        releases[0].tag,
+        releases[2].tag,
+    ]
+    diagnostic = json.loads((tmp_path / "platform-failures.json").read_text(encoding="utf-8"))
+    assert diagnostic["acceptance"] is False
+    assert diagnostic["counts"] == failure.value.counts
+    assert diagnostic["groups"] == [
+        {
+            "count": 2,
+            "error_type": "CaseJourneyFailure",
+            "signature": failure.value.failures[0].signature,
+            "starting_tags": [releases[0].tag, releases[2].tag],
+        }
+    ]
+
+
+def test_platform_collector_stops_immediately_on_infrastructure_or_integrity_failure(
+    tmp_path: Path,
+) -> None:
+    acceptance = _acceptance()
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+        _release("v1.81.1", "1.81.1", "3"),
+    )
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    attempted: list[str] = []
+
+    def journey_runner(_repo: Path, *, starting_tag: str, **_kwargs) -> object:
+        attempted.append(starting_tag)
+        if starting_tag == releases[1].tag:
+            raise release_fleet.FleetError("shared protocol identity changed")
+        return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
+
+    with pytest.raises(
+        acceptance.PlatformFleetFailure,
+        match="infrastructure or integrity failure",
+    ) as failure:
+        acceptance.collect_platform_runs(
+            tmp_path,
+            output=tmp_path,
+            releases=releases,
+            foundation_tag=FOUNDATION.tag,
+            follow_up_tag="dist/release/v1.81.1-3333333",
+            running_platform="darwin",
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
+            journey_runner=journey_runner,
+        )
+
+    assert attempted == [releases[0].tag, releases[1].tag]
+    assert failure.value.counts == {
+        "discovered": 3,
         "started": 2,
         "completed": 1,
         "passed": 1,
         "failed": 1,
     }
+    assert failure.value.failures == ()
+    assert not (tmp_path / "platform-failures.json").exists()
 
 
 def _immutable_foundation() -> release_fleet.ImmutableRelease:

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -715,6 +715,8 @@ def _execute(
     input_fn=lambda _prompt: "APPLY",
     starting: dict[str, str] | None = None,
     follow_up_cache: Path | None = None,
+    platform: str = "darwin",
+    case_started=lambda: None,
 ) -> executor.ExecutorRun:
     protocol = load_update_journey_protocol(
         (REPO_ROOT / "core/update/journey-protocol-v1.json").read_bytes()
@@ -733,7 +735,7 @@ def _execute(
         historic_surface={"release": starting, "machine_executable": False},
         foundation_surface={"release": protocol.foundation, "machine_executable": False},
         user_owned_paths=user_files,
-        platform="darwin",
+        platform=platform,
         bridge_asset_evidence=_bridge_asset_evidence(protocol, runtime.follow_up),
         bridge_asset_path=REPO_ROOT / protocol.bridge.artifact.source_path,
         initial_install_evidence={"topology": "legacy-monolithic", "brain_refs": []},
@@ -741,7 +743,36 @@ def _execute(
         input_fn=input_fn,
         output_fn=lambda _line: None,
         _runtime=runtime,
+        _case_started=case_started,
     )
+
+
+def test_executor_marks_case_execution_only_after_shared_integrity_checks(
+    tmp_path: Path,
+) -> None:
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    follow_up = _identity("1.81.0", "b")
+    started: list[str] = []
+
+    _execute(
+        tmp_path / "valid",
+        _Runtime(follow_up),
+        source_repo=source_repo,
+        source_commit=source_commit,
+        case_started=lambda: started.append("valid"),
+    )
+
+    with pytest.raises(executor.ExecutorError, match="platform is not declared"):
+        _execute(
+            tmp_path / "invalid",
+            _Runtime(follow_up),
+            source_repo=source_repo,
+            source_commit=source_commit,
+            platform="win32",
+            case_started=lambda: started.append("invalid"),
+        )
+
+    assert started == ["valid"]
 
 
 def test_cache_backed_run_cannot_satisfy_formal_acceptance_authority(

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "4c349f6f103d0d21f342c08b061f08da380c4b3a7e11025b89876de24cdf4e52",
+    "sha256": "3b9e5f9e7042407ef8c266d6846f15698f52ea4d900ccab6c64b619eba7f1fe2",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,16 +35,16 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "fe76a0e7920443bd263baccf89252a856adab32309ad4e5aec127f037b3e5ce5",
+      "sha256": "2719588befe2f471d11e71d580115200b945527ca9310b247a1ee61c53f4aced",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {
       "channel": "stable",
-      "commit": "be0e5f3a615d1f4be827006440cbfb003a17521b",
-      "tag": "dist/release/v1.81.15-be0e5f3",
-      "tag_object": "bd3f25cc51e8fc9677239c656286606b4bc0fe71",
-      "tree": "f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
-      "version": "1.81.15"
+      "commit": "281202dcc10a41540c5f72bd6b47bd7d7dcc776d",
+      "tag": "dist/release/v1.81.16-281202d",
+      "tag_object": "6abd259c87bf88519fd8b0bfa863cb99b959660f",
+      "tree": "6725b11a8756b04ba7d6b26399ab90eb75f43af0",
+      "version": "1.81.16"
     }
   },
   "platforms": [

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "ac25db8ebbc3f56e5a173ef9429ae16a31a0a834fa17f6a9327ca193f80182eb",
+    "sha256": "2ef35e88d2dc033a241cad4387882d75502fd8d805184cf721f5a49bf1796901",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "f2c16da23c777fe2cf09210f53a01e7a1b33e141134fa348f4e5dd37160d626c",
+    "sha256": "4c349f6f103d0d21f342c08b061f08da380c4b3a7e11025b89876de24cdf4e52",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -82,7 +82,7 @@ begin. The bridge is intentionally not a raw Git merge: it fetches only the
 pre-pinned foundation release, proves its annotated tag, commit, and tree, then
 uses that foundation's existing topology and receipt-backed transaction service.
 
-The bridge now pins the exact public v1.81.15 foundation: its annotated
+The bridge now pins the exact public v1.81.16 foundation: its annotated
 distribution tag, tag object, commit, and tree are all closed in the released
 journey contract. That publication is not, by itself, proof that every historic
 route works. Each supported route still needs an installed-fixture rehearsal,

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.16 release,
+Download the versioned bridge and its checksum from the public v1.81.17 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.16/dex-update-bridge-v1.81.16.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.17/dex-update-bridge-v1.81.17.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.16/dex-update-bridge-v1.81.16.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.17/dex-update-bridge-v1.81.17.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.16.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.17.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.16.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -102,9 +102,9 @@ Markdown `/dex-update` instructions into an API.
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
   --foundation-tag dist/release/v1.81.15-be0e5f3 \
-  --follow-up-tag dist/release/v1.81.16-EXACTFOLLOWUP \
-  --bridge-asset /path/to/dex-update-bridge-v1.81.16.py \
-  --bridge-checksum /path/to/dex-update-bridge-v1.81.16.py.sha256
+  --follow-up-tag dist/release/v1.81.17-EXACTFOLLOWUP \
+  --bridge-asset /path/to/dex-update-bridge-v1.81.17.py \
+  --bridge-checksum /path/to/dex-update-bridge-v1.81.17.py.sha256
 ```
 
 Historic semantic `v*` starting tags have a narrower evidence-only rule. Their
@@ -185,10 +185,10 @@ bounded transport retry does not make the PR canary acceptance evidence.
 python3 scripts/release_fleet_acceptance.py platform --repo . \
   --cohort historic-cohort.json \
   --foundation-tag dist/release/v1.81.15-be0e5f3 \
-  --follow-up-tag dist/release/v1.81.16-EXACTFOLLOWUP \
+  --follow-up-tag dist/release/v1.81.17-EXACTFOLLOWUP \
   --session acceptance-session.json --key acceptance.key \
-  --bridge-asset /path/to/dex-update-bridge-v1.81.16.py \
-  --bridge-checksum /path/to/dex-update-bridge-v1.81.16.py.sha256 \
+  --bridge-asset /path/to/dex-update-bridge-v1.81.17.py \
+  --bridge-checksum /path/to/dex-update-bridge-v1.81.17.py.sha256 \
   --output "$fleet_root/darwin"
 ```
 
@@ -226,7 +226,7 @@ constructing the same documents cannot unlock acceptance. The resulting
 content-addressed manifest records the exact executor identity, release
 identities, ordered operations, and artifact hashes.
 
-The v1.81.16 protocol and executor pin the exact public v1.81.15 foundation.
+The v1.81.17 protocol and executor pin the exact public v1.81.15 foundation.
 That publication is one prerequisite, not fleet acceptance: the distinct
 follow-up release must exist and every historic case must still complete the
 two-hop journey on macOS.

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -150,6 +150,19 @@ sequentially on macOS. It retains the evidence and exact
 discovered/started/completed/passed/failed counts on both success and failure.
 The job is time-bounded to six hours and monitors a 50 GiB working-set limit.
 
+The formal controller continues after an isolated case has crossed the journey
+execution boundary and then fails. It retains every such failure in
+`platform-failures.json`, groups matching diagnostics by a stable signature, and
+finishes the frozen cohort before returning a non-zero result. This lets one
+exhaustive run expose all version-specific failure families instead of stopping
+at the first one. A shared protocol, released-identity, public-route, evidence,
+runtime, filesystem, disk-budget, or other infrastructure/integrity failure
+still stops the job immediately. A collected failure report is diagnostic
+evidence only: it cannot mint a platform receipt or acceptance result. If the
+exhaustive run has no failures, its ordinary receipt remains valid acceptance
+evidence; otherwise all grouped fixes need targeted proof before one final full
+acceptance run.
+
 Pull requests that touch the updater route get a separate non-publishing
 macOS canary. It builds a local release-shaped candidate and runs real journeys
 from these exact seven starts:

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -101,7 +101,7 @@ Markdown `/dex-update` instructions into an API.
 ```bash
 python3 scripts/release_fleet.py journey --repo . --output "$fleet_root" \
   --starting-tag dist/release/v1.74.0-EXACTSTART \
-  --foundation-tag dist/release/v1.81.15-be0e5f3 \
+  --foundation-tag dist/release/v1.81.16-281202d \
   --follow-up-tag dist/release/v1.81.17-EXACTFOLLOWUP \
   --bridge-asset /path/to/dex-update-bridge-v1.81.17.py \
   --bridge-checksum /path/to/dex-update-bridge-v1.81.17.py.sha256
@@ -184,7 +184,7 @@ bounded transport retry does not make the PR canary acceptance evidence.
 ```bash
 python3 scripts/release_fleet_acceptance.py platform --repo . \
   --cohort historic-cohort.json \
-  --foundation-tag dist/release/v1.81.15-be0e5f3 \
+  --foundation-tag dist/release/v1.81.16-281202d \
   --follow-up-tag dist/release/v1.81.17-EXACTFOLLOWUP \
   --session acceptance-session.json --key acceptance.key \
   --bridge-asset /path/to/dex-update-bridge-v1.81.17.py \
@@ -226,7 +226,7 @@ constructing the same documents cannot unlock acceptance. The resulting
 content-addressed manifest records the exact executor identity, release
 identities, ordered operations, and artifact hashes.
 
-The v1.81.17 protocol and executor pin the exact public v1.81.15 foundation.
+The v1.81.17 protocol and executor pin the exact public v1.81.16 foundation.
 That publication is one prerequisite, not fleet acceptance: the distinct
 follow-up release must exist and every historic case must still complete the
 two-hop journey on macOS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.16",
+  "version": "1.81.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.16",
+      "version": "1.81.17",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.16",
+  "version": "1.81.17",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -106,11 +106,11 @@ class ReleasePin:
 # This pin is intentionally in the bridge source:
 # discovering a mutable "latest" release would not be a safe bootstrap.
 FOUNDATION = ReleasePin(
-    tag="dist/release/v1.81.15-be0e5f3",
-    tag_object="bd3f25cc51e8fc9677239c656286606b4bc0fe71",
-    commit="be0e5f3a615d1f4be827006440cbfb003a17521b",
-    tree="f1f55abdc7c4e4c54101b3606b162c2cba148f9c",
-    version="1.81.15",
+    tag="dist/release/v1.81.16-281202d",
+    tag_object="6abd259c87bf88519fd8b0bfa863cb99b959660f",
+    commit="281202dcc10a41540c5f72bd6b47bd7d7dcc776d",
+    tree="6725b11a8756b04ba7d6b26399ab90eb75f43af0",
+    version="1.81.16",
 )
 
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -2314,10 +2314,6 @@ def run_journey(
             )
         finally:
             _disable_all_fixture_remotes(case.vault, environment)
-    except CaseJourneyFailure:
-        raise
-    except FleetError as error:
-        raise CaseJourneyFailure(start.tag, str(error)) from error
     finally:
         _remove_disposable_fixture(vault, output)
         _remove_disposable_fixture(runtime_root, output)

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -161,6 +161,19 @@ class FleetError(RuntimeError):
     """The historic release fleet could not be built safely."""
 
 
+class CaseJourneyFailure(FleetError):
+    """One isolated historic journey failed after case execution began."""
+
+    def __init__(self, starting_tag: str, detail: str) -> None:
+        if not isinstance(starting_tag, str) or not starting_tag:
+            raise ValueError("case journey failure requires a starting tag")
+        if not isinstance(detail, str) or not detail:
+            raise ValueError("case journey failure requires a detail")
+        super().__init__(f"{starting_tag}: {detail}")
+        self.starting_tag = starting_tag
+        self.detail = detail
+
+
 @dataclass(frozen=True)
 class NodeRuntime:
     """An explicitly selected Node/npm capability for disposable fixtures."""
@@ -2131,6 +2144,30 @@ def _verify_standalone_bridge_asset(
     }
 
 
+def run_case_executor(
+    starting_tag: str,
+    executor: Callable[..., object],
+    /,
+    **kwargs: object,
+) -> object:
+    """Collect only a failure from an executor that crossed the case boundary."""
+
+    from scripts import release_fleet_executor
+
+    case_execution_started = False
+
+    def mark_case_execution_started() -> None:
+        nonlocal case_execution_started
+        case_execution_started = True
+
+    try:
+        return executor(_case_started=mark_case_execution_started, **kwargs)
+    except release_fleet_executor.ExecutorError as error:
+        if not case_execution_started:
+            raise
+        raise CaseJourneyFailure(starting_tag, str(error)) from error
+
+
 def run_journey(
     repo: Path,
     *,
@@ -2254,7 +2291,9 @@ def run_journey(
                     start,
                     environment,
                 )
-            return release_fleet_executor.execute_journey(
+            return run_case_executor(
+                start.tag,
+                release_fleet_executor.execute_journey,
                 repo_root=repo,
                 source_commit=source_commit,
                 vault_root=case.vault,
@@ -2275,6 +2314,10 @@ def run_journey(
             )
         finally:
             _disable_all_fixture_remotes(case.vault, environment)
+    except CaseJourneyFailure:
+        raise
+    except FleetError as error:
+        raise CaseJourneyFailure(start.tag, str(error)) from error
     finally:
         _remove_disposable_fixture(vault, output)
         _remove_disposable_fixture(runtime_root, output)

--- a/scripts/release_fleet_acceptance.py
+++ b/scripts/release_fleet_acceptance.py
@@ -41,6 +41,7 @@ MAX_PLATFORM_MANIFEST_BYTES = 16 * 1024 * 1024
 MAX_PUBLIC_RELEASE_ASSET_BYTES = 16 * 1024 * 1024
 PLATFORM_MANIFEST_NAME = "platform-manifest.json"
 PLATFORM_RECEIPT_NAME = "platform-receipt.json"
+PLATFORM_FAILURES_NAME = "platform-failures.json"
 CANONICAL_PUBLIC_REMOTE = "https://github.com/davekilleen/Dex.git"
 CANONICAL_PUBLIC_LATEST_RELEASE = "https://github.com/davekilleen/Dex/releases/latest"
 CANONICAL_PUBLIC_RELEASE_PAGE = "https://github.com/davekilleen/Dex/releases/tag/v{version}"
@@ -106,6 +107,24 @@ class PlatformExecution:
 
 
 @dataclass(frozen=True)
+class PlatformCaseFailure:
+    """One case-local failure retained for grouping and targeted repair."""
+
+    starting_tag: str
+    error_type: str
+    detail: str
+    signature: str
+
+    def document(self) -> dict[str, str]:
+        return {
+            "starting_tag": self.starting_tag,
+            "error_type": self.error_type,
+            "detail": self.detail,
+            "signature": self.signature,
+        }
+
+
+@dataclass(frozen=True)
 class FleetInputs:
     """All immutable identities shared by one acceptance session."""
 
@@ -121,9 +140,15 @@ class FleetInputs:
 class PlatformFleetFailure(release_fleet.FleetError):
     """One platform stopped before its complete live verdict."""
 
-    def __init__(self, message: str, counts: Mapping[str, int]) -> None:
+    def __init__(
+        self,
+        message: str,
+        counts: Mapping[str, int],
+        failures: Sequence[PlatformCaseFailure] = (),
+    ) -> None:
         super().__init__(message)
         self.counts = dict(counts)
+        self.failures = tuple(failures)
 
 
 def _fleet_case_count(inputs: FleetInputs) -> int:
@@ -625,6 +650,55 @@ def aggregate_platform_evidence(
     }
 
 
+def _platform_case_failure(
+    release: release_fleet.DistributionRelease,
+    error: release_fleet.CaseJourneyFailure,
+    *,
+    output: Path,
+) -> PlatformCaseFailure:
+    detail = error.detail.replace(str(output), "<fleet-output>")
+    error_type = type(error).__name__
+    signature = hashlib.sha256(f"{error_type}\0{detail}".encode("utf-8")).hexdigest()
+    return PlatformCaseFailure(release.tag, error_type, detail, signature)
+
+
+def _write_platform_failure_summary(
+    output: Path,
+    counts: Mapping[str, int],
+    failures: Sequence[PlatformCaseFailure],
+) -> Path:
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for failure in failures:
+        grouped.setdefault((failure.error_type, failure.signature), []).append(
+            failure.starting_tag
+        )
+    groups = [
+        {
+            "count": len(starting_tags),
+            "error_type": error_type,
+            "signature": signature,
+            "starting_tags": sorted(starting_tags),
+        }
+        for (error_type, signature), starting_tags in sorted(grouped.items())
+    ]
+    path = output / PLATFORM_FAILURES_NAME
+    _write_exclusive(
+        path,
+        _json_bytes(
+            {
+                "schema_version": 1,
+                "outcome": "HISTORIC_FLEET_CASE_FAILURES",
+                "acceptance": False,
+                "counts": dict(counts),
+                "groups": groups,
+                "failures": [failure.document() for failure in failures],
+            }
+        ),
+        mode=0o600,
+    )
+    return path
+
+
 def collect_platform_runs(
     repo: Path,
     *,
@@ -648,6 +722,7 @@ def collect_platform_runs(
     }
     executor_runs: list[object] = []
     case_documents: list[dict[str, object]] = []
+    case_failures: list[PlatformCaseFailure] = []
     for release in releases:
         counts["started"] += 1
         try:
@@ -668,12 +743,34 @@ def collect_platform_runs(
             executor_runs.append(run)
             counts["completed"] += 1
             counts["passed"] += 1
+        except release_fleet.CaseJourneyFailure as error:
+            counts["failed"] += 1
+            failure = _platform_case_failure(release, error, output=output)
+            case_failures.append(failure)
+            print(
+                json.dumps(
+                    {"fleet_case_failure": failure.document()},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
         except Exception as error:
             counts["failed"] += 1
             raise PlatformFleetFailure(
-                f"{release.tag}: platform journey failed: {error}",
+                f"{release.tag}: platform infrastructure or integrity failure: {error}",
                 counts,
+                case_failures,
             ) from error
+
+    if case_failures:
+        summary = _write_platform_failure_summary(output, counts, case_failures)
+        raise PlatformFleetFailure(
+            f"{len(case_failures)} case-local journey failures; summary: {summary}",
+            counts,
+            case_failures,
+        )
 
     try:
         report = release_fleet.acceptance_report_from_json(

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -1465,6 +1465,7 @@ def _execute_journey_with_runtime(
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
     _runtime: JourneyRuntime,
+    _case_started: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Execute and own one closed two-hop journey in the current process."""
 
@@ -1529,6 +1530,8 @@ def _execute_journey_with_runtime(
         raise ExecutorError("historic update surface is not bound to the starting release")
     if foundation_surface.get("release") != foundation:
         raise ExecutorError("foundation update surface is not bound to the foundation release")
+    if _case_started is not None:
+        _case_started()
 
     bridge_approvals: list[dict[str, str]] = []
 
@@ -1852,6 +1855,7 @@ def _executor_boundary():
         input_fn: Callable[[str], str] = input,
         output_fn: Callable[[str], None] = print,
         _runtime: JourneyRuntime | None = None,
+        _case_started: Callable[[], None] | None = None,
     ) -> ExecutorRun:
         """Execute one released journey and retain production authority here."""
 
@@ -1887,6 +1891,7 @@ def _executor_boundary():
                 input_fn=input_fn,
                 output_fn=output_fn,
                 _runtime=runtime,
+                _case_started=_case_started,
             )
         finally:
             if production_owned:

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
-PINNED_FOUNDATION_TAG="dist/release/v1.81.15-be0e5f3"
+PINNED_FOUNDATION_TAG="dist/release/v1.81.16-281202d"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
 CANARY_STARTS=(
   "v1.51.0"


### PR DESCRIPTION
## Outcome

Prepares the v1.81.17 follow-up release and changes the formal historic Mac fleet controller to collect every case-local failure across the frozen cohort instead of stopping on the first version-specific bug.

Shared protocol, release identity, public route, evidence, runtime, filesystem, disk-budget, and other infrastructure/integrity failures still abort immediately. A failure summary is diagnostic only and cannot mint acceptance.

## Release shape

- foundation: `dist/release/v1.81.16-281202d`
- follow-up candidate: v1.81.17
- freshly derived formal cohort after publication: 202 cases
- PR Mac canary: 10 real two-hop journeys, non-acceptance

## Verification

- 141 controller/executor/acceptance tests passed; 3 Mac-only tests deferred to CI
- 149 workflow/protocol/bridge/distribution tests passed
- Ruff, shell syntax, regenerated protocol identity, diff hygiene passed
- PII, founder-content, portable-contract, tag reachability, tag uniqueness gates passed

No v1.81.17 tag or GitHub Release exists. Merging this PR is a separate publication decision after CI and retained Mac canary evidence are green.
