### PR TITLE
Fix DEX-101: reject leaked tool-call delimiters in create_task

### DIFF
--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -48,6 +48,11 @@ except ImportError:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+_LEAKED_TOOL_CALL_DELIMITER_RE = re.compile(
+    r'</context\s*>|<parameter\s+name\s*=',
+    re.IGNORECASE,
+)
+
 # Add grandparent directory to path for 'core.utils' imports
 # The script is at core/mcp/work_server.py, so we need to add the vault root
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -4381,6 +4386,18 @@ async def _handle_call_tool_inner(
         people = arguments.get('people', []) or []
         source = arguments.get('source', '') or ''
         stamp_source_line = arguments.get('stamp_source_line', '') or ''
+        if _LEAKED_TOOL_CALL_DELIMITER_RE.search(context):
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    "Malformed create_task arguments: context contains leaked "
+                    "tool-call delimiters."
+                ),
+                "suggestion": (
+                    "Retry create_task with plain context and pass metadata through "
+                    "the structured account and source fields."
+                ),
+            }, indent=2))]
         if source.startswith('meeting:'):
             source = source[len('meeting:'):]
         account_link = None

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -233,7 +233,16 @@ def test_invalid_weekly_priority_lists_available_ids_without_writing(task_vault)
     assert task_vault["tasks"].read_text(encoding="utf-8") == before
 
 
-def test_create_task_rejects_leaked_tool_call_delimiters_without_writing(task_vault):
+@pytest.mark.parametrize(
+    "leaked_context",
+    [
+        "Use the customer call notes.</context>",
+        '<parameter name="account">05-Areas/Accounts/Acme_Corp.md</parameter>',
+    ],
+)
+def test_create_task_rejects_each_leaked_tool_call_delimiter_without_writing(
+    task_vault, leaked_context
+):
     before = task_vault["tasks"].read_text(encoding="utf-8")
 
     result = _call_tool(
@@ -241,13 +250,7 @@ def test_create_task_rejects_leaked_tool_call_delimiters_without_writing(task_va
         {
             "title": "Prepare the Acme Corp account follow-up",
             "pillar": "pillar_2",
-            "context": (
-                "Use the customer call notes.</context>\n"
-                '<parameter name="account">'
-                "05-Areas/Accounts/Acme_Corp.md</parameter>\n"
-                '<parameter name="source">'
-                "00-Inbox/Meetings/2026-08-13-acme.md</parameter>"
-            ),
+            "context": leaked_context,
         },
     )
 
@@ -255,6 +258,22 @@ def test_create_task_rejects_leaked_tool_call_delimiters_without_writing(task_va
     assert "malformed" in result["error"].lower()
     assert "structured account and source fields" in result["suggestion"]
     assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
+def test_create_task_preserves_ordinary_angle_bracket_context(task_vault):
+    context = "Document the <draft> state and compare 2 < 3 before publishing."
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Document the example state",
+            "pillar": "pillar_1",
+            "context": context,
+        },
+    )
+
+    assert result["success"] is True
+    assert context in task_vault["tasks"].read_text(encoding="utf-8")
 
 
 def test_find_linked_tasks_keeps_old_same_line_links(task_vault):

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -233,6 +233,30 @@ def test_invalid_weekly_priority_lists_available_ids_without_writing(task_vault)
     assert task_vault["tasks"].read_text(encoding="utf-8") == before
 
 
+def test_create_task_rejects_leaked_tool_call_delimiters_without_writing(task_vault):
+    before = task_vault["tasks"].read_text(encoding="utf-8")
+
+    result = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare the Sunrise Robotics account follow-up",
+            "pillar": "pillar_2",
+            "context": (
+                "Use the customer call notes.</context>\n"
+                '<parameter name="account">'
+                "05-Areas/Accounts/Sunrise_Robotics.md</parameter>\n"
+                '<parameter name="source">'
+                "00-Inbox/Meetings/2026-08-13-sunrise.md</parameter>"
+            ),
+        },
+    )
+
+    assert result.get("success") is False
+    assert "malformed" in result["error"].lower()
+    assert "structured account and source fields" in result["suggestion"]
+    assert task_vault["tasks"].read_text(encoding="utf-8") == before
+
+
 def test_find_linked_tasks_keeps_old_same_line_links(task_vault):
     priority_id = "week-2026-W28-p1"
     task_vault["tasks"].write_text(

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -239,14 +239,14 @@ def test_create_task_rejects_leaked_tool_call_delimiters_without_writing(task_va
     result = _call_tool(
         "create_task",
         {
-            "title": "Prepare the Sunrise Robotics account follow-up",
+            "title": "Prepare the Acme Corp account follow-up",
             "pillar": "pillar_2",
             "context": (
                 "Use the customer call notes.</context>\n"
                 '<parameter name="account">'
-                "05-Areas/Accounts/Sunrise_Robotics.md</parameter>\n"
+                "05-Areas/Accounts/Acme_Corp.md</parameter>\n"
                 '<parameter name="source">'
-                "00-Inbox/Meetings/2026-08-13-sunrise.md</parameter>"
+                "00-Inbox/Meetings/2026-08-13-acme.md</parameter>"
             ),
         },
     )


### PR DESCRIPTION
## What changed

- reject create_task context containing leaked tool-call delimiters before the canonical backlog write
- return a clear retry instruction that requires account and source to be passed as structured fields
- add a public-seam regression proving malformed input is refused and the backlog remains byte-for-byte unchanged

## Root cause

create_task trusted the already-parsed context string. When a caller folded literal delimiter syntax into context and omitted account/source as structured arguments, the server treated the whole value as normal prose, wrote it verbatim, returned success, and had no metadata left to resolve. Recovery would be ambiguous, so this change rejects instead of guessing.

## Test-first evidence

Red before implementation: the new regression failed because current main returned success and created a task ID for the malformed payload.

Green after implementation:
- 67 focused work-server, production-stdio, entity-link, round-trip, and golden-journey tests passed
- ruff passed for both changed files
- broad non-fuzz VPS run: 4,120 passed; after correcting the runner to use the repository virtual environment, all 184 dependency-affected MCP/smoke/safety tests passed
- four checks are explicitly macOS-only on this Linux VPS: three historic-fleet acceptance cases reject non-darwin hosts and one Doctor case requires plutil; macOS CI owns those checks

## Scope

No customer data changed. No merge, release, deployment, or external reply is included.