### PR TITLE
Recalibrate the 100k gate on the machine that enforces it (F1 follow-up)

### DIFF
--- a/core/lifecycle/performance-budget-v1.json
+++ b/core/lifecycle/performance-budget-v1.json
@@ -1,13 +1,13 @@
 {
   "budget_version": 1,
   "files": 100000,
-  "machine_class_note": "Calibrated 2026-07-21 on a MacBook Pro (Mac17,8), Apple M5 Pro 18-core, 48 GB RAM, using ../creds-venv Python 3.14; each seconds budget is the observed 100k stage time plus 30% headroom.",
+  "machine_class_note": "PROVISIONAL, 2026-08-12. Calibrated on the machine that ENFORCES this budget: the GitHub-hosted macos-latest runner (image macos-26-arm64, Azure), where nightly-quality.yml runs the gate. Rule: ceiling = 2.5x the projected post-#482 CI median per stage, floored at 0.5s. The 2.5x tolerates that runner's observed 1.75x night-to-night spread on identical work while still failing an algorithmic blowup (>=2.5x). The 0.5s floor exists because below it measurement noise exceeds signal -- build_adoption_plan has a ~4.6ms median, so a 2.5x ceiling (11.5ms) is inside the jitter and was observed tripping on an unmodified tree; at 0.5s it is still 109x its median, so a genuine blowup in that stage cannot hide. Untouched stages use the median of 15 observed nights (2026-07-29..08-12); customization_assessment is projected from a post-#482 100k measurement converted at the 1.80x local:CI speed ratio measured on those same untouched stages. Demonstrated both ways at 100k before merge: passes on an unmodified tree (exit 0), and fails when the #482 quadratic is deliberately reintroduced (exit 1, customization_assessment 382.8s vs 29.0s). RECALIBRATE from the live post-#482 distribution after 7 nights (see docs/gate-omission-audit-2026-08-11.md, F1 epilogue) -- these are a floor for honesty, not a final answer. PROVENANCE, NOT AUTHORITY: budget_version 1 was calibrated 2026-07-21 on a MacBook Pro (Mac17,8), Apple M5 Pro 18-core, 48 GB RAM at observed+30%. That machine never ran this gate; the resulting budget was exceeded on 17 of 17 nightly runs, including the first, and was only ever green because the step discarded its exit code (audit F1).",
   "seconds": {
-    "adoption_and_rewind": 5.718049,
-    "build_adoption_plan": 0.00288,
-    "build_inventory": 5.580281,
-    "collect_adoption_report": 5.7281,
-    "customization_assessment": 67.426542,
-    "total_measured": 84.455852
+    "adoption_and_rewind": 22.091857,
+    "build_adoption_plan": 0.5,
+    "build_inventory": 24.76495,
+    "collect_adoption_report": 24.181783,
+    "customization_assessment": 29.012497,
+    "total_measured": 100.062565
   }
 }

--- a/docs/gate-omission-audit-2026-08-11.md
+++ b/docs/gate-omission-audit-2026-08-11.md
@@ -88,6 +88,91 @@ reviewer: if the 100k budget is currently being exceeded, the next nightly will
 go red. That is the gate working for the first time, not a regression
 introduced here.
 
+### Epilogue — the next nightly did go red, and the gate had never been able to pass *(2026-08-12)*
+
+The very next nightly ([run 31564048293](https://github.com/davekilleen/Dex/actions/runs/31564048293))
+failed on this step, exactly as predicted above. Investigating it produced the
+proof that belongs with this finding, because **a gate that was born unable to
+pass is the purest specimen of this audit's class** — and the next auditor
+should inherit the evidence rather than re-derive it.
+
+The benchmark prints its measurements to stdout even when the step went green,
+so `tee` preserved them in every nightly log. Recovered for every run since the
+gate landed:
+
+| night | `total_measured` | budget in force | over |
+|---|---|---|---|
+| 2026-07-22 *(first run after D-GATE)* | 35.1s | 17.0s | 2.06x |
+| 2026-07-23 | 30.3s | 17.0s | 1.78x |
+| 2026-07-29 | 172.7s | 84.5s | 2.04x |
+| 2026-07-30 | 201.0s | 84.5s | 2.38x |
+| 2026-07-31 | 193.7s | 84.5s | 2.29x |
+| 2026-08-01 | 213.0s | 84.5s | 2.52x |
+| 2026-08-02 | 229.8s | 84.5s | 2.72x |
+| 2026-08-03 | 231.3s | 84.5s | 2.74x |
+| 2026-08-04 | 175.4s | 84.5s | 2.08x |
+| 2026-08-05 | 239.9s | 84.5s | 2.84x |
+| 2026-08-06 | 217.7s | 84.5s | 2.58x |
+| 2026-08-07 | 174.9s | 84.5s | 2.07x |
+| 2026-08-08 | 264.8s | 84.5s | 3.14x |
+| 2026-08-09 | 205.0s | 84.5s | 2.43x |
+| 2026-08-10 | 292.1s | 84.5s | 3.46x |
+| 2026-08-11 | 217.7s | 84.5s | 2.58x |
+| 2026-08-12 *(first honest failure)* | 272.4s | 84.5s | 3.22x |
+
+**17 of 17 runs over budget. Never once under, including the first.** The
+budget rose at #234 (17.0s to 84.5s) when `customization_assessment` was added;
+both budgets were exceeded from their first night onward.
+
+Two independent causes, deliberately separated:
+
+1. **A real quadratic, which the dead gate hid.** `discover()` tested
+   `entry.actual_path in inventory.unproven_paths` once per entry against a
+   *tuple* — a full scan per entry, O(n^2) on any vault where most files are
+   unproven. At 50k files that one loop was 77% of the whole assessment stage.
+   Fixed in #482 (`dffd8fb8`): 100k assessment ~4min to 20.9s on the
+   investigating host. **This is the defect the gate existed to catch, and it
+   was catching it — into `/dev/null` — from night one.**
+2. **A budget calibrated on a machine that never runs it.** `budget_version` 1
+   was measured on an 18-core M5 Pro laptop and enforced on a GitHub-hosted
+   `macos-latest` runner roughly 1.8x slower, which is why *every* stage was
+   uniformly ~1.9-2.2x over from the start. Recalibrated against the enforcing
+   runner in the follow-up to #482.
+
+Two lessons for future gates, both cheap to apply:
+
+- **Calibrate a threshold on the machine that enforces it.** A budget measured
+  somewhere faster measures the runner, not the code.
+- **Derive headroom from observed spread, never a fixed percentage.** The
+  original +30% sat *below* this runner's own 1.75x night-to-night variation on
+  identical work, so the budget could not have been stable even if it had been
+  centred correctly.
+- **Do not budget a stage smaller than the measurement noise.** Caught in the
+  replacement budget's own deliberate-break test: `build_adoption_plan` has a
+  ~4.6ms median, so even a 2.5x ceiling (11.5ms) sits inside ordinary timer
+  jitter and tripped on an *unmodified* tree. Ceilings are now floored at 0.5s,
+  which is still 109x that stage's median — a real blowup there cannot hide,
+  and a millisecond of noise cannot turn the nightly red. A threshold that can
+  fail for reasons unrelated to the code is the mirror-image of this audit's
+  bug: not a gate that cannot fail, but one that fails meaninglessly, which
+  gets muted and then ignored.
+- **Prove a replacement threshold both ways before shipping it.** Both
+  directions were demonstrated at 100k before merge — exit 0 on an unmodified
+  tree, exit 1 (382.8s vs 29.0s) with the #482 quadratic deliberately
+  reintroduced. The pass run is what caught the millisecond-stage flake above.
+
+And one for auditors: **a gate that has never once passed is as broken as a
+gate that has never once failed**, and it is detectable the same way — by
+reading what it actually measured, not whether it went green.
+
+**Dated follow-up (due 2026-08-19, 7 nights after #482 merged):** the ceilings
+now in `core/lifecycle/performance-budget-v1.json` are explicitly marked
+**provisional** — 2.5x the projected post-fix CI median. Derive final per-stage
+ceilings from the first 7 nights of the real post-#482 distribution (median
+plus spread-derived headroom, statistic argued in that PR) so the provisional
+multiplier does not silently become permanent. A provisional number left
+unrevisited is how the original budget survived 17 failing nights.
+
 ---
 
 ## F2 — The nightly flaky-test detector passes when it runs no tests *(confirmed)*


### PR DESCRIPTION
Follow-up to #482, per Front Desk's ruling. #482 removed the real quadratic the dead gate was hiding; this makes the **threshold** honest, so the gate can both pass and fail meaningfully from tonight.

## Why the old budget could never pass

```json
"machine_class_note": "Calibrated 2026-07-21 on a MacBook Pro (Mac17,8), Apple M5 Pro 18-core, 48 GB RAM…"
```

The gate runs on `macos-latest` — an Azure-hosted `macos-26-arm64` runner ~1.8× slower. A laptop number was being enforced on cloud hardware, which is why *every* stage was uniformly ~1.9–2.2× over from night one. **17 of 17 nightly runs exceeded it, including the first.** It was only ever green because the step discarded its exit code (F1).

## The new ceilings

Rule: **2.5 × the projected post-#482 CI median per stage, floored at 0.5s.**

| stage | projected CI | new ceiling | old budget | |
|---|---|---|---|---|
| `adoption_and_rewind` | 8.8367s | 22.0919s | 5.7180s | loosened |
| `build_adoption_plan` | 0.0046s | 0.5000s | 0.0029s | floored |
| `build_inventory` | 9.9060s | 24.7649s | 5.5803s | loosened |
| `collect_adoption_report` | 9.6727s | 24.1818s | 5.7281s | loosened |
| `customization_assessment` | 11.6050s | 29.0125s | 67.4265s | **tightened** |
| `total_measured` | 40.0250s | 100.0626s | 84.4559s | loosened |

`customization_assessment` **tightens by 2.3×** — #482 earns a stricter bound. This is not a blanket loosening.

**Derivation.** The four stages #482 doesn't touch keep their observed CI median across 15 nights (2026-07-29…08-12). `customization_assessment` is projected from a post-#482 100k measurement on the investigating host (20.94s), converted at the **1.80× local:CI ratio** measured on those same untouched stages at the same file count — so the projection is anchored to measurements, not a guess.

**Why 2.5×.** The runner's own spread on identical work is 1.75×. A threshold must clear that to be stable, while still failing a genuine blowup. Every ceiling sits ≥1.77× above the worst night ever observed for its stage.

**Why the 0.5s floor.** `build_adoption_plan`'s median is ~4.6ms. A 2.5× ceiling (11.5ms) is *inside* ordinary timer jitter — and it tripped on an **unmodified tree** during the pass test below. That is the mirror-image of F1: not a gate that cannot fail, but one that fails meaninglessly, gets muted, and is then ignored. At 0.5s it is still 109× that stage's median, so a real blowup there cannot hide.

## Demonstrated both ways at 100k before proposing

A threshold that cannot be shown failing is the same bug this audit was about.

| | result |
|---|---|
| unmodified tree | **exit 0** — total 69.42s vs 100.06s ceiling |
| #482 quadratic deliberately reintroduced | **exit 1** — `customization_assessment` 382.8s vs 29.0s (13.2× over); total 430.3s vs 100.1s |

Both runs were on the investigating host, which is ~1.8× *slower* than CI — so the pass is a conservative demonstration, and the working tree was verified byte-identical to `main` afterwards.

Corroborating the fail direction on the real enforcing machine: all 15 nights of observed CI data exceed the new 29.0s ceiling by **5.1–8.9×**. A regression back to today's behaviour cannot sneak through.

## Also in this PR

`machine_class_note` now names the **enforcing** runner, with the M5 laptop kept as **provenance, not authority**, and states plainly that the number it produced failed 17 of 17 nights.

The recovered 17-night history goes into `docs/gate-omission-audit-2026-08-11.md` as **F1's epilogue** — a gate born unable to pass is the purest specimen of this audit's class, and the next auditor should inherit the proof rather than re-derive it. It carries three transferable lessons: calibrate on the enforcing machine; derive headroom from observed spread; don't budget a stage smaller than the measurement noise.

**Dated follow-up: 2026-08-19** (7 nights after #482 merged) — derive final per-stage ceilings from the real post-fix distribution, statistic argued in that PR. Recorded in the epilogue so "provisional" does not quietly become permanent, which is exactly how the original budget survived 17 failing nights.

Held for Front Desk review. No release ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)