### PR TITLE
Release v1.81.18 proactive health summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.81.18] — 🩺 Proactive health summaries (2026-08-05)
+
+Dex used to make it hard to know whether background checks were current without
+asking for a full Doctor run. This release keeps the latest complete health
+summary visible while keeping session starts calm.
+
+**What this changes for you:**
+
+* **Health summaries stay trustworthy.** Reporter results are normalized into
+  immutable snapshots, so an incomplete refresh cannot replace the last known
+  complete status.
+* **Critical problems surface at the right moment.** A newly critical result
+  can interrupt the session; warnings, staleness, and recoveries stay quiet or
+  unobtrusive.
+* **Doctor can resume context safely.** A structured handoff preserves the
+  relevant issue and check identities, while stale or malformed context falls
+  back safely to general Doctor.
+* **Existing installations get it automatically.** The first refresh stays
+  quietly in a preparing state, with no new notification controls to configure.
+
 ## [1.81.17] — 🧭 Historic checks now recognise what older releases actually shipped (2026-08-05)
 
 The final public Mac fleet stopped before testing one old semantic release because

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -752,6 +752,11 @@ core/entity_engine/relationships.py
 core/entity_engine/temperature.py
 core/entity_engine/write.py
 core/entity_maintenance.py
+core/health/__init__.py
+core/health/doctor_ref.py
+core/health/doctor_reporter.py
+core/health/reporter.py
+core/health/snapshot.py
 core/integrations/BUILD_TRACKER.md
 core/integrations/__init__.py
 core/integrations/connection-manager/README.md
@@ -1040,7 +1045,12 @@ core/tests/test_fuzz_properties.py
 core/tests/test_golden_journeys.py
 core/tests/test_granola_configuration_truth.py
 core/tests/test_granola_server.py
+core/tests/test_health_compatibility.py
+core/tests/test_health_doctor_ref.py
 core/tests/test_health_page_scripts.py
+core/tests/test_health_reporter.py
+core/tests/test_health_session_surface.py
+core/tests/test_health_snapshot.py
 core/tests/test_health_telemetry.py
 core/tests/test_health_telemetry_consent_ux.py
 core/tests/test_health_telemetry_privacy.py
@@ -1147,6 +1157,7 @@ core/utils/dex_logger.py
 core/utils/doctor.py
 core/utils/entity_pages.py
 core/utils/feature_status.py
+core/utils/health_session.py
 core/utils/health_telemetry.py
 core/utils/history_hygiene.py
 core/utils/integration_credentials.py

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.81.17"
+  "release_version": "1.81.18"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.81.17",
+  "release_version": "1.81.18",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.81.17","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.81.18","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -95,23 +95,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.81.17 release,
+Download the versioned bridge and its checksum from the public v1.81.18 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.17/dex-update-bridge-v1.81.17.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.18/dex-update-bridge-v1.81.18.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.18.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.81.17/dex-update-bridge-v1.81.17.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.81.18/dex-update-bridge-v1.81.18.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.81.18.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.81.17.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.81.18.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.17.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.81.18.py" --vault "$PWD"
 ```
 
 It shows two independent previews and requires `APPLY` for each: first the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.17",
+  "version": "1.81.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.81.17",
+      "version": "1.81.18",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.81.17",
+  "version": "1.81.18",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Release v1.81.18

This release publishes the proactive health implementation merged in PR #413.

- merged implementation: PR #413, merge commit `0d35c035f58b3dc18f35fbfa12e963ef896c0465`
- release-prep commit: `7b781096`
- version: `1.81.18`
- changelog: proactive health summaries, immutable snapshots, structured Doctor handoff, quiet preparing state, and default-on existing-install behavior
- release safety repair: archived the unused canonical `dist/release/v1.76.0-be28050` as `dist/archive/v1.76.0-be28050` with the same immutable commit `be28050c774fd40c7438f194f0ffd115c4eab71d`; both release-tag reachability and uniqueness gates pass

The normal `main` release workflow should publish the v1.81.18 GitHub release, immutable distribution tag, release branch, and health deployment after merge.
