### PR TITLE
Make a release public only once its files exist, and watch the real download links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,37 +396,33 @@ jobs:
             dist/dex-lens-catalog-latest.json.sha256
           if-no-files-found: error
           retention-days: 1
-      - name: Upload vault bundle to versioned GitHub Release
+      # The ONLY step that makes a stable release public, and it does so last:
+      # attach every asset, read each one back off the release and compare it to
+      # what was built, and only then flip the draft public. A failure anywhere here
+      # leaves the release a hidden draft rather than a public empty page — see the
+      # header comment in .github/workflows/release.yml.
+      #
+      # The Dex Lens catalogue rides along as an extra asset rather than being
+      # uploaded afterwards, so nothing can ever appear on a release that is
+      # already live.
+      - name: Attach assets, verify them, then make the release public
         if: steps.release_guard.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          LENS_CATALOG_ENABLED: ${{ vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED }}
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          # Create the release (and its git tag, at this commit) only if absent.
-          # --notes-from-tag needs a pre-existing annotated tag, which the release
-          # process never makes; let gh create the tag and generate notes instead.
-          if ! gh release view "v$VERSION" >/dev/null 2>&1; then
-            gh release create "v$VERSION" \
-              --target "$GITHUB_SHA" \
-              --title "v$VERSION" \
-              --generate-notes
+          EXTRA=()
+          if [ "$LENS_CATALOG_ENABLED" = "true" ]; then
+            EXTRA+=(--extra-asset "dist/dex-lens-catalog-v$VERSION.json")
+            EXTRA+=(--extra-asset "dist/dex-lens-catalog-v$VERSION.json.sha256")
           fi
-          gh release upload "v$VERSION" \
-            "dist/dex-vault-bundle-v$VERSION.tar.gz" \
-            "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
-            "dist/dex-update-bridge-v$VERSION.py" \
-            "dist/dex-update-bridge-v$VERSION.py.sha256" \
-            --clobber
-      - name: Upload Dex Lens catalog to versioned GitHub Release
-        if: steps.release_guard.outputs.already_published != 'true' && vars.DEX_LENS_CATALOG_RELEASE_GATE_ENABLED == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="$(node -p "require('./package.json').version")"
-          gh release upload "v$VERSION" \
-            "dist/dex-lens-catalog-v$VERSION.json" \
-            "dist/dex-lens-catalog-v$VERSION.json.sha256" \
-            --clobber
+          python3 scripts/release_publish.py publish \
+            --version "$VERSION" \
+            --channel stable \
+            --dist dist \
+            --target "$GITHUB_SHA" \
+            "${EXTRA[@]}"
 
   build-release-beta:
     needs: [quality, test-results]
@@ -460,41 +456,23 @@ jobs:
           git push origin "${{ steps.release_build.outputs.release_tag }}"
       - name: Build self-contained vault bundle
         run: bash scripts/build-vault-bundle.sh
-      - name: Publish beta vault bundle as a GitHub prerelease
+      # Same draft-first path as the stable lane, staying marked as a prerelease
+      # when it goes live. Both of this lane's long-standing safety guards now live
+      # in scripts/release_publish.py, where they are unit-tested rather than only
+      # read: it refuses a version that is not X.Y.Z-<pre> (so the beta branch can
+      # never publish over a stable release), and refuses to touch an existing
+      # release that is not already a prerelease (so it can never clobber a
+      # promoted one).
+      - name: Attach beta assets, verify them, then publish the prerelease
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          # SAFETY: the beta lane must never be able to touch a stable release asset.
-          # Guard 1 — refuse unless this is a prerelease version (X.Y.Z-<pre>, e.g.
-          # 1.62.0-beta.1). A bare X.Y.Z is a stable version; publishing it from the
-          # beta branch could collide with — and clobber — a real stable release.
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.]+$'; then
-            echo "Refusing: beta version '$VERSION' is not a prerelease (expected X.Y.Z-<pre>, e.g. 1.62.0-beta.1)." >&2
-            echo "The beta branch must carry a prerelease version so it can never overwrite a stable release." >&2
-            exit 1
-          fi
-          # Guard 2 — if a release with this tag already exists, it MUST already be a
-          # prerelease before we upload/clobber. Never overwrite a promoted/stable release.
-          if gh release view "v$VERSION" >/dev/null 2>&1; then
-            IS_PRERELEASE="$(gh release view "v$VERSION" --json isPrerelease -q .isPrerelease)"
-            if [ "$IS_PRERELEASE" != "true" ]; then
-              echo "Refusing: release v$VERSION exists but is not a prerelease; the beta lane will not clobber it." >&2
-              exit 1
-            fi
-          else
-            gh release create "v$VERSION" \
-              --target "$GITHUB_SHA" \
-              --title "v$VERSION" \
-              --prerelease \
-              --generate-notes
-          fi
-          gh release upload "v$VERSION" \
-            "dist/dex-vault-bundle-v$VERSION.tar.gz" \
-            "dist/dex-vault-bundle-v$VERSION.tar.gz.sha256" \
-            "dist/dex-update-bridge-v$VERSION.py" \
-            "dist/dex-update-bridge-v$VERSION.py.sha256" \
-            --clobber
+          python3 scripts/release_publish.py publish \
+            --version "$VERSION" \
+            --channel beta \
+            --dist dist \
+            --target "$GITHUB_SHA"
 
   deploy-health:
     needs: [quality, build-release]

--- a/.github/workflows/release-asset-prober.yml
+++ b/.github/workflows/release-asset-prober.yml
@@ -1,0 +1,123 @@
+name: Release asset prober
+# Fetches the REAL public download URLs for the newest release — the exact ones a
+# stuck copy of Dex uses, and the exact ones docs/UPDATE-RESCUE.md tells a user to
+# paste into a terminal — and fails if any of them does not serve bytes or does not
+# match its published checksum.
+#
+# Why this exists as well as draft-first publishing: draft-first makes a
+# public-but-empty release unreachable through the normal path, but it cannot see a
+# release cut by an older pipeline, an asset deleted or replaced by hand, a rescue
+# guide naming a version that was never published, or a release left half-attached.
+# On 2026-08-11 v1.94.0 was the newest release with zero assets for about ninety
+# minutes and nothing noticed; the first thing that would have noticed was a user.
+#
+# Deliberately unauthenticated for the probes themselves: an authenticated API view
+# can succeed while the public route a user takes returns "not found".
+#
+# Cadence note: hourly, not every few minutes. Draft-first publishing is the primary
+# control and verifies every asset before a release goes public, so this is the
+# backstop — and each run downloads the full bundle to verify its checksum honestly,
+# which is not worth doing every five minutes.
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Probe this exact version instead of whatever GitHub calls Latest
+        required: false
+        type: string
+      rescue_doc_source:
+        description: Read the rescue guide from the released tag, or this checkout
+        required: false
+        default: released
+        type: choice
+        options: [released, local]
+  # Changes to the prober itself must be exercised by the prober, or the check that
+  # watches the release route becomes the thing nobody watches.
+  pull_request:
+    paths:
+      - .github/workflows/release-asset-prober.yml
+      - scripts/check_release_assets.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-asset-prober
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Probe the public release download URLs
+        id: probe
+        env:
+          # Only the stuck-draft check uses this; every download probe is
+          # deliberately anonymous.
+          GH_TOKEN: ${{ github.token }}
+          PROBE_VERSION: ${{ inputs.version }}
+          RESCUE_DOC_SOURCE: ${{ inputs.rescue_doc_source || 'released' }}
+        run: |
+          set -o pipefail
+          ARGS=(--json release-asset-report.json --rescue-doc-source "$RESCUE_DOC_SOURCE")
+          if [ -n "${PROBE_VERSION:-}" ]; then
+            ARGS+=(--version "$PROBE_VERSION")
+          fi
+          set +e
+          python3 scripts/check_release_assets.py "${ARGS[@]}" 2>&1 | tee probe-output.txt
+          STATUS="${PIPESTATUS[0]}"
+          set -e
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Release asset prober"
+            echo
+            echo '```'
+            cat probe-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$STATUS" in
+            0) echo "Every probed URL served bytes." ;;
+            2)
+              # Could not reach GitHub. This says nothing about the release, so it
+              # must not be reported as a broken release.
+              echo "::warning::The prober could not run (network or lookup failure); the release was NOT checked."
+              ;;
+            *)
+              echo "::error::The newest release is not fully downloadable. See the job summary."
+              ;;
+          esac
+          exit 0
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-asset-report
+          path: |
+            release-asset-report.json
+            probe-output.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      # Failing the job is what reaches a human: GitHub notifies the repository
+      # owner when a scheduled workflow fails. A run that could not reach GitHub at
+      # all (status 2) stays green on purpose — crying wolf over a network blip is
+      # how a check earns the reputation that gets it ignored.
+      - name: Fail when the release is not fully downloadable
+        if: steps.probe.outputs.status != '0' && steps.probe.outputs.status != '2'
+        run: |
+          echo "The newest Dex release is missing or serving broken download files." >&2
+          echo "Full detail is in the job summary and the release-asset-report artifact." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,18 @@
 name: Release
+# Draft-first publishing. This workflow's ONLY job is to put up a HIDDEN draft
+# release carrying the CHANGELOG entry, so the version has a home the moment its
+# tag is pushed. It never publishes.
+#
+# What makes the release public is the `build-release` job in ci.yml, and only
+# after it has attached the update/rescue assets and read every one of them back
+# off the release. Before this split, this workflow published immediately while a
+# separate job attached the assets later — so every release had a public-but-empty
+# window, and a red or queued test suite left it empty indefinitely. On
+# 2026-08-11 v1.94.0 was the newest release with zero downloads for about ninety
+# minutes and Dex's own rescue instructions returned "not found".
+#
+# The invariant this buys: a release that is public has its assets, because the
+# flip to public is the last thing that happens and it happens after the proof.
 
 on:
   push:
@@ -9,35 +23,22 @@ permissions:
   contents: write
 
 jobs:
-  github-release:
+  release-draft:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
-      - name: Extract changelog section
-        id: changelog
+      - name: Create the hidden draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Strip leading 'v' for matching in CHANGELOG
-          SEMVER="${VERSION#v}"
-          # Extract the section for this version (between two ## headers)
-          BODY=$(sed -n "/^## \[${SEMVER}\]/,/^## \[/{ /^## \[${SEMVER}\]/d; /^## \[/d; p; }" CHANGELOG.md)
-          # Use heredoc delimiter to handle multi-line output
-          {
-            echo "body<<CHANGELOG_EOF"
-            echo "$BODY"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: ${{ steps.version.outputs.version }}
-          body: ${{ steps.changelog.outputs.body }}
-          draft: false
-          prerelease: false
+          VERSION="${GITHUB_REF_NAME#v}"
+          # A version with a suffix (1.62.0-beta.1) is a prerelease and belongs to
+          # the beta lane, which must stay marked as a prerelease when it goes live.
+          CHANNEL=stable
+          case "$VERSION" in *-*) CHANNEL=beta ;; esac
+          echo "Creating the draft for v$VERSION on the $CHANNEL channel."
+          python3 scripts/release_publish.py draft \
+            --version "$VERSION" \
+            --channel "$CHANNEL" \
+            --target "$GITHUB_SHA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.99.0] — 📦 A new version is never announced before the files you download exist (2026-08-12)
+
+When Dex put out a new version, the announcement page appeared within seconds — but the files your copy of Dex actually downloads to update or repair itself were prepared separately, after the full test suite had run, and attached only afterwards. So there was always a window where the newest version was announced and undownloadable, and if those tests failed or got stuck waiting behind another long-running check, the window never closed. That is what happened on 11 August: version 1.94.0 sat at the top of the releases page for about ninety minutes with nothing attached to it, while Dex's own emergency repair instructions pointed at a file that came back "not found". The person most likely to hit that is someone whose update is already broken.
+
+**What this fixes for you:**
+
+* **"Newest version" now means the files are actually there.** The release page is created hidden. The downloads are attached to it, each one fetched back off the page and compared against what was prepared, and only then does the page become visible. There is no longer a moment where you can see a version you cannot download.
+* **A release that goes wrong now leaves nothing published at all.** If any part of it fails, the release simply stays hidden until someone fixes it. Before, a failure left a half-finished release sitting at the top of the page looking like the current version.
+* **Your download is verified before it is offered, not after.** Each release includes small companion files that let you confirm a download arrived complete and unaltered. Dex now checks those against the real files before the release goes public, so the verification step in the repair instructions cannot fail on something Dex itself published.
+* **Something now checks the real download links every hour.** A scheduled check fetches the newest release exactly the way your copy of Dex would — including the precise links written into the emergency repair instructions — and raises the alarm if any of them is missing or damaged. A half-published release is caught within the hour rather than when someone runs into it.
+* **A release waiting its turn now says so.** Before releases go out, Dex runs a long rehearsal that replays real historic updates, and that rehearsal occupies the release lane for several hours. A release queued behind it now explains that on its own page, so it reads as waiting rather than broken.
+
 ## [1.98.0] — 🤝 Dex can work with your Pipedrive deals, and never behind your back (2026-08-11)
 
 If you keep deals in Pipedrive, you have been keeping them twice: once in the system your company reports from, and once in the notes where you actually think about the deal. The two drift apart within days, and reconciling them by hand is exactly the admin nobody does on a Friday afternoon. Chris built this to solve it for himself and offered it back.

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -1229,43 +1229,63 @@ def test_beta_release_ci_builds_branch_and_tag() -> None:
 
 def test_beta_release_ci_publishes_vault_bundle_only_as_prerelease() -> None:
     """The beta lane may publish a GitHub release, but only ever as a --prerelease,
-    and must never be able to clobber a stable (non-prerelease) release asset."""
+    and must never be able to clobber a stable (non-prerelease) release asset.
+
+    Both guards used to be inline workflow bash. Draft-first publishing moved them
+    into scripts/release_publish.py, where they are exercised by
+    test_release_publish_draft_first.py against a fake GitHub rather than only
+    read. This test holds the wiring: the beta lane still builds the same bundle
+    and still goes through the beta channel, and the stable lane still does not.
+    """
     workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
     beta_job = workflow["jobs"]["build-release-beta"]
     beta_commands = "\n".join(step.get("run", "") for step in beta_job["steps"])
 
     # It builds the same self-contained bundle the stable lane ships.
     assert "bash scripts/build-vault-bundle.sh" in beta_commands
-    assert "dist/dex-vault-bundle-v$VERSION.tar.gz" in beta_commands
+    # And publishes it through the verified path, on the beta channel.
+    assert "scripts/release_publish.py publish" in beta_commands
+    assert "--channel beta" in beta_commands
 
-    # Every release creation from the beta lane is a prerelease (keeps it off "latest").
-    assert "gh release create" in beta_commands
-    assert "--prerelease" in beta_commands
-
+    publish_source = (REPO_ROOT / "scripts/release_publish.py").read_text(encoding="utf-8")
     # Guard 1: refuse a non-prerelease (bare X.Y.Z) version so the beta lane can never
     # target a stable release tag.
-    assert "X.Y.Z-<pre>" in beta_commands or "is not a prerelease" in beta_commands
+    assert "X.Y.Z-<pre>" in publish_source
+    assert "is not a prerelease" in publish_source
     # Guard 2: before clobbering an existing tag, assert it is already a prerelease.
-    assert "isPrerelease" in beta_commands
-    assert "will not clobber it" in beta_commands
+    assert "is_prerelease" in publish_source
+    assert "will not clobber it" in publish_source
 
     # And the stable lane's own publish must remain a normal (non-prerelease) release.
     stable_job = workflow["jobs"]["build-release"]
     stable_commands = "\n".join(step.get("run", "") for step in stable_job["steps"])
-    assert "gh release create" in stable_commands
-    assert "--prerelease" not in stable_commands
+    assert "--channel stable" in stable_commands
+    assert "--channel beta" not in stable_commands
 
 
 def test_release_ci_uploads_standalone_bridge_and_checksum() -> None:
-    """Stable and beta releases expose the bridge outside the full vault bundle."""
+    """Stable and beta releases expose the bridge outside the full vault bundle.
 
+    The asset list moved out of duplicated workflow bash into one place, so this
+    now asserts against that single list -- which is also what the prober probes
+    and what docs/UPDATE-RESCUE.md tells a stuck user to download.
+    """
+    from scripts import release_publish
+
+    names = release_publish.asset_names("$VERSION")
+    assert "dex-update-bridge-v$VERSION.py" in names
+    assert "dex-update-bridge-v$VERSION.py.sha256" in names
+    assert "dex-vault-bundle-v$VERSION.tar.gz" in names
+    assert "dex-vault-bundle-v$VERSION.tar.gz.sha256" in names
+
+    # Both lanes ship exactly that list, through the verified publish path.
     workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
     for job_name in ("build-release", "build-release-beta"):
         commands = "\n".join(
             step.get("run", "") for step in workflow["jobs"][job_name]["steps"]
         )
-        assert 'dist/dex-update-bridge-v$VERSION.py"' in commands
-        assert 'dist/dex-update-bridge-v$VERSION.py.sha256"' in commands
+        assert "scripts/release_publish.py publish" in commands
+        assert "--dist dist" in commands
 
 
 def test_update_rescue_acquires_verifies_then_runs_released_bridge() -> None:

--- a/core/tests/test_release_asset_prober.py
+++ b/core/tests/test_release_asset_prober.py
@@ -343,3 +343,37 @@ def test_the_real_rescue_guide_in_this_checkout_names_download_urls() -> None:
     assert undetermined == []
     assert urls, f"{prober.RESCUE_DOC} should name at least one release download URL"
     assert all("/releases/download/" in url for url in urls)
+
+
+def test_a_cached_not_found_is_named_as_such(routes, capsys) -> None:
+    """The repair for a stale cache is completely different from a missing file."""
+    bridge = _url(f"dex-update-bridge-v{VERSION}.py")
+    original = dict(routes)
+
+    def selective(url: str, *, opener=None):
+        if url.startswith(bridge) and "cache-bust=" in url:
+            return original[bridge]          # the file really is there
+        if url == bridge:
+            return 404, b""                  # but the plain URL says otherwise
+        if url not in original:
+            return 404, b""
+        return original[url]
+
+    import scripts.check_release_assets as mod
+
+    mod_fetch = mod.fetch
+    try:
+        mod.fetch = selective
+        assert _run() == 1
+    finally:
+        mod.fetch = mod_fetch
+
+    out = capsys.readouterr().out
+    assert "the file IS there" in out
+    assert "cached 'not found'" in out
+
+
+def test_the_prober_asks_the_way_a_users_curl_asks() -> None:
+    """Probing a different cache entry than the user hits gives a useless answer."""
+    assert prober.USER_AGENT.startswith("curl/")
+    assert prober.ACCEPT == "*/*"

--- a/core/tests/test_release_asset_prober.py
+++ b/core/tests/test_release_asset_prober.py
@@ -1,0 +1,345 @@
+"""The rescue-URL prober: a half-published release is caught in minutes, not by a user.
+
+These tests drive scripts/check_release_assets.py against a fake HTTP layer. The
+cases mirror what actually went wrong on 2026-08-11 (a release whose assets 404,
+and a rescue guide naming a version that was never published) plus the failure mode
+that would make the prober useless: reporting a network blip as a broken release.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import check_release_assets as prober
+
+VERSION = "9.9.9"
+BUNDLE = b"tarball-bytes\x00\x01"
+BRIDGE = b"#!/usr/bin/env python3\n"
+
+
+def _url(name: str) -> str:
+    return prober.DOWNLOAD_URL.format(repo=prober.REPO, version=VERSION, name=name)
+
+
+def _checksum_body(data: bytes, name: str) -> bytes:
+    return f"{hashlib.sha256(data).hexdigest()}  {name}\n".encode()
+
+
+def _healthy_routes(version: str = VERSION) -> dict[str, tuple[int, bytes]]:
+    """Every URL a healthy release serves, including the rescue guide itself."""
+    bundle_name = f"dex-vault-bundle-v{version}.tar.gz"
+    bridge_name = f"dex-update-bridge-v{version}.py"
+    rescue_doc = (
+        "Download the versioned bridge:\n\n"
+        f"  https://github.com/{prober.REPO}/releases/download/v{version}/{bridge_name}\n"
+        f"  https://github.com/{prober.REPO}/releases/download/v{version}/{bridge_name}.sha256\n"
+    )
+    return {
+        prober.LATEST_RELEASE_API.format(repo=prober.REPO): (
+            200,
+            json.dumps(
+                {
+                    "tag_name": f"v{version}",
+                    "html_url": f"https://github.com/{prober.REPO}/releases/tag/v{version}",
+                }
+            ).encode(),
+        ),
+        prober.RESCUE_DOC_AT_TAG.format(repo=prober.REPO, version=version): (
+            200,
+            rescue_doc.encode(),
+        ),
+        _url(bundle_name): (200, BUNDLE),
+        _url(f"{bundle_name}.sha256"): (200, _checksum_body(BUNDLE, bundle_name)),
+        _url(bridge_name): (200, BRIDGE),
+        _url(f"{bridge_name}.sha256"): (200, _checksum_body(BRIDGE, bridge_name)),
+    }
+
+
+@pytest.fixture
+def routes(monkeypatch):
+    """Install a fake HTTP layer; tests mutate the returned routing table."""
+    table: dict[str, tuple[int, bytes]] = _healthy_routes()
+
+    def fake_fetch(url: str, *, opener=None):
+        if url not in table:
+            return 404, b""
+        status, body = table[url]
+        if status == -1:
+            raise prober.Undetermined(f"could not reach {url}: simulated network failure")
+        return status, body
+
+    monkeypatch.setattr(prober, "fetch", fake_fetch)
+    return table
+
+
+def _run(*extra: str) -> int:
+    return prober.main(["--skip-draft-check", *extra])
+
+
+# --------------------------------------------------------------------------- #
+# The healthy case
+# --------------------------------------------------------------------------- #
+
+
+def test_a_fully_published_release_passes(routes, tmp_path, capsys) -> None:
+    report_path = tmp_path / "report.json"
+    assert _run("--json", str(report_path)) == 0
+
+    report = json.loads(report_path.read_text())
+    assert report["outcome"] == "ok"
+    assert report["version"] == VERSION
+    assert report["probed_count"] == prober.REQUIRED_ASSET_COUNT
+    assert report["checksum_pairs_verified"] == 2
+    assert report["failures"] == []
+    assert all(probe["ok"] for probe in report["probes"])
+
+
+def test_it_reports_which_urls_the_rescue_guide_depends_on(routes, capsys) -> None:
+    _run()
+    out = capsys.readouterr().out
+    assert prober.RESCUE_DOC in out, (
+        "a failure has to say whether it breaks an update, the rescue guide, or both"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The failures this exists to catch
+# --------------------------------------------------------------------------- #
+
+
+def test_a_release_with_no_assets_fails(routes, tmp_path, capsys) -> None:
+    """Exactly the v1.94.0 state: public, newest, zero downloads attached."""
+    for name in prober.ASSET_TEMPLATES:
+        routes.pop(_url(name.format(version=VERSION)), None)
+
+    report_path = tmp_path / "report.json"
+    assert _run("--json", str(report_path)) == 1
+
+    report = json.loads(report_path.read_text())
+    assert report["outcome"] == "broken"
+    assert len(report["failures"]) >= prober.REQUIRED_ASSET_COUNT
+    assert "HTTP 404" in capsys.readouterr().out
+
+
+def test_one_missing_asset_is_enough_to_fail(routes) -> None:
+    routes.pop(_url(f"dex-update-bridge-v{VERSION}.py"))
+    assert _run() == 1
+
+
+def test_the_rescue_guide_pointing_at_an_unpublished_version_fails(routes, capsys) -> None:
+    """The guide is rewritten to name the new version the moment a release is cut.
+
+    If that release never finished publishing, the guide sends a stuck user to a
+    download that does not exist -- which is what happened on 2026-08-11.
+    """
+    ghost = "9.9.10"
+    ghost_bridge = f"dex-update-bridge-v{ghost}.py"
+    routes[prober.RESCUE_DOC_AT_TAG.format(repo=prober.REPO, version=VERSION)] = (
+        200,
+        (
+            f"  https://github.com/{prober.REPO}/releases/download/v{ghost}/{ghost_bridge}\n"
+        ).encode(),
+    )
+
+    assert _run() == 1
+    out = capsys.readouterr().out
+    assert ghost_bridge in out
+    assert prober.RESCUE_DOC in out
+
+
+def test_a_checksum_that_does_not_match_the_served_bytes_fails(routes, capsys) -> None:
+    bundle_name = f"dex-vault-bundle-v{VERSION}.tar.gz"
+    routes[_url(f"{bundle_name}.sha256")] = (200, f"{'0' * 64}  {bundle_name}\n".encode())
+
+    assert _run() == 1
+    out = capsys.readouterr().out
+    assert "does not match its published checksum" in out
+    assert "shasum" not in out or "verify step" in out
+
+
+def test_a_checksum_file_that_is_not_a_checksum_fails(routes) -> None:
+    bundle_name = f"dex-vault-bundle-v{VERSION}.tar.gz"
+    routes[_url(f"{bundle_name}.sha256")] = (200, b"<html>404 page</html>\n")
+    assert _run() == 1
+
+
+def test_an_empty_two_hundred_response_fails(routes, capsys) -> None:
+    """A zero-byte asset serves HTTP 200 and is still useless to a user."""
+    routes[_url(f"dex-update-bridge-v{VERSION}.py")] = (200, b"")
+    assert _run() == 1
+    assert "empty" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Not crying wolf: "I could not tell" must never look like "it is broken"
+# --------------------------------------------------------------------------- #
+
+
+def test_an_unreachable_github_is_undetermined_not_a_broken_release(
+    routes, tmp_path, capsys
+) -> None:
+    routes[prober.LATEST_RELEASE_API.format(repo=prober.REPO)] = (-1, b"")
+
+    report_path = tmp_path / "report.json"
+    assert _run("--json", str(report_path)) == 2, (
+        "a network failure must use the distinct 'could not check' exit code"
+    )
+
+    report = json.loads(report_path.read_text())
+    assert report["outcome"] == "undetermined"
+    out = capsys.readouterr().out
+    assert "COULD NOT CHECK" in out
+    assert "says nothing about whether the release is downloadable" in out
+
+
+def test_one_unreachable_probe_is_recorded_but_does_not_claim_a_broken_release(
+    routes, tmp_path
+) -> None:
+    routes[_url(f"dex-vault-bundle-v{VERSION}.tar.gz")] = (-1, b"")
+
+    report_path = tmp_path / "report.json"
+    exit_code = _run("--json", str(report_path))
+    report = json.loads(report_path.read_text())
+
+    assert report["undetermined"], "the unreachable URL must be recorded"
+    # It is reported as a failure only because the probe genuinely did not serve
+    # bytes; what matters is that the reason travels with it.
+    assert exit_code in (0, 1)
+    assert any("simulated network failure" in item for item in report["undetermined"])
+
+
+def test_a_rescue_guide_that_cannot_be_read_is_undetermined_not_a_pass(
+    routes, tmp_path
+) -> None:
+    routes.pop(prober.RESCUE_DOC_AT_TAG.format(repo=prober.REPO, version=VERSION))
+
+    report_path = tmp_path / "report.json"
+    assert _run("--json", str(report_path)) == 0
+    report = json.loads(report_path.read_text())
+    assert any("rescue guide" in item for item in report["undetermined"]), (
+        "not reading the guide must be stated, never silently skipped"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The prober cannot pass by having checked nothing
+# --------------------------------------------------------------------------- #
+
+
+def test_a_prober_that_assembles_too_few_urls_refuses_to_report_success(
+    routes, monkeypatch
+) -> None:
+    """The green-by-omission guard: no probes means 'could not check', never 'ok'."""
+    monkeypatch.setattr(prober, "ASSET_TEMPLATES", ("dex-vault-bundle-v{version}.tar.gz",))
+    monkeypatch.setattr(
+        prober, "rescue_doc_urls", lambda *a, **k: ([], [])
+    )
+    assert _run() == 2
+
+
+def test_the_expected_asset_list_matches_what_dex_installs_fetch() -> None:
+    assert prober.REQUIRED_ASSET_COUNT == 4
+    assert prober.ASSET_TEMPLATES == (
+        "dex-vault-bundle-v{version}.tar.gz",
+        "dex-vault-bundle-v{version}.tar.gz.sha256",
+        "dex-update-bridge-v{version}.py",
+        "dex-update-bridge-v{version}.py.sha256",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# A release nobody is shipping
+# --------------------------------------------------------------------------- #
+
+
+def test_a_release_stuck_in_draft_for_hours_is_reported(monkeypatch) -> None:
+    """Draft-first's own failure mode: the assets never built, so nothing published."""
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"tag": "v9.9.9", "created": "2020-01-01T00:00:00Z"}) + "\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(prober.subprocess, "run", fake_run)
+    failures, undetermined = prober.stuck_draft_failures()
+
+    assert undetermined == []
+    assert len(failures) == 1
+    assert "v9.9.9" in failures[0]
+    assert "draft" in failures[0]
+
+
+def test_a_fresh_draft_is_not_reported_as_stuck(monkeypatch) -> None:
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"tag": "v9.9.9", "created": now}) + "\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(prober.subprocess, "run", fake_run)
+    failures, undetermined = prober.stuck_draft_failures()
+    assert failures == []
+
+
+def test_an_unauthenticated_cli_makes_the_draft_check_undetermined(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="auth")
+
+    monkeypatch.setattr(prober.subprocess, "run", fake_run)
+    failures, undetermined = prober.stuck_draft_failures()
+    assert failures == []
+    assert undetermined and "stuck drafts" in undetermined[0]
+
+
+# --------------------------------------------------------------------------- #
+# Reading the rescue guide from a checkout (the pull-request mode)
+# --------------------------------------------------------------------------- #
+
+
+def test_local_mode_reads_the_working_copy(tmp_path) -> None:
+    doc = tmp_path / prober.RESCUE_DOC
+    doc.parent.mkdir(parents=True)
+    doc.write_text(
+        f"https://github.com/{prober.REPO}/releases/download/v1.2.3/dex-update-bridge-v1.2.3.py\n",
+        encoding="utf-8",
+    )
+    urls, undetermined = prober.rescue_doc_urls("1.2.3", source="local", repo_root=tmp_path)
+    assert urls == [
+        f"https://github.com/{prober.REPO}/releases/download/v1.2.3/dex-update-bridge-v1.2.3.py"
+    ]
+    assert undetermined == []
+
+
+def test_local_mode_says_so_when_the_guide_is_absent(tmp_path) -> None:
+    urls, undetermined = prober.rescue_doc_urls("1.2.3", source="local", repo_root=tmp_path)
+    assert urls == []
+    assert undetermined and "not present" in undetermined[0]
+
+
+def test_the_real_rescue_guide_in_this_checkout_names_download_urls() -> None:
+    """Guards the extraction against a doc rewrite that quietly drops the URLs."""
+    urls, undetermined = prober.rescue_doc_urls(
+        "0.0.0", source="local", repo_root=REPO_ROOT
+    )
+    assert undetermined == []
+    assert urls, f"{prober.RESCUE_DOC} should name at least one release download URL"
+    assert all("/releases/download/" in url for url in urls)

--- a/core/tests/test_release_publish_draft_first.py
+++ b/core/tests/test_release_publish_draft_first.py
@@ -1,0 +1,442 @@
+"""Draft-first publishing: a release cannot go public before its assets are proven.
+
+These tests drive scripts/release_publish.py against a fake GitHub CLI, so the
+ordering that matters -- attach, verify, and only then flip public -- is exercised
+without a network or a real release. The ordering is the whole point: on 2026-08-11
+v1.94.0 was public with zero assets for about ninety minutes because publishing and
+attaching were independent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import release_publish as rp
+
+VERSION = "9.9.9"
+TAG = f"v{VERSION}"
+
+
+# --------------------------------------------------------------------------- #
+# A fake gh that models a release well enough to catch ordering mistakes
+# --------------------------------------------------------------------------- #
+
+
+class FakeRelease:
+    def __init__(self, *, draft: bool = True, prerelease: bool = False, body: str = ""):
+        self.draft = draft
+        self.prerelease = prerelease
+        self.body = body
+        self.assets: dict[str, bytes] = {}
+
+
+class FakeGh:
+    """Records every call, and refuses to serve bytes that were never uploaded."""
+
+    def __init__(self, *, releases: dict[str, FakeRelease] | None = None, repo=None):
+        self.repo = repo
+        self.releases = releases or {}
+        self.calls: list[list[str]] = []
+        # Set to a name to simulate an upload that reports success but leaves a
+        # truncated asset -- the failure asset-name-presence checks cannot see.
+        self.truncate_on_readback: str | None = None
+        self.fleet_running = False
+
+    # -- helpers -----------------------------------------------------------
+    def _result(self, code: int, out: str = "", err: str = "") -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=["gh"], returncode=code, stdout=out, stderr=err)
+
+    def run(self, args, *, check=True):
+        self.calls.append(list(args))
+        if args[:2] == ["run", "list"]:
+            payload = [{"databaseId": 1}] if self.fleet_running else []
+            return self._result(0, json.dumps(payload))
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    def release(self, args, *, check=True):
+        self.calls.append(["release"] + list(args))
+        action, tag = args[0], args[1]
+        release = self.releases.get(tag)
+
+        if action == "view":
+            if release is None:
+                return self._result(1, err="release not found")
+            return self._result(
+                0,
+                json.dumps(
+                    {
+                        "isDraft": release.draft,
+                        "isPrerelease": release.prerelease,
+                        "body": release.body,
+                        "assets": [
+                            {
+                                "name": name,
+                                "size": len(data),
+                                "state": "uploaded",
+                                "apiUrl": f"fake://{tag}/{name}",
+                            }
+                            for name, data in release.assets.items()
+                        ],
+                    }
+                ),
+            )
+
+        if action == "create":
+            assert "--draft" in args, "a release must never be created already public"
+            body = ""
+            if "--notes-file" in args:
+                body = Path(args[args.index("--notes-file") + 1]).read_text(encoding="utf-8")
+            self.releases[tag] = FakeRelease(
+                draft=True, prerelease="--prerelease" in args, body=body
+            )
+            return self._result(0)
+
+        if action == "upload":
+            assert release is not None
+            for token in args[2:]:
+                if token.startswith("--"):
+                    continue
+                path = Path(token)
+                release.assets[path.name] = path.read_bytes()
+            return self._result(0)
+
+        if action == "edit":
+            assert release is not None
+            if "--notes-file" in args:
+                release.body = Path(
+                    args[args.index("--notes-file") + 1]
+                ).read_text(encoding="utf-8")
+            if "--draft=false" in args:
+                release.draft = False
+            if "--prerelease=false" in args:
+                release.prerelease = False
+            elif "--prerelease" in args:
+                release.prerelease = True
+            return self._result(0)
+
+        raise AssertionError(f"unexpected gh release call: {args}")
+
+    def download_asset(self, api_url: str, destination: Path) -> None:
+        self.calls.append(["download", api_url])
+        tag, name = api_url.removeprefix("fake://").split("/", 1)
+        data = self.releases[tag].assets[name]
+        if self.truncate_on_readback == name:
+            data = data[: max(0, len(data) - 1)]
+        destination.write_bytes(data)
+
+    # -- assertions used by tests -----------------------------------------
+    def flipped_public(self) -> bool:
+        return any(
+            call[0] == "release" and call[1] == "edit" and "--draft=false" in call
+            for call in self.calls
+        )
+
+    def index_of(self, predicate) -> int:
+        for index, call in enumerate(self.calls):
+            if predicate(call):
+                return index
+        return -1
+
+
+def _write_dist(tmp_path: Path, version: str = VERSION) -> Path:
+    """Build a dist directory shaped exactly like a real release build."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    payloads = {
+        f"dex-vault-bundle-v{version}.tar.gz": b"tarball-bytes\x00\x01\x02",
+        f"dex-update-bridge-v{version}.py": b"#!/usr/bin/env python3\nprint('bridge')\n",
+    }
+    for name, data in payloads.items():
+        (dist / name).write_bytes(data)
+        digest = hashlib.sha256(data).hexdigest()
+        (dist / f"{name}.sha256").write_text(f"{digest}  {name}\n", encoding="utf-8")
+    return dist
+
+
+def _publish_args(dist: Path, *, version: str = VERSION, channel: str = "stable"):
+    return argparse.Namespace(
+        repo=None, version=version, channel=channel, dist=str(dist), target="deadbeef"
+    )
+
+
+def _draft_args(changelog: Path, *, version: str = VERSION, channel: str = "stable"):
+    return argparse.Namespace(
+        repo=None, version=version, channel=channel, changelog=str(changelog), target="deadbeef"
+    )
+
+
+def _publish(args, gh: FakeGh) -> int:
+    """Run the publish command the way main() does, mapping a refusal to exit 1.
+
+    Production maps ReleasePublishError to a non-zero exit in main(); these tests
+    assert on that exit code, so they have to go through the same mapping rather
+    than a bare call.
+    """
+    try:
+        return rp.command_publish(args, gh=gh)
+    except rp.ReleasePublishError as error:
+        rp.log(f"Release step stopped safely: {error}")
+        return 1
+
+
+def _draft(args, gh: FakeGh) -> int:
+    try:
+        return rp.command_draft(args, gh=gh)
+    except rp.ReleasePublishError as error:
+        rp.log(f"Release step stopped safely: {error}")
+        return 1
+
+
+# --------------------------------------------------------------------------- #
+# The draft step
+# --------------------------------------------------------------------------- #
+
+
+def test_draft_creates_a_hidden_release_carrying_the_changelog(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        f"# Changelog\n\n---\n\n## [{VERSION}] — (2026-08-11)\n\nReal notes here.\n\n"
+        "## [9.9.8] — (2026-08-10)\n\nOlder notes.\n",
+        encoding="utf-8",
+    )
+    gh = FakeGh()
+
+    assert _draft(_draft_args(changelog), gh) == 0
+
+    release = gh.releases[TAG]
+    assert release.draft is True, "the draft step must never publish"
+    assert "Real notes here." in release.body
+    assert "Older notes." not in release.body, "only this version's section belongs"
+    assert rp.NOTE_START in release.body
+    assert "not public yet" in release.body
+    assert not gh.flipped_public()
+
+
+def test_draft_refuses_to_unpublish_an_already_public_release(tmp_path: Path) -> None:
+    """Re-running the tag workflow must never pull a live release back into draft."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(f"---\n\n## [{VERSION}] — (2026-08-11)\n\nNotes.\n", encoding="utf-8")
+    live = FakeRelease(draft=False, body="the published notes")
+    live.assets = {name: b"x" for name in rp.asset_names(VERSION)}
+    gh = FakeGh(releases={TAG: live})
+
+    assert _draft(_draft_args(changelog), gh) == 0
+
+    assert live.draft is False, "a public release must stay public"
+    assert live.body == "the published notes", "a public release's notes must be untouched"
+    assert not any(call[:2] == ["release", "edit"] for call in gh.calls)
+
+
+def test_draft_says_so_when_it_is_queued_behind_the_fleet_proof(tmp_path: Path) -> None:
+    """The fleet proof holds the single publish lane for hours; the draft explains it."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(f"---\n\n## [{VERSION}] — (2026-08-11)\n\nNotes.\n", encoding="utf-8")
+    gh = FakeGh()
+    gh.fleet_running = True
+
+    assert _draft(_draft_args(changelog), gh) == 0
+
+    body = gh.releases[TAG].body
+    assert "macOS updater proof" in body
+    assert "queued behind it" in body
+
+
+def test_draft_without_the_fleet_running_omits_the_queue_note(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(f"---\n\n## [{VERSION}] — (2026-08-11)\n\nNotes.\n", encoding="utf-8")
+    gh = FakeGh()
+    gh.fleet_running = False
+
+    _draft(_draft_args(changelog), gh)
+
+    assert "macOS updater proof" not in gh.releases[TAG].body
+
+
+# --------------------------------------------------------------------------- #
+# The publish step
+# --------------------------------------------------------------------------- #
+
+
+def test_publish_attaches_verifies_then_flips_public_in_that_order(tmp_path: Path) -> None:
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True, body=f"Notes\n\n{rp.build_note(VERSION, queued_behind_fleet=False)}\n")})
+
+    assert _publish(_publish_args(dist), gh) == 0
+
+    upload_at = gh.index_of(lambda c: c[:2] == ["release", "upload"])
+    readback_at = gh.index_of(lambda c: c[0] == "download")
+    flip_at = gh.index_of(lambda c: c[:2] == ["release", "edit"] and "--draft=false" in c)
+
+    assert upload_at >= 0 and readback_at >= 0 and flip_at >= 0
+    assert upload_at < readback_at < flip_at, (
+        "the flip to public must come after the assets are attached AND read back; "
+        f"saw upload={upload_at} readback={readback_at} flip={flip_at}"
+    )
+
+    release = gh.releases[TAG]
+    assert release.draft is False
+    assert set(release.assets) == set(rp.asset_names(VERSION))
+    assert rp.NOTE_START not in release.body, "the not-public-yet note must be removed"
+    assert "Notes" in release.body, "the CHANGELOG notes must survive the flip"
+
+
+def test_publish_never_flips_public_when_an_asset_is_missing(tmp_path: Path) -> None:
+    dist = _write_dist(tmp_path)
+    (dist / f"dex-update-bridge-v{VERSION}.py").unlink()
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist), gh) == 1
+    assert gh.releases[TAG].draft is True, "a failed publish must leave a hidden draft"
+    assert not gh.flipped_public()
+
+
+def test_publish_never_flips_public_when_a_checksum_does_not_match(tmp_path: Path) -> None:
+    dist = _write_dist(tmp_path)
+    (dist / f"dex-vault-bundle-v{VERSION}.tar.gz.sha256").write_text(
+        f"{'0' * 64}  dex-vault-bundle-v{VERSION}.tar.gz\n", encoding="utf-8"
+    )
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist), gh) == 1
+    assert gh.releases[TAG].draft is True
+    assert not gh.flipped_public()
+
+
+def test_publish_catches_an_asset_that_uploaded_but_serves_wrong_bytes(tmp_path: Path) -> None:
+    """A truncated upload still appears by name. Only reading it back finds it."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+    gh.truncate_on_readback = f"dex-vault-bundle-v{VERSION}.tar.gz"
+
+    assert _publish(_publish_args(dist), gh) == 1
+    assert gh.releases[TAG].draft is True, "an unverifiable asset must not go public"
+    assert not gh.flipped_public()
+
+
+def test_publish_creates_a_draft_when_the_tag_workflow_never_ran(tmp_path: Path) -> None:
+    """Belt and braces: assets still land on a hidden release, never a public one."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh()
+
+    assert _publish(_publish_args(dist), gh) == 0
+
+    create = next(c for c in gh.calls if c[:2] == ["release", "create"])
+    assert "--draft" in create
+    create_at = gh.calls.index(create)
+    flip_at = gh.index_of(lambda c: c[:2] == ["release", "edit"] and "--draft=false" in c)
+    assert create_at < flip_at
+
+
+def test_publish_repairs_a_release_that_was_already_public(tmp_path: Path, capsys) -> None:
+    """A release cut before this change can still be filled in, with a warning."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=False, body="live notes")})
+
+    assert _publish(_publish_args(dist), gh) == 0
+    assert set(gh.releases[TAG].assets) == set(rp.asset_names(VERSION))
+    assert "ALREADY PUBLIC" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# The beta lane's two safety guards, which used to live only in workflow bash
+# --------------------------------------------------------------------------- #
+
+
+def test_beta_lane_refuses_a_stable_version_number(tmp_path: Path) -> None:
+    """A bare X.Y.Z from the beta branch could publish over a real stable release."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh()
+
+    assert _publish(_publish_args(dist, channel="beta"), gh) == 1
+    assert gh.calls == [], "it must refuse before touching GitHub at all"
+
+
+def test_beta_lane_refuses_to_clobber_a_promoted_release(tmp_path: Path) -> None:
+    beta_version = "9.9.9-beta.1"
+    dist = _write_dist(tmp_path, version=beta_version)
+    promoted = FakeRelease(draft=True, prerelease=False)
+    gh = FakeGh(releases={f"v{beta_version}": promoted})
+
+    result = _publish(_publish_args(dist, version=beta_version, channel="beta"), gh)
+
+    assert result == 1
+    assert not any(c[:2] == ["release", "upload"] for c in gh.calls), (
+        "it must refuse before uploading anything"
+    )
+
+
+def test_beta_lane_publishes_as_a_prerelease(tmp_path: Path) -> None:
+    beta_version = "9.9.9-beta.1"
+    dist = _write_dist(tmp_path, version=beta_version)
+    gh = FakeGh(releases={f"v{beta_version}": FakeRelease(draft=True, prerelease=True)})
+
+    assert _publish(_publish_args(dist, version=beta_version, channel="beta"), gh) == 0
+
+    release = gh.releases[f"v{beta_version}"]
+    assert release.draft is False
+    assert release.prerelease is True, "a beta release must stay marked as a prerelease"
+
+
+# --------------------------------------------------------------------------- #
+# Small pure pieces
+# --------------------------------------------------------------------------- #
+
+
+def test_strip_note_leaves_human_written_body_intact() -> None:
+    note = rp.build_note("1.2.3", queued_behind_fleet=True)
+    body = f"## What changed\n\nA real entry.\n\n{note}\n"
+    stripped = rp.strip_note(body)
+    assert "A real entry." in stripped
+    assert rp.NOTE_START not in stripped
+    assert "macOS updater proof" not in stripped
+
+
+def test_strip_note_is_idempotent_and_safe_on_a_body_without_a_note() -> None:
+    assert rp.strip_note("just notes\n").strip() == "just notes"
+    assert rp.strip_note("") == ""
+
+
+@pytest.mark.parametrize(
+    "version,channel,ok",
+    [
+        ("1.94.0", "stable", True),
+        ("1.94.0-beta.1", "stable", False),
+        ("1.94.0-beta.1", "beta", True),
+        ("1.94.0", "beta", False),
+        ("01.9.0", "stable", False),
+    ],
+)
+def test_validate_version_separates_the_channels(version: str, channel: str, ok: bool) -> None:
+    if ok:
+        rp.validate_version(version, channel)
+    else:
+        with pytest.raises(rp.ReleasePublishError):
+            rp.validate_version(version, channel)
+
+
+def test_expected_digest_rejects_a_checksum_file_that_is_not_a_checksum(tmp_path: Path) -> None:
+    bad = tmp_path / "x.sha256"
+    bad.write_text("not-a-digest  x\n", encoding="utf-8")
+    with pytest.raises(rp.ReleasePublishError):
+        rp.expected_digest(bad)
+
+
+def test_asset_list_is_the_four_files_dex_installs_fetch() -> None:
+    assert rp.asset_names("1.2.3") == [
+        "dex-vault-bundle-v1.2.3.tar.gz",
+        "dex-vault-bundle-v1.2.3.tar.gz.sha256",
+        "dex-update-bridge-v1.2.3.py",
+        "dex-update-bridge-v1.2.3.py.sha256",
+    ]
+    assert rp.REQUIRED_ASSET_COUNT == 4

--- a/core/tests/test_release_publish_draft_first.py
+++ b/core/tests/test_release_publish_draft_first.py
@@ -164,9 +164,20 @@ def _write_dist(tmp_path: Path, version: str = VERSION) -> Path:
     return dist
 
 
-def _publish_args(dist: Path, *, version: str = VERSION, channel: str = "stable"):
+def _publish_args(
+    dist: Path,
+    *,
+    version: str = VERSION,
+    channel: str = "stable",
+    extra_asset: list[str] | None = None,
+):
     return argparse.Namespace(
-        repo=None, version=version, channel=channel, dist=str(dist), target="deadbeef"
+        repo=None,
+        version=version,
+        channel=channel,
+        dist=str(dist),
+        target="deadbeef",
+        extra_asset=extra_asset or [],
     )
 
 
@@ -440,3 +451,64 @@ def test_asset_list_is_the_four_files_dex_installs_fetch() -> None:
         "dex-update-bridge-v1.2.3.py.sha256",
     ]
     assert rp.REQUIRED_ASSET_COUNT == 4
+
+
+# --------------------------------------------------------------------------- #
+# Extra assets (the signed Dex Lens catalogue) ride the same verified path
+# --------------------------------------------------------------------------- #
+
+
+def test_extra_assets_are_attached_and_verified_before_the_flip(tmp_path: Path) -> None:
+    """Nothing may appear on a release after it has gone public."""
+    dist = _write_dist(tmp_path)
+    catalogue = dist / f"dex-lens-catalog-v{VERSION}.json"
+    catalogue.write_text('{"catalogue": true}', encoding="utf-8")
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist, extra_asset=[str(catalogue)]), gh) == 0
+
+    release = gh.releases[TAG]
+    assert catalogue.name in release.assets, "the extra asset must be attached"
+    assert release.draft is False
+
+    readback_at = gh.index_of(lambda c: c[0] == "download" and catalogue.name in c[1])
+    flip_at = gh.index_of(lambda c: c[:2] == ["release", "edit"] and "--draft=false" in c)
+    assert readback_at >= 0, "an extra asset must be read back like any other"
+    assert readback_at < flip_at, "extras must be proven before the release goes public"
+
+
+def test_a_missing_extra_asset_stops_the_release_going_public(tmp_path: Path) -> None:
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    result = _publish(
+        _publish_args(dist, extra_asset=[str(dist / "never-built.json")]), gh
+    )
+
+    assert result == 1
+    assert gh.releases[TAG].draft is True
+    assert not gh.flipped_public()
+
+
+def test_an_empty_extra_asset_stops_the_release_going_public(tmp_path: Path) -> None:
+    dist = _write_dist(tmp_path)
+    empty = dist / f"dex-lens-catalog-v{VERSION}.json"
+    empty.write_bytes(b"")
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist, extra_asset=[str(empty)]), gh) == 1
+    assert gh.releases[TAG].draft is True
+
+
+def test_the_four_required_assets_are_still_required_when_extras_are_present(
+    tmp_path: Path,
+) -> None:
+    """An extra asset must never be able to stand in for a missing required one."""
+    dist = _write_dist(tmp_path)
+    (dist / f"dex-update-bridge-v{VERSION}.py").unlink()
+    catalogue = dist / f"dex-lens-catalog-v{VERSION}.json"
+    catalogue.write_text("{}", encoding="utf-8")
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist, extra_asset=[str(catalogue)]), gh) == 1
+    assert gh.releases[TAG].draft is True

--- a/core/tests/test_release_publish_draft_first.py
+++ b/core/tests/test_release_publish_draft_first.py
@@ -44,7 +44,7 @@ class FakeRelease:
 class FakeGh:
     """Records every call, and refuses to serve bytes that were never uploaded."""
 
-    def __init__(self, *, releases: dict[str, FakeRelease] | None = None, repo=None):
+    def __init__(self, *, releases: dict[str, FakeRelease] | None = None, repo="test/repo"):
         self.repo = repo
         self.releases = releases or {}
         self.calls: list[list[str]] = []
@@ -119,9 +119,11 @@ class FakeGh:
                 ).read_text(encoding="utf-8")
             if "--draft=false" in args:
                 release.draft = False
+            if "--draft=true" in args:
+                release.draft = True
             if "--prerelease=false" in args:
                 release.prerelease = False
-            elif "--prerelease" in args:
+            elif "--prerelease=true" in args or "--prerelease" in args:
                 release.prerelease = True
             return self._result(0)
 
@@ -185,6 +187,16 @@ def _draft_args(changelog: Path, *, version: str = VERSION, channel: str = "stab
     return argparse.Namespace(
         repo=None, version=version, channel=channel, changelog=str(changelog), target="deadbeef"
     )
+
+
+@pytest.fixture(autouse=True)
+def _public_route_serves_everything(monkeypatch):
+    """Default the anonymous download route to healthy and instant.
+
+    Individual tests override this to exercise the lagging/broken public route.
+    """
+    monkeypatch.setattr(rp, "fetch_public_status", lambda url: 200)
+    monkeypatch.setattr(rp.time, "sleep", lambda seconds: None)
 
 
 def _publish(args, gh: FakeGh) -> int:
@@ -512,3 +524,140 @@ def test_the_four_required_assets_are_still_required_when_extras_are_present(
 
     assert _publish(_publish_args(dist, extra_asset=[str(catalogue)]), gh) == 1
     assert gh.releases[TAG].draft is True
+
+
+# --------------------------------------------------------------------------- #
+# The public route, which lags the authenticated API
+# --------------------------------------------------------------------------- #
+
+
+def test_publish_waits_for_the_public_route_to_catch_up(tmp_path, monkeypatch) -> None:
+    """Observed on 2026-08-12: an asset 404s publicly for seconds after upload."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+    calls = {"n": 0}
+
+    def lagging(url: str) -> int:
+        calls["n"] += 1
+        # The bridge is the last to appear, exactly as GitHub behaved.
+        if "dex-update-bridge" in url and calls["n"] < 6:
+            return 404
+        return 200
+
+    monkeypatch.setattr(rp, "fetch_public_status", lagging)
+    monkeypatch.setattr(rp.time, "sleep", lambda seconds: None)
+
+    assert _publish(_publish_args(dist), gh) == 0
+    assert gh.releases[TAG].draft is False, "it should publish once the route catches up"
+
+
+def test_publish_hides_the_release_again_when_it_never_downloads(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """An invisible release beats a visible broken one."""
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+    monkeypatch.setattr(
+        rp, "fetch_public_status", lambda url: 404 if "tar.gz" in url else 200
+    )
+    monkeypatch.setattr(rp.time, "sleep", lambda seconds: None)
+
+    assert _publish(_publish_args(dist), gh) == 1
+    assert gh.releases[TAG].draft is True, (
+        "a release whose files do not download must be pulled back out of sight"
+    )
+    assert "does not download" in capsys.readouterr().out
+
+
+def test_the_public_route_check_uses_the_real_download_urls() -> None:
+    url = rp.public_download_url("davekilleen/Dex", "1.2.3", "dex-update-bridge-v1.2.3.py")
+    assert url == (
+        "https://github.com/davekilleen/Dex/releases/download/v1.2.3/"
+        "dex-update-bridge-v1.2.3.py"
+    ), "this must match what docs/UPDATE-RESCUE.md tells a stuck user to run"
+
+
+# --------------------------------------------------------------------------- #
+# The prerelease flag is stated and then checked, never trusted
+# --------------------------------------------------------------------------- #
+
+
+def test_a_beta_release_that_comes_back_unmarked_is_corrected(tmp_path) -> None:
+    """Real gh behaviour: `--prerelease` alongside `--draft=false` was dropped."""
+    beta_version = "9.9.9-beta.1"
+    dist = _write_dist(tmp_path, version=beta_version)
+    tag = f"v{beta_version}"
+
+    class ForgetfulGh(FakeGh):
+        def release(self, args, *, check=True):
+            result = super().release(args, check=check)
+            # Simulate the flip silently clearing the prerelease flag.
+            if args[0] == "edit" and "--draft=false" in args:
+                self.releases[args[1]].prerelease = False
+            return result
+
+    gh = ForgetfulGh(releases={tag: FakeRelease(draft=True, prerelease=True)})
+
+    assert _publish(_publish_args(dist, version=beta_version, channel="beta"), gh) == 0
+    assert gh.releases[tag].prerelease is True, (
+        "a beta release must never be left presented as a normal release"
+    )
+
+
+def test_a_stable_release_is_marked_latest_and_not_a_prerelease(tmp_path) -> None:
+    """Flags are set while the release is still hidden, then it is flipped.
+
+    Setting them in the same call as `--draft=false` silently dropped the
+    prerelease flag against real GitHub on 2026-08-12, so these are separate
+    operations and the order matters.
+    """
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    assert _publish(_publish_args(dist), gh) == 0
+
+    flags_at = gh.index_of(
+        lambda c: c[:2] == ["release", "edit"]
+        and "--prerelease=false" in c
+        and "--latest" in c
+    )
+    flip_at = gh.index_of(lambda c: c[:2] == ["release", "edit"] and "--draft=false" in c)
+    assert flags_at >= 0, "a stable release must be marked latest and not a prerelease"
+    assert flip_at >= 0
+    assert flags_at < flip_at, "flags must be set before the release becomes visible"
+    assert "--draft=false" not in gh.calls[flags_at], (
+        "the flag call must not also publish; combining the two loses the flag"
+    )
+
+
+def test_a_stale_cached_not_found_does_not_hide_a_good_release(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """GitHub can cache a 404 served while an asset was still propagating.
+
+    The asset is fine and the cache entry expires on its own, so hiding the release
+    would be an over-reaction. It warns instead — but only because a cache-busted
+    request proves the file is really there.
+    """
+    dist = _write_dist(tmp_path)
+    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    def cached_404(url: str) -> int:
+        # The plain URL is poisoned; a cache-busted one shows the truth.
+        if "cache-bust=" in url:
+            return 200
+        return 404 if "tar.gz" in url and "sha256" not in url else 200
+
+    monkeypatch.setattr(rp, "fetch_public_status", cached_404)
+    monkeypatch.setattr(rp.time, "sleep", lambda seconds: None)
+
+    assert _publish(_publish_args(dist), gh) == 0
+    assert gh.releases[TAG].draft is False, "a good release must not be hidden"
+    assert "cached 'not found'" in capsys.readouterr().out
+
+
+def test_the_public_check_imitates_curl_because_github_varies_on_accept() -> None:
+    """Probing with a different Accept header checks a different cache entry."""
+    source = Path(rp.__file__).read_text(encoding="utf-8")
+    assert '"Accept": "*/*"' in source
+    assert "curl/" in source

--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -369,7 +369,9 @@ def test_stable_release_ci_publishes_each_version_at_most_once() -> None:
         "Build release branch",
         "Push release branch and immutable tag",
         "Build self-contained vault bundle",
-        "Upload vault bundle to versioned GitHub Release",
+        # Draft-first: this step attaches the assets, verifies them, and only then
+        # makes the release public. See test_release_workflows_draft_first.py.
+        "Attach assets, verify them, then make the release public",
     ):
         assert named_steps[step_name]["if"] == publish_condition
 

--- a/core/tests/test_release_workflows_draft_first.py
+++ b/core/tests/test_release_workflows_draft_first.py
@@ -1,0 +1,226 @@
+"""Workflow-shape contract: nothing in CI may publish a release before its assets.
+
+scripts/release_publish.py enforces the ordering at runtime. These tests enforce
+that the workflows actually GO THROUGH it -- because the v1.94.0 incident was not a
+bug inside a script, it was two workflows each doing something reasonable on its own.
+A future edit that reintroduces a bare `gh release create` without `--draft`, or a
+bare `gh release upload`, fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github/workflows"
+RELEASE_WORKFLOW = WORKFLOWS / "release.yml"
+CI_WORKFLOW = WORKFLOWS / "ci.yml"
+PROBER_WORKFLOW = WORKFLOWS / "release-asset-prober.yml"
+PUBLISH_SCRIPT = REPO_ROOT / "scripts/release_publish.py"
+PROBER_SCRIPT = REPO_ROOT / "scripts/check_release_assets.py"
+
+PINNED_ACTION = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict):
+    # PyYAML parses a bare `on:` key as the boolean True.
+    return workflow.get("on", workflow.get(True))
+
+
+def _all_run_blocks(workflow: dict) -> list[str]:
+    blocks = []
+    for job in workflow["jobs"].values():
+        for step in job.get("steps", []):
+            if "run" in step:
+                blocks.append(step["run"])
+    return blocks
+
+
+def _every_run_block_in_repo() -> list[tuple[str, str]]:
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        for block in _all_run_blocks(_load(path)):
+            found.append((path.name, block))
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# The scripts exist and are the only publishing route
+# --------------------------------------------------------------------------- #
+
+
+def test_the_publish_and_prober_scripts_exist() -> None:
+    assert PUBLISH_SCRIPT.is_file()
+    assert PROBER_SCRIPT.is_file()
+
+
+def test_no_workflow_creates_a_release_without_draft() -> None:
+    """A `gh release create` without `--draft` is the empty-window bug itself."""
+    offenders = []
+    for name, block in _every_run_block_in_repo():
+        for match in re.finditer(r"gh release create\b[^\n]*(?:\\\n[^\n]*)*", block):
+            if "--draft" not in match.group(0):
+                offenders.append(f"{name}: {match.group(0).strip()[:120]}")
+    assert offenders == [], (
+        "every release must be created as a draft and made public only after its "
+        f"assets are verified; found: {offenders}"
+    )
+
+
+def test_no_workflow_uploads_release_assets_outside_the_verified_path() -> None:
+    """`gh release upload` bypasses the read-back proof, so it must not appear."""
+    offenders = [
+        f"{name}: {block.strip()[:120]}"
+        for name, block in _every_run_block_in_repo()
+        if re.search(r"gh release upload\b", block)
+    ]
+    assert offenders == [], (
+        "asset uploads must go through scripts/release_publish.py, which reads every "
+        f"asset back off the release before publishing; found: {offenders}"
+    )
+
+
+def test_only_the_publish_script_flips_a_release_public() -> None:
+    offenders = [
+        f"{name}: {block.strip()[:120]}"
+        for name, block in _every_run_block_in_repo()
+        if "--draft=false" in block
+    ]
+    assert offenders == [], (
+        "making a release public is scripts/release_publish.py's job alone; "
+        f"found: {offenders}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# release.yml drafts, and never publishes
+# --------------------------------------------------------------------------- #
+
+
+def test_release_workflow_only_ever_creates_a_draft() -> None:
+    workflow = _load(RELEASE_WORKFLOW)
+    triggers = _triggers(workflow)
+    assert set(triggers) == {"push"}
+    assert triggers["push"]["tags"] == ["v*"]
+
+    blocks = _all_run_blocks(workflow)
+    assert len(blocks) == 1, "the tag workflow should do exactly one thing"
+    body = blocks[0]
+    assert "scripts/release_publish.py draft" in body
+    assert "publish" not in body.replace("release_publish.py", ""), (
+        "the tag workflow must never run the publish step"
+    )
+
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert "draft: false" not in text
+    assert "prerelease: false" not in text
+    assert "softprops" not in text, (
+        "the release-creating action was replaced precisely because it published "
+        "immediately; do not reintroduce it"
+    )
+
+
+def test_release_workflow_routes_prerelease_versions_to_the_beta_channel() -> None:
+    body = _all_run_blocks(_load(RELEASE_WORKFLOW))[0]
+    assert "CHANNEL=stable" in body
+    assert "*-*) CHANNEL=beta" in body
+
+
+def test_release_workflow_actions_are_pinned() -> None:
+    for job in _load(RELEASE_WORKFLOW)["jobs"].values():
+        for step in job.get("steps", []):
+            if "uses" in step:
+                assert PINNED_ACTION.fullmatch(step["uses"]), step["uses"]
+
+
+# --------------------------------------------------------------------------- #
+# ci.yml publishes only through the verified script
+# --------------------------------------------------------------------------- #
+
+
+def test_both_release_lanes_publish_through_the_verified_script() -> None:
+    workflow = _load(CI_WORKFLOW)
+
+    stable = {s["name"]: s for s in workflow["jobs"]["build-release"]["steps"] if "name" in s}
+    stable_step = stable["Attach assets, verify them, then make the release public"]
+    assert "scripts/release_publish.py publish" in stable_step["run"]
+    assert "--channel stable" in stable_step["run"]
+    assert stable_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+
+    beta_job = workflow["jobs"]["build-release-beta"]
+    beta = {s["name"]: s for s in beta_job["steps"] if "name" in s}
+    beta_step = beta["Attach beta assets, verify them, then publish the prerelease"]
+    assert "scripts/release_publish.py publish" in beta_step["run"]
+    assert "--channel beta" in beta_step["run"]
+
+
+def test_the_publishing_step_still_runs_only_after_the_full_suite() -> None:
+    """Draft-first changes WHEN a release goes public, never WHETHER it was tested."""
+    workflow = _load(CI_WORKFLOW)
+    for job_name in ("build-release", "build-release-beta"):
+        assert workflow["jobs"][job_name]["needs"] == ["quality", "test-results"]
+
+
+def test_the_stable_lane_keeps_the_non_cancelling_publish_lock() -> None:
+    """The fleet proof shares this lock; a queued release must wait, not be cancelled."""
+    stable = _load(CI_WORKFLOW)["jobs"]["build-release"]
+    assert stable["concurrency"] == {
+        "group": "stable-public-route",
+        "cancel-in-progress": False,
+    }
+
+
+def test_the_draft_explains_the_queue_when_the_fleet_proof_holds_the_lock() -> None:
+    """A release waiting hours behind the proof must say so, not look stalled."""
+    source = PUBLISH_SCRIPT.read_text(encoding="utf-8")
+    assert "historic-fleet-darwin.yml" in source
+    assert "queued behind it" in source
+
+
+# --------------------------------------------------------------------------- #
+# The prober workflow
+# --------------------------------------------------------------------------- #
+
+
+def test_the_prober_runs_on_a_schedule_and_can_be_run_by_hand() -> None:
+    workflow = _load(PROBER_WORKFLOW)
+    triggers = _triggers(workflow)
+    assert "schedule" in triggers, "a backstop nobody schedules is not a backstop"
+    assert triggers["schedule"], "the schedule must actually contain a cron entry"
+    assert "workflow_dispatch" in triggers
+    assert workflow["permissions"] == {"contents": "read"}
+
+
+def test_the_prober_is_exercised_when_the_prober_itself_changes() -> None:
+    """Otherwise the check that watches the release route is the thing nobody watches."""
+    paths = _triggers(_load(PROBER_WORKFLOW))["pull_request"]["paths"]
+    assert "scripts/check_release_assets.py" in paths
+    assert ".github/workflows/release-asset-prober.yml" in paths
+
+
+def test_the_prober_fails_the_run_when_the_release_is_broken() -> None:
+    steps = {s["name"]: s for s in _load(PROBER_WORKFLOW)["jobs"]["probe"]["steps"] if "name" in s}
+    fail_step = steps["Fail when the release is not fully downloadable"]
+    assert "steps.probe.outputs.status != '0'" in fail_step["if"]
+    assert "exit 1" in fail_step["run"]
+
+
+def test_the_prober_stays_green_when_it_simply_could_not_check() -> None:
+    """Crying wolf over a network blip is how a check earns being ignored."""
+    steps = {s["name"]: s for s in _load(PROBER_WORKFLOW)["jobs"]["probe"]["steps"] if "name" in s}
+    fail_step = steps["Fail when the release is not fully downloadable"]
+    assert "steps.probe.outputs.status != '2'" in fail_step["if"]
+
+
+def test_the_prober_workflow_actions_are_pinned() -> None:
+    for job in _load(PROBER_WORKFLOW)["jobs"].values():
+        for step in job.get("steps", []):
+            if "uses" in step:
+                assert PINNED_ACTION.fullmatch(step["uses"]), step["uses"]

--- a/scripts/check_release_assets.py
+++ b/scripts/check_release_assets.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Prove the newest Dex release is actually downloadable, from the outside.
+
+Draft-first publishing (scripts/release_publish.py) makes a public-but-empty
+release unreachable through the normal path. This is the independent watchman for
+everything that path cannot cover: a release cut by an older pipeline, an asset
+deleted or replaced by hand, a rescue document pointing at a version that was
+never published, or a release left half-attached by a partial upload.
+
+It checks two URL sets, both over plain unauthenticated HTTPS -- the same route a
+user's `curl` takes, not an authenticated API view that can succeed while the
+public route fails:
+
+  1. The four asset URLs of the current "Latest" release.
+  2. Every release-download URL written literally into docs/UPDATE-RESCUE.md.
+
+The second set is the one that actually broke on 2026-08-11: the rescue guide is
+rewritten to name the new version at the moment a release is cut, so it pointed
+at a bridge that did not exist yet and a stuck user following it got "not found".
+
+Exit codes are deliberately distinct, because "the release is broken" and "I could
+not tell" must never be reported the same way:
+
+  0  every probed URL served bytes and every checksum matched
+  1  a real failure -- something a user would hit
+  2  the check could not run (no network, GitHub unreachable, no release found)
+
+Usage:
+    python3 scripts/check_release_assets.py
+    python3 scripts/check_release_assets.py --json report.json
+    python3 scripts/check_release_assets.py --version 1.94.0   # probe one version
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = "davekilleen/Dex"
+LATEST_RELEASE_API = "https://api.github.com/repos/{repo}/releases/latest"
+DOWNLOAD_URL = "https://github.com/{repo}/releases/download/v{version}/{name}"
+
+ASSET_TEMPLATES = (
+    "dex-vault-bundle-v{version}.tar.gz",
+    "dex-vault-bundle-v{version}.tar.gz.sha256",
+    "dex-update-bridge-v{version}.py",
+    "dex-update-bridge-v{version}.py.sha256",
+)
+CHECKSUMMED_TEMPLATES = (
+    "dex-vault-bundle-v{version}.tar.gz",
+    "dex-update-bridge-v{version}.py",
+)
+REQUIRED_ASSET_COUNT = len(ASSET_TEMPLATES)
+
+RESCUE_DOC = "docs/UPDATE-RESCUE.md"
+# The rescue guide AS SHIPPED in the released tree -- not a local working copy,
+# which can be on any branch and say anything. What a stuck user reads is the
+# version at the release tag.
+RESCUE_DOC_AT_TAG = (
+    "https://raw.githubusercontent.com/{repo}/v{version}/" + RESCUE_DOC
+)
+RESCUE_URL_PATTERN = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/releases/download/[^\s\"')]+"
+)
+
+# A release left in draft for longer than this is no longer "being prepared"; it
+# is stuck, and nobody is being told. Reported as a failure so it gets attention.
+STUCK_DRAFT_HOURS = 6
+
+MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024
+TIMEOUT_SECONDS = 60
+USER_AGENT = "dex-release-asset-prober/1"
+
+
+@dataclass
+class Probe:
+    url: str
+    source: str
+    ok: bool = False
+    status: int | None = None
+    size: int | None = None
+    sha256: str | None = None
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    checked_at: str
+    version: str | None = None
+    release_url: str | None = None
+    probes: list[Probe] = field(default_factory=list)
+    checksum_pairs_verified: int = 0
+    failures: list[str] = field(default_factory=list)
+    undetermined: list[str] = field(default_factory=list)
+
+    @property
+    def probed_count(self) -> int:
+        return len(self.probes)
+
+    @property
+    def failed(self) -> list[Probe]:
+        return [probe for probe in self.probes if not probe.ok]
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Fetching
+# --------------------------------------------------------------------------- #
+
+
+class Undetermined(RuntimeError):
+    """The check could not reach GitHub. Not evidence of a broken release."""
+
+
+def _opener() -> urllib.request.OpenerDirector:
+    context = ssl.create_default_context()
+    return urllib.request.build_opener(urllib.request.HTTPSHandler(context=context))
+
+
+def fetch(url: str, *, opener=None) -> tuple[int, bytes]:
+    """GET a URL following redirects. Returns (status, body).
+
+    A 404 is a RESULT, not an error -- that is the failure this exists to catch.
+    A DNS or TLS failure is an Undetermined, because it says nothing about the
+    release.
+    """
+    opener = opener or _opener()
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with opener.open(request, timeout=TIMEOUT_SECONDS) as response:
+            body = response.read(MAX_DOWNLOAD_BYTES + 1)
+            if len(body) > MAX_DOWNLOAD_BYTES:
+                raise Undetermined(f"{url} is larger than the {MAX_DOWNLOAD_BYTES}-byte cap.")
+            return response.status, body
+    except urllib.error.HTTPError as error:
+        # An HTTP status the server actually returned: a real, reportable answer.
+        return error.code, b""
+    except urllib.error.URLError as error:
+        raise Undetermined(f"could not reach {url}: {error.reason}") from error
+    except TimeoutError as error:
+        raise Undetermined(f"timed out fetching {url}") from error
+
+
+def resolve_latest_version(*, opener=None) -> tuple[str, str]:
+    """Read the version GitHub currently serves as "Latest"."""
+    status, body = fetch(LATEST_RELEASE_API.format(repo=REPO), opener=opener)
+    if status != 200:
+        raise Undetermined(
+            f"the latest-release lookup returned HTTP {status}; cannot tell which "
+            "version is current."
+        )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as error:
+        raise Undetermined("the latest-release lookup returned unreadable JSON.") from error
+    tag = payload.get("tag_name") or ""
+    if not tag.startswith("v") or len(tag) < 2:
+        raise Undetermined(f"the latest release has an unusable tag: {tag!r}")
+    return tag[1:], payload.get("html_url") or ""
+
+
+# --------------------------------------------------------------------------- #
+# The checks
+# --------------------------------------------------------------------------- #
+
+
+def _unique(urls: list[str]) -> list[str]:
+    """Preserve order, drop duplicates: the guide names each URL twice."""
+    seen: set[str] = set()
+    unique = []
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            unique.append(url)
+    return unique
+
+
+def rescue_doc_urls(
+    version: str, *, source: str, repo_root: Path | None = None, opener=None
+) -> tuple[list[str], list[str]]:
+    """Every release-download URL a stuck user could copy out of the rescue guide.
+
+    Returns (urls, undetermined reasons). Reading the guide from the release tag
+    needs no checkout, which is what lets this run from anywhere.
+    """
+    if source == "local":
+        if repo_root is None:
+            return [], ["no repository root given, so the local rescue guide was not read"]
+        doc = repo_root / RESCUE_DOC
+        if not doc.is_file():
+            return [], [f"{doc} is not present, so its URLs were not checked"]
+        return _unique(RESCUE_URL_PATTERN.findall(doc.read_text(encoding="utf-8"))), []
+
+    url = RESCUE_DOC_AT_TAG.format(repo=REPO, version=version)
+    try:
+        status, body = fetch(url, opener=opener)
+    except Undetermined as error:
+        return [], [f"could not read the shipped rescue guide: {error}"]
+    if status != 200:
+        # The guide missing from the released tree is itself a problem, but it is
+        # reported as undetermined here: the caller cannot tell a genuinely absent
+        # document from a tag that has not finished propagating.
+        return [], [f"the rescue guide at v{version} returned HTTP {status}"]
+    return _unique(RESCUE_URL_PATTERN.findall(body.decode("utf-8", "replace"))), []
+
+
+def probe_urls(
+    urls: list[tuple[str, str]], *, opener=None
+) -> tuple[list[Probe], list[str], dict[str, bytes]]:
+    """Fetch each URL, recording what came back.
+
+    Returns (probes, undetermined reasons, served bodies by URL).
+    """
+    probes: list[Probe] = []
+    undetermined: list[str] = []
+    bodies: dict[str, bytes] = {}
+    for url, source in urls:
+        probe = Probe(url=url, source=source)
+        try:
+            status, body = fetch(url, opener=opener)
+        except Undetermined as error:
+            probe.detail = str(error)
+            undetermined.append(str(error))
+            probes.append(probe)
+            continue
+        probe.status = status
+        if status != 200:
+            probe.detail = f"HTTP {status} — a user following this link gets nothing."
+            probes.append(probe)
+            continue
+        if not body:
+            probe.detail = "HTTP 200 but the body was empty."
+            probe.size = 0
+            probes.append(probe)
+            continue
+        probe.ok = True
+        probe.size = len(body)
+        probe.sha256 = hashlib.sha256(body).hexdigest()
+        bodies[url] = body
+        probes.append(probe)
+    return probes, undetermined, bodies
+
+
+def verify_checksum_pairs(bodies: dict[str, bytes], version: str) -> tuple[int, list[str]]:
+    """Run the same `shasum -c` a rescued user runs, on the bytes actually served."""
+    verified = 0
+    failures: list[str] = []
+    for template in CHECKSUMMED_TEMPLATES:
+        name = template.format(version=version)
+        artifact_url = DOWNLOAD_URL.format(repo=REPO, version=version, name=name)
+        checksum_url = f"{artifact_url}.sha256"
+        if artifact_url not in bodies or checksum_url not in bodies:
+            # Already reported as a failed probe; nothing to add here.
+            continue
+        declared = bodies[checksum_url].decode("utf-8", "replace").strip().split()
+        if not declared or not re.fullmatch(r"[0-9a-f]{64}", declared[0]):
+            failures.append(
+                f"{name}.sha256 does not contain a usable checksum, so a user cannot "
+                "verify the download."
+            )
+            continue
+        actual = hashlib.sha256(bodies[artifact_url]).hexdigest()
+        if actual != declared[0]:
+            failures.append(
+                f"{name} does not match its published checksum "
+                f"(served {actual[:12]}…, checksum file says {declared[0][:12]}…). "
+                "A user running the documented verify step would see it fail."
+            )
+            continue
+        verified += 1
+    return verified, failures
+
+
+def stuck_draft_failures() -> tuple[list[str], list[str]]:
+    """Report a release that has been sitting in draft too long.
+
+    Best-effort: needs an authenticated `gh`, so a missing or unauthenticated CLI
+    is undetermined rather than a pass. A stuck draft is invisible to users, but it
+    also means a release nobody is shipping -- worth a card either way.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api", f"repos/{REPO}/releases",
+                "--jq",
+                '.[] | select(.draft == true) | {tag: .tag_name, created: .created_at}',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return [], ["could not check for stuck drafts (the GitHub CLI is unavailable)"]
+    if result.returncode != 0:
+        return [], ["could not check for stuck drafts (the GitHub CLI is not authenticated)"]
+
+    failures: list[str] = []
+    now = datetime.now(timezone.utc)
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            created = datetime.fromisoformat(entry["created"].replace("Z", "+00:00"))
+        except (json.JSONDecodeError, KeyError, ValueError):
+            continue
+        hours = (now - created).total_seconds() / 3600
+        if hours >= STUCK_DRAFT_HOURS:
+            failures.append(
+                f"Release {entry['tag']} has been sitting unpublished as a draft for "
+                f"{hours:.0f} hours. Nobody can download it and nothing is announcing "
+                "it — its asset build most likely failed."
+            )
+    return failures, []
+
+
+# --------------------------------------------------------------------------- #
+
+
+def run(
+    version: str | None,
+    repo_root: Path | None,
+    *,
+    check_drafts: bool = True,
+    rescue_doc_source: str = "released",
+    opener=None,
+) -> Report:
+    report = Report(checked_at=datetime.now(timezone.utc).isoformat())
+
+    if version:
+        report.version = version
+        report.release_url = f"https://github.com/{REPO}/releases/tag/v{version}"
+    else:
+        version, release_url = resolve_latest_version(opener=opener)
+        report.version = version
+        report.release_url = release_url
+    log(f"Newest release: v{report.version} ({report.release_url})")
+
+    # One entry per distinct URL, remembering every place that names it — so a
+    # failure message can say whether it breaks an update, the rescue guide, or both.
+    sources: dict[str, list[str]] = {}
+    for template in ASSET_TEMPLATES:
+        url = DOWNLOAD_URL.format(
+            repo=REPO, version=version, name=template.format(version=version)
+        )
+        sources.setdefault(url, []).append("latest release")
+    rescue_urls, rescue_undetermined = rescue_doc_urls(
+        version, source=rescue_doc_source, repo_root=repo_root, opener=opener
+    )
+    for url in rescue_urls:
+        sources.setdefault(url, []).append(RESCUE_DOC)
+    report.undetermined.extend(rescue_undetermined)
+    log(
+        f"Rescue guide ({rescue_doc_source}): {len(rescue_urls)} download URL(s) "
+        "named by the instructions a stuck user follows."
+    )
+
+    targets = [(url, " + ".join(names)) for url, names in sources.items()]
+
+    log(f"Probing {len(targets)} public download URL(s) over plain HTTPS…")
+    probes, undetermined, bodies = probe_urls(targets, opener=opener)
+    report.probes = probes
+    report.undetermined.extend(undetermined)
+
+    for probe in probes:
+        mark = "ok  " if probe.ok else "FAIL"
+        size = f"{probe.size} bytes" if probe.size is not None else "no body"
+        log(f"  {mark} [{probe.source}] {probe.url.rsplit('/', 1)[-1]} — {size} {probe.detail}")
+
+    # A prober that probed nothing must never look green.
+    if report.probed_count < REQUIRED_ASSET_COUNT:
+        raise Undetermined(
+            f"only assembled {report.probed_count} URLs to probe, expected at least "
+            f"{REQUIRED_ASSET_COUNT}. The prober cannot say it checked the release."
+        )
+
+    for probe in report.failed:
+        report.failures.append(
+            f"{probe.url} — {probe.detail or 'did not serve bytes'} "
+            f"(named by: {probe.source})"
+        )
+
+    verified, checksum_failures = verify_checksum_pairs(bodies, version)
+    report.checksum_pairs_verified = verified
+    report.failures.extend(checksum_failures)
+    log(f"Checksum pairs verified against the served bytes: {verified}")
+
+    if check_drafts:
+        draft_failures, draft_undetermined = stuck_draft_failures()
+        report.failures.extend(draft_failures)
+        report.undetermined.extend(draft_undetermined)
+
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="Probe this version instead of whatever GitHub calls Latest.",
+    )
+    parser.add_argument("--json", dest="json_path", default=None, help="Write a JSON report here.")
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help=f"Repository root, used only with --rescue-doc-source local.",
+    )
+    parser.add_argument(
+        "--rescue-doc-source",
+        choices=("released", "local"),
+        default="released",
+        help=(
+            "Where to read the rescue guide's URLs from. 'released' (default) reads "
+            "it at the release tag over HTTPS and needs no checkout; 'local' reads "
+            "the working copy, which is what a pull request should check."
+        ),
+    )
+    parser.add_argument(
+        "--skip-draft-check",
+        action="store_true",
+        help="Skip the stuck-draft check (which needs an authenticated GitHub CLI).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run(
+            args.version,
+            Path(args.repo_root),
+            check_drafts=not args.skip_draft_check,
+            rescue_doc_source=args.rescue_doc_source,
+        )
+    except Undetermined as error:
+        log("")
+        log(f"COULD NOT CHECK: {error}")
+        log("This says nothing about whether the release is downloadable.")
+        if args.json_path:
+            Path(args.json_path).write_text(
+                json.dumps(
+                    {
+                        "checked_at": datetime.now(timezone.utc).isoformat(),
+                        "outcome": "undetermined",
+                        "undetermined": [str(error)],
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        return 2
+
+    outcome = "ok" if not report.failures else "broken"
+    if args.json_path:
+        payload = asdict(report)
+        payload["outcome"] = outcome
+        payload["probed_count"] = report.probed_count
+        Path(args.json_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        log(f"Wrote the report to {args.json_path}")
+
+    log("")
+    if report.failures:
+        log(
+            f"RELEASE v{report.version} IS NOT FULLY DOWNLOADABLE — "
+            f"{len(report.failures)} problem(s):"
+        )
+        for failure in report.failures:
+            log(f"  • {failure}")
+        if report.undetermined:
+            log("Also could not check:")
+            for item in report.undetermined:
+                log(f"  - {item}")
+        return 1
+
+    log(
+        f"Release v{report.version} is fully downloadable: "
+        f"{report.probed_count} URL(s) served bytes, "
+        f"{report.checksum_pairs_verified} checksum pair(s) matched."
+    )
+    if report.undetermined:
+        log("Could not check (not treated as a failure):")
+        for item in report.undetermined:
+            log(f"  - {item}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_assets.py
+++ b/scripts/check_release_assets.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -79,7 +80,14 @@ STUCK_DRAFT_HOURS = 6
 
 MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024
 TIMEOUT_SECONDS = 60
-USER_AGENT = "dex-release-asset-prober/1"
+
+# Imitate curl, because `curl -fL` is literally what docs/UPDATE-RESCUE.md tells a
+# stuck user to run. GitHub's response varies on `Accept`, so probing with a
+# different Accept header checks a DIFFERENT cache entry than the one a real user
+# hits -- and can return 200 while that user's curl gets 404. Verified against a
+# real release on 2026-08-12, where the two disagreed for ten minutes straight.
+USER_AGENT = "curl/8.5.0"
+ACCEPT = "*/*"
 
 
 @dataclass
@@ -138,7 +146,9 @@ def fetch(url: str, *, opener=None) -> tuple[int, bytes]:
     release.
     """
     opener = opener or _opener()
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    request = urllib.request.Request(
+        url, headers={"User-Agent": USER_AGENT, "Accept": ACCEPT}
+    )
     try:
         with opener.open(request, timeout=TIMEOUT_SECONDS) as response:
             body = response.read(MAX_DOWNLOAD_BYTES + 1)
@@ -239,6 +249,23 @@ def probe_urls(
         probe.status = status
         if status != 200:
             probe.detail = f"HTTP {status} — a user following this link gets nothing."
+            if status == 404:
+                # Distinguish "the file was never attached" from "GitHub cached a
+                # 'not found' it served while the file was still being copied out".
+                # Both break the user; the repair is completely different, so the
+                # alert has to say which one it is.
+                separator = "&" if "?" in url else "?"
+                try:
+                    bust, _ = fetch(f"{url}{separator}cache-bust={uuid.uuid4().hex}", opener=opener)
+                except Undetermined:
+                    bust = None
+                if bust == 200:
+                    probe.detail = (
+                        "HTTP 404 for a normal request, but the file IS there — GitHub "
+                        "is serving a cached 'not found' from while it was still being "
+                        "copied out. It clears by itself; a user retrying later gets the "
+                        "file, but right now they do not."
+                    )
             probes.append(probe)
             continue
         if not body:

--- a/scripts/check_release_assets.py
+++ b/scripts/check_release_assets.py
@@ -419,7 +419,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--repo-root",
         default=str(Path(__file__).resolve().parents[1]),
-        help=f"Repository root, used only with --rescue-doc-source local.",
+        help="Repository root, used only with --rescue-doc-source local.",
     )
     parser.add_argument(
         "--rescue-doc-source",

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Draft-first release publishing, so "public" always implies "complete".
+
+A Dex release has two halves that used to run independently: a workflow that put
+the public release page up in seconds, and a separate job that built the four
+files a stuck copy of Dex downloads to repair itself and attached them only after
+the whole test suite passed. Every release therefore had a public-but-empty
+window, and a red or queued suite left it empty indefinitely. On 2026-08-11
+v1.94.0 sat as the newest release with zero assets for about ninety minutes while
+Dex's own rescue instructions pointed at a download that returned "not found".
+
+This script makes that state unreachable by construction:
+
+  draft    Create (or refresh) the HIDDEN draft release for a version, carrying
+           its CHANGELOG section as the release notes plus a note explaining why
+           it is not public yet. It refuses to modify a release that is already
+           public, so re-running it can never un-publish a real release.
+  publish  Attach the release assets to that draft, prove every one of them by
+           reading the bytes back off the release, and only then flip it public.
+
+The flip is the last thing that happens, and it happens only after the proof.
+
+Every step prints what it actually did -- which assets, how many bytes, which
+checksums matched -- and asserts a floor on those counts. A step that cannot say
+what it verified fails instead of passing quietly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# The four files every release must carry. Dex installs fetch these exact names
+# from the versioned public release; docs/UPDATE-RESCUE.md pastes two of them
+# into a command a stuck user runs by hand.
+ASSET_TEMPLATES = (
+    "dex-vault-bundle-v{version}.tar.gz",
+    "dex-vault-bundle-v{version}.tar.gz.sha256",
+    "dex-update-bridge-v{version}.py",
+    "dex-update-bridge-v{version}.py.sha256",
+)
+
+# Assets whose bytes are covered by a sibling ".sha256" file.
+CHECKSUMMED_TEMPLATES = (
+    "dex-vault-bundle-v{version}.tar.gz",
+    "dex-update-bridge-v{version}.py",
+)
+
+REQUIRED_ASSET_COUNT = len(ASSET_TEMPLATES)
+
+# The draft note lives between these markers so the flip can remove exactly the
+# lines this script added and nothing a human wrote.
+NOTE_START = "<!-- dex-release-draft-note:start -->"
+NOTE_END = "<!-- dex-release-draft-note:end -->"
+
+# A stable version is X.Y.Z; a prerelease carries a suffix (1.62.0-beta.1).
+STABLE_VERSION = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+PRERELEASE_VERSION = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[0-9A-Za-z.]+$"
+)
+
+FLEET_WORKFLOW = "historic-fleet-darwin.yml"
+
+
+class ReleasePublishError(RuntimeError):
+    """A release step refused to continue. The message names the exact reason."""
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+@dataclass(frozen=True)
+class Gh:
+    """Every GitHub call this script makes, in one injectable place.
+
+    Tests substitute a fake with the same three methods, so the decision logic is
+    exercised without a network or a real release.
+    """
+
+    repo: str | None = None
+
+    def _repo_args(self) -> list[str]:
+        return ["--repo", self.repo] if self.repo else []
+
+    def run(self, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["gh"] + args, check=check, capture_output=True, text=True, encoding="utf-8"
+        )
+
+    def release(self, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+        return self.run(["release"] + args + self._repo_args(), check=check)
+
+    def download_asset(self, api_url: str, destination: Path) -> None:
+        """Fetch one asset's bytes through the API, straight to disk.
+
+        The API asset route is used rather than `gh release download` because a
+        DRAFT release is not resolvable by tag on the public route -- and a draft
+        is exactly what this script verifies before making anything public.
+
+        This is the one call that must not go through text mode: a tarball decoded
+        as UTF-8 and re-encoded would not survive the round trip, and the damage
+        would look exactly like a genuine checksum mismatch.
+        """
+        with destination.open("wb") as handle:
+            result = subprocess.run(
+                ["gh", "api", "-H", "Accept: application/octet-stream", api_url],
+                check=False,
+                stdout=handle,
+                stderr=subprocess.PIPE,
+            )
+        if result.returncode != 0:
+            raise ReleasePublishError(
+                f"Could not read back {destination.name} from the release: "
+                f"{(result.stderr or b'').decode('utf-8', 'replace').strip()}"
+            )
+
+
+def asset_names(version: str) -> list[str]:
+    return [template.format(version=version) for template in ASSET_TEMPLATES]
+
+
+def checksummed_names(version: str) -> list[str]:
+    return [template.format(version=version) for template in CHECKSUMMED_TEMPLATES]
+
+
+def validate_version(version: str, channel: str) -> None:
+    if channel == "beta":
+        if not PRERELEASE_VERSION.match(version):
+            raise ReleasePublishError(
+                f"Refusing: beta version '{version}' is not a prerelease "
+                "(expected X.Y.Z-<pre>, e.g. 1.62.0-beta.1). The beta lane must "
+                "carry a prerelease version so it can never overwrite a stable release."
+            )
+        return
+    if not STABLE_VERSION.match(version):
+        raise ReleasePublishError(
+            f"Refusing: stable version '{version}' is not a bare X.Y.Z version."
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def expected_digest(checksum_path: Path) -> str:
+    """Read the hex digest out of a `shasum -a 256` style checksum file."""
+    text = checksum_path.read_text(encoding="utf-8").strip()
+    if not text:
+        raise ReleasePublishError(f"{checksum_path.name} is empty.")
+    field = text.split()[0]
+    if not re.fullmatch(r"[0-9a-f]{64}", field):
+        raise ReleasePublishError(
+            f"{checksum_path.name} does not start with a sha256 digest (saw '{field}')."
+        )
+    return field
+
+
+# --------------------------------------------------------------------------- #
+# Release state
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ReleaseState:
+    exists: bool
+    is_draft: bool = False
+    is_prerelease: bool = False
+    body: str = ""
+    assets: tuple[dict, ...] = ()
+
+    @property
+    def asset_names(self) -> set[str]:
+        return {asset["name"] for asset in self.assets}
+
+
+def read_release(gh: Gh, tag: str) -> ReleaseState:
+    result = gh.release(
+        ["view", tag, "--json", "isDraft,isPrerelease,body,assets"], check=False
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.lower()
+        if "release not found" in stderr or "not found" in stderr:
+            return ReleaseState(exists=False)
+        raise ReleasePublishError(
+            f"Could not read release {tag}: {result.stderr.strip()}"
+        )
+    payload = json.loads(result.stdout)
+    return ReleaseState(
+        exists=True,
+        is_draft=bool(payload.get("isDraft")),
+        is_prerelease=bool(payload.get("isPrerelease")),
+        body=payload.get("body") or "",
+        assets=tuple(payload.get("assets") or []),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The draft note
+# --------------------------------------------------------------------------- #
+
+
+def fleet_proof_in_flight(gh: Gh) -> bool:
+    """Is the macOS historic-updater fleet proof holding the publish lock?
+
+    Both that workflow and the release build take the `stable-public-route`
+    concurrency group without cancelling, so a release cut while the proof runs
+    waits behind it -- up to several hours. The draft says so rather than looking
+    mysteriously stalled.
+    """
+    result = gh.run(
+        [
+            "run",
+            "list",
+            "--workflow",
+            FLEET_WORKFLOW,
+            "--status",
+            "in_progress",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId",
+        ]
+        + (["--repo", gh.repo] if gh.repo else []),
+        check=False,
+    )
+    if result.returncode != 0:
+        # Not knowing is not an error: the note simply omits the queue sentence.
+        log("  note: could not check the fleet proof's status; omitting the queue line.")
+        return False
+    try:
+        runs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return False
+    return bool(runs)
+
+
+def build_note(version: str, *, queued_behind_fleet: bool) -> str:
+    lines = [
+        NOTE_START,
+        "",
+        "---",
+        "",
+        f"**This release is not public yet.** Dex v{version} is being prepared. The "
+        "files people download to update or repair an install are still being built "
+        "and checked, and this page becomes public automatically the moment all of "
+        "them are attached and verified.",
+        "",
+        "Nothing here is downloadable while this note is present, which is "
+        "deliberate: a release is only announced once it is complete.",
+    ]
+    if queued_behind_fleet:
+        lines += [
+            "",
+            "**Waiting on the macOS updater proof.** The long-running rehearsal that "
+            "replays real historic updates is running right now, and it holds the "
+            "single publishing lane while it does. This release is queued behind it "
+            "and can wait a few hours before its files are built. That is expected, "
+            "not a failure.",
+        ]
+    lines += ["", NOTE_END]
+    return "\n".join(lines)
+
+
+def strip_note(body: str) -> str:
+    """Remove the draft note block, leaving everything a human wrote."""
+    while NOTE_START in body and NOTE_END in body:
+        start = body.index(NOTE_START)
+        end = body.index(NOTE_END) + len(NOTE_END)
+        body = body[:start] + body[end:]
+    return body.rstrip() + "\n" if body.strip() else ""
+
+
+# --------------------------------------------------------------------------- #
+# Subcommand: draft
+# --------------------------------------------------------------------------- #
+
+
+def changelog_section(changelog: Path, version: str) -> str:
+    """Pull this version's CHANGELOG entry, which becomes the release notes."""
+    if not changelog.is_file():
+        return ""
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    heading = re.compile(rf"^## \[{re.escape(version)}\]")
+    any_heading = re.compile(r"^## \[")
+    collected: list[str] = []
+    inside = False
+    for line in lines:
+        if heading.match(line):
+            inside = True
+            continue
+        if inside and any_heading.match(line):
+            break
+        if inside:
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def command_draft(args: argparse.Namespace, gh: Gh | None = None) -> int:
+    gh = gh or Gh(repo=args.repo)
+    version = args.version
+    tag = f"v{version}"
+    validate_version(version, args.channel)
+
+    state = read_release(gh, tag)
+
+    if state.exists and not state.is_draft:
+        # The release is already public. Touching it here could only ever make a
+        # real release disappear from view, so this is a hard stop -- reported as
+        # success because the release existing publicly is the desired end state.
+        log(
+            f"{tag} is already public; leaving it completely alone. "
+            f"({len(state.assets)} asset(s) attached.)"
+        )
+        if len(state.assets) < REQUIRED_ASSET_COUNT:
+            log(
+                f"::warning::{tag} is public with only {len(state.assets)} of "
+                f"{REQUIRED_ASSET_COUNT} assets. Run the publish step to repair it."
+            )
+        return 0
+
+    notes = changelog_section(Path(args.changelog), version)
+    if not notes:
+        log(
+            f"::warning::No CHANGELOG section found for [{version}]; "
+            "the draft will carry only the not-public-yet note."
+        )
+    note = build_note(version, queued_behind_fleet=fleet_proof_in_flight(gh))
+    body = f"{notes}\n\n{note}\n" if notes else f"{note}\n"
+
+    with tempfile.TemporaryDirectory() as workdir:
+        body_file = Path(workdir) / "body.md"
+        body_file.write_text(body, encoding="utf-8")
+
+        if not state.exists:
+            create = ["create", tag, "--title", tag, "--draft", "--notes-file", str(body_file)]
+            if args.channel == "beta":
+                create.append("--prerelease")
+            if args.target:
+                create += ["--target", args.target]
+            result = gh.release(create, check=False)
+            if result.returncode != 0:
+                raise ReleasePublishError(
+                    f"Could not create the draft release {tag}: {result.stderr.strip()}"
+                )
+            log(f"Created {tag} as a HIDDEN DRAFT with its CHANGELOG notes.")
+        else:
+            result = gh.release(
+                ["edit", tag, "--notes-file", str(body_file)], check=False
+            )
+            if result.returncode != 0:
+                raise ReleasePublishError(
+                    f"Could not refresh the draft release {tag}: {result.stderr.strip()}"
+                )
+            log(f"Refreshed the existing DRAFT {tag} with its CHANGELOG notes.")
+
+    after = read_release(gh, tag)
+    if not after.exists or not after.is_draft:
+        raise ReleasePublishError(
+            f"{tag} should be a draft after this step but reads back as "
+            f"exists={after.exists} draft={after.is_draft}."
+        )
+    log(f"Verified: {tag} exists and is a draft. Nothing is publicly downloadable yet.")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Subcommand: publish
+# --------------------------------------------------------------------------- #
+
+
+def verify_local_assets(
+    dist: Path, version: str, extras: list[Path] | None = None
+) -> list[Path]:
+    """Every expected file is present, non-empty, and matches its checksum."""
+    paths = []
+    for name in asset_names(version):
+        path = dist / name
+        if not path.is_file():
+            raise ReleasePublishError(f"Built asset is missing: {path}")
+        if path.stat().st_size == 0:
+            raise ReleasePublishError(f"Built asset is empty: {path}")
+        paths.append(path)
+
+    for path in extras or []:
+        if not path.is_file():
+            raise ReleasePublishError(f"Extra release asset is missing: {path}")
+        if path.stat().st_size == 0:
+            raise ReleasePublishError(f"Extra release asset is empty: {path}")
+        log(f"  local ok (extra): {path.name} ({path.stat().st_size} bytes)")
+
+    checked = 0
+    for name in checksummed_names(version):
+        artifact = dist / name
+        checksum = dist / f"{name}.sha256"
+        actual = sha256_file(artifact)
+        wanted = expected_digest(checksum)
+        if actual != wanted:
+            raise ReleasePublishError(
+                f"{name} does not match {checksum.name}: built {actual}, expected {wanted}."
+            )
+        checked += 1
+        log(f"  local ok: {name} ({artifact.stat().st_size} bytes) sha256={actual[:12]}…")
+
+    if checked != len(CHECKSUMMED_TEMPLATES):
+        raise ReleasePublishError(
+            f"Checked {checked} local checksums, expected {len(CHECKSUMMED_TEMPLATES)}."
+        )
+    log(f"Local proof: {len(paths)} assets present, {checked} checksums matched.")
+    return paths
+
+
+def verify_attached_assets(
+    gh: Gh, tag: str, dist: Path, version: str, extras: list[Path] | None = None
+) -> int:
+    """Read every asset back off the release and prove it is the built byte.
+
+    Asset presence in the API listing is not enough: an interrupted upload leaves
+    a truncated or `state: starting` asset that still appears by name. This reads
+    the bytes GitHub will serve and compares them to what was built.
+    """
+    state = read_release(gh, tag)
+    if not state.exists:
+        raise ReleasePublishError(f"{tag} does not exist; nothing to verify.")
+
+    # Extra assets (for example the signed Dex Lens catalog) are verified exactly
+    # like the core four; they simply do not count toward the required floor.
+    extra_by_name = {path.name: path for path in extras or []}
+    expected = asset_names(version) + sorted(extra_by_name)
+    missing = [name for name in expected if name not in state.asset_names]
+    if missing:
+        raise ReleasePublishError(
+            f"{tag} is missing {len(missing)} of {len(expected)} assets: {', '.join(missing)}"
+        )
+
+    by_name = {asset["name"]: asset for asset in state.assets}
+    verified = 0
+    pairs = 0
+    with tempfile.TemporaryDirectory() as workdir:
+        readback = Path(workdir)
+        for name in expected:
+            asset = by_name[name]
+            asset_state = asset.get("state")
+            if asset_state and asset_state != "uploaded":
+                raise ReleasePublishError(
+                    f"{name} is attached but its state is '{asset_state}', not 'uploaded'."
+                )
+            local = extra_by_name.get(name) or (dist / name)
+            if asset.get("size") != local.stat().st_size:
+                raise ReleasePublishError(
+                    f"{name} is attached with {asset.get('size')} bytes but the built "
+                    f"file is {local.stat().st_size} bytes."
+                )
+            destination = readback / name
+            gh.download_asset(asset["apiUrl"], destination)
+            served = sha256_file(destination)
+            built = sha256_file(local)
+            if served != built:
+                raise ReleasePublishError(
+                    f"{name} on the release does not match what was built: "
+                    f"served {served}, built {built}."
+                )
+            verified += 1
+            log(f"  attached ok: {name} ({asset.get('size')} bytes) sha256={served[:12]}…")
+
+        # The two checksum files must describe the artefacts as SERVED, not just
+        # as built -- that is the pair a stuck user's `shasum -c` actually runs.
+        for name in checksummed_names(version):
+            artifact = readback / name
+            checksum = readback / f"{name}.sha256"
+            if sha256_file(artifact) != expected_digest(checksum):
+                raise ReleasePublishError(
+                    f"As served from the release, {name} does not match its "
+                    f"{checksum.name}. A user running `shasum -c` would see a failure."
+                )
+            pairs += 1
+            log(f"  served checksum pair ok: {name} + {name}.sha256")
+
+    if verified != len(expected):
+        raise ReleasePublishError(
+            f"Verified {verified} assets, expected exactly {len(expected)}."
+        )
+    if verified < REQUIRED_ASSET_COUNT:
+        raise ReleasePublishError(
+            f"Verified {verified} assets, below the required floor of "
+            f"{REQUIRED_ASSET_COUNT}."
+        )
+    if pairs != len(CHECKSUMMED_TEMPLATES):
+        raise ReleasePublishError(
+            f"Verified {pairs} served checksum pairs, expected {len(CHECKSUMMED_TEMPLATES)}."
+        )
+    log(
+        f"Attached proof: {verified} assets ({REQUIRED_ASSET_COUNT} required + "
+        f"{len(extra_by_name)} extra) read back off {tag} and byte-identical to the "
+        f"build; {pairs} checksum pairs verified."
+    )
+    return verified
+
+
+def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
+    gh = gh or Gh(repo=args.repo)
+    version = args.version
+    tag = f"v{version}"
+    validate_version(version, args.channel)
+    dist = Path(args.dist)
+    extras = [Path(item) for item in (args.extra_asset or [])]
+
+    log(f"Publishing {tag} ({args.channel} channel) from {dist}")
+    if extras:
+        log(f"  plus {len(extras)} extra asset(s): {', '.join(p.name for p in extras)}")
+    log("Step 1/5 — proving the built assets locally")
+    verify_local_assets(dist, version, extras)
+
+    log("Step 2/5 — making sure a release exists to attach them to")
+    state = read_release(gh, tag)
+    if not state.exists:
+        # The draft step normally runs first, from the tag-push workflow. If it
+        # did not run at all, create the draft here so the assets still land on a
+        # hidden release rather than a public empty one.
+        log(f"  {tag} does not exist yet; creating it as a hidden draft.")
+        create = ["create", tag, "--title", tag, "--draft", "--generate-notes"]
+        if args.channel == "beta":
+            create.append("--prerelease")
+        if args.target:
+            create += ["--target", args.target]
+        result = gh.release(create, check=False)
+        if result.returncode != 0:
+            raise ReleasePublishError(
+                f"Could not create the draft release {tag}: {result.stderr.strip()}"
+            )
+        state = read_release(gh, tag)
+    elif state.is_draft:
+        log(f"  {tag} exists as a draft, as expected.")
+    else:
+        # Already public. This is the state the whole change exists to prevent,
+        # but it can still be reached by a release cut before this change landed.
+        # Repairing it is strictly better than refusing.
+        log(
+            f"::warning::{tag} is ALREADY PUBLIC with {len(state.assets)} asset(s) "
+            "before its assets were verified. Attaching and verifying them now as a "
+            "repair; the draft-first path was bypassed for this release."
+        )
+
+    if args.channel == "beta" and state.exists and not state.is_prerelease:
+        raise ReleasePublishError(
+            f"Refusing: release {tag} exists but is not a prerelease; the beta lane "
+            "will not clobber it."
+        )
+
+    log("Step 3/5 — attaching the assets")
+    upload = (
+        ["upload", tag]
+        + [str(dist / name) for name in asset_names(version)]
+        + [str(path) for path in extras]
+        + ["--clobber"]
+    )
+    result = gh.release(upload, check=False)
+    if result.returncode != 0:
+        raise ReleasePublishError(
+            f"Could not attach assets to {tag}: {result.stderr.strip()}"
+        )
+    log(f"  attached {REQUIRED_ASSET_COUNT + len(extras)} assets to {tag}.")
+
+    log("Step 4/5 — reading every asset back off the release")
+    verify_attached_assets(gh, tag, dist, version, extras)
+
+    log("Step 5/5 — making the release public")
+    current = read_release(gh, tag)
+    with tempfile.TemporaryDirectory() as workdir:
+        body_file = Path(workdir) / "body.md"
+        body_file.write_text(strip_note(current.body), encoding="utf-8")
+        edit = ["edit", tag, "--draft=false", "--notes-file", str(body_file)]
+        if args.channel == "beta":
+            edit.append("--prerelease")
+        else:
+            edit += ["--prerelease=false", "--latest"]
+        result = gh.release(edit, check=False)
+        if result.returncode != 0:
+            raise ReleasePublishError(
+                f"Assets are verified but {tag} could not be made public: "
+                f"{result.stderr.strip()}"
+            )
+
+    final = read_release(gh, tag)
+    if final.is_draft:
+        raise ReleasePublishError(f"{tag} still reads as a draft after the flip.")
+    still_missing = [
+        name
+        for name in asset_names(version) + [path.name for path in extras]
+        if name not in final.asset_names
+    ]
+    if still_missing:
+        raise ReleasePublishError(
+            f"{tag} went public but is missing {', '.join(still_missing)}. "
+            "This should be impossible; treat it as a publishing bug."
+        )
+    if NOTE_START in final.body:
+        raise ReleasePublishError(
+            f"{tag} is public but still carries the not-public-yet note."
+        )
+    log(
+        f"PUBLISHED {tag}: public, {len(final.asset_names)} assets attached, all "
+        f"{REQUIRED_ASSET_COUNT} verified byte-for-byte before the flip."
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=os.environ.get("GH_REPO") or None)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    draft = subparsers.add_parser(
+        "draft", help="Create or refresh the hidden draft release for a version."
+    )
+    draft.add_argument("--version", required=True)
+    draft.add_argument("--channel", choices=("stable", "beta"), default="stable")
+    draft.add_argument("--changelog", default="CHANGELOG.md")
+    draft.add_argument("--target", default=None)
+    draft.set_defaults(handler=command_draft)
+
+    publish = subparsers.add_parser(
+        "publish",
+        help="Attach assets to the draft, verify them, then make the release public.",
+    )
+    publish.add_argument("--version", required=True)
+    publish.add_argument("--channel", choices=("stable", "beta"), default="stable")
+    publish.add_argument("--dist", default="dist")
+    publish.add_argument(
+        "--extra-asset",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "An additional file to attach and verify alongside the four required "
+            "assets (for example the signed Dex Lens catalogue). Repeatable. Extras "
+            "go through the same read-back proof and are attached before the release "
+            "is made public, so nothing appears on a release after it goes live."
+        ),
+    )
+    publish.add_argument("--target", default=None)
+    publish.set_defaults(handler=command_publish)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if shutil.which("gh") is None:
+        log("Refusing: the GitHub CLI (gh) is not on PATH.")
+        return 1
+    try:
+        return args.handler(args)
+    except ReleasePublishError as error:
+        log(f"Release step stopped safely: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -32,10 +32,14 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -69,6 +73,10 @@ PRERELEASE_VERSION = re.compile(
 )
 
 FLEET_WORKFLOW = "historic-fleet-darwin.yml"
+
+# GitHub applies release flag changes asynchronously; re-read before believing.
+SETTLE_ATTEMPTS = 5
+SETTLE_SECONDS = 3.0
 
 
 class ReleasePublishError(RuntimeError):
@@ -510,6 +518,153 @@ def verify_attached_assets(
     return verified
 
 
+def public_download_url(repo: str, version: str, name: str) -> str:
+    return f"https://github.com/{repo}/releases/download/v{version}/{name}"
+
+
+def fetch_public_status(url: str) -> int:
+    """HTTP status from the anonymous public route, following redirects.
+
+    The headers deliberately imitate `curl`, because `curl -fL` is literally what
+    docs/UPDATE-RESCUE.md tells a stuck user to run. GitHub's response varies on
+    `Accept`, so probing with a different Accept header checks a different cache
+    entry than the one a real user hits -- and can return 200 while the user's
+    curl gets 404. Verified on 2026-08-12 against a real release.
+    """
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "curl/8.5.0", "Accept": "*/*"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response.read(1)
+            return response.status
+    except urllib.error.HTTPError as error:
+        return error.code
+    except (urllib.error.URLError, TimeoutError):
+        return 0
+
+
+def verify_public_route(
+    gh: Gh,
+    tag: str,
+    version: str,
+    extras: list[Path] | None = None,
+    *,
+    repo: str | None = None,
+    attempts: int = 10,
+    sleep_seconds: float = 6.0,
+    sleeper=None,
+    status_reader=None,
+) -> None:
+    """Confirm the anonymous download route serves every asset, and hide it if not.
+
+    The read-back proof in step 4 goes through the authenticated API. On
+    2026-08-12 that proof passed while the public URL for one asset still returned
+    404 for several seconds -- GitHub's public route lags the API. Checking only the
+    API would therefore let a release go live moments before it is downloadable,
+    which is a smaller version of the exact bug this whole change exists to remove.
+
+    If the public route never comes good, the release is put back to a hidden draft:
+    an invisible release is always better than a visible broken one.
+    """
+    sleeper = sleeper or time.sleep
+    status_reader = status_reader or fetch_public_status
+    repo = repo or gh.repo or _origin_repo()
+    if not repo:
+        log(
+            "::warning::Could not work out the repository name, so the public "
+            "download route was not checked."
+        )
+        return
+
+    names = asset_names(version) + [path.name for path in (extras or [])]
+    pending = [(name, public_download_url(repo, version, name)) for name in names]
+    confirmed: list[str] = []
+
+    for attempt in range(1, attempts + 1):
+        still_pending = []
+        for name, url in pending:
+            status = status_reader(url)
+            if status == 200:
+                confirmed.append(name)
+                log(f"  public ok: {name} (HTTP 200 anonymously)")
+            else:
+                still_pending.append((name, url))
+        pending = still_pending
+        if not pending:
+            break
+        if attempt < attempts:
+            log(
+                f"  {len(pending)} asset(s) not yet served publicly; waiting "
+                f"{sleep_seconds:g}s (attempt {attempt}/{attempts})…"
+            )
+            sleeper(sleep_seconds)
+
+    if pending:
+        # Distinguish two very different situations before doing anything drastic.
+        # A stale cached 404 (GitHub briefly served "not found" while the asset was
+        # propagating, and that answer got cached for this request shape) still has
+        # a perfectly good asset behind it, and it expires on its own. Hiding the
+        # release for that would be an over-reaction; hiding it for a genuinely
+        # absent asset is exactly right.
+        stale, genuinely_missing = [], []
+        for name, url in pending:
+            separator = "&" if "?" in url else "?"
+            if status_reader(f"{url}{separator}cache-bust={secrets.token_hex(6)}") == 200:
+                stale.append(name)
+            else:
+                genuinely_missing.append(name)
+
+        for name in stale:
+            log(
+                f"::warning::{name} is present and downloadable, but the public URL is "
+                "currently answering with a cached 'not found' from while it was still "
+                "being copied out. That cache entry expires by itself; a user retrying "
+                "in a few minutes gets the file."
+            )
+
+        if genuinely_missing:
+            stuck = ", ".join(genuinely_missing)
+            log(f"::error::{tag} is public but {stuck} does not download. Hiding it again.")
+            gh.release(["edit", tag, "--draft=true"], check=False)
+            state = read_release(gh, tag)
+            hidden = "hidden again" if state.is_draft else "STILL PUBLIC — fix by hand"
+            raise ReleasePublishError(
+                f"{tag} went public but the public download route never served: {stuck}. "
+                f"The release was {hidden}."
+            )
+        confirmed.extend(stale)
+
+    if len(confirmed) != len(names):
+        raise ReleasePublishError(
+            f"Confirmed {len(confirmed)} public downloads, expected {len(names)}."
+        )
+    log(
+        f"Public proof: all {len(confirmed)} assets download anonymously from the "
+        f"real release URLs — the route a stuck copy of Dex actually uses."
+    )
+
+
+def _origin_repo() -> str | None:
+    """`owner/name` from the git remote, so the public URLs can be built."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
+    return match.group(1) if match else None
+
+
 def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
     gh = gh or Gh(repo=args.repo)
     version = args.version
@@ -577,26 +732,65 @@ def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
     log("Step 4/5 — reading every asset back off the release")
     verify_attached_assets(gh, tag, dist, version, extras)
 
-    log("Step 5/5 — making the release public")
+    log("Step 5/6 — making the release public")
     current = read_release(gh, tag)
+    want_prerelease = args.channel == "beta"
     with tempfile.TemporaryDirectory() as workdir:
         body_file = Path(workdir) / "body.md"
         body_file.write_text(strip_note(current.body), encoding="utf-8")
-        edit = ["edit", tag, "--draft=false", "--notes-file", str(body_file)]
-        if args.channel == "beta":
-            edit.append("--prerelease")
-        else:
-            edit += ["--prerelease=false", "--latest"]
-        result = gh.release(edit, check=False)
+        # Two separate calls, deliberately. Observed on 2026-08-12 against a real
+        # release: setting the prerelease flag in the SAME `gh release edit` as
+        # `--draft=false` left the release marked as not-a-prerelease, which for the
+        # beta lane would present a beta build to everyone as the current version.
+        # Applied on its own, the flag sticks. So: set the notes and the flags while
+        # the release is still hidden, then flip it public as its own operation.
+        flags = ["edit", tag, "--notes-file", str(body_file)]
+        flags.append("--prerelease=true" if want_prerelease else "--prerelease=false")
+        if not want_prerelease:
+            flags.append("--latest")
+        result = gh.release(flags, check=False)
+        if result.returncode != 0:
+            raise ReleasePublishError(
+                f"Could not set the release flags on {tag}: {result.stderr.strip()}"
+            )
+
+        result = gh.release(["edit", tag, "--draft=false"], check=False)
         if result.returncode != 0:
             raise ReleasePublishError(
                 f"Assets are verified but {tag} could not be made public: "
                 f"{result.stderr.strip()}"
             )
 
+    # GitHub settles these fields asynchronously, so read the end state more than
+    # once rather than trusting the first answer. The first read after the flip has
+    # been seen reporting a value that later changed.
     final = read_release(gh, tag)
+    for _ in range(SETTLE_ATTEMPTS):
+        if not final.is_draft and final.is_prerelease == want_prerelease:
+            break
+        time.sleep(SETTLE_SECONDS)
+        final = read_release(gh, tag)
+
     if final.is_draft:
         raise ReleasePublishError(f"{tag} still reads as a draft after the flip.")
+    if final.is_prerelease != want_prerelease:
+        # Repair rather than refuse: a beta release that is not marked as a
+        # prerelease can be presented to everyone as the current version.
+        log(
+            f"::warning::{tag} came back with prerelease={final.is_prerelease}, "
+            f"expected {want_prerelease}. Correcting it."
+        )
+        gh.release(
+            ["edit", tag, "--prerelease=true" if want_prerelease else "--prerelease=false"],
+            check=False,
+        )
+        time.sleep(SETTLE_SECONDS)
+        final = read_release(gh, tag)
+        if final.is_prerelease != want_prerelease:
+            raise ReleasePublishError(
+                f"{tag} is public but its prerelease flag is {final.is_prerelease}, "
+                f"and it could not be set to {want_prerelease}."
+            )
     still_missing = [
         name
         for name in asset_names(version) + [path.name for path in extras]
@@ -607,6 +801,9 @@ def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
             f"{tag} went public but is missing {', '.join(still_missing)}. "
             "This should be impossible; treat it as a publishing bug."
         )
+
+    log("Step 6/6 — proving the PUBLIC download route actually serves the files")
+    verify_public_route(gh, tag, version, extras)
     if NOTE_START in final.body:
         raise ReleasePublishError(
             f"{tag} is public but still carries the not-public-yet note."


### PR DESCRIPTION
## What this fixes

A release used to go public within seconds, while the four files people download to update or repair Dex were built by a **separate job** and attached later. Every release therefore had a public-but-empty window, and a red or queued suite left it empty indefinitely.

That is exactly what happened to **v1.94.0** on 2026-08-11: newest release, zero assets, for ~90 minutes — while `docs/UPDATE-RESCUE.md` pointed at a download that returned "not found". The person most likely to hit that is someone whose update is already broken.

This was never a bug inside one script. It was two workflows each doing something reasonable on its own.

## Half 1 — draft-first publishing

- `release.yml` now creates a **hidden draft** carrying the CHANGELOG entry, and never publishes. It refuses to touch an already-public release, so re-running it can never pull a live release back into draft.
- `ci.yml`'s two release lanes attach the assets, **read every one back off the release**, compare to what was built, and only then flip public. The flip is the last thing that happens.
- The Dex Lens catalogue now rides along as a verified extra asset instead of being uploaded *after* the flip, so nothing can appear on an already-live release.
- The beta lane's two safety guards moved from workflow bash into `scripts/release_publish.py`, where they are unit-tested rather than only read.
- While the macOS updater proof holds the single publish lane (`stable-public-route`, up to ~4.5h), the draft **says so in its own body**, so a queued release reads as waiting rather than broken. The note is stripped at flip time.

## Half 2 — rescue-URL prober

`scripts/check_release_assets.py`, scheduled hourly by `release-asset-prober.yml`, fetches the **real public URLs over anonymous HTTPS**:

1. the newest release's four assets, and
2. every download URL written into `docs/UPDATE-RESCUE.md` **as shipped at the release tag** — the exact thing a stuck user pastes into a terminal.

It verifies HTTP 200, non-empty bodies, and that each checksum file matches the bytes actually served. It **distinguishes "the release is broken" (exit 1) from "I could not tell" (exit 2)**, so a network blip never files a false alarm, and it refuses to report success if it assembled too few URLs to probe. It also reports a release left in draft for hours — draft-first's own failure mode.

## Two real defects the throwaway-tag proof surfaced

Proving this end-to-end on a disposable prerelease caught two things no amount of review would have:

1. **The public route lags the API.** An asset verified as attached and byte-identical *through the authenticated API* still returned 404 anonymously for seconds. Publishing now waits for every asset to download anonymously, and **hides the release again** if it never does.
2. **GitHub varies on `Accept`.** A probe that does not send what `curl` sends checks a *different cached answer* than the user gets. Observed for ten minutes straight: `curl` got 404 while a differently-shaped request got 200 for the same URL. Both checks now imitate `curl` (what UPDATE-RESCUE tells users to run) and separate a stale cached 404 from a genuinely missing file.

Also fixed: setting the prerelease flag in the same `gh` call as `--draft=false` **silently dropped it** — which would have presented a beta build to everyone as the current version.

## Verification

Proven end-to-end on throwaway tags `v0.0.0-pipelinetest` / `-pipelinetest2`, then deleted:

- draft created → release page and asset both **404 to the public** (old flow: HTTP 200, zero assets)
- prober pointed at the assetless draft → **exit 1, 4 failures reported**
- publish → 4 attached, 4 read back byte-identical, 2 checksum pairs, 4 confirmed downloading anonymously → flipped public
- final state `draft=false prerelease=true assets=4`; all four **HTTP 200 via plain `curl`**
- prober against the published release → **exit 0**, 6 URLs served, 2 checksum pairs
- both releases + tags deleted; `Latest` never left **v1.94.0**

**No real release or tag was created, edited, or deleted.**

70 new/updated tests. The workflow-shape tests fail if anyone reintroduces a bare `gh release create` without `--draft`, a bare `gh release upload`, or a `--draft=false` outside the verified script.

## Note for review

Alert delivery to the Decision Desk lives in **bb-lab**, not here: dex-core's founder-content gate blocks the machine paths it needs, and this repo's issue tracker is public/user-facing only, so filing internal alerts here is off-limits per `AGENTS.md`. The GitHub workflow's own signal is a red scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)