### PR TITLE
Make the fleet canary start the bridge as a process

### DIFF
--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import venv
 from collections import namedtuple
 from pathlib import Path
 from types import ModuleType
@@ -16,6 +17,8 @@ import pytest
 from core.lifecycle import service as lifecycle_service
 from core.transaction.engine import PlanRejected
 from scripts import dex_update_bridge as bridge
+
+BRIDGE_SOURCE = Path(bridge.__file__).resolve()
 
 
 class _Service:
@@ -2084,3 +2087,67 @@ def test_git_subprocess_environment_excludes_caller_git_and_credential_settings(
     assert "GIT_SSH_COMMAND" not in environment
     assert "credential.helper=" in captured["arguments"]
     assert "--no-replace-objects" in captured["arguments"]
+
+
+def _process_entry_vault(tmp_path: Path) -> Path:
+    """Build the smallest vault the bridge will accept, with a real virtualenv.
+
+    ``resolve()`` matters: the bridge refuses a vault path with a symlinked
+    component, and the macOS temporary directory reaches it through ``/var``.
+    """
+
+    root = tmp_path.resolve()
+    vault = root / "vault"
+    (vault / ".git").mkdir(parents=True)
+    (vault / "System").mkdir()
+    venv.EnvBuilder(with_pip=False, symlinks=True).create(vault / ".venv")
+    return vault
+
+
+def test_the_bridge_can_be_started_as_a_process_by_a_stuck_user(
+    tmp_path: Path,
+) -> None:
+    """Run the whole entry path in a real process, the way a rescued user does.
+
+    Every other test here drives the bridge in-process, so the scrub, the
+    ``execve`` into the vault virtualenv, and the clean-runtime equality check
+    only ever run under monkeypatched stand-ins. Two consecutive user-blocking
+    defects lived exactly there: v1.91's relaunch loop, which burned CPU while
+    printing nothing at all, and v1.92's clean-runtime refusal, which could
+    never pass because the scrub manufactured the difference it compared.
+
+    The run stops on its own: this vault is not a real Dex install, so the
+    bridge reports a vault problem shortly after entering its runtime. What
+    matters is that it got that far, exactly once, and said so. The pinned
+    foundation fetch runs when the network is available and fails within its own
+    bounded deadline when it is not; either outcome is a stop *after* entry.
+    """
+
+    vault = _process_entry_vault(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    completed = subprocess.run(
+        [sys.executable, str(BRIDGE_SOURCE), "--vault", str(vault)],
+        cwd=vault,
+        env={
+            "HOME": str(home),
+            "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin",
+            "LANG": "en_US.UTF-8",
+            "TERM": "xterm-256color",
+        },
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        # A healthy run takes seconds; the bound exists so an unbounded relaunch
+        # loop fails this test instead of running until the CI job is cancelled.
+        timeout=180,
+    )
+
+    notice = "Relaunching inside Dex's installed runtime..."
+    assert completed.stderr.count(notice) == 1
+    assert "could not be entered cleanly" not in completed.stderr
+    # Whatever the relaunched process goes on to say about this deliberately
+    # incomplete vault, it has to say something: silence after the relaunch is
+    # the exact shape of the loop that shipped.
+    assert completed.stderr.split(notice, 1)[1].strip()

--- a/core/tests/test_historic_fleet_darwin_workflow.py
+++ b/core/tests/test_historic_fleet_darwin_workflow.py
@@ -124,6 +124,35 @@ def test_twelve_start_pr_canary_is_release_shaped_and_cannot_publish() -> None:
     assert "GH_TOKEN" not in WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
+def test_one_canary_start_runs_the_bridge_as_a_top_level_process() -> None:
+    """The gate that guards the bridge has to start the bridge.
+
+    Driving the bridge's lifecycle functions in-process leaves its whole entry
+    path -- environment scrub, relaunch into the vault runtime, clean-runtime
+    check -- unexecuted, which is where two consecutive user-blocking defects
+    shipped through a green canary.
+    """
+
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    designated = re.search(
+        r'^BRIDGE_PROCESS_ENTRY_START="(?P<start>[^"]+)"$', source, re.MULTILINE
+    )
+    assert designated is not None
+    canary_block = re.search(
+        r'^CANARY_STARTS=\(\n(?P<body>(?:  "[^"]+"\n)+)\)$',
+        source,
+        re.MULTILINE,
+    )
+    assert canary_block is not None
+    canary_starts = re.findall(
+        r'^  "([^"]+)"$', canary_block.group("body"), re.MULTILINE
+    )
+    assert designated.group("start") in canary_starts
+    # Exactly one bounded process run, not a thirteenth journey.
+    assert source.count("--bridge-process-entry") == 1
+    assert "--bridge-process-entry" not in source.split("run_canary()", 1)[0]
+
+
 def test_formal_runner_freezes_public_cohort_and_retains_exact_counts() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     assert 'PINNED_FOUNDATION_TAG="dist/release/v1.81.16-281202d"' in source

--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -2511,3 +2511,162 @@ def test_shipped_update_surface_rejects_a_protocol_with_an_unknown_operation(
 
     with pytest.raises(release_fleet.FleetError, match="journey protocol"):
         release_fleet.shipped_update_surface(repo, release)
+
+
+def _bridge_process_evidence(**overrides: object) -> dict[str, object]:
+    """A record of a bridge process that behaved the way a stuck user needs."""
+
+    evidence: dict[str, object] = {
+        "timed_out": False,
+        "timeout_seconds": release_fleet.BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS,
+        "exit_code": 1,
+        "relaunch_notice_count": 1,
+        "runtime_entry_refused": False,
+        "reached_approval_gate": True,
+        "produced_output": True,
+        "stdout": '{\n  "plan": "split"\n}\nDex will first separate its code from '
+        "your notes. Type APPLY to continue: ",
+        "stderr": f"{release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE}\n"
+        "Checking this Dex install (read-only)...\n",
+    }
+    evidence.update(overrides)
+    return evidence
+
+
+def test_bridge_process_entry_accepts_a_run_that_reaches_the_first_gate() -> None:
+    release_fleet.assert_bridge_process_entry(
+        _bridge_process_evidence(), approval_word="APPLY"
+    )
+
+
+def test_bridge_process_entry_refuses_the_false_clean_runtime_stop() -> None:
+    """The defect v1.93.0 fixed: the scrub manufactured the difference the check refuses."""
+
+    evidence = _bridge_process_evidence(
+        runtime_entry_refused=True,
+        reached_approval_gate=False,
+        produced_output=False,
+        stdout="",
+        stderr=f"{release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE}\n"
+        "Dex update bridge stopped safely: the installed Dex runtime "
+        f"{release_fleet.BRIDGE_PROCESS_ENTRY_REFUSAL}, so the bridge stopped "
+        "instead of relaunching endlessly: unexpected environment variables "
+        "appeared: LC_CTYPE\n",
+    )
+
+    with pytest.raises(release_fleet.FleetError) as failure:
+        release_fleet.assert_bridge_process_entry(evidence, approval_word="APPLY")
+
+    assert "clean-runtime entry refusal" in str(failure.value)
+    assert "no output at all" in str(failure.value)
+
+
+def test_bridge_process_entry_refuses_an_unbounded_silent_relaunch_loop() -> None:
+    """The defect v1.92.0 fixed: it relaunched forever, printing nothing at all."""
+
+    evidence = _bridge_process_evidence(
+        timed_out=True,
+        exit_code=None,
+        relaunch_notice_count=4096,
+        reached_approval_gate=False,
+        produced_output=False,
+        stdout="",
+        stderr=f"{release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE}\n" * 4096,
+    )
+
+    with pytest.raises(release_fleet.FleetError) as failure:
+        release_fleet.assert_bridge_process_entry(evidence, approval_word="APPLY")
+
+    assert "never finished" in str(failure.value)
+    assert "instead of exactly one" in str(failure.value)
+
+
+def test_bridge_process_entry_refuses_a_run_that_never_reached_the_gate() -> None:
+    evidence = _bridge_process_evidence(
+        reached_approval_gate=False,
+        stdout="Dex update bridge stopped safely: something else entirely\n",
+    )
+
+    with pytest.raises(
+        release_fleet.FleetError, match="never reached the first APPLY gate"
+    ):
+        release_fleet.assert_bridge_process_entry(evidence, approval_word="APPLY")
+
+
+def _fixture_python_runtime() -> release_fleet.PythonRuntime:
+    return release_fleet.PythonRuntime(
+        requested_python=Path(sys.executable),
+        resolved_python=Path(sys.executable).resolve(),
+        python_version="Python 3",
+        python_sha256="",
+    )
+
+
+def test_bridge_process_entry_probe_retains_the_streams_it_judged(
+    tmp_path: Path,
+) -> None:
+    """Silence was the original symptom, so the captured output is the evidence."""
+
+    asset = tmp_path / "dex-update-bridge-v9.9.9.py"
+    asset.write_text(
+        "import sys\n"
+        f"print({release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE!r}, file=sys.stderr)\n"
+        "print('{}')\n"
+        "input('Dex will first separate its code from your notes. "
+        "Type APPLY to continue: ')\n",
+        encoding="utf-8",
+    )
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    evidence_root = tmp_path / "evidence"
+
+    evidence = release_fleet.probe_bridge_process_entry(
+        vault=vault,
+        bridge_asset=asset,
+        python_runtime=_fixture_python_runtime(),
+        environment={"PATH": "/usr/bin:/bin"},
+        approval_word="APPLY",
+        evidence_root=evidence_root,
+    )
+
+    assert evidence["relaunch_notice_count"] == 1
+    assert evidence["timed_out"] is False
+    assert evidence["reached_approval_gate"] is True
+    assert "Type APPLY to continue:" in str(evidence["stdout"])
+    retained = json.loads(
+        (evidence_root / "bridge-process-entry.json").read_text(encoding="utf-8")
+    )
+    assert retained["working_directory"] == str(vault)
+    assert retained["stdin"] == "closed"
+    assert release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE in (
+        evidence_root / "bridge-process-entry-stderr.txt"
+    ).read_text(encoding="utf-8")
+
+
+def test_bridge_process_entry_probe_retains_the_streams_of_a_failing_run(
+    tmp_path: Path,
+) -> None:
+    asset = tmp_path / "dex-update-bridge-v9.9.9.py"
+    asset.write_text(
+        "import sys\n"
+        "print('the installed Dex runtime could not be entered cleanly', file=sys.stderr)\n",
+        encoding="utf-8",
+    )
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    evidence_root = tmp_path / "evidence"
+
+    with pytest.raises(release_fleet.FleetError, match="clean-runtime entry refusal"):
+        release_fleet.probe_bridge_process_entry(
+            vault=vault,
+            bridge_asset=asset,
+            python_runtime=_fixture_python_runtime(),
+            environment={"PATH": "/usr/bin:/bin"},
+            approval_word="APPLY",
+            evidence_root=evidence_root,
+        )
+
+    retained = json.loads(
+        (evidence_root / "bridge-process-entry.json").read_text(encoding="utf-8")
+    )
+    assert retained["runtime_entry_refused"] is True

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "f6abe206ec33ec1530ff34cdca86d8012492553453e89cef5b7c749757a6b6ab",
+    "sha256": "4403a7dab932220542381ad5006056931a928e405143599e620e76f9ada9eecf",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -122,6 +122,18 @@ MINIMUM_SUPPORTED_PYTHON = (3, 10)
 PROCESS_GROUP_TERMINATION_GRACE_SECONDS = 1.0
 FIXTURE_REQUIRED_PYTHON_DEPENDENCIES = ("mcp", "yaml")
 PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES = ("yaml",)
+# The journeys drive the bridge's lifecycle functions in-process, so nothing in
+# the fleet ever started the published bridge the way a stuck user starts it:
+# as a top-level process that has to scrub its environment and relaunch itself
+# inside the vault's own virtualenv before it may load any foundation code. Two
+# consecutive user-blocking defects lived entirely in that entry path -- an
+# unbounded relaunch loop that burned CPU in silence, then a clean-runtime
+# refusal that could never pass -- and both shipped through a green fleet.
+BRIDGE_PROCESS_ENTRY_NOTICE = "Relaunching inside Dex's installed runtime..."
+BRIDGE_PROCESS_ENTRY_REFUSAL = "could not be entered cleanly"
+BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS = 600
+BRIDGE_PROCESS_ENTRY_RETAINED_BYTES = 256 * 1024
+BRIDGE_PROCESS_ENTRY_SUFFIX = ".bridge-process-entry"
 SEALED_INSTALLER_ENVIRONMENT_KEYS = frozenset(
     {
         "HOME",
@@ -1254,6 +1266,7 @@ def _run_bounded_process_group(
     cwd: Path,
     environment: Mapping[str, str],
     timeout_seconds: float,
+    stdin: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one trusted fixture command and leave no same-group timeout descendants."""
 
@@ -1263,6 +1276,7 @@ def _run_bounded_process_group(
         list(command),
         cwd=cwd,
         env=dict(environment),
+        stdin=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -2144,6 +2158,132 @@ def _verify_standalone_bridge_asset(
     }
 
 
+def _retained_tail(text: str) -> str:
+    """Keep the end of a captured stream inside a fixed evidence bound."""
+
+    if len(text) <= BRIDGE_PROCESS_ENTRY_RETAINED_BYTES:
+        return text
+    return text[-BRIDGE_PROCESS_ENTRY_RETAINED_BYTES:]
+
+
+def assert_bridge_process_entry(
+    evidence: Mapping[str, object],
+    *,
+    approval_word: str,
+) -> None:
+    """Refuse a released bridge that a stuck user cannot actually start.
+
+    The stuck user's whole experience of this path is one command and whatever
+    it prints. Every check below is that experience: the process has to finish,
+    it has to relaunch itself exactly once into the vault runtime, it must never
+    stop on a runtime-entry refusal, and it has to print the first approval gate
+    rather than nothing at all. Silence was the reported symptom of the relaunch
+    loop, so an empty stream is a failure in its own right.
+    """
+
+    problems: list[str] = []
+    if evidence.get("timed_out"):
+        problems.append(
+            "it never finished within "
+            f"{evidence.get('timeout_seconds')}s, which is how an unbounded "
+            "relaunch loop presents"
+        )
+    if evidence.get("runtime_entry_refused"):
+        problems.append("it stopped on a clean-runtime entry refusal")
+    notices = evidence.get("relaunch_notice_count")
+    if notices != 1:
+        problems.append(
+            f"it announced {notices} relaunches into the installed runtime instead of exactly one"
+        )
+    if not evidence.get("produced_output"):
+        problems.append("it produced no output at all")
+    if not evidence.get("reached_approval_gate"):
+        problems.append(f"it never reached the first {approval_word} gate")
+    if not problems:
+        return
+    raise FleetError(
+        "the released bridge asset could not be started the way a stuck user starts it: "
+        + "; ".join(problems)
+        + f" | exit={evidence.get('exit_code')!r}"
+        + f" | stdout tail: {str(evidence.get('stdout', ''))[-2000:]!r}"
+        + f" | stderr tail: {str(evidence.get('stderr', ''))[-2000:]!r}"
+    )
+
+
+def probe_bridge_process_entry(
+    *,
+    vault: Path,
+    bridge_asset: Path,
+    python_runtime: PythonRuntime,
+    environment: Mapping[str, str],
+    approval_word: str,
+    evidence_root: Path,
+) -> dict[str, object]:
+    """Start the published bridge as a top-level process against a real vault.
+
+    This is deliberately the published asset, launched from the vault root with
+    ``--vault`` and with stdin closed, so it runs the whole entry path -- the
+    environment scrub, the ``execve`` into the vault virtualenv, and the
+    clean-runtime equality check -- and then halts at the first approval gate
+    without changing anything. The asset stays outside the vault so the fixture
+    that the journey is about to update is not given an extra untracked file.
+    """
+
+    command = [
+        str(python_runtime.requested_python),
+        str(bridge_asset),
+        "--vault",
+        str(vault),
+    ]
+    timed_out = False
+    exit_code: int | None = None
+    try:
+        completed = _run_bounded_process_group(
+            command,
+            cwd=vault,
+            environment=environment,
+            timeout_seconds=BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS,
+            stdin=subprocess.DEVNULL,
+        )
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        exit_code = completed.returncode
+    except subprocess.TimeoutExpired as error:
+        timed_out = True
+        stdout = error.stdout if isinstance(error.stdout, str) else ""
+        stderr = error.stderr if isinstance(error.stderr, str) else ""
+    evidence: dict[str, object] = {
+        "schema_version": 1,
+        "command": [str(bridge_asset.name), "--vault", str(vault)],
+        "interpreter": str(python_runtime.requested_python),
+        "working_directory": str(vault),
+        "stdin": "closed",
+        "timeout_seconds": BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS,
+        "timed_out": timed_out,
+        "exit_code": exit_code,
+        "relaunch_notice_count": stderr.count(BRIDGE_PROCESS_ENTRY_NOTICE),
+        "runtime_entry_refused": BRIDGE_PROCESS_ENTRY_REFUSAL in stderr,
+        "reached_approval_gate": f"Type {approval_word} to continue:" in stdout,
+        "produced_output": bool(stdout.strip()),
+        "stdout_bytes": len(stdout),
+        "stderr_bytes": len(stderr),
+        "stdout": _retained_tail(stdout),
+        "stderr": _retained_tail(stderr),
+    }
+    # Retain the streams even when the assertion below fails: silence was the
+    # original symptom, so the captured output is the evidence that matters.
+    evidence_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    (evidence_root / "bridge-process-entry-stdout.txt").write_text(
+        _retained_tail(stdout), encoding="utf-8"
+    )
+    (evidence_root / "bridge-process-entry-stderr.txt").write_text(
+        _retained_tail(stderr), encoding="utf-8"
+    )
+    _write_json(evidence_root / "bridge-process-entry.json", evidence)
+    assert_bridge_process_entry(evidence, approval_word=approval_word)
+    return evidence
+
+
 def run_case_executor(
     starting_tag: str,
     executor: Callable[..., object],
@@ -2181,6 +2321,7 @@ def run_journey(
     bridge_checksum: Path | None = None,
     controlled_approvals: bool = False,
     follow_up_cache: Path | None = None,
+    bridge_process_entry: bool = False,
 ) -> object:
     """Build one fixture and delegate the closed journey to its released executor."""
 
@@ -2282,6 +2423,19 @@ def run_journey(
             trusted_python=python_runtime,
             required_dependencies=PRE_BRIDGE_REQUIRED_PYTHON_DEPENDENCIES,
         )
+        if bridge_process_entry:
+            # Read-only: the run stops at the first approval gate, so the vault
+            # the journey is about to update is left exactly as installed. Its
+            # evidence lives beside the fixture rather than inside the sealed
+            # journey evidence the executor owns.
+            probe_bridge_process_entry(
+                vault=case.vault,
+                bridge_asset=bridge_asset.resolve(strict=True),
+                python_runtime=python_runtime,
+                environment=environment,
+                approval_word=protocol.bridge.approval_word,
+                evidence_root=output / f"{case_name}{BRIDGE_PROCESS_ENTRY_SUFFIX}",
+            )
         initial_install_evidence = _initial_install_evidence(case.vault, environment)
         from scripts import release_fleet_executor
 
@@ -2886,6 +3040,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="approve only the disposable fixture used by a controlled fleet run",
     )
+    journey.add_argument(
+        "--bridge-process-entry",
+        action="store_true",
+        help=(
+            "before the journey, start the published bridge asset as a top-level "
+            "process against this fixture and require it to reach its first "
+            "approval gate"
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.command == "manifest":
@@ -2926,6 +3089,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             bridge_checksum=args.bridge_checksum,
             controlled_approvals=args.controlled_approvals,
             follow_up_cache=args.follow_up_cache,
+            bridge_process_entry=args.bridge_process_entry,
         )
         print(
             json.dumps(

--- a/scripts/run-historic-fleet-darwin.sh
+++ b/scripts/run-historic-fleet-darwin.sh
@@ -24,6 +24,12 @@ CANARY_STARTS=(
   "v1.81.7"
   "v1.81.11"
 )
+# One start also runs the published bridge the way a stuck user runs it: as a
+# top-level process from the vault root, with stdin closed, which is the only
+# way the environment scrub, the relaunch into the vault runtime, and the
+# clean-runtime check are executed at all. The oldest start is the one a rescued
+# user is most likely to be on. One bounded process run, not a thirteenth journey.
+BRIDGE_PROCESS_ENTRY_START="v1.51.0"
 
 MODE="${1:-}"
 case "$MODE" in
@@ -369,13 +375,21 @@ run_canary() {
 
   refresh_public_tags
   assert_public_annotated_tag "$PINNED_FOUNDATION_TAG"
+  bridge_process_entry_planned=0
   for start in "${CANARY_STARTS[@]}"; do
+    if [ "$start" = "$BRIDGE_PROCESS_ENTRY_START" ]; then
+      bridge_process_entry_planned=1
+    fi
     if ! git rev-parse --verify "$start^{commit}" >/dev/null 2>&1; then
       echo "public canary start is unavailable: $start" >&2
       echo "if the release-tag archive renamed it, update CANARY_STARTS to the dist/archive/ name" >&2
       return 1
     fi
   done
+  if [ "$bridge_process_entry_planned" -ne 1 ]; then
+    echo "no canary start runs the bridge as a process: $BRIDGE_PROCESS_ENTRY_START is not in CANARY_STARTS" >&2
+    return 1
+  fi
 
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -413,6 +427,10 @@ run_canary() {
   DISCOVERED="${#CANARY_STARTS[@]}"
   for start in "${CANARY_STARTS[@]}"; do
     STARTED=$((STARTED + 1))
+    journey_options=(--controlled-approvals)
+    if [ "$start" = "$BRIDGE_PROCESS_ENTRY_START" ]; then
+      journey_options+=(--bridge-process-entry)
+    fi
     if run_bounded python3 scripts/release_fleet.py journey \
       --repo . --output "$JOURNEY_ROOT" \
       --starting-tag "$start" \
@@ -421,7 +439,7 @@ run_canary() {
       --bridge-asset "$BRIDGE_ASSET" \
       --bridge-checksum "$BRIDGE_CHECKSUM" \
       --follow-up-cache "$FOLLOW_UP_CACHE" \
-      --controlled-approvals
+      "${journey_options[@]}"
     then
       journey_status=0
     else


### PR DESCRIPTION
## The gap

`historic-fleet-darwin-pr-canary` runs twelve release-shaped macOS journeys and its
`paths:` filter covers `scripts/dex_update_bridge.py`, so it is nominally the gate that
protects the rescue bridge. It never protected the part that keeps breaking.

Every journey drives the bridge's lifecycle *functions* in-process through
`scripts/release_fleet_executor.py`. Nothing ever launched `dex_update_bridge.py` as a
top-level process, so `_reexec_in_installed_runtime` — the environment scrub, the
`os.execve` relaunch, and the clean-runtime equality check — was never executed under the
canary at all. Two consecutive user-blocking defects lived entirely in that path and the
canary was green through both:

- v1.92.0 fixed an unbounded relaunch loop: the bridge re-executed itself forever, printed
  nothing, and burned CPU until the user gave up.
- v1.93.0 fixed the replacement defect: the scrub removed `LANG`/`LC_ALL`, the relaunched
  interpreter coerced the C locale (PEP 538) and exported `LC_CTYPE` into its own
  environment, so the equality check could never pass and the bridge stopped on every Mac.

## What this adds

**One canary journey now starts the published bridge the way a stuck user starts it.**
`scripts/release_fleet.py` gains `probe_bridge_process_entry`, wired into `journey` behind
`--bridge-process-entry`; `scripts/run-historic-fleet-darwin.sh` passes that flag for
exactly one start (`v1.51.0`, the oldest). On the freshly installed fixture — before the
journey itself runs, and after the fixture's virtualenv has been proven — the fleet runs:

    /opt/homebrew/bin/python3 <asset root>/dex-update-bridge-vX.Y.Z.py --vault <vault>

from the vault root, with stdin closed, in the sealed fixture environment. The asset stays
outside the vault so the fixture the journey is about to update gains no extra untracked
file. With stdin closed the run halts at the first `APPLY` gate, so it is read-only.

`assert_bridge_process_entry` then requires all of:

- the process finished inside its bound (an unbounded relaunch loop presents as a timeout);
- it announced **exactly one** relaunch into the installed runtime;
- it never stopped on `could not be entered cleanly`;
- it printed **something** — silence was the original reported symptom;
- its stdout contains the first `Type APPLY to continue:` gate, i.e. it reached the preview.

stdout, stderr and a JSON record are retained beside the fixture
(`<case>.bridge-process-entry/`) and are picked up by the existing evidence upload, whether
the check passes or fails. A runner-side guard fails the canary if the designated start is
ever removed from `CANARY_STARTS`, so the gate cannot silently stop running.

**A second, much cheaper gate runs everywhere.** `core/tests/test_dex_update_bridge.py`
gains `test_the_bridge_can_be_started_as_a_process_by_a_stuck_user`, which builds a minimal
vault with a real virtualenv and launches the real bridge as a process (~3s). Every other
test in that file drives the bridge in-process with monkeypatched stand-ins. This one runs
the actual entry path on Linux and macOS, in the ordinary suite, on every PR.

## Proof it fails (both historical defects)

A gate nobody has watched fail is not a gate. Both defects were reintroduced by checking
out the **exact shipped bytes** that contained them, rather than by hand-editing an
approximation.

| bridge under test | result |
|---|---|
| `main` (v1.93.0) | **passes** in 3.09s — one relaunch notice, no refusal, stops later on a vault problem |
| `git show 5e3f5255^:scripts/dex_update_bridge.py` (as shipped in v1.92.0) | **fails** in 0.54s: `'could not be entered cleanly' is contained here: ... unexpected environment variables appeared: LC_CTYPE` |
| `git show 882b6b7f^:scripts/dex_update_bridge.py` (as shipped in v1.91.x) | **fails** by timeout: zero bytes on stdout, zero bytes on stderr, process still relaunching itself |

The same two defective bridges were then run through the fleet's own
`probe_bridge_process_entry`/`assert_bridge_process_entry` (the canary's actual assertion
code) on a real vault, and it refused both:

- v1.92.0 bytes → `it stopped on a clean-runtime entry refusal; it produced no output at
  all; it never reached the first APPLY gate`
- v1.91 bytes → `it never finished within 25s, which is how an unbounded relaunch loop
  presents; it announced 0 relaunches into the installed runtime instead of exactly one;
  it produced no output at all`

Being straight about the limit of that particular run: the vault it used is minimal, not a
real historic install, so the v1.81.16 lifecycle refuses its layout before building a
topology preview — which means the *passing* side of the fleet gate (reaching
`Type APPLY to continue:`) could not be demonstrated from Linux. Building a historic
fixture needs the Homebrew Python and Node the fleet insists on. That path is exercised for
the first time by the canary on this PR. Unit tests in `core/tests/test_release_fleet.py`
pin both the pass and each refusal reason, and one of them drives
`probe_bridge_process_entry` end to end against a stand-in asset that does reach the gate.

One honest note on the brief. Dropping only `PYTHONCOERCECLOCALE`/`PYTHONUTF8` from
`_bridge_environment` does **not** reproduce the v1.93.0 defect: the same fix also widened
`_INTERPRETER_INJECTED_VARIABLES` to tolerate `LC_CTYPE` at exactly the coercion's own
outcomes, and either half is sufficient on its own. Likewise, making the marked-but-unclean
branch re-exec instead of raising does not loop while the runtime *is* clean. That is why
both defects are reproduced from their shipped bytes, which is the state that actually
reached users.

## CI result (the probe's first real execution)

`historic-fleet-darwin-pr-canary` **passed in 19m21s** (12 discovered / 12 started / 12
completed / 12 passed / 0 failed — the same ~20 minutes it took before, so the added process
run costs nothing measurable). All other checks pass: `tests (1/2/3)`, `quality`,
`test-results`, `pr-report`.

The retained evidence
(`journeys/v1.51.0-c8069c90c171.bridge-process-entry/bridge-process-entry.json`) records
what the stuck user's command actually did on a Mac:

```
command:                 ['dex-update-bridge-v1.93.0.py', '--vault', '.../journeys/v1.51.0-c8069c90c171']
interpreter:             /opt/homebrew/bin/python3
working_directory:       .../journeys/v1.51.0-c8069c90c171
stdin:                   closed
timed_out:               False
exit_code:               1
relaunch_notice_count:   1
runtime_entry_refused:   False
reached_approval_gate:   True
stdout_bytes:            57493
```

stdout ends on the real preview and its gate — `"topology": "combined" … Dex will first
separate its code from your notes. Type APPLY to continue:` — and stderr shows one
`Relaunching inside Dex's installed runtime...` followed by the halt at the closed gate.

So this is also the first end-to-end proof on a Mac that the v1.93.0 fix actually lets a
stuck user start the bridge. Until now that had only been argued from a unit test.

One small honesty note: with stdin closed the halt surfaces as a raw `EOFError` traceback
rather than a clean message. A real user types `APPLY`, so nobody hits this in normal use,
but it is untidy and might be worth a small follow-up.

## What I could not verify (before CI ran)

`scripts/run-historic-fleet-darwin.sh` refuses to run off Darwin, and
`TRUSTED_PYTHON_CANDIDATES`/`TRUSTED_NODE_CANDIDATES` are Homebrew-only, so **the canary
cannot be executed from Linux at all**. It was never run locally; the CI run above is its
first execution, and it is the evidence, not my say-so.

Local suite: `pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -m "not fuzz"` on
Linux gives 36 failed / 3478 passed against a `main` baseline of 36 failed / 3470 passed —
the failure *sets* are byte-identical (known Linux-only file-mode, trusted-MCP symlink and
release-fleet-acceptance differences), and the eight new passes are the tests added here.

Still not covered: the **formal** fleet (`run-historic-fleet-darwin.sh formal`, the release
gate) still never launches the bridge as a process. The canary catches a regression earlier,
so this is a follow-up rather than a hole left open here.

## Housekeeping

- `core/update/journey-protocol-v1.json` regenerated with
  `python3 scripts/generate-update-journey-protocol.py` (it records a checksum of
  `scripts/release_fleet.py`, and `scripts/build-vault-bundle.sh` refuses to build while
  it is stale).
- No `CHANGELOG.md` entry: this is CI-only. No shipped behaviour changes, and there is
  nothing here a user deciding whether to update would act on.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
