### PR TITLE
Start the bridge probe from an untidy caller environment

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -2643,6 +2643,108 @@ def test_bridge_process_entry_probe_retains_the_streams_it_judged(
     ).read_text(encoding="utf-8")
 
 
+def test_bridge_process_entry_probe_starts_from_an_untidy_caller_environment(
+    tmp_path: Path,
+) -> None:
+    """A clean launch lets the scrub pass by doing nothing.
+
+    The v1.93.0 defect was produced by a caller-chosen locale: the bridge
+    removes it, and the relaunched interpreter must not reintroduce a
+    difference the clean-runtime check then refuses. Launching from the fleet's
+    own sealed environment never presents that input, so the probe deliberately
+    dirties it first. This asserts the dirt actually arrives in the child.
+    """
+
+    asset = tmp_path / "dex-update-bridge-v9.9.9.py"
+    asset.write_text(
+        "import json, os, sys\n"
+        f"print({release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE!r}, file=sys.stderr)\n"
+        "print(json.dumps(dict(os.environ)), file=sys.stderr)\n"
+        "print('{}')\n"
+        "input('Type APPLY to continue: ')\n",
+        encoding="utf-8",
+    )
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    evidence_root = tmp_path / "evidence"
+
+    evidence = release_fleet.probe_bridge_process_entry(
+        vault=vault,
+        bridge_asset=asset,
+        python_runtime=_fixture_python_runtime(),
+        environment={"PATH": "/usr/bin:/bin"},
+        approval_word="APPLY",
+        evidence_root=evidence_root,
+    )
+
+    arrived = json.loads(str(evidence["stderr"]).splitlines()[1])
+    for name, value in release_fleet.BRIDGE_PROCESS_ENTRY_CALLER_NOISE.items():
+        assert arrived[name] == value, f"{name} never reached the launched bridge"
+    # The caller's own environment is preserved, not replaced.
+    assert arrived["PATH"] == "/usr/bin:/bin"
+
+    retained = json.loads(
+        (evidence_root / "bridge-process-entry.json").read_text(encoding="utf-8")
+    )
+    assert retained["caller_environment_noise"] == dict(
+        release_fleet.BRIDGE_PROCESS_ENTRY_CALLER_NOISE
+    )
+
+
+def test_the_caller_noise_is_the_input_class_that_produced_the_defect() -> None:
+    """Pin the parts that matter, so a future tidy-up cannot quietly drop them."""
+
+    noise = release_fleet.BRIDGE_PROCESS_ENTRY_CALLER_NOISE
+
+    # A caller-chosen locale: the bridge tolerates only the coercion's own
+    # outcomes, so a leak of this exact value must fail the clean-runtime check.
+    assert noise["LC_CTYPE"] == "en_GB.UTF-8"
+    assert noise["LC_CTYPE"] not in {"C.UTF-8", "C.utf8", "UTF-8"}
+    # ...and it only stays caller-chosen if the whole locale is. A lone
+    # LC_CTYPE over a C locale is coerced to C.UTF-8 before the launched
+    # process sees it, which the clean-runtime check tolerates -- so the probe
+    # would present no caller-chosen locale at all.
+    assert noise["LANG"] == noise["LC_CTYPE"]
+    assert noise["LC_ALL"] == noise["LC_CTYPE"]
+    # An import path the relaunched interpreter must not inherit.
+    assert "PYTHONPATH" in noise
+
+
+def test_the_caller_locale_survives_even_a_bare_environment(tmp_path: Path) -> None:
+    """The noise must not depend on what the fixture environment happens to set.
+
+    Regression for a real near-miss: with only LC_CTYPE in the noise, this probe
+    presented a caller-chosen locale when the fixture environment set LANG and
+    LC_ALL, and presented none when it did not -- silently, and identically
+    green either way.
+    """
+
+    asset = tmp_path / "dex-update-bridge-v9.9.9.py"
+    asset.write_text(
+        "import json, os, sys\n"
+        f"print({release_fleet.BRIDGE_PROCESS_ENTRY_NOTICE!r}, file=sys.stderr)\n"
+        "print(json.dumps(dict(os.environ)), file=sys.stderr)\n"
+        "print('{}')\n"
+        "input('Type APPLY to continue: ')\n",
+        encoding="utf-8",
+    )
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    evidence = release_fleet.probe_bridge_process_entry(
+        vault=vault,
+        bridge_asset=asset,
+        python_runtime=_fixture_python_runtime(),
+        # Deliberately bare: no LANG, no LC_ALL.
+        environment={"PATH": "/usr/bin:/bin"},
+        approval_word="APPLY",
+        evidence_root=tmp_path / "evidence",
+    )
+
+    arrived = json.loads(str(evidence["stderr"]).splitlines()[1])
+    assert arrived["LC_CTYPE"] == "en_GB.UTF-8"
+
+
 def test_bridge_process_entry_probe_retains_the_streams_of_a_failing_run(
     tmp_path: Path,
 ) -> None:

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "4403a7dab932220542381ad5006056931a928e405143599e620e76f9ada9eecf",
+    "sha256": "43e8631bbe31557750a04ca059e17e1f6ba6a774b0bf6a409a0a05cdc856b789",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -171,6 +171,21 @@ discrepancy is listed, with file and line, in
 [docs/gate-omission-audit-2026-08-11.md](gate-omission-audit-2026-08-11.md).
 Read that before relying on any gate named here.
 
+**Configuration that has never been executed against the live system is not a
+control — it just reads like one in review.** That audit's sharpest finding was
+`scripts/configure-branch-protection.sh`, which required a status name nothing
+reports. It would have blocked every merge on the first run, and it passed
+review repeatedly because reviewing a script only checks its logic, never its
+contact with reality. Two rules follow, and they apply to any file that
+configures a gate rather than being one:
+
+- Before trusting a name, check it against what the system actually emits —
+  e.g. `gh api repos/<owner>/<repo>/commits/main/check-runs --jq '.check_runs[].name'`
+  for a required status context.
+- Prefer configuration that can only widen. A script that reads live state and
+  submits the union of it with its own floor cannot silently remove a control,
+  however stale its floor becomes.
+
 ## Regression Rule
 - Bug-fix PRs must include a regression test or explicit reviewer-approved exception.
 

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -134,6 +134,31 @@ BRIDGE_PROCESS_ENTRY_REFUSAL = "could not be entered cleanly"
 BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS = 600
 BRIDGE_PROCESS_ENTRY_RETAINED_BYTES = 256 * 1024
 BRIDGE_PROCESS_ENTRY_SUFFIX = ".bridge-process-entry"
+# The scrub is the thing this probe exists to exercise, so it has to start from
+# an environment shaped like a terminal's rather than like the fleet's own
+# sealed one. A caller-chosen LC_CTYPE is the exact input class that produced
+# the v1.93.0 defect: the bridge removes the caller's locale, and the relaunched
+# interpreter must not reintroduce a difference the clean-runtime check then
+# refuses. PYTHONPATH is the import-path equivalent, and the remaining two are
+# what any real shell carries. None of them may survive into the relaunched
+# child -- if one does, the clean-runtime check refuses and this probe fails,
+# which is precisely the coupling that makes launching from a clean environment
+# a weaker test than launching from a dirty one.
+#
+# The locale is set coherently, as a real shell sets it, and deliberately not
+# left to the caller. A lone LC_CTYPE on top of a C locale does not survive:
+# PEP 538 coercion rewrites it to C.UTF-8 before the launched process sees it,
+# which is a *tolerated* value, so the probe would quietly stop presenting the
+# caller-chosen locale at all. Naming all three here keeps that impossible
+# whatever the surrounding fixture environment does.
+BRIDGE_PROCESS_ENTRY_CALLER_NOISE = {
+    "LANG": "en_GB.UTF-8",
+    "LC_ALL": "en_GB.UTF-8",
+    "LC_CTYPE": "en_GB.UTF-8",
+    "PYTHONPATH": "/nonexistent/caller-import-path",
+    "SHELL": "/bin/zsh",
+    "TERM": "xterm-256color",
+}
 SEALED_INSTALLER_ENVIRONMENT_KEYS = frozenset(
     {
         "HOME",
@@ -2227,6 +2252,11 @@ def probe_bridge_process_entry(
     clean-runtime equality check -- and then halts at the first approval gate
     without changing anything. The asset stays outside the vault so the fixture
     that the journey is about to update is not given an extra untracked file.
+
+    The launch environment is the caller's, plus the untidiness a real terminal
+    carries (``BRIDGE_PROCESS_ENTRY_CALLER_NOISE``). Starting from a clean
+    environment would let a scrub pass by doing nothing; starting from a dirty
+    one is what makes the relaunch prove something.
     """
 
     command = [
@@ -2235,13 +2265,14 @@ def probe_bridge_process_entry(
         "--vault",
         str(vault),
     ]
+    launch_environment = {**environment, **BRIDGE_PROCESS_ENTRY_CALLER_NOISE}
     timed_out = False
     exit_code: int | None = None
     try:
         completed = _run_bounded_process_group(
             command,
             cwd=vault,
-            environment=environment,
+            environment=launch_environment,
             timeout_seconds=BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS,
             stdin=subprocess.DEVNULL,
         )
@@ -2258,6 +2289,9 @@ def probe_bridge_process_entry(
         "interpreter": str(python_runtime.requested_python),
         "working_directory": str(vault),
         "stdin": "closed",
+        # Recorded so a reader can see the run really did start untidy; a clean
+        # launch would make the scrub look correct without exercising it.
+        "caller_environment_noise": dict(BRIDGE_PROCESS_ENTRY_CALLER_NOISE),
         "timeout_seconds": BRIDGE_PROCESS_ENTRY_TIMEOUT_SECONDS,
         "timed_out": timed_out,
         "exit_code": exit_code,


### PR DESCRIPTION
Follow-up to #458, agreed with its author and with the reviewer of #457.

## Why

#458's process-entry probe launches the published bridge from the fleet's own
**sealed** environment. A stuck user launches it from a shell — and what a shell
carries is the exact input class that produced the v1.93.0 defect: the bridge
removes the caller's locale, and the relaunched interpreter must not reintroduce
a difference the clean-runtime equality check then refuses.

Launching from a clean environment lets that scrub pass by doing nothing. The
probe is measurably weaker without the dirt.

## What changes

`probe_bridge_process_entry` overlays `BRIDGE_PROCESS_ENTRY_CALLER_NOISE` on the
caller's environment — a coherent locale, an import path, `TERM`, `SHELL` — and
records it in the retained evidence so a reader can see the run really did start
untidy. Nothing else about the probe changes. No new assertion is needed: if any
of that noise leaks into the relaunched child, the existing
`runtime_entry_refused` check already fails, which is the coupling that makes
this worth doing.

## A near-miss worth reading

My first version set only `LC_CTYPE=en_GB.UTF-8`. My own test caught that the
child received `C.UTF-8` instead:

```
A) only LC_CTYPE set (locale is C):                LC_CTYPE -> C.UTF-8
B) fleet env shape (LANG+LC_ALL=C.UTF-8) + LC_CTYPE: LC_CTYPE -> en_GB.UTF-8
C) coherent British terminal:                      LC_CTYPE -> en_GB.UTF-8
```

PEP 538 coercion — the same mechanism as the original bug — rewrites a lone
`LC_CTYPE` to `C.UTF-8` whenever the surrounding locale is C. And `C.UTF-8` is a
value the clean-runtime check **tolerates**.

So the probe would have presented a caller-chosen locale only when the fixture
environment happened to set `LANG` and `LC_ALL`, and none at all when it did
not — silently, and identically green either way. A hidden dependency on
`_case_environment` that would have quietly voided the whole point of this
change if anyone tidied that function.

Naming all three makes it independent of the caller. Pinned by two tests: one
asserting the noise arrives in the launched child, and one launching from a
deliberately bare environment to prove the locale no longer depends on what the
caller sets.

## Also here

One paragraph in `docs/testing-governance.md`, requested during #457 review:
*configuration that has never been executed against the live system is not a
control — it just reads like one in review*, with the two rules that follow
(check names against what the system emits; prefer configuration that can only
widen).

`core/update/journey-protocol-v1.json` regenerated — it checksums
`scripts/release_fleet.py`.

## Verification

233 tests pass locally across the fleet, executor, bridge, workflow-contract and
protection-script suites. Architecture inventory, PII, path consistency,
security and doc-drift gates all pass.

This touches `scripts/release_fleet.py`, so the macOS canary runs on this PR —
that is the real end-to-end proof, since the change is to what the canary hands
the bridge. Holding for review; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)