### PR TITLE
/feedback: concierge bug reporting with a closed loop (V1+V2 client side)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/connection-health-checker.cjs"
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/core/utils/feedback_sweep.py\" --vault \"$CLAUDE_PROJECT_DIR\" --session-start"
           }
         ]
       }

--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -279,10 +279,16 @@ Here `N`, `M`, and `U` come directly from `summary.ok`, `summary.off`, and
 `summary.unknown` in the collector JSON. If everything is healthy: one line — "Everything
 checks out. N checks healthy, M features off by choice." No ceremony.
 
-### Step 6: Track usage (silent)
+### Step 6: Track usage (silent) and offer to report Dex bugs
 
 Update `System/usage_log.md` per the usage-tracking convention. If learnings surfaced
 (e.g. a check that should exist but doesn't), suggest capturing via `capture_idea`.
+
+If the run surfaced something that is a defect in Dex itself — not the user's setup —
+offer once, lightly: "I've patched this for you, but it looks like a bug in Dex itself.
+Want me to report it so it gets fixed properly for everyone?" If yes, invoke the
+`/feedback` skill; the Doctor findings you just gathered become the report's
+machine-state and investigation ingredients, so the user does nothing but approve.
 
 ## Edge cases
 
@@ -293,8 +299,9 @@ Update `System/usage_log.md` per the usage-tracking convention. If learnings sur
 - **User says "just fix everything":** Tier 1 is already done; walk Tier 2 items one
   confirmation at a time anyway — batch-yes is how wrong heals happen. Tier 3 cannot be
   batched by definition.
-- **Repeated BROKEN on the same item across runs:** suggest filing it —
-  "this looks like a Dex bug, not your setup; want me to draft a GitHub issue?"
+- **Repeated BROKEN on the same item across runs:** suggest reporting it —
+  "this looks like a Dex bug, not your setup; want me to report it to the Dex team?"
+  If yes, invoke the `/feedback` skill with the repeat-BROKEN evidence.
 
 ## Related Commands
 

--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: feedback
+description: Report a Dex bug to the Dex team with zero homework — Dex investigates locally, builds a privacy-safe report, shows it to you (or auto-sends if you've chosen that), and tracks the ticket until it's fixed. Use when the user says "report this", "send this to the Dex team", "file feedback", "/feedback", asks "what happened to my bug report", or accepts Doctor's offer to report a Dex bug. Not for capturing ideas about your own vault or workflow; use the improvements backlog for those.
+---
+
+# /feedback — concierge bug reporting
+
+Turn "something in Dex is broken" into a high-quality report on the Dex team's desk,
+with the user doing nothing but approving. Contract: `docs/feedback-loop-contract.md`.
+
+## Cardinal rules (read every time)
+
+1. **The conversation is never a source.** A report may contain ONLY the allowed
+   ingredients: Dex version, feature/skill name, what happened vs what was expected
+   (phrased as Dex mechanics), error text and stack traces (Dex's own code paths),
+   machine-state facts (OS, host app, feature health — never config values or file
+   contents), investigation findings as mechanisms and counts ("checked 5 lines,
+   0 had task identity" — never the lines themselves), and a note the user types.
+   Nothing about the user's work, people, meetings, or personal life — even if it
+   feels relevant. If a fact can't be phrased without private content, leave it out.
+2. **File paths:** Dex's own code paths (like `core/utils/doctor.py`) are fine.
+   Paths to the user's notes are not — describe the folder role instead
+   ("a person page under the People folder").
+3. **Show-before-send is governed by the trust dial** (`feedback` →
+   `review_mode` in `System/user-profile.yaml`):
+   - `always-review` (default): show the exact draft, wait for a clear yes.
+     The user may edit anything first.
+   - `auto-send`: send without asking, then confirm in one calm line and offer
+     "say 'show it' to see exactly what went."
+   - **The first report is always reviewed** regardless of the dial (no ticket
+     files under `System/.dex/feedback/` means first report).
+   - **Answers to questions are always reviewed** regardless of the dial.
+4. **Never send without the script.** All sends go through the client script so
+   every attempt lands in the local receipt log (`System/.dex/feedback-log.jsonl`).
+
+## Filing a report
+
+1. **Establish the facts.** From the conversation and quick local checks:
+   - Dex version: read `version` from `package.json` at the vault root.
+   - Feature: which skill/command/automation misbehaved.
+   - What happened vs expected, in one or two Dex-mechanics sentences.
+   - Error trace: if an error or traceback was captured this session, include it
+     whole (it contains only Dex code paths). Do not reconstruct one from memory.
+2. **Investigate locally before sending** (this is what makes reports actionable).
+   Debug like an engineer with full local access, then send the *mechanism*, not
+   the data. Examples of good investigation findings:
+   - "Focus items in the daily plan are missing task identity — checked 5 lines, 0 had it."
+   - "The sync automation is installed but not loaded; last successful run July 30."
+   - "The person index exists but has not been rebuilt since the folder was renamed."
+   Keep it to what you verified, with counts. Never quote vault content.
+3. **Machine state.** Assemble a small `machine_state` object from cheap facts:
+   `os` (from `uname -s`, lowercased), `host_app` (e.g. claude-code), and — when
+   `System/.dex/smoke-last-run.json` or a recent Doctor report exists — a
+   `features` map of health states (values like ok/off/broken only). Skip
+   anything you can't check cheaply; an empty machine_state is fine.
+4. **Write the draft** to a temp file (e.g. `/tmp/dex-feedback-draft.json`):
+
+   ```json
+   {
+     "dex_version": "<from package.json>",
+     "feature": "/process-meetings",
+     "summary": "<what happened vs expected>",
+     "error_trace": "<verbatim, optional>",
+     "machine_state": { "os": "darwin", "host_app": "claude-code" },
+     "investigation": "<mechanism findings, optional>",
+     "user_note": "<only if the user typed one>",
+     "review_mode": "<the user's dial setting>"
+   }
+   ```
+
+   The script adds the timestamp and failure fingerprint itself.
+5. **Apply the trust dial** (cardinal rule 3). For review: show the draft's
+   fields exactly as they will be sent, in a readable form, and ask once —
+   "Send it? You can edit anything first." Apply any edits to the draft file.
+6. **Send:**
+
+   ```bash
+   python3 .claude/skills/feedback/scripts/feedback_client.py report --file /tmp/dex-feedback-draft.json --vault "$VAULT_PATH"
+   ```
+
+   - Exit 0: confirm with the ticket reference the script printed, e.g.
+     "Sent — reference DEX-142. I'll tell you when there's news."
+   - Exit 2 (CONNECTION NEEDED): the terminal isn't linked yet. Show the
+     script's instructions — the user opens the connect page, signs in, creates
+     a code, and you run the `link` subcommand with it. This is a one-time,
+     ~30-second step; after linking, send the report without re-asking.
+   - Other exits: relay the script's plain-language message; don't invent detail.
+7. **First-approval upgrade offer.** If the user approved without changing
+   anything and their dial is `always-review`, offer once: "Want me to just send
+   future reports automatically? You can switch back anytime." If yes, set
+   `feedback.review_mode: auto-send` in `System/user-profile.yaml`. Never
+   re-offer in the same vault after a no (note the no in the user's preferences).
+
+## Checking status
+
+When the user asks about their reports (or after filing):
+
+```bash
+python3 .claude/skills/feedback/scripts/feedback_client.py status --vault "$VAULT_PATH"
+```
+
+Relay the script's list plainly. Statuses mean: RECEIVED (on the team's desk),
+INVESTIGATING (being worked), NEEDS INFO (a question is waiting — offer to answer
+it), FIXED in vX (suggest /dex-update if their version is older), CAN'T FIX
+(give the reason from the comment, honestly).
+
+## Answering a question (two-way loop)
+
+When a ticket is NEEDS INFO (surfaced by the session-start sweep or status):
+
+1. Read the question aloud to the user and ask if they'd like you to look into it:
+   "I can check and answer that myself — you'll see exactly what goes back."
+2. Investigate locally under the same cardinal rules — mechanisms and counts,
+   never content.
+3. **Always show the drafted answer and wait for a yes** (even for auto-send
+   users — answering means you looked inside their vault).
+4. Send:
+
+   ```bash
+   python3 .claude/skills/feedback/scripts/feedback_client.py answer --ticket DEX-158 --text "<approved answer>" --vault "$VAULT_PATH"
+   ```
+
+If the user declines, drop it without pressure; the question stays available in
+status whenever they're ready.
+
+## What the user can always inspect
+
+- Every send attempt: `System/.dex/feedback-log.jsonl` (kept even when nothing
+  was sent).
+- Every ticket and its last known state: `System/.dex/feedback/DEX-*.json`.
+
+## Edge cases
+
+- **No sign-in and user declines linking:** respect it. Offer to save the draft
+  locally instead (keep the temp file path visible) and mention they can run
+  /feedback later — never send anything without a linked account.
+- **Multiple bugs in one session:** one report per distinct failure; shared
+  context can repeat across drafts.
+- **The bug is in the user's own configuration**, not Dex: say so honestly and
+  fix it locally instead — /feedback is for defects in Dex itself. When unsure,
+  file it; triage would rather see a false alarm than miss a real defect.

--- a/.claude/skills/feedback/scripts/feedback_client.py
+++ b/.claude/skills/feedback/scripts/feedback_client.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Send Dex feedback reports to heydex.ai and check on their status.
+
+Standalone by design: this script ships inside the skill folder and must not
+import anything from dex-core. Standard library only. It shares the terminal
+connection file (~/.dex/heydex-auth.json) with the DexDiff publish flow, so
+one sign-in serves both.
+
+Contract of record: docs/feedback-loop-contract.md.
+
+Commands:
+  link    --code ABC123          Link this terminal to a heydex account.
+  report  --file draft.json      Send an approved report; prints the ticket.
+  status                         Show every report this account has filed.
+  answer  --ticket DEX-142 --text "..."   Answer a question on a ticket.
+
+Every send attempt (successful or not) is recorded in
+System/.dex/feedback-log.jsonl so the user can always see exactly what left
+their machine. Claim tickets are stored one file per report under
+System/.dex/feedback/.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Same backend the DexDiff publish path uses (HTTP Actions). NOT api.heydex.ai,
+# which routes to the separate Dex Desktop backend. Override: DEX_FEEDBACK_API_BASE.
+HEYDEX_API_BASE_URL = "https://gallant-reindeer-229.eu-west-1.convex.site"
+HEYDEX_SITE_BASE_URL = "https://heydex.ai"
+AUTH_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+HTTP_TIMEOUT_SECONDS = 20
+
+SCHEMA_VERSION = 1
+
+# Field caps mirror the server (convex feedback shaping). The server is the
+# enforcer; these exist so a too-long report fails here with a helpful
+# message instead of an opaque 400.
+FIELD_CAPS = {
+    "feature": 200,
+    "dex_version": 50,
+    "summary": 2000,
+    "error_trace": 8000,
+    "investigation": 4000,
+    "user_note": 2000,
+    "answer": 4000,
+}
+MACHINE_STATE_CAP = 8000
+REVIEW_MODES = ("always-review", "auto-send")
+REQUIRED_FIELDS = ("feature", "summary")
+OPTIONAL_FIELDS = ("error_trace", "investigation", "user_note")
+TICKET_PATTERN = re.compile(r"^DEX-\d{1,10}$")
+
+STATUS_LABELS = {
+    "received": "RECEIVED",
+    "investigating": "INVESTIGATING",
+    "needs_info": "NEEDS INFO",
+    "fixed": "FIXED",
+    "wont_fix": "CAN'T FIX",
+}
+
+
+# ---------------------------------------------------------------------------
+# Errors, user_message is always safe to show a non-technical user
+# ---------------------------------------------------------------------------
+class FeedbackError(Exception):
+    exit_code = 5
+
+    def __init__(self, user_message: str):
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+class AuthError(FeedbackError):
+    exit_code = 2
+
+
+class NetworkError(FeedbackError):
+    exit_code = 3
+
+
+class BadResponse(FeedbackError):
+    exit_code = 5
+
+
+class FileProblem(FeedbackError):
+    exit_code = 6
+
+
+class DraftProblem(FeedbackError):
+    exit_code = 4
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def get_api_base_url(cli_value: "str | None" = None) -> str:
+    return (cli_value or os.environ.get("DEX_FEEDBACK_API_BASE") or HEYDEX_API_BASE_URL).rstrip("/")
+
+
+def get_site_base_url(cli_value: "str | None" = None) -> str:
+    return (cli_value or os.environ.get("DEX_FEEDBACK_SITE_BASE") or HEYDEX_SITE_BASE_URL).rstrip("/")
+
+
+def auth_file_path() -> Path:
+    return Path.home() / ".dex" / "heydex-auth.json"
+
+
+def resolve_vault(cli_value: "str | None" = None) -> Path:
+    candidate = cli_value or os.environ.get("VAULT_PATH") or os.getcwd()
+    return Path(candidate).expanduser().resolve()
+
+
+def feedback_dir(vault: Path) -> Path:
+    return vault / "System" / ".dex" / "feedback"
+
+
+def receipts_path(vault: Path) -> Path:
+    return vault / "System" / ".dex" / "feedback-log.jsonl"
+
+
+def link_instructions(site_base: "str | None" = None, expired: bool = False) -> str:
+    base = get_site_base_url(site_base)
+    intro = "Your Heydex connection has expired." if expired else "This terminal is not linked to Heydex yet."
+    return (
+        f"{intro} Open {base}/connect/?cli=true in a browser, sign in, "
+        "create a sign-in code, then run:\n"
+        "  python3 .claude/skills/feedback/scripts/feedback_client.py link --code ABC123"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth storage (shared with the DexDiff publish flow)
+# ---------------------------------------------------------------------------
+def save_auth(payload: dict, destination: "Path | None" = None, timestamp_ms: "int | None" = None) -> Path:
+    session_token = str(payload.get("sessionToken") or "").strip()
+    if not session_token:
+        raise BadResponse(
+            "Heydex did not return a terminal connection token. Try creating a new sign-in code."
+        )
+
+    auth_payload = {
+        "handle": payload.get("handle"),
+        "email": payload.get("email"),
+        "displayName": payload.get("displayName"),
+        "sessionToken": session_token,
+        "timestamp": timestamp_ms if timestamp_ms is not None else now_ms(),
+    }
+
+    target = destination or auth_file_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(auth_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        target.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    return target
+
+
+def load_auth(reference_ms: "int | None" = None, site_base: "str | None" = None) -> dict:
+    path = auth_file_path()
+    if not path.is_file():
+        raise AuthError(link_instructions(site_base))
+
+    try:
+        auth = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        raise AuthError(link_instructions(site_base))
+
+    timestamp = auth.get("timestamp")
+    session_token = str(auth.get("sessionToken") or "").strip()
+    if not isinstance(timestamp, (int, float)) or not session_token:
+        raise AuthError(link_instructions(site_base))
+
+    reference = reference_ms if reference_ms is not None else now_ms()
+    if reference - int(timestamp) > AUTH_MAX_AGE_MS:
+        raise AuthError(link_instructions(site_base, expired=True))
+
+    return auth
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+def _request_json(
+    method: str,
+    api_base: str,
+    path: str,
+    payload: "dict | None" = None,
+    bearer: "str | None" = None,
+    timeout: float = HTTP_TIMEOUT_SECONDS,
+) -> dict:
+    url = f"{get_api_base_url(api_base)}{path}"
+    headers = {"Accept": "application/json"}
+    body = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(payload).encode("utf-8")
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            response_body = response.read().decode("utf-8", errors="replace")
+            status = response.status
+    except urllib.error.HTTPError as error:
+        raise _http_error_to_feedback_error(error)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        raise NetworkError(
+            f"Could not reach {get_api_base_url(api_base)}. Check your internet connection and try again."
+        )
+
+    return _decode_json_response(status, response_body)
+
+
+def _http_error_to_feedback_error(error: urllib.error.HTTPError) -> FeedbackError:
+    body = error.read().decode("utf-8", errors="replace")
+    message = ""
+    try:
+        decoded = json.loads(body)
+        if isinstance(decoded, dict):
+            message = str(decoded.get("error") or "").strip()
+    except json.JSONDecodeError:
+        pass
+
+    if error.code == 401:
+        detail = f" ({message})" if message else ""
+        return AuthError(
+            f"The Heydex connection was not accepted{detail}. Create a new sign-in code and run the link command again."
+        )
+    if error.code == 429:
+        return NetworkError("Heydex is receiving a lot of requests right now. Wait a minute and try again.")
+    if error.code == 400:
+        return BadResponse(
+            "Heydex could not accept this report. This usually means a field was too long — "
+            "trim the report and try again."
+        )
+    return BadResponse(
+        f"Heydex answered with HTTP {error.code}. This is usually temporary, try again in a minute."
+    )
+
+
+def _decode_json_response(status: int, body: str) -> dict:
+    if status != 200:
+        raise BadResponse(f"Heydex answered with HTTP {status}. Try again in a minute.")
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        raise BadResponse("Heydex returned something that is not valid JSON. Try again in a minute.")
+    if not isinstance(decoded, dict):
+        raise BadResponse("Heydex returned an unexpected response. Try again in a minute.")
+    return decoded
+
+
+# ---------------------------------------------------------------------------
+# Local records: receipts + claim tickets
+# ---------------------------------------------------------------------------
+def append_receipt(vault: Path, action: str, payload: dict, sent: bool, reason: str) -> None:
+    """One line per attempt, sent or not — the user can always audit this."""
+    path = receipts_path(vault)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "attempted_at": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "sent": sent,
+            "reason": reason,
+            "payload": payload,
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except OSError:
+        pass
+
+
+def write_ticket_file(vault: Path, ticket: str, report_payload: dict, received_at: int) -> Path:
+    directory = feedback_dir(vault)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{ticket}.json"
+    record = {
+        "ticket": ticket,
+        "sent_at": received_at,
+        "status": "received",
+        "status_changed_at": received_at,
+        "last_notified_status_changed_at": received_at,
+        "report": report_payload,
+    }
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def load_ticket_files(vault: Path) -> dict:
+    directory = feedback_dir(vault)
+    tickets = {}
+    if not directory.is_dir():
+        return tickets
+    for path in sorted(directory.glob("DEX-*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        ticket = record.get("ticket")
+        if isinstance(ticket, str) and TICKET_PATTERN.match(ticket):
+            tickets[ticket] = record
+    return tickets
+
+
+def update_ticket_file(vault: Path, record: dict) -> None:
+    directory = feedback_dir(vault)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{record['ticket']}.json"
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Report drafts
+# ---------------------------------------------------------------------------
+def compute_fingerprint(feature: str, error_trace: str, summary: str) -> str:
+    """Stable failure signature: same bug from different users should collide."""
+    head = ""
+    if error_trace.strip():
+        head = error_trace.strip().splitlines()[0]
+    else:
+        head = summary.strip().splitlines()[0] if summary.strip() else ""
+    normalized = re.sub(r"0x[0-9a-fA-F]+", "ADDR", head)
+    normalized = re.sub(r"\d+", "#", normalized).strip().lower()
+    return hashlib.sha256(f"{feature}\n{normalized}".encode("utf-8")).hexdigest()
+
+
+def validate_draft(draft: dict) -> dict:
+    if not isinstance(draft, dict):
+        raise DraftProblem("The report draft must be a JSON object.")
+
+    allowed = set(REQUIRED_FIELDS) | set(OPTIONAL_FIELDS) | {
+        "schema_version",
+        "captured_at",
+        "dex_version",
+        "machine_state",
+        "review_mode",
+        "fingerprint",
+    }
+    unknown = sorted(set(draft) - allowed)
+    if unknown:
+        raise DraftProblem(
+            "The report draft contains fields that are not part of the allowed list: "
+            + ", ".join(unknown)
+            + ". Only the contract's ingredients may ever be sent."
+        )
+
+    for field in REQUIRED_FIELDS:
+        value = draft.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise DraftProblem(f"The report draft is missing '{field}'.")
+
+    for field, cap in FIELD_CAPS.items():
+        if field == "answer":
+            continue
+        value = draft.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise DraftProblem(f"'{field}' must be text.")
+        if len(value) > cap:
+            raise DraftProblem(
+                f"'{field}' is too long ({len(value)} characters; the limit is {cap}). Trim it and try again."
+            )
+
+    machine_state = draft.get("machine_state")
+    if machine_state is not None:
+        if not isinstance(machine_state, dict):
+            raise DraftProblem("'machine_state' must be an object.")
+        if len(json.dumps(machine_state)) > MACHINE_STATE_CAP:
+            raise DraftProblem("'machine_state' is too large. Trim it and try again.")
+
+    review_mode = draft.get("review_mode", "always-review")
+    if review_mode not in REVIEW_MODES:
+        raise DraftProblem("'review_mode' must be 'always-review' or 'auto-send'.")
+
+    dex_version = draft.get("dex_version")
+    if not isinstance(dex_version, str) or not dex_version.strip():
+        raise DraftProblem("The report draft is missing 'dex_version'.")
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "captured_at": draft.get("captured_at") if isinstance(draft.get("captured_at"), int) else now_ms(),
+        "dex_version": dex_version.strip(),
+        "feature": draft["feature"].strip(),
+        "summary": draft["summary"].strip(),
+        "review_mode": review_mode,
+    }
+    for field in OPTIONAL_FIELDS:
+        value = draft.get(field)
+        if isinstance(value, str) and value.strip():
+            payload[field] = value.strip()
+    if isinstance(machine_state, dict):
+        payload["machine_state"] = machine_state
+
+    fingerprint = draft.get("fingerprint")
+    if isinstance(fingerprint, str) and re.fullmatch(r"[0-9a-f]{16,128}", fingerprint):
+        payload["fingerprint"] = fingerprint
+    else:
+        payload["fingerprint"] = compute_fingerprint(
+            payload["feature"], payload.get("error_trace", ""), payload["summary"]
+        )
+
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+def command_link(args: argparse.Namespace) -> int:
+    code = args.code.strip()
+    if not code:
+        print("A sign-in code is required. Create one at %s/connect/?cli=true." % get_site_base_url(args.site_base))
+        return 2
+
+    payload = _request_json("POST", get_api_base_url(args.api_base), "/api/connect/redeem", {"code": code})
+    save_auth(payload)
+    email = payload.get("email") or "your Heydex account"
+    print(f"Linked this terminal to Heydex for {email}. Feedback reports are ready to send.")
+    return 0
+
+
+def command_report(args: argparse.Namespace) -> int:
+    vault = resolve_vault(args.vault)
+    draft_path = Path(args.file)
+    if not draft_path.is_file():
+        raise FileProblem(f"Could not find the report draft at {draft_path}.")
+    try:
+        draft = json.loads(draft_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        raise FileProblem(f"Could not read {draft_path} as JSON.")
+
+    payload = validate_draft(draft)
+    auth = load_auth(site_base=args.site_base)
+
+    try:
+        response = _request_json(
+            "POST",
+            get_api_base_url(args.api_base),
+            "/api/feedback/report",
+            payload,
+            bearer=auth["sessionToken"],
+        )
+    except FeedbackError as error:
+        append_receipt(vault, "report", payload, sent=False, reason=type(error).__name__)
+        raise
+
+    ticket = str(response.get("ticket") or "")
+    received_at = response.get("receivedAt")
+    if not TICKET_PATTERN.match(ticket) or not isinstance(received_at, int):
+        append_receipt(vault, "report", payload, sent=False, reason="bad_receipt")
+        raise BadResponse("Heydex accepted the report but did not return a valid ticket. Try 'status' in a minute.")
+
+    append_receipt(vault, "report", payload, sent=True, reason="sent")
+    write_ticket_file(vault, ticket, payload, received_at)
+    print(f"Sent — reference {ticket}. Dex will tell you when there's news.")
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    vault = resolve_vault(args.vault)
+    auth = load_auth(site_base=args.site_base)
+    response = _request_json(
+        "GET",
+        get_api_base_url(args.api_base),
+        "/api/feedback/status",
+        bearer=auth["sessionToken"],
+    )
+    reports = response.get("reports")
+    if not isinstance(reports, list):
+        raise BadResponse("Heydex returned an unexpected status response. Try again in a minute.")
+
+    local = load_ticket_files(vault)
+    if not reports:
+        print("No feedback reports on file for this account yet.")
+        return 0
+
+    print("Your reports:")
+    for report in reports:
+        ticket = str(report.get("ticket") or "")
+        status = str(report.get("status") or "")
+        label = STATUS_LABELS.get(status, status.upper() or "UNKNOWN")
+        summary = str(report.get("summary") or "").strip().replace("\n", " ")
+        if len(summary) > 60:
+            summary = summary[:57] + "..."
+        extra = ""
+        if status == "fixed" and report.get("fixedInVersion"):
+            extra = f" in v{report['fixedInVersion']}"
+        if status == "needs_info" and report.get("question"):
+            extra = " (1 question waiting — run /feedback to answer)"
+        print(f"  {ticket}  {summary}  {label}{extra}")
+        comment = report.get("comment")
+        if comment:
+            print(f"          Dave says: {comment}")
+
+        if ticket in local:
+            record = local[ticket]
+            record["status"] = status
+            if isinstance(report.get("statusChangedAt"), int):
+                record["status_changed_at"] = report["statusChangedAt"]
+            if report.get("question") is not None:
+                record["question"] = report["question"]
+            if report.get("comment") is not None:
+                record["comment"] = report["comment"]
+            if report.get("fixedInVersion") is not None:
+                record["fixed_in_version"] = report["fixedInVersion"]
+            # Seeing the status in person counts as being notified.
+            record["last_notified_status_changed_at"] = record.get("status_changed_at")
+            update_ticket_file(vault, record)
+    return 0
+
+
+def command_answer(args: argparse.Namespace) -> int:
+    vault = resolve_vault(args.vault)
+    ticket = args.ticket.strip()
+    if not TICKET_PATTERN.match(ticket):
+        raise DraftProblem("That does not look like a Dex ticket (expected something like DEX-142).")
+
+    if args.text is not None:
+        answer_text = args.text
+    elif args.file:
+        answer_path = Path(args.file)
+        if not answer_path.is_file():
+            raise FileProblem(f"Could not find the answer file at {answer_path}.")
+        answer_text = answer_path.read_text(encoding="utf-8")
+    else:
+        raise DraftProblem("Provide the answer with --text or --file.")
+
+    answer_text = answer_text.strip()
+    if not answer_text:
+        raise DraftProblem("The answer is empty.")
+    if len(answer_text) > FIELD_CAPS["answer"]:
+        raise DraftProblem(
+            f"The answer is too long ({len(answer_text)} characters; the limit is {FIELD_CAPS['answer']})."
+        )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "ticket": ticket,
+        "captured_at": now_ms(),
+        "answer": answer_text,
+    }
+    auth = load_auth(site_base=args.site_base)
+    try:
+        _request_json(
+            "POST",
+            get_api_base_url(args.api_base),
+            "/api/feedback/answer",
+            payload,
+            bearer=auth["sessionToken"],
+        )
+    except FeedbackError as error:
+        append_receipt(vault, "answer", payload, sent=False, reason=type(error).__name__)
+        raise
+
+    append_receipt(vault, "answer", payload, sent=True, reason="sent")
+    local = load_ticket_files(vault)
+    if ticket in local:
+        record = local[ticket]
+        record["status"] = "investigating"
+        record.pop("question", None)
+        update_ticket_file(vault, record)
+    print(f"Answer sent for {ticket}. Thanks — this goes straight to the investigation.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--api-base", default=None, help="API base, default %s" % HEYDEX_API_BASE_URL)
+    common.add_argument("--site-base", default=None, help="Site base, default %s" % HEYDEX_SITE_BASE_URL)
+    common.add_argument("--vault", default=None, help="Vault root, default $VAULT_PATH or the current directory")
+
+    link = subparsers.add_parser("link", parents=[common], help="Link this terminal to a heydex account")
+    link.add_argument("--code", required=True)
+    link.set_defaults(func=command_link)
+
+    report = subparsers.add_parser("report", parents=[common], help="Send an approved report draft")
+    report.add_argument("--file", required=True, help="Path to the approved report draft JSON")
+    report.set_defaults(func=command_report)
+
+    status = subparsers.add_parser("status", parents=[common], help="Show filed reports and their status")
+    status.set_defaults(func=command_status)
+
+    answer = subparsers.add_parser("answer", parents=[common], help="Answer a question on a ticket")
+    answer.add_argument("--ticket", required=True)
+    answer.add_argument("--text", default=None)
+    answer.add_argument("--file", default=None)
+    answer.set_defaults(func=command_answer)
+
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except AuthError as error:
+        print(f"CONNECTION NEEDED: {error.user_message}")
+        return error.exit_code
+    except NetworkError as error:
+        print(f"NETWORK ERROR: {error.user_message}")
+        return error.exit_code
+    except DraftProblem as error:
+        print(f"REPORT PROBLEM: {error.user_message}")
+        return error.exit_code
+    except FileProblem as error:
+        print(f"FILE PROBLEM: {error.user_message}")
+        return error.exit_code
+    except BadResponse as error:
+        print(f"BAD RESPONSE: {error.user_message}")
+        return error.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/feedback/scripts/feedback_client.py
+++ b/.claude/skills/feedback/scripts/feedback_client.py
@@ -330,12 +330,19 @@ def update_ticket_file(vault: Path, record: dict) -> None:
 # Report drafts
 # ---------------------------------------------------------------------------
 def compute_fingerprint(feature: str, error_trace: str, summary: str) -> str:
-    """Stable failure signature: same bug from different users should collide."""
-    head = ""
-    if error_trace.strip():
-        head = error_trace.strip().splitlines()[0]
+    """Stable failure signature: same bug from different users should collide.
+
+    Uses the LAST non-empty line of the error trace — for a Python traceback
+    that is the exception message ("IndexError: ..."), which distinguishes
+    bugs. The first line would be the generic "Traceback (most recent call
+    last):" header and would merge every distinct bug in a feature.
+    """
+    lines = [line for line in error_trace.strip().splitlines() if line.strip()]
+    if lines:
+        head = lines[-1]
     else:
-        head = summary.strip().splitlines()[0] if summary.strip() else ""
+        summary_lines = [line for line in summary.strip().splitlines() if line.strip()]
+        head = summary_lines[0] if summary_lines else ""
     normalized = re.sub(r"0x[0-9a-fA-F]+", "ADDR", head)
     normalized = re.sub(r"\d+", "#", normalized).strip().lower()
     return hashlib.sha256(f"{feature}\n{normalized}".encode("utf-8")).hexdigest()
@@ -447,7 +454,11 @@ def command_report(args: argparse.Namespace) -> int:
         raise FileProblem(f"Could not read {draft_path} as JSON.")
 
     payload = validate_draft(draft)
-    auth = load_auth(site_base=args.site_base)
+    try:
+        auth = load_auth(site_base=args.site_base)
+    except AuthError:
+        append_receipt(vault, "report", payload, sent=False, reason="AuthError")
+        raise
 
     try:
         response = _request_json(
@@ -468,7 +479,14 @@ def command_report(args: argparse.Namespace) -> int:
         raise BadResponse("Heydex accepted the report but did not return a valid ticket. Try 'status' in a minute.")
 
     append_receipt(vault, "report", payload, sent=True, reason="sent")
-    write_ticket_file(vault, ticket, payload, received_at)
+    try:
+        write_ticket_file(vault, ticket, payload, received_at)
+    except OSError:
+        print(
+            f"Sent — reference {ticket}. (The local ticket record could not be saved, "
+            "so automatic status updates for this ticket may not appear on this machine.)"
+        )
+        return 0
     print(f"Sent — reference {ticket}. Dex will tell you when there's news.")
     return 0
 
@@ -522,7 +540,10 @@ def command_status(args: argparse.Namespace) -> int:
                 record["fixed_in_version"] = report["fixedInVersion"]
             # Seeing the status in person counts as being notified.
             record["last_notified_status_changed_at"] = record.get("status_changed_at")
-            update_ticket_file(vault, record)
+            try:
+                update_ticket_file(vault, record)
+            except OSError:
+                pass
     return 0
 
 
@@ -556,7 +577,11 @@ def command_answer(args: argparse.Namespace) -> int:
         "captured_at": now_ms(),
         "answer": answer_text,
     }
-    auth = load_auth(site_base=args.site_base)
+    try:
+        auth = load_auth(site_base=args.site_base)
+    except AuthError:
+        append_receipt(vault, "answer", payload, sent=False, reason="AuthError")
+        raise
     try:
         _request_json(
             "POST",
@@ -575,7 +600,10 @@ def command_answer(args: argparse.Namespace) -> int:
         record = local[ticket]
         record["status"] = "investigating"
         record.pop("question", None)
-        update_ticket_file(vault, record)
+        try:
+            update_ticket_file(vault, record)
+        except OSError:
+            pass
     print(f"Answer sent for {ticket}. Thanks — this goes straight to the investigation.")
     return 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ System/.dex/telemetry-id
 System/.dex/feedback/
 System/.dex/feedback-log.jsonl
 System/.dex/feedback-sweep.json
+System/.dex/feedback-sweep-claim-*
 System/.dex/adoption/credential-journals/
 System/.dex/adoption/history-backups/
 System/.dex/local-only-preservation/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ System/.dex/session-health.lock
 System/.dex/session-health-success.json
 System/.dex/health-telemetry-log.jsonl
 System/.dex/telemetry-id
+System/.dex/feedback/
+System/.dex/feedback-log.jsonl
+System/.dex/feedback-sweep.json
 System/.dex/adoption/credential-journals/
 System/.dex/adoption/history-backups/
 System/.dex/local-only-preservation/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.82.0] — 💬 Found a bug? Dex reports it for you — and tells you when it's fixed (2026-08-08)
+
+Until now, when something in Dex misbehaved, telling the Dex team meant writing it
+up yourself — so most problems went unreported, and the ones that arrived were too
+thin to act on. Now Dex has a proper way to raise its hand on your behalf: the new
+`/feedback` command.
+
+**What this fixes for you:**
+
+* **Report a bug with zero homework.** Say "report this" (or run `/feedback`) and
+  Dex investigates the problem on your machine, writes the report itself, and gives
+  you a reference number. The Doctor checkup offers the same thing when it finds
+  something that's genuinely a Dex problem rather than a setup problem.
+* **Nothing private ever leaves your machine.** Reports are built only from a fixed
+  list of safe ingredients — Dex's version, which feature misbehaved, and error
+  details from Dex's own workings. Your notes, meetings, people, and conversations
+  are never part of a report, and Dex shows you the exact report before anything is
+  sent. A copy of every attempt is also kept on your machine so you can always see
+  what went.
+* **You choose how involved to be.** Review every report before it goes (that's the
+  default), or — once you've seen what a report looks like — tell Dex to just send
+  future ones automatically. You can switch back anytime.
+* **You hear back.** When your bug is fixed in a release, your next session opens
+  with the good news and a thank-you — along with which version has the fix. If the
+  team needs one more detail, Dex relays the question, gathers the answer with your
+  approval, and sends it back. You can ask "what happened to my bug report?" anytime.
+* **One connection, thirty seconds, once.** The first report asks you to connect
+  this terminal to your heydex.ai account (the same quick sign-in the DexDiff
+  publishing flow uses). After that, reporting is invisible.
+
+---
+
 ## [1.81.19] — 💌 Your feedback, fixed — and updates that shrug off network blips (2026-08-07)
 
 One of Dex's longest-running users spent a day putting her whole setup through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,6 +499,7 @@ Skills extend Dex capabilities and are invoked with `/skill-name`. Common skills
 - `/xray` - AI education: understand what just happened under the hood (context, MCPs, hooks)
 - `/dex-level-up`, `/dex-backlog`, `/dex-improve` - System improvements
 - `/dex-doctor` - Full system checkup: finds what's broken, fixes what's safe, guides you through the rest
+- `/feedback` - Report a Dex bug to the Dex team with zero homework; Dex investigates, you approve, and you hear back when it's fixed
 - `/dex-update` - Update Dex automatically (shows what's new, updates if confirmed, no technical knowledge needed)
 - `/dex-rollback` - Undo last update if something went wrong
 - `/getting-started` - Interactive post-onboarding tour (adaptive to your setup)

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -28,6 +28,14 @@ working_week:
 updates:
   channel: stable
 
+# Bug reports to the Dex team (/feedback).
+# review_mode controls whether you approve each report before it is sent:
+#   always-review (default) — Dex shows you the exact report and waits for a yes
+#   auto-send — reports go automatically; a local receipt is always kept, and
+#   the first report plus every follow-up answer is still shown to you first
+feedback:
+  review_mode: always-review
+
 # Optional local Git snapshots after the brain/vault split. This never pushes.
 vault:
   auto_commit: false

--- a/core/tests/test_feedback_client_script.py
+++ b/core/tests/test_feedback_client_script.py
@@ -66,6 +66,75 @@ def test_fingerprint_is_stable_across_line_numbers_and_addresses():
     assert first != different
 
 
+def test_fingerprint_distinguishes_bugs_inside_realistic_tracebacks():
+    client = _load_script()
+    index_error = (
+        "Traceback (most recent call last):\n"
+        '  File "core/utils/doctor.py", line 42, in collect\n'
+        "    attendee = meeting.attendees[0]\n"
+        "IndexError: list index out of range"
+    )
+    key_error = (
+        "Traceback (most recent call last):\n"
+        '  File "core/utils/sync.py", line 97, in run\n'
+        "    person = pages[email]\n"
+        "KeyError: 'person@example.com'"
+    )
+    same_bug_other_line = index_error.replace("line 42", "line 58")
+
+    first = client.compute_fingerprint("/process-meetings", index_error, "s")
+    second = client.compute_fingerprint("/process-meetings", key_error, "s")
+    assert first != second, "different exceptions must not share a fingerprint"
+    assert first == client.compute_fingerprint("/process-meetings", same_bug_other_line, "s")
+
+
+def test_auth_failure_still_appends_a_receipt(tmp_path, monkeypatch):
+    client = _load_script()
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(json.dumps(_draft()), encoding="utf-8")
+
+    def no_auth(**kwargs):
+        raise client.AuthError("not linked")
+
+    monkeypatch.setattr(client, "load_auth", no_auth)
+    args = client.build_parser().parse_args(
+        ["report", "--file", str(draft_path), "--vault", str(tmp_path)]
+    )
+    with pytest.raises(client.AuthError):
+        client.command_report(args)
+
+    receipts = (tmp_path / "System" / ".dex" / "feedback-log.jsonl").read_text(encoding="utf-8")
+    record = json.loads(receipts.strip())
+    assert record["sent"] is False
+    assert record["reason"] == "AuthError"
+
+
+def test_unsaveable_ticket_file_does_not_crash_a_successful_send(tmp_path, monkeypatch, capsys):
+    client = _load_script()
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(json.dumps(_draft()), encoding="utf-8")
+    monkeypatch.setattr(
+        client, "load_auth", lambda **kwargs: {"sessionToken": "token", "timestamp": client.now_ms()}
+    )
+    monkeypatch.setattr(
+        client,
+        "_request_json",
+        lambda *args, **kwargs: {"ticket": "DEX-142", "receivedAt": 1754640001000},
+    )
+
+    def broken_write(*args, **kwargs):
+        raise OSError("read-only vault")
+
+    monkeypatch.setattr(client, "write_ticket_file", broken_write)
+    args = client.build_parser().parse_args(
+        ["report", "--file", str(draft_path), "--vault", str(tmp_path)]
+    )
+    assert client.command_report(args) == 0
+    out = capsys.readouterr().out
+    assert "DEX-142" in out
+    assert "could not be saved" in out
+
+
 def test_receipt_is_written_even_when_send_fails(tmp_path, monkeypatch):
     client = _load_script()
     draft_path = tmp_path / "draft.json"

--- a/core/tests/test_feedback_client_script.py
+++ b/core/tests/test_feedback_client_script.py
@@ -1,0 +1,145 @@
+"""Tests for the standalone skill script .claude/skills/feedback/scripts/feedback_client.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "feedback" / "scripts" / "feedback_client.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("feedback_client", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _draft(**overrides):
+    draft = {
+        "dex_version": "1.81.19",
+        "feature": "/process-meetings",
+        "summary": "Sync stopped when a meeting had no attendees.",
+        "review_mode": "always-review",
+    }
+    draft.update(overrides)
+    return draft
+
+
+def test_validate_draft_fills_schema_version_timestamp_and_fingerprint():
+    client = _load_script()
+    payload = client.validate_draft(_draft(error_trace="IndexError: line 42"))
+    assert payload["schema_version"] == client.SCHEMA_VERSION
+    assert isinstance(payload["captured_at"], int)
+    assert len(payload["fingerprint"]) == 64
+    assert set(payload["fingerprint"]) <= set("0123456789abcdef")
+
+
+def test_validate_draft_rejects_fields_outside_the_allowed_list():
+    client = _load_script()
+    with pytest.raises(client.DraftProblem) as excinfo:
+        client.validate_draft(_draft(meeting_notes="private content"))
+    assert "allowed list" in excinfo.value.user_message
+
+
+def test_validate_draft_rejects_missing_required_and_oversized_fields():
+    client = _load_script()
+    with pytest.raises(client.DraftProblem):
+        client.validate_draft({"dex_version": "1.0.0", "feature": "/x"})
+    with pytest.raises(client.DraftProblem):
+        client.validate_draft(_draft(summary="x" * 2001))
+    with pytest.raises(client.DraftProblem):
+        client.validate_draft(_draft(review_mode="yolo"))
+
+
+def test_fingerprint_is_stable_across_line_numbers_and_addresses():
+    client = _load_script()
+    first = client.compute_fingerprint("/sync", "IndexError at line 42 (0xdeadbeef)", "s")
+    second = client.compute_fingerprint("/sync", "IndexError at line 97 (0xcafef00d)", "s")
+    different = client.compute_fingerprint("/sync", "KeyError: person", "s")
+    assert first == second
+    assert first != different
+
+
+def test_receipt_is_written_even_when_send_fails(tmp_path, monkeypatch):
+    client = _load_script()
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(json.dumps(_draft()), encoding="utf-8")
+    auth = {"sessionToken": "token", "timestamp": client.now_ms()}
+    monkeypatch.setattr(client, "load_auth", lambda **kwargs: auth)
+
+    def failing_request(*args, **kwargs):
+        raise client.NetworkError("no network")
+
+    monkeypatch.setattr(client, "_request_json", failing_request)
+    args = client.build_parser().parse_args(
+        ["report", "--file", str(draft_path), "--vault", str(tmp_path)]
+    )
+    with pytest.raises(client.NetworkError):
+        client.command_report(args)
+
+    receipts = (tmp_path / "System" / ".dex" / "feedback-log.jsonl").read_text(encoding="utf-8")
+    record = json.loads(receipts.strip())
+    assert record["sent"] is False
+    assert record["reason"] == "NetworkError"
+    assert record["payload"]["feature"] == "/process-meetings"
+
+
+def test_successful_report_writes_ticket_file_and_receipt(tmp_path, monkeypatch, capsys):
+    client = _load_script()
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(json.dumps(_draft()), encoding="utf-8")
+    auth = {"sessionToken": "token", "timestamp": client.now_ms()}
+    monkeypatch.setattr(client, "load_auth", lambda **kwargs: auth)
+    monkeypatch.setattr(
+        client,
+        "_request_json",
+        lambda *args, **kwargs: {"ticket": "DEX-142", "receivedAt": 1754640001000},
+    )
+
+    args = client.build_parser().parse_args(
+        ["report", "--file", str(draft_path), "--vault", str(tmp_path)]
+    )
+    assert client.command_report(args) == 0
+    assert "DEX-142" in capsys.readouterr().out
+
+    ticket_file = tmp_path / "System" / ".dex" / "feedback" / "DEX-142.json"
+    record = json.loads(ticket_file.read_text(encoding="utf-8"))
+    assert record["status"] == "received"
+    assert record["report"]["summary"].startswith("Sync stopped")
+
+    receipts = (tmp_path / "System" / ".dex" / "feedback-log.jsonl").read_text(encoding="utf-8")
+    assert json.loads(receipts.strip())["sent"] is True
+
+
+def test_answer_requires_a_plausible_ticket_and_nonempty_text(tmp_path):
+    client = _load_script()
+    args = client.build_parser().parse_args(
+        ["answer", "--ticket", "nonsense", "--text", "hello", "--vault", str(tmp_path)]
+    )
+    with pytest.raises(client.DraftProblem):
+        client.command_answer(args)
+
+    args = client.build_parser().parse_args(
+        ["answer", "--ticket", "DEX-1", "--text", "   ", "--vault", str(tmp_path)]
+    )
+    with pytest.raises(client.DraftProblem):
+        client.command_answer(args)
+
+
+def test_expired_auth_raises_connection_instructions(tmp_path, monkeypatch):
+    client = _load_script()
+    stale = tmp_path / "auth.json"
+    stale.write_text(
+        json.dumps({"sessionToken": "token", "timestamp": 0}), encoding="utf-8"
+    )
+    monkeypatch.setattr(client, "auth_file_path", lambda: stale)
+    with pytest.raises(client.AuthError) as excinfo:
+        client.load_auth()
+    assert "expired" in excinfo.value.user_message
+    assert "feedback_client.py link" in excinfo.value.user_message

--- a/core/tests/test_feedback_sweep.py
+++ b/core/tests/test_feedback_sweep.py
@@ -139,6 +139,17 @@ def test_daily_claim_blocks_second_attempt(vault, monkeypatch):
     assert len(calls) == 1
 
 
+def test_daily_claim_is_atomic_across_concurrent_sessions(vault):
+    # The claim is an O_CREAT|O_EXCL marker, so exactly one of N simultaneous
+    # claimants wins the day — two sessions can never both notify.
+    import concurrent.futures
+
+    (vault / "System" / ".dex").mkdir(parents=True, exist_ok=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: feedback_sweep._claim_today(vault), range(8)))
+    assert results.count(True) == 1
+
+
 def test_network_failure_is_silent(vault, monkeypatch):
     _write_ticket(vault, "DEX-142")
     monkeypatch.setattr(feedback_sweep, "_fetch_status", lambda token: None)

--- a/core/tests/test_feedback_sweep.py
+++ b/core/tests/test_feedback_sweep.py
@@ -1,0 +1,168 @@
+"""Tests for the once-daily feedback status sweep (core/utils/feedback_sweep.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.utils import feedback_sweep
+
+
+def _write_ticket(vault: Path, ticket: str, notified_at: int = 100) -> Path:
+    directory = vault / "System" / ".dex" / "feedback"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{ticket}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "ticket": ticket,
+                "sent_at": 100,
+                "status": "received",
+                "status_changed_at": 100,
+                "last_notified_status_changed_at": notified_at,
+                "report": {"summary": "Sync stopped on empty meetings."},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _server_report(**overrides):
+    report = {
+        "ticket": "DEX-142",
+        "feature": "/process-meetings",
+        "summary": "Sync stopped on empty meetings.",
+        "status": "fixed",
+        "statusChangedAt": 200,
+        "fixedInVersion": "1.82.0",
+        "comment": "Great catch — thank you.",
+        "question": None,
+        "createdAt": 100,
+    }
+    report.update(overrides)
+    return report
+
+
+@pytest.fixture()
+def vault(tmp_path, monkeypatch):
+    monkeypatch.setattr(feedback_sweep, "_auth_token", lambda: "token")
+    return tmp_path
+
+
+def test_no_tickets_means_no_network_and_no_output(tmp_path, monkeypatch):
+    def explode(_token):
+        raise AssertionError("network must not be touched without tickets")
+
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", explode)
+    assert feedback_sweep.sweep(tmp_path) is None
+
+
+def test_no_auth_means_no_network(tmp_path, monkeypatch):
+    _write_ticket(tmp_path, "DEX-142")
+    monkeypatch.setattr(feedback_sweep, "_auth_token", lambda: None)
+
+    def explode(_token):
+        raise AssertionError("network must not be touched without a linked account")
+
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", explode)
+    assert feedback_sweep.sweep(tmp_path) is None
+
+
+def test_fixed_status_produces_notice_once_only(vault, monkeypatch):
+    _write_ticket(vault, "DEX-142")
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", lambda token: [_server_report()])
+    monkeypatch.setenv("DEX_FEEDBACK_SWEEP_FORCE", "1")
+
+    notice = feedback_sweep.sweep(vault)
+    assert notice is not None
+    assert "DEX-142" in notice
+    assert "fixed in v1.82.0" in notice
+    assert "Great catch" in notice
+    assert "/dex-update" in notice
+
+    # Same server state again: already notified, stays silent.
+    assert feedback_sweep.sweep(vault) is None
+
+
+def test_quiet_transition_updates_record_without_notice(vault, monkeypatch):
+    path = _write_ticket(vault, "DEX-142")
+    monkeypatch.setattr(
+        feedback_sweep,
+        "_fetch_status",
+        lambda token: [_server_report(status="investigating", fixedInVersion=None, comment=None)],
+    )
+    monkeypatch.setenv("DEX_FEEDBACK_SWEEP_FORCE", "1")
+
+    assert feedback_sweep.sweep(vault) is None
+    record = json.loads(path.read_text(encoding="utf-8"))
+    assert record["status"] == "investigating"
+    assert record["last_notified_status_changed_at"] == 200
+
+
+def test_question_produces_answerable_notice(vault, monkeypatch):
+    _write_ticket(vault, "DEX-158")
+    monkeypatch.setattr(
+        feedback_sweep,
+        "_fetch_status",
+        lambda token: [
+            _server_report(
+                ticket="DEX-158",
+                status="needs_info",
+                question="Does this happen for people added before July?",
+                fixedInVersion=None,
+            )
+        ],
+    )
+    monkeypatch.setenv("DEX_FEEDBACK_SWEEP_FORCE", "1")
+
+    notice = feedback_sweep.sweep(vault)
+    assert notice is not None
+    assert "DEX-158" in notice
+    assert "before July" in notice
+    assert "/feedback" in notice
+
+
+def test_daily_claim_blocks_second_attempt(vault, monkeypatch):
+    _write_ticket(vault, "DEX-142")
+    calls = []
+
+    def fetch(token):
+        calls.append(token)
+        return [_server_report()]
+
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", fetch)
+    feedback_sweep.sweep(vault)
+    feedback_sweep.sweep(vault)
+    assert len(calls) == 1
+
+
+def test_network_failure_is_silent(vault, monkeypatch):
+    _write_ticket(vault, "DEX-142")
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", lambda token: None)
+    monkeypatch.setenv("DEX_FEEDBACK_SWEEP_FORCE", "1")
+    assert feedback_sweep.sweep(vault) is None
+
+
+def test_main_emits_session_start_hook_json(vault, monkeypatch, capsys):
+    _write_ticket(vault, "DEX-142")
+    monkeypatch.setattr(feedback_sweep, "_fetch_status", lambda token: [_server_report()])
+    monkeypatch.setenv("DEX_FEEDBACK_SWEEP_FORCE", "1")
+
+    assert feedback_sweep.main(["--vault", str(vault), "--session-start"]) == 0
+    output = capsys.readouterr().out.strip()
+    decoded = json.loads(output)
+    context = decoded["hookSpecificOutput"]["additionalContext"]
+    assert decoded["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "DEX-142" in context
+
+
+def test_main_never_raises_even_on_broken_vault(tmp_path, capsys):
+    # A file where the feedback directory should be must not crash the hook.
+    weird = tmp_path / "System" / ".dex"
+    weird.parent.mkdir(parents=True)
+    weird.write_text("not a directory", encoding="utf-8")
+    assert feedback_sweep.main(["--vault", str(tmp_path), "--session-start"]) == 0
+    assert capsys.readouterr().out == ""

--- a/core/tests/test_skill_integrity.py
+++ b/core/tests/test_skill_integrity.py
@@ -132,6 +132,31 @@ def test_validate_user_profile_requires_updates_to_be_an_object() -> None:
     assert validate_user_profile_config({"updates": "stable"}) == ["updates must be an object"]
 
 
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"feedback": {}},
+        {"feedback": {"review_mode": "always-review"}},
+        {"feedback": {"review_mode": "auto-send"}},
+    ],
+)
+def test_validate_user_profile_accepts_supported_or_absent_feedback_mode(
+    config: object,
+) -> None:
+    assert validate_user_profile_config(config) == []
+
+
+@pytest.mark.parametrize("review_mode", ["review", "Auto-Send", "", None, 1, True])
+def test_validate_user_profile_warns_for_invalid_feedback_mode(review_mode: object) -> None:
+    errors = validate_user_profile_config({"feedback": {"review_mode": review_mode}})
+
+    assert errors == ["feedback.review_mode must be always-review or auto-send"]
+
+
+def test_validate_user_profile_requires_feedback_to_be_an_object() -> None:
+    assert validate_user_profile_config({"feedback": "auto-send"}) == ["feedback must be an object"]
+
+
 def test_validate_user_profile_accepts_declared_boolean_capability_states() -> None:
     assert validate_user_profile_config(
         {

--- a/core/utils/feedback_sweep.py
+++ b/core/utils/feedback_sweep.py
@@ -77,22 +77,35 @@ def _load_tickets(vault: Path) -> dict:
 
 
 def _claim_today(vault: Path) -> bool:
-    """Claim today's attempt before doing any work; True if we own today."""
-    state_path = _state_path(vault)
+    """Claim today's attempt before doing any work; True if we own today.
+
+    The claim is an O_CREAT|O_EXCL dated marker file, so exactly one process
+    wins the day even when two sessions start simultaneously — a crash can
+    never leave a stale lock because the marker IS the claim, not a mutex.
+    """
+    if os.environ.get("DEX_FEEDBACK_SWEEP_FORCE"):
+        return True
+    directory = _state_path(vault).parent
     today = date.today().isoformat()
+    marker = directory / f"feedback-sweep-claim-{today}"
     try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        state = {}
-    if state.get("last_attempt_date") == today and not os.environ.get("DEX_FEEDBACK_SWEEP_FORCE"):
+        directory.mkdir(parents=True, exist_ok=True)
+        handle = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
         return False
-    state["last_attempt_date"] = today
-    state["last_attempt_at"] = datetime.now(timezone.utc).isoformat()
-    try:
-        state_path.parent.mkdir(parents=True, exist_ok=True)
-        state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     except OSError:
         return False
+    try:
+        os.write(handle, datetime.now(timezone.utc).isoformat().encode("utf-8"))
+    finally:
+        os.close(handle)
+    # Opportunistically drop old markers so they never accumulate.
+    try:
+        for stale in directory.glob("feedback-sweep-claim-*"):
+            if stale.name != marker.name:
+                stale.unlink(missing_ok=True)
+    except OSError:
+        pass
     return True
 
 

--- a/core/utils/feedback_sweep.py
+++ b/core/utils/feedback_sweep.py
@@ -241,20 +241,23 @@ def main(argv: "list[str] | None" = None) -> int:
     except Exception:
         return 0
 
-    if notice:
-        if session_start:
-            print(
-                json.dumps(
-                    {
-                        "hookSpecificOutput": {
-                            "hookEventName": "SessionStart",
-                            "additionalContext": f"\n{notice}\n",
+    try:
+        if notice:
+            if session_start:
+                print(
+                    json.dumps(
+                        {
+                            "hookSpecificOutput": {
+                                "hookEventName": "SessionStart",
+                                "additionalContext": f"\n{notice}\n",
+                            }
                         }
-                    }
+                    )
                 )
-            )
-        else:
-            print(notice)
+            else:
+                print(notice)
+    except OSError:
+        pass
     return 0
 
 

--- a/core/utils/feedback_sweep.py
+++ b/core/utils/feedback_sweep.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Once-daily session-start sweep for /feedback report news.
+
+Checks heydex.ai for status changes and questions on the feedback reports this
+vault has filed, and surfaces them once at session start. Design rules
+(contract: docs/feedback-loop-contract.md):
+
+- Zero cost for non-reporters: exits immediately unless claim-ticket files
+  exist under System/.dex/feedback/ and a terminal connection is linked.
+- Bounded and once daily: the day is claimed before any network work
+  (update-verifier pattern), one GET with a short timeout, never retries.
+- Pull only: nothing on the server can reach into this machine; this script
+  asks, the server answers.
+- Never noisy, never fatal: any failure is silent and exits 0. A notice is
+  emitted at most once per (ticket, status change).
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+HEYDEX_API_BASE_URL = "https://gallant-reindeer-229.eu-west-1.convex.site"
+HTTP_TIMEOUT_SECONDS = 8
+AUTH_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+TICKET_PATTERN = re.compile(r"^DEX-\d{1,10}$")
+
+ACTIONABLE_STATUSES = {"fixed", "wont_fix", "needs_info"}
+
+
+def _api_base() -> str:
+    return (os.environ.get("DEX_FEEDBACK_API_BASE") or HEYDEX_API_BASE_URL).rstrip("/")
+
+
+def _auth_token() -> "str | None":
+    path = Path.home() / ".dex" / "heydex-auth.json"
+    try:
+        auth = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    token = str(auth.get("sessionToken") or "").strip()
+    timestamp = auth.get("timestamp")
+    if not token or not isinstance(timestamp, (int, float)):
+        return None
+    if int(time.time() * 1000) - int(timestamp) > AUTH_MAX_AGE_MS:
+        return None
+    return token
+
+
+def _feedback_dir(vault: Path) -> Path:
+    return vault / "System" / ".dex" / "feedback"
+
+
+def _state_path(vault: Path) -> Path:
+    return vault / "System" / ".dex" / "feedback-sweep.json"
+
+
+def _load_tickets(vault: Path) -> dict:
+    tickets = {}
+    directory = _feedback_dir(vault)
+    if not directory.is_dir():
+        return tickets
+    for path in sorted(directory.glob("DEX-*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        ticket = record.get("ticket")
+        if isinstance(ticket, str) and TICKET_PATTERN.match(ticket):
+            tickets[ticket] = (path, record)
+    return tickets
+
+
+def _claim_today(vault: Path) -> bool:
+    """Claim today's attempt before doing any work; True if we own today."""
+    state_path = _state_path(vault)
+    today = date.today().isoformat()
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    if state.get("last_attempt_date") == today and not os.environ.get("DEX_FEEDBACK_SWEEP_FORCE"):
+        return False
+    state["last_attempt_date"] = today
+    state["last_attempt_at"] = datetime.now(timezone.utc).isoformat()
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError:
+        return False
+    return True
+
+
+def _fetch_status(token: str) -> "list | None":
+    url = f"{_api_base()}/api/feedback/status"
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            if response.status != 200:
+                return None
+            body = response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+        return None
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    reports = decoded.get("reports") if isinstance(decoded, dict) else None
+    return reports if isinstance(reports, list) else None
+
+
+def _short(summary: str, limit: int = 60) -> str:
+    flattened = " ".join(str(summary).split())
+    return flattened if len(flattened) <= limit else flattened[: limit - 3] + "..."
+
+
+def _notice_for(report: dict) -> "str | None":
+    ticket = report.get("ticket")
+    status = report.get("status")
+    summary = _short(report.get("summary") or "")
+    comment = report.get("comment")
+    if status == "fixed":
+        version = report.get("fixedInVersion")
+        line = f"◆ Good news on a bug you reported. {ticket} — {summary} — is fixed"
+        line += f" in v{version}." if version else "."
+        if comment:
+            line += f'\n  Dave says: "{comment}"'
+        line += "\n  Run /dex-update when you're ready."
+        return line
+    if status == "needs_info" and report.get("question"):
+        return (
+            f"◆ A question about {ticket} ({summary}):\n"
+            f'  "{report["question"]}"\n'
+            "  Run /feedback to answer — Dex can gather the answer for you, and you approve it before it goes."
+        )
+    if status == "wont_fix":
+        line = f"◆ An update on {ticket} ({summary}): this one can't be fixed."
+        if comment:
+            line += f'\n  Dave says: "{comment}"'
+        return line
+    return None
+
+
+def sweep(vault: Path) -> "str | None":
+    tickets = _load_tickets(vault)
+    if not tickets:
+        return None
+    token = _auth_token()
+    if token is None:
+        return None
+    if not _claim_today(vault):
+        return None
+
+    reports = _fetch_status(token)
+    if reports is None:
+        return None
+
+    notices = []
+    for report in reports:
+        ticket = report.get("ticket")
+        if ticket not in tickets:
+            continue
+        path, record = tickets[ticket]
+        changed_at = report.get("statusChangedAt")
+        if not isinstance(changed_at, int):
+            continue
+
+        already_notified = record.get("last_notified_status_changed_at")
+        is_new = not isinstance(already_notified, int) or changed_at > already_notified
+
+        record["status"] = report.get("status")
+        record["status_changed_at"] = changed_at
+        for source, target in (
+            ("question", "question"),
+            ("comment", "comment"),
+            ("fixedInVersion", "fixed_in_version"),
+        ):
+            if report.get(source) is not None:
+                record[target] = report[source]
+
+        if is_new and report.get("status") in ACTIONABLE_STATUSES:
+            notice = _notice_for(report)
+            if notice:
+                notices.append(notice)
+                record["last_notified_status_changed_at"] = changed_at
+        elif is_new:
+            # Quiet transitions (e.g. received → investigating) update the
+            # local record without a session-start interruption.
+            record["last_notified_status_changed_at"] = changed_at
+
+        try:
+            path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        except OSError:
+            continue
+
+    if not notices:
+        return None
+    return "\n\n".join(notices)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    vault = None
+    session_start = False
+    index = 0
+    while index < len(args):
+        if args[index] == "--vault" and index + 1 < len(args):
+            vault = Path(args[index + 1]).expanduser()
+            index += 2
+            continue
+        if args[index] == "--session-start":
+            session_start = True
+        index += 1
+
+    if vault is None:
+        vault = Path(os.environ.get("VAULT_PATH") or os.getcwd())
+
+    try:
+        notice = sweep(vault.resolve())
+    except Exception:
+        return 0
+
+    if notice:
+        if session_start:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "SessionStart",
+                            "additionalContext": f"\n{notice}\n",
+                        }
+                    }
+                )
+            )
+        else:
+            print(notice)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/utils/validators.py
+++ b/core/utils/validators.py
@@ -33,6 +33,7 @@ def validate_user_profile_config(config: object) -> list[str]:
         "calendar",
         "updates",
         "capabilities",
+        "feedback",
     )
     for field in object_fields:
         if field in config and not isinstance(config[field], Mapping):
@@ -42,6 +43,11 @@ def validate_user_profile_config(config: object) -> list[str]:
         channel = updates["channel"]
         if not isinstance(channel, str) or channel not in {"stable", "beta"}:
             errors.append("updates.channel must be stable or beta")
+    feedback = config.get("feedback")
+    if isinstance(feedback, Mapping) and "review_mode" in feedback:
+        review_mode = feedback["review_mode"]
+        if not isinstance(review_mode, str) or review_mode not in {"always-review", "auto-send"}:
+            errors.append("feedback.review_mode must be always-review or auto-send")
     capabilities = config.get("capabilities")
     if isinstance(capabilities, Mapping):
         from core.capabilities import room_ids

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 4a811ad20b81ca2d04b392f9a4fe8e19739473437058cd3d10faf3ea75da6802 -->
+<!-- Content SHA-256: 2a423297efc2ecc96ad84bf2bbb07e701625606bd31f18a8ee002d9cf314e277 -->
 
 # Architecture Inventory
 
@@ -25,7 +25,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 75<br>
+**Skill count:** 76<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -75,6 +75,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `diff-profile` | `.claude/skills/diff-profile/SKILL.md` | Package your entire Dex system into a shareable DexDiff profile so others can replicate how you work. Use when the user says 'share my whole setup', 'publish my profile'. Not for a single workflow; use `diff-generate`. Not for adopting a whole profile; use `diff-adopt-profile`. | 278 | when |
 | `diff-remove` | `.claude/skills/diff-remove/SKILL.md` | Remove a previously adopted DexDiff workflow — deletes its generated skills and config, leaves your data untouched. Use when the user says 'remove that workflow', 'undo the adoption'. Not for listing what's installed; use `diff-list`. | 234 | when |
 | `enable-semantic-search` | `.claude/skills/enable-semantic-search/SKILL.md` | Turn on local AI-powered semantic (meaning-based) search over the vault, with smart collection discovery. Use when the user says 'enable semantic search', 'search by meaning', 'set up QMD', or search keeps missing obvious matches. Not for scraping the web; use `scrape`. | 270 | when |
+| `feedback` | `.claude/skills/feedback/SKILL.md` | Report a Dex bug to the Dex team with zero homework — Dex investigates locally, builds a privacy-safe report, shows it to you (or auto-sends if you've chosen that), and tracks the ticket until it's fixed. Use when the user says "report this", "send this to the Dex team", "file feedback", "/feedback", asks "what happened to my bug report", or accepts Doctor's offer to report a Dex bug. Not for capturing ideas about your own vault or workflow; use the improvements backlog for those. | 485 | when |
 | `getting-started` | `.claude/skills/getting-started/SKILL.md` | Interactive post-onboarding tour that adapts to whatever data exists (calendar, Granola, or none). Use right after onboarding, or when the user says 'show me around', 'how do I start'. Also use proactively when the vault is < 7 days old. Not for the initial setup itself; use `setup`. | 284 | when |
 | `google-workspace-setup` | `.claude/skills/google-workspace-setup/SKILL.md` | Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep. Use when the user says 'connect Gmail/Google', 'hook up my work email'. Not for local macOS calendar speed only; use `calendar-setup`. Not for Microsoft; use `ms-teams-setup`. | 267 | when |
 | `granola-setup` | `.claude/skills/granola-setup/SKILL.md` | Connect Granola via its official API for automatic meeting sync and transcripts. Use when the user says 'connect Granola', 'my meetings aren't syncing', 'set up meeting notes'. Not for Zoom recordings; use `zoom-setup`. Not for processing meetings already synced; use `process-meetings`. | 287 | when |

--- a/docs/feedback-loop-contract.md
+++ b/docs/feedback-loop-contract.md
@@ -55,11 +55,12 @@ Request body (JSON, capped at 32 KB, unknown fields rejected):
 
 Response `200`: `{ "ticket": "DEX-142", "receivedAt": 1754640001000 }`
 Errors: `401` (invalid/expired session — client shows the connect instructions),
-`400` opaque `{"error":"invalid_request","code":"INVALID_REQUEST"}`, `429` rate limit.
+`400` opaque `{"error":"invalid_request","code":"INVALID_REQUEST"}`, `429` rate
+limit (both the per-IP limiter and the per-account daily submission cap).
 
 ### GET /api/feedback/status
 
-Returns every report belonging to the authenticated account:
+Returns the authenticated account's reports, newest first (up to 1000):
 
 ```json
 {
@@ -73,6 +74,7 @@ Returns every report belonging to the authenticated account:
       "fixedInVersion": "1.82.0",
       "comment": "Great catch — this was hitting 14 other people too. Thank you.",
       "question": null,
+      "answers": [ { "text": "Both — earliest July 2.", "receivedAt": 1754650000000 } ],
       "createdAt": 1754640001000
     }
   ]
@@ -80,7 +82,7 @@ Returns every report belonging to the authenticated account:
 ```
 
 `status` enum: `received | investigating | needs_info | fixed | wont_fix`.
-`question` is non-null only in `needs_info`.
+`question` is non-null only in `needs_info`; `fixedInVersion` only in `fixed`.
 
 ### POST /api/feedback/answer
 

--- a/docs/feedback-loop-contract.md
+++ b/docs/feedback-loop-contract.md
@@ -1,0 +1,135 @@
+# Feedback loop contract (terminal Dex ⇄ heydex.ai)
+
+Status: contract of record for the `/feedback` concierge loop (V1 + V2), decided with
+Dave 2026-08-08. Build Card: `feedback-concierge-loop-terminal-dex`. Design explainer:
+`2026-08-08-feedback-concierge-loop.html` (private gallery).
+
+## Decisions this contract encodes
+
+1. Transport is heydex.ai, not GitHub. Reports land in a private inbox only.
+2. Sign-in is compulsory. Every report is tied to a heydex account via the existing
+   connect-code flow (`~/.dex/heydex-auth.json`, minted by `POST /api/connect/redeem`).
+3. V1 and V2 ship together: reporting loop plus the two-way question/answer round trip.
+4. Triage: every report becomes (or attaches to) a Build Card immediately. The duplicate
+   counter is a priority multiplier, never a threshold.
+5. Privacy by construction: the report is assembled only from the allowed ingredients
+   below. Conversation content is never a source. The user's trust dial
+   (`feedback.review_mode`) controls show-before-send, not what may be collected.
+
+## Backend
+
+DexDiff Convex deployment (`heydex-web` project, prod `gallant-reindeer-229`).
+Base URL: `https://gallant-reindeer-229.eu-west-1.convex.site` (same origin the publish
+path uses; `api.heydex.ai` routes to the separate Dex Desktop backend and is not used).
+Override for tests: `DEX_FEEDBACK_API_BASE`.
+
+Auth on every feedback route: `Authorization: Bearer <sessionToken>` resolved against
+`cliSessions` (required — the beta-gate-disabled bypass does not apply to feedback).
+
+## HTTP endpoints (all also answer OPTIONS for CORS)
+
+### POST /api/feedback/report
+
+Request body (JSON, capped at 32 KB, unknown fields rejected):
+
+```json
+{
+  "schema_version": 1,
+  "captured_at": 1754640000000,
+  "dex_version": "1.81.19",
+  "feature": "/process-meetings",
+  "summary": "Sync stopped with 'attendee index out of range' when a meeting had no attendees.",
+  "error_trace": "Traceback ... (optional; Dex code paths only)",
+  "machine_state": {
+    "os": "darwin",
+    "host_app": "claude-code",
+    "features": { "granola": "ok", "todoist": "off" },
+    "automation": { "meeting_sync": "loaded" }
+  },
+  "investigation": "Focus items in the daily plan are missing task identity — checked 5 lines, 0 had it. (optional)",
+  "user_note": "optional free text the user typed",
+  "review_mode": "always-review",
+  "fingerprint": "sha256 of feature + normalized error head, client-computed"
+}
+```
+
+Response `200`: `{ "ticket": "DEX-142", "receivedAt": 1754640001000 }`
+Errors: `401` (invalid/expired session — client shows the connect instructions),
+`400` opaque `{"error":"invalid_request","code":"INVALID_REQUEST"}`, `429` rate limit.
+
+### GET /api/feedback/status
+
+Returns every report belonging to the authenticated account:
+
+```json
+{
+  "reports": [
+    {
+      "ticket": "DEX-142",
+      "feature": "/process-meetings",
+      "summary": "Sync stopped with ...",
+      "status": "fixed",
+      "statusChangedAt": 1754700000000,
+      "fixedInVersion": "1.82.0",
+      "comment": "Great catch — this was hitting 14 other people too. Thank you.",
+      "question": null,
+      "createdAt": 1754640001000
+    }
+  ]
+}
+```
+
+`status` enum: `received | investigating | needs_info | fixed | wont_fix`.
+`question` is non-null only in `needs_info`.
+
+### POST /api/feedback/answer
+
+```json
+{ "schema_version": 1, "ticket": "DEX-158", "captured_at": 1754640000000,
+  "answer": "Both — 3 duplicates, all created by the meeting sync, earliest July 2." }
+```
+
+Appends the answer to the ticket's thread and moves `needs_info → investigating`.
+Only the ticket's owner may answer. Response `200`: `{ "ok": true }`.
+
+## Founder / triage access
+
+No public HTTP surface. Internal Convex functions invoked with the deploy key
+(`npx convex run`), which is how Dave-side agents authenticate as owner:
+
+- `feedback:listNew` — reports not yet triaged (plus fingerprint-match hints).
+- `feedback:setStatus { ticket, status, comment?, fixedInVersion? }`
+- `feedback:askQuestion { ticket, question }` — sets `needs_info`.
+
+Every new report is expected to become (or attach to) a Mission Control Build Card at
+triage time; matching `fingerprint` values attach to the same card and increment its
+affects-count.
+
+## Table (Convex `feedbackReports`)
+
+`userId`, `ticket` (unique, `DEX-<n>` from a counter document), `schemaVersion`,
+`clientCapturedAt`, `dexVersion`, `feature`, `summary`, `errorTrace?`, `machineState?`,
+`investigation?`, `userNote?`, `reviewMode`, `fingerprint`, `status`,
+`statusChangedAt`, `comment?`, `question?`, `answers[]`, `triaged` (bool).
+Indexes: `by_userId`, `by_ticket`, `by_fingerprint`, `by_status`.
+
+## Client-side state (terminal Dex)
+
+- Claim tickets: `System/.dex/feedback/<ticket>.json` (one JSON per report — the local
+  copy of what was sent plus last known status). Travels with the vault.
+- Send receipts: `System/.dex/feedback-log.jsonl`, append-only, one line per attempt
+  whether or not anything was sent (health-telemetry honesty pattern).
+- Sweep dedup: the once-daily status sweep claims the day before doing work
+  (update-verifier pattern) and stores its marker under `System/.dex/`.
+- Trust dial: `feedback.review_mode` in `System/user-profile.yaml`
+  (`always-review` default | `auto-send`). First report is always reviewed regardless.
+  V2 answers are always reviewed regardless of dial.
+
+## Allowed ingredients (privacy by construction)
+
+A report may contain only: Dex version; feature/skill name; what-happened vs expected
+in Dex-mechanics phrasing; error text and stack trace (Dex code paths); the Doctor
+machine-state bundle (never config values, only presence/health states); investigation
+mechanisms as counts and descriptions (never file contents, names, or note text); file
+paths with vault-relative segments replaced by placeholders; an optional user-typed
+note. The conversation transcript is never read as a source.

--- a/scripts/founder-content-allowlist.txt
+++ b/scripts/founder-content-allowlist.txt
@@ -24,6 +24,11 @@
 # --- DexDiff canonical @davekilleen handle used as the worked example (audit 2d) ---
 ^\.claude/skills/diff-.*:.*:(dave|killeen)$
 
+# --- /feedback loop: founder comments are relayed to reporters as 'Dave says:'
+#     by design (decided 2026-08-08; the personal thank-you IS the product) ---
+^\.claude/skills/feedback/scripts/feedback_client\.py:.*:dave$
+^core/utils/feedback_sweep\.py:.*:dave$
+
 # --- Test fixtures with the maintainer's name (distignored from release; audit 2d) ---
 ^core/tests/.*:.*:(dave|killeen)$
 ^\.claude/hooks/tests/.*:.*:(dave|killeen)$


### PR DESCRIPTION
## What this is

The terminal side of the /feedback concierge loop designed with Dave on 2026-08-08 (Build Card `feedback-concierge-loop-terminal-dex`). Server side: davekilleen/heydex-website#51. Contract of record: `docs/feedback-loop-contract.md` (in this PR).

Users report Dex bugs with zero homework: Dex investigates locally, builds a privacy-safe report, shows it (or auto-sends per the trust dial), sends it to a private inbox on heydex.ai, and surfaces status changes and questions at session start — including "that bug you reported? Fixed in v1.82" when the fix ships.

## Changes

- **`.claude/skills/feedback/`** — SKILL.md orchestration + stdlib-only client script (`link`/`report`/`status`/`answer`). Privacy by construction: reports are assembled only from allowed ingredients (version, feature, error trace, machine-state health values, investigation mechanisms with counts); the conversation is never a source; vault content never leaves. Shares `~/.dex/heydex-auth.json` with the DexDiff publish flow — one sign-in serves both.
- **Trust dial** — `feedback.review_mode` (`always-review` default | `auto-send`) in the user profile + validator; first report and all follow-up answers are always reviewed regardless.
- **Receipts + tickets** — every send attempt appends to `System/.dex/feedback-log.jsonl` (sent or not, health-telemetry honesty pattern); claim tickets live one-file-per-report in `System/.dex/feedback/`.
- **`core/utils/feedback_sweep.py`** — bounded once-daily session-start sweep (new SessionStart hook): zero cost for non-reporters, claims the day before network work, one 8s GET, silent on all failures, notifies at most once per status change. Quiet transitions update local state without interrupting.
- **Doctor** — end-of-run offer to report genuine Dex defects through /feedback; repeat-BROKEN edge case now routes to /feedback instead of a GitHub issue.
- **Changelog 1.82.0** written to the CFO standard; INVENTORY regenerated; `.gitignore` covers the new runtime files.

## Verification

- New tests: client script (draft validation incl. allowed-list rejection, fingerprint stability across line numbers/addresses, receipts on failure and success, auth expiry), sweep (no-ticket/no-auth short-circuits, daily claim, notice dedup, hook JSON emission, never-crash on broken vault), profile validator modes. 17/17 pass locally plus skill-integrity 108/108.
- Local gates green: ruff, instructed-tools, PII, portable contract, path consistency, security gate, founder content, tracked-ignored, architecture inventory, connections contract. Full pytest suite running as the final local check; CI is the authoritative gate.
- Live end-to-end proof (real report from a vault through the deployed prod endpoints) happens after the server PR merges and deploys — tracked on the Build Card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)