### PR TITLE
Show Lens the everyday half of Dex, and stop a shipped file passing as proof

### DIFF
--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -14,8 +14,8 @@
     },
     {
       "job_id": "process-meetings",
-      "title": "Process meetings",
-      "description": "Convert meeting records into context, actions and organised notes without losing what was agreed."
+      "title": "Prepare for and close out meetings",
+      "description": "Go into a meeting already holding the useful context, and turn what was said into decisions, named owners and follow-up before it fades."
     },
     {
       "job_id": "keep-system-healthy",
@@ -26,6 +26,26 @@
       "job_id": "compound-learning",
       "title": "Compound learning",
       "description": "Capture decisions, insights and reusable patterns so future work starts with better context."
+    },
+    {
+      "job_id": "stay-on-top-of-commitments",
+      "title": "Stay on top of commitments",
+      "description": "Keep promises made, asks received and work handed to other people from scattering across meetings, notes and inboxes until they quietly go unmet."
+    },
+    {
+      "job_id": "decide-and-record",
+      "title": "Decide and record",
+      "description": "Make a choice and leave a durable record of what was decided, what else was considered and why, so the reasoning can be reconstructed months later."
+    },
+    {
+      "job_id": "know-my-market",
+      "title": "Know my market",
+      "description": "Make the beliefs a strategy rests on explicit and time-horizoned, so decisions are checked against them rather than quietly assuming them."
+    },
+    {
+      "job_id": "keep-my-work-recoverable",
+      "title": "Keep my work recoverable",
+      "description": "Answer the question a healthy system still cannot: if this went wrong, could the person actually get their work back, and has that been proved rather than hoped?"
     }
   ],
   "entries": [
@@ -273,6 +293,780 @@
       },
       "docs_url": "https://github.com/davekilleen/Dex",
       "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "daily-review",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/daily-review/SKILL.md",
+        "sha256": "df2e77a13ccd34cce7c9b34b1d92d99b1c09fbe93ebce60e486bbfa5b878ae8a",
+        "byte_size": 19256
+      },
+      "value": "Closes the day the morning plan opened: what actually got done against what was intended, what a meeting left behind, and what tomorrow starts with — so the loop finishes instead of drifting.",
+      "jobs_served": ["plan-my-work", "compound-learning"],
+      "foundation_capabilities": ["context-orientation", "scoped-agency-human-control", "compounding-correctability"],
+      "prerequisites": ["Today's plan, tasks or notes in a place the system can read.", "A few minutes with the person; the review asks questions it cannot answer for them."],
+      "trade_offs": ["A review can only see the parts of the day that were written down somewhere.", "It proposes tomorrow's focus and any change to the record; the person confirms both."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_review_retirement.py",
+          "summary": "A dedicated test pins the end-of-day behaviour Dex ships: the review runs in the current conversation, and where a review already exists for today it checks that one rather than writing a competing second version. It reads the shipped instructions, not a live day."
+        },
+        {
+          "kind": "test",
+          "reference": "core/tests/test_skill_delegated_gathering.py",
+          "summary": "Covers the paired gathering instructions this review depends on for a large collection of notes, so the heavy reading step cannot be silently orphaned by a later edit."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/daily-review/SKILL.md",
+          "summary": "The shipped skill defines the end-of-day workflow, the check against an existing review, and the confirmation rules before anything is written."
+        }
+      ],
+      "brief": {
+        "goal": "Create an end-of-day routine that compares intention with what actually happened and sets one starting point for tomorrow.",
+        "method_outline": ["Read the day's plan, completed work and any meeting record the person approved.", "Name what was finished, what slipped and what a meeting left owing.", "Check whether a review already exists for today and correct it rather than duplicating it.", "Agree one starting point for tomorrow with the person before writing anything."],
+        "verification_checklist": ["The review distinguishes finished work from work that merely moved.", "A second run on the same day does not create a competing record.", "Nothing is written to the person's own material without their confirmation."],
+        "rollback_advice": "Stop running the routine and delete the generated review files; the underlying tasks, notes and meeting records are never rewritten by it, so they need no undo."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "readable-task-source", "durable-memory-store"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "week-review",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/week-review/SKILL.md",
+        "sha256": "30b052197bb91b3b48d41021789ec577eaab394ec1a910001773c2c8e9319d16",
+        "byte_size": 18517
+      },
+      "value": "Reviews the week in concrete finished work and the patterns behind it, and deliberately refuses to invent a completion percentage that would make a bad week look measured.",
+      "jobs_served": ["plan-my-work", "compound-learning"],
+      "foundation_capabilities": ["context-orientation", "honest-health-observability", "compounding-correctability"],
+      "prerequisites": ["A record of the week's priorities or goals to review against.", "The person's own working week, so the review lands on their last working day rather than an assumed Friday."],
+      "trade_offs": ["An honest review depends on the week having been written down as it happened.", "The patterns it names are prompts for the person's judgement, not conclusions about them."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_instruction_honesty.py",
+          "summary": "A dedicated test pins that the weekly review reads the person's own configured working week and lands on their last working day, rather than assuming everyone finishes on a Friday."
+        },
+        {
+          "kind": "test",
+          "reference": "core/tests/test_skill_delegated_gathering.py",
+          "summary": "Covers the paired gathering instructions the weekly review depends on, so the bulk reading step cannot be orphaned by a later edit."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/week-review/SKILL.md",
+          "summary": "The shipped skill defines the weekly review, its insistence on concrete measures over percentages, and the goal and pattern discussion that stays with the person."
+        }
+      ],
+      "brief": {
+        "goal": "Create a weekly review that reports concrete finished work and honest gaps instead of a synthetic progress score.",
+        "method_outline": ["Gather the week's priorities, completed work and meeting record first.", "Report what finished, what did not, and what changed — in countable terms.", "Surface repeating patterns as questions for the person rather than verdicts.", "Confirm next week's priorities with the person before recording them."],
+        "verification_checklist": ["No percentage or score appears that the underlying data cannot support.", "Unfinished work is named plainly rather than folded into an average.", "The review runs on the person's own last working day, not a fixed one."],
+        "rollback_advice": "Stop running the routine and delete the generated weekly summaries; priorities and goals live in their own records and are left as they were."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-goals-or-tasks"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "meeting-prep",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/meeting-prep/SKILL.md",
+        "sha256": "f0365cfcd014a836429498c306ae9accf71370f2dde06e9049da8334385d49ea",
+        "byte_size": 12203
+      },
+      "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
+      "jobs_served": ["process-meetings"],
+      "foundation_capabilities": ["context-orientation", "privacy-minimal-disclosure", "durable-memory-provenance"],
+      "prerequisites": ["A calendar entry, or simply the meeting named out loud.", "Some history worth gathering: earlier notes, people records or related project material."],
+      "trade_offs": ["A brief is only as good as the history already captured; a genuinely first meeting has little to gather.", "Anything the brief claims should be checked against the real file before it is repeated in the room."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_instruction_honesty.py",
+          "summary": "A dedicated test pins that this capability reports a source that is switched off or broken in Dex's honest wording, rather than letting a gap in the gathering pass as a finished brief."
+        },
+        {
+          "kind": "test",
+          "reference": "core/tests/test_skill_delegated_gathering.py",
+          "summary": "Covers the paired gathering instructions the prep depends on when the history is large, so the reading step cannot be orphaned by a later edit."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/meeting-prep/SKILL.md",
+          "summary": "The shipped skill defines what is gathered, how the brief is shaped for the person's seniority and preferences, and the requirement to spot-check claims before presenting them."
+        }
+      ],
+      "brief": {
+        "goal": "Create a pre-meeting brief that gathers attendee history and open threads from approved sources and states what it could not find.",
+        "method_outline": ["Identify the meeting and its attendees from the calendar or the person's own words.", "Read only approved history: past notes, people records, related project material.", "Confirm a sample of the files the brief cites actually exist before repeating them.", "Present context, open threads and suggested talking points, and name the gaps."],
+        "verification_checklist": ["Every claim in the brief traces to a file that exists.", "Missing history is stated as missing rather than filled in plausibly.", "No source outside the approved reading scope is opened."],
+        "rollback_advice": "Stop running the routine; the brief is produced for the conversation and changes nothing in the person's own records, so there is nothing to unwind."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "relationship-history", "meeting-source"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "meeting-closeout",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/meeting-closeout/SKILL.md",
+        "sha256": "d9b9110fb2f49a3b161c71fbc793ac2738641f1b40bf69c6a765a7d20d3a365b",
+        "byte_size": 6690
+      },
+      "value": "Locks one meeting's decisions, owners and personal promises while it is still fresh, and refuses to invent an owner or a recap for a meeting it cannot actually see.",
+      "jobs_served": ["process-meetings"],
+      "foundation_capabilities": ["durable-memory-provenance", "scoped-agency-human-control", "privacy-minimal-disclosure"],
+      "prerequisites": ["Notes from the meeting — pasted, dictated, or already saved wherever the person keeps them.", "Somewhere to write the follow-ups the person approves."],
+      "trade_offs": ["It will not go looking in outside services for a meeting it cannot find; it asks for the notes instead.", "Owners the notes do not name are recorded as unknown rather than guessed, which leaves real gaps visible."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_meeting_closeout_skill.py",
+          "summary": "Dedicated tests pin the load-bearing promises: this is one meeting rather than a bulk catch-up, owners are named or honestly marked unknown, the person's setting for creating new people records is respected, no task is created without confirmation, and a meeting it cannot find is asked for rather than reconstructed. The tests read the shipped instructions, not a live meeting."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/meeting-closeout/SKILL.md",
+          "summary": "The shipped skill defines the closeout, the hard boundary on where meeting material may be read from, and the read-back before anything is reported as captured."
+        }
+      ],
+      "brief": {
+        "goal": "Create a single-meeting closeout that captures decisions, owners, personal promises and one next step while they are still fresh.",
+        "method_outline": ["Work only from notes the person supplied or from their own configured store.", "Extract decisions, action items with a named owner, personal promises and one next step.", "Mark an owner the notes do not name as unknown instead of assigning one.", "Offer each follow-up for confirmation, then read back what was actually saved."],
+        "verification_checklist": ["No decision, owner or promise appears that the notes do not support.", "A meeting with no available notes produces a request, never a recap.", "What is reported as saved matches what is actually on disk."],
+        "rollback_advice": "Delete the generated closeout note and any follow-ups it created; the original meeting notes are appended to or left alone, never rewritten."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "meeting-source", "task-or-note-store"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "commitments",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/commitments/SKILL.md",
+        "sha256": "8936fea6f6e7a0e8a3f67bbe3fbede95dde26e752f339d86fa34e01d9dfc90b7",
+        "byte_size": 6092
+      },
+      "value": "Pulls the small promises — “I’ll send that over”, “can you review this” — out of meetings and notes into one list of who owes what, and tracks only the ones the person confirms are real.",
+      "jobs_served": ["stay-on-top-of-commitments"],
+      "foundation_capabilities": ["context-orientation", "scoped-agency-human-control", "durable-memory-provenance"],
+      "prerequisites": ["Meeting notes or people records the scan can read.", "A task list the confirmed commitments can become."],
+      "trade_offs": ["Which direction a promise runs is inferred from wording, so genuinely unclear items are shown as unclear rather than guessed.", "Nothing becomes tracked without item-by-item confirmation, which costs the person a little attention each time."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_commitments_skill.py",
+          "summary": "Dedicated tests pin the load-bearing promises: it reuses the existing scanner rather than building a second one, never creates a task without confirmation, says so plainly when the scan is unavailable instead of inventing a list, and reads back what it created before reporting. The tests read the shipped instructions, not a live scan."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/commitments/SKILL.md",
+          "summary": "The shipped skill defines the present-then-confirm flow, the split between promises made and asks received, and the refusal to pad an empty result."
+        }
+      ],
+      "brief": {
+        "goal": "Create a review that surfaces open promises and asks from existing records and tracks only the ones the person confirms.",
+        "method_outline": ["Read the existing commitment sources rather than building a second store.", "Drop anything already tracked, and group the rest by who owes whom.", "Put genuinely ambiguous items in an unclear group instead of guessing direction.", "Offer each item for confirmation, then read back exactly what was created."],
+        "verification_checklist": ["An empty result is reported as empty, not padded with vague follow-ups.", "No item becomes tracked work without an explicit yes.", "Every item reported as captured has a real identifier behind it."],
+        "rollback_advice": "Delete the tasks the review created; the meetings and notes it read from are never modified, so the source record is unaffected."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "meeting-source", "task-or-note-store"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "delegate-check",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/delegate-check/SKILL.md",
+        "sha256": "c4cc8a0bb2c7b48edddf3aa809a0756fa123fb6f6be8c60076357454b96edc34",
+        "byte_size": 4435
+      },
+      "value": "Shows what was handed to other people, what is moving, what is stuck and the one short nudge worth sending — and reports silence as unknown rather than as progress.",
+      "jobs_served": ["stay-on-top-of-commitments"],
+      "foundation_capabilities": ["context-orientation", "scoped-agency-human-control", "durable-memory-provenance"],
+      "prerequisites": ["Tasks or meeting notes that record who owns what.", "The person's approval before any nudge is sent or any status is changed."],
+      "trade_offs": ["Where two records disagree about status, it shows the disagreement instead of quietly picking one.", "It will not chase a handoff whose agreed date has not arrived, so a genuinely early risk can still be missed."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_adoption_effective_behavior.py",
+          "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the review conversation itself."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/delegate-check/SKILL.md",
+          "summary": "The shipped skill defines what counts as an open handoff, the order attention is spent in, and the rule that no message is sent and no record changed without approval."
+        }
+      ],
+      "brief": {
+        "goal": "Create a delegation review that separates moving work from stuck work and proposes one proportionate follow-up.",
+        "method_outline": ["Collect open handoffs from tasks and recent meeting notes, and merge duplicates.", "For each, record what, who, when it was handed over, what is expected and when.", "Order the review by what needs attention, keeping healthy items brief.", "Draft one short nudge per stuck item and send nothing without approval."],
+        "verification_checklist": ["Silence is reported as unclear status, never as progress or failure.", "Conflicting records are shown as a conflict rather than resolved silently.", "No message leaves and no status changes without an explicit yes."],
+        "rollback_advice": "Stop running the review and discard its drafts; it changes a record only after the person confirms, so nothing needs to be undone on their behalf."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "task-or-note-store", "relationship-history"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "triage",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/triage/SKILL.md",
+        "sha256": "472605767b79c8af009ad4e265fc70c441618f446b3690d0e05a49f086093cb6",
+        "byte_size": 14395
+      },
+      "value": "Clears the pile-up: loose files and stray unticked boxes get routed to the project, person or goal they belong to, weighted by what the person said matters this week.",
+      "jobs_served": ["stay-on-top-of-commitments"],
+      "foundation_capabilities": ["context-orientation", "durable-memory-provenance", "scoped-agency-human-control"],
+      "prerequisites": ["A capture folder or set of notes where loose items actually accumulate.", "Current priorities or goals, so routing follows what matters now rather than in general."],
+      "trade_offs": ["Routing is a fast suggestion rather than a considered judgement, and is meant to be reviewed.", "An item with no clear home is left where it is rather than filed somewhere merely plausible."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/triage/SKILL.md",
+          "summary": "The shipped skill defines the routing workflow, the index it builds of existing projects and people, and the way current priorities raise confidence in a destination. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Create a routing pass that clears loose captures into the right home using the person's current priorities.",
+        "method_outline": ["Read current priorities and goals before touching the pile.", "Build an index of the existing projects, people and areas that could receive an item.", "Route each item to its best home, and leave anything genuinely unclear untouched.", "Keep the decision per item fast; this is a clearing pass, not an analysis."],
+        "verification_checklist": ["Items matching current priorities surface first.", "Nothing is filed to a destination the person cannot recognise.", "Unclear items are left in place rather than moved somewhere plausible."],
+        "rollback_advice": "Move the routed files back to the capture folder; the routing only relocates and links items, so their content is unchanged."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-goals-or-tasks", "task-or-note-store"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "project-health",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/project-health/SKILL.md",
+        "sha256": "9196c6be1f953775212c6992f0c099d0c80c67cbb47e0a22b20392d168e937ca",
+        "byte_size": 2605
+      },
+      "value": "Answers “what’s stuck?” across every active project in one pass: how long since anything moved, what is blocked, and whether the next step is actually clear.",
+      "jobs_served": ["plan-my-work"],
+      "foundation_capabilities": ["context-orientation", "honest-health-observability"],
+      "prerequisites": ["Project notes the scan can read.", "Some record of recent activity, so going quiet means something."],
+      "trade_offs": ["Quietness is judged from when project files last changed, which misreads work happening somewhere else.", "It is deliberately small: it flags what to look at, it does not diagnose why."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/project-health/SKILL.md",
+          "summary": "The shipped skill defines the four checks it makes per project — activity, active tasks, blockers and next-step clarity — and the traffic-light thresholds behind them. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Create a fast scan across active projects that reports what is stale, blocked or missing a clear next step.",
+        "method_outline": ["List the active projects and read when each last changed.", "Check whether each has current tasks, a recorded blocker and a clear next action.", "Report one line per project with the reason it was flagged.", "Keep the output short enough to read in one pass."],
+        "verification_checklist": ["Every flag names the specific reason it was raised.", "Thresholds for stale and blocked are stated, not implied.", "A healthy project takes one line, not a paragraph."],
+        "rollback_advice": "Stop running the scan; it reads project material and writes a report, so removing the report leaves the projects exactly as they were."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "project-records"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "decision-log",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/decision-log/SKILL.md",
+        "sha256": "e6c5d64940fe7135bfacd06aebcffae7ac40ca0f1971503b6f4a46551c505283",
+        "byte_size": 4518
+      },
+      "value": "Keeps the reason behind a choice — the options, the rationale, the date to look at it again — so nobody has to reconstruct it from memory months later.",
+      "jobs_served": ["decide-and-record"],
+      "foundation_capabilities": ["durable-memory-provenance", "compounding-correctability", "context-orientation"],
+      "prerequisites": ["A home for decisions that is separate from the meeting they came out of.", "The person's own account of the options; the record never supplies reasoning they did not give."],
+      "trade_offs": ["A decision record earns its keep only if it can be found again, which depends on where it is filed.", "A superseded decision is added as a new entry rather than edited, so the history grows rather than tidies."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_adoption_effective_behavior.py",
+          "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the recording conversation itself."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/decision-log/SKILL.md",
+          "summary": "The shipped skill defines what a decision record must contain, where it is filed, and the rule that earlier entries are never rewritten to make history look cleaner."
+        }
+      ],
+      "brief": {
+        "goal": "Create a decision record that captures the choice, the real alternatives, the reasoning and when to revisit it.",
+        "method_outline": ["Search for an earlier decision on the same topic before recording a new one.", "Capture the choice, what made it necessary, the options considered and why this one won.", "Set a review date, or state plainly that no review is needed.", "File it in the narrowest useful place and confirm where it went."],
+        "verification_checklist": ["The record contains no option or reason the person did not actually give.", "An earlier decision it replaces is linked rather than overwritten.", "Dates are absolute, so the record still reads correctly years later."],
+        "rollback_advice": "Delete the appended decision entry; earlier entries are never modified, so removing the new one restores the previous state exactly."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-memory-store"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "initiative-kickoff",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/initiative-kickoff/SKILL.md",
+        "sha256": "0b7db35d2bc39bc85bc94067348b3a3e04066698f7b1886c410e91e11001c9e3",
+        "byte_size": 4862
+      },
+      "value": "Turns “we’ve decided to do this” into something that can actually start: an outcome, signs of success somebody could check later, a named owner and the first few steps.",
+      "jobs_served": ["decide-and-record"],
+      "foundation_capabilities": ["scoped-agency-human-control", "durable-memory-provenance", "context-orientation"],
+      "prerequisites": ["A decision already taken; this is where a decision becomes work, not where it gets made.", "Somewhere to keep the initiative, and existing goals to connect it to if any exist."],
+      "trade_offs": ["Where an initiative does not connect to a real goal it is recorded as a standalone bet rather than tied to an invented one.", "Success signals have to be checkable later, which takes more thought up front than a general aim."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_initiative_kickoff_skill.py",
+          "summary": "Dedicated tests pin the load-bearing promises: success signals must be checkable, no connection to a goal is manufactured where none fits, nothing is created without confirmation, and the person's setting for creating new people records is respected. The tests read the shipped instructions, not a live kickoff."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/initiative-kickoff/SKILL.md",
+          "summary": "The shipped skill defines the framing questions, the honest ladder to goals, and the read-back of what was created before anything is called kicked off."
+        }
+      ],
+      "brief": {
+        "goal": "Create a kickoff routine that turns a decision to start something into an outcome, checkable success signals, an owner and first steps.",
+        "method_outline": ["Get the outcome, the reason it is worth starting now, and what is out of scope.", "Name two to four signals somebody could actually check later.", "Name the accountable owner and the people involved.", "Connect it to a real existing goal, or record it honestly as a standalone bet.", "Draft the first few steps and create only the ones confirmed."],
+        "verification_checklist": ["Every success signal could be verified by someone else months later.", "No connection to a goal exists that the goals themselves do not support.", "What is reported as created matches what actually exists."],
+        "rollback_advice": "Delete the initiative record and the first steps it created; nothing else in the person's goals or projects is altered by the kickoff."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-goals-or-tasks", "project-records"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "product-brief",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/product-brief/SKILL.md",
+        "sha256": "745a0899a364299b0b1b119044e7bdcc0819c8fd8aa4bc64fe276378c8bc14ac",
+        "byte_size": 16845
+      },
+      "value": "Draws a half-formed product idea out through questions and leaves a written brief a team could actually build from, instead of an idea that only made sense in one head.",
+      "jobs_served": ["decide-and-record"],
+      "foundation_capabilities": ["context-orientation", "durable-memory-provenance", "scoped-agency-human-control"],
+      "prerequisites": ["An idea worth the time; the questioning is guided but not instant.", "Somewhere to keep the finished brief next to the work it belongs to."],
+      "trade_offs": ["The brief is only as sharp as the answers given; it will not invent a market, a user or a measure.", "It is shaped around product work, so a hire, a partnership or an operational bet is served better elsewhere."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/product-brief/SKILL.md",
+          "summary": "The shipped skill defines the guided extraction, the questions asked in conversation rather than as a form, and the structure of the brief it produces. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Create a guided questioning routine that turns a rough product idea into a written brief a team could execute.",
+        "method_outline": ["Start from whatever the person has, however rough, without judging it.", "Ask two or three questions at a time, conversationally, and wait for answers.", "Fill the gaps that matter — who it is for, what problem, what success looks like.", "Produce the written brief and keep it where the work will happen."],
+        "verification_checklist": ["Nothing in the brief was supplied by the system rather than the person.", "Open questions are listed as open, not resolved by assumption.", "The brief is specific enough for someone else to act on."],
+        "rollback_advice": "Delete the generated brief; the questioning changes nothing else, so no other record needs restoring."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "project-records"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "industry-truths",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/industry-truths/SKILL.md",
+        "sha256": "b2eb362df0d00962dbdf9fe8a988e499b9f584431e02e585ba3f376453b2b8c0",
+        "byte_size": 8712
+      },
+      "value": "Makes the beliefs a strategy rests on explicit — what is true today, in six months, in a year — so later decisions can be checked against them instead of quietly assuming them.",
+      "jobs_served": ["know-my-market"],
+      "foundation_capabilities": ["durable-memory-provenance", "compounding-correctability", "context-orientation"],
+      "prerequisites": ["A domain the person genuinely follows, and roughly fifteen minutes of conversation.", "A willingness to be wrong in writing; the value arrives when the beliefs are checked later."],
+      "trade_offs": ["Assumptions written once and never revisited age badly, and can mislead more than having none.", "It records beliefs, not evidence; the sources behind them remain the person's responsibility."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/industry-truths/SKILL.md",
+          "summary": "The shipped skill defines the three time horizons, the interview that draws the beliefs out, and the later passes that review them and compare them against what actually happened. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Create a record of time-horizoned beliefs about a market so strategic choices can be checked against stated assumptions.",
+        "method_outline": ["Draw out beliefs by conversation rather than by form-filling.", "Separate them into what is true now, what is emerging, and what is a bet.", "Record who or what the person watches for signals of change.", "Schedule a later pass that compares the beliefs against what actually happened."],
+        "verification_checklist": ["Each belief is specific enough to be proved wrong.", "The horizon each belief sits in is explicit.", "There is a stated point at which the beliefs get reviewed."],
+        "rollback_advice": "Delete the assumptions file; it is a standalone record, and strategy notes that referenced it simply lose the link."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-memory-store"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "identity-snapshot",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/identity-snapshot/SKILL.md",
+        "sha256": "9aa571d6fe78dfea5c8d78b32d3ec2ba78a7ea40ca5faf9d62be8b6c47922303",
+        "byte_size": 3285
+      },
+      "value": "Writes a dated profile of how the person actually works, built from their own accumulated records rather than from what they say about themselves — so drift over months becomes visible.",
+      "jobs_served": ["compound-learning"],
+      "foundation_capabilities": ["durable-memory-provenance", "compounding-correctability", "honest-health-observability"],
+      "prerequisites": ["Enough accumulated history for a pattern to exist; a new system has nothing to read.", "A place for the profile to live and be replaced as it changes."],
+      "trade_offs": ["It sees only what was captured, so habits that never got written down are invisible to it.", "Generated too early it describes noise; it becomes useful after months of material."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/identity-snapshot/SKILL.md",
+          "summary": "The shipped skill defines the sources it reads, the structure of the profile it writes, and its rule to report a neglected area honestly rather than flatter the person. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Create an observed profile of how a person works, generated from their own records rather than from self-description.",
+        "method_outline": ["Read the accumulated goals, priorities, tasks and captured learnings.", "Describe patterns using actual data points, not general statements.", "Say plainly where an area is neglected or where pace dropped.", "Date every generation so change over time is visible."],
+        "verification_checklist": ["Nothing in the profile was asked of the person directly.", "A missing source is marked as missing rather than smoothed over.", "Each claim can be traced to a specific record."],
+        "rollback_advice": "Delete the generated profile; it is written from other records and never modifies them, so removing it loses nothing else."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-memory-store", "durable-goals-or-tasks"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "weekly-reflection",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/weekly-reflection/SKILL.md",
+        "sha256": "7a8fdd0bf4dfb517bcc076d2f9cc899efa1d678c5efa3f0bd6457d9186ef4ffb",
+        "byte_size": 3929
+      },
+      "value": "Three questions about how the week felt — what gave energy, what took it, one thing to change — kept deliberately separate from the record of what got done.",
+      "jobs_served": ["compound-learning"],
+      "foundation_capabilities": ["durable-memory-provenance", "scoped-agency-human-control", "compounding-correctability"],
+      "prerequisites": ["A few quiet minutes; this is the one thing that cannot be done on the person's behalf.", "Somewhere private to keep the answers, or the choice not to keep them at all."],
+      "trade_offs": ["It deliberately does not measure or score the week, which some people will want instead.", "Reflection compounds only if the answers are kept and read again later."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_adoption_effective_behavior.py",
+          "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the reflection conversation itself."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/weekly-reflection/SKILL.md",
+          "summary": "The shipped skill defines the three questions, the one-at-a-time pacing, and the rule against turning a feeling into a task or forcing a positive lesson."
+        }
+      ],
+      "brief": {
+        "goal": "Create a short weekly reflection on how work felt, kept separate from any measure of what was produced.",
+        "method_outline": ["Ask what gave energy, one question at a time, and reflect the answer back.", "Ask what drained energy, and offer any pattern as a possibility rather than a diagnosis.", "Ask for one small, observable change the person controls.", "Offer to keep the answers; accept no as an answer."],
+        "verification_checklist": ["The week is not graded, scored or turned into a lesson.", "The chosen change is small enough to actually happen.", "Nothing is saved that the person did not agree to save."],
+        "rollback_advice": "Delete the saved reflection entry; entries are appended, so earlier writing is untouched and removal restores the previous state."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "durable-memory-store"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "enable-semantic-search",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/enable-semantic-search/SKILL.md",
+        "sha256": "cfd8cda3a6fd2fbd63129ed59a94db64a9dda24007dce2b488144043ee0459af",
+        "byte_size": 18978
+      },
+      "value": "Makes the person's own notes searchable by meaning rather than exact wording, on their own machine — so looking for “customer churn” still finds the note that said “people keep leaving”.",
+      "jobs_served": ["compound-learning"],
+      "foundation_capabilities": ["context-orientation", "privacy-minimal-disclosure", "ownership-portability"],
+      "prerequisites": ["A one-off local setup with room on the machine for the search index.", "Enough accumulated notes that exact-word searching is already missing things."],
+      "trade_offs": ["The guided setup names macOS package steps; other systems need their own equivalents.", "Meaning-based results are broader than exact matches, so an occasional loose result is the price of finding the right one."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/enable-semantic-search/SKILL.md",
+          "summary": "The shipped skill defines the pre-flight checks, the guided local install, the collections it discovers from the person's own material, and the later health check on those collections. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Add meaning-based search over the person's own notes, running locally, without sending their material anywhere.",
+        "method_outline": ["Check what is already installed before proposing anything.", "Explain in plain terms what is being installed and roughly what it costs in space.", "Discover the natural groupings in the person's own material rather than imposing one.", "Fall back cleanly to exact-word search wherever the index is unavailable."],
+        "verification_checklist": ["Notes never leave the person's machine as part of the setup.", "A search by meaning finds a note that shares no words with the query.", "Every routine that uses it still works when the index is absent."],
+        "rollback_advice": "Remove the local search index and its tool; every workflow that used it falls back to exact-word search, and the notes themselves are never modified."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "local-search-index", "durable-memory-store"],
+        "needs_hooks": false,
+        "needs_mcp": true,
+        "platforms": ["macos", "linux"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "xray",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/xray/SKILL.md",
+        "sha256": "4ac35ac8c17b738e53210200694e027988f7a92dbda04d28a1285a4b1fd27631",
+        "byte_size": 25061
+      },
+      "value": "Explains what the system just did and why — which files it read, which tools ran, what was loaded before the conversation even started — so the person learns their own setup instead of trusting it blindly.",
+      "jobs_served": ["compound-learning"],
+      "foundation_capabilities": ["honest-health-observability", "context-orientation", "compounding-correctability"],
+      "prerequisites": ["A conversation that has actually done something worth explaining.", "A host that can report the steps it took during that conversation."],
+      "trade_offs": ["It explains what happened; it is not a health check and will not say whether anything is broken.", "The explanation is only as accurate as what the host exposes about its own run."],
+      "evidence": [
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/xray/SKILL.md",
+          "summary": "The shipped skill defines the default mode that explains the current conversation, the deeper modes on how the system is built and how to extend it, and the show-the-work-then-explain-why structure. There is no test of the workflow's own judgement calls; the shipped skill file is the definition of the behaviour, which is why this entry claims support rather than proof."
+        }
+      ],
+      "brief": {
+        "goal": "Explain the mechanics of what the system just did, using the current conversation as the teaching material.",
+        "method_outline": ["Identify what was read, written, and which tools ran in this conversation.", "Explain why each step was necessary, in the person's own terms.", "Connect each concrete step to the underlying idea it demonstrates.", "End with what the person could change or extend themselves."],
+        "verification_checklist": ["Every step described actually happened in this conversation.", "Nothing is presented as a health verdict about the system.", "The explanation would make sense to someone who did not build it."],
+        "rollback_advice": "Stop offering the explanation; it only reads and describes the conversation, so nothing in the person's system needs to be undone."
+      },
+      "compatibility": {
+        "host_requirements": ["skills-directory", "local-diagnostics"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux", "windows"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.80.0",
+      "changed_in": []
+    },
+    {
+      "id": "backup-setup",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/backup-setup/SKILL.md",
+        "sha256": "bbcec8b57013f56e10d3de80ae5db46d2fe56dd5e77e3f9c68fa5ac8c12167da",
+        "byte_size": 5265
+      },
+      "value": "Puts the person's whole working record on a schedule that copies it somewhere else, keeps a ladder of older copies, and says so loudly when it quietly stops working.",
+      "jobs_served": ["keep-my-work-recoverable"],
+      "foundation_capabilities": ["safe-change-recovery", "ownership-portability", "honest-health-observability"],
+      "prerequisites": ["A synced folder or a cloud storage account for the copies to go to.", "Automatic scheduling is wired up for macOS; on other systems the person is given the exact line to schedule it themselves, and nothing is installed behind their back."],
+      "trade_offs": ["Keys and sign-in tokens are deliberately left out of the copies, so rebuilding on a new machine means entering those again.", "A backup that has never been test-restored is still only a hope, which is why proving the restore is a separate step."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_backup_vault.py",
+          "summary": "Real behaviour coverage of the copying engine and its scheduler: the ladder of older copies keeps what it claims and never deletes the newest one, a real sign-in token never reaches the archive, an ordinary note that merely looks secret is still kept, and on a system without the supported scheduler nothing is installed and the equivalent instruction is printed instead."
+        },
+        {
+          "kind": "test",
+          "reference": "core/tests/test_doctor.py",
+          "summary": "The health check's backup probe is covered directly: a recent, successful run that quietly stored less than a full copy is reported as broken rather than passing as fine."
+        },
+        {
+          "kind": "doc",
+          "reference": "docs/backup-restore.md",
+          "summary": "The shipped recovery guide states what a full rebuild needs beyond the copies themselves, including the things deliberately excluded from them."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/backup-setup/SKILL.md",
+          "summary": "The shipped skill defines the destination choice, the retention ladder, the scheduling step, and the rule that setup is not reported as done until a real run has succeeded."
+        }
+      ],
+      "brief": {
+        "goal": "Set up scheduled, verified copies of the person's whole working record, kept somewhere other than the machine that made them.",
+        "method_outline": ["Choose a destination off the machine, and never write credentials into it.", "Exclude keys, tokens and caches from the copy on purpose, and say what was excluded.", "Keep a ladder of recent and older copies, and never delete the newest one.", "Prove it by running one for real before calling the setup finished.", "Add a health check that treats a stale copy as a problem, not a warning."],
+        "verification_checklist": ["A real credential file is provably absent from the copy.", "The newest copy survives even a retention rule that would delete everything.", "A run that failed is reported as failed, with the recorded reason."],
+        "rollback_advice": "Remove the scheduled job and the backup settings; existing copies stay where they are and the person's live material is never touched by the setup."
+      },
+      "compatibility": {
+        "host_requirements": ["local-file-access", "off-machine-destination", "scheduler"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.95.1",
+      "changed_in": []
+    },
+    {
+      "id": "backup-now",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/backup-now/SKILL.md",
+        "sha256": "38b8ab7eff8980521852bc223fcdef9d194f8c35f5647683d08e4d8ff8d556c0",
+        "byte_size": 1731
+      },
+      "value": "Takes a copy right now, before a bulk edit or a migration, and reports what actually landed rather than treating a finished command as a success.",
+      "jobs_served": ["keep-my-work-recoverable"],
+      "foundation_capabilities": ["safe-change-recovery", "honest-health-observability", "ownership-portability"],
+      "prerequisites": ["Backups already configured; without a destination the run fails with a plain message rather than improvising one.", "A minute or so, and room at the destination."],
+      "trade_offs": ["An on-demand copy covers one moment and is not a substitute for a schedule.", "Success is read from the run record rather than from the command exiting, so a partial copy is reported as a failure."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_backup_vault.py",
+          "summary": "Real behaviour coverage of a single run: a successful run stores the set and records it, a failure records the actual error rather than a generic one, and a run that fails part-way leaves no half-written copy behind to be mistaken for a good one."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/backup-now/SKILL.md",
+          "summary": "The shipped skill defines the on-demand run, the rule against inferring success from the command finishing, and the quiet note when the last successful copy is old."
+        }
+      ],
+      "brief": {
+        "goal": "Take a verified copy on demand before a risky change, and report the recorded result rather than the command's exit.",
+        "method_outline": ["Run the same copying path the schedule uses; do not build a second one.", "Read the run record afterwards and report what it says.", "On failure, repeat the recorded reason exactly rather than softening it.", "Mention quietly when the previous successful copy is old."],
+        "verification_checklist": ["A failed run is never reported as a copy that exists.", "The reported size and destination come from the record, not the intent.", "A run with no configured destination fails clearly instead of guessing one."],
+        "rollback_advice": "Delete the copy that was just made; on-demand runs add a copy and never change the live material."
+      },
+      "compatibility": {
+        "host_requirements": ["local-file-access", "off-machine-destination"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.95.1",
+      "changed_in": []
+    },
+    {
+      "id": "backup-restore",
+      "source": {
+        "kind": "skill",
+        "path": ".claude/skills/backup-restore/SKILL.md",
+        "sha256": "eae4e6c405acf8f8bba6bfe0a6ef60186e44e136e20501b66d7d7c56a54773bd",
+        "byte_size": 2778
+      },
+      "value": "Proves the copies actually come back — fingerprints checked, the whole thing unpacked into a scratch folder — and, when a real recovery is needed, puts it somewhere new instead of over the live work.",
+      "jobs_served": ["keep-my-work-recoverable"],
+      "foundation_capabilities": ["safe-change-recovery", "ownership-portability", "honest-health-observability"],
+      "prerequisites": ["At least one completed copy to check.", "A new or empty folder to restore into when a real recovery is wanted."],
+      "trade_offs": ["A restore never overwrites the live material, so moving it back into place stays a deliberate human step.", "Where a copy is damaged it says so and points at the next intact one rather than pretending the newest is usable."],
+      "evidence": [
+        {
+          "kind": "test",
+          "reference": "core/tests/test_backup_vault.py",
+          "summary": "Real behaviour coverage of all three modes: verification passes on an intact copy and detects a damaged one, the test mode unpacks only into a temporary folder, a real restore refuses the live location and any folder that is not empty, and a damaged newest copy points at the newest intact one instead."
+        },
+        {
+          "kind": "doc",
+          "reference": "docs/backup-restore.md",
+          "summary": "The shipped recovery guide covers what a full rebuild needs beyond the copies, including the credentials and schedules deliberately left out of them."
+        },
+        {
+          "kind": "runtime-path",
+          "reference": ".claude/skills/backup-restore/SKILL.md",
+          "summary": "The shipped skill defines the three modes, the routine test restore, and the rule to report exactly what the tool printed rather than a reassuring summary."
+        }
+      ],
+      "brief": {
+        "goal": "Prove a backup restores, and perform a real restore without ever writing over the live material.",
+        "method_outline": ["Check the copy's fingerprints and history before trusting it.", "Offer a routine test that unpacks into a throwaway folder and then deletes it.", "For a real restore, require a new or empty destination and refuse the live one.", "State plainly what is not in the copy and must be re-established by hand."],
+        "verification_checklist": ["A deliberately damaged copy is detected rather than restored.", "The live material is provably untouched after a restore.", "A failed verification is reported as failure, with the next intact copy named."],
+        "rollback_advice": "Delete the folder the restore was written into; because a restore never targets the live location, removing that folder returns the system to its prior state."
+      },
+      "compatibility": {
+        "host_requirements": ["local-file-access", "off-machine-destination"],
+        "needs_hooks": false,
+        "needs_mcp": false,
+        "platforms": ["macos", "linux"]
+      },
+      "docs_url": "https://github.com/davekilleen/Dex",
+      "since_release": "1.95.1",
       "changed_in": []
     }
   ]

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -65,6 +65,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_commitments_skill.py",
           "summary": "The planning path is covered where commitments become bounded, reviewable tasks."
         },
@@ -106,6 +107,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_work_server_weekly_priority_creation.py",
           "summary": "Weekly priority creation is covered through the Work MCP path."
         },
@@ -147,6 +149,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_process_meetings_soft_commitment_wiring.py",
           "summary": "Meeting processing is covered where soft commitments are detected and routed."
         },
@@ -188,6 +191,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "behavioral",
           "reference": "core/tests/test_doctor.py",
           "summary": "Doctor behavior is covered by the main health-check test suite."
         },
@@ -229,6 +233,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_relationship_radar_skill.py",
           "summary": "Relationship radar skill behavior is covered in the skill test."
         },
@@ -270,6 +275,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_learning_capture_command_name.py",
           "summary": "Learning capture command naming is pinned by tests."
         },
@@ -311,11 +317,13 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_review_retirement.py",
           "summary": "A dedicated test pins the end-of-day behaviour Dex ships: the review runs in the current conversation, and where a review already exists for today it checks that one rather than writing a competing second version. It reads the shipped instructions, not a live day."
         },
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_skill_delegated_gathering.py",
           "summary": "Covers the paired gathering instructions this review depends on for a large collection of notes, so the heavy reading step cannot be silently orphaned by a later edit."
         },
@@ -357,11 +365,13 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_instruction_honesty.py",
           "summary": "A dedicated test pins that the weekly review reads the person's own configured working week and lands on their last working day, rather than assuming everyone finishes on a Friday."
         },
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_skill_delegated_gathering.py",
           "summary": "Covers the paired gathering instructions the weekly review depends on, so the bulk reading step cannot be orphaned by a later edit."
         },
@@ -403,11 +413,13 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_instruction_honesty.py",
           "summary": "A dedicated test pins that this capability reports a source that is switched off or broken in Dex's honest wording, rather than letting a gap in the gathering pass as a finished brief."
         },
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_skill_delegated_gathering.py",
           "summary": "Covers the paired gathering instructions the prep depends on when the history is large, so the reading step cannot be orphaned by a later edit."
         },
@@ -449,6 +461,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_meeting_closeout_skill.py",
           "summary": "Dedicated tests pin the load-bearing promises: this is one meeting rather than a bulk catch-up, owners are named or honestly marked unknown, the person's setting for creating new people records is respected, no task is created without confirmation, and a meeting it cannot find is asked for rather than reconstructed. The tests read the shipped instructions, not a live meeting."
         },
@@ -490,6 +503,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_commitments_skill.py",
           "summary": "Dedicated tests pin the load-bearing promises: it reuses the existing scanner rather than building a second one, never creates a task without confirmation, says so plainly when the scan is unavailable instead of inventing a list, and reads back what it created before reporting. The tests read the shipped instructions, not a live scan."
         },
@@ -531,6 +545,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_adoption_effective_behavior.py",
           "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the review conversation itself."
         },
@@ -644,6 +659,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_adoption_effective_behavior.py",
           "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the recording conversation itself."
         },
@@ -685,6 +701,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_initiative_kickoff_skill.py",
           "summary": "Dedicated tests pin the load-bearing promises: success signals must be checkable, no connection to a goal is manufactured where none fits, nothing is created without confirmation, and the person's setting for creating new people records is respected. The tests read the shipped instructions, not a live kickoff."
         },
@@ -834,6 +851,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "supporting",
           "reference": "core/tests/test_adoption_effective_behavior.py",
           "summary": "Real behaviour coverage of how this capability is switched on and off again: the test adopts it through Dex's live change system, proves the change can be rewound exactly, and proves a rewind refuses rather than overwrite a file the person has since edited. That covers the switch-on path, not the reflection conversation itself."
         },
@@ -947,11 +965,13 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "behavioral",
           "reference": "core/tests/test_backup_vault.py",
           "summary": "Real behaviour coverage of the copying engine and its scheduler: the ladder of older copies keeps what it claims and never deletes the newest one, a real sign-in token never reaches the archive, an ordinary note that merely looks secret is still kept, and on a system without the supported scheduler nothing is installed and the equivalent instruction is printed instead."
         },
         {
           "kind": "test",
+          "coverage": "behavioral",
           "reference": "core/tests/test_doctor.py",
           "summary": "The health check's backup probe is covered directly: a recent, successful run that quietly stored less than a full copy is reported as broken rather than passing as fine."
         },
@@ -998,6 +1018,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "behavioral",
           "reference": "core/tests/test_backup_vault.py",
           "summary": "Real behaviour coverage of a single run: a successful run stores the set and records it, a failure records the actual error rather than a generic one, and a run that fails part-way leaves no half-written copy behind to be mistaken for a good one."
         },
@@ -1039,6 +1060,7 @@
       "evidence": [
         {
           "kind": "test",
+          "coverage": "behavioral",
           "reference": "core/tests/test_backup_vault.py",
           "summary": "Real behaviour coverage of all three modes: verification passes on an intact copy and detects a damaged one, the test mode unpacks only into a temporary folder, a real restore refuses the live location and any folder that is not empty, and a damaged newest copy points at the newest intact one instead."
         },

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -42,6 +42,8 @@ def _skill(root: Path, skill_id: str, description: str = "Use when planning a da
 
 def _registry(root: Path) -> None:
     skill_bytes = _skill(root, "daily-plan")
+    _write(root / "core/tests/test_commitments_skill.py", "# fixture test evidence\n")
+    _write(root / "docs/backup-restore.md", "# fixture documentation evidence\n")
     schema_source = REPO_ROOT / "core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json"
     _write(
         root / "core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json",
@@ -85,6 +87,7 @@ def _registry(root: Path) -> None:
                         "evidence": [
                             {
                                 "kind": "test",
+                                "coverage": "behavioral",
                                 "reference": "core/tests/test_commitments_skill.py",
                                 "summary": "Daily planning skill coverage exercises task creation boundaries.",
                             }
@@ -658,29 +661,36 @@ def _rewrite_registry_evidence(root: Path, evidence: list[dict[str, str]]) -> No
 
 
 @pytest.mark.parametrize(
-    ("kind", "reference", "expected_level"),
+    ("kind", "reference", "coverage", "expected_level"),
     (
-        ("test", "core/tests/test_commitments_skill.py", "verified"),
-        ("runtime-path", ".claude/skills/daily-plan/SKILL.md", "supported"),
-        ("doc", "docs/backup-restore.md", "supported"),
-        ("release-note", "CHANGELOG.md", "supported"),
+        ("test", "core/tests/test_commitments_skill.py", "behavioral", "verified"),
+        ("test", "core/tests/test_commitments_skill.py", "supporting", "supported"),
+        ("runtime-path", ".claude/skills/daily-plan/SKILL.md", None, "supported"),
+        ("doc", "docs/backup-restore.md", None, "supported"),
+        ("release-note", "CHANGELOG.md", None, "supported"),
     ),
 )
-def test_only_a_test_reference_earns_the_verified_evidence_level(
-    tmp_path: Path, kind: str, reference: str, expected_level: str
+def test_only_behavioral_test_evidence_earns_the_verified_evidence_level(
+    tmp_path: Path, kind: str, reference: str, coverage: str | None, expected_level: str
 ) -> None:
-    """A runtime path proves a capability ships, not that its behaviour is exercised.
+    """A test name alone must not turn supporting evidence into verified behaviour.
 
-    Levels are derived by the producer, never declared by the registry, so this is
-    the only place the distinction can be enforced. If runtime-path evidence were
-    to read as `verified`, an entry backed by nothing but its own shipped file
-    would be indistinguishable from one a test actually covers -- which is exactly
-    the overclaim the catalogue's evidence vocabulary exists to prevent.
+    The registry must say whether a test exercises the capability itself or merely
+    supports a related promise. That distinction is deliberately derived by the
+    producer: a review of shipped instructions, an adoption test, or a runtime
+    path cannot accidentally read as behaviourally proven.
     """
     _registry(tmp_path)
+    evidence = {
+        "kind": kind,
+        "reference": reference,
+        "summary": "Evidence level derivation probe.",
+    }
+    if coverage is not None:
+        evidence["coverage"] = coverage
     _rewrite_registry_evidence(
         tmp_path,
-        [{"kind": kind, "reference": reference, "summary": "Evidence level derivation probe."}],
+        [evidence],
     )
 
     result = _generate(tmp_path)
@@ -691,13 +701,50 @@ def test_only_a_test_reference_earns_the_verified_evidence_level(
     assert [item["level"] for item in evidence] == [expected_level]
 
 
-def test_real_entries_without_test_evidence_never_claim_verified(tmp_path: Path) -> None:
-    """No shipped entry may read as behaviourally proven on its own file alone.
+def test_generator_rejects_unclassified_or_missing_test_evidence(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    _rewrite_registry_evidence(
+        tmp_path,
+        [
+            {
+                "kind": "test",
+                "reference": "core/tests/test_commitments_skill.py",
+                "summary": "A test without an explicit scope must fail closed.",
+            }
+        ],
+    )
 
-    Wave 2 deliberately includes capabilities that no test exercises. Those entries
-    are honest only while their evidence declares the lower level, so this gate
-    reads the real catalogue rather than a fixture: it fails the moment an entry
-    without a test reference starts claiming `verified`.
+    unclassified = _generate(tmp_path)
+
+    assert unclassified.returncode == 1
+    assert "missing coverage" in unclassified.stderr
+
+    _registry(tmp_path)
+    _rewrite_registry_evidence(
+        tmp_path,
+        [
+            {
+                "kind": "test",
+                "coverage": "behavioral",
+                "reference": "core/tests/missing.py",
+                "summary": "A made-up test cannot be evidence.",
+            }
+        ],
+    )
+
+    missing = _generate(tmp_path)
+
+    assert missing.returncode == 1
+    assert "evidence 0 reference is missing or not a regular file" in missing.stderr
+
+
+def test_real_test_evidence_is_explicit_and_only_behavioral_evidence_verifies(tmp_path: Path) -> None:
+    """The real catalogue can only verify sources manually classified as behavioural.
+
+    This is the release-facing guard. Every test reference must have a narrow
+    coverage classification, and the emitted catalogue must match it exactly.
+    That makes an instruction-contract or adoption test visibly supporting evidence
+    until a behavioural test is genuinely added.
     """
     result = subprocess.run(
         [
@@ -717,24 +764,35 @@ def test_real_entries_without_test_evidence_never_claim_verified(tmp_path: Path)
     assert result.returncode == 0, result.stderr
 
     envelope = json.loads((tmp_path / "dist/dex-lens-catalog-latest.json").read_text())
-    overclaiming = {
-        capability["capability_id"]
-        for capability in envelope["catalogue"]["capabilities"]
-        if not any(item["source"].startswith("test: ") for item in capability["evidence"])
-        and any(item["level"] == "verified" for item in capability["evidence"])
-    }
-    assert not overclaiming, (
-        "these shipped capabilities claim verified evidence without a single test"
-        f" reference behind them: {sorted(overclaiming)}"
+    registry = json.loads(REAL_REGISTRY.read_text(encoding="utf-8"))
+    test_evidence = [
+        (entry["id"], item)
+        for entry in registry["entries"]
+        for item in entry["evidence"]
+        if item["kind"] == "test"
+    ]
+    invalid_coverage = [
+        f"{entry_id}: {item['reference']} ({item.get('coverage')!r})"
+        for entry_id, item in test_evidence
+        if item.get("coverage") not in {"behavioral", "supporting"}
+    ]
+    assert not invalid_coverage, (
+        "every test evidence record must say whether it exercises the capability itself "
+        f"or only supports a related promise: {invalid_coverage}"
     )
-
-    # The gate is only meaningful while entries of both kinds actually exist.
-    levels = {
-        item["level"]
+    expected_verified_evidence = {
+        (entry_id, f"test: {item['reference']}")
+        for entry_id, item in test_evidence
+        if item["coverage"] == "behavioral"
+    }
+    verified_evidence = {
+        (capability["capability_id"], item["source"])
         for capability in envelope["catalogue"]["capabilities"]
         for item in capability["evidence"]
+        if item["level"] == "verified"
     }
-    assert levels == {"verified", "supported"}, (
-        "the shipped catalogue no longer contains both evidence levels, so this gate"
-        f" would pass without proving anything: {sorted(levels)}"
+    assert verified_evidence == expected_verified_evidence, (
+        "the released catalogue's verified evidence does not exactly match the test "
+        f"records classified as behavioural: expected {sorted(expected_verified_evidence)}, "
+        f"got {sorted(verified_evidence)}"
     )

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -648,3 +648,93 @@ def test_shipped_registry_builds_the_release_catalogue(tmp_path: Path, signing_k
     assert [capability["capability_id"] for capability in envelope["catalogue"]["capabilities"]] == [
         entry["id"] for entry in registry["entries"]
     ]
+
+
+def _rewrite_registry_evidence(root: Path, evidence: list[dict[str, str]]) -> None:
+    registry_path = root / "core/lens-catalog/registry.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["entries"][0]["evidence"] = evidence
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("kind", "reference", "expected_level"),
+    (
+        ("test", "core/tests/test_commitments_skill.py", "verified"),
+        ("runtime-path", ".claude/skills/daily-plan/SKILL.md", "supported"),
+        ("doc", "docs/backup-restore.md", "supported"),
+        ("release-note", "CHANGELOG.md", "supported"),
+    ),
+)
+def test_only_a_test_reference_earns_the_verified_evidence_level(
+    tmp_path: Path, kind: str, reference: str, expected_level: str
+) -> None:
+    """A runtime path proves a capability ships, not that its behaviour is exercised.
+
+    Levels are derived by the producer, never declared by the registry, so this is
+    the only place the distinction can be enforced. If runtime-path evidence were
+    to read as `verified`, an entry backed by nothing but its own shipped file
+    would be indistinguishable from one a test actually covers -- which is exactly
+    the overclaim the catalogue's evidence vocabulary exists to prevent.
+    """
+    _registry(tmp_path)
+    _rewrite_registry_evidence(
+        tmp_path,
+        [{"kind": kind, "reference": reference, "summary": "Evidence level derivation probe."}],
+    )
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    envelope = json.loads((tmp_path / "dist/dex-lens-catalog-latest.json").read_text())
+    evidence = envelope["catalogue"]["capabilities"][0]["evidence"]
+    assert [item["level"] for item in evidence] == [expected_level]
+
+
+def test_real_entries_without_test_evidence_never_claim_verified(tmp_path: Path) -> None:
+    """No shipped entry may read as behaviourally proven on its own file alone.
+
+    Wave 2 deliberately includes capabilities that no test exercises. Those entries
+    are honest only while their evidence declares the lower level, so this gate
+    reads the real catalogue rather than a fixture: it fails the moment an entry
+    without a test reference starts claiming `verified`.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--release-root",
+            str(REPO_ROOT),
+            "--output-dir",
+            str(tmp_path / "dist"),
+            "--issued-at",
+            "2026-08-11T12:00:00Z",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    envelope = json.loads((tmp_path / "dist/dex-lens-catalog-latest.json").read_text())
+    overclaiming = {
+        capability["capability_id"]
+        for capability in envelope["catalogue"]["capabilities"]
+        if not any(item["source"].startswith("test: ") for item in capability["evidence"])
+        and any(item["level"] == "verified" for item in capability["evidence"])
+    }
+    assert not overclaiming, (
+        "these shipped capabilities claim verified evidence without a single test"
+        f" reference behind them: {sorted(overclaiming)}"
+    )
+
+    # The gate is only meaningful while entries of both kinds actually exist.
+    levels = {
+        item["level"]
+        for capability in envelope["catalogue"]["capabilities"]
+        for item in capability["evidence"]
+    }
+    assert levels == {"verified", "supported"}, (
+        "the shipped catalogue no longer contains both evidence levels, so this gate"
+        f" would pass without proving anything: {sorted(levels)}"
+    )

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -263,23 +263,36 @@ def _source(entry: Mapping[str, object], release_root: Path, *, context: str) ->
     }
 
 
-def _evidence(value: object, *, context: str) -> tuple[dict[str, str], ...]:
+def _evidence(
+    value: object, release_root: Path, *, context: str
+) -> tuple[dict[str, str], ...]:
     if not isinstance(value, list) or not value:
         raise LensCatalogError(f"{context} evidence must be a non-empty array")
     result = []
     for index, item in enumerate(value):
         item_context = f"{context} evidence {index}"
         raw = _mapping(item, context=item_context)
-        _exact_fields(raw, {"kind", "reference", "summary"}, context=item_context)
         kind = _text(raw.get("kind"), context=f"{item_context} kind", max_length=32)
         if kind not in {"test", "doc", "release-note", "runtime-path"}:
             raise LensCatalogError(f"{item_context} kind is not recognized")
-        reference = _text(raw.get("reference"), context=f"{item_context} reference", max_length=256)
+        if kind == "test":
+            _exact_fields(raw, {"kind", "coverage", "reference", "summary"}, context=item_context)
+            coverage = _text(raw.get("coverage"), context=f"{item_context} coverage", max_length=32)
+            if coverage not in {"behavioral", "supporting"}:
+                raise LensCatalogError(
+                    f"{item_context} coverage must be behavioral or supporting"
+                )
+        else:
+            _exact_fields(raw, {"kind", "reference", "summary"}, context=item_context)
+            coverage = "supporting"
+        reference, _ = _release_file(
+            release_root, raw.get("reference"), context=f"{item_context} reference"
+        )
         summary = _text(raw.get("summary"), context=f"{item_context} summary")
-        # Only a test earns "verified". A runtime path proves the capability ships,
-        # not that its behaviour is exercised, so it declares the lower level and an
-        # entry backed by nothing else cannot read as behaviourally proven.
-        level = "verified" if kind == "test" else "supported"
+        # A test earns "verified" only when it explicitly exercises the capability
+        # itself. Instruction-contract, adoption, and runtime evidence still support
+        # the entry, but cannot overclaim behavioural proof.
+        level = "verified" if kind == "test" and coverage == "behavioral" else "supported"
         result.append(
             {
                 "level": level,
@@ -454,7 +467,7 @@ def _build_catalogue(release_root: Path) -> tuple[int, str, dict[str, object]]:
                 "jobs": jobs_served,
                 "prerequisites": _text_tuple(entry.get("prerequisites"), context=f"{context} prerequisites"),
                 "trade_offs": _text_tuple(entry.get("trade_offs"), context=f"{context} trade_offs"),
-                "evidence": _evidence(entry.get("evidence"), context=context),
+                "evidence": _evidence(entry.get("evidence"), release_root, context=context),
                 "brief": _brief(entry.get("brief"), context=context),
                 "compatibility": {
                     **compatibility,

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -276,7 +276,10 @@ def _evidence(value: object, *, context: str) -> tuple[dict[str, str], ...]:
             raise LensCatalogError(f"{item_context} kind is not recognized")
         reference = _text(raw.get("reference"), context=f"{item_context} reference", max_length=256)
         summary = _text(raw.get("summary"), context=f"{item_context} summary")
-        level = "verified" if kind in {"test", "runtime-path"} else "supported"
+        # Only a test earns "verified". A runtime path proves the capability ships,
+        # not that its behaviour is exercised, so it declares the lower level and an
+        # entry backed by nothing else cannot read as behaviourally proven.
+        level = "verified" if kind == "test" else "supported"
         result.append(
             {
                 "level": level,


### PR DESCRIPTION
## In plain English

Dex Lens privately compares a person's own AI system with proven Dex capabilities. This expands its signed catalogue from 6 to 25 useful capabilities, grouped into 9 clear job areas.

It also makes the proof labels honest: a test now has to explicitly exercise the capability before the catalogue calls it **verified**. Instruction checks, adoption checks, docs, and shipped-file references remain useful but read as **supported** instead. Every evidence link must point to a real release file.

## What changes

- Adds 19 everyday capabilities: reviews, meeting prep and closeout, commitments, decisions, market thinking, and recovery.
- Adds 4 job areas without renaming existing ones.
- Keeps intentionally excluded or later work out of this release.
- Adds a fail-closed publisher rule: unclassified test evidence and missing evidence files stop catalogue generation.

## Proof

- 106 targeted Python tests pass, including the real-catalogue generation check.
- 163 script tests pass.
- Static checks pass.
- CI is rerunning on this exact commit before merge.

The visible catalogue will show 5 genuinely behavioural test references as **verified** and 17 supporting test references as **supported**. That is deliberately conservative.