### PR TITLE
Make the composed .gitignore section correct in both directions, including nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.96.2] — 🔒 A company network that inspects traffic no longer looks like a corrupt release (2026-08-13)
+## [1.96.2] — 🛡️ Your history saves again, and company networks get an honest answer (2026-08-13)
 
 If you're on a corporate network that intercepts secure connections — Zscaler, Netskope, most large enterprises — or on a hotel or airport captive portal, Dex's daily update check could fail and report that the release evidence was **invalid**. That wording means something specific and alarming: that the version of Dex being offered looks tampered with. It was never true. What had actually happened is that Dex couldn't verify it was really talking to GitHub, because something on your network was sitting in the middle of the connection. Worse, Dex treated it as a permanent verdict and didn't try again, so the check stayed broken for exactly the people most likely to hit it.
 
@@ -18,6 +18,17 @@ If you're on a corporate network that intercepts secure connections — Zscaler,
 * **Dex still refuses to trust a certificate it can't verify, and there is no way to turn that off.** This release changes what Dex *tells* you and whether it *retries* — it does not change what Dex is willing to trust. There is no setting, visible or hidden, that makes Dex skip certificate checking, and there deliberately never will be: if something really is intercepting your connection to GitHub, that is exactly the moment Dex should stop.
 * **When something does go wrong, it's now diagnosable.** Update failures were being recorded as a bare category with the underlying error thrown away, which is why this particular fault took hours to track down. The underlying message is now kept — trimmed, single-line, and with anything credential-shaped stripped out before it's written anywhere.
 * **Several other failures stop being mislabelled too.** A missing file, a permissions problem, or a timed-out command were all being filed under the same "invalid evidence" heading as a genuinely bad release. Each now reports as itself.
+
+Chris Jackson found a second regression before this release went out: the rules Dex ships for its own source repository were also being copied into people's vaults. Those rules told Git to ignore the folders where their inbox, goals, tasks, projects, areas, resources, and archives live. The session snapshot hook could sometimes force past that rule, but an ordinary Git save refused the files outright — exactly when someone needed their local history as a safety net.
+
+**What this fixes for you:**
+
+* **Every personal working folder is tracked again.** Your inbox, goals, priorities, tasks, projects, areas, resources, and archives can all be saved in your local Git history after an install or update.
+* **Dex's own files stay out of your personal history.** Product files delivered inside Resources are still excluded, while your own notes beside them remain trackable.
+* **Secrets remain excluded.** Files such as `.env` stay ignored; repairing personal history does not weaken the privacy boundary.
+* **The release now proves the real recovery path.** The test installs the shipped rules through Dex's updater, creates real user and product files, commits them with Git, and inspects the resulting history. Removing the fix makes that test fail at the same command users hit.
+
+Thanks to Chris, who traced the missing-history symptom back to the generated vault rules and contributed both halves of the correction.
 
 ## [1.96.1] — 🔎 Lens can read every role and planning capability (2026-08-13)
 

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.1"
+  "release_version": "1.96.2"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.1",
+  "release_version": "1.96.2",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.1","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.2","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -334,6 +334,19 @@ RULES: tuple[Rule, ...] = (
     _r("vault-trusted-mcps", "System/trusted-mcps.yaml", "file", "vault"),
 )
 
+
+def brain_paths_inside_vault_regions() -> tuple[str, ...]:
+    """Release-owned paths nested inside otherwise user-owned vault regions."""
+    region_prefixes = tuple(f"{region}/" for region in VAULT_REGIONS)
+    return tuple(
+        sorted(
+            rule.path
+            for rule in RULES
+            if rule.ownership == "brain" and rule.path.startswith(region_prefixes)
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # Capability rooms (Decision C, Option 2). The meetings/people/tasks spine is
 # NOT a capability — it is always on and has no registry entry by design.

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1651,21 +1651,38 @@ def test_composed_gitignore_appends_contract_derived_vault_section() -> None:
     assert "\n/.claude/\n" not in section
 
 
-def test_composed_shipped_gitignore_saves_user_files_and_excludes_product_files(
-    tmp_path: Path,
+def test_applied_shipped_gitignore_saves_user_files_and_excludes_product_files(
+    split_release_fixture: dict[str, object],
 ) -> None:
-    """Exercise the installed vault contract through Git, not generated text."""
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    _git(vault, "init", "--quiet")
-    _write(
-        vault,
-        ".gitignore",
-        apply_update.COMPOSERS[".gitignore"](
-            (REPO_ROOT / ".gitignore").read_bytes(),
-            vault,
-        ),
+    """Install the shipped rules, commit real files, and inspect Git history."""
+    release = split_release_fixture["release"]
+    vault = split_release_fixture["vault"]
+    brain = split_release_fixture["brain"]
+
+    _write(release, ".gitignore", (REPO_ROOT / ".gitignore").read_bytes())
+    target = _commit_release(release, "1.65.0")
+    split_release_fixture["target"] = target
+    _target_tag, _target_tag_object, target_commit, _target_tree = target
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={brain}",
+            "fetch",
+            "--quiet",
+            "--tags",
+            str(release),
+            f"+{target_commit}:refs/remotes/upstream/release",
+        ],
+        check=True,
     )
+
+    result = apply_update.apply_verified_release(vault, _verified(split_release_fixture))
+    assert result["committed"] is True
+    assert ".gitignore" in result["replaced"]
+
+    _git(vault, "init", "--quiet")
+    _git(vault, "config", "user.name", "Dex Vault Test")
+    _git(vault, "config", "user.email", "vault@example.com")
 
     user_files = {
         f"{region}/user-note.md" for region in portable_contract.VAULT_REGIONS
@@ -1673,32 +1690,31 @@ def test_composed_shipped_gitignore_saves_user_files_and_excludes_product_files(
     for relative in user_files:
         _write(vault, relative, b"user-owned\n")
 
-    product_file = "06-Resources/Dex_System/Dex_System_Guide.md"
+    product_files = set(portable_contract.brain_paths_inside_vault_regions())
+    assert product_files
+    product_files.add("README.md")
     customization = ".claude/skills-custom/mine/SKILL.md"
     secret = ".env"
-    _write(vault, product_file, b"release-owned\n")
+    for relative in product_files:
+        _write(vault, relative, b"release-owned\n")
     _write(vault, customization, b"user customization\n")
     _write(vault, secret, b"API_KEY=never-stage\n")
 
     _git(vault, "add", "-A", "--", *portable_contract.VAULT_REGIONS)
     _git(vault, "add", "-A", "--", customization)
-    staged = set(_git(vault, "diff", "--cached", "--name-only").splitlines())
+    _git(vault, "commit", "--quiet", "-m", "save user work")
+    committed = set(_git(vault, "show", "--format=", "--name-only", "HEAD").splitlines())
 
-    assert user_files <= staged
-    assert customization in staged
-    assert product_file not in staged
-    assert secret not in staged
+    assert user_files <= committed
+    assert customization in committed
+    assert product_files.isdisjoint(committed)
+    assert secret not in committed
 
-    product_ignored = subprocess.run(
-        ["git", "-C", str(vault), "check-ignore", "--quiet", "--", product_file],
-        check=False,
+    ignored = set(
+        _git(vault, "check-ignore", "--", *sorted(product_files), secret).splitlines()
     )
-    secret_ignored = subprocess.run(
-        ["git", "-C", str(vault), "check-ignore", "--quiet", "--", secret],
-        check=False,
-    )
-    assert product_ignored.returncode == 0
-    assert secret_ignored.returncode == 0
+    assert product_files <= ignored
+    assert secret in ignored
 
 
 def test_composed_gitignore_reincludes_every_vault_region() -> None:

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1651,6 +1651,56 @@ def test_composed_gitignore_appends_contract_derived_vault_section() -> None:
     assert "\n/.claude/\n" not in section
 
 
+def test_composed_shipped_gitignore_saves_user_files_and_excludes_product_files(
+    tmp_path: Path,
+) -> None:
+    """Exercise the installed vault contract through Git, not generated text."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _git(vault, "init", "--quiet")
+    _write(
+        vault,
+        ".gitignore",
+        apply_update.COMPOSERS[".gitignore"](
+            (REPO_ROOT / ".gitignore").read_bytes(),
+            vault,
+        ),
+    )
+
+    user_files = {
+        f"{region}/user-note.md" for region in portable_contract.VAULT_REGIONS
+    }
+    for relative in user_files:
+        _write(vault, relative, b"user-owned\n")
+
+    product_file = "06-Resources/Dex_System/Dex_System_Guide.md"
+    customization = ".claude/skills-custom/mine/SKILL.md"
+    secret = ".env"
+    _write(vault, product_file, b"release-owned\n")
+    _write(vault, customization, b"user customization\n")
+    _write(vault, secret, b"API_KEY=never-stage\n")
+
+    _git(vault, "add", "-A", "--", *portable_contract.VAULT_REGIONS)
+    _git(vault, "add", "-A", "--", customization)
+    staged = set(_git(vault, "diff", "--cached", "--name-only").splitlines())
+
+    assert user_files <= staged
+    assert customization in staged
+    assert product_file not in staged
+    assert secret not in staged
+
+    product_ignored = subprocess.run(
+        ["git", "-C", str(vault), "check-ignore", "--quiet", "--", product_file],
+        check=False,
+    )
+    secret_ignored = subprocess.run(
+        ["git", "-C", str(vault), "check-ignore", "--quiet", "--", secret],
+        check=False,
+    )
+    assert product_ignored.returncode == 0
+    assert secret_ignored.returncode == 0
+
+
 def test_composed_gitignore_reincludes_every_vault_region() -> None:
     """The distribution file ignores the PARA folders; a vault must track them.
 

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1651,6 +1651,39 @@ def test_composed_gitignore_appends_contract_derived_vault_section() -> None:
     assert "\n/.claude/\n" not in section
 
 
+def test_composed_gitignore_reincludes_every_vault_region() -> None:
+    """The distribution file ignores the PARA folders; a vault must track them.
+
+    Without this the failure is not cosmetic: `git add 04-Projects/` refuses
+    outright, so every pathspec-based staging path (the vault-autocommit hook)
+    stops committing the user's own work, silently.
+    """
+    release_blob = b"# distribution rules\n00-Inbox/\n03-Tasks/\n04-Projects/\n"
+
+    composed = apply_update._compose_gitignore(release_blob, Path("/unused")).decode()
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+
+    for region in portable_contract.VAULT_REGIONS:
+        assert f"\n!/{region}/\n" in section, region
+
+    # the negations must come after the distribution's ignore rules, or they
+    # are dead letters: last match wins
+    assert composed.index("04-Projects/") < composed.index("!/04-Projects/")
+
+
+def test_composed_gitignore_vault_regions_track_the_contract() -> None:
+    """Derived from the contract, so a new region cannot be forgotten here."""
+    composed = apply_update._compose_gitignore(b"# rules\n", Path("/unused")).decode()
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+
+    emitted = {
+        line[2:].rstrip("/")
+        for line in section.splitlines()
+        if line.startswith("!/") and "/" not in line[2:].rstrip("/")
+    }
+    assert set(portable_contract.VAULT_REGIONS) <= emitted
+
+
 def test_composed_gitignore_is_idempotent_and_replaces_stale_section() -> None:
     release_blob = b"# rules\n"
     once = apply_update._compose_gitignore(release_blob, Path("/unused"))

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1731,16 +1731,10 @@ def test_composed_gitignore_reignores_product_files_inside_vault_regions() -> No
     composed = apply_update._compose_gitignore(b"# rules\n", Path("/unused")).decode()
     section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
 
-    nested = [
-        rule.path for rule in portable_contract.RULES
-        if rule.ownership == "brain"
-        and rule.path.startswith(
-            tuple(f"{region}/" for region in portable_contract.VAULT_REGIONS)
-        )
-    ]
-    assert nested, "expected the contract to declare product files inside a vault region"
+    brain_paths = portable_contract.brain_paths_inside_vault_regions()
+    assert brain_paths, "expected product files inside a vault region"
 
-    for path in nested:
+    for path in brain_paths:
         assert f"\n/{path}\n" in section, path
         region = path.split("/", 1)[0]
         # ordering is the whole point: the negation first, the re-ignore after

--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -1671,6 +1671,41 @@ def test_composed_gitignore_reincludes_every_vault_region() -> None:
     assert composed.index("04-Projects/") < composed.index("!/04-Projects/")
 
 
+def test_composed_gitignore_reignores_product_files_inside_vault_regions() -> None:
+    """The release delivers reference docs into 06-Resources, a vault region.
+
+    Tracking them would put product churn in the user's private history and
+    re-dirty the working tree on every update. The re-ignore must come AFTER
+    the region negation or last-match keeps them tracked.
+    """
+    composed = apply_update._compose_gitignore(b"# rules\n", Path("/unused")).decode()
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+
+    nested = [
+        rule.path for rule in portable_contract.RULES
+        if rule.ownership == "brain"
+        and rule.path.startswith(
+            tuple(f"{region}/" for region in portable_contract.VAULT_REGIONS)
+        )
+    ]
+    assert nested, "expected the contract to declare product files inside a vault region"
+
+    for path in nested:
+        assert f"\n/{path}\n" in section, path
+        region = path.split("/", 1)[0]
+        # ordering is the whole point: the negation first, the re-ignore after
+        assert section.index(f"!/{region}/") < section.index(f"/{path}")
+
+
+def test_composed_gitignore_leaves_user_files_in_a_vault_region_tracked() -> None:
+    """Per-file, not per-directory: a note the user writes stays theirs."""
+    composed = apply_update._compose_gitignore(b"# rules\n", Path("/unused")).decode()
+    section = composed.split(apply_update.GITIGNORE_SECTION_BEGIN, 1)[1]
+
+    # a blanket directory ignore would sweep up anything the user put alongside
+    assert "\n/06-Resources/Dex_System/\n" not in section
+
+
 def test_composed_gitignore_vault_regions_track_the_contract() -> None:
     """Derived from the contract, so a new region cannot be forgotten here."""
     composed = apply_update._compose_gitignore(b"# rules\n", Path("/unused")).decode()

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -128,6 +128,13 @@ def _vault_mode_gitignore_section() -> str:
     place to restore vault-side behavior is the end of the file itself
     (last match wins). The section is derived from the ownership contract so
     there is no second path list to drift.
+
+    The distribution file is wrong inside a vault in BOTH directions, so this
+    section corrects both. Its negations un-ignore brain-owned product files,
+    handled above. Its ignore rules for the PARA folders hide the user's own
+    content, handled below with ``VAULT_REGIONS``. Fixing only the first leaves
+    ``git add 04-Projects/`` failing, which silently disables any pathspec-based
+    staging such as the vault-autocommit hook.
     """
     tops = sorted(
         (rule for rule in portable_contract.RULES
@@ -163,6 +170,17 @@ def _vault_mode_gitignore_section() -> str:
             lines.extend(f"!/{exception}/" for exception in exceptions)
         else:
             lines.append(f"/{top.path}/")
+
+    # The distribution .gitignore also ignores the PARA folders, because in the
+    # product repository they hold sample content. Inside a vault they are the
+    # user's entire history, and ignoring them is worse than a cosmetic wart:
+    # `git add 04-Projects/` fails outright with "The following paths are
+    # ignored", so any pathspec-based staging (the vault-autocommit hook)
+    # hard-fails and stops committing. Re-include them last so the negation
+    # wins, derived from the same contract as the rules above.
+    lines.append("# Vault regions are the user's own content and stay tracked.")
+    lines.extend(f"!/{region}/" for region in sorted(portable_contract.VAULT_REGIONS))
+
     lines.append(GITIGNORE_SECTION_END)
     return "\n".join(lines)
 

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -188,11 +188,7 @@ def _vault_mode_gitignore_section() -> str:
     # after the region negation, or last-match keeps them tracked. Emitted
     # per file rather than per directory: the contract declares individual
     # files, so a note the user writes alongside them stays theirs.
-    brain_in_regions = sorted(
-        rule.path for rule in portable_contract.RULES
-        if rule.ownership == "brain"
-        and rule.path.startswith(tuple(f"{region}/" for region in portable_contract.VAULT_REGIONS))
-    )
+    brain_in_regions = portable_contract.brain_paths_inside_vault_regions()
     if brain_in_regions:
         lines.append("# Product files delivered inside a vault region stay untracked.")
         lines.extend(f"/{path}" for path in brain_in_regions)

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -181,6 +181,22 @@ def _vault_mode_gitignore_section() -> str:
     lines.append("# Vault regions are the user's own content and stay tracked.")
     lines.extend(f"!/{region}/" for region in sorted(portable_contract.VAULT_REGIONS))
 
+    # Mirror of the brain-with-vault-children case above. The release also
+    # delivers product files INTO vault regions (the Dex_System reference docs
+    # under 06-Resources), and those are refreshed by every update, so tracking
+    # them puts product churn in the user's private history. Re-ignore them
+    # after the region negation, or last-match keeps them tracked. Emitted
+    # per file rather than per directory: the contract declares individual
+    # files, so a note the user writes alongside them stays theirs.
+    brain_in_regions = sorted(
+        rule.path for rule in portable_contract.RULES
+        if rule.ownership == "brain"
+        and rule.path.startswith(tuple(f"{region}/" for region in portable_contract.VAULT_REGIONS))
+    )
+    if brain_in_regions:
+        lines.append("# Product files delivered inside a vault region stay untracked.")
+        lines.extend(f"/{path}" for path in brain_in_regions)
+
     lines.append(GITIGNORE_SECTION_END)
     return "\n".join(lines)
 

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.1 release,
+Download the versioned bridge and its checksum from the public v1.96.2 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.1/dex-update-bridge-v1.96.1.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.2/dex-update-bridge-v1.96.2.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.1/dex-update-bridge-v1.96.1.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.2/dex-update-bridge-v1.96.2.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.1.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.2.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.1.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/docs/portable-vault-contract-design.md
+++ b/docs/portable-vault-contract-design.md
@@ -113,6 +113,22 @@ Longest-prefix rule wins; explicit file rules beat directory rules; deny beats a
 `resolve(path) -> {class, rule_id, deny: bool}`. Loader is pure stdlib (no pyyaml
 dependency in the hot path — JSON only), mirroring `core/path_contract.py`.
 
+### Installed-vault Git tracking
+
+The release repository's base `.gitignore` excludes the PARA regions because they
+contain shipped examples in the public source tree. An installed vault has the
+opposite ownership boundary: every path named by `VAULT_REGIONS` is re-included so
+the user's notes, tasks, projects, and resources remain eligible for private Git
+history. This vault-mode section is appended after the distribution rules because
+Git's last matching rule wins.
+
+The temporary exception is release-owned reference material still shipped inside
+`06-Resources/Dex_System/`. `brain_paths_inside_vault_regions()` derives those exact
+file paths from the ownership contract and the composer excludes each file again
+after re-including the region. The exclusion is deliberately per-file, never the
+whole directory, so a user note beside a shipped reference file remains user-owned
+and trackable. Secrets and other hard-denied paths remain excluded independently.
+
 ## Non-goals for PR-0
 No behavior change: nothing consumes the contract for writes yet. PR-1 (snapshot/journal
 core) and the migrator/updater ports build on it. `ownership.json` CJS bridge is

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -22,6 +22,8 @@ Dex uses repository-enforced quality gates so unsafe changes cannot merge.
 - Hook harness tests pass.
 - Security gate passes (secret leakage detection).
 - Large-vault performance budget passes.
+- The package version matches the newest changelog entry, so a green main build
+  cannot silently skip the release its notes promise.
 
 The PII gate is merge-base-aware and diff-scoped. Fake email addresses under
 `core/tests/fixtures/**` are allowed, but tracked personal-config shapes remain blocked

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.1",
+  "version": "1.96.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.1",
+      "version": "1.96.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.1",
+  "version": "1.96.2",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/scripts/verify-distribution.sh
+++ b/scripts/verify-distribution.sh
@@ -254,8 +254,9 @@ echo "✓ Checking package.json version matches CHANGELOG..."
 PKG_VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 CHANGELOG_VERSION=$(grep -m1 '^\#\# \[' CHANGELOG.md | sed 's/.*\[\([0-9][0-9.]*\)\].*/\1/')
 if [ "$PKG_VERSION" != "$CHANGELOG_VERSION" ]; then
-    echo "  ⚠️  WARNING: package.json ($PKG_VERSION) != CHANGELOG ($CHANGELOG_VERSION)"
-    WARNINGS=$((WARNINGS + 1))
+    echo "  ❌ ERROR: package.json ($PKG_VERSION) != CHANGELOG ($CHANGELOG_VERSION)"
+    echo "     CI would otherwise rebuild the already-published package version and skip this release."
+    ERRORS=$((ERRORS + 1))
 else
     echo "  ✅ Versions match: $PKG_VERSION"
 fi


### PR DESCRIPTION
Follow-on to the vault-mode `.gitignore` composer. That change fixed one direction of a two-directional problem; this fixes the other.

## The gap

The distribution `.gitignore` is wrong inside a vault in two ways:

1. Its "Keep Template Files" negations (`!core/` and friends) leave **brain-owned product files un-ignored**. The composed section already handles this.
2. Its ignore rules for the PARA folders hide the **user's own content**. Nothing handled this.

`VAULT_REGIONS` already exists in `portable_contract`, listing exactly the folders that must stay tracked. The composer derives its brain rules from `RULES` but never referenced the second constant, so the correction only ever ran in one direction.

## Why it matters more than it looks

This is not a cosmetic wart. With `04-Projects/` ignored, git refuses the whole pathspec:

```
$ git add 04-Projects/
The following paths are ignored by one of your .gitignore files:
04-Projects
```

The `vault-autocommit` hook stages exactly that way. So it does not partially work: it fails outright, and it fails quietly. The user's notes, tasks and project files stop being committed and nothing says so.

That is how a **336-file uncommitted backlog** built up on my vault before I noticed (#485). It is the same shape as the recent run of diagnostic faults: the failure is silent, and everything around it keeps reporting healthy.

## The change

Emit `!/<region>/` for each entry in `portable_contract.VAULT_REGIONS`, appended after the brain rules so the negation wins on last-match:

```
# Vault regions are the user's own content and stay tracked.
!/00-Inbox/
!/01-Quarter_Goals/
!/02-Week_Priorities/
!/03-Tasks/
!/04-Projects/
!/05-Areas/
!/06-Resources/
!/07-Archives/
```

Derived from the contract rather than hand-listed, so a new region cannot be forgotten here, which is the same discipline the brain half already follows.

## Verification

Scratch repository, shipped `.gitignore`, composed section appended:

| | `git add 04-Projects/` | `core/paths.py` | `.claude/skills-custom/` |
|---|---|---|---|
| before | **refuses** | ignored | tracked |
| after | succeeds | ignored | tracked |

So the fix restores staging without weakening either brain-side rule.

**Two tests, both of which fail when the change is reverted** (confirmed by reverting it and watching them go red, then restoring):

- `test_composed_gitignore_reincludes_every_vault_region` also asserts ordering, since a negation emitted before the distribution's ignore rule would be a dead letter
- `test_composed_gitignore_vault_regions_track_the_contract` compares emitted negations against `VAULT_REGIONS`, so the two cannot drift

Locally green: `ruff` clean, `test_apply_update.py` 60 passed, `test_portable_contract.py` 96 passed.

## Note on what this replaces

I have been carrying a local script that re-appends these lines after every update, because the composed section did not supply them. With this merged that script loses its main reason to exist, which is the outcome I would rather have than a better workaround.

## Second commit: the nesting mirror

Re-including `06-Resources` exposes a second gap, which is why it is in this PR rather than a follow-up: the two interact through ordering, and fixing one without the other is worse than fixing neither.

The release delivers the `Dex_System` reference docs **into** `06-Resources` and refreshes them every update. Once the region is tracked, those 13 files are tracked too, so product churn lands in the user's private history and re-dirties the tree after every update.

This is the exact mirror of a case the section already handles:

| | ignore | then re-include |
|---|---|---|
| vault inside brain (already handled) | `/core/*` | `!/core/mcp-custom/` |
| **brain inside vault (this commit)** | `!/06-Resources/` | `/06-Resources/Dex_System/README.md` … |

The contract already declares all 13 as `ownership=brain`. The composer simply never looked at nested brain rules, filtering to `"/" not in rule.path`. No new contract data was needed.

**Emitted per file, not per directory.** A blanket `/06-Resources/Dex_System/` would be three lines shorter but asserts the whole folder is product-owned, which the contract does not say. Per-file means a note the user writes alongside the docs stays tracked and stays theirs, and the list follows the contract when docs are added or removed.

**Ordering is load-bearing and asserted in the test**: the re-ignore must follow the region negation, or last-match keeps the files tracked.

## Combined verification

Scratch repo, shipped `.gitignore`, composed section appended:

| path | expected | result |
|---|---|---|
| `04-Projects/P.md` | tracked | pass |
| `git add 04-Projects/` | succeeds | pass (refuses without the change) |
| `core/paths.py` | ignored | pass |
| `.claude/skills-custom/x.md` | tracked | pass |
| `06-Resources/Dex_System/Dex_System_Guide.md` | ignored | pass |
| `06-Resources/Dex_System/My_Own_Note.md` | **tracked** | pass |
| `06-Resources/Learnings/Working_Preferences.md` | tracked | pass |

Four tests total. Three fail when their respective change is reverted. The fourth (`..._leaves_user_files_in_a_vault_region_tracked`) passes either way by design: it asserts the absence of a blanket directory ignore, so it guards against a future wrong implementation rather than testing this one. Flagging that rather than claiming four teeth where there are three.

Gates locally: `ruff` clean, `test_apply_update.py` 62 passed, `test_portable_contract.py` 96 passed.
