### PR TITLE
Stop the pre-update scan re-reading one list per file (the 100k gate's first honest failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.95.1] — ⚡ Big vaults get ready to update in seconds instead of minutes (2026-08-12)
+
+Before Dex updates itself, it reads through your vault to find everything you have personally changed or added, so that your own work is protected rather than overwritten. On a big vault that step had been taking far longer than its size warranted: doubling the number of files made it four to eight times slower rather than twice as slow, so it got worse the more you put in. On a vault of around a hundred thousand files it was spending about four minutes on that one step.
+
+**What this fixes for you:**
+
+* **The check before an update finishes far quicker.** Measured on a vault of about a hundred thousand files, the slow step went from roughly four minutes to roughly twenty seconds. The larger your vault, the larger the saving — small vaults were never really affected.
+* **It now slows down in step with your vault instead of ahead of it.** Dex was re-reading the same long list from the beginning once for every file it considered. It now looks that list up directly, so the time grows steadily with your vault rather than running away as the vault fills up.
+* **Nothing it decides has changed.** The step examines exactly the same files and reaches exactly the same conclusions as before — only the waiting is different.
+
+Found by Dex's own overnight performance check, which had been reporting this step as over its time limit every night since it was introduced.
+
+---
+
 ## [1.95.0] — 🗄️ Your notes now back themselves up — plus Pipedrive, roomier daily rituals, and releases that never announce a file that isn't there (2026-08-12)
 
 A larger release than usual: five pieces of work landed together, three of them from Chris, who has been running Dex hard and reporting what broke. Each is written up in full below.

--- a/core/customization_migration/inventory.py
+++ b/core/customization_migration/inventory.py
@@ -769,10 +769,14 @@ def discover(vault_root: Path) -> DiscoveryResult:
         colliding_canonical_paths,
     )
     accounted_paths = set(candidate_paths)
+    # unproven_paths is a tuple, so testing membership against it once per
+    # entry is a full scan per entry -- quadratic in vault size, and the
+    # dominant cost of the whole assessment on a large vault.
+    unproven_paths = frozenset(inventory.unproven_paths)
     for entry in inventory.entries:
         if (
             entry.kind in {"file", "symlink"}
-            and entry.actual_path in inventory.unproven_paths
+            and entry.actual_path in unproven_paths
             and entry.actual_path not in accounted_paths
             and _dependency_root(entry.actual_path) is None
             and not any(


### PR DESCRIPTION
## What last night's failure actually was

Nightly Quality [run 31564048293](https://github.com/davekilleen/Dex/actions/runs/31564048293) failed on **Adoption journey + 100k performance gate**. This was the first run after #457 added `set -o pipefail` to that step (audit finding **F1** — the step's exit code had been `tee`'s, so an exceeded budget was always green).

It is **not** a regression from yesterday's merges. It is a **pre-existing breach the dead gate hid**, and it is real.

### Evidence: the gate has never once been capable of passing

Every nightly prints the benchmark JSON even when the step was green, so the history is recoverable. Reading it back for every run since the gate landed:

| night | total_measured | budget in force | over |
|---|---|---|---|
| 2026-07-22 (first run) | 35.1s | 17.0s | 2.06× |
| 2026-07-23 | 30.3s | 17.0s | 1.78× |
| 2026-07-29 … 2026-08-11 (14 runs) | 172.7s – 292.1s | 84.5s | 2.04× – 3.46× |
| 2026-08-12 (this failure) | 272.4s | 84.5s | 3.22× |

**17 of 17 runs over budget. Never once under**, including the very first one.

Last night was also not an outlier: `customization_assessment` at 238.5s sits at z = +1.61 against the prior 14 nights (mean 187.6s, sd 31.6s) — 2026-08-10 was worse at 259.3s.

### One secondary signal, investigated and cleared

`adoption_and_rewind` at 12.45s *was* a genuine statistical outlier (z = +4.25), and `core/lifecycle/engine.py` gained 196 lines yesterday in #459 — so this looked like a candidate regression. It is not: #459's new code is topology classification, and an AST call-graph trace confirms `execute_adoption`, `rewind_adoption`, `build_adoption_preview` and `rewind_acknowledgement_token` reach **none** of the new functions. They are reachable only from Doctor and `apply_update`. Single-sample runner noise.

## The real defect this uncovered, and the fix here

Profiling `assess()` at two sizes put the growth in `discover()`'s own body (tottime 1.49s → 27.77s for 4× the files; every callee scaled linearly). Timing the phase boundaries narrowed it to the block after the read loop, and the cause is one line:

```python
entry.actual_path in inventory.unproven_paths   # unproven_paths is a tuple[str, ...]
```

tested once per entry — a full scan per entry. On any vault where most files are unproven (any large user vault, and the benchmark) that is O(n²), and it is the dominant cost of the whole assessment.

Hoisting it into a `frozenset` makes it linear. Timing that loop in isolation on this host:

| files | as-written | with set | speedup | scaling per 2× files |
|---|---|---|---|---|
| 12,500 | 1.663s | 0.073s | 23× | — |
| 25,000 | 7.884s | 0.164s | 48× | 4.74× → 2.25× |
| 50,000 | 67.355s | 0.335s | 201× | 8.54× → 2.05× |

At 50k that one loop was **77% of the entire stage**.

End to end via `scripts/benchmark_adoption_engine.py` on this host:

| | before | after |
|---|---|---|
| 50k `customization_assessment` | 87.35s | **10.69s** |
| 50k `total_measured` | 113.19s | **34.32s** |
| 100k `customization_assessment` | ~4 min | **20.94s** (budget 67.43s) |
| 100k `total_measured` | — | **70.28s** (budget 84.46s) |

## Verification

- Behaviour unchanged: identical hit counts from the loop as-written vs with the set at all three sizes.
- `core/tests/` filtered to customization/lifecycle/adoption/inventory/doctor: **830 passed, 17 failed**, and the 17 are **byte-identical in set** with and without this change (`diff` empty) — pre-existing environment failures on this Linux host, e.g. Doctor returning `UNKNOWN` where the test expects `OK`. macOS CI is the authoritative gate.
- Targeted suites clean: 88 passed across the six customization/adoption journey files.
- `ruff check` clean.

## What this does NOT fix — please read before merging

**This does not make the nightly green.** Four per-stage budgets are still exceeded on CI, for a completely different reason:

> `"machine_class_note": "Calibrated 2026-07-21 on a MacBook Pro (Mac17,8), Apple M5 Pro 18-core, 48 GB RAM…"`

The gate runs on `macos-latest` — an Azure-hosted `macos-26-arm64` runner roughly half that speed. That is why every stage was uniformly ~1.9–2.2× over from day one. A laptop-calibrated budget enforced on shared cloud CI can never pass.

Projected on CI after this fix: `customization_assessment` ~11–12s (budget 67.4s) ✅ and `total_measured` ~45s (budget 84.5s) ✅, but `build_inventory` (~10.7s vs 5.58s), `collect_adoption_report` (~10.7s vs 5.73s), `adoption_and_rewind` (~8–12s vs 5.72s) and `build_adoption_plan` (~0.005s vs 0.0029s) still fail.

**Recalibration is deliberately not folded into this PR** — loosening a budget is exactly the dead gate coming back with paperwork, so it should be an argued decision, not a quiet edit riding along with an optimisation. The argument, for Front Desk:

1. **Calibrate on the machine that enforces it.** A budget measured on an 18-core laptop and enforced on a 2-core cloud runner measures the runner, not the code.
2. **30% headroom is below the noise floor.** Identical work varied 148s–259s (1.75×) across nights on that runner. Any threshold with 30% headroom will flake regardless of where it is centred; headroom must come from observed spread.
3. **What the gate is for.** It should catch an algorithmic blow-up like the one fixed here — which was ~3.5× over — not a 20% runner mood swing. A ceiling set from the observed CI distribution would have caught this defect on day one while staying quiet otherwise.

**Hold for Front Desk review.** Not a release-ops change; no gate weakening included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)