### PR TITLE
fix: preserve calendar attendee identity through meeting prep

### DIFF
--- a/.claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md
@@ -6,8 +6,14 @@ brief. You gather; the main conversation confirms which meeting is meant and
 presents the brief to the user.
 
 **Meeting:** {{MEETING_TITLE}}
-**Attendees:** {{ATTENDEES}}
+**Attendee records (JSON):** {{ATTENDEE_RECORDS}}
 **Date:** {{TARGET_DATE}}
+
+The main conversation has already selected the meeting and normalized its
+attendees from the calendar invite or the user's fallback answer. Treat these
+structured records as authoritative. Each record carries `name`, `person_page`,
+`email`, `status`, `type`, and `is_current_user`; do not replace them with a
+fresh display-name search.
 
 ---
 
@@ -19,7 +25,7 @@ is not set up, skip it silently.
 ### 1.1 Meeting Intelligence
 
 ```
-Use: get_meeting_context(meeting_title="{{MEETING_TITLE}}", attendees=[...attendee names...])
+Use: get_meeting_context(meeting_title="{{MEETING_TITLE}}", attendees=[...names derived from {{ATTENDEE_RECORDS}}...])
 ```
 
 Get: related project, project status, outstanding tasks with attendees, prep
@@ -27,15 +33,19 @@ suggestions.
 
 ### 1.2 Attendee Lookup
 
-For each attendee:
+For each record in `{{ATTENDEE_RECORDS}}`:
 
-1. **Fast lookup first:** `lookup_person(name="Attendee Name")`
-2. **If found**, read the person page and extract: role and company, last
+1. **Use the invite's resolution first.** When `person_page` is non-empty,
+   read that exact path. Do not call `lookup_person` for that attendee.
+2. Call `lookup_person` only when `person_page` is empty. Pass the record's
+   `email` as `name` when available because it is more reliable than an invite
+   display name; otherwise pass the record's `name`.
+3. **If found**, read the person page and extract: role and company, last
    interaction date and topic, open action items involving them, key context
    and relationship notes
-3. **If not found in the index**, check `05-Areas/People/Internal/` and
+4. **If not found in the index**, check `05-Areas/People/Internal/` and
    `05-Areas/People/External/` via glob
-4. **If no person page exists**, note: "No person page for [Name]; consider
+5. **If no person page exists**, note: "No person page for [Name]; consider
    creating one after the meeting"
 
 ### 1.3 Related Projects
@@ -46,7 +56,7 @@ pages, relate to the meeting topic, or were surfaced by `get_meeting_context`.
 ### 1.4 Recent Meeting History
 
 ```
-Use: query_meeting_cache(attendee="Attendee Name")
+Use: query_meeting_cache(attendee="Attendee name from {{ATTENDEE_RECORDS}}")
 Use: query_meeting_cache(keyword="{{MEETING_TITLE}}")
 ```
 
@@ -58,7 +68,7 @@ Check the QMD `status` tool. If available:
 
 1. **Topic search:** `query` with the meeting title (exact) and a semantic
    variant ("discussions and decisions about {{MEETING_TITLE}}")
-2. **Attendee search (beyond person pages):** `query` per attendee for
+2. **Attendee search (beyond person pages):** `query` per attendee record for
    context, discussions, decisions and commitments
 
 Only surface NEW insights not found in steps 1.1 to 1.4. If QMD is
@@ -101,7 +111,7 @@ header:
 AGENT COMPLETE
 
 Meeting: {{MEETING_TITLE}} on {{TARGET_DATE}}
-Attendees with person pages: [N] of [M]
+Attendees with person pages: [N] of [M filtered person records]
 Related projects: [N]
 Key open items: [N]
 

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -108,20 +108,60 @@ If not provided, prompt the user for:
 
 ### Step 0: Gather Context (if needed)
 
-**If $MEETING or $ATTENDEES are not provided:**
+**If $MEETING or $ATTENDEES are not provided, try the calendar before asking.** The user booked
+the meeting; the invite already holds the title and the attendee list, and asking them to retype
+it is both friction and a source of duplicate person pages from misspelt names.
 
-Ask: "Which meeting are you prepping for?"
-- Get meeting topic/title
+When the calendar integration is available:
 
-Ask: "Who's attending? (comma-separated names or just list them)"
-- Accept formats: "Sarah Chen, Mike Rodriguez" or "Sarah, Mike" or natural list
-- Parse into individual attendee names
+```
+mcp__calendar-mcp__calendar_get_events_with_attendees(start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
+```
+
+**The end date is exclusive.** For a single day, pass the following day as `end_date`. Passing
+the same date twice returns zero events with no error, which is indistinguishable from an empty
+calendar.
+
+Match the user's phrasing to an event:
+
+- **A time** ("prep me for the 2pm", "tomorrow's 1:30"): match on start time, usually
+  unambiguous on its own.
+- **A person or topic** ("prep me for the Acme call"): match on title, or on an attendee name
+  within the event's `attendees` list.
+- **Nothing specified:** list today's and tomorrow's events and ask which one is meant.
+
+Each attendee carries `name`, `email`, `status`, `is_organizer`, plus `has_person_page` and
+`person_page`, so the vault lookup in Step 1 is already done for anyone who has a page.
+
+**Ask when the calendar cannot answer.** The calendar is the preferred source, not a required
+one, and this skill must still work without it:
+
+- **No calendar integration, or the tool is unavailable or refused** (a non-macOS machine, or
+  calendar access not granted): ask for the meeting and the attendees as before. Say once, in
+  passing, that you are asking because the calendar is not connected. A feature the user never
+  set up is not a fault and should not be reported as one.
+- **No matching event** in the range returned: ask which meeting is meant rather than guessing.
+- **Two events match a stated time:** that is a double-booking. Name both and let the user
+  choose; it is worth telling them about in itself.
+
+Never treat an empty result as proof of an empty calendar. A tool that is absent, a permission
+that was refused, and a query built with the wrong range all return nothing, and none of them
+mean "no meetings". If you cannot tell which it was, say so and ask.
+
+When asking, accept any natural format: "Sarah Chen, Mike Rodriguez", "Sarah, Mike", or a plain
+list.
 
 ### Step 1: Attendee Lookup
 
-For each attendee in $ATTENDEES:
+For each attendee:
 
-1. Search `05-Areas/People/Internal/` and `05-Areas/People/External/` for matching names
+1. **If the calendar supplied `person_page`, use it.** That resolution is already done and is
+   more reliable than matching a name, particularly for the display forms invites actually
+   carry: `Surname, First`, a job title in parentheses, or a bare email address where the name
+   should be. Only fall back to searching when `has_person_page` is false or the attendee came
+   from the user rather than the calendar.
+
+   Otherwise search `05-Areas/People/Internal/` and `05-Areas/People/External/` for matching names
 2. If found, extract:
    - Role and company
    - Last interaction date
@@ -366,6 +406,14 @@ This only fires if the user has opted into analytics. No action needed if it ret
 - Before any meeting with multiple attendees
 - When meeting someone you haven't seen in a while
 - Before important meetings where you want full context
+
+## MCP Dependencies
+
+| Integration | MCP Server | Tools Used |
+|-------------|------------|------------|
+| Calendar | calendar-mcp | `calendar_get_events_with_attendees` (optional: resolves the meeting and its attendees; the skill asks the user when it is unavailable) |
+
+---
 
 ## Tips
 

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -25,7 +25,11 @@ Agent tool, using the self-contained prompt in this skill's
 
 1. Read `.claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md`.
 2. Substitute its placeholders (`{{TARGET_DATE}}`, `{{MEETING_TITLE}}`,
-   `{{ATTENDEES}}`).
+   `{{ATTENDEE_RECORDS}}`). `{{ATTENDEE_RECORDS}}` is the filtered JSON array
+   from the selected invite, preserving `name`, `person_page`, `email`,
+   `status`, `type`, and `is_current_user` for each attendee. For attendees the
+   user supplied manually, use the same fields with unknown values set to
+   `null`, `type` set to `Person`, and `is_current_user` set to `false`.
 3. Call the Agent tool with `subagent_type: "general-purpose"`, that prompt, and
    a short description.
 4. Present its findings as the prep brief, in the Output Format below.
@@ -89,9 +93,9 @@ See CLAUDE.md → "Communication Adaptation" for full guidelines.
 
 **Optional:** $MEETING, $ATTENDEES
 
-If not provided, prompt the user for:
-1. Meeting topic or title
-2. List of attendees (comma-separated names)
+If either value is missing, try the calendar before prompting. Ask for the
+meeting topic or attendee list only when the calendar status or the returned
+events cannot identify the meeting safely.
 
 **Examples:**
 - `/meeting-prep "Q1 Planning" "Sarah Chen, Mike Rodriguez"`
@@ -99,10 +103,11 @@ If not provided, prompt the user for:
 
 ## What This Does
 
-1. Looks up each attendee in `People/` folder
-2. Surfaces recent interactions and open action items
-3. Checks for related projects
-4. Suggests talking points based on context
+1. Reads the matching calendar invite and keeps its resolved attendee records
+2. Looks up only attendees whose invite record has no `person_page`
+3. Surfaces recent interactions and open action items
+4. Checks for related projects
+5. Suggests talking points based on context
 
 ## Process
 
@@ -112,11 +117,18 @@ If not provided, prompt the user for:
 the meeting; the invite already holds the title and the attendee list, and asking them to retype
 it is both friction and a source of duplicate person pages from misspelt names.
 
-When the calendar integration is available:
+When the calendar integration is available, search every calendar visible to
+Apple Calendar by default:
 
 ```
-mcp__calendar-mcp__calendar_get_events_with_attendees(start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
+mcp__calendar-mcp__calendar_get_events_with_attendees(calendar_name="all", start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
 ```
+
+`calendar_name="all"` means all calendars currently visible to the local Apple
+Calendar integration. It cannot see a calendar account that is not synced into
+Apple Calendar, and on hosts that do not support the `all` selector you must say
+which single calendar was searched. Never describe a no-match from one calendar
+as proof that the meeting is absent from every calendar.
 
 **The end date is exclusive.** For a single day, pass the following day as `end_date`. Passing
 the same date twice returns zero events with no error, which is indistinguishable from an empty
@@ -130,16 +142,41 @@ Match the user's phrasing to an event:
   within the event's `attendees` list.
 - **Nothing specified:** list today's and tomorrow's events and ask which one is meant.
 
-Each attendee carries `name`, `email`, `status`, `is_organizer`, plus `has_person_page` and
-`person_page`, so the vault lookup in Step 1 is already done for anyone who has a page.
+Each attendee carries `name`, `email`, `status`, `type`, `is_organizer`,
+`is_current_user`, plus `has_person_page` and (when resolved) `person_page`, so
+the vault lookup in Step 1 is already done for anyone who has a page.
 
-**Ask when the calendar cannot answer.** The calendar is the preferred source, not a required
-one, and this skill must still work without it:
+Before delegating gathering, build `{{ATTENDEE_RECORDS}}` from the selected
+event. Preserve `name`, `person_page` (or `null`), `email`, `status`, `type`, and
+`is_current_user`; do not reduce the records to display names. Filter out:
 
-- **No calendar integration, or the tool is unavailable or refused** (a non-macOS machine, or
-  calendar access not granted): ask for the meeting and the attendees as before. Say once, in
-  passing, that you are asking because the calendar is not connected. A feature the user never
-  set up is not a fault and should not be reported as one.
+- the user (`is_current_user: true`)
+- `Room`, `Resource`, and `Group` attendee types
+- invitees whose status is `Declined` or `Delegated`
+
+Keep `Person` attendees who are `Accepted` or `Tentative`. A `Pending` or
+`Unknown` person may still attend: keep them, but do not describe their
+attendance as confirmed. If an attendee has an unknown type, keep them only
+when they have a usable name or email and flag that uncertainty in the brief.
+
+**Ask when the calendar cannot answer.** The calendar is the preferred source,
+not a required one, and this skill must still work without it. Inspect the
+calendar response before reading its event list. When it contains
+`feature_status`, follow CLAUDE.md's `feature_status` rendering convention:
+
+- `off` or `not_installed`: say once, calmly, that calendar context is not set
+  up, then ask for the meeting and attendees.
+- `broken`: show the returned `user_message`, including its permission or fix
+  guidance, then ask for the meeting and attendees so prep can continue.
+- `unknown`: say the calendar could not be checked, then ask rather than guess.
+
+Do not turn `broken` calendar permission into “not connected,” and do not treat
+any non-`ok` status as an empty but healthy calendar.
+
+- **No calendar integration or the tool is unavailable** (for example, a
+  non-macOS machine): ask for the meeting and the attendees as before. A
+  feature the user never set up is not a fault and should not be reported as
+  one.
 - **No matching event** in the range returned: ask which meeting is meant rather than guessing.
 - **Two events match a stated time:** that is a double-booking. Name both and let the user
   choose; it is worth telling them about in itself.
@@ -153,15 +190,17 @@ list.
 
 ### Step 1: Attendee Lookup
 
-For each attendee:
+For each filtered attendee record:
 
-1. **If the calendar supplied `person_page`, use it.** That resolution is already done and is
+1. **If the calendar supplied `person_page`, use it and pass it through to
+   delegated gathering.** That resolution is already done and is
    more reliable than matching a name, particularly for the display forms invites actually
    carry: `Surname, First`, a job title in parentheses, or a bare email address where the name
    should be. Only fall back to searching when `has_person_page` is false or the attendee came
    from the user rather than the calendar.
 
-   Otherwise search `05-Areas/People/Internal/` and `05-Areas/People/External/` for matching names
+   Otherwise search `05-Areas/People/Internal/` and
+   `05-Areas/People/External/` using the attendee's email first, then name.
 2. If found, extract:
    - Role and company
    - Last interaction date

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -412,8 +412,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/meeting-prep/SKILL.md",
-        "sha256": "5139fed4ded9ad40d4af9b7ba35f4d84e670477579d78ed4e16302359bd7a868",
-        "byte_size": 14864
+        "sha256": "f520f14b0136162641bd60c68247f59e803887bb664a4a9a5945afb0fa2558ab",
+        "byte_size": 17211
       },
       "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
       "jobs_served": ["process-meetings"],
@@ -421,6 +421,12 @@
       "prerequisites": ["A calendar entry, or simply the meeting named out loud.", "Some history worth gathering: earlier notes, people records or related project material."],
       "trade_offs": ["A brief is only as good as the history already captured; a genuinely first meeting has little to gather.", "Anything the brief claims should be checked against the real file before it is repeated in the room."],
       "evidence": [
+        {
+          "kind": "test",
+          "coverage": "behavioral",
+          "reference": "core/tests/test_meeting_prep_calendar_journey.py",
+          "summary": "Exercises the calendar-first journey across the inline skill and its delegated research prompt, including attendee filtering, feature-status honesty, and preservation of resolved person-page records."
+        },
         {
           "kind": "test",
           "coverage": "supporting",

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -423,9 +423,9 @@
       "evidence": [
         {
           "kind": "test",
-          "coverage": "behavioral",
+          "coverage": "supporting",
           "reference": "core/tests/test_meeting_prep_calendar_journey.py",
-          "summary": "Exercises the calendar-first journey across the inline skill and its delegated research prompt, including attendee filtering, feature-status honesty, and preservation of resolved person-page records."
+          "summary": "Statically checks the calendar-first instruction contract and journey order across the inline skill and delegated research prompt, including required attendee filters, feature-status guidance, and the structured person-page handoff; it does not simulate Calendar MCP runtime behavior."
         },
         {
           "kind": "test",

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -412,8 +412,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/meeting-prep/SKILL.md",
-        "sha256": "f0365cfcd014a836429498c306ae9accf71370f2dde06e9049da8334385d49ea",
-        "byte_size": 12203
+        "sha256": "5139fed4ded9ad40d4af9b7ba35f4d84e670477579d78ed4e16302359bd7a868",
+        "byte_size": 14864
       },
       "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
       "jobs_served": ["process-meetings"],

--- a/core/tests/test_meeting_prep_calendar_journey.py
+++ b/core/tests/test_meeting_prep_calendar_journey.py
@@ -40,7 +40,7 @@ def _assert_calendar_invite_journey(skill: str, agent: str) -> None:
     for state in ("feature_status", "broken", "permission", "user_message"):
         assert state in calendar_step
 
-    # The inline phase filters a mixed invite before delegation.
+    # The instruction contract requires attendee filtering before delegation.
     for field in ("person_page", "email", "status", "type", "is_current_user"):
         assert field in calendar_step
         assert field in delegation
@@ -66,13 +66,12 @@ def _assert_calendar_invite_journey(skill: str, agent: str) -> None:
     assert "only when `person_page` is empty" in agent_lookup
 
 
-def test_calendar_invite_drives_structured_attendee_research_journey() -> None:
-    """A real invite remains authoritative through delegated research.
+def test_calendar_first_instruction_contract_preserves_structured_attendee_handoff() -> None:
+    """The written journey keeps calendar identity fields across delegation.
 
-    The representative invite contains the user, a room, a group, a declined
-    guest, and two attending people.  The workflow must describe filtering the
-    first four and must carry the attending people's resolved identity fields
-    into the gathering prompt instead of reducing them back to names.
+    This is an instruction-contract and journey-order test. It checks the
+    shipped inline and delegated prompts together; it does not simulate a
+    Calendar MCP response or execute a representative mixed invite at runtime.
     """
 
     _assert_calendar_invite_journey(

--- a/core/tests/test_meeting_prep_calendar_journey.py
+++ b/core/tests/test_meeting_prep_calendar_journey.py
@@ -1,0 +1,81 @@
+"""Journey contract for calendar-first meeting preparation.
+
+The meeting-prep surface is an instruction workflow rather than Python code, so
+this test evaluates the two prompts that execute the journey together.  A
+presence-only check can stay green while the inline skill reads a rich calendar
+record and then hands only display names to its gathering agent.  This contract
+pins the information flow across that boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = REPO_ROOT / ".claude/skills/meeting-prep/SKILL.md"
+AGENT_PATH = REPO_ROOT / ".claude/skills/meeting-prep/AGENT_INSTRUCTIONS.md"
+
+
+def _section(body: str, start: str, end: str) -> str:
+    return body.split(start, 1)[1].split(end, 1)[0]
+
+
+def _assert_calendar_invite_journey(skill: str, agent: str) -> None:
+    arguments = _section(skill, "## Arguments", "## What This Does")
+    calendar_step = _section(skill, "### Step 0:", "### Step 1:")
+    delegation = _section(
+        skill,
+        "### Delegated gathering (large-vault scaling)",
+        "Prepare for an upcoming meeting",
+    )
+    agent_lookup = _section(agent, "### 1.2 Attendee Lookup", "### 1.3 Related Projects")
+
+    # Default journey: calendar first, across the user's calendars, then ask
+    # only when the returned status or matching result requires a fallback.
+    assert "calendar before prompting" in arguments
+    assert 'calendar_name="all"' in calendar_step
+    assert calendar_step.index("calendar_get_events_with_attendees") < calendar_step.index(
+        "**Ask when the calendar cannot answer.**"
+    )
+    for state in ("feature_status", "broken", "permission", "user_message"):
+        assert state in calendar_step
+
+    # The inline phase filters a mixed invite before delegation.
+    for field in ("person_page", "email", "status", "type", "is_current_user"):
+        assert field in calendar_step
+        assert field in delegation
+        assert field in agent
+    for excluded in (
+        "is_current_user",
+        "Room",
+        "Resource",
+        "Group",
+        "Declined",
+        "Delegated",
+    ):
+        assert excluded in calendar_step
+
+    # The cross-context seam is structured records, not a comma-separated
+    # display-name placeholder.  Resolved pages win; email/name lookup is only
+    # a fallback for records without one.
+    assert "{{ATTENDEE_RECORDS}}" in delegation
+    assert "{{ATTENDEE_RECORDS}}" in agent
+    assert "{{ATTENDEES}}" not in delegation
+    assert "{{ATTENDEES}}" not in agent
+    assert agent_lookup.index("person_page") < agent_lookup.index("lookup_person")
+    assert "only when `person_page` is empty" in agent_lookup
+
+
+def test_calendar_invite_drives_structured_attendee_research_journey() -> None:
+    """A real invite remains authoritative through delegated research.
+
+    The representative invite contains the user, a room, a group, a declined
+    guest, and two attending people.  The workflow must describe filtering the
+    first four and must carry the attending people's resolved identity fields
+    into the gathering prompt instead of reducing them back to names.
+    """
+
+    _assert_calendar_invite_journey(
+        SKILL_PATH.read_text(encoding="utf-8"),
+        AGENT_PATH.read_text(encoding="utf-8"),
+    )

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 52f444e5914466ad8f7b5d338f00fbfafb985330de3a98f83e9f53b3b07008bc -->
+<!-- Content SHA-256: 0146bb6c16e07c908ef325bcf0ce04512eefe8249a4ce8bb898d3d9b0a5afa1f -->
 
 # Architecture Inventory
 
@@ -122,7 +122,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
 | `dex-analytics` | 28 | **over-surfaced** | `commitments` (`track_event`); `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-closeout` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `relationship-radar` (`track_event`); `reset` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
-| `dex-calendar-mcp` | 4 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
+| `dex-calendar-mcp` | 5 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `meeting-prep` (`calendar_get_events_with_attendees`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-customization-migration-mcp` | 1 | normal | `dex-update` (`read_customization_capsule_blob`, `read_customization_capsule_section`) |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |


### PR DESCRIPTION
## Summary

- preserve Chris Jackson's calendar-first meeting-prep commits from #509
- carry structured attendee records into delegated research instead of re-searching display names
- filter the current user, rooms/resources/groups, declined and delegated invitees
- preserve Calendar feature-status and permission guidance, and search all calendars visible to Apple Calendar without overclaiming coverage
- reconcile the command arguments so the default path is calendar-first

## Verification

- red on the preserved #509 state: the new journey contract failed at the prompt-first argument and missing structured handoff
- green: 95 focused tests
- deliberate removal of the calendar-first lookup: journey contract exits non-zero
- deliberate replacement of structured records with display names: journey contract exits non-zero
- Ruff, architecture inventory drift, instructed-tool existence, PII, founder-content, diff-check, and test-delta gates pass

## Attribution and ownership

The first two commits retain Chris Jackson's authorship and intent from #509. The third commit contains the bounded maintainer hardening and behavioral regression. This PR is intentionally draft; the coordinating parent thread owns merge, release, and any public contributor reply.
