### PR TITLE
Teach the feedback loop and the checkup during setup

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -735,6 +735,44 @@ Ask: "Install background automation?"
 **If no:**
 Say: "No problem! Self-learning checks will still run inline during session start and `/daily-plan`. You can install later with `bash .scripts/install-learning-automation.sh`"
 
+### When Something Goes Wrong (Inform, Don't Ask)
+
+**Shown to everyone, no question attached.** This is where a user learns Dex has a repair
+loop at all. Most never find it on their own, and an unreported bug stays broken for
+everyone. Say it warmly, once, and move on — there is nothing to save and no config to write.
+
+Say: "Two last things, both for when Dex itself misbehaves.
+
+**Just tell me what happened, in whatever words come naturally.** 'The meeting sync is doing
+something weird' is plenty — you don't need a special phrase. I'll investigate on this
+machine, write the bug report for you, and show it to you before anything leaves. (If I
+don't pick it up as a bug, say 'report this' or run `/feedback` and I will.) The first
+report asks you to sign in once, about thirty seconds, so the fix can find its way back to you.
+
+After that it's hands-off. Your report lands on the Dex team's private desk with a reference
+number. If they need one more detail, the question comes back here — you'll see it next time
+you start a session, and I can go and find the answer and show it to you before it goes.
+Ask me how your reports are doing any time. And when a release fixes your bug, your next
+session opens with the news and the version that has it.
+
+Nothing from your notes, meetings, people or our conversations ever goes into a report. A
+report is built from a fixed list of ingredients — which version of Dex you're on, which
+feature broke, the error, and what I found described as counts — and that list is enforced
+in the code, not just promised. The whole list is here: https://heydex.ai/help/feedback.html
+
+**And if things just feel off, run `/dex-doctor`.** It checks every part of Dex and tells you
+honestly what's working, what's switched off, what's broken, and what it couldn't check —
+then repairs what it can repair on its own, without touching your notes, and walks you
+through anything left. Worth running after an
+update, on a new machine, or when something has quietly stopped happening:
+https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor
+
+Genuinely — feedback is the most useful thing you can give us. Dex gets better because
+someone took a moment to say 'this is broken'. Please be that someone."
+
+**Do not turn this into a setup step.** If they ask a question about it, answer it and carry
+on. Never ask them to file anything now.
+
 ## Step 11: Completion & Phase 2 Bridge
 
 ### Cursor Version Check (If Cursor Detected)
@@ -786,7 +824,7 @@ You've already seen the first-week snapshot from the calendar data Dex could rea
 
 📖 One more thing worth bookmarking: the **Dex Guide** at https://heydex.ai/help/ — a plain-English walkthrough of everything Dex can do, with copy-paste prompts to steal. Great for your first week.
 
-💬 And if Dex itself ever misbehaves, just say "report this" (or run `/feedback`). Dex investigates on your machine, writes the bug report for you, shows it to you before anything is sent, and tells you when the fix ships. Nothing from your notes, meetings or conversations ever goes into a report — a report is built from a fixed list of ingredients, and you can read exactly what that list is at https://heydex.ai/help/feedback.html."
+💬 And remember: if Dex ever misbehaves, just tell me in your own words. I'll investigate, write the report for you, and show it to you before anything is sent — what a report can and can't contain is at https://heydex.ai/help/feedback.html. When things feel off generally, `/dex-doctor` is the checkup."
 
 Then ask: "Want me to put a few gentle nudges in your calendar for your first few weeks? One a day, each with something to try. They're all-day reminders marked private and free, so they never block your time or make you look busy — and you can delete the whole thing in one tap."
 

--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -763,8 +763,8 @@ in the code, not just promised. The whole list is here: https://heydex.ai/help/f
 **And if things just feel off, run `/dex-doctor`.** It checks every part of Dex and tells you
 honestly what's working, what's switched off, what's broken, and what it couldn't check —
 then repairs what it can repair on its own, without touching your notes, and walks you
-through anything left. Worth running after an
-update, on a new machine, or when something has quietly stopped happening:
+through anything left. Worth running after an update, on a new machine, or when something
+has quietly stopped happening:
 https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor
 
 Genuinely — feedback is the most useful thing you can give us. Dex gets better because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.93.1] — 💬 Setup now shows you how to get something fixed (2026-08-11)
+
+Dex finished setting itself up without ever telling you what to do when Dex itself goes wrong. There was one line about it in the sign-off, easy to miss and gone forever once the screen scrolled. So people hit a problem, assumed it was theirs to live with, and never said anything — and a fault nobody reports stays broken for everyone who has it.
+
+**What this fixes for you:**
+
+* **You learn you can just say it.** Setup now explains, near the end, that if something misbehaves you describe it however you like — "the meeting sync is doing something weird" is plenty. Dex looks into it on your machine, writes the report for you, and shows it to you before anything is sent. If Dex doesn't pick it up as a bug, saying "report this" gets you there.
+* **You find out what happens after you send one.** Your report arrives on the Dex team's private desk with a reference number. If they need one more detail, the question comes back to you the next time you open Dex, and Dex can go and find the answer and show it to you before it goes. You can ask how your reports are doing whenever you like, and when a release contains your fix, Dex opens with the news and the version that has it.
+* **The privacy line is said out loud, with the full list a click away.** Nothing from your notes, meetings, people or your conversations with Dex ever goes into a report. Setup says so plainly and links the guide that lists every single thing a report is allowed to contain.
+* **You meet the checkup before you need it.** Setup introduces `/dex-doctor` for the times when nothing looks broken but something feels off — it tells you honestly what's working, what's switched off, what's broken and what it couldn't check, then repairs what it can without touching your notes.
+
+Every promise in that new part of setup was checked against the code that has to keep it, so what Dex tells you at the start is what actually happens later.
+
+---
+
 ## [1.93.0] — 🌉 The rescue bridge for stuck installs actually starts now (2026-08-11)
 
 Dex's rescue bridge — the one-time tool that gets a very old install updating again — clears out its surroundings before it runs, so nothing already on your machine can quietly steer the update. The last release taught it to stop safely instead of spinning forever when that clean start didn't take. It duly stopped, and told a user it couldn't continue. The cause turned out to be the cleaning itself.

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -364,6 +364,36 @@ def test_onboarding_documents_the_explicit_no_company_domain_path() -> None:
     assert "This step CANNOT be skipped" not in domain_step
 
 
+def test_onboarding_teaches_the_feedback_loop_without_overpromising() -> None:
+    """Setup must teach the repair loop, and promise only what the code does today."""
+    flow = _read(".claude/flows/onboarding.md")
+    section = flow.split("### When Something Goes Wrong", 1)[1].split("## Step 11:", 1)[0]
+    # The copy is hard-wrapped; match on the spoken sentence, not the line breaks.
+    beat = " ".join(section.split())
+
+    # The four things a user has to learn: report in their own words, what it
+    # can never contain, the checkup, and where each of those is documented.
+    assert "whatever words come naturally" in beat
+    assert "/feedback" in beat
+    assert "/dex-doctor" in beat
+    assert "https://heydex.ai/help/feedback.html" in beat
+    assert "https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor" in beat
+
+    # Honesty guards. Questions and fix news arrive through the once-daily
+    # session-start sweep (core/utils/feedback_sweep.py), not mid-conversation,
+    # and sending requires the one-time connect-code sign-in.
+    assert "next time you start a session" in beat
+    assert "sign in once" in beat
+    assert "mid-conversation" not in beat
+    assert "instantly" not in beat
+
+    # The privacy boundary must match the contract's allowed ingredients, and
+    # must not be inflated into a promise the transport does not make.
+    assert "Nothing from your notes, meetings, people or our conversations" in beat
+    assert "encrypted" not in beat
+    assert "anonymous" not in beat
+
+
 def test_reset_uses_the_canonical_onboarding_route_without_moving_user_content() -> None:
     """A role change must not revive the retired hand-written reset procedure."""
     reset = _read(".claude/skills/reset/SKILL.md")


### PR DESCRIPTION
## What this changes

New users finished onboarding without ever learning that Dex has a repair loop. The only mention of `/feedback` was one line in the Step 11 sign-off — the last thing said before the screen scrolls away.

This adds a short education beat at the end of **Step 10**, once the optional setups are done and trust is established. It covers, in a few warm sentences:

1. Report a problem in your own words — no special phrase needed, with `report this` / `/feedback` as the explicit fallback.
2. What happens after you send one: private desk, reference number, questions coming back, status on request, fix news on release.
3. The privacy boundary, stated plainly, linking the live guide that lists every allowed ingredient.
4. `/dex-doctor` for when nothing looks broken but something feels off.
5. A closing note that feedback is the most useful thing a user can give us.

Step 11 keeps a one-line callback instead of repeating the whole thing.

## Honesty gate — every promise checked against the code, not the docs

| Claim | Verdict | Evidence |
|---|---|---|
| Report reaches the team automatically | **True** | `feedback_client.py report` → `POST /api/feedback/report` → ticket `DEX-n` in the private inbox (`docs/feedback-loop-contract.md`) |
| Team can ask you a follow-up question | **True, with timing softened** | `core/utils/feedback_sweep.py` surfaces `needs_info` **once daily at session start**, not mid-conversation. Copy says "next time you start a session". |
| Privacy: nothing from your notes | **True** | Allowed-ingredient list in the contract + client-side field allowlist; copy matches the shipped guide rather than strengthening it |
| Check status any time | **True** | `feedback_client.py status` |
| Automated message when a release fixes your item | **True** | `_notice_for()` emits "fixed in vX … Run /dex-update" via the session-start sweep |
| Dex recognises a bug from casual wording | **Partly — model judgement, not a guaranteed route** | No deterministic router exists; skill-description matching only. Copy keeps the "say 'report this'" escape hatch rather than promising it. |

Two things the copy adds because the code requires them: the **one-time sign-in** (sending is gated on the connect-code flow) and the fact that fix news arrives **at session start**.

## Links

Both curled and verified 200 before commit:
- https://heydex.ai/help/feedback.html
- https://heydex.ai/help/updating-troubleshooting.html#health-dex-doctor (anchor `id="health-dex-doctor"` confirmed in the served HTML)

## Tests

`test_instruction_honesty.py` gains `test_onboarding_teaches_the_feedback_loop_without_overpromising`, following the file's existing flow-contract convention. It pins the four things a user must learn **and** the four claims that must not creep back in (`mid-conversation`, `instantly`, `encrypted`, `anonymous`).

Local: 161 passed across instruction-honesty, skill-integrity and release-feed; 250 passed across the onboarding + feedback files. Two failures in `core/mcp/tests/test_onboarding_server.py::TestCapabilityStep` ("Provisioner returned an invalid receipt") reproduce unchanged on `main` at `fcfd5a97` — pre-existing, not from this branch. Local gates green: PII, doc drift, founder content, test delta.

Scope: flow copy, changelog, one test. No product code touched. Changelog version `1.93.1` can be renumbered at release time if another PR lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)