### PR TITLE
Vault .gitignore stops re-including Dex product files (vault-mode section composed on update)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ System/user-profile.yaml
 System/pillars.yaml
 System/trusted-mcps.yaml
 System/.last-update-check
+System/.last-qmd-update
 System/.update-available
 System/.smoke-last-run.json
 System/.dex/smoke-history.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.93.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
+## [1.95.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
 
 Chris found his vault's change list crowded with dozens of files he never touched — Dex's own product files, freshly rewritten by an update and showing up as if they were his edits. The cause: the file that tells your vault what to overlook is written for the team that builds Dex, and it deliberately keeps Dex's own files visible there. Inside *your* vault that's backwards — one broad "save everything" moment quietly folds hundreds of Dex files into your private history, and every update after that dirties them all again.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.93.0] — 🧹 Your list of changes stays yours — Dex's own files stop showing up in it (2026-08-10)
+
+Chris found his vault's change list crowded with dozens of files he never touched — Dex's own product files, freshly rewritten by an update and showing up as if they were his edits. The cause: the file that tells your vault what to overlook is written for the team that builds Dex, and it deliberately keeps Dex's own files visible there. Inside *your* vault that's backwards — one broad "save everything" moment quietly folds hundreds of Dex files into your private history, and every update after that dirties them all again.
+
+**What this fixes for you:**
+
+* **Dex's files no longer masquerade as your changes.** When an update refreshes that overlook-list in a vault, Dex now appends a clearly marked section telling your vault to disregard its product files — while everything of yours, including your custom skills and custom connections, stays visible and versioned exactly as before. The section is rebuilt from Dex's own ownership rules on every update, so it can never drift out of date.
+* **A background bookkeeping file stops appearing as something new to save.** The small timestamp Dex keeps to know when your search index was last refreshed is now overlooked like the rest of Dex's working state.
+* **If your vault already caught some of Dex's files,** they'll stop changing on their own once told to let them go — ask Dex to "untrack Dex's product files" and it takes one command, with nothing deleted from disk.
+
+Thanks to Chris for the report, traced from a single noisy update all the way to the root cause.
+
 ## [1.94.0] — 📦 Moving your Dex folder no longer locks you out of updating (2026-08-11)
 
 Dex writes down where your vault lives. Move that folder, rename it, or work from a copy of it, and the note still points at the old place — and Dex was reading that mismatch as damage. It refused to update at all, with a message that didn't say why. A user hit this while rehearsing the rescue route on a duplicate of his own vault, and spent an hour reading Dex's code to work out which of its nine checks had failed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Chris found his vault's change list crowded with dozens of files he never touche
 
 * **Dex's files no longer masquerade as your changes.** When an update refreshes that overlook-list in a vault, Dex now appends a clearly marked section telling your vault to disregard its product files — while everything of yours, including your custom skills and custom connections, stays visible and versioned exactly as before. The section is rebuilt from Dex's own ownership rules on every update, so it can never drift out of date.
 * **A background bookkeeping file stops appearing as something new to save.** The small timestamp Dex keeps to know when your search index was last refreshed is now overlooked like the rest of Dex's working state.
-* **If your vault already caught some of Dex's files,** they'll stop changing on their own once told to let them go — ask Dex to "untrack Dex's product files" and it takes one command, with nothing deleted from disk.
+* **If Dex's files were already folded into your history, no more will join them.** This change stops the leak; it can't undo what a past update already captured, so those particular files keep appearing as changed for now. Releasing them — without deleting a single file from your folder — is the next piece of work.
 
 Thanks to Chris for the report, traced from a single noisy update all the way to the root cause.
 

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from core import portable_contract
 from core.lifecycle import service
 from core.lifecycle.bridge import ACTIVATION_RELATIVE, activate_vault
 from core.lifecycle.catalog import canonical_catalog_bytes, load_catalog
@@ -1624,3 +1625,74 @@ def test_each_broken_split_is_still_refused_by_the_planner_and_names_itself(
     with pytest.raises(apply_update.UpdateError) as refusal:
         apply_update._topology(vault)
     assert expected_clause in str(refusal.value)
+
+
+# --- .gitignore vault-mode composition -------------------------------------
+
+
+def test_composed_gitignore_appends_contract_derived_vault_section() -> None:
+    release_blob = b"# distribution rules\n!core/\n!docs/\n"
+
+    composed = apply_update._compose_gitignore(release_blob, Path("/unused")).decode()
+
+    assert composed.startswith("# distribution rules\n")
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+    assert apply_update.GITIGNORE_SECTION_END in section
+    for expected in ("/docs/", "/scripts/", "/CHANGELOG.md", "/README.md", "/LICENSE"):
+        assert f"\n{expected}\n" in section
+    # brain dirs with vault-owned children switch to /*-plus-negation form
+    assert "\n/core/*\n" in section
+    assert "\n!/core/mcp-custom/\n" in section
+    assert "\n!/core/mcp-premium/\n" in section
+    assert "\n/.claude/*\n" in section
+    assert "\n!/.claude/skills-custom/\n" in section
+    # a plain dir ignore for core/.claude would make the negations dead rules
+    assert "\n/core/\n" not in section
+    assert "\n/.claude/\n" not in section
+
+
+def test_composed_gitignore_is_idempotent_and_replaces_stale_section() -> None:
+    release_blob = b"# rules\n"
+    once = apply_update._compose_gitignore(release_blob, Path("/unused"))
+    twice = apply_update._compose_gitignore(once, Path("/unused"))
+
+    assert once == twice
+    assert once.decode().count(apply_update.GITIGNORE_SECTION_BEGIN) == 1
+
+    stale = (
+        b"# rules\n\n"
+        + apply_update.GITIGNORE_SECTION_BEGIN.encode()
+        + b"\nstale-entry/\n"
+        + apply_update.GITIGNORE_SECTION_END.encode()
+        + b"\n"
+    )
+    recomposed = apply_update._compose_gitignore(stale, Path("/unused")).decode()
+    assert "stale-entry/" not in recomposed
+    assert recomposed.count(apply_update.GITIGNORE_SECTION_BEGIN) == 1
+
+
+def test_composed_gitignore_refuses_non_utf8_release_bytes() -> None:
+    with pytest.raises(apply_update.CompositionError):
+        apply_update._compose_gitignore(b"\xff\xfe", Path("/unused"))
+
+
+def test_vault_section_assumes_direct_child_exceptions_only() -> None:
+    """Guard the contract shape the generator relies on.
+
+    Every vault-owned path nested under a top-level brain directory must be a
+    direct child: gitignore cannot re-include a file whose parent directory is
+    excluded, so a deeper nesting would need recursive /*-negation chains the
+    generator deliberately does not emit. If this fails, extend
+    _vault_mode_gitignore_section before changing the contract.
+    """
+    tops = {
+        rule.path
+        for rule in portable_contract.RULES
+        if rule.ownership == "brain" and "/" not in rule.path
+    }
+    for rule in portable_contract.RULES:
+        if rule.ownership != "vault" or "/" not in rule.path:
+            continue
+        root = rule.path.split("/", 1)[0]
+        if root in tops:
+            assert rule.path.count("/") == 1, rule.path

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -3226,6 +3226,56 @@ def test_post_split_core_drift_accepts_only_installer_normalized_package_metadat
     assert "package.json" in result.detail
 
 
+def test_post_split_core_drift_accepts_the_composed_vault_mode_gitignore(
+    context,
+) -> None:
+    """The vault-mode section Dex composes at delivery is not user drift.
+
+    ``.gitignore`` is brain-owned and shipped, so the post-split probe compares
+    its worktree bytes against ``refs/dex/installed``. The update deliberately
+    appends a managed vault-mode section when it writes the file into a vault,
+    so a plain byte comparison would report every updated vault as carrying
+    modified shipped files. Edits outside that section are still drift.
+    """
+    from core.update import apply_update
+
+    brain = _write_split_topology(context)
+    release_blob = b"# distribution rules\n!core/\n!docs/\n"
+    (context.vault_root / ".gitignore").write_bytes(release_blob)
+    (context.vault_root / "System/.installed-files.manifest").write_text(
+        ".gitignore\n",
+        encoding="utf-8",
+    )
+    _git(context.vault_root, "add", ".gitignore", "System/.installed-files.manifest")
+    _git(context.vault_root, "commit", "--quiet", "-m", "release gitignore")
+    installed = _git(context.vault_root, "rev-parse", "HEAD").stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={brain}",
+            "fetch",
+            "--quiet",
+            str(context.vault_root),
+            f"+{installed}:refs/dex/installed",
+        ],
+        check=True,
+    )
+
+    composed = apply_update._compose_gitignore(release_blob, context.vault_root)
+    assert composed != release_blob
+    (context.vault_root / ".gitignore").write_bytes(composed)
+
+    result = doctor._probe_core_drift(context)
+
+    assert result.verdict == "OK"
+    assert result.detail == "No shipped brain files differ from refs/dex/installed"
+
+    (context.vault_root / ".gitignore").write_bytes(composed + b"secret-exfil/\n")
+    edited = doctor._probe_core_drift(context)
+    assert edited.verdict == "UNKNOWN"
+    assert ".gitignore" in edited.detail
+
+
 def test_repository_credential_named_release_files_match_head_without_python_reads(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -106,8 +106,80 @@ def _compose_claude(release_blob: bytes, vault_root: Path) -> bytes:
     return _regenerate_claude(release_blob, custom_content)
 
 
+GITIGNORE_SECTION_BEGIN = "# >>> dex-vault-mode (managed by Dex updates) >>>"
+GITIGNORE_SECTION_END = "# <<< dex-vault-mode (managed by Dex updates) <<<"
+_GITIGNORE_MANAGED_SECTION = re.compile(
+    rf"\n*{re.escape(GITIGNORE_SECTION_BEGIN)}.*?{re.escape(GITIGNORE_SECTION_END)}\n?",
+    re.DOTALL,
+)
+
+
+def _vault_mode_gitignore_section() -> str:
+    """Ignore rules that neutralize the distribution re-include block in a vault.
+
+    The release ships the distribution repository's ``.gitignore``, whose
+    "Keep Template Files" negations (``!core/``, ``!docs/`` and friends) exist
+    so the development repository tracks its own product files. Inside a split
+    vault those same negations leave every brain-owned file un-ignored, so one
+    broad ``git add -A`` silently captures hundreds of release files into the
+    user's private history — and every later update then dirties them all.
+
+    Because ``.gitignore`` outranks ``.git/info/exclude``, the only reliable
+    place to restore vault-side behavior is the end of the file itself
+    (last match wins). The section is derived from the ownership contract so
+    there is no second path list to drift.
+    """
+    tops = sorted(
+        (rule for rule in portable_contract.RULES
+         if rule.ownership == "brain" and "/" not in rule.path),
+        key=lambda rule: rule.path,
+    )
+    vault_children = [
+        rule for rule in portable_contract.RULES
+        if rule.ownership == "vault" and "/" in rule.path
+    ]
+    lines = [
+        GITIGNORE_SECTION_BEGIN,
+        "# This repository is your private vault. The Dex product files below are",
+        "# delivered and refreshed by Dex's receipt-backed updates, not tracked",
+        "# here. Derived from the ownership contract; edits inside this section",
+        "# are replaced on every update.",
+    ]
+    for top in tops:
+        exceptions = sorted(
+            rule.path for rule in vault_children
+            if rule.path.startswith(f"{top.path}/")
+        )
+        for exception in exceptions:
+            if exception.count("/") != top.path.count("/") + 1:
+                raise CompositionError(
+                    "vault-owned contract path nested deeper than one level "
+                    f"under brain-owned {top.path!r}: {exception!r}"
+                )
+        if top.kind == "file":
+            lines.append(f"/{top.path}")
+        elif exceptions:
+            lines.append(f"/{top.path}/*")
+            lines.extend(f"!/{exception}/" for exception in exceptions)
+        else:
+            lines.append(f"/{top.path}/")
+    lines.append(GITIGNORE_SECTION_END)
+    return "\n".join(lines)
+
+
+def _compose_gitignore(release_blob: bytes, vault_root: Path) -> bytes:
+    del vault_root  # the section depends only on the ownership contract
+    try:
+        text = release_blob.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise CompositionError("release .gitignore is not UTF-8") from error
+    base = _GITIGNORE_MANAGED_SECTION.sub("", text).rstrip("\n")
+    return f"{base}\n\n{_vault_mode_gitignore_section()}\n".encode("utf-8")
+
+
 COMPOSERS: dict[str, Callable[[bytes, Path], bytes]] = {
     "CLAUDE.md": _compose_claude,
+    ".gitignore": _compose_gitignore,
 }
 
 

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -108,7 +108,7 @@ def _compose_claude(release_blob: bytes, vault_root: Path) -> bytes:
 
 GITIGNORE_SECTION_BEGIN = "# >>> dex-vault-mode (managed by Dex updates) >>>"
 GITIGNORE_SECTION_END = "# <<< dex-vault-mode (managed by Dex updates) <<<"
-_GITIGNORE_MANAGED_SECTION = re.compile(
+GITIGNORE_MANAGED_SECTION = re.compile(
     rf"\n*{re.escape(GITIGNORE_SECTION_BEGIN)}.*?{re.escape(GITIGNORE_SECTION_END)}\n?",
     re.DOTALL,
 )
@@ -173,7 +173,7 @@ def _compose_gitignore(release_blob: bytes, vault_root: Path) -> bytes:
         text = release_blob.decode("utf-8")
     except UnicodeDecodeError as error:
         raise CompositionError("release .gitignore is not UTF-8") from error
-    base = _GITIGNORE_MANAGED_SECTION.sub("", text).rstrip("\n")
+    base = GITIGNORE_MANAGED_SECTION.sub("", text).rstrip("\n")
     return f"{base}\n\n{_vault_mode_gitignore_section()}\n".encode("utf-8")
 
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -3934,17 +3934,43 @@ def _mcp_without_custom_entries(text: str) -> str | None:
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
 
 
+def _without_vault_mode_gitignore_section(text: str) -> str:
+    """Drop the update-managed vault-mode block so only real edits remain.
+
+    A vault's ``.gitignore`` is composed at delivery: the update appends a
+    marked section that stops the distribution re-include block from exposing
+    Dex's own product files inside the user's private history. Those bytes are
+    Dex's, rebuilt on every update, so comparing them against the release blob
+    would report the composition itself as user drift.
+    """
+    from core.update.apply_update import GITIGNORE_MANAGED_SECTION
+
+    return GITIGNORE_MANAGED_SECTION.sub("", text).rstrip("\n")
+
+
+# Shipped files Dex composes per vault at delivery time: their worktree bytes
+# are expected to differ from the release blob, so drift is judged on the
+# non-composed remainder instead of a plain byte comparison.
+COMPOSED_SHIPPED_PATHS = frozenset({"CLAUDE.md", ".mcp.json", ".gitignore"})
+
+
 def _only_sanctioned_file_changes(
     context: DoctorContext,
     baseline: str,
     relative: str,
+    *,
+    git_directory: Path | None = None,
 ) -> bool:
-    baseline_text = _git_file(context, baseline, relative)
+    baseline_text = _git_file(context, baseline, relative, git_directory=git_directory)
     working_text = _working_file(context, relative)
     if baseline_text is None or working_text is None:
         return False
     if relative == "CLAUDE.md":
         return _strip_user_extensions(baseline_text) == _strip_user_extensions(working_text)
+    if relative == ".gitignore":
+        return _without_vault_mode_gitignore_section(
+            baseline_text
+        ) == _without_vault_mode_gitignore_section(working_text)
     if relative == ".mcp.json":
         baseline_config = _mcp_without_custom_entries(baseline_text)
         working_config = _mcp_without_custom_entries(working_text)
@@ -4276,6 +4302,15 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
                 baseline,
                 brain,
             )
+            and not (
+                relative in COMPOSED_SHIPPED_PATHS
+                and _only_sanctioned_file_changes(
+                    context,
+                    baseline,
+                    relative,
+                    git_directory=brain,
+                )
+            )
         )
         if not drifted:
             return ProbeResult(
@@ -4325,7 +4360,7 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
     drifted = [
         relative
         for relative in candidates
-        if relative not in {"CLAUDE.md", ".mcp.json"}
+        if relative not in COMPOSED_SHIPPED_PATHS
         or not _only_sanctioned_file_changes(context, baseline, relative)
     ]
     if not drifted:


### PR DESCRIPTION
Chris Jackson's fix from #445, carried onto a branch in this repository so CI actually runs on it (fork PRs from outside contributors currently get zero check runs), plus one follow-up defect found in review.

**His commits are unchanged and authored to him.** #445 can close in favour of this.

## What Chris found and fixed

Field report from his own vault: after v1.92.0, `git status` showed 17 modified files he never touched, and inspection found **386 brain-owned files tracked in his private vault history**.

Root cause is not the migration. The release ships the distribution repository's `.gitignore` into the vault, and its "Keep Template Files" negation block (`!core/`, `!docs/`, `!scripts/`, `!.claude/`, `!CHANGELOG.md`, `!README.md`, `!LICENSE`) — correct for this repo — leaves every brain-owned file un-ignored *inside a vault*. One broad `git add -A` captures hundreds of release files into the user's private history, and every later update dirties them all. `.git/info/exclude` cannot mitigate it: `.gitignore` outranks it.

His fix adds a second entry to the existing `COMPOSERS` registry (the precedent `CLAUDE.md` already sets): `_compose_gitignore` appends a marker-delimited vault-mode section at delivery, derived from `portable_contract.RULES` rather than a second hand-maintained list, using the `/*`-plus-negation form for brain directories with vault-owned children so `.claude/skills-custom`, `core/mcp-custom` and `core/mcp-premium` stay visible and versioned. Idempotent, refuses non-UTF-8 with `CompositionError`, and guarded by a contract-shape test.

## The defect review found (third commit)

`.gitignore` is **brain**-owned and listed in `System/.installed-files.manifest`, so Doctor's post-split shipped-drift probe (`_probe_core_drift`) compares its worktree bytes against `refs/dex/installed`. Composition makes those bytes intentionally differ, so **every split vault would have reported `Modified shipped brain files: .gitignore` and an UNKNOWN checkup verdict after updating** — caused by Dex's own composition. `CLAUDE.md` escapes this only because it is `generated`-ownership and therefore never in the brain path set.

Fix: judge composed shipped files on the non-composed remainder — strip the managed section from both sides before comparing, the same shape the pre-split probe already uses for CLAUDE.md's user-extensions block. Edits *outside* the managed section are still reported as drift. Verified both directions by a new regression test (it fails with `UNKNOWN` when the composed path is not exempted).

Also drops a CHANGELOG bullet promising already-affected users a one-command untrack — no such command exists, and repair is deliberately out of scope here. Replaced with an accurate statement that the leak stops but past capture is not undone.

## Verification

- `core/tests/test_apply_update.py`, `test_doctor.py`, `test_split_probe_regression.py`, `test_lifecycle_service_contract.py`, `test_dex_update_bridge.py`, `test_update_journey_protocol.py`, `test_update_rollback_journey.py`, `test_manifest_lifecycle_paths.py`: **356 passed**, 5 failures pre-existing on `main` on this machine (missing optional modules, macOS-only `launchctl`) and unrelated.
- Generated section inspected against the live contract; `git check-ignore` semantics of the `/*`-plus-negation form confirmed.
- Confirmed no other consumer compares release blobs to worktree bytes for brain paths, and that `probe_tracked_despite_ignored` (E13) reports rather than blocks, so already-affected vaults are not gated out of updating.

Not in scope, as Chris proposed: repairing vaults that already captured product files (a Doctor detection plus a `git rm --cached`-only heal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)