### PR TITLE
Fix six defects from two field reports (activation staleness, context forks, silent bridge loop, meeting sources, worktree-hijacked sync, feedback preflight)

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -120,6 +120,8 @@ Do not ask eligibility questions. Route only what Dex can honestly read:
 
 After a selected reader is connected, start its initial sync as a background task and continue to Step 1 without waiting for the backfill. For a folder, start the import the same way. Say plainly: "I'll keep that running in the background while we finish setting up."
 
+**Persist the choice.** Record what the user picked in `System/user-profile.yaml` → `meeting_sources`: set `primary` (granola / zoom / teams / exported-folder / none) and, for a folder, `notes_folder` (the vault-relative folder where the notes land). Meeting skills read this later to know where notes live — an unrecorded choice is forgotten the moment onboarding ends. If the user skips, leave the template default.
+
 If nothing relevant is detected, offer the exported-notes folder once. If the user says skip, later, or no, continue immediately. This offer has no validation step and must never block onboarding.
 
 ---

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -360,7 +360,7 @@ fi
 # Background job staleness — keep in sync with core/utils/doctor.py's JOB_FRESHNESS table.
 {
     DEX_LAUNCH_AGENTS_DIR="${DEX_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
-    while IFS='|' read -r JOB_NAME JOB_LOG_RELATIVE_PATH JOB_MAX_AGE_SECONDS JOB_EXPECTED_CADENCE JOB_LABEL; do
+    while IFS='|' read -r JOB_NAME JOB_LOG_RELATIVE_PATH JOB_MAX_AGE_SECONDS JOB_EXPECTED_CADENCE JOB_LABEL JOB_MODE; do
         [[ -f "$DEX_LAUNCH_AGENTS_DIR/$JOB_NAME.plist" ]] || continue
 
         JOB_LOG="$CLAUDE_DIR/$JOB_LOG_RELATIVE_PATH"
@@ -369,9 +369,21 @@ fi
             continue
         fi
 
-        JOB_MTIME=$(stat -f %m "$JOB_LOG" 2>/dev/null || true)
-        if [[ ! "$JOB_MTIME" =~ ^[0-9]+$ ]]; then
-            JOB_MTIME=$(stat -c %Y "$JOB_LOG" 2>/dev/null || true)
+        if [[ "$JOB_MODE" == "lastSync" ]]; then
+            # A completed run is the only writer of lastSync; the log keeps
+            # updating even when every run fails, so log age proves nothing.
+            JOB_TS=$(sed -n 's/.*"lastSync"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$JOB_LOG" | head -1)
+            if [[ -z "$JOB_TS" ]]; then
+                echo "⏰ $JOB_LABEL is installed but has never completed a successful run — run /dex-doctor to investigate."
+                continue
+            fi
+            JOB_TS_SECONDS="${JOB_TS%%.*}"; JOB_TS_SECONDS="${JOB_TS_SECONDS%Z}"
+            JOB_MTIME=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "$JOB_TS_SECONDS" +%s 2>/dev/null || date -u -d "$JOB_TS" +%s 2>/dev/null || true)
+        else
+            JOB_MTIME=$(stat -f %m "$JOB_LOG" 2>/dev/null || true)
+            if [[ ! "$JOB_MTIME" =~ ^[0-9]+$ ]]; then
+                JOB_MTIME=$(stat -c %Y "$JOB_LOG" 2>/dev/null || true)
+            fi
         fi
         [[ "$JOB_MTIME" =~ ^[0-9]+$ && "$NOW" =~ ^[0-9]+$ ]] || continue
 
@@ -387,13 +399,15 @@ fi
             if (( JOB_AGE == 1 )); then
                 JOB_AGE_UNIT="${JOB_AGE_UNIT%s}"
             fi
-            echo "⏰ $JOB_LABEL last ran $JOB_AGE $JOB_AGE_UNIT ago (expected every $JOB_EXPECTED_CADENCE) — run /dex-doctor to investigate."
+            JOB_VERB="last ran"
+            [[ "$JOB_MODE" == "lastSync" ]] && JOB_VERB="last completed successfully"
+            echo "⏰ $JOB_LABEL $JOB_VERB $JOB_AGE $JOB_AGE_UNIT ago (expected every $JOB_EXPECTED_CADENCE) — run /dex-doctor to investigate."
         fi
     done <<'EOF'
-com.dex.smoke-nightly|.scripts/logs/smoke-nightly.log|93600|26 hours|Nightly smoke
-com.dex.meeting-intel|.scripts/logs/meeting-intel.log|172800|2 days|Meeting sync
-com.dex.changelog-checker|.scripts/logs/changelog-checker.log|604800|7 days|Claude update watcher
-com.dex.learning-review|.scripts/logs/learning-review.log|604800|7 days|Learning review
+com.dex.smoke-nightly|.scripts/logs/smoke-nightly.log|93600|26 hours|Nightly smoke|mtime
+com.dex.meeting-intel|.scripts/meeting-intel/processed-meetings.json|172800|2 days|Meeting sync|lastSync
+com.dex.changelog-checker|.scripts/logs/changelog-checker.log|604800|7 days|Claude update watcher|mtime
+com.dex.learning-review|.scripts/logs/learning-review.log|604800|7 days|Learning review|mtime
 EOF
 } || true
 

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -7,7 +7,7 @@ const path = require('node:path');
 
 const HOOK_PATH = path.resolve(__dirname, '..', 'session-start.sh');
 const MEETING_INTEL_PLIST = 'com.dex.meeting-intel.plist';
-const MEETING_INTEL_LOG = '.scripts/logs/meeting-intel.log';
+const MEETING_INTEL_STATE = '.scripts/meeting-intel/processed-meetings.json';
 
 function createSandbox(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-session-staleness-'));
@@ -28,11 +28,14 @@ function installMeetingIntel(sandbox) {
   fs.writeFileSync(path.join(sandbox.launchAgents, MEETING_INTEL_PLIST), '<plist/>\n');
 }
 
-function writeMeetingIntelLog(sandbox) {
-  const logPath = path.join(sandbox.vault, MEETING_INTEL_LOG);
-  fs.mkdirSync(path.dirname(logPath), { recursive: true });
-  fs.writeFileSync(logPath, 'meeting sync ran\n');
-  return logPath;
+function writeMeetingIntelState(sandbox, lastSync) {
+  const statePath = path.join(sandbox.vault, MEETING_INTEL_STATE);
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const state = lastSync === undefined
+    ? { processedIds: [] }
+    : { processedIds: [], lastSync: lastSync.toISOString() };
+  fs.writeFileSync(statePath, `${JSON.stringify(state)}\n`);
+  return statePath;
 }
 
 function completeOnboarding(sandbox) {
@@ -121,36 +124,32 @@ function runSessionStart(sandbox) {
   return result.stdout;
 }
 
-test('session start warns when an installed meeting sync log is stale', (t) => {
+test('session start warns when an installed meeting sync last succeeded 3 days ago', (t) => {
   const sandbox = createSandbox(t);
   installMeetingIntel(sandbox);
-  const logPath = writeMeetingIntelLog(sandbox);
-  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
-  fs.utimesSync(logPath, threeDaysAgo, threeDaysAgo);
+  writeMeetingIntelState(sandbox, new Date(Date.now() - 3 * 24 * 60 * 60 * 1000));
 
   const stdout = runSessionStart(sandbox);
 
   assert.match(
     stdout,
-    /⏰ Meeting sync last ran 3 days ago \(expected every 2 days\) — run \/dex-doctor to investigate\./,
+    /⏰ Meeting sync last completed successfully 3 days ago \(expected every 2 days\) — run \/dex-doctor to investigate\./,
   );
 });
 
-test('session start stays silent for a fresh installed meeting sync log', (t) => {
+test('session start stays silent for a recently succeeded meeting sync', (t) => {
   const sandbox = createSandbox(t);
   installMeetingIntel(sandbox);
-  writeMeetingIntelLog(sandbox);
+  writeMeetingIntelState(sandbox, new Date());
 
   const stdout = runSessionStart(sandbox);
 
   assert.doesNotMatch(stdout, /⏰ Meeting sync/);
 });
 
-test('session start ignores stale logs for launch agents that are not installed', (t) => {
+test('session start ignores stale sync state for launch agents that are not installed', (t) => {
   const sandbox = createSandbox(t);
-  const logPath = writeMeetingIntelLog(sandbox);
-  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
-  fs.utimesSync(logPath, threeDaysAgo, threeDaysAgo);
+  writeMeetingIntelState(sandbox, new Date(Date.now() - 3 * 24 * 60 * 60 * 1000));
 
   const stdout = runSessionStart(sandbox);
 
@@ -166,6 +165,19 @@ test('session start warns when an installed meeting sync has never run', (t) => 
   assert.match(
     stdout,
     /⏰ Meeting sync is installed but has never run — run \/dex-doctor to investigate\./,
+  );
+});
+
+test('session start warns when meeting sync keeps running but has never succeeded', (t) => {
+  const sandbox = createSandbox(t);
+  installMeetingIntel(sandbox);
+  writeMeetingIntelState(sandbox, undefined);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.match(
+    stdout,
+    /⏰ Meeting sync is installed but has never completed a successful run — run \/dex-doctor to investigate\./,
   );
 });
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -195,12 +195,12 @@ Built specifically for personal knowledge management and productivity workflows 
 - `/getting-started` - Interactive post-onboarding tour (adaptive to your setup)
 
 **Daily Workflow:**
-- `/daily-plan` - Context-aware daily planning *(v1.11: isolated context, quickref summary, agent memory tracks trends)*
-- `/daily-review` - End of day review with learning capture *(v1.11: isolated context)*
+- `/daily-plan` - Context-aware daily planning *(quickref summary, agent memory tracks trends)*
+- `/daily-review` - End of day review with learning capture
 - `/journal` - Start or manage journaling
 
 **Weekly Workflow:**
-- `/week-plan` - Set weekly priorities *(v1.11: isolated context)*
+- `/week-plan` - Set weekly priorities
 - `/week-review` - Weekly synthesis
 
 **Quarterly Workflow:**
@@ -208,8 +208,8 @@ Built specifically for personal knowledge management and productivity workflows 
 - `/quarter-review` - Review and capture learnings
 
 **Meetings:**
-- `/meeting-prep` - Prepare for meetings *(v1.11: isolated context)*
-- `/process-meetings` - Process Granola meetings *(v1.11: isolated context, auto-updates person pages, background execution)*
+- `/meeting-prep` - Prepare for meetings
+- `/process-meetings` - Process Granola meetings *(auto-updates person pages)*
 
 **Integrations (Connect Your Tools):**
 - `/todoist-setup` - Connect Todoist for two-way task sync (any platform)
@@ -225,7 +225,7 @@ Built specifically for personal knowledge management and productivity workflows 
 
 **Career Development:**
 - `/career-setup` - Initialize career system
-- `/career-coach` - Career reflections and assessments *(v1.11: isolated context, auto-captures career evidence)*
+- `/career-coach` - Career reflections and assessments *(auto-captures career evidence)*
 - `/resume-builder` - Build resume through guided interview
 
 **Projects:**

--- a/.claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md
+++ b/.claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: career-coach
 description: "Personal career coach with 4 modes: weekly reports, monthly reflections, self-reviews, promotion assessments"
-context: fork
 hooks:
   PostToolUse:
     - matcher: Write
       type: command
       command: "node .claude/hooks/career-evidence-capture.cjs"
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -6,12 +6,19 @@ model_routing:
   steps:
     data-gathering: fast
     synthesis: balanced
-context: fork
 hooks:
   Stop:
     - type: command
       command: "node .claude/hooks/daily-plan-quick-ref.cjs"
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/decision-log/SKILL.md
+++ b/.claude/skills/decision-log/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: decision-log
 description: Capture an important decision with its context, options, rationale, and review date, then find it again when it matters.
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/delegate-check/SKILL.md
+++ b/.claude/skills/delegate-check/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: delegate-check
 description: "Review open delegations — what you handed off, to whom, its status, and the next useful nudge. Use when the user says 'what did I delegate', 'who owes me', 'check my handoffs', 'follow up with someone'. Not for prepping a meeting; use meeting-prep."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -35,6 +35,19 @@ with the user doing nothing but approving. Contract: `docs/feedback-loop-contrac
 
 ## Filing a report
 
+0. **Preflight the connection first** — before investigating or drafting anything:
+
+   ```bash
+   python3 .claude/skills/feedback/scripts/feedback_client.py check --vault "$VAULT_PATH"
+   ```
+
+   - Exit 0 (LINKED): carry on.
+   - Exit 2 (CONNECTION NEEDED): tell the user now, not after drafting: "One-time
+     setup first (~30 seconds): open the connect page, sign in, create a code, and
+     I'll link this terminal." Show the script's instructions, run the `link`
+     subcommand with their code, then continue. If they'd rather not link right
+     now, offer to draft the report anyway and save it locally so nothing is lost —
+     but never let them discover the missing link only after approving a draft.
 1. **Establish the facts.** From the conversation and quick local checks:
    - Dex version: read `version` from `package.json` at the vault root.
    - Feature: which skill/command/automation misbehaved.

--- a/.claude/skills/feedback/scripts/feedback_client.py
+++ b/.claude/skills/feedback/scripts/feedback_client.py
@@ -430,11 +430,24 @@ def validate_draft(draft: dict) -> dict:
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
+def command_check(args: argparse.Namespace) -> int:
+    """Preflight: is this terminal linked and fresh enough to send right now?
+
+    Raises AuthError (exit 2, CONNECTION NEEDED) when it is not, so callers can
+    resolve the link before any report is drafted.
+    """
+    auth = load_auth(site_base=args.site_base)
+    identity = auth.get("email") or auth.get("handle") or "your Heydex account"
+    print(f"LINKED: this terminal can send feedback as {identity}.")
+    return 0
+
+
 def command_link(args: argparse.Namespace) -> int:
     code = args.code.strip()
     if not code:
-        print("A sign-in code is required. Create one at %s/connect/?cli=true." % get_site_base_url(args.site_base))
-        return 2
+        raise FeedbackError(
+            "A sign-in code is required. Create one at %s/connect/?cli=true." % get_site_base_url(args.site_base)
+        )
 
     payload = _request_json("POST", get_api_base_url(args.api_base), "/api/connect/redeem", {"code": code})
     save_auth(payload)
@@ -617,6 +630,9 @@ def build_parser() -> argparse.ArgumentParser:
     common.add_argument("--site-base", default=None, help="Site base, default %s" % HEYDEX_SITE_BASE_URL)
     common.add_argument("--vault", default=None, help="Vault root, default $VAULT_PATH or the current directory")
 
+    check = subparsers.add_parser("check", parents=[common], help="Preflight: is this terminal linked and ready to send?")
+    check.set_defaults(func=command_check)
+
     link = subparsers.add_parser("link", parents=[common], help="Link this terminal to a heydex account")
     link.add_argument("--code", required=True)
     link.set_defaults(func=command_link)
@@ -656,6 +672,9 @@ def main(argv: "list[str] | None" = None) -> int:
         return error.exit_code
     except BadResponse as error:
         print(f"BAD RESPONSE: {error.user_message}")
+        return error.exit_code
+    except FeedbackError as error:
+        print(f"PROBLEM: {error.user_message}")
         return error.exit_code
 
 

--- a/.claude/skills/industry-truths/SKILL.md
+++ b/.claude/skills/industry-truths/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: industry-truths
 description: "Define time-horizoned assumptions about your industry (today / 6mo / 12mo) that ground strategic thinking. Use when the user is making roadmap, positioning or investment calls, or says 'what am I assuming about the market'. Also use proactively before a big strategic recommendation. Not for capturing a single decision; use `decision-log`."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/meeting-closeout/SKILL.md
+++ b/.claude/skills/meeting-closeout/SKILL.md
@@ -16,7 +16,11 @@ It is the single-meeting, in-the-moment ritual. It is **not** the bulk "catch up
 Work from whichever exists, in this order:
 1. **Notes the user just pasted or dictated** — the common case; use them directly even if the meeting was never synced.
 2. **The meeting they name** ("my 3pm with Acme") — pull it via `get_meeting_context`.
-3. **A provider-neutral source note elsewhere in the vault** — if the named meeting
+3. **The user's configured meeting source** — read `meeting_sources` in
+   `System/user-profile.yaml`. If a `notes_folder` is set, search that folder for
+   the meeting by title, attendee, and date before anything else. A configured
+   source always outranks improvised discovery.
+4. **A provider-neutral source note elsewhere in the vault** — if the named meeting
    was not returned, search the vault by meeting title, attendee, and date. This
    includes notes created by ClickUp AI and other recorders. Provider-neutral
    discovery is not only `00-Inbox/Meetings/`. Exclude Dex internals, dependency folders, archives that
@@ -24,7 +28,17 @@ Work from whichever exists, in this order:
    otherwise use a bounded Markdown filename/content search. Read the matched note
    before treating it as the meeting.
 
-If there are no notes and no matching synced meeting, **ask for the notes** (or a two-line recap) — do not fabricate a summary of a meeting you can't see.
+**Source boundary (hard rule).** Meeting notes come from the vault (and the
+configured `meeting_sources` folder) only. Never go looking in external services —
+Google Drive, Gemini notes, Notion, email, or any connected tool — for a meeting
+the vault doesn't have, unless the user explicitly points at that source for this
+meeting in this conversation. Auto-generated notes from an unconfigured source can
+describe a different meeting or contain invented content, and a closeout built on
+them is worse than no closeout.
+
+If there are no notes and no matching vault note, **the search is over — ask for
+the notes** (or a two-line recap) — do not fabricate a summary of a meeting you
+can't see, and do not widen the search to external tools.
 
 ## Step 2 — Extract the closeout essentials
 

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: meeting-prep
 description: "Prepare for a specific upcoming meeting by gathering attendee context, history and related topics. Use when the user says 'prep me for my meeting with X', 'what do I need for the 2pm', or before a calendar event. Also use proactively when a meeting is imminent. Not for writing up a meeting that already happened; use `process-meetings`."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 Prepare for an upcoming meeting by gathering context on attendees and related topics.
 

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -2,13 +2,20 @@
 name: process-meetings
 description: "Turn synced meetings into updated person pages, extracted tasks and organized notes. Use when the user says 'process my meetings', 'catch up my notes', or after Granola/Otter syncs. Also use proactively when unprocessed meetings exist. Not for prepping an upcoming meeting; use `meeting-prep`."
 model_hint: balanced
-context: fork
 hooks:
   PostToolUse:
     - matcher: Write
       type: command
       command: "node .claude/hooks/post-meeting-person-update.cjs"
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 # Process Meetings
 

--- a/.claude/skills/week-plan/SKILL.md
+++ b/.claude/skills/week-plan/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: week-plan
 description: "Set the week's priorities against goals, calendar shape and task effort. Use when the user says 'plan my week', 'what should I focus on this week', or on their first working day. Also use proactively at the first session of a new week. Not for reviewing the week just past; use `week-review`."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: week-review
 description: "Review the week with concrete accomplishments (not fake percentages), pattern detection and goal tracking. Use when the user says 'how was my week', 'week review', or it's their last working day. Also use proactively when a week's priorities are largely resolved. Not for planning the coming week; use `week-plan`."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.claude/skills/weekly-reflection/SKILL.md
+++ b/.claude/skills/weekly-reflection/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: weekly-reflection
 description: "A short guided reflection on what energized you, what drained you, and one change for next week. Use when the user wants to reflect on how work *felt*, not what got done — 'reflect on my week', 'what's draining me'. Not for progress-and-goals tracking; use `week-review`."
-context: fork
 ---
+
+## Execution mode
+
+Run inline in the current conversation by default, so this work can see what the
+user has already discussed, decided, or settled this session. Do not fork merely
+because this skill was selected. Only run in the background when the user
+explicitly asks for a background run or the host has already obtained a specific
+background-work approval for this run.
 
 ## Purpose
 

--- a/.scripts/install-learning-automation.sh
+++ b/.scripts/install-learning-automation.sh
@@ -79,6 +79,14 @@ VAULT_ROOT="$(dirname "$SCRIPT_DIR")"
 echo "Vault path: $VAULT_ROOT"
 echo ""
 
+# Never point machine-wide background jobs at a temporary checkout. A git
+# worktree marks .git as a file; a real clone or plain vault does not.
+if [[ -f "$VAULT_ROOT/.git" || "$VAULT_ROOT" == */worktrees/* ]]; then
+  echo -e "${RED}✗${NC} $VAULT_ROOT looks like a temporary working copy (a git worktree), not your real Dex vault." >&2
+  echo "  Run this installer from your real vault." >&2
+  exit 1
+fi
+
 NODE_PATH="$(find_node)"
 
 # Create LaunchAgents directory if it doesn't exist

--- a/.scripts/install-smoke-automation.sh
+++ b/.scripts/install-smoke-automation.sh
@@ -43,6 +43,14 @@ if [ "${1:-}" != "" ]; then
     exit 2
 fi
 
+# Never point machine-wide background jobs (or the shared Dex path record) at a
+# temporary checkout. A git worktree marks .git as a file; a real vault does not.
+if [ -f "$VAULT_PATH/.git" ] || case "$VAULT_PATH" in */worktrees/*) true;; *) false;; esac; then
+    echo "$VAULT_PATH looks like a temporary working copy (a git worktree), not your real Dex vault." >&2
+    echo "Run this installer from your real vault." >&2
+    exit 1
+fi
+
 mkdir -p "$HOME/.config/dex" "$HOME/Library/LaunchAgents" "$VAULT_PATH/.scripts/logs"
 echo "$VAULT_PATH" > "$HOME/.config/dex/vault-path"
 chmod +x "$VAULT_PATH/.scripts/nightly-smoke.sh"

--- a/.scripts/meeting-intel/install-automation.sh
+++ b/.scripts/meeting-intel/install-automation.sh
@@ -106,6 +106,18 @@ if [ "$1" = "--stop" ] || [ "$1" = "--uninstall" ]; then
 fi
 
 # Installation
+
+# Never point machine-wide background jobs (or the shared Dex path record) at a
+# temporary checkout: agent tooling runs this installer from short-lived git
+# worktrees, which then vanish and leave the job failing silently every 30 min.
+# A git worktree marks .git as a file; a real clone or plain vault does not.
+if [ -f "$VAULT_PATH/.git" ] || case "$VAULT_PATH" in */worktrees/*) true;; *) false;; esac; then
+    echo -e "${RED}✗${NC} $VAULT_PATH looks like a temporary working copy (a git worktree), not your real Dex vault."
+    echo "  Installing from here would point background sync — and the machine-wide Dex path record —"
+    echo "  at a folder that may disappear. Run this installer from your real vault."
+    exit 1
+fi
+
 echo "Installing background sync..."
 echo ""
 

--- a/06-Resources/Dex_System/Dex_System_Guide.md
+++ b/06-Resources/Dex_System/Dex_System_Guide.md
@@ -555,33 +555,17 @@ Without memory, every planning session starts from zero. The same blind spots pe
 
 ---
 
-## Context Isolation
+## Skills See Your Conversation
 
-**The Problem:** Long conversations slow down. You start a planning session in the morning, then by afternoon your chat is sluggish because it's carrying the full weight of every skill you ran.
+**The Problem:** Earlier versions ran the planning, review, and meeting skills in an isolated workspace to keep long chats fast. That isolation had a hidden cost: an isolated skill couldn't see what you had already discussed and settled in the conversation, so a plan could resurface items you'd resolved minutes earlier. It looked like Dex was forgetting — it never had the information.
 
-**What Dex Does:** Heavy skills now run in isolated context. Your main conversation stays clean all day.
-
-### Which Skills Are Isolated
-
-These skills run in their own context, separate from your main conversation:
-
-- `/daily-plan`
-- `/daily-review`
-- `/week-plan`
-- `/week-review`
-- `/meeting-prep`
-- `/process-meetings`
-- `/career-coach`
+**What Dex Does now:** Planning, review, and meeting skills run inside your current conversation by default, so they always know what you've already covered. Dex only moves work to the background when you explicitly ask for a background run.
 
 ### What This Means for You
 
-- **No more starting fresh chats.** You can run `/daily-plan` in the morning, work all day, run `/daily-review` at night, and the conversation stays responsive.
-- **Results still flow back.** The output of each skill (your plan, review, meeting prep) is available in your conversation — only the heavy processing happens in isolation.
-- **Lighter skills stay inline.** Quick things like `/triage` or task creation happen in your current conversation as before.
-
-### Why This Matters
-
-Before context isolation, running three or four skills in one session could noticeably slow things down. Now each heavy skill gets a clean workspace, does its work, and returns the result without cluttering your main thread.
+- **Plans and reviews respect the conversation.** If you settled something earlier in the chat, `/daily-plan` and `/daily-review` won't bring it back as an open item.
+- **Background runs are opt-in.** Say "run this in the background" if you want the old behavior for a heavy run; Dex will ask before doing that on its own.
+- **Long sessions can still be split.** If a day-long chat gets sluggish, starting a fresh session is always safe — plans, reviews, and notes live in your files, not in the chat.
 
 **Reference:** See `06-Resources/Dex_System/Named_Sessions_Guide.md` for details on how named sessions work.
 

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -88,6 +88,14 @@ meeting_processing:
   # API provider for automatic mode: gemini, anthropic, or openai
   api_provider: gemini
 
+# Where meeting notes come from. Meeting skills consult this before searching.
+# primary: granola | zoom | teams | exported-folder | none
+# notes_folder: vault-relative folder where exported/recorder notes land
+#   (for exported-folder, or a recorder like ClickUp AI dropping notes into the vault)
+meeting_sources:
+  primary: none
+  notes_folder: ""
+
 # Person-page creation from repeated meeting observations.
 # Options: auto, suggest, off. Fresh setup starts at suggest until the user chooses.
 entity_creation:

--- a/core/lifecycle/bridge.py
+++ b/core/lifecycle/bridge.py
@@ -190,6 +190,44 @@ def _validate_activation(raw: bytes, bridge: BridgeRelease) -> dict[str, object]
         raise BridgeActivationError(f"existing activation is invalid: {error}") from error
 
 
+def _stale_activation(raw: bytes, bridge: BridgeRelease) -> bool:
+    """True when the record is a well-formed activation for a different bridge release.
+
+    A delivered release rewrites the shipped bridge declaration, but the
+    activation record is runtime state no release may write, so after every
+    update the existing record still references the prior release. That
+    staleness is routine, not evidence of tampering; activation re-records
+    the baseline exactly as a first run would. Anything structurally invalid
+    stays refused.
+    """
+    try:
+        value = _closed(
+            _strict_json(raw, "existing activation"),
+            {
+                "activation_version",
+                "api_version",
+                "bridge_release_version",
+                "baseline_inventory_sha256",
+            },
+            "existing activation",
+        )
+    except BridgeError:
+        return False
+    recorded = value["bridge_release_version"]
+    digest = value["baseline_inventory_sha256"]
+    return (
+        type(value["activation_version"]) is int
+        and value["activation_version"] == ACTIVATION_VERSION
+        and isinstance(value["api_version"], str)
+        and isinstance(recorded, str)
+        and SEMVER.fullmatch(recorded) is not None
+        and recorded != bridge.release_version
+        and isinstance(digest, str)
+        and HEX_SHA256.fullmatch(digest) is not None
+        and raw == _canonical(dict(value))
+    )
+
+
 def _fsync_directory(directory: Path) -> None:
     descriptor = os.open(directory, os.O_RDONLY)
     try:
@@ -219,22 +257,32 @@ def activate_vault(
     *,
     release_root: str | Path | None = None,
 ) -> dict[str, object]:
-    """Read current vault state, then atomically record first-run activation.
+    """Read current vault state, then atomically record activation.
 
     The inventory pass is read-only.  The only durable output is the runtime
     activation record (plus its same-directory temporary file during publish).
+    A well-formed record left behind by an earlier bridge release is re-recorded
+    against the currently installed release rather than refused, so a delivered
+    update never strands plan, state, adoption, or rewind operations.
     """
     root = Path(vault_root)
     release = root if release_root is None else Path(release_root)
     bridge = load_bridge_release(release)
     target = root / ACTIVATION_RELATIVE
+    stale_record: bytes | None = None
     if target.exists() or target.is_symlink():
         if target.is_symlink() or not target.is_file():
             raise BridgeActivationError("existing activation path is unsafe")
         try:
-            return _validate_activation(target.read_bytes(), bridge)
+            raw = target.read_bytes()
         except OSError as error:
             raise BridgeActivationError(f"existing activation could not be read: {error}") from error
+        try:
+            return _validate_activation(raw, bridge)
+        except BridgeActivationError:
+            if not _stale_activation(raw, bridge):
+                raise
+            stale_record = raw
 
     try:
         catalog = load_catalog(root / CATALOG_RELATIVE, release_root=root)
@@ -269,10 +317,12 @@ def activate_vault(
         os.close(descriptor)
         descriptor = None
         if target.exists() or target.is_symlink():
-            existing = _validate_activation(target.read_bytes(), bridge)
-            temporary.unlink()
-            _fsync_directory(directory)
-            return existing
+            current = target.read_bytes()
+            if stale_record is None or current != stale_record:
+                existing = _validate_activation(current, bridge)
+                temporary.unlink()
+                _fsync_directory(directory)
+                return existing
         os.replace(temporary, target)
         os.chmod(target, 0o600)
         _fsync_directory(directory)

--- a/core/lifecycle/catalog/official-capabilities.json
+++ b/core/lifecycle/catalog/official-capabilities.json
@@ -160,7 +160,7 @@
           "path": ".claude/skills/decision-log/SKILL.md",
           "source_path": ".claude/skills/decision-log/SKILL.md",
           "sha256": "e6c5d64940fe7135bfacd06aebcffae7ac40ca0f1971503b6f4a46551c505283",
-          "byte_size": 4156
+          "byte_size": 4518
         }
       ],
       "dependencies": [],
@@ -175,7 +175,7 @@
           "path": ".claude/skills/delegate-check/SKILL.md",
           "source_path": ".claude/skills/delegate-check/SKILL.md",
           "sha256": "c4cc8a0bb2c7b48edddf3aa809a0756fa123fb6f6be8c60076357454b96edc34",
-          "byte_size": 4073
+          "byte_size": 4435
         }
       ],
       "dependencies": [],
@@ -400,7 +400,7 @@
           "path": ".claude/skills/weekly-reflection/SKILL.md",
           "source_path": ".claude/skills/weekly-reflection/SKILL.md",
           "sha256": "7a8fdd0bf4dfb517bcc076d2f9cc899efa1d678c5efa3f0bd6457d9186ef4ffb",
-          "byte_size": 3567
+          "byte_size": 3929
         }
       ],
       "dependencies": [],

--- a/core/lifecycle/catalog/official-capabilities.json
+++ b/core/lifecycle/catalog/official-capabilities.json
@@ -159,7 +159,7 @@
         {
           "path": ".claude/skills/decision-log/SKILL.md",
           "source_path": ".claude/skills/decision-log/SKILL.md",
-          "sha256": "ba989a5a1030c4963e7d0d2a7fc123be28bbde93befc2a027bc29049d758d4c5",
+          "sha256": "e6c5d64940fe7135bfacd06aebcffae7ac40ca0f1971503b6f4a46551c505283",
           "byte_size": 4156
         }
       ],
@@ -174,7 +174,7 @@
         {
           "path": ".claude/skills/delegate-check/SKILL.md",
           "source_path": ".claude/skills/delegate-check/SKILL.md",
-          "sha256": "3c1cc1ff18b6653969c2475d6e33b3cadb37db17c4de96e06865f78c4ba5b234",
+          "sha256": "c4cc8a0bb2c7b48edddf3aa809a0756fa123fb6f6be8c60076357454b96edc34",
           "byte_size": 4073
         }
       ],
@@ -399,7 +399,7 @@
         {
           "path": ".claude/skills/weekly-reflection/SKILL.md",
           "source_path": ".claude/skills/weekly-reflection/SKILL.md",
-          "sha256": "5fedf671cad93fc6c1a36caf4970efd1059f5d2b7b31216e025ef06cad303589",
+          "sha256": "7a8fdd0bf4dfb517bcc076d2f9cc899efa1d678c5efa3f0bd6457d9186ef4ffb",
           "byte_size": 3567
         }
       ],

--- a/core/obsidian/install_sync_daemon.sh
+++ b/core/obsidian/install_sync_daemon.sh
@@ -6,6 +6,14 @@ set -e  # Exit on error
 VAULT_PATH="${VAULT_PATH:-$(pwd)}"
 PLIST_PATH="$HOME/Library/LaunchAgents/com.dex.obsidian-sync.plist"
 
+# Never point machine-wide background jobs at a temporary checkout. A git
+# worktree marks .git as a file; a real clone or plain vault does not.
+if [[ -f "$VAULT_PATH/.git" || "$VAULT_PATH" == */worktrees/* ]]; then
+    echo "Error: $VAULT_PATH looks like a temporary working copy (a git worktree), not your real Dex vault."
+    echo "Run this installer from your real vault."
+    exit 1
+fi
+
 echo "Dex Obsidian Sync Daemon Installer"
 echo "===================================="
 echo ""

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -1861,18 +1861,15 @@ def test_main_resumes_completed_foundation_from_installed_service_without_downlo
     assert reexec_calls == [(vault, ["--vault", str(vault)])]
 
 
-def test_runtime_reexec_cleans_a_hostile_same_interpreter_and_preset_marker(
+def test_runtime_reexec_with_preset_marker_and_dirty_environment_stops_instead_of_looping(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_execve(interpreter: str, argv: list[str], environment: dict[str, str]) -> None:
-        captured["interpreter"] = interpreter
-        captured["argv"] = argv
-        captured["environment"] = environment
-
     monkeypatch.setattr(bridge, "_installed_python", lambda _vault: Path(sys.executable))
-    monkeypatch.setattr(bridge.os, "execve", fake_execve)
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("a marked process must never relaunch again"),
+    )
     monkeypatch.setenv(bridge._CLEAN_RUNTIME_MARKER, "1")
     monkeypatch.setenv("PATH", "/private/attacker-bin")
     monkeypatch.setenv("GIT_DIR", "/private/attacker-repository")
@@ -1881,52 +1878,53 @@ def test_runtime_reexec_cleans_a_hostile_same_interpreter_and_preset_marker(
     monkeypatch.setenv("PYTHONPATH", "/private/attacker-python")
     monkeypatch.setenv("NODE_OPTIONS", "--require=/private/attacker-node")
 
-    bridge._reexec_in_installed_runtime(_vault(tmp_path), ["--vault", "/safe/vault"])
-
-    assert captured["interpreter"] == str(Path(sys.executable))
-    assert captured["argv"] == [
-        str(Path(sys.executable)),
-        str(Path(bridge.__file__).resolve()),
-        "--vault",
-        "/safe/vault",
-    ]
-    environment = captured["environment"]
-    assert isinstance(environment, dict)
-    assert environment[bridge._CLEAN_RUNTIME_MARKER] == "1"
-    assert "/private/attacker-bin" not in environment["PATH"]
-    assert environment["GIT_CONFIG_GLOBAL"] == os.devnull
-    for name in ("GIT_DIR", "GIT_SSH_COMMAND", "PYTHONPATH", "NODE_OPTIONS"):
-        assert name not in environment
+    with pytest.raises(bridge.BridgeError, match="stopped instead of relaunching"):
+        bridge._reexec_in_installed_runtime(_vault(tmp_path), ["--vault", "/safe/vault"])
 
 
 def test_runtime_reexec_rejects_a_forged_exact_clean_environment_from_host_python(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    captured: dict[str, object] = {}
     vault = _vault(tmp_path)
     selected_interpreter = vault / ".venv" / "bin" / "python"
     clean_environment = bridge._bridge_environment()
     clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
 
-    def fake_execve(interpreter: str, argv: list[str], environment: dict[str, str]) -> None:
-        captured["interpreter"] = interpreter
-        captured["argv"] = argv
-        captured["environment"] = environment
-
     monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
-    monkeypatch.setattr(bridge.os, "execve", fake_execve)
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("a marked process must never relaunch again"),
+    )
     monkeypatch.setattr(bridge.os, "environ", clean_environment)
 
-    bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+    with pytest.raises(bridge.BridgeError, match="stopped instead of relaunching") as excinfo:
+        bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+    assert "the running Python is" in str(excinfo.value)
 
-    assert captured["interpreter"] == str(selected_interpreter)
-    assert captured["argv"] == [
-        str(selected_interpreter),
-        str(Path(bridge.__file__).resolve()),
-        "--vault",
-        "/safe/vault",
-    ]
-    assert captured["environment"] == clean_environment
+
+def test_runtime_marker_tolerates_the_macos_interpreter_launcher_variable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path)
+    selected_interpreter = vault / ".venv" / "bin" / "python"
+    selected_prefix = selected_interpreter.parent.parent
+    clean_environment = bridge._bridge_environment()
+    clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+    clean_environment["__PYVENV_LAUNCHER__"] = str(selected_interpreter)
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
+    monkeypatch.setattr(bridge.os, "environ", clean_environment)
+    monkeypatch.setattr(bridge.sys, "executable", str(selected_interpreter))
+    monkeypatch.setattr(bridge.sys, "prefix", str(selected_prefix))
+    monkeypatch.setattr(bridge.sys, "exec_prefix", str(selected_prefix))
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("selected clean virtualenv must not re-exec"),
+    )
+
+    bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
 
 
 def test_runtime_marker_accepts_only_the_selected_virtualenv_process(

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1916,23 +1916,32 @@ def test_freshness_thresholds_are_strictly_greater_than_the_limit(label, expecte
     _write_plist(context, label)
     policy = doctor.JOB_FRESHNESS[label]
     assert policy.max_age == expected_max_age
-    log = context.vault_root / policy.log_path
-    log.parent.mkdir(parents=True, exist_ok=True)
-    log.touch()
 
-    fresh_mtime = (NOW - expected_max_age + timedelta(seconds=1)).timestamp()
-    os.utime(log, (fresh_mtime, fresh_mtime))
+    def record_run(when):
+        if policy.success_state_path is not None:
+            state = context.vault_root / policy.success_state_path
+            state.parent.mkdir(parents=True, exist_ok=True)
+            state.write_text(
+                json.dumps({"lastSync": when.isoformat().replace("+00:00", "Z")}),
+                encoding="utf-8",
+            )
+        else:
+            log = context.vault_root / policy.log_path
+            log.parent.mkdir(parents=True, exist_ok=True)
+            log.touch()
+            os.utime(log, (when.timestamp(), when.timestamp()))
+
+    record_run(NOW - expected_max_age + timedelta(seconds=1))
     assert doctor._probe_jobs_fresh(context).verdict == "OK"
 
-    exact_mtime = (NOW - expected_max_age).timestamp()
-    os.utime(log, (exact_mtime, exact_mtime))
+    record_run(NOW - expected_max_age)
     assert doctor._probe_jobs_fresh(context).verdict == "OK"
 
-    stale_mtime = (NOW - expected_max_age - timedelta(seconds=1)).timestamp()
-    os.utime(log, (stale_mtime, stale_mtime))
+    stale_at = NOW - expected_max_age - timedelta(seconds=1)
+    record_run(stale_at)
     result = doctor._probe_jobs_fresh(context)
     assert result.verdict == "BROKEN"
-    assert datetime.fromtimestamp(stale_mtime, tz=timezone.utc).date().isoformat() in result.detail
+    assert stale_at.date().isoformat() in result.detail
 
 
 def test_freshness_is_off_when_job_is_not_installed_even_if_log_is_stale(context):
@@ -1947,12 +1956,91 @@ def test_freshness_is_off_when_job_is_not_installed_even_if_log_is_stale(context
 
 
 def test_freshness_is_broken_when_installed_job_has_no_log(context):
-    _write_plist(context, "com.dex.meeting-intel")
+    _write_plist(context, "com.dex.smoke-nightly")
 
     result = doctor._probe_jobs_fresh(context)
 
     assert result.verdict == "BROKEN"
     assert "no run log" in result.detail
+
+
+def test_meeting_sync_freshness_reads_last_success_not_log_activity(context):
+    """A job that fails every run keeps appending its log; only lastSync counts."""
+    _write_plist(context, "com.dex.meeting-intel")
+    policy = doctor.JOB_FRESHNESS["com.dex.meeting-intel"]
+    log = context.vault_root / policy.log_path
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.touch()
+    os.utime(log, (NOW.timestamp(), NOW.timestamp()))
+
+    never = doctor._probe_jobs_fresh(context)
+    assert never.verdict == "BROKEN"
+    assert "never recorded a completed run" in never.detail
+
+    state = context.vault_root / policy.success_state_path
+    state.parent.mkdir(parents=True, exist_ok=True)
+    stale_at = NOW - timedelta(days=6)
+    state.write_text(
+        json.dumps({"lastSync": stale_at.isoformat().replace("+00:00", "Z")}),
+        encoding="utf-8",
+    )
+
+    stale = doctor._probe_jobs_fresh(context)
+    assert stale.verdict == "BROKEN"
+    assert "last completed successfully" in stale.detail
+    assert stale_at.date().isoformat() in stale.detail
+
+
+def test_jobs_loaded_flags_a_dex_plist_repointed_at_a_worktree(monkeypatch, context):
+    """A worktree-pointed job is a repointed install, not another product's."""
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    worktree = context.home.parent / ".bb" / "worktrees" / "env_x" / "dex-core"
+    plist = agents / "com.dex.meeting-intel.plist"
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.dex.meeting-intel",
+                "ProgramArguments": ["/bin/bash", str(worktree / ".scripts" / "dex-launcher.sh")],
+                "WorkingDirectory": str(worktree),
+            },
+            handle,
+        )
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "BROKEN"
+    assert "temporary working copy" in result.detail
+    assert "reinstall it from the real vault" in result.detail
+
+
+def test_jobs_loaded_flags_a_dex_plist_pointing_into_a_git_worktree_checkout(
+    monkeypatch, context
+):
+    checkout = context.home.parent / "checkouts" / "dex-copy"
+    (checkout / ".scripts").mkdir(parents=True)
+    (checkout / ".git").write_text("gitdir: /somewhere/else\n", encoding="utf-8")
+    script = checkout / ".scripts" / "dex-launcher.sh"
+    script.write_text("#!/bin/bash\n", encoding="utf-8")
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    plist = agents / "com.dex.meeting-intel.plist"
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.dex.meeting-intel",
+                "ProgramArguments": ["/bin/bash", str(script)],
+                "WorkingDirectory": str(checkout),
+            },
+            handle,
+        )
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "BROKEN"
+    assert "temporary working copy" in result.detail
 
 
 def test_preflight_queue_maps_server_and_queued_errors_to_broken(monkeypatch, context):

--- a/core/tests/test_feedback_client_script.py
+++ b/core/tests/test_feedback_client_script.py
@@ -212,3 +212,61 @@ def test_expired_auth_raises_connection_instructions(tmp_path, monkeypatch):
         client.load_auth()
     assert "expired" in excinfo.value.user_message
     assert "feedback_client.py link" in excinfo.value.user_message
+
+
+def test_check_subcommand_exits_2_with_connection_needed_when_unlinked(tmp_path, monkeypatch, capsys):
+    client = _load_script()
+    monkeypatch.setattr(client, "auth_file_path", lambda: tmp_path / "missing-auth.json")
+
+    code = client.main(["check", "--vault", str(tmp_path)])
+
+    assert code == 2
+    out = capsys.readouterr().out
+    assert out.startswith("CONNECTION NEEDED: ")
+    assert "feedback_client.py link" in out
+
+
+def test_check_subcommand_exits_0_when_linked(tmp_path, monkeypatch, capsys):
+    client = _load_script()
+    auth = tmp_path / "auth.json"
+    auth.write_text(
+        json.dumps(
+            {"sessionToken": "token", "timestamp": client.now_ms(), "email": "user@example.com"}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(client, "auth_file_path", lambda: auth)
+
+    code = client.main(["check", "--vault", str(tmp_path)])
+
+    assert code == 0
+    assert "LINKED" in capsys.readouterr().out
+
+
+def test_report_exit_code_through_main_is_2_when_unlinked_and_receipt_is_kept(
+    tmp_path, monkeypatch, capsys
+):
+    client = _load_script()
+    monkeypatch.setattr(client, "auth_file_path", lambda: tmp_path / "missing-auth.json")
+    draft = tmp_path / "draft.json"
+    draft.write_text(json.dumps(_draft()), encoding="utf-8")
+
+    code = client.main(["report", "--file", str(draft), "--vault", str(tmp_path)])
+
+    assert code == 2
+    assert capsys.readouterr().out.startswith("CONNECTION NEEDED: ")
+    receipts = (tmp_path / "System" / ".dex" / "feedback-log.jsonl").read_text(encoding="utf-8")
+    record = json.loads(receipts.strip())
+    assert record["sent"] is False
+    assert record["reason"] == "AuthError"
+
+
+def test_link_with_blank_code_does_not_reuse_the_connection_needed_exit_code(capsys):
+    client = _load_script()
+
+    code = client.main(["link", "--code", "   "])
+
+    assert code == client.FeedbackError.exit_code
+    out = capsys.readouterr().out
+    assert "sign-in code is required" in out
+    assert "CONNECTION NEEDED" not in out

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -162,6 +162,73 @@ def test_activation_accepts_a_self_consistent_release_and_refuses_a_mismatch(
     assert not (mismatched / ACTIVATION_RELATIVE).exists()
 
 
+def _deliver_release(vault: Path, release_version: str) -> None:
+    """Simulate a delivered update: bridge declaration + catalog move together."""
+    from core.lifecycle.catalog import canonical_catalog_bytes, with_catalog_identity
+
+    _write_bridge_release(vault, release_version=release_version)
+    catalog_path = vault / "System/.release-catalog.json"
+    document = json.loads(catalog_path.read_text(encoding="utf-8"))
+    document["release"]["version"] = release_version
+    document["release"]["immutable_distribution_tag"] = (
+        f"dist/release/v{release_version}-0123456"
+    )
+    catalog_path.write_bytes(canonical_catalog_bytes(with_catalog_identity(document)))
+
+
+def test_stale_activation_from_a_previous_release_is_rerecorded(
+    tmp_path: Path,
+) -> None:
+    vault = _activation_fixture(tmp_path)
+    first = activate_vault(vault)
+    assert first["bridge_release_version"] == "1.64.0"
+
+    _deliver_release(vault, "1.64.1")
+
+    refreshed = activate_vault(vault)
+
+    catalog = load_catalog(vault / "System/.release-catalog.json", release_root=vault)
+    expected_hash = build_inventory(vault, catalog=catalog).to_dict()["inventory_sha256"]
+    activation_path = vault / ACTIVATION_RELATIVE
+    assert refreshed == {
+        "activation_version": 1,
+        "api_version": service.api_version,
+        "bridge_release_version": "1.64.1",
+        "baseline_inventory_sha256": expected_hash,
+    }
+    assert activation_path.read_bytes() == _canonical(refreshed)
+    assert stat.S_IMODE(activation_path.stat().st_mode) == 0o600
+    assert not list(activation_path.parent.glob(".activation.json.tmp-*"))
+    assert activate_vault(vault) == refreshed
+
+
+def test_stale_activation_refresh_still_refuses_a_torn_install(
+    tmp_path: Path,
+) -> None:
+    vault = _activation_fixture(tmp_path)
+    stale = activate_vault(vault)
+    _write_bridge_release(vault, release_version="1.64.1")
+
+    with pytest.raises(
+        BridgeActivationError,
+        match="installed catalog release does not match the designated bridge release",
+    ):
+        activate_vault(vault)
+    assert (vault / ACTIVATION_RELATIVE).read_bytes() == _canonical(stale)
+
+
+def test_gated_operations_recover_after_a_delivered_release(tmp_path: Path) -> None:
+    vault = _activation_fixture(tmp_path)
+    activate_vault(vault)
+    _deliver_release(vault, "1.64.1")
+
+    state = service.read_lifecycle_state(vault)
+
+    assert "ledger_state" in state
+    plan = service.build_inventory_and_plan(vault)
+    assert "plan" in plan
+
+
 def test_lifecycle_service_translates_bridge_activation_failure_to_plain_refusal(
     tmp_path: Path,
 ) -> None:

--- a/core/tests/test_meeting_closeout_skill.py
+++ b/core/tests/test_meeting_closeout_skill.py
@@ -72,6 +72,15 @@ def test_named_meeting_discovery_is_provider_neutral_and_not_folder_bound() -> N
     assert "clickup" in text
     assert "not only `00-inbox/meetings/`" in text
     assert "original source note" in text
+    assert "meeting_sources" in text
+
+
+def test_source_boundary_forbids_external_services() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "source boundary" in text
+    assert "never go looking in external services" in text
+    assert "google drive" in text
+    assert "do not widen the search to external tools" in text
 
 
 @pytest.mark.parametrize(

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "774e744216a0ec41cfef2c3ac68d441b3030729c64d937c2d05c7390ab6b5635",
+      "sha256": "9484230fe6586de6731ac535eb6c70920711d85784097345e04894e97e4adb6e",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -141,10 +141,17 @@ class ProbeResult:
 
 @dataclass(frozen=True)
 class JobFreshness:
-    """The application log and allowed age for one installed job."""
+    """The application log and allowed age for one installed job.
+
+    ``success_state_path`` names a JSON file whose ``lastSync`` field is
+    written only by a completed run.  When present it replaces the log-mtime
+    check: a job can fail on every run while still appending to its log, so
+    log age proves activity, not success.
+    """
 
     log_path: Path
     max_age: timedelta
+    success_state_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -597,6 +604,7 @@ JOB_FRESHNESS = {
     "com.dex.meeting-intel": JobFreshness(
         Path(".scripts/logs/meeting-intel.log"),
         timedelta(hours=48),
+        success_state_path=Path(".scripts/meeting-intel/processed-meetings.json"),
     ),
     "com.dex.changelog-checker": JobFreshness(
         Path(".scripts/logs/changelog-checker.log"),
@@ -2330,6 +2338,43 @@ def _plist_owned_by_vault(plist: Path, data: dict[str, Any], context: DoctorCont
     return False
 
 
+_TEMPORARY_CHECKOUT_MARKER = "/worktrees/"
+
+
+def _launch_agent_orphan_issue(data: dict[str, Any]) -> str | None:
+    """Name the defect when a Dex launch agent targets a dead or temporary path.
+
+    A foreign-but-healthy plist can belong to another Dex vault on the same
+    Mac and is none of this vault's business. One whose embedded absolute
+    path lives inside a git worktree cannot belong to any durable install —
+    it is a repointed job that runs (and fails) silently forever, so it must
+    be surfaced rather than skipped as another product's.
+    """
+    candidates: list[Path] = []
+    arguments = data.get("ProgramArguments")
+    strings: list[object] = list(arguments) if isinstance(arguments, list) else []
+    working_directory = data.get("WorkingDirectory")
+    if isinstance(working_directory, str):
+        strings.append(working_directory)
+    for argument in strings:
+        if not isinstance(argument, str):
+            continue
+        candidate = Path(argument).expanduser()
+        if candidate.is_absolute():
+            candidates.append(candidate)
+    for candidate in candidates:
+        if _TEMPORARY_CHECKOUT_MARKER in candidate.as_posix():
+            return f"points at a temporary working copy ({candidate})"
+        try:
+            if candidate.exists():
+                for ancestor in (candidate, *candidate.parents):
+                    if (ancestor / ".git").is_file():
+                        return f"points at a temporary working copy ({candidate})"
+        except OSError:
+            continue
+    return None
+
+
 def _with_skipped_launch_agents(detail: str, skipped_count: int) -> str:
     if not skipped_count:
         return detail
@@ -2452,6 +2497,17 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
             unknowns.append(_unattributable_launch_agent_detail(plist, error))
             continue
         if not _plist_owned_by_vault(plist, data, context):
+            orphan_issue = _launch_agent_orphan_issue(data)
+            if orphan_issue is not None:
+                orphan_label = str(data.get("Label") or plist.stem)
+                issues.append(
+                    (
+                        2,
+                        f"{orphan_label} {orphan_issue} — likely installed from a "
+                        "temporary checkout; reinstall it from the real vault",
+                    )
+                )
+                continue
             skipped_count += 1
             continue
         owned_count += 1
@@ -2490,7 +2546,7 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
                     unknowns.append(f"{label} is loaded but has no observable LastExitStatus")
                 elif status["last_exit_status"] != 0:
                     issues.append((2, f"{label} last exited with status {status['last_exit_status']}"))
-    if not owned_count:
+    if not owned_count and not issues:
         if unknowns:
             return ProbeResult(
                 "UNKNOWN",
@@ -2528,6 +2584,26 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     )
 
 
+def _last_success_timestamp(state_path: Path) -> datetime | None:
+    """Read the last completed-run timestamp a sync job records only on success."""
+    if not state_path.is_file():
+        return None
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = state.get("lastSync") if isinstance(state, dict) else None
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     installed = set()
     unknowns = []
@@ -2548,6 +2624,20 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     stale = []
     for label in monitored:
         policy = JOB_FRESHNESS[label]
+        if policy.success_state_path is not None:
+            succeeded = _last_success_timestamp(context.vault_root / policy.success_state_path)
+            if succeeded is None:
+                stale.append(
+                    f"{label} has never recorded a completed run "
+                    "(a job can keep writing its log while failing every time)"
+                )
+                continue
+            if context.now.astimezone(timezone.utc) - succeeded > policy.max_age:
+                stale.append(
+                    f"{label} last completed successfully on {succeeded.date().isoformat()} "
+                    "— it may still be running without succeeding"
+                )
+            continue
         log_path = context.vault_root / policy.log_path
         if not log_path.is_file():
             stale.append(f"{label} has no run log")

--- a/docs/Dex_System/Dex_System_Guide.md
+++ b/docs/Dex_System/Dex_System_Guide.md
@@ -555,33 +555,17 @@ Without memory, every planning session starts from zero. The same blind spots pe
 
 ---
 
-## Context Isolation
+## Skills See Your Conversation
 
-**The Problem:** Long conversations slow down. You start a planning session in the morning, then by afternoon your chat is sluggish because it's carrying the full weight of every skill you ran.
+**The Problem:** Earlier versions ran the planning, review, and meeting skills in an isolated workspace to keep long chats fast. That isolation had a hidden cost: an isolated skill couldn't see what you had already discussed and settled in the conversation, so a plan could resurface items you'd resolved minutes earlier. It looked like Dex was forgetting — it never had the information.
 
-**What Dex Does:** Heavy skills now run in isolated context. Your main conversation stays clean all day.
-
-### Which Skills Are Isolated
-
-These skills run in their own context, separate from your main conversation:
-
-- `/daily-plan`
-- `/daily-review`
-- `/week-plan`
-- `/week-review`
-- `/meeting-prep`
-- `/process-meetings`
-- `/career-coach`
+**What Dex Does now:** Planning, review, and meeting skills run inside your current conversation by default, so they always know what you've already covered. Dex only moves work to the background when you explicitly ask for a background run.
 
 ### What This Means for You
 
-- **No more starting fresh chats.** You can run `/daily-plan` in the morning, work all day, run `/daily-review` at night, and the conversation stays responsive.
-- **Results still flow back.** The output of each skill (your plan, review, meeting prep) is available in your conversation — only the heavy processing happens in isolation.
-- **Lighter skills stay inline.** Quick things like `/triage` or task creation happen in your current conversation as before.
-
-### Why This Matters
-
-Before context isolation, running three or four skills in one session could noticeably slow things down. Now each heavy skill gets a clean workspace, does its work, and returns the result without cluttering your main thread.
+- **Plans and reviews respect the conversation.** If you settled something earlier in the chat, `/daily-plan` and `/daily-review` won't bring it back as an open item.
+- **Background runs are opt-in.** Say "run this in the background" if you want the old behavior for a heavy run; Dex will ask before doing that on its own.
+- **Long sessions can still be split.** If a day-long chat gets sluggish, starting a fresh session is always safe — plans, reviews, and notes live in your files, not in the chat.
 
 **Reference:** See `06-Resources/Dex_System/Named_Sessions_Guide.md` for details on how named sessions work.
 

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -17,6 +17,10 @@ because an update failed: follow this page exactly; do not improvise beyond it.
   checker in these releases refused when too many release tags existed. The
   repository's tag list has been cleaned so these versions announce updates again.
   If a notice still never appears, use the fallback below.
+- **Versions v1.74 through v1.79 whose `/dex-update` cannot fetch a new release**:
+  these versions predate the delivered-release mechanism and need the one-time
+  bridge — skip the Git fallback below and go straight to
+  "Lifecycle-era bridge — v1.74 through v1.79" further down this page.
 - **Versions before v1.62**: your built-in update instructions already use the
   fallback route; follow your own `/dex-update` skill as written.
 
@@ -114,12 +118,21 @@ curl -fL \
 python3 "$BRIDGE_DIR/dex-update-bridge-v1.83.0.py" --vault "$PWD"
 ```
 
-It shows two independent previews and requires `APPLY` for each: first the
-one-time separation of Dex code from the user's notes, then the exact files for
-the verified foundation release. It never pushes, never uses a branch, and
-stops before a user-file change if either proof or approval is missing. Only a
-published bridge whose historical fixture proof is green may say that later
-updates are the ordinary `/dex-update` route.
+It shows up to three independent previews and requires `APPLY` for each: the
+one-time separation of Dex code from the user's notes (skipped when the vault
+is already split), the exact files for the verified foundation release, and the
+one-line registration of Dex's update-support tool. It never pushes, never uses
+a branch, and stops before a user-file change if either proof or approval is
+missing. Only a published bridge whose historical fixture proof is green may
+say that later updates are the ordinary `/dex-update` route.
+
+**What you should see.** The bridge narrates each stage on the terminal:
+relaunching into Dex's installed runtime, checking the install, fetching the
+pinned release, then building the exact preview (which can take a few minutes
+on a large vault). If it stops, it prints one line starting
+`Dex update bridge stopped safely:` explaining why. A bridge that runs for
+minutes with **no output at all** is wedged, not working — press Ctrl-C and
+report exactly what you ran and saw.
 
 Windows is not part of this P0 bridge. Do not substitute an unverified PowerShell
 or Git command; use the supported rescue path until a Windows bridge is

--- a/docs/architecture/STATE.md
+++ b/docs/architecture/STATE.md
@@ -7,7 +7,7 @@ A compact snapshot of released, local, and planned Dex Core work.
 
 SHIPPED/LOCAL are computed live — run `/dex-orient` or `python3 scripts/dex_state.py` for current truth.
 
-Released: v1.81.0 (2026-07-31)
+Released: v1.83.0 (2026-08-08)
 
 ### LOCAL — on main, not yet released (0)
 

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1284,6 +1284,7 @@ def _bridge_environment() -> dict[str, str]:
         "GIT_TERMINAL_PROMPT": "0",
         "PYTHONNOUSERSITE": "1",
         "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
     }
 
 
@@ -1780,6 +1781,45 @@ def _running_in_selected_runtime(interpreter: Path) -> bool:
     )
 
 
+# macOS framework builds launch a virtualenv Python through a stub that injects
+# this variable into the child's environment after execve; its presence is a
+# property of the selected interpreter itself, not of the caller.
+_INTERPRETER_INJECTED_VARIABLES = frozenset({"__PYVENV_LAUNCHER__"})
+
+
+def _observed_clean_environment() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _INTERPRETER_INJECTED_VARIABLES
+    }
+
+
+def _runtime_reentry_diagnostic(interpreter: Path, environment: Mapping[str, str]) -> str:
+    """Name exactly why the relaunched process still isn't the closed runtime."""
+    observed = _observed_clean_environment()
+    problems: list[str] = []
+    unexpected = sorted(set(observed) - set(environment))
+    if unexpected:
+        problems.append("unexpected environment variables appeared: " + ", ".join(unexpected))
+    changed = sorted(key for key in environment if observed.get(key) != environment[key])
+    if changed:
+        problems.append("environment variables disagree: " + ", ".join(changed))
+    if os.path.abspath(sys.executable) != str(interpreter):
+        problems.append(
+            f"the running Python is {os.path.abspath(sys.executable)} instead of {interpreter}"
+        )
+    selected_prefix = str(interpreter.parent.parent)
+    if os.path.abspath(sys.prefix) != selected_prefix or os.path.abspath(sys.exec_prefix) != selected_prefix:
+        problems.append(
+            f"the running Python reports prefix {os.path.abspath(sys.prefix)} "
+            f"instead of the vault virtualenv {selected_prefix}"
+        )
+    if not problems:
+        problems.append("no difference could be identified")
+    return "; ".join(problems)
+
+
 def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
     """Enter one clean process before loading any foundation code.
 
@@ -1787,19 +1827,30 @@ def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
     but running it by its venv path still selects the installed dependencies.
     Never trust a caller-supplied runtime marker: it is accepted only when the
     complete environment already equals the closed runtime environment and the
-    running Python identifies as the selected vault virtualenv.
+    running Python identifies as the selected vault virtualenv.  The marker can
+    never grant a dirty runtime — when it is present but the runtime still is
+    not clean, a second relaunch would reproduce the same state exactly, so the
+    bridge stops with a diagnostic instead of relaunching itself forever.
     """
     interpreter = _installed_python(vault_root)
     if interpreter is None:
         raise BridgeError("Dex's installed virtualenv is required for the one-time update bridge")
     environment = _bridge_environment()
     environment[_CLEAN_RUNTIME_MARKER] = "1"
-    if (
-        os.environ.get(_CLEAN_RUNTIME_MARKER) == "1"
-        and dict(os.environ) == environment
-        and _running_in_selected_runtime(interpreter)
-    ):
-        return
+    if os.environ.get(_CLEAN_RUNTIME_MARKER) == "1":
+        if _observed_clean_environment() == environment and _running_in_selected_runtime(interpreter):
+            return
+        raise BridgeError(
+            "the installed Dex runtime could not be entered cleanly, so the bridge "
+            "stopped instead of relaunching endlessly: "
+            + _runtime_reentry_diagnostic(interpreter, environment)
+            + f" (if {_CLEAN_RUNTIME_MARKER} was set in your shell, unset it and re-run)"
+        )
+    print(
+        "Relaunching inside Dex's installed runtime...",
+        file=sys.stderr,
+        flush=True,
+    )
     os.execve(
         str(interpreter),
         [str(interpreter), str(Path(__file__).resolve()), *argv],
@@ -2832,6 +2883,17 @@ def _complete_mcp_registration(
     )
 
 
+def _progress(message: str) -> None:
+    """Narrate long-running read-only stages on stderr.
+
+    The bridge can legitimately work for minutes between approvals (building
+    the exact preview reads every release file); a user watching a silent
+    terminal cannot tell working from wedged, so every long stage announces
+    itself.  Approval previews and results stay on stdout unchanged.
+    """
+    print(message, file=sys.stderr, flush=True)
+
+
 def run_bridge(
     vault_root: Path,
     service: LifecycleService,
@@ -2843,6 +2905,7 @@ def run_bridge(
 ) -> Mapping[str, Any]:
     """Run up to three fresh approval boundaries through the foundation service."""
     root = _validate_vault(vault_root)
+    _progress("Checking this Dex install (read-only)...")
     # This local ref is the authoritative resume marker. Check it before
     # importing/calling lifecycle code or attempting any network operation: a
     # completed bridge must work offline and must not be disturbed merely
@@ -2880,7 +2943,12 @@ def run_bridge(
 
     # This fetch touches only Dex's private code store. The following preview is
     # still the sole authority for every vault-content write.
+    _progress(f"Fetching pinned Dex release v{pin.version} (network; this can take a minute)...")
     fetch_foundation(root, pin)
+    _progress(
+        "Building the exact update preview — nothing is written yet. "
+        "This reads every release file and can take a few minutes on a large vault..."
+    )
     delivery = service.build_and_preview_delivered_release(root, pin.identity())
     release_preview = delivery.get("preview")
     if not isinstance(release_preview, Mapping):


### PR DESCRIPTION
Two detailed user reports (one on v1.83.0/macOS, one on v1.79.0) surfaced six real defects. This PR fixes all six.

## 1. Activation record staleness bricked plan/state/adopt/rewind after every update
`activate_vault` wrote `System/.dex/lifecycle/activation.json` once; the delivered-release path never refreshed it (it's runtime state no release may write), yet `_validate_activation` bound it to the *current* bridge release. Result: the first update after activation permanently broke `build_inventory_and_plan`, `read_lifecycle_state`, adoption, and rewind — while deliveries kept working, hiding it. Fix: a structurally valid record for a different bridge release is recognized as routine post-update staleness and re-recorded against the installed release (same proof as first-run activation; torn installs still refuse; malformed records still refuse). Stuck installs self-heal on their next gated operation. Tests: refresh, torn-install refusal, and service-level recovery.

## 2. `context: fork` removed from the remaining nine skills + staged career-coach
Forked skills can't see the conversation — plans resurfaced items settled minutes earlier. Applied the daily-review pattern (PR #336) everywhere: inline by default with an explicit Execution mode section. Docs rewritten (System Guide "Context Isolation" → "Skills See Your Conversation"; README annotations). Catalog item hashes restamped for decision-log/delegate-check/weekly-reflection.

## 3. Update-rescue bridge could relaunch itself forever, silently
`_reexec_in_installed_runtime` re-execs into the vault venv expecting an exactly clean environment + venv identity; when unsatisfiable (macOS `__PYVENV_LAUNCHER__` injection, shim venv python), it re-execed forever in the same PID with zero output (the exec drops `-u`/`-X faulthandler` and stripped `PYTHONUNBUFFERED`). Fix: tolerate the interpreter-injected variable, bound the relaunch to one attempt with a diagnostic naming exactly what differed, add `PYTHONUNBUFFERED` to the closed environment, and narrate long read-only stages on stderr. `UPDATE-RESCUE.md` now routes v1.74–v1.79 to the bridge section at the top, corrects the approval count, and documents expected output. `journey-protocol-v1.json` regenerated for the new bridge bytes. The forged-marker security property is preserved (a marked-but-dirty process now refuses instead of relaunching — strictly fail-closed).

## 4. Meeting-closeout could build a closeout from an unconfigured, hallucinating source
No meeting-source setting was ever persisted (onboarding asked, recorded nothing), and the skill's discovery prose let the model widen to external services — one user got a closeout built on Gemini Drive notes containing a fabricated action item. Fix: new `meeting_sources` profile setting (persisted by onboarding), consulted first by meeting-closeout, plus a hard source boundary: vault files only, never external services, and an empty search is terminal (ask for the notes).

## 5. Background sync hijacked by temporary worktrees; health checks blind to it
Installers derived the vault path from their own location and rewrote `~/.config/dex/vault-path`, so any agent session in a worktree that re-ran an installer repointed every Dex launch agent at a disappearing folder — and Doctor skipped the hijacked plist as "another Dex product's". Fix: all four installers refuse temporary checkouts; Doctor flags a Dex plist pointing into a worktree as BROKEN with a repair instruction; meeting-intel freshness now reads the `lastSync` success timestamp (written only by completed syncs) instead of log mtime, in both Doctor and session start — a job that fails every run no longer stays green.

## 6. /feedback discovered the missing terminal link only after drafting
New `check` preflight subcommand; the skill verifies the link *before* investigating or drafting. The reported exit-0-on-CONNECTION-NEEDED did not reproduce (the script exits 2 and always has), but the report exposed real gaps now closed: exit codes pinned through `main()` by tests, blank link code no longer shares exit 2, and base `FeedbackError` no longer escapes as a traceback.

## Verification
- `core/tests`: 3272 passed locally; failures match the unmodified-HEAD environmental baseline on this Linux box (`plutil`, node modules, trusted-mcp sandbox) — final comparison in thread; CI is the authoritative gate.
- Repo gates green locally: founder-content, portable-contract, architecture-inventory drift; journey protocol regenerated and verified by `build-vault-bundle`'s staleness check.
- Shell installers: `bash -n` + functional guard test (fires in a worktree, silent in a normal directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)