### PR TITLE
Fix stable release publishing after draft verification

### DIFF
--- a/core/tests/test_release_publish_draft_first.py
+++ b/core/tests/test_release_publish_draft_first.py
@@ -605,27 +605,47 @@ def test_a_beta_release_that_comes_back_unmarked_is_corrected(tmp_path) -> None:
 
 
 def test_a_stable_release_is_marked_latest_and_not_a_prerelease(tmp_path) -> None:
-    """Flags are set while the release is still hidden, then it is flipped.
+    """Stable releases become latest only after they are public.
 
     Setting them in the same call as `--draft=false` silently dropped the
     prerelease flag against real GitHub on 2026-08-12, so these are separate
-    operations and the order matters.
+    operations and the order matters. GitHub also rejects `--latest` while a
+    release is still a draft, so the latest flag must follow the public flip.
     """
     dist = _write_dist(tmp_path)
-    gh = FakeGh(releases={TAG: FakeRelease(draft=True)})
+
+    class RejectsLatestWhileDraftGh(FakeGh):
+        def release(self, args, *, check=True):
+            if (
+                args[0] == "edit"
+                and "--latest" in args
+                and self.releases[args[1]].draft
+            ):
+                self.calls.append(["release"] + list(args))
+                return self._result(
+                    1, err="Latest release cannot be draft or prerelease."
+                )
+            return super().release(args, check=check)
+
+    gh = RejectsLatestWhileDraftGh(releases={TAG: FakeRelease(draft=True)})
 
     assert _publish(_publish_args(dist), gh) == 0
 
-    flags_at = gh.index_of(
+    prerelease_at = gh.index_of(
         lambda c: c[:2] == ["release", "edit"]
         and "--prerelease=false" in c
-        and "--latest" in c
     )
     flip_at = gh.index_of(lambda c: c[:2] == ["release", "edit"] and "--draft=false" in c)
-    assert flags_at >= 0, "a stable release must be marked latest and not a prerelease"
+    latest_at = gh.index_of(
+        lambda c: c[:2] == ["release", "edit"] and "--latest" in c
+    )
+    assert prerelease_at >= 0, "a stable release must not be a prerelease"
     assert flip_at >= 0
-    assert flags_at < flip_at, "flags must be set before the release becomes visible"
-    assert "--draft=false" not in gh.calls[flags_at], (
+    assert latest_at >= 0, "a stable release must be marked latest"
+    assert prerelease_at < flip_at < latest_at, (
+        "GitHub requires the release to be public before it can become latest"
+    )
+    assert "--draft=false" not in gh.calls[prerelease_at], (
         "the flag call must not also publish; combining the two loses the flag"
     )
 

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -742,12 +742,13 @@ def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
         # release: setting the prerelease flag in the SAME `gh release edit` as
         # `--draft=false` left the release marked as not-a-prerelease, which for the
         # beta lane would present a beta build to everyone as the current version.
-        # Applied on its own, the flag sticks. So: set the notes and the flags while
-        # the release is still hidden, then flip it public as its own operation.
+        # Applied on its own, the flag sticks. So: set the notes and prerelease
+        # state while the release is still hidden, then flip it public as its own
+        # operation. A stable release cannot be marked latest while it is a draft:
+        # GitHub rejects that combination with HTTP 422. Mark it latest only after
+        # the public-state readback below has proved it is no longer a draft.
         flags = ["edit", tag, "--notes-file", str(body_file)]
         flags.append("--prerelease=true" if want_prerelease else "--prerelease=false")
-        if not want_prerelease:
-            flags.append("--latest")
         result = gh.release(flags, check=False)
         if result.returncode != 0:
             raise ReleasePublishError(
@@ -790,6 +791,13 @@ def command_publish(args: argparse.Namespace, gh: Gh | None = None) -> int:
             raise ReleasePublishError(
                 f"{tag} is public but its prerelease flag is {final.is_prerelease}, "
                 f"and it could not be set to {want_prerelease}."
+            )
+    if not want_prerelease:
+        latest = gh.release(["edit", tag, "--latest"], check=False)
+        if latest.returncode != 0:
+            raise ReleasePublishError(
+                f"{tag} is public and verified but could not be marked latest: "
+                f"{latest.stderr.strip()}"
             )
     still_missing = [
         name


### PR DESCRIPTION
## What this fixes

GitHub rejects a release being marked as the latest version while it is still hidden as a draft. That left v1.95.2 safely complete but unable to flip public automatically.

This changes the sequence to:

1. Verify every release file while hidden.
2. Make the release public.
3. Only then mark the stable release as latest.

The regression test recreates GitHub’s rejection, so the old order cannot return unnoticed.

## Verification

- Release-publishing checks: 66 passed
- Whitespace check passed

No user data or release assets are changed by this PR.