### PR TITLE
meeting-prep: read the invite before asking who is attending

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -108,20 +108,60 @@ If not provided, prompt the user for:
 
 ### Step 0: Gather Context (if needed)
 
-**If $MEETING or $ATTENDEES are not provided:**
+**If $MEETING or $ATTENDEES are not provided, try the calendar before asking.** The user booked
+the meeting; the invite already holds the title and the attendee list, and asking them to retype
+it is both friction and a source of duplicate person pages from misspelt names.
 
-Ask: "Which meeting are you prepping for?"
-- Get meeting topic/title
+When the calendar integration is available:
 
-Ask: "Who's attending? (comma-separated names or just list them)"
-- Accept formats: "Sarah Chen, Mike Rodriguez" or "Sarah, Mike" or natural list
-- Parse into individual attendee names
+```
+mcp__calendar-mcp__calendar_get_events_with_attendees(start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
+```
+
+**The end date is exclusive.** For a single day, pass the following day as `end_date`. Passing
+the same date twice returns zero events with no error, which is indistinguishable from an empty
+calendar.
+
+Match the user's phrasing to an event:
+
+- **A time** ("prep me for the 2pm", "tomorrow's 1:30"): match on start time, usually
+  unambiguous on its own.
+- **A person or topic** ("prep me for the Acme call"): match on title, or on an attendee name
+  within the event's `attendees` list.
+- **Nothing specified:** list today's and tomorrow's events and ask which one is meant.
+
+Each attendee carries `name`, `email`, `status`, `is_organizer`, plus `has_person_page` and
+`person_page`, so the vault lookup in Step 1 is already done for anyone who has a page.
+
+**Ask when the calendar cannot answer.** The calendar is the preferred source, not a required
+one, and this skill must still work without it:
+
+- **No calendar integration, or the tool is unavailable or refused** (a non-macOS machine, or
+  calendar access not granted): ask for the meeting and the attendees as before. Say once, in
+  passing, that you are asking because the calendar is not connected. A feature the user never
+  set up is not a fault and should not be reported as one.
+- **No matching event** in the range returned: ask which meeting is meant rather than guessing.
+- **Two events match a stated time:** that is a double-booking. Name both and let the user
+  choose; it is worth telling them about in itself.
+
+Never treat an empty result as proof of an empty calendar. A tool that is absent, a permission
+that was refused, and a query built with the wrong range all return nothing, and none of them
+mean "no meetings". If you cannot tell which it was, say so and ask.
+
+When asking, accept any natural format: "Sarah Chen, Mike Rodriguez", "Sarah, Mike", or a plain
+list.
 
 ### Step 1: Attendee Lookup
 
-For each attendee in $ATTENDEES:
+For each attendee:
 
-1. Search `05-Areas/People/Internal/` and `05-Areas/People/External/` for matching names
+1. **If the calendar supplied `person_page`, use it.** That resolution is already done and is
+   more reliable than matching a name, particularly for the display forms invites actually
+   carry: `Surname, First`, a job title in parentheses, or a bare email address where the name
+   should be. Only fall back to searching when `has_person_page` is false or the attendee came
+   from the user rather than the calendar.
+
+   Otherwise search `05-Areas/People/Internal/` and `05-Areas/People/External/` for matching names
 2. If found, extract:
    - Role and company
    - Last interaction date
@@ -366,6 +406,14 @@ This only fires if the user has opted into analytics. No action needed if it ret
 - Before any meeting with multiple attendees
 - When meeting someone you haven't seen in a while
 - Before important meetings where you want full context
+
+## MCP Dependencies
+
+| Integration | MCP Server | Tools Used |
+|-------------|------------|------------|
+| Calendar | calendar-mcp | `calendar_get_events_with_attendees` (optional: resolves the meeting and its attendees; the skill asks the user when it is unavailable) |
+
+---
 
 ## Tips
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -412,8 +412,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/meeting-prep/SKILL.md",
-        "sha256": "f0365cfcd014a836429498c306ae9accf71370f2dde06e9049da8334385d49ea",
-        "byte_size": 12203
+        "sha256": "5139fed4ded9ad40d4af9b7ba35f4d84e670477579d78ed4e16302359bd7a868",
+        "byte_size": 14864
       },
       "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
       "jobs_served": ["process-meetings"],

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 52f444e5914466ad8f7b5d338f00fbfafb985330de3a98f83e9f53b3b07008bc -->
+<!-- Content SHA-256: 0146bb6c16e07c908ef325bcf0ce04512eefe8249a4ce8bb898d3d9b0a5afa1f -->
 
 # Architecture Inventory
 
@@ -122,7 +122,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
 | `dex-analytics` | 28 | **over-surfaced** | `commitments` (`track_event`); `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-closeout` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `relationship-radar` (`track_event`); `reset` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
-| `dex-calendar-mcp` | 4 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
+| `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `meeting-prep` (`calendar_get_events_with_attendees`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-customization-migration-mcp` | 1 | normal | `dex-update` (`read_customization_capsule_blob`, `read_customization_capsule_section`) |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |


### PR DESCRIPTION
Picking up your note on #446: *"your version looks up the meeting in the calendar cache and takes the attendee list straight off the invite, rather than asking you who is coming to a meeting you booked yourself. The release version still asks. So the sensible reading is that the release should adopt yours."*

This is that, generalised, with one change of mind after using it: **asking stays, as the fallback.**

## The change

`meeting-prep` Step 0 currently asks two questions:

```
Ask: "Which meeting are you prepping for?"
Ask: "Who's attending? (comma-separated names or just list them)"
```

The user booked the meeting, so the invite already holds both answers. Try `calendar_get_events_with_attendees` first, matching on whatever they actually said: a time ("prep me for the 2pm"), a person, or a topic.

Asking has a cost beyond friction. Hand-typed names are a reliable source of duplicate person pages, because invites carry display forms that do not match page names: `Surname, First`, a job title in parentheses, or a bare email address sitting in the name field. On my own vault, matching raw display names against existing pages read **11 of 27 people as new**, all of whom already had pages.

Each attendee also comes back with `has_person_page` and `person_page`, so Step 1's vault lookup is already done for anyone who has a page. Step 1 now prefers that resolution and falls back to name search only where it is absent.

## Asking stays, deliberately

My local version removed the ask entirely. That was wrong and I have reversed it here.

The calendar is the **preferred** source, not a required one. This skill has to keep working with no calendar integration, on a non-macOS machine, or where calendar access was refused. In those cases it asks exactly as it does today, and says once, in passing, why it is asking. A feature the user never set up is not a fault and should not be reported as one.

Three cases fall back explicitly: no integration or the tool is unavailable, no matching event in the range, and two events matching a stated time (a double-booking, worth surfacing in itself rather than guessing).

## Two silent failure modes, called out in the text

Both return nothing, and neither means "no meetings":

- **The end date is exclusive.** A same-day `start_date` and `end_date` returns zero events with no error. I hit this myself before noticing.
- **Absent tool, refused permission, wrong range** are indistinguishable from an empty calendar at the call site. The skill is told never to treat an empty result as proof of an empty calendar, and to say which case it is in when it cannot tell.

That second point is the same shape as the diagnostic faults in #499 and the Apple Mail index problem in #446: a query that could not run, reported as a finding.

## Notes

- Declared as an **optional** MCP dependency, matching how `week-review` and `week-plan` already reference the same tool.
- `test_instructed_tools_gate.py` passes (13).
- Honest about the rest: `test_provision_parity.py` shows 35 failures on my machine, but they fail identically on clean `upstream/main` with none of my changes applied, so they are environmental to my shallow clone rather than caused by this. I did not want to claim a green suite I had not got.
