### PR TITLE
Fix #450 config-error masking and #451 Doctor adoption-plan gate bypass

### DIFF
--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -16,10 +16,18 @@ from pathlib import Path
 import pytest
 
 from core.health import promises as health_promises
+from core.lifecycle import service as lifecycle_service
+from core.lifecycle.bridge import activate_vault
 from core.lifecycle.catalog import with_catalog_identity
 from core.lifecycle.engine import AdoptionReceipt
 from core.lifecycle.ledger import record_adoption
-from core.tests.lifecycle_test_helpers import SOURCE_COMMIT, write_file, write_manifest
+from core.tests.lifecycle_test_helpers import (
+    SOURCE_COMMIT,
+    write_bridge_release,
+    write_file,
+    write_manifest,
+)
+from core.transaction.engine import PlanRejected
 from core.utils import doctor, release_channel
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -792,8 +800,15 @@ def test_release_catalog_probe_reports_non_utf8_corruption_as_broken(context):
     assert "codec can't decode" in result.detail
 
 
+def _activate_release_catalog(context) -> None:
+    """Stand in for the one-time bridge activation a real install already has."""
+    write_bridge_release(context.vault_root)
+    activate_vault(context.vault_root)
+
+
 def test_adoption_plan_probe_summarizes_valid_catalog_in_memory(context):
     _write_release_catalog(context)
+    _activate_release_catalog(context)
     before = _tree_snapshot(context.vault_root)
 
     result = doctor._probe_adoption_plan(context)
@@ -805,6 +820,7 @@ def test_adoption_plan_probe_summarizes_valid_catalog_in_memory(context):
 
 def test_adoption_plan_probe_counts_receipt_backed_adoptions(context):
     _write_release_catalog(context)
+    _activate_release_catalog(context)
     content = b"release skill\n"
     transaction_id = "20260807T120000-00000001"
     receipt = AdoptionReceipt.from_dict(
@@ -845,16 +861,46 @@ def test_adoption_plan_probe_is_off_without_a_release_catalog(context):
 
 def test_adoption_plan_probe_maps_internal_failures_to_unknown(monkeypatch, context):
     _write_release_catalog(context)
+    _activate_release_catalog(context)
 
     def explode(*_args, **_kwargs):
         raise RuntimeError("inventory exploded")
 
-    monkeypatch.setattr(doctor, "build_inventory", explode)
+    monkeypatch.setattr(lifecycle_service, "build_inventory_and_plan", explode)
 
     result = doctor._probe_adoption_plan(context)
 
     assert result.verdict == "UNKNOWN"
     assert "inventory exploded" in result.detail
+
+
+def test_adoption_plan_probe_reports_broken_when_the_update_gate_refuses(monkeypatch, context):
+    """A refusal from the same gate /dex-update uses must not read as a clean bill of health."""
+    _write_release_catalog(context)
+    _activate_release_catalog(context)
+
+    def refuse(*_args, **_kwargs):
+        raise PlanRejected("this Dex copy's update engine doesn't match its release information — run /dex-doctor")
+
+    monkeypatch.setattr(lifecycle_service, "build_inventory_and_plan", refuse)
+
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "BROKEN"
+    assert "Updating is blocked" in result.detail
+    assert "doesn't match its release information" in result.detail
+
+
+def test_adoption_plan_probe_is_broken_on_a_real_bridge_pin_mismatch(context):
+    """Reproduces the #252-style refusal: the probe must go through the real gate, not just build a plan in memory."""
+    _write_release_catalog(context)
+    write_bridge_release(context.vault_root, release_version="9.9.9")
+
+    result = doctor._probe_adoption_plan(context)
+
+    assert result.verdict == "BROKEN"
+    assert "Updating is blocked" in result.detail
+    assert "doesn't match its release information" in result.detail
 
 
 def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
@@ -3389,6 +3435,17 @@ def test_core_drift_invalid_channel_is_unknown_and_does_not_use_stable(tmp_path)
 
     assert result.verdict == "UNKNOWN"
     assert result.detail == "couldn't verify your update channel"
+
+
+def test_core_drift_missing_pyyaml_is_reported_distinctly_from_a_broken_profile(monkeypatch, tmp_path):
+    """A missing dependency must not be reported as if the user's settings file were broken."""
+    drift_context = _drift_context(tmp_path, channel="beta")
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    result = doctor._probe_core_drift(drift_context)
+
+    assert result.verdict == "UNKNOWN"
+    assert result.detail == "PyYAML isn't installed — Dex can't read your update channel setting"
 
 
 def test_core_drift_never_executes_repo_fsmonitor_or_ambient_git(

--- a/core/tests/test_release_channel.py
+++ b/core/tests/test_release_channel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,17 @@ def test_read_channel_returns_invalid_when_profile_yaml_cannot_be_parsed(tmp_pat
     _write_profile(tmp_path, "updates:\n  channel: [beta\n")
 
     assert read_channel(tmp_path) == "invalid"
+
+
+def test_read_channel_distinguishes_missing_pyyaml_from_a_broken_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A missing PyYAML must not be reported the same way as a genuinely broken settings file."""
+    _write_profile(tmp_path, "updates:\n  channel: beta\n")
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    assert read_channel(tmp_path) == "missing-dependency"
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -1550,6 +1550,15 @@ def test_task_lifecycle_invalid_channel_is_unknown_and_refuses_execution(tmp_pat
     assert "not executed for safety" in result["detail"]
 
 
+def test_missing_release_ref_reason_distinguishes_missing_pyyaml_from_a_broken_channel() -> None:
+    """A missing dependency must not be reported as if the user's settings file were broken."""
+    assert (
+        smoke._missing_release_ref_reason("missing-dependency")
+        == "PyYAML isn't installed — Dex can't read your update channel setting"
+    )
+    assert smoke._missing_release_ref_reason("invalid") == "couldn't verify your update channel"
+
+
 def test_task_lifecycle_runs_verified_release_and_refuses_dependency_drift(tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     repo = _release_repo(tmp_path)

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -35,7 +35,7 @@ from core.lifecycle.catalog import CatalogError, load_catalog
 from core.lifecycle.inventory import build_inventory
 from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
-from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry
+from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry, PlanRejected
 from core.transaction.journal import Journal, JournalCorruptError
 from core.utils import dex_logger, launch_agents, preflight, release_channel
 
@@ -1718,7 +1718,7 @@ def _probe_release_catalog(context: DoctorContext) -> ProbeResult:
 
 
 def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
-    """Build and summarize the adoption plan entirely in memory."""
+    """Build and summarize the adoption plan through the same gated entry point /dex-update uses."""
     catalog_path = _release_catalog_path(context)
     if not os.path.lexists(catalog_path):
         return ProbeResult(
@@ -1726,32 +1726,17 @@ def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
             "Adoption planning is unavailable on this older Dex release because no release catalog is installed",
         )
     try:
-        catalog = load_catalog(catalog_path, release_root=context.vault_root)
-        inventory = build_inventory(context.vault_root, catalog=catalog)
-        ledger_state = lifecycle_ledger.project_state(context.vault_root)
-        adopted = ledger_state["adopted"]
-        held_back = ledger_state["held_back"]
-        assert isinstance(adopted, dict)
-        assert isinstance(held_back, list)
-        catalog_ids = {item.id for item in catalog.items}
-        plan = build_adoption_plan(
-            catalog,
-            inventory,
-            adoption_states={
-                item_id: AdoptionState.ADOPTED
-                for item_id in adopted
-                if item_id in catalog_ids
-            },
-            held_back=frozenset(held_back) & catalog_ids,
-        )
-        counts = plan.counts
-        return ProbeResult(
-            "OK",
-            f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / "
-            f"{counts['conflict']} conflicts",
-        )
+        result = lifecycle_service.build_inventory_and_plan(context.vault_root)
+    except PlanRejected as error:
+        return ProbeResult("BROKEN", f"Updating is blocked: {_one_line(error)}")
     except Exception as error:
         return ProbeResult("UNKNOWN", f"The adoption plan could not be built: {_one_line(error)}")
+    counts = result["plan"]["counts"]
+    return ProbeResult(
+        "OK",
+        f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / "
+        f"{counts['conflict']} conflicts",
+    )
 
 
 CUSTOMIZATION_RECORD_PERSISTENCE_CAP = 25
@@ -4332,6 +4317,8 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
                 "UNKNOWN",
                 "beta channel selected but no beta release found — staying on stable is safe",
             )
+        if channel == "missing-dependency":
+            return ProbeResult("UNKNOWN", "PyYAML isn't installed — Dex can't read your update channel setting")
         if channel == "invalid":
             return ProbeResult("UNKNOWN", "couldn't verify your update channel")
         return ProbeResult("UNKNOWN", "no upstream remote — can't compare")

--- a/core/utils/release_channel.py
+++ b/core/utils/release_channel.py
@@ -91,7 +91,7 @@ def sanitized_path_with_tools(
 
 
 def read_channel(vault_root: str | Path) -> str:
-    """Return the configured channel, the stable default, or ``invalid``."""
+    """Return the configured channel, the stable default, ``missing-dependency``, or ``invalid``."""
     profile_path = Path(vault_root) / "System" / "user-profile.yaml"
     try:
         content = profile_path.read_text(encoding="utf-8")
@@ -102,7 +102,12 @@ def read_channel(vault_root: str | Path) -> str:
 
     try:
         import yaml
+    except ImportError:
+        # A missing PyYAML is not a broken settings file — keep the two distinguishable
+        # so callers don't send users hunting for a config problem that doesn't exist.
+        return "missing-dependency"
 
+    try:
         profile = yaml.safe_load(content)
     except Exception:
         return "invalid"

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -1984,6 +1984,8 @@ def _git_release_ref(repo_root: Path, channel: str | None = None) -> str | None:
 def _missing_release_ref_reason(channel: str, *, server: bool = False) -> str:
     if channel == "beta":
         return "beta channel selected but no beta release found — staying on stable is safe"
+    if channel == "missing-dependency":
+        return "PyYAML isn't installed — Dex can't read your update channel setting"
     if channel == "invalid":
         return "couldn't verify your update channel"
     suffix = " to verify the server" if server else ""


### PR DESCRIPTION
## Summary
Fixes two bugs Amit Godbole reported this morning (11 Aug), both verified against the real code before this branch was written.

- **#450** — `read_channel()` in `core/utils/release_channel.py` caught a missing PyYAML import in the same trap as a broken `user-profile.yaml`, so a missing library read to the user as "your settings file is broken." Now returns a distinct `missing-dependency` value, and the two places that turn that into a user-facing message (`doctor.py`'s core-drift probe, `smoke.py`'s release-ref reason) say so plainly instead of pointing at a healthy config file.
- **#451** — Doctor's `adoption.plan` probe built the adoption plan directly in memory instead of going through `core.lifecycle.service.build_inventory_and_plan`, the same gated entry point `/dex-update` uses. That meant a bridge-pin or activation-record refusal (the failure mode behind #252 and #433) never surfaced in Doctor — it could report a clean "N adoptable / N adopted / 0 conflicts" at the exact moment an update would refuse. The probe now routes through the same gate and maps a refusal (`PlanRejected`) to a `BROKEN` verdict.

## Test plan
- [x] `core/tests/test_release_channel.py` — new test for the missing-PyYAML case, distinct from the existing "unreadable"/"malformed" invalid cases
- [x] `core/tests/test_doctor.py` — new tests: core-drift probe reports the missing-dependency message distinctly; adoption-plan probe reports `BROKEN` on a mocked gate refusal and on a real bridge/catalog version mismatch (reproducing the #252 shape); existing OK-path tests updated to pre-activate the vault so the probe stays read-only in the common case
- [x] `core/tests/test_smoke.py` — new unit test for the missing-dependency reason string
- [x] Full `test_release_channel.py` + `test_doctor.py` + `test_smoke.py` suites pass locally (284 passed; the 3 remaining failures are pre-existing on `main`, unrelated to this change — two need macOS's `plutil`, one is an existing environment-dependent hooks-journey test)
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)