### PR TITLE
Point the two dead nudge links at the page that holds their prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.93.2] — 🔗 Two dead links in your first-week reminders now go somewhere (2026-08-11)
+
+If you accepted the optional calendar reminders during setup, two of them — the one teaching the HARVEST trick, and the one about making Dex argue against your decision — linked to guide pages that don't exist. Clicking either gave you a "page not found" in your first week, which is the worst possible moment to look unfinished.
+
+**What this fixes for you:**
+
+* **Both links now land on the prompt they're teaching.** They point at the "prompts to steal" page, at the exact section holding that prompt — the HARVEST wording in one case, the argue-against-me wording in the other. That page was always the right home; the reminders just pointed at page names that were never built.
+* **It can't happen again quietly.** A check now runs with every change and fails if a reminder links to a guide page that isn't published, naming the page.
+
+Nothing else changed, and your calendar reminders are untouched — reminders already in your calendar keep their old text until you regenerate them.
+
+---
+
 ## [1.93.1] — 💬 Setup now shows you how to get something fixed (2026-08-11)
 
 Dex finished setting itself up without ever telling you what to do when Dex itself goes wrong. There was one line about it in the sign-off, easy to miss and gone forever once the screen scrolled. So people hit a problem, assumed it was theirs to live with, and never said anything — and a fault nobody reports stays broken for everyone who has it.

--- a/core/tests/test_nudge_calendar.py
+++ b/core/tests/test_nudge_calendar.py
@@ -47,7 +47,7 @@ TEACHING_COPY = (
             'Paste this: "I\'m going to dump thoughts at you in no particular order. Don\'t respond beyond \'noted\'. When I say HARVEST, turn everything into a board update, in my voice, ready to use. File anything that sounds like a task where it belongs."',
             "Best on a walk after a big meeting. Dump the debrief, say HARVEST, done — and the leftovers get filed instead of lost.",
             "Skill: /triage",
-            "https://heydex.ai/help/capture.html",
+            "https://heydex.ai/help/prompts-to-steal.html#magic-words-voice-in-finished-work-out",
         ),
     ),
     (
@@ -56,7 +56,7 @@ TEACHING_COPY = (
             'Paste this: "Here\'s what I\'m about to do: [decision]. You have my goals and my history. Make the strongest honest case AGAINST it — not strawmen, the version my smartest critic would make. Then tell me what evidence would change your mind, and what you\'d do instead."',
             "Most people use AI to agree with them. This is the opposite, and it's where the value is.",
             "Skill: /decision-log",
-            "https://heydex.ai/help/goals-decisions.html",
+            "https://heydex.ai/help/prompts-to-steal.html#set-traps-for-your-blind-spots",
         ),
     ),
     (
@@ -682,3 +682,50 @@ def test_ritual_calendar_analysis_ignores_dex_nudges() -> None:
     )
 
     assert [event.title for event in events] == ["Customer review"]
+
+
+# The guide pages actually published at heydex.ai/help/ (the Dex Guide nav).
+# A nudge that links anywhere else is a 404 in a user's calendar, which is how
+# help/capture.html and help/goals-decisions.html shipped in #287 — both were
+# invented at writing time and never existed on the site.
+PUBLISHED_HELP_PAGES = frozenset(
+    {
+        "",
+        "index.html",
+        "automations.html",
+        "claude-code-primer.html",
+        "connect.html",
+        "daily-rhythm.html",
+        "extend-dex.html",
+        "feedback.html",
+        "first-week.html",
+        "how-dex-works.html",
+        "install.html",
+        "integrations.html",
+        "make-it-your-own.html",
+        "meetings.html",
+        "onboarding.html",
+        "people-projects.html",
+        "proactive-health.html",
+        "prompts-to-steal.html",
+        "search-memory.html",
+        "tasks-planning.html",
+        "updating-troubleshooting.html",
+        "xray.html",
+    }
+)
+
+
+def test_every_nudge_link_points_at_a_published_help_page() -> None:
+    """A nudge link is clicked by a brand-new user in week one; it must resolve."""
+    source = (Path(__file__).resolve().parents[1] / "utils" / "nudge_calendar.py").read_text(
+        encoding="utf-8"
+    )
+    links = re.findall(r"https://heydex\.ai/help/([A-Za-z0-9._#-]*)", source)
+
+    assert links, "nudge copy should still be teaching with help links"
+    unknown = sorted({link.split("#", 1)[0] for link in links} - PUBLISHED_HELP_PAGES)
+    assert not unknown, (
+        f"nudge copy links to help pages that are not published: {unknown}. "
+        "Point at an existing page, or get the page written before shipping the link."
+    )

--- a/core/utils/nudge_calendar.py
+++ b/core/utils/nudge_calendar.py
@@ -78,7 +78,7 @@ _TEACHING_COPY = (
             'Paste this: "I\'m going to dump thoughts at you in no particular order. Don\'t respond beyond \'noted\'. When I say HARVEST, turn everything into a board update, in my voice, ready to use. File anything that sounds like a task where it belongs."',
             "Best on a walk after a big meeting. Dump the debrief, say HARVEST, done — and the leftovers get filed instead of lost.",
             "Skill: /triage",
-            "https://heydex.ai/help/capture.html",
+            "https://heydex.ai/help/prompts-to-steal.html#magic-words-voice-in-finished-work-out",
         ),
     ),
     _EventCopy(
@@ -87,7 +87,7 @@ _TEACHING_COPY = (
             'Paste this: "Here\'s what I\'m about to do: [decision]. You have my goals and my history. Make the strongest honest case AGAINST it — not strawmen, the version my smartest critic would make. Then tell me what evidence would change your mind, and what you\'d do instead."',
             "Most people use AI to agree with them. This is the opposite, and it's where the value is.",
             "Skill: /decision-log",
-            "https://heydex.ai/help/goals-decisions.html",
+            "https://heydex.ai/help/prompts-to-steal.html#set-traps-for-your-blind-spots",
         ),
     ),
     _EventCopy(


### PR DESCRIPTION
## Which side was wrong

**The links, not the site.** Neither page was renamed or moved — they never existed. Searching the entire `heydex-website` history for `capture.html` or `goals-decisions` returns nothing, and both URLs were introduced in the same commit that wrote the nudges (`7780bcae`, PR #287). They read as plausible page names written while drafting the copy, and no gate checks that a link Dex hands a user resolves.

So: no pages need authoring, and no placeholder pages were invented.

## The fix

Both prompts are already published, word for word, on `prompts-to-steal.html`:

| Nudge | Was | Now |
|---|---|---|
| "Think out loud, get finished work back" (the HARVEST trick) | `help/capture.html` → 404 | `prompts-to-steal.html#magic-words-voice-in-finished-work-out` |
| "Make Dex argue against you" | `help/goals-decisions.html` → 404 | `prompts-to-steal.html#set-traps-for-your-blind-spots` |

Verified against the live site before opening this: both URLs return 200, and both anchor ids are present in the served HTML.

## Guard

`test_every_nudge_link_points_at_a_published_help_page` pins every `heydex.ai/help/` link in the nudge copy against the set of pages actually published in the Dex Guide nav. Run against the pre-fix file it names both offenders (`capture.html`, `goals-decisions.html`) — so it catches the real bug, not just the fixed state. It needs no network, so it's safe in CI.

## Scope check

While here I curled all 22 `heydex.ai` URLs anywhere in `core/`, `.claude/` and `docs/`. These two were the only broken user-facing links. The other two non-200s are false alarms: `/contracts/connections.schema.json` is a JSON Schema identifier rather than a page, and `/api/profile-bundle` only answers with its `?handle=` parameter.

Existing nudge tests updated to match (the test file mirrors the copy). Local: 22 passed. Changelog `1.93.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)