### PR TITLE
Meeting skills: read the configured source instead of assuming a recorder

### DIFF
--- a/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
@@ -25,8 +25,9 @@ than silently skipping it.
 Why the window matters: a same-day filter loses meetings permanently on any day
 the review does not run.
 
-If the meeting source (Granola via `GRANOLA_API_KEY`, or another configured
-source) has unprocessed meetings in the window, process them following the
+Read `meeting_sources` in `System/user-profile.yaml` to learn which source the
+user actually configured, rather than assuming a particular recorder. If that
+source has unprocessed meetings in the window, process them following the
 conventions in `.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md`,
 including updating person pages directly rather than counting on a hook.
 Note which meetings were processed. If no source is connected or nothing is

--- a/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
@@ -48,8 +48,17 @@ find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
 This includes synced notes in day directories and flat notes in the folder
-root (manually captured meetings with no `granola_id`); process and stamp those
+root (manually captured meetings with no capture id); process and stamp those
 the same way. Skip notes containing `<!-- dex:skip-processing -->`.
+
+**Which folder, and which source.** Read `meeting_sources` in
+`System/user-profile.yaml` before searching. If `notes_folder` is set, search
+that folder; it is the user's declared answer and outranks the default above.
+`primary` names the capture tool they actually use. Dex does not assume a
+particular recorder, and neither should this skill: treat the configured source
+as the source, and fall back to provider-neutral discovery in the vault when it
+returns nothing. `meeting-closeout` resolves sources the same way; follow it
+rather than inventing a second convention.
 
 If `00-Inbox/Meetings/queue/*.json` files exist, consume each queued meeting
 first, following the queue rules in this skill's `SKILL.md` (Step 2.5): create
@@ -62,7 +71,9 @@ invoked. You ARE the subagent, so you must never call the Agent tool or spawn a
 subagent of your own.
 
 For each meeting file:
-1. Read frontmatter for `granola_id`, `participants`, `company`, `date`
+1. Read frontmatter for the capture id, `participants`, `company`, `date`.
+   The id key is whatever the configured source writes (`granola_id` and
+   `wispr_id` are both in the wild); match on presence, not on a fixed name
 2. Check whether person/company pages need updating
 3. Check whether tasks need extracting (unchecked items in the "For Me"
    section, no `tasks-extracted` marker)


### PR DESCRIPTION
**1 of 3. Suggested review order: this one, then calendar degradation, then identity matching.** The three are independent (disjoint regions, verified to merge in any order); the order is about how the reasoning reads, not a dependency.

## The problem

`meeting_sources` already exists as a config surface. Onboarding asks for it, `user-profile-template` declares it, the Doctor spec covers it, `config.meeting_sources` probes it, and `meeting-closeout` resolves through it with a ladder ending in provider-neutral vault discovery.

The heavy meeting skills ignore all of it:

- `process-meetings` reads a `granola_id` frontmatter key **by name**
- `daily-review` describes the source as "Granola via `GRANOLA_API_KEY`"

So a user on a different recorder gets instructions written for someone else's tool. The Doctor docstring already names the cost:

> A configured source that quietly stops matching reality is how a meeting closeout ends up built from the wrong tool's notes: the vault search finds nothing and the model improvises.

## The change

Two skills now honour the surface the rest of the system already assumes, following `meeting-closeout`'s existing convention rather than inventing a second one. Read `meeting_sources` before searching; if `notes_folder` is set, search there.

Also stops matching the capture id by a fixed key name. `granola_id` and `wispr_id` are both in the wild, so match on **presence**, not on a hardcoded name.

## Compatibility

No behaviour change for anyone who has not set `meeting_sources`. The default folder and the provider-neutral discovery path are untouched. This is not a new concept, a new config key, or a new file.

## Verification

Lens catalogue PASS, architecture inventory no drift, instructed-tools gate 13 passed. Touches `AGENT_INSTRUCTIONS.md` only, which the Lens registry does not pin (it pins `SKILL.md`), so no pin refresh is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)