### PR TITLE
ci: catch non-canonical dist/archive tags in the 2-minute quality job, not 4.5h into historic-fleet-darwin

### DIFF
--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -122,6 +122,54 @@ def test_gate_reports_every_new_version_with_duplicate_tags(tmp_path: Path) -> N
     assert "v1.79.0" in result.stderr
 
 
+def test_gate_rejects_non_canonical_archive_tag_without_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # The executor requires exactly 7 hex characters in a dist/archive tag and
+    # only says so per-journey, hours into historic-fleet-darwin. A lone
+    # non-canonical start must fail here instead.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/archive/v1.81.12-3a8245ab",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "dist/archive/v1.81.12-3a8245ab" in result.stderr
+    assert "no canonical twin" in result.stderr
+    assert "Remedy: create dist/archive/v1.81.12-" in result.stderr
+    assert "Delete nothing" in result.stderr
+
+
+def test_gate_accepts_non_canonical_archive_tag_with_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # Discovery de-duplicates journeys by tree, so a canonical tag at the same
+    # commit already shadows the non-canonical one. That is today's tag set.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/archive/v1.81.12-3a8245ab",
+        "dist/archive/v1.81.12-3a8245a",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def _newer_release_tags(count: int) -> tuple[str, ...]:
     return tuple(
         f"dist/release/v1.{minor}.0-{minor:07x}"

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -42,4 +42,75 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
+# dist/archive tags are the historic fleet's starting points. Discovery
+# (scripts/release_fleet.py ARCHIVE_RELEASE_TAG) accepts a 7-64 hex suffix, but
+# the executor (scripts/release_fleet_executor.py _ARCHIVE_RELEASE_TAG) requires
+# exactly 7 and raises "starting release identity is malformed" per journey,
+# hours into the 4.5h historic-fleet-darwin run. Catch it here in seconds.
+#
+# Discovery de-duplicates journeys by tree, so a non-canonical tag that has a
+# canonical twin at the same commit is already shadowed and can never be picked
+# as a starting point. Fail only on a lone non-canonical tag.
+ARCHIVE_TAGS="$(
+  git ls-remote --tags origin 'refs/tags/dist/archive/v*'
+)"
+
+UNTWINNED_ARCHIVE_TAGS="$(
+  printf '%s\n' "$ARCHIVE_TAGS" |
+    awk '
+      # An annotated tags peeled ^{} ref carries the commit the tag resolves
+      # to; the bare ref carries the tag object. Prefer the peeled value so
+      # twins pointing at one commit compare equal.
+      {
+        ref = $2
+        peeled = (ref ~ /\^\{\}$/)
+        sub(/\^\{\}$/, "", ref)
+        if (ref !~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/) {
+          next
+        }
+        if (peeled || !(ref in commit)) {
+          commit[ref] = $1
+        }
+      }
+      END {
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            canonical[commit[ref]] = 1
+          }
+        }
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            continue
+          }
+          if (commit[ref] in canonical) {
+            continue
+          }
+          tag = ref
+          sub(/^refs\/tags\//, "", tag)
+          print tag, commit[ref]
+        }
+      }
+    ' |
+    sort
+)"
+
+ARCHIVE_FAILED=0
+while read -r TAG COMMIT; do
+  [ -n "${TAG:-}" ] || continue
+  ARCHIVE_VERSION="${TAG#dist/archive/v}"
+  ARCHIVE_VERSION="${ARCHIVE_VERSION%%-*}"
+  CANONICAL_SHORT="$(printf '%s' "$COMMIT" | cut -c1-7)"
+  echo "❌ $TAG (commit $COMMIT) is a non-canonical dist/archive tag with no canonical twin at that commit." >&2
+  echo "The fleet executor requires exactly 7 hex characters in a dist/archive tag, so this start fails hours into historic-fleet-darwin." >&2
+  echo "Remedy: create dist/archive/v$ARCHIVE_VERSION-$CANONICAL_SHORT at $COMMIT. Delete nothing — the existing tag stays, and discovery's tree de-duplication will shadow it." >&2
+  ARCHIVE_FAILED=1
+done <<EOF
+$UNTWINNED_ARCHIVE_TAGS
+EOF
+
+if [ "$ARCHIVE_FAILED" -ne 0 ]; then
+  echo "❌ Release-tag uniqueness gate failed: one or more dist/archive tags are non-canonical with no canonical twin." >&2
+  exit 1
+fi
+
 echo "Release-tag uniqueness gate passed."


### PR DESCRIPTION
## Why

Run [31517782051](https://github.com/davekilleen/Dex/actions/runs/31517782051) burned **4.5 hours** of macOS runner time and then failed with:

```
dist/archive/v1.81.12-3a8245ab: platform infrastructure or integrity failure: starting release identity is malformed
```

That is not an upgrade regression. It is a **tag-naming mismatch**:

- Discovery accepts `[0-9a-f]{7,64}` — `scripts/release_fleet.py:41` (`ARCHIVE_RELEASE_TAG`)
- The executor requires exactly `[0-9a-f]{7}` — `scripts/release_fleet_executor.py:44` (`_ARCHIVE_RELEASE_TAG`)
- `_strict_identity` (`scripts/release_fleet_executor.py:1038`, called from `:1570`) raises **per journey**, hours into the run

So a typo in a tag name costs 4.5 hours to find out about. This moves that check into the 2-minute `quality` job, where it costs seconds.

## What

Appends an archive-canonicality check to `scripts/check-release-tag-uniqueness.sh`, in the style the script already uses (`git ls-remote`, skipping `^{}` peel refs).

**The rule, precisely:** fail only when a non-canonical `dist/archive/` tag has **no canonical twin** (`dist/archive/v<X.Y.Z>-<exactly 7 hex>`) at the same commit.

This mirrors discovery's tree de-duplication: a non-canonical tag that has a canonical twin at the same commit is already shadowed and can never be selected as a starting point. So the gate is green against today's tag set while still catching a lone bad tag.

Twin resolution uses the annotated tag's peeled `^{}` value, since two annotated tags at one commit have different tag-object SHAs but the same peeled commit.

The error text names the offending tag, its commit, and the remedy — **create** `dist/archive/v<X.Y.Z>-<7char>` for that commit. It never asks anyone to delete a tag.

## Proof the gate actually gates

**1. The strict form of the rule is red against the live tag set today** (137 archive tags, one offender):

```
$ git ls-remote --tags origin 'refs/tags/dist/archive/v*' | awk '$2 !~ /\^\{\}$/ && $2 !~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/ {print "NON-CANONICAL:", $2}'
NON-CANONICAL: refs/tags/dist/archive/v1.81.12-3a8245ab
```

**2. The shipped twin-tolerant rule is green today**, because the canonical twin exists:

```
$ git ls-remote --tags origin 'refs/tags/dist/archive/v1.81.12-3a8245a*'
7c07350435504e22dd823b21b2e3fe94de3a01c0	refs/tags/dist/archive/v1.81.12-3a8245a
3a8245ab6a99c483d0b6079d162fd433fec6a697	refs/tags/dist/archive/v1.81.12-3a8245a^{}
f64c77f959e99e38ae6222abd38e311d837c5fa7	refs/tags/dist/archive/v1.81.12-3a8245ab
3a8245ab6a99c483d0b6079d162fd433fec6a697	refs/tags/dist/archive/v1.81.12-3a8245ab^{}

$ bash scripts/check-release-tag-uniqueness.sh
Release-tag uniqueness gate passed.
EXIT=0
```

**3. The shipped rule is red in a scratch fixture where the twin is absent:**

```
=== FIXTURE A: lone non-canonical tag, twin ABSENT
❌ dist/archive/v1.81.12-3a8245ab (commit 9505cb89ae484c71abed3257447693a6779585c9) is a non-canonical dist/archive tag with no canonical twin at that commit.
The fleet executor requires exactly 7 hex characters in a dist/archive tag, so this start fails hours into historic-fleet-darwin.
Remedy: create dist/archive/v1.81.12-9505cb8 at 9505cb89ae484c71abed3257447693a6779585c9. Delete nothing — the existing tag stays, and discovery's tree de-duplication will shadow it.
❌ Release-tag uniqueness gate failed: one or more dist/archive tags are non-canonical with no canonical twin.
EXIT=1

=== FIXTURE B: same tag, canonical twin PRESENT at same commit
Release-tag uniqueness gate passed.
EXIT=0
```

## Tests

Two cases added to `core/tests/test_release_tag_uniqueness.py`, using the existing `_repository_with_remote_tags` fixture unchanged:

```
$ python3 -m pytest core/tests/test_release_tag_uniqueness.py -q
................                                                         [100%]
16 passed in 3.17s
```

Confirmed non-vacuous — reverting only the script change makes `test_gate_rejects_non_canonical_archive_tag_without_a_canonical_twin` fail.

## Scope and safety

- **No tag or ref was created, deleted, moved, renamed, or force-updated on the remote.** `dist/archive/v1.81.12-3a8245ab` stays exactly as it is.
- `historic-fleet-darwin` was **not** dispatched.
- No Python change was needed, so no third copy of the archive-tag regex was introduced.
- Purely additive, two files, 119 insertions and 0 deletions — reverts with a single `git revert`.

## Relationship to #472

Complementary, not a replacement, and #472 is untouched. #472 adds the fail-fast guard at discovery, which is the right structural fix, but it sits after tree de-duplication so it is silent against today's tag set. This gate sits upstream of the whole fleet run and is loud in seconds. Merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)