### PR TITLE
Doctor: preserve truthful diagnostics for issue #499

### DIFF
--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1251,13 +1251,28 @@ def test_raising_probe_becomes_unknown_and_main_still_returns_valid_json(monkeyp
 
 
 @pytest.mark.parametrize(
-    "error",
+    ("error", "guidance"),
     [
-        ModuleNotFoundError("No module named 'yaml'"),
-        RuntimeError("subprocess failed: ModuleNotFoundError: No module named 'EventKit'"),
+        (
+            ModuleNotFoundError("No module named 'yaml'"),
+            "Python packages not installed (missing module 'yaml') — run /dex-update "
+            "(or pip install -r requirements.txt) then re-run /dex-doctor",
+        ),
+        (
+            RuntimeError("subprocess failed: ModuleNotFoundError: No module named 'EventKit'"),
+            "Python packages not installed (missing module 'EventKit') — run /dex-update "
+            "(or pip install -r requirements.txt) then re-run /dex-doctor",
+        ),
+        (
+            RuntimeError("subprocess failed: ModuleNotFoundError: No module named 'core.paths'"),
+            "Dex's own code could not be loaded (missing module 'core.paths'). "
+            "This is a Dex checkup fault, not a missing Python package.",
+        ),
     ],
 )
-def test_missing_optional_packages_have_actionable_unknown_detail(monkeypatch, context, error):
+def test_missing_modules_have_truthful_actionable_unknown_detail(
+    monkeypatch, context, error, guidance
+):
     _stub_probes(monkeypatch)
 
     def missing_dependency(_context):
@@ -1267,12 +1282,9 @@ def test_missing_optional_packages_have_actionable_unknown_detail(monkeypatch, c
 
     report = doctor.collect(context=context)
 
-    guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-        "then re-run /dex-doctor"
-    )
     assert _check(report, "vault.configs")["verdict"] == "UNKNOWN"
-    assert _check(report, "vault.configs")["detail"] == guidance + "."
+    expected_detail = guidance if guidance.endswith(".") else guidance + "."
+    assert _check(report, "vault.configs")["detail"] == expected_detail
     assert report["instruments"]["failed"] == [{"id": "vault.configs", "error": guidance}]
 
 
@@ -1290,7 +1302,8 @@ def test_probe_owned_unknown_missing_package_detail_is_actionable(monkeypatch, c
     report = doctor.collect(deep=True, context=context)
 
     assert _check(report, "calendar.access")["detail"] == (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+        "Python packages not installed (missing module 'EventKit') — run /dex-update "
+        "(or pip install -r requirements.txt) "
         "then re-run /dex-doctor."
     )
     assert report["instruments"]["failed"] == []
@@ -1517,7 +1530,8 @@ def test_cli_still_emits_json_when_yaml_is_not_importable(tmp_path):
     assert result.returncode == 0
     report = json.loads(result.stdout)
     guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+        "Python packages not installed (missing module 'yaml') — run /dex-update "
+        "(or pip install -r requirements.txt) "
         "then re-run /dex-doctor."
     )
     for check_id in ("vault.configs", "customizations.skills", "customizations.mcp"):
@@ -3755,6 +3769,43 @@ def test_smoke_harness_exit_two_becomes_an_unknown_failed_instrument(monkeypatch
     assert _check(report, "doctor.self")["verdict"] == "BROKEN"
 
 
+def test_collect_preserves_smokes_missing_dex_module_diagnosis(monkeypatch, context):
+    _stub_probes(monkeypatch, exclude={"smoke.journeys"})
+    payload = {
+        "schema_version": 1,
+        "generated_at": NOW.isoformat(),
+        "journeys": [
+            {
+                "id": "configs",
+                "verdict": "UNKNOWN",
+                "detail": "Dex's own code could not be loaded (No module named 'core'). "
+                "This is a Dex checkup fault, not a missing Python package.",
+                "duration_ms": 1,
+            }
+        ],
+        "summary": {"ok": 0, "broken": 0, "unknown": 1, "off": 0},
+    }
+    monkeypatch.setattr(
+        doctor.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    report = doctor.collect(deep=True, context=context)
+
+    assert _check(report, "smoke.journeys")["detail"] == (
+        "configs [UNKNOWN]: Dex's own code could not be loaded (No module named 'core'). "
+        "This is a Dex checkup fault, not a missing Python package."
+    )
+    assert report["instruments"]["failed"] == []
+    assert _check(report, "doctor.self")["verdict"] == "OK"
+
+
 def test_granola_no_key_is_off_and_api_400_is_broken(monkeypatch, context):
     monkeypatch.setattr(doctor, "_granola_api_key", lambda _context: None)
     monkeypatch.setattr(
@@ -4065,6 +4116,61 @@ def test_qmd_respects_opt_in_and_reports_live_status_failures(monkeypatch, conte
     assert doctor._probe_qmd_live(context).verdict == "OK"
 
 
+def test_qmd_timeout_is_unknown_without_breaking_doctor_self(monkeypatch, context):
+    _stub_probes(monkeypatch, exclude={"qmd.live"})
+    _write_mcp_config(context, {"qmd": {"command": "qmd", "args": ["mcp"]}})
+    monkeypatch.setattr(doctor, "_qmd_binary", lambda _context: "/tmp/qmd")
+
+    def time_out(_binary):
+        raise subprocess.TimeoutExpired(["/tmp/qmd", "status"], timeout=10)
+
+    monkeypatch.setattr(doctor, "_qmd_status", time_out)
+
+    report = doctor.collect(deep=True, context=context)
+
+    qmd = _check(report, "qmd.live")
+    assert qmd["verdict"] == "UNKNOWN"
+    assert "10 seconds" in qmd["detail"]
+    assert report["instruments"]["failed"] == []
+    assert _check(report, "doctor.self")["verdict"] == "OK"
+
+
+def test_qmd_unexpected_exception_still_breaks_doctor_self(monkeypatch, context):
+    _stub_probes(monkeypatch, exclude={"qmd.live"})
+    _write_mcp_config(context, {"qmd": {"command": "qmd", "args": ["mcp"]}})
+    monkeypatch.setattr(doctor, "_qmd_binary", lambda _context: "/tmp/qmd")
+    monkeypatch.setattr(
+        doctor,
+        "_qmd_status",
+        lambda _binary: (_ for _ in ()).throw(RuntimeError("unexpected qmd adapter failure")),
+    )
+
+    report = doctor.collect(deep=True, context=context)
+
+    assert _check(report, "qmd.live")["verdict"] == "UNKNOWN"
+    assert report["instruments"]["failed"] == [
+        {"id": "qmd.live", "error": "unexpected qmd adapter failure"}
+    ]
+    assert _check(report, "doctor.self")["verdict"] == "BROKEN"
+
+
+def test_qmd_nonzero_status_is_broken_without_breaking_doctor_self(monkeypatch, context):
+    _stub_probes(monkeypatch, exclude={"qmd.live"})
+    _write_mcp_config(context, {"qmd": {"command": "qmd", "args": ["mcp"]}})
+    monkeypatch.setattr(doctor, "_qmd_binary", lambda _context: "/tmp/qmd")
+    monkeypatch.setattr(
+        doctor,
+        "_qmd_status",
+        lambda _binary: (False, "index metadata is corrupt"),
+    )
+
+    report = doctor.collect(deep=True, context=context)
+
+    assert _check(report, "qmd.live")["verdict"] == "BROKEN"
+    assert report["instruments"]["failed"] == []
+    assert _check(report, "doctor.self")["verdict"] == "OK"
+
+
 def test_qmd_adapters_use_existing_discovery_and_status_command(monkeypatch, context):
     from core.utils import qmd_query
 
@@ -4253,14 +4359,45 @@ def test_mcp_importable_runs_registered_core_servers_in_subprocess(monkeypatch, 
     assert doctor._probe_mcp_importable(context).verdict == "OK"
     assert calls == [("core.mcp.work_server", sys.executable)]
 
+
+@pytest.mark.parametrize(
+    ("subprocess_detail", "expected_detail", "expected_heal"),
+    [
+        (
+            "ModuleNotFoundError: No module named 'core.paths'",
+            "Dex's own code could not be loaded (missing module 'core.paths')",
+            "Run /dex-update to restore Dex's own code, then re-run /dex-doctor.",
+        ),
+        (
+            "ModuleNotFoundError: No module named 'yaml'",
+            "missing module 'yaml'",
+            "Reinstall missing MCP dependency 'yaml' into the vault .venv, then re-run /dex-doctor.",
+        ),
+    ],
+)
+def test_mcp_importable_gives_truthful_missing_module_remediation(
+    monkeypatch, context, subprocess_detail, expected_detail, expected_heal
+):
+    mcp_dir = context.vault_root / "core" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    server = mcp_dir / "work_server.py"
+    server.touch()
+    _write_mcp_config(
+        context,
+        {"work-mcp": {"command": sys.executable, "args": [str(server)]}},
+    )
     monkeypatch.setattr(
         doctor,
         "_mcp_import_check",
-        lambda _context, _module, _interpreter: (False, "ImportError: missing package"),
+        lambda _context, _module, _interpreter: (False, subprocess_detail),
     )
+
     result = doctor._probe_mcp_importable(context)
+
     assert result.verdict == "BROKEN"
-    assert "ImportError" in result.detail
+    assert expected_detail in result.detail
+    assert result.heal is not None
+    assert result.heal.action == expected_heal
 
 
 def test_mcp_import_subprocess_uses_an_ephemeral_vault(monkeypatch, context):

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -223,6 +223,24 @@ def test_missing_anthropic_key_points_to_env_file() -> None:
     ) == "API key missing — add it to your .env file"
 
 
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "subprocess failed: ModuleNotFoundError: No module named 'core.paths'",
+            "Work MCP can't start: Dex's own code could not be loaded "
+            "(missing module 'core.paths'); this is a Dex fault, not a missing Python package",
+        ),
+        (
+            "subprocess failed: ModuleNotFoundError: No module named 'yaml'",
+            "Work MCP can't start: missing Python package 'yaml'",
+        ),
+    ],
+)
+def test_logger_names_missing_modules_truthfully(message: str, expected: str) -> None:
+    assert dex_logger._generate_human_message("Work MCP", message) == expected
+
+
 def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     flow = _read(".claude/flows/onboarding.md")
     calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -733,6 +733,7 @@ def test_runner_fallback_is_import_complete_for_the_runner_entry(
 ) -> None:
     required = {
         Path("core/utils/smoke.py"),
+        Path("core/utils/dex_logger.py"),
         Path("core/utils/release_channel.py"),
         Path("core/utils/update_verifier.py"),
     }

--- a/core/utils/dex_logger.py
+++ b/core/utils/dex_logger.py
@@ -26,6 +26,10 @@ from typing import Any, Dict, Optional
 STALE_ERROR_DAYS = 30
 MAX_ERROR_ENTRIES = 50
 _SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+_MISSING_MODULE_RE = re.compile(
+    r"No module named\s+['\"](?P<module>[A-Za-z0-9_.-]+)['\"]",
+    re.IGNORECASE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +82,19 @@ def _installed_dex_version() -> Optional[str]:
 # Error-to-human message mapping
 # ---------------------------------------------------------------------------
 
+
+def missing_module_name(value: object) -> str | None:
+    """Return the named missing module, including from embedded subprocess output."""
+    if isinstance(value, ModuleNotFoundError) and isinstance(value.name, str) and value.name:
+        return value.name
+    match = _MISSING_MODULE_RE.search(str(value))
+    return match.group("module") if match else None
+
+
+def is_dex_module(module: str | None) -> bool:
+    """Whether a missing import belongs to Dex itself rather than a dependency."""
+    return module == "core" or (isinstance(module, str) and module.startswith("core."))
+
 _ERROR_PATTERNS = [
     ("ModuleNotFoundError", "{source} can't start: missing Python package"),
     ("No module named", "{source} can't start: missing Python package"),
@@ -95,6 +112,15 @@ _ERROR_PATTERNS = [
 
 def _generate_human_message(source: str, message: str) -> str:
     """Map technical error to plain-language description."""
+    missing_module = missing_module_name(message)
+    if is_dex_module(missing_module):
+        return (
+            f"{source} can't start: Dex's own code could not be loaded "
+            f"(missing module {missing_module!r}); this is a Dex fault, "
+            "not a missing Python package"
+        )
+    if missing_module:
+        return f"{source} can't start: missing Python package {missing_module!r}"
     for pattern, template in _ERROR_PATTERNS:
         if pattern.lower() in message.lower():
             return template.format(source=source)

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -41,6 +41,7 @@ from core.utils import dex_logger, launch_agents, preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
+QMD_STATUS_TIMEOUT_SECONDS = 10
 MISSING_PACKAGES_DETAIL = (
     "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
     "then re-run /dex-doctor"
@@ -674,16 +675,22 @@ def _sentence(value: object) -> str:
 
 
 def _actionable_probe_error(error: Exception) -> str:
-    detail = _one_line(error)
-    if _is_missing_package_error(error, detail):
-        return MISSING_PACKAGES_DETAIL
-    return detail
+    missing_module_detail = _missing_module_detail(error)
+    return missing_module_detail or _one_line(error)
 
 
-def _is_missing_package_error(value: object, detail: str | None = None) -> bool:
-    rendered = detail or _one_line(value)
-    return isinstance(value, ModuleNotFoundError) or any(
-        marker in rendered for marker in ("ModuleNotFoundError", "No module named")
+def _missing_module_detail(value: object) -> str | None:
+    module = dex_logger.missing_module_name(value)
+    if module is None:
+        return MISSING_PACKAGES_DETAIL if isinstance(value, ModuleNotFoundError) else None
+    if dex_logger.is_dex_module(module):
+        return (
+            f"Dex's own code could not be loaded (missing module {module!r}). "
+            "This is a Dex checkup fault, not a missing Python package."
+        )
+    return (
+        f"Python packages not installed (missing module {module!r}) — run /dex-update "
+        "(or pip install -r requirements.txt) then re-run /dex-doctor"
     )
 
 
@@ -1030,11 +1037,26 @@ def collect(
                 result = ProbeResult(
                     "UNKNOWN",
                     error_text
-                    if error_text == MISSING_PACKAGES_DETAIL
+                    if _missing_module_detail(error) is not None
                     else f"The {definition.feature} probe could not run: {error_text}",
                 )
-            if result.verdict == "UNKNOWN" and _is_missing_package_error(result.detail):
-                result = ProbeResult("UNKNOWN", MISSING_PACKAGES_DETAIL, result.heal)
+            missing_module = dex_logger.missing_module_name(result.detail)
+            missing_detail = _missing_module_detail(result.detail)
+            truthful_missing_diagnosis = bool(
+                missing_module
+                and (
+                    (
+                        dex_logger.is_dex_module(missing_module)
+                        and "Dex checkup fault" in result.detail
+                    )
+                    or (
+                        not dex_logger.is_dex_module(missing_module)
+                        and f"missing module {missing_module!r}" in result.detail
+                    )
+                )
+            )
+            if result.verdict == "UNKNOWN" and missing_detail and not truthful_missing_diagnosis:
+                result = ProbeResult("UNKNOWN", missing_detail, result.heal)
             check_actions = t1_actions.get(definition.id, [])
             if definition.id == "vault.structure" and check_actions:
                 action = "; ".join(check_actions) + "."
@@ -5010,7 +5032,7 @@ def _qmd_status(binary: str) -> tuple[bool, str]:
         [binary, "status"],
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=QMD_STATUS_TIMEOUT_SECONDS,
         check=False,
     )
     detail = _one_line(result.stdout if result.returncode == 0 else result.stderr or result.stdout)
@@ -5031,7 +5053,14 @@ def _probe_qmd_live(context: DoctorContext) -> ProbeResult:
             "qmd is registered but its binary is not installed",
             Heal(tier=3, action="Run /enable-semantic-search to install and configure qmd.", applied=False),
         )
-    healthy, detail = _qmd_status(binary)
+    try:
+        healthy, detail = _qmd_status(binary)
+    except subprocess.TimeoutExpired:
+        return ProbeResult(
+            "UNKNOWN",
+            "qmd status did not finish within "
+            f"{QMD_STATUS_TIMEOUT_SECONDS} seconds, so semantic search health could not be checked",
+        )
     if not healthy:
         if _looks_like_sandbox_failure(detail):
             return ProbeResult("UNKNOWN", f"The sandbox or GPU environment blocked qmd status: {detail}")
@@ -5243,16 +5272,39 @@ def _probe_mcp_importable(context: DoctorContext) -> ProbeResult:
     config = _load_mcp_config(context)
     registered = _registered_core_scripts(context, config)
     failures = []
+    missing_dependencies: set[str] = set()
+    dex_code_missing = False
+    unclassified_failure = False
     for _name, (target, interpreter) in registered.items():
         module = f"core.mcp.{target.stem}"
         importable, detail = _mcp_import_check(context, module, interpreter)
         if not importable:
-            failures.append(f"{module}: {detail}")
+            missing_module = dex_logger.missing_module_name(detail)
+            classified_detail = _missing_module_detail(detail)
+            failures.append(f"{module}: {classified_detail or detail}")
+            if dex_logger.is_dex_module(missing_module):
+                dex_code_missing = True
+            elif missing_module:
+                missing_dependencies.add(missing_module)
+            else:
+                unclassified_failure = True
     if failures:
+        remedies = []
+        if dex_code_missing:
+            remedies.append("Run /dex-update to restore Dex's own code, then re-run /dex-doctor.")
+        if missing_dependencies:
+            noun = "dependency" if len(missing_dependencies) == 1 else "dependencies"
+            named = ", ".join(repr(name) for name in sorted(missing_dependencies))
+            remedies.append(
+                f"Reinstall missing MCP {noun} {named} into the vault .venv, "
+                "then re-run /dex-doctor."
+            )
+        if unclassified_failure:
+            remedies.append("Reinstall the missing MCP dependencies into the vault .venv.")
         return ProbeResult(
             "BROKEN",
             f"Registered MCP imports failed: {'; '.join(failures)}",
-            Heal(tier=2, action="Reinstall the missing MCP dependencies into the vault .venv.", applied=False),
+            Heal(tier=2, action=" ".join(remedies), applied=False),
         )
     return ProbeResult("OK", f"All {len(registered)} registered core MCP servers import in a subprocess")
 

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -31,7 +31,7 @@ if str(RUNNER_ROOT) in sys.path:
     sys.path.remove(str(RUNNER_ROOT))
 sys.path.insert(0, str(RUNNER_ROOT))
 
-from core.utils import release_channel
+from core.utils import dex_logger, release_channel
 
 SCHEMA_VERSION = 1
 HISTORY_LIMIT = 120
@@ -71,8 +71,8 @@ SENSITIVE_CONFIG_KEY = re.compile(
 
 
 def _missing_module_detail(error: ModuleNotFoundError) -> str:
-    module = error.name
-    if module == "core" or (isinstance(module, str) and module.startswith("core.")):
+    module = dex_logger.missing_module_name(error)
+    if dex_logger.is_dex_module(module):
         return (
             f"Dex's own code could not be loaded ({_one_line(error)}). "
             "This is a Dex checkup fault, not a missing Python package."
@@ -94,6 +94,7 @@ RUNNER_FALLBACK_RELATIVES = (
     Path("core/__init__.py"),
     Path("core/paths.py"),
     Path("core/utils/__init__.py"),
+    Path("core/utils/dex_logger.py"),
     Path("core/utils/release_channel.py"),
     Path("core/utils/smoke.py"),
     Path("core/utils/trust_registry.py"),


### PR DESCRIPTION
## Summary

- Keep the truthful missing-core diagnosis from Smoke when Doctor collects the deep report.
- Use one classifier across Doctor, Smoke, Dex Logger, and MCP import remediation so Dex-owned modules and named third-party dependencies get different advice.
- Treat the expected 10-second QMD status timeout as UNKNOWN without failing Doctor instruments; preserve BROKEN for nonzero status and Doctor self-failure for unexpected exceptions.

Relates to #499.

## Red before green

- The full Doctor collect regression first failed because the Smoke result was replaced with generic package advice.
- The QMD collect regression first failed because the timeout appeared in instruments.failed and made doctor.self BROKEN.
- Logger and MCP-import cases first failed because both still used generic dependency wording.

## Verification

- 19 focused Doctor, Smoke, logger, and MCP-import checks pass.
- 210 Doctor tests pass locally; one macOS-only plutil test is deselected on Linux.
- 35 instruction/logger tests pass.
- The Smoke fallback/import regression passes. The unfiltered Linux Smoke file contains process-group tests that terminate this BB shell, so the complete macOS CI lane is the authoritative wider Smoke result.
- ruff check core/ passes.