### PR TITLE
Tell people behind a corporate proxy the truth: we couldn't verify the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.2] — 🔒 A company network that inspects traffic no longer looks like a corrupt release (2026-08-13)
+
+If you're on a corporate network that intercepts secure connections — Zscaler, Netskope, most large enterprises — or on a hotel or airport captive portal, Dex's daily update check could fail and report that the release evidence was **invalid**. That wording means something specific and alarming: that the version of Dex being offered looks tampered with. It was never true. What had actually happened is that Dex couldn't verify it was really talking to GitHub, because something on your network was sitting in the middle of the connection. Worse, Dex treated it as a permanent verdict and didn't try again, so the check stayed broken for exactly the people most likely to hit it.
+
+**What this fixes for you:**
+
+* **Dex now says what actually happened.** "Dex couldn't verify a secure connection to GitHub. This usually means a network proxy is inspecting traffic." No implication that anything is wrong with the release itself.
+* **Dex tries again.** A certificate failure is now treated like a dropped connection: up to three attempts, backing off in between. A transient proxy hiccup no longer ends your update check.
+* **Dex still refuses to trust a certificate it can't verify, and there is no way to turn that off.** This release changes what Dex *tells* you and whether it *retries* — it does not change what Dex is willing to trust. There is no setting, visible or hidden, that makes Dex skip certificate checking, and there deliberately never will be: if something really is intercepting your connection to GitHub, that is exactly the moment Dex should stop.
+* **When something does go wrong, it's now diagnosable.** Update failures were being recorded as a bare category with the underlying error thrown away, which is why this particular fault took hours to track down. The underlying message is now kept — trimmed, single-line, and with anything credential-shaped stripped out before it's written anywhere.
+* **Several other failures stop being mislabelled too.** A missing file, a permissions problem, or a timed-out command were all being filed under the same "invalid evidence" heading as a genuinely bad release. Each now reports as itself.
+
 ## [1.96.1] — 🔎 Lens can read every role and planning capability (2026-08-13)
 
 The v1.96.0 catalogue was correctly signed but Lens refused it before deployment: two quarterly-planning requirements used Dex's internal underscore spelling instead of the public catalogue's hyphenated ID format. The canonical Lens URL stayed on the already-proven v1.95.2 catalogue, so nobody received the rejected file.

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -483,3 +483,123 @@ def test_failure_diagnostic_cleans_temporary_file_when_file_fsync_fails(
 
     assert not (evidence / "foundation-doctor-failure.diagnostic.json").exists()
     assert list(evidence.glob("*.tmp")) == []
+
+
+# --- TLS-trust routing and detail retention ---------------------------------
+
+
+def test_tls_untrusted_delivery_is_retried_as_a_transient_network_fault() -> None:
+    """A TLS-inspecting proxy is momentary for the fleet, exactly like a dropped link."""
+    assert "tls-untrusted" in executor._TRANSIENT_NETWORK_DELIVERY_REASONS
+    assert executor._transient_network_delivery(
+        {"status": "not-delivered", "evidence": {"reason": "tls-untrusted"}}
+    )
+    assert executor._transient_network_error(
+        "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+        "SSL certificate problem: self signed certificate"
+    )
+    assert "ssl certificate problem" in executor._TRANSIENT_NETWORK_ERROR_FRAGMENTS
+    assert "self signed certificate" in executor._TRANSIENT_NETWORK_ERROR_FRAGMENTS
+    # Bounded retry is unchanged: three attempts, 10s then 30s.
+    assert executor._TRANSIENT_DELIVERY_MAX_ATTEMPTS == 3
+    assert executor._TRANSIENT_DELIVERY_BACKOFF_SECONDS == (10.0, 30.0)
+
+
+def test_failure_diagnostic_keeps_tls_untrusted_as_a_classified_reason(
+    tmp_path: Path,
+) -> None:
+    vault, _user_paths = _vault(tmp_path)
+    document = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={
+            "status": "not-delivered",
+            "evidence": {"reason": "tls-untrusted"},
+        },
+    )
+
+    assert document["delivery"]["failure_reason"] == "tls-untrusted"
+
+
+def test_failure_diagnostic_retains_the_sanitized_underlying_detail(
+    tmp_path: Path,
+) -> None:
+    """Dropping the detail is why diagnosing a proxy fault took hours, not one cat."""
+    vault, _user_paths = _vault(tmp_path)
+    document = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={
+            "status": "not-delivered",
+            "evidence": {
+                "reason": "tls-untrusted",
+                "detail": (
+                    "fatal: unable to access "
+                    "'https://github.com/davekilleen/Dex.git/': "
+                    "SSL certificate problem: self signed certificate"
+                ),
+            },
+        },
+    )
+
+    detail = document["delivery"]["detail"]
+    assert "SSL certificate problem: self signed certificate" in detail
+
+
+def test_failure_diagnostic_detail_is_bounded_and_strips_credentials(
+    tmp_path: Path,
+) -> None:
+    vault, _user_paths = _vault(tmp_path)
+    secret = "ghp_" + "A" * 36
+    document = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={
+            "status": "not-delivered",
+            "evidence": {
+                "reason": "evidence-invalid",
+                "detail": (
+                    f"fatal: unable to access 'https://dave:{secret}@github.com/x.git/'"
+                    f" Authorization: Bearer {secret} token={secret} "
+                    + "padding " * 400
+                ),
+            },
+        },
+    )
+
+    detail = document["delivery"]["detail"]
+    assert secret not in detail
+    assert "dave:" not in detail
+    assert len(detail) <= 512
+
+
+def test_failure_diagnostic_omits_detail_when_the_foundation_supplies_none(
+    tmp_path: Path,
+) -> None:
+    vault, _user_paths = _vault(tmp_path)
+    document = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={"status": "not-delivered", "evidence": {"reason": "evidence-invalid"}},
+    )
+
+    assert "detail" not in document["delivery"]
+    document_bad_detail = executor._failure_diagnostic(
+        phase="follow-up-delivery",
+        vault=vault,
+        foundation=_identity("1.81.0", "a"),
+        follow_up=_identity("1.81.10", "b"),
+        delivery={
+            "status": "not-delivered",
+            "evidence": {"reason": "evidence-invalid", "detail": ["unsafe"]},
+        },
+    )
+    assert "detail" not in document_bad_detail["delivery"]

--- a/core/tests/test_update_checker.py
+++ b/core/tests/test_update_checker.py
@@ -1228,3 +1228,192 @@ def test_latest_release_identity_proof_reports_up_to_date(tmp_path: Path) -> Non
         "current_version": "1.63.0",
         "latest_version": "1.63.0",
     }
+
+
+# --- TLS-trust classification and subclass-safe failure dispatch -------------
+#
+# A TLS-inspecting corporate proxy (Zscaler, Netskope) or a captive portal makes
+# git fail with a certificate error. That is neither "offline" nor "the release
+# evidence is invalid": it is "Dex could not verify a secure connection". These
+# tests pin the distinct classification, and pin that the failure dispatch uses
+# isinstance so exception subclasses stop collapsing into evidence-invalid.
+
+
+_TLS_INTERCEPTION_STDERR = (
+    "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+    "SSL certificate problem: self signed certificate",
+    "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+    "server certificate verification failed. CAfile: none CRLfile: none",
+    "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+    "SSL certificate problem: unable to get local issuer certificate",
+    "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+    "SSL certificate problem: certificate has expired",
+    "fatal: unable to access 'https://github.com/davekilleen/Dex.git/': "
+    "schannel: CertGetCertificateChain trust error CERT_TRUST_IS_UNTRUSTED_ROOT",
+)
+
+
+@pytest.mark.parametrize("detail", _TLS_INTERCEPTION_STDERR)
+def test_network_git_classifies_tls_trust_failures_distinctly(
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    """A certificate failure is its own risk class, not offline and not invalid."""
+    fake_git = tmp_path / "git"
+    _write(fake_git, f'#!/bin/sh\necho "{detail}" >&2\nexit 128\n'.encode())
+    fake_git.chmod(0o755)
+    runner = GitRunner(git_path=fake_git)
+
+    with pytest.raises(update_verifier_module.TlsTrustError) as error_info:
+        runner.run_plain("ls-remote", network=True)
+
+    # It stays inside the evidence-error family so existing handlers still catch
+    # it, but it must never be indistinguishable from a generic EvidenceError.
+    assert isinstance(error_info.value, EvidenceError)
+    assert type(error_info.value) is not EvidenceError
+    assert not isinstance(error_info.value, OfflineError)
+    # Same stderr-retention rule the HTTP-429 classification already follows.
+    assert "github.com" not in str(error_info.value)
+
+
+def test_tls_trust_markers_are_not_folded_into_the_offline_markers(tmp_path: Path) -> None:
+    """Conflating 'cannot verify the certificate' with 'offline' would hide a MITM."""
+    for marker in (
+        "ssl certificate problem",
+        "server certificate verification failed",
+        "unable to get local issuer certificate",
+        "certificate has expired",
+        "schannel:",
+    ):
+        assert marker not in update_verifier_module._OFFLINE_MARKERS
+
+
+def test_release_identity_proof_reports_tls_untrusted_not_evidence_invalid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+
+    def reject(*_args, **_kwargs):
+        raise update_verifier_module.TlsTrustError(
+            "bounded canonical fetch could not verify a secure connection"
+        )
+
+    monkeypatch.setattr(UpdateVerifier, "_remote_release_tags", reject)
+
+    result = update_verifier_module.prove_latest_release(
+        vault,
+        "stable",
+        state_root=tmp_path / "state",
+        wall_clock_seconds=10.0,
+    )
+
+    assert result["status"] == STATUS_UNKNOWN
+    assert result["reason"] == "tls-untrusted"
+    assert result["reason"] != "evidence-invalid"
+    message = result["message"]
+    assert "secure connection" in message
+    assert "proxy" in message
+
+
+def test_check_reports_tls_untrusted_with_an_honest_user_facing_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "1.62.0")
+
+    def reject(*_args, **_kwargs):
+        raise update_verifier_module.TlsTrustError(
+            "bounded canonical fetch could not verify a secure connection"
+        )
+
+    monkeypatch.setattr(UpdateVerifier, "_remote_release_tags", reject)
+
+    result = _verifier(vault, remote, tmp_path / "state").check()
+
+    assert result["status"] == STATUS_UNKNOWN
+    assert result["should_notify"] is False
+    assert result["reason"] == "tls-untrusted"
+    assert "secure connection" in result["message"]
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_reason"),
+    (
+        (FileNotFoundError(2, "no such file"), "io-error"),
+        (PermissionError(13, "permission denied"), "io-error"),
+        (OSError(5, "input/output error"), "io-error"),
+        (subprocess.CalledProcessError(128, ("git", "ls-remote")), "subprocess-failed"),
+        (subprocess.TimeoutExpired(("git", "ls-remote"), 10.0), "subprocess-failed"),
+        (subprocess.SubprocessError("generic subprocess failure"), "subprocess-failed"),
+        (UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"), "encoding-invalid"),
+        (CancelledError("synthetic cancellation"), "cancelled"),
+        (EvidenceError("genuinely invalid evidence"), "evidence-invalid"),
+    ),
+)
+def test_failure_dispatch_classifies_exception_subclasses_by_isinstance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_reason: str,
+) -> None:
+    """Exact-type dispatch silently collapsed every subclass into evidence-invalid."""
+    vault = _installed_vault(tmp_path / "vault")
+
+    def reject(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(UpdateVerifier, "_remote_release_tags", reject)
+
+    result = update_verifier_module.prove_latest_release(
+        vault,
+        "stable",
+        state_root=tmp_path / "state",
+        wall_clock_seconds=10.0,
+    )
+
+    assert result == {"status": STATUS_UNKNOWN, "reason": expected_reason}
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_reason"),
+    (
+        (FileNotFoundError(2, "no such file"), "io-error"),
+        (subprocess.CalledProcessError(128, ("git", "ls-remote")), "subprocess-failed"),
+    ),
+)
+def test_check_failure_dispatch_classifies_exception_subclasses_by_isinstance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_reason: str,
+) -> None:
+    vault = _installed_vault(tmp_path / "vault")
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _release(remote, "1.62.0")
+
+    def reject(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(UpdateVerifier, "_remote_release_tags", reject)
+
+    result = _verifier(vault, remote, tmp_path / "state").check()
+
+    assert result["reason"] == expected_reason
+
+
+def test_no_certificate_verification_escape_hatch_exists_in_the_verifier() -> None:
+    """The fix improves the message and the retry, never the trust decision."""
+    source = Path(update_verifier_module.__file__).read_text(encoding="utf-8")
+    for forbidden in (
+        "GIT_SSL_NO_VERIFY",
+        "sslVerify",
+        "GIT_SSL_CAINFO",
+        "http.sslVerify",
+        "--no-verify-ssl",
+    ):
+        assert forbidden not in source

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "d84f6d0759b573e49ec7adefc4e2944201d767d5a52416c990647109b97c4c66",
+    "sha256": "e87f38fcd9b0154b10cf8b94746f5d09c450eafe557dcd09306e4ce8bb2ecf39",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -55,6 +55,22 @@ _OFFLINE_MARKERS = (
     "couldn't connect to server",
     "temporary failure in name resolution",
 )
+# Deliberately NOT merged into _OFFLINE_MARKERS. "We could not reach GitHub"
+# and "we reached something claiming to be GitHub but could not verify it" are
+# different risk classes: the second one is what an interception looks like.
+# Folding them together would make a genuine man-in-the-middle read as routine.
+_TLS_TRUST_MARKERS = (
+    "ssl certificate problem",
+    "server certificate verification failed",
+    "unable to get local issuer certificate",
+    "certificate has expired",
+    "schannel:",
+)
+TLS_UNTRUSTED_MESSAGE = (
+    "Dex couldn't verify a secure connection to GitHub. This usually means a "
+    "network proxy is inspecting traffic. Dex did not check for an update and "
+    "did not relax certificate verification."
+)
 _TRANSIENT_HTTP_REJECTION_RE = re.compile(
     r"(?:\bHTTP(?:/[0-9.]+)?\s+429\b|\brequested URL returned error:\s*429\b)",
     re.IGNORECASE,
@@ -109,6 +125,16 @@ class TransientHttpRejectionError(EvidenceError):
 
     def __init__(self) -> None:
         super().__init__("canonical Git endpoint returned a transient HTTP rejection")
+
+
+class TlsTrustError(EvidenceError):
+    """The canonical Git endpoint's certificate chain could not be trusted.
+
+    This is a transport-trust failure, not a claim about the release evidence.
+    It is surfaced as its own reason so users behind a TLS-inspecting proxy are
+    never told their release evidence is invalid. Dex never responds to it by
+    weakening or bypassing certificate verification.
+    """
 
 
 class CancelledError(RuntimeError):
@@ -215,6 +241,30 @@ class TagObjectMovedError(EvidenceError):
 
 class TagObjectMismatchError(EvidenceError):
     """Fetched tag identity differs from the canonical remote advertisement."""
+
+
+# Ordered most-specific-first and matched with isinstance, so exception
+# subclasses (FileNotFoundError, PermissionError, CalledProcessError,
+# TimeoutExpired, UnicodeDecodeError) classify honestly instead of silently
+# collapsing into "evidence-invalid" the way exact-type dispatch made them.
+_FAILURE_REASONS: tuple[tuple[type[BaseException], str], ...] = (
+    (CancelledError, "cancelled"),
+    (TagObjectMovedError, "tag-object-moved"),
+    (TagObjectMismatchError, "tag-object-mismatch"),
+    (TlsTrustError, "tls-untrusted"),
+    (EvidenceError, "evidence-invalid"),
+    (UnicodeError, "encoding-invalid"),
+    (OSError, "io-error"),
+    (subprocess.SubprocessError, "subprocess-failed"),
+)
+
+
+def _failure_reason(error: BaseException) -> str:
+    """Classify one caught evidence failure into its closed reason code."""
+    for error_type, reason in _FAILURE_REASONS:
+        if isinstance(error, error_type):
+            return reason
+    return "evidence-invalid"
 
 
 @dataclass
@@ -506,7 +556,13 @@ class GitRunner:
                 detail = stderr[: 64 * 1024].decode("utf-8", errors="replace").strip()
                 if network and _TRANSIENT_HTTP_REJECTION_RE.search(detail):
                     raise TransientHttpRejectionError
-                if network and any(marker in detail.lower() for marker in _OFFLINE_MARKERS):
+                lowered = detail.lower()
+                if network and any(marker in lowered for marker in _TLS_TRUST_MARKERS):
+                    # Retain no stderr, exactly as the HTTP-429 classification does.
+                    raise TlsTrustError(
+                        "bounded canonical fetch could not verify a secure connection"
+                    )
+                if network and any(marker in lowered for marker in _OFFLINE_MARKERS):
                     raise OfflineError("bounded canonical fetch was unavailable")
                 raise EvidenceError(detail or "Git evidence command failed")
             stdout_file.seek(0)
@@ -1085,15 +1141,13 @@ class UpdateVerifier:
         except OfflineError:
             return {"status": STATUS_OFFLINE, "reason": "network-unavailable"}
         except (CancelledError, EvidenceError, OSError, UnicodeError, subprocess.SubprocessError) as error:
-            reason = {
-                CancelledError: "cancelled",
-                TagObjectMovedError: "tag-object-moved",
-                TagObjectMismatchError: "tag-object-mismatch",
-                EvidenceError: "evidence-invalid",
-                OSError: "io-error",
-                UnicodeError: "encoding-invalid",
-                subprocess.SubprocessError: "subprocess-failed",
-            }.get(type(error), "evidence-invalid")
+            reason = _failure_reason(error)
+            if reason == "tls-untrusted":
+                return {
+                    "status": STATUS_UNKNOWN,
+                    "reason": reason,
+                    "message": TLS_UNTRUSTED_MESSAGE,
+                }
             return {"status": STATUS_UNKNOWN, "reason": reason}
         finally:
             self._budget = None
@@ -1390,17 +1444,11 @@ class UpdateVerifier:
                 return {**result, "reason": reason}
             return {**result, "status": STATUS_OFFLINE, "reason": reason}
         except (CancelledError, EvidenceError, OSError, UnicodeError, subprocess.SubprocessError) as error:
-            reason = {
-                CancelledError: "cancelled",
-                TagObjectMovedError: "tag-object-moved",
-                TagObjectMismatchError: "tag-object-mismatch",
-                EvidenceError: "evidence-invalid",
-                OSError: "io-error",
-                UnicodeError: "encoding-invalid",
-                subprocess.SubprocessError: "subprocess-failed",
-            }.get(type(error), "evidence-invalid")
+            reason = _failure_reason(error)
             if not self._persist_failure(today=today, status=STATUS_UNKNOWN, reason=reason):
                 reason = "state-write-failed"
+            if reason == "tls-untrusted":
+                return {**result, "reason": reason, "message": TLS_UNTRUSTED_MESSAGE}
             return {**result, "reason": reason}
         finally:
             self._budget = None

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -68,6 +68,7 @@ _SAFE_DELIVERY_FAILURE_REASONS = frozenset(
         "subprocess-failed",
         "tag-object-mismatch",
         "tag-object-moved",
+        "tls-untrusted",
     }
 )
 _MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS = 900_000
@@ -76,7 +77,12 @@ _MAX_FAILURE_DIAGNOSTIC_ELAPSED_MS = 900_000
 # executor retries only transient network failures around each delivery hop.
 _TRANSIENT_DELIVERY_MAX_ATTEMPTS = 3
 _TRANSIENT_DELIVERY_BACKOFF_SECONDS = (10.0, 30.0)
-_TRANSIENT_NETWORK_DELIVERY_REASONS = frozenset({"network-unavailable"})
+# A TLS-inspecting proxy or captive portal is momentary for the fleet in the
+# same way a dropped link is. Retrying is safe because nothing about the trust
+# decision changes between attempts: each attempt still verifies the chain.
+_TRANSIENT_NETWORK_DELIVERY_REASONS = frozenset(
+    {"network-unavailable", "tls-untrusted"}
+)
 _TRANSIENT_NETWORK_ERROR_FRAGMENTS = (
     "connection refused",
     "connection reset",
@@ -88,9 +94,38 @@ _TRANSIENT_NETWORK_ERROR_FRAGMENTS = (
     "network-unavailable",
     "nodename nor servname provided",
     "operation timed out",
+    "self signed certificate",
+    "ssl certificate problem",
     "ssl connect error",
     "temporary failure in name resolution",
 )
+_MAX_FAILURE_DETAIL_CHARS = 512
+# Credential-shaped substrings are removed before any detail reaches disk.
+_CREDENTIAL_SHAPED = re.compile(
+    r"(?:gh[pousr]_[A-Za-z0-9]{16,}"
+    r"|github_pat_[A-Za-z0-9_]{16,}"
+    r"|xox[abposr]-[A-Za-z0-9-]{8,}"
+    r"|(?:(?i:authorization|bearer|token|password|passwd|secret|api[_-]?key)"
+    r"\s*[:=]\s*)\S+"
+    r"|//[^/\s:@]+:[^/\s@]+@)"
+)
+
+
+def _sanitized_failure_detail(detail: str) -> str | None:
+    """Keep the underlying failure text that made diagnosis possible, safely.
+
+    The reason code alone cannot distinguish a corporate TLS proxy from a
+    genuinely malformed release, which is what turned a one-line diagnosis into
+    an hours-long one. Retain a bounded, credential-stripped single line.
+    """
+
+    collapsed = " ".join(detail.split())
+    if not collapsed:
+        return None
+    redacted = _CREDENTIAL_SHAPED.sub("<redacted>", collapsed)
+    if len(redacted) > _MAX_FAILURE_DETAIL_CHARS:
+        redacted = redacted[: _MAX_FAILURE_DETAIL_CHARS - 1] + "\u2026"
+    return redacted
 
 
 def _transient_network_error(detail: str) -> bool:
@@ -1443,6 +1478,11 @@ def _failure_diagnostic(
         }
         if route_drift_release is not None:
             delivery_diagnostic["delivered_release"] = route_drift_release
+        raw_detail = evidence.get("detail") if isinstance(evidence, Mapping) else None
+        if isinstance(raw_detail, str):
+            sanitized_detail = _sanitized_failure_detail(raw_detail)
+            if sanitized_detail is not None:
+                delivery_diagnostic["detail"] = sanitized_detail
         document["delivery"] = delivery_diagnostic
     return document
 


### PR DESCRIPTION
## Linked Issue
- Linear issue: `DEX-XX` (none; found forensically while diagnosing a failed update check)

## What Changed

Anyone on a TLS-inspecting corporate network (Zscaler, Netskope, most large enterprises) or a captive portal gets a git failure like:

```
fatal: unable to access 'https://github.com/davekilleen/Dex.git/': SSL certificate problem: self signed certificate
```

No certificate string was in `_OFFLINE_MARKERS`, so that fell through to a bare `EvidenceError` and classified as **`evidence-invalid`** — which tells the user Dex's *release evidence* is invalid, i.e. that the release looks tampered with or corrupt. `evidence-invalid` is also not in the retry set, so **Dex gave up on the first attempt**. Dex's target users are enterprise; this is the exact population most likely to hit it.

Three fixes, all of them about the *message* and the *retry*, none of them about the *trust decision*:

1. **A distinct TLS-trust classification.** New `TlsTrustError`, raised at the git-failure site when the detail matches `ssl certificate problem`, `server certificate verification failed`, `unable to get local issuer certificate`, `certificate has expired`, or `schannel:`. Surfaced as reason **`tls-untrusted`** with an honest message: *"Dex couldn't verify a secure connection to GitHub. This usually means a network proxy is inspecting traffic. Dex did not check for an update and did not relax certificate verification."*

   It is deliberately **not** appended to `_OFFLINE_MARKERS`. "We could not reach GitHub" and "we reached something claiming to be GitHub that we could not verify" are different risk classes, and folding them together is exactly what would make a genuine man-in-the-middle read as routine. Like the existing HTTP-429 classification, `TlsTrustError` retains no stderr.

2. **`isinstance` ladder replaces exact-type dispatch.** Both dispatch sites used `.get(type(error), "evidence-invalid")`, so *every* subclass silently collapsed into `evidence-invalid`: `FileNotFoundError` and `PermissionError` (OSError), `CalledProcessError` and `TimeoutExpired` (SubprocessError), `UnicodeDecodeError` (UnicodeError). Now one shared `_failure_reason()` ladder, ordered most-specific-first.

3. **The underlying detail is no longer discarded.** `_failure_diagnostic` recorded only the sanitized reason code and dropped the detail string — which is why diagnosing this took hours instead of one `cat`. It now retains a bounded (512 char), credential-stripped, single-line `evidence.detail` when the foundation supplies one, and omits the key entirely when it does not.

**Retry routing:** `tls-untrusted` joins `_TRANSIENT_NETWORK_DELIVERY_REASONS`, and `ssl certificate problem` / `self signed certificate` join `_TRANSIENT_NETWORK_ERROR_FRAGMENTS`. Both already had bounded 3-attempt retry with 10s/30s backoff; this only routes cert faults into it. Retrying is safe precisely *because* the trust decision does not change between attempts — every attempt still verifies the chain in full.

`core/update/journey-protocol-v1.json` carries one regenerated digest because the executor's bytes changed (`scripts/generate-update-journey-protocol.py`); the executor self-verifies its own bytes against that contract.

## Test Plan

- Unit/integration tests added or updated: `core/tests/test_update_checker.py`, `core/tests/test_release_fleet_failure_diagnostics.py`
- Negative/error-path tests added or updated: all of them — this PR is entirely error-path.

**Every new test was demonstrated failing against unmodified code first (18 failures):**

```
FAILED test_update_checker.py::test_network_git_classifies_tls_trust_failures_distinctly[...self signed certificate]
FAILED test_update_checker.py::test_network_git_classifies_tls_trust_failures_distinctly[...server certificate verification failed...]
FAILED test_update_checker.py::test_network_git_classifies_tls_trust_failures_distinctly[...unable to get local issuer certificate]
FAILED test_update_checker.py::test_network_git_classifies_tls_trust_failures_distinctly[...certificate has expired]
FAILED test_update_checker.py::test_network_git_classifies_tls_trust_failures_distinctly[...schannel: ...CERT_TRUST_IS_UNTRUSTED_ROOT]
FAILED test_update_checker.py::test_release_identity_proof_reports_tls_untrusted_not_evidence_invalid
FAILED test_update_checker.py::test_check_reports_tls_untrusted_with_an_honest_user_facing_message
FAILED test_update_checker.py::test_failure_dispatch_classifies_exception_subclasses_by_isinstance[error0-io-error]          # FileNotFoundError
FAILED test_update_checker.py::test_failure_dispatch_classifies_exception_subclasses_by_isinstance[error1-io-error]          # PermissionError
FAILED test_update_checker.py::test_failure_dispatch_classifies_exception_subclasses_by_isinstance[error3-subprocess-failed] # CalledProcessError
FAILED test_update_checker.py::test_failure_dispatch_classifies_exception_subclasses_by_isinstance[error4-subprocess-failed] # TimeoutExpired
FAILED test_update_checker.py::test_failure_dispatch_classifies_exception_subclasses_by_isinstance[error6-encoding-invalid]  # UnicodeDecodeError
FAILED test_update_checker.py::test_check_failure_dispatch_classifies_exception_subclasses_by_isinstance[error0-io-error]
FAILED test_update_checker.py::test_check_failure_dispatch_classifies_exception_subclasses_by_isinstance[error1-subprocess-failed]
FAILED test_release_fleet_failure_diagnostics.py::test_tls_untrusted_delivery_is_retried_as_a_transient_network_fault
FAILED test_release_fleet_failure_diagnostics.py::test_failure_diagnostic_keeps_tls_untrusted_as_a_classified_reason
FAILED test_release_fleet_failure_diagnostics.py::test_failure_diagnostic_retains_the_sanitized_underlying_detail
FAILED test_release_fleet_failure_diagnostics.py::test_failure_diagnostic_detail_is_bounded_and_strips_credentials
18 failed, 72 passed in 19.30s
```

The unchanged-behaviour assertions (`evidence-invalid` for a genuine `EvidenceError`, `cancelled`, plain `OSError` → `io-error`, no escape hatch in the source, TLS markers absent from `_OFFLINE_MARKERS`) passed before and after — they pin what must not move.

**After the fix, same selection:**

```
90 passed, 1 warning in 19.24s
```

**No existing test regressed** — full run across every touched and dependent module:

```
$ python3 -m pytest core/tests/test_update_checker.py core/tests/test_update_checker_real_installs.py \
    core/tests/test_apply_update.py core/tests/test_release_fleet_executor.py \
    core/tests/test_release_fleet_failure_diagnostics.py core/tests/test_dex_update_bridge.py \
    core/tests/test_update_journey_protocol.py core/tests/test_distribution_artifacts.py -q

376 passed, 2 warnings in 704.21s (0:11:44)
```

`ruff check` clean on all four touched Python files; `scripts/security-gate.sh` passes.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant). — **this PR needs security review before merge; see below.**
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact (CHANGELOG entry added under 1.99.0, which is not cut yet).
- [x] CI checks for lint + tests + coverage are expected to pass.

## The trust decision is untouched

**No certificate verification is relaxed, skipped, or made configurable anywhere in this diff.** There is no `GIT_SSL_NO_VERIFY`, no `http.sslVerify=false`, no `GIT_SSL_CAINFO` override, no `--no-check-certificate`, and no user-facing bypass of any kind. A certificate failure still stops the update check dead; the only things that changed are what Dex *tells you* about it and whether it *tries again*. `test_no_certificate_verification_escape_hatch_exists_in_the_verifier` asserts those strings stay absent from `core/utils/update_verifier.py`, so a future change cannot quietly add one.

The one shortcut that would have made this a two-line diff — appending the cert strings to `_OFFLINE_MARKERS` — is specifically what this PR avoids, with a comment at the definition site explaining why.

## Risk & Rollback
- Risk level: **low**. Additive classification on a previously-terminal error path. No behaviour changes on any success path, and every existing failure classification is preserved (verified by the 376-test run).
- Rollback plan: single `git revert` of this one commit. No migrations, no state format change, no remote refs or tags touched.

## Docs Impact
- Files updated: `CHANGELOG.md`
