### PR TITLE
release: run Lens catalogue signing in an isolated Python venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,8 +408,17 @@ jobs:
           # environment secret; no generated private key belongs in the repo.
           DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64: ${{ secrets.DEX_LENS_CATALOG_ED25519_PRIVATE_KEY_B64 }}
         run: |
-          python3 -m pip install 'cryptography>=42'
-          python3 scripts/generate-dex-lens-catalog.py \
+          # build-release never runs actions/setup-python, so `python3` here is the
+          # runner's Homebrew interpreter and PEP 668 refuses a system-wide install:
+          # `pip install cryptography` died with externally-managed-environment and
+          # took the whole release with it. An isolated venv keeps the install off the
+          # system interpreter without --break-system-packages (which Homebrew warns
+          # can break the runner) and without changing `python3` for any other step.
+          # jsonschema is installed too: the producer imports it at module scope, so
+          # a venv holding only cryptography would fail on the very next line.
+          python3 -m venv .lens-venv
+          .lens-venv/bin/python -m pip install --quiet 'cryptography>=42' jsonschema
+          .lens-venv/bin/python scripts/generate-dex-lens-catalog.py \
             --release-root "$PWD" \
             --output-dir dist \
             --sign \


### PR DESCRIPTION
## Summary
- Fixes the `build-release` Lens catalogue step that failed on macOS/Homebrew Python with `externally-managed-environment` before the producer ran.
- Creates a step-local `.lens-venv`, installs `cryptography>=42` and `jsonschema`, then runs `scripts/generate-dex-lens-catalog.py` through that venv.
- Leaves every other build-release step on the runner default Python; no tag, release, registry, signing key, gate variable, deploy, or public claim changed.

## Root Cause
Run 31583388550 reached `Generate signed Dex Lens catalog` and failed on its first line:

```
python3 -m pip install 'cryptography>=42'
error: externally-managed-environment
× This environment is externally managed
```

`build-release` does not run `actions/setup-python`, so `python3` is Homebrew-managed on macOS and refuses system-wide pip installs under PEP 668. The producer imports `jsonschema` at module scope, so the venv installs that as well as `cryptography`.

## Verification
- `gh run view 31583388550 --job 94073698744 --log` confirms the failure at `Generate signed Dex Lens catalog` before the producer ran.
- `python3 - <<PY ... yaml.safe_load(...)` -> workflow YAML parses.
- `python3 -m py_compile scripts/generate-dex-lens-catalog.py` -> passed.
- Local venv proof with exactly `cryptography>=42` + `jsonschema` generated signed `dex-lens-catalog-v1.95.1.json`, `dex-lens-catalog-latest.json`, and both sha256 sidecars; `sha256sum -c dex-lens-catalog-v1.95.1.json.sha256` -> OK.
- `python3 -m pytest -q core/tests/test_dex_lens_catalog_generation.py` -> 20 passed.
- `python3 -m ruff check scripts/generate-dex-lens-catalog.py core/tests/test_dex_lens_catalog_generation.py` -> passed.

## Boundary
This is a release-lane unblocker PR only. It does not publish the release; release owner still verifies assets before anything is called live.
