### PR TITLE
Fix Lens catalogue producer contract and release v1.96.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.1] — 🔎 Lens can read every role and planning capability (2026-08-13)
+
+The v1.96.0 catalogue was correctly signed but Lens refused it before deployment: two quarterly-planning requirements used Dex's internal underscore spelling instead of the public catalogue's hyphenated ID format. The canonical Lens URL stayed on the already-proven v1.95.2 catalogue, so nobody received the rejected file.
+
+**What this fixes for you:**
+
+* **The complete 55-capability catalogue now uses the exact contract Lens reads.** Quarterly planning and review keep their real room dependency, expressed as the valid `quarter-goals-room-enabled` requirement.
+* **The producer now catches this class of mismatch before signing.** Host requirements must use Lens catalogue IDs, duplicates are refused, and the exported cross-repository schema carries the same identifier and uniqueness rules as Lens's runtime verifier.
+* **The correction supersedes the rejected signed file honestly.** Catalogue version 3 replaces version 2 rather than rewriting the published v1.96.0 artifact.
+
 ## [1.96.0] — 🧭 Lens can now find the Dex built for your role (2026-08-12)
 
 Dex Lens is the private guide that looks at your own AI setup and suggests useful Dex capabilities without changing anything. Its first expansion covered the everyday work almost everyone shares. This release adds the next layer: thirty adoptable capabilities for sales, product, marketing, engineering, finance, customer success, operations, design, career development, and quarterly planning.

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -908,6 +908,7 @@ core/paths.py
 core/portable_contract.py
 core/provision-contract.json
 core/provision.cjs
+core/provision_transaction.py
 core/ritual_intelligence/__init__.py
 core/ritual_intelligence/__main__.py
 core/ritual_intelligence/actions.py
@@ -1133,6 +1134,7 @@ core/tests/test_pr_report.py
 core/tests/test_preflight_paths.py
 core/tests/test_process_meetings_soft_commitment_wiring.py
 core/tests/test_provision_parity.py
+core/tests/test_provision_transaction.py
 core/tests/test_qmd_query_grep_fallback.py
 core/tests/test_relationship_radar_skill.py
 core/tests/test_relationships_feed.py

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.0"
+  "release_version": "1.96.1"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.0",
+  "release_version": "1.96.1",
   "schema_version": 1
 }

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -1,6 +1,6 @@
 {
   "registry_version": 1,
-  "catalog_version": 2,
+  "catalog_version": 3,
   "jobs": [
     {
       "job_id": "plan-my-work",
@@ -2432,7 +2432,7 @@
         "rollback_advice": "Disable the room through the capability manager; preserve the person's room content and remove only release-owned surfaced skill copies."
       },
       "compatibility": {
-        "host_requirements": ["skills-directory", "quarter_goals-room-enabled", "room-capability-manager"],
+        "host_requirements": ["skills-directory", "quarter-goals-room-enabled", "room-capability-manager"],
         "needs_hooks": false,
         "needs_mcp": true,
         "platforms": ["macos", "linux", "windows"]
@@ -2479,7 +2479,7 @@
         "rollback_advice": "Disable the room through the capability manager; preserve the person's room content and remove only release-owned surfaced skill copies."
       },
       "compatibility": {
-        "host_requirements": ["skills-directory", "quarter_goals-room-enabled", "room-capability-manager"],
+        "host_requirements": ["skills-directory", "quarter-goals-room-enabled", "room-capability-manager"],
         "needs_hooks": false,
         "needs_mcp": true,
         "platforms": ["macos", "linux", "windows"]

--- a/core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json
+++ b/core/lens-catalog/schemas/dex-lens-catalogue-v2.schema.json
@@ -5,30 +5,36 @@
       "properties": {
         "foundation_capabilities": {
           "items": {
+            "pattern": "^[a-z][a-z0-9-]{2,80}$",
             "type": "string"
           },
           "maxItems": 20,
           "minItems": 1,
           "title": "Foundation Capabilities",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         },
         "host_adapters": {
           "items": {
+            "pattern": "^[a-z][a-z0-9-]{2,80}$",
             "type": "string"
           },
           "maxItems": 20,
           "minItems": 1,
           "title": "Host Adapters",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         },
         "host_requirements": {
           "items": {
+            "pattern": "^[a-z][a-z0-9-]{2,80}$",
             "type": "string"
           },
           "maxItems": 20,
           "minItems": 1,
           "title": "Host Requirements",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         },
         "limitations": {
           "items": {
@@ -184,11 +190,13 @@
         },
         "changed_in": {
           "items": {
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
             "type": "string"
           },
           "maxItems": 40,
           "title": "Changed In",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         },
         "compatibility": {
           "$ref": "#/$defs/CapabilityCompatibilityV2"
@@ -210,12 +218,14 @@
         },
         "jobs": {
           "items": {
+            "pattern": "^[a-z][a-z0-9-]{2,80}$",
             "type": "string"
           },
           "maxItems": 20,
           "minItems": 1,
           "title": "Jobs",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         },
         "portable_brief": {
           "$ref": "#/$defs/CapabilityPortableBriefV2"

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.0","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.1","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/tests/test_dex_lens_catalog_generation.py
+++ b/core/tests/test_dex_lens_catalog_generation.py
@@ -242,6 +242,37 @@ def test_generator_rejects_unknown_fields_in_registry(tmp_path: Path) -> None:
     assert "unknown capabilities" in result.stderr
 
 
+def test_generator_rejects_non_kebab_host_requirement_ids(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    registry_path = tmp_path / "core/lens-catalog/registry.json"
+    data = json.loads(registry_path.read_text())
+    data["entries"][0]["compatibility"]["host_requirements"] = [
+        "quarter_goals-room-enabled"
+    ]
+    _write(registry_path, json.dumps(data))
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 1
+    assert "host_requirements item must be kebab-case" in result.stderr
+
+
+def test_generator_rejects_duplicate_host_requirement_ids(tmp_path: Path) -> None:
+    _registry(tmp_path)
+    registry_path = tmp_path / "core/lens-catalog/registry.json"
+    data = json.loads(registry_path.read_text())
+    data["entries"][0]["compatibility"]["host_requirements"] = [
+        "skills-directory",
+        "skills-directory",
+    ]
+    _write(registry_path, json.dumps(data))
+
+    result = _generate(tmp_path)
+
+    assert result.returncode == 1
+    assert "host_requirements contains duplicate Lens catalogue ids" in result.stderr
+
+
 def test_generator_rejects_unknown_job_and_foundation_references(tmp_path: Path) -> None:
     _registry(tmp_path)
     data = json.loads((tmp_path / "core/lens-catalog/registry.json").read_text())
@@ -696,7 +727,7 @@ def test_wave3_source_partition_is_exact_and_resolves_to_unique_targets() -> Non
     registry = json.loads(REAL_REGISTRY.read_text(encoding="utf-8"))
     wave3 = registry["entries"][-len(WAVE3_IDS) :]
 
-    assert registry["catalog_version"] == 2
+    assert registry["catalog_version"] == 3
     assert len(registry["jobs"]) == 11
     assert [job["job_id"] for job in registry["jobs"][-2:]] == [
         "run-my-role",

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -58,6 +58,7 @@ RELEASE_BUILD_INPUTS = (
     ".scripts/lib/tests/entity-pages.test.cjs",
     "06-Resources/Dex_System/Dex_Technical_Guide.md",
     *DOCS_BRIDGE_PATHS,
+    "docs/UPDATE-RESCUE.md",
     "package.json",
     "requirements.txt",
     "requirements-dev.txt",

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.0 release,
+Download the versioned bridge and its checksum from the public v1.96.1 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.0/dex-update-bridge-v1.96.0.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.0.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.1/dex-update-bridge-v1.96.1.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.0/dex-update-bridge-v1.96.0.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.0.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.1/dex-update-bridge-v1.96.1.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.0.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.1.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.0.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.0",
+  "version": "1.96.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.0",
+      "version": "1.96.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.0",
+  "version": "1.96.1",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/generate-dex-lens-catalog.py
+++ b/scripts/generate-dex-lens-catalog.py
@@ -33,6 +33,7 @@ MINIMUM_LENS_CONTRACT = "0.1.0"
 REGISTRY_VERSION = 1
 SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?$")
 KEBAB = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+CATALOG_ID = re.compile(r"^[a-z][a-z0-9-]{2,80}$")
 CONTROL = re.compile(r"[\x00-\x1f\x7f]")
 FOUNDATION_CAPABILITIES = frozenset(
     {
@@ -121,6 +122,16 @@ def _text_tuple(value: object, *, context: str, max_length: int = 512) -> tuple[
     if not isinstance(value, list) or not value:
         raise LensCatalogError(f"{context} must be a non-empty array")
     return tuple(_text(item, context=f"{context} item", max_length=max_length) for item in value)
+
+
+def _catalog_id_tuple(value: object, *, context: str) -> tuple[str, ...]:
+    identifiers = _text_tuple(value, context=context, max_length=81)
+    for identifier in identifiers:
+        if CATALOG_ID.fullmatch(identifier) is None:
+            raise LensCatalogError(f"{context} item must be kebab-case Lens catalogue id")
+    if len(set(identifiers)) != len(identifiers):
+        raise LensCatalogError(f"{context} contains duplicate Lens catalogue ids")
+    return identifiers
 
 
 def _relative_path(raw_path: object, *, context: str) -> str:
@@ -314,7 +325,7 @@ def _compatibility(value: object, *, context: str) -> dict[str, object]:
         "platforms": platforms,
         "needs_hooks": raw["needs_hooks"],
         "needs_mcp": raw["needs_mcp"],
-        "host_requirements": _text_tuple(
+        "host_requirements": _catalog_id_tuple(
             raw.get("host_requirements"),
             context=f"{context} compatibility host_requirements",
         ),


### PR DESCRIPTION
## The short version

Lens correctly refused the signed v1.96.0 catalogue before deployment because two quarterly-planning host requirement IDs contained an underscore. The canonical heydex.ai catalogue remained on proven v1.95.2.

This correction:

- fixes both IDs to quarter-goals-room-enabled;
- makes the Core producer reject malformed or duplicate requirement IDs before signing;
- vendors the strengthened Lens schema, including identifier and uniqueness rules;
- advances the catalogue from version 2 to version 3 so the public bad artifact is superseded rather than rewritten;
- bumps the corrected release to v1.96.1 and synchronizes all release metadata.

## Verification

- 78 focused catalogue/release tests passed.
- 81 of 82 distribution tests passed in the full run; the only failure exposed an omitted pre-commit rescue-guide input, which was repaired and then passed on rerun, giving all 82 green across the two runs.
- Lens verified an ephemeral real Ed25519 signature over the corrected v1.96.1 catalogue: catalog version 3, 55 capabilities, 11 jobs.
- Distribution safety, portable contract, release tag gates, Ruff, and diff checks passed.

v1.96.0 remains public but is not deployed to the canonical Lens URL. Publish v1.96.1 only after exact-head CI and independent review pass.