### PR TITLE
docs(feedback): contract of record — sign-in required, beta membership not

### DIFF
--- a/docs/feedback-loop-contract.md
+++ b/docs/feedback-loop-contract.md
@@ -25,6 +25,9 @@ Override for tests: `DEX_FEEDBACK_API_BASE`.
 
 Auth on every feedback route: `Authorization: Bearer <sessionToken>` resolved against
 `cliSessions` (required — the beta-gate-disabled bypass does not apply to feedback).
+Sign-in is compulsory, but DexDiff beta membership is NOT (Dave, 2026-08-10): any
+signed-in Heydex account may link a terminal and file feedback. The DexDiff private
+beta continues to gate publishing, love letters, and diff/profile reads only.
 
 ## HTTP endpoints (all also answer OPTIONS for CORS)
 


### PR DESCRIPTION
Companion to davekilleen/heydex-website#56 (opens /feedback to any signed-in account). Updates the feedback-loop contract doc so the auth requirement reads as it was always decided: sign-in compulsory, DexDiff beta membership not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)