### PR TITLE
Stop a later merge cancelling the run that builds a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,29 @@ on:
   # Merge queue: CI validates the QUEUED BATCH exactly as it will land on main,
   # then everything in the batch merges together on one green run.
   merge_group:
-# A superseded push to the same PR/branch cancels its stale in-flight run.
+# A superseded push to the same PULL REQUEST cancels its stale in-flight run.
+# Nothing else is ever cancelled.
+#
+# The grouping carries that rule, rather than a boolean expression deciding it. A
+# pull request groups by its number, so its own later pushes supersede it. Every
+# other run — main, beta, tags, the merge queue — groups by its unique run id, so it
+# shares a group with nothing and cannot be cancelled by anything.
+#
+# This was previously expressed as `cancel-in-progress: ${{ github.event_name ==
+# 'pull_request' }}` over a group keyed on `github.ref`, which meant every push to
+# main shared one group. Observed on 2026-08-12: 10 of the last 15 main runs ended
+# `cancelled`, each at the exact second the next merge created its run, with no jobs
+# ever scheduled. That matters well beyond wasted minutes — `build-release` only runs
+# on main, so a main run cancelled by a later merge is a release whose download files
+# are never built. Draft-first publishing makes that state safe (the release stays a
+# hidden draft and the prober flags it) but safe is not the same as shipped.
+#
+# Serialising the actual release work does not depend on this: the `build-release`
+# job holds the `stable-public-route` concurrency lock with `cancel-in-progress:
+# false`, so concurrent main runs still queue behind each other for publishing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   # Gates, JS suites, lint, and static checks. The Python test suite runs in the
   # sharded `tests` matrix below; its thresholds are enforced by `test-results`.

--- a/core/tests/test_ci_concurrency_never_cancels_main.py
+++ b/core/tests/test_ci_concurrency_never_cancels_main.py
@@ -1,0 +1,86 @@
+"""A later merge must never cancel a run that could be building a release.
+
+`build-release` runs only on pushes to main. If a main run is cancelled by the next
+merge, that release's download files are never built. Draft-first publishing makes
+the result safe -- the release stays a hidden draft and the prober flags it -- but a
+release nobody ships is still a release nobody gets.
+
+Observed on 2026-08-12 before this was fixed: 10 of the last 15 main runs ended
+`cancelled`, each at the exact second the following merge created its run, with no
+jobs ever scheduled.
+
+The rule is carried by the concurrency GROUP, not by a boolean expression: a pull
+request groups by its number so its own later pushes supersede it, and every other
+run groups by its unique run id so it shares a group with nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+FLEET_WORKFLOW = REPO_ROOT / ".github/workflows/historic-fleet-darwin.yml"
+
+
+def _ci() -> dict:
+    return yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_non_pull_request_runs_are_alone_in_their_concurrency_group() -> None:
+    group = _ci()["concurrency"]["group"]
+    assert "github.event.pull_request.number" in group, (
+        "pull requests must group by number so their own pushes supersede each other"
+    )
+    assert "github.run_id" in group, (
+        "everything that is not a pull request must group by its unique run id, so a "
+        "later merge cannot cancel a run that might be building a release"
+    )
+    assert "github.ref" not in group, (
+        "grouping by ref puts every push to main in ONE group, which is exactly how "
+        "main runs were cancelling each other"
+    )
+
+
+def test_the_cancel_rule_is_a_literal_not_an_expression() -> None:
+    """An expression here decides a boolean; a wrong answer silently kills releases.
+
+    With the group above, `true` is safe: only pull-request runs ever share a group.
+    """
+    cancel = _ci()["concurrency"]["cancel-in-progress"]
+    assert cancel is True, (
+        "expected a literal true (safe, because only pull requests share a group); "
+        f"saw {cancel!r}"
+    )
+
+
+def test_ci_matches_the_idiom_the_fleet_workflow_already_uses() -> None:
+    """The repo already had this right in one place; the two should not diverge."""
+    fleet_group = yaml.safe_load(FLEET_WORKFLOW.read_text(encoding="utf-8"))["concurrency"][
+        "group"
+    ]
+    for token in ("github.event.pull_request.number", "github.run_id"):
+        assert token in fleet_group
+        assert token in _ci()["concurrency"]["group"]
+
+
+def test_the_release_lane_is_still_serialised_by_its_own_lock() -> None:
+    """Run-level serialisation was never what kept two releases apart.
+
+    Publishing is serialised by the job-level `stable-public-route` lock, which does
+    not cancel. Concurrent main runs are therefore safe.
+    """
+    build_release = _ci()["jobs"]["build-release"]
+    assert build_release["concurrency"] == {
+        "group": "stable-public-route",
+        "cancel-in-progress": False,
+    }
+
+
+def test_build_release_still_only_runs_on_main_pushes() -> None:
+    """The premise of this whole file: main is the only place releases get built."""
+    condition = _ci()["jobs"]["build-release"]["if"]
+    assert "refs/heads/main" in condition
+    assert "github.event_name == 'push'" in condition


### PR DESCRIPTION
Follow-up commissioned by Front Desk from the finding flagged in #475.

## The problem, with evidence

`build-release` runs **only** on pushes to `main`. Every push to main shared one concurrency group (keyed on `github.ref`), and whether they cancelled each other was decided by `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.

Measured on 2026-08-12: **10 of the last 15 main runs ended `cancelled`**, and the two I inspected at API level had **no jobs ever scheduled**, each cancelled at the *exact second* the following merge created its run:

| run | created | cancelled | next run created |
|---|---|---|---|
| 31553282570 | 01:20:33Z | 01:37:00Z | 01:36:59Z |
| 31554187852 | 01:36:59Z | 01:46:49Z | 01:46Z |

On a busy merge night that is a release whose download files are never built. Draft-first publishing (#475) already makes the *outcome* safe — the release stays a hidden draft instead of going public empty, and the hourly prober flags it after six hours — but safe is not shipped, and the delay is silent.

## Which fix, and why this one

Front Desk offered a choice: fix the concurrency expression, or make `build-release` re-runnable/resilient. **The concurrency fix is the cleaner of the two**, because:

1. It addresses the cause rather than the symptom. Resilience would leave every main run still being cancelled — we would just get better at recovering from a thing that should not happen.
2. `build-release` is *already* resilient, as of #475: `release_guard` skips an already-published version, and the draft-first path means a re-run repairs a half-finished release rather than duplicating it. Adding more recovery machinery would be building a second answer to a question that stops being asked.
3. The repo already has the correct idiom — `historic-fleet-darwin.yml` groups by `pull_request.number || run_id`. This aligns ci.yml with it rather than inventing anything.

## The change

The rule now lives in the **group**, not in a boolean expression — which is correct *however* that expression would have evaluated, so it removes the ambiguity rather than betting on a reading of it:

- a pull request groups by its **number**, so its own later pushes supersede it (the behaviour actually wanted, unchanged);
- every other run — main, beta, tags, merge queue — groups by its unique **run id**, so it shares a group with nothing and cannot be cancelled by anything.

`cancel-in-progress: true` is then a literal, and safe, because only pull-request runs ever share a group.

## Why concurrent main runs are fine

Serialising the release work never depended on this. `build-release` holds the job-level `stable-public-route` lock with `cancel-in-progress: false`, so publishing still queues behind the macOS updater proof and behind any other release build. That lock is asserted by both `test_historic_fleet_darwin_workflow.py` and the new test here.

## Verification

`core/tests/test_ci_concurrency_never_cancels_main.py` — **demonstrated failing against the old block before being committed**: 3 of its 5 assertions go red on the previous configuration, and all 5 pass on this one. It also pins the release lock and the fact that `build-release` is main-push-only, which is the premise the whole file rests on.

No CHANGELOG entry: CI-internal, no user-visible behaviour change, consistent with this repo's other CI-only commits (`5eaa52d5`, `21ba5a2c`).

**Holding for Front Desk review — not self-merging; this touches release reliability.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)