### PR TITLE
Classify the vault backup subsystem's shipped restore guide (unblocks #461)

### DIFF
--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -183,6 +183,10 @@ RULES: tuple[Rule, ...] = (
     _r("brain-beta-communications", "System/Beta_Communications", "dir", "brain",
        "release-doc retained until the schema-2 baseline-reduction follow-up"),
     _r("brain-system-readme", "System/README.md", "file", "brain"),
+    _r("brain-backup-restore-guide", "System/backup/RESTORE.md", "file", "brain",
+       "the restore runbook must sit inside the vault so it travels inside "
+       "every backup archive and is readable on a bare machine; shipped and "
+       "release-owned, so an update replaces it like any other brain doc"),
     # --- seed: shipped once, then the user's; update writes only if absent -
     _r("seed-templates", "System/Templates", "dir", "seed"),
     _r("seed-user-profile-live", "System/user-profile.yaml", "file", "seed",
@@ -287,6 +291,9 @@ RULES: tuple[Rule, ...] = (
     _r("runtime-onboarding-session", "System/.onboarding-session.json", "file", "runtime",
        "pre-engine onboarding scratch; deleted by receipt-declared finalization"),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
+    _r("runtime-backup-logs", "System/backup", "dir", "runtime",
+       "the backup engine's own logs; the shipped RESTORE.md inside it carries "
+       "its own brain rule and wins by exact-file match"),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),
     _r("runtime-logs", ".logs", "dir", "runtime"),

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: b11c8bc055791f064b96d7851e30cbb9a7c5175f696653a0e6c997f6a621b5b1 -->
+<!-- Content SHA-256: f41822c24b3bdb401c6791e57dea2003419fbfeee51fb903414cfc63f593133f -->
 
 # Architecture Inventory
 
@@ -143,13 +143,13 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 | Class | Rule count | Update action |
 | --- | ---: | --- |
-| `brain` | 45 | `replace` |
+| `brain` | 46 | `replace` |
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 9 | `regenerate` |
 | `vault` | 17 | `never` |
-| `runtime` | 13 | `never` |
+| `runtime` | 14 | `never` |
 
-<details><summary><code>brain</code> declared paths (45)</summary>
+<details><summary><code>brain</code> declared paths (46)</summary>
 
 - `.agents` (dir; `brain-agents`)
 - `.ci` (dir; `brain-ci`)
@@ -183,6 +183,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `README.md` (file; `brain-readme`)
 - `System/Beta_Communications` (dir; `brain-beta-communications`)
 - `System/README.md` (file; `brain-system-readme`)
+- `System/backup/RESTORE.md` (file; `brain-backup-restore-guide`)
 - `core` (dir; `brain-core`)
 - `core/data/sync-folder-markers.json` (file; `brain-sync-folder-markers`)
 - `docs` (dir; `brain-docs`)
@@ -278,7 +279,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 </details>
 
-<details><summary><code>runtime</code> declared paths (13)</summary>
+<details><summary><code>runtime</code> declared paths (14)</summary>
 
 - `.logs` (dir; `runtime-logs`)
 - `System/.dex` (dir; `runtime-dex-dir`)
@@ -291,6 +292,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `System/.onboarding-session.json` (file; `runtime-onboarding-session`)
 - `System/Session_Learnings` (dir; `runtime-session-learnings`)
 - `System/Session_Memory` (dir; `runtime-session-memory`)
+- `System/backup` (dir; `runtime-backup-logs`)
 - `System/claude-code-state.json` (file; `runtime-claude-state`)
 - `System/usage_log.md` (file; `runtime-usage-log`)
 

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -625,6 +625,20 @@
       "ownership": "seed"
     },
     {
+      "id": "runtime-backup-logs",
+      "path": "System/backup",
+      "kind": "dir",
+      "ownership": "runtime",
+      "note": "the backup engine's own logs; the shipped RESTORE.md inside it carries its own brain rule and wins by exact-file match"
+    },
+    {
+      "id": "brain-backup-restore-guide",
+      "path": "System/backup/RESTORE.md",
+      "kind": "file",
+      "ownership": "brain",
+      "note": "the restore runbook must sit inside the vault so it travels inside every backup archive and is readable on a bare machine; shipped and release-owned, so an update replaces it like any other brain doc"
+    },
+    {
       "id": "runtime-claude-state",
       "path": "System/claude-code-state.json",
       "kind": "file",


### PR DESCRIPTION
Unblocks **#461** (Chris Jackson's first-party vault backup). Small and standalone: it should land **before** #461 so that PR's own checks go green without anyone rewriting a contributor's branch.

## The problem

#461 ships `System/backup/RESTORE.md` into the user's vault and writes engine logs beside it. No ownership rule in `core/portable_contract.py` classifies either path, so #461's checks fail three contract tests:

- `test_every_tracked_path_classifies`
- `test_no_tracked_path_is_release_forbidden`
- `test_legacy_shipped_runtime_surfaces_the_baseline_debt`

This is not a test-only concern. An unclassified tracked path also:

- makes `scripts/generate-release-catalog.py` raise during a release build (`core/../scripts/generate-release-catalog.py:203`),
- makes Doctor's installed-release probe report `installed brain release has an unclassified path` on **every vault** (`core/utils/doctor.py:4136`) — the same false-alarm shape found in #445,
- makes `apply_update` refuse to write the file (`unclassified-never-write`, `core/update/apply_update.py:429`), so the restore runbook the whole feature points users at would never actually reach them.

## The fix

Two rules:

- `brain-backup-restore-guide` — `System/backup/RESTORE.md` as a shipped, release-owned brain doc. It is deliberately inside the vault rather than under `docs/` so it travels inside every backup archive and can be read on a bare machine after a disk failure.
- `runtime-backup-logs` — `System/backup` as a runtime directory for the engine's logs. The exact-file rule wins over the directory rule, so the guide stays replaceable by an update while the logs stay runtime.

`packages/dex-contracts/dist/portable-vault.contract.json` regenerated via `scripts/generate-portable-contract.py`, as `test_committed_dist_matches_source_of_truth` requires.

## Verification

- `core/tests/test_portable_contract.py` — 78 passed on this branch (same as `main`).
- `scripts/check-portable-contract.py` — green, 1338 tracked paths classified.
- Applied on top of #461's head: `test_portable_contract.py` + `test_backup_vault.py` → **112 passed**, and the contract gate reports 1347 tracked paths classified, dist in sync. That is the proof this unblocks #461.

No orphan-rule test exists, so registering rules ahead of the files they describe is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)