### PR TITLE
Tool-existence gate: check the `Use: tool(...)` call form the skills actually use

### DIFF
--- a/core/tests/test_instructed_tools_gate.py
+++ b/core/tests/test_instructed_tools_gate.py
@@ -149,3 +149,26 @@ def test_plugin_skill_path_is_not_an_instruction_surface() -> None:
         Path(".claude/plugins/example/skills/example/SKILL.md")
     )
     assert checker.is_instruction_surface(Path(".claude/skills/example/SKILL.md"))
+
+
+def test_use_directive_reference_is_detected() -> None:
+    """`Use: tool(...)` is how skills write a call inside a fenced block.
+
+    Inline backticks are absent inside fences, so a gate that matches only
+    backticked calls reads these files and finds nothing -- leaving the most
+    common call form in the shipped skills entirely unchecked.
+    """
+    findings = _find_unknown("```\nUse: missing_tool(start_date=\"2026-08-11\")\n```\n")
+
+    assert [(finding.name, finding.line) for finding in findings] == [
+        ("missing_tool", 2)
+    ]
+
+
+def test_known_use_directive_reference_passes() -> None:
+    findings = _find_unknown(
+        "Use: known_tool(days_ahead=1)\n",
+        defined={"known_tool"},
+    )
+
+    assert findings == []

--- a/scripts/check-instructed-tools.py
+++ b/scripts/check-instructed-tools.py
@@ -24,6 +24,13 @@ FASTMCP_TOOL_DECLARATION = re.compile(
     re.MULTILINE,
 )
 CALL_REFERENCE = re.compile(rf"`(?P<name>{TOOL_NAME_PATTERN})\([^`\r\n]*\)`")
+# Skills also instruct a call as a bare `Use: tool_name(...)` line, nearly always
+# inside a fenced block where inline backticks are not used. A gate that matches
+# only backticked calls reads those files and finds nothing, so a misspelled or
+# invented tool name in the dominant call form ships unchallenged.
+USE_DIRECTIVE_REFERENCE = re.compile(
+    rf"^[ \t>*-]*Use:[ \t]*(?P<name>{TOOL_NAME_PATTERN})[ \t]*\("
+)
 MCP_NAME_REFERENCE = re.compile(rf"`(?P<name>{TOOL_NAME_PATTERN})`")
 SNAKE_CASE_NAME = re.compile(r"[a-z][a-z0-9]*_[a-z0-9_]+")
 
@@ -85,6 +92,11 @@ def extract_instructed_references(source: str, path: Path) -> list[ToolReference
             ToolReference(match.group("name"), path, line_number)
             for match in CALL_REFERENCE.finditer(line)
         )
+        use_directive = USE_DIRECTIVE_REFERENCE.match(line)
+        if use_directive is not None:
+            references.append(
+                ToolReference(use_directive.group("name"), path, line_number)
+            )
         if "mcp" not in line.casefold():
             continue
         references.extend(


### PR DESCRIPTION
## The tool-existence gate wasn't checking the call form the skills actually use

`scripts/check-instructed-tools.py` fails CI when an instruction names an MCP tool that doesn't exist. Its matcher requires the call to be wrapped in inline backticks. Skills overwhelmingly write a call as a bare `Use: tool_name(...)` line inside a fenced block, where backticks aren't used — so the gate read those files and matched nothing.

**On `main` today, that leaves 29 tool calls unchecked** across five shipped skills:

| Skill | Unchecked `Use:` calls |
|---|---|
| `daily-plan` | 10 |
| `week-plan` | 8 |
| `daily-review` | 6 |
| `week-review` | 4 |
| `quarter-review` | 1 |

All 29 currently name real tools, so **this fixes no live defect** — it closes the hole that lets the next misspelling through silently. That matters because the failure lands at the point of use, in front of the user, and several skills instruct "skip the source silently if the call fails", which turns a wrong name into a missing section with no error shown.

### Verification

- Negative control on plain `main`: misspelled `get_week_progress` as `get_week_progres` in a fenced `Use:` line in daily-plan. Before, the gate passed green. Now it fails with *"unknown instructed MCP tool 'get_week_progres'. Did you mean 'get_week_progress'?"*
- `python scripts/check-instructed-tools.py`: passes on unmodified `main` (114 instruction files) — the widening surfaces no pre-existing violations.
- `core/tests/test_instructed_tools_gate.py`: **11 passed** (2 new — the `Use:` form is detected when unknown, and passes when known).

### Why this is separate

Found while reviewing #462, which introduces a second instruction-file kind (`AGENT_INSTRUCTIONS.md`) and hit exactly this hole — a nonexistent calendar tool name shipped in three of its briefs and `quality` passed green. That PR carries this same matcher plus the coverage for its own new file type.

This PR is the half that predates #462 and is worth landing on its own merits, whatever happens to that one. **The two overlap**, so whichever merges second needs a small rebase on this file — and if #462 lands first, this PR is already contained in it and can simply be closed.

No changelog entry: nothing user-visible changes, and claiming a version number would add to a queue that was just deconflicted across three branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
