### PR TITLE
Task IDs no longer collide past 999 (widen \d{3} at 16 sites; digit-boundary matching)

### DIFF
--- a/.claude/hooks/adapters/todoist.cjs
+++ b/.claude/hooks/adapters/todoist.cjs
@@ -11,7 +11,7 @@ const REQUEST_TIMEOUT_MS = 15_000;
 const MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY_MS = 2_000;
 const COMPLETION_WINDOW_MS = 89 * 24 * 60 * 60 * 1_000;
-const DEX_ID_PATTERN = /\[dex:(task-\d{8}-\d{3})\]/;
+const DEX_ID_PATTERN = /\[dex:(task-\d{8}-\d{3,})\]/;
 const DEX_TO_TODOIST_PRIORITY = { P0: 4, P1: 3, P2: 2, P3: 1 };
 
 const projectCache = new Map();

--- a/.claude/hooks/meeting-cache-builder.cjs
+++ b/.claude/hooks/meeting-cache-builder.cjs
@@ -103,7 +103,7 @@ function extractSection(content, heading) {
       item = item.replace(/^\[[ x]\]\s*/, "");
       // Strip completion timestamps and task IDs in either stored layout.
       item = item.replace(/\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}/, "");
-      item = item.replace(/\s*\^task-\d{8}-\d{3}\b/, "");
+      item = item.replace(/\s*\^task-\d{8}-\d{3,}\b/, "");
       // Strip WikiLink wrappers: [[path|display]] -> display
       item = item.replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, "$1");
       item = item.replace(/\[\[([^\]]*)\]\]/g, "$1");

--- a/core/integrations/task_sync.py
+++ b/core/integrations/task_sync.py
@@ -25,7 +25,7 @@ from core.utils.strict_yaml import load_yaml_path
 
 ADAPTERS_DIR = VAULT_ROOT / ".claude" / "hooks" / "adapters"
 _SERVICE_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
-_TASK_ID_PATTERN = re.compile(r"^task-(\d{8})-\d{3}$")
+_TASK_ID_PATTERN = re.compile(r"^task-(\d{8})-\d{3,}$")
 
 
 def _now_iso() -> str:

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -448,7 +448,7 @@ def generate_task_id() -> str:
         for md_file in folder.rglob('*.md'):
             try:
                 content = md_file.read_text()
-                pattern = r'\^task-\d{8}-(\d{3})'
+                pattern = r'\^task-\d{8}-(\d{3,})'
                 matches = re.findall(pattern, content)
                 existing_ids.extend([int(m) for m in matches])
             except Exception:
@@ -460,7 +460,7 @@ def generate_task_id() -> str:
 
 def extract_task_id(line: str) -> Optional[str]:
     """Extract task ID from a line"""
-    match = re.search(r'\^(task-\d{8}-\d{3})', line)
+    match = re.search(r'\^(task-\d{8}-\d{3,})', line)
     return match.group(1) if match else None
 
 def _is_indented_bullet(line: str) -> bool:
@@ -564,7 +564,7 @@ def _task_title_from_line(line: str) -> str:
     """Extract task text while accepting both completion timestamp layouts."""
     title = re.sub(r'^\s*-\s*\[[x ]\]\s*', '', line, count=1)
     title = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', title)
-    title = re.sub(r'\s*\^task-\d{8}-\d{3}\b', '', title)
+    title = re.sub(r'\s*\^task-\d{8}-\d{3,}\b', '', title)
     title = title.strip()
     bold_match = re.match(r'^\*\*(.+?)\*\*(.*)$', title)
     if bold_match:
@@ -596,7 +596,7 @@ def _source_page_path(source: str) -> Optional[Path]:
 
 def _line_without_task_anchor(line: str) -> str:
     """Remove a task anchor for idempotent source-line comparison."""
-    return re.sub(r'\s+\^task-\d{8}-\d{3}\b', '', line).strip()
+    return re.sub(r'\s+\^task-\d{8}-\d{3,}\b', '', line).strip()
 
 
 def stamp_task_source_line(source: str, source_line: str,
@@ -626,8 +626,8 @@ def stamp_task_source_line(source: str, source_line: str,
             if stripped == target:
                 exact_matches.append(index)
             elif (
-                not re.search(r'\^task-\d{8}-\d{3}\b', target)
-                and re.search(r'\^task-\d{8}-\d{3}\b', stripped)
+                not re.search(r'\^task-\d{8}-\d{3,}\b', target)
+                and re.search(r'\^task-\d{8}-\d{3,}\b', stripped)
                 and _line_without_task_anchor(stripped) == target
             ):
                 anchored_matches.append(index)
@@ -641,7 +641,7 @@ def stamp_task_source_line(source: str, source_line: str,
         if len(exact_matches) == 1:
             match_index = exact_matches[0]
             matched_line = lines[match_index].rstrip('\r\n')
-            if re.search(r'\^task-\d{8}-\d{3}\b', matched_line):
+            if re.search(r'\^task-\d{8}-\d{3,}\b', matched_line):
                 return {**result, 'reason': 'already_anchored'}
 
             line_ending = lines[match_index][len(matched_line):]
@@ -669,14 +669,17 @@ def stamp_task_source_line(source: str, source_line: str,
 def find_task_by_id(task_id: str) -> List[Dict[str, Any]]:
     """Find all instances of a task ID across all markdown files"""
     instances = []
-    
+    # Anchor on a digit boundary: a plain substring test lets task-...-100
+    # match inside task-...-1000 and update the wrong row.
+    anchored = re.compile(r'\^' + re.escape(task_id) + r'(?!\d)')
+
     for md_file in BASE_DIR.rglob('*.md'):
         try:
             content = md_file.read_text()
             lines = content.split('\n')
-            
+
             for i, line in enumerate(lines):
-                if f'^{task_id}' in line and ('- [ ]' in line or '- [x]' in line):
+                if anchored.search(line) and ('- [ ]' in line or '- [x]' in line):
                     # Extract task title
                     title = _task_title_from_line(line).split('|', 1)[0].strip()
                     
@@ -758,7 +761,7 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
             if completed:
                 new_line = old_line.replace('- [ ]', '- [x]')
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
-                task_id_match = re.search(r'\^' + re.escape(task_id), new_line)
+                task_id_match = re.search(r'\^' + re.escape(task_id) + r'(?!\d)', new_line)
                 if task_id_match:
                     without_anchor = (
                         new_line[:task_id_match.start()] + new_line[task_id_match.end():]
@@ -768,7 +771,7 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
                 # Uncompleting: change checkbox and remove timestamp
                 new_line = old_line.replace('- [x]', '- [ ]')
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
-                task_id_match = re.search(r'\^' + re.escape(task_id), new_line)
+                task_id_match = re.search(r'\^' + re.escape(task_id) + r'(?!\d)', new_line)
                 if task_id_match:
                     without_anchor = (
                         new_line[:task_id_match.start()] + new_line[task_id_match.end():]
@@ -1795,7 +1798,7 @@ def _parse_meeting_file_python(content: str, filename: str, rel_path: str) -> Di
                 item = stripped[2:].strip()
                 item = re.sub(r'^\[[ x]\]\s*', '', item)
                 item = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', item)
-                item = re.sub(r'\s*\^task-\d{8}-\d{3}\b', '', item)
+                item = re.sub(r'\s*\^task-\d{8}-\d{3,}\b', '', item)
                 item = re.sub(r'\[\[[^\]|]*\|([^\]]*)\]\]', r'\1', item)
                 item = re.sub(r'\[\[([^\]]*)\]\]', r'\1', item)
                 item = re.sub(r'\*\*([^*]+)\*\*', r'\1', item)
@@ -2704,7 +2707,7 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
             # Clean title - remove file path references for display
             clean_title = re.sub(r'\s*\|\s*(?:People|Active)/[^\s]+', '', title)
             clean_title = re.sub(r'\s+\.md\b', '', clean_title)
-            clean_title = re.sub(r'\s*\^task-\d{8}-\d{3}\s*', '', clean_title)  # Remove task ID
+            clean_title = re.sub(r'\s*\^task-\d{8}-\d{3,}\s*', '', clean_title)  # Remove task ID
             if not clean_title.strip():
                 continue
             
@@ -3757,7 +3760,7 @@ async def handle_list_tools() -> list[types.Tool]:
                 "properties": {
                     "task_id": {
                         "type": "string",
-                        "pattern": r"^task-\d{8}-\d{3}$",
+                        "pattern": r"^task-\d{8}-\d{3,}$",
                         "description": "Task ID without the leading caret (e.g., task-20260128-001)",
                     },
                     "action": {

--- a/core/obsidian/migrate_to_wikilinks.py
+++ b/core/obsidian/migrate_to_wikilinks.py
@@ -98,7 +98,7 @@ def convert_references_in_file(content: str, person_idx: dict,
             changes += matches
     
     # Convert task ID references (^task-YYYYMMDD-XXX)
-    pattern = r'(?<!\[\[)\^(task-\d{8}-\d{3})(?!\]\])'
+    pattern = r'(?<!\[\[)\^(task-\d{8}-\d{3,})(?!\]\])'
     matches = len(re.findall(pattern, content))
     if matches > 0:
         content = re.sub(pattern, r'[[^\1]]', content)

--- a/core/obsidian/sync_daemon.py
+++ b/core/obsidian/sync_daemon.py
@@ -30,7 +30,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-TASK_PATTERN = re.compile(r'- \[([ xX])\].*?\^(task-\d{8}-\d{3})')
+TASK_PATTERN = re.compile(r'- \[([ xX])\].*?\^(task-\d{8}-\d{3,})')
 
 
 class DexSyncHandler(FileSystemEventHandler):

--- a/core/tests/test_confirm_goal_link.py
+++ b/core/tests/test_confirm_goal_link.py
@@ -68,7 +68,7 @@ def test_confirm_goal_link_schema_requires_task_id_and_action():
     confirm_goal_link = next(tool for tool in tools if tool.name == "confirm_goal_link")
 
     assert confirm_goal_link.inputSchema["required"] == ["task_id", "action"]
-    assert confirm_goal_link.inputSchema["properties"]["task_id"]["pattern"] == r"^task-\d{8}-\d{3}$"
+    assert confirm_goal_link.inputSchema["properties"]["task_id"]["pattern"] == r"^task-\d{8}-\d{3,}$"
     assert confirm_goal_link.inputSchema["properties"]["action"]["enum"] == ["confirm", "clear"]
 
 

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -581,7 +581,7 @@ def test_golden_task_lifecycle_propagates_and_rolls_up(fixture_vault: Path, tmp_
     title = journey["title"]
     task_id = created["task"]["task_id"]
     assert created["success"] is True
-    assert re.fullmatch(r"task-\d{8}-\d{3}", task_id)
+    assert re.fullmatch(r"task-\d{8}-\d{3,}", task_id)
     assert journey["person_path"] in created["synced_pages"]
     assert f"^{task_id}" in journey["tasks_after_create"]
     assert f"| ⏳ | {title} | P2 |" in journey["person_after_create"]

--- a/core/tests/test_task_id_rollover.py
+++ b/core/tests/test_task_id_rollover.py
@@ -1,0 +1,60 @@
+"""Task IDs past 999: generation, parsing, and boundary-safe matching.
+
+Field report (Martin, 2026-08-10): the ID sequence regex matched exactly three
+digits, so once a vault reached task 999 the observed maximum froze there and
+every new task was assigned 1000 — colliding forever. A plain substring test
+in find_task_by_id compounded it: task-...-100 matched inside task-...-1000.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+
+@pytest.fixture
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "03-Tasks").mkdir(parents=True)
+    monkeypatch.setattr(work_server, "BASE_DIR", tmp_path)
+    return tmp_path
+
+
+def _write_tasks(vault: Path, ids: list[str]) -> Path:
+    tasks = vault / "03-Tasks" / "Tasks.md"
+    lines = ["# Tasks", ""]
+    lines.extend(f"- [ ] Task number {task_id} ^{task_id}" for task_id in ids)
+    tasks.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return tasks
+
+
+def test_generation_rolls_past_999_without_colliding(vault: Path) -> None:
+    _write_tasks(vault, [f"task-20260810-{n:03d}" for n in (1, 998, 999)])
+
+    first = work_server.generate_task_id()
+    assert first.endswith("-1000")
+
+    _write_tasks(vault, ["task-20260810-999", "task-20260810-1000"])
+    second = work_server.generate_task_id()
+    assert second.endswith("-1001")
+
+
+def test_extract_task_id_reads_four_digit_ids() -> None:
+    line = "- [ ] The thousandth task ^task-20260810-1000"
+    assert work_server.extract_task_id(line) == "task-20260810-1000"
+
+
+def test_find_task_by_id_never_matches_a_longer_id(vault: Path) -> None:
+    _write_tasks(vault, ["task-20260810-100", "task-20260810-1000"])
+
+    short = work_server.find_task_by_id("task-20260810-100")
+    long = work_server.find_task_by_id("task-20260810-1000")
+
+    assert [i["line_content"] for i in short] == [
+        "- [ ] Task number task-20260810-100 ^task-20260810-100"
+    ]
+    assert [i["line_content"] for i in long] == [
+        "- [ ] Task number task-20260810-1000 ^task-20260810-1000"
+    ]

--- a/core/tests/test_task_id_rollover.py
+++ b/core/tests/test_task_id_rollover.py
@@ -58,3 +58,20 @@ def test_find_task_by_id_never_matches_a_longer_id(vault: Path) -> None:
     assert [i["line_content"] for i in long] == [
         "- [ ] Task number task-20260810-1000 ^task-20260810-1000"
     ]
+
+
+def test_wikilink_migration_converts_four_digit_task_anchors() -> None:
+    from core.obsidian.migrate_to_wikilinks import convert_references_in_file
+
+    content = "- [ ] The thousandth task ^task-20260810-1000\n"
+    converted, changes = convert_references_in_file(content, {}, {}, {})
+
+    assert changes == 1
+    assert "[[^task-20260810-1000]]" in converted
+
+
+def test_smoke_task_anchor_scan_reads_four_digit_ids() -> None:
+    from core.utils.smoke import _task_anchor_ids
+
+    text = "- [ ] a ^task-20260810-999\n- [ ] b ^task-20260810-1000\n"
+    assert _task_anchor_ids(text) == ["task-20260810-999", "task-20260810-1000"]

--- a/core/tests/test_work_server_production_paths.py
+++ b/core/tests/test_work_server_production_paths.py
@@ -76,7 +76,7 @@ def test_create_task_succeeds_over_production_stdio(fixture_vault: Path, tmp_pat
 
     tasks_text = (vault / "03-Tasks" / "Tasks.md").read_text(encoding="utf-8")
     assert TASK_TITLE in tasks_text
-    assert re.search(r"\^task-\d{8}-\d{3}", tasks_text)
+    assert re.search(r"\^task-\d{8}-\d{3,}", tasks_text)
 
 
 def test_task_lifecycle_succeeds_in_process_without_qmd_patching(tmp_path: Path, monkeypatch):

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -1846,6 +1846,11 @@ def _decode_tool_response(contents: Sequence[object]) -> dict[str, Any]:
     return decoded
 
 
+def _task_anchor_ids(text: str) -> list[str]:
+    """Task anchors in a document; the sequence part may exceed three digits."""
+    return re.findall(r"\^(task-\d{8}-\d{3,})", text)
+
+
 def _journey_task_lifecycle(vault: Path, _release_root: Path) -> dict[str, str]:
     tasks_file = _core_path(vault, "TASKS_FILE")
     tasks_dir = tasks_file.parent
@@ -1878,7 +1883,7 @@ def _journey_task_lifecycle(vault: Path, _release_root: Path) -> dict[str, str]:
 
         original = tasks_file.read_text(encoding="utf-8")
         original_lines = original.splitlines()
-        original_task_ids = re.findall(r"\^(task-\d{8}-\d{3,})", original)
+        original_task_ids = _task_anchor_ids(original)
 
         from core.mcp import work_server as work
 

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -1878,7 +1878,7 @@ def _journey_task_lifecycle(vault: Path, _release_root: Path) -> dict[str, str]:
 
         original = tasks_file.read_text(encoding="utf-8")
         original_lines = original.splitlines()
-        original_task_ids = re.findall(r"\^(task-\d{8}-\d{3})", original)
+        original_task_ids = re.findall(r"\^(task-\d{8}-\d{3,})", original)
 
         from core.mcp import work_server as work
 


### PR DESCRIPTION
Field report from Martin (manual — his /feedback isn't linked yet): after a vault's task sequence reached 999, every new task was assigned ID 1000, colliding four times in one day.

**Root cause (his diagnosis, verified here):** the sequence regex `\^task-\d{8}-(\d{3})` matches exactly three digits, so `task-20260810-1000` parses as 100; the observed maximum can never exceed 999 and `generate_task_id` returns 1000 forever.

**Fix:** widened to `\d{3,}` at all 16 sites across 7 files — `work_server.py` (generator, extractor, strippers, and the `confirm_goal_link` input schema), `sync_daemon.py`, `migrate_to_wikilinks.py`, `smoke.py`, `task_sync.py`, `todoist.cjs`, `meeting-cache-builder.cjs`. Fixing only the generator would have left sync and hook layers silently mis-parsing four-digit IDs (also his observation — confirmed).

**Second bug (also his catch, verified):** `find_task_by_id` used a plain substring test, so `task-...-100` matched inside `task-...-1000` — the wrong-row completion bug, latent until IDs pass 999. Now anchored on a digit boundary, along with the two update-path anchor searches that had the same pattern (one site beyond his report).

**Tests:** new `test_task_id_rollover.py` — 999→1000→1001 generation without collision, four-digit extraction, and boundary-safe lookup (100 vs 1000). Three existing test pins updated to the widened pattern. Task/sync/hook suites green locally; remaining failures match the environmental baseline exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)