### PR TITLE
release: exercise Lens catalogue before burning release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, beta]
     tags: ['v*']
   pull_request:
+  workflow_dispatch:
   # Merge queue: CI validates the QUEUED BATCH exactly as it will land on main,
   # then everything in the batch merges together on one green run.
   merge_group:
@@ -316,6 +317,48 @@ jobs:
             echo "::warning::The token cannot read PR comments (common for forks); use the job summary report."
           fi
 
+  lens-catalog-release-dry-run:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - name: Decide whether the Lens catalogue release path changed
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" | tee "$RUNNER_TEMP/lens-catalog-changed-files.txt"
+          if grep -E '^(\.github/workflows/ci\.yml|scripts/generate-dex-lens-catalog\.py|core/lens-catalog/)' "$RUNNER_TEMP/lens-catalog-changed-files.txt"; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No Lens catalogue release-path changes; dry-run skipped."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Dry-run the Lens catalogue release environment
+        if: steps.changes.outputs.should_run == 'true'
+        run: |
+          OUTPUT_DIR="$RUNNER_TEMP/dex-lens-catalog-dry-run"
+          python3 -m venv .lens-venv
+          .lens-venv/bin/python -m pip install --quiet 'cryptography>=42' jsonschema
+          .lens-venv/bin/python scripts/generate-dex-lens-catalog.py \
+            --release-root "$PWD" \
+            --output-dir "$OUTPUT_DIR"
+          VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
+          test -f "$OUTPUT_DIR/dex-lens-catalog-v$VERSION.json"
+          test -f "$OUTPUT_DIR/dex-lens-catalog-v$VERSION.json.sha256"
+          test -f "$OUTPUT_DIR/dex-lens-catalog-latest.json"
+          test -f "$OUTPUT_DIR/dex-lens-catalog-latest.json.sha256"
+
   build-release:
     needs: [quality, test-results]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -391,11 +434,6 @@ jobs:
           RELEASE_TAG="dist/release/v${VERSION}-$(git rev-parse --short release)"
           git rev-parse --verify "refs/tags/$RELEASE_TAG"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-      - name: Push release branch and immutable tag
-        if: steps.release_guard.outputs.already_published != 'true'
-        run: |
-          git push origin release --force
-          git push origin "${{ steps.release_build.outputs.release_tag }}"
       - name: Build self-contained vault bundle
         if: steps.release_guard.outputs.already_published != 'true'
         run: bash scripts/build-vault-bundle.sh
@@ -433,6 +471,11 @@ jobs:
             dist/dex-lens-catalog-latest.json.sha256
           if-no-files-found: error
           retention-days: 1
+      - name: Push release branch and immutable tag
+        if: steps.release_guard.outputs.already_published != 'true'
+        run: |
+          git push origin release --force
+          git push origin "${{ steps.release_build.outputs.release_tag }}"
       # The ONLY step that makes a stable release public, and it does so last:
       # attach every asset, read each one back off the release and compare it to
       # what was built, and only then flip the draft public. A failure anywhere here

--- a/core/tests/test_release_workflows_draft_first.py
+++ b/core/tests/test_release_workflows_draft_first.py
@@ -177,6 +177,54 @@ def test_the_stable_lane_keeps_the_non_cancelling_publish_lock() -> None:
     }
 
 
+def test_lens_catalog_release_environment_has_a_pr_dry_run() -> None:
+    """The release-only Lens step must be exercised before it can burn a version."""
+    workflow = _load(CI_WORKFLOW)
+    triggers = _triggers(workflow)
+    assert "workflow_dispatch" in triggers
+
+    dry_run = workflow["jobs"]["lens-catalog-release-dry-run"]
+    assert dry_run["runs-on"] == "macos-latest"
+    assert dry_run["permissions"] == {"contents": "read"}
+    assert dry_run["if"] == (
+        "github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'"
+    )
+
+    steps = {s["name"]: s for s in dry_run["steps"] if "name" in s}
+    changed = steps["Decide whether the Lens catalogue release path changed"]["run"]
+    assert r"\.github/workflows/ci\.yml" in changed
+    assert r"scripts/generate-dex-lens-catalog\.py" in changed
+    assert "core/lens-catalog/" in changed
+
+    run = steps["Dry-run the Lens catalogue release environment"]["run"]
+    assert "python3 -m venv .lens-venv" in run
+    assert ".lens-venv/bin/python -m pip install --quiet 'cryptography>=42' jsonschema" in run
+    assert ".lens-venv/bin/python scripts/generate-dex-lens-catalog.py" in run
+    assert "--release-root \"$PWD\"" in run
+    assert "--output-dir \"$OUTPUT_DIR\"" in run
+    assert "--sign" not in run
+    assert "dex-lens-catalog-latest.json" in run
+
+
+def test_lens_catalog_is_generated_before_the_immutable_release_tag_is_pushed() -> None:
+    """A catalogue failure must fail the run before a version marker is burned."""
+    workflow = _load(CI_WORKFLOW)
+    steps = [
+        step["name"]
+        for step in workflow["jobs"]["build-release"]["steps"]
+        if "name" in step
+    ]
+    assert steps.index("Build self-contained vault bundle") < steps.index(
+        "Push release branch and immutable tag"
+    )
+    assert steps.index("Generate signed Dex Lens catalog") < steps.index(
+        "Push release branch and immutable tag"
+    )
+    assert steps.index("Push release branch and immutable tag") < steps.index(
+        "Attach assets, verify them, then make the release public"
+    )
+
+
 def test_the_draft_explains_the_queue_when_the_fleet_proof_holds_the_lock() -> None:
     """A release waiting hours behind the proof must say so, not look stalled."""
     source = PUBLISH_SCRIPT.read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

This closes the release-safety gap behind the Dex Lens catalogue step.

- Adds a macOS `lens-catalog-release-dry-run` job to `ci.yml`.
- The job runs on `workflow_dispatch`, and on PRs when the release workflow, Lens catalogue producer, or catalogue registry/schema changes.
- It creates the same isolated `.lens-venv`, installs both `cryptography>=42` and `jsonschema`, and builds the real registry catalogue unsigned into `$RUNNER_TEMP`. No secret, signing, tag, publish, deploy, or public claim is touched.
- Moves `Push release branch and immutable tag` until after the vault bundle and signed Lens catalogue generation, so catalogue failure happens before the immutable dist tag is burned.
- Adds workflow-contract tests for the dry-run job and the tag-push ordering.

## Root cause

The release-only Lens catalogue step was behind the real release path. It could fail for runner-environment reasons that PR tests never exercised. That burned version markers before the failure was found.

## Local verification

- `python3 -m pytest -q core/tests/test_release_workflows_draft_first.py -q` failed first on current main because there was no dry-run trigger/job.
- Added the dry-run job, then added the ordering test; it failed first because the immutable tag push happened before bundle/catalogue generation.
- `python3 -m pytest -q core/tests/test_release_workflows_draft_first.py core/tests/test_dex_lens_catalog_generation.py` -> 39 passed.
- `python3 -m pytest -q core/tests/test_release_workflows_draft_first.py core/tests/test_release_publish_draft_first.py core/tests/test_release_tag_uniqueness.py core/tests/test_distribution_artifacts.py` -> 148 passed, 1 existing xdist mark warning.
- `python3 -m ruff check core/tests/test_release_workflows_draft_first.py` -> passed.
- YAML parse for `.github/workflows/ci.yml` -> passed.
- Local venv dry-run with exactly `cryptography>=42` + `jsonschema` generated `dex-lens-catalog-v1.95.1.json`, latest JSON, and both sha256 sidecars.
- `git diff --check` -> passed.
- `bash scripts/check-pii.sh` -> passed.
- `bash scripts/check-test-delta.sh` / `check-doc-drift.sh` -> no changed files detected for their filters.
- `bash scripts/check-architecture-inventory.sh` -> passed.

## Required remote proof

The new macOS `lens-catalog-release-dry-run` job must run on this PR and pass. That is the proof the release-step environment is now exercised before a real release.

## Boundaries

No release, tag, deploy, DNS, secret, public bridge claim, or user-facing copy touched.
