### PR TITLE
Fix obsidian-sync daemon crash under busy file activity (#362)

### DIFF
--- a/core/obsidian/sync_daemon.py
+++ b/core/obsidian/sync_daemon.py
@@ -84,13 +84,17 @@ class DexSyncHandler(FileSystemEventHandler):
         logger.info(f"Processing {len(self.pending_files)} changed files")
         
         canonical_states = None
-        for file_path in self.pending_files:
+        # Snapshot-and-swap: the watchdog observer thread mutates pending_files
+        # while this loop iterates it, which raises "RuntimeError: Set changed
+        # size during iteration" and kills the daemon under busy file activity
+        # (issue #362). Draining atomically also preserves events that arrive
+        # mid-pass for the next cycle instead of losing them to clear().
+        batch, self.pending_files = self.pending_files, set()
+        for file_path in batch:
             try:
                 canonical_states = self.sync_file_tasks(file_path, canonical_states)
             except Exception as e:
                 logger.error(f"Error syncing {file_path}: {e}")
-        
-        self.pending_files.clear()
         self.last_process_time = time.time()
     
     def sync_file_tasks(self, file_path: Path, canonical_states=None):


### PR DESCRIPTION
## What

Three-line fix for #362: `process_pending_files()` iterates `self.pending_files` while the watchdog observer thread is still adding to it, raising `RuntimeError: Set changed size during iteration` and killing the daemon whenever file activity gets busy (bulk syncs, migrations, meeting processing). launchd restarts it, so the failure is silent apart from repeated nonzero exit statuses — the exact watchdog-goes-blind failure mode the July audit note in dex-doctor describes.

## How

Snapshot-and-swap before iterating:

```python
batch, self.pending_files = self.pending_files, set()
for file_path in batch:
    ...
```

Side benefit: events that land mid-pass are preserved in the fresh set for the next cycle, where the previous `clear()` could silently drop them.

## Evidence

- Original crash trace and diagnosis in #362.
- Running in production on a real (large, busy) vault since 31 July, including through the v1.81.6 brain/vault topology migration which previously crash-looped the unfixed daemon continuously.
- Re-applied locally after both v1.81.18 and v1.81.19 shipped the file without it — this PR ends that cycle.

No behaviour change beyond not crashing; the rest of the (much improved) v1.81.19 daemon logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)