### PR TITLE
Let a moved or copied vault update, and say why when Dex refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.94.0] — 📦 Moving your Dex folder no longer locks you out of updating (2026-08-11)
+
+Dex writes down where your vault lives. Move that folder, rename it, or work from a copy of it, and the note still points at the old place — and Dex was reading that mismatch as damage. It refused to update at all, with a message that didn't say why. A user hit this while rehearsing the rescue route on a duplicate of his own vault, and spent an hour reading Dex's code to work out which of its nine checks had failed.
+
+**What this fixes for you:**
+
+* **A vault you moved, renamed, or copied updates normally again.** Dex now treats that note for what it is — a stale reminder of where the folder used to be — and writes the new location down the next time it updates. You don't have to put the folder back, and nothing about your files or your history has to change. Anything that would signal real damage is still refused exactly as strictly as before; only the out-of-date location became forgivable.
+* **When Dex does refuse, it tells you which thing is wrong.** These refusals used to end with "Dex will not guess how to convert it" and nothing more. Each one now names the specific file or folder that didn't check out, and says what it expected to find there — so the next step is obvious in a minute rather than an hour.
+* **Trying the rescue tool without answering it no longer looks like a crash.** Starting it with its input closed — the ordinary way to watch how far it gets before you commit to anything — produced a page of programmer error text. It now stops with the same single plain sentence as every other stop, saying that nothing was changed because it couldn't read an answer.
+* **A stray warning about task numbering no longer interrupts a rescue.** The rescue tool's output opened with an alarming note that had nothing to do with updating: a different part of Dex talking over the top of it. It no longer reaches you there, and the rescue tool's own messages are unaffected.
+* **The rescue route now says up front that it takes two runs.** Finishing the rescue tool puts you on a release from 4 August, not the newest one; a second, ordinary `/dex-update` covers the rest. The guide now says that before you start and the tool says it when it finishes, instead of hinting at it afterwards.
+
+Thanks to Jim, who checked all nine conditions by hand against both his real vault and the duplicate, found that only the recorded location differed, then proved everything behind that check was sound by correcting that one line and re-running.
+
+---
+
 ## [1.93.3] — 🗣️ Tell Dex something's broken however you like (2026-08-11)
 
 Setup now promises that if something goes wrong you can just say so in your own words. That promise needed the other half: Dex reliably recognising a description of a fault as a fault. Until now it leaned on you using the words "report this" or running the command — which is exactly the homework the whole feature was built to remove.

--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -1431,19 +1431,23 @@ def relocated_split(vault_root: Path) -> bool:
     if split_layout_failures(root):
         return False
     recorded = recorded_vault_path(topology)
+    if recorded is None:
+        return False
     try:
-        return recorded is not None and Path(recorded).resolve() != root.resolve()
-    except OSError:
+        return Path(recorded).resolve() != root.resolve()
+    except (OSError, RuntimeError):
+        # An unresolvable recorded path names nowhere reachable, which is the
+        # strongest possible evidence that it is not this vault.
         return True
 
 
 def split_layout_failures(vault_root: Path) -> tuple[str, ...]:
     """Name every structural condition a recorded split layout fails.
 
-    Read-only, and deliberately exhaustive rather than short-circuiting: a
-    refusal that names one of six possible causes is what turns an hour of
-    source reading into a minute. The recorded vault *path* is not among these
-    conditions; only its absence is (see :func:`relocated_split`).
+    Read-only, and deliberately exhaustive rather than short-circuiting: naming
+    every cause at once is what turns an hour of source reading into a minute.
+    The recorded vault *path* is not among these conditions; only its absence
+    is (see :func:`relocated_split`).
     """
     root = Path(vault_root)
     vault_git = root / ".git"
@@ -1500,8 +1504,9 @@ def topology_state(vault_root: Path) -> str:
 
     A structurally sound split is ``post-split`` even when its recorded vault
     path names somewhere else: that record is runtime state, and a moved or
-    copied vault is relocated, not invalid. :func:`repair_relocated_split`
-    re-records it where a write is already legitimate.
+    copied vault is relocated, not invalid.
+    ``core.update.apply_update._finalize_release_metadata`` re-records it on the
+    next install, which is where a write to that marker is already legitimate.
     """
     root = Path(vault_root)
     vault_git = root / ".git"

--- a/core/lifecycle/engine.py
+++ b/core/lifecycle/engine.py
@@ -1398,43 +1398,118 @@ def _regular_json(path: Path) -> dict[str, Any] | None:
         return None
 
 
-def topology_state(vault_root: Path) -> str:
-    """Classify the installed brain/vault layout without changing it."""
+def recorded_vault_path(topology: Mapping[str, Any] | None) -> str | None:
+    """Return the vault path a split topology marker records, if well formed.
+
+    The marker has to *record* a path for the layout to be a recognizable
+    split, so a missing or non-string value stays fail-closed evidence. The
+    value itself is a different matter — see :func:`split_layout_failures`.
+    """
+    if not isinstance(topology, Mapping):
+        return None
+    environment = topology.get("environment")
+    if not isinstance(environment, Mapping):
+        return None
+    recorded = environment.get("DEX_VAULT")
+    return recorded if isinstance(recorded, str) and recorded else None
+
+
+def relocated_split(vault_root: Path) -> bool:
+    """True when a sound split records a vault path other than this one.
+
+    Absolute paths are runtime state, so copying, moving, or renaming a vault
+    leaves the recorded path naming somewhere else. That staleness is routine
+    relocation, not damage: nothing reads the recorded value as a path (every
+    consumer derives its paths from the vault root it was handed), so it can
+    only ever be a consistency note. A layout that fails any *structural*
+    condition is not relocated, and stays refused.
+    """
+    root = Path(vault_root)
+    topology = _regular_json(root / "System/.dex/topology.json")
+    if not topology or topology.get("topology") != "brain-vault-split":
+        return False
+    if split_layout_failures(root):
+        return False
+    recorded = recorded_vault_path(topology)
+    try:
+        return recorded is not None and Path(recorded).resolve() != root.resolve()
+    except OSError:
+        return True
+
+
+def split_layout_failures(vault_root: Path) -> tuple[str, ...]:
+    """Name every structural condition a recorded split layout fails.
+
+    Read-only, and deliberately exhaustive rather than short-circuiting: a
+    refusal that names one of six possible causes is what turns an hour of
+    source reading into a minute. The recorded vault *path* is not among these
+    conditions; only its absence is (see :func:`relocated_split`).
+    """
     root = Path(vault_root)
     vault_git = root / ".git"
     brain_git = root / ".dex/brain.git"
     topology = _regular_json(root / "System/.dex/topology.json")
     vault_marker = _regular_json(vault_git / "dex-vault-v2")
     brain_marker = _regular_json(brain_git / "dex-brain-v2")
-    if topology and topology.get("topology") == "brain-vault-split":
-        environment = topology.get("environment")
-        wired_vault = (
-            environment.get("DEX_VAULT")
-            if isinstance(environment, dict)
-            else None
+    failures: list[str] = []
+    if not topology or topology.get("topology") != "brain-vault-split":
+        return ("System/.dex/topology.json does not record a brain/vault split",)
+    if topology.get("vaultGitDir") != ".git":
+        failures.append(
+            "System/.dex/topology.json records vaultGitDir "
+            f"{topology.get('vaultGitDir')!r} instead of '.git'"
         )
-        try:
-            wiring_matches = (
-                isinstance(wired_vault, str)
-                and Path(wired_vault).resolve() == root.resolve()
-            )
-        except OSError:
-            wiring_matches = False
-        if (
-            topology.get("vaultGitDir") == ".git"
-            and topology.get("brainGitDir") == ".dex/brain.git"
-            and wiring_matches
-            and vault_git.is_dir()
-            and not vault_git.is_symlink()
-            and brain_git.is_dir()
-            and not brain_git.is_symlink()
-            and vault_marker
-            and vault_marker.get("role") == "vault"
-            and brain_marker
-            and brain_marker.get("role") == "brain"
-        ):
-            return "post-split"
-        return "invalid-split"
+    if topology.get("brainGitDir") != ".dex/brain.git":
+        failures.append(
+            "System/.dex/topology.json records brainGitDir "
+            f"{topology.get('brainGitDir')!r} instead of '.dex/brain.git'"
+        )
+    if recorded_vault_path(topology) is None:
+        failures.append(
+            "System/.dex/topology.json records no environment.DEX_VAULT path"
+        )
+    if vault_git.is_symlink():
+        failures.append(".git is a symbolic link, which Dex refuses to follow")
+    elif not vault_git.is_dir():
+        failures.append(".git is missing or is not a directory")
+    if brain_git.is_symlink():
+        failures.append(
+            ".dex/brain.git is a symbolic link, which Dex refuses to follow"
+        )
+    elif not brain_git.is_dir():
+        failures.append(".dex/brain.git is missing or is not a directory")
+    if not vault_marker:
+        failures.append(".git/dex-vault-v2 is missing or unreadable")
+    elif vault_marker.get("role") != "vault":
+        failures.append(
+            f".git/dex-vault-v2 records role {vault_marker.get('role')!r} "
+            "instead of 'vault'"
+        )
+    if not brain_marker:
+        failures.append(".dex/brain.git/dex-brain-v2 is missing or unreadable")
+    elif brain_marker.get("role") != "brain":
+        failures.append(
+            ".dex/brain.git/dex-brain-v2 records role "
+            f"{brain_marker.get('role')!r} instead of 'brain'"
+        )
+    return tuple(failures)
+
+
+def topology_state(vault_root: Path) -> str:
+    """Classify the installed brain/vault layout without changing it.
+
+    A structurally sound split is ``post-split`` even when its recorded vault
+    path names somewhere else: that record is runtime state, and a moved or
+    copied vault is relocated, not invalid. :func:`repair_relocated_split`
+    re-records it where a write is already legitimate.
+    """
+    root = Path(vault_root)
+    vault_git = root / ".git"
+    topology = _regular_json(root / "System/.dex/topology.json")
+    if topology and topology.get("topology") == "brain-vault-split":
+        if split_layout_failures(root):
+            return "invalid-split"
+        return "post-split"
 
     migration_state = _regular_json(
         root / "System/.dex/migration-v2-state.json"
@@ -1460,6 +1535,54 @@ def topology_state(vault_root: Path) -> str:
     if not vault_git.exists():
         return "zip-or-manual"
     return "invalid-combined"
+
+
+def topology_refusal_detail(vault_root: Path, state: str) -> str:
+    """Say in one clause why this exact layout cannot be converted.
+
+    Every branch names the condition that actually failed, so nobody has to
+    read Dex's source to learn why they were refused. Only paths the user
+    already owns appear here.
+    """
+    root = Path(vault_root)
+    if state == "invalid-split":
+        failures = split_layout_failures(root)
+        return (
+            "this vault records the separated brain/vault layout, but "
+            + "; ".join(failures)
+        )
+    if state == "migration-in-progress":
+        migration_state = _regular_json(
+            root / "System/.dex/migration-v2-state.json"
+        )
+        if migration_state and migration_state.get("status") != "complete":
+            return (
+                "System/.dex/migration-v2-state.json records an earlier "
+                f"separation that stopped at {migration_state.get('status')!r} "
+                "and was never finished"
+            )
+        leftovers = [
+            relative
+            for relative in (".dex/pre-split-archive.git", ".dex/vault-staging.git")
+            if (root / relative).exists()
+        ]
+        return (
+            "an earlier separation left "
+            + " and ".join(leftovers)
+            + " behind, so Dex cannot tell finished work from unfinished work"
+        )
+    if state == "zip-or-manual":
+        return (
+            "this folder has no .git directory, so it is a copied or "
+            "downloaded folder rather than an install Dex can update in place"
+        )
+    if state == "invalid-combined":
+        return (
+            "this folder has a .git directory but no separation tool at "
+            f"{TOPOLOGY_MIGRATOR_RELATIVE.as_posix()}, so its Dex release is "
+            "too old or incomplete for Dex to separate it"
+        )
+    return f"the current layout is {state}"
 
 
 def _topology_groups(
@@ -1590,7 +1713,9 @@ def build_topology_migration_preview(
         return state, preview, None
     if state != "combined":
         raise _topology_refuse(
-            f"the current layout is {state}; Dex will not guess how to convert it"
+            f"the current layout is {state} — "
+            f"{topology_refusal_detail(root, state)}. Dex will not guess how "
+            "to convert it"
         )
 
     report_existed = (root / TOPOLOGY_REPORT_RELATIVE).is_file()
@@ -1807,6 +1932,10 @@ __all__ = [
     "build_topology_migration_preview",
     "canonical_topology_preview_bytes",
     "execute_topology_migration",
+    "recorded_vault_path",
+    "relocated_split",
+    "split_layout_failures",
     "topology_preview_sha256",
+    "topology_refusal_detail",
     "topology_state",
 ]

--- a/core/paths.py
+++ b/core/paths.py
@@ -17,11 +17,18 @@ import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+# This module is a library that many entry points import, so it must not decide
+# where anyone's log output goes. Warning through the root logger did: it
+# installed a stderr handler as a side effect of being imported, and the notice
+# below then surfaced in the update bridge's own user-facing output, where it is
+# both alarming and irrelevant. A NullHandler keeps the notice available to any
+# program that configures logging, and silent in every program that does not.
+logger.addHandler(logging.NullHandler())
 
 # --- Vault root ---
 _vault_path = os.environ.get('VAULT_PATH')
 if not _vault_path:
-    logging.warning(
+    logger.warning(
         "VAULT_PATH not set — falling back to cwd(). "
         "Task ID generation may produce duplicates."
     )

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time as real_time
@@ -1476,3 +1477,150 @@ def test_apply_update_can_finalize_when_every_release_mutation_already_matches(
     assert result["committed"] is True
     assert result["targets"] == []
     assert _git(vault / ".dex/brain.git", "rev-parse", "refs/dex/installed") == release.commit
+
+
+def _edit_topology(vault: Path, **fields: object) -> None:
+    path = vault / "System/.dex/topology.json"
+    value = json.loads(path.read_text())
+    value.update(fields)
+    path.write_text(json.dumps(value, indent=2) + "\n")
+
+
+def test_relocated_split_is_accepted_and_its_recorded_path_is_re_recorded(
+    split_release_fixture: dict[str, object],
+) -> None:
+    """A moved vault updates, and the install puts its recorded location right.
+
+    The recorded path is an absolute path in local runtime state, so a vault
+    that was moved or renamed records somewhere else. Nothing here reads it as a
+    path, so it can only ever be a consistency note — and this is the one place
+    that legitimately rewrites the marker, so it is where the note is corrected.
+    """
+    vault: Path = split_release_fixture["vault"]
+    _edit_topology(vault, environment={"DEX_VAULT": str(vault.parent / "somewhere-else")})
+
+    # Accepted despite the stale record: the layout itself is sound.
+    brain_git, topology, _marker = apply_update._topology(vault)
+    assert brain_git == vault / ".dex/brain.git"
+    assert topology["environment"]["DEX_VAULT"] != str(vault.resolve())
+
+    release = _verified(split_release_fixture)
+    result = apply_update.apply_verified_release(vault, release)
+
+    assert result["committed"] is True
+    _, _, target_commit, _ = split_release_fixture["target"]
+    rewritten = json.loads((vault / "System/.dex/topology.json").read_text())
+    assert rewritten["environment"]["DEX_VAULT"] == str(vault.resolve())
+    assert rewritten["installedRelease"] == target_commit
+    # Only that one field moved; nothing else in the marker was rewritten.
+    assert rewritten["vaultGitDir"] == ".git"
+    assert rewritten["brainGitDir"] == ".dex/brain.git"
+
+
+def test_copied_split_vault_is_accepted_by_the_release_planner(
+    split_release_fixture: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    """The duplicate-vault rehearsal: a copy is relocated, not inconsistent."""
+    original: Path = split_release_fixture["vault"]
+    duplicate = tmp_path / "Documents" / "Dex"
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+
+    recorded = json.loads((duplicate / "System/.dex/topology.json").read_text())
+    assert Path(recorded["environment"]["DEX_VAULT"]) == original.resolve()
+
+    brain_git, _topology, marker = apply_update._topology(duplicate)
+    assert brain_git == duplicate / ".dex/brain.git"
+    assert marker["role"] == "brain"
+
+
+def test_an_unmoved_vault_keeps_its_recorded_path_byte_for_byte(
+    split_release_fixture: dict[str, object],
+) -> None:
+    vault: Path = split_release_fixture["vault"]
+    release = _verified(split_release_fixture)
+
+    apply_update.apply_verified_release(vault, release)
+
+    rewritten = json.loads((vault / "System/.dex/topology.json").read_text())
+    assert rewritten["environment"] == {"DEX_VAULT": str(vault.resolve())}
+
+
+_PLANNER_BREAKS: tuple[tuple[str, object, str], ...] = (
+    (
+        "not-a-split",
+        lambda vault: _edit_topology(vault, topology="combined"),
+        "does not record a brain/vault split",
+    ),
+    (
+        "wrong-vault-git-dir",
+        lambda vault: _edit_topology(vault, vaultGitDir=".vault.git"),
+        "records vaultGitDir '.vault.git' instead of '.git'",
+    ),
+    (
+        "wrong-brain-git-dir",
+        lambda vault: _edit_topology(vault, brainGitDir=".dex/other.git"),
+        "records brainGitDir '.dex/other.git' instead of '.dex/brain.git'",
+    ),
+    (
+        "no-recorded-vault-path",
+        lambda vault: _edit_topology(vault, environment={}),
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "non-string-recorded-vault-path",
+        lambda vault: _edit_topology(vault, environment={"DEX_VAULT": 7}),
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "wrong-vault-marker-role",
+        lambda vault: _write(vault, ".git/dex-vault-v2", b'{"role":"brain"}\n'),
+        "records role 'brain' instead of 'vault'",
+    ),
+    (
+        "wrong-brain-marker-role",
+        lambda vault: _write(
+            vault,
+            ".dex/brain.git/dex-brain-v2",
+            b'{"role":"vault","installed":"x"}\n',
+        ),
+        "records role 'vault' instead of 'brain'",
+    ),
+    (
+        "missing-brain-git",
+        lambda vault: (
+            (vault / ".dex/brain.git/dex-brain-v2").rename(
+                vault / ".dex/dex-brain-v2"
+            ),
+            shutil.rmtree(vault / ".dex/brain.git"),
+            (vault / ".dex/brain.git").mkdir(),
+            (vault / ".dex/dex-brain-v2").rename(
+                vault / ".dex/brain.git/dex-brain-v2"
+            ),
+            (vault / ".dex/brain.git").rename(vault / ".dex/brain.git.moved"),
+            (vault / ".dex/brain.git").symlink_to(vault / ".dex/brain.git.moved"),
+        ),
+        "split update refuses a symlinked .dex/brain.git",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "break_layout", "expected_clause"),
+    _PLANNER_BREAKS,
+    ids=[entry[0] for entry in _PLANNER_BREAKS],
+)
+def test_each_broken_split_is_still_refused_by_the_planner_and_names_itself(
+    split_release_fixture: dict[str, object],
+    label: str,
+    break_layout: object,
+    expected_clause: str,
+) -> None:
+    """Only the recorded-path value became tolerable; nothing structural did."""
+    vault: Path = split_release_fixture["vault"]
+    break_layout(vault)
+
+    with pytest.raises(apply_update.UpdateError) as refusal:
+        apply_update._topology(vault)
+    assert expected_clause in str(refusal.value)

--- a/core/tests/test_dex_update_bridge.py
+++ b/core/tests/test_dex_update_bridge.py
@@ -1109,10 +1109,14 @@ def test_foundation_service_keeps_unknown_or_ambiguous_topology_fail_closed(
         lambda _name: pytest.fail("unknown topology must not select Node"),
     )
 
-    assert service.build_and_preview_topology_migration(vault) == {
-        "topology": "invalid-combined",
-        "command": None,
-    }
+    # Still fail-closed, and no Node was selected — the monkeypatched
+    # _trusted_executable above fails the test if it ever is. The refusal now
+    # names the condition instead of leaving the reader to guess which of the
+    # layout checks tripped.
+    with pytest.raises(bridge.BridgeError) as refusal:
+        service.build_and_preview_topology_migration(vault)
+    assert bridge._TOPOLOGY_MIGRATOR_RELATIVE.as_posix() in str(refusal.value)
+    assert "nothing was changed" in str(refusal.value)
 
 
 def test_foundation_service_does_not_bypass_an_unsafe_vault_migrator(
@@ -1129,10 +1133,11 @@ def test_foundation_service_does_not_bypass_an_unsafe_vault_migrator(
         lambda _root: pytest.fail("unsafe migrator must be rejected before authorization"),
     )
 
-    assert service.build_and_preview_topology_migration(vault) == {
-        "topology": "invalid-combined",
-        "command": None,
-    }
+    # Still fail-closed, and authorization was never attempted — the
+    # monkeypatched _legacy_topology_authorization above fails the test if it is.
+    with pytest.raises(bridge.BridgeError) as refusal:
+        service.build_and_preview_topology_migration(vault)
+    assert bridge._TOPOLOGY_MIGRATOR_RELATIVE.as_posix() in str(refusal.value)
 
 
 def test_foundation_service_refuses_migrator_changed_after_verification(
@@ -1558,8 +1563,21 @@ def test_legacy_delivery_reader_rejects_any_other_symlink(
 
 def test_bridge_success_copy_names_the_canonical_dex_update_command() -> None:
     source = Path(bridge.__file__).read_text(encoding="utf-8")
-    assert "future updates use /dex-update." in source
-    assert "Future updates use /dex update." not in source
+    assert "Run /dex-update" in source
+    assert "/dex update" not in source
+
+
+def test_bridge_success_copy_says_a_second_ordinary_update_is_still_needed() -> None:
+    """The bridge is stage one of two, and has to say so where it succeeds.
+
+    A completed run lands on the pinned foundation, not the current release. The
+    old line said only that "future updates use /dex-update", which reads as a
+    note about later releases rather than an instruction to run one now.
+    """
+    source = Path(bridge.__file__).read_text(encoding="utf-8")
+    assert "Stage one of two is complete" in source
+    assert bridge.FOUNDATION.version in source
+    assert "4 August 2026" in source
 
 
 def test_release_pin_rejects_a_mutable_or_incomplete_identity() -> None:
@@ -2151,3 +2169,358 @@ def test_the_bridge_can_be_started_as_a_process_by_a_stuck_user(
     # incomplete vault, it has to say something: silence after the relaunch is
     # the exact shape of the loop that shipped.
     assert completed.stderr.split(notice, 1)[1].strip()
+    # The vault's own logging must not surface in the bridge's user-facing
+    # output. This notice used to arrive through the root logger before the
+    # bridge had run a single check of its own.
+    assert "VAULT_PATH not set" not in completed.stderr
+    assert "VAULT_PATH not set" not in completed.stdout
+    # Every refusal is one plain sentence. A traceback here is a defect.
+    assert "Traceback (most recent call last)" not in completed.stderr
+
+
+def test_a_closed_stdin_stops_with_one_plain_sentence_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    """The designed dry run: run with stdin closed and read the refusal.
+
+    Running non-interactively so the bridge halts at its first gate is what the
+    rescue guidance encourages. ``input`` raises ``EOFError`` on a closed stdin,
+    which no handler caught, so the gate that promises one clear line produced a
+    stack trace instead.
+    """
+
+    def closed_stdin(_prompt: str) -> str:
+        raise EOFError
+
+    service = _Service()
+
+    with pytest.raises(bridge.BridgeError) as refusal:
+        bridge.run_bridge(
+            _vault(tmp_path),
+            service,
+            fetch_foundation=lambda _vault, _pin: pytest.fail("release fetch must not happen"),
+            input_fn=closed_stdin,
+            output_fn=lambda _line: None,
+        )
+
+    message = str(refusal.value)
+    assert "no change was made because no approval could be read" in message
+    assert "standard input" in message
+    assert service.calls == ["topology-preview"]
+
+
+def test_main_reports_a_closed_stdin_as_a_safe_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``main`` must turn the same condition into the standard stop line."""
+    vault = _vault(tmp_path)
+    monkeypatch.setattr(bridge, "_trusted_git_binary", lambda: Path("/usr/bin/git"))
+    monkeypatch.setattr(bridge, "_reexec_in_installed_runtime", lambda *_args: None)
+    monkeypatch.setattr(bridge, "_foundation_is_installed", lambda *_args: False)
+
+    def acquire() -> tuple[object, Path]:
+        raise EOFError("no approval could be read")
+
+    monkeypatch.setattr(bridge, "acquire_foundation_source", acquire)
+
+    assert bridge.main(["--vault", str(vault)]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.err.strip() == (
+        "Dex update bridge stopped safely: no approval could be read"
+    )
+    assert "Traceback" not in captured.err
+
+
+def _split_topology_bytes(vault: Path, recorded: Path, installed: str) -> bytes:
+    return (
+        json.dumps(
+            {
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "installedRelease": installed,
+                "environment": {"DEX_VAULT": str(recorded)},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _relocated_completed_vault(tmp_path: Path) -> Path:
+    """A completed bridge that was then copied somewhere else."""
+    original = _completed_vault(tmp_path)
+    duplicate = tmp_path / "Documents" / "Dex"
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+    return duplicate
+
+
+def test_repair_rewires_a_relocated_split_and_leaves_everything_else_alone(
+    tmp_path: Path,
+) -> None:
+    """A copied or moved vault is relocated runtime state, not a broken layout."""
+    duplicate = _relocated_completed_vault(tmp_path)
+    marker = duplicate / "System" / ".dex" / "topology.json"
+    before = json.loads(marker.read_text(encoding="utf-8"))
+    assert Path(before["environment"]["DEX_VAULT"]) != duplicate.resolve()
+
+    assert bridge._split_layout_failures(duplicate) == ()
+    assert bridge._repair_relocated_split(duplicate) is True
+
+    after = json.loads(marker.read_text(encoding="utf-8"))
+    assert Path(after["environment"]["DEX_VAULT"]) == duplicate.resolve()
+    assert {key: value for key, value in after.items() if key != "environment"} == {
+        key: value for key, value in before.items() if key != "environment"
+    }
+    # Repeating it is a no-op rather than a second rewrite.
+    assert bridge._repair_relocated_split(duplicate) is False
+
+
+def test_repair_is_a_no_op_for_a_vault_that_never_moved(tmp_path: Path) -> None:
+    vault = _completed_vault(tmp_path)
+    marker = vault / "System" / ".dex" / "topology.json"
+    before = marker.read_bytes()
+
+    assert bridge._repair_relocated_split(vault) is False
+    assert marker.read_bytes() == before
+
+
+def test_a_completed_bridge_resumes_after_the_vault_is_copied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finished install that was then copied must still resume offline.
+
+    The recorded path alone used to stop this, even though every other marker
+    agreed with the pinned foundation.
+    """
+    duplicate = _relocated_completed_vault(tmp_path)
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda *_args, **_kwargs: bridge.FOUNDATION.commit,
+    )
+
+    bridge._validate_completed_foundation(duplicate, bridge.FOUNDATION)
+    assert bridge._foundation_is_installed(duplicate, bridge.FOUNDATION) is True
+    assert bridge._repair_relocated_split(duplicate) is True
+    bridge._validate_completed_foundation(duplicate, bridge.FOUNDATION)
+
+
+def test_a_completed_bridge_still_refuses_a_disagreeing_release_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tolerating the recorded path must not tolerate the wrong release."""
+    vault = _completed_vault(tmp_path)
+    monkeypatch.setattr(
+        bridge,
+        "_run_git",
+        lambda *_args, **_kwargs: bridge.FOUNDATION.commit,
+    )
+    _edit_bridge_topology(vault, installedRelease="d" * 40)
+
+    with pytest.raises(bridge.BridgeError) as refusal:
+        bridge._validate_completed_foundation(vault, bridge.FOUNDATION)
+    assert "records installedRelease" in str(refusal.value)
+    assert bridge.FOUNDATION.commit in str(refusal.value)
+
+    _edit_bridge_topology(vault, installedRelease=bridge.FOUNDATION.commit)
+    (vault / ".dex" / "brain.git" / "dex-brain-v2").write_text(
+        '{"role":"brain","installed":"' + "e" * 40 + '"}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(bridge.BridgeError) as refusal:
+        bridge._validate_completed_foundation(vault, bridge.FOUNDATION)
+    assert "dex-brain-v2 records installed" in str(refusal.value)
+
+
+def _edit_bridge_topology(vault: Path, **fields: object) -> None:
+    path = vault / "System" / ".dex" / "topology.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value.update(fields)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+# label, how to break it, the clause _split_layout_failures must name, and the
+# clause the completed-bridge validator must name (its own path and marker
+# pre-checks fire first for some breaks, and already say which file they mean).
+_BRIDGE_BREAKS: tuple[tuple[str, object, str, str], ...] = (
+    (
+        "wrong-vault-git-dir",
+        lambda vault: _edit_bridge_topology(vault, vaultGitDir=".vault.git"),
+        "records vaultGitDir '.vault.git' instead of '.git'",
+        "records vaultGitDir '.vault.git' instead of '.git'",
+    ),
+    (
+        "wrong-brain-git-dir",
+        lambda vault: _edit_bridge_topology(vault, brainGitDir=".dex/other.git"),
+        "records brainGitDir '.dex/other.git' instead of '.dex/brain.git'",
+        "records brainGitDir '.dex/other.git' instead of '.dex/brain.git'",
+    ),
+    (
+        "no-recorded-vault-path",
+        lambda vault: _edit_bridge_topology(vault, environment={}),
+        "records no environment.DEX_VAULT path",
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "symlinked-vault-git",
+        lambda vault: (
+            shutil.rmtree(vault / ".git"),
+            (vault / "elsewhere.git").mkdir(),
+            (vault / ".git").symlink_to(vault / "elsewhere.git"),
+        ),
+        ".git is a symbolic link, which Dex refuses to follow",
+        "unsafe .git directory",
+    ),
+    (
+        "symlinked-brain-git",
+        lambda vault: (
+            shutil.rmtree(vault / ".dex" / "brain.git"),
+            (vault / ".dex" / "elsewhere.git").mkdir(),
+            (vault / ".dex" / "brain.git").symlink_to(vault / ".dex" / "elsewhere.git"),
+        ),
+        ".dex/brain.git is a symbolic link, which Dex refuses to follow",
+        "unsafe .dex/brain.git directory",
+    ),
+    (
+        "missing-brain-git",
+        lambda vault: shutil.rmtree(vault / ".dex" / "brain.git"),
+        ".dex/brain.git is missing or is not a directory",
+        "unsafe .dex/brain.git directory",
+    ),
+    (
+        "missing-vault-marker",
+        lambda vault: (vault / ".git" / "dex-vault-v2").unlink(),
+        ".git/dex-vault-v2 is missing or unreadable",
+        "vault Git marker is not a regular file",
+    ),
+    (
+        "missing-brain-marker",
+        lambda vault: (vault / ".dex" / "brain.git" / "dex-brain-v2").unlink(),
+        ".dex/brain.git/dex-brain-v2 is missing or unreadable",
+        "brain Git marker is not a regular file",
+    ),
+    (
+        "wrong-vault-marker-role",
+        lambda vault: (vault / ".git" / "dex-vault-v2").write_text(
+            '{"role":"brain"}\n', encoding="utf-8"
+        ),
+        ".git/dex-vault-v2 records role 'brain' instead of 'vault'",
+        ".git/dex-vault-v2 records role 'brain' instead of 'vault'",
+    ),
+    (
+        "wrong-brain-marker-role",
+        lambda vault: (vault / ".dex" / "brain.git" / "dex-brain-v2").write_text(
+            '{"role":"vault","installed":"'
+            + bridge.FOUNDATION.commit
+            + '"}\n',
+            encoding="utf-8",
+        ),
+        ".dex/brain.git/dex-brain-v2 records role 'vault' instead of 'brain'",
+        ".dex/brain.git/dex-brain-v2 records role 'vault' instead of 'brain'",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "break_layout", "expected_failure", "expected_refusal"),
+    _BRIDGE_BREAKS,
+    ids=[entry[0] for entry in _BRIDGE_BREAKS],
+)
+def test_repair_refuses_every_structurally_broken_split_and_names_it(
+    tmp_path: Path,
+    label: str,
+    break_layout: object,
+    expected_failure: str,
+    expected_refusal: str,
+) -> None:
+    """Relocation is tolerable; damage is not, and each cause names itself."""
+    duplicate = _relocated_completed_vault(tmp_path)
+    break_layout(duplicate)
+    marker = duplicate / "System" / ".dex" / "topology.json"
+    before = marker.read_bytes()
+
+    failures = bridge._split_layout_failures(duplicate)
+    assert any(expected_failure in failure for failure in failures)
+    assert bridge._repair_relocated_split(duplicate) is False
+    assert marker.read_bytes() == before
+
+    with pytest.raises(bridge.BridgeError) as refusal:
+        bridge._validate_completed_foundation(duplicate, bridge.FOUNDATION)
+    assert expected_refusal in str(refusal.value)
+
+
+def test_run_bridge_rewires_a_relocated_vault_before_the_foundation_sees_it(
+    tmp_path: Path,
+) -> None:
+    """The pinned foundation shipped before relocation was understood.
+
+    It cannot be changed retroactively, so the record is put right here, before
+    the foundation service is ever handed the vault.
+    """
+    original = _vault(tmp_path)
+    (original / "System" / ".dex").mkdir()
+    (original / "System" / ".dex" / "topology.json").write_bytes(
+        _split_topology_bytes(original, original, "b" * 40)
+    )
+    (original / ".git" / "dex-vault-v2").write_text('{"role":"vault"}\n', encoding="utf-8")
+    (original / ".dex" / "brain.git" / "dex-brain-v2").write_text(
+        '{"role":"brain"}\n', encoding="utf-8"
+    )
+    duplicate = tmp_path / "Documents" / "Dex"
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+
+    observed: list[str] = []
+
+    class _RecordingService(_SplitService):
+        def build_and_preview_topology_migration(self, vault_root: Path):
+            observed.append(
+                json.loads(
+                    (vault_root / "System/.dex/topology.json").read_text(encoding="utf-8")
+                )["environment"]["DEX_VAULT"]
+            )
+            return super().build_and_preview_topology_migration(vault_root)
+
+    bridge.run_bridge(
+        duplicate,
+        _RecordingService(),
+        fetch_foundation=lambda _vault, _pin: None,
+        input_fn=lambda _prompt: bridge._APPROVAL_WORD,
+        output_fn=lambda _line: None,
+    )
+
+    assert observed == [str(duplicate.resolve())]
+
+
+def test_the_bridge_names_the_condition_that_made_a_split_invalid(
+    tmp_path: Path,
+) -> None:
+    """The pinned foundation refuses without naming any of its conditions.
+
+    That cost a beta user an hour in engine.py. The bridge refuses first, and
+    says which condition failed.
+    """
+    adapter, engine, vault, _migrator = _foundation_topology_adapter(tmp_path)
+    (vault / "System" / ".dex").mkdir(parents=True)
+    (vault / "System" / ".dex" / "topology.json").write_bytes(
+        _split_topology_bytes(vault, vault, "c" * 40)
+    )
+    (vault / ".git" / "dex-vault-v2").write_text('{"role":"vault"}\n', encoding="utf-8")
+    # No brain marker: a genuinely broken split, not a relocated one.
+    engine.topology_state = lambda _vault_root: "invalid-split"
+
+    with adapter._topology_source():
+        with pytest.raises(bridge.BridgeError) as refusal:
+            engine.topology_state(vault)
+
+    message = str(refusal.value)
+    assert "dex-brain-v2 is missing or unreadable" in message
+    assert "nothing was changed" in message

--- a/core/tests/test_lifecycle_relocated_vault.py
+++ b/core/tests/test_lifecycle_relocated_vault.py
@@ -1,0 +1,326 @@
+"""A moved or copied vault is relocated, not invalid — and refusals say why.
+
+Two contracts live here.
+
+The first is that a brain/vault split whose structure is entirely intact but
+whose recorded vault path names somewhere else is *relocated*. The recorded path
+is an absolute path held in local runtime state, so copying, moving, or renaming
+a vault makes it stale as a matter of course. Nothing reads that value as a path
+— every consumer derives its paths from the vault root it was handed — so a
+stale one cannot redirect a read or a write, and treating it as damage locked
+any relocated vault out of updating at all.
+
+The second is that every refusal names the condition that failed. The previous
+message ("the current layout is invalid-split; Dex will not guess how to convert
+it") cost a beta user an hour of reading engine.py to discover which of nine
+checks had tripped.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from core.lifecycle import engine, service
+
+MIGRATOR_RELATIVE = Path("core/migrations/v1-to-v2-brain-vault-split.cjs")
+
+
+def _split_vault(root: Path) -> Path:
+    """A structurally sound brain/vault split that records its own location."""
+    (root / ".git").mkdir(parents=True)
+    (root / ".git/dex-vault-v2").write_text('{"role":"vault"}\n', encoding="utf-8")
+    (root / ".dex/brain.git").mkdir(parents=True)
+    (root / ".dex/brain.git/dex-brain-v2").write_text(
+        '{"role":"brain"}\n',
+        encoding="utf-8",
+    )
+    (root / "System/.dex").mkdir(parents=True)
+    (root / "System/.dex/topology.json").write_text(
+        json.dumps(
+            {
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "installedRelease": "a" * 40,
+                "environment": {"DEX_VAULT": str(root.resolve())},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _recorded(vault: Path) -> str:
+    topology = json.loads(
+        (vault / "System/.dex/topology.json").read_text(encoding="utf-8")
+    )
+    return topology["environment"]["DEX_VAULT"]
+
+
+def _edit_topology(root: Path, **fields: object) -> None:
+    path = root / "System/.dex/topology.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value.update(fields)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def test_split_vault_that_never_moved_is_post_split_and_not_relocated(
+    tmp_path: Path,
+) -> None:
+    vault = _split_vault(tmp_path / "Dex")
+
+    assert engine.split_layout_failures(vault) == ()
+    assert engine.relocated_split(vault) is False
+    assert engine.topology_state(vault) == "post-split"
+    assert service.build_and_preview_topology_migration(vault)["topology"] == "post-split"
+
+
+def test_copied_split_vault_is_accepted_as_post_split(tmp_path: Path) -> None:
+    """A duplicate of a sound vault is relocated, not invalid.
+
+    Every structural condition passes identically in the copy; only the recorded
+    absolute path still names the original.
+    """
+    original = _split_vault(tmp_path / "Dex")
+    duplicate = tmp_path / "Documents" / "Dex"
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+
+    assert Path(_recorded(duplicate)) == original
+    assert engine.split_layout_failures(duplicate) == ()
+    assert engine.relocated_split(duplicate) is True
+    assert engine.topology_state(duplicate) == "post-split"
+    assert service.build_and_preview_topology_migration(duplicate)["topology"] == "post-split"
+
+
+def test_moved_split_vault_is_accepted_as_post_split(tmp_path: Path) -> None:
+    """Moving ~/Dex to ~/Documents/Dex must not lock the vault out of updating."""
+    original = _split_vault(tmp_path / "Dex")
+    moved = tmp_path / "Documents" / "Dex"
+    moved.parent.mkdir(parents=True)
+    shutil.move(str(original), str(moved))
+
+    assert engine.relocated_split(moved) is True
+    assert engine.topology_state(moved) == "post-split"
+    assert service.build_and_preview_topology_migration(moved)["topology"] == "post-split"
+
+
+def test_classifying_a_relocated_vault_changes_nothing_on_disk(
+    tmp_path: Path,
+) -> None:
+    """topology_state documents itself as read-only; tolerating must not write."""
+    original = _split_vault(tmp_path / "Dex")
+    duplicate = tmp_path / "Documents" / "Dex"
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+    marker = duplicate / "System/.dex/topology.json"
+    before = marker.read_bytes()
+
+    assert engine.topology_state(duplicate) == "post-split"
+    assert engine.relocated_split(duplicate) is True
+    assert engine.topology_refusal_detail(duplicate, "post-split")
+    assert service.build_and_preview_topology_migration(duplicate)["topology"] == "post-split"
+
+    assert marker.read_bytes() == before
+
+
+def test_a_relocated_vault_that_resolves_to_the_same_place_is_not_relocated(
+    tmp_path: Path,
+) -> None:
+    """A recorded path that merely spells the vault differently is not stale."""
+    vault = _split_vault(tmp_path / "Dex")
+    _edit_topology(
+        vault,
+        environment={"DEX_VAULT": str(vault / "." / "..") + f"/{vault.name}"},
+    )
+
+    assert engine.relocated_split(vault) is False
+    assert engine.topology_state(vault) == "post-split"
+
+
+_STRUCTURAL_BREAKS: tuple[tuple[str, object, str], ...] = (
+    (
+        "wrong-vault-git-dir",
+        lambda root: _edit_topology(root, vaultGitDir=".vault.git"),
+        "records vaultGitDir '.vault.git' instead of '.git'",
+    ),
+    (
+        "wrong-brain-git-dir",
+        lambda root: _edit_topology(root, brainGitDir=".dex/other.git"),
+        "records brainGitDir '.dex/other.git' instead of '.dex/brain.git'",
+    ),
+    (
+        "no-recorded-vault-path",
+        lambda root: _edit_topology(root, environment={}),
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "non-string-recorded-vault-path",
+        lambda root: _edit_topology(root, environment={"DEX_VAULT": 7}),
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "empty-recorded-vault-path",
+        lambda root: _edit_topology(root, environment={"DEX_VAULT": ""}),
+        "records no environment.DEX_VAULT path",
+    ),
+    (
+        "symlinked-vault-git",
+        lambda root: (
+            shutil.rmtree(root / ".git"),
+            (root / "elsewhere.git").mkdir(),
+            (root / ".git").symlink_to(root / "elsewhere.git"),
+        ),
+        ".git is a symbolic link, which Dex refuses to follow",
+    ),
+    (
+        "symlinked-brain-git",
+        lambda root: (
+            shutil.rmtree(root / ".dex/brain.git"),
+            (root / ".dex/elsewhere.git").mkdir(),
+            (root / ".dex/brain.git").symlink_to(root / ".dex/elsewhere.git"),
+        ),
+        ".dex/brain.git is a symbolic link, which Dex refuses to follow",
+    ),
+    (
+        "missing-vault-git",
+        lambda root: shutil.rmtree(root / ".git"),
+        ".git is missing or is not a directory",
+    ),
+    (
+        "missing-brain-git",
+        lambda root: shutil.rmtree(root / ".dex/brain.git"),
+        ".dex/brain.git is missing or is not a directory",
+    ),
+    (
+        "missing-vault-marker",
+        lambda root: (root / ".git/dex-vault-v2").unlink(),
+        ".git/dex-vault-v2 is missing or unreadable",
+    ),
+    (
+        "wrong-vault-marker-role",
+        lambda root: (root / ".git/dex-vault-v2").write_text(
+            '{"role":"brain"}\n', encoding="utf-8"
+        ),
+        ".git/dex-vault-v2 records role 'brain' instead of 'vault'",
+    ),
+    (
+        "missing-brain-marker",
+        lambda root: (root / ".dex/brain.git/dex-brain-v2").unlink(),
+        ".dex/brain.git/dex-brain-v2 is missing or unreadable",
+    ),
+    (
+        "wrong-brain-marker-role",
+        lambda root: (root / ".dex/brain.git/dex-brain-v2").write_text(
+            '{"role":"vault"}\n', encoding="utf-8"
+        ),
+        ".dex/brain.git/dex-brain-v2 records role 'vault' instead of 'brain'",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "break_layout", "expected_clause"),
+    _STRUCTURAL_BREAKS,
+    ids=[entry[0] for entry in _STRUCTURAL_BREAKS],
+)
+def test_each_structural_break_is_still_refused_and_names_itself(
+    tmp_path: Path,
+    label: str,
+    break_layout: object,
+    expected_clause: str,
+) -> None:
+    """Tolerating relocation tolerates nothing else, and each cause explains itself."""
+    vault = _split_vault(tmp_path / label)
+    break_layout(vault)
+
+    assert engine.topology_state(vault) == "invalid-split"
+    assert engine.relocated_split(vault) is False
+    assert any(
+        expected_clause in failure for failure in engine.split_layout_failures(vault)
+    )
+
+    with pytest.raises(service.TopologyMigrationError) as refusal:
+        service.build_and_preview_topology_migration(vault)
+    assert expected_clause in str(refusal.value)
+    assert "Dex will not guess how to convert it" in str(refusal.value)
+
+
+@pytest.mark.parametrize(
+    ("label", "break_layout", "expected_clause"),
+    _STRUCTURAL_BREAKS,
+    ids=[entry[0] for entry in _STRUCTURAL_BREAKS],
+)
+def test_a_structural_break_in_a_relocated_vault_is_still_refused(
+    tmp_path: Path,
+    label: str,
+    break_layout: object,
+    expected_clause: str,
+) -> None:
+    """Relocation is tolerable only when every other condition passes."""
+    original = _split_vault(tmp_path / "Dex")
+    duplicate = tmp_path / "Documents" / label
+    duplicate.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(original, duplicate, symlinks=True)
+    break_layout(duplicate)
+
+    assert engine.topology_state(duplicate) == "invalid-split"
+    assert engine.relocated_split(duplicate) is False
+    with pytest.raises(service.TopologyMigrationError) as refusal:
+        service.build_and_preview_topology_migration(duplicate)
+    assert expected_clause in str(refusal.value)
+
+
+def test_a_marker_that_records_no_split_at_all_is_refused(tmp_path: Path) -> None:
+    vault = _split_vault(tmp_path / "Dex")
+    _edit_topology(vault, topology="something-else")
+
+    # A marker that does not claim the split is not an invalid split; it falls
+    # through to the ordinary combined/zip classification, which still refuses.
+    assert engine.topology_state(vault) != "post-split"
+    assert engine.relocated_split(vault) is False
+    assert engine.split_layout_failures(vault) == (
+        "System/.dex/topology.json does not record a brain/vault split",
+    )
+
+
+def test_every_unconvertible_layout_says_which_condition_stopped_it(
+    tmp_path: Path,
+) -> None:
+    """Nobody should have to read Dex's source to learn why they were refused."""
+    downloaded = tmp_path / "downloaded"
+    (downloaded / "System").mkdir(parents=True)
+
+    too_old = tmp_path / "too-old"
+    (too_old / ".git").mkdir(parents=True)
+
+    stalled = tmp_path / "stalled"
+    (stalled / ".git").mkdir(parents=True)
+    (stalled / "System/.dex").mkdir(parents=True)
+    (stalled / "System/.dex/migration-v2-state.json").write_text(
+        '{"status":"staging"}\n',
+        encoding="utf-8",
+    )
+
+    leftovers = tmp_path / "leftovers"
+    (leftovers / ".git").mkdir(parents=True)
+    (leftovers / ".dex/vault-staging.git").mkdir(parents=True)
+
+    expectations = (
+        (downloaded, "zip-or-manual", "has no .git directory"),
+        (too_old, "invalid-combined", MIGRATOR_RELATIVE.as_posix()),
+        (stalled, "migration-in-progress", "stopped at 'staging'"),
+        (leftovers, "migration-in-progress", ".dex/vault-staging.git behind"),
+    )
+    for vault, expected_state, expected_clause in expectations:
+        assert engine.topology_state(vault) == expected_state
+        with pytest.raises(service.TopologyMigrationError) as refusal:
+            service.build_and_preview_topology_migration(vault)
+        assert expected_state in str(refusal.value)
+        assert expected_clause in str(refusal.value)

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -224,6 +224,31 @@ def _verify_manifest(
         raise ReleaseVerificationError("release manifest contradicts the exact release tree")
 
 
+def _recorded_vault_path(topology: dict[str, Any]) -> str | None:
+    """Return the vault path the split marker records, if it records one.
+
+    Kept consistent with ``core.lifecycle.engine.recorded_vault_path``: the
+    marker has to record *a* path, but the value is runtime state and a moved
+    or copied vault legitimately records somewhere else.
+    """
+    environment = topology.get("environment")
+    if not isinstance(environment, dict):
+        return None
+    recorded = environment.get("DEX_VAULT")
+    return recorded if isinstance(recorded, str) and recorded else None
+
+
+def _relocated_vault(root: Path, topology: dict[str, Any]) -> bool:
+    """True when a sound split records a vault path other than this one."""
+    recorded = _recorded_vault_path(topology)
+    if recorded is None:
+        return False
+    try:
+        return Path(recorded).resolve() != root
+    except (OSError, RuntimeError):
+        return True
+
+
 def _topology(vault_root: Path) -> tuple[Path, dict[str, Any], dict[str, Any]]:
     root = Path(vault_root).resolve()
     for relative in (Path(".git"), Path(".dex"), BRAIN_RELATIVE, Path("System"), Path("System/.dex")):
@@ -234,22 +259,48 @@ def _topology(vault_root: Path) -> tuple[Path, dict[str, Any], dict[str, Any]]:
     vault_marker = _read_regular_json(root / VAULT_MARKER_RELATIVE, "vault Git marker")
     brain_git = root / BRAIN_RELATIVE
     brain_marker = _read_regular_json(brain_git / BRAIN_MARKER_NAME, "brain Git marker")
-    environment = topology.get("environment")
-    wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
-    try:
-        vault_wiring_matches = isinstance(wired_vault, str) and Path(wired_vault).resolve() == root
-    except (OSError, RuntimeError):
-        vault_wiring_matches = False
-    if (
-        topology.get("topology") != "brain-vault-split"
-        or topology.get("vaultGitDir") != ".git"
-        or topology.get("brainGitDir") != ".dex/brain.git"
-        or not vault_wiring_matches
-        or vault_marker.get("role") != "vault"
-        or brain_marker.get("role") != "brain"
-        or not brain_git.is_dir()
-    ):
-        raise UpdateError("the brain/vault split topology is incomplete or inconsistent")
+    # The recorded vault path is deliberately *not* a condition here. It is an
+    # absolute path held in runtime state, so any copied, moved, or renamed
+    # vault records somewhere else; nothing in this module reads it as a path
+    # (every path below derives from ``root``). A relocated vault is therefore
+    # sound, and _finalize_release_metadata re-records it on install. Structural
+    # damage still fails closed, and each cause now names itself.
+    failures: list[str] = []
+    if topology.get("topology") != "brain-vault-split":
+        failures.append(
+            f"{TOPOLOGY_RELATIVE.as_posix()} does not record a brain/vault split"
+        )
+    if topology.get("vaultGitDir") != ".git":
+        failures.append(
+            f"{TOPOLOGY_RELATIVE.as_posix()} records vaultGitDir "
+            f"{topology.get('vaultGitDir')!r} instead of '.git'"
+        )
+    if topology.get("brainGitDir") != ".dex/brain.git":
+        failures.append(
+            f"{TOPOLOGY_RELATIVE.as_posix()} records brainGitDir "
+            f"{topology.get('brainGitDir')!r} instead of '.dex/brain.git'"
+        )
+    if _recorded_vault_path(topology) is None:
+        failures.append(
+            f"{TOPOLOGY_RELATIVE.as_posix()} records no environment.DEX_VAULT path"
+        )
+    if vault_marker.get("role") != "vault":
+        failures.append(
+            f"{VAULT_MARKER_RELATIVE.as_posix()} records role "
+            f"{vault_marker.get('role')!r} instead of 'vault'"
+        )
+    if brain_marker.get("role") != "brain":
+        failures.append(
+            f"{BRAIN_RELATIVE.as_posix()}/{BRAIN_MARKER_NAME} records role "
+            f"{brain_marker.get('role')!r} instead of 'brain'"
+        )
+    if not brain_git.is_dir():
+        failures.append(f"{BRAIN_RELATIVE.as_posix()} is missing or is not a directory")
+    if failures:
+        raise UpdateError(
+            "the brain/vault split topology is incomplete or inconsistent: "
+            + "; ".join(failures)
+        )
     return brain_git, topology, brain_marker
 
 
@@ -465,6 +516,15 @@ def _finalize_release_metadata(
     release: VerifiedReleaseRef,
     previous_commit: str,
 ) -> None:
+    """Record the installed release, and re-record a relocated vault path.
+
+    This is the one place that legitimately rewrites the split marker, so it is
+    where a vault that was copied, moved, or renamed gets its recorded path put
+    right — the same routine-staleness repair the lifecycle activation record
+    already does. ``_topology`` has re-proved the layout by the time this runs,
+    and the existing restore-on-failure covers the extra field.
+    """
+    root = Path(vault_root).resolve()
     topology_path = vault_root / TOPOLOGY_RELATIVE
     marker_path = release.brain_git / BRAIN_MARKER_NAME
     topology = _read_regular_json(topology_path, "split topology marker")
@@ -472,6 +532,10 @@ def _finalize_release_metadata(
     previous_topology = dict(topology)
     previous_marker = dict(marker)
     topology["installedRelease"] = release.commit
+    if _relocated_vault(root, topology):
+        environment = topology.get("environment")
+        if isinstance(environment, dict):
+            topology["environment"] = {**environment, "DEX_VAULT": str(root)}
     marker["installed"] = release.commit
     try:
         _atomic_json(topology_path, topology)

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "e24b5f741286a364ab501140baae2372ef2e9cc73330157ca60c38b5845ce2b8",
+      "sha256": "e848ded5bff5539003cf9a092ee8a1429de3c4c5032700bdc052fa30380bce2f",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -35,7 +35,7 @@
       "word": "APPLY"
     },
     "artifact": {
-      "sha256": "e848ded5bff5539003cf9a092ee8a1429de3c4c5032700bdc052fa30380bce2f",
+      "sha256": "543e89166865525cfce15a4d67853902a44d1394dee8785e17279bad4629f6ff",
       "source_path": "scripts/dex_update_bridge.py"
     },
     "foundation": {

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -4,6 +4,26 @@ This page is for any Dex install whose `/dex-update` cannot complete, and for th
 assistant driving it. If you are the AI assistant inside a Dex vault reading this
 because an update failed: follow this page exactly; do not improvise beyond it.
 
+## Read this first: getting unstuck takes two runs, not one
+
+The one-time bridge on this page does not bring a stuck install up to the newest
+version of Dex. It brings it up to **v1.81.16, a release from 4 August 2026** —
+the oldest version that can then update itself the normal way. That is on
+purpose: the bridge aims at one exact release it can check thoroughly, rather
+than at a moving target.
+
+So a full rescue is two runs:
+
+1. **The bridge** (this page) gets the install to v1.81.16 and gives it a working
+   update route again. Expect up to three approval prompts.
+2. **`/dex-update`** then takes it from v1.81.16 to the current release. This is
+   the ordinary update everybody else uses, and it can be repeated any time.
+
+Finishing step 1 and stopping there is safe: nothing is broken and no notes are
+at risk — the install is simply behind. Run `/dex-update` when you are ready.
+
+If you already know you only need step 2, you do not need this page at all.
+
 ## Who this applies to
 
 **First, check the vault's shape — it decides the route.** If the vault contains a
@@ -157,9 +177,24 @@ say that later updates are the ordinary `/dex-update` route.
 relaunching into Dex's installed runtime, checking the install, fetching the
 pinned release, then building the exact preview (which can take a few minutes
 on a large vault). If it stops, it prints one line starting
-`Dex update bridge stopped safely:` explaining why. A bridge that runs for
-minutes with **no output at all** is wedged, not working — press Ctrl-C and
-report exactly what you ran and saw.
+`Dex update bridge stopped safely:` explaining why, and that line names the
+specific thing that stopped it — you should never have to guess, or read Dex's
+code, to find out. A bridge that runs for minutes with **no output at all** is
+wedged, not working — press Ctrl-C and report exactly what you ran and saw.
+
+**Running it without answering.** If you want to see how far it gets without
+changing anything, start it with its input closed
+(`python3 … --vault "$PWD" < /dev/null`). It reaches the first approval prompt,
+cannot read an answer, and stops with one line saying nothing was changed. That
+is a deliberate, safe dry run.
+
+**When it finishes.** The last line says stage one of two is complete, names the
+version now installed, and tells you to run `/dex-update` next. Do that: the
+install is working, but it is not yet on the current release.
+
+**If the vault has been moved, copied, or renamed.** That is fine. Dex records
+where the vault lives, and moving it makes that note stale; the bridge notices,
+says so, updates the note, and carries on. It does not need the folder put back.
 
 Windows is not part of this P0 bridge. Do not substitute an unverified PowerShell
 or Git command; use the supported rescue path until a Windows bridge is

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -182,11 +182,13 @@ specific thing that stopped it — you should never have to guess, or read Dex's
 code, to find out. A bridge that runs for minutes with **no output at all** is
 wedged, not working — press Ctrl-C and report exactly what you ran and saw.
 
-**Running it without answering.** If you want to see how far it gets without
-changing anything, start it with its input closed
+**Running it without answering.** To see how far it gets before you commit to
+anything, start it with its input closed
 (`python3 … --vault "$PWD" < /dev/null`). It reaches the first approval prompt,
-cannot read an answer, and stops with one line saying nothing was changed. That
-is a deliberate, safe dry run.
+cannot read an answer, and stops with one line saying so. Nothing it asked you
+to approve is applied. The one thing a run like this does leave behind is
+`System/migration-report-v2.md`, the preview report it writes for you to read —
+that file is the preview, not the change.
 
 **When it finishes.** The last line says stage one of two is complete, names the
 version now installed, and tells you to run `/dex-update` next. Do that: the

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -50,6 +50,12 @@ _APPROVAL_WORD = "APPLY"
 _CLEAN_RUNTIME_MARKER = "DEX_UPDATE_BRIDGE_CLEAN_RUNTIME"
 _TRUSTED_EXECUTABLE_DIRECTORIES = (Path("/usr/bin"), Path("/bin"), Path("/usr/local/bin"), Path("/opt/homebrew/bin"))
 _TOPOLOGY_MIGRATOR_RELATIVE = Path("core/migrations/v1-to-v2-brain-vault-split.cjs")
+# The layouts every supported foundation refuses to convert. Closed on purpose:
+# the bridge substitutes a refusal that names the failing condition only for
+# these, and any other state a foundation reports is passed through untouched.
+_UNCONVERTIBLE_TOPOLOGY_STATES = frozenset(
+    {"invalid-split", "invalid-combined", "migration-in-progress", "zip-or-manual"}
+)
 _PRE_SPLIT_ARCHIVE_MARKER = "dex-pre-split-v2-archive.json"
 _LEGACY_QMD_RECONCILIATION_PURPOSE = "legacy-qmd-reconciliation"
 _TRACKED_IGNORE_POLICY_RELATIVE = Path("core/migrations/tracked-ignored-policy.yaml")
@@ -2040,12 +2046,14 @@ class _FoundationLifecycleService:
                 if authorization is not None:
                     authorized_roots[root] = authorization
                     return "combined"
-            if state not in {"combined", "post-split", "brain-vault-split"}:
-                # The pinned foundation refuses every remaining state with one
-                # sentence that names none of its conditions, which is an hour
-                # in its source for anyone who hits it. Refuse here instead,
-                # naming the condition that actually stopped the run. This is
-                # only reached where the foundation would have refused anyway.
+            if state in _UNCONVERTIBLE_TOPOLOGY_STATES:
+                # The pinned foundation refuses each of these with one sentence
+                # that names none of its conditions, which is an hour in its
+                # source for anyone who hits it. Refuse here instead, naming the
+                # condition that actually stopped the run. Deliberately a closed
+                # list of the states the foundation already refuses: any state
+                # not named here still passes through to the foundation exactly
+                # as before.
                 raise BridgeError(
                     f"{_topology_refusal_detail(root, state)} — Dex will not "
                     "guess how to convert it, and nothing was changed"
@@ -3028,10 +3036,6 @@ def _validate_completed_foundation(vault_root: Path, pin: ReleasePin) -> None:
             f"{brain_marker.get('installed')!r} instead of the pinned "
             f"foundation {pin.commit}"
         )
-    if vault_marker.get("role") != "vault" and not any(
-        "dex-vault-v2 records role" in entry for entry in disagreements
-    ):  # pragma: no cover - _split_layout_failures already names this
-        disagreements.append(".git/dex-vault-v2 does not record the vault role")
     if disagreements:
         raise BridgeError(
             "completed bridge markers do not agree with the pinned foundation: "
@@ -3141,9 +3145,12 @@ def run_bridge(
 ) -> Mapping[str, Any]:
     """Run up to three fresh approval boundaries through the foundation service."""
     root = _validate_vault(vault_root)
-    _progress("Checking this Dex install (read-only)...")
-    # Idempotent, and a no-op for every vault that has not moved.
+    # Before the read-only notice below, because a vault that has moved gets one
+    # line of local runtime state put right and says so. Idempotent, silent, and
+    # a no-op for every vault that has not moved; main() has normally done it
+    # already, and this covers callers that enter here directly.
     _repair_relocated_split(root)
+    _progress("Checking this Dex install (read-only)...")
     # This local ref is the authoritative resume marker. Check it before
     # importing/calling lifecycle code or attempting any network operation: a
     # completed bridge must work offline and must not be disturbed merely
@@ -3274,7 +3281,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Dex update bridge stopped safely: {error}", file=sys.stderr)
         return 1
     print(
-        f"Stage one of two is complete: this Dex install is now on foundation "
+        "Stage one of two is complete: this Dex install is now on foundation "
         f"v{FOUNDATION.version}, a release from 4 August 2026. Run /dex-update "
         "next to come up to the current release — that is an ordinary update "
         "and you can repeat it whenever you like."

--- a/scripts/dex_update_bridge.py
+++ b/scripts/dex_update_bridge.py
@@ -16,6 +16,7 @@ import hmac
 import importlib
 import inspect
 import json
+import logging
 import os
 import re
 import shutil
@@ -2039,6 +2040,16 @@ class _FoundationLifecycleService:
                 if authorization is not None:
                     authorized_roots[root] = authorization
                     return "combined"
+            if state not in {"combined", "post-split", "brain-vault-split"}:
+                # The pinned foundation refuses every remaining state with one
+                # sentence that names none of its conditions, which is an hour
+                # in its source for anyone who hits it. Refuse here instead,
+                # naming the condition that actually stopped the run. This is
+                # only reached where the foundation would have refused anyway.
+                raise BridgeError(
+                    f"{_topology_refusal_detail(root, state)} — Dex will not "
+                    "guess how to convert it, and nothing was changed"
+                )
             return state
 
         def migrator_command(vault_root: Path, mode: str) -> list[str]:
@@ -2756,7 +2767,18 @@ def _approved_preview(
     if not isinstance(approval_token, str) or not approval_token:
         raise BridgeError("lifecycle preview did not return an approval token")
     output_fn(json.dumps(preview, indent=2, sort_keys=True))
-    if input_fn(f"{prompt} Type {_APPROVAL_WORD} to continue: ") != _APPROVAL_WORD:
+    try:
+        answer = input_fn(f"{prompt} Type {_APPROVAL_WORD} to continue: ")
+    except EOFError as error:
+        # A closed or exhausted stdin is the ordinary shape of a deliberate
+        # dry run, and every other refusal here is one plain sentence. Without
+        # this, the designed gate raised a traceback instead.
+        raise BridgeError(
+            "no change was made because no approval could be read — "
+            "this run had no answer available on standard input, so the "
+            f"gate that asks you to type {_APPROVAL_WORD} could not be answered"
+        ) from error
+    if answer != _APPROVAL_WORD:
         raise BridgeError("no change was made because the displayed preview was not approved")
     return preview, approval_token
 
@@ -2798,6 +2820,182 @@ def _regular_json(path: Path, description: str) -> dict[str, Any]:
     return value
 
 
+def _optional_json(path: Path) -> dict[str, Any] | None:
+    """Read a regular JSON object, or None — for classification, never a gate."""
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _recorded_vault_path(topology: Mapping[str, Any]) -> str | None:
+    """Return the vault path the split marker records, if it records one."""
+    environment = topology.get("environment")
+    if not isinstance(environment, Mapping):
+        return None
+    recorded = environment.get("DEX_VAULT")
+    return recorded if isinstance(recorded, str) and recorded else None
+
+
+def _split_layout_failures(vault_root: Path) -> tuple[str, ...]:
+    """Name every structural condition a recorded split layout fails.
+
+    Read-only. This exists so a refusal can say which condition failed instead
+    of asking the reader to work through Dex's source. The recorded vault path
+    is not one of these conditions; only its absence is.
+    """
+    root = Path(vault_root)
+    vault_git = root / ".git"
+    brain_git = root / ".dex" / "brain.git"
+    topology = _optional_json(root / "System" / ".dex" / "topology.json")
+    vault_marker = _optional_json(vault_git / "dex-vault-v2")
+    brain_marker = _optional_json(brain_git / "dex-brain-v2")
+    if not topology or topology.get("topology") != "brain-vault-split":
+        return ("System/.dex/topology.json does not record a brain/vault split",)
+    failures: list[str] = []
+    if topology.get("vaultGitDir") != ".git":
+        failures.append(
+            "System/.dex/topology.json records vaultGitDir "
+            f"{topology.get('vaultGitDir')!r} instead of '.git'"
+        )
+    if topology.get("brainGitDir") != ".dex/brain.git":
+        failures.append(
+            "System/.dex/topology.json records brainGitDir "
+            f"{topology.get('brainGitDir')!r} instead of '.dex/brain.git'"
+        )
+    if _recorded_vault_path(topology) is None:
+        failures.append("System/.dex/topology.json records no environment.DEX_VAULT path")
+    if vault_git.is_symlink():
+        failures.append(".git is a symbolic link, which Dex refuses to follow")
+    elif not vault_git.is_dir():
+        failures.append(".git is missing or is not a directory")
+    if brain_git.is_symlink():
+        failures.append(".dex/brain.git is a symbolic link, which Dex refuses to follow")
+    elif not brain_git.is_dir():
+        failures.append(".dex/brain.git is missing or is not a directory")
+    if not vault_marker:
+        failures.append(".git/dex-vault-v2 is missing or unreadable")
+    elif vault_marker.get("role") != "vault":
+        failures.append(
+            f".git/dex-vault-v2 records role {vault_marker.get('role')!r} instead of 'vault'"
+        )
+    if not brain_marker:
+        failures.append(".dex/brain.git/dex-brain-v2 is missing or unreadable")
+    elif brain_marker.get("role") != "brain":
+        failures.append(
+            ".dex/brain.git/dex-brain-v2 records role "
+            f"{brain_marker.get('role')!r} instead of 'brain'"
+        )
+    return tuple(failures)
+
+
+def _topology_refusal_detail(vault_root: Path, state: str) -> str:
+    """Say in one clause why this exact layout cannot be converted.
+
+    Kept in step with ``core.lifecycle.engine.topology_refusal_detail``. It has
+    to live here as well because the bridge delegates to a pinned foundation
+    release whose own refusal names none of its conditions and cannot be changed
+    after the fact. Only paths the user already owns appear here.
+    """
+    root = Path(vault_root)
+    if state == "invalid-split":
+        return (
+            "this vault records the separated brain/vault layout, but "
+            + "; ".join(_split_layout_failures(root))
+        )
+    if state == "migration-in-progress":
+        migration_state = _optional_json(
+            root / "System" / ".dex" / "migration-v2-state.json"
+        )
+        if migration_state and migration_state.get("status") != "complete":
+            return (
+                "System/.dex/migration-v2-state.json records an earlier "
+                f"separation that stopped at {migration_state.get('status')!r} "
+                "and was never finished"
+            )
+        leftovers = [
+            relative
+            for relative in (".dex/pre-split-archive.git", ".dex/vault-staging.git")
+            if (root / relative).exists()
+        ]
+        return (
+            "an earlier separation left "
+            + " and ".join(leftovers)
+            + " behind, so Dex cannot tell finished work from unfinished work"
+        )
+    if state == "zip-or-manual":
+        return (
+            "this folder has no .git directory, so it is a copied or downloaded "
+            "folder rather than an install Dex can update in place"
+        )
+    if state == "invalid-combined":
+        return (
+            "this folder has a .git directory but no separation tool at "
+            f"{_TOPOLOGY_MIGRATOR_RELATIVE.as_posix()}, and its Dex release is "
+            "not one of the historic layouts this bridge knows how to start from"
+        )
+    return f"the current layout is {state}"
+
+
+def _repair_relocated_split(vault_root: Path) -> bool:
+    """Re-record the vault path of a structurally sound split that was moved.
+
+    The recorded path is an absolute path held in local runtime state, so a
+    vault that was copied, moved, or renamed records somewhere else. Nothing
+    reads that value as a path — every check derives its paths from the vault
+    root it was given — so the record is a consistency note, and a relocated
+    vault is sound rather than damaged.
+
+    The pinned foundation this bridge delegates to shipped before that was
+    understood and refuses on the mismatch, so the record is put right here,
+    before the foundation ever sees it. Only that one field changes, only when
+    every structural condition passes, and the surrounding markers are left
+    exactly as they are.
+    """
+    root = Path(vault_root).resolve()
+    target = root / "System" / ".dex" / "topology.json"
+    topology = _optional_json(target)
+    if not topology or topology.get("topology") != "brain-vault-split":
+        return False
+    if _split_layout_failures(root):
+        return False
+    recorded = _recorded_vault_path(topology)
+    if recorded is None:
+        return False
+    try:
+        if Path(recorded).resolve() == root:
+            return False
+    except (OSError, RuntimeError):
+        pass
+    environment = topology.get("environment")
+    if not isinstance(environment, dict):
+        return False
+    rewritten = dict(topology)
+    rewritten["environment"] = {**environment, "DEX_VAULT": str(root)}
+    data = (json.dumps(rewritten, sort_keys=True, indent=2) + "\n").encode("utf-8")
+    temporary = target.parent / f".{target.name}.relocated-{os.getpid()}"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(descriptor, data)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.replace(temporary, target)
+    directory = os.open(target.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+    _progress(
+        "This vault has moved since Dex last recorded where it lives; "
+        f"re-recording it as {root} and continuing."
+    )
+    return True
+
+
 def _validate_completed_foundation(vault_root: Path, pin: ReleasePin) -> None:
     """Prove every durable split marker agrees with the installed pin."""
     brain = vault_root / ".dex" / "brain.git"
@@ -2814,23 +3012,31 @@ def _validate_completed_foundation(vault_root: Path, pin: ReleasePin) -> None:
     topology = _regular_json(vault_root / "System" / ".dex" / "topology.json", "split topology marker")
     vault_marker = _regular_json(vault_root / ".git" / "dex-vault-v2", "vault Git marker")
     brain_marker = _regular_json(brain / "dex-brain-v2", "brain Git marker")
-    environment = topology.get("environment")
-    wired_vault = environment.get("DEX_VAULT") if isinstance(environment, dict) else None
-    try:
-        wiring_matches = isinstance(wired_vault, str) and Path(wired_vault).resolve() == vault_root
-    except (OSError, RuntimeError):
-        wiring_matches = False
-    if (
-        topology.get("topology") != "brain-vault-split"
-        or topology.get("vaultGitDir") != ".git"
-        or topology.get("brainGitDir") != ".dex/brain.git"
-        or not wiring_matches
-        or topology.get("installedRelease") != pin.commit
-        or vault_marker.get("role") != "vault"
-        or brain_marker.get("role") != "brain"
-        or brain_marker.get("installed") != pin.commit
-    ):
-        raise BridgeError("completed bridge markers do not agree with the pinned foundation")
+    # The recorded vault path is deliberately not a condition: see
+    # _repair_relocated_split. Everything structural still fails closed, and
+    # each cause now names itself rather than leaving the reader to guess.
+    disagreements = list(_split_layout_failures(vault_root))
+    if topology.get("installedRelease") != pin.commit:
+        disagreements.append(
+            "System/.dex/topology.json records installedRelease "
+            f"{topology.get('installedRelease')!r} instead of the pinned "
+            f"foundation {pin.commit}"
+        )
+    if brain_marker.get("installed") != pin.commit:
+        disagreements.append(
+            ".dex/brain.git/dex-brain-v2 records installed "
+            f"{brain_marker.get('installed')!r} instead of the pinned "
+            f"foundation {pin.commit}"
+        )
+    if vault_marker.get("role") != "vault" and not any(
+        "dex-vault-v2 records role" in entry for entry in disagreements
+    ):  # pragma: no cover - _split_layout_failures already names this
+        disagreements.append(".git/dex-vault-v2 does not record the vault role")
+    if disagreements:
+        raise BridgeError(
+            "completed bridge markers do not agree with the pinned foundation: "
+            + "; ".join(disagreements)
+        )
 
 
 def _foundation_is_installed(vault_root: Path, pin: ReleasePin) -> bool:
@@ -2936,6 +3142,8 @@ def run_bridge(
     """Run up to three fresh approval boundaries through the foundation service."""
     root = _validate_vault(vault_root)
     _progress("Checking this Dex install (read-only)...")
+    # Idempotent, and a no-op for every vault that has not moved.
+    _repair_relocated_split(root)
     # This local ref is the authoritative resume marker. Check it before
     # importing/calling lifecycle code or attempting any network operation: a
     # completed bridge must work offline and must not be disturbed merely
@@ -3007,7 +3215,27 @@ def run_bridge(
     }
 
 
+def _own_this_process_logging() -> None:
+    """Keep imported Dex code's logging out of the bridge's own output.
+
+    The bridge's stderr is a user-facing surface: every stage it narrates, and
+    every way it can stop, is a plain sentence written with ``print``. It uses
+    no logger of its own. The pinned foundation release it imports does, and
+    warned through the root logger as a side effect of being imported, which put
+    ``VAULT_PATH not set — falling back to cwd()`` in front of the bridge's first
+    check, where it is both alarming and irrelevant. That release cannot be
+    changed after the fact.
+
+    An entry point is the right place to decide where log output goes, so this
+    one decides: attaching a handler to the root logger stops Python's
+    last-resort handler writing library records to stderr. No bridge diagnostic
+    travels this way, so none is suppressed.
+    """
+    logging.getLogger().addHandler(logging.NullHandler())
+
+
 def main(argv: list[str] | None = None) -> int:
+    _own_this_process_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--vault", type=Path, default=Path.cwd(), help="old Dex vault (defaults to current directory)")
     args = parser.parse_args(argv)
@@ -3016,6 +3244,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         _trusted_git_binary()
         vault = _validate_vault(args.vault)
+        # Put a moved vault's recorded location right before anything reads it:
+        # the resume check below and the pinned foundation both compare it, and
+        # both shipped before relocation was understood as routine.
+        _repair_relocated_split(vault)
         # A completed bridge has all durable state locally.  Check before
         # selecting the old virtualenv or downloading source so resuming it is
         # genuinely offline and independent of a later stable-channel change.
@@ -3035,10 +3267,18 @@ def main(argv: list[str] | None = None) -> int:
                 result = run_bridge(vault, _load_lifecycle_service(source))
             finally:
                 temporary.cleanup()
-    except (BridgeError, OSError, RuntimeError) as error:
+    except (BridgeError, EOFError, OSError, RuntimeError) as error:
+        # EOFError belongs here as a backstop: every approval gate converts it
+        # into a plain BridgeError sentence, and no gate may ever be able to
+        # reach the user as a traceback instead.
         print(f"Dex update bridge stopped safely: {error}", file=sys.stderr)
         return 1
-    print("Foundation delivery is complete. Once historical support is verified, future updates use /dex-update.")
+    print(
+        f"Stage one of two is complete: this Dex install is now on foundation "
+        f"v{FOUNDATION.version}, a release from 4 August 2026. Run /dex-update "
+        "next to come up to the current release — that is an ordinary update "
+        "and you can repeat it whenever you like."
+    )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 


### PR DESCRIPTION
Four defects from one report by Jim McDermott, rehearsing the v1.93.0 rescue bridge against a duplicate of his own vault. His run reached the APPLY gate in ~12 seconds, so the locale scrub fix (#452, v1.93.0) is confirmed working; these are what he found next.

Card: `moved-vault-is-refused-as-an-invalid-layout` (dex-cards `286d8ec`).

---

## Defect 1 — a relocated vault is classified invalid and refused

`core/lifecycle/engine.py::topology_state` classified a split vault by nine conditions. One required `System/.dex/topology.json`'s `environment.DEX_VAULT` to resolve equal to the vault root. That value is an **absolute path**, so any vault that is copied, moved, or renamed fails it, is classified `invalid-split`, and the bridge stops with the message Jim reported.

Jim verified all nine conditions against both his real vault and his duplicate: eight passed identically, only the recorded path differed. He corrected that one line, touched nothing else, and the run fetched the release, built the full preview, and reached the APPLY gate — so everything behind the check was already sound.

**Beyond his rehearsal, this locked out any user who relocates their vault.** Move `~/Dex` to `~/Documents/Dex` and you were refused from updating at all, with an error that did not say why.

### Before and after, reproduced

`topology_state` against a real split fixture, its copy, and after a move:

| vault | before | after |
| --- | --- | --- |
| original, never moved | `post-split` | `post-split` |
| copy (Jim's duplicate) | **`invalid-split`** | `post-split` |
| moved `~/Dex` → `~/Documents/Dex` | **`invalid-split`** | `post-split` |

Full before-run output, on `origin/main`:

```
COPY (Jim's duplicate)
  vault on disk           : .../Documents/Dex
  recorded DEX_VAULT      : .../Dex
  topology_state()        : invalid-split
  apply_update._topology(): UpdateError: the brain/vault split topology is incomplete or inconsistent
  bridge/dex-update sees  : topology migration refused: the current layout is invalid-split; Dex will not guess how to convert it

MOVED (~/Dex -> ~/Documents/Dex)
  topology_state()        : invalid-split
  bridge/dex-update sees  : topology migration refused: the current layout is invalid-split; Dex will not guess how to convert it
```

The same script on this branch — all three accepted, including through `apply_update._topology` and the bridge's own preview path:

```
COPY (Jim's duplicate)
  recorded DEX_VAULT      : .../Dex          <- still stale, deliberately
  topology_state()        : post-split
  apply_update._topology(): accepted
  bridge/dex-update sees  : accepted

MOVED (~/Dex -> ~/Documents/Dex)
  topology_state()        : post-split
  apply_update._topology(): accepted
  bridge/dex-update sees  : accepted
```

`/dex-doctor` is a third surface the same change fixes — it reads `topology_state`, so it was calling a copied vault broken:

```
BEFORE   unmoved -> post-split      copied -> invalid-split
AFTER    unmoved -> post-split      copied -> post-split
```

Before, `_probe_vault_git` and `_probe_brain_git` both reported `BROKEN` with "use /dex-update recovery" for a vault whose only fault was having been moved.

### Safety basis

The recorded value is used **only as a consistency assertion, never as a path anything operates on**. Both consumers — `topology_state` and `apply_update._topology` — derive every real path from the `vault_root` argument they are handed (`brain_git = root / BRAIN_RELATIVE`). Nothing follows the recorded value, so tolerating a stale one cannot redirect any read or write; it can only stop refusing a structurally sound split. Verified by reading both call sites.

Corroboration already in the repo: `core/utils/smoke.py::_prepare_topology_vault` rewrites `environment.DEX_VAULT` to the new location whenever it copies a split vault into a test vault. The harness has always treated relocation as something to re-record, not refuse.

### Shape, mirroring v1.84.0's activation-record fix

A well-formed record naming a different location is routine staleness after a move, not tampering — so it is re-recorded, while anything structurally suspect is still refused. Classification and repair stay separate:

- **`topology_state` stays read-only** (it documents itself that way) and returns `post-split` when every structural condition passes, regardless of the recorded path. A moved vault's *layout* is post-split; the recorded path is not part of the layout. This also means no downstream consumer needs to learn a new state — `core/utils/doctor.py`, `build_topology_migration_preview` and the bridge are correct unchanged.
- **`split_layout_failures()`** names every failing structural condition, exhaustively rather than short-circuiting.
- **`relocated_split()`** is the narrow predicate: sound structure, recorded path resolves elsewhere.
- **A missing or malformed record is still fail-closed** (`recorded_vault_path()`). Only a *stale value* became tolerable — the faithful mirror of the activation precedent, which required well-formedness and tolerated only a different value.
- **The repair lives in `apply_update._finalize_release_metadata`**, the one function that already rewrites that marker, inside its existing restore-on-failure. Only `environment.DEX_VAULT` changes.
- **`apply_update._topology` tolerates the same single condition**, so nobody can pass the bridge and then be refused by `/dex-update`.

### Why the bridge repairs it itself

`scripts/dex_update_bridge.py` delegates to the **pinned v1.81.16 foundation** and imports *that* tree's `engine.py` and `apply_update.py`. Those copies cannot be changed after the fact, so fixing current `main` alone would not have helped Jim. The bridge therefore puts the record right itself (`_repair_relocated_split`) before the foundation ever sees the vault — in `main()` before the resume check and at the top of `run_bridge`, idempotent, a no-op for any vault that has not moved.

This is strictly safer than monkeypatching the pinned checks: every one of them still runs exactly as shipped. It is also literally what Jim did by hand.

---

## Defect 2 — the stop line did not say which condition failed

`topology_refusal_detail()` explains all five unconvertible states: `invalid-split` naming each failing structural condition, plus `zip-or-manual`, `invalid-combined`, and both `migration-in-progress` causes. Wired into `build_topology_migration_preview`. `_topology`'s refusal lists its failures the same way, and the bridge's `_validate_completed_foundation` names which marker disagreed.

The bridge carries its own copy and intercepts in `_topology_source`, for the same pinned-code reason — the foundation's message names none of its conditions and would otherwise reach the user unchanged. The interception fires only for states the foundation would refuse anyway, only inside the two topology calls the wrapper covers.

Real bridge process, stdin closed. Before, on `origin/main`:

```
Relaunching inside Dex's installed runtime...
WARNING:root:VAULT_PATH not set — falling back to cwd(). Task ID generation may produce duplicates.
Checking this Dex install (read-only)...
Dex update bridge stopped safely: topology migration refused: the current layout is invalid-combined; Dex will not guess how to convert it
```

After:

```
Relaunching inside Dex's installed runtime...
Checking this Dex install (read-only)...
Dex update bridge stopped safely: this folder has a .git directory but no separation tool at core/migrations/v1-to-v2-brain-vault-split.cjs, and its Dex release is not one of the historic layouts this bridge knows how to start from — Dex will not guess how to convert it, and nothing was changed
```

Every one of thirteen structural breaks now names itself, e.g. `.git/dex-vault-v2 records role 'brain' instead of 'vault'`, `.dex/brain.git is a symbolic link, which Dex refuses to follow`, `System/.dex/topology.json records vaultGitDir '.vault.git' instead of '.git'`.

---

## Defect 3 — the APPLY gate raised a traceback on closed stdin

`input` raises `EOFError` on a closed stdin, and `main()`'s `except (BridgeError, OSError, RuntimeError)` did not include it, so a deliberate dry run got a stack trace out of `_approved_preview` instead of the designed plain sentence. The PR #458 canary probe recorded exactly this independently.

Driving the real gate with the real `input` on a closed stdin, before:

```
Dex will now install verified foundation v1.81.16. Type APPLY to continue:
  File ".../scripts/dex_update_bridge.py", line 2759, in _approved_preview
    if input_fn(f"{prompt} Type {_APPROVAL_WORD} to continue: ") != _APPROVAL_WORD:
EOFError: EOF when reading a line
```

After:

```
BridgeError: no change was made because no approval could be read — this run had no answer available on standard input, so the gate that asks you to type APPLY could not be answered
```

`EOFError` also joins `main()`'s tuple as a backstop, so no gate can ever reach a user as a stack trace.

### The canary's own recorded evidence, before and after

This is the strongest confirmation available, and it covers defects 3 and 4 together: the macOS canary drives the built bridge asset as a real process with stdin closed and records its exact stderr.

**Before** — `historic-fleet-darwin-pr-canary` on #458 (run `31489540713`), `journeys/v1.51.0-c8069c90c171.bridge-process-entry/bridge-process-entry-stderr.txt`:

```
Relaunching inside Dex's installed runtime...
WARNING:root:VAULT_PATH not set — falling back to cwd(). Task ID generation may produce duplicates.
Checking this Dex install (read-only)...
Traceback (most recent call last):
  File ".../dex-update-bridge-v1.93.0.py", line 3047, in <module>
    raise SystemExit(main())
  ...
  File ".../dex-update-bridge-v1.93.0.py", line 2759, in _approved_preview
    if input_fn(f"{prompt} Type {_APPROVAL_WORD} to continue: ") != _APPROVAL_WORD:
EOFError: EOF when reading a line
```

**After** — this PR's canary (run `31499569131`), same file:

```
Relaunching inside Dex's installed runtime...
Checking this Dex install (read-only)...
Dex update bridge stopped safely: no change was made because no approval could be read — this run had no answer available on standard input, so the gate that asks you to type APPLY could not be answered
```

Recorded probe fields: `reached_approval_gate: true`, `stdin: "closed"`, `timed_out: false`, `relaunch_notice_count: 1`, `exit_code: 1` (unchanged — a refusal is exit 1 by design), `stderr_bytes` down from a traceback to 290.

---

## Defect 4 — vault logging leaked into bridge output

`core/paths.py` warned through the **root** logger, which installs a stderr handler as a side effect of being imported. Fixed in two places, because both are true:

- `core/paths.py` now uses its own logger with a `NullHandler` — correct library hygiene, so the notice stays available to any program that configures logging (verified: `logging.basicConfig()` then import still shows it) and silent in every program that does not.
- The **pinned foundation's copy cannot be fixed**, so `main()` also claims root logging (`_own_this_process_logging`). The bridge uses no logger of its own — every stage and every stop is a `print` — so no bridge diagnostic is suppressed.

The real-process test now asserts no `VAULT_PATH` leak and no traceback in either stream.

---

## Also in scope — the rescue doc oversold one run

`docs/UPDATE-RESCUE.md` never said the bridge is stage one. A completed run lands on v1.81.16 (2026-08-04) and reaching current needs a second, ordinary `/dex-update`; the bridge only hinted at it after success. Both surfaces now state the two-stage shape up front, in plain language, plus notes on the closed-stdin dry run and on moved vaults.

The pinned foundation identity is unchanged. The download URLs in that doc are bumped by the release commit, not by hand (confirmed against `fcfd5a97`).

---

## Tests

- **`core/tests/test_lifecycle_relocated_vault.py`** (new, 33 cases): unmoved / copied / moved acceptance; classification proven not to write; **each of thirteen structural breaks refused independently and naming itself**, both on an unmoved vault and on a relocated one; all four non-split states explaining themselves.
- **`core/tests/test_apply_update.py`** (+11): relocated vault accepted and its recorded path re-recorded on install with no other field touched; copy accepted; unmoved vault's record unchanged; eight planner breaks refused independently.
- **`core/tests/test_dex_update_bridge.py`** (+~20): repair rewires only the recorded path and is idempotent; no-op when unmoved; a completed install resumes after being copied; wrong release identity still refused; ten breaks refused with the marker named; `run_bridge` rewires before the foundation is handed the vault; closed stdin gives the plain sentence and `main` gives the standard stop line.

Two pre-existing fail-closed tests changed **shape only** — `test_foundation_service_keeps_unknown_or_ambiguous_topology_fail_closed` and `test_foundation_service_does_not_bypass_an_unsafe_vault_migrator` now assert a legible refusal instead of a returned unconvertible state. Their real assertions — that Node is never selected and authorization is never attempted — are unchanged and still enforced by their `pytest.fail` guards.

## Baseline

Established on `origin/main` in a separate worktree, comparing failure **sets**, not counts. Measured twice: once against `1627488f`, then re-measured after rebasing onto current `main` (`43ab9823`, after #455 landed).

| | baseline (`43ab9823`) | branch (`b0dc57b4`) |
| --- | --- | --- |
| Python (`core/tests`, `core/mcp/tests`, `core/migrations/tests`, `-m "not fuzz"`) | 36 failed / 3503 passed | 36 failed / **3566** passed |
| `npm run test:scripts` | 152 pass / 11 fail | 152 pass / 11 fail |

**Failure sets identical in both suites**, verified by `diff` — the known Linux environmental baseline (file modes vs macOS, trusted-MCP symlinks, release-fleet acceptance), and the same 36 before and after #455. 63 new passing tests, zero new failures. `npm run test:hooks` 186/0, `npm run test:integrations` 224/0.

Locally green: `ruff check core/`, doc drift, PII, test delta, path-contract usage, architecture inventory, portable contract, founder content, path consistency, security gate, distribution verification, release-tag uniqueness + reachability, instructed tools, health promises, tracked-ignored, large-vault perf budget, connections contract. `core/update/journey-protocol-v1.json` regenerated for the new bridge checksum and `scripts/build-vault-bundle.sh` builds.

`quality` on macOS is green, and I checked its step list rather than just the job conclusion: all 23 gates plus the three JS suites genuinely ran.

`historic-fleet-darwin-pr-canary` green: **12 discovered / 12 started / 12 completed / 12 passed / 0 failed** (run `31499569131`), with the recorded bridge evidence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
