### PR TITLE
ci(build-release): set up Python, so the Lens catalogue step can install its dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,14 @@ jobs:
       - name: Refuse to label a different tree as this version
         if: steps.release_guard.outputs.already_published == 'false'
         run: bash scripts/check-release-tree-matches-tag.sh
+      # The Lens catalogue step pip-installs cryptography. Without this, python3 is
+      # the runner's system interpreter, which is externally managed (PEP 668) and
+      # refuses a bare pip install — so that step failed the moment it was first
+      # enabled for a real release. Every other job here that pip-installs already
+      # sets up Python this way.
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Blocking the v1.95.1 release right now

`build-release` failed on the tagged tree at the **Generate signed Dex Lens catalog** step:

```
Run python3 -m pip install 'cryptography>=42'
error: externally-managed-environment
```

My release-tree gate passed immediately before it (`v1.95.1 and this build share tree f61b1181`), and the bridge and bundle were already built — so the failure is purely this step, and it left the release a draft with nothing attached.

## Cause

`build-release` sets up **Node** but never **Python**. So `python3` is the macOS runner's system interpreter, which is externally managed (PEP 668) and refuses a bare `pip install`.

## Why it has never been seen before

The step is gated behind `DEX_LENS_CATALOG_RELEASE_GATE_ENABLED`, which was switched on for the first time at **09:13Z today**. The v1.95.1 build is the first release build ever to reach this step. It could not have succeeded on any earlier attempt either — the flag hid a step that had never run, rather than the step having regressed.

Worth recording in the gate-omission family for that reason: a release-path step behind a feature flag is a step nothing exercises until a live release does.

## Fix

`actions/setup-python` at the same pinned SHA every other pip-installing job in this workflow already uses, placed before the step that needs it. Nothing about the catalogue's contents or signing changes.

## Verification

- YAML parses; step order confirmed (`setup-python` precedes `setup-node`, `npm ci`, and the catalogue step)
- The catalogue generator itself is already proven on this tree: run unsigned against `50dbce6b` it exits 0 and writes `dex-lens-catalog-v1.95.1.json`, so only the dependency install was broken
- Cannot be verified locally beyond that: the failure is specific to the macOS runner's interpreter, so CI is the proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)