### PR TITLE
fix(calendar): creating and deleting calendar events works again

### DIFF
--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -152,13 +152,21 @@ def run_shell_script(script_name: str, *args) -> tuple[bool, str]:
         return False, f"Script not found: {script_name}"
 
     try:
-        # Run the helper under THIS interpreter (the venv python, which has
-        # pyobjc EventKit) with the repo root on PYTHONPATH so its
-        # `from core.paths import ...` resolves. The script's shebang would
-        # otherwise pick up system python3, which lacks EventKit. (adapted from #63)
         env = {**os.environ, "PYTHONPATH": str(VAULT_PATH)}
+        if script_path.suffix == ".sh":
+            # Shell helpers must run under bash — forcing them through
+            # sys.executable fails with a Python SyntaxError at the first
+            # bash line.
+            command = ["/bin/bash", str(script_path), *args]
+        else:
+            # Run Python helpers under THIS interpreter (the venv python,
+            # which has pyobjc EventKit) with the repo root on PYTHONPATH so
+            # `from core.paths import ...` resolves. The script's shebang would
+            # otherwise pick up system python3, which lacks EventKit.
+            # (adapted from #63)
+            command = [sys.executable, str(script_path), *args]
         result = subprocess.run(
-            [sys.executable, str(script_path), *args],
+            command,
             capture_output=True, text=True, timeout=120, env=env
         )
 

--- a/core/tests/test_calendar_server.py
+++ b/core/tests/test_calendar_server.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
+import sys
 
 import pytest
 
@@ -10,6 +12,61 @@ from core.mcp import calendar_server
 
 def _decode_tool_result(result):
     return json.loads(result[0].text)
+
+
+def _capture_subprocess_command(monkeypatch):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(calendar_server.subprocess, "run", fake_run)
+    return captured
+
+
+def test_run_shell_script_dispatches_sh_scripts_to_bash(monkeypatch):
+    captured = _capture_subprocess_command(monkeypatch)
+
+    success, output = calendar_server.run_shell_script(
+        "calendar_create_event.sh", "Work", "Test", "2026-08-08 10:00", "30"
+    )
+
+    assert success
+    assert output == "ok"
+    assert captured["command"][0] == "/bin/bash"
+    assert captured["command"][1].endswith("calendar_create_event.sh")
+    assert captured["command"][2:] == ["Work", "Test", "2026-08-08 10:00", "30"]
+
+
+def test_run_shell_script_dispatches_py_scripts_to_python(monkeypatch):
+    captured = _capture_subprocess_command(monkeypatch)
+
+    success, output = calendar_server.run_shell_script(
+        "calendar_eventkit.py", "list"
+    )
+
+    assert success
+    assert output == "ok"
+    assert captured["command"][0] == sys.executable
+    assert captured["command"][1].endswith("calendar_eventkit.py")
+
+
+def test_allowed_sh_scripts_are_valid_bash():
+    """Guard the helper scripts themselves: every allowed .sh must parse under bash."""
+    for script_name in sorted(calendar_server.ALLOWED_SCRIPTS):
+        if not script_name.endswith(".sh"):
+            continue
+        script_path = calendar_server.SCRIPTS_DIR / script_name
+        assert script_path.exists(), f"Missing allowed script: {script_name}"
+        check = subprocess.run(
+            ["/bin/bash", "-n", str(script_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert check.returncode == 0, (
+            f"{script_name} is not valid bash: {check.stderr.strip()}"
+        )
 
 
 def test_add_missing_calendar_warning_reports_available_calendars(monkeypatch):


### PR DESCRIPTION
## What was broken

Two Calendar MCP actions — creating an event and deleting an event — have been silently broken. The server runs its small helper scripts, but it ran *every* helper through Python, including the two that are written in bash (`calendar_create_event.sh`, `calendar_delete_event.sh`). Python can't read bash, so those two helpers failed instantly with a syntax error every single time. Asking Dex to put something on your calendar, or take something off it, could never succeed through this path.

**Michelle found and reported this** — she reproduced the exact failure, confirmed the scripts themselves are fine, and confirmed the same bug exists byte-for-byte on upstream main. Thank you, Michelle.

## The fix

`run_shell_script()` in `core/mcp/calendar_server.py` now looks at the script's file type: `.sh` helpers run under bash, `.py` helpers keep the existing behavior (the venv interpreter with `PYTHONPATH` set, which the EventKit helpers need — unchanged from #63).

## Verification

- Reproduced the reported failure first: running `calendar_create_event.sh` through Python fails with `SyntaxError: invalid syntax` at line 13, exactly as reported. Confirmed both `.sh` helpers pass `bash -n`.
- Added tests in `core/tests/test_calendar_server.py`:
  - `.sh` scripts dispatch to `/bin/bash` with args passed through
  - `.py` scripts still dispatch to `sys.executable`
  - every allowed `.sh` helper parses as valid bash
- Confirmed the new dispatch test **fails on the previous code** (expects `/bin/bash`, gets the Python interpreter) — it would have caught this bug.
- `pytest core/tests/test_calendar_server.py`: **10 passed** (3 new, 7 pre-existing).
- `ruff check core/`: all checks passed.

Note: verified on Linux (test-level; the dispatch and bash-syntax checks are platform-independent). The end-to-end AppleScript path needs macOS and was not run here.

## Proposed CHANGELOG entry (not committed — for the release that includes this)

> ### Putting events on your calendar works again
>
> Asking Dex to create or delete a calendar event quietly failed every time — the two helpers that do that work were being started the wrong way, so they crashed before they could begin. Thanks to Michelle for catching this and pinning down exactly where it broke.
>
> **What this fixes for you:**
> - **Dex can create calendar events again.** "Put a 30-minute hold on my calendar tomorrow at 10" now actually lands on your calendar instead of failing.
> - **Dex can delete calendar events again.** Removing an event you asked Dex to clean up now works.
> - **This can't silently break again.** A new automatic check makes sure each helper is always started the right way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)