### PR TITLE
Prove Apple Mail search health from the real local index

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -221,6 +221,7 @@ Built specifically for personal knowledge management and productivity workflows 
 - `/atlassian-setup` - Jira tickets and Confluence docs in daily plans
 - `/granola-setup` - Connect Granola for automatic meeting capture
 - `/calendar-setup` - Connect your calendar
+- `/apple-mail-setup` - Connect Apple Mail search and build the index it needs (macOS)
 - `/integrate-mcp` - Browse and connect more tools via the MCP marketplace
 
 **Career Development:**

--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: apple-mail-setup
+description: "Set up and verify Apple Mail search on macOS, including the search index that silently returns nothing when it was never built. Use when the user says 'connect Apple Mail', 'set up mail search', 'Dex can't find my emails', 'mail search returns nothing'. Not for Gmail or Google Workspace; use `google-workspace-setup`."
+---
+
+# Apple Mail Setup — Make Mail Search Actually Work
+
+**Purpose:** Connect a community Apple Mail MCP server and — critically — build and verify its
+search index, so mail search reports honestly instead of failing silently.
+
+**When to run:**
+- User types `/apple-mail-setup`
+- User asks about connecting Apple Mail, or wants Dex to read their inbox
+- `/dex-doctor` reports `mail.apple-search` as broken
+- User says mail search "finds nothing" or their daily plan misses obvious emails
+
+---
+
+## The failure this prevents
+
+Apple Mail servers have **two data paths with different permissions**, and only one of them
+announces failure:
+
+| Path | Needs | What happens when it's missing |
+|---|---|---|
+| List / read messages | Automation permission | Prompts you — you notice |
+| **Search** | A pre-built index at `~/.apple-mail-mcp/index.db`, which requires **Full Disk Access** to build | **Returns empty. Forever. Silently.** |
+
+Because list and read keep working, the integration *looks* healthy. Search returns nothing,
+Dex falls back to reading messages one at a time, and nobody ever learns the index was never
+built. One reporter ran that way for months.
+
+So this setup is not finished when the server is registered. It is finished when the index
+exists and is fresh.
+
+---
+
+## Process
+
+### 1. Confirm the platform
+
+Apple Mail is macOS-only. On any other platform, say so plainly and stop:
+"Apple Mail integration only works on macOS. For Gmail, run `/google-workspace-setup`."
+
+### 2. Install the server
+
+Check whether it is already installed: `which apple-mail-mcp`
+
+If not, install it: `pipx install apple-mail-mcp`
+
+If `pipx` itself is missing: `brew install pipx && pipx ensurepath`
+
+### 3. Register the server at user scope
+
+Dex requires an explicit scope (a hook enforces this). Register it for the user:
+
+```
+claude mcp add --scope user apple-mail -- apple-mail-mcp serve
+```
+
+### 4. Grant Full Disk Access — do this before building the index
+
+This is the step people skip, and skipping it is what produces the silent failure. Building
+the index reads `~/Library/Mail` directly, which macOS protects.
+
+Walk the user through it:
+
+```
+1. Open System Settings (Command+Space, type "System Settings")
+2. Click "Privacy & Security" in the sidebar
+3. Click "Full Disk Access"
+4. Click "+" and add Terminal (or whichever terminal app you'll run the next command in)
+5. Toggle it ON
+6. Quit and reopen Terminal — the permission only applies to a fresh launch
+```
+
+Explain why in one line: "macOS treats your mail files as private, so the indexer needs
+explicit permission to read them — without it, it exits quietly and builds nothing."
+
+### 5. Build the index
+
+Have the user run, in the terminal they just granted access to:
+
+```
+apple-mail-mcp index
+```
+
+This takes a few minutes on a large mailbox. It must be run manually — the server's own
+startup sync **silently does nothing** when launched without Full Disk Access, which is the
+second half of the trap.
+
+### 6. Verify — do not skip this
+
+```
+apple-mail-mcp status
+```
+
+- **"No index found"** → Full Disk Access was not actually in effect. The most common cause is
+  not quitting and reopening Terminal after toggling it. Go back to step 4, then step 5.
+- **An index with a recent build time** → working.
+
+Then confirm through Dex itself: `/dex-doctor` — check `mail.apple-search` reports `OK`.
+
+### 7. After success
+
+Confirm: "✅ Mail search is working — indexed and fresh."
+
+Then tell them the one maintenance fact that matters: **the index does not update itself
+reliably.** If the server is launched without Full Disk Access, its background sync no-ops and
+the index quietly ages. Dex's Doctor check now catches this — it reports mail search as broken
+once the index is more than 7 days old, rather than letting it silently return stale results.
+
+---
+
+## Ongoing health
+
+`/dex-doctor` runs `mail.apple-search` as a deep check and reports:
+
+| Verdict | Meaning |
+|---|---|
+| `OFF` | No Apple Mail server registered — opt-in, not a problem |
+| `OK` | Index exists and was built within 7 days |
+| `BROKEN` | Command missing, index never built, index empty, or index stale — each with the exact fix |
+| `UNKNOWN` | A server is registered but this isn't macOS, or the index couldn't be read |
+
+---
+
+## Troubleshooting
+
+**Search returns empty but `status` says an index exists:**
+Rebuild it — `apple-mail-mcp index`. The index can be present but stale or partial.
+
+**"No index found" even after granting Full Disk Access:**
+Quit Terminal completely (Command+Q, not just closing the window) and reopen it. macOS applies
+the permission at launch.
+
+**Search worked before and stopped:**
+The startup sync swallows a Full Disk Access denial. Confirm the permission is still granted,
+then rebuild the index manually.
+
+**The model keeps retrying searches with different keywords:**
+That's the server's empty-result hint ("try fewer keywords") being misread as a search miss
+rather than a missing index. Run `apple-mail-mcp status` to check the real cause — and if it
+says no index, that hint was the bug, not your query.
+
+---
+
+## Technical Notes
+
+- **Index location:** `~/.apple-mail-mcp/index.db` (FTS5 SQLite)
+- **Why an index at all:** searching it takes ~2ms versus seconds for driving Mail.app directly
+- **Privacy:** the index is local, built from your own mail, and never sent anywhere
+- **Community server:** this is not a first-party Dex integration; behaviour depends on the
+  server you install

--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -24,7 +24,7 @@ announces failure:
 | Path | Needs | What happens when it's missing |
 |---|---|---|
 | List / read messages | Automation permission | Prompts you — you notice |
-| **Search** | A pre-built index at `~/.apple-mail-mcp/index.db`, which requires **Full Disk Access** to build | **Returns empty. Forever. Silently.** |
+| **Search** | A pre-built local index (default `~/.apple-mail-mcp/index.db`), which requires **Full Disk Access** to build | **Returns empty. Forever. Silently.** |
 
 Because list and read keep working, the integration *looks* healthy. Search returns nothing,
 Dex falls back to reading messages one at a time, and nobody ever learns the index was never
@@ -58,10 +58,14 @@ Dex requires an explicit scope (a hook enforces this). Register it for the user:
 claude mcp add --scope user apple-mail -- apple-mail-mcp serve
 ```
 
-### 4. Grant Full Disk Access — do this before building the index
+### 4. Grant narrowly scoped Full Disk Access — do this before building the index
 
 This is the step people skip, and skipping it is what produces the silent failure. Building
 the index reads `~/Library/Mail` directly, which macOS protects.
+
+Full Disk Access is a broad macOS permission: the approved app can read protected personal
+data across the Mac, not only Mail. Grant it to the specific terminal app used for this
+one-off build. Do **not** grant it to Dex, Claude, or the ordinary MCP server process.
 
 Walk the user through it:
 
@@ -74,20 +78,21 @@ Walk the user through it:
 6. Quit and reopen Terminal — the permission only applies to a fresh launch
 ```
 
-Explain why in one line: "macOS treats your mail files as private, so the indexer needs
-explicit permission to read them — without it, it exits quietly and builds nothing."
+Explain why in one line: "macOS treats your mail files as private, so this one-off indexer
+needs explicit permission to read them — without it, it exits quietly and builds nothing."
 
 ### 5. Build the index
 
 Have the user run, in the terminal they just granted access to:
 
 ```
-apple-mail-mcp index
+umask 077; apple-mail-mcp index --verbose
 ```
 
-This takes a few minutes on a large mailbox. It must be run manually — the server's own
-startup sync **silently does nothing** when launched without Full Disk Access, which is the
-second half of the trap.
+`umask 077` makes any new database and SQLite sidecar files private to this Mac account.
+The build takes a few minutes on a large mailbox and must be run manually. Do not solve future
+freshness by giving the always-running MCP host Full Disk Access; refresh from the narrowly
+approved terminal when Doctor says the configured freshness limit has been exceeded.
 
 ### 6. Verify — do not skip this
 
@@ -97,18 +102,24 @@ apple-mail-mcp status
 
 - **"No index found"** → Full Disk Access was not actually in effect. The most common cause is
   not quitting and reopening Terminal after toggling it. Go back to step 4, then step 5.
-- **An index with a recent build time** → working.
+- **A non-zero email count and a recent last-sync time** → continue to the Doctor check.
 
 Then confirm through Dex itself: `/dex-doctor` — check `mail.apple-search` reports `OK`.
+Doctor also verifies that the database and any `-wal` / `-shm` sidecars are exactly `0600`
+(readable and writable only by this Mac account).
 
 ### 7. After success
 
 Confirm: "✅ Mail search is working — indexed and fresh."
 
-Then tell them the one maintenance fact that matters: **the index does not update itself
-reliably.** If the server is launched without Full Disk Access, its background sync no-ops and
-the index quietly ages. Dex's Doctor check now catches this — it reports mail search as broken
-once the index is more than 7 days old, rather than letting it silently return stale results.
+Then tell them the two maintenance facts that matter:
+
+1. **The index may not update itself reliably without protected-file access.** Doctor reads
+   the server's real last-sync record and applies its configured freshness limit (24 hours by
+   default), rather than guessing from the database file's modified time.
+2. **Full Disk Access can be removed from the terminal after the build.** Grant it again only
+   when a manual refresh is needed. This is safer than leaving the always-running MCP host with
+   broad access to the Mac.
 
 ---
 
@@ -119,8 +130,8 @@ once the index is more than 7 days old, rather than letting it silently return s
 | Verdict | Meaning |
 |---|---|
 | `OFF` | No Apple Mail server registered — opt-in, not a problem |
-| `OK` | Index exists and was built within 7 days |
-| `BROKEN` | Command missing, index never built, index empty, or index stale — each with the exact fix |
+| `OK` | The configured SQLite index has real schema and data, a successful sync within its configured freshness limit, and private file permissions |
+| `BROKEN` | Command missing; config invalid; index missing, empty, corrupt, incomplete, stale, or readable by other local accounts — each with the exact fix |
 | `UNKNOWN` | A server is registered but this isn't macOS, or the index couldn't be read |
 
 ---
@@ -128,15 +139,20 @@ once the index is more than 7 days old, rather than letting it silently return s
 ## Troubleshooting
 
 **Search returns empty but `status` says an index exists:**
-Rebuild it — `apple-mail-mcp index`. The index can be present but stale or partial.
+Run `/dex-doctor`. A file can exist while its schema is broken, it contains zero messages,
+or its recorded sync is stale. Rebuild with `apple-mail-mcp rebuild --verbose` if instructed.
+
+**The index is in a custom location:**
+Dex follows `APPLE_MAIL_INDEX_PATH` from the registered MCP server first, then `[index] path`
+in `~/.apple-mail-mcp/config.toml`, then the default location. Doctor applies the same order.
 
 **"No index found" even after granting Full Disk Access:**
 Quit Terminal completely (Command+Q, not just closing the window) and reopen it. macOS applies
 the permission at launch.
 
 **Search worked before and stopped:**
-The startup sync swallows a Full Disk Access denial. Confirm the permission is still granted,
-then rebuild the index manually.
+Run `apple-mail-mcp status`, then `/dex-doctor`. If the recorded sync is older than the
+configured limit, temporarily grant the indexing terminal Full Disk Access and refresh.
 
 **The model keeps retrying searches with different keywords:**
 That's the server's empty-result hint ("try fewer keywords") being misread as a search miss
@@ -147,8 +163,14 @@ says no index, that hint was the bug, not your query.
 
 ## Technical Notes
 
-- **Index location:** `~/.apple-mail-mcp/index.db` (FTS5 SQLite)
+- **Index location:** `~/.apple-mail-mcp/index.db` by default; the server supports a custom
+  path through its MCP environment or `config.toml`
 - **Why an index at all:** searching it takes ~2ms versus seconds for driving Mail.app directly
-- **Privacy:** the index is local, built from your own mail, and never sent anywhere
+- **What it contains:** message subjects, senders, bodies, local `.emlx` paths, attachment
+  metadata, and sync records; the database plus any `-wal` / `-shm` sidecars must be `0600`
+- **What leaves the Mac:** the index file stays local. Doctor reads only schema, counts,
+  timestamps, integrity, and file permissions—not message text. Mail search results are returned
+  to the configured AI client and may be sent to that client's model provider under its normal
+  privacy settings; setup must never claim that no mail content leaves the Mac.
 - **Community server:** this is not a first-party Dex integration; behaviour depends on the
   server you install

--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -46,7 +46,12 @@ Apple Mail is macOS-only. On any other platform, say so plainly and stop:
 
 Check whether it is already installed: `which apple-mail-mcp`
 
-If not, install it: `pipx install apple-mail-mcp`
+If not, install the version Dex currently supports and tests:
+`pipx install 'apple-mail-mcp==0.4.3'`
+
+`apple-mail-mcp` is community-maintained. Version 0.4.3 is Dex's current supported
+contract for its index schema and CLI. Do not upgrade it during setup; a newer community
+release should be adopted only after Dex's health checks and macOS CI prove compatibility.
 
 If `pipx` itself is missing: `brew install pipx && pipx ensurepath`
 

--- a/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -111,15 +111,22 @@ from them; triage is an interactive step in the main conversation.
 
 ### 1.9 Email Intelligence (if connected)
 
-Check `System/integrations/config.yaml`. If an email integration is enabled
-(for example `google-workspace.enabled: true`) and its MCP is healthy:
+Check `System/integrations/config.yaml`. Also treat a registered `apple-mail-mcp`
+server as connected. Before querying any connected email source, run
+`python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`mail.apple-search` check reports `OK` / `feature_status: ok`.
+
+If the source is connected and healthy:
 
 - Get unread count and priority emails
 - Flag emails needing reply (received more than 48 hours ago, from key contacts
   in `05-Areas/People/`)
 - Surface threads involving the target date's meeting attendees
 
-If not connected or unhealthy, skip silently.
+For Apple Mail, do not interpret an empty search as an empty mailbox unless that
+check is OK. If a connected source is broken or unknown, **do not silently skip**:
+report it under `Sources skipped` with Doctor's `user_message` or fix path. If the
+source is not connected (`OFF`), omit it without noise.
 
 ### 1.10 Chat Intelligence (if connected)
 

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -338,11 +338,14 @@ For each completed item:
 
 **If nothing to sync:** Skip silently.
 
-### 5.8 Email Intelligence (if Gmail connected)
+### 5.8 Email Intelligence (if connected)
 
-Check `System/integrations/config.yaml` for `google-workspace.enabled: true`.
+Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. Also treat a
+registered `apple-mail-mcp` server as a connected source. Before querying a connected email
+source, run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`mail.apple-search` check reports `OK` / `feature_status: ok`.
 
-If enabled and MCP healthy:
+If connected and healthy:
 1. Get unread count and priority emails from monitored labels
 2. Flag emails needing reply (> 48h since received, from key contacts in `05-Areas/People/`)
 3. Surface email threads with today's meeting attendees
@@ -351,7 +354,10 @@ Include in plan:
 
 > "Email: [X] unread, [Y] need replies. [Z] threads with today's meeting attendees."
 
-If unhealthy: skip silently (graceful degradation -- no error to user).
+For Apple Mail, never interpret an empty search as "no matching mail" unless that health check
+is OK. If a connected source is broken or could not be checked, **do not silently skip**:
+include one calm "Email context omitted" line with Doctor's `user_message` or fix path. If the
+source is not connected (`OFF`), omit it without noise.
 
 ### 5.9 Teams Intelligence (if Teams connected)
 
@@ -729,4 +735,5 @@ The plan works at multiple levels:
 | Work | work-mcp | `list_tasks`, `get_week_progress`, `get_meeting_context`, `get_commitments_due`, `analyze_calendar_capacity`, `suggest_task_scheduling` |
 | Improvements | dex-improvements-mcp | `synthesize_changelog`, `synthesize_learnings`, `list_ideas` |
 | Google Workspace | google-workspace-mcp | Gmail query, email search (if enabled) |
+| Apple Mail | apple-mail-mcp | Local full-text mail search (only after `mail.apple-search` is healthy) |
 | Teams | teams-mcp | `teams_list_chats`, `teams_search_messages`, `teams_health_check` (if enabled) |

--- a/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
@@ -70,15 +70,21 @@ follow-ups that may have slipped.
 
 ### 1.6 Email Weekly Review (if connected)
 
-Check `System/integrations/config.yaml`. If an email integration is enabled and
-its MCP is healthy, analyse the week's mail:
+Check `System/integrations/config.yaml`. Also treat a registered `apple-mail-mcp`
+server as connected. Before querying any connected email source, run
+`python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`mail.apple-search` check reports `OK` / `feature_status: ok`. If healthy, analyse
+the week's mail:
 - Total volume (received vs sent)
 - Key relationship threads (most contact)
 - Unresolved threads carrying into next week
 - Promises made with no matching task
 - New contacts who may need person pages
 
-If not connected or unhealthy, skip silently.
+For Apple Mail, do not interpret an empty search as an empty mailbox unless that
+check is OK. If a connected source is broken or unknown, **do not silently skip**:
+report it under skipped sources with Doctor's `user_message` or fix path. If the
+source is not connected (`OFF`), omit it without noise.
 
 ### 1.7 Learning Compilation & Pattern Detection
 

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -252,11 +252,14 @@ Review meeting notes from the week:
 - Action items created
 - Follow-ups that might have slipped
 
-### 5.5 Email Communication Stats (if Gmail connected)
+### 5.5 Email Communication Stats (if connected)
 
-Check `System/integrations/config.yaml` for `google-workspace.enabled: true`.
+Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. Also treat a
+registered `apple-mail-mcp` server as connected. Before querying a connected email source,
+run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`mail.apple-search` check reports `OK` / `feature_status: ok`.
 
-If enabled and Google Workspace MCP is healthy:
+If connected and healthy:
 - **Emails sent this week** — count of sent messages in the review period
 - **Average response time** — how quickly you replied to incoming emails
 - **Threads still open** — conversations with no resolution (back-and-forth still active)
@@ -275,7 +278,10 @@ Surface in the review:
 >
 > **Observation:** You have 3 emails waiting for replies longer than 48 hours. Consider clearing those early next week."
 
-If unhealthy or not enabled: skip this section silently.
+For Apple Mail, never interpret an empty search as "no matching mail" unless that check is OK.
+If a connected source is broken or could not be checked, **do not silently skip**: include one
+calm "Email review omitted" line with Doctor's `user_message` or fix path. If the source is not
+connected (`OFF`), omit the section without noise.
 
 ### 6. Learning Compilation & Pattern Detection
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -64,8 +64,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/daily-plan/SKILL.md",
-        "sha256": "311c9cdf45842936cee4a91d1ac116ce9e1eeae576c01aacdce989e44b912221",
-        "byte_size": 30797
+        "sha256": "ed6b1cb03cc69b597669cc3f0eb520b8769a28cc7730a0f054df10185c7ecf47",
+        "byte_size": 31420
       },
       "value": "Helps a person choose a small, realistic focus list before the day scatters across meetings, tasks and loose commitments.",
       "jobs_served": ["plan-my-work"],
@@ -364,8 +364,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-review/SKILL.md",
-        "sha256": "30b052197bb91b3b48d41021789ec577eaab394ec1a910001773c2c8e9319d16",
-        "byte_size": 18517
+        "sha256": "7972089ecf86d0ce8cc23281f490afabbd11ce8683856cf91479a856444ff905",
+        "byte_size": 19021
       },
       "value": "Reviews the week in concrete finished work and the patterns behind it, and deliberately refuses to invent a completion percentage that would make a bad week look measured.",
       "jobs_served": ["plan-my-work", "compound-learning"],

--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -123,6 +123,22 @@ def _write_real_apple_mail_index(
     return path
 
 
+def _add_indexed_mailbox(path, *, account, mailbox, last_sync):
+    with sqlite3.connect(path) as connection:
+        rowid = int(connection.execute("SELECT MAX(rowid) FROM emails").fetchone()[0]) + 1
+        connection.execute(
+            "INSERT INTO emails "
+            "(rowid, message_id, account, mailbox, subject, sender, content) "
+            "VALUES (?, ?, ?, ?, 'Second mailbox', 'fixture@example.com', 'Searchable body')",
+            (rowid, rowid, account, mailbox),
+        )
+        connection.execute(
+            "INSERT INTO sync_state (account, mailbox, last_sync, message_count) "
+            "VALUES (?, ?, ?, 1)",
+            (account, mailbox, last_sync),
+        )
+
+
 def test_apple_mail_search_is_off_when_no_server_is_registered(context):
     result = apple_mail_health.probe(context)
 
@@ -437,6 +453,40 @@ def test_apple_mail_search_uses_configured_sync_freshness_not_file_mtime(
     (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 48\n")
     fresh_by_policy = apple_mail_health.probe(context)
     assert fresh_by_policy.verdict == "OK"
+
+
+@pytest.mark.parametrize(
+    ("second_sync", "expected_detail"),
+    [
+        pytest.param(
+            (NOW - timedelta(hours=48)).isoformat(),
+            "configured 24-hour freshness limit",
+            id="mixed-fresh-and-stale",
+        ),
+        pytest.param(None, "has no successful sync", id="mixed-fresh-and-missing"),
+    ],
+)
+def test_apple_mail_search_checks_every_indexed_mailbox_sync(
+    context,
+    second_sync,
+    expected_detail,
+):
+    _register_apple_mail_user_scope(context)
+    index = _write_real_apple_mail_index(
+        context.home / ".apple-mail-mcp" / "index.db",
+        last_sync=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    _add_indexed_mailbox(
+        index,
+        account="Second",
+        mailbox="Archive",
+        last_sync=second_sync,
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert expected_detail in result.detail
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -1,0 +1,488 @@
+"""Behavior contract for the community Apple Mail full-text index adapter."""
+
+import json
+import os
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core.utils import apple_mail_health
+
+NOW = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def context(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    return apple_mail_health.Context(
+        home=home,
+        vault_root=vault,
+        now=NOW,
+        user_config_path=home / ".claude.json",
+        project_config_path=vault / ".mcp.json",
+        environment=os.environ,
+        macos=True,
+        cli_present=True,
+    )
+
+
+def _register_apple_mail_user_scope(context, name="user-apple-mail", *, env=None):
+    entry = {"command": "apple-mail-mcp", "args": ["serve"]}
+    if env is not None:
+        entry["env"] = env
+    (context.home / ".claude.json").write_text(json.dumps({"mcpServers": {name: entry}}))
+
+
+def _write_apple_mail_index(context, *, age_days=0.0, size=4096):
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    if size == 0:
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_bytes(b"")
+        index.chmod(0o600)
+        return index
+    last_sync = (context.now - timedelta(days=age_days)).isoformat()
+    _write_real_apple_mail_index(index, last_sync=last_sync)
+    return index
+
+
+def _write_real_apple_mail_index(
+    path,
+    *,
+    last_sync="2026-07-11T11:00:00+00:00",
+    email_count=1,
+    fts_searchable=True,
+):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (5);
+        CREATE TABLE emails (
+            rowid INTEGER PRIMARY KEY,
+            message_id INTEGER NOT NULL,
+            account TEXT NOT NULL,
+            mailbox TEXT NOT NULL,
+            subject TEXT,
+            sender TEXT,
+            content TEXT,
+            date_received TEXT,
+            emlx_path TEXT,
+            attachment_count INTEGER DEFAULT 0,
+            indexed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE VIRTUAL TABLE emails_fts USING fts5(
+            subject, sender, content, content='emails', content_rowid='rowid'
+        );
+        CREATE TRIGGER emails_ai AFTER INSERT ON emails BEGIN
+            INSERT INTO emails_fts(rowid, subject, sender, content)
+            VALUES (new.rowid, new.subject, new.sender, new.content);
+        END;
+        CREATE TRIGGER emails_ad AFTER DELETE ON emails BEGIN
+            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
+            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
+        END;
+        CREATE TRIGGER emails_au AFTER UPDATE ON emails BEGIN
+            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
+            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
+            INSERT INTO emails_fts(rowid, subject, sender, content)
+            VALUES (new.rowid, new.subject, new.sender, new.content);
+        END;
+        CREATE TABLE sync_state (
+            account TEXT NOT NULL,
+            mailbox TEXT NOT NULL,
+            last_sync TEXT,
+            message_count INTEGER DEFAULT 0,
+            PRIMARY KEY(account, mailbox)
+        );
+        """
+    )
+    for rowid in range(1, email_count + 1):
+        connection.execute(
+            "INSERT INTO emails "
+            "(rowid, message_id, account, mailbox, subject, sender, content) "
+            "VALUES (?, ?, 'Fixture', 'INBOX', 'Fixture subject', "
+            "'fixture@example.com', 'Fixture body')",
+            (rowid, rowid),
+        )
+    connection.execute(
+        "INSERT INTO sync_state VALUES ('Fixture', 'INBOX', ?, ?)",
+        (last_sync, email_count),
+    )
+    if not fts_searchable:
+        connection.execute("INSERT INTO emails_fts(emails_fts) VALUES ('delete-all')")
+    connection.commit()
+    connection.close()
+    path.chmod(0o600)
+    return path
+
+
+def test_apple_mail_search_is_off_when_no_server_is_registered(context):
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OFF"
+    assert result.feature_status == "off"
+    assert result.action is None
+
+
+def test_apple_mail_search_detects_registration_at_either_scope(monkeypatch, context):
+    context = replace(context, macos=False)
+    _register_apple_mail_user_scope(context)
+    assert apple_mail_health.probe(context).verdict == "UNKNOWN"
+
+    (context.home / ".claude.json").unlink()
+    assert apple_mail_health.probe(context).verdict == "OFF"
+
+    (context.vault_root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"mail": {"command": "pipx", "args": ["run", "apple-mail-mcp"]}}})
+    )
+    assert apple_mail_health.probe(context).verdict == "UNKNOWN"
+
+
+def test_apple_mail_search_is_unknown_off_macos(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    context = replace(context, macos=False)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert result.feature_status == "unknown"
+
+
+def test_apple_mail_search_is_broken_when_the_command_is_missing(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    context = replace(context, cli_present=False)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "pipx install 'apple-mail-mcp==0.4.3'" in result.action
+
+
+def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch, context):
+    """The silent failure from #446: list/read work, so search looks healthy while returning nothing."""
+    _register_apple_mail_user_scope(context)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "apple-mail-mcp index" in result.action
+    assert "Full Disk Access" in result.action
+    assert "returns nothing" in result.user_message
+
+
+def test_apple_mail_search_is_broken_when_the_index_is_empty(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, size=0)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "empty" in result.detail
+
+
+def test_apple_mail_search_is_broken_when_the_index_has_gone_stale(monkeypatch, context):
+    """Startup sync silently no-ops without Full Disk Access, so a built index quietly stales."""
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=30)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "30 days ago" in result.detail
+    assert "apple-mail-mcp index" in result.action
+
+
+def test_apple_mail_search_is_ok_with_a_fresh_index(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=1)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert result.feature_status == "ok"
+    assert result.action is None
+
+
+def test_apple_mail_search_uses_custom_path_and_real_sqlite_state(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    custom_index = context.home / "private-mail" / "search.sqlite"
+    _write_real_apple_mail_index(custom_index)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        f'config_version = 1\n[index]\npath = "{custom_index}"\nstaleness_hours = 24\n'
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert str(custom_index) in result.detail
+    assert "1 indexed message" in result.detail
+
+
+def test_apple_mail_search_mcp_environment_overrides_toml_settings(monkeypatch, context):
+    custom_index = context.home / "client-specific" / "index.db"
+    _register_apple_mail_user_scope(
+        context,
+        env={
+            "APPLE_MAIL_INDEX_PATH": str(custom_index),
+            "APPLE_MAIL_INDEX_STALENESS_HOURS": "48",
+        },
+    )
+    _write_real_apple_mail_index(
+        custom_index,
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        'config_version = 1\n[index]\npath = "/wrong/index.db"\nstaleness_hours = 1\n'
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert str(custom_index) in result.detail
+
+
+def test_apple_mail_search_reports_invalid_config_as_broken(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("config_version = [not valid TOML")
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config" in result.detail.lower()
+    assert "config.toml" in result.action
+
+
+def test_apple_mail_search_reports_semantically_invalid_config_as_broken(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("[index]\nstaleness_hours = 24\n")
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config_version = 1" in result.detail
+    assert "config.toml" in result.action
+
+
+def test_apple_mail_search_reports_empty_existing_config_as_broken(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("")
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config_version = 1" in result.detail
+
+
+def test_apple_mail_search_reports_malformed_registration_as_broken(
+    monkeypatch,
+    context,
+):
+    (context.home / ".claude.json").write_text('{"mcpServers": {"apple-mail": ')
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "could not be read" in result.detail
+    assert "MCP JSON" in result.action
+
+
+def test_apple_mail_search_reports_null_registration_container_as_broken(
+    monkeypatch,
+    context,
+):
+    (context.home / ".claude.json").write_text('{"mcpServers": null}')
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "must contain an mcpServers object" in result.detail
+    assert "MCP JSON" in result.action
+
+
+@pytest.mark.parametrize(
+    "broken_shape",
+    ["fake", "missing-schema", "empty-data", "empty-fts"],
+)
+def test_apple_mail_search_rejects_files_that_cannot_answer_searches(
+    monkeypatch,
+    context,
+    broken_shape,
+):
+    _register_apple_mail_user_scope(context)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    if broken_shape == "fake":
+        index.write_bytes(b"not a sqlite database")
+    elif broken_shape == "missing-schema":
+        with sqlite3.connect(index) as connection:
+            connection.execute("CREATE TABLE unrelated (value TEXT)")
+    elif broken_shape == "empty-data":
+        _write_real_apple_mail_index(index, email_count=0)
+    else:
+        _write_real_apple_mail_index(index, fts_searchable=False)
+    index.chmod(0o600)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "rebuild" in result.action
+
+
+def test_apple_mail_search_process_environment_overrides_registration_and_toml(
+    monkeypatch,
+    context,
+):
+    registered_index = context.home / "registered" / "index.db"
+    process_index = context.home / "runtime" / "index.db"
+    _register_apple_mail_user_scope(
+        context,
+        env={
+            "APPLE_MAIL_INDEX_PATH": str(registered_index),
+            "APPLE_MAIL_INDEX_STALENESS_HOURS": "1",
+        },
+    )
+    monkeypatch.setenv("APPLE_MAIL_INDEX_PATH", str(process_index))
+    monkeypatch.setenv("APPLE_MAIL_INDEX_STALENESS_HOURS", "48")
+    _write_real_apple_mail_index(
+        process_index,
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        f'config_version = 1\n[index]\npath = "{context.home / "toml" / "index.db"}"\nstaleness_hours = 1\n'
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert str(process_index) in result.detail
+
+
+def test_apple_mail_search_resolves_relative_path_from_server_vault(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(
+        context,
+        env={"APPLE_MAIL_INDEX_PATH": "runtime/mail-index.db"},
+    )
+    relative_index = context.vault_root / "runtime" / "mail-index.db"
+    _write_real_apple_mail_index(relative_index)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert str(relative_index) in result.detail
+
+
+def test_apple_mail_search_default_freshness_is_24_hours(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    _write_real_apple_mail_index(
+        index,
+        last_sync=(context.now - timedelta(hours=25)).isoformat(),
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "configured 24-hour freshness limit" in result.detail
+
+
+def test_apple_mail_search_uses_configured_sync_freshness_not_file_mtime(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    index = _write_real_apple_mail_index(
+        context.home / ".apple-mail-mcp" / "index.db",
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    os.utime(index, (context.now.timestamp(), context.now.timestamp()))
+    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 24\n")
+
+    stale = apple_mail_health.probe(context)
+    assert stale.verdict == "BROKEN"
+    assert "configured 24-hour freshness limit" in stale.detail
+
+    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 48\n")
+    fresh_by_policy = apple_mail_health.probe(context)
+    assert fresh_by_policy.verdict == "OK"
+
+
+@pytest.mark.parametrize(
+    "last_sync",
+    [
+        pytest.param("2026-07-11T11:00:00", id="upstream-naive-local-iso"),
+        pytest.param("2026-07-11T12:00:00+01:00", id="offset-aware-iso"),
+    ],
+)
+def test_apple_mail_search_accepts_upstream_and_offset_sync_timestamps(
+    monkeypatch,
+    context,
+    last_sync,
+):
+    _register_apple_mail_user_scope(context)
+    _write_real_apple_mail_index(
+        context.home / ".apple-mail-mcp" / "index.db",
+        last_sync=last_sync,
+    )
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "OK"
+    assert "last synced 1 hour ago" in result.detail
+
+
+@pytest.mark.parametrize(
+    ("sidecar", "mode"),
+    [("", 0o644), ("-wal", 0o644), ("-shm", 0o644), ("", 0o700)],
+)
+def test_apple_mail_search_rejects_non_private_index_files(
+    monkeypatch,
+    context,
+    sidecar,
+    mode,
+):
+    _register_apple_mail_user_scope(context)
+    index = _write_real_apple_mail_index(context.home / ".apple-mail-mcp" / "index.db")
+    exposed = Path(f"{index}{sidecar}")
+    if sidecar:
+        exposed.write_bytes(b"fixture sidecar")
+    exposed.chmod(mode)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert "chmod 600" in result.action
+    assert str(exposed) in result.detail
+    assert "subjects, senders, bodies, file paths, and attachment metadata" in result.user_message

--- a/core/tests/test_apple_mail_runtime_macos.py
+++ b/core/tests/test_apple_mail_runtime_macos.py
@@ -52,10 +52,11 @@ def test_real_apple_mail_status_and_full_disk_access_denial(tmp_path):
                 'db.execute("INSERT INTO emails '
                 "(message_id,account,mailbox,subject,sender,content,date_received,emlx_path) "
                 "VALUES (1,'Fixture','INBOX','Runtime proof','fixture@example.com',"
-                "'searchable body','2026-08-13T10:00:00+00:00','fixture.emlx')\"); "
+                "'searchable body','2026-08-13T10:00:00','fixture.emlx')\"); "
                 'db.execute("INSERT INTO sync_state '
                 "(account,mailbox,last_sync,message_count) "
-                "VALUES ('Fixture','INBOX','2026-08-13T10:00:00+00:00',1)\"); "
+                # Pinned upstream 0.4.3 writes/parses last_sync as naive local ISO.
+                "VALUES ('Fixture','INBOX','2026-08-13T10:00:00',1)\"); "
                 "db.commit(); db.close()"
             ),
         ],

--- a/core/tests/test_apple_mail_runtime_macos.py
+++ b/core/tests/test_apple_mail_runtime_macos.py
@@ -1,0 +1,99 @@
+"""Real macOS seams for the optional apple-mail-mcp runtime.
+
+The portable health logic has deterministic Linux coverage.  These tests run
+only on the repository's macOS CI runner and prove the pinned upstream CLI can
+read a real FTS5 index and emits its actionable Full Disk Access failure.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="apple-mail-mcp runtime and Full Disk Access are macOS-only",
+)
+
+
+def _runtime_environment(home: Path, index: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "APPLE_MAIL_INDEX_PATH": str(index),
+            "APPLE_MAIL_INDEX_STALENESS_HOURS": "24",
+        }
+    )
+    return environment
+
+
+def test_real_apple_mail_status_and_full_disk_access_denial(tmp_path):
+    cli = shutil.which("apple-mail-mcp")
+    assert cli is not None, "requirements-dev.txt must install the pinned Apple Mail runtime"
+
+    home = tmp_path / "home"
+    home.mkdir()
+    index = home / ".apple-mail-mcp" / "index.db"
+    environment = _runtime_environment(home, index)
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from apple_mail_mcp.config import get_index_path; "
+                "from apple_mail_mcp.index.schema import init_database; "
+                "db=init_database(get_index_path()); "
+                'db.execute("INSERT INTO emails '
+                "(message_id,account,mailbox,subject,sender,content,date_received,emlx_path) "
+                "VALUES (1,'Fixture','INBOX','Runtime proof','fixture@example.com',"
+                "'searchable body','2026-08-13T10:00:00+00:00','fixture.emlx')\"); "
+                'db.execute("INSERT INTO sync_state '
+                "(account,mailbox,last_sync,message_count) "
+                "VALUES ('Fixture','INBOX','2026-08-13T10:00:00+00:00',1)\"); "
+                "db.commit(); db.close()"
+            ),
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert create.returncode == 0, create.stderr
+
+    status = subprocess.run(
+        [cli, "status"],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert status.returncode == 0, status.stderr
+    assert f"Location:     {index}" in status.stdout
+    assert "Emails:       1" in status.stdout
+
+    denied_home = tmp_path / "denied-home"
+    denied_mail = denied_home / "Library" / "Mail" / "V10"
+    denied_mail.mkdir(parents=True)
+    denied_mail.chmod(0o000)
+    try:
+        denied = subprocess.run(
+            [cli, "index"],
+            env=_runtime_environment(
+                denied_home,
+                denied_home / ".apple-mail-mcp" / "index.db",
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        denied_mail.chmod(0o700)
+
+    assert denied.returncode != 0
+    assert "Full Disk Access" in denied.stderr

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -6,6 +6,7 @@ import os
 import plistlib
 import re
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -93,9 +94,7 @@ def foreign_launch_agents(context):
     agents.mkdir(parents=True, exist_ok=True)
     definitions = {
         "com.dex.research-scan": ".scripts/research-scan.py",
-        "com.dex.other-product": str(
-            context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"
-        ),
+        "com.dex.other-product": str(context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"),
     }
     plists = []
     for label, script in definitions.items():
@@ -178,21 +177,37 @@ def _write_plist(context, label):
 def _write_entity_probe_files(context, *, mode="auto", unresolved=None):
     runtime = context.vault_root / "System" / ".dex"
     runtime.mkdir(parents=True, exist_ok=True)
-    (runtime / "contacts.json").write_text(json.dumps({
-        "contacts": {"one": {}}, "observations": {"m1": {}, "m2": {}},
-    }))
-    (runtime / "entity-suggestions.json").write_text(json.dumps({
-        "suggestions": [{"status": "suggested"}],
-    }))
-    (runtime / "entity-verification.json").write_text(json.dumps({
-        "generated_at": NOW.isoformat(), "unresolved": unresolved or [],
-    }))
-    (context.vault_root / "System" / "user-profile.yaml").write_text(
-        f"entity_creation:\n  mode: {mode}\n"
+    (runtime / "contacts.json").write_text(
+        json.dumps(
+            {
+                "contacts": {"one": {}},
+                "observations": {"m1": {}, "m2": {}},
+            }
+        )
     )
-    (context.vault_root / "System" / "People_Index.json").write_text(json.dumps({
-        "built_at": NOW.isoformat(),
-    }))
+    (runtime / "entity-suggestions.json").write_text(
+        json.dumps(
+            {
+                "suggestions": [{"status": "suggested"}],
+            }
+        )
+    )
+    (runtime / "entity-verification.json").write_text(
+        json.dumps(
+            {
+                "generated_at": NOW.isoformat(),
+                "unresolved": unresolved or [],
+            }
+        )
+    )
+    (context.vault_root / "System" / "user-profile.yaml").write_text(f"entity_creation:\n  mode: {mode}\n")
+    (context.vault_root / "System" / "People_Index.json").write_text(
+        json.dumps(
+            {
+                "built_at": NOW.isoformat(),
+            }
+        )
+    )
 
 
 def _write_release_catalog(context, *, content=b"release skill\n"):
@@ -285,11 +300,7 @@ def _drift_context(tmp_path, *, release_ref=True, channel=None):
     (vault / "core").mkdir()
     (vault / "core" / "shipped.py").write_text("SHIPPED = 1\n")
     (vault / "CLAUDE.md").write_text(
-        "# Dex\n\n"
-        "## USER_EXTENSIONS_START\n"
-        "<!-- personal instructions -->\n"
-        "## USER_EXTENSIONS_END\n\n"
-        "Shipped tail.\n"
+        "# Dex\n\n## USER_EXTENSIONS_START\n<!-- personal instructions -->\n## USER_EXTENSIONS_END\n\nShipped tail.\n"
     )
     (vault / ".mcp.json").write_text(
         json.dumps(
@@ -366,9 +377,14 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     _write_entity_probe_files(context)
     (context.vault_root / "System" / "user-profile.yaml").write_text("name: Test\n")
     verification = context.vault_root / "System" / ".dex" / "entity-verification.json"
-    verification.write_text(json.dumps({
-        "generated_at": (NOW - timedelta(hours=49)).isoformat(), "unresolved": [],
-    }))
+    verification.write_text(
+        json.dumps(
+            {
+                "generated_at": (NOW - timedelta(hours=49)).isoformat(),
+                "unresolved": [],
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert result.verdict == "OK"
     assert "suggest (default — key missing)" in result.detail
@@ -386,10 +402,7 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
                 "meeting_id": "meeting-1",
                 "meeting_ids": ["meeting-1"],
                 "op_type": "mutate",
-                "entity_path": (
-                    str(context.vault_root)
-                    + "/05-Areas/People/External/Jane_Example.md"
-                ),
+                "entity_path": (str(context.vault_root) + "/05-Areas/People/External/Jane_Example.md"),
                 "entity_identity": {
                     "kind": "person",
                     "name": "Jane Example",
@@ -414,9 +427,7 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
         action="Re-queue the dead-lettered entity write with retry counters reset.",
         applied=False,
     )
-    definition = next(
-        item for item in doctor.QUICK_CHECKS if item.id == "entity.engine"
-    )
+    definition = next(item for item in doctor.QUICK_CHECKS if item.id == "entity.engine")
     rendered = doctor._result_json(definition, result)
     assert rendered["feature_status"] == "broken"
     assert rendered["user_message"] == result.user_message
@@ -435,10 +446,13 @@ def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
     monkeypatch.setattr(
         doctor,
         "_requeue_entity_dead_letters",
-        lambda candidate: calls.append(candidate) or {
-            "requeued": 1,
-            "dead_letter_ids": ["example-dead-letter"],
-        },
+        lambda candidate: (
+            calls.append(candidate)
+            or {
+                "requeued": 1,
+                "dead_letter_ids": ["example-dead-letter"],
+            }
+        ),
     )
 
     actions, errors = doctor._apply_t1_heals(context)
@@ -454,13 +468,7 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
     _write_entity_probe_files(context)
     operation = {
         "op": "create",
-        "path": str(
-            context.vault_root
-            / "05-Areas"
-            / "People"
-            / "External"
-            / "Jane_Example.md"
-        ),
+        "path": str(context.vault_root / "05-Areas" / "People" / "External" / "Jane_Example.md"),
         "content": "# Jane Example\n",
         "allowed_root": str(context.vault_root),
     }
@@ -489,9 +497,7 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
 
     assert healed["requeued"] == 1
     assert not dead_letter.exists()
-    pending = json.loads(
-        (context.vault_root / "System" / ".dex" / "entity-pending.json").read_text()
-    )
+    pending = json.loads((context.vault_root / "System" / ".dex" / "entity-pending.json").read_text())
     assert pending["batches"][0]["ops"] == [operation]
     assert doctor._probe_entity_engine(context).verdict == "OK"
 
@@ -505,10 +511,17 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(json.dumps({"version": 2, "pages": {
-        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-        "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "pages": {
+                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+                    "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
+                },
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert "gardener on (2 pages maintained), 1 user-owned summary" in result.detail
 
@@ -517,9 +530,16 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     result = doctor._probe_entity_engine(context)
     assert "gardener off (disabled), 1 user-owned summary" in result.detail
 
-    gardener.write_text(json.dumps({"version": 1, "pages": {
-        "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "pages": {
+                    "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
+                },
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert "1 legacy lock pending migration" in result.detail
 
@@ -529,9 +549,16 @@ def test_entity_engine_probe_reads_llm_key_from_vault_env_file(monkeypatch, cont
         monkeypatch.delenv(key, raising=False)
     _write_entity_probe_files(context)
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(json.dumps({"version": 2, "pages": {
-        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "pages": {
+                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+                },
+            }
+        )
+    )
     env_path = context.vault_root / ".env"
     env_path.write_text("# local keys\nexport GEMINI_API_KEY='test-placeholder-key'\n")
 
@@ -905,9 +932,7 @@ def test_adoption_plan_probe_is_broken_on_a_real_bridge_pin_mismatch(context):
 
 
 def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
-    (context.vault_root / "System/.release-catalog.json").write_text(
-        "{not json", encoding="utf-8"
-    )
+    (context.vault_root / "System/.release-catalog.json").write_text("{not json", encoding="utf-8")
     _stub_probes(monkeypatch, exclude={"release.catalog", "adoption.plan"})
 
     report = doctor.collect(context=context)
@@ -936,9 +961,7 @@ def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
         ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
         check=True,
     )
-    (brain / "dex-brain-v2").write_text(
-        json.dumps({"role": "brain", "installed": commit}) + "\n"
-    )
+    (brain / "dex-brain-v2").write_text(json.dumps({"role": "brain", "installed": commit}) + "\n")
     topology = context.vault_root / "System/.dex/topology.json"
     topology.parent.mkdir(parents=True, exist_ok=True)
     topology.write_text(
@@ -961,10 +984,7 @@ def test_topology_probe_distinguishes_combined_split_and_invalid(context):
     assert doctor._topology_state(context) == "combined"
     assert doctor._probe_migration_pending(context).verdict == "OFF"
 
-    migrator = (
-        context.vault_root
-        / "core/migrations/v1-to-v2-brain-vault-split.cjs"
-    )
+    migrator = context.vault_root / "core/migrations/v1-to-v2-brain-vault-split.cjs"
     migrator.parent.mkdir(parents=True)
     migrator.write_text("'use strict';\n", encoding="utf-8")
     assert doctor._topology_state(context) == "migration-pending"
@@ -1269,8 +1289,7 @@ def test_missing_optional_packages_have_actionable_unknown_detail(monkeypatch, c
     report = doctor.collect(context=context)
 
     guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-        "then re-run /dex-doctor"
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor"
     )
     assert _check(report, "vault.configs")["verdict"] == "UNKNOWN"
     assert _check(report, "vault.configs")["detail"] == guidance + "."
@@ -1291,8 +1310,7 @@ def test_probe_owned_unknown_missing_package_detail_is_actionable(monkeypatch, c
     report = doctor.collect(deep=True, context=context)
 
     assert _check(report, "calendar.access")["detail"] == (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-        "then re-run /dex-doctor."
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor."
     )
     assert report["instruments"]["failed"] == []
 
@@ -1361,10 +1379,7 @@ def test_heal_applies_all_t1_actions_and_leaves_t2_suggestion_untouched(
     assert "Missing standard PARA directories: 00-Inbox" in structure["detail"]
     assert structure["heal"] == {
         "tier": 1,
-        "action": (
-            "regenerated core/paths.json; restored executable permission on "
-            ".scripts/repo-tool.sh."
-        ),
+        "action": ("regenerated core/paths.json; restored executable permission on .scripts/repo-tool.sh."),
         "applied": True,
     }
     assert _check(report, "mcp.registered")["heal"] == {
@@ -1394,9 +1409,7 @@ def test_quick_mode_does_not_apply_t1_without_heal(monkeypatch, context):
     assert not script.stat().st_mode & stat.S_IXUSR
 
 
-def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(
-    monkeypatch, context
-):
+def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(monkeypatch, context):
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     script = context.vault_root / ".scripts" / "repair-me.sh"
@@ -1468,9 +1481,7 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
     structure = _check(report, "vault.structure")
     assert structure["verdict"] == "UNKNOWN"
     assert structure["heal"]["applied"] is True
-    assert report["instruments"]["failed"] == [
-        {"id": "vault.structure", "error": "structure probe exploded"}
-    ]
+    assert report["instruments"]["failed"] == [{"id": "vault.structure", "error": "structure probe exploded"}]
 
 
 def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, capsys):
@@ -1518,8 +1529,7 @@ def test_cli_still_emits_json_when_yaml_is_not_importable(tmp_path):
     assert result.returncode == 0
     report = json.loads(result.stdout)
     guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-        "then re-run /dex-doctor."
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor."
     )
     for check_id in ("vault.configs", "customizations.skills", "customizations.mcp"):
         assert _check(report, check_id)["verdict"] == "UNKNOWN"
@@ -1575,10 +1585,7 @@ def test_capability_rooms_probe_detects_missing_on_assets_and_live_off_skills(
     assert "quarter-plan" in result.detail
     assert result.heal == doctor.Heal(
         tier=1,
-        action=(
-            "Reconcile capability room folders and shipped skills without "
-            "deleting user content."
-        ),
+        action=("Reconcile capability room folders and shipped skills without deleting user content."),
         applied=False,
     )
 
@@ -1601,9 +1608,7 @@ def test_capability_seed_probe_advises_update_only_for_enabled_rooms(
     )
     career = context.vault_root / "05-Areas/Career"
     career.mkdir(parents=True)
-    dormant = (
-        REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
-    )
+    dormant = REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
     for skill in ("career-setup", "career-coach", "resume-builder"):
         shutil.copytree(dormant / skill, context.vault_root / ".claude/skills" / skill)
 
@@ -1638,8 +1643,7 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     (context.vault_root / "System/user-profile.yaml").write_text(
-        "name: Legacy User\n"
-        "role: Founder\n",
+        "name: Legacy User\nrole: Founder\n",
         encoding="utf-8",
     )
     user_note = context.vault_root / "05-Areas/Career/private-review.md"
@@ -1648,8 +1652,7 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     existing_skill = context.vault_root / ".claude/skills/quarter-plan/SKILL.md"
     existing_skill.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(
-        REPO_ROOT
-        / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
+        REPO_ROOT / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
         existing_skill,
     )
     context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1670,13 +1673,9 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "applied": True,
     }
     assert user_note.read_text(encoding="utf-8") == "Keep this forever.\n"
-    assert (
-        context.vault_root / "05-Areas/Career/Evidence/README.md"
-    ).is_file()
+    assert (context.vault_root / "05-Areas/Career/Evidence/README.md").is_file()
     for skill in ("career-setup", "career-coach", "resume-builder"):
-        assert (
-            context.vault_root / ".claude/skills" / skill / "SKILL.md"
-        ).is_file()
+        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
     for skill in (
         "career-setup",
         "career-coach",
@@ -1684,12 +1683,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "quarter-plan",
         "quarter-review",
     ):
-        assert (
-            context.vault_root / ".claude/skills" / skill / "SKILL.md"
-        ).is_file()
-    profile = (
-        context.vault_root / "System/user-profile.yaml"
-    ).read_text(encoding="utf-8")
+        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
+    profile = (context.vault_root / "System/user-profile.yaml").read_text(encoding="utf-8")
     assert "companies:\n    enabled: true" in profile
 
 
@@ -1807,11 +1802,7 @@ def test_mcp_probes_read_legacy_config_without_moving_it(context):
     server = mcp_dir / "alpha_server.py"
     server.touch()
     legacy = context.vault_root / "System" / ".mcp.json"
-    legacy.write_text(
-        json.dumps(
-            {"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}
-        )
-    )
+    legacy.write_text(json.dumps({"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}))
 
     before = _tree_snapshot(context.vault_root)
     registered = doctor._probe_mcp_registered(context)
@@ -1880,9 +1871,7 @@ def test_hooks_wired_detects_dangling_hook_files(context):
         json.dumps(
             {
                 "hooks": {
-                    "SessionStart": [
-                        {"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}
-                    ]
+                    "SessionStart": [{"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}]
                 }
             }
         )
@@ -1946,8 +1935,7 @@ def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "2 Dex launch agents from other Dex products were skipped"
+        "No launch agents for this vault are installed; 2 Dex launch agents from other Dex products were skipped"
     )
     assert "research-scan.py" not in result.detail
 
@@ -1975,8 +1963,7 @@ def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypa
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2004,8 +1991,7 @@ def test_shipped_job_from_another_worktree_vault_is_not_a_failure(monkeypatch, c
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2367,9 +2353,7 @@ def _write_breadcrumb(context, former_vault):
     return breadcrumb
 
 
-def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkeypatch, context):
     """A job left behind by a vault move is owned-and-stale, never foreign (#364)."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2400,9 +2384,7 @@ def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
     assert str(context.vault_root) in result.heal.action
 
 
-def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(monkeypatch, context):
     """The hook and the doctor must agree: any label pointing at the former root."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2443,12 +2425,7 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
                 "Label": "com.dex.sibling-product",
                 "ProgramArguments": [
                     "/bin/bash",
-                    str(
-                        context.home.parent
-                        / "old-vault-other"
-                        / ".scripts"
-                        / "run.sh"
-                    ),
+                    str(context.home.parent / "old-vault-other" / ".scripts" / "run.sh"),
                 ],
             },
             handle,
@@ -2462,9 +2439,7 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
     assert "was skipped" in result.detail
 
 
-def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
-    monkeypatch, context
-):
+def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch, context):
     """User-installed com.<user>.dex.* jobs get real monitoring coverage (#253)."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2487,16 +2462,12 @@ def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
     assert str(missing_script) in result.detail
 
 
-def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
-    monkeypatch, context
-):
+def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkeypatch, context):
     """Ownership is path evidence, not the label: any plist into this vault counts."""
     plist = _write_plist(context, "com.mycompany.sync")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(
-        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
-    )
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2509,9 +2480,7 @@ def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
     assert "All 1 installed launch agents for this vault are loaded" in result.detail
 
 
-def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(
-    monkeypatch, context
-):
+def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(monkeypatch, context):
     """com.dexcom.* / com.samsung.dex.* / com.fedex.* are other products."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2562,9 +2531,7 @@ def test_corrupt_third_party_plists_never_degrade_job_monitoring(monkeypatch, co
     plist = _write_plist(context, "com.dex.smoke-nightly")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(
-        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
-    )
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2586,9 +2553,7 @@ def test_truncated_shipped_plist_is_unknown_not_a_probe_crash(monkeypatch, conte
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
     plist = agents / "com.dex.meeting-intel.plist"
-    plist.write_bytes(
-        b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>'
-    )
+    plist.write_bytes(b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>')
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
 
     loaded = doctor._probe_jobs_loaded(context)
@@ -2611,9 +2576,7 @@ def test_legacy_claudesidian_jobs_get_real_freshness_audits(context):
     assert "checked for loading only" not in result.detail
 
 
-def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(monkeypatch, context):
     """A partially repointed job (invocation current, other keys stale) is surfaced.
 
     The session-start hook greps raw bytes and keeps warning about the
@@ -2737,9 +2700,7 @@ def test_stored_former_vault_root_rejects_current_and_degenerate_roots(context):
     assert doctor._stored_former_vault_root(context) == former
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
-    monkeypatch, context
-):
+def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch, context):
     """A worktree path is foreign unless it is this vault's path evidence."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2760,14 +2721,11 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(
-    monkeypatch, context
-):
+def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(monkeypatch, context):
     checkout = context.home.parent / "checkouts" / "dex-copy"
     (checkout / ".scripts").mkdir(parents=True)
     (checkout / ".git").write_text("gitdir: /somewhere/else\n", encoding="utf-8")
@@ -2791,8 +2749,7 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checko
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
 
 
@@ -3001,8 +2958,7 @@ def test_customization_mcp_compiles_custom_python_without_running_or_littering(c
     target = context.vault_root / "custom-mcp" / "server.py"
     target.parent.mkdir()
     target.write_text(
-        "from pathlib import Path\n"
-        f"Path({str(sentinel)!r}).write_text('executed')\n",
+        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
         encoding="utf-8",
     )
     _write_mcp_config(
@@ -3179,8 +3135,7 @@ def test_worktree_blob_ids_hash_large_release_trees_in_pipe_safe_batches(
 ) -> None:
     relatives = [f"core/release-file-{index:04d}.py" for index in range(600)]
     expected = {
-        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest()
-        for relative in relatives
+        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest() for relative in relatives
     }
     observed_batches: list[list[str]] = []
 
@@ -3384,8 +3339,7 @@ def test_repository_credential_named_release_files_match_head_without_python_rea
     credential_paths = sorted(
         relative
         for relative in release_entries
-        if "credential" in relative.casefold()
-        and not relative.startswith("core/tests/")
+        if "credential" in relative.casefold() and not relative.startswith("core/tests/")
     )
     assert credential_paths == [
         "core/utils/credential_migration_exceptions.json",
@@ -3710,9 +3664,7 @@ def test_smoke_journeys_roll_up_broken_from_exit_one(monkeypatch, context):
     payload = {
         "schema_version": 1,
         "generated_at": NOW.isoformat(),
-        "journeys": [
-            {"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}
-        ],
+        "journeys": [{"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}],
         "summary": {"ok": 0, "broken": 1, "unknown": 0, "off": 0},
     }
     monkeypatch.setattr(
@@ -3776,20 +3728,14 @@ def test_granola_no_key_is_off_and_api_400_is_broken(monkeypatch, context):
     result = doctor._probe_granola_query_path(context)
     assert result.verdict == "BROKEN"
     assert result.detail == (
-        "Granola query failed (HTTP 400) — the connector may need updating. "
-        "Response: created_after is invalid"
+        "Granola query failed (HTTP 400) — the connector may need updating. Response: created_after is invalid"
     )
 
 
 def _write_backup_config(context, *, enabled=True):
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir(parents=True, exist_ok=True)
-    config.write_text(
-        "backup:\n"
-        f"  enabled: {str(enabled).lower()}\n"
-        "  backend: folder\n"
-        "  destination: /backups\n"
-    )
+    config.write_text(f"backup:\n  enabled: {str(enabled).lower()}\n  backend: folder\n  destination: /backups\n")
 
 
 def _write_backup_stamp(context, *, ok, timestamp, error=None, warnings=None):
@@ -3816,9 +3762,11 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
         context,
         ok=True,
         timestamp="2026-07-10T02:00:00+00:00",
-        warnings=["the vault's version history could not be bundled, so this "
-                  "set holds the notes archive only: fatal: Refusing to create "
-                  "empty bundle."],
+        warnings=[
+            "the vault's version history could not be bundled, so this "
+            "set holds the notes archive only: fatal: Refusing to create "
+            "empty bundle."
+        ],
     )
     result = doctor._probe_backup_freshness(context)
     assert result.verdict == "BROKEN"
@@ -3829,8 +3777,7 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
 
 def test_backup_freshness_stays_ok_when_the_run_recorded_no_warnings(context):
     _write_backup_config(context)
-    _write_backup_stamp(
-        context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
+    _write_backup_stamp(context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
     assert doctor._probe_backup_freshness(context).verdict == "OK"
 
 
@@ -3939,9 +3886,7 @@ def test_calendar_permission_boundaries_and_configured_name(monkeypatch, context
     )
     assert doctor._probe_calendar_access(context).verdict == "OFF"
 
-    (context.vault_root / "System" / "user-profile.yaml").write_text(
-        "calendar:\n  work_calendar: Team Calendar\n"
-    )
+    (context.vault_root / "System" / "user-profile.yaml").write_text("calendar:\n  work_calendar: Team Calendar\n")
     assert doctor._probe_calendar_access(context).verdict == "BROKEN"
 
     monkeypatch.setattr(doctor, "_calendar_permission_status", lambda _context: "denied")
@@ -3977,19 +3922,95 @@ def test_calendar_sandbox_failure_is_unknown(monkeypatch, context):
     assert doctor._probe_calendar_access(context).verdict == "UNKNOWN"
 
 
-def _register_apple_mail_user_scope(context, name="user-apple-mail"):
-    (context.home / ".claude.json").write_text(
-        json.dumps({"mcpServers": {name: {"command": "apple-mail-mcp", "args": ["serve"]}}})
-    )
+def _register_apple_mail_user_scope(context, name="user-apple-mail", *, env=None):
+    entry = {"command": "apple-mail-mcp", "args": ["serve"]}
+    if env is not None:
+        entry["env"] = env
+    (context.home / ".claude.json").write_text(json.dumps({"mcpServers": {name: entry}}))
 
 
 def _write_apple_mail_index(context, *, age_days=0.0, size=4096):
     index = context.home / ".apple-mail-mcp" / "index.db"
-    index.parent.mkdir(parents=True, exist_ok=True)
-    index.write_bytes(b"x" * size)
-    built = (context.now - timedelta(days=age_days)).timestamp()
-    os.utime(index, (built, built))
+    if size == 0:
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_bytes(b"")
+        index.chmod(0o600)
+        return index
+    last_sync = (context.now - timedelta(days=age_days)).isoformat()
+    _write_real_apple_mail_index(index, last_sync=last_sync)
     return index
+
+
+def _write_real_apple_mail_index(
+    path,
+    *,
+    last_sync="2026-07-11T11:00:00+00:00",
+    email_count=1,
+    fts_searchable=True,
+):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (5);
+        CREATE TABLE emails (
+            rowid INTEGER PRIMARY KEY,
+            message_id INTEGER NOT NULL,
+            account TEXT NOT NULL,
+            mailbox TEXT NOT NULL,
+            subject TEXT,
+            sender TEXT,
+            content TEXT,
+            date_received TEXT,
+            emlx_path TEXT,
+            attachment_count INTEGER DEFAULT 0,
+            indexed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE VIRTUAL TABLE emails_fts USING fts5(
+            subject, sender, content, content='emails', content_rowid='rowid'
+        );
+        CREATE TRIGGER emails_ai AFTER INSERT ON emails BEGIN
+            INSERT INTO emails_fts(rowid, subject, sender, content)
+            VALUES (new.rowid, new.subject, new.sender, new.content);
+        END;
+        CREATE TRIGGER emails_ad AFTER DELETE ON emails BEGIN
+            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
+            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
+        END;
+        CREATE TRIGGER emails_au AFTER UPDATE ON emails BEGIN
+            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
+            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
+            INSERT INTO emails_fts(rowid, subject, sender, content)
+            VALUES (new.rowid, new.subject, new.sender, new.content);
+        END;
+        CREATE TABLE sync_state (
+            account TEXT NOT NULL,
+            mailbox TEXT NOT NULL,
+            last_sync TEXT,
+            message_count INTEGER DEFAULT 0,
+            PRIMARY KEY(account, mailbox)
+        );
+        """
+    )
+    for rowid in range(1, email_count + 1):
+        connection.execute(
+            "INSERT INTO emails "
+            "(rowid, message_id, account, mailbox, subject, sender, content) "
+            "VALUES (?, ?, 'Fixture', 'INBOX', 'Fixture subject', "
+            "'fixture@example.com', 'Fixture body')",
+            (rowid, rowid),
+        )
+    connection.execute(
+        "INSERT INTO sync_state VALUES ('Fixture', 'INBOX', ?, ?)",
+        (last_sync, email_count),
+    )
+    if not fts_searchable:
+        connection.execute("INSERT INTO emails_fts(emails_fts) VALUES ('delete-all')")
+    connection.commit()
+    connection.close()
+    path.chmod(0o600)
+    return path
 
 
 def test_apple_mail_search_is_off_when_no_server_is_registered(context):
@@ -4000,17 +4021,18 @@ def test_apple_mail_search_is_off_when_no_server_is_registered(context):
     assert result.heal is None
 
 
-def test_apple_mail_search_detects_registration_at_either_scope(context):
+def test_apple_mail_search_detects_registration_at_either_scope(monkeypatch, context):
+    monkeypatch.setattr(doctor, "_is_macos", lambda: False)
     _register_apple_mail_user_scope(context)
-    assert doctor._apple_mail_registered(context) is True
+    assert doctor._probe_apple_mail_search(context).verdict == "UNKNOWN"
 
     (context.home / ".claude.json").unlink()
-    assert doctor._apple_mail_registered(context) is False
+    assert doctor._probe_apple_mail_search(context).verdict == "OFF"
 
     (context.vault_root / ".mcp.json").write_text(
         json.dumps({"mcpServers": {"mail": {"command": "pipx", "args": ["run", "apple-mail-mcp"]}}})
     )
-    assert doctor._apple_mail_registered(context) is True
+    assert doctor._probe_apple_mail_search(context).verdict == "UNKNOWN"
 
 
 def test_apple_mail_search_is_unknown_off_macos(monkeypatch, context):
@@ -4087,6 +4109,282 @@ def test_apple_mail_search_is_ok_with_a_fresh_index(monkeypatch, context):
     assert result.verdict == "OK"
     assert result.feature_status == "ok"
     assert result.heal is None
+
+
+def test_apple_mail_search_uses_custom_path_and_real_sqlite_state(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    custom_index = context.home / "private-mail" / "search.sqlite"
+    _write_real_apple_mail_index(custom_index)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        f'config_version = 1\n[index]\npath = "{custom_index}"\nstaleness_hours = 24\n'
+    )
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert str(custom_index) in result.detail
+    assert "1 indexed message" in result.detail
+
+
+def test_apple_mail_search_mcp_environment_overrides_toml_settings(monkeypatch, context):
+    custom_index = context.home / "client-specific" / "index.db"
+    _register_apple_mail_user_scope(
+        context,
+        env={
+            "APPLE_MAIL_INDEX_PATH": str(custom_index),
+            "APPLE_MAIL_INDEX_STALENESS_HOURS": "48",
+        },
+    )
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_real_apple_mail_index(
+        custom_index,
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        'config_version = 1\n[index]\npath = "/wrong/index.db"\nstaleness_hours = 1\n'
+    )
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert str(custom_index) in result.detail
+
+
+def test_apple_mail_search_reports_invalid_config_as_broken(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("config_version = [not valid TOML")
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config" in result.detail.lower()
+    assert "config.toml" in result.heal.action
+
+
+def test_apple_mail_search_reports_semantically_invalid_config_as_broken(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("[index]\nstaleness_hours = 24\n")
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config_version = 1" in result.detail
+    assert "config.toml" in result.heal.action
+
+
+def test_apple_mail_search_reports_empty_existing_config_as_broken(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text("")
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "config_version = 1" in result.detail
+
+
+def test_apple_mail_search_reports_malformed_registration_as_broken(
+    monkeypatch,
+    context,
+):
+    (context.home / ".claude.json").write_text('{"mcpServers": {"apple-mail": ')
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "could not be read" in result.detail
+    assert "MCP JSON" in result.heal.action
+
+
+def test_apple_mail_search_reports_null_registration_container_as_broken(
+    monkeypatch,
+    context,
+):
+    (context.home / ".claude.json").write_text('{"mcpServers": null}')
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "must contain an mcpServers object" in result.detail
+    assert "MCP JSON" in result.heal.action
+
+
+@pytest.mark.parametrize(
+    "broken_shape",
+    ["fake", "missing-schema", "empty-data", "empty-fts"],
+)
+def test_apple_mail_search_rejects_files_that_cannot_answer_searches(
+    monkeypatch,
+    context,
+    broken_shape,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    if broken_shape == "fake":
+        index.write_bytes(b"not a sqlite database")
+    elif broken_shape == "missing-schema":
+        with sqlite3.connect(index) as connection:
+            connection.execute("CREATE TABLE unrelated (value TEXT)")
+    elif broken_shape == "empty-data":
+        _write_real_apple_mail_index(index, email_count=0)
+    else:
+        _write_real_apple_mail_index(index, fts_searchable=False)
+    index.chmod(0o600)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "rebuild" in result.heal.action
+
+
+def test_apple_mail_search_process_environment_overrides_registration_and_toml(
+    monkeypatch,
+    context,
+):
+    registered_index = context.home / "registered" / "index.db"
+    process_index = context.home / "runtime" / "index.db"
+    _register_apple_mail_user_scope(
+        context,
+        env={
+            "APPLE_MAIL_INDEX_PATH": str(registered_index),
+            "APPLE_MAIL_INDEX_STALENESS_HOURS": "1",
+        },
+    )
+    monkeypatch.setenv("APPLE_MAIL_INDEX_PATH", str(process_index))
+    monkeypatch.setenv("APPLE_MAIL_INDEX_STALENESS_HOURS", "48")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_real_apple_mail_index(
+        process_index,
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    config_dir = context.home / ".apple-mail-mcp"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        f'config_version = 1\n[index]\npath = "{context.home / "toml" / "index.db"}"\nstaleness_hours = 1\n'
+    )
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert str(process_index) in result.detail
+
+
+def test_apple_mail_search_resolves_relative_path_from_server_vault(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(
+        context,
+        env={"APPLE_MAIL_INDEX_PATH": "runtime/mail-index.db"},
+    )
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    relative_index = context.vault_root / "runtime" / "mail-index.db"
+    _write_real_apple_mail_index(relative_index)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert str(relative_index) in result.detail
+
+
+def test_apple_mail_search_default_freshness_is_24_hours(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    _write_real_apple_mail_index(
+        index,
+        last_sync=(context.now - timedelta(hours=25)).isoformat(),
+    )
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "configured 24-hour freshness limit" in result.detail
+
+
+def test_apple_mail_search_uses_configured_sync_freshness_not_file_mtime(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    index = _write_real_apple_mail_index(
+        context.home / ".apple-mail-mcp" / "index.db",
+        last_sync="2026-07-10T11:00:00+00:00",
+    )
+    os.utime(index, (context.now.timestamp(), context.now.timestamp()))
+    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 24\n")
+
+    stale = doctor._probe_apple_mail_search(context)
+    assert stale.verdict == "BROKEN"
+    assert "configured 24-hour freshness limit" in stale.detail
+
+    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 48\n")
+    fresh_by_policy = doctor._probe_apple_mail_search(context)
+    assert fresh_by_policy.verdict == "OK"
+
+
+@pytest.mark.parametrize(
+    ("sidecar", "mode"),
+    [("", 0o644), ("-wal", 0o644), ("-shm", 0o644), ("", 0o700)],
+)
+def test_apple_mail_search_rejects_non_private_index_files(
+    monkeypatch,
+    context,
+    sidecar,
+    mode,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    index = _write_real_apple_mail_index(context.home / ".apple-mail-mcp" / "index.db")
+    exposed = Path(f"{index}{sidecar}")
+    if sidecar:
+        exposed.write_bytes(b"fixture sidecar")
+    exposed.chmod(mode)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "chmod 600" in result.heal.action
+    assert str(exposed) in result.detail
+    assert "subjects, senders, bodies, file paths, and attachment metadata" in result.user_message
 
 
 def test_calendar_permission_adapter_preserves_eventkit_status(monkeypatch, context):
@@ -4210,12 +4508,7 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir()
     config.write_text(
-        "todoist:\n"
-        "  enabled: true\n"
-        "  task_sync: true\n"
-        "  api_key_env_var: TODOIST_API_KEY\n"
-        "notion:\n"
-        "  enabled: true\n"
+        "todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\nnotion:\n  enabled: true\n"
     )
     (context.vault_root / ".env").write_text('TODOIST_API_KEY="secret"\n')
     (context.vault_root / ".env").chmod(0o600)
@@ -4258,12 +4551,7 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     assert with_unverifiable.verdict == "UNKNOWN"
     assert "notion" in with_unverifiable.detail
 
-    config.write_text(
-        "todoist:\n"
-        "  enabled: true\n"
-        "  task_sync: true\n"
-        "  api_key_env_var: TODOIST_API_KEY\n"
-    )
+    config.write_text("todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\n")
     assert doctor._probe_integrations_enabled(context).verdict == "OK"
 
 
@@ -4333,11 +4621,7 @@ def test_integrations_engine_stored_but_unverified_rows_are_unknown(monkeypatch,
         lambda command, **_kwargs: subprocess.CompletedProcess(
             command,
             0,
-            stdout=(
-                '{"connections":[{"service":"google","status":"'
-                + status
-                + '","verified":false}]}\n'
-            ),
+            stdout=('{"connections":[{"service":"google","status":"' + status + '","verified":false}]}\n'),
             stderr="",
         ),
     )
@@ -4506,7 +4790,7 @@ def test_post_update_canary_probe_reads_the_receipt(context):
 
 def test_meeting_sources_probe_is_ok_for_api_sources_without_folders(context):
     profile = context.vault_root / "System" / "user-profile.yaml"
-    profile.write_text("meeting_sources:\n  primary: granola\n  notes_folder: \"\"\n", encoding="utf-8")
+    profile.write_text('meeting_sources:\n  primary: granola\n  notes_folder: ""\n', encoding="utf-8")
     result = doctor._probe_meeting_sources(context)
     assert result.verdict == "OK"
     assert "granola" in result.detail

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -4361,6 +4361,32 @@ def test_apple_mail_search_uses_configured_sync_freshness_not_file_mtime(
 
 
 @pytest.mark.parametrize(
+    "last_sync",
+    [
+        pytest.param("2026-07-11T11:00:00", id="upstream-naive-local-iso"),
+        pytest.param("2026-07-11T12:00:00+01:00", id="offset-aware-iso"),
+    ],
+)
+def test_apple_mail_search_accepts_upstream_and_offset_sync_timestamps(
+    monkeypatch,
+    context,
+    last_sync,
+):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_real_apple_mail_index(
+        context.home / ".apple-mail-mcp" / "index.db",
+        last_sync=last_sync,
+    )
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert "last synced 1 hour ago" in result.detail
+
+
+@pytest.mark.parametrize(
     ("sidecar", "mode"),
     [("", 0o644), ("-wal", 0o644), ("-shm", 0o644), ("", 0o700)],
 )

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -68,6 +68,7 @@ DEEP_IDS = [
     "config.meeting_sources",
     "update.post-canary",
     "calendar.access",
+    "mail.apple-search",
     "qmd.live",
     "integrations.enabled",
     "mcp.importable",
@@ -3974,6 +3975,118 @@ def test_calendar_sandbox_failure_is_unknown(monkeypatch, context):
     )
 
     assert doctor._probe_calendar_access(context).verdict == "UNKNOWN"
+
+
+def _register_apple_mail_user_scope(context, name="user-apple-mail"):
+    (context.home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {name: {"command": "apple-mail-mcp", "args": ["serve"]}}})
+    )
+
+
+def _write_apple_mail_index(context, *, age_days=0.0, size=4096):
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_bytes(b"x" * size)
+    built = (context.now - timedelta(days=age_days)).timestamp()
+    os.utime(index, (built, built))
+    return index
+
+
+def test_apple_mail_search_is_off_when_no_server_is_registered(context):
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OFF"
+    assert result.feature_status == "off"
+    assert result.heal is None
+
+
+def test_apple_mail_search_detects_registration_at_either_scope(context):
+    _register_apple_mail_user_scope(context)
+    assert doctor._apple_mail_registered(context) is True
+
+    (context.home / ".claude.json").unlink()
+    assert doctor._apple_mail_registered(context) is False
+
+    (context.vault_root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"mail": {"command": "pipx", "args": ["run", "apple-mail-mcp"]}}})
+    )
+    assert doctor._apple_mail_registered(context) is True
+
+
+def test_apple_mail_search_is_unknown_off_macos(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: False)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert result.feature_status == "unknown"
+
+
+def test_apple_mail_search_is_broken_when_the_command_is_missing(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: False)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "pipx install apple-mail-mcp" in result.heal.action
+
+
+def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch, context):
+    """The silent failure from #446: list/read work, so search looks healthy while returning nothing."""
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "apple-mail-mcp index" in result.heal.action
+    assert "Full Disk Access" in result.heal.action
+    assert "returns nothing" in result.user_message
+
+
+def test_apple_mail_search_is_broken_when_the_index_is_empty(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_apple_mail_index(context, size=0)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "empty" in result.detail
+
+
+def test_apple_mail_search_is_broken_when_the_index_has_gone_stale(monkeypatch, context):
+    """Startup sync silently no-ops without Full Disk Access, so a built index quietly stales."""
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_apple_mail_index(context, age_days=30)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "BROKEN"
+    assert "30 days ago" in result.detail
+    assert "apple-mail-mcp index" in result.heal.action
+
+
+def test_apple_mail_search_is_ok_with_a_fresh_index(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+    _write_apple_mail_index(context, age_days=1)
+
+    result = doctor._probe_apple_mail_search(context)
+
+    assert result.verdict == "OK"
+    assert result.feature_status == "ok"
+    assert result.heal is None
 
 
 def test_calendar_permission_adapter_preserves_eventkit_status(monkeypatch, context):

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -4054,7 +4054,7 @@ def test_apple_mail_search_is_broken_when_the_command_is_missing(monkeypatch, co
 
     assert result.verdict == "BROKEN"
     assert result.feature_status == "broken"
-    assert "pipx install apple-mail-mcp" in result.heal.action
+    assert "pipx install 'apple-mail-mcp==0.4.3'" in result.heal.action
 
 
 def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch, context):

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -6,7 +6,6 @@ import os
 import plistlib
 import re
 import shutil
-import sqlite3
 import stat
 import subprocess
 import sys
@@ -94,7 +93,9 @@ def foreign_launch_agents(context):
     agents.mkdir(parents=True, exist_ok=True)
     definitions = {
         "com.dex.research-scan": ".scripts/research-scan.py",
-        "com.dex.other-product": str(context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"),
+        "com.dex.other-product": str(
+            context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"
+        ),
     }
     plists = []
     for label, script in definitions.items():
@@ -177,37 +178,21 @@ def _write_plist(context, label):
 def _write_entity_probe_files(context, *, mode="auto", unresolved=None):
     runtime = context.vault_root / "System" / ".dex"
     runtime.mkdir(parents=True, exist_ok=True)
-    (runtime / "contacts.json").write_text(
-        json.dumps(
-            {
-                "contacts": {"one": {}},
-                "observations": {"m1": {}, "m2": {}},
-            }
-        )
+    (runtime / "contacts.json").write_text(json.dumps({
+        "contacts": {"one": {}}, "observations": {"m1": {}, "m2": {}},
+    }))
+    (runtime / "entity-suggestions.json").write_text(json.dumps({
+        "suggestions": [{"status": "suggested"}],
+    }))
+    (runtime / "entity-verification.json").write_text(json.dumps({
+        "generated_at": NOW.isoformat(), "unresolved": unresolved or [],
+    }))
+    (context.vault_root / "System" / "user-profile.yaml").write_text(
+        f"entity_creation:\n  mode: {mode}\n"
     )
-    (runtime / "entity-suggestions.json").write_text(
-        json.dumps(
-            {
-                "suggestions": [{"status": "suggested"}],
-            }
-        )
-    )
-    (runtime / "entity-verification.json").write_text(
-        json.dumps(
-            {
-                "generated_at": NOW.isoformat(),
-                "unresolved": unresolved or [],
-            }
-        )
-    )
-    (context.vault_root / "System" / "user-profile.yaml").write_text(f"entity_creation:\n  mode: {mode}\n")
-    (context.vault_root / "System" / "People_Index.json").write_text(
-        json.dumps(
-            {
-                "built_at": NOW.isoformat(),
-            }
-        )
-    )
+    (context.vault_root / "System" / "People_Index.json").write_text(json.dumps({
+        "built_at": NOW.isoformat(),
+    }))
 
 
 def _write_release_catalog(context, *, content=b"release skill\n"):
@@ -300,7 +285,11 @@ def _drift_context(tmp_path, *, release_ref=True, channel=None):
     (vault / "core").mkdir()
     (vault / "core" / "shipped.py").write_text("SHIPPED = 1\n")
     (vault / "CLAUDE.md").write_text(
-        "# Dex\n\n## USER_EXTENSIONS_START\n<!-- personal instructions -->\n## USER_EXTENSIONS_END\n\nShipped tail.\n"
+        "# Dex\n\n"
+        "## USER_EXTENSIONS_START\n"
+        "<!-- personal instructions -->\n"
+        "## USER_EXTENSIONS_END\n\n"
+        "Shipped tail.\n"
     )
     (vault / ".mcp.json").write_text(
         json.dumps(
@@ -377,14 +366,9 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     _write_entity_probe_files(context)
     (context.vault_root / "System" / "user-profile.yaml").write_text("name: Test\n")
     verification = context.vault_root / "System" / ".dex" / "entity-verification.json"
-    verification.write_text(
-        json.dumps(
-            {
-                "generated_at": (NOW - timedelta(hours=49)).isoformat(),
-                "unresolved": [],
-            }
-        )
-    )
+    verification.write_text(json.dumps({
+        "generated_at": (NOW - timedelta(hours=49)).isoformat(), "unresolved": [],
+    }))
     result = doctor._probe_entity_engine(context)
     assert result.verdict == "OK"
     assert "suggest (default — key missing)" in result.detail
@@ -402,7 +386,10 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
                 "meeting_id": "meeting-1",
                 "meeting_ids": ["meeting-1"],
                 "op_type": "mutate",
-                "entity_path": (str(context.vault_root) + "/05-Areas/People/External/Jane_Example.md"),
+                "entity_path": (
+                    str(context.vault_root)
+                    + "/05-Areas/People/External/Jane_Example.md"
+                ),
                 "entity_identity": {
                     "kind": "person",
                     "name": "Jane Example",
@@ -427,7 +414,9 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
         action="Re-queue the dead-lettered entity write with retry counters reset.",
         applied=False,
     )
-    definition = next(item for item in doctor.QUICK_CHECKS if item.id == "entity.engine")
+    definition = next(
+        item for item in doctor.QUICK_CHECKS if item.id == "entity.engine"
+    )
     rendered = doctor._result_json(definition, result)
     assert rendered["feature_status"] == "broken"
     assert rendered["user_message"] == result.user_message
@@ -446,13 +435,10 @@ def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
     monkeypatch.setattr(
         doctor,
         "_requeue_entity_dead_letters",
-        lambda candidate: (
-            calls.append(candidate)
-            or {
-                "requeued": 1,
-                "dead_letter_ids": ["example-dead-letter"],
-            }
-        ),
+        lambda candidate: calls.append(candidate) or {
+            "requeued": 1,
+            "dead_letter_ids": ["example-dead-letter"],
+        },
     )
 
     actions, errors = doctor._apply_t1_heals(context)
@@ -468,7 +454,13 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
     _write_entity_probe_files(context)
     operation = {
         "op": "create",
-        "path": str(context.vault_root / "05-Areas" / "People" / "External" / "Jane_Example.md"),
+        "path": str(
+            context.vault_root
+            / "05-Areas"
+            / "People"
+            / "External"
+            / "Jane_Example.md"
+        ),
         "content": "# Jane Example\n",
         "allowed_root": str(context.vault_root),
     }
@@ -497,7 +489,9 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
 
     assert healed["requeued"] == 1
     assert not dead_letter.exists()
-    pending = json.loads((context.vault_root / "System" / ".dex" / "entity-pending.json").read_text())
+    pending = json.loads(
+        (context.vault_root / "System" / ".dex" / "entity-pending.json").read_text()
+    )
     assert pending["batches"][0]["ops"] == [operation]
     assert doctor._probe_entity_engine(context).verdict == "OK"
 
@@ -511,17 +505,10 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 2,
-                "pages": {
-                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-                    "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 2, "pages": {
+        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+        "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
+    }}))
     result = doctor._probe_entity_engine(context)
     assert "gardener on (2 pages maintained), 1 user-owned summary" in result.detail
 
@@ -530,16 +517,9 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     result = doctor._probe_entity_engine(context)
     assert "gardener off (disabled), 1 user-owned summary" in result.detail
 
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "pages": {
-                    "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 1, "pages": {
+        "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
+    }}))
     result = doctor._probe_entity_engine(context)
     assert "1 legacy lock pending migration" in result.detail
 
@@ -549,16 +529,9 @@ def test_entity_engine_probe_reads_llm_key_from_vault_env_file(monkeypatch, cont
         monkeypatch.delenv(key, raising=False)
     _write_entity_probe_files(context)
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 2,
-                "pages": {
-                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 2, "pages": {
+        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+    }}))
     env_path = context.vault_root / ".env"
     env_path.write_text("# local keys\nexport GEMINI_API_KEY='test-placeholder-key'\n")
 
@@ -932,7 +905,9 @@ def test_adoption_plan_probe_is_broken_on_a_real_bridge_pin_mismatch(context):
 
 
 def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
-    (context.vault_root / "System/.release-catalog.json").write_text("{not json", encoding="utf-8")
+    (context.vault_root / "System/.release-catalog.json").write_text(
+        "{not json", encoding="utf-8"
+    )
     _stub_probes(monkeypatch, exclude={"release.catalog", "adoption.plan"})
 
     report = doctor.collect(context=context)
@@ -961,7 +936,9 @@ def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
         ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
         check=True,
     )
-    (brain / "dex-brain-v2").write_text(json.dumps({"role": "brain", "installed": commit}) + "\n")
+    (brain / "dex-brain-v2").write_text(
+        json.dumps({"role": "brain", "installed": commit}) + "\n"
+    )
     topology = context.vault_root / "System/.dex/topology.json"
     topology.parent.mkdir(parents=True, exist_ok=True)
     topology.write_text(
@@ -984,7 +961,10 @@ def test_topology_probe_distinguishes_combined_split_and_invalid(context):
     assert doctor._topology_state(context) == "combined"
     assert doctor._probe_migration_pending(context).verdict == "OFF"
 
-    migrator = context.vault_root / "core/migrations/v1-to-v2-brain-vault-split.cjs"
+    migrator = (
+        context.vault_root
+        / "core/migrations/v1-to-v2-brain-vault-split.cjs"
+    )
     migrator.parent.mkdir(parents=True)
     migrator.write_text("'use strict';\n", encoding="utf-8")
     assert doctor._topology_state(context) == "migration-pending"
@@ -1289,7 +1269,8 @@ def test_missing_optional_packages_have_actionable_unknown_detail(monkeypatch, c
     report = doctor.collect(context=context)
 
     guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor"
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+        "then re-run /dex-doctor"
     )
     assert _check(report, "vault.configs")["verdict"] == "UNKNOWN"
     assert _check(report, "vault.configs")["detail"] == guidance + "."
@@ -1310,7 +1291,8 @@ def test_probe_owned_unknown_missing_package_detail_is_actionable(monkeypatch, c
     report = doctor.collect(deep=True, context=context)
 
     assert _check(report, "calendar.access")["detail"] == (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor."
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+        "then re-run /dex-doctor."
     )
     assert report["instruments"]["failed"] == []
 
@@ -1379,7 +1361,10 @@ def test_heal_applies_all_t1_actions_and_leaves_t2_suggestion_untouched(
     assert "Missing standard PARA directories: 00-Inbox" in structure["detail"]
     assert structure["heal"] == {
         "tier": 1,
-        "action": ("regenerated core/paths.json; restored executable permission on .scripts/repo-tool.sh."),
+        "action": (
+            "regenerated core/paths.json; restored executable permission on "
+            ".scripts/repo-tool.sh."
+        ),
         "applied": True,
     }
     assert _check(report, "mcp.registered")["heal"] == {
@@ -1409,7 +1394,9 @@ def test_quick_mode_does_not_apply_t1_without_heal(monkeypatch, context):
     assert not script.stat().st_mode & stat.S_IXUSR
 
 
-def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(monkeypatch, context):
+def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(
+    monkeypatch, context
+):
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     script = context.vault_root / ".scripts" / "repair-me.sh"
@@ -1481,7 +1468,9 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
     structure = _check(report, "vault.structure")
     assert structure["verdict"] == "UNKNOWN"
     assert structure["heal"]["applied"] is True
-    assert report["instruments"]["failed"] == [{"id": "vault.structure", "error": "structure probe exploded"}]
+    assert report["instruments"]["failed"] == [
+        {"id": "vault.structure", "error": "structure probe exploded"}
+    ]
 
 
 def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, capsys):
@@ -1529,7 +1518,8 @@ def test_cli_still_emits_json_when_yaml_is_not_importable(tmp_path):
     assert result.returncode == 0
     report = json.loads(result.stdout)
     guidance = (
-        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor."
+        "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+        "then re-run /dex-doctor."
     )
     for check_id in ("vault.configs", "customizations.skills", "customizations.mcp"):
         assert _check(report, check_id)["verdict"] == "UNKNOWN"
@@ -1585,7 +1575,10 @@ def test_capability_rooms_probe_detects_missing_on_assets_and_live_off_skills(
     assert "quarter-plan" in result.detail
     assert result.heal == doctor.Heal(
         tier=1,
-        action=("Reconcile capability room folders and shipped skills without deleting user content."),
+        action=(
+            "Reconcile capability room folders and shipped skills without "
+            "deleting user content."
+        ),
         applied=False,
     )
 
@@ -1608,7 +1601,9 @@ def test_capability_seed_probe_advises_update_only_for_enabled_rooms(
     )
     career = context.vault_root / "05-Areas/Career"
     career.mkdir(parents=True)
-    dormant = REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
+    dormant = (
+        REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
+    )
     for skill in ("career-setup", "career-coach", "resume-builder"):
         shutil.copytree(dormant / skill, context.vault_root / ".claude/skills" / skill)
 
@@ -1643,7 +1638,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     (context.vault_root / "System/user-profile.yaml").write_text(
-        "name: Legacy User\nrole: Founder\n",
+        "name: Legacy User\n"
+        "role: Founder\n",
         encoding="utf-8",
     )
     user_note = context.vault_root / "05-Areas/Career/private-review.md"
@@ -1652,7 +1648,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     existing_skill = context.vault_root / ".claude/skills/quarter-plan/SKILL.md"
     existing_skill.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(
-        REPO_ROOT / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
+        REPO_ROOT
+        / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
         existing_skill,
     )
     context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1673,9 +1670,13 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "applied": True,
     }
     assert user_note.read_text(encoding="utf-8") == "Keep this forever.\n"
-    assert (context.vault_root / "05-Areas/Career/Evidence/README.md").is_file()
+    assert (
+        context.vault_root / "05-Areas/Career/Evidence/README.md"
+    ).is_file()
     for skill in ("career-setup", "career-coach", "resume-builder"):
-        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
+        assert (
+            context.vault_root / ".claude/skills" / skill / "SKILL.md"
+        ).is_file()
     for skill in (
         "career-setup",
         "career-coach",
@@ -1683,8 +1684,12 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "quarter-plan",
         "quarter-review",
     ):
-        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
-    profile = (context.vault_root / "System/user-profile.yaml").read_text(encoding="utf-8")
+        assert (
+            context.vault_root / ".claude/skills" / skill / "SKILL.md"
+        ).is_file()
+    profile = (
+        context.vault_root / "System/user-profile.yaml"
+    ).read_text(encoding="utf-8")
     assert "companies:\n    enabled: true" in profile
 
 
@@ -1802,7 +1807,11 @@ def test_mcp_probes_read_legacy_config_without_moving_it(context):
     server = mcp_dir / "alpha_server.py"
     server.touch()
     legacy = context.vault_root / "System" / ".mcp.json"
-    legacy.write_text(json.dumps({"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}))
+    legacy.write_text(
+        json.dumps(
+            {"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}
+        )
+    )
 
     before = _tree_snapshot(context.vault_root)
     registered = doctor._probe_mcp_registered(context)
@@ -1871,7 +1880,9 @@ def test_hooks_wired_detects_dangling_hook_files(context):
         json.dumps(
             {
                 "hooks": {
-                    "SessionStart": [{"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}]
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}
+                    ]
                 }
             }
         )
@@ -1935,7 +1946,8 @@ def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 2 Dex launch agents from other Dex products were skipped"
+        "No launch agents for this vault are installed; "
+        "2 Dex launch agents from other Dex products were skipped"
     )
     assert "research-scan.py" not in result.detail
 
@@ -1963,7 +1975,8 @@ def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypa
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -1991,7 +2004,8 @@ def test_shipped_job_from_another_worktree_vault_is_not_a_failure(monkeypatch, c
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2353,7 +2367,9 @@ def _write_breadcrumb(context, former_vault):
     return breadcrumb
 
 
-def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkeypatch, context):
+def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
+    monkeypatch, context
+):
     """A job left behind by a vault move is owned-and-stale, never foreign (#364)."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2384,7 +2400,9 @@ def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkey
     assert str(context.vault_root) in result.heal.action
 
 
-def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(monkeypatch, context):
+def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(
+    monkeypatch, context
+):
     """The hook and the doctor must agree: any label pointing at the former root."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2425,7 +2443,12 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
                 "Label": "com.dex.sibling-product",
                 "ProgramArguments": [
                     "/bin/bash",
-                    str(context.home.parent / "old-vault-other" / ".scripts" / "run.sh"),
+                    str(
+                        context.home.parent
+                        / "old-vault-other"
+                        / ".scripts"
+                        / "run.sh"
+                    ),
                 ],
             },
             handle,
@@ -2439,7 +2462,9 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
     assert "was skipped" in result.detail
 
 
-def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch, context):
+def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
+    monkeypatch, context
+):
     """User-installed com.<user>.dex.* jobs get real monitoring coverage (#253)."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2462,12 +2487,16 @@ def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch
     assert str(missing_script) in result.detail
 
 
-def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkeypatch, context):
+def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
+    monkeypatch, context
+):
     """Ownership is path evidence, not the label: any plist into this vault counts."""
     plist = _write_plist(context, "com.mycompany.sync")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
+    monkeypatch.setattr(
+        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
+    )
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2480,7 +2509,9 @@ def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkey
     assert "All 1 installed launch agents for this vault are loaded" in result.detail
 
 
-def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(monkeypatch, context):
+def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(
+    monkeypatch, context
+):
     """com.dexcom.* / com.samsung.dex.* / com.fedex.* are other products."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2531,7 +2562,9 @@ def test_corrupt_third_party_plists_never_degrade_job_monitoring(monkeypatch, co
     plist = _write_plist(context, "com.dex.smoke-nightly")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
+    monkeypatch.setattr(
+        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
+    )
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2553,7 +2586,9 @@ def test_truncated_shipped_plist_is_unknown_not_a_probe_crash(monkeypatch, conte
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
     plist = agents / "com.dex.meeting-intel.plist"
-    plist.write_bytes(b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>')
+    plist.write_bytes(
+        b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>'
+    )
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
 
     loaded = doctor._probe_jobs_loaded(context)
@@ -2576,7 +2611,9 @@ def test_legacy_claudesidian_jobs_get_real_freshness_audits(context):
     assert "checked for loading only" not in result.detail
 
 
-def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(monkeypatch, context):
+def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(
+    monkeypatch, context
+):
     """A partially repointed job (invocation current, other keys stale) is surfaced.
 
     The session-start hook greps raw bytes and keeps warning about the
@@ -2700,7 +2737,9 @@ def test_stored_former_vault_root_rejects_current_and_degenerate_roots(context):
     assert doctor._stored_former_vault_root(context) == former
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch, context):
+def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
+    monkeypatch, context
+):
     """A worktree path is foreign unless it is this vault's path evidence."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2721,11 +2760,14 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch,
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(monkeypatch, context):
+def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(
+    monkeypatch, context
+):
     checkout = context.home.parent / "checkouts" / "dex-copy"
     (checkout / ".scripts").mkdir(parents=True)
     (checkout / ".git").write_text("gitdir: /somewhere/else\n", encoding="utf-8")
@@ -2749,7 +2791,8 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checko
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
 
 
@@ -2958,7 +3001,8 @@ def test_customization_mcp_compiles_custom_python_without_running_or_littering(c
     target = context.vault_root / "custom-mcp" / "server.py"
     target.parent.mkdir()
     target.write_text(
-        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
+        "from pathlib import Path\n"
+        f"Path({str(sentinel)!r}).write_text('executed')\n",
         encoding="utf-8",
     )
     _write_mcp_config(
@@ -3135,7 +3179,8 @@ def test_worktree_blob_ids_hash_large_release_trees_in_pipe_safe_batches(
 ) -> None:
     relatives = [f"core/release-file-{index:04d}.py" for index in range(600)]
     expected = {
-        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest() for relative in relatives
+        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest()
+        for relative in relatives
     }
     observed_batches: list[list[str]] = []
 
@@ -3339,7 +3384,8 @@ def test_repository_credential_named_release_files_match_head_without_python_rea
     credential_paths = sorted(
         relative
         for relative in release_entries
-        if "credential" in relative.casefold() and not relative.startswith("core/tests/")
+        if "credential" in relative.casefold()
+        and not relative.startswith("core/tests/")
     )
     assert credential_paths == [
         "core/utils/credential_migration_exceptions.json",
@@ -3664,7 +3710,9 @@ def test_smoke_journeys_roll_up_broken_from_exit_one(monkeypatch, context):
     payload = {
         "schema_version": 1,
         "generated_at": NOW.isoformat(),
-        "journeys": [{"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}],
+        "journeys": [
+            {"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}
+        ],
         "summary": {"ok": 0, "broken": 1, "unknown": 0, "off": 0},
     }
     monkeypatch.setattr(
@@ -3728,14 +3776,20 @@ def test_granola_no_key_is_off_and_api_400_is_broken(monkeypatch, context):
     result = doctor._probe_granola_query_path(context)
     assert result.verdict == "BROKEN"
     assert result.detail == (
-        "Granola query failed (HTTP 400) — the connector may need updating. Response: created_after is invalid"
+        "Granola query failed (HTTP 400) — the connector may need updating. "
+        "Response: created_after is invalid"
     )
 
 
 def _write_backup_config(context, *, enabled=True):
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir(parents=True, exist_ok=True)
-    config.write_text(f"backup:\n  enabled: {str(enabled).lower()}\n  backend: folder\n  destination: /backups\n")
+    config.write_text(
+        "backup:\n"
+        f"  enabled: {str(enabled).lower()}\n"
+        "  backend: folder\n"
+        "  destination: /backups\n"
+    )
 
 
 def _write_backup_stamp(context, *, ok, timestamp, error=None, warnings=None):
@@ -3762,11 +3816,9 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
         context,
         ok=True,
         timestamp="2026-07-10T02:00:00+00:00",
-        warnings=[
-            "the vault's version history could not be bundled, so this "
-            "set holds the notes archive only: fatal: Refusing to create "
-            "empty bundle."
-        ],
+        warnings=["the vault's version history could not be bundled, so this "
+                  "set holds the notes archive only: fatal: Refusing to create "
+                  "empty bundle."],
     )
     result = doctor._probe_backup_freshness(context)
     assert result.verdict == "BROKEN"
@@ -3777,7 +3829,8 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
 
 def test_backup_freshness_stays_ok_when_the_run_recorded_no_warnings(context):
     _write_backup_config(context)
-    _write_backup_stamp(context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
+    _write_backup_stamp(
+        context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
     assert doctor._probe_backup_freshness(context).verdict == "OK"
 
 
@@ -3886,7 +3939,9 @@ def test_calendar_permission_boundaries_and_configured_name(monkeypatch, context
     )
     assert doctor._probe_calendar_access(context).verdict == "OFF"
 
-    (context.vault_root / "System" / "user-profile.yaml").write_text("calendar:\n  work_calendar: Team Calendar\n")
+    (context.vault_root / "System" / "user-profile.yaml").write_text(
+        "calendar:\n  work_calendar: Team Calendar\n"
+    )
     assert doctor._probe_calendar_access(context).verdict == "BROKEN"
 
     monkeypatch.setattr(doctor, "_calendar_permission_status", lambda _context: "denied")
@@ -3922,495 +3977,42 @@ def test_calendar_sandbox_failure_is_unknown(monkeypatch, context):
     assert doctor._probe_calendar_access(context).verdict == "UNKNOWN"
 
 
-def _register_apple_mail_user_scope(context, name="user-apple-mail", *, env=None):
-    entry = {"command": "apple-mail-mcp", "args": ["serve"]}
-    if env is not None:
-        entry["env"] = env
-    (context.home / ".claude.json").write_text(json.dumps({"mcpServers": {name: entry}}))
-
-
-def _write_apple_mail_index(context, *, age_days=0.0, size=4096):
-    index = context.home / ".apple-mail-mcp" / "index.db"
-    if size == 0:
-        index.parent.mkdir(parents=True, exist_ok=True)
-        index.write_bytes(b"")
-        index.chmod(0o600)
-        return index
-    last_sync = (context.now - timedelta(days=age_days)).isoformat()
-    _write_real_apple_mail_index(index, last_sync=last_sync)
-    return index
-
-
-def _write_real_apple_mail_index(
-    path,
-    *,
-    last_sync="2026-07-11T11:00:00+00:00",
-    email_count=1,
-    fts_searchable=True,
+def test_apple_mail_search_is_a_deep_check_and_adapts_the_focused_probe(
+    monkeypatch,
+    context,
 ):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    connection = sqlite3.connect(path)
-    connection.executescript(
-        """
-        CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
-        INSERT INTO schema_version VALUES (5);
-        CREATE TABLE emails (
-            rowid INTEGER PRIMARY KEY,
-            message_id INTEGER NOT NULL,
-            account TEXT NOT NULL,
-            mailbox TEXT NOT NULL,
-            subject TEXT,
-            sender TEXT,
-            content TEXT,
-            date_received TEXT,
-            emlx_path TEXT,
-            attachment_count INTEGER DEFAULT 0,
-            indexed_at TEXT DEFAULT (datetime('now'))
-        );
-        CREATE VIRTUAL TABLE emails_fts USING fts5(
-            subject, sender, content, content='emails', content_rowid='rowid'
-        );
-        CREATE TRIGGER emails_ai AFTER INSERT ON emails BEGIN
-            INSERT INTO emails_fts(rowid, subject, sender, content)
-            VALUES (new.rowid, new.subject, new.sender, new.content);
-        END;
-        CREATE TRIGGER emails_ad AFTER DELETE ON emails BEGIN
-            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
-            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
-        END;
-        CREATE TRIGGER emails_au AFTER UPDATE ON emails BEGIN
-            INSERT INTO emails_fts(emails_fts, rowid, subject, sender, content)
-            VALUES ('delete', old.rowid, old.subject, old.sender, old.content);
-            INSERT INTO emails_fts(rowid, subject, sender, content)
-            VALUES (new.rowid, new.subject, new.sender, new.content);
-        END;
-        CREATE TABLE sync_state (
-            account TEXT NOT NULL,
-            mailbox TEXT NOT NULL,
-            last_sync TEXT,
-            message_count INTEGER DEFAULT 0,
-            PRIMARY KEY(account, mailbox)
-        );
-        """
-    )
-    for rowid in range(1, email_count + 1):
-        connection.execute(
-            "INSERT INTO emails "
-            "(rowid, message_id, account, mailbox, subject, sender, content) "
-            "VALUES (?, ?, 'Fixture', 'INBOX', 'Fixture subject', "
-            "'fixture@example.com', 'Fixture body')",
-            (rowid, rowid),
+    assert "mail.apple-search" in DEEP_IDS
+    definition = next(check for check in doctor.DEEP_CHECKS if check.id == "mail.apple-search")
+    assert definition.probe == "_probe_apple_mail_search"
+
+    observed = {}
+
+    def probe(adapter_context):
+        observed["context"] = adapter_context
+        return doctor.apple_mail_health.Result(
+            "BROKEN",
+            "Index cannot answer searches",
+            action="Rebuild it",
+            feature_status="broken",
+            user_message="Mail search needs attention.",
         )
-    connection.execute(
-        "INSERT INTO sync_state VALUES ('Fixture', 'INBOX', ?, ?)",
-        (last_sync, email_count),
-    )
-    if not fts_searchable:
-        connection.execute("INSERT INTO emails_fts(emails_fts) VALUES ('delete-all')")
-    connection.commit()
-    connection.close()
-    path.chmod(0o600)
-    return path
 
-
-def test_apple_mail_search_is_off_when_no_server_is_registered(context):
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OFF"
-    assert result.feature_status == "off"
-    assert result.heal is None
-
-
-def test_apple_mail_search_detects_registration_at_either_scope(monkeypatch, context):
-    monkeypatch.setattr(doctor, "_is_macos", lambda: False)
-    _register_apple_mail_user_scope(context)
-    assert doctor._probe_apple_mail_search(context).verdict == "UNKNOWN"
-
-    (context.home / ".claude.json").unlink()
-    assert doctor._probe_apple_mail_search(context).verdict == "OFF"
-
-    (context.vault_root / ".mcp.json").write_text(
-        json.dumps({"mcpServers": {"mail": {"command": "pipx", "args": ["run", "apple-mail-mcp"]}}})
-    )
-    assert doctor._probe_apple_mail_search(context).verdict == "UNKNOWN"
-
-
-def test_apple_mail_search_is_unknown_off_macos(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: False)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "UNKNOWN"
-    assert result.feature_status == "unknown"
-
-
-def test_apple_mail_search_is_broken_when_the_command_is_missing(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
+    monkeypatch.setattr(doctor.apple_mail_health, "probe", probe)
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: False)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
 
     result = doctor._probe_apple_mail_search(context)
 
     assert result.verdict == "BROKEN"
+    assert result.detail == "Index cannot answer searches"
     assert result.feature_status == "broken"
-    assert "pipx install 'apple-mail-mcp==0.4.3'" in result.heal.action
-
-
-def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch, context):
-    """The silent failure from #446: list/read work, so search looks healthy while returning nothing."""
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
-    assert "apple-mail-mcp index" in result.heal.action
-    assert "Full Disk Access" in result.heal.action
-    assert "returns nothing" in result.user_message
-
-
-def test_apple_mail_search_is_broken_when_the_index_is_empty(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_apple_mail_index(context, size=0)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "empty" in result.detail
-
-
-def test_apple_mail_search_is_broken_when_the_index_has_gone_stale(monkeypatch, context):
-    """Startup sync silently no-ops without Full Disk Access, so a built index quietly stales."""
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_apple_mail_index(context, age_days=30)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "30 days ago" in result.detail
-    assert "apple-mail-mcp index" in result.heal.action
-
-
-def test_apple_mail_search_is_ok_with_a_fresh_index(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_apple_mail_index(context, age_days=1)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert result.feature_status == "ok"
-    assert result.heal is None
-
-
-def test_apple_mail_search_uses_custom_path_and_real_sqlite_state(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    custom_index = context.home / "private-mail" / "search.sqlite"
-    _write_real_apple_mail_index(custom_index)
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text(
-        f'config_version = 1\n[index]\npath = "{custom_index}"\nstaleness_hours = 24\n'
-    )
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert str(custom_index) in result.detail
-    assert "1 indexed message" in result.detail
-
-
-def test_apple_mail_search_mcp_environment_overrides_toml_settings(monkeypatch, context):
-    custom_index = context.home / "client-specific" / "index.db"
-    _register_apple_mail_user_scope(
-        context,
-        env={
-            "APPLE_MAIL_INDEX_PATH": str(custom_index),
-            "APPLE_MAIL_INDEX_STALENESS_HOURS": "48",
-        },
-    )
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_real_apple_mail_index(
-        custom_index,
-        last_sync="2026-07-10T11:00:00+00:00",
-    )
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text(
-        'config_version = 1\n[index]\npath = "/wrong/index.db"\nstaleness_hours = 1\n'
-    )
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert str(custom_index) in result.detail
-
-
-def test_apple_mail_search_reports_invalid_config_as_broken(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text("config_version = [not valid TOML")
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "config" in result.detail.lower()
-    assert "config.toml" in result.heal.action
-
-
-def test_apple_mail_search_reports_semantically_invalid_config_as_broken(
-    monkeypatch,
-    context,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text("[index]\nstaleness_hours = 24\n")
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "config_version = 1" in result.detail
-    assert "config.toml" in result.heal.action
-
-
-def test_apple_mail_search_reports_empty_existing_config_as_broken(
-    monkeypatch,
-    context,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text("")
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "config_version = 1" in result.detail
-
-
-def test_apple_mail_search_reports_malformed_registration_as_broken(
-    monkeypatch,
-    context,
-):
-    (context.home / ".claude.json").write_text('{"mcpServers": {"apple-mail": ')
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
-    assert "could not be read" in result.detail
-    assert "MCP JSON" in result.heal.action
-
-
-def test_apple_mail_search_reports_null_registration_container_as_broken(
-    monkeypatch,
-    context,
-):
-    (context.home / ".claude.json").write_text('{"mcpServers": null}')
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
-    assert "must contain an mcpServers object" in result.detail
-    assert "MCP JSON" in result.heal.action
-
-
-@pytest.mark.parametrize(
-    "broken_shape",
-    ["fake", "missing-schema", "empty-data", "empty-fts"],
-)
-def test_apple_mail_search_rejects_files_that_cannot_answer_searches(
-    monkeypatch,
-    context,
-    broken_shape,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    index = context.home / ".apple-mail-mcp" / "index.db"
-    index.parent.mkdir(parents=True, exist_ok=True)
-    if broken_shape == "fake":
-        index.write_bytes(b"not a sqlite database")
-    elif broken_shape == "missing-schema":
-        with sqlite3.connect(index) as connection:
-            connection.execute("CREATE TABLE unrelated (value TEXT)")
-    elif broken_shape == "empty-data":
-        _write_real_apple_mail_index(index, email_count=0)
-    else:
-        _write_real_apple_mail_index(index, fts_searchable=False)
-    index.chmod(0o600)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
-    assert "rebuild" in result.heal.action
-
-
-def test_apple_mail_search_process_environment_overrides_registration_and_toml(
-    monkeypatch,
-    context,
-):
-    registered_index = context.home / "registered" / "index.db"
-    process_index = context.home / "runtime" / "index.db"
-    _register_apple_mail_user_scope(
-        context,
-        env={
-            "APPLE_MAIL_INDEX_PATH": str(registered_index),
-            "APPLE_MAIL_INDEX_STALENESS_HOURS": "1",
-        },
-    )
-    monkeypatch.setenv("APPLE_MAIL_INDEX_PATH", str(process_index))
-    monkeypatch.setenv("APPLE_MAIL_INDEX_STALENESS_HOURS", "48")
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_real_apple_mail_index(
-        process_index,
-        last_sync="2026-07-10T11:00:00+00:00",
-    )
-    config_dir = context.home / ".apple-mail-mcp"
-    config_dir.mkdir()
-    (config_dir / "config.toml").write_text(
-        f'config_version = 1\n[index]\npath = "{context.home / "toml" / "index.db"}"\nstaleness_hours = 1\n'
-    )
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert str(process_index) in result.detail
-
-
-def test_apple_mail_search_resolves_relative_path_from_server_vault(
-    monkeypatch,
-    context,
-):
-    _register_apple_mail_user_scope(
-        context,
-        env={"APPLE_MAIL_INDEX_PATH": "runtime/mail-index.db"},
-    )
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    relative_index = context.vault_root / "runtime" / "mail-index.db"
-    _write_real_apple_mail_index(relative_index)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert str(relative_index) in result.detail
-
-
-def test_apple_mail_search_default_freshness_is_24_hours(monkeypatch, context):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    index = context.home / ".apple-mail-mcp" / "index.db"
-    _write_real_apple_mail_index(
-        index,
-        last_sync=(context.now - timedelta(hours=25)).isoformat(),
-    )
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "configured 24-hour freshness limit" in result.detail
-
-
-def test_apple_mail_search_uses_configured_sync_freshness_not_file_mtime(
-    monkeypatch,
-    context,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    index = _write_real_apple_mail_index(
-        context.home / ".apple-mail-mcp" / "index.db",
-        last_sync="2026-07-10T11:00:00+00:00",
-    )
-    os.utime(index, (context.now.timestamp(), context.now.timestamp()))
-    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 24\n")
-
-    stale = doctor._probe_apple_mail_search(context)
-    assert stale.verdict == "BROKEN"
-    assert "configured 24-hour freshness limit" in stale.detail
-
-    (index.parent / "config.toml").write_text("config_version = 1\n[index]\nstaleness_hours = 48\n")
-    fresh_by_policy = doctor._probe_apple_mail_search(context)
-    assert fresh_by_policy.verdict == "OK"
-
-
-@pytest.mark.parametrize(
-    "last_sync",
-    [
-        pytest.param("2026-07-11T11:00:00", id="upstream-naive-local-iso"),
-        pytest.param("2026-07-11T12:00:00+01:00", id="offset-aware-iso"),
-    ],
-)
-def test_apple_mail_search_accepts_upstream_and_offset_sync_timestamps(
-    monkeypatch,
-    context,
-    last_sync,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    _write_real_apple_mail_index(
-        context.home / ".apple-mail-mcp" / "index.db",
-        last_sync=last_sync,
-    )
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "OK"
-    assert "last synced 1 hour ago" in result.detail
-
-
-@pytest.mark.parametrize(
-    ("sidecar", "mode"),
-    [("", 0o644), ("-wal", 0o644), ("-shm", 0o644), ("", 0o700)],
-)
-def test_apple_mail_search_rejects_non_private_index_files(
-    monkeypatch,
-    context,
-    sidecar,
-    mode,
-):
-    _register_apple_mail_user_scope(context)
-    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
-    index = _write_real_apple_mail_index(context.home / ".apple-mail-mcp" / "index.db")
-    exposed = Path(f"{index}{sidecar}")
-    if sidecar:
-        exposed.write_bytes(b"fixture sidecar")
-    exposed.chmod(mode)
-
-    result = doctor._probe_apple_mail_search(context)
-
-    assert result.verdict == "BROKEN"
-    assert "chmod 600" in result.heal.action
-    assert str(exposed) in result.detail
-    assert "subjects, senders, bodies, file paths, and attachment metadata" in result.user_message
+    assert result.user_message == "Mail search needs attention."
+    assert result.heal.action == "Rebuild it"
+    assert observed["context"].home == context.home
+    assert observed["context"].vault_root == context.vault_root
+    assert observed["context"].project_config_path == context.vault_root / ".mcp.json"
+    assert observed["context"].macos is True
+    assert observed["context"].cli_present is True
 
 
 def test_calendar_permission_adapter_preserves_eventkit_status(monkeypatch, context):
@@ -4534,7 +4136,12 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir()
     config.write_text(
-        "todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\nnotion:\n  enabled: true\n"
+        "todoist:\n"
+        "  enabled: true\n"
+        "  task_sync: true\n"
+        "  api_key_env_var: TODOIST_API_KEY\n"
+        "notion:\n"
+        "  enabled: true\n"
     )
     (context.vault_root / ".env").write_text('TODOIST_API_KEY="secret"\n')
     (context.vault_root / ".env").chmod(0o600)
@@ -4577,7 +4184,12 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     assert with_unverifiable.verdict == "UNKNOWN"
     assert "notion" in with_unverifiable.detail
 
-    config.write_text("todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\n")
+    config.write_text(
+        "todoist:\n"
+        "  enabled: true\n"
+        "  task_sync: true\n"
+        "  api_key_env_var: TODOIST_API_KEY\n"
+    )
     assert doctor._probe_integrations_enabled(context).verdict == "OK"
 
 
@@ -4647,7 +4259,11 @@ def test_integrations_engine_stored_but_unverified_rows_are_unknown(monkeypatch,
         lambda command, **_kwargs: subprocess.CompletedProcess(
             command,
             0,
-            stdout=('{"connections":[{"service":"google","status":"' + status + '","verified":false}]}\n'),
+            stdout=(
+                '{"connections":[{"service":"google","status":"'
+                + status
+                + '","verified":false}]}\n'
+            ),
             stderr="",
         ),
     )
@@ -4816,7 +4432,7 @@ def test_post_update_canary_probe_reads_the_receipt(context):
 
 def test_meeting_sources_probe_is_ok_for_api_sources_without_folders(context):
     profile = context.vault_root / "System" / "user-profile.yaml"
-    profile.write_text('meeting_sources:\n  primary: granola\n  notes_folder: ""\n', encoding="utf-8")
+    profile.write_text("meeting_sources:\n  primary: granola\n  notes_folder: \"\"\n", encoding="utf-8")
     result = doctor._probe_meeting_sources(context)
     assert result.verdict == "OK"
     assert "granola" in result.detail

--- a/core/tests/test_health_reporter.py
+++ b/core/tests/test_health_reporter.py
@@ -45,11 +45,11 @@ def test_doctor_report_is_normalized_across_the_complete_registry():
     assert envelope.contract == "dex.health.reporter/v1"
     assert envelope.reporter == DOCTOR_REPORTER_IDENTITY
     assert envelope.refresh_id == "refresh-001"
-    # 35: the Pipedrive CRM connection probe and the backup freshness probe
-    # both joined the deep checks. This literal is a deliberate tripwire, and
-    # two branches each bumping it to 34 merges clean while being wrong - so it
-    # is set from the registry's measured size, not from either branch's guess.
-    assert len(envelope.results) == 35
+    # 36: Apple Mail search joined the Pipedrive CRM and backup freshness deep
+    # checks. This literal is a deliberate tripwire, and parallel branches can
+    # each bump it to the same stale value while merging cleanly — so it is set
+    # from the complete registry's measured size, not from either branch's guess.
+    assert len(envelope.results) == 36
     assert [result.id for result in envelope.results] == [
         f"doctor.core/{definition.id}"
         for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -77,13 +77,22 @@ def _integration_status(*, installed: bool, recommended: bool = False) -> dict:
 
 
 def test_retired_pi_model_setup_is_not_shipped_or_advertised() -> None:
-    assert not [path for path in RETIRED_PI_ARTIFACTS if (REPO_ROOT / path).exists()]
+    assert not [
+        path for path in RETIRED_PI_ARTIFACTS if (REPO_ROOT / path).exists()
+    ]
 
     retired_commands = ("/ai-" + "setup", "/ai-" + "status")
-    offenders = {path: command for path in LIVE_AI_GUIDANCE for command in retired_commands if command in _read(path)}
+    offenders = {
+        path: command
+        for path in LIVE_AI_GUIDANCE
+        for command in retired_commands
+        if command in _read(path)
+    }
     assert offenders == {}
     assert ".env" in _read("core/utils/dex_logger.py")
-    assert r"LLM API key to \`.env\`" in _read(".scripts/meeting-intel/sync-from-granola.cjs")
+    assert r"LLM API key to \`.env\`" in _read(
+        ".scripts/meeting-intel/sync-from-granola.cjs"
+    )
 
 
 def test_retired_pi_usage_metrics_are_removed() -> None:
@@ -101,7 +110,10 @@ def test_retired_pi_usage_metrics_are_removed() -> None:
 
 def test_live_usage_signals_preserve_the_55_point_journey_score(monkeypatch) -> None:
     usage_log = _read("System/usage_log.md")
-    feature_names = {match.group(1) for match in re.finditer(r"- \[[ x]\] (.+)", usage_log)}
+    feature_names = {
+        match.group(1)
+        for match in re.finditer(r"- \[[ x]\] (.+)", usage_log)
+    }
     monkeypatch.setattr(
         analytics_helper,
         "load_usage_log",
@@ -130,27 +142,23 @@ def test_mcp_added_counts_as_integration_adoption(monkeypatch) -> None:
 
 
 def test_parked_rollout_and_dev_only_scripts_are_not_shipped() -> None:
-    assert not [path for path in PARKED_OR_DEV_ONLY_ARTIFACTS if (REPO_ROOT / path).exists()]
+    assert not [
+        path
+        for path in PARKED_OR_DEV_ONLY_ARTIFACTS
+        if (REPO_ROOT / path).exists()
+    ]
     assert "ritual" not in _read(".claude/skills/daily-plan/SKILL.md").lower()
 
 
-def test_email_aware_plans_do_not_silently_skip_a_broken_mail_index() -> None:
-    for relative in (
-        ".claude/skills/daily-plan/SKILL.md",
-        ".claude/skills/daily-plan/AGENT_INSTRUCTIONS.md",
-        ".claude/skills/week-review/SKILL.md",
-        ".claude/skills/week-review/AGENT_INSTRUCTIONS.md",
-    ):
-        instructions = _read(relative)
-        assert "mail.apple-search" in instructions, relative
-        assert "do not silently skip" in instructions.lower(), relative
-        assert "python3 core/utils/doctor.py --deep" in instructions, relative
-
-
 def test_live_integration_guidance_only_names_the_shipped_entrypoint() -> None:
-    dead_commands = tuple("/integrate-" + service for service in ("notion", "slack", "google"))
+    dead_commands = tuple(
+        "/integrate-" + service for service in ("notion", "slack", "google")
+    )
     offenders = {
-        path: command for path in LIVE_INTEGRATION_GUIDANCE for command in dead_commands if command in _read(path)
+        path: command
+        for path in LIVE_INTEGRATION_GUIDANCE
+        for command in dead_commands
+        if command in _read(path)
     }
     assert offenders == {}
     for path in LIVE_INTEGRATION_GUIDANCE:
@@ -198,7 +206,9 @@ def test_post_update_upgrade_points_to_integrate_mcp(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("setup_module", (notion_setup, slack_setup, google_setup))
-def test_integration_connection_failures_point_to_integrate_mcp(monkeypatch, setup_module) -> None:
+def test_integration_connection_failures_point_to_integrate_mcp(
+    monkeypatch, setup_module
+) -> None:
     monkeypatch.setattr(setup_module, "is_installed", lambda: False)
 
     success, message = setup_module.test_connection()
@@ -208,15 +218,16 @@ def test_integration_connection_failures_point_to_integrate_mcp(monkeypatch, set
 
 
 def test_missing_anthropic_key_points_to_env_file() -> None:
-    assert (
-        dex_logger._generate_human_message("Meeting sync", "ANTHROPIC_API_KEY is missing")
-        == "API key missing — add it to your .env file"
-    )
+    assert dex_logger._generate_human_message(
+        "Meeting sync", "ANTHROPIC_API_KEY is missing"
+    ) == "API key missing — add it to your .env file"
 
 
 def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
 
     assert "uname -s" in calendar_step
     assert "non-macOS" in calendar_step
@@ -226,13 +237,17 @@ def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     assert "Do not call `calendar_list_calendars`" in calendar_step
     assert "show macOS settings guidance" in calendar_step
     assert "block onboarding" in calendar_step
-    assert calendar_step.index("uname -s") < calendar_step.index("calendar_list_calendars")
+    assert calendar_step.index("uname -s") < calendar_step.index(
+        "calendar_list_calendars"
+    )
     assert flow.index("## Calendar First (Before Step 1)") < flow.index("## Step 1:")
 
 
 def test_onboarding_confirms_calendar_identity_through_existing_validation() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
 
     assert "Before I ask you anything" in calendar_step
     assert "your actual week, organised" in calendar_step
@@ -241,14 +256,22 @@ def test_onboarding_confirms_calendar_identity_through_existing_validation() -> 
     assert "You're [name], at [domain] — right?" in calendar_step
     assert "Yes, that's right" in calendar_step
     assert "Let me correct that" in calendar_step
-    assert 'validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})' in calendar_step
-    assert 'validate_and_save_step(step_number=4, step_data={"email_domain": "[confirmed domain]"})' in calendar_step
+    assert (
+        'validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})'
+        in calendar_step
+    )
+    assert (
+        'validate_and_save_step(step_number=4, step_data={"email_domain": '
+        '"[confirmed domain]"})' in calendar_step
+    )
     assert "Do not bypass either validation call" in calendar_step
 
 
 def test_onboarding_keeps_conservative_identity_fallbacks() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
+        "## Step 1:", 1
+    )[0]
     name_step = flow.split("## Step 1:", 1)[1].split("## Step 2:", 1)[0]
     domain_step = flow.split("## Step 4:", 1)[1].split("## Step 5:", 1)[0]
 
@@ -278,8 +301,13 @@ def test_onboarding_narrows_roles_by_area_before_saving_existing_role_number() -
         "Something else",
     ):
         assert area in role_step
-    assert role_step.index("First ask for their AREA") < role_step.index("Then ask for their ROLE")
-    assert 'validate_and_save_step(step_number=2, step_data={"role_number": [selected id as integer]})' in role_step
+    assert role_step.index("First ask for their AREA") < role_step.index(
+        "Then ask for their ROLE"
+    )
+    assert (
+        'validate_and_save_step(step_number=2, step_data={"role_number": '
+        "[selected id as integer]})" in role_step
+    )
     assert (
         'validate_and_save_step(step_number=2, step_data={"role": '
         '"[their description]", "role_group": "Custom"})' in role_step
@@ -290,11 +318,14 @@ def test_onboarding_keeps_pillars_intentional_and_grounds_them_in_calendar_evide
     flow = _read(".claude/flows/onboarding.md")
     pillar_step = flow.split("## Step 5:", 1)[1].split("## Step 6:", 1)[0]
     unchanged_question = (
-        'Ask: "What are the 2-3 long-term areas of focus for your role? Think broad themes, not specific goals.'
+        'Ask: "What are the 2-3 long-term areas of focus for your role? '
+        "Think broad themes, not specific goals."
     )
 
     assert "run_first_week_analysis()" in pillar_step
-    assert pillar_step.index("run_first_week_analysis()") < pillar_step.index(unchanged_question)
+    assert pillar_step.index("run_first_week_analysis()") < pillar_step.index(
+        unchanged_question
+    )
     assert "`recurring_commitments`" in pillar_step
     assert "`internal_external_split`" in pillar_step
     assert "`observations`" in pillar_step
@@ -392,7 +423,10 @@ def test_onboarding_confirms_working_days_and_allows_correction() -> None:
     assert "Which days do you work?" in working_week_step
     assert "Monday to Friday" in working_week_step
     assert "confirm" in working_week_step.lower()
-    assert 'validate_and_save_step(step_number=7, step_data={"working_week": {"days": [...]}})' in working_week_step
+    assert (
+        'validate_and_save_step(step_number=7, step_data={"working_week": '
+        '{"days": [...]}})' in working_week_step
+    )
 
 
 def test_week_skills_read_the_users_working_week_for_timing() -> None:
@@ -443,7 +477,9 @@ def test_onboarding_connect_step_explains_connect_without_overpromising() -> Non
     assert "google and linear" in lowered
     assert "--allow-unvetted" in connect_step
     assert "explicit opt-in" in lowered
-    assert connect_step.index("get explicit opt-in") < connect_step.index("--allow-unvetted")
+    assert connect_step.index("get explicit opt-in") < connect_step.index(
+        "--allow-unvetted"
+    )
     for forbidden_claim in ("secure", "safe", "malware"):
         assert forbidden_claim not in lowered
 
@@ -468,7 +504,8 @@ def test_onboarding_completion_offers_the_optional_nudge_calendar() -> None:
         "Want me to put a few gentle nudges in your calendar for your first "
         "few weeks? One a day, each with something to try. They're all-day "
         "reminders marked private and free, so they never block your time or "
-        "make you look busy — and you can delete the whole thing in one tap." in completion
+        "make you look busy — and you can delete the whole thing in one tap."
+        in completion
     )
     assert "**Yes, add them**" in completion
     assert "**No thanks**" in completion
@@ -511,17 +548,6 @@ def test_core_behavior_defines_feature_status_rendering() -> None:
     assert "never invent" in section.lower()
 
 
-def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:
-    supported_runtime = "apple-mail-mcp==0.4.3"
-    setup = _read(".claude/skills/apple-mail-setup/SKILL.md")
-    requirements = _read("requirements-dev.txt")
-
-    assert f"pipx install '{supported_runtime}'" in setup
-    assert supported_runtime in requirements
-    assert "community-maintained" in setup
-    assert "health checks and macOS CI prove compatibility" in setup
-
-
 @pytest.mark.parametrize(
     "skill_path",
     (
@@ -532,3 +558,27 @@ def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:
 )
 def test_high_traffic_skills_follow_feature_status_rendering(skill_path: str) -> None:
     assert "`feature_status` rendering convention" in _read(skill_path)
+
+
+def test_email_aware_plans_do_not_silently_skip_a_broken_mail_index() -> None:
+    for relative in (
+        ".claude/skills/daily-plan/SKILL.md",
+        ".claude/skills/daily-plan/AGENT_INSTRUCTIONS.md",
+        ".claude/skills/week-review/SKILL.md",
+        ".claude/skills/week-review/AGENT_INSTRUCTIONS.md",
+    ):
+        instructions = _read(relative)
+        assert "mail.apple-search" in instructions, relative
+        assert "do not silently skip" in instructions.lower(), relative
+        assert "python3 core/utils/doctor.py --deep" in instructions, relative
+
+
+def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:
+    supported_runtime = "apple-mail-mcp==0.4.3"
+    setup = _read(".claude/skills/apple-mail-setup/SKILL.md")
+    requirements = _read("requirements-dev.txt")
+
+    assert f"pipx install '{supported_runtime}'" in setup
+    assert supported_runtime in requirements
+    assert "community-maintained" in setup
+    assert "health checks and macOS CI prove compatibility" in setup

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -77,22 +77,13 @@ def _integration_status(*, installed: bool, recommended: bool = False) -> dict:
 
 
 def test_retired_pi_model_setup_is_not_shipped_or_advertised() -> None:
-    assert not [
-        path for path in RETIRED_PI_ARTIFACTS if (REPO_ROOT / path).exists()
-    ]
+    assert not [path for path in RETIRED_PI_ARTIFACTS if (REPO_ROOT / path).exists()]
 
     retired_commands = ("/ai-" + "setup", "/ai-" + "status")
-    offenders = {
-        path: command
-        for path in LIVE_AI_GUIDANCE
-        for command in retired_commands
-        if command in _read(path)
-    }
+    offenders = {path: command for path in LIVE_AI_GUIDANCE for command in retired_commands if command in _read(path)}
     assert offenders == {}
     assert ".env" in _read("core/utils/dex_logger.py")
-    assert r"LLM API key to \`.env\`" in _read(
-        ".scripts/meeting-intel/sync-from-granola.cjs"
-    )
+    assert r"LLM API key to \`.env\`" in _read(".scripts/meeting-intel/sync-from-granola.cjs")
 
 
 def test_retired_pi_usage_metrics_are_removed() -> None:
@@ -110,10 +101,7 @@ def test_retired_pi_usage_metrics_are_removed() -> None:
 
 def test_live_usage_signals_preserve_the_55_point_journey_score(monkeypatch) -> None:
     usage_log = _read("System/usage_log.md")
-    feature_names = {
-        match.group(1)
-        for match in re.finditer(r"- \[[ x]\] (.+)", usage_log)
-    }
+    feature_names = {match.group(1) for match in re.finditer(r"- \[[ x]\] (.+)", usage_log)}
     monkeypatch.setattr(
         analytics_helper,
         "load_usage_log",
@@ -142,11 +130,7 @@ def test_mcp_added_counts_as_integration_adoption(monkeypatch) -> None:
 
 
 def test_parked_rollout_and_dev_only_scripts_are_not_shipped() -> None:
-    assert not [
-        path
-        for path in PARKED_OR_DEV_ONLY_ARTIFACTS
-        if (REPO_ROOT / path).exists()
-    ]
+    assert not [path for path in PARKED_OR_DEV_ONLY_ARTIFACTS if (REPO_ROOT / path).exists()]
     assert "ritual" not in _read(".claude/skills/daily-plan/SKILL.md").lower()
 
 
@@ -164,14 +148,9 @@ def test_email_aware_plans_do_not_silently_skip_a_broken_mail_index() -> None:
 
 
 def test_live_integration_guidance_only_names_the_shipped_entrypoint() -> None:
-    dead_commands = tuple(
-        "/integrate-" + service for service in ("notion", "slack", "google")
-    )
+    dead_commands = tuple("/integrate-" + service for service in ("notion", "slack", "google"))
     offenders = {
-        path: command
-        for path in LIVE_INTEGRATION_GUIDANCE
-        for command in dead_commands
-        if command in _read(path)
+        path: command for path in LIVE_INTEGRATION_GUIDANCE for command in dead_commands if command in _read(path)
     }
     assert offenders == {}
     for path in LIVE_INTEGRATION_GUIDANCE:
@@ -219,9 +198,7 @@ def test_post_update_upgrade_points_to_integrate_mcp(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("setup_module", (notion_setup, slack_setup, google_setup))
-def test_integration_connection_failures_point_to_integrate_mcp(
-    monkeypatch, setup_module
-) -> None:
+def test_integration_connection_failures_point_to_integrate_mcp(monkeypatch, setup_module) -> None:
     monkeypatch.setattr(setup_module, "is_installed", lambda: False)
 
     success, message = setup_module.test_connection()
@@ -231,16 +208,15 @@ def test_integration_connection_failures_point_to_integrate_mcp(
 
 
 def test_missing_anthropic_key_points_to_env_file() -> None:
-    assert dex_logger._generate_human_message(
-        "Meeting sync", "ANTHROPIC_API_KEY is missing"
-    ) == "API key missing — add it to your .env file"
+    assert (
+        dex_logger._generate_human_message("Meeting sync", "ANTHROPIC_API_KEY is missing")
+        == "API key missing — add it to your .env file"
+    )
 
 
 def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
-        "## Step 1:", 1
-    )[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
 
     assert "uname -s" in calendar_step
     assert "non-macOS" in calendar_step
@@ -250,17 +226,13 @@ def test_onboarding_skips_calendar_cleanly_on_non_macos() -> None:
     assert "Do not call `calendar_list_calendars`" in calendar_step
     assert "show macOS settings guidance" in calendar_step
     assert "block onboarding" in calendar_step
-    assert calendar_step.index("uname -s") < calendar_step.index(
-        "calendar_list_calendars"
-    )
+    assert calendar_step.index("uname -s") < calendar_step.index("calendar_list_calendars")
     assert flow.index("## Calendar First (Before Step 1)") < flow.index("## Step 1:")
 
 
 def test_onboarding_confirms_calendar_identity_through_existing_validation() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
-        "## Step 1:", 1
-    )[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
 
     assert "Before I ask you anything" in calendar_step
     assert "your actual week, organised" in calendar_step
@@ -269,22 +241,14 @@ def test_onboarding_confirms_calendar_identity_through_existing_validation() -> 
     assert "You're [name], at [domain] — right?" in calendar_step
     assert "Yes, that's right" in calendar_step
     assert "Let me correct that" in calendar_step
-    assert (
-        'validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})'
-        in calendar_step
-    )
-    assert (
-        'validate_and_save_step(step_number=4, step_data={"email_domain": '
-        '"[confirmed domain]"})' in calendar_step
-    )
+    assert 'validate_and_save_step(step_number=1, step_data={"name": "[confirmed name]"})' in calendar_step
+    assert 'validate_and_save_step(step_number=4, step_data={"email_domain": "[confirmed domain]"})' in calendar_step
     assert "Do not bypass either validation call" in calendar_step
 
 
 def test_onboarding_keeps_conservative_identity_fallbacks() -> None:
     flow = _read(".claude/flows/onboarding.md")
-    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split(
-        "## Step 1:", 1
-    )[0]
+    calendar_step = flow.split("## Calendar First (Before Step 1)", 1)[1].split("## Step 1:", 1)[0]
     name_step = flow.split("## Step 1:", 1)[1].split("## Step 2:", 1)[0]
     domain_step = flow.split("## Step 4:", 1)[1].split("## Step 5:", 1)[0]
 
@@ -314,13 +278,8 @@ def test_onboarding_narrows_roles_by_area_before_saving_existing_role_number() -
         "Something else",
     ):
         assert area in role_step
-    assert role_step.index("First ask for their AREA") < role_step.index(
-        "Then ask for their ROLE"
-    )
-    assert (
-        'validate_and_save_step(step_number=2, step_data={"role_number": '
-        "[selected id as integer]})" in role_step
-    )
+    assert role_step.index("First ask for their AREA") < role_step.index("Then ask for their ROLE")
+    assert 'validate_and_save_step(step_number=2, step_data={"role_number": [selected id as integer]})' in role_step
     assert (
         'validate_and_save_step(step_number=2, step_data={"role": '
         '"[their description]", "role_group": "Custom"})' in role_step
@@ -331,14 +290,11 @@ def test_onboarding_keeps_pillars_intentional_and_grounds_them_in_calendar_evide
     flow = _read(".claude/flows/onboarding.md")
     pillar_step = flow.split("## Step 5:", 1)[1].split("## Step 6:", 1)[0]
     unchanged_question = (
-        'Ask: "What are the 2-3 long-term areas of focus for your role? '
-        "Think broad themes, not specific goals."
+        'Ask: "What are the 2-3 long-term areas of focus for your role? Think broad themes, not specific goals.'
     )
 
     assert "run_first_week_analysis()" in pillar_step
-    assert pillar_step.index("run_first_week_analysis()") < pillar_step.index(
-        unchanged_question
-    )
+    assert pillar_step.index("run_first_week_analysis()") < pillar_step.index(unchanged_question)
     assert "`recurring_commitments`" in pillar_step
     assert "`internal_external_split`" in pillar_step
     assert "`observations`" in pillar_step
@@ -436,10 +392,7 @@ def test_onboarding_confirms_working_days_and_allows_correction() -> None:
     assert "Which days do you work?" in working_week_step
     assert "Monday to Friday" in working_week_step
     assert "confirm" in working_week_step.lower()
-    assert (
-        'validate_and_save_step(step_number=7, step_data={"working_week": '
-        '{"days": [...]}})' in working_week_step
-    )
+    assert 'validate_and_save_step(step_number=7, step_data={"working_week": {"days": [...]}})' in working_week_step
 
 
 def test_week_skills_read_the_users_working_week_for_timing() -> None:
@@ -490,9 +443,7 @@ def test_onboarding_connect_step_explains_connect_without_overpromising() -> Non
     assert "google and linear" in lowered
     assert "--allow-unvetted" in connect_step
     assert "explicit opt-in" in lowered
-    assert connect_step.index("get explicit opt-in") < connect_step.index(
-        "--allow-unvetted"
-    )
+    assert connect_step.index("get explicit opt-in") < connect_step.index("--allow-unvetted")
     for forbidden_claim in ("secure", "safe", "malware"):
         assert forbidden_claim not in lowered
 
@@ -517,8 +468,7 @@ def test_onboarding_completion_offers_the_optional_nudge_calendar() -> None:
         "Want me to put a few gentle nudges in your calendar for your first "
         "few weeks? One a day, each with something to try. They're all-day "
         "reminders marked private and free, so they never block your time or "
-        "make you look busy — and you can delete the whole thing in one tap."
-        in completion
+        "make you look busy — and you can delete the whole thing in one tap." in completion
     )
     assert "**Yes, add them**" in completion
     assert "**No thanks**" in completion
@@ -559,6 +509,17 @@ def test_core_behavior_defines_feature_status_rendering() -> None:
     assert "fix path" in section
     assert "could not be checked" in section
     assert "never invent" in section.lower()
+
+
+def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:
+    supported_runtime = "apple-mail-mcp==0.4.3"
+    setup = _read(".claude/skills/apple-mail-setup/SKILL.md")
+    requirements = _read("requirements-dev.txt")
+
+    assert f"pipx install '{supported_runtime}'" in setup
+    assert supported_runtime in requirements
+    assert "community-maintained" in setup
+    assert "health checks and macOS CI prove compatibility" in setup
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -150,6 +150,19 @@ def test_parked_rollout_and_dev_only_scripts_are_not_shipped() -> None:
     assert "ritual" not in _read(".claude/skills/daily-plan/SKILL.md").lower()
 
 
+def test_email_aware_plans_do_not_silently_skip_a_broken_mail_index() -> None:
+    for relative in (
+        ".claude/skills/daily-plan/SKILL.md",
+        ".claude/skills/daily-plan/AGENT_INSTRUCTIONS.md",
+        ".claude/skills/week-review/SKILL.md",
+        ".claude/skills/week-review/AGENT_INSTRUCTIONS.md",
+    ):
+        instructions = _read(relative)
+        assert "mail.apple-search" in instructions, relative
+        assert "do not silently skip" in instructions.lower(), relative
+        assert "python3 core/utils/doctor.py --deep" in instructions, relative
+
+
 def test_live_integration_guidance_only_names_the_shipped_entrypoint() -> None:
     dead_commands = tuple(
         "/integrate-" + service for service in ("notion", "slack", "google")

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -254,7 +254,7 @@ def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
 
 
-def _index_state(index: Path) -> tuple[int, str]:
+def _index_state(index: Path) -> tuple[int, tuple[str, ...]]:
     uri = index.resolve().as_uri() + "?mode=ro"
     with sqlite3.connect(uri, uri=True, timeout=2) as connection:
         quick_check = connection.execute("PRAGMA quick_check").fetchone()
@@ -299,12 +299,18 @@ def _index_state(index: Path) -> tuple[int, str]:
         searchable_terms = int(connection.execute("SELECT COUNT(*) FROM temp.apple_mail_health_vocab").fetchone()[0])
         if email_count and searchable_terms == 0:
             raise sqlite3.DatabaseError("FTS5 contains no searchable terms")
-        last_sync = connection.execute("SELECT MAX(last_sync) FROM sync_state WHERE last_sync IS NOT NULL").fetchone()[
-            0
-        ]
-    if not last_sync:
-        raise sqlite3.DatabaseError("no successful sync is recorded")
-    return email_count, str(last_sync)
+        required_syncs = connection.execute(
+            """
+            SELECT state.last_sync
+            FROM (SELECT DISTINCT account, mailbox FROM emails) AS indexed
+            LEFT JOIN sync_state AS state
+              ON state.account = indexed.account
+             AND state.mailbox = indexed.mailbox
+            """
+        ).fetchall()
+    if email_count and (not required_syncs or any(row[0] is None for row in required_syncs)):
+        raise sqlite3.DatabaseError("one or more indexed mailboxes has no successful sync")
+    return email_count, tuple(str(row[0]) for row in required_syncs)
 
 
 def _sync_age(now: datetime, raw_timestamp: str) -> timedelta:
@@ -397,8 +403,7 @@ def probe(context: Context) -> Result:
     if permissions:
         return permissions
     try:
-        email_count, last_sync = _index_state(index)
-        age = _sync_age(context.now, last_sync)
+        email_count, required_syncs = _index_state(index)
     except (OSError, sqlite3.DatabaseError, ValueError) as error:
         detail = _one_line(error)
         return Result(
@@ -418,6 +423,17 @@ def probe(context: Context) -> Result:
             action=APPLE_MAIL_INDEX_REBUILD_FIX,
             feature_status="broken",
             user_message="Mail search's local index contains no messages. " + APPLE_MAIL_INDEX_REBUILD_FIX,
+        )
+    try:
+        age = max(_sync_age(context.now, last_sync) for last_sync in required_syncs)
+    except ValueError as error:
+        detail = _one_line(error)
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} is not usable: {detail}",
+            action=APPLE_MAIL_INDEX_REBUILD_FIX,
+            feature_status="broken",
+            user_message="Mail search's local index is not usable. " + APPLE_MAIL_INDEX_REBUILD_FIX,
         )
     if age > settings.stale_after:
         allowed_hours = settings.stale_after.total_seconds() / 3600

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -20,6 +20,8 @@ from typing import Mapping
 
 APPLE_MAIL_CONFIG_VERSION = 1
 APPLE_MAIL_DEFAULT_STALENESS_HOURS = 24.0
+APPLE_MAIL_MCP_SUPPORTED_VERSION = "0.4.3"
+APPLE_MAIL_MCP_INSTALL = f"pipx install 'apple-mail-mcp=={APPLE_MAIL_MCP_SUPPORTED_VERSION}'"
 APPLE_MAIL_CONFIG_SCHEMA: dict[str, dict[str, tuple[type, ...]]] = {
     "defaults": {"account": (str,), "mailbox": (str,)},
     "index": {
@@ -349,11 +351,12 @@ def probe(context: Context) -> Result:
             "BROKEN",
             "An Apple Mail server is registered but the apple-mail-mcp command is not installed, "
             "so mail search cannot work",
-            action="Install the server with `pipx install apple-mail-mcp`, then run /apple-mail-setup.",
+            action=f"Install the supported server with `{APPLE_MAIL_MCP_INSTALL}`, then run /apple-mail-setup.",
             feature_status="broken",
             user_message=(
                 "Mail search is registered but the apple-mail-mcp command is missing. "
-                "Install it with `pipx install apple-mail-mcp`, then run /apple-mail-setup."
+                f"Install the tested community release with `{APPLE_MAIL_MCP_INSTALL}`, "
+                "then run /apple-mail-setup."
             ),
         )
     try:

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -1,0 +1,434 @@
+"""Read-only Apple Mail search health adapter.
+
+The community MCP server can list and read mail without its local FTS5 index,
+which makes search failures unusually easy to hide.  This module keeps the
+integration-specific config, SQLite, freshness, and privacy checks out of the
+Doctor orchestrator.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sqlite3
+import stat
+import tomllib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Mapping
+
+APPLE_MAIL_CONFIG_VERSION = 1
+APPLE_MAIL_DEFAULT_STALENESS_HOURS = 24.0
+APPLE_MAIL_CONFIG_SCHEMA: dict[str, dict[str, tuple[type, ...]]] = {
+    "defaults": {"account": (str,), "mailbox": (str,)},
+    "index": {
+        "path": (str,),
+        "max_emails": (int,),
+        "staleness_hours": (int, float),
+        "exclude_mailboxes": (list,),
+        "exclude_accounts": (list,),
+        "include_mailboxes": (list,),
+    },
+    "server": {"read_only": (bool,), "lock_retry_seconds": (int, float)},
+}
+REQUIRED_EMAIL_COLUMNS = {
+    "rowid",
+    "message_id",
+    "account",
+    "mailbox",
+    "subject",
+    "sender",
+    "content",
+    "date_received",
+    "emlx_path",
+}
+REQUIRED_SYNC_COLUMNS = {"account", "mailbox", "last_sync", "message_count"}
+REQUIRED_FTS_TRIGGERS = {"emails_ai", "emails_ad", "emails_au"}
+
+
+def setup_action(command: str) -> str:
+    """Return stable, explicit privacy guidance for an index operation."""
+    operation = "rebuilding" if command == "rebuild" else "building"
+    return (
+        f"Run `umask 077; apple-mail-mcp {command} --verbose` from a terminal app "
+        "temporarily granted Full Disk Access: System Settings > Privacy & Security > "
+        "Full Disk Access. Quit and reopen that terminal before "
+        f"{operation}; searching the completed local index does not need this permission."
+    )
+
+
+APPLE_MAIL_INDEX_BUILD_FIX = setup_action("index")
+APPLE_MAIL_INDEX_REBUILD_FIX = setup_action("rebuild")
+
+
+@dataclass(frozen=True)
+class Context:
+    home: Path
+    vault_root: Path
+    now: datetime
+    user_config_path: Path
+    project_config_path: Path
+    environment: Mapping[str, str]
+    macos: bool
+    cli_present: bool
+
+
+@dataclass(frozen=True)
+class IndexSettings:
+    path: Path
+    stale_after: timedelta
+
+
+@dataclass(frozen=True)
+class Result:
+    verdict: str
+    detail: str
+    action: str | None = None
+    feature_status: str | None = None
+    user_message: str | None = None
+
+
+def _one_line(error: BaseException) -> str:
+    return " ".join(str(error).split())
+
+
+def _read_servers(path: Path, *, servers_optional: bool) -> dict[str, object]:
+    try:
+        loaded = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as error:
+        raise ValueError(f"{path} could not be read: {_one_line(error)}") from error
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    if "mcpServers" not in loaded and servers_optional:
+        return {}
+    servers = loaded.get("mcpServers")
+    if not isinstance(servers, dict):
+        raise ValueError(f"{path} must contain an mcpServers object")
+    return servers
+
+
+def _registration(context: Context) -> dict[str, object] | None:
+    entries = _read_servers(context.user_config_path, servers_optional=True)
+    entries.update(_read_servers(context.project_config_path, servers_optional=False))
+    for name, entry in entries.items():
+        if "apple-mail" in name.lower().replace("_", "-"):
+            if not isinstance(entry, dict):
+                raise ValueError(f"Apple Mail MCP registration {name!r} must be an object")
+            return entry
+        if not isinstance(entry, dict):
+            continue
+        tokens = [str(entry.get("command", ""))]
+        args = entry.get("args", [])
+        if isinstance(args, list):
+            tokens.extend(str(argument) for argument in args if isinstance(argument, str))
+        if any("apple-mail-mcp" in token for token in tokens):
+            return entry
+    return None
+
+
+def _validate_config(data: dict[str, object], path: Path) -> None:
+    version = data.get("config_version")
+    if version != APPLE_MAIL_CONFIG_VERSION:
+        raise ValueError(f"{path} must set config_version = {APPLE_MAIL_CONFIG_VERSION}; got {version!r}")
+    allowed_top = {"config_version", *APPLE_MAIL_CONFIG_SCHEMA}
+    unknown_top = sorted(set(data) - allowed_top)
+    if unknown_top:
+        raise ValueError(f"{path} has unknown top-level key {unknown_top[0]!r}")
+    for section, allowed in APPLE_MAIL_CONFIG_SCHEMA.items():
+        section_data = data.get(section)
+        if section_data is None:
+            continue
+        if not isinstance(section_data, dict):
+            raise ValueError(f"{path} [{section}] must be a TOML table")
+        for key, value in section_data.items():
+            if key not in allowed:
+                raise ValueError(f"{path} has unknown [{section}] key {key!r}")
+            expected = allowed[key]
+            bool_in_number_slot = isinstance(value, bool) and bool not in expected and int in expected
+            if bool_in_number_slot or not isinstance(value, expected):
+                names = " or ".join(item.__name__ for item in expected)
+                raise ValueError(f"{path} [{section}] {key} must be {names}")
+            if isinstance(value, list) and any(not isinstance(item, str) for item in value):
+                raise ValueError(f"{path} [{section}] {key} must contain only strings")
+    index = data.get("index", {})
+    if isinstance(index, dict):
+        if "max_emails" in index and index["max_emails"] < 0:
+            raise ValueError(f"{path} [index] max_emails must be zero or greater")
+        if "staleness_hours" in index and index["staleness_hours"] < 0:
+            raise ValueError(f"{path} [index] staleness_hours must be zero or greater")
+    server = data.get("server", {})
+    if isinstance(server, dict) and "lock_retry_seconds" in server and server["lock_retry_seconds"] < 1:
+        raise ValueError(f"{path} [server] lock_retry_seconds must be at least 1")
+
+
+def _config(context: Context) -> dict[str, object]:
+    path = context.home / ".apple-mail-mcp" / "config.toml"
+    try:
+        with path.open("rb") as handle:
+            loaded = tomllib.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"Apple Mail config could not be read: {_one_line(error)}") from error
+    if not isinstance(loaded, dict):
+        raise ValueError("Apple Mail config must contain a TOML object")
+    _validate_config(loaded, path)
+    return loaded
+
+
+def _expand_path(raw: object, context: Context) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Apple Mail index path must be a non-empty string")
+    rendered = raw.replace("${HOME}", str(context.home)).replace("$HOME", str(context.home))
+    if rendered == "~":
+        return context.home
+    if rendered.startswith("~/"):
+        return context.home / rendered[2:]
+    path = Path(rendered)
+    # apple-mail-mcp uses Path(...).expanduser(), so a relative value is resolved
+    # from the server process cwd. Dex launches the project MCP from the vault.
+    return path if path.is_absolute() else context.vault_root / path
+
+
+def _settings(context: Context, registration: dict[str, object]) -> IndexSettings:
+    config = _config(context)
+    index_config = config.get("index", {})
+    if not isinstance(index_config, dict):
+        raise ValueError("Apple Mail config [index] must be a TOML table")
+    registered_environment = registration.get("env", {})
+    if not isinstance(registered_environment, dict):
+        raise ValueError("Apple Mail MCP registration env must be an object")
+    environment = {
+        str(key): str(value)
+        for key, value in registered_environment.items()
+        if isinstance(key, str) and isinstance(value, (str, int, float))
+    }
+    # Match the server contract: the process environment overrides TOML.  The
+    # registration env is the process environment Claude will give the server;
+    # an actual process override wins when Doctor is run in that same runtime.
+    environment.update({key: value for key, value in context.environment.items() if key.startswith("APPLE_MAIL_")})
+    raw_path = environment.get("APPLE_MAIL_INDEX_PATH") or index_config.get("path")
+    path = _expand_path(raw_path, context) if raw_path else context.home / ".apple-mail-mcp" / "index.db"
+    raw_staleness: object = environment.get("APPLE_MAIL_INDEX_STALENESS_HOURS", "")
+    if raw_staleness in (None, ""):
+        raw_staleness = index_config.get("staleness_hours", APPLE_MAIL_DEFAULT_STALENESS_HOURS)
+    try:
+        staleness_hours = float(raw_staleness)
+    except (TypeError, ValueError) as error:
+        raise ValueError("Apple Mail index staleness_hours must be a number") from error
+    if staleness_hours < 0:
+        raise ValueError("Apple Mail index staleness_hours must be zero or greater")
+    return IndexSettings(path=path, stale_after=timedelta(hours=staleness_hours))
+
+
+def _private_files(index: Path) -> list[Path]:
+    bases = {index, index.resolve()}
+    candidates = {path for base in bases for path in (base, Path(f"{base}-wal"), Path(f"{base}-shm"))}
+    return sorted(path for path in candidates if path.exists())
+
+
+def _permissions_result(index: Path) -> Result | None:
+    exposed = [path for path in _private_files(index) if stat.S_IMODE(path.stat().st_mode) != 0o600]
+    if not exposed:
+        return None
+    names = ", ".join(str(path) for path in exposed)
+    command = "chmod 600 " + " ".join(shlex.quote(str(path)) for path in exposed)
+    return Result(
+        "BROKEN",
+        f"Apple Mail's local full-text index files do not have the required 0600 permissions: {names}",
+        action=f"Make the index private with `{command}`.",
+        feature_status="broken",
+        user_message=(
+            "Mail search's local index contains message subjects, senders, bodies, file paths, "
+            f"and attachment metadata. Make it private with `{command}`."
+        ),
+    )
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
+
+
+def _index_state(index: Path) -> tuple[int, str]:
+    uri = index.resolve().as_uri() + "?mode=ro"
+    with sqlite3.connect(uri, uri=True, timeout=2) as connection:
+        quick_check = connection.execute("PRAGMA quick_check").fetchone()
+        if not quick_check or quick_check[0] != "ok":
+            raise sqlite3.DatabaseError(f"SQLite quick check returned {quick_check!r}")
+        objects = {
+            str(row[0]): (str(row[1]), str(row[2] or ""))
+            for row in connection.execute(
+                "SELECT name, type, sql FROM sqlite_master WHERE type IN ('table', 'view', 'trigger')"
+            )
+        }
+        required = {"schema_version", "emails", "emails_fts", "sync_state"}
+        missing = sorted(required - set(objects))
+        if missing:
+            raise sqlite3.DatabaseError(f"missing required tables: {', '.join(missing)}")
+        fts_sql = objects["emails_fts"][1].upper()
+        if "VIRTUAL TABLE" not in fts_sql or "USING FTS5" not in fts_sql:
+            raise sqlite3.DatabaseError("emails_fts is not an FTS5 virtual table")
+        missing_triggers = sorted(REQUIRED_FTS_TRIGGERS - set(objects))
+        if missing_triggers:
+            raise sqlite3.DatabaseError(f"missing FTS maintenance triggers: {', '.join(missing_triggers)}")
+        missing_email_columns = sorted(REQUIRED_EMAIL_COLUMNS - _columns(connection, "emails"))
+        if missing_email_columns:
+            raise sqlite3.DatabaseError(f"emails is missing columns: {', '.join(missing_email_columns)}")
+        missing_sync_columns = sorted(REQUIRED_SYNC_COLUMNS - _columns(connection, "sync_state"))
+        if missing_sync_columns:
+            raise sqlite3.DatabaseError(f"sync_state is missing columns: {', '.join(missing_sync_columns)}")
+        version_row = connection.execute("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").fetchone()
+        if not version_row or not isinstance(version_row[0], int) or version_row[0] < 1:
+            raise sqlite3.DatabaseError("schema_version has no supported version")
+        email_count = int(connection.execute("SELECT COUNT(*) FROM emails").fetchone()[0])
+        # The FTS5 docsize shadow table proves that each base row has a searchable
+        # document without reading any subject, sender, or body text.
+        indexed_count = int(
+            connection.execute(
+                "SELECT COUNT(*) FROM emails e JOIN emails_fts_docsize fts ON fts.id = e.rowid"
+            ).fetchone()[0]
+        )
+        if indexed_count != email_count:
+            raise sqlite3.DatabaseError(f"FTS5 contains {indexed_count} searchable rows for {email_count} messages")
+        connection.execute("CREATE VIRTUAL TABLE temp.apple_mail_health_vocab USING fts5vocab(main, emails_fts, 'row')")
+        searchable_terms = int(connection.execute("SELECT COUNT(*) FROM temp.apple_mail_health_vocab").fetchone()[0])
+        if email_count and searchable_terms == 0:
+            raise sqlite3.DatabaseError("FTS5 contains no searchable terms")
+        last_sync = connection.execute("SELECT MAX(last_sync) FROM sync_state WHERE last_sync IS NOT NULL").fetchone()[
+            0
+        ]
+    if not last_sync:
+        raise sqlite3.DatabaseError("no successful sync is recorded")
+    return email_count, str(last_sync)
+
+
+def _sync_age(now: datetime, raw_timestamp: str) -> timedelta:
+    try:
+        synced = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"invalid last-sync timestamp: {raw_timestamp}") from error
+    comparable_now = now.astimezone().replace(tzinfo=None) if synced.tzinfo is None else now.astimezone(synced.tzinfo)
+    return max(comparable_now - synced, timedelta())
+
+
+def _describe_age(age: timedelta) -> str:
+    if age.days >= 1:
+        return f"{age.days} day{'s' if age.days != 1 else ''} ago"
+    hours = int(age.total_seconds() // 3600)
+    if hours >= 1:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    return "in the last hour"
+
+
+def probe(context: Context) -> Result:
+    """Prove the configured local FTS index can truthfully answer searches."""
+    try:
+        registration = _registration(context)
+    except ValueError as error:
+        detail = _one_line(error)
+        return Result(
+            "BROKEN",
+            detail,
+            action="Fix the malformed MCP JSON, then run /dex-doctor again.",
+            feature_status="broken",
+            user_message=f"Mail search configuration cannot be verified. {detail}",
+        )
+    if registration is None:
+        return Result("OFF", "Apple Mail search is not connected, so it stays opt-in", feature_status="off")
+    if not context.macos:
+        return Result(
+            "UNKNOWN",
+            "An Apple Mail server is registered but its index can only be checked on macOS",
+            feature_status="unknown",
+        )
+    if not context.cli_present:
+        return Result(
+            "BROKEN",
+            "An Apple Mail server is registered but the apple-mail-mcp command is not installed, "
+            "so mail search cannot work",
+            action="Install the server with `pipx install apple-mail-mcp`, then run /apple-mail-setup.",
+            feature_status="broken",
+            user_message=(
+                "Mail search is registered but the apple-mail-mcp command is missing. "
+                "Install it with `pipx install apple-mail-mcp`, then run /apple-mail-setup."
+            ),
+        )
+    try:
+        settings = _settings(context, registration)
+    except ValueError as error:
+        detail = _one_line(error)
+        return Result(
+            "BROKEN",
+            detail,
+            action="Fix ~/.apple-mail-mcp/config.toml or the Apple Mail MCP environment, then run /dex-doctor again.",
+            feature_status="broken",
+            user_message=detail,
+        )
+    index = settings.path
+    try:
+        index_stat = index.stat()
+    except FileNotFoundError:
+        return Result(
+            "BROKEN",
+            f"Apple Mail search has no index, so every mail search returns nothing (expected {index})",
+            action=APPLE_MAIL_INDEX_BUILD_FIX,
+            feature_status="broken",
+            user_message="Mail search has never been built, so it silently returns nothing. "
+            + APPLE_MAIL_INDEX_BUILD_FIX,
+        )
+    except OSError as error:
+        detail = _one_line(error)
+        return Result("UNKNOWN", f"The Apple Mail index could not be read: {detail}", feature_status="unknown")
+    if index_stat.st_size == 0:
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} is empty, so every mail search returns nothing",
+            action=APPLE_MAIL_INDEX_BUILD_FIX,
+            feature_status="broken",
+            user_message="Mail search's index is empty, so it returns nothing. " + APPLE_MAIL_INDEX_BUILD_FIX,
+        )
+    permissions = _permissions_result(index)
+    if permissions:
+        return permissions
+    try:
+        email_count, last_sync = _index_state(index)
+        age = _sync_age(context.now, last_sync)
+    except (OSError, sqlite3.DatabaseError, ValueError) as error:
+        detail = _one_line(error)
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} is not usable: {detail}",
+            action=APPLE_MAIL_INDEX_REBUILD_FIX,
+            feature_status="broken",
+            user_message="Mail search's local index is not usable. " + APPLE_MAIL_INDEX_REBUILD_FIX,
+        )
+    permissions = _permissions_result(index)
+    if permissions:
+        return permissions
+    if email_count == 0:
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} has its schema but contains no messages",
+            action=APPLE_MAIL_INDEX_REBUILD_FIX,
+            feature_status="broken",
+            user_message="Mail search's local index contains no messages. " + APPLE_MAIL_INDEX_REBUILD_FIX,
+        )
+    if age > settings.stale_after:
+        allowed_hours = settings.stale_after.total_seconds() / 3600
+        described_age = _describe_age(age)
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} last synced {described_age}, beyond its configured {allowed_hours:g}-hour freshness limit",
+            action=APPLE_MAIL_INDEX_BUILD_FIX,
+            feature_status="broken",
+            user_message=f"Mail search is running on an index last synced {described_age}, so recent mail may be invisible. "
+            + APPLE_MAIL_INDEX_BUILD_FIX,
+        )
+    return Result(
+        "OK",
+        f"Apple Mail search is using {index} with {email_count} indexed message{'s' if email_count != 1 else ''}, last synced {_describe_age(age)}",
+        feature_status="ok",
+    )

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -646,6 +646,7 @@ DEEP_CHECKS = (
     CheckDefinition("config.meeting_sources", "Configured meeting source", "_probe_meeting_sources"),
     CheckDefinition("update.post-canary", "Post-update canary", "_probe_post_update_canary"),
     CheckDefinition("calendar.access", "Calendar access", "_probe_calendar_access"),
+    CheckDefinition("mail.apple-search", "Apple Mail search", "_probe_apple_mail_search"),
     CheckDefinition("qmd.live", "Semantic search", "_probe_qmd_live"),
     CheckDefinition("integrations.enabled", "Enabled integrations", "_probe_integrations_enabled"),
     CheckDefinition("mcp.importable", "MCP imports", "_probe_mcp_importable"),
@@ -4986,6 +4987,158 @@ def _probe_calendar_access(context: DoctorContext) -> ProbeResult:
             ),
         )
     return ProbeResult("OK", f"Calendar access works and {len(calendars)} calendar names were returned")
+
+
+APPLE_MAIL_INDEX_STALE_AFTER = timedelta(days=7)
+APPLE_MAIL_INDEX_FIX = (
+    "Run `apple-mail-mcp index` in Terminal. It needs Full Disk Access: "
+    "System Settings > Privacy & Security > Full Disk Access, add Terminal, then re-run the command."
+)
+
+
+def _apple_mail_user_scope_config(context: DoctorContext) -> dict[str, Any]:
+    """Read the user-scope MCP registrations Dex's own hook steers people towards."""
+    user_config = context.home / ".claude.json"
+    try:
+        loaded = json.loads(user_config.read_text())
+    except (FileNotFoundError, ValueError, OSError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    servers = loaded.get("mcpServers")
+    return servers if isinstance(servers, dict) else {}
+
+
+def _apple_mail_registered(context: DoctorContext) -> bool:
+    """An Apple Mail server counts whether it is registered at user or project scope."""
+    entries: dict[str, Any] = dict(_apple_mail_user_scope_config(context))
+    try:
+        entries.update(_load_mcp_config(context).get("mcpServers", {}))
+    except (FileNotFoundError, ValueError, OSError):
+        pass
+    for name, entry in entries.items():
+        if "apple-mail" in name.lower().replace("_", "-"):
+            return True
+        if not isinstance(entry, dict):
+            continue
+        tokens = [str(entry.get("command", ""))]
+        tokens.extend(str(argument) for argument in entry.get("args", []) if isinstance(argument, str))
+        if any("apple-mail-mcp" in token for token in tokens):
+            return True
+    return False
+
+
+def _apple_mail_index_path(context: DoctorContext) -> Path:
+    return context.home / ".apple-mail-mcp" / "index.db"
+
+
+def _apple_mail_cli_present() -> bool:
+    return shutil.which("apple-mail-mcp") is not None
+
+
+def _probe_apple_mail_search(context: DoctorContext) -> ProbeResult:
+    """Tell the truth about Apple Mail search instead of letting it fail silently.
+
+    The community server's list/read tools work on Automation permission alone, so the
+    integration looks healthy while its search tool returns empty every time because the
+    FTS index was never built (that needs a manual run plus Full Disk Access).
+    """
+    if not _apple_mail_registered(context):
+        return ProbeResult(
+            "OFF",
+            "Apple Mail search is not connected, so it stays opt-in",
+            feature_status="off",
+        )
+    if not _is_macos():
+        return ProbeResult(
+            "UNKNOWN",
+            "An Apple Mail server is registered but its index can only be checked on macOS",
+            feature_status="unknown",
+        )
+    if not _apple_mail_cli_present():
+        return ProbeResult(
+            "BROKEN",
+            "An Apple Mail server is registered but the apple-mail-mcp command is not installed, "
+            "so mail search cannot work",
+            Heal(
+                tier=3,
+                action="Install the server with `pipx install apple-mail-mcp`, then run /apple-mail-setup.",
+                applied=False,
+            ),
+            feature_status="broken",
+            user_message=(
+                "Mail search is registered but the apple-mail-mcp command is missing. "
+                "Install it with `pipx install apple-mail-mcp`, then run /apple-mail-setup."
+            ),
+        )
+
+    index = _apple_mail_index_path(context)
+    try:
+        stat = index.stat()
+    except FileNotFoundError:
+        return ProbeResult(
+            "BROKEN",
+            "Apple Mail search has no index, so every mail search returns nothing "
+            f"(expected {index})",
+            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
+            feature_status="broken",
+            user_message=(
+                "Mail search has never been built, so it silently returns nothing. "
+                + APPLE_MAIL_INDEX_FIX
+            ),
+        )
+    except OSError as error:
+        detail = _one_line(error)
+        if _looks_like_sandbox_failure(detail):
+            return ProbeResult(
+                "UNKNOWN",
+                f"The sandbox blocked the Apple Mail index check: {detail}",
+                feature_status="unknown",
+            )
+        return ProbeResult(
+            "UNKNOWN",
+            f"The Apple Mail index could not be read: {detail}",
+            feature_status="unknown",
+        )
+
+    if stat.st_size == 0:
+        return ProbeResult(
+            "BROKEN",
+            f"The Apple Mail search index at {index} is empty, so every mail search returns nothing",
+            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
+            feature_status="broken",
+            user_message="Mail search's index is empty, so it returns nothing. " + APPLE_MAIL_INDEX_FIX,
+        )
+
+    built = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+    age = context.now - built
+    if age > APPLE_MAIL_INDEX_STALE_AFTER:
+        days = max(age.days, 1)
+        return ProbeResult(
+            "BROKEN",
+            f"The Apple Mail search index was last built {days} days ago, so recent mail is missing "
+            "from every search",
+            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
+            feature_status="broken",
+            user_message=(
+                f"Mail search is running on a {days}-day-old index, so recent mail is invisible to it. "
+                + APPLE_MAIL_INDEX_FIX
+            ),
+        )
+    return ProbeResult(
+        "OK",
+        f"Apple Mail search has an index built {_describe_index_age(age)}",
+        feature_status="ok",
+    )
+
+
+def _describe_index_age(age: timedelta) -> str:
+    if age.days >= 1:
+        return f"{age.days} day{'s' if age.days != 1 else ''} ago"
+    hours = int(age.total_seconds() // 3600)
+    if hours >= 1:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    return "in the last hour"
 
 
 def _qmd_registered(config: dict[str, Any]) -> bool:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -37,7 +37,7 @@ from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
 from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry, PlanRejected
 from core.transaction.journal import Journal, JournalCorruptError
-from core.utils import dex_logger, launch_agents, preflight, release_channel
+from core.utils import apple_mail_health, dex_logger, launch_agents, preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
@@ -4989,156 +4989,32 @@ def _probe_calendar_access(context: DoctorContext) -> ProbeResult:
     return ProbeResult("OK", f"Calendar access works and {len(calendars)} calendar names were returned")
 
 
-APPLE_MAIL_INDEX_STALE_AFTER = timedelta(days=7)
-APPLE_MAIL_INDEX_FIX = (
-    "Run `apple-mail-mcp index` in Terminal. It needs Full Disk Access: "
-    "System Settings > Privacy & Security > Full Disk Access, add Terminal, then re-run the command."
-)
-
-
-def _apple_mail_user_scope_config(context: DoctorContext) -> dict[str, Any]:
-    """Read the user-scope MCP registrations Dex's own hook steers people towards."""
-    user_config = context.home / ".claude.json"
-    try:
-        loaded = json.loads(user_config.read_text())
-    except (FileNotFoundError, ValueError, OSError):
-        return {}
-    if not isinstance(loaded, dict):
-        return {}
-    servers = loaded.get("mcpServers")
-    return servers if isinstance(servers, dict) else {}
-
-
-def _apple_mail_registered(context: DoctorContext) -> bool:
-    """An Apple Mail server counts whether it is registered at user or project scope."""
-    entries: dict[str, Any] = dict(_apple_mail_user_scope_config(context))
-    try:
-        entries.update(_load_mcp_config(context).get("mcpServers", {}))
-    except (FileNotFoundError, ValueError, OSError):
-        pass
-    for name, entry in entries.items():
-        if "apple-mail" in name.lower().replace("_", "-"):
-            return True
-        if not isinstance(entry, dict):
-            continue
-        tokens = [str(entry.get("command", ""))]
-        tokens.extend(str(argument) for argument in entry.get("args", []) if isinstance(argument, str))
-        if any("apple-mail-mcp" in token for token in tokens):
-            return True
-    return False
-
-
-def _apple_mail_index_path(context: DoctorContext) -> Path:
-    return context.home / ".apple-mail-mcp" / "index.db"
-
-
 def _apple_mail_cli_present() -> bool:
     return shutil.which("apple-mail-mcp") is not None
 
 
 def _probe_apple_mail_search(context: DoctorContext) -> ProbeResult:
-    """Tell the truth about Apple Mail search instead of letting it fail silently.
-
-    The community server's list/read tools work on Automation permission alone, so the
-    integration looks healthy while its search tool returns empty every time because the
-    FTS index was never built (that needs a manual run plus Full Disk Access).
-    """
-    if not _apple_mail_registered(context):
-        return ProbeResult(
-            "OFF",
-            "Apple Mail search is not connected, so it stays opt-in",
-            feature_status="off",
+    """Adapt the focused Apple Mail checker to Doctor's normalized result."""
+    result = apple_mail_health.probe(
+        apple_mail_health.Context(
+            home=context.home,
+            vault_root=context.vault_root,
+            now=context.now,
+            user_config_path=context.home / ".claude.json",
+            project_config_path=_mcp_config_path(context),
+            environment=os.environ,
+            macos=_is_macos(),
+            cli_present=_apple_mail_cli_present(),
         )
-    if not _is_macos():
-        return ProbeResult(
-            "UNKNOWN",
-            "An Apple Mail server is registered but its index can only be checked on macOS",
-            feature_status="unknown",
-        )
-    if not _apple_mail_cli_present():
-        return ProbeResult(
-            "BROKEN",
-            "An Apple Mail server is registered but the apple-mail-mcp command is not installed, "
-            "so mail search cannot work",
-            Heal(
-                tier=3,
-                action="Install the server with `pipx install apple-mail-mcp`, then run /apple-mail-setup.",
-                applied=False,
-            ),
-            feature_status="broken",
-            user_message=(
-                "Mail search is registered but the apple-mail-mcp command is missing. "
-                "Install it with `pipx install apple-mail-mcp`, then run /apple-mail-setup."
-            ),
-        )
-
-    index = _apple_mail_index_path(context)
-    try:
-        stat = index.stat()
-    except FileNotFoundError:
-        return ProbeResult(
-            "BROKEN",
-            "Apple Mail search has no index, so every mail search returns nothing "
-            f"(expected {index})",
-            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
-            feature_status="broken",
-            user_message=(
-                "Mail search has never been built, so it silently returns nothing. "
-                + APPLE_MAIL_INDEX_FIX
-            ),
-        )
-    except OSError as error:
-        detail = _one_line(error)
-        if _looks_like_sandbox_failure(detail):
-            return ProbeResult(
-                "UNKNOWN",
-                f"The sandbox blocked the Apple Mail index check: {detail}",
-                feature_status="unknown",
-            )
-        return ProbeResult(
-            "UNKNOWN",
-            f"The Apple Mail index could not be read: {detail}",
-            feature_status="unknown",
-        )
-
-    if stat.st_size == 0:
-        return ProbeResult(
-            "BROKEN",
-            f"The Apple Mail search index at {index} is empty, so every mail search returns nothing",
-            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
-            feature_status="broken",
-            user_message="Mail search's index is empty, so it returns nothing. " + APPLE_MAIL_INDEX_FIX,
-        )
-
-    built = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
-    age = context.now - built
-    if age > APPLE_MAIL_INDEX_STALE_AFTER:
-        days = max(age.days, 1)
-        return ProbeResult(
-            "BROKEN",
-            f"The Apple Mail search index was last built {days} days ago, so recent mail is missing "
-            "from every search",
-            Heal(tier=3, action=APPLE_MAIL_INDEX_FIX, applied=False),
-            feature_status="broken",
-            user_message=(
-                f"Mail search is running on a {days}-day-old index, so recent mail is invisible to it. "
-                + APPLE_MAIL_INDEX_FIX
-            ),
-        )
-    return ProbeResult(
-        "OK",
-        f"Apple Mail search has an index built {_describe_index_age(age)}",
-        feature_status="ok",
     )
-
-
-def _describe_index_age(age: timedelta) -> str:
-    if age.days >= 1:
-        return f"{age.days} day{'s' if age.days != 1 else ''} ago"
-    hours = int(age.total_seconds() // 3600)
-    if hours >= 1:
-        return f"{hours} hour{'s' if hours != 1 else ''} ago"
-    return "in the last hour"
+    heal = Heal(tier=3, action=result.action, applied=False) if result.action else None
+    return ProbeResult(
+        result.verdict,
+        result.detail,
+        heal,
+        feature_status=result.feature_status,
+        user_message=result.user_message,
+    )
 
 
 def _qmd_registered(config: dict[str, Any]) -> bool:

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 52f444e5914466ad8f7b5d338f00fbfafb985330de3a98f83e9f53b3b07008bc -->
+<!-- Content SHA-256: e092b40e3861afbbd63ebff9151734abd5f456f86b5db8f6032d43b3ce39b344 -->
 
 # Architecture Inventory
 
@@ -26,7 +26,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 81<br>
+**Skill count:** 82<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -49,6 +49,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `anthropic-web-artifacts-builder` | `.claude/skills/anthropic-web-artifacts-builder/SKILL.md` | Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts. | 288 | **discoverability-risk** |
 | `anthropic-webapp-testing` | `.claude/skills/anthropic-webapp-testing/SKILL.md` | Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs. | 204 | **discoverability-risk** |
 | `anthropic-xlsx` | `.claude/skills/anthropic-xlsx/SKILL.md` | Comprehensive spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization. When Claude needs to work with spreadsheets (.xlsx, .xlsm, .csv, .tsv, etc) for: (1) Creating new spreadsheets with formulas and formatting, (2) Reading or analyzing data, (3) Modify existing spreadsheets while preserving formulas, (4) Data analysis and visualization in spreadsheets, or (5) Recalculating formulas | 445 | when |
+| `apple-mail-setup` | `.claude/skills/apple-mail-setup/SKILL.md` | Set up and verify Apple Mail search on macOS, including the search index that silently returns nothing when it was never built. Use when the user says 'connect Apple Mail', 'set up mail search', 'Dex can't find my emails', 'mail search returns nothing'. Not for Gmail or Google Workspace; use `google-workspace-setup`. | 318 | when |
 | `atlassian-setup` | `.claude/skills/atlassian-setup/SKILL.md` | Connect Jira and Confluence for project tracking and knowledge search. Use when the user says 'connect Jira', 'hook up Confluence', 'my tickets/board'. Not for a personal task app like Todoist/Things/Trello; use `todoist-setup`/`things-setup`/`trello-setup`. | 258 | when |
 | `backup-now` | `.claude/skills/backup-now/SKILL.md` | Run a vault backup right now and report the verified result. Use when the user says 'back up now', 'take a backup before I do this', or is about to make a big change. Not for scheduling or changing where backups go (`backup-setup`); not for getting files back (`backup-restore`). | 279 | when |
 | `backup-restore` | `.claude/skills/backup-restore/SKILL.md` | Verify a vault backup, prove it restores, or restore it to a folder of the user's choosing. Use when the user says 'restore my backup', 'test my backups', 'are my backups any good', or after data loss. Never overwrites the live vault. Not for taking a backup (`backup-now`); not for scheduling (`backup-setup`). | 311 | when |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ hypothesis
 pytest-split
 cryptography>=42
 jsonschema>=4.23,<5
+# Real macOS contract seam for the optional Apple Mail search health check.
+apple-mail-mcp==0.4.3


### PR DESCRIPTION
## Why

Chris Jackson's diagnosis in #446 was right: Apple Mail list/read can work while search silently returns nothing because its separate local FTS5 index was never built or stopped syncing. The earlier repair in #469 also showed the right product intent, but trusted one hard-coded file's size and seven-day mtime rather than the server's actual configured index state.

This draft preserves that intent and the original setup/ritual commit while replacing the health proof with behavior that cannot call a fake, empty, unsearchable, stale, misconfigured, or exposed index healthy.

## What changed

- Resolve the index using the pinned upstream runtime contract: process/MCP environment, then validated TOML, then the default path; custom and relative paths are covered.
- Open SQLite read-only and prove integrity, schema version/columns, the real FTS5 virtual table and maintenance triggers, searchable row/term coverage, non-empty mail data, and a completed sync for every indexed account/mailbox within the configured 24-hour default or override.
- Require owner-only `0600` permissions on the database and any WAL/SHM sidecars, including a resolved symlink target.
- Add guided setup that narrows Full Disk Access to the temporary indexing terminal, explains the local index contents, and states that search results sent through an AI client may reach its provider.
- Make daily/week rituals surface a connected-but-broken Mail source instead of silently treating a false-empty search as an empty inbox.
- Keep Doctor orchestration small by isolating Apple Mail config/SQLite/security logic in a focused adapter.
- Pin `apple-mail-mcp==0.4.3` in development requirements and add a macOS-only real CLI `status` plus permission-denial guidance seam.

No JXA fallback architecture is introduced.

## Red/green evidence

Deliberate FTS mutation (both searchable-row safeguards disabled):

```text
python3 -m pytest core/tests/test_apple_mail_health.py::test_apple_mail_search_rejects_files_that_cannot_answer_searches -q -k empty-fts
FAILED: expected BROKEN, got OK
```

Restored:

```text
1 passed, 3 deselected
```

Deliberate empty-config mutation (restore the old `if not data: return`):

```text
python3 -m pytest core/tests/test_apple_mail_health.py::test_apple_mail_search_reports_empty_existing_config_as_broken -q
FAILED: missing `config_version = 1` guidance; fell through to unrelated no-index diagnosis
```

Mixed fresh/stale and fresh/missing sync rows before the fix:

```text
python3 -m pytest core/tests/test_apple_mail_health.py::test_apple_mail_search_checks_every_indexed_mailbox_sync -q
2 failed: expected BROKEN, got OK
```

Restored: `2 passed`.

Restored focused/broader proof:

```text
31 focused Apple Mail adapter cases passed
278 focused adapter, Doctor, instruction-honesty, and runtime tests passed; 1 macOS-only skip and 2 known environment-only deselections on Linux
199 adjacent health reporter, skill integrity, release, and current-main work-server tests passed
75 Lens catalog tests passed
ruff / py_compile / diff / architecture / path / portable-contract / docs / test-delta / PII / founder gates passed
distribution: 0 errors, 8 pre-existing warnings
```

## Review-focused test layout

The 31-case config/path/schema/freshness/permissions/FTS contract now lives in `core/tests/test_apple_mail_health.py`. The legacy Doctor test file has only the deep-check ID plus one thin adapter-wiring test (+39/-0 versus current main), and instruction honesty has only its two new static checks (+24/-0); unrelated formatter churn was removed.

## Security and privacy

The local FTS index contains subjects, senders, message bodies, mail file paths, and attachment metadata. Doctor reads only SQLite integrity/schema, counts, sync timestamps, and file modes; it does not read message text. Indexing needs broad macOS Full Disk Access to the user's Mail store, so setup grants it only to the terminal doing the build and explains that it can be revoked afterward. Searching the completed local index does not require FDA. Search results passed to the configured AI client may leave the Mac for that provider; the setup copy says so explicitly.

## Residual macOS proof

Linux cannot prove Apple's TCC permission system. Fresh macOS CI must run the pinned upstream CLI test. That test proves the real runtime can report a synthetic FTS5 index and emits actionable Full Disk Access wording on a denied filesystem seam. It still cannot prove a real user's TCC grant/denial, live Mail store, or an end-to-end search of personal mail; those remain release-canary evidence, not unit-test evidence.

Integrated base: `3d1f7b99854ef183880c71ffb6dafdc1d9af3081` via merge commit `e04a0f43b71db15ab4b5bf7385c38c767419638f` (history preserved).

Related: #446, #469