### PR TITLE
test: prove Lens vendored-source guard blocks the real shape

### DIFF
--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -237,9 +237,22 @@ def test_generator_rejects_unshipped_or_stale_source(tmp_path: Path) -> None:
 
 
 def test_generator_rejects_vendored_third_party_skill_sources(tmp_path: Path) -> None:
+    """Dex must never present a vendored third-party skill as its own capability.
+
+    Sixteen `.claude/skills/anthropic-*` skills ship in the tree, and without the
+    structural guard the producer signs and publishes them as Dex capabilities --
+    verified by removing the guard and watching this fixture build cleanly.
+
+    The entry id deliberately MATCHES the vendored path. With a mismatched id the
+    entry-id/path check refuses first, so the test would pass with the guard
+    deleted and prove nothing: the exact registry shape that actually slips
+    through is the one where the id agrees with the path. The negative assertions
+    below hold this property in place.
+    """
     _registry(tmp_path)
-    vendored_bytes = _skill(tmp_path, "anthropic-pdf")
+    vendored_bytes = _skill(tmp_path, "anthropic-pdf", description="Vendored third-party PDF skill.")
     data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
+    data["entries"][0]["id"] = "anthropic-pdf"
     data["entries"][0]["source"] = {
         "kind": "skill",
         "path": ".claude/skills/anthropic-pdf/SKILL.md",
@@ -252,6 +265,11 @@ def test_generator_rejects_vendored_third_party_skill_sources(tmp_path: Path) ->
 
     assert result.returncode == 1
     assert "must not be a vendored third-party skill" in result.stderr
+    # The guard is the reason, not some other check that happens to fire first.
+    assert "must match entry id" not in result.stderr
+    assert "must be a shipped skill SKILL.md" not in result.stderr
+    # Fails closed: nothing left for the release job's upload steps to publish.
+    assert _lens_artifacts(tmp_path) == []
 
 
 def test_signing_requires_environment_secret_and_never_generates_a_key(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Strengthens the Dex Lens catalogue vendored-source guard test only.
- Makes the fixture use an `anthropic-pdf` entry id with `.claude/skills/anthropic-pdf/SKILL.md`, so the test exercises the shape that could actually be signed without the guard.
- Adds negative assertions so it cannot pass through the older id/path or shipped-skill checks, and asserts no Lens catalogue artifacts are left behind.

## Verification
- `python3 -m pytest -q core/tests/test_dex_lens_catalog_generation.py` -> 20 passed.
- `python3 -m ruff check core/tests/test_dex_lens_catalog_generation.py scripts/generate-dex-lens-catalog.py` -> passed.
- Mutation proof: locally removed the `.claude/skills/anthropic-` guard from `scripts/generate-dex-lens-catalog.py`, then ran `python3 -m pytest -q core/tests/test_dex_lens_catalog_generation.py::test_generator_rejects_vendored_third_party_skill_sources`; it failed because the generator returned 0 and wrote artifacts. Restored the guard and reran the focused test -> passed.

## Boundaries
- Test-only follow-up after #489.
- No registry, generator, release setting, tag, release, deploy, public copy, secrets, or live-bridge claim changed.
