### PR TITLE
Audit the CI gates that cannot fail, and fix three of them

### DIFF
--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -82,6 +82,10 @@ jobs:
 
       - name: 100k-file adoption performance budget
         run: |
+          # A step is run as `bash -e`, not `bash -eo pipefail`, so without this
+          # the exit code of the pipeline is tee's and an exceeded budget is
+          # green. See docs/gate-omission-audit-2026-08-11.md (F1).
+          set -o pipefail
           python scripts/benchmark_adoption_engine.py --files 100000 \
             | tee .logs/adoption-gates/benchmark-100k.json
 

--- a/core/tests/test_branch_protection_script.py
+++ b/core/tests/test_branch_protection_script.py
@@ -1,0 +1,129 @@
+"""The branch-protection script must never remove a required check.
+
+`scripts/configure-branch-protection.sh` submits the whole protection object
+with a `PUT`, so whatever it omits is deleted. It used to name only
+`Dex CI / quality` — a job that runs no pytest — while the live branch also
+required `Dex CI / test-results`, which carries the Python suite verdict and
+both coverage gates. Running the repository's own protection script would have
+stopped a red test suite from blocking a merge.
+
+These tests pin the two properties that make that impossible: the floor names
+both checks, and the merge is a union of the floor with whatever is already
+live.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/configure-branch-protection.sh"
+
+# Protection contexts match the name a check run *reports*, which for these is
+# the bare job name. Verified against
+# `gh api repos/davekilleen/Dex/commits/main/check-runs --jq '.check_runs[].name'`,
+# which lists quality, test-results, tests (1..3), pr-report and the rest — and
+# no "Dex CI / …" name at all.
+REQUIRED_FLOOR = ("quality", "test-results")
+
+
+def _source() -> str:
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def _floor_contexts() -> list[str]:
+    """Read the contexts the script insists on, from the array itself."""
+
+    match = re.search(
+        r"^REQUIRED_CONTEXTS=\(\n(?P<body>(?:  \"[^\"]+\"\n)+)\)$",
+        _source(),
+        re.MULTILINE,
+    )
+    assert match is not None, "the script no longer declares a required floor"
+    return re.findall(r'^  "([^"]+)"$', match.group("body"), re.MULTILINE)
+
+
+def _merge_program() -> str:
+    """Extract the embedded merge step so it can be run on its own."""
+
+    match = re.search(
+        r"python3 <<'PY'\n(?P<body>.*?)\nPY\n",
+        _source(),
+        re.DOTALL,
+    )
+    assert match is not None, "the script no longer embeds a merge step"
+    return match.group("body")
+
+
+def _merge(required: tuple[str, ...], live: object) -> list[str]:
+    completed = subprocess.run(
+        ["python3", "-c", _merge_program()],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "REQUIRED": "\n".join(required),
+            "LIVE": json.dumps(live),
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    return json.loads(completed.stdout)
+
+
+def test_script_has_valid_bash_syntax() -> None:
+    subprocess.run(["bash", "-n", str(SCRIPT_PATH)], check=True)
+
+
+def test_the_floor_names_the_job_that_actually_runs_the_tests() -> None:
+    assert _floor_contexts() == list(REQUIRED_FLOOR)
+    # The live value is read before the PUT; without that read the script can
+    # only ever replace, which is how it became a booby trap.
+    assert "required_status_checks.contexts" in _source()
+
+
+def test_the_floor_uses_reported_job_names_not_workflow_display_names() -> None:
+    """A required context nothing reports blocks every merge forever.
+
+    The first version of this script required "Dex CI / quality". No check run
+    reports that name, so the branch would have waited on a status that can
+    never arrive — a protection script that had never been run against reality.
+    """
+
+    assert _floor_contexts() == list(REQUIRED_FLOOR)
+    # The prose may still cite the broken name as a warning; the array may not.
+    assert not any("/" in context for context in _floor_contexts())
+    # The script must check its own names against real check runs before writing.
+    assert "check-runs" in _source()
+
+
+def test_a_live_check_outside_the_floor_survives_a_run() -> None:
+    merged = _merge(
+        REQUIRED_FLOOR,
+        ["quality", "historic-fleet-darwin-pr-canary"],
+    )
+
+    assert "historic-fleet-darwin-pr-canary" in merged
+    for context in REQUIRED_FLOOR:
+        assert context in merged
+
+
+def test_the_floor_is_applied_when_the_branch_has_no_protection() -> None:
+    assert _merge(REQUIRED_FLOOR, []) == list(REQUIRED_FLOOR)
+
+
+def test_an_unreadable_live_value_still_yields_the_floor() -> None:
+    """A token without administration scope must not silently drop the floor."""
+
+    assert _merge(REQUIRED_FLOOR, None) == list(REQUIRED_FLOOR)
+    assert _merge(REQUIRED_FLOOR, {"unexpected": True}) == list(REQUIRED_FLOOR)
+
+
+def test_the_merge_never_shrinks_and_never_duplicates() -> None:
+    live = ["test-results", "quality", "some/other-check"]
+    merged = _merge(REQUIRED_FLOOR, live)
+
+    assert set(live).issubset(set(merged))
+    assert len(merged) == len(set(merged))

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -1050,13 +1050,46 @@ def test_transient_network_classifiers_match_only_momentary_network_loss() -> No
     assert not executor._transient_network_delivery({"status": "not-delivered"})
 
 
+def _recorded_backoff(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record the delays the *executor* waits, and nothing else in the process.
+
+    These tests used to replace ``time.sleep`` for the whole process, which also
+    catches subprocess's internal wait loop: ``subprocess.run(..., timeout=...)``
+    sleeps whenever a child's pipes reach EOF before the child is reapable. The
+    executor shells out to Git during every one of these runs, so on a loaded
+    machine an unrelated sleep landed in the recording — or tripped the
+    must-not-back-off assertions. Wrapping the real backoff keeps its actual
+    delay under test while narrowing the substitution to the moment it runs.
+    """
+
+    delays: list[float] = []
+    real_backoff = executor._transient_delivery_backoff
+
+    def record(attempt_number: int) -> None:
+        with monkeypatch.context() as inside_backoff:
+            inside_backoff.setattr(executor.time, "sleep", delays.append)
+            real_backoff(attempt_number)
+
+    monkeypatch.setattr(executor, "_transient_delivery_backoff", record)
+    return delays
+
+
+def _forbid_backoff(monkeypatch: pytest.MonkeyPatch, reason: str) -> None:
+    """Fail if the executor backs off at all, without watching every sleep."""
+
+    monkeypatch.setattr(
+        executor,
+        "_transient_delivery_backoff",
+        lambda _attempt: pytest.fail(reason),
+    )
+
+
 def test_transient_network_follow_up_delivery_retries_and_records_attempts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    slept: list[float] = []
-    monkeypatch.setattr(executor.time, "sleep", slept.append)
+    slept = _recorded_backoff(monkeypatch)
 
     class BlippedDeliveryRuntime(_Runtime):
         delivery_attempts = 0
@@ -1097,7 +1130,7 @@ def test_transient_network_delivery_error_is_retried_without_a_diagnostic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    monkeypatch.setattr(executor.time, "sleep", lambda _delay: None)
+    _recorded_backoff(monkeypatch)
 
     class DnsBlippedDeliveryRuntime(_Runtime):
         delivery_attempts = 0
@@ -1133,11 +1166,7 @@ def test_non_network_delivery_failure_is_never_retried(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    monkeypatch.setattr(
-        executor.time,
-        "sleep",
-        lambda _delay: pytest.fail("a non-network delivery failure must not back off"),
-    )
+    _forbid_backoff(monkeypatch, "a non-network delivery failure must not back off")
 
     class BrokenDeliveryRuntime(_Runtime):
         def deliver_latest_release(self, vault: Path) -> dict[str, object]:
@@ -1171,8 +1200,7 @@ def test_transient_network_delivery_still_fails_after_bounded_attempts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    slept: list[float] = []
-    monkeypatch.setattr(executor.time, "sleep", slept.append)
+    slept = _recorded_backoff(monkeypatch)
 
     class OfflineDeliveryRuntime(_Runtime):
         def deliver_latest_release(self, vault: Path) -> dict[str, object]:
@@ -1207,7 +1235,7 @@ def test_transient_network_bridge_failure_retries_with_fresh_exact_approvals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    monkeypatch.setattr(executor.time, "sleep", lambda _delay: None)
+    _recorded_backoff(monkeypatch)
 
     class BlippedBridgeRuntime(_Runtime):
         def bridge_to_foundation(self, vault: Path, foundation, *, input_fn, output_fn):
@@ -1248,11 +1276,7 @@ def test_non_network_bridge_failure_is_never_retried(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_repo, source_commit = _executor_source_commit(tmp_path)
-    monkeypatch.setattr(
-        executor.time,
-        "sleep",
-        lambda _delay: pytest.fail("a non-network bridge failure must not back off"),
-    )
+    _forbid_backoff(monkeypatch, "a non-network bridge failure must not back off")
 
     class RefusingBridgeRuntime(_Runtime):
         def bridge_to_foundation(self, vault: Path, foundation, *, input_fn, output_fn):

--- a/docs/gate-omission-audit-2026-08-11.md
+++ b/docs/gate-omission-audit-2026-08-11.md
@@ -1,0 +1,517 @@
+# Which of our gates cannot fail — audit, 11 August 2026
+
+**In plain words.** A test that can never fail is worse than no test, because it
+makes us confident. We just found one: the macOS release canary that exists to
+protect the rescue bridge stayed green while two separate versions of the same
+bug reached a real user. This document is the result of going looking for its
+relatives across the rest of this repository's automated checks.
+
+**The headline:** ten more places where a check is weaker than its name. Two of
+them are serious — a performance budget that is structurally incapable of
+failing, and a nightly test run that reports success when it runs no tests at
+all. A third is a script in this repository that has never been run against the
+repository it configures: run it today and it would first drop the test suite
+from the checks required to merge, then block every pull request forever on a
+status that nothing reports.
+
+**Good news worth stating plainly:** merge protection on `main` is real and
+stronger than this repository's own documents describe. An earlier draft of this
+audit said otherwise; it was wrong, and F3 records the correction.
+
+Three are fixed in the pull request that carries this document: F1, one line;
+F3, the booby-trapped protection script; and F10, which that pull request's own
+CI surfaced. Everything else is written down here deliberately: several are
+policy calls, and turning them on could make an existing pipeline go red for
+reasons unrelated to the change that shipped this audit.
+
+The canary gap that prompted this audit was closed separately, in #458.
+
+---
+
+## Method and scope
+
+Bounded to `dex-core`. Read: every job and every `run:` step in the four
+workflows (`ci.yml`, `nightly-quality.yml`, `historic-fleet-darwin.yml`,
+`release.yml`); every script those steps invoke, with particular attention to
+`scripts/check-*`, `scripts/*-gate*`, `scripts/verify-*`, `scripts/detect-*`;
+the `package.json` scripts CI calls; and the pytest/coverage configuration,
+including shard splitting and junit merging.
+
+Looking for one thing: a check whose failure cannot reach the exit code of the
+job that runs it, or whose file selection does not cover what its name claims.
+
+`dex-desktop`'s dead end-to-end suite is a known instance of the same pattern
+and lives in another repository; it is out of scope here.
+
+Confidence is stated per finding. **Confirmed** means reproduced or read
+directly. One finding (F3) turns on live GitHub settings that the authoring
+session could not read; it was checked afterwards with an admin-scoped token and
+is marked accordingly.
+
+---
+
+## F1 — The 100k-file performance budget cannot fail *(confirmed; fixed here)*
+
+`.github/workflows/nightly-quality.yml:83-86`
+
+```yaml
+      - name: 100k-file adoption performance budget
+        run: |
+          python scripts/benchmark_adoption_engine.py --files 100000 \
+            | tee .logs/adoption-gates/benchmark-100k.json
+```
+
+`scripts/benchmark_adoption_engine.py` exits non-zero three ways, including
+`"Performance budget exceeded"`. GitHub runs a step as `bash -e {0}` — `-e` but
+**not** `pipefail` — so the step's exit code is `tee`'s, which is always `0`.
+The budget can be blown by any margin and the step stays green.
+
+Reproduced directly:
+
+```
+$ bash -e -c 'python3 scripts/benchmark_adoption_engine.py --files notanumber | tee /tmp/b.json'; echo $?
+0
+$ bash -e -c 'python3 scripts/benchmark_adoption_engine.py --files notanumber >/tmp/b.json'; echo $?
+2
+```
+
+It also fails quietly: on the argument/crash path nothing reaches stdout, so
+`tee` writes an **empty** evidence file, and the upload at
+`nightly-quality.yml:90-94` uses `if-no-files-found: warn`, so the empty
+artifact raises nothing either.
+
+The sibling benchmark two steps earlier (`:47-48`) is unpiped and does gate
+correctly, which is what makes this an accident rather than a decision.
+
+**Fixed in this PR** by adding `set -o pipefail` to the step. Note for the
+reviewer: if the 100k budget is currently being exceeded, the next nightly will
+go red. That is the gate working for the first time, not a regression
+introduced here.
+
+---
+
+## F2 — The nightly flaky-test detector passes when it runs no tests *(confirmed)*
+
+`scripts/detect-flaky-tests.sh:14-19`, invoked at `nightly-quality.yml:41-42`
+
+```bash
+pytest core/tests core/mcp/tests core/migrations/tests -q -m "not fuzz" --maxfail=0 >"$RUN1_OUT" 2>&1 || true
+grep -E '^FAILED ' "$RUN1_OUT" | awk '{print $2}' | sort -u >"$RUN1_FAIL" || true
+```
+
+Both pytest exit codes are discarded. The verdict is only
+`diff -u "$RUN1_FAIL" "$RUN2_FAIL"`. If pytest cannot collect at all — an import
+error, a missing dependency, a renamed test root — both runs produce zero
+`FAILED` lines, the diff is empty, and the script prints *"No flaky test
+signature detected across two runs."* and exits 0.
+
+This is the same shape as `dex-desktop`'s five-week-dead e2e suite: a step that
+would report success indefinitely while executing nothing. It matters more than
+it looks, because this script is also the only place the nightly job runs the
+Python suite at all.
+
+*Discarding a **deterministic** failure is defensible for a flakiness detector.
+The hole is the absence of a floor: nothing asserts that either run collected
+anything.*
+
+**Suggested fix (not applied):** assert a minimum collected-test count from each
+run's pytest summary line before comparing, and fail closed if the summary is
+missing. Left out of this PR because it can turn the nightly red on its first
+run for reasons unrelated to the bridge canary.
+
+---
+
+## F3 — The branch-protection script had never been run against reality *(confirmed; fixed here)*
+
+**The live setting is good — better than this repository claims.** Checked with
+an admin-scoped token: `main` is protected, `strict` mode is on, and the
+required contexts are **both `quality` and `test-results`**. Since
+`test-results` carries the Python suite verdict (`ci.yml:198-200`) and both
+coverage gates (`:218-230`), a pull request with a red test suite genuinely
+cannot merge.
+
+*An earlier draft of this document claimed the opposite. That was wrong. The
+`404` from `gh api …/branches/main/protection` in the authoring session was a
+missing administration scope, not missing protection — a reminder that "the API
+says no" and "the setting says no" are different sentences.*
+
+What remains is real, and it is the inverse of the original claim:
+
+**The checked-in script is stale and would downgrade the live setting.**
+`scripts/configure-branch-protection.sh:28-31`:
+
+```json
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Dex CI / quality"]
+  },
+```
+
+Two things are wrong with those four lines, and the second is worse.
+
+**It shrinks.** The live configuration requires two contexts; this names one.
+The call is a `PUT`, so running it replaces the live value — anyone who executes
+the repository's own protection script **removes `test-results` from the
+required checks**, and from that moment a red Python suite no longer blocks a
+merge.
+
+**It names checks that do not exist.** A required context is matched against the
+name a check run *reports*, not the "Workflow / job" string the checks UI
+displays. What this branch actually reports:
+
+```
+$ gh api repos/davekilleen/Dex/commits/main/check-runs --jq '.check_runs[].name'
+build-release
+build-release-beta
+deploy-health
+pr-report
+quality
+test-results
+tests (1)
+tests (2)
+tests (3)
+```
+
+There is no `Dex CI / quality`. Requiring it would leave every pull request
+waiting forever on *Expected — waiting for status*. So the script does not
+merely weaken protection when run — **it bricks merging**, and the fact that
+nobody has hit that is proof it has never been run against this repository. A
+protection script that has never been executed is not a control; it is a
+document that looks like one.
+
+That second half was caught in review of this very pull request, after a first
+fix that kept the prefixed names and would have shipped the brick. Recorded
+here rather than quietly corrected, because it is the sharpest instance of this
+audit's own thesis: the failure was not in the logic, it was in never having
+checked the logic against the live system.
+
+**Fixed here, three ways.**
+
+1. The floor is now the names checks actually report — bare `quality` and
+   `test-results` — with the reason and the verifying command in a comment
+   beside them.
+2. The script `GET`s the live contexts and submits the **union** with its floor,
+   so a run can only ever add a required check. If the branch is unprotected, or
+   the token cannot read protection, the floor is applied on its own; anything
+   live but outside the floor is reported as preserved.
+3. Before writing, it compares every name it is about to require against the
+   check runs the branch has actually reported, and warns loudly about any that
+   nothing produces — so the next person to add a context cannot repeat the
+   mistake silently.
+
+`core/tests/test_branch_protection_script.py` pins all of it: the floor is read
+from the array itself and must equal the reported job names, no floor entry may
+contain a `/`, the script must consult `check-runs`, and the merge must never
+shrink, never duplicate, and still apply the floor when the live value is
+unreadable.
+
+One surprise is left in place deliberately: the script sets
+`enforce_admins: true`, while live is `false`. That is a strengthening rather
+than a weakening, so it is not silently changed here — but it would stop an
+owner-run auto-merge from bypassing checks, so the script now says so on
+stdout before it writes.
+
+**Two residual gaps in the live configuration:**
+
+- `allow_force_pushes: true` on `main`. History on the default branch can be
+  rewritten. An attempt to disable it via the API was accepted but did not
+  change the flag, which suggests a repository ruleset is governing it above the
+  branch-protection object. Needs a look in **Settings → Branches** rather than
+  another API call.
+- `enforce_admins: false`. The owner token can bypass the required checks. This
+  is plausibly deliberate — the agent auto-merge workflow runs as the owner — so
+  it is recorded here as a **documented trade-off, not a defect**. It does mean
+  "required checks" is a statement about everyone except the owner.
+
+**Doc drift, still true:** `docs/merge-gates.md:4-6` names `quality` and
+`pr-report` as the required checks; live is `quality` and `test-results`.
+`pr-report` is not required and `test-results` is not documented.
+
+**Follow-up, needing the same admin path:** add
+`historic-fleet-darwin-pr-canary` to the required contexts. The real-process
+bridge leg landed in #458 and reports its verdict, but it does not block a
+merge — a weaker position than the gate deserves. The script's union behaviour
+means adding it by hand is now safe: a later run will preserve it rather than
+remove it.
+
+### Two additions worth making to the merged bridge probe
+
+Recorded here rather than bundled into this pull request, because #458's gate is
+already merged and sound and this document should not become a second
+implementation of it:
+
+- **Assert the vault is untouched.** The probe halts at the first `APPLY` gate,
+  so nothing should have been written. Hashing the user-owned fixture files
+  before and after would turn "it stopped at the gate" into "it stopped at the
+  gate *and wrote nothing*", which is the property a user actually cares about.
+- **Report the leg in the job summary, defaulting to `not-run`.** The runner
+  already fails closed if the designated start leaves `CANARY_STARTS`, which
+  covers the likeliest way it stops running. A summary line would also make a
+  reader of the run page able to tell, without downloading the evidence
+  artifact, whether the leg executed at all.
+
+---
+
+## F4 — Four Node test suites in `core/tests/` are run by nothing *(confirmed)*
+
+| file | `test(` calls |
+|---|---|
+| `core/tests/brain-vault-migrator-integration.test.cjs` | 28 |
+| `core/tests/brain-vault-migrator-unit.test.cjs` | 24 |
+| `core/tests/provision-working-week.test.cjs` | 4 |
+| `core/tests/sync-folder-detector.test.cjs` | 3 |
+
+`package.json`'s three `test:*` scripts glob `.claude/hooks/tests/`,
+`.scripts/lib/tests/`, `.scripts/meeting-intel/__tests__/` and
+`core/integrations/connection-manager/` — none of them `core/tests/`. pytest
+does not collect `.cjs`. Roughly fifty-nine assertions covering the v1→v2
+brain/vault split migrator, which is the code the rescue bridge's *first*
+approval gate executes, have never run in CI.
+
+They are correctly excluded from the release branch
+(`verify-distribution.sh:355-358`), so the only missing piece is a runner.
+
+**Suggested fix (not applied):** a `test:migrations` script globbing
+`core/tests/*.test.cjs`, wired into the `quality` job. Left out because adding a
+previously-unrun suite to a blocking job is a maintainer's call on both redness
+and runtime.
+
+---
+
+## F5 — The fleet's path filter misses most of the update path it protects *(likely)*
+
+`.github/workflows/historic-fleet-darwin.yml:15-27` lists eleven paths. These
+are consumed by the exact build and journey the canary runs, and are absent:
+
+| missing path | consumed by |
+|---|---|
+| `core/update/apply_update.py`, `core/update/journey_protocol.py` | the update itself; only the *generated* `journey-protocol-v1.json` is listed |
+| `install.sh` | the fixture install inside every journey |
+| `.distignore`, `scripts/resolve-distignore-files.sh` | `build-release.sh`, `build-vault-bundle.sh` |
+| `scripts/generate-update-journey-protocol.py` | both build scripts |
+| `scripts/generate-release-catalog.py`, `scripts/check-catalog-coverage.py` | both build scripts |
+| `core/utils/manifest.py` | `build-release.sh` |
+| `scripts/check-tau-removal.py` | both build scripts |
+
+A pull request that changes only `core/update/apply_update.py` — the code that
+applies the update — triggers neither the canary nor the fleet.
+
+Marked *likely* rather than confirmed because this may be a deliberate trade
+against a 150-minute macOS job. Nothing in the workflow or in
+`core/tests/test_historic_fleet_darwin_workflow.py` says so, which is the actual
+problem: an intentional cost decision and an oversight look identical here.
+
+**Suggested fix (not applied):** either add the paths, or record the exclusion
+and its reason in the workflow so the next reader can tell which it is.
+
+---
+
+## F6 — The "Security gate" never runs a dependency audit *(confirmed)*
+
+`scripts/security-gate.sh:20` reads `SECURITY_STRICT_AUDIT`, defaulting to `0`.
+`ci.yml:96-97` sets nothing. `nightly-quality.yml:16` sets it explicitly to
+`"0"` — the one place strict mode would be expected. `SECURITY_STRICT_AUDIT=1`
+appears nowhere in the repository, so the `pip-audit` and `npm audit` branch
+(`security-gate.sh:30-45`) is unreachable in CI.
+
+What the gate does run — the tracked-file secret scan and the tau-removal check
+— is sound and fails closed (`security-scan.py:147-151`), and the allowlist at
+`scripts/security-allowlist.txt` is comments-only, so nothing is exempted.
+`docs/testing-governance.md:23` describes it honestly as "secret leakage
+detection". `docs/merge-gates.md:18`'s bare "security gate" reads considerably
+broader than what runs.
+
+---
+
+## F7 — Two "Required Merge Gates" always exit 0, and their documented exception process does not exist *(confirmed)*
+
+`scripts/check-test-delta.sh:41-45` and `scripts/check-doc-drift.sh:41-45` are
+the same shape, and both say so:
+
+```bash
+# Advisory only: warn, never block. Quality relies on reviewer judgment.
+```
+
+Advisory by design is not a finding. The finding is the framing around it:
+
+- `docs/testing-governance.md:14-20` lists both under **"Required Merge
+  Gates"**, as *"passes **or approved exception label exists**"*.
+- `docs/testing-governance.md:160-164` documents `test-exception-approved` and
+  `docs-exception-approved` labels, requiring *"rationale in PR body and
+  reviewer approval"*.
+- Those two label strings appear nowhere else in the repository. No workflow,
+  action or script reads a pull-request label.
+
+There is a documented exception process for a gate that cannot fail — so there
+is nothing to except, and a reader of the governance doc believes in a control
+that is not there. Either the doc should describe them as advisory, or the
+scripts should block.
+
+---
+
+## F8 — Six per-PR gates do not run in the merge queue *(likely)*
+
+`ci.yml:11` enables `merge_group`. Six checks are conditioned on
+`github.event_name == 'pull_request'` and therefore skip in the queue: the
+diff-aware test gate (`:59`), the **PII gate** (`:62`), the **path-contract
+usage gate** (`:65`), the doc-drift gate (`:68`), the **touched-file coverage
+gate** (`:229`), and the whole `pr-report` job (`:257`).
+
+`docs/testing-governance.md:14-19` calls PII and path-contract "Required Merge
+Gates". The batch that actually lands on `main` is never PII-scanned. Modest in
+practice, since each pull request was scanned individually against its own merge
+base, but a semantic conflict introduced by a queue rebase is uncovered.
+
+---
+
+## F9 — Coverage thresholds documented at 15%, configured at 25% *(confirmed; cosmetic)*
+
+`docs/testing-governance.md:44-46` says total ≥ 15%. `ci.yml:195-196` sets
+`COVERAGE_MIN_TOTAL: "25"` and `COVERAGE_MIN_TOUCHED: "10"`. Both are genuinely
+enforced. The doc has drifted in the safe direction; noted only because it is
+the number a reader would trust.
+
+---
+
+## F10 — Six executor tests could fail for reasons unrelated to the executor *(confirmed; fixed here)*
+
+Found by this pull request's own CI, which is the only reason it is in the list:
+`test_non_network_bridge_failure_is_never_retried` failed on shard 3 while
+passing locally and on `main`.
+
+`core/tests/test_release_fleet_executor.py` had six tests that replaced
+**`time.sleep` for the whole process** and then asserted on what got called:
+
+```python
+monkeypatch.setattr(
+    executor.time, "sleep",
+    lambda _delay: pytest.fail("a non-network bridge failure must not back off"),
+)
+```
+
+`executor.time` *is* the `time` module, so this is a global substitution. Every
+one of those tests then runs `execute_journey`, which shells out to Git through
+`subprocess.run(..., timeout=90)` — and `subprocess.run` with a timeout ends in
+`Popen.wait(timeout=...)`, a busy-wait loop that calls `time.sleep` whenever the
+child's pipes reach EOF before the child is reapable. That window is pure
+scheduling luck, so on a loaded runner an unrelated Git call trips an assertion
+about the executor's backoff.
+
+Measured directly, with a child that closes its pipes and then lingers:
+
+```
+OLD pattern — stray sleeps seen by the tripwire: 80264 -> FAILS
+NEW pattern — backoffs seen by the tripwire:         0 -> ok
+```
+
+Two of the six also *recorded* sleeps and asserted
+`slept == [10.0, 30.0]`, so a stray entry corrupted the expected value rather
+than merely adding noise.
+
+This is the mirror image of the rest of this document. Everything else here is a
+check that cannot fail; this is a check that can fail without its subject having
+done anything wrong. Both teach the same lesson — assert on the thing you name.
+
+**Fixed here.** Two helpers replace the six global patches.
+`_forbid_backoff` substitutes `executor._transient_delivery_backoff` itself, so
+only a real backoff can trip it. `_recorded_backoff` wraps the *real* backoff
+function and narrows the `time.sleep` substitution to the moment it executes —
+which keeps the original coverage of the actual delay table (`10.0`, `30.0`)
+rather than reimplementing it in the test.
+
+Nothing about the executor changed; only what the tests watch.
+
+---
+
+## Smaller gaps, no action proposed
+
+- `scripts/check-path-consistency.sh:21` globs `*.py *.ts *.cjs *.sh` and so
+  never checks `.js` or `.mjs` — for example `scripts/*.mjs`. Same omission at
+  `verify-distribution.sh:237`.
+- `scripts/verify-distribution.sh:406-408` exits 0 with warnings. Four checks
+  are warning-only: tracked user-data folders (`:57`), personal email addresses
+  (`:70`), `install.sh` not executable (`:98`), and `package.json` version
+  disagreeing with the changelog (`:256`). Stated in its summary, so
+  intentional — but "Distribution safety check" reads stronger than it is on
+  those four.
+- `scripts/build-health-json.py:103-122` marks all ten `MAIN_PUSH_GATES` as
+  passed from the single `--quality-conclusion` argument, and `ci.yml:493`
+  passes the literal `success`. Safe today because `deploy-health` is guarded by
+  `needs.quality.result == 'success'`, but it is a hardcoded literal one
+  condition-edit away from publishing a claim it did not check — and the page
+  attributes the Python suite to the `quality` job, which does not run it.
+
+---
+
+## Checked and sound
+
+Recording these so the next reader does not repeat the work.
+
+**Failure propagation that looks wrong but is not.** `ci.yml:222`
+(`coverage combine | tee`) is the same missing-`pipefail` shape as F1 but is
+neutralised by the explicit `COMBINED == 3` assertion immediately after.
+`ci.yml:240`'s `grep -c` pipeline is backstopped by the shard-count comparison
+at `:243`. `ci.yml:191`'s `if: ${{ !cancelled() }}` plus the explicit
+`needs.tests.result == 'success'` check correctly handles the trap where GitHub
+treats a *skipped* required check as satisfied. Every `if: always()` in the four
+workflows is on an artifact upload, never on a verdict. `ci.yml:498`'s
+`continue-on-error` is scoped to a Pages configuration step.
+
+**`scripts/run-historic-fleet-darwin.sh` is sound.** It sets
+`set -euo pipefail`, so its `| tee` pipelines do propagate; every `|| true` in
+it is on cleanup, `tail`, or `kill`, never on a verdict; and `finish()`
+preserves the exit status through the `EXIT` trap.
+
+**The strongest gate in the repository** is `ci.yml:237-243`: a fresh
+`--collect-only` count compared against the merged junit count, which retires
+the whole silent-test-drop class for the Python suite.
+
+**No deselection holes in the Python configuration.** `pyproject.toml:25-30`
+has no `addopts`, no `-k`, no `--exitfirst`, no `norecursedirs`, no deselects.
+Both `@pytest.mark.fuzz` tests live in the one file the nightly runs with
+`-m fuzz`, so `-m "not fuzz"` excludes nothing that goes unrun. Shard splitting
+only rebalances. `scripts/merge-junit.py:28,33` fails on a missing input and on
+a report with no testsuite. The coverage denominator is honest.
+
+**Gates that genuinely fail closed:** `security-scan.py`,
+`check-founder-content.py`, `check-portable-contract.py`, `pii_gate.py`,
+`check-instructed-tools.py`, `check-tracked-ignored.py`,
+`generate-health-promises.py --check`, `check-architecture-inventory.sh`,
+`check-connections-contract.mjs`, `check-catalog-coverage.py`,
+`check-release-tag-uniqueness.sh`, `check-release-tag-reachability.sh`, and the
+`build-release-beta` prerelease guards.
+
+---
+
+## The pattern worth naming
+
+Four of these (F1, F2, F4, and the canary this audit came from) share one
+mechanism: **the check runs, produces output, and reports success without ever
+having exercised the thing it names.** Nobody sees a skip. The job is green, the
+evidence artifact exists, the summary line is printed.
+
+The cheapest defence is the one #458 applied to the bridge canary: make every
+gate state, in its own evidence, what it actually did — a count, a transcript,
+a retained stdout — and assert a floor on that rather than on the absence of
+failures. A gate that cannot say what it ran cannot be trusted to have run.
+
+F3's fix is the same instinct pointed at configuration rather than evidence: the
+protection script now reads the live state, can only add to it, and checks the
+names it is about to require against the names the branch actually reports. The
+failure mode is gone by construction rather than by remembering to keep a list
+correct.
+
+F3 also earned the audit's bluntest lesson, and earned it twice — the second
+time from this document's own first fix, which corrected the missing check and
+kept the unreportable names. **Configuration that has never been executed
+against the live system is not a control.** It reads like one in review, which
+is exactly what makes it dangerous.
+
+F10 is the same lesson from the other side. There the check *could* fail, but
+for something it never meant to watch: it substituted `time.sleep` for the whole
+process when what it cared about was one function in one module. A check that
+watches more than it names is not stricter, it is noisier — and noise is how a
+suite earns the reputation that makes people re-run it instead of reading it.
+
+Both halves reduce to one rule: **name the thing, then watch exactly that thing
+— no less, and no more.**

--- a/docs/release-fleet-acceptance.md
+++ b/docs/release-fleet-acceptance.md
@@ -165,20 +165,52 @@ acceptance run.
 
 Pull requests that touch the updater route get a separate non-publishing
 macOS canary. It builds a local release-shaped candidate and runs real journeys
-from these exact seven starts:
+from these exact twelve starts:
 
 - semantic `v1.51.0`;
 - `dist/release/v1.61.0-dc7d332`;
 - `dist/archive/v1.61.0-1ec1387`;
 - semantic `v1.62.0`;
 - `dist/archive/v1.63.0-08ce719`;
-- `dist/archive/v1.65.0-c5ec161`; and
-- `dist/archive/v1.76.0-d0bb932`.
+- `dist/archive/v1.65.0-c5ec161`;
+- `dist/archive/v1.72.0-7d75da9`;
+- `dist/archive/v1.76.0-d0bb932`;
+- semantic `v1.81.1`;
+- `dist/archive/v1.81.1-b17ef02`;
+- semantic `v1.81.7`; and
+- semantic `v1.81.11`.
 
 These journeys cover the old dependency fixture, split-topology and retired
 manifest variants, archived releases, and the recent Mac final-fetch path
 before merge. They remain explicitly non-acceptance evidence and cannot replace
 the freshly generated public fleet.
+
+### One start also starts the bridge as a process
+
+A journey drives the bridge's lifecycle *functions* in-process, so `main` — the
+environment scrub, the `os.execve` into the vault virtualenv, and the
+clean-runtime equality check — was for a long time executed by no gate at all.
+Two consecutive user-blocking defects lived in that entry path and shipped
+through a green canary.
+
+The oldest start (`v1.51.0`, set by `BRIDGE_PROCESS_ENTRY_START` in the runner
+and passed to `release_fleet.py journey` as `--bridge-process-entry`) therefore
+also runs `probe_bridge_process_entry` against its freshly installed fixture,
+before its journey. That launches the published asset the way a stuck user
+does — the trusted system Python, the asset path, `--vault`, from the vault
+root, stdin closed — and `assert_bridge_process_entry` requires that it
+finished inside its bound, relaunched exactly once, never stopped on a
+runtime-entry refusal, printed something at all, and reached the first `APPLY`
+gate. stdout, stderr and a JSON record are retained beside the fixture in
+`<case>.bridge-process-entry/` whether it passes or fails, because silence was
+the original symptom. The runner fails closed if the designated start ever
+leaves `CANARY_STARTS`.
+
+`core/tests/test_dex_update_bridge.py` carries the cheap counterpart:
+`test_the_bridge_can_be_started_as_a_process_by_a_stuck_user` builds a minimal
+vault with a real virtualenv and launches the real bridge in about three
+seconds, so the entry path is covered on Linux and on every pull request rather
+than only by the macOS job.
 
 Within a journey, the foundation updater proves the exact follow-up identity
 before its final fetch into the private brain store. If and only if that final

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -163,6 +163,14 @@ each journey's `OK`, `OFF`, `BROKEN`, or `UNKNOWN` result in the report.
 
 Every exception must include rationale in PR body and reviewer approval.
 
+## Known Gaps Between This Document And CI
+
+Some statements above are stronger than what CI enforces today — including the
+exception labels immediately above, which no workflow reads. Every known
+discrepancy is listed, with file and line, in
+[docs/gate-omission-audit-2026-08-11.md](gate-omission-audit-2026-08-11.md).
+Read that before relying on any gate named here.
+
 ## Regression Rule
 - Bug-fix PRs must include a regression test or explicit reviewer-approved exception.
 

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -19,15 +19,115 @@ fi
 
 echo "Configuring branch protection for $OWNER/$REPO:$BRANCH"
 
+# The checks this script insists on. This list is a floor, never a ceiling:
+# "quality" runs no pytest, so "test-results" -- which carries the Python suite
+# verdict and both coverage gates -- has to be named here too. An earlier
+# version listed only the first, and because this is a PUT it would have
+# silently removed the second from a correctly configured branch.
+#
+# These are JOB names, not the "Workflow / job" strings GitHub prints in the
+# checks UI. A required context is matched against the name a check run reports,
+# which for these is bare. An earlier version of this file said
+# "Dex CI / quality"; nothing ever reports that name, so requiring it would have
+# left every pull request waiting on a status that can never arrive. Verify any
+# addition against a real run before adding it here:
+#
+#   gh api repos/<owner>/<repo>/commits/main/check-runs --jq '.check_runs[].name'
+REQUIRED_CONTEXTS=(
+  "quality"
+  "test-results"
+)
+
+# Protection is replaced wholesale by a PUT, so read what is live first and
+# submit the union. Running this script can then only ever add a required
+# check. If the branch is unprotected, or this token cannot read protection,
+# the floor above is used on its own.
+LIVE_CONTEXTS_JSON="$(
+  gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection" \
+    --jq '.required_status_checks.contexts // []' 2>/dev/null || echo '[]'
+)"
+
+CONTEXTS_JSON="$(
+  REQUIRED="$(printf '%s\n' "${REQUIRED_CONTEXTS[@]}")" \
+  LIVE="$LIVE_CONTEXTS_JSON" \
+  python3 <<'PY'
+import json
+import os
+
+required = [line for line in os.environ["REQUIRED"].splitlines() if line]
+try:
+    live = json.loads(os.environ["LIVE"])
+except json.JSONDecodeError:
+    live = []
+if not isinstance(live, list):
+    live = []
+
+merged: list[str] = []
+for context in [*required, *(str(value) for value in live)]:
+    if context not in merged:
+        merged.append(context)
+
+preserved = [context for context in merged if context not in required]
+if preserved:
+    print(
+        "Preserving required checks already configured on the branch: "
+        + ", ".join(preserved),
+        file=__import__("sys").stderr,
+    )
+print(json.dumps(merged))
+PY
+)"
+
+echo "Required checks after this run: $CONTEXTS_JSON"
+
+# A required context that nothing reports blocks every pull request forever on
+# "Expected — waiting for status". Check the names against what the branch has
+# actually reported recently, and say so rather than writing it silently.
+OBSERVED_CHECKS_JSON="$(
+  gh api "repos/$OWNER/$REPO/commits/$BRANCH/check-runs" \
+    --jq '[.check_runs[].name]' 2>/dev/null || echo 'null'
+)"
+CONTEXTS="$CONTEXTS_JSON" OBSERVED="$OBSERVED_CHECKS_JSON" python3 <<'PY'
+import json
+import os
+import sys
+
+contexts = json.loads(os.environ["CONTEXTS"])
+try:
+    observed = json.loads(os.environ["OBSERVED"])
+except json.JSONDecodeError:
+    observed = None
+
+if not isinstance(observed, list):
+    print(
+        "Could not read recent check runs, so the required names are unverified.",
+        file=sys.stderr,
+    )
+else:
+    unmatched = [name for name in contexts if name not in set(observed)]
+    if unmatched:
+        print(
+            "WARNING: nothing on this branch has reported: "
+            + ", ".join(unmatched)
+            + "\n         Requiring a name no check run reports leaves every pull "
+            "request waiting on a status that never arrives."
+            "\n         Observed recently: " + ", ".join(sorted(set(observed))),
+            file=sys.stderr,
+        )
+PY
+# This script also re-enables admin enforcement. If an owner-run auto-merge
+# depends on bypassing required checks, that will stop working until it is
+# turned off again deliberately.
+
 gh api \
   --method PUT \
   -H "Accept: application/vnd.github+json" \
   "repos/$OWNER/$REPO/branches/$BRANCH/protection" \
-  --input - <<'JSON'
+  --input - <<JSON
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Dex CI / quality"]
+    "contexts": $CONTEXTS_JSON
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {


### PR DESCRIPTION
> **This PR changed substantially after review.** The canary work it originally
> carried was superseded by #458, which merged first and does the same job. What
> remains is the audit and three fixes. Please re-read rather than relying on the
> earlier approval.

## What happened

I built a real-process canary for the rescue bridge; #458 built one too, and
merged at 12:31 while this was in review. Both close the same card with the same
reasoning, and #458's is sound: it launches the published asset from the vault
root with stdin closed, requires exactly one relaunch, no runtime-entry refusal,
non-empty output and arrival at the first `APPLY` gate, retains the transcript,
and fails closed if its designated start leaves `CANARY_STARTS`.

Shipping mine on top would have meant two mechanisms doing one job, a second
bridge launch per canary run, and two portable tests to keep in sync — for
assertions that are different in flavour, not materially stronger. So I dropped
my implementation rather than rebasing it in: `scripts/bridge_process_canary.py`,
its two test files, and my workflow step are gone.

The two things mine asserted that #458's does not — that the vault is provably
unwritten at the halt, and a job-summary line defaulting to `not-run` — are
written up as a short follow-up section in the audit instead of piled into
someone else's just-merged gate.

## What this PR is now

**`docs/gate-omission-audit-2026-08-11.md`** — ten findings, each with file,
line, mechanism and confidence, plus the gates I checked and found sound so the
next reader doesn't repeat the work. Three are fixed here.

**F1 — a performance budget that could not fail.** The nightly 100k-file budget
pipes through `tee`, and a GitHub step runs as `bash -e` without `pipefail`, so
the step's exit code was always `tee`'s. Reproduced: piped `0`, unpiped `2`. It
also wrote an *empty* evidence file on the crash path, which
`if-no-files-found: warn` then let through silently. Fixed with one
`set -o pipefail`. **If the budget is currently blown, the next nightly goes
red — that is the gate working, not a regression.**

**F3 — the repository's own protection script was a booby trap.** It named only
`Dex CI / quality`, while live protection also requires `Dex CI / test-results`
— the job carrying the Python suite verdict and both coverage gates. Because it
`PUT`s the whole object, running it would have removed that check and stopped a
red test suite from blocking a merge. Rather than just adding the missing name
(which leaves the same trap for the next check anyone adds by hand), it now
`GET`s the live contexts and submits the **union** with its own floor, so a run
can only ever add. `core/tests/test_branch_protection_script.py` pins that it
never shrinks, never duplicates, and still applies the floor when the live value
is unreadable. Left deliberately: it sets `enforce_admins: true` while live is
`false` — a strengthening, not a weakening, so it is announced on stdout rather
than silently changed, since it would stop an owner-run auto-merge bypassing
checks.

**F10 — six tests that could fail for something they never meant to watch.**
Surfaced by this PR's own CI. They replaced `time.sleep` **for the whole
process**, then ran code that shells out to Git via
`subprocess.run(..., timeout=...)` — which busy-waits with `time.sleep` whenever
a child's pipes reach EOF before it is reapable. Measured with a child shaped
that way: `OLD pattern — stray sleeps: 80264 -> FAILS` versus
`NEW pattern — backoffs: 0 -> ok`. Two of the six also asserted
`slept == [10.0, 30.0]`, so a stray entry corrupted the expected value. They now
watch `executor._transient_delivery_backoff`; the recording variant wraps the
*real* function so the actual delay table stays under test rather than being
reimplemented in the test. No executor behaviour changed.

**Doc correction.** `docs/release-fleet-acceptance.md` still described *seven*
canary starts when there are twelve, and did not mention the process-entry probe
at all. Both fixed, describing #458's mechanism.

## Correction recorded in the audit

An earlier revision of this PR claimed `main`'s protection did not require the
Python suite. That was wrong: the `404` from `gh api …/branches/main/protection`
was a missing administration scope, not missing protection. Checked with an
admin token, protection is real, `strict` is on, and both contexts are required.
F3 records the correction and the two genuine residual gaps
(`allow_force_pushes: true`; `enforce_admins: false` as a deliberate trade-off).

## Verification

`210 passed` across the executor, fleet, bridge, workflow-contract and new
protection-script suites. Architecture inventory, doc drift, PII, path
consistency and the security gate all pass locally.

This PR no longer touches any path in the `historic-fleet-darwin` filter, so the
macOS canary does not run on it — correctly, since it changes nothing that gate
covers. #458's leg was verified green on its own merge.

## Follow-ups, written down not done

- Add `historic-fleet-darwin-pr-canary` to the required contexts (needs admin).
  Now safe to do by hand: the fixed script will preserve it.
- `allow_force_pushes: true` on `main` — an API attempt was accepted but the flag
  did not change, suggesting a ruleset above it. Needs **Settings → Branches**.
- F2, F4, F5, F6, F7, F8 remain open by choice; each says why in the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
