### PR TITLE
Troubleshooting home for /dex-doctor and /feedback (rebased remainder)

### DIFF
--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -307,4 +307,5 @@ machine-state and investigation ingredients, so the user does nothing but approv
 
 - `/granola-setup`, `/calendar-setup`, `/enable-semantic-search` — Tier-3 fix paths
 - `/dex-update` — often the fix for package/version drift
+- `/feedback` — when a finding is a genuine Dex bug (not the user's setup), report it to the Dex team; the Doctor evidence becomes the report and the user only approves
 - `/xray` — understand what the doctor checked and why

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -721,7 +721,8 @@ After any pathway completes:
 **Discovery:**
 • `/dex-level-up` - Find features you haven't tried
 • `/integrate-mcp` - Add more tools anytime
-• `/feedback` - Something misbehaving? Dex writes the bug report for you and tells you when it's fixed. What a report can and can't contain: https://heydex.ai/help/feedback.html
+• `/dex-doctor` - Anytime checkup: finds what's wrong, fixes what it can on its own, guides you through the rest: https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor
+• `/feedback` - Something misbehaving? Just say so in your own words — Dex writes the bug report for you and tells you when it's fixed. What a report can and can't contain: https://heydex.ai/help/feedback.html
 • Smithery.ai - Browse MCP marketplace
 
 **Come back anytime:**

--- a/06-Resources/Dex_System/Dex_System_Guide.md
+++ b/06-Resources/Dex_System/Dex_System_Guide.md
@@ -631,6 +631,12 @@ Run `/dex-doctor` or say "check my vault." Dex will report what it finds and sug
 
 No configuration is required. Run it whenever your vault feels messy or meeting contacts do not look right.
 
+### Troubleshooting: When Something Seems Broken
+
+`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system, fixes what's safe to fix on its own, and guides you through the rest.
+
+If the problem turns out to be a bug in Dex itself rather than your setup, run `/feedback` (or just say "report this"). Dex investigates on your machine, writes the bug report for you, and shows you exactly what would be sent before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report — and when the fix ships, Dex tells you.
+
 ---
 
 ## Role-Specific Skills

--- a/06-Resources/Dex_System/Dex_System_Guide.md
+++ b/06-Resources/Dex_System/Dex_System_Guide.md
@@ -633,9 +633,9 @@ No configuration is required. Run it whenever your vault feels messy or meeting 
 
 ### Troubleshooting: When Something Seems Broken
 
-`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system, fixes what's safe to fix on its own, and guides you through the rest.
+`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system and tells you honestly what's working, what's switched off, what's broken and what it couldn't check, repairs what it can on its own without touching your notes, and guides you through the rest. How it works: https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor
 
-If the problem turns out to be a bug in Dex itself rather than your setup, run `/feedback` (or just say "report this"). Dex investigates on your machine, writes the bug report for you, and shows you exactly what would be sent before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report — and when the fix ships, Dex tells you.
+If the problem turns out to be a bug in Dex itself rather than your setup, just say what went wrong in your own words — "the meeting sync is doing something weird" is enough, and you don't need a special command (`/feedback` works too if you prefer to be explicit). Dex investigates on your machine, writes the bug report for you, and by default every report waits for your yes before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report; the full list of what a report can contain is at https://heydex.ai/help/feedback.html. When the fix ships, Dex tells you.
 
 ---
 

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1080,9 +1080,11 @@ matching configuration/custom-skill modification times or a Dex version change. 
 automation heartbeat lives at `.scripts/logs/smoke-nightly.log`.
 
 When a check stays broken across runs and points to a defect in Dex itself rather than
-local setup, Doctor offers to report it through `/feedback`. The user-facing
-troubleshooting path is documented in `Dex_System_Guide.md` under
-"Troubleshooting: When Something Seems Broken".
+local setup, Doctor offers to report it through `/feedback`. That is not the only route:
+the persona's "Something in Dex Is Broken (Natural Language Triggers)" block in `CLAUDE.md`
+(shipped v1.94.0) routes ordinary descriptions of a fault to the same place, and routes
+setup problems back to Doctor instead. The user-facing troubleshooting path is documented
+in `Dex_System_Guide.md` under "Troubleshooting: When Something Seems Broken".
 
 ---
 

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1079,6 +1079,11 @@ The doctor's quick `smoke.history` check narrows the change window and reports o
 matching configuration/custom-skill modification times or a Dex version change. The
 automation heartbeat lives at `.scripts/logs/smoke-nightly.log`.
 
+When a check stays broken across runs and points to a defect in Dex itself rather than
+local setup, Doctor offers to report it through `/feedback`. The user-facing
+troubleshooting path is documented in `Dex_System_Guide.md` under
+"Troubleshooting: When Something Seems Broken".
+
 ---
 
 ## Design Constraints

--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ If `/daily-plan` doesn't show your meetings, or your recurring meetings (e.g. we
 
 See **[Calendar_Setup.md](06-Resources/Dex_System/Calendar_Setup.md)** for the full guide.
 
+---
+
+### Something else seems broken after setup?
+
+Once Dex is running, ask it to run `/dex-doctor` — a whole-system checkup that finds what's wrong, fixes what's safe on its own, and guides you through the rest. And if the problem turns out to be a bug in Dex itself, run `/feedback` (or just say "report this"): Dex writes the bug report for you, shows you what would be sent before anything leaves (never anything from your notes or meetings), and tells you when the fix ships.
+
 </details>
 
 ### Step 3: Tell Dex About Your Role

--- a/README.md
+++ b/README.md
@@ -351,7 +351,9 @@ See **[Calendar_Setup.md](06-Resources/Dex_System/Calendar_Setup.md)** for the f
 
 ### Something else seems broken after setup?
 
-Once Dex is running, ask it to run `/dex-doctor` — a whole-system checkup that finds what's wrong, fixes what's safe on its own, and guides you through the rest. And if the problem turns out to be a bug in Dex itself, run `/feedback` (or just say "report this"): Dex writes the bug report for you, shows you what would be sent before anything leaves (never anything from your notes or meetings), and tells you when the fix ships.
+Once Dex is running, ask it to run `/dex-doctor` — a whole-system checkup that tells you honestly what's working, what's switched off and what's broken, repairs what it can on its own, and guides you through the rest.
+
+And if the problem turns out to be a bug in Dex itself, you don't need a command or the right words: just describe what happened ("the meeting sync is doing something weird"). Dex investigates on your machine, writes the bug report for you, and by default waits for your yes before anything leaves — never anything from your notes, meetings or conversations. It tells you when the fix ships. Details: [what a report can contain](https://heydex.ai/help/feedback.html) · [the checkup](https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor)
 
 </details>
 

--- a/docs/Dex_System/Dex_System_Guide.md
+++ b/docs/Dex_System/Dex_System_Guide.md
@@ -631,6 +631,12 @@ Run `/dex-doctor` or say "check my vault." Dex will report what it finds and sug
 
 No configuration is required. Run it whenever your vault feels messy or meeting contacts do not look right.
 
+### Troubleshooting: When Something Seems Broken
+
+`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system, fixes what's safe to fix on its own, and guides you through the rest.
+
+If the problem turns out to be a bug in Dex itself rather than your setup, run `/feedback` (or just say "report this"). Dex investigates on your machine, writes the bug report for you, and shows you exactly what would be sent before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report — and when the fix ships, Dex tells you.
+
 ---
 
 ## Role-Specific Skills

--- a/docs/Dex_System/Dex_System_Guide.md
+++ b/docs/Dex_System/Dex_System_Guide.md
@@ -633,9 +633,9 @@ No configuration is required. Run it whenever your vault feels messy or meeting 
 
 ### Troubleshooting: When Something Seems Broken
 
-`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system, fixes what's safe to fix on its own, and guides you through the rest.
+`/dex-doctor` is also your first stop when Dex itself misbehaves — a command that errors out, meetings that stop coming through, a feature that used to work. It checks the whole system and tells you honestly what's working, what's switched off, what's broken and what it couldn't check, repairs what it can on its own without touching your notes, and guides you through the rest. How it works: https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor
 
-If the problem turns out to be a bug in Dex itself rather than your setup, run `/feedback` (or just say "report this"). Dex investigates on your machine, writes the bug report for you, and shows you exactly what would be sent before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report — and when the fix ships, Dex tells you.
+If the problem turns out to be a bug in Dex itself rather than your setup, just say what went wrong in your own words — "the meeting sync is doing something weird" is enough, and you don't need a special command (`/feedback` works too if you prefer to be explicit). Dex investigates on your machine, writes the bug report for you, and by default every report waits for your yes before anything leaves. Nothing from your notes, meetings, or conversations ever goes into a report; the full list of what a report can contain is at https://heydex.ai/help/feedback.html. When the fix ships, Dex tells you.
 
 ---
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -1080,9 +1080,11 @@ matching configuration/custom-skill modification times or a Dex version change. 
 automation heartbeat lives at `.scripts/logs/smoke-nightly.log`.
 
 When a check stays broken across runs and points to a defect in Dex itself rather than
-local setup, Doctor offers to report it through `/feedback`. The user-facing
-troubleshooting path is documented in `Dex_System_Guide.md` under
-"Troubleshooting: When Something Seems Broken".
+local setup, Doctor offers to report it through `/feedback`. That is not the only route:
+the persona's "Something in Dex Is Broken (Natural Language Triggers)" block in `CLAUDE.md`
+(shipped v1.94.0) routes ordinary descriptions of a fault to the same place, and routes
+setup problems back to Doctor instead. The user-facing troubleshooting path is documented
+in `Dex_System_Guide.md` under "Troubleshooting: When Something Seems Broken".
 
 ---
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -1079,6 +1079,11 @@ The doctor's quick `smoke.history` check narrows the change window and reports o
 matching configuration/custom-skill modification times or a Dex version change. The
 automation heartbeat lives at `.scripts/logs/smoke-nightly.log`.
 
+When a check stays broken across runs and points to a defect in Dex itself rather than
+local setup, Doctor offers to report it through `/feedback`. The user-facing
+troubleshooting path is documented in `Dex_System_Guide.md` under
+"Troubleshooting: When Something Seems Broken".
+
 ---
 
 ## Design Constraints


### PR DESCRIPTION
## ⚠️ Holding for review — do not merge

Rebased onto current `main` and reconciled against everything that shipped since it was opened on Aug 8. Was conflicting; now clean. **Recommendation: merge the remainder** (details below), but holding per the Front Desk.

## What changed in this reconciliation

This PR predated three things that have since shipped, so it has been **split**: the superseded half is dropped, the still-valuable half is kept and brought up to date.

### Dropped as superseded (1 of 6 changes)

| Original change | Why it's gone |
|---|---|
| `.claude/flows/onboarding.md` — add `/dex-doctor` to the completion-message beat | Fully superseded by #454, which gave feedback **and** Doctor a dedicated education beat at the end of Step 10, and reduced the Step 11 line to a short callback. The line this PR edited no longer exists in that form. Rebasing it would have re-introduced older copy. |

### Kept — genuinely not done anywhere else (5 of 6)

Verified against current `main` before keeping: `Dex_System_Guide.md`, `README.md` and `Dex_Technical_Guide.md` contain **zero** mentions of `/feedback` today. Workstream 4 of the `feedback-loop-launch-awareness` card is real and still open.

- **`06-Resources/Dex_System/Dex_System_Guide.md`** — the canonical "Troubleshooting: When Something Seems Broken" passage.
- **`README.md`** — pointer in the setup-troubleshooting block, for "something broke after setup".
- **`06-Resources/Dex_System/Dex_Technical_Guide.md`** — pointer from the Doctor testing section.
- **`.claude/skills/dex-doctor/SKILL.md`** — `/feedback` in Related Commands (the skill body already invokes it twice; the list didn't mention it).
- **`.claude/skills/getting-started/SKILL.md`** — a `/dex-doctor` discovery bullet. Its `/feedback` bullet was improved separately since Aug 8, so the merge keeps the newer bullet rather than reverting it.
- `docs/Dex_System/` mirrors kept byte-identical, as `test_docs_bridge.py` requires.

### Brought up to date (new commit)

The Aug 8 copy is factually behind `v1.94.0`:

1. **It told users to run a command or say "report this."** Since #455 shipped, ordinary descriptions route to the same place, so the guides now say what's true: describe it however you like, with `/feedback` as the explicit alternative.
2. **Both help pages now exist**, so the passages link them (`help/feedback.html`, `help/updating-troubleshooting.html#health-dex-doctor`) instead of describing them. Both verified 200 with anchors present.
3. **Two claims tightened.** Doctor now "repairs what it can on its own without touching your notes" rather than "fixes what's safe" — this repo deliberately avoids calling things safe in user copy about what a tool may touch. And reports "by default wait for your yes" rather than promising unqualified show-before-send, which isn't true for users who explicitly opted into auto-send.
4. **The Technical Guide** now records that the persona trigger block is a second route into `/feedback`, and that setup problems route back to Doctor.

## Verified

- 175 passed: `test_docs_bridge.py` (mirror equality), `test_skill_integrity.py`, `test_instruction_honesty.py`, `test_feedback_trigger_routing.py`
- Gates green locally: founder-content, PII, doc-drift, instructed-tools, architecture-inventory
- Original author's commit preserved by cherry-pick rather than rewritten; the reconciliation is a separate commit on top

No changelog entry: guide and README copy only, no behaviour change. The behaviour it documents already shipped in 1.93.1–1.93.3 / v1.94.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
