### PR TITLE
Meeting skills: degrade properly when calendar access is not available

### DIFF
--- a/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
@@ -67,6 +67,26 @@ Check `00-Inbox/Meetings/{{TARGET_DATE}}/` for meeting notes. Also call
 `calendar_get_today()` for the calendar view. Combine meetings processed in
 Step 0 with any manually created notes.
 
+**When the calendar is not available.** Calendar access is an optional
+integration and is frequently absent: a managed device where the org withholds
+it, a non-macOS machine, or a user who simply declined the permission prompt.
+The skill must still produce a useful result, and must not present a feature the
+user never enabled as a fault.
+
+- **No calendar integration, or the tool errors:** carry on with what the
+  capture and the vault provide. Say once, in passing, that attendees could not
+  be confirmed against the invite. Do not repeat it per meeting.
+- **The query returns nothing:** that is not the same as "no meetings". An
+  absent tool, a refused permission, and a query built with the wrong range all
+  return empty. Establish which before writing anything, and say which it was
+  when you cannot tell.
+- **Never downgrade a fact to a guess silently.** If attendees came from the
+  capture rather than the invite, they are less reliable; mark them as such
+  rather than presenting them with the same confidence.
+
+This is the same rule the source handling already follows: report the source's
+status, never claim absence because a tool errored.
+
 ### 2.4 Semantic Context Enrichment (if QMD available)
 
 Check the QMD `status` tool. If available:

--- a/.claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md
@@ -38,6 +38,26 @@ For each attendee:
 4. **If no person page exists**, note: "No person page for [Name]; consider
    creating one after the meeting"
 
+**When the calendar is not available.** Calendar access is an optional
+integration and is frequently absent: a managed device where the org withholds
+it, a non-macOS machine, or a user who simply declined the permission prompt.
+The skill must still produce a useful result, and must not present a feature the
+user never enabled as a fault.
+
+- **No calendar integration, or the tool errors:** carry on with what the
+  capture and the vault provide. Say once, in passing, that attendees could not
+  be confirmed against the invite. Do not repeat it per meeting.
+- **The query returns nothing:** that is not the same as "no meetings". An
+  absent tool, a refused permission, and a query built with the wrong range all
+  return empty. Establish which before writing anything, and say which it was
+  when you cannot tell.
+- **Never downgrade a fact to a guess silently.** If attendees came from the
+  capture rather than the invite, they are less reliable; mark them as such
+  rather than presenting them with the same confidence.
+
+This is the same rule the source handling already follows: report the source's
+status, never claim absence because a tool errored.
+
 ### 1.3 Related Projects
 
 Search `04-Projects/` for projects that are mentioned in attendees' person

--- a/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
@@ -102,6 +102,26 @@ them for you.
 
 ---
 
+**When the calendar is not available.** Calendar access is an optional
+integration and is frequently absent: a managed device where the org withholds
+it, a non-macOS machine, or a user who simply declined the permission prompt.
+The skill must still produce a useful result, and must not present a feature the
+user never enabled as a fault.
+
+- **No calendar integration, or the tool errors:** carry on with what the
+  capture and the vault provide. Say once, in passing, that attendees could not
+  be confirmed against the invite. Do not repeat it per meeting.
+- **The query returns nothing:** that is not the same as "no meetings". An
+  absent tool, a refused permission, and a query built with the wrong range all
+  return empty. Establish which before writing anything, and say which it was
+  when you cannot tell.
+- **Never downgrade a fact to a guess silently.** If attendees came from the
+  capture rather than the invite, they are less reliable; mark them as such
+  rather than presenting them with the same confidence.
+
+This is the same rule the source handling already follows: report the source's
+status, never claim absence because a tool errored.
+
 ## Step 4: Update Company Pages
 
 For each unique external company:


### PR DESCRIPTION
**2 of 3.** Suggested order: #510 first, then this, then identity matching. Independent of both (disjoint regions, verified to merge in any order).

## The problem

Calendar is an optional integration and it is absent more often than the instructions assume:

- a managed device where the organisation withholds calendar access (the common enterprise case)
- a non-macOS machine
- a user who simply declined the permission prompt

On those setups the meeting skills have **no stated behaviour**, so the model improvises. The commonest improvisation is to treat an empty result as a finding, and report a feature the user never enabled as though something were broken.

## The change

Three rules, added to the skills that touch attendees (`process-meetings`, `daily-review`, `meeting-prep`):

1. **No integration, or the tool errors:** carry on with what the capture and the vault provide. Say once, in passing, that attendees could not be confirmed against the invite. Not once per meeting.
2. **An empty result is not "no meetings".** An absent tool, a refused permission, and a query built with the wrong range all return empty. Establish which before writing anything, and say which it was when you cannot tell.
3. **Never downgrade a fact to a guess silently.** Attendees taken from a capture rather than an invite are less reliable, and are marked as such rather than presented with equal confidence.

This mirrors the rule the source handling already follows: report the source's status, never claim absence because a tool errored.

## Why it is worth stating explicitly

Asking the user remains the fallback, and should. The point is that "ask" is a deliberate branch with a stated trigger, rather than something the model arrives at after having already written a confident and wrong attendee list.

## Verification

Lens catalogue PASS, architecture inventory no drift, instructed-tools gate 13 passed. `AGENT_INSTRUCTIONS.md` only, which is not pinned by the Lens registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)