### PR TITLE
fix(install): tell users which folder to open their chat app in

### DIFF
--- a/core/tests/test_install_convergence.py
+++ b/core/tests/test_install_convergence.py
@@ -16,7 +16,11 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
-def _install_fixture(tmp_path: Path, scenario: str) -> tuple[Path, dict[str, str]]:
+def _install_fixture(
+    tmp_path: Path,
+    scenario: str,
+    chat_app: str | None = None,
+) -> tuple[Path, dict[str, str]]:
     root = tmp_path / "dex-install"
     root.mkdir()
     shutil.copy2(REPO_ROOT / "install.sh", root / "install.sh")
@@ -88,6 +92,8 @@ exit 0
     for command in ("npm", "npx"):
         _write_executable(shim_dir / command, "#!/bin/sh\nexit 0\n")
     _write_executable(shim_dir / "xcode-select", "#!/bin/sh\nexit 0\n")
+    if chat_app is not None:
+        _write_executable(shim_dir / chat_app, "#!/bin/sh\nexit 0\n")
 
     environment = os.environ.copy()
     environment.update(
@@ -105,8 +111,9 @@ def _run_install(
     tmp_path: Path,
     scenario: str,
     *arguments: str,
+    chat_app: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    root, environment = _install_fixture(tmp_path, scenario)
+    root, environment = _install_fixture(tmp_path, scenario, chat_app)
     result = subprocess.run(
         ["/bin/bash", "install.sh", *arguments],
         cwd=root,
@@ -174,3 +181,24 @@ def test_migration_failure_stops_install_with_plain_english_recovery(tmp_path: P
     assert "could not finish the brain/vault split" in result.stdout
     assert "migration-report-v2.md" in result.stdout
     assert "Dex installation complete" not in result.stdout
+
+
+def test_install_points_claude_code_users_at_the_install_folder(tmp_path: Path) -> None:
+    result, _ = _run_install(tmp_path, "zip", chat_app="claude")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Open Claude Code in this folder" in result.stdout
+    assert "the folder you just installed into" in result.stdout
+    assert "In Claude Code chat, type: /setup" in result.stdout
+    # Detection must name one app only, never leak the other.
+    assert "In Cursor chat, type: /setup" not in result.stdout
+
+
+def test_install_points_cursor_users_at_the_install_folder(tmp_path: Path) -> None:
+    result, _ = _run_install(tmp_path, "zip", chat_app="cursor")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Open Cursor in this folder" in result.stdout
+    assert "the folder you just installed into" in result.stdout
+    assert "In Cursor chat, type: /setup" in result.stdout
+    assert "In Claude Code chat, type: /setup" not in result.stdout

--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,9 @@ if [[ "$WORK_MCP_STATUS" == *"Needs"* ]]; then
 fi
 echo ""
 echo "Next steps:"
-echo "  1. In $DEX_CHAT_APP chat, type: /setup"
-echo "  2. Answer the setup questions (~5 minutes)"
-echo "  3. Start using Dex!"
+echo "  1. Open $DEX_CHAT_APP in this folder"
+echo "     (the folder you just installed into — not somewhere else)"
+echo "  2. In $DEX_CHAT_APP chat, type: /setup"
+echo "  3. Answer the setup questions (~5 minutes)"
+echo "  4. Start using Dex!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## What

One extra step in the installer's closing output:

```
Next steps:
  1. Open Claude Code in this folder
     (the folder you just installed into — not somewhere else)
  2. In Claude Code chat, type: /setup
  3. Answer the setup questions (~5 minutes)
  4. Start using Dex!
```

App detection (`Claude Code` / `Cursor` / `your AI app`) is unchanged — that landed in `b45c3755`.

## Why

The documented install path is a Terminal one-liner:

```
curl -fsSL https://heydex.ai/install.sh | bash
```

So this text is read by someone sitting in a terminal with **no chat app open**. `main` currently says "In Claude Code chat, type: /setup" without saying where to open Claude Code, and opening it somewhere other than the freshly installed folder is the mistake people actually make — the chat then can't see any of Dex's files.

## What this deliberately does *not* say

An earlier draft told users to "start a **new** chat" because "a new chat loads Dex's MCP servers". That was dropped: `/setup` works fine in an already-open session, so it added a step most people don't need and gave a reason that isn't the real one. This PR only tells them *where*, not to restart anything.

## Tests

`core/tests/test_install_convergence.py` — 7 passed (5 existing, 2 new).

The fixture gains an optional `chat_app` shim so the detected-app path is exercisable at all, which it wasn't before. Both new tests also assert detection names one app only and never leaks the other.

## Notes

- Supersedes #421, which conflicted with `main` because it carried a parallel implementation of app detection already merged as `b45c3755`. This branch is built directly on `main` and touches only the closing output.
- No CHANGELOG entry — per house rules, versioning happens at release time via `/dex-push`.