### PR TITLE
Vault .gitignore stops re-including Dex product files (vault-mode section composed on update)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ System/user-profile.yaml
 System/pillars.yaml
 System/trusted-mcps.yaml
 System/.last-update-check
+System/.last-qmd-update
 System/.update-available
 System/.smoke-last-run.json
 System/.dex/smoke-history.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.93.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
+## [1.95.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
 
 Chris found his vault's change list crowded with dozens of files he never touched — Dex's own product files, freshly rewritten by an update and showing up as if they were his edits. The cause: the file that tells your vault what to overlook is written for the team that builds Dex, and it deliberately keeps Dex's own files visible there. Inside *your* vault that's backwards — one broad "save everything" moment quietly folds hundreds of Dex files into your private history, and every update after that dirties them all again.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.93.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
+
+Chris found his vault's change list crowded with dozens of files he never touched — Dex's own product files, freshly rewritten by an update and showing up as if they were his edits. The cause: the file that tells your vault what to overlook is written for the team that builds Dex, and it deliberately keeps Dex's own files visible there. Inside *your* vault that's backwards — one broad "save everything" moment quietly folds hundreds of Dex files into your private history, and every update after that dirties them all again.
+
+**What this fixes for you:**
+
+* **Dex's files no longer masquerade as your changes.** When an update refreshes that overlook-list in a vault, Dex now appends a clearly marked section telling your vault to disregard its product files — while everything of yours, including your custom skills and custom connections, stays visible and versioned exactly as before. The section is rebuilt from Dex's own ownership rules on every update, so it can never drift out of date.
+* **A background bookkeeping file stops appearing as something new to save.** The small timestamp Dex keeps to know when your search index was last refreshed is now overlooked like the rest of Dex's working state.
+* **If your vault already caught some of Dex's files,** they'll stop changing on their own once told to let them go — ask Dex to "untrack Dex's product files" and it takes one command, with nothing deleted from disk.
+
+Thanks to Chris for the report, traced from a single noisy update all the way to the root cause.
+
 ## [1.94.0] — 📦 Moving your Dex folder no longer locks you out of updating (2026-08-11)
 
 Dex writes down where your vault lives. Move that folder, rename it, or work from a copy of it, and the note still points at the old place — and Dex was reading that mismatch as damage. It refused to update at all, with a message that didn't say why. A user hit this while rehearsing the rescue route on a duplicate of his own vault, and spent an hour reading Dex's code to work out which of its nine checks had failed.

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from core import portable_contract
 from core.lifecycle import service
 from core.lifecycle.bridge import ACTIVATION_RELATIVE, activate_vault
 from core.lifecycle.catalog import canonical_catalog_bytes, load_catalog
@@ -1624,3 +1625,74 @@ def test_each_broken_split_is_still_refused_by_the_planner_and_names_itself(
     with pytest.raises(apply_update.UpdateError) as refusal:
         apply_update._topology(vault)
     assert expected_clause in str(refusal.value)
+
+
+# --- .gitignore vault-mode composition -------------------------------------
+
+
+def test_composed_gitignore_appends_contract_derived_vault_section() -> None:
+    release_blob = b"# distribution rules\n!core/\n!docs/\n"
+
+    composed = apply_update._compose_gitignore(release_blob, Path("/unused")).decode()
+
+    assert composed.startswith("# distribution rules\n")
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+    assert apply_update.GITIGNORE_SECTION_END in section
+    for expected in ("/docs/", "/scripts/", "/CHANGELOG.md", "/README.md", "/LICENSE"):
+        assert f"\n{expected}\n" in section
+    # brain dirs with vault-owned children switch to /*-plus-negation form
+    assert "\n/core/*\n" in section
+    assert "\n!/core/mcp-custom/\n" in section
+    assert "\n!/core/mcp-premium/\n" in section
+    assert "\n/.claude/*\n" in section
+    assert "\n!/.claude/skills-custom/\n" in section
+    # a plain dir ignore for core/.claude would make the negations dead rules
+    assert "\n/core/\n" not in section
+    assert "\n/.claude/\n" not in section
+
+
+def test_composed_gitignore_is_idempotent_and_replaces_stale_section() -> None:
+    release_blob = b"# rules\n"
+    once = apply_update._compose_gitignore(release_blob, Path("/unused"))
+    twice = apply_update._compose_gitignore(once, Path("/unused"))
+
+    assert once == twice
+    assert once.decode().count(apply_update.GITIGNORE_SECTION_BEGIN) == 1
+
+    stale = (
+        b"# rules\n\n"
+        + apply_update.GITIGNORE_SECTION_BEGIN.encode()
+        + b"\nstale-entry/\n"
+        + apply_update.GITIGNORE_SECTION_END.encode()
+        + b"\n"
+    )
+    recomposed = apply_update._compose_gitignore(stale, Path("/unused")).decode()
+    assert "stale-entry/" not in recomposed
+    assert recomposed.count(apply_update.GITIGNORE_SECTION_BEGIN) == 1
+
+
+def test_composed_gitignore_refuses_non_utf8_release_bytes() -> None:
+    with pytest.raises(apply_update.CompositionError):
+        apply_update._compose_gitignore(b"\xff\xfe", Path("/unused"))
+
+
+def test_vault_section_assumes_direct_child_exceptions_only() -> None:
+    """Guard the contract shape the generator relies on.
+
+    Every vault-owned path nested under a top-level brain directory must be a
+    direct child: gitignore cannot re-include a file whose parent directory is
+    excluded, so a deeper nesting would need recursive /*-negation chains the
+    generator deliberately does not emit. If this fails, extend
+    _vault_mode_gitignore_section before changing the contract.
+    """
+    tops = {
+        rule.path
+        for rule in portable_contract.RULES
+        if rule.ownership == "brain" and "/" not in rule.path
+    }
+    for rule in portable_contract.RULES:
+        if rule.ownership != "vault" or "/" not in rule.path:
+            continue
+        root = rule.path.split("/", 1)[0]
+        if root in tops:
+            assert rule.path.count("/") == 1, rule.path

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -106,8 +106,80 @@ def _compose_claude(release_blob: bytes, vault_root: Path) -> bytes:
     return _regenerate_claude(release_blob, custom_content)
 
 
+GITIGNORE_SECTION_BEGIN = "# >>> dex-vault-mode (managed by Dex updates) >>>"
+GITIGNORE_SECTION_END = "# <<< dex-vault-mode (managed by Dex updates) <<<"
+_GITIGNORE_MANAGED_SECTION = re.compile(
+    rf"\n*{re.escape(GITIGNORE_SECTION_BEGIN)}.*?{re.escape(GITIGNORE_SECTION_END)}\n?",
+    re.DOTALL,
+)
+
+
+def _vault_mode_gitignore_section() -> str:
+    """Ignore rules that neutralize the distribution re-include block in a vault.
+
+    The release ships the distribution repository's ``.gitignore``, whose
+    "Keep Template Files" negations (``!core/``, ``!docs/`` and friends) exist
+    so the development repository tracks its own product files. Inside a split
+    vault those same negations leave every brain-owned file un-ignored, so one
+    broad ``git add -A`` silently captures hundreds of release files into the
+    user's private history — and every later update then dirties them all.
+
+    Because ``.gitignore`` outranks ``.git/info/exclude``, the only reliable
+    place to restore vault-side behavior is the end of the file itself
+    (last match wins). The section is derived from the ownership contract so
+    there is no second path list to drift.
+    """
+    tops = sorted(
+        (rule for rule in portable_contract.RULES
+         if rule.ownership == "brain" and "/" not in rule.path),
+        key=lambda rule: rule.path,
+    )
+    vault_children = [
+        rule for rule in portable_contract.RULES
+        if rule.ownership == "vault" and "/" in rule.path
+    ]
+    lines = [
+        GITIGNORE_SECTION_BEGIN,
+        "# This repository is your private vault. The Dex product files below are",
+        "# delivered and refreshed by Dex's receipt-backed updates, not tracked",
+        "# here. Derived from the ownership contract; edits inside this section",
+        "# are replaced on every update.",
+    ]
+    for top in tops:
+        exceptions = sorted(
+            rule.path for rule in vault_children
+            if rule.path.startswith(f"{top.path}/")
+        )
+        for exception in exceptions:
+            if exception.count("/") != top.path.count("/") + 1:
+                raise CompositionError(
+                    "vault-owned contract path nested deeper than one level "
+                    f"under brain-owned {top.path!r}: {exception!r}"
+                )
+        if top.kind == "file":
+            lines.append(f"/{top.path}")
+        elif exceptions:
+            lines.append(f"/{top.path}/*")
+            lines.extend(f"!/{exception}/" for exception in exceptions)
+        else:
+            lines.append(f"/{top.path}/")
+    lines.append(GITIGNORE_SECTION_END)
+    return "\n".join(lines)
+
+
+def _compose_gitignore(release_blob: bytes, vault_root: Path) -> bytes:
+    del vault_root  # the section depends only on the ownership contract
+    try:
+        text = release_blob.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise CompositionError("release .gitignore is not UTF-8") from error
+    base = _GITIGNORE_MANAGED_SECTION.sub("", text).rstrip("\n")
+    return f"{base}\n\n{_vault_mode_gitignore_section()}\n".encode("utf-8")
+
+
 COMPOSERS: dict[str, Callable[[bytes, Path], bytes]] = {
     "CLAUDE.md": _compose_claude,
+    ".gitignore": _compose_gitignore,
 }
 
 


### PR DESCRIPTION
## Summary

Field report from my own vault: after applying v1.92.0, `git status` showed 17 modified files I never touched — all Dex product files — and inspection found **386 brain-owned files tracked in my private vault history** (all of `core/tests`, `.claude/hooks`, `docs/`, `scripts/`, `CHANGELOG.md`, even `.mcp.json`).

**Root cause (not the migration).** The v1→v2 split correctly excludes brain files from the rebuilt vault history — mine had a clean 10-commit history rooted at "Your vault — everything here is yours". They leaked back in *afterwards*: the release ships the distribution repository's `.gitignore` into the vault, and its **"Keep Template Files" negation block** (`!core/`, `!docs/`, `!scripts/`, `!.claude/`, `!CHANGELOG.md`, `!README.md`, `!LICENSE`) — correct for the dev repo — leaves every brain-owned file **un-ignored inside the vault**. One broad `git add -A` (a user, or their AI assistant, tidying up) silently captures hundreds of release files into the private history, and every later update dirties them all, forever. `.git/info/exclude` cannot mitigate it: `.gitignore` outranks it, so the negations win.

(The vault-autocommit hook is already contract-filtered and is *not* a leak vector — this is defense for the manual/broad-add path.)

## The fix

A second entry in the existing `COMPOSERS` registry — the exact precedent `CLAUDE.md` already uses for per-vault composition at release-write time:

- `_compose_gitignore` appends a marker-delimited **vault-mode section** to the release `.gitignore` when the update writes it into a vault. Last-match-wins neutralizes the distribution negations there, without changing distribution behavior (the apply path only ever runs in split vaults).
- The section is **derived from `portable_contract.RULES`**, not a second hand-maintained list: top-level brain paths are ignored; brain directories with vault-owned children (`.claude/skills-custom`, `core/mcp-custom`, `core/mcp-premium`) use the `/*`-plus-negation form so user customizations stay visible and versioned.
- Idempotent — a stale managed section is stripped and rebuilt, so the section self-heals across releases and contract changes.
- Non-UTF-8 release bytes refuse via `CompositionError`, keeping the current file (consistent with the `CLAUDE.md` composer's failure mode).
- A contract-shape guard test fails loudly if a future vault-owned rule ever nests deeper than one level under a brain directory (gitignore cannot re-include below an excluded parent, so the generator would need extending first).

Also adds `System/.last-qmd-update` (the semantic-search freshness marker `session-start.sh` writes) to the base ignore rules — it was showing as a perpetually-untracked file.

## What this deliberately does not do

- **No repair of already-affected vaults.** Untracking previously-captured product files is an index mutation on the user's private repo — I'd suggest a Doctor detection (report tracked brain-owned files, offer a Tier-1-style heal that runs `git rm --cached` only, content untouched) as a follow-up rather than smuggling it into the update transaction. Happy to take that on if you agree with the shape.
- **No migration change.** Fresh splits get the section at their first release apply; the window between split and first apply is narrow and the autocommit hook is already contract-filtered.

## What was verified, and how

- Both failure links confirmed on a real affected vault before writing code: the negation block re-including brain paths (verified `git check-ignore` behavior), and `.git/info/exclude` losing to the negations.
- 4 new tests: contract-derived section content (including the `/*`-plus-negation form and that plain dir-ignores are absent where negations exist), idempotency + stale-section replacement, non-UTF-8 refusal, and the contract-shape guard.
- `core/tests/test_apply_update.py`: **47/47 pass** (43 pre-existing + 4 new).
- Adjacent suites (`test_lifecycle_service_contract`, `test_dex_update_bridge`, `test_update_journey_protocol`, `test_update_rollback_journey`, `test_manifest_lifecycle_paths`): **91/91 pass**.
- Verified end-to-end on my own vault: applied the composed `.gitignore` form and confirmed `git status` drops to user-content-only.

Adds a CHANGELOG entry ([1.93.0]) in the house plain-English style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)