### PR TITLE
The file holding your AI keys is now private — and the checkup finally sees it (#361 safe subset)

### DIFF
--- a/.claude/skills/create-mcp/SKILL.md
+++ b/.claude/skills/create-mcp/SKILL.md
@@ -608,7 +608,7 @@ Let me verify everything is in place:
    ```
    export [ENV_VAR]="your-value-here"
    ```
-   Or add to your shell config / .env file.
+   Or add to your shell config / the vault-root `.env` file (keep `.env` owner-only: `chmod 600 .env`).
 
 3. Configure Claude Desktop to use the server:
    Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:

--- a/.claude/skills/granola-setup/SKILL.md
+++ b/.claude/skills/granola-setup/SKILL.md
@@ -135,7 +135,8 @@ Wait for the user to paste the key.
 1. Locate the vault root `.env` file (`VAULT_ROOT/.env`). Create it if it doesn't exist.
 2. Write or update the line `GRANOLA_API_KEY=<pasted key>` in that file.
    - If a `GRANOLA_API_KEY=` line already exists, replace it; otherwise append it.
-3. Confirm `.env` is gitignored (it is by convention — never commit it).
+3. Make the file owner-only: `chmod 600 "$VAULT_ROOT/.env"`. Run this every time — it also tightens a pre-existing `.env` that was left readable by other users of the machine.
+4. Confirm `.env` is gitignored (it is by convention — never commit it).
 
 **Verify it with a real request:**
 

--- a/.claude/skills/integrate-mcp/SKILL.md
+++ b/.claude/skills/integrate-mcp/SKILL.md
@@ -202,6 +202,8 @@ ENVVAR_1=value1
 ENV_VAR_2=value2
 ```
 
+After writing, make the file owner-only (`chmod 600 .env`) — create it with that mode if it's new, and tighten it if an existing `.env` was left readable by other users.
+
 ### Step 5: Update MCP Config
 
 Add to `System/.mcp.json`:

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -77,7 +77,7 @@ ls .scripts/meeting-intel/processed-meetings.json
 >
 > **Requirements:**
 > - A Granola Business plan, with your Granola API key connected via `/granola-setup`
-> - An LLM API key in `.env` (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY)"
+> - An LLM API key in the vault-root `.env` (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY) — keep that file owner-only (`chmod 600 .env`)"
 
 If user runs `--setup`:
 ```bash

--- a/.claude/skills/prompt-improver/SKILL.md
+++ b/.claude/skills/prompt-improver/SKILL.md
@@ -206,6 +206,7 @@ For best results, add your Anthropic API key:
 
 1. Create `.env` file in vault root (if not exists)
 2. Add: `ANTHROPIC_API_KEY=your-key-here`
+3. Make the file owner-only: `chmod 600 .env` (API keys should never be readable by other users of the machine)
 
 Without the API key, the skill still works using the current LLM session.
 

--- a/.scripts/lib/llm-client.cjs
+++ b/.scripts/lib/llm-client.cjs
@@ -107,7 +107,9 @@ async function generateContent(prompt, options = {}) {
   
   if (!provider) {
     throw new Error(
-      'No LLM API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY in your .env file'
+      'No LLM API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY in the vault-root .env file '
+        + 'and keep that file owner-only (chmod 600 .env). Dex\'s encrypted credential store (/connect) does not '
+        + 'feed background LLM features yet, so .env is still the supported location for these keys.'
     );
   }
   

--- a/.scripts/meeting-intel/install-automation.sh
+++ b/.scripts/meeting-intel/install-automation.sh
@@ -132,6 +132,9 @@ echo -e "${GREEN}✓${NC} Node.js found at: $NODE_PATH"
 
 if [ ! -f "$VAULT_PATH/.env" ]; then
     echo -e "${YELLOW}!${NC} Warning: .env file not found. Make sure GEMINI_API_KEY (or another LLM key) is set."
+else
+    # API keys live in this file — keep it owner-only.
+    chmod 600 "$VAULT_PATH/.env" 2>/dev/null || true
 fi
 
 # Check the same authentication source the sync worker uses.

--- a/.scripts/meeting-intel/sync-from-granola.cjs
+++ b/.scripts/meeting-intel/sync-from-granola.cjs
@@ -607,7 +607,7 @@ async function analyzeWithLLM(meeting, profile, pillars) {
   const { generateContent, isConfigured, getActiveProvider } = require('../lib/llm-client.cjs');
 
   if (!isConfigured()) {
-    throw new Error('No LLM API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY in .env');
+    throw new Error('No LLM API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY in the vault-root .env (keep that file owner-only: chmod 600 .env)');
   }
 
   const prompt = buildAnalysisPrompt(meeting, profile, pillars);
@@ -1244,7 +1244,7 @@ async function main() {
     } catch (err) {
       if (err.message.includes('No LLM API key') || err.message.includes('not configured')) {
         // No LLM configured — create a basic structured note instead
-        log(`  No LLM available — creating basic note (add ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY to .env for background analysis)`);
+        log(`  No LLM available — creating basic note (add ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY to the vault-root .env — owner-only, chmod 600 — for background analysis)`);
         result = createBasicMeetingNote(meeting, profile);
       } else {
         log(`  Failed: ${err.message}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.88.0] — 🔐 The file holding your AI keys is now private — and the checkup finally sees it (2026-08-10)
+
+If you gave Dex an AI key so meetings get analyzed in the background, that key sat in a small file at the top of your vault that other accounts on the same computer could read — and Dex's own checkup couldn't see the key at all, so it reported "no key" and recommended you put one exactly where it already was.
+
+**What this fixes for you:**
+
+* **Only you can read your key file now.** Every place Dex creates or updates that file makes it private to your account, and the checkup (`/dex-doctor`) safely tightens an existing file that was left open — without reading or changing anything inside it.
+* **The checkup stops calling a configured key "missing."** The health check now looks in the same place the background features actually read the key from, so a key you've already set up is recognised instead of reported absent. The key itself never appears in any report or log — the check only confirms one exists.
+* **Advice that no longer points you wrong.** Wherever Dex tells you to add an AI key, it now also tells you to keep that file private — and it's honest that Dex's encrypted credential storage doesn't yet feed these background features, so the file is still the right place for now. Moving those keys into encrypted storage is a separate, deliberately unhurried piece of work.
+
+Thanks to Chris, whose report mapped the whole problem — including the parts this release fixes and the deeper move it defers.
+
 ## [1.86.0] — 🧭 The checkup now sees all your background jobs — and stops crying wolf (2026-08-10)
 
 Three community bug reports showed the same pattern from different angles: Dex's health checkup could miss real problems with background jobs while flagging healthy things as broken. This release makes the checkup match reality in both directions. Thanks to the three reporters whose unusually precise write-ups made these fixes straightforward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ If you gave Dex an AI key so meetings get analyzed in the background, that key s
 
 **What this fixes for you:**
 
-* **Only you can read your key file now.** Every place Dex creates or updates that file makes it private to your account, and the checkup (`/dex-doctor`) safely tightens an existing file that was left open — without reading or changing anything inside it.
+* **Only you can read your key file now.** Every place Dex creates or updates that file makes it private to your account, and the checkup (`/dex-doctor`) safely tightens an existing file that was left open — without reading or changing anything inside it. In the two cases where fixing it automatically would be wrong — the file belongs to a different account, or it's a shortcut-style link to a file elsewhere — the checkup reports the problem and gives you the exact command instead of guessing.
 * **The checkup stops calling a configured key "missing."** The health check now looks in the same place the background features actually read the key from, so a key you've already set up is recognised instead of reported absent. The key itself never appears in any report or log — the check only confirms one exists.
 * **Advice that no longer points you wrong.** Wherever Dex tells you to add an AI key, it now also tells you to keep that file private — and it's honest that Dex's encrypted credential storage doesn't yet feed these background features, so the file is still the right place for now. Moving those keys into encrypted storage is a separate, deliberately unhurried piece of work.
 

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -511,6 +511,105 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     assert "1 legacy lock pending migration" in result.detail
 
 
+def test_entity_engine_probe_reads_llm_key_from_vault_env_file(monkeypatch, context):
+    for key in doctor.LLM_KEY_NAMES:
+        monkeypatch.delenv(key, raising=False)
+    _write_entity_probe_files(context)
+    gardener = context.core_path("GARDENER_STATE_FILE")
+    gardener.write_text(json.dumps({"version": 2, "pages": {
+        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+    }}))
+    env_path = context.vault_root / ".env"
+    env_path.write_text("# local keys\nexport GEMINI_API_KEY='test-placeholder-key'\n")
+
+    result = doctor._probe_entity_engine(context)
+
+    assert "gardener on (1 pages maintained)" in result.detail
+    assert "test-placeholder-key" not in result.detail
+
+    env_path.write_text("GEMINI_API_KEY=\n")
+    result = doctor._probe_entity_engine(context)
+    assert "gardener off (no LLM key)" in result.detail
+
+    env_path.unlink()
+    result = doctor._probe_entity_engine(context)
+    assert "gardener off (no LLM key)" in result.detail
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_vault_configs_flags_group_readable_env_with_t1_heal(context):
+    _write_valid_configs(context)
+    assert doctor._probe_vault_configs(context).verdict == "OK"
+
+    env_path = context.vault_root / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+    result = doctor._probe_vault_configs(context)
+    assert result.verdict == "BROKEN"
+    assert "readable by other users" in result.detail
+    assert "644" in result.detail
+    assert "test-placeholder-not-a-real-key" not in result.detail
+    assert result.heal == doctor.Heal(
+        tier=1,
+        action="Tighten .env to owner-only permissions.",
+        applied=False,
+    )
+
+    env_path.chmod(0o600)
+    assert doctor._probe_vault_configs(context).verdict == "OK"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_t1_heal_tightens_env_permissions_without_touching_contents(monkeypatch, context):
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+    env_path = context.vault_root / ".env"
+    env_path.write_text("OPENAI_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+
+    actions, errors = doctor._apply_t1_heals(context)
+
+    assert errors == []
+    assert "tightened .env to owner-only permissions" in actions
+    assert stat.S_IMODE(env_path.lstat().st_mode) == 0o600
+    assert env_path.read_text() == "OPENAI_API_KEY=test-placeholder-not-a-real-key\n"
+
+    actions, errors = doctor._apply_t1_heals(context)
+    assert errors == []
+    assert actions == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_heal_tightens_env_permissions_and_annotates_vault_configs(monkeypatch, context):
+    _write_valid_configs(context)
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+    env_path = context.vault_root / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+    _stub_probes(monkeypatch, exclude={"vault.configs"})
+
+    report = doctor.collect(heal=True, context=context)
+
+    assert stat.S_IMODE(env_path.lstat().st_mode) == 0o600
+    assert env_path.read_text() == "ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n"
+    configs = _check(report, "vault.configs")
+    assert configs["verdict"] == "OK"
+    assert "after a safe Tier-1 permission repair" in configs["detail"]
+    assert configs["heal"] == {
+        "tier": 1,
+        "action": "tightened .env to owner-only permissions.",
+        "applied": True,
+    }
+    assert "test-placeholder-not-a-real-key" not in json.dumps(report)
+
+
 def test_registry_ids_match_the_approved_spec():
     assert [definition.id for definition in doctor.QUICK_CHECKS] == QUICK_IDS
     assert [definition.id for definition in doctor.DEEP_CHECKS] == DEEP_IDS

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -434,7 +434,9 @@ def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
 
     assert errors == []
     assert calls == [context]
-    assert actions == ["re-queued 1 dead-lettered entity write with retry counters reset"]
+    assert actions == {
+        "entity.engine": ["re-queued 1 dead-lettered entity write with retry counters reset"],
+    }
 
 
 def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
@@ -573,13 +575,13 @@ def test_t1_heal_tightens_env_permissions_without_touching_contents(monkeypatch,
     actions, errors = doctor._apply_t1_heals(context)
 
     assert errors == []
-    assert "tightened .env to owner-only permissions" in actions
+    assert actions == {"vault.configs": ["tightened .env to owner-only permissions"]}
     assert stat.S_IMODE(env_path.lstat().st_mode) == 0o600
     assert env_path.read_text() == "OPENAI_API_KEY=test-placeholder-not-a-real-key\n"
 
     actions, errors = doctor._apply_t1_heals(context)
     assert errors == []
-    assert actions == []
+    assert actions == {}
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
@@ -608,6 +610,140 @@ def test_heal_tightens_env_permissions_and_annotates_vault_configs(monkeypatch, 
         "applied": True,
     }
     assert "test-placeholder-not-a-real-key" not in json.dumps(report)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_vault_configs_reports_env_permissions_even_with_parse_failures(context):
+    _write_valid_configs(context)
+    (context.vault_root / "System" / "pillars.yaml").write_text("pillars: [\n")
+    env_path = context.vault_root / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+
+    result = doctor._probe_vault_configs(context)
+
+    assert result.verdict == "BROKEN"
+    assert "pillars.yaml" in result.detail
+    assert "readable by other users" in result.detail
+    assert "test-placeholder-not-a-real-key" not in result.detail
+    assert result.heal.tier == 3  # the parse-failure guidance survives
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_heal_annotation_merges_into_a_still_broken_vault_configs(monkeypatch, context):
+    # A parse failure and a loose .env together: --heal tightens the file but
+    # must not replace the BROKEN verdict or the Tier-3 hand-repair guidance.
+    _write_valid_configs(context)
+    (context.vault_root / "System" / "pillars.yaml").write_text("pillars: [\n")
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+    env_path = context.vault_root / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+    _stub_probes(monkeypatch, exclude={"vault.configs"})
+
+    report = doctor.collect(heal=True, context=context)
+
+    assert stat.S_IMODE(env_path.lstat().st_mode) == 0o600
+    configs = _check(report, "vault.configs")
+    assert configs["verdict"] == "BROKEN"
+    assert configs["heal"] == {
+        "tier": 3,
+        "action": "Repair the named configuration file by hand.",
+        "applied": False,
+    }
+    assert "pillars.yaml" in configs["detail"]
+    assert "tightened .env to owner-only permissions" in configs["detail"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_symlinked_env_is_reported_but_never_auto_tightened(monkeypatch, context, tmp_path):
+    _write_valid_configs(context)
+    target = tmp_path / "real-env"
+    target.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    target.chmod(0o644)
+    env_path = context.vault_root / ".env"
+    env_path.symlink_to(target)
+
+    result = doctor._probe_vault_configs(context)
+
+    assert result.verdict == "BROKEN"
+    assert "symlink" in result.detail
+    assert "test-placeholder-not-a-real-key" not in result.detail
+    assert result.heal.tier == 3
+    assert result.heal.applied is False
+    assert str(env_path.resolve()) in result.heal.action
+
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+
+    actions, errors = doctor._apply_t1_heals(context)
+
+    assert errors == []
+    assert "vault.configs" not in actions
+    assert stat.S_IMODE(target.lstat().st_mode) == 0o644  # untouched
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_foreign_owned_env_degrades_to_manual_guidance(monkeypatch, context):
+    _write_valid_configs(context)
+    env_path = context.vault_root / ".env"
+    env_path.write_text("ANTHROPIC_API_KEY=test-placeholder-not-a-real-key\n")
+    env_path.chmod(0o644)
+    monkeypatch.setattr(doctor.os, "geteuid", lambda: env_path.lstat().st_uid + 1)
+
+    result = doctor._probe_vault_configs(context)
+
+    assert result.verdict == "BROKEN"
+    assert "owned by another user" in result.detail
+    assert result.heal.tier == 3
+    assert result.heal.applied is False
+
+    for name in doctor.PARA_PATH_NAMES:
+        context.core_path(name).mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
+    context.paths_json_path.write_text(json.dumps(doctor._paths_export_for(context)))
+    monkeypatch.setattr(doctor, "_repo_shipped_executables", lambda _context: [])
+
+    actions, errors = doctor._apply_t1_heals(context)
+
+    assert errors == []  # no unappliable heal breaking doctor.self on every run
+    assert "vault.configs" not in actions
+    assert stat.S_IMODE(env_path.lstat().st_mode) == 0o644
+
+
+def test_entity_engine_probe_tolerates_undecodable_env_file(monkeypatch, context):
+    for key in doctor.LLM_KEY_NAMES:
+        monkeypatch.delenv(key, raising=False)
+    _write_entity_probe_files(context)
+    (context.vault_root / ".env").write_bytes(b"ANTHROPIC_API_KEY=caf\xe9\n")
+
+    result = doctor._probe_entity_engine(context)
+
+    assert result.verdict == "OK"
+    assert "gardener off (no LLM key)" in result.detail
+
+
+def test_granola_api_key_distinguishes_absent_from_unreadable(monkeypatch, context):
+    monkeypatch.delenv("GRANOLA_API_KEY", raising=False)
+    assert doctor._granola_api_key(context) is None  # no .env file at all
+
+    env_path = context.vault_root / ".env"
+    env_path.write_text("GRANOLA_API_KEY=\n")
+    assert doctor._granola_api_key(context) is None  # empty value
+
+    env_path.write_text('GRANOLA_API_KEY="grn_\\u0066ile_key"\n')
+    assert doctor._granola_api_key(context) == "grn_file_key"  # shared JSON decoding
+
+    env_path.write_bytes(b"not a valid assignment line\n")
+    with pytest.raises(ValueError):
+        doctor._granola_api_key(context)  # present-but-unparseable surfaces, never "no key"
 
 
 def test_registry_ids_match_the_approved_spec():
@@ -1236,8 +1372,9 @@ def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(
     actions, errors = doctor._apply_t1_heals(context)
 
     assert errors == []
-    assert "regenerated core/paths.json" in actions
-    assert any("restored executable permission" in action for action in actions)
+    structure_actions = actions["vault.structure"]
+    assert "regenerated core/paths.json" in structure_actions
+    assert any("restored executable permission" in action for action in structure_actions)
     assert len(calls) == 1
     assert calls[0][1]["purpose"] == "doctor-tier-1"
     assert (context.vault_root / "core/paths.json").is_file()
@@ -1269,7 +1406,7 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
     monkeypatch.setattr(
         doctor,
         "_apply_t1_heals",
-        lambda _context: (["regenerated core/paths.json"], []),
+        lambda _context: ({"vault.structure": ["regenerated core/paths.json"]}, []),
     )
 
     def explode(_context):
@@ -1290,7 +1427,7 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
 def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, capsys):
     _stub_probes(monkeypatch)
     calls = []
-    monkeypatch.setattr(doctor, "_apply_t1_heals", lambda candidate: (calls.append(candidate) or [], []))
+    monkeypatch.setattr(doctor, "_apply_t1_heals", lambda candidate: (calls.append(candidate) or {}, []))
 
     assert doctor.main(["--heal"], context=context) == 0
     assert json.loads(capsys.readouterr().out)["mode"] == "quick"

--- a/core/tests/test_error_queue_lifecycle.py
+++ b/core/tests/test_error_queue_lifecycle.py
@@ -272,7 +272,7 @@ def test_tier_one_heal_acknowledges_only_errors_resolved_by_newer_success(
     actions, errors = doctor._apply_t1_heals(context)
 
     assert errors == []
-    assert actions == ["acknowledged 1 resolved preflight error"]
+    assert actions == {"preflight.queue": ["acknowledged 1 resolved preflight error"]}
     saved = {entry["source"]: entry for entry in _queue(vault)}
     assert saved["update-checker"]["acknowledged"] is True
     assert saved["work-mcp"]["acknowledged"] is False

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -73,8 +73,9 @@ def test_service_owned_repair_crosses_transaction_and_declares_every_write(
     after = snapshot_vault(vault)
 
     assert errors == []
-    assert "regenerated core/paths.json" in actions
-    assert any("restored executable permission" in action for action in actions)
+    structure_actions = actions["vault.structure"]
+    assert "regenerated core/paths.json" in structure_actions
+    assert any("restored executable permission" in action for action in structure_actions)
     assert len(receipts) == 1
     receipt = receipts[0]
     assert receipt["purpose"] == "doctor-tier-1"

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator, Mapping
@@ -790,9 +790,36 @@ def _requeue_entity_dead_letters(context: DoctorContext) -> dict[str, Any]:
     return parsed
 
 
-def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
-    """Preview and apply contract-authorized Tier-1 repairs through the service."""
-    actions: list[str] = []
+def _tighten_env_permissions(context: DoctorContext) -> None:
+    """chmod the vault .env to 0600 through a no-follow descriptor.
+
+    Metadata-only: no bytes are ever read from the file. The descriptor-based
+    re-verification (regular file, owned by us) closes the lstat→chmod race a
+    path-based ``os.chmod`` would leave open — a symlink swapped in between
+    would otherwise be followed to an arbitrary target.
+    """
+    descriptor = os.open(
+        context.vault_root / ".env",
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(".env changed identity during the permission repair")
+        if hasattr(os, "geteuid") and opened.st_uid != os.geteuid():
+            raise OSError(".env is owned by another user")
+        os.fchmod(descriptor, 0o600)
+    finally:
+        os.close(descriptor)
+
+
+def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[str]]:
+    """Preview and apply contract-authorized Tier-1 repairs through the service.
+
+    Returns applied actions keyed by the check id they belong to — routing on
+    check id, never on the human wording of an action string — plus errors.
+    """
+    actions: dict[str, list[str]] = {}
     errors: list[str] = []
     planned: list[PlanEntry] = []
     planned_paths_export = False
@@ -859,11 +886,16 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
             errors.append(f"Executable-mode heal failed for {script}: {_one_line(error)}")
 
     try:
-        if _env_permissions_issue(context) is not None:
+        finding = _env_permission_finding(context)
+        if finding is not None and finding.auto_tighten:
             # Metadata-only repair: never reads, copies, or snapshots the
             # secrets inside .env — it only removes group/other access.
-            os.chmod(context.vault_root / ".env", 0o600)
-            actions.append("tightened .env to owner-only permissions")
+            # Findings that cannot be auto-tightened (foreign owner, symlink)
+            # carry their own Tier-3 guidance and are never attempted here.
+            _tighten_env_permissions(context)
+            actions.setdefault("vault.configs", []).append(
+                "tightened .env to owner-only permissions"
+            )
     except OSError as error:
         errors.append(f".env permission heal failed: {_one_line(error)}")
 
@@ -874,7 +906,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
             requeued = healed["requeued"]
             if requeued:
                 noun = "write" if requeued == 1 else "writes"
-                actions.append(
+                actions.setdefault("entity.engine", []).append(
                     f"re-queued {requeued} dead-lettered entity {noun} with retry counters reset"
                 )
         except Exception as error:
@@ -884,7 +916,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
         acknowledged = _acknowledge_resolved_preflight_errors(context)
         if acknowledged:
             noun = "error" if acknowledged == 1 else "errors"
-            actions.append(
+            actions.setdefault("preflight.queue", []).append(
                 f"acknowledged {acknowledged} resolved preflight {noun}"
             )
     except Exception as error:
@@ -905,7 +937,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
             )
             if any(result.get("user_content_deleted") is not False for result in reconciled):
                 raise RuntimeError("capability reconciliation did not preserve user content")
-            actions.append(
+            actions.setdefault("capabilities.rooms", []).append(
                 "reconciled capability room assets without deleting user content"
             )
     except Exception as error:
@@ -928,10 +960,10 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
             errors.append(f"Tier-1 transaction failed: {_one_line(error)}")
         else:
             if planned_paths_export:
-                actions.append("regenerated core/paths.json")
+                actions.setdefault("vault.structure", []).append("regenerated core/paths.json")
             if planned_executables:
                 noun = "permission" if len(planned_executables) == 1 else "permissions"
-                actions.append(
+                actions.setdefault("vault.structure", []).append(
                     f"restored executable {noun} on {', '.join(planned_executables)}"
                 )
 
@@ -972,7 +1004,7 @@ def collect(
     results: dict[str, ProbeResult] = {}
     failed: list[dict[str, str]] = []
 
-    t1_actions: list[str] = []
+    t1_actions: dict[str, list[str]] = {}
     if heal:
         try:
             t1_actions, t1_errors = _apply_t1_heals(context)
@@ -1001,72 +1033,55 @@ def collect(
                 )
             if result.verdict == "UNKNOWN" and _is_missing_package_error(result.detail):
                 result = ProbeResult("UNKNOWN", MISSING_PACKAGES_DETAIL, result.heal)
-            entity_actions = [
-                action for action in t1_actions if action.startswith("re-queued ")
-            ]
-            preflight_actions = [
-                action for action in t1_actions if action.startswith("acknowledged ")
-            ]
-            capability_actions = [
-                action for action in t1_actions if action.startswith("reconciled capability ")
-            ]
-            config_actions = [
-                action for action in t1_actions if action.startswith("tightened ")
-            ]
-            structure_actions = [
-                action
-                for action in t1_actions
-                if not action.startswith(
-                    ("re-queued ", "acknowledged ", "reconciled capability ", "tightened ")
-                )
-            ]
-            if definition.id == "vault.structure" and structure_actions:
-                action = "; ".join(structure_actions) + "."
+            check_actions = t1_actions.get(definition.id, [])
+            if definition.id == "vault.structure" and check_actions:
+                action = "; ".join(check_actions) + "."
                 if result.verdict == "OK":
-                    repair_word = _repair_count_word(len(structure_actions))
-                    repair_noun = "repair" if len(structure_actions) == 1 else "repairs"
+                    repair_word = _repair_count_word(len(check_actions))
+                    repair_noun = "repair" if len(check_actions) == 1 else "repairs"
                     detail = f"All standard PARA directories exist after {repair_word} safe {repair_noun}"
                 else:
                     detail = f"{result.detail.rstrip('.')} while safe Tier-1 repairs were also applied"
-                result = ProbeResult(
-                    result.verdict,
-                    detail,
-                    Heal(tier=1, action=action, applied=True),
+                result = replace(
+                    result,
+                    detail=detail,
+                    heal=Heal(tier=1, action=action, applied=True),
                 )
-            if definition.id == "entity.engine" and entity_actions:
-                result = ProbeResult(
-                    result.verdict,
-                    result.detail,
-                    Heal(tier=1, action="; ".join(entity_actions) + ".", applied=True),
-                    feature_status=result.feature_status,
-                    user_message=result.user_message,
+            if definition.id == "entity.engine" and check_actions:
+                result = replace(
+                    result,
+                    heal=Heal(tier=1, action="; ".join(check_actions) + ".", applied=True),
                 )
-            if definition.id == "preflight.queue" and preflight_actions:
-                action = "; ".join(preflight_actions) + "."
-                result = ProbeResult(
-                    result.verdict,
-                    f"{result.detail.rstrip('.')} after a safe Tier-1 queue repair",
-                    Heal(tier=1, action=action, applied=True),
-                    feature_status=result.feature_status,
-                    user_message=result.user_message,
+            if definition.id == "preflight.queue" and check_actions:
+                result = replace(
+                    result,
+                    detail=f"{result.detail.rstrip('.')} after a safe Tier-1 queue repair",
+                    heal=Heal(tier=1, action="; ".join(check_actions) + ".", applied=True),
                 )
-            if definition.id == "vault.configs" and config_actions:
-                action = "; ".join(config_actions) + "."
-                result = ProbeResult(
-                    result.verdict,
-                    f"{result.detail.rstrip('.')} after a safe Tier-1 permission repair",
-                    Heal(tier=1, action=action, applied=True),
-                    feature_status=result.feature_status,
-                    user_message=result.user_message,
-                )
-            if definition.id == "capabilities.rooms" and capability_actions:
-                action = "; ".join(capability_actions) + "."
-                result = ProbeResult(
-                    result.verdict,
-                    f"{result.detail.rstrip('.')} after a safe Tier-1 reconciliation",
-                    Heal(tier=1, action=action, applied=True),
-                    feature_status=result.feature_status,
-                    user_message=result.user_message,
+            if definition.id == "vault.configs" and check_actions:
+                # Merge, never replace: when the probe is still BROKEN (a
+                # parse failure, or a symlink/foreign-owner .env finding),
+                # its verdict and actionable heal must survive — the applied
+                # env repair is only appended as extra detail.
+                if result.verdict == "OK" and result.heal is None:
+                    result = replace(
+                        result,
+                        detail=f"{result.detail.rstrip('.')} after a safe Tier-1 permission repair",
+                        heal=Heal(tier=1, action="; ".join(check_actions) + ".", applied=True),
+                    )
+                else:
+                    result = replace(
+                        result,
+                        detail=(
+                            f"{result.detail.rstrip('.')}; a safe Tier-1 repair separately "
+                            + "; ".join(check_actions)
+                        ),
+                    )
+            if definition.id == "capabilities.rooms" and check_actions:
+                result = replace(
+                    result,
+                    detail=f"{result.detail.rstrip('.')} after a safe Tier-1 reconciliation",
+                    heal=Heal(tier=1, action="; ".join(check_actions) + ".", applied=True),
                 )
             results[definition.id] = result
     finally:
@@ -1180,23 +1195,84 @@ def _probe_vault_structure(context: DoctorContext) -> ProbeResult:
     return ProbeResult("OK", "All standard PARA directories exist")
 
 
-def _env_permissions_issue(context: DoctorContext) -> str | None:
-    """Report a vault .env readable by other users; never reads its contents."""
+@dataclass(frozen=True)
+class EnvPermissionFinding:
+    """One diagnosable problem with the vault-root .env's file authority."""
+
+    detail: str
+    heal: Heal
+    auto_tighten: bool
+
+
+def _env_permission_finding(context: DoctorContext) -> EnvPermissionFinding | None:
+    """Classify a vault .env readable by other users; never reads its contents.
+
+    Three shapes, matching how (and whether) the Tier-1 heal may act:
+    - a regular file we own → Tier-1, auto-tightenable;
+    - a regular file owned by another user → Tier-3 manual guidance (a chmod
+      attempt would fail on every heal run and flip doctor.self BROKEN);
+    - a symlink whose target is loose → Tier-3 manual guidance (Dex never
+      chmods through a link, but every .env reader follows it, so staying
+      silent would pass a world-readable key file as OK).
+    """
     if os.name != "posix":
         return None
+    env_path = context.vault_root / ".env"
     try:
-        metadata = (context.vault_root / ".env").lstat()
+        metadata = env_path.lstat()
     except OSError:
         return None
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            target = env_path.stat()
+        except OSError:
+            return None
+        target_mode = stat.S_IMODE(target.st_mode)
+        if not stat.S_ISREG(target.st_mode) or not target_mode & 0o077:
+            return None
+        try:
+            resolved = env_path.resolve(strict=True)
+        except OSError:
+            return None
+        return EnvPermissionFinding(
+            detail=(
+                f".env is a symlink whose target is readable by other users of this "
+                f"machine (permissions {target_mode:03o}); Dex never auto-tightens "
+                "through a link"
+            ),
+            heal=Heal(
+                tier=3,
+                action=f"Run: chmod 600 '{resolved}' (the symlink's real target).",
+                applied=False,
+            ),
+            auto_tighten=False,
+        )
     if not stat.S_ISREG(metadata.st_mode):
         return None
     mode = stat.S_IMODE(metadata.st_mode)
-    if mode & 0o077:
-        return (
+    if not mode & 0o077:
+        return None
+    if hasattr(os, "geteuid") and metadata.st_uid != os.geteuid():
+        return EnvPermissionFinding(
+            detail=(
+                f".env is readable by other users of this machine (permissions "
+                f"{mode:03o}) and is owned by another user, so Dex cannot tighten it"
+            ),
+            heal=Heal(
+                tier=3,
+                action="As the file's owner, run: chmod 600 .env — and chown it to your user.",
+                applied=False,
+            ),
+            auto_tighten=False,
+        )
+    return EnvPermissionFinding(
+        detail=(
             f".env is readable by other users of this machine (permissions {mode:03o}; "
             "the API keys it holds belong in an owner-only file)"
-        )
-    return None
+        ),
+        heal=Heal(tier=1, action="Tighten .env to owner-only permissions.", applied=False),
+        auto_tighten=True,
+    )
 
 
 def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
@@ -1221,19 +1297,21 @@ def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
             raise
         except Exception as error:
             failures.append(f"{config_path.name} could not be parsed ({_one_line(error)})")
+    env_finding = _env_permission_finding(context)
     if failures:
+        # The parse failures keep the Tier-3 hand-repair heal, but the
+        # security finding must never be masked by an unrelated config
+        # problem — report both in the same detail.
+        detail = "; ".join(failures)
+        if env_finding is not None:
+            detail += f"; {env_finding.detail}"
         return ProbeResult(
             "BROKEN",
-            "; ".join(failures),
+            detail,
             Heal(tier=3, action="Repair the named configuration file by hand.", applied=False),
         )
-    env_issue = _env_permissions_issue(context)
-    if env_issue:
-        return ProbeResult(
-            "BROKEN",
-            env_issue,
-            Heal(tier=1, action="Tighten .env to owner-only permissions.", applied=False),
-        )
+    if env_finding is not None:
+        return ProbeResult("BROKEN", env_finding.detail, env_finding.heal)
     return ProbeResult("OK", "user-profile.yaml, pillars.yaml, and .claude/settings.json all parse")
 
 
@@ -4462,26 +4540,26 @@ def _looks_like_sandbox_failure(detail: str) -> bool:
     )
 
 
-def _env_file_value(env_path: Path, name: str) -> str | None:
-    """Parse one value from a dotenv-style file without executing it."""
+def _read_vault_env_values(context: DoctorContext) -> dict[str, str]:
+    """Parse the vault-root .env with the shared strict credential parser.
+
+    Delegates decoding to ``integration_credentials.parse_env_assignments`` so
+    the doctor sees exactly the values every credential path sees (quoted and
+    JSON-escaped values decode identically) instead of keeping a divergent
+    dotenv dialect. Returns ``{}`` when the file is absent; a present-but-
+    unreadable or unparseable file raises (``OSError``/``UnicodeDecodeError``/
+    ``ValueError``) so callers can distinguish "no file" from "cannot read".
+    Deliberately does not validate permissions or ownership — the doctor must
+    be able to see keys inside a loose-permission .env (that looseness is the
+    vault.configs finding, not a reason to go blind).
+    """
+    from core.utils.integration_credentials import parse_env_assignments
+
     try:
-        content = env_path.read_text()
-    except OSError:
-        return None
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line.removeprefix("export ").strip()
-        key, separator, value = line.partition("=")
-        if not separator or key.strip() != name:
-            continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            value = value[1:-1]
-        return value or None
-    return None
+        raw = (context.vault_root / ".env").read_bytes()
+    except FileNotFoundError:
+        return {}
+    return parse_env_assignments(raw)
 
 
 LLM_KEY_NAMES = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")
@@ -4492,19 +4570,30 @@ def _llm_key_available(context: DoctorContext) -> bool:
 
     Presence only: this mirrors how the background LLM consumers resolve keys
     (environment first, then the vault-root .env via dotenv). The key values
-    are never returned, logged, or included in any probe detail.
+    are never returned, logged, or included in any probe detail. An unreadable
+    or unparseable .env counts as "no key confirmed" rather than an error, so
+    a stray byte in .env can never flip the entity-engine check to UNKNOWN.
     """
     if any((os.environ.get(name) or "").strip() for name in LLM_KEY_NAMES):
         return True
-    env_path = context.vault_root / ".env"
-    return any(_env_file_value(env_path, name) for name in LLM_KEY_NAMES)
+    try:
+        values = _read_vault_env_values(context)
+    except (OSError, UnicodeDecodeError, ValueError):
+        return False
+    return any(values.get(name) for name in LLM_KEY_NAMES)
 
 
 def _granola_api_key(context: DoctorContext) -> str | None:
+    """Resolve the Granola key: environment first, then the vault-root .env.
+
+    Returns ``None`` only when the key is genuinely absent. A present-but-
+    unreadable or unparseable .env raises so the probe surfaces the real cause
+    as UNKNOWN instead of telling the user to add a key that is already there.
+    """
     configured = os.environ.get("GRANOLA_API_KEY")
     if configured and configured.strip():
         return configured.strip()
-    return _env_file_value(context.vault_root / ".env", "GRANOLA_API_KEY")
+    return _read_vault_env_values(context).get("GRANOLA_API_KEY") or None
 
 
 def _granola_filtered_query(context: DoctorContext) -> list[dict[str, Any]]:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -858,6 +858,15 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[list[str], list[str]]:
         except OSError as error:
             errors.append(f"Executable-mode heal failed for {script}: {_one_line(error)}")
 
+    try:
+        if _env_permissions_issue(context) is not None:
+            # Metadata-only repair: never reads, copies, or snapshots the
+            # secrets inside .env — it only removes group/other access.
+            os.chmod(context.vault_root / ".env", 0o600)
+            actions.append("tightened .env to owner-only permissions")
+    except OSError as error:
+        errors.append(f".env permission heal failed: {_one_line(error)}")
+
     dead_letter_path = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
     if dead_letter_path.exists():
         try:
@@ -1001,11 +1010,14 @@ def collect(
             capability_actions = [
                 action for action in t1_actions if action.startswith("reconciled capability ")
             ]
+            config_actions = [
+                action for action in t1_actions if action.startswith("tightened ")
+            ]
             structure_actions = [
                 action
                 for action in t1_actions
                 if not action.startswith(
-                    ("re-queued ", "acknowledged ", "reconciled capability ")
+                    ("re-queued ", "acknowledged ", "reconciled capability ", "tightened ")
                 )
             ]
             if definition.id == "vault.structure" and structure_actions:
@@ -1034,6 +1046,15 @@ def collect(
                 result = ProbeResult(
                     result.verdict,
                     f"{result.detail.rstrip('.')} after a safe Tier-1 queue repair",
+                    Heal(tier=1, action=action, applied=True),
+                    feature_status=result.feature_status,
+                    user_message=result.user_message,
+                )
+            if definition.id == "vault.configs" and config_actions:
+                action = "; ".join(config_actions) + "."
+                result = ProbeResult(
+                    result.verdict,
+                    f"{result.detail.rstrip('.')} after a safe Tier-1 permission repair",
                     Heal(tier=1, action=action, applied=True),
                     feature_status=result.feature_status,
                     user_message=result.user_message,
@@ -1159,6 +1180,25 @@ def _probe_vault_structure(context: DoctorContext) -> ProbeResult:
     return ProbeResult("OK", "All standard PARA directories exist")
 
 
+def _env_permissions_issue(context: DoctorContext) -> str | None:
+    """Report a vault .env readable by other users; never reads its contents."""
+    if os.name != "posix":
+        return None
+    try:
+        metadata = (context.vault_root / ".env").lstat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(metadata.st_mode):
+        return None
+    mode = stat.S_IMODE(metadata.st_mode)
+    if mode & 0o077:
+        return (
+            f".env is readable by other users of this machine (permissions {mode:03o}; "
+            "the API keys it holds belong in an owner-only file)"
+        )
+    return None
+
+
 def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
     config_files = (
         (context.core_path("USER_PROFILE_FILE"), "yaml"),
@@ -1186,6 +1226,13 @@ def _probe_vault_configs(context: DoctorContext) -> ProbeResult:
             "BROKEN",
             "; ".join(failures),
             Heal(tier=3, action="Repair the named configuration file by hand.", applied=False),
+        )
+    env_issue = _env_permissions_issue(context)
+    if env_issue:
+        return ProbeResult(
+            "BROKEN",
+            env_issue,
+            Heal(tier=1, action="Tighten .env to owner-only permissions.", applied=False),
         )
     return ProbeResult("OK", "user-profile.yaml, pillars.yaml, and .claude/settings.json all parse")
 
@@ -4316,7 +4363,7 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         )
         if profile.get("entity_gardener", {}).get("enabled") is False:
             gardener_label = "off (disabled)"
-        elif not any(os.environ.get(key) for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")):
+        elif not _llm_key_available(context):
             gardener_label = "off (no LLM key)"
         else:
             maintained = sum(bool(item.get("output_hash")) for item in gardener_pages.values())
@@ -4415,27 +4462,49 @@ def _looks_like_sandbox_failure(detail: str) -> bool:
     )
 
 
-def _granola_api_key(context: DoctorContext) -> str | None:
-    configured = os.environ.get("GRANOLA_API_KEY")
-    if configured and configured.strip():
-        return configured.strip()
-    env_path = context.vault_root / ".env"
-    if not env_path.exists():
+def _env_file_value(env_path: Path, name: str) -> str | None:
+    """Parse one value from a dotenv-style file without executing it."""
+    try:
+        content = env_path.read_text()
+    except OSError:
         return None
-    for raw_line in env_path.read_text().splitlines():
+    for raw_line in content.splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         if line.startswith("export "):
             line = line.removeprefix("export ").strip()
-        name, separator, value = line.partition("=")
-        if not separator or name.strip() != "GRANOLA_API_KEY":
+        key, separator, value = line.partition("=")
+        if not separator or key.strip() != name:
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
             value = value[1:-1]
         return value or None
     return None
+
+
+LLM_KEY_NAMES = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")
+
+
+def _llm_key_available(context: DoctorContext) -> bool:
+    """True when an LLM key exists in the environment or the vault-root .env.
+
+    Presence only: this mirrors how the background LLM consumers resolve keys
+    (environment first, then the vault-root .env via dotenv). The key values
+    are never returned, logged, or included in any probe detail.
+    """
+    if any((os.environ.get(name) or "").strip() for name in LLM_KEY_NAMES):
+        return True
+    env_path = context.vault_root / ".env"
+    return any(_env_file_value(env_path, name) for name in LLM_KEY_NAMES)
+
+
+def _granola_api_key(context: DoctorContext) -> str | None:
+    configured = os.environ.get("GRANOLA_API_KEY")
+    if configured and configured.strip():
+        return configured.strip()
+    return _env_file_value(context.vault_root / ".env", "GRANOLA_API_KEY")
 
 
 def _granola_filtered_query(context: DoctorContext) -> list[dict[str, Any]]:

--- a/docs/dex-doctor-spec.md
+++ b/docs/dex-doctor-spec.md
@@ -32,7 +32,9 @@ where that is provably safe and user guidance only where Dex genuinely cannot ac
    - **T1 — auto-fix silently, report after.** Only actions that are provably safe,
      idempotent, and reversible, touching no user data and no credentials:
      create missing standard PARA directories; regenerate the generated `core/paths.json`;
-     restore executable bits on repo-shipped scripts.
+     restore executable bits on repo-shipped scripts; tighten a vault-root `.env` that other
+     accounts could read to owner-only permissions (permission bits only — the file's
+     contents are never read, copied, or logged).
    - **T2 — propose, fix on explicit yes.** State-changing but standard: load an installed-
      but-unloaded `com.dex.*` launch agent; re-run plist substitution from templates;
      repair a `.mcp.json` entry whose target file is missing (additive/corrective edits

--- a/docs/dex-doctor-spec.md
+++ b/docs/dex-doctor-spec.md
@@ -42,8 +42,10 @@ where that is provably safe and user guidance only where Dex genuinely cannot ac
    - **T3 — user-only, guided.** Grant macOS Calendar/Reminders permission; paste an API
      key; install an app (Granola, node, bun/qmd); sign in. Doctor gives exact steps and
      the skill to run (e.g. `/granola-setup`).
-   - **Never:** delete or overwrite user data; touch credentials; force-anything. A doctor
-     that mis-heals is worse than one that only reports.
+   - **Never:** delete or overwrite user data; touch credential *contents*; force-anything.
+     (The one credential-adjacent T1 heal — tightening `.env` to owner-only — changes
+     permission bits through a no-follow descriptor and never reads, copies, or logs a
+     byte of the file.) A doctor that mis-heals is worse than one that only reports.
 
 ## Architecture
 
@@ -103,7 +105,7 @@ repointed to `/dex-doctor`.
 | id | probe | OFF when | BROKEN when |
 |---|---|---|---|
 | vault.structure | PARA dirs from `core.paths` exist | — | missing dirs (T1 heal: create) |
-| vault.configs | `user-profile.yaml`, `pillars.yaml`, `.claude/settings.json` parse | — | parse error (T3: guided repair) |
+| vault.configs | `user-profile.yaml`, `pillars.yaml`, `.claude/settings.json` parse; vault-root `.env` is owner-only | — | parse error (T3: guided repair) / `.env` readable by other users (T1 heal: tighten to 0600 when we own the regular file; T3 manual guidance when `.env` is a symlink or owned by another user). Both conditions are always evaluated — a parse failure never hides the permission finding, and the post-heal annotation appends to a still-BROKEN result instead of replacing its heal |
 | mcp.registered | `.mcp.json` exists, valid; every entry's target file exists | no `.mcp.json` + never onboarded | entry → missing file (T2 repair) |
 | mcp.orphans | every `core/mcp/*_server.py` present in `.mcp.json` | — | orphaned server (T2 add) |
 | python.env | `.venv` python exists; `mcp`, `yaml`, `dateutil`, `requests` importable | — | missing (T2: pip install into venv) |


### PR DESCRIPTION
## What this does

Chris's report (#361) found that LLM API keys sit in a plain-text `.env` at the vault root, readable by other accounts on the machine, while Dex's checkup couldn't even see them. This PR ships the three safe hardening effects he listed — without touching how the keys are consumed.

### 1. Permissions — `.env` becomes owner-only

- Every skill flow that creates or writes `.env` (`/granola-setup`, `/integrate-mcp`, `/prompt-improver`, `/create-mcp`) now sets it owner-only (`chmod 600`). The Todoist/Trello setups already required mode 0600, and the credential-remediation engine already wrote it that way — this closes the remaining doors.
- The meeting-intel installer (`install-automation.sh`) tightens an existing `.env` when it runs.
- **Doctor Tier-1 heal:** `vault.configs` now flags a group/other-readable `.env` as BROKEN with a Tier-1 heal, and `--heal` tightens it. The heal is metadata-only — it changes permission bits and never reads, copies, snapshots, or logs the file's contents (which is also why it deliberately does not go through the transaction engine: a content-declared write would copy the secrets into a snapshot). Matches today's conventions: unapplied `Heal(tier=1, applied=False)` on the probe, applied action attributed back to the check with `applied=True`, same as the PARA-directory and executable-bit heals.

### 2. Doctor blind spot — the entity check now looks where the feature looks

`_probe_entity_engine`'s gardener status tested `os.environ` only, so a key sitting in `.env` produced "off (no LLM key)" — the doctor recommended a storage location it didn't itself check. The check now resolves keys the way the background consumers actually do: environment first, then a **parsed** (never sourced/executed) vault-root `.env`. It's a presence check only — the key's value is never returned, and a regression test asserts no key value can appear anywhere in the report. The existing Granola `.env` lookup was refactored onto the same shared parser.

### 3. Guidance — stop steering users wrong

Messages that instruct users to put keys in `.env` (llm-client, sync-from-granola, the setup skills) still point there — it's the only location these features read — but now say to keep the file owner-only, and the main error message is honest that `/connect`'s encrypted store does not feed the background LLM features yet.

## Deliberately deferred (out of scope)

Migrating `.scripts/lib/llm-client.cjs` and the entity gardener onto the encrypted connection manager (connection-manager-first resolution with `.env` fallback, per the issue's main suggestion) is a design decision being discussed separately and is **not** attempted here.

## Tests

- 4 new regression tests in `core/tests/test_doctor.py`: probe flags loose permissions with a Tier-1 heal; `_apply_t1_heals` tightens to 0600 without touching contents (and is idempotent); `collect(heal=True)` annotates `vault.configs` with the applied heal; the entity probe finds a key in `.env`, treats an empty value as absent, and never leaks the value. All key strings in tests are obvious placeholders.
- `core/tests/test_doctor.py`: 176 passed, 1 pre-existing environment failure (`test_launchctl_domain_failure_is_an_unknown_instrument` — macOS-only `launchctl`, fails identically on a clean checkout of main on this Linux box).
- `npm run test:scripts`: 152 passed, 11 pre-existing failures identical on clean main (Python-bridge byte-equality tests needing the vault venv).
- `ruff check` on changed files: clean (repo-wide ruff shows the same 35 pre-existing findings on clean main).
- `scripts/check-founder-content.sh`, `scripts/check-architecture-inventory.sh`: pass.

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)