### PR TITLE
fleet: reject a non-canonical archived start at discovery, not 4.5h in

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -101,6 +101,52 @@ def test_discovers_archived_distribution_tree_when_the_canonical_tag_is_absent(
     assert [release.tag for release in releases] == [archive_tag]
 
 
+def test_rejects_archived_start_the_executor_would_refuse_mid_run(
+    tmp_path: Path,
+) -> None:
+    """A non-canonical archived start must fail discovery, not journey 191 of 202.
+
+    The executor accepts archived starts only in the canonical seven-character
+    form. Discovery is deliberately wider, so before this guard a hand-made tag
+    with a longer short sha was admitted here and then refused hours later,
+    aborting the whole fleet. Reproduces dist/archive/v1.81.12-3a8245ab.
+    """
+
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.81.12", "historic release")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    oversized = f"dist/archive/v1.81.12-{commit[:8]}"
+    _git(repo, "tag", "-a", oversized, commit, "-m", oversized)
+    _git(repo, "tag", "-d", tag)
+
+    with pytest.raises(release_fleet.FleetError, match="canonical"):
+        release_fleet.discover_distribution_releases(repo)
+
+
+def test_canonical_archived_start_supersedes_its_oversized_twin(
+    tmp_path: Path,
+) -> None:
+    """Adding the canonical tag is enough; the oversized one needs no deletion.
+
+    Discovery keeps one start per tree and sorts by tag, so the shorter tag wins
+    and its oversized twin is skipped as a duplicate tree. This is the property
+    the dist/archive/v1.81.12-3a8245a fix relies on.
+    """
+
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.81.12", "historic release")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    oversized = f"dist/archive/v1.81.12-{commit[:8]}"
+    canonical = f"dist/archive/v1.81.12-{commit[:7]}"
+    _git(repo, "tag", "-a", oversized, commit, "-m", oversized)
+    _git(repo, "tag", "-a", canonical, commit, "-m", canonical)
+    _git(repo, "tag", "-d", tag)
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == [canonical]
+
+
 def test_discovers_exact_v164_archived_starting_tree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     tag = "dist/archive/v1.64.0-366c168"
     commit = "366c168af61c50ee7157976a9eb8a154ca0fd7f4"

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "4403a7dab932220542381ad5006056931a928e405143599e620e76f9ada9eecf",
+    "sha256": "652c1553e7058ecb67b32ae645765ea1715be63330e3b824c732d1ca1064c631",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -40,6 +40,14 @@ RELEASE_TAG = re.compile(
 ARCHIVE_RELEASE_TAG = re.compile(
     r"^dist/archive/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
+# The journey executor accepts an archived start only in the canonical
+# seven-character form (`_ARCHIVE_RELEASE_TAG` in scripts/release_fleet_executor.py).
+# Discovery above is deliberately wider so a non-canonical tag is still seen rather
+# than silently ignored; this pattern is what lets discovery reject it up front
+# instead of letting the fleet refuse it hours later, mid-run.
+EXECUTOR_ARCHIVE_RELEASE_TAG = re.compile(
+    r"^dist/archive/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7})$"
+)
 LEGACY_RELEASE_TAG = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 USER_FIXTURES = {
     str(INBOX_DIR.relative_to(VAULT_ROOT) / "keep.md"): b"# User note\nThis must survive updates.\n",
@@ -1027,6 +1035,18 @@ def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...
                 commit=commit,
                 tree=tree,
             )
+        )
+    for release in discovered:
+        if not release.tag.startswith("dist/archive/"):
+            continue
+        if EXECUTOR_ARCHIVE_RELEASE_TAG.fullmatch(release.tag) is not None:
+            continue
+        raise FleetError(
+            f"{release.tag}: archived start tag is not in the canonical "
+            f"seven-character form, so the journey executor would refuse it "
+            f"part-way through a run. Add the canonical tag for commit "
+            f"{release.commit} alongside it; nothing needs deleting, because "
+            f"discovery keeps one start per tree and prefers the shorter tag."
         )
     return tuple(sorted(discovered, key=lambda item: (_version_key(item.version), item.tag)))
 


### PR DESCRIPTION
## What this is

Last night's public macOS fleet proof for v1.94.0 ran for **4h31m** and then aborted at journey **191 of 202**, leaving 9 untested, with:

```
dist/archive/v1.81.12-3a8245ab: platform infrastructure or integrity failure:
starting release identity is malformed
```

Nothing was wrong with the release under test. The two halves of the fleet disagree about what an archived start tag may look like:

| | pattern | file |
|---|---|---|
| discovery | `[0-9a-f]{7,64}` | `release_fleet.py:41` |
| executor | `[0-9a-f]{7}` (exactly) | `release_fleet_executor.py:41` |

So discovery admits a start the executor will later refuse, and you find out hours later.

## Why that tag existed

`dist/archive/v1.81.12-3a8245ab` has an 8-character short sha. It is the only non-7 tag of 136; it was created by hand on 2026-08-03, where `github-actions[bot]` always emits 7. It was harmless while it lived under `dist/release/` (which permits 7–40) and only became fatal once archived.

## The change

Discovery now validates each surviving start against the executor's own rule and fails immediately, naming the tag, its commit, and the remedy.

The check runs **after** tree de-duplication, which matters: a non-canonical tag already superseded by its canonical twin stays harmless and silent. That is exactly why adding `dist/archive/v1.81.12-3a8245a` (same commit, nothing deleted) cleared the live blockage — and this PR keeps that path quiet rather than turning it into a new failure.

## What I deliberately did not do

Widen the executor to `{7,40}`. It looks like a one-character typo fix, but the strictness is a guard asserted by `test_executor_rejects_malformed_or_arbitrary_starting_refs`, which parametrises an 8-character archive tag as one that *must* be rejected. Because that test builds its identity from a synthetic all-`a` commit, the separate `commit.startswith(short)` check would not catch a loosened pattern either. Loosening would trade an integrity boundary for a green run.

## Tests

- `test_rejects_archived_start_the_executor_would_refuse_mid_run` — reproduces the real tag shape; **verified it fails without the production guard** (`DID NOT RAISE FleetError`) and passes with it.
- `test_canonical_archived_start_supersedes_its_oversized_twin` — pins the de-duplication property the live fix depends on.

`core/update/journey-protocol-v1.json` is regenerated because it pins the runner source by hash; exactly one hash line changes.

## Verification

- `core/tests/test_release_fleet.py`: **78 passed** (76 on `main` + the 2 new).
- `test_release_fleet_executor.py`, `test_historic_fleet_darwin_workflow.py`, `test_release_catalog.py`: green.
- `test_release_fleet_acceptance.py`: 3 failures, **identical on pristine `main`** — the known Linux baseline, not from this change.

No CHANGELOG entry: release-harness machinery with no user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)