### PR TITLE
Prevent public route rollover during historic fleet acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,9 @@ jobs:
     needs: [quality, test-results]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: macos-latest
+    concurrency:
+      group: stable-public-route
+      cancel-in-progress: false
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -38,6 +38,9 @@ jobs:
     name: historic-fleet-darwin
     runs-on: macos-14
     timeout-minutes: 360
+    concurrency:
+      group: stable-public-route
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -10,6 +10,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/historic-fleet-darwin.yml"
+CI_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/ci.yml"
 RUNNER_PATH = REPO_ROOT / "scripts/run-historic-fleet-darwin.sh"
 PINNED_ACTION = re.compile(r"^[^@]+@[0-9a-f]{40}$")
 
@@ -50,6 +51,20 @@ def test_formal_workflow_is_manual_read_only_and_pinned() -> None:
     upload = formal["steps"][-1]
     assert upload["if"] == "always()"
     assert upload["with"]["if-no-files-found"] == "warn"
+
+
+def test_stable_release_and_formal_fleet_share_non_cancelling_route_lock() -> None:
+    fleet_workflow = _workflow()
+    ci_workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    expected_lock = {
+        "group": "stable-public-route",
+        "cancel-in-progress": False,
+    }
+
+    assert fleet_workflow["jobs"]["historic-fleet-darwin"]["concurrency"] == expected_lock
+    assert ci_workflow["jobs"]["build-release"]["concurrency"] == expected_lock
+    assert "concurrency" not in fleet_workflow["jobs"]["historic-fleet-darwin-pr-canary"]
+    assert "concurrency" not in ci_workflow["jobs"]["build-release-beta"]
 
 
 def test_release_version_bump_triggers_the_pr_canary() -> None:

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -1955,6 +1955,36 @@ def test_case_executor_collects_only_failures_after_case_execution_starts() -> N
     ):
         release_fleet.run_case_executor("v1.61.0", integrity_failure)
 
+    expected = {
+        "tag": "dist/release/v1.81.17-aaaaaaa",
+        "tag_object": "b" * 40,
+        "commit": "a" * 40,
+        "tree": "c" * 40,
+        "version": "1.81.17",
+        "channel": "stable",
+    }
+    delivered = {
+        "tag": "dist/release/v1.81.18-ddddddd",
+        "tag_object": "e" * 40,
+        "commit": "d" * 40,
+        "tree": "f" * 40,
+        "version": "1.81.18",
+        "channel": "stable",
+    }
+
+    def public_route_drift(*, _case_started, **_kwargs):
+        _case_started()
+        raise release_fleet_executor.PublicRouteDriftError(expected, delivered)
+
+    with pytest.raises(
+        release_fleet_executor.PublicRouteDriftError,
+        match="public release route drifted",
+    ) as failure:
+        release_fleet.run_case_executor("v1.61.0", public_route_drift)
+
+    assert failure.value.expected_release == expected
+    assert failure.value.delivered_release == delivered
+
 
 @pytest.mark.parametrize("split_topology", [False, True])
 @pytest.mark.parametrize("controlled_approvals", [False, True])

--- a/core/tests/test_release_fleet_acceptance.py
+++ b/core/tests/test_release_fleet_acceptance.py
@@ -919,6 +919,70 @@ def test_platform_collector_stops_immediately_on_infrastructure_or_integrity_fai
     assert not (tmp_path / "platform-failures.json").exists()
 
 
+def test_platform_collector_stops_immediately_on_public_route_drift(
+    tmp_path: Path,
+) -> None:
+    from scripts import release_fleet_executor
+
+    acceptance = _acceptance()
+    releases = (
+        _release("v1.20.1", "1.20.1", "1"),
+        _release("dist/release/v1.80.5-2222222", "1.80.5", "2"),
+        _release("v1.81.1", "1.81.1", "3"),
+    )
+    bridge_asset, bridge_checksum = _bridge_pair(tmp_path)
+    attempted: list[str] = []
+    expected = {
+        "tag": "dist/release/v1.81.17-aaaaaaa",
+        "tag_object": "b" * 40,
+        "commit": "a" * 40,
+        "tree": "c" * 40,
+        "version": "1.81.17",
+        "channel": "stable",
+    }
+    delivered = {
+        "tag": "dist/release/v1.81.18-ddddddd",
+        "tag_object": "e" * 40,
+        "commit": "d" * 40,
+        "tree": "f" * 40,
+        "version": "1.81.18",
+        "channel": "stable",
+    }
+
+    def journey_runner(_repo: Path, *, starting_tag: str, **_kwargs) -> object:
+        attempted.append(starting_tag)
+        if starting_tag == releases[1].tag:
+            raise release_fleet_executor.PublicRouteDriftError(expected, delivered)
+        return SimpleNamespace(case=_case_document(_case(starting_tag, "darwin")))
+
+    with pytest.raises(
+        acceptance.PlatformFleetFailure,
+        match="public release route drifted",
+    ) as failure:
+        acceptance.collect_platform_runs(
+            tmp_path,
+            output=tmp_path,
+            releases=releases,
+            foundation_tag=FOUNDATION.tag,
+            follow_up_tag=expected["tag"],
+            running_platform="darwin",
+            bridge_asset=bridge_asset,
+            bridge_checksum=bridge_checksum,
+            journey_runner=journey_runner,
+        )
+
+    assert attempted == [releases[0].tag, releases[1].tag]
+    assert failure.value.counts == {
+        "discovered": 3,
+        "started": 2,
+        "completed": 1,
+        "passed": 1,
+        "failed": 1,
+    }
+    assert failure.value.failures == ()
+    assert not (tmp_path / "platform-failures.json").exists()
+
+
 def _immutable_foundation() -> release_fleet.ImmutableRelease:
     identity = FOUNDATION.identity()
     return release_fleet.ImmutableRelease(

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -128,6 +128,14 @@ class _Runtime:
                     "reason": "TOP-SECRET-NOT-FOR-DIAGNOSTICS",
                 },
             }
+        if self.failure == "public-route-drift":
+            return {
+                "status": "delivered",
+                "release": _identity("1.81.6", "c"),
+                "unsafe": {
+                    "token": "TOP-SECRET-NOT-FOR-DIAGNOSTICS",
+                },
+            }
         return {"status": "delivered", "release": self.follow_up}
 
     def build_and_preview_delivered_release(self, vault, release):
@@ -155,6 +163,8 @@ def _run_failure(
     tmp_path: Path,
     failure: str,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    expected_error: type[executor.ExecutorError] = executor.ExecutorError,
 ) -> Path:
     source, source_commit = _released_executor_source(tmp_path)
     monkeypatch.setattr(
@@ -170,7 +180,7 @@ def _run_failure(
     follow_up = _identity("1.81.5", "b")
     bridge_name = f"dex-update-bridge-v{follow_up['version']}.py"
     checksum = f"{protocol.bridge.artifact.sha256}  {bridge_name}\n".encode()
-    with pytest.raises(executor.ExecutorError) as error:
+    with pytest.raises(expected_error) as error:
         executor.execute_journey(
             repo_root=source,
             source_commit=source_commit,
@@ -208,6 +218,7 @@ def _run_failure(
         "foundation-doctor": "foundation Doctor is unhealthy",
         "follow-up-delivery": "lifecycle delivery did not prove",
         "follow-up-doctor": "follow-up Doctor is unhealthy",
+        "public-route-drift": "public release route drifted",
     }[failure]
     assert expected in str(error.value)
     return tmp_path / "case.evidence"
@@ -274,6 +285,31 @@ def test_failed_journey_retains_only_private_sanitized_diagnostic(
         }
         assert isinstance(document["delivery"]["elapsed_ms"], int)
         assert 0 <= document["delivery"]["elapsed_ms"] <= 900_000
+
+
+def test_closed_delivery_mismatch_is_shared_public_route_drift_with_safe_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = _run_failure(
+        tmp_path,
+        "public-route-drift",
+        monkeypatch,
+        expected_error=executor.PublicRouteDriftError,
+    )
+    diagnostic = evidence / "follow-up-delivery-failure.diagnostic.json"
+    document = json.loads(diagnostic.read_text(encoding="utf-8"))
+
+    assert document["delivery"] == {
+        "delivered_release": _identity("1.81.6", "c"),
+        "elapsed_ms": document["delivery"]["elapsed_ms"],
+        "failure_reason": "public-route-drift",
+        "release_matches_expected": False,
+        "status": "delivered",
+    }
+    serialized = diagnostic.read_text(encoding="utf-8")
+    assert "TOP-SECRET-NOT-FOR-DIAGNOSTICS" not in serialized
+    assert ".mcp.json" not in serialized
 
 
 def test_failure_diagnostic_retains_only_allowlisted_delivery_reason(

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -312,6 +312,37 @@ def test_closed_delivery_mismatch_is_shared_public_route_drift_with_safe_identit
     assert ".mcp.json" not in serialized
 
 
+def test_public_route_drift_identity_returns_only_a_closed_mismatch() -> None:
+    expected = _identity("1.81.5", "b")
+    delivered = _identity("1.81.6", "c")
+
+    assert executor._public_route_drift_identity(
+        {"status": "delivered", "release": delivered},
+        expected,
+    ) == delivered
+    assert (
+        executor._public_route_drift_identity(
+            {"status": "delivered", "release": expected},
+            expected,
+        )
+        is None
+    )
+    assert (
+        executor._public_route_drift_identity(
+            {"status": "delivered", "release": {"unsafe": "value"}},
+            expected,
+        )
+        is None
+    )
+    assert (
+        executor._public_route_drift_identity(
+            {"status": "not-delivered", "release": delivered},
+            expected,
+        )
+        is None
+    )
+
+
 def test_failure_diagnostic_retains_only_allowlisted_delivery_reason(
     tmp_path: Path,
 ) -> None:

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "2ef35e88d2dc033a241cad4387882d75502fd8d805184cf721f5a49bf1796901",
+    "sha256": "b956b02f0bbe86c79cff9d6ec69250bd0390ad98b561cae506f643b16591172b",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "3b9e5f9e7042407ef8c266d6846f15698f52ea4d900ccab6c64b619eba7f1fe2",
+    "sha256": "f6abe206ec33ec1530ff34cdca86d8012492553453e89cef5b7c749757a6b6ab",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "b956b02f0bbe86c79cff9d6ec69250bd0390ad98b561cae506f643b16591172b",
+    "sha256": "d7469d68ec133b4872a8eab0308078d45ba97101ae15300fcd2cc8f57c877366",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -2162,6 +2162,8 @@ def run_case_executor(
 
     try:
         return executor(_case_started=mark_case_execution_started, **kwargs)
+    except release_fleet_executor.PublicRouteDriftError:
+        raise
     except release_fleet_executor.ExecutorError as error:
         if not case_execution_started:
             raise

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -1044,6 +1044,18 @@ def _closed_delivered_release(
         return None
 
 
+def _public_route_drift_identity(
+    delivery: Mapping[str, object],
+    follow_up: Mapping[str, str],
+) -> dict[str, str] | None:
+    """Return the validated delivered identity only when the public route drifted."""
+
+    delivered_release = _closed_delivered_release(delivery)
+    if delivered_release is None or delivered_release == dict(follow_up):
+        return None
+    return delivered_release
+
+
 def _git_show(repo_root: Path, commit: str, relative: str) -> bytes:
     result = subprocess.run(
         [
@@ -1362,12 +1374,8 @@ def _failure_diagnostic(
     if delivery is not None:
         evidence = delivery.get("evidence")
         reason = evidence.get("reason") if isinstance(evidence, Mapping) else None
-        delivered_release = _closed_delivered_release(delivery)
-        route_drift = (
-            delivered_release is not None
-            and delivered_release != dict(follow_up)
-        )
-        if route_drift:
+        route_drift_release = _public_route_drift_identity(delivery, follow_up)
+        if route_drift_release is not None:
             failure_reason = "public-route-drift"
         elif isinstance(reason, str) and reason in _SAFE_DELIVERY_FAILURE_REASONS:
             failure_reason = reason
@@ -1384,8 +1392,8 @@ def _failure_diagnostic(
                 _MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS,
             ),
         }
-        if delivered_release is not None:
-            delivery_diagnostic["delivered_release"] = delivered_release
+        if route_drift_release is not None:
+            delivery_diagnostic["delivered_release"] = route_drift_release
         document["delivery"] = delivery_diagnostic
     return document
 
@@ -1625,12 +1633,8 @@ def _execute_journey_with_runtime(
     delivery_started = time.monotonic_ns()
     delivered = dict(_runtime.deliver_latest_release(vault))
     delivery_elapsed_ms = (time.monotonic_ns() - delivery_started) // 1_000_000
-    delivered_release = _closed_delivered_release(delivered)
-    if (
-        delivered.get("status") == "delivered"
-        and delivered_release is not None
-        and delivered_release != follow_up
-    ):
+    delivered_release = _public_route_drift_identity(delivered, follow_up)
+    if delivered_release is not None:
         _write_failure_diagnostic(
             evidence_root,
             "follow-up-delivery-failure.diagnostic.json",

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -77,6 +77,22 @@ class ExecutorError(RuntimeError):
     """The released journey executor could not prove a safe completed run."""
 
 
+class PublicRouteDriftError(ExecutorError):
+    """The public latest route differs from the session's pinned follow-up."""
+
+    def __init__(
+        self,
+        expected_release: Mapping[str, str],
+        delivered_release: Mapping[str, str],
+    ) -> None:
+        self.expected_release = dict(expected_release)
+        self.delivered_release = dict(delivered_release)
+        super().__init__(
+            "public release route drifted from pinned "
+            f"{self.expected_release['tag']} to {self.delivered_release['tag']}"
+        )
+
+
 class ExecutorRun:
     """One live executor result that cannot be reconstructed from JSON."""
 
@@ -1014,6 +1030,20 @@ def _strict_identity(
     return identity
 
 
+def _closed_delivered_release(
+    delivery: Mapping[str, object],
+) -> dict[str, str] | None:
+    """Return only a complete public release identity safe for diagnostics."""
+
+    release = delivery.get("release")
+    if delivery.get("status") != "delivered" or not isinstance(release, Mapping):
+        return None
+    try:
+        return _strict_identity(release, "delivered")
+    except ExecutorError:
+        return None
+
+
 def _git_show(repo_root: Path, commit: str, relative: str) -> bytes:
     result = subprocess.run(
         [
@@ -1332,22 +1362,31 @@ def _failure_diagnostic(
     if delivery is not None:
         evidence = delivery.get("evidence")
         reason = evidence.get("reason") if isinstance(evidence, Mapping) else None
-        document["delivery"] = {
+        delivered_release = _closed_delivered_release(delivery)
+        route_drift = (
+            delivered_release is not None
+            and delivered_release != dict(follow_up)
+        )
+        if route_drift:
+            failure_reason = "public-route-drift"
+        elif isinstance(reason, str) and reason in _SAFE_DELIVERY_FAILURE_REASONS:
+            failure_reason = reason
+        else:
+            failure_reason = "unclassified"
+        delivery_diagnostic: dict[str, object] = {
             "status": (
                 "delivered" if delivery.get("status") == "delivered" else "not-delivered"
             ),
             "release_matches_expected": delivery.get("release") == dict(follow_up),
-            "failure_reason": (
-                reason
-                if isinstance(reason, str)
-                and reason in _SAFE_DELIVERY_FAILURE_REASONS
-                else "unclassified"
-            ),
+            "failure_reason": failure_reason,
             "elapsed_ms": min(
                 max(delivery_elapsed_ms or 0, 0),
                 _MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS,
             ),
         }
+        if delivered_release is not None:
+            delivery_diagnostic["delivered_release"] = delivered_release
+        document["delivery"] = delivery_diagnostic
     return document
 
 
@@ -1586,6 +1625,25 @@ def _execute_journey_with_runtime(
     delivery_started = time.monotonic_ns()
     delivered = dict(_runtime.deliver_latest_release(vault))
     delivery_elapsed_ms = (time.monotonic_ns() - delivery_started) // 1_000_000
+    delivered_release = _closed_delivered_release(delivered)
+    if (
+        delivered.get("status") == "delivered"
+        and delivered_release is not None
+        and delivered_release != follow_up
+    ):
+        _write_failure_diagnostic(
+            evidence_root,
+            "follow-up-delivery-failure.diagnostic.json",
+            _failure_diagnostic(
+                phase="follow-up-delivery",
+                vault=vault,
+                foundation=foundation,
+                follow_up=follow_up,
+                delivery=delivered,
+                delivery_elapsed_ms=delivery_elapsed_ms,
+            ),
+        )
+        raise PublicRouteDriftError(follow_up, delivered_release)
     if (
         delivered.get("status") != "delivered"
         or delivered.get("release") != follow_up
@@ -1941,6 +1999,7 @@ __all__ = [
     "EXECUTOR_INTERFACE_VERSION",
     "ExecutorError",
     "ExecutorRun",
+    "PublicRouteDriftError",
     "JourneyRuntime",
     "execute_journey",
     "is_authoritative_executor_run",


### PR DESCRIPTION
## Why

The formal 202-case historic fleet run was healthy through 121 cases, then the public stable route advanced from v1.81.17 to v1.81.18 mid-run. The remaining 81 cases correctly installed the newer public release, so the pinned acceptance target no longer matched.

## What changed

- serialize stable release publication and formal historic-fleet runs with one non-cancelling concurrency lock
- detect a closed, valid delivered release identity that differs from the pinned target
- classify that condition as public-route-drift and fail the shared fleet immediately
- keep malformed or incomplete case evidence as ordinary case-local failures
- regenerate the canonical updater journey protocol

## Verification

- 167 safeguard tests passed in the implementation worktree; 3 existing Darwin-only tests deselected on Linux
- 59 focused tests independently passed after integration
- generated protocol is byte-identical to a fresh regeneration
- Python compilation and git diff checks are clean
- independent standards and specification reviews found no blocking issues

This PR does not bump or publish a release. The current public stable release remains v1.81.18.