### PR TITLE
release: refuse to label a different tree as this version, and fix the flake that caused it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,15 @@ jobs:
           else
             echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
+      # This job builds from whatever main HEAD is when it runs, but labels the
+      # result with package.json's version. If the run at the release commit
+      # never reaches the build — one flaky test is enough — a later run builds
+      # a newer tree under the old version. The read-back check downstream
+      # cannot see it: it compares attached against built, and both sides are
+      # the same wrong tree.
+      - name: Refuse to label a different tree as this version
+        if: steps.release_guard.outputs.already_published == 'false'
+        run: bash scripts/check-release-tree-matches-tag.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'

--- a/core/tests/test_release_tree_matches_tag.py
+++ b/core/tests/test_release_tree_matches_tag.py
@@ -1,0 +1,108 @@
+"""Regression tests for the tag-vs-built CI guard.
+
+On 2026-08-12 a v1.95.0 bundle was built from a tree two commits ahead of the
+v1.95.0 tag and attached to the release, because the run at the release commit
+failed on a flaky test and a later run built the assets under the old version.
+The downstream read-back check could not see it: it compares what was attached
+against what was built, and both sides were the same wrong tree. Nothing
+compared the tag against the built tree. These tests pin that comparison.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATE = REPO_ROOT / "scripts/check-release-tree-matches-tag.sh"
+
+# The gate waits for the tag to appear on origin, because release.sh pushes main
+# first and the tag immediately after. Tests supply the tag up front, so collapse
+# the wait rather than paying it.
+NO_WAIT = {"RELEASE_TAG_WAIT_ATTEMPTS": "1", "RELEASE_TAG_WAIT_SECONDS": "0"}
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _repository(tmp_path: Path, version: str = "1.95.0") -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True
+    )
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "-b", "main")
+    _git(repository, "config", "user.name", "Dex Tests")
+    _git(repository, "config", "user.email", "tests@example.com")
+    (repository / "package.json").write_text(f'{{"version":"{version}"}}\n', encoding="utf-8")
+    (repository / "shipped.py").write_text("original\n", encoding="utf-8")
+    _git(repository, "add", "package.json", "shipped.py")
+    _git(repository, "commit", "-m", "release: v" + version)
+    _git(repository, "tag", "-a", f"v{version}", "-m", f"Release v{version}")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "origin", "main", "--tags")
+    return repository, remote
+
+
+def _run(repository: Path) -> subprocess.CompletedProcess[str]:
+    import os
+
+    return subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **NO_WAIT},
+    )
+
+
+def test_gate_passes_when_the_build_runs_on_the_release_commit(tmp_path: Path) -> None:
+    repository, _ = _repository(tmp_path)
+
+    result = _run(repository)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "share tree" in result.stdout
+
+
+def test_gate_rejects_a_build_running_ahead_of_the_tag(tmp_path: Path) -> None:
+    """The exact v1.95.0 failure: version says 1.95.0, HEAD is the tag plus commits."""
+    repository, _ = _repository(tmp_path)
+    (repository / "shipped.py").write_text("changed after the tag\n", encoding="utf-8")
+    _git(repository, "add", "shipped.py")
+    _git(repository, "commit", "-m", "a merge that landed after the tag was pushed")
+
+    result = _run(repository)
+
+    assert result.returncode == 1
+    assert "would label a different tree as 1.95.0" in result.stderr
+    # The operator has to be able to see WHICH files would ship wrongly.
+    assert "shipped.py" in result.stderr
+
+
+def test_gate_passes_when_a_later_commit_changed_nothing(tmp_path: Path) -> None:
+    """Trees, not commits: identical content under a new commit is safe to publish."""
+    repository, _ = _repository(tmp_path)
+    _git(repository, "commit", "--allow-empty", "-m", "empty commit after the tag")
+
+    result = _run(repository)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_gate_refuses_when_the_version_has_no_tag(tmp_path: Path) -> None:
+    """A version nothing can be checked against is not a version worth publishing."""
+    repository, _ = _repository(tmp_path)
+    (repository / "package.json").write_text('{"version":"9.9.9"}\n', encoding="utf-8")
+    _git(repository, "add", "package.json")
+    _git(repository, "commit", "-m", "bump without a release tag")
+
+    result = _run(repository)
+
+    assert result.returncode == 1
+    assert "no v9.9.9 exists on origin" in result.stderr

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -997,17 +997,24 @@ def test_hanging_journey_is_killed_and_returns_exit_two(monkeypatch, tmp_path: P
 def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     sentinel = tmp_path / "timed-out-descendant-survived"
-    # The survival window and the post-run wait below are seconds apart on purpose:
-    # with a tight margin (formerly 0.7s sleep / 0.8s wait) a CPU-starved descendant
-    # on a loaded runner could be delayed past the check and fake a pass even when
-    # the kill logic is broken. Wide margins keep this test honest under parallel load.
+    spawned = tmp_path / "descendant-was-spawned"
+    # Three timings, and the order between them is the whole test:
+    #   spawn happens well inside the journey budget (so there is something to kill),
+    #   the budget expires long before the descendant would write (so a working kill
+    #   leaves no sentinel), and the post-run wait outlasts the descendant (so a
+    #   survivor is actually observed rather than merely not-yet-arrived).
+    # The former 0.4s budget was the flake (F11, #477): on a loaded runner it could
+    # expire before the parent had spawned the descendant at all, orphaning a process
+    # the kill never saw, which then wrote the sentinel and blamed the kill logic.
+    budget, descendant_delay, post_run_wait = 3.0, 8.0, 10.0
     descendant = (
-        "import time; from pathlib import Path; time.sleep(2.5); "
+        f"import time; from pathlib import Path; time.sleep({descendant_delay}); "
         f"Path({str(sentinel)!r}).touch()"
     )
     parent = (
-        "import subprocess, sys, time; "
+        "import subprocess, sys, time; from pathlib import Path; "
         f"subprocess.Popen([sys.executable, '-c', {descendant!r}]); "
+        f"Path({str(spawned)!r}).touch(); "
         "time.sleep(60)"
     )
     monkeypatch.setattr(
@@ -1019,12 +1026,18 @@ def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path
     run = smoke.run_smoke(
         vault_root=vault,
         repo_root=REPO_ROOT,
-        journey_definitions=(_definition("configs", 0.4),),
+        journey_definitions=(_definition("configs", budget),),
     )
-    time.sleep(4.0)
+    time.sleep(post_run_wait)
 
     assert run.exit_code == 2
     assert "timed out" in run.report["journeys"][0]["detail"]
+    # Without this, a run where the descendant was never spawned passes while
+    # proving nothing: no descendant, no sentinel, no kill exercised.
+    assert spawned.exists(), (
+        "the parent never spawned a descendant, so this test did not exercise the "
+        "kill path at all; it cannot pass on that basis"
+    )
     assert not sentinel.exists()
 
 

--- a/scripts/check-release-tree-matches-tag.sh
+++ b/scripts/check-release-tree-matches-tag.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Refuse to build release assets from a tree that is not the tree of the tag
+# whose version they will be labelled with.
+#
+# Why this exists: build-release triggers on pushes to main and builds from
+# whatever main HEAD is at execution time, while taking the release identity
+# from package.json. If the run at the release commit does not reach the build
+# step — a flaky test is enough — a later run builds the assets from a newer
+# tree and still labels them with the old version. On 2026-08-12 that shipped a
+# v1.95.0 bundle containing core/customization_migration/inventory.py from two
+# commits later; only an unrelated TLS failure in the read-back step stopped it
+# going public.
+#
+# The existing read-back check cannot catch this: it compares what was ATTACHED
+# against what was BUILT, and both sides are the later tree, so it agrees with
+# itself. Nothing compared the TAG against the BUILT tree. This does.
+#
+# Trees, not commits: a later commit whose tree is identical (a revert pair, an
+# empty commit) ships byte-identical content and is safe. Content drift is the
+# thing to refuse.
+set -euo pipefail
+
+VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
+TAG="v${VERSION}"
+REF="refs/tags/${TAG}"
+
+# release.sh pushes main first and the tag immediately after, so a run that
+# starts between the two would see no tag yet. Wait briefly rather than fail a
+# legitimate release on a few seconds of ordering.
+ATTEMPTS="${RELEASE_TAG_WAIT_ATTEMPTS:-12}"
+SLEEP_SECONDS="${RELEASE_TAG_WAIT_SECONDS:-5}"
+FOUND=""
+for _ in $(seq 1 "$ATTEMPTS"); do
+  if [ -n "$(git ls-remote --tags origin "$REF" 2>/dev/null)" ]; then
+    FOUND=1
+    break
+  fi
+  sleep "$SLEEP_SECONDS"
+done
+
+if [ -z "$FOUND" ]; then
+  echo "❌ Release-tree gate failed: package.json says $VERSION but no $TAG exists on origin." >&2
+  echo "Assets labelled $VERSION would have no tag to be checked against, so they cannot be trusted to name their own contents." >&2
+  echo "Push the release tag, or bump the version in a release commit that carries one." >&2
+  exit 1
+fi
+
+git fetch --quiet origin "$REF:$REF" 2>/dev/null || true
+
+if ! TAG_TREE="$(git rev-parse --verify --quiet "${TAG}^{tree}")"; then
+  echo "❌ Release-tree gate failed: $TAG exists on origin but could not be resolved locally." >&2
+  echo "Refusing to build rather than guess which tree $VERSION names." >&2
+  exit 1
+fi
+HEAD_TREE="$(git rev-parse "HEAD^{tree}")"
+
+if [ "$TAG_TREE" != "$HEAD_TREE" ]; then
+  TAG_COMMIT="$(git rev-parse "${TAG}^{commit}")"
+  HEAD_COMMIT="$(git rev-parse HEAD)"
+  echo "❌ Release-tree gate failed: this build would label a different tree as $VERSION." >&2
+  echo "  $TAG names commit $TAG_COMMIT (tree $TAG_TREE)" >&2
+  echo "  this build is running on $HEAD_COMMIT (tree $HEAD_TREE)" >&2
+  echo "" >&2
+  echo "Files that differ between them:" >&2
+  git diff --name-only "$TAG_TREE" "$HEAD_TREE" 2>/dev/null | sed 's/^/  /' >&2 || true
+  echo "" >&2
+  echo "Publishing now would produce assets whose contents are not the contents of $TAG." >&2
+  echo "Re-run the build on the release commit itself, or cut a fresh version for the current tree." >&2
+  exit 1
+fi
+
+echo "Release-tree gate passed: $TAG and this build share tree $TAG_TREE."


### PR DESCRIPTION
## What happened

The v1.95.0 assets were built from a tree **two commits ahead of the tag** and attached to the release:

```
bundled core/customization_migration/inventory.py  3c9436f1…   ← matches 9fab1a45
same file at tag v1.95.0                           ae92a542…   ← does not match
```

Anyone installing "1.95.0" would have got `inventory.py` from #482, which is not in 1.95.0. `dist/release/v1.95.0-63da767` records the later tree too, so the immutable record was wrong as well.

It never reached a user: the release was a hidden draft throughout, and an unrelated TLS failure in the read-back step stopped the flip to public. Its four assets have since been deleted and the draft carries a note explaining why.

## Fault 1 — nothing compared the tag against the built tree

`build-release` triggers on pushes to `main` and builds from whatever HEAD is at execution time, while taking the release *identity* from `package.json`. The run at the release commit failed on a flaky test, so its build was skipped; a later run built the assets under the old version.

**The existing read-back check structurally cannot catch this.** Step 4/5 compares **attached** against **built** — both sides are the same wrong tree, so it agrees with itself and passes. This is the F1/F2/F4 shape from the gate audit: a check that runs, produces output, and verifies the wrong pair.

`scripts/check-release-tree-matches-tag.sh` makes the missing comparison. Notes on the design:

- **Trees, not commits.** An empty commit or a revert pair ships byte-identical content and still publishes. Content drift is the thing to refuse.
- **Waits, then fails closed.** `release.sh` pushes `main` first and the tag immediately after, so a run starting between the two would see no tag. It waits briefly rather than failing a legitimate release on ordering, then refuses if the tag never appears — a version with nothing to check against cannot be trusted to name its own contents.
- **Names the damage.** On refusal it prints both commits, both trees, and every differing file.

### Demonstrated failing before being trusted

Run against the real repository state — `package.json` 1.95.0, HEAD `9fab1a45`:

```
❌ Release-tree gate failed: this build would label a different tree as 1.95.0.
  v1.95.0 names commit 51e84a72… (tree 75fd8e8a…)
  this build is running on 9fab1a45… (tree 96bc6820…)

Files that differ between them:
  CHANGELOG.md
  core/customization_migration/inventory.py
  core/lifecycle/performance-budget-v1.json
  docs/gate-omission-audit-2026-08-11.md
```

And passing on the correct case, checked out at the release commit itself:

```
Release-tree gate passed: v1.95.0 and this build share tree 75fd8e8a…
```

Four tests pin it: passes on the release commit, refuses a build ahead of the tag (asserting the differing file is named), passes for a later commit with an identical tree, refuses a version with no tag.

## Fault 2 — the flaky test that triggered it, which could pass while proving nothing

`test_timed_out_journey_kills_delayed_descendants` gave the journey a **0.4s** budget. On a loaded runner that can expire before the parent has spawned its descendant, so the kill has nothing to kill, the orphan survives, writes the sentinel, and the failure is attributed to the kill logic (F11, #477).

Worse: **a run where the descendant was never spawned passed** — no descendant, no sentinel, no kill exercised. Now the budget comfortably covers the spawn, the descendant outlives the kill by a wide margin, the post-run wait outlasts the descendant so a survivor is genuinely observed, and a new assertion fails the test outright if nothing was ever spawned.

## Verification, including what I could not verify

- Gate script + 4 tests: **verified locally, both directions.**
- Workflow YAML parses; the gate sits between the already-published check and the build.
- **The smoke test fix is NOT verified on Linux.** It fails on this machine both before and after the change — `run_smoke` does not produce journey timeouts here, so `assert run.exit_code == 2` cannot pass locally. That needs the macOS runners, and I would not claim it fixed on local evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)