### PR TITLE
fix: make usage attempt records privacy-safe

### DIFF
--- a/.agents/skills/process-meetings/SKILL.md
+++ b/.agents/skills/process-meetings/SKILL.md
@@ -362,7 +362,7 @@ Update `System/usage_log.md` to mark meeting processing as used.
 
 **Analytics (Silent):**
 
-Call `track_event` with event_name `meetings_processed` and properties:
+Call `track_event` with event_name `meeting_processed` and properties:
 - `meetings_count`: number of meetings processed
 - `people_created`: number of new person pages created
 - `todos_extracted`: number of tasks extracted

--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -699,7 +699,9 @@ Then:
      enabled: true
      anonymous: true
    ```
-3. Fire `analytics_consent_given` event.
+
+Do not emit an analytics consent event from this default setting. A default-on
+state is not an affirmative consent action.
 
 ---
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -74,10 +74,43 @@ if [[ -f "$ONBOARDING_MARKER" ]]; then
         if [[ -f "$CLAUDE_DIR/.venv/bin/python" ]]; then
             ANALYTICS_PYTHON="$CLAUDE_DIR/.venv/bin/python"
         fi
+        ANALYTICS_TOTAL_TIMEOUT_SECONDS=3
+        # macOS has no GNU timeout command. This standard-library wrapper
+        # bounds the whole helper process (startup, imports, receipt work, and
+        # request), not just requests.post, and kills its process group on a
+        # timeout so a stalled descendant cannot outlive session start.
         ANALYTICS_RESULT=$(
             cd "$CLAUDE_DIR" && VAULT_PATH="$CLAUDE_DIR" \
-                "$ANALYTICS_PYTHON" core/mcp/analytics_helper.py --event session_started --request-timeout-seconds 2 \
-                2>/dev/null
+                "$ANALYTICS_PYTHON" - "$ANALYTICS_PYTHON" \
+                    core/mcp/analytics_helper.py --event session_started \
+                    --request-timeout-seconds 2 "$ANALYTICS_TOTAL_TIMEOUT_SECONDS" \
+                    2>/dev/null <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+command = sys.argv[1:-1]
+timeout_seconds = float(sys.argv[-1])
+process = subprocess.Popen(
+    command,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    start_new_session=True,
+)
+try:
+    output, _ = process.communicate(timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.communicate()
+    raise SystemExit(124)
+sys.stdout.write(output)
+raise SystemExit(process.returncode)
+PY
         )
         ANALYTICS_STATUS=$?
         if [[ "$ANALYTICS_STATUS" -ne 0 || "$ANALYTICS_RESULT" == *receipt_write_failed* ]]; then

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -65,6 +65,26 @@ fi
 # These are fast checks with interval throttling - only run when needed
 if [[ -f "$ONBOARDING_MARKER" ]]; then
 
+    # This records only the built-in session_started event and the analytics
+    # helper owns consent, delivery, and the safe local receipt. Keep the
+    # result long enough to show a fixed, non-sensitive receipt failure; never
+    # print helper output or retry the delivery. A first-run vault emits none.
+    if [[ -f "$CLAUDE_DIR/core/mcp/analytics_helper.py" ]]; then
+        ANALYTICS_PYTHON="python3"
+        if [[ -f "$CLAUDE_DIR/.venv/bin/python" ]]; then
+            ANALYTICS_PYTHON="$CLAUDE_DIR/.venv/bin/python"
+        fi
+        ANALYTICS_RESULT=$(
+            cd "$CLAUDE_DIR" && VAULT_PATH="$CLAUDE_DIR" \
+                "$ANALYTICS_PYTHON" core/mcp/analytics_helper.py --event session_started --request-timeout-seconds 2 \
+                2>/dev/null
+        )
+        ANALYTICS_STATUS=$?
+        if [[ "$ANALYTICS_STATUS" -ne 0 || "$ANALYTICS_RESULT" == *receipt_write_failed* ]]; then
+            echo "Dex could not save the local analytics receipt. No usage event was retried."
+        fi
+    fi
+
     # Claude Code changelog is now checked in daily plan Step 0.5 via fetch-changelog.cjs
     # Background checker removed (was never installed as LaunchAgent, redundant)
 

--- a/.claude/hooks/tests/first-run-directive.test.cjs
+++ b/.claude/hooks/tests/first-run-directive.test.cjs
@@ -20,7 +20,7 @@ function createSandbox(t) {
   return { vault, home, launchAgents, dedupFile };
 }
 
-function runSessionStart(sandbox) {
+function runSessionStart(sandbox, { timeoutMs = 10_000 } = {}) {
   const result = spawnSync('/bin/bash', [HOOK_PATH], {
     cwd: sandbox.vault,
     encoding: 'utf-8',
@@ -35,12 +35,14 @@ function runSessionStart(sandbox) {
       DEX_SESSION_ANALYTICS_CALLS: sandbox.analyticsCalls
         || path.join(path.dirname(sandbox.vault), 'unused-session-analytics-calls'),
       DEX_SESSION_ANALYTICS_RESULT: sandbox.analyticsResult || '',
+      DEX_SESSION_ANALYTICS_FINISHED: sandbox.analyticsFinished
+        || path.join(path.dirname(sandbox.vault), 'unused-session-analytics-finished'),
       DEX_SESSION_HEALTH_CALLS: path.join(
         path.dirname(sandbox.vault),
         'unused-session-health-calls',
       ),
     },
-    timeout: 10_000,
+    timeout: timeoutMs,
   });
 
   assert.equal(
@@ -71,6 +73,24 @@ function installAnalyticsProbe(sandbox) {
       'result = os.environ.get("DEX_SESSION_ANALYTICS_RESULT", "")',
       'if result:',
       '    print(result)',
+      '',
+    ].join('\n'),
+  );
+}
+
+function installHangingAnalyticsProbe(sandbox) {
+  const helper = path.join(sandbox.vault, 'core', 'mcp', 'analytics_helper.py');
+  sandbox.analyticsFinished = path.join(path.dirname(sandbox.vault), 'session-analytics-finished');
+  fs.mkdirSync(path.dirname(helper), { recursive: true });
+  fs.writeFileSync(
+    helper,
+    [
+      'import os',
+      'import time',
+      'from pathlib import Path',
+      'print("private relay token")',
+      'time.sleep(4)',
+      'Path(os.environ["DEX_SESSION_ANALYTICS_FINISHED"]).write_text("finished\\n", encoding="utf-8")',
       '',
     ].join('\n'),
   );
@@ -153,6 +173,27 @@ test('a completed vault visibly reports a safe receipt-write failure', (t) => {
   assert.match(stdout, /Dex could not save the local analytics receipt/);
   assert.match(stdout, /No usage event was retried/);
   assert.doesNotMatch(stdout, /private relay token/);
+});
+
+test('a hanging analytics helper is killed within the session-start total budget', async (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  installHangingAnalyticsProbe(sandbox);
+
+  const startedAt = Date.now();
+  const stdout = runSessionStart(sandbox, { timeoutMs: 5_000 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.ok(elapsedMs < 3_750, `session start took ${elapsedMs}ms`);
+  assert.match(stdout, /Dex could not save the local analytics receipt/);
+  assert.match(stdout, /No usage event was retried/);
+  assert.doesNotMatch(stdout, /private relay token/);
+  await new Promise((resolve) => setTimeout(resolve, 1_250));
+  assert.equal(fs.existsSync(sandbox.analyticsFinished), false);
+  assert.equal(
+    fs.existsSync(path.join(sandbox.vault, 'System', '.dex', 'analytics-attempts.jsonl')),
+    false,
+  );
 });
 
 test('a never-onboarded vault does not start a session event', async (t) => {

--- a/.claude/hooks/tests/first-run-directive.test.cjs
+++ b/.claude/hooks/tests/first-run-directive.test.cjs
@@ -32,6 +32,9 @@ function runSessionStart(sandbox) {
       HOME: sandbox.home,
       PATH: process.env.PATH || '/usr/bin:/bin',
       VAULT_PATH: sandbox.vault,
+      DEX_SESSION_ANALYTICS_CALLS: sandbox.analyticsCalls
+        || path.join(path.dirname(sandbox.vault), 'unused-session-analytics-calls'),
+      DEX_SESSION_ANALYTICS_RESULT: sandbox.analyticsResult || '',
       DEX_SESSION_HEALTH_CALLS: path.join(
         path.dirname(sandbox.vault),
         'unused-session-health-calls',
@@ -52,6 +55,34 @@ function completeOnboarding(sandbox) {
   const marker = path.join(sandbox.vault, 'System', '.onboarding-complete');
   fs.mkdirSync(path.dirname(marker), { recursive: true });
   fs.writeFileSync(marker, '{}\n');
+}
+
+function installAnalyticsProbe(sandbox) {
+  const helper = path.join(sandbox.vault, 'core', 'mcp', 'analytics_helper.py');
+  sandbox.analyticsCalls = path.join(path.dirname(sandbox.vault), 'session-analytics-calls');
+  fs.mkdirSync(path.dirname(helper), { recursive: true });
+  fs.writeFileSync(
+    helper,
+    [
+      'import os',
+      'import sys',
+      'from pathlib import Path',
+      'Path(os.environ["DEX_SESSION_ANALYTICS_CALLS"]).write_text(" ".join(sys.argv[1:]) + "\\n", encoding="utf-8")',
+      'result = os.environ.get("DEX_SESSION_ANALYTICS_RESULT", "")',
+      'if result:',
+      '    print(result)',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function waitForFile(filePath, timeoutMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return fs.existsSync(filePath);
 }
 
 test('a never-onboarded vault begins canonical onboarding on its first session', (t) => {
@@ -92,4 +123,44 @@ test('an onboarded vault emits no first-time setup directive', (t) => {
   assert.doesNotMatch(stdout, /FIRST-TIME SETUP REQUIRED/);
   assert.doesNotMatch(stdout, /begin onboarding NOW/);
   assert.doesNotMatch(stdout, /resume setup NOW/);
+});
+
+test('a completed vault starts the named session event with a bounded request once', async (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  installAnalyticsProbe(sandbox);
+
+  runSessionStart(sandbox);
+
+  assert.equal(await waitForFile(sandbox.analyticsCalls), true);
+  assert.equal(
+    fs.readFileSync(sandbox.analyticsCalls, 'utf8'),
+    '--event session_started --request-timeout-seconds 2\n',
+  );
+});
+
+test('a completed vault visibly reports a safe receipt-write failure', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  sandbox.analyticsResult = JSON.stringify({
+    receipt_written: false,
+    receipt_reason: 'receipt_write_failed',
+  });
+  installAnalyticsProbe(sandbox);
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.match(stdout, /Dex could not save the local analytics receipt/);
+  assert.match(stdout, /No usage event was retried/);
+  assert.doesNotMatch(stdout, /private relay token/);
+});
+
+test('a never-onboarded vault does not start a session event', async (t) => {
+  const sandbox = createSandbox(t);
+  installAnalyticsProbe(sandbox);
+
+  runSessionStart(sandbox);
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(fs.existsSync(sandbox.analyticsCalls), false);
 });

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -480,7 +480,7 @@ Update `System/usage_log.md` to mark meeting processing as used.
 
 **Analytics (Silent):**
 
-Call `track_event` with event_name `meetings_processed` and properties:
+Call `track_event` with event_name `meeting_processed` and properties:
 - `meetings_count`: number of meetings processed
 - `people_created`: number of new person pages created
 - `todos_extracted`: number of tasks extracted

--- a/core/analytics_events.py
+++ b/core/analytics_events.py
@@ -1,0 +1,81 @@
+"""The finite, non-user-controlled names Dex may use for analytics attempts."""
+
+from __future__ import annotations
+
+# These names describe Dex features, never a person, their work, or an input
+# supplied through an MCP call. Keep this list deliberately closed: a new
+# feature must make its event name an explicit code-review decision.
+SAFE_ANALYTICS_EVENT_NAMES = frozenset(
+    {
+        "backlog_reviewed",
+        "career_coach_session",
+        "career_coverage_analyzed",
+        "career_evidence_scanned",
+        "career_setup_completed",
+        "commitments_reviewed",
+        "custom_skill_created",
+        "daily_plan_completed",
+        "daily_review_completed",
+        "dex_analytics_test",
+        "getting_started_completed",
+        "idea_captured",
+        "idea_implemented",
+        "improvement_workshopped",
+        "initiative_kicked_off",
+        "insight_saved",
+        "integration_google_completed",
+        "integration_notion_completed",
+        "integration_slack_completed",
+        "journal_entry_created",
+        "level_up_viewed",
+        "mcp_added",
+        "mcp_created",
+        "mcp_integrated",
+        "meeting_closed_out",
+        "meeting_prep_completed",
+        "meeting_processed",
+        "obsidian_enabled",
+        "onboarding_completed",
+        "person_page_created",
+        "promotion_readiness_checked",
+        "product_brief_created",
+        "project_health_checked",
+        "prompt_improved",
+        "quarter_plan_completed",
+        "quarter_review_completed",
+        "relationship_radar_run",
+        "resume_compiled",
+        "resume_builder_used",
+        "session_started",
+        "skill_rated",
+        "task_completed",
+        "task_created",
+        "triage_completed",
+        "user_identified",
+        "vault_reset",
+        "week_plan_completed",
+        "week_review_completed",
+        "whats_new_viewed",
+        "xray_used",
+    }
+)
+
+# An invalid caller-supplied name is represented locally by this fixed marker,
+# never by the original value.
+REDACTED_ANALYTICS_EVENT_NAME = "invalid_event"
+RECEIPT_ANALYTICS_EVENT_NAMES = SAFE_ANALYTICS_EVENT_NAMES | {
+    REDACTED_ANALYTICS_EVENT_NAME,
+}
+
+
+def is_safe_analytics_event_name(value: object) -> bool:
+    """True only for an explicitly reviewed, non-user-controlled event name."""
+    return isinstance(value, str) and value in SAFE_ANALYTICS_EVENT_NAMES
+
+
+__all__ = [
+    "RECEIPT_ANALYTICS_EVENT_NAMES",
+    "REDACTED_ANALYTICS_EVENT_NAME",
+    "SAFE_ANALYTICS_EVENT_NAMES",
+    "is_safe_analytics_event_name",
+]

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -148,8 +148,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/process-meetings/SKILL.md",
-        "sha256": "eb7e819ed4c4e32fb5ec1f5477b249ec4bd6d8805870360107098d893a04642c",
-        "byte_size": 19094
+        "sha256": "9ab3d1efe11917602ce86c5a65350c5645a5c29a6571cab9e5dae42dca9f6148",
+        "byte_size": 19093
       },
       "value": "Turns meeting material into people context and follow-up tasks, reducing the chance that decisions or promises disappear after the call.",
       "jobs_served": ["process-meetings", "keep-relationships-warm"],

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -76,7 +76,10 @@ _ANALYTICS_RECEIPT_REASONS = frozenset(
     }
 )
 _ANALYTICS_EVENT_NAME = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
-_MAX_ANALYTICS_RECEIPT_BYTES = (
+_MAX_ANALYTICS_RECEIPT_INPUT_BYTES = (
+    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+)
+_MAX_RETAINED_ANALYTICS_RECEIPT_BYTES = (
     portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
 )
 _ANALYTICS_RECEIPT_APPEND_ATTEMPTS = 2
@@ -390,6 +393,35 @@ def _validated_analytics_receipt_prefix(raw: bytes) -> bytes:
     return raw
 
 
+def _retain_newest_analytics_receipt_records(
+    existing: bytes,
+    record: bytes,
+) -> bytes:
+    """Keep a bounded rolling receipt without splitting or skipping records.
+
+    ``existing`` has already been fully validated, including every record that
+    may be dropped.  That makes retention safe: an old malformed or unsafe
+    line fails closed instead of being silently hidden by truncation.
+    """
+    combined = existing + record
+    if len(combined) <= _MAX_RETAINED_ANALYTICS_RECEIPT_BYTES:
+        return combined
+
+    lines = combined.splitlines(keepends=True)
+    retained_size = len(combined)
+    first_retained = 0
+    while retained_size > _MAX_RETAINED_ANALYTICS_RECEIPT_BYTES:
+        retained_size -= len(lines[first_retained])
+        first_retained += 1
+
+    retained = b"".join(lines[first_retained:])
+    if not retained or not retained.endswith(b"\n"):
+        raise PlanRejected("analytics receipt retention must keep complete records")
+    if len(retained) != retained_size:
+        raise PlanRejected("analytics receipt retention size is inconsistent")
+    return retained
+
+
 def _is_stale_analytics_receipt_plan(error: PlanRejected) -> bool:
     """Recognize only a stale precondition for this one local receipt file."""
     message = str(error)
@@ -453,7 +485,7 @@ def _append_analytics_attempt_receipt(
             bounded_read(
                 root,
                 _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
-                max_bytes=_MAX_ANALYTICS_RECEIPT_BYTES,
+                max_bytes=_MAX_ANALYTICS_RECEIPT_INPUT_BYTES,
             )
             if target_exists
             else b""
@@ -461,7 +493,7 @@ def _append_analytics_attempt_receipt(
         prefix = _validated_analytics_receipt_prefix(existing)
         entry = PlanEntry(
             _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
-            prefix + record_bytes,
+            _retain_newest_analytics_receipt_records(prefix, record_bytes),
             mode=0o600,
             expected_current_sha256=(
                 hashlib.sha256(existing).hexdigest() if target_exists else None

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -19,9 +19,11 @@ import os
 import re
 import shutil
 from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core import portable_contract
+from core.analytics_events import RECEIPT_ANALYTICS_EVENT_NAMES
 from core.customization_migration.registration import mcp_registration_snippet
 from core.lifecycle.catalog import load_catalog, load_catalog_payload_sources
 from core.lifecycle.conflict import (
@@ -58,6 +60,29 @@ _ARCHIVE_RECEIPTS_RELATIVE = "System/.dex/archive-removals"
 _MCP_CONFIG_RELATIVE = ".mcp.json"
 _MCP_REGISTRATION_NAME = "customization-migration-mcp"
 _ONBOARDING_PROFILE_RELATIVE = "System/user-profile.yaml"
+_ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE
+_ANALYTICS_RECEIPT_FIELDS = frozenset({"timestamp", "event", "outcome", "reason"})
+_ANALYTICS_RECEIPT_OUTCOMES = frozenset({"sent", "not_sent"})
+_ANALYTICS_RECEIPT_REASONS = frozenset(
+    {
+        "analytics_disabled",
+        "no_analytics_endpoint",
+        "no_pendo_secret",
+        "requests_not_installed",
+        "sent",
+        "http_error",
+        "invalid_event_name",
+        "request_failed",
+    }
+)
+_ANALYTICS_EVENT_NAME = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
+_MAX_ANALYTICS_RECEIPT_BYTES = (
+    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+)
+_ANALYTICS_RECEIPT_APPEND_ATTEMPTS = 2
+_ANALYTICS_RECEIPT_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$"
+)
 _REBUILD_TRANSACTION_PATH = re.compile(
     r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
     r"receipts/(?:capsule|activation|rewind)\.json|"
@@ -91,6 +116,35 @@ def _transaction_preview_document(
     purpose: str,
     operation: str = "update",
 ) -> dict[str, object]:
+    """Build the historic private service-to-Transaction approval binding."""
+    return _transaction_preview_document_with_bounded_reads(
+        vault_root,
+        plan,
+        purpose=purpose,
+        operation=operation,
+        max_read_bytes_by_relative=_internal_transaction_read_limits(operation),
+    )
+
+
+def _internal_transaction_read_limits(operation: str) -> dict[str, int]:
+    """Return the one service-owned cap required by a private receipt operation."""
+    if operation != "analytics-receipt":
+        return {}
+    return {
+        _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
+            portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+        )
+    }
+
+
+def _transaction_preview_document_with_bounded_reads(
+    vault_root: str | Path,
+    plan: Sequence[PlanEntry],
+    *,
+    purpose: str,
+    operation: str,
+    max_read_bytes_by_relative: Mapping[str, int],
+) -> dict[str, object]:
     """Build the private service-to-Transaction approval binding.
 
     This is deliberately outside the frozen public ABI.  It gives trusted
@@ -102,6 +156,7 @@ def _transaction_preview_document(
     if not plan:
         raise ValueError("transaction preview needs at least one write")
     root = Path(vault_root)
+    read_limits = dict(max_read_bytes_by_relative)
     writes: list[dict[str, object]] = []
     seen: set[str] = set()
     for entry in plan:
@@ -127,7 +182,12 @@ def _transaction_preview_document(
         if target.exists():
             if target.is_symlink() or not target.is_file():
                 raise PlanRejected(f"{entry.relative}: existing target is not a regular file")
-            raw = target.read_bytes()
+            max_bytes = read_limits.get(entry.relative)
+            raw = (
+                bounded_read(root, entry.relative, max_bytes=max_bytes)
+                if max_bytes is not None
+                else target.read_bytes()
+            )
             current = {
                 "exists": True,
                 "sha256": hashlib.sha256(raw).hexdigest(),
@@ -226,8 +286,11 @@ def _execute_approved_transaction(
     )
     tx_root_relative = Path("System/.dex/tx")
     tx_paths_before = _tree_paths(root, tx_root_relative)
-    result = Transaction.begin(root, list(plan), operation=operation).run(
-        before_commit=before_commit
+    result = _run_internal_transaction(
+        root,
+        plan,
+        operation=operation,
+        before_commit=before_commit,
     )
     tx_paths_after = _tree_paths(root, tx_root_relative)
     declared_paths = (
@@ -253,6 +316,181 @@ def _execute_approved_transaction(
             "declared_paths": sorted(declared_paths),
         }
     )
+
+
+def _run_internal_transaction(
+    vault_root: Path,
+    plan: Sequence[PlanEntry],
+    *,
+    operation: str,
+    before_commit: Callable[[], None] | None,
+) -> dict[str, object]:
+    """Run one private transaction while keeping bounded reads off legacy seams."""
+    return Transaction.begin(
+        vault_root,
+        list(plan),
+        operation=operation,
+        max_read_bytes_by_relative=_internal_transaction_read_limits(operation),
+    ).run(before_commit=before_commit)
+
+
+def _validate_analytics_receipt_record(record: object) -> None:
+    """Refuse to append to a receipt that could already contain unsafe data."""
+    if not isinstance(record, dict) or set(record) != _ANALYTICS_RECEIPT_FIELDS:
+        raise PlanRejected("analytics receipt has unsupported fields")
+    timestamp = record.get("timestamp")
+    event = record.get("event")
+    outcome = record.get("outcome")
+    reason = record.get("reason")
+    if not isinstance(timestamp, str) or _ANALYTICS_RECEIPT_TIMESTAMP.fullmatch(timestamp) is None:
+        raise PlanRejected("analytics receipt timestamp is invalid")
+    if (
+        not isinstance(event, str)
+        or _ANALYTICS_EVENT_NAME.fullmatch(event) is None
+        or event not in RECEIPT_ANALYTICS_EVENT_NAMES
+    ):
+        raise PlanRejected("analytics receipt event name is invalid")
+    if outcome not in _ANALYTICS_RECEIPT_OUTCOMES:
+        raise PlanRejected("analytics receipt outcome is invalid")
+    if reason not in _ANALYTICS_RECEIPT_REASONS:
+        raise PlanRejected("analytics receipt reason is invalid")
+
+
+def _analytics_receipt_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Build a receipt object only when each JSON field occurs once.
+
+    Python's normal JSON decoder accepts duplicate keys and silently keeps the
+    last value.  That would let an unsafe earlier value remain on disk even
+    though schema validation sees only the safe replacement.
+    """
+    record: dict[str, object] = {}
+    for key, value in pairs:
+        if key in record:
+            raise ValueError("analytics receipt contains duplicate JSON keys")
+        record[key] = value
+    return record
+
+
+def _validated_analytics_receipt_prefix(raw: bytes) -> bytes:
+    """Return only an existing receipt whose every line follows the safe schema."""
+    if not raw:
+        return b""
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PlanRejected("analytics receipt is not UTF-8") from error
+    if not text.endswith("\n"):
+        raise PlanRejected("analytics receipt must end with a newline")
+    for line in text.splitlines():
+        try:
+            record = json.loads(line, object_pairs_hook=_analytics_receipt_json_object)
+        except (json.JSONDecodeError, ValueError) as error:
+            raise PlanRejected("analytics receipt contains invalid JSON") from error
+        _validate_analytics_receipt_record(record)
+    return raw
+
+
+def _is_stale_analytics_receipt_plan(error: PlanRejected) -> bool:
+    """Recognize only a stale precondition for this one local receipt file."""
+    message = str(error)
+    if message == "transaction approval token does not match the current preview":
+        return True
+    if _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE not in message:
+        return False
+    return any(
+        marker in message
+        for marker in (
+            "changed after the mutation plan was built",
+            "changed after the mutation snapshot",
+            "appeared after the mutation plan was built",
+            "appeared after the mutation snapshot",
+            "appeared in the vault after authorization",
+        )
+    )
+
+
+def _append_analytics_attempt_receipt(
+    vault_root: str | Path,
+    *,
+    event_name: str,
+    outcome: str,
+    reason: str,
+) -> dict[str, object]:
+    """Append one safe analytics-attempt receipt through the transaction core.
+
+    This private service seam is intentionally narrow: it owns the four-field
+    receipt shape and can write only its exact runtime file. It is not part of
+    the frozen public lifecycle API.
+    """
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": event_name,
+        "outcome": outcome,
+        "reason": reason,
+    }
+    _validate_analytics_receipt_record(record)
+    record_bytes = _canonical(record)
+    if (
+        len(record_bytes)
+        > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+    ):
+        raise PlanRejected("analytics receipt record exceeds its bounded size")
+
+    root = Path(vault_root)
+    for attempt in range(_ANALYTICS_RECEIPT_APPEND_ATTEMPTS):
+        # Check the entire route before even asking whether the receipt exists:
+        # a user-owned symlinked parent must never be traversed to read it.
+        unsafe_parent = unsafe_existing_parent(root, _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE)
+        if unsafe_parent is not None:
+            raise PlanRejected(f"analytics receipt: {unsafe_parent}")
+        target = root / _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE
+        if target.is_symlink():
+            raise PlanRejected("analytics receipt target must be a regular file")
+        target_exists = target.exists()
+        if target_exists and not target.is_file():
+            raise PlanRejected("analytics receipt target must be a regular file")
+        existing = (
+            bounded_read(
+                root,
+                _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
+                max_bytes=_MAX_ANALYTICS_RECEIPT_BYTES,
+            )
+            if target_exists
+            else b""
+        )
+        prefix = _validated_analytics_receipt_prefix(existing)
+        entry = PlanEntry(
+            _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
+            prefix + record_bytes,
+            mode=0o600,
+            expected_current_sha256=(
+                hashlib.sha256(existing).hexdigest() if target_exists else None
+            ),
+            expected_absent=not target_exists,
+        )
+        plan = [entry]
+        preview = _preview_transaction(
+            root,
+            plan,
+            purpose="analytics-receipt",
+            operation="analytics-receipt",
+        )
+        try:
+            return _execute_approved_transaction(
+                root,
+                plan,
+                purpose="analytics-receipt",
+                operation="analytics-receipt",
+                approved_token=str(preview["approval_token"]),
+            )
+        except PlanRejected as error:
+            if (
+                attempt + 1 < _ANALYTICS_RECEIPT_APPEND_ATTEMPTS
+                and _is_stale_analytics_receipt_plan(error)
+            ):
+                continue
+            raise
+    raise RuntimeError("analytics receipt retry loop ended unexpectedly")
 
 
 def _confirmed_onboarding_context(

--- a/core/mcp/analytics_helper.py
+++ b/core/mcp/analytics_helper.py
@@ -15,11 +15,23 @@ Usage in skills:
 """
 
 import hashlib
+import json
 import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.analytics_events import (
+    REDACTED_ANALYTICS_EVENT_NAME,
+    is_safe_analytics_event_name,
+)
+from core.lifecycle import service as lifecycle_service
 
 try:
     import requests
@@ -32,6 +44,20 @@ except ImportError:
 DEFAULT_PENDO_ENDPOINT = "https://app.pendo.io/data/track"
 ANALYTICS_MODE_DIRECT = "direct"
 ANALYTICS_MODE_PROXY = "proxy"
+_CONNECTION_TEST_EVENT = "dex_analytics_test"
+_CONNECTION_TEST_VISITOR_ID = "dex-analytics-test"
+_CONNECTION_TEST_ACCOUNT_ID = "dex-analytics-test"
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+def _bounded_request_timeout_seconds(value: object) -> float:
+    """Return a finite delivery-only timeout without affecting receipt writes."""
+    if (
+        type(value) in (int, float)
+        and 0 < value <= _DEFAULT_REQUEST_TIMEOUT_SECONDS
+    ):
+        return float(value)
+    return _DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 
 def get_vault_path() -> Path:
@@ -338,7 +364,41 @@ def get_visitor_info() -> Dict[str, str]:
     }
 
 
-def fire_event(event_name: str, properties: Dict[str, Any] = None) -> Dict[str, Any]:
+def _with_attempt_receipt(
+    result: Dict[str, Any],
+    *,
+    event_name: str,
+    outcome: str,
+    reason: str,
+) -> Dict[str, Any]:
+    """Return the delivery result with its one safe, local receipt outcome.
+
+    Receipt failures are deliberately visible but never include the underlying
+    filesystem error: that text can carry a user path or transport detail.
+    """
+    try:
+        lifecycle_service._append_analytics_attempt_receipt(
+            get_vault_path(),
+            event_name=event_name,
+            outcome=outcome,
+            reason=reason,
+        )
+    except Exception:
+        return {
+            **result,
+            'receipt_written': False,
+            'receipt_reason': 'receipt_write_failed',
+        }
+    return {**result, 'receipt_written': True}
+
+
+def fire_event(
+    event_name: str,
+    properties: Dict[str, Any] = None,
+    *,
+    _connection_test: bool = False,
+    _request_timeout_seconds: float | None = None,
+) -> Dict[str, Any]:
     """
     Fire an analytics event to Pendo.
     
@@ -347,61 +407,134 @@ def fire_event(event_name: str, properties: Dict[str, Any] = None) -> Dict[str, 
     Args:
         event_name: Name of the event (e.g., 'daily_plan_completed')
         properties: Additional event properties (counts, categories only - no content!)
+        _request_timeout_seconds: Private delivery-only timeout for callers
+            such as session start. It never interrupts the local receipt.
     
     Returns:
         Result dict with success status
     """
-    if not is_analytics_enabled():
-        return {'fired': False, 'reason': 'analytics_disabled'}
+    request_timeout_seconds = _bounded_request_timeout_seconds(
+        _request_timeout_seconds
+    )
+    if not is_safe_analytics_event_name(event_name):
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'invalid_event_name'},
+            event_name=REDACTED_ANALYTICS_EVENT_NAME,
+            outcome='not_sent',
+            reason='invalid_event_name',
+        )
+
+    if _connection_test and event_name != _CONNECTION_TEST_EVENT:
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'invalid_event_name'},
+            event_name=REDACTED_ANALYTICS_EVENT_NAME,
+            outcome='not_sent',
+            reason='invalid_event_name',
+        )
+
+    try:
+        analytics_enabled = is_analytics_enabled()
+    except Exception:
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'request_failed'},
+            event_name=event_name,
+            outcome='not_sent',
+            reason='request_failed',
+        )
+
+    if not analytics_enabled:
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'analytics_disabled'},
+            event_name=event_name,
+            outcome='not_sent',
+            reason='analytics_disabled',
+        )
     
     if not HAS_REQUESTS:
-        return {'fired': False, 'reason': 'requests_not_installed'}
-    
-    transport = get_analytics_transport()
-    if not transport.get('configured'):
-        return {'fired': False, 'reason': transport.get('reason', 'transport_not_configured')}
-    
-    visitor_info = get_visitor_info()
-    journey = calculate_journey_metadata()
-    profile = load_user_profile()
-    
-    # Build properties with journey context
-    event_props = {
-        'journey_stage': journey['journey_stage'],
-        'days_since_setup': journey['days_since_setup'],
-        'feature_adoption_score': journey['feature_adoption_score'],
-        'most_active_area': journey['most_active_area'],
-        'role': profile.get('role_group', 'unknown'),
-        'company_size': profile.get('company_size', 'unknown'),
-        **(properties or {})
-    }
-    
-    payload = {
-        'type': 'track',
-        'event': event_name,
-        'visitorId': visitor_info['visitor_id'],
-        'accountId': visitor_info['account_id'],
-        'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
-        'properties': event_props
-    }
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'requests_not_installed'},
+            event_name=event_name,
+            outcome='not_sent',
+            reason='requests_not_installed',
+        )
     
     try:
+        transport = get_analytics_transport()
+        if not transport.get('configured'):
+            transport_reason = transport.get('reason')
+            if transport_reason not in {'no_analytics_endpoint', 'no_pendo_secret'}:
+                transport_reason = 'no_analytics_endpoint'
+            return _with_attempt_receipt(
+                {'fired': False, 'reason': transport_reason},
+                event_name=event_name,
+                outcome='not_sent',
+                reason=transport_reason,
+            )
+
+        if _connection_test:
+            # A connection check must prove only that the transport works. It
+            # must never read or send a person's identity, profile, journey
+            # metadata, or caller-supplied properties.
+            visitor_info = {
+                'visitor_id': _CONNECTION_TEST_VISITOR_ID,
+                'account_id': _CONNECTION_TEST_ACCOUNT_ID,
+            }
+            event_props = {'connection_test': True}
+        else:
+            visitor_info = get_visitor_info()
+            journey = calculate_journey_metadata()
+            profile = load_user_profile()
+
+            # Build properties with journey context.
+            event_props = {
+                'journey_stage': journey['journey_stage'],
+                'days_since_setup': journey['days_since_setup'],
+                'feature_adoption_score': journey['feature_adoption_score'],
+                'most_active_area': journey['most_active_area'],
+                'role': profile.get('role_group', 'unknown'),
+                'company_size': profile.get('company_size', 'unknown'),
+                **(properties or {})
+            }
+
+        payload = {
+            'type': 'track',
+            'event': event_name,
+            'visitorId': visitor_info['visitor_id'],
+            'accountId': visitor_info['account_id'],
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
+            'properties': event_props
+        }
+
         response = requests.post(
             transport['endpoint'],
             json=payload,
             headers=transport['headers'],
-            timeout=10
+            timeout=request_timeout_seconds,
         )
         if response.status_code == 200:
-            return {'fired': True, 'event': event_name, 'mode': transport['mode']}
-        else:
-            return {
+            return _with_attempt_receipt(
+                {'fired': True, 'event': event_name, 'mode': transport['mode']},
+                event_name=event_name,
+                outcome='sent',
+                reason='sent',
+            )
+        return _with_attempt_receipt(
+            {
                 'fired': False,
                 'mode': transport['mode'],
-                'error': f'HTTP {response.status_code}'
-            }
-    except Exception as e:
-        return {'fired': False, 'error': str(e)}
+                'reason': 'http_error',
+            },
+            event_name=event_name,
+            outcome='not_sent',
+            reason='http_error',
+        )
+    except Exception:
+        return _with_attempt_receipt(
+            {'fired': False, 'reason': 'request_failed'},
+            event_name=event_name,
+            outcome='not_sent',
+            reason='request_failed',
+        )
 
 
 def update_consent(decision: str):
@@ -469,7 +602,6 @@ class Events:
     # Lifecycle
     SESSION_STARTED = 'session_started'
     ONBOARDING_COMPLETED = 'onboarding_completed'
-    ANALYTICS_CONSENT_GIVEN = 'analytics_consent_given'
     
     # Core Skills
     DAILY_PLAN_COMPLETED = 'daily_plan_completed'
@@ -496,8 +628,28 @@ class Events:
 
 
 if __name__ == '__main__':
-    # Test the helper
-    print("Consent status:", check_consent())
-    print("\nJourney metadata:")
-    for k, v in calculate_journey_metadata().items():
-        print(f"  {k}: {v}")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fire one Dex analytics event safely.")
+    parser.add_argument("--event", help="Built-in event name to record")
+    parser.add_argument(
+        "--request-timeout-seconds",
+        type=float,
+        help="Delivery-only limit for a caller that must remain responsive",
+    )
+    args = parser.parse_args()
+    if args.event:
+        print(
+            json.dumps(
+                fire_event(
+                    args.event,
+                    _request_timeout_seconds=args.request_timeout_seconds,
+                ),
+                sort_keys=True,
+            )
+        )
+    else:
+        print("Consent status:", check_consent())
+        print("\nJourney metadata:")
+        for k, v in calculate_journey_metadata().items():
+            print(f"  {k}: {v}")

--- a/core/mcp/analytics_receipts.py
+++ b/core/mcp/analytics_receipts.py
@@ -1,0 +1,47 @@
+"""One safe way for MCP callers to surface a failed analytics receipt."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, MutableMapping
+
+_SAFE_RECEIPT_FAILURE = {
+    "written": False,
+    "reason": "receipt_write_failed",
+}
+
+
+def unavailable_analytics_delivery() -> dict[str, object]:
+    """Return the fixed outcome when the shared analytics helper is unavailable."""
+    return {
+        "fired": False,
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+
+
+def receipt_failure_status(delivery: object) -> dict[str, object] | None:
+    """Expose a receipt failure without carrying delivery or exception details."""
+    if (
+        isinstance(delivery, Mapping)
+        and delivery.get("receipt_written") is False
+        and delivery.get("receipt_reason") == "receipt_write_failed"
+    ):
+        return dict(_SAFE_RECEIPT_FAILURE)
+    return None
+
+
+def surface_analytics_attempt(
+    result: MutableMapping[str, object],
+    fire_event: Callable[[str, object], object],
+    event_name: str,
+    properties: object = None,
+) -> dict[str, object] | None:
+    """Record one attempt and attach only a fixed receipt failure to its result."""
+    try:
+        delivery = fire_event(event_name, properties)
+    except Exception:
+        delivery = unavailable_analytics_delivery()
+    receipt_failure = receipt_failure_status(delivery)
+    if receipt_failure is not None:
+        result["analytics_receipt"] = receipt_failure
+    return receipt_failure

--- a/core/mcp/analytics_server.py
+++ b/core/mcp/analytics_server.py
@@ -12,6 +12,7 @@ Usage:
 import json
 import os
 import sys
+from importlib.util import find_spec
 
 # Health system — error queue and health reporting
 try:
@@ -22,7 +23,6 @@ try:
 except ImportError:
     _HAS_HEALTH = False
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 
 # MCP SDK imports
@@ -40,7 +40,6 @@ from analytics_helper import (
     check_consent,
     fire_event,
     get_analytics_transport,
-    get_vault_path,
     get_visitor_info,
     is_analytics_enabled,
     load_user_profile,
@@ -48,11 +47,7 @@ from analytics_helper import (
 
 from core.utils.feature_status import feature_status
 
-try:
-    import requests
-    HAS_REQUESTS = True
-except ImportError:
-    HAS_REQUESTS = False
+HAS_REQUESTS = find_spec("requests") is not None
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -68,20 +63,16 @@ def _meeting_processing_mode(value):
     return None
 
 
-def log_event_locally(event_name: str, properties: dict, visitor_id: str):
-    """Log event to local file as backup."""
-    log_path = get_vault_path() / 'System' / 'analytics_log.jsonl'
-    entry = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "event": event_name,
-        "visitor_id": visitor_id,
-        "properties": properties
+def _identify_delivery_response(delivery: dict) -> dict:
+    """Map a failed or disabled identify attempt to its legacy-safe shape."""
+    result = {
+        "identified": delivery.get("fired", False),
+        "reason": delivery.get("reason", "request_failed"),
+        "receipt_written": delivery.get("receipt_written", False),
     }
-    try:
-        with open(log_path, 'a') as f:
-            f.write(json.dumps(entry) + '\n')
-    except Exception:
-        pass
+    if "receipt_reason" in delivery:
+        result["receipt_reason"] = delivery["receipt_reason"]
+    return result
 
 
 # Create MCP server
@@ -100,7 +91,7 @@ async def list_tools():
                 "properties": {
                     "event_name": {
                         "type": "string",
-                        "description": "Event name (e.g., 'skill_invoked', 'task_completed')"
+                        "description": "Event name (e.g., 'task_completed', 'daily_plan_completed')"
                     },
                     "properties": {
                         "type": "object",
@@ -189,119 +180,95 @@ async def _call_tool_inner(name: str, arguments: dict) -> list[TextContent]:
         properties = arguments.get("properties", {})
 
         if not event_name:
-            return [TextContent(type="text", text=json.dumps({"error": "event_name required"}))]
+            delivery = fire_event(event_name)
+            result = {
+                "error": "event_name required",
+                "receipt_written": delivery.get("receipt_written", False),
+            }
+            if "receipt_reason" in delivery:
+                result["receipt_reason"] = delivery["receipt_reason"]
+            return [TextContent(type="text", text=json.dumps(result))]
 
-        # Check if analytics is enabled (consent-gated)
-        if not is_analytics_enabled():
-            visitor_info = get_visitor_info()
-            log_event_locally(event_name, properties, visitor_info['visitor_id'])
-            return [TextContent(type="text", text=json.dumps({
-                "fired": False,
-                "reason": "analytics_disabled",
-                "logged_locally": True
-            }))]
-
-        # Fire via helper (uses requests, handles journey metadata)
+        # fire_event is the sole analytics-attempt route. It records one safe
+        # local receipt whether delivery is disabled, unavailable, or successful.
         result = fire_event(event_name, properties)
-
-        # Also log locally as backup
-        visitor_info = get_visitor_info()
-        log_event_locally(event_name, properties, visitor_info['visitor_id'])
-        result["logged_locally"] = True
-
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "identify_user":
         metadata = arguments.get("metadata", {})
 
-        if not is_analytics_enabled():
-            return [TextContent(type="text", text=json.dumps({
-                "identified": False,
-                "reason": "analytics_disabled"
-            }))]
+        try:
+            analytics_enabled = is_analytics_enabled()
+        except Exception:
+            return [TextContent(
+                type="text",
+                text=json.dumps(_identify_delivery_response(fire_event("user_identified"))),
+            )]
 
-        profile = load_user_profile()
+        if not analytics_enabled:
+            # Keep the legacy identify_user response shape while still sending
+            # every delivery outcome through fire_event's single receipt route.
+            delivery = fire_event("user_identified")
+            result = _identify_delivery_response(delivery)
+            return [TextContent(type="text", text=json.dumps(result))]
 
-        # Merge profile data with provided metadata
-        identify_props = {
-            "role": profile.get("role", "unknown"),
-            "role_group": profile.get("role_group", "unknown"),
-            "company_size": profile.get("company_size", "unknown"),
-            "pillars_count": len(profile.get("pillars", [])),
-            "obsidian_enabled": profile.get("obsidian_mode", False),
-            "granola_enabled": _meeting_processing_mode(profile.get("meeting_processing")) == "automatic",
-            **metadata
-        }
+        try:
+            profile = load_user_profile()
+
+            # Merge profile data with provided metadata.
+            identify_props = {
+                "role": profile.get("role", "unknown"),
+                "role_group": profile.get("role_group", "unknown"),
+                "company_size": profile.get("company_size", "unknown"),
+                "pillars_count": len(profile.get("pillars", [])),
+                "obsidian_enabled": profile.get("obsidian_mode", False),
+                "granola_enabled": _meeting_processing_mode(profile.get("meeting_processing")) == "automatic",
+                **metadata
+            }
+        except Exception:
+            # The helper owns one normalized receipt even if the MCP's
+            # optional profile enrichment cannot be prepared.
+            return [TextContent(
+                type="text",
+                text=json.dumps(_identify_delivery_response(fire_event("user_identified"))),
+            )]
 
         result = fire_event("user_identified", identify_props)
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "test_connection":
-        if not HAS_REQUESTS:
-            error = "requests library not installed. Run: pip install requests"
-            payload = feature_status(
-                "Usage analytics",
-                "not_installed",
-                error,
-                error=error,
-            )
-            return [TextContent(type="text", text=json.dumps(payload))]
-
-        transport = get_analytics_transport()
-        if not transport.get("configured"):
-            return [TextContent(type="text", text=json.dumps({
-                "success": False,
-                "error": f"Analytics transport not configured ({transport.get('reason', 'unknown')})."
-            }))]
-
-        visitor_info = get_visitor_info()
-        test_visitor = "test-" + visitor_info['visitor_id'][:8]
-
-        payload = {
-            "type": "track",
-            "event": "dex_analytics_test",
-            "visitorId": test_visitor,
-            "accountId": "dex-test",
-            "timestamp": int(datetime.now(timezone.utc).timestamp() * 1000),
-            "properties": {"test": True, "timestamp": datetime.now().isoformat()}
-        }
-
-        try:
-            response = requests.post(
-                transport["endpoint"],
-                json=payload,
-                headers=transport["headers"],
-                timeout=10
-            )
-            if response.status_code == 200:
-                return [TextContent(type="text", text=json.dumps({
-                    "success": True,
-                    "status": response.status_code,
-                    "visitor_id_used": test_visitor,
-                    "transport_mode": transport.get("mode"),
-                    "transport_endpoint": transport.get("endpoint"),
-                }))]
-            else:
-                message = f"Analytics connection failed (HTTP {response.status_code})."
-                payload = feature_status(
-                    "Usage analytics",
-                    "broken",
-                    message,
-                    status=response.status_code,
-                    transport_mode=transport.get("mode"),
-                    transport_endpoint=transport.get("endpoint"),
-                    body=response.text[:200],
-                )
-                return [TextContent(type="text", text=json.dumps(payload))]
-        except Exception as e:
-            error = str(e)
-            payload = feature_status(
-                "Usage analytics",
-                "broken",
-                error,
-                error=error,
-            )
-            return [TextContent(type="text", text=json.dumps(payload))]
+        # The connection check is an ordinary analytics attempt: it must obey
+        # consent and use the exact same receipt route as every other caller.
+        result = fire_event("dex_analytics_test", _connection_test=True)
+        reason = result.get("reason")
+        if result.get("fired"):
+            state = "ok"
+            message = "Usage analytics connection check sent."
+        elif reason == "requests_not_installed":
+            state = "not_installed"
+            message = "Usage analytics needs the request library installed."
+        elif reason in {
+            "analytics_disabled",
+            "no_analytics_endpoint",
+            "no_pendo_secret",
+        }:
+            state = "off"
+            message = "Usage analytics is not ready to send a connection check."
+        else:
+            state = "broken"
+            message = "Usage analytics could not send the connection check."
+        payload = feature_status(
+            "Usage analytics",
+            state,
+            message,
+            reason=reason,
+            receipt_written=result.get("receipt_written", False),
+        )
+        if "mode" in result:
+            payload["transport_mode"] = result["mode"]
+        if "receipt_reason" in result:
+            payload["receipt_reason"] = result["receipt_reason"]
+        return [TextContent(type="text", text=json.dumps(payload))]
 
     else:
         return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -24,6 +24,15 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
+_ANALYTICS_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _ANALYTICS_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _ANALYTICS_REPO_ROOT)
+
+from core.mcp.analytics_receipts import (
+    surface_analytics_attempt,
+    unavailable_analytics_delivery,
+)
+
 # QMD semantic search (optional - gracefully degrade if not available)
 try:
     from utils.qmd_query import is_qmd_available, vault_search
@@ -31,14 +40,17 @@ try:
 except ImportError:
     HAS_QMD = False
 
-# Analytics helper (optional - gracefully degrade if not available)
+# Analytics receipts must remain observable in both direct-launch and package
+# import modes. If the helper cannot load, callers receive only the fixed safe
+# receipt failure below.
 try:
-    from analytics_helper import fire_event as _fire_analytics_event
+    from core.mcp.analytics_helper import fire_event as _fire_analytics_event
     HAS_ANALYTICS = True
 except ImportError:
     HAS_ANALYTICS = False
+
     def _fire_analytics_event(event_name, properties=None):
-        return {'fired': False, 'reason': 'analytics_not_available'}
+        return unavailable_analytics_delivery()
 
 # Ensure sibling modules (career_parser) and repo root are importable
 _mcp_dir = str(Path(__file__).parent)
@@ -443,10 +455,11 @@ async def handle_scan_evidence(arguments: dict) -> list[types.TextContent]:
         }
     }
     
-    try:
-        _fire_analytics_event('career_evidence_scanned')
-    except Exception:
-        pass
+    surface_analytics_attempt(
+        result,
+        _fire_analytics_event,
+        'career_evidence_scanned',
+    )
     
     return [types.TextContent(
         type="text",
@@ -526,29 +539,31 @@ async def handle_analyze_coverage(arguments: dict) -> list[types.TextContent]:
     evidence_files = scan_evidence_directory(EVIDENCE_DIR, date_range)
     
     if not evidence_files:
-        try:
-            _fire_analytics_event('career_coverage_analyzed')
-        except Exception:
-            pass
+        result = {
+            "success": True,
+            "target_level": ladder_data.get('target_level'),
+            "analysis_date": datetime.now().isoformat(),
+            "total_evidence_files": 0,
+            "note": "No evidence files found. Start capturing achievements with /career-coach",
+            "coverage_by_competency": [
+                {
+                    "competency": comp['category'],
+                    "evidence_count": 0,
+                    "coverage_level": "none",
+                    "example_files": [],
+                    "skills_mentioned": []
+                }
+                for comp in ladder_data['competencies']
+            ]
+        }
+        surface_analytics_attempt(
+            result,
+            _fire_analytics_event,
+            'career_coverage_analyzed',
+        )
         return [types.TextContent(
             type="text",
-            text=json.dumps({
-                "success": True,
-                "target_level": ladder_data.get('target_level'),
-                "analysis_date": datetime.now().isoformat(),
-                "total_evidence_files": 0,
-                "note": "No evidence files found. Start capturing achievements with /career-coach",
-                "coverage_by_competency": [
-                    {
-                        "competency": comp['category'],
-                        "evidence_count": 0,
-                        "coverage_level": "none",
-                        "example_files": [],
-                        "skills_mentioned": []
-                    }
-                    for comp in ladder_data['competencies']
-                ]
-            }, indent=2, cls=DateTimeEncoder)
+            text=json.dumps(result, indent=2, cls=DateTimeEncoder)
         )]
     
     # Analyze coverage
@@ -570,10 +585,11 @@ async def handle_analyze_coverage(arguments: dict) -> list[types.TextContent]:
         **coverage_analysis
     }
     
-    try:
-        _fire_analytics_event('career_coverage_analyzed')
-    except Exception:
-        pass
+    surface_analytics_attempt(
+        result,
+        _fire_analytics_event,
+        'career_coverage_analyzed',
+    )
     
     return [types.TextContent(
         type="text",
@@ -1198,10 +1214,11 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
         'score_breakdown': score_breakdown
     }
     
-    try:
-        _fire_analytics_event('promotion_readiness_checked')
-    except Exception:
-        pass
+    surface_analytics_attempt(
+        result,
+        _fire_analytics_event,
+        'promotion_readiness_checked',
+    )
     
     return [types.TextContent(
         type="text",

--- a/core/mcp/dex_improvements_server.py
+++ b/core/mcp/dex_improvements_server.py
@@ -26,6 +26,15 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
+_ANALYTICS_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _ANALYTICS_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _ANALYTICS_REPO_ROOT)
+
+from core.mcp.analytics_receipts import (
+    surface_analytics_attempt,
+    unavailable_analytics_delivery,
+)
+
 # QMD semantic search (optional - gracefully degrade if not available)
 try:
     from utils.qmd_query import is_qmd_available, vault_search
@@ -33,14 +42,17 @@ try:
 except ImportError:
     HAS_QMD = False
 
-# Analytics helper (optional - gracefully degrade if not available)
+# Analytics receipts must remain observable in both direct-launch and package
+# import modes. If the helper cannot load, callers receive only the fixed safe
+# receipt failure below.
 try:
-    from analytics_helper import fire_event as _fire_analytics_event
+    from core.mcp.analytics_helper import fire_event as _fire_analytics_event
     HAS_ANALYTICS = True
 except ImportError:
     HAS_ANALYTICS = False
+
     def _fire_analytics_event(event_name, properties=None):
-        return {'fired': False, 'reason': 'analytics_not_available'}
+        return unavailable_analytics_delivery()
 
 # Health system — error queue and health reporting
 try:
@@ -1104,10 +1116,12 @@ async def _handle_call_tool_inner(
                     "Check `System/Dex_Backlog.md` to see all your ideas"
                 ]
             }
-            try:
-                _fire_analytics_event('idea_captured', {'category': category})
-            except Exception:
-                pass
+            surface_analytics_attempt(
+                result,
+                _fire_analytics_event,
+                'idea_captured',
+                {'category': category},
+            )
         else:
             result = {
                 "success": False,
@@ -1171,10 +1185,11 @@ async def _handle_call_tool_inner(
         result = mark_idea_implemented(idea_id, impl_date)
         
         if result.get('success'):
-            try:
-                _fire_analytics_event('idea_implemented')
-            except Exception:
-                pass
+            surface_analytics_attempt(
+                result,
+                _fire_analytics_event,
+                'idea_implemented',
+            )
         
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
     

--- a/core/mcp/onboarding_server.py
+++ b/core/mcp/onboarding_server.py
@@ -48,6 +48,10 @@ if _repo_root not in sys.path:
     sys.path.append(_repo_root)
 from core import capabilities as capability_rooms
 from core.lifecycle import service as lifecycle_service
+from core.mcp.analytics_receipts import (
+    surface_analytics_attempt,
+    unavailable_analytics_delivery,
+)
 from core.paths import (
     MARKER_FILE,
     MCP_CONFIG_EXAMPLE,
@@ -58,6 +62,21 @@ from core.paths import (
 )
 from core.transaction.engine import PlanRejected
 from core.utils.nudge_calendar import build_nudge_calendar, is_dex_nudge_event
+
+
+def _analytics_helper_unavailable_result() -> dict[str, object]:
+    """Return only the fixed safe outcome when the shared helper cannot load."""
+    return unavailable_analytics_delivery()
+
+
+try:
+    from core.mcp.analytics_helper import fire_event as _fire_analytics_event
+    HAS_ANALYTICS = True
+except ImportError:
+    HAS_ANALYTICS = False
+
+    def _fire_analytics_event(event_name, properties=None):
+        return _analytics_helper_unavailable_result()
 
 # User-configured working week (defaults to Monday-Friday)
 try:
@@ -2537,6 +2556,11 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[types.Text
                 result = create_success_response(
                     summary,
                     f"Onboarding complete! Created {len(summary['folders_created'])} folders, {len(summary['files_created'])} files"
+                )
+                surface_analytics_attempt(
+                    result,
+                    _fire_analytics_event,
+                    "onboarding_completed",
                 )
                 
             except Exception as e:

--- a/core/mcp/resume_server.py
+++ b/core/mcp/resume_server.py
@@ -34,14 +34,26 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
-# Analytics helper (optional - gracefully degrade if not available)
+_ANALYTICS_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _ANALYTICS_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _ANALYTICS_REPO_ROOT)
+
+from core.mcp.analytics_receipts import (
+    surface_analytics_attempt,
+    unavailable_analytics_delivery,
+)
+
+# Analytics receipts must remain observable in both direct-launch and package
+# import modes. If the helper cannot load, callers receive only the fixed safe
+# receipt failure below.
 try:
-    from analytics_helper import fire_event as _fire_analytics_event
+    from core.mcp.analytics_helper import fire_event as _fire_analytics_event
     HAS_ANALYTICS = True
 except ImportError:
     HAS_ANALYTICS = False
+
     def _fire_analytics_event(event_name, properties=None):
-        return {'fired': False, 'reason': 'analytics_not_available'}
+        return unavailable_analytics_delivery()
 
 # Ensure sibling modules (resume_parser) are importable
 _mcp_dir = str(Path(__file__).parent)
@@ -1038,10 +1050,11 @@ async def handle_compile_resume(arguments: dict) -> list[types.TextContent]:
         "message": "Resume compiled. Use export_resume to save to file."
     }
     
-    try:
-        _fire_analytics_event('resume_compiled')
-    except Exception:
-        pass
+    surface_analytics_attempt(
+        result,
+        _fire_analytics_event,
+        'resume_compiled',
+    )
     
     return [types.TextContent(
         type="text",

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -35,22 +35,39 @@ import mcp.types as types
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 
-# Analytics helper (optional - gracefully degrade if not available)
+# Make the canonical package import work both when this file is launched as a
+# script and when it is imported by another Dex server. This must happen before
+# the required analytics receipt route is resolved.
+_ANALYTICS_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _ANALYTICS_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _ANALYTICS_REPO_ROOT)
+
+from core.mcp.analytics_receipts import (
+    surface_analytics_attempt,
+    unavailable_analytics_delivery,
+)
+
+
+def _analytics_helper_unavailable_result() -> dict[str, object]:
+    """Return only the fixed safe outcome when the shared helper cannot load."""
+    return unavailable_analytics_delivery()
+
+
+# This is a required receipt route, not a best-effort no-op: use the one
+# package helper in every launch mode, and make an unavailable helper visible
+# through the caller's existing safe result path.
 try:
-    from analytics_helper import fire_event as _fire_analytics_event
+    from core.mcp.analytics_helper import fire_event as _fire_analytics_event
     HAS_ANALYTICS = True
 except ImportError:
     HAS_ANALYTICS = False
+
     def _fire_analytics_event(event_name, properties=None):
-        return {'fired': False, 'reason': 'analytics_not_available'}
+        return _analytics_helper_unavailable_result()
 
 # Set up logging first (before any imports that might use it)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Add grandparent directory to path for 'core.utils' imports
-# The script is at core/mcp/work_server.py, so we need to add the vault root
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # QMD semantic search (optional - gracefully degrade if not available)
 try:
@@ -4694,15 +4711,6 @@ async def _handle_call_tool_inner(
             except Exception as error:
                 logger.warning("Could not sync task references for %s: %s", page, error)
         
-        # Fire analytics event (silent, best-effort)
-        try:
-            _fire_analytics_event('task_created', {
-                'pillar': pillar,
-                'priority': priority,
-            })
-        except Exception:
-            pass
-        
         result = {
             "success": True,
             "task": {
@@ -4732,6 +4740,15 @@ async def _handle_call_tool_inner(
         }
         if priority_warning:
             result["priority_warning"] = priority_warning
+        surface_analytics_attempt(
+            result,
+            _fire_analytics_event,
+            'task_created',
+            {
+                'pillar': pillar,
+                'priority': priority,
+            },
+        )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
 
     elif name == "confirm_goal_link":
@@ -4865,10 +4882,12 @@ async def _handle_call_tool_inner(
             result['related_tasks_synced'] = synced_pages
             
             if completed:
-                try:
-                    _fire_analytics_event('task_completed', {'method': 'task_id'})
-                except Exception:
-                    pass
+                surface_analytics_attempt(
+                    result,
+                    _fire_analytics_event,
+                    'task_completed',
+                    {'method': 'task_id'},
+                )
             
             return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
         
@@ -4916,10 +4935,12 @@ async def _handle_call_tool_inner(
                 result['related_tasks_synced'] = synced_pages
                 
                 if completed:
-                    try:
-                        _fire_analytics_event('task_completed', {'method': 'task_title'})
-                    except Exception:
-                        pass
+                    surface_analytics_attempt(
+                        result,
+                        _fire_analytics_event,
+                        'task_completed',
+                        {'method': 'task_title'},
+                    )
                 
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
             
@@ -4948,12 +4969,6 @@ async def _handle_call_tool_inner(
                 
                 status_name = STATUS_CODES.get(new_status, new_status)
                 
-                if completed:
-                    try:
-                        _fire_analytics_event('task_completed', {'method': 'legacy'})
-                    except Exception:
-                        pass
-                
                 result = {
                     "success": True,
                     "task": task['title'],
@@ -4962,6 +4977,13 @@ async def _handle_call_tool_inner(
                     "synced_pages": synced_pages,
                     "note": "Task has no ID - only updated in source file. Create new tasks with IDs for multi-location sync."
                 }
+                if completed:
+                    surface_analytics_attempt(
+                        result,
+                        _fire_analytics_event,
+                        'task_completed',
+                        {'method': 'legacy'},
+                    )
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
         
         else:
@@ -6050,6 +6072,12 @@ async def _handle_call_tool_inner(
             notes=arguments.get('notes'),
             allow_duplicate=arguments.get('allow_duplicate', False),
         )
+        if result.get('success') is True and result.get('created') is True:
+            surface_analytics_attempt(
+                result,
+                _fire_analytics_event,
+                'person_page_created',
+            )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
 
     elif name == "query_meeting_cache":
@@ -6089,20 +6117,21 @@ async def _handle_call_tool_inner(
         with open(SKILL_RATINGS_FILE, 'a') as f:
             f.write(json.dumps(entry) + '\n')
 
-        # Fire analytics event (anonymous, consent-checked)
-        try:
-            _fire_analytics_event('skill_rated', {
-                'skill_name': skill_name,
-                'rating': rating,
-            })
-        except Exception:
-            pass
-
-        return [types.TextContent(type="text", text=json.dumps({
+        result = {
             "success": True,
             "message": f"Rated {skill_name}: {rating}/5" + (f" — {note}" if note else ""),
             "entry": entry
-        }, indent=2))]
+        }
+        surface_analytics_attempt(
+            result,
+            _fire_analytics_event,
+            'skill_rated',
+            {
+                'skill_name': skill_name,
+                'rating': rating,
+            },
+        )
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "get_skill_ratings":
         skill_filter = arguments.get('skill_name', '') if arguments else ''

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -41,6 +41,16 @@ from typing import Iterable
 CONTRACT_VERSION = 2
 SUPPORTED_CONTRACT_VERSIONS = (1, CONTRACT_VERSION)
 VAULT_SCHEMA_SUPPORTED = ">=1 <2"
+ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = "System/.dex/analytics-attempts.jsonl"
+# A receipt is deliberately small and bounded twice: existing content is read
+# under the smaller cap, while the transaction has room for precisely one new
+# safe record to verify and recover the atomic append.
+ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES = 256 * 1024
+ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES = 256
+ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES = (
+    ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+    + ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+)
 
 OWNERSHIP_CLASSES = ("brain", "vault", "seed", "generated", "runtime")
 
@@ -580,6 +590,7 @@ def update_write_verdict(
         "legacy-qmd-reconciliation",
         "onboarding-context",
         "onboarding-provision",
+        "analytics-receipt",
     ):
         raise ValueError(f"unknown write operation: {operation}")
 
@@ -699,6 +710,46 @@ def update_write_verdict(
             candidate,
             False,
             "outside-onboarding-context",
+            resolution.ownership if resolution is not None else None,
+            resolution.rule_id if resolution is not None else None,
+        )
+
+    if operation == "analytics-receipt":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+        except ContractViolation:
+            return WriteVerdict(
+                str(path),
+                False,
+                "outside-analytics-receipt",
+                None,
+                None,
+            )
+        try:
+            resolution = resolve(candidate)
+        except ContractViolation:
+            resolution = None
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        if candidate == ANALYTICS_ATTEMPT_RECEIPT_RELATIVE:
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-analytics-receipt",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-analytics-receipt",
             resolution.ownership if resolution is not None else None,
             resolution.rule_id if resolution is not None else None,
         )

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -42,9 +42,10 @@ CONTRACT_VERSION = 2
 SUPPORTED_CONTRACT_VERSIONS = (1, CONTRACT_VERSION)
 VAULT_SCHEMA_SUPPORTED = ">=1 <2"
 ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = "System/.dex/analytics-attempts.jsonl"
-# A receipt is deliberately small and bounded twice: existing content is read
-# under the smaller cap, while the transaction has room for precisely one new
-# safe record to verify and recover the atomic append.
+# A receipt retains a bounded rolling history. A prior release could write one
+# safe record beyond the retained cap, so the transaction has exactly that
+# extra recovery room to validate the full existing file before it keeps whole
+# newest records under the retained cap.
 ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES = 256 * 1024
 ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES = 256
 ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES = (

--- a/core/tests/test_analytics_attempt_receipts.py
+++ b/core/tests/test_analytics_attempt_receipts.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,6 +22,14 @@ from core.transaction.engine import PlanRejected
 RECEIPT_RELATIVE = Path("System/.dex/analytics-attempts.jsonl")
 RECEIPT_FIELDS = {"timestamp", "event", "outcome", "reason"}
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _FixedReceiptDatetime(datetime):
+    """Make timestamp-content tests deterministic rather than clock-dependent."""
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 8, 13, 13, 50, 30, 503000, tzinfo=tz or timezone.utc)
 
 
 def _read_receipts(vault: Path) -> list[dict[str, object]]:
@@ -327,6 +336,9 @@ def test_http_rejection_receipt_hides_status_and_transport_details(
         return SimpleNamespace(status_code=503)
 
     _configure_enabled_delivery(monkeypatch, post)
+    # A valid timestamp can naturally contain the same digits as an HTTP code.
+    # Pin one such value so the privacy assertion must inspect structured fields.
+    monkeypatch.setattr(lifecycle_service, "datetime", _FixedReceiptDatetime)
 
     result = analytics_helper.fire_event("task_created")
 
@@ -338,9 +350,14 @@ def test_http_rejection_receipt_hides_status_and_transport_details(
     }
     assert posts == 1
     receipt = _read_receipts(vault)
-    assert receipt[0]["outcome"] == "not_sent"
-    assert receipt[0]["reason"] == "http_error"
-    assert "503" not in json.dumps(receipt[0], sort_keys=True)
+    assert receipt == [
+        {
+            "timestamp": "2026-08-13T13:50:30.503000+00:00",
+            "event": "task_created",
+            "outcome": "not_sent",
+            "reason": "http_error",
+        }
+    ]
 
 
 def test_successful_delivery_receipt_records_only_the_final_safe_outcome(

--- a/core/tests/test_analytics_attempt_receipts.py
+++ b/core/tests/test_analytics_attempt_receipts.py
@@ -1,0 +1,1047 @@
+"""Privacy and delivery proofs for the local analytics-attempt receipt."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core import portable_contract
+from core.lifecycle import service as lifecycle_service
+from core.mcp import analytics_helper, analytics_server
+from core.transaction.engine import PlanRejected
+
+RECEIPT_RELATIVE = Path("System/.dex/analytics-attempts.jsonl")
+RECEIPT_FIELDS = {"timestamp", "event", "outcome", "reason"}
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_receipts(vault: Path) -> list[dict[str, object]]:
+    receipt_path = vault / RECEIPT_RELATIVE
+    return [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
+
+
+def _configure_enabled_delivery(monkeypatch, post) -> None:
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: True)
+    monkeypatch.setattr(analytics_helper, "HAS_REQUESTS", True)
+    monkeypatch.setattr(
+        analytics_helper,
+        "get_analytics_transport",
+        lambda: {
+            "configured": True,
+            "mode": "proxy",
+            "endpoint": "https://private.example.test/track",
+            "headers": {"Authorization": "Bearer never-store-this"},
+        },
+    )
+    monkeypatch.setattr(
+        analytics_helper,
+        "get_visitor_info",
+        lambda: {"visitor_id": "visitor-123", "account_id": "account-123"},
+    )
+    monkeypatch.setattr(
+        analytics_helper,
+        "calculate_journey_metadata",
+        lambda: {
+            "journey_stage": "new",
+            "days_since_setup": 1,
+            "feature_adoption_score": 1,
+            "most_active_area": "tasks",
+        },
+    )
+    monkeypatch.setattr(analytics_helper, "load_user_profile", lambda: {"role_group": "test"})
+    monkeypatch.setattr(analytics_helper, "requests", SimpleNamespace(post=post), raising=False)
+
+
+def test_analytics_receipt_operation_authorizes_only_the_one_safe_file() -> None:
+    allowed = portable_contract.update_write_verdict(
+        RECEIPT_RELATIVE.as_posix(),
+        exists=False,
+        operation="analytics-receipt",
+    )
+    neighboring_file = portable_contract.update_write_verdict(
+        "System/.dex/analytics-attempts.jsonl.bak",
+        exists=False,
+        operation="analytics-receipt",
+    )
+    legacy_file = portable_contract.update_write_verdict(
+        "System/analytics_log.jsonl",
+        exists=False,
+        operation="analytics-receipt",
+    )
+
+    assert allowed.allowed is True
+    assert allowed.action == "write-analytics-receipt"
+    assert neighboring_file.allowed is False
+    assert neighboring_file.action == "outside-analytics-receipt"
+    assert legacy_file.allowed is False
+    assert legacy_file.action == "outside-analytics-receipt"
+
+
+def test_analytics_receipt_keeps_historical_lifecycle_helper_signatures() -> None:
+    """A receipt must not widen seams pinned by historic update bridges."""
+    expected_parameters = {
+        "_transaction_preview_document": (
+            "vault_root",
+            "plan",
+            "purpose",
+            "operation",
+        ),
+        "_preview_transaction": (
+            "vault_root",
+            "plan",
+            "purpose",
+            "operation",
+        ),
+        "_execute_approved_transaction": (
+            "vault_root",
+            "plan",
+            "purpose",
+            "approved_token",
+            "operation",
+            "before_commit",
+        ),
+    }
+
+    assert {
+        name: tuple(inspect.signature(getattr(lifecycle_service, name)).parameters)
+        for name in expected_parameters
+    } == expected_parameters
+
+
+def test_disabled_event_leaves_one_safe_receipt_and_never_uses_the_legacy_log(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event(
+        "task_created",
+        {
+            "person": "Ada Lovelace",
+            "meeting_notes": "Project Blackbird is confidential",
+            "endpoint": "https://private.example.test/track",
+            "authorization": "Bearer never-store-this",
+        },
+    )
+
+    assert result["fired"] is False
+    assert result["reason"] == "analytics_disabled"
+    records = _read_receipts(vault)
+    assert len(records) == 1
+    receipt = records[0]
+    assert set(receipt) == RECEIPT_FIELDS
+    assert receipt["event"] == "task_created"
+    assert receipt["outcome"] == "not_sent"
+    assert receipt["reason"] == "analytics_disabled"
+    serialized = json.dumps(receipt, sort_keys=True)
+    for unsafe_value in (
+        "Ada Lovelace",
+        "Project Blackbird",
+        "https://private.example.test/track",
+        "never-store-this",
+        "visitor_id",
+        "properties",
+    ):
+        assert unsafe_value not in serialized
+    assert not (vault / "System/analytics_log.jsonl").exists()
+
+
+def test_consent_check_failure_records_a_safe_not_sent_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(
+        analytics_helper,
+        "is_analytics_enabled",
+        lambda: (_ for _ in ()).throw(RuntimeError("Ada's private file is unreadable")),
+    )
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "request_failed",
+        "receipt_written": True,
+    }
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "task_created",
+            "outcome": "not_sent",
+            "reason": "request_failed",
+        }
+    ]
+    assert "Ada" not in json.dumps({"result": result, "receipt": receipts}, sort_keys=True)
+
+
+def test_analytics_helper_cli_outputs_a_safe_receipt_result(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "core/mcp/analytics_helper.py"),
+            "--event",
+            "session_started",
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "VAULT_PATH": str(vault)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert json.loads(completed.stdout) == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": True,
+    }
+    assert _read_receipts(vault)[0]["event"] == "session_started"
+
+
+def test_fire_event_uses_a_short_helper_request_bound_and_still_writes_a_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    request_timeouts: list[float] = []
+
+    class Response:
+        status_code = 200
+
+    def post(*_args, **kwargs):
+        request_timeouts.append(kwargs["timeout"])
+        return Response()
+
+    _configure_enabled_delivery(monkeypatch, post)
+
+    result = analytics_helper.fire_event(
+        "session_started",
+        _request_timeout_seconds=2.0,
+    )
+
+    assert result == {
+        "fired": True,
+        "event": "session_started",
+        "mode": "proxy",
+        "receipt_written": True,
+    }
+    assert request_timeouts == [2.0]
+    assert _read_receipts(vault)[0]["event"] == "session_started"
+
+
+def test_receipt_write_failure_is_visible_without_leaking_the_underlying_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    def fail_receipt_write(*_args, **_kwargs):
+        raise OSError("private relay token must never reach the caller")
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "_append_analytics_attempt_receipt",
+        fail_receipt_write,
+    )
+    result = analytics_helper.fire_event("task_created")
+
+    assert result["fired"] is False
+    assert result["reason"] == "analytics_disabled"
+    assert result["receipt_written"] is False
+    assert result["receipt_reason"] == "receipt_write_failed"
+    assert "private relay token" not in json.dumps(result, sort_keys=True)
+
+
+def test_missing_collection_address_leaves_a_safe_not_sent_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: True)
+    monkeypatch.setattr(analytics_helper, "HAS_REQUESTS", True)
+    monkeypatch.setattr(
+        analytics_helper,
+        "get_analytics_transport",
+        lambda: {
+            "configured": False,
+            "mode": "proxy",
+            "endpoint": "",
+            "headers": {},
+            "reason": "no_analytics_endpoint",
+        },
+    )
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "no_analytics_endpoint",
+        "receipt_written": True,
+    }
+    receipt = _read_receipts(vault)
+    assert len(receipt) == 1
+    assert receipt[0]["outcome"] == "not_sent"
+    assert receipt[0]["reason"] == "no_analytics_endpoint"
+
+
+def test_http_rejection_receipt_hides_status_and_transport_details(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=503)
+
+    _configure_enabled_delivery(monkeypatch, post)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "mode": "proxy",
+        "reason": "http_error",
+        "receipt_written": True,
+    }
+    assert posts == 1
+    receipt = _read_receipts(vault)
+    assert receipt[0]["outcome"] == "not_sent"
+    assert receipt[0]["reason"] == "http_error"
+    assert "503" not in json.dumps(receipt[0], sort_keys=True)
+
+
+def test_successful_delivery_receipt_records_only_the_final_safe_outcome(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts: list[dict[str, object]] = []
+
+    def post(url, **kwargs):
+        posts.append({"url": url, **kwargs})
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+
+    result = analytics_helper.fire_event(
+        "task_created",
+        {"meeting_notes": "Project Blackbird is confidential"},
+    )
+
+    assert result["fired"] is True
+    assert result["receipt_written"] is True
+    assert len(posts) == 1
+    records = _read_receipts(vault)
+    assert len(records) == 1
+    receipt = records[0]
+    assert set(receipt) == RECEIPT_FIELDS
+    assert receipt["event"] == "task_created"
+    assert receipt["outcome"] == "sent"
+    assert receipt["reason"] == "sent"
+    serialized = json.dumps(receipt, sort_keys=True)
+    for unsafe_value in (
+        "visitor-123",
+        "account-123",
+        "Project Blackbird",
+        "https://private.example.test/track",
+        "never-store-this",
+    ):
+        assert unsafe_value not in serialized
+
+
+def test_failed_delivery_receipt_normalizes_the_error_without_resending(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        raise OSError("relay https://private.example.test failed with token never-store-this")
+
+    _configure_enabled_delivery(monkeypatch, post)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "request_failed",
+        "receipt_written": True,
+    }
+    assert posts == 1
+    receipt = _read_receipts(vault)
+    assert len(receipt) == 1
+    assert receipt[0]["outcome"] == "not_sent"
+    assert receipt[0]["reason"] == "request_failed"
+    assert "private.example.test" not in json.dumps(receipt[0], sort_keys=True)
+    assert "never-store-this" not in json.dumps(receipt[0], sort_keys=True)
+
+
+def test_unsafe_existing_receipt_is_not_extended_or_silently_accepted(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-08-12T15:00:00+00:00",
+                "event": "task_created",
+                "outcome": "not_sent",
+                "reason": "analytics_disabled",
+                "visitor_id": "do-not-keep",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original = receipt_path.read_text(encoding="utf-8")
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert receipt_path.read_text(encoding="utf-8") == original
+
+
+def test_duplicate_json_keys_cannot_hide_unsafe_existing_receipt_data(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    original = (
+        '{"timestamp":"2026-08-12T15:00:00+00:00",'
+        '"event":"Ada Lovelace",'
+        '"event":"task_created",'
+        '"outcome":"not_sent",'
+        '"reason":"analytics_disabled"}\n'
+    )
+    receipt_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert receipt_path.read_text(encoding="utf-8") == original
+
+
+def test_mcp_track_event_delegates_to_fire_event_without_a_second_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+    monkeypatch.setattr(analytics_server, "fire_event", analytics_helper.fire_event)
+
+    response = asyncio.run(
+        analytics_server._call_tool_inner(
+            "track_event",
+            {"event_name": "task_created", "properties": {"person": "Ada Lovelace"}},
+        )
+    )
+    result = json.loads(response[0].text)
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": True,
+    }
+    receipts = _read_receipts(vault)
+    assert len(receipts) == 1
+    assert receipts[0]["event"] == "task_created"
+    assert not (vault / "System/analytics_log.jsonl").exists()
+
+
+def test_mcp_track_event_missing_name_uses_the_redacted_receipt_route(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+    monkeypatch.setattr(analytics_server, "fire_event", analytics_helper.fire_event)
+
+    response = asyncio.run(analytics_server._call_tool_inner("track_event", {}))
+    result = json.loads(response[0].text)
+
+    assert result == {
+        "error": "event_name required",
+        "receipt_written": True,
+    }
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "invalid_event",
+            "outcome": "not_sent",
+            "reason": "invalid_event_name",
+        }
+    ]
+
+
+def test_disabled_mcp_identify_user_records_one_safe_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+    monkeypatch.setattr(analytics_server, "is_analytics_enabled", lambda: False)
+    monkeypatch.setattr(analytics_server, "fire_event", analytics_helper.fire_event)
+
+    response = asyncio.run(
+        analytics_server._call_tool_inner(
+            "identify_user",
+            {"metadata": {"person": "Ada Lovelace"}},
+        )
+    )
+    result = json.loads(response[0].text)
+
+    assert result == {
+        "identified": False,
+        "reason": "analytics_disabled",
+        "receipt_written": True,
+    }
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "user_identified",
+            "outcome": "not_sent",
+            "reason": "analytics_disabled",
+        }
+    ]
+    assert "Ada Lovelace" not in json.dumps(receipts, sort_keys=True)
+
+
+def test_enabled_mcp_identify_profile_failure_records_one_safe_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+    monkeypatch.setattr(analytics_server, "is_analytics_enabled", lambda: True)
+    monkeypatch.setattr(analytics_server, "fire_event", analytics_helper.fire_event)
+    monkeypatch.setattr(
+        analytics_server,
+        "load_user_profile",
+        lambda: (_ for _ in ()).throw(RuntimeError("Ada profile must not leak")),
+    )
+    monkeypatch.setattr(
+        analytics_helper,
+        "load_user_profile",
+        lambda: (_ for _ in ()).throw(RuntimeError("Ada profile must not leak")),
+    )
+
+    response = asyncio.run(analytics_server._call_tool_inner("identify_user", {}))
+    result = json.loads(response[0].text)
+
+    assert result == {
+        "identified": False,
+        "reason": "request_failed",
+        "receipt_written": True,
+    }
+    assert posts == 0
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "user_identified",
+            "outcome": "not_sent",
+            "reason": "request_failed",
+        }
+    ]
+
+
+def test_receipt_failure_preserves_the_true_delivery_result_without_a_retry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+
+    def fail_receipt_write(*_args, **_kwargs):
+        raise OSError("private relay token must never reach the caller")
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "_append_analytics_attempt_receipt",
+        fail_receipt_write,
+    )
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": True,
+        "event": "task_created",
+        "mode": "proxy",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert posts == 1
+    assert not (vault / RECEIPT_RELATIVE).exists()
+    assert "private relay token" not in json.dumps(result, sort_keys=True)
+
+
+def test_event_preparation_failure_records_one_normalized_safe_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+    monkeypatch.setattr(
+        analytics_helper,
+        "calculate_journey_metadata",
+        lambda: (_ for _ in ()).throw(RuntimeError("profile for Ada must not leak")),
+    )
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "request_failed",
+        "receipt_written": True,
+    }
+    assert posts == 0
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "task_created",
+            "outcome": "not_sent",
+            "reason": "request_failed",
+        }
+    ]
+    assert "Ada" not in json.dumps({"result": result, "receipt": receipts}, sort_keys=True)
+
+
+def test_stale_receipt_plan_retries_only_the_local_write_without_resending(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+    original_execute = analytics_helper.lifecycle_service._execute_approved_transaction
+    receipt_attempts = 0
+
+    def stale_once(*args, **kwargs):
+        nonlocal receipt_attempts
+        receipt_attempts += 1
+        if receipt_attempts == 1:
+            receipt_path = vault / RECEIPT_RELATIVE
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "timestamp": "2026-08-12T15:00:00+00:00",
+                        "event": "session_started",
+                        "outcome": "not_sent",
+                        "reason": "analytics_disabled",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            # A real concurrent append changes the service's preview token
+            # before the transaction begins. This is the exact stale-plan
+            # signal that the narrow retry recognizes.
+            raise PlanRejected("transaction approval token does not match the current preview")
+        return original_execute(*args, **kwargs)
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "_execute_approved_transaction",
+        stale_once,
+    )
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result["fired"] is True
+    assert result["receipt_written"] is True
+    assert posts == 1
+    assert receipt_attempts == 2
+    receipts = _read_receipts(vault)
+    assert [receipt["event"] for receipt in receipts] == [
+        "session_started",
+        "task_created",
+    ]
+
+
+def test_untrusted_event_name_is_redacted_before_delivery_or_local_storage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    posts = 0
+
+    def post(*_args, **_kwargs):
+        nonlocal posts
+        posts += 1
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+    unsafe_name = "Ada Lovelace — Project Blackbird"
+
+    result = analytics_helper.fire_event(unsafe_name, {"notes": unsafe_name})
+
+    assert result == {
+        "fired": False,
+        "reason": "invalid_event_name",
+        "receipt_written": True,
+    }
+    assert posts == 0
+    receipts = _read_receipts(vault)
+    assert receipts == [
+        {
+            "timestamp": receipts[0]["timestamp"],
+            "event": "invalid_event",
+            "outcome": "not_sent",
+            "reason": "invalid_event_name",
+        }
+    ]
+    assert unsafe_name not in json.dumps(receipts, sort_keys=True)
+
+
+def test_symlinked_receipt_parent_is_rejected_before_any_direct_read(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "analytics-attempts.jsonl").write_text(
+        "private data that must not be read\n",
+        encoding="utf-8",
+    )
+    (vault / "System" / ".dex").symlink_to(outside, target_is_directory=True)
+    target = vault / RECEIPT_RELATIVE
+    direct_reads: list[Path] = []
+    original_read_bytes = Path.read_bytes
+
+    def record_direct_read(path: Path) -> bytes:
+        if path == target:
+            direct_reads.append(path)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", record_direct_read)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert direct_reads == []
+    assert (outside / "analytics-attempts.jsonl").read_text(encoding="utf-8") == (
+        "private data that must not be read\n"
+    )
+
+
+def test_existing_receipt_uses_the_bounded_reader(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_bytes(b"x" * (analytics_helper.lifecycle_service._MAX_ANALYTICS_RECEIPT_BYTES + 1))
+    bounded_reads: list[tuple[Path, str, int]] = []
+    direct_reads: list[Path] = []
+    original_bounded_read = analytics_helper.lifecycle_service.bounded_read
+    original_read_bytes = Path.read_bytes
+
+    def record_bounded_read(root: Path, relative: str, *, max_bytes: int) -> bytes:
+        bounded_reads.append((root, relative, max_bytes))
+        return original_bounded_read(root, relative, max_bytes=max_bytes)
+
+    def record_direct_read(path: Path) -> bytes:
+        if path == receipt_path:
+            direct_reads.append(path)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "bounded_read",
+        record_bounded_read,
+    )
+    monkeypatch.setattr(Path, "read_bytes", record_direct_read)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert bounded_reads
+    assert all(
+        read
+        == (
+            vault,
+            RECEIPT_RELATIVE.as_posix(),
+            analytics_helper.lifecycle_service._MAX_ANALYTICS_RECEIPT_BYTES,
+        )
+        for read in bounded_reads
+    )
+    assert direct_reads == []
+
+
+def test_existing_receipt_directory_is_rejected_before_the_bounded_reader(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.mkdir(parents=True)
+    bounded_reads: list[tuple[Path, str, int]] = []
+
+    def fail_bounded_read(root: Path, relative: str, *, max_bytes: int) -> bytes:
+        bounded_reads.append((root, relative, max_bytes))
+        raise AssertionError("a non-regular receipt target must not be opened")
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "bounded_read",
+        fail_bounded_read,
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert bounded_reads == []
+
+
+def test_existing_receipt_fifo_is_rejected_before_the_bounded_reader(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("this platform does not support FIFO creation")
+
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    try:
+        os.mkfifo(receipt_path)
+    except OSError as error:
+        pytest.skip(f"FIFO creation is unavailable: {error.__class__.__name__}")
+    bounded_reads: list[tuple[Path, str, int]] = []
+
+    def fail_bounded_read(root: Path, relative: str, *, max_bytes: int) -> bytes:
+        bounded_reads.append((root, relative, max_bytes))
+        raise AssertionError("a FIFO receipt target must not be opened")
+
+    monkeypatch.setattr(
+        analytics_helper.lifecycle_service,
+        "bounded_read",
+        fail_bounded_read,
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert bounded_reads == []
+
+
+def test_mcp_test_connection_uses_the_same_single_receipt_route(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+    calls: list[tuple[str, object, dict[str, object]]] = []
+    original_fire_event = analytics_helper.fire_event
+
+    def record_fire_event(event_name: str, properties=None, **kwargs):
+        calls.append((event_name, properties, kwargs))
+        return original_fire_event(event_name, properties, **kwargs)
+
+    monkeypatch.setattr(analytics_server, "fire_event", record_fire_event)
+
+    response = asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
+    result = json.loads(response[0].text)
+
+    assert result == {
+        "feature": "Usage analytics",
+        "feature_status": "off",
+        "user_message": "Usage analytics is not ready to send a connection check.",
+        "success": False,
+        "reason": "analytics_disabled",
+        "receipt_written": True,
+    }
+    assert calls == [("dex_analytics_test", None, {"_connection_test": True})]
+    receipts = _read_receipts(vault)
+    assert len(receipts) == 1
+    assert receipts[0]["event"] == "dex_analytics_test"
+
+
+def test_connection_test_uses_no_real_identity_or_profile_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_server, "fire_event", analytics_helper.fire_event)
+    delivered: list[dict[str, object]] = []
+
+    def post(_url, *, json, **_kwargs):
+        delivered.append(json)
+        return SimpleNamespace(status_code=200)
+
+    _configure_enabled_delivery(monkeypatch, post)
+    monkeypatch.setattr(
+        analytics_helper,
+        "get_visitor_info",
+        lambda: {"visitor_id": "real-visitor-123", "account_id": "real-account-456"},
+    )
+    monkeypatch.setattr(
+        analytics_helper,
+        "calculate_journey_metadata",
+        lambda: (_ for _ in ()).throw(AssertionError("journey metadata must not be read")),
+    )
+    monkeypatch.setattr(
+        analytics_helper,
+        "load_user_profile",
+        lambda: (_ for _ in ()).throw(AssertionError("profile must not be read")),
+    )
+
+    response = asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
+    result = json.loads(response[0].text)
+
+    assert result["feature_status"] == "ok"
+    assert result["receipt_written"] is True
+    assert delivered == [
+        {
+            "type": "track",
+            "event": "dex_analytics_test",
+            "visitorId": "dex-analytics-test",
+            "accountId": "dex-analytics-test",
+            "timestamp": delivered[0]["timestamp"],
+            "properties": {"connection_test": True},
+        }
+    ]
+    serialized = json.dumps(delivered, sort_keys=True)
+    for unsafe_value in ("real-visitor-123", "real-account-456", "journey_stage", "role"):
+        assert unsafe_value not in serialized

--- a/core/tests/test_analytics_attempt_receipts.py
+++ b/core/tests/test_analytics_attempt_receipts.py
@@ -37,6 +37,51 @@ def _read_receipts(vault: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in receipt_path.read_text(encoding="utf-8").splitlines()]
 
 
+def _safe_receipt_line(
+    index: int,
+    *,
+    event: str = "task_created",
+    outcome: str = "not_sent",
+    reason: str = "analytics_disabled",
+) -> bytes:
+    return (
+        json.dumps(
+            {
+                "timestamp": f"2026-08-13T12:00:00.{index:06d}+00:00",
+                "event": event,
+                "outcome": outcome,
+                "reason": reason,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _receipt_lines_just_over_retention_cap(
+    first_line: bytes | None = None,
+) -> list[bytes]:
+    lines = [] if first_line is None else [first_line]
+    size = sum(len(line) for line in lines)
+    index = 0
+    while size <= portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES:
+        line = _safe_receipt_line(index)
+        assert len(line) <= portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+        lines.append(line)
+        size += len(line)
+        index += 1
+    assert size <= portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+    return lines
+
+
+def _newest_receipt_lines_within_cap(lines: list[bytes]) -> list[bytes]:
+    retained = list(lines)
+    while sum(len(line) for line in retained) > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES:
+        retained.pop(0)
+    return retained
+
+
 def _configure_enabled_delivery(monkeypatch, post) -> None:
     monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: True)
     monkeypatch.setattr(analytics_helper, "HAS_REQUESTS", True)
@@ -856,17 +901,112 @@ def test_symlinked_receipt_parent_is_rejected_before_any_direct_read(
     )
 
 
-def test_existing_receipt_uses_the_bounded_reader(
+def test_saturated_valid_receipt_keeps_whole_newest_records_under_the_cap(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     vault = tmp_path / "vault"
     receipt_path = vault / RECEIPT_RELATIVE
     receipt_path.parent.mkdir(parents=True)
-    receipt_path.write_bytes(b"x" * (analytics_helper.lifecycle_service._MAX_ANALYTICS_RECEIPT_BYTES + 1))
+    existing_lines = _receipt_lines_just_over_retention_cap()
+    receipt_path.write_bytes(b"".join(existing_lines))
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+    monkeypatch.setattr(lifecycle_service, "datetime", _FixedReceiptDatetime)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": True,
+    }
+    actual = receipt_path.read_bytes()
+    expected_new_line = (
+        json.dumps(
+            {
+                "timestamp": "2026-08-13T13:50:30.503000+00:00",
+                "event": "task_created",
+                "outcome": "not_sent",
+                "reason": "analytics_disabled",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+    expected_lines = _newest_receipt_lines_within_cap(existing_lines + [expected_new_line])
+
+    assert len(actual) <= portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+    assert actual == b"".join(expected_lines)
+    assert actual.endswith(b"\n")
+    assert len(expected_lines) < len(existing_lines) + 1
+    assert _read_receipts(vault)[-1] == json.loads(expected_new_line)
+
+
+def test_saturation_validates_an_oldest_record_before_it_can_be_trimmed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    unsafe_oldest_line = (
+        json.dumps(
+            {
+                "timestamp": "2026-08-13T12:00:00.999999+00:00",
+                "event": "task_created",
+                "outcome": "not_sent",
+                "reason": "analytics_disabled",
+                "visitor_id": "must-not-survive",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+    existing = b"".join(_receipt_lines_just_over_retention_cap(unsafe_oldest_line))
+    receipt_path.write_bytes(existing)
+    validated: list[bytes] = []
+    original_validate = lifecycle_service._validated_analytics_receipt_prefix
+
+    def record_validation(raw: bytes) -> bytes:
+        validated.append(raw)
+        return original_validate(raw)
+
+    monkeypatch.setattr(
+        lifecycle_service,
+        "_validated_analytics_receipt_prefix",
+        record_validation,
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
+
+    result = analytics_helper.fire_event("task_created")
+
+    assert result == {
+        "fired": False,
+        "reason": "analytics_disabled",
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+    assert validated == [existing]
+    assert receipt_path.read_bytes() == existing
+
+
+def test_receipt_above_the_recovery_bound_is_rejected_by_the_bounded_reader(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    receipt_path = vault / RECEIPT_RELATIVE
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_bytes(
+        b"x" * (portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES + 1)
+    )
     bounded_reads: list[tuple[Path, str, int]] = []
     direct_reads: list[Path] = []
-    original_bounded_read = analytics_helper.lifecycle_service.bounded_read
+    original_bounded_read = lifecycle_service.bounded_read
     original_read_bytes = Path.read_bytes
 
     def record_bounded_read(root: Path, relative: str, *, max_bytes: int) -> bytes:
@@ -878,11 +1018,7 @@ def test_existing_receipt_uses_the_bounded_reader(
             direct_reads.append(path)
         return original_read_bytes(path)
 
-    monkeypatch.setattr(
-        analytics_helper.lifecycle_service,
-        "bounded_read",
-        record_bounded_read,
-    )
+    monkeypatch.setattr(lifecycle_service, "bounded_read", record_bounded_read)
     monkeypatch.setattr(Path, "read_bytes", record_direct_read)
     monkeypatch.setenv("VAULT_PATH", str(vault))
     monkeypatch.setattr(analytics_helper, "is_analytics_enabled", lambda: False)
@@ -901,7 +1037,7 @@ def test_existing_receipt_uses_the_bounded_reader(
         == (
             vault,
             RECEIPT_RELATIVE.as_posix(),
-            analytics_helper.lifecycle_service._MAX_ANALYTICS_RECEIPT_BYTES,
+            portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES,
         )
         for read in bounded_reads
     )

--- a/core/tests/test_analytics_event_wiring.py
+++ b/core/tests/test_analytics_event_wiring.py
@@ -1,0 +1,349 @@
+"""Proof that named product events fire only at real completion points."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+from core.analytics_events import SAFE_ANALYTICS_EVENT_NAMES
+from core.mcp import (
+    analytics_helper,
+    analytics_server,
+    career_server,
+    dex_improvements_server,
+    onboarding_server,
+    resume_server,
+    work_server,
+)
+from core.mcp.analytics_receipts import surface_analytics_attempt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEETING_SKILL = REPO_ROOT / ".claude/skills/process-meetings/SKILL.md"
+AGENT_MEETING_SKILL = REPO_ROOT / ".agents/skills/process-meetings/SKILL.md"
+ONBOARDING_FLOW = REPO_ROOT / ".claude/flows/onboarding.md"
+ANALYTICS_CALLER_EVENTS = {
+    "core/mcp/work_server.py": Counter(
+        {
+            "task_created": 1,
+            "task_completed": 3,
+            "person_page_created": 1,
+            "skill_rated": 1,
+        }
+    ),
+    "core/mcp/onboarding_server.py": Counter({"onboarding_completed": 1}),
+    "core/mcp/career_server.py": Counter(
+        {
+            "career_evidence_scanned": 1,
+            "career_coverage_analyzed": 2,
+            "promotion_readiness_checked": 1,
+        }
+    ),
+    "core/mcp/resume_server.py": Counter({"resume_compiled": 1}),
+    "core/mcp/dex_improvements_server.py": Counter({"idea_captured": 1, "idea_implemented": 1}),
+}
+
+
+def _decode_tool_result(result) -> dict[str, object]:
+    return json.loads(result[0].text)
+
+
+def _ready_onboarding_session() -> dict[str, object]:
+    return {
+        "completed_steps": list(onboarding_server.REQUIRED_ONBOARDING_STEPS),
+        "data": {"email_domain": "example.test"},
+    }
+
+
+def test_every_python_analytics_caller_uses_the_safe_receipt_surface() -> None:
+    for relative, expected_events in ANALYTICS_CALLER_EVENTS.items():
+        module = ast.parse((REPO_ROOT / relative).read_text(encoding="utf-8"))
+        direct_calls = [
+            call
+            for call in ast.walk(module)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "_fire_analytics_event"
+        ]
+        surface_events = Counter(
+            ast.literal_eval(call.args[2])
+            for call in ast.walk(module)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "surface_analytics_attempt"
+        )
+
+        assert direct_calls == []
+        assert surface_events == expected_events
+
+
+def test_shared_receipt_surface_hides_call_errors_and_preserves_the_result() -> None:
+    result: dict[str, object] = {"success": True, "title": "Kept intact"}
+
+    def fail_delivery(*_args, **_kwargs):
+        raise RuntimeError("private relay token must not reach the caller")
+
+    receipt_failure = surface_analytics_attempt(
+        result,
+        fail_delivery,
+        "task_created",
+    )
+
+    assert receipt_failure == {
+        "written": False,
+        "reason": "receipt_write_failed",
+    }
+    assert result == {
+        "success": True,
+        "title": "Kept intact",
+        "analytics_receipt": receipt_failure,
+    }
+    assert "private relay token" not in json.dumps(result, sort_keys=True)
+
+
+def test_every_required_server_imports_the_shared_analytics_helper() -> None:
+    for server in (
+        work_server,
+        onboarding_server,
+        career_server,
+        resume_server,
+        dex_improvements_server,
+    ):
+        assert server.HAS_ANALYTICS is True
+        assert server._fire_analytics_event is analytics_helper.fire_event
+
+
+def test_work_server_package_import_uses_the_shared_receipt_helper() -> None:
+    assert work_server.HAS_ANALYTICS is True
+    assert work_server._fire_analytics_event is analytics_helper.fire_event
+
+
+def test_unavailable_analytics_helpers_return_only_fixed_receipt_status() -> None:
+    expected = {
+        "fired": False,
+        "receipt_written": False,
+        "receipt_reason": "receipt_write_failed",
+    }
+
+    assert onboarding_server._analytics_helper_unavailable_result() == expected
+    assert work_server._analytics_helper_unavailable_result() == expected
+
+
+def test_onboarding_completion_event_follows_successful_finalization(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+    session = _ready_onboarding_session()
+    monkeypatch.setattr(onboarding_server, "load_session", lambda: session)
+    monkeypatch.setattr(onboarding_server, "_calendar_addressed", lambda _session: True)
+    monkeypatch.setattr(
+        onboarding_server,
+        "_finalize_through_provisioner",
+        lambda _session: {"folders_created": [], "files_created": []},
+    )
+    monkeypatch.setattr(
+        onboarding_server,
+        "_fire_analytics_event",
+        lambda event_name, properties=None: events.append((event_name, properties)),
+        raising=False,
+    )
+
+    payload = _decode_tool_result(asyncio.run(onboarding_server.handle_call_tool("finalize_onboarding", {})))
+
+    assert payload["success"] is True
+    assert events == [("onboarding_completed", None)]
+
+
+def test_onboarding_completion_surfaces_a_safe_receipt_write_failure(monkeypatch) -> None:
+    session = _ready_onboarding_session()
+    monkeypatch.setattr(onboarding_server, "load_session", lambda: session)
+    monkeypatch.setattr(onboarding_server, "_calendar_addressed", lambda _session: True)
+    monkeypatch.setattr(
+        onboarding_server,
+        "_finalize_through_provisioner",
+        lambda _session: {"folders_created": [], "files_created": []},
+    )
+    monkeypatch.setattr(
+        onboarding_server,
+        "_fire_analytics_event",
+        lambda *_args, **_kwargs: {
+            "fired": False,
+            "reason": "analytics_disabled",
+            "receipt_written": False,
+            "receipt_reason": "receipt_write_failed",
+        },
+    )
+
+    payload = _decode_tool_result(asyncio.run(onboarding_server.handle_call_tool("finalize_onboarding", {})))
+
+    assert payload["success"] is True
+    assert payload["analytics_receipt"] == {
+        "written": False,
+        "reason": "receipt_write_failed",
+    }
+    assert "analytics_disabled" not in json.dumps(payload, sort_keys=True)
+
+
+def test_failed_onboarding_does_not_claim_completion(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+    session = _ready_onboarding_session()
+    monkeypatch.setattr(onboarding_server, "load_session", lambda: session)
+    monkeypatch.setattr(onboarding_server, "_calendar_addressed", lambda _session: True)
+
+    def fail_finalization(_session):
+        raise RuntimeError("provisioning failed")
+
+    monkeypatch.setattr(onboarding_server, "_finalize_through_provisioner", fail_finalization)
+    monkeypatch.setattr(
+        onboarding_server,
+        "_fire_analytics_event",
+        lambda event_name, properties=None: events.append((event_name, properties)),
+        raising=False,
+    )
+
+    payload = _decode_tool_result(asyncio.run(onboarding_server.handle_call_tool("finalize_onboarding", {})))
+
+    assert payload["success"] is False
+    assert events == []
+
+
+def test_person_page_event_follows_a_real_created_page(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        work_server,
+        "create_person_data",
+        lambda **_kwargs: {
+            "success": True,
+            "path": "05-Areas/People/External/Example.md",
+            "location": "external",
+            "created": True,
+        },
+    )
+    monkeypatch.setattr(
+        work_server,
+        "_fire_analytics_event",
+        lambda event_name, properties=None: events.append((event_name, properties)),
+    )
+
+    payload = _decode_tool_result(asyncio.run(work_server.handle_call_tool("create_person", {"name": "Example"})))
+
+    assert payload["success"] is True
+    assert events == [("person_page_created", None)]
+
+
+def test_person_page_creation_surfaces_a_safe_receipt_write_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        work_server,
+        "create_person_data",
+        lambda **_kwargs: {
+            "success": True,
+            "path": "05-Areas/People/External/Example.md",
+            "location": "external",
+            "created": True,
+        },
+    )
+    monkeypatch.setattr(
+        work_server,
+        "_fire_analytics_event",
+        lambda *_args, **_kwargs: {
+            "fired": False,
+            "reason": "analytics_disabled",
+            "receipt_written": False,
+            "receipt_reason": "receipt_write_failed",
+        },
+    )
+
+    payload = _decode_tool_result(asyncio.run(work_server.handle_call_tool("create_person", {"name": "Example"})))
+
+    assert payload["success"] is True
+    assert payload["analytics_receipt"] == {
+        "written": False,
+        "reason": "receipt_write_failed",
+    }
+    assert "analytics_disabled" not in json.dumps(payload, sort_keys=True)
+
+
+def test_failed_person_creation_does_not_claim_a_page(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        work_server,
+        "create_person_data",
+        lambda **_kwargs: {"success": False, "error": "already exists"},
+    )
+    monkeypatch.setattr(
+        work_server,
+        "_fire_analytics_event",
+        lambda event_name, properties=None: events.append((event_name, properties)),
+    )
+
+    payload = _decode_tool_result(asyncio.run(work_server.handle_call_tool("create_person", {"name": "Example"})))
+
+    assert payload["success"] is False
+    assert events == []
+
+
+def test_meeting_skill_uses_the_declared_singular_event_name() -> None:
+    for skill_path in (MEETING_SKILL, AGENT_MEETING_SKILL):
+        skill = skill_path.read_text(encoding="utf-8")
+
+        assert "event_name `meeting_processed`" in skill
+        assert "meetings_processed" not in skill
+
+
+def test_onboarding_never_treats_a_default_as_analytics_consent() -> None:
+    flow = ONBOARDING_FLOW.read_text(encoding="utf-8")
+
+    assert "### Analytics Notice (Inform, Don't Ask):" in flow
+    assert "Consent decision: opted-in" in flow
+    assert "enabled: true" in flow
+    assert "analytics_consent_given" not in flow
+
+
+def test_no_tracked_source_declares_the_retired_consent_event() -> None:
+    tracked = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    offenders = []
+    for relative in tracked:
+        path = Path(relative)
+        if "tests" in path.parts:
+            continue
+        source = REPO_ROOT / path
+        if "analytics_consent_given" in source.read_text(encoding="utf-8", errors="ignore"):
+            offenders.append(relative)
+
+    assert offenders == []
+    assert not hasattr(analytics_helper.Events, "ANALYTICS_CONSENT_GIVEN")
+
+
+def test_every_named_shipped_skill_event_is_explicitly_allowlisted() -> None:
+    # The reference checklist deliberately contains placeholders; only shipped
+    # skill instructions name events that the MCP may accept at runtime.
+    documented: set[str] = set()
+    for skill_root in (
+        REPO_ROOT / ".claude" / "skills",
+        REPO_ROOT / ".agents" / "skills",
+    ):
+        for skill in skill_root.rglob("*.md"):
+            text = skill.read_text(encoding="utf-8")
+            for marker in ("event_name `", "fire_event('"):
+                for fragment in text.split(marker)[1:]:
+                    event_name = fragment.split("`", 1)[0].split("'", 1)[0]
+                    if event_name:
+                        documented.add(event_name)
+
+    assert documented <= SAFE_ANALYTICS_EVENT_NAMES
+
+
+def test_track_event_tool_advertises_only_an_allowlisted_example() -> None:
+    tools = asyncio.run(analytics_server.list_tools())
+    track_event = next(tool for tool in tools if tool.name == "track_event")
+    event_description = track_event.inputSchema["properties"]["event_name"]["description"]
+
+    assert "task_completed" in event_description
+    assert "skill_invoked" not in event_description

--- a/core/tests/test_feature_status.py
+++ b/core/tests/test_feature_status.py
@@ -332,87 +332,79 @@ def test_resume_missing_career_evidence_reports_calm_off_state(
 def test_analytics_missing_requests_reports_not_installed_and_preserves_error(
     monkeypatch,
 ):
-    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", False)
+    monkeypatch.setattr(
+        analytics_server,
+        "fire_event",
+        lambda *_args, **_kwargs: {
+            "fired": False,
+            "reason": "requests_not_installed",
+            "receipt_written": True,
+        },
+    )
 
     payload = _decode_tool_result(
         asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
     )
 
-    assert payload["feature"] == "Usage analytics"
-    assert payload["feature_status"] == "not_installed"
-    assert payload["user_message"] == payload["error"]
-    assert payload["success"] is False
-    assert payload["error"] == "requests library not installed. Run: pip install requests"
+    assert payload == {
+        "feature": "Usage analytics",
+        "feature_status": "not_installed",
+        "user_message": "Usage analytics needs the request library installed.",
+        "success": False,
+        "reason": "requests_not_installed",
+        "receipt_written": True,
+    }
 
 
-def test_analytics_http_failure_reports_broken_and_preserves_transport_keys(
+def test_analytics_http_failure_returns_only_the_safe_delivery_result(
     monkeypatch,
 ):
-    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", True)
     monkeypatch.setattr(
         analytics_server,
-        "get_analytics_transport",
-        lambda: {
-            "configured": True,
+        "fire_event",
+        lambda *_args, **_kwargs: {
+            "fired": False,
             "mode": "proxy",
-            "endpoint": "https://analytics.example.test",
-            "headers": {},
+            "reason": "http_error",
+            "receipt_written": True,
         },
-    )
-    monkeypatch.setattr(
-        analytics_server,
-        "get_visitor_info",
-        lambda: {"visitor_id": "visitor-123", "account_id": "account-123"},
-    )
-    monkeypatch.setattr(
-        analytics_server.requests,
-        "post",
-        lambda *args, **kwargs: SimpleNamespace(status_code=503, text="unavailable"),
     )
 
     payload = _decode_tool_result(
         asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
     )
 
-    assert payload["feature"] == "Usage analytics"
-    assert payload["feature_status"] == "broken"
-    assert payload["user_message"] == "Analytics connection failed (HTTP 503)."
-    assert payload["success"] is False
-    assert payload["status"] == 503
-    assert payload["transport_mode"] == "proxy"
-    assert payload["transport_endpoint"] == "https://analytics.example.test"
-    assert payload["body"] == "unavailable"
+    assert payload == {
+        "feature": "Usage analytics",
+        "feature_status": "broken",
+        "user_message": "Usage analytics could not send the connection check.",
+        "success": False,
+        "reason": "http_error",
+        "receipt_written": True,
+        "transport_mode": "proxy",
+    }
 
 
-def test_analytics_request_exception_reports_broken_and_preserves_error(monkeypatch):
-    monkeypatch.setattr(analytics_server, "HAS_REQUESTS", True)
+def test_analytics_request_exception_returns_a_normalized_failure(monkeypatch):
     monkeypatch.setattr(
         analytics_server,
-        "get_analytics_transport",
-        lambda: {
-            "configured": True,
-            "mode": "proxy",
-            "endpoint": "https://analytics.example.test",
-            "headers": {},
+        "fire_event",
+        lambda *_args, **_kwargs: {
+            "fired": False,
+            "reason": "request_failed",
+            "receipt_written": True,
         },
     )
-    monkeypatch.setattr(
-        analytics_server,
-        "get_visitor_info",
-        lambda: {"visitor_id": "visitor-123", "account_id": "account-123"},
-    )
-
-    def raise_network_error(*_args, **_kwargs):
-        raise OSError("network unavailable")
-
-    monkeypatch.setattr(analytics_server.requests, "post", raise_network_error)
 
     payload = _decode_tool_result(
         asyncio.run(analytics_server._call_tool_inner("test_connection", {}))
     )
 
-    assert payload["feature"] == "Usage analytics"
-    assert payload["feature_status"] == "broken"
-    assert payload["user_message"] == "network unavailable"
-    assert payload["success"] is False
-    assert payload["error"] == "network unavailable"
+    assert payload == {
+        "feature": "Usage analytics",
+        "feature_status": "broken",
+        "user_message": "Usage analytics could not send the connection check.",
+        "success": False,
+        "reason": "request_failed",
+        "receipt_written": True,
+    }

--- a/core/tests/test_golden_journeys.py
+++ b/core/tests/test_golden_journeys.py
@@ -522,9 +522,42 @@ def test_golden_onboarding_drives_state_machine_to_real_vault(fixture_vault: Pat
     assert journey["finalize"]["success"] is True
     assert journey["finalize"]["data"]["errors"] == []
     assert journey["finalize"]["data"]["executor"] == "core/provision.cjs"
-    assert journey["finalize_observed"] == journey["finalize"]["data"]["receipt"][
-        "mutation_receipt"
-    ]["declared_paths"]
+    primary_declared = set(
+        journey["finalize"]["data"]["receipt"]["mutation_receipt"]["declared_paths"]
+    )
+    observed = set(journey["finalize_observed"])
+    receipt_relative = "System/.dex/analytics-attempts.jsonl"
+    analytics_runtime = observed - primary_declared
+    transaction_ids = {
+        Path(path).parts[3]
+        for path in analytics_runtime
+        if path.startswith("System/.dex/tx/")
+    }
+    assert len(transaction_ids) == 1
+    analytics_transaction_id = transaction_ids.pop()
+    expected_analytics_runtime = {receipt_relative} | _transaction_paths(
+        analytics_transaction_id,
+        writes_payload=True,
+        snapshot_blob=False,
+    )
+    if "System/.dex/tx" not in primary_declared:
+        expected_analytics_runtime.add("System/.dex/tx")
+    # This stays an exact observed-write check: onboarding's provision receipt
+    # owns its writes, and the new analytics receipt owns precisely one receipt
+    # file plus one transaction runtime directory—nothing else.
+    assert analytics_runtime == expected_analytics_runtime
+    assert observed == primary_declared | expected_analytics_runtime
+
+    analytics_records = [
+        json.loads(line)
+        for line in (vault / receipt_relative).read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(analytics_records) == 1
+    analytics_record = analytics_records[0]
+    assert set(analytics_record) == {"timestamp", "event", "outcome", "reason"}
+    assert analytics_record["event"] == "onboarding_completed"
+    assert analytics_record["outcome"] == "not_sent"
+    assert analytics_record["reason"] == "analytics_disabled"
 
     for directory in (
         "00-Inbox",

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from core import portable_contract
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction, TransactionError
 from core.transaction.journal import Journal, JournalCorruptError
 from core.transaction.lock import LockBusyError, acquire_owned_lock
@@ -675,6 +676,98 @@ def test_resume_removes_expected_absent_publish_when_temp_is_gone_but_target_mat
     Transaction.resume(vault)
 
     assert not target.exists()
+
+
+def test_resume_rehydrates_a_receipt_read_cap_before_comparing_a_target(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = "System/.dex/analytics-attempts.jsonl"
+    planned = b'{"event":"task_created"}\n'
+    max_read_bytes = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+    tx = Transaction.begin(
+        vault,
+        [PlanEntry(relative, planned, expected_absent=True)],
+        operation="analytics-receipt",
+        max_read_bytes_by_relative={relative: max_read_bytes},
+    )
+    begin = Journal(tx.tx_dir / "journal.jsonl").read()[0]
+    assert begin.payload["max_read_bytes_by_relative"] == {
+        relative: max_read_bytes,
+    }
+    tx._snapshot_phase()
+    tx.journal.append("APPLY-START")
+    tx.journal.append(
+        "APPLYING",
+        {"index": 0, "relative": relative, "expected_absent": True},
+    )
+    target = vault / relative
+    target.write_bytes(planned)
+    assert tx._release is not None
+    tx._release()
+    tx._release = None
+
+    Transaction.resume(vault)
+
+    assert not target.exists()
+
+
+def test_engine_analytics_receipt_requires_its_exact_bounded_read_limit(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = "System/.dex/analytics-attempts.jsonl"
+
+    with pytest.raises(PlanRejected, match="required bounded-read limit"):
+        Transaction.begin(
+            vault,
+            [PlanEntry(relative, b"{}\n", expected_absent=True)],
+            operation="analytics-receipt",
+        )
+
+
+def test_resume_quarantines_analytics_receipt_without_a_persisted_read_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    tx_id = "20260812T000000-receipt"
+    relative = "System/.dex/analytics-attempts.jsonl"
+    target = vault / relative
+    target.write_bytes(b"private bytes must not be read")
+    journal = Journal(vault / "System/.dex/tx" / tx_id / "journal.jsonl")
+    journal.append(
+        "BEGIN",
+        {
+            "tx_id": tx_id,
+            "operation": "analytics-receipt",
+            "plan": [
+                {
+                    "relative": relative,
+                    "sha256": hashlib.sha256(b"{}\n").hexdigest(),
+                    "size": 3,
+                    "expected_absent": True,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        Transaction,
+        "_target_matches_planned_content",
+        staticmethod(lambda *_args, **_kwargs: pytest.fail("receipt target was read")),
+    )
+
+    outcomes = Transaction.resume(vault)
+
+    assert outcomes == [
+        {
+            "tx_id": tx_id,
+            "committed": False,
+            "resumed": True,
+            "quarantined": "analytics receipt transaction lacks the required bounded-read limit",
+        }
+    ]
+    assert target.read_bytes() == b"private bytes must not be read"
 
 
 def test_resume_preserves_expected_absent_user_file_matching_plan_when_temp_inode_differs(

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -31,11 +31,12 @@ import shutil
 import stat
 import time
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 from core import portable_contract
+from core.lifecycle.filesystem import bounded_read
 from core.path_safety import unsafe_existing_parent
 from core.transaction.fsync import fsync_directory
 from core.transaction.journal import Journal, JournalCorruptError, JournalSchemaError
@@ -107,11 +108,13 @@ class Transaction:
         tx_id: str,
         *,
         operation: str = "update",
+        max_read_bytes_by_relative: Mapping[str, int] | None = None,
         _resumed: bool = False,
     ) -> None:
         self.vault_root = Path(vault_root).resolve()
         self.tx_id = tx_id
         self.operation = operation
+        self._max_read_bytes_by_relative = dict(max_read_bytes_by_relative or {})
         self.tx_dir = self.vault_root / TX_ROOT_RELATIVE / tx_id
         self.journal = Journal(self.tx_dir / "journal.jsonl")
         self.snapshot = Snapshot(self.tx_dir / "snapshot")
@@ -129,6 +132,7 @@ class Transaction:
         *,
         allow_empty: bool = False,
         operation: str = "update",
+        max_read_bytes_by_relative: Mapping[str, int] | None = None,
     ) -> "Transaction":
         """Authorize the whole plan, take the lock, journal BEGIN."""
         return cls._begin_with_id(
@@ -136,6 +140,7 @@ class Transaction:
             plan,
             allow_empty=allow_empty,
             operation=operation,
+            max_read_bytes_by_relative=max_read_bytes_by_relative,
             tx_id=None,
         )
 
@@ -148,10 +153,31 @@ class Transaction:
         allow_empty: bool,
         operation: str,
         tx_id: str | None,
+        max_read_bytes_by_relative: Mapping[str, int] | None = None,
     ) -> "Transaction":
         """Internal begin seam for plans that must persist their tx id."""
         if not plan and not allow_empty:
             raise TransactionError("a transaction needs at least one plan entry")
+
+        read_limits = dict(max_read_bytes_by_relative or {})
+        plan_paths = {entry.relative for entry in plan}
+        if any(
+            relative not in plan_paths
+            or type(max_bytes) is not int
+            or max_bytes < 0
+            for relative, max_bytes in read_limits.items()
+        ):
+            raise PlanRejected("transaction bounded-read limits are invalid")
+        if operation == "analytics-receipt":
+            expected_receipt_limit = {
+                portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
+                    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+                )
+            }
+            if read_limits != expected_receipt_limit:
+                raise PlanRejected(
+                    "analytics receipt transaction lacks the required bounded-read limit"
+                )
 
         # Target modes are bounded: no setuid/setgid/sticky, no bits beyond
         # permissions. A buggy or hostile plan must not mint a 4777 file.
@@ -209,6 +235,7 @@ class Transaction:
             vault_root,
             tx_id or time.strftime("%Y%m%dT%H%M%S-") + uuid.uuid4().hex[:8],
             operation=operation,
+            max_read_bytes_by_relative=read_limits,
         )
         tx._plan = list(plan)
         unsafe_directory = _unsafe_infrastructure_directory(tx.vault_root, tx.tx_dir)
@@ -229,6 +256,11 @@ class Transaction:
                 {
                     "tx_id": tx.tx_id,
                     "operation": operation,
+                    # Recovery may need to distinguish a transaction-owned
+                    # expected-absent target from a user-created one. Persist
+                    # service-owned caps so that comparison cannot reopen an
+                    # unbounded read after a crash.
+                    "max_read_bytes_by_relative": read_limits,
                     "plan": [
                         {
                             "relative": entry.relative,
@@ -315,7 +347,11 @@ class Transaction:
                     entry,
                     changed_when="after the mutation plan was built",
                 )
-        self.snapshot.capture(self.vault_root, [entry.relative for entry in self._plan])
+        self.snapshot.capture(
+            self.vault_root,
+            [entry.relative for entry in self._plan],
+            max_read_bytes_by_relative=self._max_read_bytes_by_relative,
+        )
         self.journal.append("SNAPSHOT-DONE")
 
     def _apply_phase(self) -> None:
@@ -406,9 +442,17 @@ class Transaction:
         return (
             not target.is_symlink()
             and target.is_file()
-            and hashlib.sha256(target.read_bytes()).hexdigest() == entry.expected_current_sha256
+            and hashlib.sha256(self._read_entry_bytes(entry)).hexdigest()
+            == entry.expected_current_sha256
             and (not check_mode or target.stat().st_mode & 0o777 == entry.mode)
         )
+
+    def _read_entry_bytes(self, entry: PlanEntry) -> bytes:
+        """Read a planned file, honoring a service-owned cap when supplied."""
+        max_bytes = self._max_read_bytes_by_relative.get(entry.relative)
+        if max_bytes is not None:
+            return bounded_read(self.vault_root, entry.relative, max_bytes=max_bytes)
+        return (self.vault_root / entry.relative).read_bytes()
 
     def _apply_one(self, index: int, entry: PlanEntry) -> None:
         relative = entry.relative
@@ -488,7 +532,7 @@ class Transaction:
                 if target.is_symlink() or target.exists():
                     raise TransactionError(f"verification failed for {entry.relative}: deleted target still exists")
                 continue
-            digest = hashlib.sha256(target.read_bytes()).hexdigest()
+            digest = hashlib.sha256(self._read_entry_bytes(entry)).hexdigest()
             if digest != entry.sha256():
                 raise TransactionError(f"verification failed for {entry.relative}: applied bytes do not match the plan")
             actual_mode = target.stat().st_mode & 0o777
@@ -541,7 +585,10 @@ class Transaction:
         *,
         planned_sha256: str,
         planned_size: int,
+        max_bytes: int | None = None,
     ) -> bool:
+        if max_bytes is not None and planned_size > max_bytes:
+            return False
         try:
             nofollow = os.O_NOFOLLOW
         except AttributeError:
@@ -657,6 +704,7 @@ class Transaction:
                         target,
                         planned_sha256=planned[0],
                         planned_size=planned[1],
+                        max_bytes=self._max_read_bytes_by_relative.get(relative),
                     )
                 )
                 if target_is_ours:
@@ -720,6 +768,39 @@ class Transaction:
             "journal_ok": journal_ok,
         }
 
+    @staticmethod
+    def _read_limits_from_begin_payload(payload: dict) -> dict[str, int]:
+        """Restore only valid service-owned bounded-read limits from BEGIN."""
+        raw_limits = payload.get("max_read_bytes_by_relative", {})
+        if not isinstance(raw_limits, dict):
+            raise TransactionError("transaction bounded-read limits are invalid")
+        plan = payload.get("plan", [])
+        plan_paths = {
+            planned.get("relative")
+            for planned in plan
+            if isinstance(planned, dict) and isinstance(planned.get("relative"), str)
+        } if isinstance(plan, list) else set()
+        if any(
+            not isinstance(relative, str)
+            or relative not in plan_paths
+            or type(max_bytes) is not int
+            or max_bytes < 0
+            for relative, max_bytes in raw_limits.items()
+        ):
+            raise TransactionError("transaction bounded-read limits are invalid")
+        read_limits = dict(raw_limits)
+        if payload.get("operation", "update") == "analytics-receipt":
+            expected_receipt_limit = {
+                portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
+                    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+                )
+            }
+            if read_limits != expected_receipt_limit:
+                raise TransactionError(
+                    "analytics receipt transaction lacks the required bounded-read limit"
+                )
+        return read_limits
+
     @classmethod
     def resume(
         cls,
@@ -775,6 +856,9 @@ class Transaction:
                     )
                     if begin is not None:
                         tx.operation = begin.payload.get("operation", "update")
+                        tx._max_read_bytes_by_relative = (
+                            tx._read_limits_from_begin_payload(begin.payload)
+                        )
                 except JournalSchemaError:
                     events = None
                     rollback_only = True

--- a/core/transaction/snapshot.py
+++ b/core/transaction/snapshot.py
@@ -17,9 +17,11 @@ import hashlib
 import json
 import os
 import shutil
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from core.lifecycle.filesystem import bounded_read
 from core.path_safety import unsafe_existing_parent
 from core.transaction.fsync import fsync_directory
 
@@ -64,7 +66,13 @@ class Snapshot:
 
     # -- capture -----------------------------------------------------------
 
-    def capture(self, vault_root: Path, relatives: list[str]) -> list[SnapshotEntry]:
+    def capture(
+        self,
+        vault_root: Path,
+        relatives: list[str],
+        *,
+        max_read_bytes_by_relative: Mapping[str, int] | None = None,
+    ) -> list[SnapshotEntry]:
         """Capture the current state of every relative path, fsynced.
 
         Refuses symlinked targets outright: a transaction plan must operate
@@ -72,6 +80,7 @@ class Snapshot:
         restore onto) the wrong object.
         """
         vault = Path(vault_root)
+        read_limits = dict(max_read_bytes_by_relative or {})
         try:
             manifest_relative = (self.root / MANIFEST_NAME).relative_to(vault)
         except ValueError:
@@ -96,13 +105,24 @@ class Snapshot:
                 raise SnapshotError(f"plans operate on files, not directories: {relative}")
             if target.exists():
                 store = self.root / _store_name(index)
-                shutil.copyfile(target, store)
+                max_bytes = read_limits.get(relative)
+                if max_bytes is None:
+                    shutil.copyfile(target, store)
+                else:
+                    store.write_bytes(
+                        bounded_read(vault, relative, max_bytes=max_bytes)
+                    )
                 os.chmod(store, 0o600)
                 digest, size = _sha256(store)
                 # The copy must byte-match the source AT CAPTURE TIME; if the
                 # source is being mutated concurrently the lock was violated
                 # and we must not proceed on a torn snapshot.
-                source_digest, _ = _sha256(target)
+                if max_bytes is None:
+                    source_digest, _ = _sha256(target)
+                else:
+                    source_digest = hashlib.sha256(
+                        bounded_read(vault, relative, max_bytes=max_bytes)
+                    ).hexdigest()
                 if digest != source_digest:
                     raise SnapshotError(f"target changed while being snapshotted: {relative}")
                 descriptor = os.open(store, os.O_RDONLY)


### PR DESCRIPTION
## Summary

- Replaces the legacy local analytics log with a small on-device attempt receipt: timestamp, approved event name, outcome, and a safe reason code.
- Routes code-backed analytics and the analytics tool through that same receipt path, so a local write failure is visible rather than silently lost.
- Makes session start, successful onboarding, and real person-page creation observable; corrects the meeting event name.
- Retains whole, newest safe receipts locally under the size limit instead of permanently stopping after a long-running file fills up.
- Gives the session-start receipt helper a true three-second total budget, so a hung helper cannot delay Dex startup.

## Privacy boundary

- This does not enable a relay, endpoint, token, consent change, or data collection.
- Receipts never contain a person identity, content, properties, endpoint, credentials, or raw error details.
- Existing legacy logs are left untouched; Dex simply stops creating new ones.
- Malformed or unsafe old receipt data fails closed rather than being silently discarded.

## Verification

- Focused behavior and ownership suite: 372 passed.
- Full Linux Python gate: 4,292 passed, 2 skipped, 2 deselected. Four unchanged platform-only failures remain on Linux: one Apple plutil path and three macOS-only historic fleet acceptance cases.
- Hook suite: 199 passed. Scripts, integrations, connections contract, portable-contract, PII, founder-content, shell syntax, and generated-file drift checks passed.
- Rolling-retention red/green: before the repair, a valid saturated receipt file rejected a fresh receipt and did not prove every old line was checked; after it, all three saturation tests pass while retaining only complete newest safe records.
- Hanging-helper red/green: before the repair, session start took 4.26 seconds, exceeding the 3.75-second journey budget; after it, the helper is stopped within the budget with no helper output leak, receipt write, or delayed marker.
- Fresh exact-head macOS CI [run 31708344789](https://github.com/davekilleen/Dex/actions/runs/31708344789): all 7 applicable checks passed (quality, three test shards, aggregate results, Lens catalog, and PR report). Release and deploy jobs were correctly skipped for this draft PR.
- Independent review found no remaining issues.