### PR TITLE
fix(skills): wire evening journal, gate Reminders steps, safe Tasks.md clear-down, sync-ready focus items

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -263,6 +263,8 @@ Check if any tasks were completed on phone since the last plan:
 Use: reminders_list_completed(list_name="Dex Today")
 ```
 
+**If the tool is unavailable or errors** (Apple Reminders sync is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled. Note: Reminders access never works when Claude Code runs inside the VS Code extension (macOS never shows the permission dialog to that process) — see the known limitation in `06-Resources/Dex_System/Calendar_Setup.md`. Do not advise reinstalling or reconfiguring; skip silently.
+
 For each completed item:
 - Match to a Dex task by title
 - Update task status via Work MCP: `update_task_status(task_title="...", status="d")`
@@ -432,6 +434,28 @@ Generate 3 recommended focus items based on:
 > 2. **Reply to Mike** — Commitment due today
 > 3. **Task X from Priority 1** — Keeps momentum on your shipped priority"
 
+**Task IDs are mandatory on focus items (completion sync depends on them):**
+
+Completion sync (Work MCP `update_task_status`, which updates every file the task
+appears in) only finds a line if that single line contains BOTH a `- [ ]` / `- [x]`
+checkbox AND the task's `^task-YYYYMMDD-XXX` anchor. A focus item written without the ID — or with the ID on
+a different line — is invisible to sync: ticking the task done in Tasks.md never
+updates the plan, and marking the plan item done never updates Tasks.md.
+
+So, for each recommended focus item:
+1. **If it maps to an existing Tasks.md task** (search by title/keywords), you MUST
+   write it in the plan as a `- [ ]` checkbox line with that task's `^task-YYYYMMDD-XXX`
+   anchor at the end of the same line. Never omit the ID, never put it on its own line.
+2. **If it's real work with no Tasks.md entry yet**, create the task first via Work MCP
+   `create_task`, then embed the returned task ID the same way.
+3. **Only if it isn't a task at all** (e.g. "protect the 2-4pm free block") may the line
+   omit an ID — and then it gets no checkbox either, so it can't masquerade as a
+   syncable task.
+
+Format notes that matter: use `- [ ]` (dash checkbox), not `1. [ ]` — numbered
+checkboxes do not contain the literal `- [ ]` string the sync matcher looks for, so
+they never sync even with an ID present.
+
 ### Meeting Prep (Enhanced)
 
 For each meeting, show:
@@ -454,6 +478,11 @@ Flag potential issues:
 ## Step 7: Generate Daily Plan
 
 **ALWAYS generate and save a new plan file.** Never skip generation because a plan from a previous day exists in the conversation or vault. Even if context from a prior plan is visible, today is a new day and requires its own plan. If a plan for today's date already exists, overwrite it (the user is requesting a refresh).
+
+**Filling in `{{^task-id}}` in Today's Focus:** replace it with the item's real
+`^task-YYYYMMDD-XXX` anchor per the Task IDs rule in Step 6 (mandatory whenever the
+item maps to a Tasks.md task — create the task first if needed). If the item is not a
+task at all, drop both the placeholder and the `- [ ]` checkbox for that line.
 
 Create `07-Archives/Plans/YYYY-MM-DD.md`:
 
@@ -509,9 +538,9 @@ integrations_used: [calendar, tasks, people, work-intelligence]
 
 **If I only do three things today:**
 
-1. [ ] {{Focus item 1}} — {{Pillar}} *(supports Week Priority #X)*
-2. [ ] {{Focus item 2}} — {{Pillar}} *(supports Week Priority #Y)*
-3. [ ] {{Focus item 3}} — {{Pillar}}
+- [ ] {{Focus item 1}} — {{Pillar}} *(supports Week Priority #X)* {{^task-id}}
+- [ ] {{Focus item 2}} — {{Pillar}} *(supports Week Priority #Y)* {{^task-id}}
+- [ ] {{Focus item 3}} — {{Pillar}} {{^task-id}}
 
 ---
 
@@ -588,7 +617,7 @@ After generating the plan, push today's P0 and P1 focus tasks to Apple Reminders
 3. **Confirm silently:**
    > "📱 Pushed 3 focus tasks to iPhone Reminders (Dex Today)"
 
-**If Reminders MCP unavailable:** Skip silently.
+**If the tool is unavailable or errors:** Skip silently — do not surface an error for a feature the user never enabled. (This includes Claude Code running inside the VS Code extension, where macOS never grants Reminders access — see `06-Resources/Dex_System/Calendar_Setup.md`.)
 
 ---
 

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -110,7 +110,7 @@ Check for tasks added from phone during the day that weren't triaged in the morn
 Use: reminders_list_items(list_name="Dex Inbox")
 ```
 
-**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled.
+**If the tool is unavailable or errors** (Apple Reminders phone-capture is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled. Note: Reminders access never works when Claude Code runs inside the VS Code extension (macOS never shows the permission dialog to that process) — see the known limitation in `06-Resources/Dex_System/Calendar_Setup.md`. Do not advise reinstalling or reconfiguring; skip silently.
 
 If items found:
 - Surface them: "📱 **Phone captures not yet triaged** (X items in Dex Inbox)"
@@ -130,6 +130,8 @@ Check if tasks were completed on phone since the morning plan:
 ```
 Use: reminders_list_completed(list_name="Dex Today")
 ```
+
+**If the tool is unavailable or errors** (Apple Reminders sync is optional and may not be set up on this machine): skip this step silently — do not surface an error for a feature the user never enabled. Note: Reminders access never works when Claude Code runs inside the VS Code extension (macOS never shows the permission dialog to that process) — see the known limitation in `06-Resources/Dex_System/Calendar_Setup.md`. Do not advise reinstalling or reconfiguring; skip silently.
 
 For each completed item:
 - Match to a Dex task by title
@@ -349,7 +351,25 @@ This only fires if the user has opted into analytics. No action needed if it ret
 
 ## Step 11: Evening Journal (If Enabled)
 
-If `journaling.evening: true`, prompt for evening reflection.
+Check `System/user-profile.yaml` → `journaling.evening`.
+
+**If `journaling.evening: true`, run the actual `/journal evening` flow** from
+`.claude/skills/journal/SKILL.md` — do not just mention reflection and move on, and do
+not substitute a single ad-hoc question. The real flow:
+
+1. Check if today's evening journal exists in `00-Inbox/Journals/`
+   - If yes: acknowledge it ("You already journaled this evening") and skip to Step 12
+   - If no: create it from the template
+2. Pull in this morning's journal intention (if one exists) for reflection
+3. Guide the user through the evening prompts conversationally — one question at a
+   time, per the journal skill's Prompting Style
+4. Save the entry, then continue the review
+
+Offer it plainly: "You have evening journaling enabled — want to do a quick reflection
+before we close the day?" If the user declines, skip without pushing back and continue
+to Step 12.
+
+**If `journaling.evening` is false or missing:** Skip this step silently.
 
 ---
 

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -464,7 +464,17 @@ Add a section to the review:
 
 After synthesis:
 1. Update Tasks.md with new priorities
-2. Archive completed items
+2. Clear completed tasks out of `03-Tasks/Tasks.md` — **remove whole task blocks, never
+   individual lines.** Tasks.md entries can span multiple lines: the `- [x]` checkbox
+   line plus its indented sub-lines (priority, due date, notes) and any continuation
+   paragraphs. A task's block runs from its checkbox line down to (but not including)
+   the next non-indented line — the next task's checkbox, a heading, or a blank line
+   followed by unindented content. When removing a completed task, remove that entire
+   block together so no orphaned sub-lines are left behind. Never do a per-line sweep
+   of `[x]` lines: that strands sub-lines, and it also removes completed sub-checkboxes
+   out from under tasks that are still open (only remove a block whose own top-level
+   checkbox is `[x]`). Before deleting anything, tell the user how many completed tasks
+   you're clearing and confirm.
 3. Update project pages with status changes
 4. Offer to run `/week-plan` for next week
 

--- a/06-Resources/Dex_System/Calendar_Setup.md
+++ b/06-Resources/Dex_System/Calendar_Setup.md
@@ -51,6 +51,19 @@ The first time Cursor tries to read your calendar, macOS may show a popup: **"Cu
 
 ---
 
+## Known limitation: the VS Code extension can't use Apple Reminders
+
+macOS grants calendar and reminders access **per app** — it looks at which app is asking. When Dex runs through the **Claude Code extension inside VS Code** (rather than from a normal terminal window), macOS never shows the permission popup to that process at all, and access granted to Terminal does **not** carry over. The result: Apple Reminders features (phone capture via a "Dex Inbox" list, "Dex Today" sync) are simply unavailable in that setup — not misconfigured, unavailable. Reinstalling or redoing the setup steps will not change this.
+
+What to do instead:
+
+- **Run Dex from a standalone terminal window** (Terminal.app, or another terminal app launched on its own). The permission popup appears there, and access works after you click Allow.
+- **Or keep using the VS Code extension without Reminders features.** Dex skips them silently when access is unavailable — daily planning and reviews work normally without them.
+
+This was verified directly (August 2026): the same check succeeds from Terminal.app, and fails from both VS Code's built-in terminal and the extension's own process — even after access was granted in Terminal.app first.
+
+---
+
 ## Optional: Tell Dex which calendar is "work"
 
 If you have several calendars and want Dex to focus on one (e.g. your work calendar) for faster answers, you can set it in **System/user-profile.yaml** under a `calendar` section with `work_calendar: "your.email@example.com"` (use the exact name as it appears in the Calendar app). You can skip this—Dex will still show your events without it.

--- a/docs/Dex_System/Calendar_Setup.md
+++ b/docs/Dex_System/Calendar_Setup.md
@@ -51,6 +51,19 @@ The first time Cursor tries to read your calendar, macOS may show a popup: **"Cu
 
 ---
 
+## Known limitation: the VS Code extension can't use Apple Reminders
+
+macOS grants calendar and reminders access **per app** — it looks at which app is asking. When Dex runs through the **Claude Code extension inside VS Code** (rather than from a normal terminal window), macOS never shows the permission popup to that process at all, and access granted to Terminal does **not** carry over. The result: Apple Reminders features (phone capture via a "Dex Inbox" list, "Dex Today" sync) are simply unavailable in that setup — not misconfigured, unavailable. Reinstalling or redoing the setup steps will not change this.
+
+What to do instead:
+
+- **Run Dex from a standalone terminal window** (Terminal.app, or another terminal app launched on its own). The permission popup appears there, and access works after you click Allow.
+- **Or keep using the VS Code extension without Reminders features.** Dex skips them silently when access is unavailable — daily planning and reviews work normally without them.
+
+This was verified directly (August 2026): the same check succeeds from Terminal.app, and fails from both VS Code's built-in terminal and the extension's own process — even after access was granted in Terminal.app first.
+
+---
+
 ## Optional: Tell Dex which calendar is "work"
 
 If you have several calendars and want Dex to focus on one (e.g. your work calendar) for faster answers, you can set it in **System/user-profile.yaml** under a `calendar` section with `work_calendar: "your.email@example.com"` (use the exact name as it appears in the Calendar app). You can skip this—Dex will still show your events without it.


### PR DESCRIPTION
Fixes four verified workflow gaps from Michelle's 5–6 August power-user feedback. Every finding was re-verified against `main` before changing anything. Related: #139 (instruction reliability — "the instruction exists but doesn't reliably fire" is exactly this category).

## What was wrong, and what changed

**1. Evening journaling never fired from the daily review** (`daily-review` Step 11)
The step was a one-line stub — "prompt for evening reflection" — that never invoked the real `/journal evening` flow that already exists with proper prompts. Michelle enabled journaling mid-day and her evening review ran straight through without a single journal question. Step 11 now runs the actual journal flow: checks for an existing entry, pulls in the morning intention, guides the prompts one at a time, and skips gracefully if declined or disabled.

**2. Reminders steps without a failure gate** (`daily-review` Steps 2.55 & 2.6; also found in `daily-plan` 5.7 & 7.5)
Verification note: the task brief said daily-plan's Reminders steps had been removed on main — they haven't. What main actually has is a skip-silently gate ("if the tool is unavailable or errors…", added in `1c636aa2`) on *some* steps. daily-review Step 2.6 had no gate at all, and daily-plan Step 5.7 had the identical hole (7.5 gated "unavailable" but not errors). All Reminders steps in both skills now carry the same gate, plus a pointer to the newly documented VS Code limitation so the model never suggests "reinstall and reconfigure" for something that can't work.

**3. Weekly Tasks.md clear-down could orphan multi-line tasks** (`week-review`, Follow-up Actions)
The instruction was a bare "Archive completed items", which invites a per-line sweep of `[x]` lines. Tasks.md entries span multiple lines (indented priority/due/notes sub-lines, continuation paragraphs), so a per-line delete strands fragments — and can also delete completed sub-checkboxes out from under still-open tasks. The instruction now defines a task block precisely, requires removing whole blocks only when the block's own top-level checkbox is `[x]`, and confirms with the user before deleting.

**4. "Today's Focus" items never synced** (`daily-plan` Step 6 + plan template)
Verified against the code: Work MCP completion sync (`update_task_status` → `update_task_status_everywhere` → `find_task_by_id`) only matches a line containing **both** the literal `- [ ]`/`- [x]` checkbox **and** the `^task-YYYYMMDD-XXX` anchor on that same line. The template rendered focus items as numbered checkboxes (`1. [ ]`) with no ID — doubly invisible to sync (numbered checkboxes don't contain the `- [ ]` string the matcher looks for, even with an ID). The template now uses dash checkboxes with a `{{^task-id}}` placeholder, and Step 6 mandates embedding the real task ID inline for any focus item that maps to a Tasks.md task — creating the task first via `create_task` when it doesn't exist yet.

**Also: documented the VS Code + Apple Reminders limitation.** Michelle verified that macOS never shows the Reminders/EventKit permission dialog to Claude Code running inside the VS Code extension, and a Terminal.app grant does not transfer. Added a "Known limitation" section to `docs/Dex_System/Calendar_Setup.md` (mirrored byte-identically to the `06-Resources` bridge copy) with the working alternative: run Dex from a standalone terminal.

## Verification

- `python scripts/check-instructed-tools.py` ✅ (caught and fixed one wording issue: an internal function named as if it were an MCP tool)
- `bash scripts/check-architecture-inventory.sh` ✅
- `bash scripts/check-doc-drift.sh` ✅ · `bash scripts/check-test-delta.sh` ✅
- `bash scripts/check-pii.sh` ✅ · `bash scripts/check-founder-content.sh` ✅
- No Python/Node code changed, so the test suites are unaffected (docs + skill instruction files only).

## Proposed CHANGELOG entry (not committed — for the release that picks this up)

> ### Your evening wind-down, your task list, and your daily plan now keep their promises
>
> A power user who runs Dex every day spent a full day checking what actually happens versus what Dex promises, and found four places where a written promise quietly wasn't kept. Thank you, Michelle.
>
> **What this fixes for you:**
>
> - **Evening journaling actually happens now.** If you turned on evening journaling, the end-of-day review used to skip right past it without asking a single question. Now it walks you through your evening reflection properly — and steps aside just as quietly if you've already journaled or say no thanks.
> - **Ticking off a focus item now counts everywhere.** Items in your daily plan's "Today's Focus" were written in a way Dex's completion tracking couldn't see, so finishing one never updated your task list, and finishing a task never updated the plan. Focus items are now written so both sides stay in step.
> - **The weekly tidy-up of your task list can't leave scraps behind anymore.** Some tasks take several lines — a due date here, a note there. The old clean-up could remove a task's first line and strand the rest. It now removes each finished task whole, and tells you what it's clearing before it does.
> - **No more dead-end advice about phone reminders.** If you use Dex inside VS Code (a popular code editor), Apple's reminders simply can't be reached from there — that's how the Mac's privacy protections work, not something a reinstall fixes. Dex now knows this, skips those steps quietly, and the setup guide explains the one change that helps: run Dex from a regular Terminal window instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
