### PR TITLE
fix(doctor): count receipt-backed adoptions in the adoption.plan probe

### DIFF
--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import pytest
 
 from core.lifecycle.catalog import with_catalog_identity
+from core.lifecycle.engine import AdoptionReceipt
+from core.lifecycle.ledger import record_adoption
 from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
 from core.utils import doctor, release_channel
 
@@ -558,6 +560,39 @@ def test_adoption_plan_probe_summarizes_valid_catalog_in_memory(context):
 
     assert result.verdict == "OK"
     assert result.detail == "1 adoptable / 0 adopted / 0 conflicts"
+    assert _tree_snapshot(context.vault_root) == before
+
+
+def test_adoption_plan_probe_counts_receipt_backed_adoptions(context):
+    _write_release_catalog(context)
+    content = b"release skill\n"
+    transaction_id = "20260807T120000-00000001"
+    receipt = AdoptionReceipt.from_dict(
+        {
+            "receipt_version": 1,
+            "items_adopted": ["fixture-item"],
+            "files_written": [
+                {
+                    "item_id": "fixture-item",
+                    "path": ".claude/skills/fixture-item/SKILL.md",
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "byte_size": len(content),
+                }
+            ],
+            "transaction_id": transaction_id,
+            "snapshot_ref": f"System/.dex/tx/{transaction_id}/snapshot",
+            "catalog_sha256": "a" * 64,
+            "inventory_sha256": "b" * 64,
+            "preview_sha256": "c" * 64,
+        }
+    )
+    record_adoption(context.vault_root, receipt, {"fixture-item": "1.0.0"})
+    before = _tree_snapshot(context.vault_root)
+
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "0 adoptable / 1 adopted / 0 conflicts"
     assert _tree_snapshot(context.vault_root) == before
 
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -1617,7 +1617,22 @@ def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
     try:
         catalog = load_catalog(catalog_path, release_root=context.vault_root)
         inventory = build_inventory(context.vault_root, catalog=catalog)
-        plan = build_adoption_plan(catalog, inventory)
+        ledger_state = lifecycle_ledger.project_state(context.vault_root)
+        adopted = ledger_state["adopted"]
+        held_back = ledger_state["held_back"]
+        assert isinstance(adopted, dict)
+        assert isinstance(held_back, list)
+        catalog_ids = {item.id for item in catalog.items}
+        plan = build_adoption_plan(
+            catalog,
+            inventory,
+            adoption_states={
+                item_id: AdoptionState.ADOPTED
+                for item_id in adopted
+                if item_id in catalog_ids
+            },
+            held_back=frozenset(held_back) & catalog_ids,
+        )
         counts = plan.counts
         return ProbeResult(
             "OK",


### PR DESCRIPTION
## What this fixes

A user reading one `/dex-doctor` report saw numbers that contradict each other: the `adoption.plan` quick check said **"27 adoptable / 0 adopted / 0 conflicts"** while `receipts-and-rewind` in the same report showed **27 adopted receipt records**, and the previous `/dex-update` run had correctly reported "adopt: 0, already-adopted: 27".

Reported by Jim McDermott (Digital Redefined) by email on 2026-08-07, observed on his v1.79.0-with-receipts test install. His diagnosis was essentially correct: the probe was counting catalog membership, not pending work.

## Root cause

`_probe_adoption_plan` in `core/utils/doctor.py` called `build_adoption_plan(catalog, inventory)` with no `adoption_states`, so no item could ever plan as `ALREADY_ADOPTED`. The real update route (`core/lifecycle/service.py`, `_inventory_and_plan_models`) and Doctor's own deeper adoption report both pass receipt-backed states projected from the lifecycle ledger — the quick-check probe was the one surface that didn't.

## Fix

The probe now projects the ledger state read-only (`lifecycle_ledger.project_state`), filters to catalog item ids, and passes `adoption_states` and `held_back` into `build_adoption_plan` — the same pattern as the adoption report a few hundred lines above it. Fresh installs with a catalog and no ledger still work (an absent ledger projects to an empty state), and ledger errors fall into the probe's existing UNKNOWN handling.

Display-only severity: the update transaction path was never affected.

## Tests

- New: `test_adoption_plan_probe_counts_receipt_backed_adoptions` — records a real adoption receipt, asserts the detail line reads "0 adoptable / 1 adopted / 0 conflicts", and asserts the probe made no writes.
- Existing `adoption_plan` probe tests still pass (no-receipt install still reads "1 adoptable / 0 adopted / 0 conflicts").
- `test_doctor.py` + both adoption journey suites: 150 passed locally; the 2 failures (`test_entity_dead_letter_heal_round_trip_returns_probe_to_ok`, `test_launchctl_domain_failure_is_an_unknown_instrument`) fail identically on a clean tree on this Linux box (macOS-dependent) and are untouched by this change.

## Changelog note for release prep

Suggested user-facing line: **"Doctor's adoption numbers now tell the truth."** Doctor could report items as waiting to be adopted when the same report's receipts showed they were already done. It now reads the same adoption records the update process reads, so the numbers agree everywhere.

Build Card: `doctor-adoption-counts-tell-the-truth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)