### PR TITLE
Retry transient updater network failures

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -99,7 +99,7 @@ jobs:
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
           npm ci
-      - name: Run ten release-shaped macOS journeys
+      - name: Run twelve release-shaped macOS journeys
         env:
           FLEET_WORK_ROOT: ${{ runner.temp }}/historic-fleet-darwin-pr-canary
         run: bash scripts/run-historic-fleet-darwin.sh canary

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -437,6 +437,55 @@ def test_pre_delivery_proof_retries_one_sanitized_http_429_within_original_deadl
     assert len(runner.calls) == 1
 
 
+def test_pre_delivery_proof_retries_one_sanitized_network_failure_within_original_deadline(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = split_release_fixture["vault"]
+    tag, tag_object, commit, tree = split_release_fixture["target"]
+    identity = {
+        "status": update_verifier.STATUS_IDENTITY,
+        "tag": tag,
+        "tag_object": tag_object,
+        "commit": commit,
+        "tree": tree,
+    }
+    offline = {
+        "status": update_verifier.STATUS_OFFLINE,
+        "reason": "network-unavailable",
+    }
+    proof_budgets: list[float] = []
+
+    def prove_latest_release(
+        *_args, wall_clock_seconds: float, **_kwargs
+    ) -> dict[str, object]:
+        proof_budgets.append(wall_clock_seconds)
+        return offline if len(proof_budgets) == 1 else identity
+
+    moments = iter((100.0, 100.2, 100.3))
+    monkeypatch.setattr(apply_update, "_monotonic", lambda: next(moments), raising=False)
+    sleeps: list[float] = []
+    monkeypatch.setattr(apply_update, "time", SimpleNamespace(sleep=sleeps.append))
+    monkeypatch.setattr(update_verifier, "prove_latest_release", prove_latest_release)
+    runner = _ScriptedDeliveryFetch((None,))
+
+    result = apply_update.deliver_latest_release(
+        vault,
+        state_root=tmp_path / "evidence-state",
+        git_runner=runner,
+        wall_clock_seconds=10.0,
+    )
+
+    assert result["status"] == "delivered"
+    assert result["release"]["tag_object"] == tag_object
+    assert result["release"]["commit"] == commit
+    assert result["release"]["tree"] == tree
+    assert proof_budgets == [10.0, pytest.approx(9.7)]
+    assert sleeps == [apply_update.PRE_DELIVERY_PROOF_RETRY_BACKOFF_SECONDS]
+    assert len(runner.calls) == 1
+
+
 def test_pre_delivery_proof_does_not_retry_when_429_exhausts_original_deadline(
     split_release_fixture: dict[str, object],
     tmp_path: Path,

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -307,6 +307,36 @@ def test_public_foundation_fetch_retries_one_closed_network_failure_then_succeed
     assert sleeps == [bridge._PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS]
 
 
+def test_public_foundation_fetch_preserves_transient_error_when_retry_delay_exceeds_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failure = bridge.BridgeError("connection timed out")
+    calls: list[tuple[str, ...]] = []
+    sleeps: list[float] = []
+    monotonic = iter((100.0, 100.0, 189.95, 190.0))
+
+    def run_git(
+        _directory: Path,
+        *arguments: str,
+        timeout_seconds: float = 90.0,
+    ) -> str:
+        del timeout_seconds
+        calls.append(arguments)
+        raise failure
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+    monkeypatch.setattr(bridge.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(bridge.time, "sleep", sleeps.append)
+
+    with pytest.raises(bridge.BridgeError) as raised:
+        bridge._fetch_public_foundation_tag(tmp_path, bridge.FOUNDATION)
+
+    assert raised.value is failure
+    assert len(calls) == 1
+    assert sleeps == []
+
+
 def test_public_foundation_fetch_stops_after_two_closed_network_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -224,7 +224,12 @@ def test_foundation_fetch_survives_public_release_channel_advancing(
     calls: list[tuple[str, ...]] = []
     private_release_ref = follow_up_commit
 
-    def run_git(_directory: Path, *arguments: str) -> str:
+    def run_git(
+        _directory: Path,
+        *arguments: str,
+        timeout_seconds: float = 90.0,
+    ) -> str:
+        del timeout_seconds
         nonlocal private_release_ref
         calls.append(arguments)
         if arguments == (
@@ -259,6 +264,144 @@ def test_foundation_fetch_survives_public_release_channel_advancing(
         "refs/remotes/upstream/release",
         pin.commit,
     ) in calls
+
+
+def test_public_foundation_fetch_retries_one_closed_network_failure_then_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes: list[bridge.BridgeError | None] = [
+        bridge.BridgeError(
+            "fatal: unable to access the public release: Could not resolve host: github.com"
+        ),
+        None,
+    ]
+    calls: list[tuple[str, ...]] = []
+    timeouts: list[float] = []
+    sleeps: list[float] = []
+
+    def run_git(
+        _directory: Path,
+        *arguments: str,
+        timeout_seconds: float = 90.0,
+    ) -> str:
+        calls.append(arguments)
+        timeouts.append(timeout_seconds)
+        outcome = outcomes.pop(0)
+        if outcome is not None:
+            raise outcome
+        return ""
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+    monkeypatch.setattr(bridge.time, "sleep", sleeps.append)
+
+    bridge._fetch_public_foundation_tag(tmp_path, bridge.FOUNDATION)
+
+    assert len(calls) == 2
+    assert calls[0] == calls[1]
+    assert calls[0][-2:] == (
+        bridge.OFFICIAL_REMOTE,
+        f"refs/tags/{bridge.FOUNDATION.tag}:refs/tags/{bridge.FOUNDATION.tag}",
+    )
+    assert 0 < timeouts[1] <= timeouts[0] <= bridge._PUBLIC_FOUNDATION_FETCH_TOTAL_SECONDS
+    assert sleeps == [bridge._PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS]
+
+
+def test_public_foundation_fetch_stops_after_two_closed_network_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = iter(
+        (
+            bridge.BridgeError("temporary failure in name resolution"),
+            bridge.BridgeError("connection timed out"),
+        )
+    )
+    calls: list[tuple[str, ...]] = []
+    sleeps: list[float] = []
+
+    def run_git(
+        _directory: Path,
+        *arguments: str,
+        timeout_seconds: float = 90.0,
+    ) -> str:
+        del timeout_seconds
+        calls.append(arguments)
+        raise next(outcomes)
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+    monkeypatch.setattr(bridge.time, "sleep", sleeps.append)
+
+    with pytest.raises(bridge.BridgeError, match="^connection timed out$"):
+        bridge._fetch_public_foundation_tag(tmp_path, bridge.FOUNDATION)
+
+    assert len(calls) == 2
+    assert sleeps == [bridge._PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS]
+
+
+def test_public_foundation_fetch_does_not_retry_non_network_git_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    sleeps: list[float] = []
+
+    def run_git(
+        _directory: Path,
+        *arguments: str,
+        timeout_seconds: float = 90.0,
+    ) -> str:
+        del timeout_seconds
+        calls.append(arguments)
+        raise bridge.BridgeError("fatal: repository not found")
+
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+    monkeypatch.setattr(bridge.time, "sleep", sleeps.append)
+
+    with pytest.raises(bridge.BridgeError, match="^fatal: repository not found$"):
+        bridge._fetch_public_foundation_tag(tmp_path, bridge.FOUNDATION)
+
+    assert len(calls) == 1
+    assert sleeps == []
+
+
+def test_both_public_foundation_fetch_sites_use_the_bounded_retry_helper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    helper_calls: list[tuple[Path, bridge.ReleasePin]] = []
+
+    def fetch_public_foundation_tag(repository: Path, pin: bridge.ReleasePin) -> None:
+        helper_calls.append((repository, pin))
+
+    def run_git(_directory: Path, *arguments: str) -> str:
+        if arguments == ("rev-parse", "--verify", f"refs/tags/{bridge.FOUNDATION.tag}"):
+            return bridge.FOUNDATION.tag_object
+        if arguments == ("rev-parse", "--verify", f"{bridge.FOUNDATION.tag}^{{commit}}"):
+            return bridge.FOUNDATION.commit
+        if arguments == ("rev-parse", "--verify", f"{bridge.FOUNDATION.tag}^{{tree}}"):
+            return bridge.FOUNDATION.tree
+        if arguments == (
+            "rev-parse",
+            "--verify",
+            "refs/remotes/upstream/release^{commit}",
+        ):
+            return bridge.FOUNDATION.commit
+        return ""
+
+    monkeypatch.setattr(bridge, "_fetch_public_foundation_tag", fetch_public_foundation_tag)
+    monkeypatch.setattr(bridge, "_run_git", run_git)
+
+    temporary, _source = bridge.acquire_foundation_source()
+    try:
+        bridge._fetch_foundation_into_brain(_vault(tmp_path), bridge.FOUNDATION)
+    finally:
+        temporary.cleanup()
+
+    assert [(repository.name, pin) for repository, pin in helper_calls] == [
+        ("evidence.git", bridge.FOUNDATION),
+        ("brain.git", bridge.FOUNDATION),
+    ]
 
 
 def test_legacy_topology_pin_is_closed_to_exact_v1201_release() -> None:

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -75,12 +75,12 @@ def test_release_version_bump_triggers_the_pr_canary() -> None:
     assert "package.json" in pull_request_paths
 
 
-def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
+def test_twelve_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     workflow = _workflow()
     canary = workflow["jobs"]["historic-fleet-darwin-pr-canary"]
     assert canary["if"] == "github.event_name == 'pull_request'"
     assert any(
-        step.get("name") == "Run ten release-shaped macOS journeys"
+        step.get("name") == "Run twelve release-shaped macOS journeys"
         for step in canary["steps"]
     )
     assert any(
@@ -97,7 +97,7 @@ def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     canary_starts = tuple(
         re.findall(r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE)
     )
-    assert len(canary_starts) == 10
+    assert len(canary_starts) == 12
     assert canary_starts == (
         "v1.51.0",
         "dist/release/v1.61.0-dc7d332",
@@ -105,9 +105,11 @@ def test_ten_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         "v1.62.0",
         "dist/archive/v1.63.0-08ce719",
         "dist/archive/v1.65.0-c5ec161",
+        "dist/archive/v1.72.0-7d75da9",
         "dist/archive/v1.76.0-d0bb932",
         "v1.81.1",
         "dist/release/v1.81.1-b17ef02",
+        "v1.81.7",
         "v1.81.11",
     )
     assert "build-release.sh --source candidate --target release" in source

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -556,12 +556,19 @@ def _release_identity(release: VerifiedReleaseRef) -> dict[str, str]:
 
 
 def _is_retryable_public_proof_rejection(evidence: dict[str, object]) -> bool:
-    """Accept only the verifier's closed, sanitized HTTP 429 classification."""
-    return set(evidence) == {"status", "reason", "diagnostic"} and evidence == {
-        "status": "UNKNOWN",
-        "reason": "transient-http-rejection",
-        "diagnostic": {"classification": "http-429"},
-    }
+    """Accept only closed, sanitized transient public-proof classifications."""
+    if set(evidence) == {"status", "reason"}:
+        return evidence == {
+            "status": "offline",
+            "reason": "network-unavailable",
+        }
+    if set(evidence) == {"status", "reason", "diagnostic"}:
+        return evidence == {
+            "status": "UNKNOWN",
+            "reason": "transient-http-rejection",
+            "diagnostic": {"classification": "http-429"},
+        }
+    return False
 
 
 def _prove_latest_release_with_bounded_retry(
@@ -574,7 +581,7 @@ def _prove_latest_release_with_bounded_retry(
     git_runner: Any | None,
     wall_clock_seconds: float,
 ) -> dict[str, object]:
-    """Retry one explicit HTTP 429 without extending the original proof deadline."""
+    """Retry one closed transient rejection without extending the proof deadline."""
     from core.utils.update_verifier import prove_latest_release
 
     initial_budget = max(0.0, wall_clock_seconds)

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "2719588befe2f471d11e71d580115200b945527ca9310b247a1ee61c53f4aced",
+      "sha256": "89840ea06edfed8a7599bcd3bddc10c6a1fba5b549958761353d8c39e1886cf4",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "89840ea06edfed8a7599bcd3bddc10c6a1fba5b549958761353d8c39e1886cf4",
+      "sha256": "774e744216a0ec41cfef2c3ac68d441b3030729c64d937c2d05c7390ab6b5635",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +31,18 @@ from typing import Any, Callable, Iterator, Mapping, Protocol
 
 OFFICIAL_REMOTE = "https://github.com/davekilleen/Dex.git"
 _FLEET_FOLLOW_UP_DELIVERY_WALL_CLOCK_SECONDS = 60.0
+_PUBLIC_FOUNDATION_FETCH_ATTEMPTS = 2
+_PUBLIC_FOUNDATION_FETCH_TOTAL_SECONDS = 90.0
+_PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS = 0.1
+_PUBLIC_FOUNDATION_FETCH_TRANSIENT_MARKERS = (
+    "could not resolve host",
+    "failed to connect",
+    "network is unreachable",
+    "connection timed out",
+    "connection refused",
+    "couldn't connect to server",
+    "temporary failure in name resolution",
+)
 _HEX = re.compile(r"^[0-9a-f]{40}$")
 _RELEASE_TAG = re.compile(r"^dist/release/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,40}$")
 _APPROVAL_WORD = "APPLY"
@@ -1274,7 +1287,7 @@ def _bridge_environment() -> dict[str, str]:
     }
 
 
-def _run_git(directory: Path, *arguments: str) -> str:
+def _run_git(directory: Path, *arguments: str, timeout_seconds: float = 90.0) -> str:
     """Run a non-interactive Git operation with hooks and non-HTTPS blocked."""
     completed = subprocess.run(
         [
@@ -1295,7 +1308,7 @@ def _run_git(directory: Path, *arguments: str) -> str:
         check=False,
         capture_output=True,
         env=_bridge_environment(),
-        timeout=90,
+        timeout=timeout_seconds,
     )
     if completed.returncode:
         detail = completed.stderr.decode("utf-8", "replace").strip()
@@ -1304,6 +1317,42 @@ def _run_git(directory: Path, *arguments: str) -> str:
         return completed.stdout.decode("utf-8").strip()
     except UnicodeDecodeError as error:
         raise BridgeError("Git returned non-text release metadata") from error
+
+
+def _fetch_public_foundation_tag(repository: Path, pin: ReleasePin) -> None:
+    """Fetch one immutable tag with one bounded retry for closed network failures."""
+
+    arguments = (
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "--no-recurse-submodules",
+        OFFICIAL_REMOTE,
+        f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
+    )
+    deadline = time.monotonic() + _PUBLIC_FOUNDATION_FETCH_TOTAL_SECONDS
+    for attempt in range(1, _PUBLIC_FOUNDATION_FETCH_ATTEMPTS + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise BridgeError("public foundation fetch exceeded its fixed deadline")
+        try:
+            _run_git(repository, *arguments, timeout_seconds=remaining)
+            return
+        except subprocess.TimeoutExpired as error:
+            raise BridgeError("public foundation fetch exceeded its fixed deadline") from error
+        except BridgeError as error:
+            transient = any(
+                marker in str(error).lower()
+                for marker in _PUBLIC_FOUNDATION_FETCH_TRANSIENT_MARKERS
+            )
+            if not transient or attempt == _PUBLIC_FOUNDATION_FETCH_ATTEMPTS:
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise BridgeError("public foundation fetch exceeded its fixed deadline") from error
+            time.sleep(min(_PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS, remaining))
+    raise BridgeError("public foundation fetch exhausted its bounded attempts")
 
 
 def _assert_equal(actual: str, expected: str, description: str) -> None:
@@ -1650,16 +1699,7 @@ def acquire_foundation_source(pin: ReleasePin = FOUNDATION) -> tuple[tempfile.Te
     source = root / "foundation"
     try:
         _run_git(root, "init", "--bare", "--quiet", str(bare))
-        _run_git(
-            bare,
-            "fetch",
-            "--quiet",
-            "--no-tags",
-            "--no-write-fetch-head",
-            "--no-recurse-submodules",
-            OFFICIAL_REMOTE,
-            f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
-        )
+        _fetch_public_foundation_tag(bare, pin)
         _verify_pin(bare, pin)
         # A linked worktree keeps the verified objects in the disposable bare
         # evidence store. It avoids opening the local ``file`` transport, which
@@ -2650,16 +2690,7 @@ def _fetch_foundation_into_brain(vault_root: Path, pin: ReleasePin) -> None:
     brain = vault_root / ".dex" / "brain.git"
     if brain.is_symlink() or not brain.is_dir():
         raise BridgeError("topology conversion did not create a safe Dex brain store")
-    _run_git(
-        brain,
-        "fetch",
-        "--quiet",
-        "--no-tags",
-        "--no-write-fetch-head",
-        "--no-recurse-submodules",
-        OFFICIAL_REMOTE,
-        f"refs/tags/{pin.tag}:refs/tags/{pin.tag}",
-    )
+    _fetch_public_foundation_tag(brain, pin)
     _verify_pin(brain, pin)
     _run_git(
         brain,

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1349,9 +1349,9 @@ def _fetch_public_foundation_tag(repository: Path, pin: ReleasePin) -> None:
             if not transient or attempt == _PUBLIC_FOUNDATION_FETCH_ATTEMPTS:
                 raise
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise BridgeError("public foundation fetch exceeded its fixed deadline") from error
-            time.sleep(min(_PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS, remaining))
+            if remaining <= _PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS:
+                raise
+            time.sleep(_PUBLIC_FOUNDATION_FETCH_RETRY_DELAY_SECONDS)
     raise BridgeError("public foundation fetch exhausted its bounded attempts")
 
 

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -14,9 +14,11 @@ CANARY_STARTS=(
   "v1.62.0"
   "dist/archive/v1.63.0-08ce719"
   "dist/archive/v1.65.0-c5ec161"
+  "dist/archive/v1.72.0-7d75da9"
   "dist/archive/v1.76.0-d0bb932"
   "v1.81.1"
   "dist/release/v1.81.1-b17ef02"
+  "v1.81.7"
   "v1.81.11"
 )
 


### PR DESCRIPTION
## Outcome\n\nAdds one bounded retry for the two closed transient network failures observed in the locked historic fleet:\n\n- public foundation tag fetches retry only known transient Git transport errors\n- installed release proof retries only the exact sanitized offline/network-unavailable result\n- both retries preserve the original fixed deadline and remain fail-closed for identity, evidence, filesystem, cancellation, and unclassified failures\n\n## Verification\n\n- 103 focused bridge, release-delivery, and protocol tests pass\n- Ruff, Python compilation, generated protocol fingerprint, and diff checks pass\n\nThis PR does **not** publish a release or claim fleet acceptance. A new foundation and a distinct pinned follow-up are required before the freshly derived full fleet can run.