### PR TITLE
Let the rescue bridge start after it scrubs its own environment

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -786,7 +786,7 @@ You've already seen the first-week snapshot from the calendar data Dex could rea
 
 📖 One more thing worth bookmarking: the **Dex Guide** at https://heydex.ai/help/ — a plain-English walkthrough of everything Dex can do, with copy-paste prompts to steal. Great for your first week.
 
-💬 And if Dex itself ever misbehaves, just say "report this" (or run `/feedback`). Dex investigates on your machine, writes the bug report for you, shows it to you before anything is sent, and tells you when the fix ships. Nothing from your notes or meetings ever goes into a report."
+💬 And if Dex itself ever misbehaves, just say "report this" (or run `/feedback`). Dex investigates on your machine, writes the bug report for you, shows it to you before anything is sent, and tells you when the fix ships. Nothing from your notes, meetings or conversations ever goes into a report — a report is built from a fixed list of ingredients, and you can read exactly what that list is at https://heydex.ai/help/feedback.html."
 
 Then ask: "Want me to put a few gentle nudges in your calendar for your first few weeks? One a day, each with something to try. They're all-day reminders marked private and free, so they never block your time or make you look busy — and you can delete the whole thing in one tap."
 

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -721,7 +721,7 @@ After any pathway completes:
 **Discovery:**
 • `/dex-level-up` - Find features you haven't tried
 • `/integrate-mcp` - Add more tools anytime
-• `/feedback` - Something misbehaving? Dex writes the bug report for you and tells you when it's fixed
+• `/feedback` - Something misbehaving? Dex writes the bug report for you and tells you when it's fixed. What a report can and can't contain: https://heydex.ai/help/feedback.html
 • Smithery.ai - Browse MCP marketplace
 
 **Come back anytime:**

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ System/.update-available
 System/.smoke-last-run.json
 System/.dex/smoke-history.jsonl
 System/.dex/session-health.lock
+System/.dex/release-notes-state.lock
 System/.dex/session-health-success.json
 System/.dex/health-telemetry-log.jsonl
 System/.dex/telemetry-id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.93.0] — 🌉 The rescue bridge for stuck installs actually starts now (2026-08-11)
+
+Dex's rescue bridge — the one-time tool that gets a very old install updating again — clears out its surroundings before it runs, so nothing already on your machine can quietly steer the update. The last release taught it to stop safely instead of spinning forever when that clean start didn't take. It duly stopped, and told a user it couldn't continue. The cause turned out to be the cleaning itself.
+
+**What this fixes for you:**
+
+* **The bridge gets past its own front door.** Clearing the surroundings removed the setting that tells a program which characters and alphabet to expect, and the language Dex runs on quietly put its own replacement back. The bridge saw a setting it hadn't put there, assumed something had interfered, and stopped. It now asks for that replacement not to happen, and pins character handling directly instead — so the clean start it asks for is the clean start it gets.
+* **Two harmless leftovers no longer halt an update.** Apple's system stamps a text-encoding marker onto every program it runs, and there is no way to switch that off. The bridge now recognises that marker, and the character setting above, for what they are — the machine's own housekeeping, not something that arrived with you — while still refusing anything that could genuinely redirect an update somewhere else.
+* **If it ever does stop, the message is worth something.** The single line it prints now says plainly that your vault is untouched and that the line itself is everything the Dex team needs in order to fix it.
+
+Thanks to Jim, whose measurements pinned the cause exactly — including that it would have happened on any Mac, not only his.
+
 ## [1.92.0] — 🔢 Task numbers no longer stop counting at 999 (2026-08-10)
 
 A user with a well-used vault found that once his tasks passed number 999, every new task got the same number — four collisions in one day. His report arrived with the diagnosis already done (thank you, Martin), and it checked out exactly.

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -1927,6 +1927,89 @@ def test_runtime_marker_tolerates_the_macos_interpreter_launcher_variable(
     bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
 
 
+def test_relaunching_a_real_interpreter_adds_nothing_the_clean_check_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scrub must not manufacture the difference the clean check refuses.
+
+    Removing the caller's locale leaves the C locale behind, and a Python that
+    inherits the C locale coerces it by exporting LC_CTYPE into its own
+    environment.  This drives a real interpreter with exactly the environment
+    the bridge hands its relaunched self and reads back what actually arrived.
+    """
+    environment = bridge._bridge_environment()
+    environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+
+    completed = subprocess.run(
+        [sys.executable, "-c", "import json, os; print(json.dumps(dict(os.environ)))"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    monkeypatch.setattr(bridge.os, "environ", json.loads(completed.stdout))
+
+    assert bridge._observed_clean_environment() == environment
+
+
+def test_clean_check_tolerates_platform_injected_locale_and_text_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path)
+    selected_interpreter = vault / ".venv" / "bin" / "python"
+    selected_prefix = selected_interpreter.parent.parent
+    clean_environment = bridge._bridge_environment()
+    clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+    clean_environment["LC_CTYPE"] = "C.UTF-8"
+    clean_environment["__CF_USER_TEXT_ENCODING"] = "0x1F5:0x8000100:0x8000100"
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
+    monkeypatch.setattr(bridge.os, "environ", clean_environment)
+    monkeypatch.setattr(bridge.sys, "executable", str(selected_interpreter))
+    monkeypatch.setattr(bridge.sys, "prefix", str(selected_prefix))
+    monkeypatch.setattr(bridge.sys, "exec_prefix", str(selected_prefix))
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("selected clean virtualenv must not re-exec"),
+    )
+
+    bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+
+
+def test_clean_check_still_refuses_a_caller_chosen_locale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the coercion's own outcomes are tolerated, not any locale at all."""
+    vault = _vault(tmp_path)
+    selected_interpreter = vault / ".venv" / "bin" / "python"
+    selected_prefix = selected_interpreter.parent.parent
+    clean_environment = bridge._bridge_environment()
+    clean_environment[bridge._CLEAN_RUNTIME_MARKER] = "1"
+    clean_environment["LC_CTYPE"] = "tr_TR.ISO8859-9"
+
+    monkeypatch.setattr(bridge, "_installed_python", lambda _vault: selected_interpreter)
+    monkeypatch.setattr(bridge.os, "environ", clean_environment)
+    monkeypatch.setattr(bridge.sys, "executable", str(selected_interpreter))
+    monkeypatch.setattr(bridge.sys, "prefix", str(selected_prefix))
+    monkeypatch.setattr(bridge.sys, "exec_prefix", str(selected_prefix))
+    monkeypatch.setattr(
+        bridge.os,
+        "execve",
+        lambda *_arguments: pytest.fail("a marked process must never relaunch again"),
+    )
+
+    with pytest.raises(bridge.BridgeError, match="LC_CTYPE"):
+        bridge._reexec_in_installed_runtime(vault, ["--vault", "/safe/vault"])
+
+
+def test_bridge_environment_declines_the_locale_coercion_it_would_otherwise_cause() -> None:
+    environment = bridge._bridge_environment()
+
+    assert environment["PYTHONCOERCECLOCALE"] == "0"
+    assert environment["PYTHONUTF8"] == "1"
+
+
 def test_runtime_marker_accepts_only_the_selected_virtualenv_process(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -108,7 +108,9 @@ def test_twelve_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
         "dist/archive/v1.72.0-7d75da9",
         "dist/archive/v1.76.0-d0bb932",
         "v1.81.1",
-        "dist/release/v1.81.1-b17ef02",
+        # The release-tag archive renamed this exact annotated tag (object
+        # 8fe3516f, commit b17ef028) from dist/release/ to dist/archive/.
+        "dist/archive/v1.81.1-b17ef02",
         "v1.81.7",
         "v1.81.11",
     )

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "9484230fe6586de6731ac535eb6c70920711d85784097345e04894e97e4adb6e",
+      "sha256": "e24b5f741286a364ab501140baae2372ef2e9cc73330157ca60c38b5845ce2b8",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -1285,6 +1285,14 @@ def _bridge_environment() -> dict[str, str]:
         "PYTHONNOUSERSITE": "1",
         "PYTHONDONTWRITEBYTECODE": "1",
         "PYTHONUNBUFFERED": "1",
+        # Removing the caller's locale leaves the C locale behind, and a Python
+        # that inherits the C locale coerces it (PEP 538) by exporting LC_CTYPE
+        # into its own environment -- the scrub would otherwise manufacture the
+        # very difference the clean-runtime check then refuses.  Declining the
+        # coercion keeps the child's environment exactly what was handed to it;
+        # UTF-8 mode then fixes the text encoding without relying on a locale.
+        "PYTHONCOERCECLOCALE": "0",
+        "PYTHONUTF8": "1",
     }
 
 
@@ -1781,17 +1789,37 @@ def _running_in_selected_runtime(interpreter: Path) -> bool:
     )
 
 
-# macOS framework builds launch a virtualenv Python through a stub that injects
-# this variable into the child's environment after execve; its presence is a
-# property of the selected interpreter itself, not of the caller.
-_INTERPRETER_INJECTED_VARIABLES = frozenset({"__PYVENV_LAUNCHER__"})
+# The values a Python that inherits the C locale may coerce it to (PEP 538).
+_LOCALE_COERCION_VALUES = frozenset({"C.UTF-8", "C.utf8", "UTF-8"})
+
+# The operating system and the interpreter both add variables to the child
+# *after* execve, so they can be present in a genuinely clean relaunch and are
+# properties of the selected runtime rather than of the caller.  Each entry
+# names a variable that carries no repository, credential, import path, or
+# executable-lookup influence, paired with the values the platform may inject.
+_INTERPRETER_INJECTED_VARIABLES: dict[str, Callable[[str], bool]] = {
+    # macOS framework builds launch a virtualenv Python through a stub.
+    "__PYVENV_LAUNCHER__": lambda _value: True,
+    # CoreFoundation stamps the account's text encoding into any process it
+    # touches, including one started from a completely empty environment.
+    "__CF_USER_TEXT_ENCODING": lambda _value: True,
+    # A Python left in the C locale coerces it and exports the result; the
+    # bridge declines that coercion, so accept only its exact outcomes.
+    "LC_CTYPE": lambda value: value in _LOCALE_COERCION_VALUES,
+}
 
 
 def _observed_clean_environment() -> dict[str, str]:
+    """Return the caller-attributable environment of this process.
+
+    Platform-injected variables are dropped so that a clean relaunch is never
+    mistaken for a dirty one; everything else, including any injected name
+    carrying an unexpected value, is reported exactly as it stands.
+    """
     return {
         key: value
         for key, value in os.environ.items()
-        if key not in _INTERPRETER_INJECTED_VARIABLES
+        if not _INTERPRETER_INJECTED_VARIABLES.get(key, lambda _value: False)(value)
     }
 
 
@@ -1844,7 +1872,9 @@ def _reexec_in_installed_runtime(vault_root: Path, argv: list[str]) -> None:
             "the installed Dex runtime could not be entered cleanly, so the bridge "
             "stopped instead of relaunching endlessly: "
             + _runtime_reentry_diagnostic(interpreter, environment)
-            + f" (if {_CLEAN_RUNTIME_MARKER} was set in your shell, unset it and re-run)"
+            + f" (if {_CLEAN_RUNTIME_MARKER} was set in your shell, unset it and re-run;"
+            " otherwise your vault is untouched and this whole line is what the Dex"
+            " team needs to fix it)"
         )
     print(
         "Relaunching inside Dex's installed runtime...",

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 CANONICAL_PUBLIC_REMOTE="https://github.com/davekilleen/Dex.git"
 PINNED_FOUNDATION_TAG="dist/release/v1.81.16-281202d"
 MAX_DISK_KIB=$((50 * 1024 * 1024))
+# Every entry must still resolve on the public remote. The release-tag archive
+# renames tags from dist/release/ to dist/archive/ without moving the object, so
+# an archived start is updated here rather than dropped.
 CANARY_STARTS=(
   "v1.51.0"
   "dist/release/v1.61.0-dc7d332"
@@ -17,7 +20,7 @@ CANARY_STARTS=(
   "dist/archive/v1.72.0-7d75da9"
   "dist/archive/v1.76.0-d0bb932"
   "v1.81.1"
-  "dist/release/v1.81.1-b17ef02"
+  "dist/archive/v1.81.1-b17ef02"
   "v1.81.7"
   "v1.81.11"
 )
@@ -369,6 +372,7 @@ run_canary() {
   for start in "${CANARY_STARTS[@]}"; do
     if ! git rev-parse --verify "$start^{commit}" >/dev/null 2>&1; then
       echo "public canary start is unavailable: $start" >&2
+      echo "if the release-tag archive renamed it, update CANARY_STARTS to the dist/archive/ name" >&2
       return 1
     fi
   done


### PR DESCRIPTION
## What broke

v1.92.0's bounded relaunch works exactly as designed — the bridge stops in ~1s with the
vault untouched instead of spinning forever. But no affected install can *complete* it,
because the scrub manufactures the difference the clean-runtime check then refuses.

Removing `LANG`/`LC_ALL` leaves the C locale behind. The relaunched interpreter applies
PEP 538 locale coercion and exports `LC_CTYPE=C.UTF-8` into its own environment *after*
the relaunch, so `_observed_clean_environment() == environment` can never hold. macOS
additionally injects `__CF_USER_TEXT_ENCODING`, which cannot be suppressed. Only
`__PYVENV_LAUNCHER__` was tolerated.

Reported by Jim McDermott, with the three-environment comparison that identifies it:

```
empty                       -> LC_CTYPE = C.UTF-8
empty + LANG=en_US.UTF-8    -> absent
empty + PYTHONCOERCECLOCALE=0 -> absent
```

Not Mac-specific. Reproduced here on Linux / Python 3.13; any platform, Python 3.7+.

## The fix

Two changes, either sufficient alone, both taken because the failure mode is a dead end
for the user:

1. **`_bridge_environment()` declines the coercion it provokes** — `PYTHONCOERCECLOCALE=0`,
   plus `PYTHONUTF8=1` so text handling is pinned directly rather than depending on a
   locale that was just removed. The child's environment now stays exactly what was
   passed to it.
2. **`_INTERPRETER_INJECTED_VARIABLES` becomes name+value predicates** covering
   `__PYVENV_LAUNCHER__` (any value), `__CF_USER_TEXT_ENCODING` (any value), and
   `LC_CTYPE` at only the coercion's own outcomes (`C.UTF-8`, `C.utf8`, `UTF-8`). A
   caller-chosen locale, and every name off the list, still fails closed — the forged-marker
   test with `GIT_DIR`/`PYTHONPATH`/`NODE_OPTIONS` is unchanged and still passes.

The stop message now states the vault is untouched and that the line itself is what the
team needs, so a future wedge routes to `/feedback` instead of a dead end.

## Why the tests didn't catch it

Every existing test for that check built its environment synthetically in-process, so no
test ever asked what a real interpreter does with the environment the bridge hands its
child. `test_relaunching_a_real_interpreter_adds_nothing_the_clean_check_rejects` now
drives a real interpreter with exactly that environment and reads back what arrived. It
fails against the old code and passes against the new.

## Also here

- `core/update/journey-protocol-v1.json` regenerated — it records a checksum of
  `scripts/dex_update_bridge.py` and the bundle build refuses to ship while it is stale.
- Onboarding and the getting-started tour now link https://heydex.ai/help/feedback.html
  alongside their privacy line (Jim asked what the Dex-to-Dex channel actually sends;
  the guide's answer is being expanded in a companion heydex-website PR).
- `.gitignore` covers the release-notes sweep lock, which is runtime state the
  session-end autocommit would otherwise carry into a release.

## Verification

- `core/tests/test_dex_update_bridge.py` — 66 passed.
- Full suite (`core/tests core/mcp/tests core/migrations/tests -m "not fuzz"`) run against
  this branch and against pre-change `56eeb083` under identical conditions: **36 failed,
  3470 passed** here versus **36 failed, 3466 passed** at baseline — the same 36 failures
  (Linux-vs-macOS file modes, trusted-MCP symlink behaviour, release-fleet acceptance),
  zero new, and the 4 extra passes are the new tests.
- `bash scripts/build-vault-bundle.sh` completes and emits the bridge asset + checksum.

Card: `rescue-bridge-scrub-blocks-its-own-clean-start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)