### PR TITLE
Vault auto-commit can save your notes again, instead of failing every session (#485)

### DIFF
--- a/.claude/hooks/tests/vault-autocommit.test.cjs
+++ b/.claude/hooks/tests/vault-autocommit.test.cjs
@@ -181,6 +181,76 @@ test('the shared transaction lock pauses auto-commit and is held while Git runs'
   assert.equal(fs.existsSync(lock), false);
 });
 
+test('enabled hook still snapshots a vault whose PARA folders the shipped .gitignore ignores', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  // Every real vault carries the shipped .gitignore, which ignores the PARA folders — and
+  // the v1-to-v2 migration tracks the vault's existing content through them with a forced
+  // add. Reproduced together, a pathspec add used to fail as a whole and the hook returned
+  // broken on every session end without committing anything (#485). The fixtures above
+  // never wrote a .gitignore, which is why the suite stayed green while vaults did not.
+  fs.copyFileSync(path.join(REPO_ROOT, '.gitignore'), path.join(root, '.gitignore'));
+  fs.mkdirSync(path.join(root, '03-Tasks'), { recursive: true });
+  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), '# tasks before\n');
+  git(root, '-c', 'core.excludesFile=/dev/null', 'add', '-f', '--', '03-Tasks/Tasks.md');
+  git(root, '-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '--quiet', '-m', 'vault history');
+  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), '# tasks after\n');
+  // A note written today lives in an ignored folder and is untracked: the case that made a
+  // healthy-looking snapshot save nothing new.
+  fs.mkdirSync(path.join(root, '00-Inbox'), { recursive: true });
+  fs.writeFileSync(path.join(root, '00-Inbox', 'captured.md'), 'captured today\n');
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'alpha.md'), 'new project note\n');
+
+  const result = hook.run({ root, now: new Date('2026-08-12T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(result.success, true);
+  assert.equal(git(root, 'log', '-1', '--format=%s'), 'Dex vault 2026-08-12');
+  assert.equal(git(root, 'show', 'HEAD:03-Tasks/Tasks.md'), '# tasks after');
+  assert.equal(git(root, 'show', 'HEAD:00-Inbox/captured.md'), 'captured today');
+  assert.equal(git(root, 'show', 'HEAD:04-Projects/alpha.md'), 'new project note');
+  assert.equal(git(root, 'rev-list', '--count', 'HEAD'), '2');
+});
+
+test('the ignored-path sweep is scoped to vault regions and never widens to private ignored files', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  // Reaching past .gitignore for the user's notes must not start sweeping in the ignored
+  // paths that are ignored precisely because they should stay out of history.
+  fs.copyFileSync(path.join(REPO_ROOT, '.gitignore'), path.join(root, '.gitignore'));
+  fs.mkdirSync(path.join(root, 'System', 'integrations'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'System', 'credentials'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'node_modules', 'left-over'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.env'), 'API_KEY=fixture-secret-value\n');
+  fs.writeFileSync(path.join(root, 'System', 'trusted-mcps.yaml'), 'trusted: [fixture]\n');
+  fs.writeFileSync(
+    path.join(root, 'System', 'integrations', '.pipedrive-cache.json'),
+    '{"deal":"fixture deal title"}\n',
+  );
+  fs.writeFileSync(path.join(root, 'System', 'integrations', 'pipedrive.yaml'), 'enabled: true\n');
+  fs.writeFileSync(path.join(root, 'System', 'credentials', 'fixture.json'), '{"refresh_token":"x"}\n');
+  fs.writeFileSync(path.join(root, 'node_modules', 'left-over', 'index.js'), 'module.exports = 1;\n');
+  fs.mkdirSync(path.join(root, '05-Areas'), { recursive: true });
+  fs.writeFileSync(path.join(root, '05-Areas', 'health.md'), 'a real note\n');
+
+  const result = hook.run({ root, now: new Date('2026-08-12T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(git(root, 'show', 'HEAD:05-Areas/health.md'), 'a real note');
+  for (const relative of [
+    '.env',
+    'System/trusted-mcps.yaml',
+    'System/integrations/.pipedrive-cache.json',
+    'System/integrations/pipedrive.yaml',
+    'System/credentials/fixture.json',
+    'node_modules/left-over/index.js',
+  ]) {
+    assert.equal(git(root, 'ls-tree', '-r', '--name-only', 'HEAD', '--', relative), '', relative);
+  }
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
 test('settings wires the opt-in hook after session-end and the shipped profile defaults off', () => {
   const settings = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, '.claude', 'settings.json'), 'utf8'));
   const commands = settings.hooks.SessionEnd[0].hooks.map((entry) => entry.command);

--- a/.claude/hooks/vault-autocommit.cjs
+++ b/.claude/hooks/vault-autocommit.cjs
@@ -255,12 +255,22 @@ function nulPaths(result) {
   return result.stdout.toString('utf8').split('\0').filter(Boolean);
 }
 
-function candidateWorktreePaths(root) {
+function candidateWorktreePaths(root, contract) {
   const commands = [
     ['diff', '--name-only', '-z'],
     ['diff', '--cached', '--name-only', '-z'],
     ['ls-files', '--others', '--exclude-standard', '-z'],
   ];
+  // The shipped .gitignore ignores the PARA folders wholesale, so the sweep above cannot
+  // see a note the user wrote today — it would report a healthy snapshot that saved
+  // nothing new (#485). Look inside the contract's own vault regions for ignored-but-
+  // untracked content as well. Scoped deliberately to those regions: other ignored paths
+  // (the Pipedrive cache, trusted-mcps.yaml, per-user integration settings) are ignored
+  // because they should stay out of history, and this must not start sweeping them in.
+  const regions = Array.isArray(contract.vault_regions) ? contract.vault_regions : [];
+  if (regions.length > 0) {
+    commands.push(['ls-files', '--others', '--ignored', '--exclude-standard', '-z', '--', ...regions]);
+  }
   const paths = [];
   for (const command of commands) {
     const result = nulPaths(git(root, command, { encoding: null }));
@@ -333,12 +343,19 @@ function run(options = {}) {
     if (!ensureLocalIdentity(root)) {
       return status('broken', 'Vault auto-commit could not set a local-only commit identity.');
     }
-    const candidates = candidateWorktreePaths(root);
+    const candidates = candidateWorktreePaths(root, contract);
     if (candidates === null) {
       return status('unknown', 'Vault auto-commit could not determine eligible local files.');
     }
     const eligible = candidates.filter((relative) => eligiblePath(contract, relative));
-    if (eligible.length > 0 && git(root, ['add', '-A', '--', ...eligible]).status !== 0) {
+    // The shipped .gitignore ignores the PARA folders, and a pathspec add that touches an
+    // ignored directory hard-fails as a whole — so a vault whose PARA content is tracked
+    // (what the v1-to-v2 migration leaves behind) could never stage anything, and every
+    // run returned broken into the SessionEnd void (#485). Eligibility here is decided by
+    // the ownership contract above and the protected-file sweep below, not by .gitignore,
+    // so bypass the ignore objection for exactly these paths — the same way the migration
+    // stages the vault's existing history.
+    if (eligible.length > 0 && git(root, ['add', '-A', '-f', '--', ...eligible]).status !== 0) {
       return status('broken', 'Vault auto-commit could not prepare the local snapshot. Files are unchanged.');
     }
     const rejected = stagedRejectedPaths(root, contract);


### PR DESCRIPTION
Fixes #485. Reported by @chrisjackson-coding, who found it on a live vault: auto-commit on, sessions ending daily, zero commits, no error visible anywhere.

## What was broken

The shipped `.gitignore` ignores the PARA folders. The hook stages with pathspecs (`git add -A -- <eligible paths>`), and **a pathspec add that touches an ignored directory hard-fails as a whole** — so nothing was ever staged, the hook returned `broken` on every run, and that status went to `SessionEnd`, where nothing reads it.

Reproduced here from a stock vault shape, with the reporter's error verbatim:

```
The following paths are ignored by one of your .gitignore files:
03-Tasks
04-Projects
hint: Use -f if you really want to add them.
```

Worth being precise about the blast radius: **a single tracked, modified note is enough.** It does not need new files, and it is not configuration-specific. The hook shipped in v1.64.0 on 21 July and has not been touched since, so this has been the behaviour for every user who enabled the feature, for three weeks.

## The fix, in two halves

**1. Staging** — the eligible set is staged with `add -A -f`, the way `v1-to-v2-brain-vault-split.cjs` already stages the vault's existing history. What may be committed is decided by the ownership contract and the protected-file/secret sweep, not by `.gitignore`.

**2. Discovery** — `candidateWorktreePaths` now also lists ignored-but-untracked content inside the contract's own `vault_regions`.

The second half is not optional, and this was the most useful thing to come out of the fix. With only the staging half, the hook reports:

```
status: ok | Dex saved this session to local vault history.
files in the snapshot: 03-Tasks/Tasks.md
STILL UNSAVED: 00-Inbox/captured.md, 03-Tasks/brand-new-task.md, 04-Projects/
```

A green status over three unsaved notes is a worse outcome than the loud failure it replaced, because nobody would go looking. Both halves are needed for the feature to mean what it says.

## Scoping, deliberately

The ignored-path sweep is limited to `vault_regions` (the eight PARA folders) rather than dropping `--exclude-standard`. The other ignored paths are ignored *because they should stay out of history* — `System/integrations/.pipedrive-cache.json` (real deal titles and CRM ids), `System/trusted-mcps.yaml`, per-user integration settings, `.env`, `node_modules`. A new test pins that all six stay out while a real note goes in.

## Verification

- `node --test .claude/hooks/tests/vault-autocommit.test.cjs` — 9/9 pass.
- **Both new tests fail if either half of the fix is reverted** (checked in both directions, one half at a time). They are not decorative.
- `npm run test:hooks`: 34 failures before my change and the same 34 after, identical test names — all in unrelated meeting/Obsidian hooks, on Linux rather than CI's macOS. My change neither adds nor fixes any of them.
- `scripts/check-pii.sh` and `scripts/check-founder-content.sh` pass.

## Why the suite was green while every vault was broken

No fixture ever wrote a `.gitignore` — the one condition every real vault has. The tests exercised a repo shape that does not ship. Both new tests copy the real shipped `.gitignore` in.

## Two things for a reviewer to weigh, not fixed here

1. **`core/utils/safe_autosave.py:330` has the same defect.** It stages with `add --pathspec-from-file=-` and no `-f`, and `_autosave_paths` feeds it tracked-modified paths from `git status`, which includes notes inside the ignored PARA folders. Confirmed at the git level with the same fixture. Left alone deliberately: it sits on the transaction/CAS path, and it raises rather than failing silently, so it is a different severity and deserves its own change.
2. **The reporter's deeper question stands** — whether the PARA ignore lines belong in a *vault's* `.gitignore` at all, given they are the vault's entire content, and whether the vault-mode composer is the right owner. This PR fixes the feature without settling that.

A third point from the report is also still open and is not addressed here: **a `broken` status returned at `SessionEnd` is invisible by construction.** Surfacing it at the next session start would have caught this on day one.