### PR TITLE
Fix false post-update diagnostic alarms

### DIFF
--- a/core/health/post_update.py
+++ b/core/health/post_update.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import os
 import secrets
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -66,6 +67,9 @@ def run_canary(vault_root: str | Path) -> dict[str, object]:
         "error": None,
     }
     try:
+        source_root = str(Path(__file__).resolve().parents[2])
+        if source_root not in sys.path:
+            sys.path.insert(0, source_root)
         from core.lifecycle import service
 
         state = service.read_lifecycle_state(root)

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2112,6 +2112,23 @@ def test_jobs_loaded_treats_a_live_pid_as_authoritative_over_a_previous_exit(mon
     assert result.verdict == "OK"
 
 
+def test_jobs_loaded_does_not_treat_pid_zero_as_a_running_service(monkeypatch, context):
+    _write_plist(context, "com.dex.meeting-intel")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda _plist: "/bin/bash")
+    monkeypatch.setattr(
+        doctor,
+        "_launchctl_status",
+        lambda _label: {"loaded": True, "pid": 0, "last_exit_status": -15},
+    )
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "BROKEN"
+    assert "last exited with status -15" in result.detail
+
+
 def test_jobs_loaded_maps_invalid_or_unsubstituted_plist_to_broken_t2(monkeypatch, context):
     plist = _write_plist(context, "com.dex.meeting-intel")
     with plist.open("wb") as handle:

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -2096,6 +2096,22 @@ def test_jobs_loaded_checks_interpreter_exit_status_and_healthy_state(monkeypatc
     assert doctor._probe_jobs_loaded(context).verdict == "UNKNOWN"
 
 
+def test_jobs_loaded_treats_a_live_pid_as_authoritative_over_a_previous_exit(monkeypatch, context):
+    _write_plist(context, "com.dex.meeting-intel")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda _plist: "/bin/bash")
+    monkeypatch.setattr(
+        doctor,
+        "_launchctl_status",
+        lambda _label: {"loaded": True, "pid": 5266, "last_exit_status": -15},
+    )
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "OK"
+
+
 def test_jobs_loaded_maps_invalid_or_unsubstituted_plist_to_broken_t2(monkeypatch, context):
     plist = _write_plist(context, "com.dex.meeting-intel")
     with plist.open("wb") as handle:
@@ -2188,14 +2204,18 @@ def test_empty_plutil_failure_is_unknown_not_malformed(monkeypatch, context):
 
 
 def test_launchctl_status_adapter_parses_last_exit_status(monkeypatch):
-    output = '{\n    "LastExitStatus" = 7;\n}\n'
+    output = '{\n    "PID" = 5266;\n    "LastExitStatus" = 7;\n}\n'
     monkeypatch.setattr(
         doctor.subprocess,
         "run",
         lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, stdout=output, stderr=""),
     )
 
-    assert doctor._launchctl_status("com.dex.test") == {"loaded": True, "last_exit_status": 7}
+    assert doctor._launchctl_status("com.dex.test") == {
+        "loaded": True,
+        "pid": 5266,
+        "last_exit_status": 7,
+    }
 
     monkeypatch.setattr(
         doctor.subprocess,
@@ -2207,7 +2227,11 @@ def test_launchctl_status_adapter_parses_last_exit_status(monkeypatch):
             stderr="Could not find service",
         ),
     )
-    assert doctor._launchctl_status("com.dex.missing") == {"loaded": False, "last_exit_status": None}
+    assert doctor._launchctl_status("com.dex.missing") == {
+        "loaded": False,
+        "pid": None,
+        "last_exit_status": None,
+    }
 
 
 def test_jobs_loaded_degrades_to_unknown_off_macos(monkeypatch, context):

--- a/core/tests/test_health_promises.py
+++ b/core/tests/test_health_promises.py
@@ -177,6 +177,7 @@ def test_canary_cli_reports_a_torn_install_plainly_without_a_traceback(tmp_path:
 
     assert completed.returncode == 1
     assert "Post-update check FAILED" in completed.stdout
+    assert "PlanRejected" in completed.stdout
     assert "Traceback" not in completed.stdout + completed.stderr
     stored = json.loads((vault / RECEIPT_RELATIVE).read_text(encoding="utf-8"))
     assert stored["ok"] is False

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -493,7 +493,7 @@ def test_main_exit_one_for_a_broken_journey(tmp_path: Path, capsys) -> None:
         ),
         (
             "yaml",
-            "Python module 'yaml' is not installed in this vault's .venv — run /dex-update "
+            "Python packages not installed in this vault's .venv (missing module 'yaml') — run /dex-update "
             "(or reinstall requirements.txt into that .venv), then re-run /dex-doctor",
         ),
     ],

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -483,6 +483,83 @@ def test_main_exit_one_for_a_broken_journey(tmp_path: Path, capsys) -> None:
     assert report["summary"] == {"ok": 0, "broken": 1, "unknown": 0, "off": 0}
 
 
+@pytest.mark.parametrize(
+    ("missing_module", "expected_detail"),
+    [
+        (
+            "core",
+            "Dex's own code could not be loaded (No module named 'core'). "
+            "This is a Dex checkup fault, not a missing Python package.",
+        ),
+        (
+            "yaml",
+            "Python module 'yaml' is not installed in this vault's .venv — run /dex-update "
+            "(or reinstall requirements.txt into that .venv), then re-run /dex-doctor",
+        ),
+    ],
+)
+def test_smoke_preparation_names_the_missing_module_truthfully(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    missing_module: str,
+    expected_detail: str,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(smoke, "_authorize_internal", lambda *_args: None)
+    monkeypatch.setattr(smoke, "_block_python_network", lambda: None)
+    monkeypatch.setattr(smoke, "_internal_release_root", lambda *_args: tmp_path)
+
+    def fail_with_missing_module(*_args) -> None:
+        raise ModuleNotFoundError(f"No module named '{missing_module}'", name=missing_module)
+
+    monkeypatch.setattr(smoke, "_prepare_vault", fail_with_missing_module)
+
+    exit_code = smoke.main(
+        [
+            "--_prepare",
+            "configs",
+            "--source-root",
+            str(tmp_path),
+            "--vault-root",
+            str(vault),
+        ]
+    )
+
+    result = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert result == {"verdict": "UNKNOWN", "detail": expected_detail}
+
+
+def test_smoke_journey_names_a_missing_dex_module_truthfully(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(smoke, "_authorize_internal", lambda *_args: None)
+    monkeypatch.setattr(smoke, "_block_python_network", lambda: None)
+    monkeypatch.setattr(smoke, "_internal_release_root", lambda *_args: tmp_path)
+
+    def fail_with_missing_core(*_args) -> dict[str, str]:
+        raise ModuleNotFoundError("No module named 'core'", name="core")
+
+    monkeypatch.setitem(smoke.INTERNAL_JOURNEYS, "configs", fail_with_missing_core)
+
+    exit_code = smoke.main(["--_journey", "configs"])
+
+    result = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert result == {
+        "verdict": "UNKNOWN",
+        "detail": "Dex's own code could not be loaded (No module named 'core'). "
+        "This is a Dex checkup fault, not a missing Python package.",
+    }
+
+
 def test_ledger_writes_latest_and_versioned_history(tmp_path: Path, capsys) -> None:
     vault = _write_valid_vault(tmp_path)
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -2542,11 +2542,13 @@ def _launchctl_status(label: str) -> dict[str, int | bool | None]:
     if result.returncode != 0:
         if _looks_like_sandbox_failure(combined):
             raise PermissionError(combined)
-        return {"loaded": False, "last_exit_status": None}
-    match = re.search(r"LastExitStatus\D+(-?\d+)", result.stdout)
+        return {"loaded": False, "pid": None, "last_exit_status": None}
+    pid_match = re.search(r"\bPID\D+(\d+)", result.stdout)
+    exit_match = re.search(r"LastExitStatus\D+(-?\d+)", result.stdout)
     return {
         "loaded": True,
-        "last_exit_status": int(match.group(1)) if match else None,
+        "pid": int(pid_match.group(1)) if pid_match else None,
+        "last_exit_status": int(exit_match.group(1)) if exit_match else None,
     }
 
 
@@ -2761,6 +2763,10 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
                     continue
                 if not status["loaded"]:
                     issues.append((2, f"{label} is installed but not loaded"))
+                elif status.get("pid") is not None:
+                    # LastExitStatus describes the previous process. A live PID
+                    # is the current state and must win over stale history.
+                    continue
                 elif status["last_exit_status"] is None:
                     unknowns.append(f"{label} is loaded but has no observable LastExitStatus")
                 elif status["last_exit_status"] != 0:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -2763,7 +2763,7 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
                     continue
                 if not status["loaded"]:
                     issues.append((2, f"{label} is installed but not loaded"))
-                elif status.get("pid") is not None:
+                elif isinstance(status.get("pid"), int) and status["pid"] > 0:
                     # LastExitStatus describes the previous process. A live PID
                     # is the current state and must win over stale history.
                     continue

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -68,6 +68,23 @@ SENSITIVE_CONFIG_KEY = re.compile(
     r"(?:api[_-]?key|authorization|credential|password|secret|token)",
     re.IGNORECASE,
 )
+
+
+def _missing_module_detail(error: ModuleNotFoundError) -> str:
+    module = error.name
+    if module == "core" or (isinstance(module, str) and module.startswith("core.")):
+        return (
+            f"Dex's own code could not be loaded ({_one_line(error)}). "
+            "This is a Dex checkup fault, not a missing Python package."
+        )
+    if module:
+        return (
+            f"Python module {module!r} is not installed in this vault's .venv — run /dex-update "
+            "(or reinstall requirements.txt into that .venv), then re-run /dex-doctor"
+        )
+    return MISSING_PACKAGES_DETAIL
+
+
 SNAPSHOT_CHANGED_DETAIL = "snapshot changed before launch"
 MCP_ONCE_CONSENT_DETAIL = "valid fresh single-use consent token is required"
 MCP_ONCE_TOKEN_PREFIX = "dex-mcp-once-consent-"
@@ -2693,8 +2710,8 @@ def main(
             result = {"verdict": "BROKEN", "detail": _one_line(exc)}
         except JourneySafetySkip as exc:
             result = {"verdict": "UNKNOWN", "detail": _one_line(exc)}
-        except ModuleNotFoundError:
-            result = {"verdict": "UNKNOWN", "detail": MISSING_PACKAGES_DETAIL}
+        except ModuleNotFoundError as error:
+            result = {"verdict": "UNKNOWN", "detail": _missing_module_detail(error)}
         except (OSError, PermissionError) as exc:
             print(f"smoke preparation refused: {_one_line(exc)}", file=sys.stderr)
             return 2
@@ -2710,8 +2727,8 @@ def main(
             _block_python_network()
             release_root = _internal_release_root(args.run_marker, args.release_root)
             result = INTERNAL_JOURNEYS[args._journey](vault, release_root)
-        except ModuleNotFoundError:
-            result = {"verdict": "UNKNOWN", "detail": MISSING_PACKAGES_DETAIL}
+        except ModuleNotFoundError as error:
+            result = {"verdict": "UNKNOWN", "detail": _missing_module_detail(error)}
         except (KeyError, OSError, PermissionError) as exc:
             print(f"internal smoke journey refused: {_one_line(exc)}", file=sys.stderr)
             return 2

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -79,7 +79,7 @@ def _missing_module_detail(error: ModuleNotFoundError) -> str:
         )
     if module:
         return (
-            f"Python module {module!r} is not installed in this vault's .venv — run /dex-update "
+            f"Python packages not installed in this vault's .venv (missing module {module!r}) — run /dex-update "
             "(or reinstall requirements.txt into that .venv), then re-run /dex-doctor"
         )
     return MISSING_PACKAGES_DETAIL


### PR DESCRIPTION
## What this repairs

Addresses the three diagnostic truthfulness defects reported in #499:

- The documented direct post-update command now imports Dex from its checked-out source rather than failing with `No module named core`.
- Doctor treats a positive live launch-agent PID as current state, even if its previous exit was non-zero; PID 0 remains non-running.
- Smoke reports the actual missing module and does not call a missing Dex module a missing third-party package.

## Verified locally

- Eight focused regression checks pass, including the direct CLI, positive/zero PID behavior, launchctl parsing, the existing fresh-release case, and both smoke paths.
- Ruff is clean on all six changed Python files.
- The exact direct CLI succeeds on a newly activated fixture with `PYTHONPATH` removed.

The broader health/Doctor/smoke run reaches 108 passing checks locally, then stops at an existing macOS-only Doctor test because this Linux runner has no `plutil`. A Linux-only full smoke run also lacks its normal YAML dependency. macOS CI is required before merge.

## Scope

This changes diagnostic accuracy only; it does not release or publish anything.