### PR TITLE
Add Dex Lens capability catalogue producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,7 @@ jobs:
           # environment secret; no generated private key belongs in the repo.
           DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64: ${{ secrets.DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64 }}
         run: |
+          python3 -m pip install 'cryptography>=42'
           python3 scripts/generate-dex-lens-catalog.py \
             --release-root "$PWD" \
             --output-dir dist \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
       contents: write
     outputs:
       release_sha: ${{ steps.release_guard.outputs.release_sha || steps.release_build.outputs.release_sha }}
+      already_published: ${{ steps.release_guard.outputs.already_published }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -370,6 +371,30 @@ jobs:
       - name: Build self-contained vault bundle
         if: steps.release_guard.outputs.already_published != 'true'
         run: bash scripts/build-vault-bundle.sh
+      - name: Generate signed Dex Lens catalog
+        if: steps.release_guard.outputs.already_published != 'true' && vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED == 'true'
+        env:
+          # Front Desk release review and Lens M1 verifier confirmation are required before
+          # setting DEX_LENS_CATALOG_RELEASE_GATE_ENABLED=true for a live release.
+          # The value must be a base64-encoded Ed25519 PEM private key stored as an
+          # environment secret; no generated private key belongs in the repo.
+          DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64: ${{ secrets.DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64 }}
+        run: |
+          python3 scripts/generate-dex-lens-catalog.py \
+            --release-root "$PWD" \
+            --output-dir dist \
+            --sign \
+            --key-id dex-core-lens-1
+      - name: Upload Dex Lens catalog for Pages
+        if: steps.release_guard.outputs.already_published != 'true' && vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dex-lens-catalog-pages
+          path: |
+            dist/dex-lens-catalog-latest.json
+            dist/dex-lens-catalog-latest.json.sha256
+          if-no-files-found: error
+          retention-days: 1
       - name: Upload vault bundle to versioned GitHub Release
         if: steps.release_guard.outputs.already_published != 'true'
         env:
@@ -390,6 +415,16 @@ jobs:
             "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
             "dist/dex-update-bridge-v$VERSION.py" \
             "dist/dex-update-bridge-v$VERSION.py.sha256" \
+            --clobber
+      - name: Upload Dex Lens catalog to versioned GitHub Release
+        if: steps.release_guard.outputs.already_published != 'true' && vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          gh release upload "v$VERSION" \
+            "dist/dex-lens-catalog-v$VERSION.json" \
+            "dist/dex-lens-catalog-v$VERSION.json.sha256" \
             --clobber
 
   build-release-beta:
@@ -481,11 +516,18 @@ jobs:
         with:
           name: release-health-inputs
           path: .
+      - name: Download Dex Lens latest catalog
+        if: needs['build-release'].outputs.already_published != 'true' && vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dex-lens-catalog-pages
+          path: dex-lens-catalog-pages
       - name: Build release health page
         env:
           SOURCE_SHA: ${{ github.sha }}
           RELEASE_SHA: ${{ needs['build-release'].outputs.release_sha }}
         run: |
+          mkdir -p public
           python scripts/build-health-json.py \
             --source-sha "$SOURCE_SHA" \
             --release-sha "$RELEASE_SHA" \
@@ -493,6 +535,10 @@ jobs:
             --quality-conclusion success \
             --output health.json
           python scripts/render-health-page.py --input health.json --output public/health.html
+          if [ -f dex-lens-catalog-pages/dex-lens-catalog-latest.json ]; then
+            cp dex-lens-catalog-pages/dex-lens-catalog-latest.json public/dex-lens-catalog-latest.json
+            cp dex-lens-catalog-pages/dex-lens-catalog-latest.json.sha256 public/dex-lens-catalog-latest.json.sha256
+          fi
       - name: Configure GitHub Pages
         id: pages
         continue-on-error: true

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -34,8 +34,8 @@
       "source": {
         "kind": "skill",
         "path": ".claude/skills/daily-plan/SKILL.md",
-        "sha256": "afbe7ced7c39d3b6d2fb0856e2602b69ba30bd18fc6949d21cc4657615cf2a27",
-        "byte_size": 27519
+        "sha256": "311c9cdf45842936cee4a91d1ac116ce9e1eeae576c01aacdce989e44b912221",
+        "byte_size": 30797
       },
       "value": "Helps a person choose a small, realistic focus list before the day scatters across meetings, tasks and loose commitments.",
       "jobs_served": ["plan-my-work"],
@@ -116,8 +116,8 @@
       "source": {
         "kind": "skill",
         "path": ".claude/skills/process-meetings/SKILL.md",
-        "sha256": "06849f800f65386bd49ce103ad23f9fcb7c3ffdd81111e878100fb2d3246dc9f",
-        "byte_size": 15297
+        "sha256": "eb7e819ed4c4e32fb5ec1f5477b249ec4bd6d8805870360107098d893a04642c",
+        "byte_size": 19094
       },
       "value": "Turns meeting material into people context and follow-up tasks, reducing the chance that decisions or promises disappear after the call.",
       "jobs_served": ["process-meetings", "keep-relationships-warm"],

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -1,0 +1,279 @@
+{
+  "registry_version": 1,
+  "catalog_version": 1,
+  "jobs": [
+    {
+      "job_id": "plan-my-work",
+      "title": "Plan my work",
+      "description": "Turn current commitments, calendar pressure and goals into a realistic plan for the day or week."
+    },
+    {
+      "job_id": "keep-relationships-warm",
+      "title": "Keep relationships warm",
+      "description": "Notice important people and accounts going quiet, then prepare useful follow-up before the relationship goes cold."
+    },
+    {
+      "job_id": "process-meetings",
+      "title": "Process meetings",
+      "description": "Convert meeting records into context, actions and organised notes without losing what was agreed."
+    },
+    {
+      "job_id": "keep-system-healthy",
+      "title": "Keep the system healthy",
+      "description": "Check what is working, what is off or broken, and what can be safely repaired or escalated."
+    },
+    {
+      "job_id": "compound-learning",
+      "title": "Compound learning",
+      "description": "Capture decisions, insights and reusable patterns so future work starts with better context."
+    }
+  ],
+  "entries": [
+    {
+      "id": "daily-plan",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/daily-plan/SKILL.md",
+        "sha256": "afbe7ced7c39d3b6d2fb0856e2602b69ba30bd18fc6949d21cc4657615cf2a27",
+        "byte_size": 27519
+      },
+      "value": "Helps a person choose a small, realistic focus list before the day scatters across meetings, tasks and loose commitments.",
+      "jobs_served": ["plan-my-work"],
+      "foundation_capabilities": ["context-orientation", "scoped-agency-human-control"],
+      "prerequisites": ["A readable task list or commitment source.", "Calendar access improves the plan but is not the only input."],
+      "trade_offs": ["The plan is only as current as the sources it can inspect.", "It drafts priorities; the person still chooses what to do."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_commitments_skill.py",
+          "summary": "The planning path is covered where commitments become bounded, reviewable tasks."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/daily-plan/SKILL.md",
+          "summary": "The shipped skill defines the daily planning workflow and its required source checks."
+        }
+      ],
+      "brief": {
+        "goal": "Create a daily planning routine that combines meetings, tasks and commitments into one bounded plan.",
+        "method_outline": ["Read current commitments and calendar shape.", "Choose a short list that fits the available time.", "Keep any task creation reviewable by the person."],
+        "verification_checklist": ["The output names a realistic number of actions for today.", "The person can reject or edit task changes before anything persists."],
+        "rollback_advice": "Disable or remove the planning command; the workflow should not require irreversible data changes."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "readable-task-source"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "week-plan",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/week-plan/SKILL.md",
+        "sha256": "23b5acf167fb02f41fa31fb75c38c366afab2263a53b0b4a9dcbdc62966b4bf2",
+        "byte_size": 12007
+      },
+      "value": "Turns goals, capacity and open work into a weekly focus plan, so repeated work starts from priorities rather than a blank chat.",
+      "jobs_served": ["plan-my-work"],
+      "foundation_capabilities": ["context-orientation", "durable-memory-provenance", "scoped-agency-human-control"],
+      "prerequisites": ["Some durable goal or task record the host can read.", "A cadence for reviewing the plan."],
+      "trade_offs": ["A weekly plan can become stale mid-week unless the person revisits it.", "It depends on honest capacity data."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_work_server_weekly_priority_creation.py",
+          "summary": "Weekly priority creation is covered through the Work MCP path."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/week-plan/SKILL.md",
+          "summary": "The shipped skill defines the weekly planning routine."
+        }
+      ],
+      "brief": {
+        "goal": "Create a weekly planning routine that maps goals and commitments to a bounded set of priorities.",
+        "method_outline": ["Read goals, open tasks and calendar pressure.", "Select a short priority set for the week.", "Expose uncertainty instead of forcing a fake complete plan."],
+        "verification_checklist": ["The plan names priorities, not a generic task dump.", "Capacity limits are visible in the output."],
+        "rollback_advice": "Remove the weekly planning command or its scheduled reminder; preserve the underlying tasks and goals."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-goals-or-tasks"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "process-meetings",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/process-meetings/SKILL.md",
+        "sha256": "06849f800f65386bd49ce103ad23f9fcb7c3ffdd81111e878100fb2d3246dc9f",
+        "byte_size": 15297
+      },
+      "value": "Turns meeting material into people context and follow-up tasks, reducing the chance that decisions or promises disappear after the call.",
+      "jobs_served": ["process-meetings", "keep-relationships-warm"],
+      "foundation_capabilities": ["context-orientation", "durable-memory-provenance", "privacy-minimal-disclosure"],
+      "prerequisites": ["Meeting notes or transcripts in a readable local source.", "A place to write reviewable follow-up tasks."],
+      "trade_offs": ["Transcript quality controls output quality.", "Private meeting material must stay within the host's declared read scope."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_process_meetings_soft_commitment_wiring.py",
+          "summary": "Meeting processing is covered where soft commitments are detected and routed."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/process-meetings/SKILL.md",
+          "summary": "The shipped skill defines the meeting processing workflow."
+        }
+      ],
+      "brief": {
+        "goal": "Create a meeting processing routine that extracts decisions, commitments and relationship context from approved meeting material.",
+        "method_outline": ["Read only the approved meeting source.", "Identify decisions, action items and people references.", "Offer reviewable tasks or note updates."],
+        "verification_checklist": ["No unrelated meeting content is read.", "Every proposed follow-up cites the meeting source.", "The person can edit before task creation."],
+        "rollback_advice": "Disable the meeting processor and remove generated follow-up drafts; keep original meeting notes untouched."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "meeting-source", "task-or-note-store"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "dex-doctor",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/dex-doctor/SKILL.md",
+        "sha256": "a36a2aa7df05a9bc23542685ec239b682fb0365b1a451900869381aa27d7dc89",
+        "byte_size": 17429
+      },
+      "value": "Gives the person an honest system check: what works, what is off, what is broken and what should not be guessed.",
+      "jobs_served": ["keep-system-healthy"],
+      "foundation_capabilities": ["honest-health-observability", "safe-change-recovery", "privacy-minimal-disclosure"],
+      "prerequisites": ["A host can run local checks against its own configuration.", "Repair paths must be separately gated from diagnosis."],
+      "trade_offs": ["A check can report unknown when evidence is missing.", "Automatic repair must remain limited to provably safe fixes."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_doctor.py",
+          "summary": "Doctor behavior is covered by the main health-check test suite."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/dex-doctor/SKILL.md",
+          "summary": "The shipped skill defines the checkup flow and safe repair boundary."
+        }
+      ],
+      "brief": {
+        "goal": "Create a local health check that distinguishes working, off, broken and unknown states without over-claiming.",
+        "method_outline": ["Probe the same paths the real features use.", "Report unknown when evidence is incomplete.", "Keep any repair action behind a separate approval path."],
+        "verification_checklist": ["A sabotaged probe does not become working.", "Unknown and off states are visible to the person.", "No secret value appears in output."],
+        "rollback_advice": "Disable repair actions first; the diagnostic report can remain read-only."
+      },
+      "compatibility": {
+        "host_requirements": ["local-diagnostics", "feature-status-vocabulary"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "relationship-radar",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/relationship-radar/SKILL.md",
+        "sha256": "e28b91f08f068368a8d66dc51e090fa807ab3f7fa0ec88c62de10344ea44f78e",
+        "byte_size": 5811
+      },
+      "value": "Shows important relationships that are going quiet so the person can reconnect before silence becomes a problem.",
+      "jobs_served": ["keep-relationships-warm"],
+      "foundation_capabilities": ["context-orientation", "durable-memory-provenance", "scoped-agency-human-control"],
+      "prerequisites": ["A relationship or meeting history source.", "A rule for what counts as important enough to surface."],
+      "trade_offs": ["Recency signals can miss context the system cannot see.", "The person still decides whether to reach out."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_relationship_radar_skill.py",
+          "summary": "Relationship radar skill behavior is covered in the skill test."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/relationship-radar/SKILL.md",
+          "summary": "The shipped skill defines the cold-relationship workflow."
+        }
+      ],
+      "brief": {
+        "goal": "Create a relationship review that identifies important contacts with stale recent engagement.",
+        "method_outline": ["Read approved relationship or meeting evidence.", "Rank by importance and recency.", "Suggest reviewable next actions rather than sending messages."],
+        "verification_checklist": ["The output names why each person surfaced.", "No message is sent automatically.", "The person can dismiss or defer a suggestion."],
+        "rollback_advice": "Remove the radar command or delete its generated suggestions; do not alter source relationship history."
+      },
+      "compatibility": {
+        "host_requirements": ["relationship-history", "skills-directory"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "save-insight",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/save-insight/SKILL.md",
+        "sha256": "1fdb8303f5b56ff4f2b95f69fb430ac0821eccd15027bd55476973dce61ce9d1",
+        "byte_size": 2658
+      },
+      "value": "Turns a learning from completed work into durable context future agents can reuse instead of rediscovering it.",
+      "jobs_served": ["compound-learning"],
+      "foundation_capabilities": ["durable-memory-provenance", "compounding-correctability", "context-orientation"],
+      "prerequisites": ["A durable memory or notes store.", "A review habit for deciding what is worth keeping."],
+      "trade_offs": ["Low-quality memories can clutter future context.", "The person or system needs a rule for when to save learning."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_learning_capture_command_name.py",
+          "summary": "Learning capture command naming is pinned by tests."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/save-insight/SKILL.md",
+          "summary": "The shipped skill defines the reusable-learning capture flow."
+        }
+      ],
+      "brief": {
+        "goal": "Create a lightweight learning capture routine for reusable lessons from completed work.",
+        "method_outline": ["Ask what changed future behavior.", "Store only the reusable rule and source context.", "Prefer small scoped memories over broad summaries."],
+        "verification_checklist": ["The saved item has a clear reuse condition.", "It does not contain secrets or raw private material.", "Future work can cite where it came from."],
+        "rollback_advice": "Delete or archive the saved learning entry; keep original project records separate."
+      },
+      "compatibility": {
+        "host_requirements": ["durable-memory-store", "skills-directory"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    }
+  ]
+}

--- a/core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json
+++ b/core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json
@@ -1,0 +1,467 @@
+{
+  "$defs": {
+    "CapabilityCompatibilityV2": {
+      "additionalProperties": false,
+      "properties": {
+        "foundation_capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Foundation Capabilities",
+          "type": "array"
+        },
+        "host_adapters": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Host Adapters",
+          "type": "array"
+        },
+        "host_requirements": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Host Requirements",
+          "type": "array"
+        },
+        "limitations": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "minimum_lens_contract": {
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "title": "Minimum Lens Contract",
+          "type": "string"
+        },
+        "needs_hooks": {
+          "title": "Needs Hooks",
+          "type": "boolean"
+        },
+        "needs_mcp": {
+          "title": "Needs Mcp",
+          "type": "boolean"
+        },
+        "platforms": {
+          "items": {
+            "enum": [
+              "macos",
+              "linux",
+              "windows"
+            ],
+            "type": "string"
+          },
+          "maxItems": 3,
+          "minItems": 1,
+          "title": "Platforms",
+          "type": "array"
+        }
+      },
+      "required": [
+        "host_adapters",
+        "foundation_capabilities",
+        "minimum_lens_contract",
+        "platforms",
+        "needs_hooks",
+        "needs_mcp",
+        "host_requirements",
+        "limitations"
+      ],
+      "title": "CapabilityCompatibilityV2",
+      "type": "object"
+    },
+    "CapabilityEvidenceV2": {
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "enum": [
+            "verified",
+            "supported",
+            "reported",
+            "unknown"
+          ],
+          "title": "Level",
+          "type": "string"
+        },
+        "limitations": {
+          "maxLength": 1000,
+          "minLength": 1,
+          "title": "Limitations",
+          "type": "string"
+        },
+        "source": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Source",
+          "type": "string"
+        },
+        "summary": {
+          "maxLength": 1000,
+          "minLength": 1,
+          "title": "Summary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "level",
+        "source",
+        "summary",
+        "limitations"
+      ],
+      "title": "CapabilityEvidenceV2",
+      "type": "object"
+    },
+    "CapabilityPortableBriefV2": {
+      "additionalProperties": false,
+      "properties": {
+        "goal": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Goal",
+          "type": "string"
+        },
+        "method_outline": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Method Outline",
+          "type": "array"
+        },
+        "rollback_advice": {
+          "maxLength": 1000,
+          "minLength": 1,
+          "title": "Rollback Advice",
+          "type": "string"
+        },
+        "safety_notes": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Safety Notes",
+          "type": "array"
+        },
+        "verification_checklist": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Verification Checklist",
+          "type": "array"
+        }
+      },
+      "required": [
+        "goal",
+        "method_outline",
+        "verification_checklist",
+        "rollback_advice",
+        "safety_notes"
+      ],
+      "title": "CapabilityPortableBriefV2",
+      "type": "object"
+    },
+    "CatalogueCapabilityEntryV2": {
+      "additionalProperties": false,
+      "properties": {
+        "capability_id": {
+          "pattern": "^[a-z][a-z0-9-]{2,80}$",
+          "title": "Capability Id",
+          "type": "string"
+        },
+        "changed_in": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 40,
+          "title": "Changed In",
+          "type": "array"
+        },
+        "compatibility": {
+          "$ref": "#/$defs/CapabilityCompatibilityV2"
+        },
+        "docs_url": {
+          "maxLength": 300,
+          "minLength": 1,
+          "title": "Docs Url",
+          "type": "string"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/CapabilityEvidenceV2"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Evidence",
+          "type": "array"
+        },
+        "jobs": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Jobs",
+          "type": "array"
+        },
+        "portable_brief": {
+          "$ref": "#/$defs/CapabilityPortableBriefV2"
+        },
+        "prerequisites": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Prerequisites",
+          "type": "array"
+        },
+        "release_provenance": {
+          "const": "core-release",
+          "title": "Release Provenance",
+          "type": "string"
+        },
+        "since_release": {
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "title": "Since Release",
+          "type": "string"
+        },
+        "summary": {
+          "maxLength": 1200,
+          "minLength": 1,
+          "title": "Summary",
+          "type": "string"
+        },
+        "title": {
+          "maxLength": 140,
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        },
+        "trade_offs": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "minItems": 1,
+          "title": "Trade Offs",
+          "type": "array"
+        },
+        "value": {
+          "maxLength": 1200,
+          "minLength": 1,
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "capability_id",
+        "title",
+        "summary",
+        "value",
+        "jobs",
+        "prerequisites",
+        "trade_offs",
+        "evidence",
+        "compatibility",
+        "docs_url",
+        "since_release",
+        "changed_in",
+        "release_provenance",
+        "portable_brief"
+      ],
+      "title": "CatalogueCapabilityEntryV2",
+      "type": "object"
+    },
+    "CatalogueMetadataV2": {
+      "additionalProperties": false,
+      "properties": {
+        "catalog_version": {
+          "minimum": 1,
+          "title": "Catalog Version",
+          "type": "integer"
+        },
+        "contract_version": {
+          "const": "dex-lens-catalogue-v2",
+          "title": "Contract Version",
+          "type": "string"
+        },
+        "core_release": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Core Release",
+          "type": "string"
+        },
+        "expires_at": {
+          "format": "date-time",
+          "title": "Expires At",
+          "type": "string"
+        },
+        "key_id": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Key Id",
+          "type": "string"
+        },
+        "produced_at": {
+          "format": "date-time",
+          "title": "Produced At",
+          "type": "string"
+        },
+        "producer": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Producer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "contract_version",
+        "catalog_version",
+        "produced_at",
+        "expires_at",
+        "producer",
+        "core_release",
+        "key_id"
+      ],
+      "title": "CatalogueMetadataV2",
+      "type": "object"
+    },
+    "CatalogueV2": {
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {
+          "items": {
+            "$ref": "#/$defs/CatalogueCapabilityEntryV2"
+          },
+          "maxItems": 300,
+          "minItems": 1,
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "jobs_taxonomy": {
+          "items": {
+            "$ref": "#/$defs/JobTaxonomyEntryV2"
+          },
+          "maxItems": 80,
+          "minItems": 1,
+          "title": "Jobs Taxonomy",
+          "type": "array"
+        },
+        "portable_brief": {
+          "$ref": "#/$defs/PortableBriefContractV2"
+        }
+      },
+      "required": [
+        "jobs_taxonomy",
+        "capabilities",
+        "portable_brief"
+      ],
+      "title": "CatalogueV2",
+      "type": "object"
+    },
+    "JobTaxonomyEntryV2": {
+      "additionalProperties": false,
+      "properties": {
+        "confirmed_gap_signals": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 12,
+          "minItems": 1,
+          "title": "Confirmed Gap Signals",
+          "type": "array"
+        },
+        "description": {
+          "maxLength": 600,
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "job_id": {
+          "pattern": "^[a-z][a-z0-9-]{2,80}$",
+          "title": "Job Id",
+          "type": "string"
+        },
+        "label": {
+          "maxLength": 120,
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "job_id",
+        "label",
+        "description",
+        "confirmed_gap_signals"
+      ],
+      "title": "JobTaxonomyEntryV2",
+      "type": "object"
+    },
+    "PortableBriefContractV2": {
+      "additionalProperties": false,
+      "properties": {
+        "audience": {
+          "const": "the person's own AI system",
+          "title": "Audience",
+          "type": "string"
+        },
+        "format": {
+          "const": "markdown",
+          "title": "Format",
+          "type": "string"
+        },
+        "safety_boundary": {
+          "maxLength": 400,
+          "minLength": 1,
+          "title": "Safety Boundary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "format",
+        "audience",
+        "safety_boundary"
+      ],
+      "title": "PortableBriefContractV2",
+      "type": "object"
+    }
+  },
+  "$id": "https://heydex.ai/catalogue/dex-lens/v2.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "catalogue": {
+      "$ref": "#/$defs/CatalogueV2"
+    },
+    "metadata": {
+      "$ref": "#/$defs/CatalogueMetadataV2"
+    },
+    "signature": {
+      "minLength": 1,
+      "title": "Signature",
+      "type": "string"
+    }
+  },
+  "required": [
+    "metadata",
+    "catalogue",
+    "signature"
+  ],
+  "title": "SignedCatalogueEnvelopeV2",
+  "type": "object"
+}

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "scripts/generate-dex-lens-catalog.py"
@@ -240,20 +242,12 @@ def test_signing_requires_environment_secret_and_never_generates_a_key(tmp_path:
 
 
 def test_real_ed25519_signing_hook_uses_only_environment_key(tmp_path: Path) -> None:
-    if shutil.which("openssl") is None:
-        return
     _registry(tmp_path)
-    private_key = tmp_path / "ed25519.pem"
-    public_key = tmp_path / "ed25519.pub.pem"
-    subprocess.run(
-        ["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(private_key)],
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["openssl", "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)],
-        check=True,
-        capture_output=True,
+    private_key = Ed25519PrivateKey.generate()
+    private_pem = private_key.private_bytes(
+        Encoding.PEM,
+        PrivateFormat.PKCS8,
+        NoEncryption(),
     )
 
     signed = subprocess.run(
@@ -273,31 +267,11 @@ def test_real_ed25519_signing_hook_uses_only_environment_key(tmp_path: Path) -> 
             "ed25519-test-key",
         ],
         cwd=REPO_ROOT,
-        env={"DEX_LENS_TEST_KEY": base64.b64encode(private_key.read_bytes()).decode("ascii")},
+        env={"DEX_LENS_TEST_KEY": base64.b64encode(private_pem).decode("ascii")},
         capture_output=True,
         text=True,
     )
     assert signed.returncode == 0, signed.stderr
     envelope = json.loads((tmp_path / "dist/dex-lens-catalog-v1.94.0.json").read_text())
     signature = base64.b64decode(envelope["signature"])
-    payload_file = tmp_path / "payload.json"
-    payload_file.write_text(_signed_payload(envelope), encoding="utf-8")
-    sigfile = tmp_path / "sig.bin"
-    sigfile.write_bytes(signature)
-    verify = subprocess.run(
-        [
-            "openssl",
-            "pkeyutl",
-            "-verify",
-            "-rawin",
-            "-pubin",
-            "-inkey",
-            str(public_key),
-            "-sigfile",
-            str(sigfile),
-            "-in",
-            str(payload_file),
-        ],
-        capture_output=True,
-    )
-    assert verify.returncode == 0, verify.stderr.decode("utf-8", errors="replace")
+    private_key.public_key().verify(signature, _signed_payload(envelope).encode("utf-8"))

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -39,6 +39,11 @@ def _skill(root: Path, skill_id: str, description: str = "Use when planning a da
 
 def _registry(root: Path) -> None:
     skill_bytes = _skill(root, "daily-plan")
+    schema_source = REPO_ROOT / "core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json"
+    _write(
+        root / "core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json",
+        schema_source.read_text(encoding="utf-8"),
+    )
     _write(
         root / "CHANGELOG.md",
         "# Changelog\n\n## [1.94.0] - Test release\n\n## [1.80.0] - Older release\n",
@@ -159,9 +164,15 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert capability["release_provenance"] == "core-release"
     assert capability["evidence"][0]["level"] == "verified"
     assert capability["compatibility"]["minimum_lens_contract"] == "0.1.0"
-    assert capability["portable_brief"]["headline"].startswith(
+    assert capability["compatibility"]["platforms"] == ["macos", "linux", "windows"]
+    assert capability["compatibility"]["needs_hooks"] is False
+    assert capability["compatibility"]["needs_mcp"] is True
+    assert capability["compatibility"]["host_requirements"] == ["skills-directory"]
+    assert "Needs hooks" not in " ".join(capability["compatibility"]["limitations"])
+    assert capability["portable_brief"]["goal"].startswith(
         "Create a daily planning routine"
     )
+    assert "adaptation_notes" not in capability["portable_brief"]
     assert capability["portable_brief"]["method_outline"] == [
         "Read today's meetings and open tasks.",
         "Choose a short focus list that fits the available time.",

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -144,13 +144,21 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert envelope["metadata"]["key_id"] == "dex-core-lens-1"
     assert envelope["catalogue"]["jobs_taxonomy"][0]["job_id"] == "plan-my-day"
     assert envelope["catalogue"]["jobs_taxonomy"][0]["label"] == "Plan my day"
-    assert envelope["catalogue"]["capabilities"][0]["capability_id"] == "daily-plan"
-    assert envelope["catalogue"]["capabilities"][0]["summary"] == (
+    capability = envelope["catalogue"]["capabilities"][0]
+    assert capability["capability_id"] == "daily-plan"
+    assert capability["summary"] == (
         "Helps a person choose what matters today before work scatters."
     )
-    assert envelope["catalogue"]["capabilities"][0]["evidence"][0]["level"] == "verified"
-    assert envelope["catalogue"]["capabilities"][0]["compatibility"]["minimum_lens_contract"] == "0.1.0"
-    assert envelope["catalogue"]["capabilities"][0]["portable_brief"]["headline"].startswith(
+    assert capability["value"] == "Helps a person choose what matters today before work scatters."
+    assert capability["prerequisites"] == ["A task list or calendar the host can inspect."]
+    assert capability["trade_offs"] == ["The plan is only as current as the source material."]
+    assert capability["docs_url"] == "https://github.com/davekilleen/Dex"
+    assert capability["since_release"] == "1.80.0"
+    assert capability["changed_in"] == []
+    assert capability["release_provenance"] == "core-release"
+    assert capability["evidence"][0]["level"] == "verified"
+    assert capability["compatibility"]["minimum_lens_contract"] == "0.1.0"
+    assert capability["portable_brief"]["headline"].startswith(
         "Create a daily planning routine"
     )
     assert envelope["catalogue"]["portable_brief"]["format"] == "markdown"

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -1,0 +1,303 @@
+"""Dex Lens catalog producer gates."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "scripts/generate-dex-lens-catalog.py"
+
+
+def _signed_payload(envelope: dict) -> str:
+    return json.dumps(
+        {"metadata": envelope["metadata"], "catalogue": envelope["catalogue"]},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _skill(root: Path, skill_id: str, description: str = "Use when planning a day.") -> bytes:
+    content = f"---\nname: {skill_id}\ndescription: {description}\n---\n\n# {skill_id}\n"
+    path = root / ".claude/skills" / skill_id / "SKILL.md"
+    _write(path, content)
+    return content.encode("utf-8")
+
+
+def _registry(root: Path) -> None:
+    skill_bytes = _skill(root, "daily-plan")
+    _write(
+        root / "CHANGELOG.md",
+        "# Changelog\n\n## [1.94.0] - Test release\n\n## [1.80.0] - Older release\n",
+    )
+    _write(root / "package.json", '{"version":"1.94.0"}\n')
+    _write(
+        root / "core/lens-catalog/registry.json",
+        json.dumps(
+            {
+                "registry_version": 1,
+                "catalog_version": 7,
+                "jobs": [
+                    {
+                        "job_id": "plan-my-day",
+                        "title": "Plan my day",
+                        "description": "Turn calendar and tasks into one realistic daily plan.",
+                    }
+                ],
+                "entries": [
+                    {
+                        "id": "daily-plan",
+                        "source": {
+                            "kind": "skill",
+                            "path": ".claude/skills/daily-plan/SKILL.md",
+                            "sha256": hashlib.sha256(skill_bytes).hexdigest(),
+                            "byte_size": len(skill_bytes),
+                        },
+                        "value": "Helps a person choose what matters today before work scatters.",
+                        "jobs_served": ["plan-my-day"],
+                        "foundation_capabilities": [
+                            "context-orientation",
+                            "scoped-agency-human-control",
+                        ],
+                        "prerequisites": ["A task list or calendar the host can inspect."],
+                        "trade_offs": ["The plan is only as current as the source material."],
+                        "evidence": [
+                            {
+                                "kind": "test",
+                                "reference": "core/tests/test_commitments_skill.py",
+                                "summary": "Daily planning skill coverage exercises task creation boundaries.",
+                            }
+                        ],
+                        "brief": {
+                            "goal": "Create a daily planning routine that combines commitments and calendar shape.",
+                            "method_outline": [
+                                "Read today's meetings and open tasks.",
+                                "Choose a short focus list that fits the available time.",
+                            ],
+                            "verification_checklist": [
+                                "The output names a bounded set of actions for today."
+                            ],
+                            "rollback_advice": "Remove the routine or disable the command; it does not need to touch user content.",
+                        },
+                        "compatibility": {
+                            "host_requirements": ["skills-directory"],
+                            "needs_hooks": False,
+                            "needs_mcp": True,
+                            "platforms": ["macos", "linux", "windows"],
+                        },
+                        "docs_url": "https://github.com/davekilleen/Dex",
+                        "since_release": "1.80.0",
+                        "changed_in": [],
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+
+def _generate(root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--release-root",
+            str(root),
+            "--output-dir",
+            str(root / "dist"),
+            "--issued-at",
+            "2026-08-11T12:00:00Z",
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> None:
+    _registry(tmp_path)
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    envelope = json.loads((tmp_path / "dist/dex-lens-catalog-v1.94.0.json").read_text())
+    assert set(envelope) == {"metadata", "catalogue", "signature"}
+    assert envelope["signature"] == ""
+    assert envelope["metadata"]["contract_version"] == "dex-lens-catalogue-v2"
+    assert envelope["metadata"]["catalog_version"] == 7
+    assert envelope["metadata"]["producer"] == "Dex Core release pipeline v1.94.0"
+    assert envelope["metadata"]["key_id"] == "dex-core-lens-1"
+    assert envelope["catalogue"]["jobs_taxonomy"][0]["job_id"] == "plan-my-day"
+    assert envelope["catalogue"]["jobs_taxonomy"][0]["label"] == "Plan my day"
+    assert envelope["catalogue"]["capabilities"][0]["capability_id"] == "daily-plan"
+    assert envelope["catalogue"]["capabilities"][0]["summary"] == (
+        "Helps a person choose what matters today before work scatters."
+    )
+    assert envelope["catalogue"]["capabilities"][0]["evidence"][0]["level"] == "verified"
+    assert envelope["catalogue"]["capabilities"][0]["compatibility"]["minimum_lens_contract"] == "0.1.0"
+    assert envelope["catalogue"]["capabilities"][0]["portable_brief"]["headline"].startswith(
+        "Create a daily planning routine"
+    )
+    assert envelope["catalogue"]["portable_brief"]["format"] == "markdown"
+    assert (tmp_path / "dist/dex-lens-catalog-latest.json").read_text() == json.dumps(
+        envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ) + "\n"
+    assert (tmp_path / "dist/dex-lens-catalog-v1.94.0.json.sha256").read_text().strip()
+
+
+def test_generator_rejects_unknown_fields_in_registry(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
+    data["entries"][0]["capabilities"] = []
+    _write(tmp_path / "core/lens-catalog/registry.json", json.dumps(data))
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 1
+    assert "unknown capabilities" in result.stderr
+
+
+def test_generator_rejects_unknown_job_and_foundation_references(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
+    data["entries"][0]["jobs_served"] = ["missing-job"]
+    data["entries"][0]["foundation_capabilities"] = ["invented-foundation"]
+    _write(tmp_path / "core/lens-catalog/registry.json", json.dumps(data))
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 1
+    assert "unknown job reference" in result.stderr
+
+
+def test_generator_rejects_unshipped_or_stale_source(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
+    data["entries"][0]["source"]["path"] = ".claude/skills/missing/SKILL.md"
+    _write(tmp_path / "core/lens-catalog/registry.json", json.dumps(data))
+
+    missing = _generate(tmp_path)
+    assert missing.returncode == 1
+    assert "missing or not a regular file" in missing.stderr
+
+    _registry(tmp_path)
+    data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
+    data["entries"][0]["source"]["sha256"] = "0" * 64
+    _write(tmp_path / "core/lens-catalog/registry.json", json.dumps(data))
+
+    stale = _generate(tmp_path)
+    assert stale.returncode == 1
+    assert "does not match its declared sha256 or byte_size" in stale.stderr
+
+
+def test_signing_requires_environment_secret_and_never_generates_a_key(tmp_path: Path) -> None:
+    _registry(tmp_path)
+
+    missing = _generate(tmp_path, "--sign", "--signing-key-env", "DEX_LENS_TEST_KEY")
+    assert missing.returncode == 1
+    assert "environment secret DEX_LENS_TEST_KEY is not set" in missing.stderr
+
+    key = base64.b64encode(b"test-only-not-a-real-ed25519-private-key").decode("ascii")
+    signed = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--release-root",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path / "dist"),
+            "--issued-at",
+            "2026-08-11T12:00:00Z",
+            "--sign",
+            "--signing-key-env",
+            "DEX_LENS_TEST_KEY",
+            "--key-id",
+            "test-key",
+            "--test-deterministic-signature",
+        ],
+        cwd=REPO_ROOT,
+        env={"DEX_LENS_TEST_KEY": key},
+        capture_output=True,
+        text=True,
+    )
+    assert signed.returncode == 0, signed.stderr
+    envelope = json.loads((tmp_path / "dist/dex-lens-catalog-v1.94.0.json").read_text())
+    assert envelope["metadata"]["key_id"] == "test-key"
+    assert len(base64.b64decode(envelope["signature"], validate=True)) == 64
+
+
+def test_real_ed25519_signing_hook_uses_only_environment_key(tmp_path: Path) -> None:
+    if shutil.which("openssl") is None:
+        return
+    _registry(tmp_path)
+    private_key = tmp_path / "ed25519.pem"
+    public_key = tmp_path / "ed25519.pub.pem"
+    subprocess.run(
+        ["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(private_key)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)],
+        check=True,
+        capture_output=True,
+    )
+
+    signed = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--release-root",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path / "dist"),
+            "--issued-at",
+            "2026-08-11T12:00:00Z",
+            "--sign",
+            "--signing-key-env",
+            "DEX_LENS_TEST_KEY",
+            "--key-id",
+            "ed25519-test-key",
+        ],
+        cwd=REPO_ROOT,
+        env={"DEX_LENS_TEST_KEY": base64.b64encode(private_key.read_bytes()).decode("ascii")},
+        capture_output=True,
+        text=True,
+    )
+    assert signed.returncode == 0, signed.stderr
+    envelope = json.loads((tmp_path / "dist/dex-lens-catalog-v1.94.0.json").read_text())
+    signature = base64.b64decode(envelope["signature"])
+    payload_file = tmp_path / "payload.json"
+    payload_file.write_text(_signed_payload(envelope), encoding="utf-8")
+    sigfile = tmp_path / "sig.bin"
+    sigfile.write_bytes(signature)
+    verify = subprocess.run(
+        [
+            "openssl",
+            "pkeyutl",
+            "-verify",
+            "-rawin",
+            "-pubin",
+            "-inkey",
+            str(public_key),
+            "-sigfile",
+            str(sigfile),
+            "-in",
+            str(payload_file),
+        ],
+        capture_output=True,
+    )
+    assert verify.returncode == 0, verify.stderr.decode("utf-8", errors="replace")

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -147,6 +147,7 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert envelope["catalogue"]["jobs_taxonomy"][0]["label"] == "Plan my day"
     capability = envelope["catalogue"]["capabilities"][0]
     assert capability["capability_id"] == "daily-plan"
+    assert capability["title"] == "Daily Plan"
     assert capability["summary"] == "Use when planning a day."
     assert capability["value"] == "Helps a person choose what matters today before work scatters."
     assert capability["summary"] != capability["value"]
@@ -161,6 +162,14 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert capability["portable_brief"]["headline"].startswith(
         "Create a daily planning routine"
     )
+    assert capability["portable_brief"]["method_outline"] == [
+        "Read today's meetings and open tasks.",
+        "Choose a short focus list that fits the available time.",
+    ]
+    assert capability["portable_brief"]["verification_checklist"] == [
+        "The output names a bounded set of actions for today."
+    ]
+    assert capability["portable_brief"]["rollback_advice"].startswith("Remove the routine")
     assert envelope["catalogue"]["portable_brief"]["format"] == "markdown"
     assert (tmp_path / "dist/dex-lens-catalog-latest.json").read_text() == json.dumps(
         envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":")

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -147,10 +147,9 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert envelope["catalogue"]["jobs_taxonomy"][0]["label"] == "Plan my day"
     capability = envelope["catalogue"]["capabilities"][0]
     assert capability["capability_id"] == "daily-plan"
-    assert capability["summary"] == (
-        "Helps a person choose what matters today before work scatters."
-    )
+    assert capability["summary"] == "Use when planning a day."
     assert capability["value"] == "Helps a person choose what matters today before work scatters."
+    assert capability["summary"] != capability["value"]
     assert capability["prerequisites"] == ["A task list or calendar the host can inspect."]
     assert capability["trade_offs"] == ["The plan is only as current as the source material."]
     assert capability["docs_url"] == "https://github.com/davekilleen/Dex"

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -141,6 +141,7 @@ def test_generates_canonical_unsigned_lens_catalog_payload(tmp_path: Path) -> No
     assert envelope["metadata"]["contract_version"] == "dex-lens-catalogue-v2"
     assert envelope["metadata"]["catalog_version"] == 7
     assert envelope["metadata"]["producer"] == "Dex Core release pipeline v1.94.0"
+    assert envelope["metadata"]["core_release"] == "v1.94.0"
     assert envelope["metadata"]["key_id"] == "dex-core-lens-1"
     assert envelope["catalogue"]["jobs_taxonomy"][0]["job_id"] == "plan-my-day"
     assert envelope["catalogue"]["jobs_taxonomy"][0]["label"] == "Plan my day"
@@ -247,6 +248,37 @@ def test_signing_requires_environment_secret_and_never_generates_a_key(tmp_path:
     envelope = json.loads((tmp_path / "dist/dex-lens-catalog-v1.94.0.json").read_text())
     assert envelope["metadata"]["key_id"] == "test-key"
     assert len(base64.b64decode(envelope["signature"], validate=True)) == 64
+
+
+def test_deterministic_test_signature_is_unreachable_in_ci(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    key = base64.b64encode(b"test-only-not-a-real-ed25519-private-key").decode("ascii")
+
+    signed = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--release-root",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path / "dist"),
+            "--issued-at",
+            "2026-08-11T12:00:00Z",
+            "--sign",
+            "--signing-key-env",
+            "DEX_LENS_TEST_KEY",
+            "--key-id",
+            "test-key",
+            "--test-deterministic-signature",
+        ],
+        cwd=REPO_ROOT,
+        env={"DEX_LENS_TEST_KEY": key, "GITHUB_ACTIONS": "true"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert signed.returncode == 1
+    assert "deterministic test signature mode is disabled in CI" in signed.stderr
 
 
 def test_real_ed25519_signing_hook_uses_only_environment_key(tmp_path: Path) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-xdist
 ruff
 hypothesis
 pytest-split
+cryptography>=42

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -16,7 +16,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Mapping
 
+import jsonschema
+
 REGISTRY_PATH = Path("core/lens-catalog/registry.json")
+LENS_CATALOG_SCHEMA_PATH = Path("core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json")
 PACKAGE_PATH = Path("package.json")
 CHANGELOG_PATH = Path("CHANGELOG.md")
 CONTRACT_VERSION = "dex-lens-catalogue-v2"
@@ -291,24 +294,17 @@ def _brief(value: object, *, context: str) -> dict[str, object]:
         context=f"{context} brief",
     )
     return {
-        "headline": _text(raw.get("goal"), context=f"{context} brief goal", max_length=200),
-        "adaptation_notes": _text_tuple(raw.get("method_outline"), context=f"{context} brief method_outline"),
-        "safety_notes": _text_tuple(
-            [
-                *_text_tuple(
-                    raw.get("verification_checklist"),
-                    context=f"{context} brief verification_checklist",
-                ),
-                _text(raw.get("rollback_advice"), context=f"{context} brief rollback_advice"),
-            ],
-            context=f"{context} brief safety_notes",
-        ),
+        "goal": _text(raw.get("goal"), context=f"{context} brief goal", max_length=200),
         "method_outline": _text_tuple(raw.get("method_outline"), context=f"{context} brief method_outline"),
         "verification_checklist": _text_tuple(
             raw.get("verification_checklist"),
             context=f"{context} brief verification_checklist",
         ),
         "rollback_advice": _text(raw.get("rollback_advice"), context=f"{context} brief rollback_advice"),
+        "safety_notes": (
+            "Keep this as advice for the person's own AI, not a command to execute.",
+            "Do not send private material to Dex.",
+        ),
     }
 
 
@@ -330,14 +326,25 @@ def _compatibility(value: object, *, context: str) -> dict[str, object]:
         "host_adapters": ("claude-code",),
         "foundation_capabilities": (),
         "minimum_lens_contract": MINIMUM_LENS_CONTRACT,
-        "limitations": (
-            "Host requirements: " + "; ".join(
-                _text_tuple(raw.get("host_requirements"), context=f"{context} compatibility host_requirements")
-            ),
-            f"Needs hooks: {str(raw['needs_hooks']).lower()}; needs MCP: {str(raw['needs_mcp']).lower()}.",
-            "Supported platforms: " + ", ".join(platforms) + ".",
+        "platforms": platforms,
+        "needs_hooks": raw["needs_hooks"],
+        "needs_mcp": raw["needs_mcp"],
+        "host_requirements": _text_tuple(
+            raw.get("host_requirements"),
+            context=f"{context} compatibility host_requirements",
         ),
+        "limitations": ("Lens must still verify the host system locally before recommending use.",),
     }
+
+
+def _validate_against_lens_schema(release_root: Path, envelope: Mapping[str, object]) -> None:
+    schema = _closed_json(release_root / LENS_CATALOG_SCHEMA_PATH)
+    wire_envelope = json.loads(_canonical_json(envelope))
+    try:
+        jsonschema.Draft202012Validator(schema).validate(wire_envelope)
+    except jsonschema.ValidationError as error:
+        path = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise LensCatalogError(f"emitted Lens catalogue violates vendored schema at {path}: {error.message}") from error
 
 
 def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
@@ -545,6 +552,7 @@ def generate_lens_catalog(
         "key_id": key_id,
     }
     signed_payload = {"metadata": metadata, "catalogue": catalogue}
+    _validate_against_lens_schema(release_root, {**signed_payload, "signature": "schema-validation-placeholder"})
     payload = _canonical_json(signed_payload)
     signature = ""
     if sign:

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -455,7 +455,7 @@ def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
             {
                 "capability_id": entry["capability_id"],
                 "title": entry["title"],
-                "summary": entry["value"],
+                "summary": entry["summary"],
                 "value": entry["value"],
                 "jobs": entry["jobs"],
                 "prerequisites": entry["prerequisites"],

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -483,44 +483,22 @@ def _signature(payload: str, *, signing_key_env: str, key_id: str, test_determin
     if test_deterministic:
         digest = hashlib.sha512(key_bytes + b"\0" + payload.encode("utf-8")).digest()
         return base64.b64encode(digest).decode("ascii")
-    descriptor, private_key_name = tempfile.mkstemp(prefix=".dex-lens-ed25519-", suffix=".pem")
-    payload_descriptor, payload_name = tempfile.mkstemp(prefix=".dex-lens-payload-", suffix=".json")
-    private_key = Path(private_key_name)
-    payload_file = Path(payload_name)
     try:
-        with os.fdopen(descriptor, "wb") as file:
-            file.write(key_bytes)
-            file.flush()
-            os.fsync(file.fileno())
-        with os.fdopen(payload_descriptor, "wb") as file:
-            file.write(payload.encode("utf-8"))
-            file.flush()
-            os.fsync(file.fileno())
-        os.chmod(private_key, 0o600)
-        result = subprocess.run(
-            [
-                "openssl",
-                "pkeyutl",
-                "-sign",
-                "-rawin",
-                "-inkey",
-                str(private_key),
-                "-in",
-                str(payload_file),
-            ],
-            check=False,
-            capture_output=True,
-        )
-    finally:
-        private_key.unlink(missing_ok=True)
-        payload_file.unlink(missing_ok=True)
-    if result.returncode != 0:
-        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    except ImportError as error:
         raise LensCatalogError(
-            f"Ed25519 signing failed for key_id {key_id!r}; verify the CI secret contains a base64 PEM private key"
-            + (f": {detail}" if detail else "")
-        )
-    return base64.b64encode(result.stdout).decode("ascii")
+            "cryptography>=42 is required to sign the Dex Lens catalog on this runner"
+        ) from error
+    try:
+        private_key = serialization.load_pem_private_key(key_bytes, password=None)
+    except ValueError as error:
+        raise LensCatalogError(
+            f"Ed25519 signing failed for key_id {key_id!r}; CI secret must contain a base64 PEM private key"
+        ) from error
+    if not isinstance(private_key, Ed25519PrivateKey):
+        raise LensCatalogError(f"signing key_id {key_id!r} is not an Ed25519 private key")
+    return base64.b64encode(private_key.sign(payload.encode("utf-8"))).decode("ascii")
 
 
 def generate_lens_catalog(

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -456,9 +456,16 @@ def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
                 "capability_id": entry["capability_id"],
                 "title": entry["title"],
                 "summary": entry["value"],
+                "value": entry["value"],
                 "jobs": entry["jobs"],
+                "prerequisites": entry["prerequisites"],
+                "trade_offs": entry["trade_offs"],
                 "evidence": entry["evidence"],
                 "compatibility": entry["compatibility"],
+                "docs_url": entry["docs_url"],
+                "since_release": entry["since_release"],
+                "changed_in": entry["changed_in"],
+                "release_provenance": entry["release_provenance"],
                 "portable_brief": entry["portable_brief"],
             }
             for entry in entries

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -182,6 +182,10 @@ def _skill_description(path: Path) -> str:
     raise LensCatalogError(f"shipped skill source has no description: {path}")
 
 
+def _human_title(entry_id: str) -> str:
+    return " ".join(part.capitalize() for part in entry_id.split("-"))
+
+
 def _is_git_tracked(release_root: Path, relative: str) -> bool:
     git_dir = release_root / ".git"
     if not git_dir.exists():
@@ -299,6 +303,12 @@ def _brief(value: object, *, context: str) -> dict[str, object]:
             ],
             context=f"{context} brief safety_notes",
         ),
+        "method_outline": _text_tuple(raw.get("method_outline"), context=f"{context} brief method_outline"),
+        "verification_checklist": _text_tuple(
+            raw.get("verification_checklist"),
+            context=f"{context} brief verification_checklist",
+        ),
+        "rollback_advice": _text(raw.get("rollback_advice"), context=f"{context} brief rollback_advice"),
     }
 
 
@@ -426,7 +436,7 @@ def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
         entries.append(
             {
                 "capability_id": entry_id,
-                "title": entry_id,
+                "title": _human_title(entry_id),
                 "summary": _skill_description(release_root / str(source["path"])),
                 "value": _text(entry.get("value"), context=f"{context} value"),
                 "jobs": jobs_served,

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -488,6 +488,8 @@ def _signature(payload: str, *, signing_key_env: str, key_id: str, test_determin
     except ValueError as error:
         raise LensCatalogError(f"environment secret {signing_key_env} is not base64") from error
     if test_deterministic:
+        if os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+            raise LensCatalogError("deterministic test signature mode is disabled in CI")
         digest = hashlib.sha512(key_bytes + b"\0" + payload.encode("utf-8")).digest()
         return base64.b64encode(digest).decode("ascii")
     try:
@@ -529,6 +531,7 @@ def generate_lens_catalog(
         "produced_at": issued.isoformat().replace("+00:00", "Z"),
         "expires_at": (issued + timedelta(days=30)).isoformat().replace("+00:00", "Z"),
         "producer": f"Dex Core release pipeline v{release_version}",
+        "core_release": f"v{release_version}",
         "key_id": key_id,
     }
     signed_payload = {"metadata": metadata, "catalogue": catalogue}

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Generate the signed Dex Lens catalog envelope from publisher-owned Core data."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import posixpath
+import re
+import subprocess
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Mapping
+
+REGISTRY_PATH = Path("core/lens-catalog/registry.json")
+PACKAGE_PATH = Path("package.json")
+CHANGELOG_PATH = Path("CHANGELOG.md")
+CONTRACT_VERSION = "dex-lens-catalogue-v2"
+MINIMUM_LENS_CONTRACT = "0.1.0"
+REGISTRY_VERSION = 1
+HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?$")
+KEBAB = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+FOUNDATION_CAPABILITIES = frozenset(
+    {
+        "ownership-portability",
+        "privacy-minimal-disclosure",
+        "context-orientation",
+        "durable-memory-provenance",
+        "scoped-agency-human-control",
+        "safe-change-recovery",
+        "honest-health-observability",
+        "compounding-correctability",
+    }
+)
+
+
+class LensCatalogError(RuntimeError):
+    """The publisher-owned registry cannot produce a trusted Lens catalog."""
+
+
+def _closed_json(path: Path) -> object:
+    def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise LensCatalogError(f"{path} repeats JSON field {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=unique_object,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                LensCatalogError(f"{path} contains non-finite JSON number {value}")
+            ),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise LensCatalogError(f"cannot read {path}: {error}") from error
+
+
+def _mapping(value: object, *, context: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise LensCatalogError(f"{context} must be a JSON object")
+    return value
+
+
+def _exact_fields(value: Mapping[str, object], expected: set[str], *, context: str) -> None:
+    missing = sorted(expected - set(value))
+    unknown = sorted(set(value) - expected)
+    if missing or unknown:
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        raise LensCatalogError(f"{context} fields are not closed ({'; '.join(details)})")
+
+
+def _text(value: object, *, context: str, max_length: int = 512) -> str:
+    if not isinstance(value, str):
+        raise LensCatalogError(f"{context} must be text")
+    if not value.strip():
+        raise LensCatalogError(f"{context} must be non-empty")
+    if len(value) > max_length:
+        raise LensCatalogError(f"{context} exceeds {max_length} characters")
+    if CONTROL.search(value):
+        raise LensCatalogError(f"{context} contains control characters")
+    return value
+
+
+def _kebab(value: object, *, context: str) -> str:
+    text = _text(value, context=context, max_length=128)
+    if KEBAB.fullmatch(text) is None:
+        raise LensCatalogError(f"{context} must be kebab-case")
+    return text
+
+
+def _semver(value: object, *, context: str) -> str:
+    text = _text(value, context=context, max_length=64)
+    if SEMVER.fullmatch(text) is None:
+        raise LensCatalogError(f"{context} must be a semantic version")
+    return text
+
+
+def _text_tuple(value: object, *, context: str, max_length: int = 512) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise LensCatalogError(f"{context} must be a non-empty array")
+    return tuple(_text(item, context=f"{context} item", max_length=max_length) for item in value)
+
+
+def _relative_path(raw_path: object, *, context: str) -> str:
+    path = _text(raw_path, context=context, max_length=512)
+    if "\\" in path:
+        raise LensCatalogError(f"{context} is not a canonical POSIX path: {path!r}")
+    normalized = posixpath.normpath(path)
+    if (
+        normalized != path
+        or normalized in ("", ".", "..")
+        or normalized.startswith("/")
+        or normalized.startswith("../")
+    ):
+        raise LensCatalogError(f"{context} is not a canonical POSIX path: {path!r}")
+    return path
+
+
+def _release_file(release_root: Path, raw_path: object, *, context: str) -> tuple[str, Path]:
+    relative = _relative_path(raw_path, context=context)
+    candidate = release_root / relative
+    resolved = candidate.resolve(strict=False)
+    if not resolved.is_relative_to(release_root):
+        raise LensCatalogError(f"{context} escapes the release root: {relative!r}")
+    if candidate.is_symlink() or not candidate.is_file():
+        raise LensCatalogError(f"{context} is missing or not a regular file: {relative}")
+    return relative, candidate
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _package_version(release_root: Path) -> str:
+    package = _mapping(_closed_json(release_root / PACKAGE_PATH), context=str(PACKAGE_PATH))
+    return _semver(package.get("version"), context="package.json version")
+
+
+def _changelog_versions(release_root: Path) -> set[str]:
+    try:
+        text = (release_root / CHANGELOG_PATH).read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise LensCatalogError(f"cannot read {CHANGELOG_PATH}: {error}") from error
+    return set(re.findall(r"^## \[([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)\]", text, re.MULTILINE))
+
+
+def _skill_description(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise LensCatalogError(f"cannot read shipped skill source {path}: {error}") from error
+    if not text.startswith("---\n"):
+        raise LensCatalogError(f"shipped skill source has no frontmatter: {path}")
+    lines = text.splitlines()
+    for line in lines[1:]:
+        if line == "---":
+            break
+        if line.startswith("description:"):
+            return _text(
+                line.split(":", 1)[1].strip().strip('"'),
+                context=f"{path} description",
+                max_length=1024,
+            )
+    raise LensCatalogError(f"shipped skill source has no description: {path}")
+
+
+def _is_git_tracked(release_root: Path, relative: str) -> bool:
+    git_dir = release_root / ".git"
+    if not git_dir.exists():
+        return True
+    result = subprocess.run(
+        ["git", "-C", str(release_root), "ls-files", "--error-unmatch", relative],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _canonical_json(value: Mapping[str, object]) -> str:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_issued_at(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise LensCatalogError(f"issued_at is not an ISO-8601 timestamp: {value!r}") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LensCatalogError("issued_at must include a timezone")
+    return parsed.astimezone(UTC).replace(microsecond=0)
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as file:
+            file.write(content)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _source(entry: Mapping[str, object], release_root: Path, *, context: str) -> dict[str, object]:
+    raw = _mapping(entry.get("source"), context=f"{context} source")
+    _exact_fields(raw, {"kind", "path", "sha256", "byte_size"}, context=f"{context} source")
+    kind = _text(raw.get("kind"), context=f"{context} source kind", max_length=32)
+    if kind != "skill":
+        raise LensCatalogError(f"{context} source kind must be skill")
+    relative, absolute = _release_file(release_root, raw.get("path"), context=f"{context} source path")
+    if not relative.startswith(".claude/skills/") or not relative.endswith("/SKILL.md"):
+        raise LensCatalogError(f"{context} source path must be a shipped skill SKILL.md")
+    if "/_available/" in relative:
+        raise LensCatalogError(f"{context} source path must not be a dormant optional skill")
+    if not _is_git_tracked(release_root, relative):
+        raise LensCatalogError(f"{context} source path is not tracked by the release tree: {relative}")
+    declared_sha = raw.get("sha256")
+    if not isinstance(declared_sha, str) or HEX_SHA256.fullmatch(declared_sha) is None:
+        raise LensCatalogError(f"{context} source sha256 must be a lowercase sha256 digest")
+    declared_size = raw.get("byte_size")
+    if type(declared_size) is not int or declared_size < 0:
+        raise LensCatalogError(f"{context} source byte_size must be a non-negative integer")
+    actual_sha = _sha256(absolute)
+    actual_size = absolute.stat().st_size
+    if actual_sha != declared_sha or actual_size != declared_size:
+        raise LensCatalogError(f"{context} source does not match its declared sha256 or byte_size")
+    return {
+        "kind": kind,
+        "path": relative,
+        "sha256": actual_sha,
+        "byte_size": actual_size,
+    }
+
+
+def _evidence(value: object, *, context: str) -> tuple[dict[str, str], ...]:
+    if not isinstance(value, list) or not value:
+        raise LensCatalogError(f"{context} evidence must be a non-empty array")
+    result = []
+    for index, item in enumerate(value):
+        item_context = f"{context} evidence {index}"
+        raw = _mapping(item, context=item_context)
+        _exact_fields(raw, {"kind", "reference", "summary"}, context=item_context)
+        kind = _text(raw.get("kind"), context=f"{item_context} kind", max_length=32)
+        if kind not in {"test", "doc", "release-note", "runtime-path"}:
+            raise LensCatalogError(f"{item_context} kind is not recognized")
+        reference = _text(raw.get("reference"), context=f"{item_context} reference", max_length=256)
+        summary = _text(raw.get("summary"), context=f"{item_context} summary")
+        level = "verified" if kind in {"test", "runtime-path"} else "supported"
+        result.append(
+            {
+                "level": level,
+                "source": f"{kind}: {reference}",
+                "summary": summary,
+                "limitations": "This is evidence about Dex's shipped capability, not proof about the Lens user's own system.",
+            }
+        )
+    return tuple(result)
+
+
+def _brief(value: object, *, context: str) -> dict[str, object]:
+    raw = _mapping(value, context=f"{context} brief")
+    _exact_fields(
+        raw,
+        {"goal", "method_outline", "verification_checklist", "rollback_advice"},
+        context=f"{context} brief",
+    )
+    return {
+        "headline": _text(raw.get("goal"), context=f"{context} brief goal", max_length=200),
+        "adaptation_notes": _text_tuple(raw.get("method_outline"), context=f"{context} brief method_outline"),
+        "safety_notes": _text_tuple(
+            [
+                *_text_tuple(
+                    raw.get("verification_checklist"),
+                    context=f"{context} brief verification_checklist",
+                ),
+                _text(raw.get("rollback_advice"), context=f"{context} brief rollback_advice"),
+            ],
+            context=f"{context} brief safety_notes",
+        ),
+    }
+
+
+def _compatibility(value: object, *, context: str) -> dict[str, object]:
+    raw = _mapping(value, context=f"{context} compatibility")
+    _exact_fields(
+        raw,
+        {"host_requirements", "needs_hooks", "needs_mcp", "platforms"},
+        context=f"{context} compatibility",
+    )
+    platforms = tuple(_text_tuple(raw.get("platforms"), context=f"{context} compatibility platforms", max_length=32))
+    unknown_platforms = sorted(set(platforms) - {"macos", "linux", "windows"})
+    if unknown_platforms:
+        raise LensCatalogError(f"{context} compatibility has unknown platforms: {', '.join(unknown_platforms)}")
+    for key in ("needs_hooks", "needs_mcp"):
+        if type(raw.get(key)) is not bool:
+            raise LensCatalogError(f"{context} compatibility {key} must be true or false")
+    return {
+        "host_adapters": ("claude-code",),
+        "foundation_capabilities": (),
+        "minimum_lens_contract": MINIMUM_LENS_CONTRACT,
+        "limitations": (
+            "Host requirements: " + "; ".join(
+                _text_tuple(raw.get("host_requirements"), context=f"{context} compatibility host_requirements")
+            ),
+            f"Needs hooks: {str(raw['needs_hooks']).lower()}; needs MCP: {str(raw['needs_mcp']).lower()}.",
+            "Supported platforms: " + ", ".join(platforms) + ".",
+        ),
+    }
+
+
+def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
+    registry = _mapping(_closed_json(release_root / REGISTRY_PATH), context=str(REGISTRY_PATH))
+    _exact_fields(registry, {"registry_version", "catalog_version", "jobs", "entries"}, context=str(REGISTRY_PATH))
+    if registry["registry_version"] != REGISTRY_VERSION:
+        raise LensCatalogError(f"{REGISTRY_PATH} has an unsupported registry version")
+    catalog_version = registry["catalog_version"]
+    if type(catalog_version) is not int or catalog_version <= 0:
+        raise LensCatalogError("catalog_version must be a positive integer")
+
+    release_version = _package_version(release_root)
+    released_versions = _changelog_versions(release_root)
+    if release_version not in released_versions:
+        raise LensCatalogError(f"package version {release_version} has no shipped source in CHANGELOG.md")
+
+    jobs_raw = registry["jobs"]
+    if not isinstance(jobs_raw, list) or not jobs_raw:
+        raise LensCatalogError("jobs must be a non-empty array")
+    jobs = []
+    seen_jobs: set[str] = set()
+    for index, raw_job in enumerate(jobs_raw):
+        context = f"job {index}"
+        job = _mapping(raw_job, context=context)
+        _exact_fields(job, {"job_id", "title", "description"}, context=context)
+        job_id = _kebab(job.get("job_id"), context=f"{context} job_id")
+        if job_id in seen_jobs:
+            raise LensCatalogError(f"duplicate job id {job_id!r}")
+        seen_jobs.add(job_id)
+        jobs.append(
+            {
+                "job_id": job_id,
+                "label": _text(job.get("title"), context=f"{context} title", max_length=96),
+                "description": _text(job.get("description"), context=f"{context} description"),
+                "confirmed_gap_signals": (
+                    f"The Lens session finds a gap related to {job_id.replace('-', ' ')}."
+                ,),
+            }
+        )
+
+    entries_raw = registry["entries"]
+    if not isinstance(entries_raw, list) or not entries_raw:
+        raise LensCatalogError("entries must be a non-empty array")
+    entries = []
+    seen_entries: set[str] = set()
+    for index, raw_entry in enumerate(entries_raw):
+        context = f"entry {index}"
+        entry = _mapping(raw_entry, context=context)
+        _exact_fields(
+            entry,
+            {
+                "id",
+                "source",
+                "value",
+                "jobs_served",
+                "foundation_capabilities",
+                "prerequisites",
+                "trade_offs",
+                "evidence",
+                "brief",
+                "compatibility",
+                "docs_url",
+                "since_release",
+                "changed_in",
+            },
+            context=context,
+        )
+        entry_id = _kebab(entry.get("id"), context=f"{context} id")
+        if entry_id in seen_entries:
+            raise LensCatalogError(f"duplicate entry id {entry_id!r}")
+        seen_entries.add(entry_id)
+        source = _source(entry, release_root, context=context)
+        if source["path"] != f".claude/skills/{entry_id}/SKILL.md":
+            raise LensCatalogError(f"{context} source path must match entry id {entry_id!r}")
+        jobs_served = _text_tuple(entry.get("jobs_served"), context=f"{context} jobs_served", max_length=128)
+        for job_id in jobs_served:
+            if job_id not in seen_jobs:
+                raise LensCatalogError(f"{context} has unknown job reference: {job_id}")
+        foundations = _text_tuple(
+            entry.get("foundation_capabilities"), context=f"{context} foundation_capabilities", max_length=128
+        )
+        for foundation in foundations:
+            if foundation not in FOUNDATION_CAPABILITIES:
+                raise LensCatalogError(f"{context} has unknown foundation reference: {foundation}")
+        since_release = _semver(entry.get("since_release"), context=f"{context} since_release")
+        if since_release not in released_versions:
+            raise LensCatalogError(f"{context} since_release has no shipped source in CHANGELOG.md: {since_release}")
+        changed_in = entry.get("changed_in")
+        if not isinstance(changed_in, list):
+            raise LensCatalogError(f"{context} changed_in must be an array")
+        changed = tuple(_semver(item, context=f"{context} changed_in item") for item in changed_in)
+        for version in changed:
+            if version not in released_versions:
+                raise LensCatalogError(f"{context} changed_in has no shipped source in CHANGELOG.md: {version}")
+        compatibility = _compatibility(entry.get("compatibility"), context=context)
+        entries.append(
+            {
+                "capability_id": entry_id,
+                "title": entry_id,
+                "summary": _skill_description(release_root / str(source["path"])),
+                "value": _text(entry.get("value"), context=f"{context} value"),
+                "jobs": jobs_served,
+                "prerequisites": _text_tuple(entry.get("prerequisites"), context=f"{context} prerequisites"),
+                "trade_offs": _text_tuple(entry.get("trade_offs"), context=f"{context} trade_offs"),
+                "evidence": _evidence(entry.get("evidence"), context=context),
+                "brief": _brief(entry.get("brief"), context=context),
+                "compatibility": {
+                    **compatibility,
+                    "foundation_capabilities": foundations,
+                },
+                "portable_brief": _brief(entry.get("brief"), context=context),
+                "docs_url": _text(entry.get("docs_url"), context=f"{context} docs_url", max_length=256),
+                "since_release": since_release,
+                "changed_in": changed,
+                "source": source,
+                "version_hash": f"sha256:{source['sha256']}",
+                "core_release": f"v{release_version}",
+                "release_provenance": "core-release",
+            }
+        )
+
+    catalogue = {
+        "jobs_taxonomy": jobs,
+        "capabilities": [
+            {
+                "capability_id": entry["capability_id"],
+                "title": entry["title"],
+                "summary": entry["value"],
+                "jobs": entry["jobs"],
+                "evidence": entry["evidence"],
+                "compatibility": entry["compatibility"],
+                "portable_brief": entry["portable_brief"],
+            }
+            for entry in entries
+        ],
+        "portable_brief": {
+            "format": "markdown",
+            "audience": "the person's own AI system",
+            "safety_boundary": "Brief only: Lens presents adaptation guidance and never applies Dex changes automatically.",
+        },
+    }
+    return catalog_version, release_version, catalogue
+
+
+def _signature(payload: str, *, signing_key_env: str, key_id: str, test_deterministic: bool) -> str:
+    secret = os.environ.get(signing_key_env, "")
+    if not secret:
+        raise LensCatalogError(f"environment secret {signing_key_env} is not set")
+    try:
+        key_bytes = base64.b64decode(secret, validate=True)
+    except ValueError as error:
+        raise LensCatalogError(f"environment secret {signing_key_env} is not base64") from error
+    if test_deterministic:
+        digest = hashlib.sha512(key_bytes + b"\0" + payload.encode("utf-8")).digest()
+        return base64.b64encode(digest).decode("ascii")
+    descriptor, private_key_name = tempfile.mkstemp(prefix=".dex-lens-ed25519-", suffix=".pem")
+    payload_descriptor, payload_name = tempfile.mkstemp(prefix=".dex-lens-payload-", suffix=".json")
+    private_key = Path(private_key_name)
+    payload_file = Path(payload_name)
+    try:
+        with os.fdopen(descriptor, "wb") as file:
+            file.write(key_bytes)
+            file.flush()
+            os.fsync(file.fileno())
+        with os.fdopen(payload_descriptor, "wb") as file:
+            file.write(payload.encode("utf-8"))
+            file.flush()
+            os.fsync(file.fileno())
+        os.chmod(private_key, 0o600)
+        result = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-sign",
+                "-rawin",
+                "-inkey",
+                str(private_key),
+                "-in",
+                str(payload_file),
+            ],
+            check=False,
+            capture_output=True,
+        )
+    finally:
+        private_key.unlink(missing_ok=True)
+        payload_file.unlink(missing_ok=True)
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise LensCatalogError(
+            f"Ed25519 signing failed for key_id {key_id!r}; verify the CI secret contains a base64 PEM private key"
+            + (f": {detail}" if detail else "")
+        )
+    return base64.b64encode(result.stdout).decode("ascii")
+
+
+def generate_lens_catalog(
+    release_root: Path,
+    *,
+    output_dir: Path,
+    issued_at: str | None = None,
+    sign: bool = False,
+    signing_key_env: str = "DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64",
+    key_id: str = "dex-core-lens-1",
+    test_deterministic_signature: bool = False,
+) -> tuple[Path, Path]:
+    release_root = release_root.resolve()
+    issued = _parse_issued_at(
+        issued_at or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    catalog_version, release_version, catalogue = _build_catalogue(release_root)
+    metadata = {
+        "contract_version": CONTRACT_VERSION,
+        "catalog_version": catalog_version,
+        "produced_at": issued.isoformat().replace("+00:00", "Z"),
+        "expires_at": (issued + timedelta(days=30)).isoformat().replace("+00:00", "Z"),
+        "producer": f"Dex Core release pipeline v{release_version}",
+        "key_id": key_id,
+    }
+    signed_payload = {"metadata": metadata, "catalogue": catalogue}
+    payload = _canonical_json(signed_payload)
+    signature = ""
+    if sign:
+        signature = _signature(
+            payload,
+            signing_key_env=signing_key_env,
+            key_id=key_id,
+            test_deterministic=test_deterministic_signature,
+        )
+    envelope = {**signed_payload, "signature": signature}
+    encoded = (_canonical_json(envelope) + "\n").encode("utf-8")
+    destination = output_dir / f"dex-lens-catalog-v{release_version}.json"
+    latest = output_dir / "dex-lens-catalog-latest.json"
+    _atomic_write(destination, encoded)
+    _atomic_write(latest, encoded)
+    digest_line = f"{hashlib.sha256(encoded).hexdigest()}  {destination.name}\n".encode("utf-8")
+    _atomic_write(destination.with_suffix(destination.suffix + ".sha256"), digest_line)
+    latest_digest_line = f"{hashlib.sha256(encoded).hexdigest()}  {latest.name}\n".encode("utf-8")
+    _atomic_write(latest.with_suffix(latest.suffix + ".sha256"), latest_digest_line)
+    return destination, latest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--issued-at")
+    parser.add_argument("--sign", action="store_true")
+    parser.add_argument("--signing-key-env", default="DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64")
+    parser.add_argument("--key-id", default="dex-core-lens-1")
+    parser.add_argument("--test-deterministic-signature", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        versioned, latest = generate_lens_catalog(
+            args.release_root,
+            output_dir=args.output_dir,
+            issued_at=args.issued_at,
+            sign=args.sign,
+            signing_key_env=args.signing_key_env,
+            key_id=args.key_id,
+            test_deterministic_signature=args.test_deterministic_signature,
+        )
+    except LensCatalogError as error:
+        parser.exit(1, f"Dex Lens catalog generation failed: {error}\n")
+    print(f"Wrote {versioned}")
+    print(f"Wrote {latest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- adds a publisher-owned Dex Lens catalogue registry for shipped Core skills
- adds a generator for the Lens catalogue v2 envelope signed by the release pipeline
- wires release upload behind an explicit opt-in CI variable, leaving normal releases unchanged

## Verification
- python3 -m pytest -q core/tests/test_dex_lens_catalog_generation.py
- python3 -m py_compile scripts/generate-dex-lens-catalog.py
- bash scripts/check-portable-contract.sh
- workflow YAML parsed with python/yaml
- cross-repo proof: generated signed Core catalogue verified with the Lens v2 verifier from davekilleen/dex-lens PR #6

## Release hold
This touches release gating. Do not merge or enable DEX_LENS_CATALOG_RELEASE_GATE_ENABLED until Front Desk/Dave review the signing-key setup and Lens has a pinned production public key.