### PR TITLE
fix: harden configured meeting-source handling

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -15,8 +15,9 @@ The copies here are **adapters**, not a second source of truth: when a skill
 that exists in both places changes in `.claude/skills/`, the change should be
 mirrored here in the same PR.
 
-> Last synced 2026-07-27 (canonical body verbatim; Claude-Code-only frontmatter
-> keys like `hooks:`/`context:` dropped). These files are covered by
+> Last synced 2026-08-13 (`process-meetings` source selection mirrored; the
+> adapter remains harness-neutral and omits Claude-only delegation/frontmatter).
+> These files are covered by
 > instruction-honesty and configuration-truth tests
 > (`core/tests/test_instruction_honesty.py`,
 > `core/tests/test_granola_configuration_truth.py`,

--- a/.agents/skills/process-meetings/SKILL.md
+++ b/.agents/skills/process-meetings/SKILL.md
@@ -111,7 +111,9 @@ For each meeting file, including a manual note with no capture id:
    matching a string `source`; if that key is absent, report the mismatch and
    use the note path. When `source` is absent, use an id only when exactly one
    non-empty scalar candidate exists. Empty or non-scalar values do not count;
-   multiple ids fall back to note-path identity
+   multiple ids fall back to note-path identity. The path identity is the
+   normalized vault-relative Markdown path, with `/` separators and the `.md`
+   extension retained; never reduce it to a basename
 2. Check if person/company pages need updating
 3. Check if tasks need extracting (look for unchecked items in "For Me" section)
 

--- a/.agents/skills/process-meetings/SKILL.md
+++ b/.agents/skills/process-meetings/SKILL.md
@@ -33,26 +33,43 @@ Meetings are synced automatically every 30 minutes by a background process. This
 - `--no-todos`: Create notes but don't extract tasks
 - `--setup`: Install/check background automation
 
-## Pre-flight: Granola Check
+## Pre-flight: Local Source Check
 
-Granola sync uses the official Granola public API. Desktop and mobile recordings both come through it once your Granola API key is connected. If `GRANOLA_API_KEY` isn't set (checked in the environment, then the `.env` file at the vault root), say: "Granola isn't connected yet — run `/granola-setup` to add your Granola API key (requires a Granola Business plan)." and continue with any meetings already synced.
+Read `meeting_sources` in `System/user-profile.yaml` before assuming a recorder.
+The configured `primary` is provenance, not permission or tool access. A valid
+vault-relative `notes_folder` outranks the default landing zone. Missing or
+malformed config, an invalid primary, an absolute path, `..`, the vault root, or
+a symlink escape must be reported and ignored; continue with safe local notes.
+Never widen into an external service just because the profile names it.
+
+For `primary: granola`, Granola sync uses the official public API. If
+`GRANOLA_API_KEY` is absent, offer `/granola-setup` and continue with local
+notes. Other primaries do not inherit a direct reader from this setting.
 
 ---
 
 ## Process
 
-### Step 1: Check Background Sync Status
+### Step 1: Check Source and Background Sync Status
 
-First, check if background sync is set up:
+Resolve `meeting_sources.notes_folder` using the rules above: only a valid
+vault-relative folder is accepted; missing or malformed config, an absolute
+path, `..`, the vault root, or a symlink escape falls back safely. The configured
+primary does not grant access to an external service. Then check whether
+Granola background sync has left its optional state file:
 
 ```bash
 # Check for state file (indicates sync has run)
 ls .scripts/meeting-intel/processed-meetings.json
 ```
 
-**If state file exists:** Background sync is working. Continue to Step 2.
+**If the state file exists:** Granola background sync has run. Continue to Step 2.
 
-**If state file doesn't exist:**
+**If it does not exist and Granola is configured:** offer setup, but continue
+with local notes. The missing file is not a gate for an `exported-folder`, Zoom,
+Teams, manual note, or provider-neutral local source.
+
+For Granola setup guidance:
 > "Background meeting sync isn't set up yet. This runs automatically every 30 minutes so `/process-meetings` doesn't need terminal commands.
 >
 > **To set up (one-time, takes 30 seconds):**
@@ -73,18 +90,28 @@ cd .scripts/meeting-intel && ./install-automation.sh
 
 ### Step 2: Find Synced Meetings
 
-Read the processed meetings state:
+Read the processed meetings state when it exists:
 ```javascript
 const state = JSON.parse(fs.readFileSync('.scripts/meeting-intel/processed-meetings.json'));
 ```
 
-List meeting files in `00-Inbox/Meetings/`:
+Search the valid configured folder first, then `00-Inbox/Meetings/`. If neither
+contains a candidate, use bounded provider-neutral Markdown discovery in the
+vault by date plus title, attendee, or meeting frontmatter. Exclude Dex
+internals, dependencies, binaries, and archives outside the requested window;
+never treat arbitrary Markdown as a meeting. For the default folder:
 ```bash
 find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
-For each meeting file:
-1. Read frontmatter to get `granola_id`, `participants`, `company`, `date`
+For each meeting file, including a manual note with no capture id:
+1. Preserve its actual vault-relative path. Read `participants`, `company`,
+   `date`, and recorder provenance. A capture id is a non-empty scalar key
+   ending in `_id` (for example `granola_id` or `wispr_id`). Prefer the key
+   matching a string `source`; if that key is absent, report the mismatch and
+   use the note path. When `source` is absent, use an id only when exactly one
+   non-empty scalar candidate exists. Empty or non-scalar values do not count;
+   multiple ids fall back to note-path identity
 2. Check if person/company pages need updating
 3. Check if tasks need extracting (look for unchecked items in "For Me" section)
 

--- a/.claude/hooks/post-meeting-person-update.cjs
+++ b/.claude/hooks/post-meeting-person-update.cjs
@@ -53,7 +53,33 @@ function isWithin(candidate, directory) {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function configuredNotesDirectory() {
+  const profilePath = path.join(vaultRoot, 'System', 'user-profile.yaml');
+  try {
+    const profile = yaml.load(fs.readFileSync(profilePath, 'utf8'));
+    const folder = profile?.meeting_sources?.notes_folder;
+    if (typeof folder !== 'string' || !folder.trim() || path.isAbsolute(folder)) return null;
+    const parts = folder.trim().split(/[\\/]+/);
+    if (parts.includes('..')) return null;
+    const candidate = path.resolve(vaultRoot, folder.trim());
+    if (candidate === path.resolve(vaultRoot) || !isWithin(candidate, vaultRoot)) return null;
+    const realVault = fs.realpathSync(vaultRoot);
+    const realCandidate = fs.realpathSync(candidate);
+    return isWithin(realCandidate, realVault) ? realCandidate : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+const configuredNotesDir = configuredNotesDirectory();
+let realFilePath = filePath;
+try {
+  realFilePath = fs.realpathSync(filePath);
+} catch (_) {
+  // The ordinary not-found check below owns missing or unreadable paths.
+}
 if (!isWithin(filePath, meetingsDir)
+    && !(configuredNotesDir && isWithin(realFilePath, configuredNotesDir))
     && !filePath.includes('Meeting_Intel')
     && !filePath.includes('Meeting_Notes')) {
   skip('not-a-meeting-note');
@@ -125,10 +151,24 @@ if (fallbackNames.length === 0) skip('no-person-references-found');
 
 const relativeMeetingPath = path.relative(vaultRoot, filePath).split(path.sep).join('/');
 const date = meetingDate(metadata);
-const granolaId = typeof metadata.granola_id === 'string'
-  ? metadata.granola_id.trim()
-  : '';
-const sourceId = granolaId || path.basename(relativeMeetingPath, '.md');
+function captureSourceId(frontmatter) {
+  const candidates = Object.entries(frontmatter)
+    .filter(([key, value]) => key.endsWith('_id')
+      && (typeof value === 'string' || typeof value === 'number')
+      && String(value).trim())
+    .map(([key, value]) => [key, String(value).trim()]);
+  const source = typeof frontmatter.source === 'string'
+    ? frontmatter.source.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+    : '';
+  if (source) {
+    const matched = candidates.find(([key]) => key.toLowerCase() === `${source}_id`);
+    if (matched) return matched[1];
+    return '';
+  }
+  return candidates.length === 1 ? candidates[0][1] : '';
+}
+
+const sourceId = captureSourceId(metadata) || path.basename(relativeMeetingPath, '.md');
 const interaction = `- [${meetingTitle(metadata)}](${relativeMeetingPath}) — ${date}`;
 const seen = new Set();
 const ops = [];

--- a/.claude/hooks/post-meeting-person-update.cjs
+++ b/.claude/hooks/post-meeting-person-update.cjs
@@ -168,7 +168,10 @@ function captureSourceId(frontmatter) {
   return candidates.length === 1 ? candidates[0][1] : '';
 }
 
-const sourceId = captureSourceId(metadata) || path.basename(relativeMeetingPath, '.md');
+// Capture ids are globally stable when unambiguous. The fallback must be the
+// normalized vault-relative Markdown path (POSIX separators, `.md` retained):
+// basenames collide as soon as configured and default folders share a title.
+const sourceId = captureSourceId(metadata) || relativeMeetingPath;
 const interaction = `- [${meetingTitle(metadata)}](${relativeMeetingPath}) — ${date}`;
 const seen = new Set();
 const ops = [];

--- a/.claude/hooks/tests/post-meeting-person-update.test.cjs
+++ b/.claude/hooks/tests/post-meeting-person-update.test.cjs
@@ -64,13 +64,15 @@ function personPage(name, region = true) {
   ].join('\n');
 }
 
-function meetingNote(vault, name = 'roadmap.md', granolaId = null) {
+function meetingNote(vault, name = 'roadmap.md', granolaId = null, extraFrontmatter = []) {
   const meeting = path.join(vault, '00-Inbox', 'Meetings', name);
+  fs.mkdirSync(path.dirname(meeting), { recursive: true });
   fs.writeFileSync(meeting, [
     '---',
     'title: Roadmap Review',
     'date: 2026-07-10',
     ...(granolaId ? [`granola_id: ${granolaId}`] : []),
+    ...extraFrontmatter,
     'attendees:',
     '  - name: Alice Smith',
     '    email: alice@example.com',
@@ -81,6 +83,121 @@ function meetingNote(vault, name = 'roadmap.md', granolaId = null) {
   ].join('\n'));
   return meeting;
 }
+
+test('a provider-neutral capture id becomes the meeting touch source', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  const meeting = meetingNote(vault, 'roadmap.md', null, [
+    'source: wispr',
+    'wispr_id: wispr-meeting-456',
+  ]);
+
+  const result = runHook(vault, { tool_input: { file_path: meeting } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parseEntityPage(person).touches[0].source.id, 'wispr-meeting-456');
+});
+
+test('multiple provider capture ids fall back to path identity', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  const meeting = meetingNote(vault, 'roadmap.md', null, [
+    'first_id: capture-one',
+    'second_id: capture-two',
+  ]);
+
+  const result = runHook(vault, { tool_input: { file_path: meeting } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+});
+
+test('empty and non-scalar capture ids fall back to path identity', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  const meeting = meetingNote(vault, 'roadmap.md', null, [
+    'wispr_id: ""',
+    'other_id: [not, scalar]',
+  ]);
+
+  const result = runHook(vault, { tool_input: { file_path: meeting } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+});
+
+test('a source and capture-id key mismatch falls back to path identity', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  const meeting = meetingNote(vault, 'roadmap.md', null, [
+    'source: wispr',
+    'granola_id: granola-meeting-123',
+  ]);
+
+  const result = runHook(vault, { tool_input: { file_path: meeting } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+});
+
+test('a configured vault-relative notes folder is a meeting source', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  fs.mkdirSync(path.join(vault, 'System'), { recursive: true });
+  fs.writeFileSync(
+    path.join(vault, 'System', 'user-profile.yaml'),
+    'meeting_sources:\n  primary: exported-folder\n  notes_folder: 00-Inbox/ClickUp\n',
+  );
+  const meeting = meetingNote(
+    vault,
+    '../ClickUp/roadmap.md',
+    null,
+    ['source: wispr', 'wispr_id: wispr-meeting-789'],
+  );
+
+  const result = runHook(vault, { tool_input: { file_path: meeting } });
+
+  assert.equal(result.status, 0, result.stderr);
+  const updated = fs.readFileSync(person, 'utf8');
+  assert.match(updated, /\(00-Inbox\/ClickUp\/roadmap\.md\)/);
+  assert.equal(parseEntityPage(person).touches[0].source.id, 'wispr-meeting-789');
+});
+
+test('a symlink escape below the configured notes folder is ignored', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  const original = personPage('Alice Smith');
+  fs.writeFileSync(person, original);
+  fs.mkdirSync(path.join(vault, 'System'), { recursive: true });
+  fs.mkdirSync(path.join(vault, '00-Inbox/ClickUp'), { recursive: true });
+  fs.writeFileSync(
+    path.join(vault, 'System', 'user-profile.yaml'),
+    'meeting_sources:\n  primary: exported-folder\n  notes_folder: 00-Inbox/ClickUp\n',
+  );
+  const outside = path.join(path.dirname(vault), `${path.basename(vault)}-outside.md`);
+  fs.writeFileSync(outside, [
+    '---',
+    'title: Roadmap Review',
+    'date: 2026-07-10',
+    'attendees:',
+    '  - name: Alice Smith',
+    '---',
+    '# Notes',
+  ].join('\n'));
+  t.after(() => fs.rmSync(outside, { force: true }));
+  const linked = path.join(vault, '00-Inbox/ClickUp/escaped.md');
+  fs.symlinkSync(outside, linked);
+
+  const result = runHook(vault, { tool_input: { file_path: linked } });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(person, 'utf8'), original);
+});
 
 test('attendees update an existing machine region and last_interaction', (t) => {
   const vault = createVault(t);

--- a/.claude/hooks/tests/post-meeting-person-update.test.cjs
+++ b/.claude/hooks/tests/post-meeting-person-update.test.cjs
@@ -111,7 +111,10 @@ test('multiple provider capture ids fall back to path identity', (t) => {
   const result = runHook(vault, { tool_input: { file_path: meeting } });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+  assert.equal(
+    parseEntityPage(person).touches[0].source.id,
+    '00-Inbox/Meetings/roadmap.md',
+  );
 });
 
 test('empty and non-scalar capture ids fall back to path identity', (t) => {
@@ -126,7 +129,10 @@ test('empty and non-scalar capture ids fall back to path identity', (t) => {
   const result = runHook(vault, { tool_input: { file_path: meeting } });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+  assert.equal(
+    parseEntityPage(person).touches[0].source.id,
+    '00-Inbox/Meetings/roadmap.md',
+  );
 });
 
 test('a source and capture-id key mismatch falls back to path identity', (t) => {
@@ -141,7 +147,32 @@ test('a source and capture-id key mismatch falls back to path identity', (t) => 
   const result = runHook(vault, { tool_input: { file_path: meeting } });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(parseEntityPage(person).touches[0].source.id, 'roadmap');
+  assert.equal(
+    parseEntityPage(person).touches[0].source.id,
+    '00-Inbox/Meetings/roadmap.md',
+  );
+});
+
+test('same-basename notes in default and configured folders have distinct path identities', (t) => {
+  const vault = createVault(t);
+  const person = path.join(vault, '05-Areas/People/Internal/Alice_Smith.md');
+  fs.writeFileSync(person, personPage('Alice Smith'));
+  fs.mkdirSync(path.join(vault, 'System'), { recursive: true });
+  fs.writeFileSync(
+    path.join(vault, 'System', 'user-profile.yaml'),
+    'meeting_sources:\n  primary: exported-folder\n  notes_folder: 00-Inbox/ClickUp\n',
+  );
+  const defaultMeeting = meetingNote(vault, 'roadmap.md');
+  const configuredMeeting = meetingNote(vault, '../ClickUp/roadmap.md');
+
+  assert.equal(runHook(vault, { tool_input: { file_path: defaultMeeting } }).status, 0);
+  assert.equal(runHook(vault, { tool_input: { file_path: configuredMeeting } }).status, 0);
+
+  const sourceIds = parseEntityPage(person).touches.map((touch) => touch.source.id);
+  assert.deepEqual(new Set(sourceIds), new Set([
+    '00-Inbox/Meetings/roadmap.md',
+    '00-Inbox/ClickUp/roadmap.md',
+  ]));
 });
 
 test('a configured vault-relative notes folder is a meeting source', (t) => {
@@ -215,9 +246,9 @@ test('attendees update an existing machine region and last_interaction', (t) => 
     ts: '2026-07-10',
     type: 'meeting',
     direction: 'none',
-    source: { id: 'roadmap', title: 'Roadmap Review' },
+    source: { id: '00-Inbox/Meetings/roadmap.md', title: 'Roadmap Review' },
   }]);
-  assert.match(updated, /meeting · two-way — Roadmap Review \[roadmap\]/);
+  assert.match(updated, /meeting · two-way — Roadmap Review \[00-Inbox\/Meetings\/roadmap\.md\]/);
 });
 
 test('legacy page receives the interaction under its existing heading', (t) => {
@@ -329,7 +360,7 @@ test('a deferred interaction rematerializes after a page edit and then lands', (
       path: '00-Inbox/Meetings/roadmap.md',
       line: '- [Roadmap Review](00-Inbox/Meetings/roadmap.md) — 2026-07-10',
       date: '2026-07-10',
-      source_id: 'roadmap',
+      source_id: '00-Inbox/Meetings/roadmap.md',
     },
   });
   assert.equal(Object.hasOwn(pending.batches[0].ops[0], 'base_fingerprint'), false);

--- a/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
@@ -15,23 +15,27 @@ context. Do not rely on hook-driven side effects for any write you make.
 
 ## Step 0: Meeting Catch-Up (not same-day only)
 
-Check for meetings that have not yet reached the vault. Process every
-unprocessed meeting since the last one that did, NOT only {{TARGET_DATE}}: find
-the newest dated folder under `00-Inbox/Meetings/`; the catch-up window runs
-from that date to {{TARGET_DATE}} inclusive. If the window is wider than seven
-days, process the most recent seven days and REPORT the older backlog rather
-than silently skipping it.
+Check for meetings that have not yet been processed. Read `meeting_sources` in
+`System/user-profile.yaml` first, using the exact validation, vault-boundary,
+source-order, and degradation rules in
+`.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md`. The profile records
+provenance and a local folder; it does not grant access to an external recorder.
+
+Process every unprocessed meeting since the last one that did, NOT only
+{{TARGET_DATE}}. Compute that catch-up window from dated notes across the valid
+configured `notes_folder` and `00-Inbox/Meetings/`, not from the default folder
+alone. If no dated local note exists, use the most recent seven days. If the
+window is wider than seven days, process the most recent seven days and REPORT
+the older backlog rather than silently skipping it.
 
 Why the window matters: a same-day filter loses meetings permanently on any day
 the review does not run.
 
-Read `meeting_sources` in `System/user-profile.yaml` to learn which source the
-user actually configured, rather than assuming a particular recorder. If that
-source has unprocessed meetings in the window, process them following the
-conventions in `.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md`,
-including updating person pages directly rather than counting on a hook.
-Note which meetings were processed. If no source is connected or nothing is
-unprocessed, skip silently.
+Process local candidates following the process-meetings instructions, including
+provider-neutral discovery and updating person pages directly rather than
+counting on a hook. Note the actual path of every meeting processed. If the
+profile is missing or malformed, report that once and use the safe local
+fallback. If nothing is unprocessed, skip silently.
 
 ---
 
@@ -64,9 +68,12 @@ weekly goals. Also call `get_week_priorities()` for the full list.
 
 ### 2.3 Meetings
 
-Check `00-Inbox/Meetings/{{TARGET_DATE}}/` for meeting notes. Also call
-`calendar_get_today()` for the calendar view. Combine meetings processed in
-Step 0 with any manually created notes.
+Use the actual meeting paths returned by Step 0, then check both the valid
+configured notes folder and `00-Inbox/Meetings/{{TARGET_DATE}}/` for additional
+local meeting notes. Also call `calendar_get_today()` for the calendar view.
+Calendar events are scheduling evidence, not meeting-note content. Combine the
+local notes with any manually created notes without widening into an external
+notes service.
 
 ### 2.4 Semantic Context Enrichment (if QMD available)
 

--- a/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
@@ -25,8 +25,9 @@ than silently skipping it.
 Why the window matters: a same-day filter loses meetings permanently on any day
 the review does not run.
 
-If the meeting source (Granola via `GRANOLA_API_KEY`, or another configured
-source) has unprocessed meetings in the window, process them following the
+Read `meeting_sources` in `System/user-profile.yaml` to learn which source the
+user actually configured, rather than assuming a particular recorder. If that
+source has unprocessed meetings in the window, process them following the
 conventions in `.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md`,
 including updating person pages directly rather than counting on a hook.
 Note which meetings were processed. If no source is connected or nothing is

--- a/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
@@ -104,7 +104,9 @@ For each meeting file:
    report the mismatch and use the note path as identity. When `source` is
    absent, use a capture id only when exactly one such key is present. Empty or
    non-scalar values do not count. If multiple capture-id keys remain, report
-   the ambiguity and use the note path as identity. A manual note with no
+   the ambiguity and use the note path as identity. The path identity is the
+   normalized vault-relative Markdown path, with `/` separators and the `.md`
+   extension retained; never reduce it to a basename. A manual note with no
    capture id remains valid.
 2. Check whether person/company pages need updating
 3. Check whether tasks need extracting (unchecked items in the "For Me"

--- a/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
@@ -48,8 +48,17 @@ find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
 This includes synced notes in day directories and flat notes in the folder
-root (manually captured meetings with no `granola_id`); process and stamp those
+root (manually captured meetings with no capture id); process and stamp those
 the same way. Skip notes containing `<!-- dex:skip-processing -->`.
+
+**Which folder, and which source.** Read `meeting_sources` in
+`System/user-profile.yaml` before searching. If `notes_folder` is set, search
+that folder; it is the user's declared answer and outranks the default above.
+`primary` names the capture tool they actually use. Dex does not assume a
+particular recorder, and neither should this skill: treat the configured source
+as the source, and fall back to provider-neutral discovery in the vault when it
+returns nothing. `meeting-closeout` resolves sources the same way; follow it
+rather than inventing a second convention.
 
 If `00-Inbox/Meetings/queue/*.json` files exist, consume each queued meeting
 first, following the queue rules in this skill's `SKILL.md` (Step 2.5): create
@@ -62,7 +71,9 @@ invoked. You ARE the subagent, so you must never call the Agent tool or spawn a
 subagent of your own.
 
 For each meeting file:
-1. Read frontmatter for `granola_id`, `participants`, `company`, `date`
+1. Read frontmatter for the capture id, `participants`, `company`, `date`.
+   The id key is whatever the configured source writes (`granola_id` and
+   `wispr_id` are both in the wild); match on presence, not on a fixed name
 2. Check whether person/company pages need updating
 3. Check whether tasks need extracting (unchecked items in the "For Me"
    section, no `tasks-extracted` marker)

--- a/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/process-meetings/AGENT_INSTRUCTIONS.md
@@ -19,17 +19,37 @@ hook does also run, because both skip a page that already lists the meeting.
 
 ---
 
-## Step 1: Check Background Sync Status
+## Step 1: Resolve the Local Meeting Sources
 
-From the vault root:
+Read `System/user-profile.yaml` before looking for notes. Its exact supported
+shape is:
 
-```bash
-ls .scripts/meeting-intel/processed-meetings.json
+```yaml
+meeting_sources:
+  primary: granola | zoom | teams | exported-folder | none
+  notes_folder: "vault-relative/folder/or/empty"
 ```
 
-If the state file exists, continue. If not, stop and return a message telling
-the conversation that background sync is not set up (the conversation will
-guide the user through `--setup`); do not attempt setup yourself.
+`primary` records provenance; it does not grant access to that recorder or
+prove that a matching MCP tool exists. This delegated prompt has the vault and
+the inherited Dex tools. It has no general Zoom, Teams, Wispr, email, Drive, or
+Notion reader. Never search an external service merely because `primary` names
+it. Process only notes already present in the vault.
+
+Resolve `notes_folder` only when it is a non-empty string. It is vault-relative:
+reject an absolute path, `..`, the vault root itself, and any symlink whose real
+target escapes the vault. Report that invalid configuration, then continue with
+the safe default and provider-neutral fallback below. If the profile is missing,
+malformed YAML, not an object, `meeting_sources` is not an object, or `primary`
+is not one of the supported values, report the configuration problem and use
+the same safe fallback. Never guess a path from malformed configuration.
+
+The Granola state file (`.scripts/meeting-intel/processed-meetings.json`) is
+optional bookkeeping for Granola sync, not a gate on local notes. Read it when
+it exists. If it is absent and `primary` is `granola`, report that background
+sync is not set up so the conversation can offer `--setup`; still continue with
+any local meeting notes. Its absence must never stop an exported-folder, Zoom,
+Teams, manual-note, or provider-neutral local pass.
 
 ---
 
@@ -41,24 +61,29 @@ Read the processed meetings state:
 cat .scripts/meeting-intel/processed-meetings.json
 ```
 
-List meeting files:
+Search candidate folders in this order:
+
+1. the valid configured `notes_folder`, when present
+2. `00-Inbox/Meetings/`
+3. bounded provider-neutral Markdown discovery elsewhere in the vault, only
+   when the first two sources return no candidates
+
+For the fallback, match likely meeting notes by the requested date window plus
+meeting title, attendee, or meeting frontmatter. Exclude `.git`, `.claude`,
+`.agents`, `.scripts`, `System`, dependency folders, binary files, and archives
+outside the requested date. Do not treat arbitrary Markdown as a meeting.
+
+List Markdown meeting files from each local candidate folder without following
+directory symlinks. For the default folder that is equivalent to:
 
 ```bash
 find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
 This includes synced notes in day directories and flat notes in the folder
-root (manually captured meetings with no capture id); process and stamp those
-the same way. Skip notes containing `<!-- dex:skip-processing -->`.
-
-**Which folder, and which source.** Read `meeting_sources` in
-`System/user-profile.yaml` before searching. If `notes_folder` is set, search
-that folder; it is the user's declared answer and outranks the default above.
-`primary` names the capture tool they actually use. Dex does not assume a
-particular recorder, and neither should this skill: treat the configured source
-as the source, and fall back to provider-neutral discovery in the vault when it
-returns nothing. `meeting-closeout` resolves sources the same way; follow it
-rather than inventing a second convention.
+root. A manual note with no capture id is still a meeting candidate and must be
+processed and stamped the same way. Skip notes containing
+`<!-- dex:skip-processing -->`.
 
 If `00-Inbox/Meetings/queue/*.json` files exist, consume each queued meeting
 first, following the queue rules in this skill's `SKILL.md` (Step 2.5): create
@@ -71,9 +96,16 @@ invoked. You ARE the subagent, so you must never call the Agent tool or spawn a
 subagent of your own.
 
 For each meeting file:
-1. Read frontmatter for the capture id, `participants`, `company`, `date`.
-   The id key is whatever the configured source writes (`granola_id` and
-   `wispr_id` are both in the wild); match on presence, not on a fixed name
+1. Preserve its actual vault-relative path; never reconstruct it under
+   `00-Inbox/Meetings/`. Read frontmatter for `participants`, `company`, `date`,
+   and recorder provenance. A capture id is a non-empty scalar frontmatter key
+   ending in `_id` (for example `granola_id` or `wispr_id`). When `source` names
+   a provider, use only that provider's matching `<source>_id`; if it is absent,
+   report the mismatch and use the note path as identity. When `source` is
+   absent, use a capture id only when exactly one such key is present. Empty or
+   non-scalar values do not count. If multiple capture-id keys remain, report
+   the ambiguity and use the note path as identity. A manual note with no
+   capture id remains valid.
 2. Check whether person/company pages need updating
 3. Check whether tasks need extracting (unchecked items in the "For Me"
    section, no `tasks-extracted` marker)
@@ -100,7 +132,7 @@ For each participant in synced meetings:
    line format the rest of Dex writes and reads:
 
    ```
-   - [{Meeting Title}](00-Inbox/Meetings/{date}/{slug}.md) — {date}
+   - [{Meeting Title}]({actual vault-relative meeting path}) — {date}
    ```
 
    The path must be the vault-relative meeting path. Keep a maximum of 20

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -194,7 +194,9 @@ For each meeting file, skip notes containing `<!-- dex:skip-processing -->`:
    key matching a string `source`; if that key is absent, report the mismatch
    and use the note path. When `source` is absent, use an id only when exactly
    one non-empty scalar candidate is present. `granola_id` and `wispr_id` are
-   examples, not a closed list. Multiple ids fall back to note-path identity
+   examples, not a closed list. Multiple ids fall back to note-path identity.
+   The path identity is the normalized vault-relative Markdown path, with `/`
+   separators and the `.md` extension retained; never reduce it to a basename
 2. Check if person/company pages need updating
 3. Check if tasks need extracting (look for unchecked items in "For Me" section)
 

--- a/.claude/skills/process-meetings/SKILL.md
+++ b/.claude/skills/process-meetings/SKILL.md
@@ -115,26 +115,40 @@ Meetings are synced automatically every 30 minutes by a background process. This
 - `--no-todos`: Create notes but don't extract tasks
 - `--setup`: Install/check background automation
 
-## Pre-flight: Granola Check
+## Pre-flight: Local Source Check
 
-Granola sync uses the official Granola public API. Desktop and mobile recordings both come through it once your Granola API key is connected. If `GRANOLA_API_KEY` isn't set (checked in the environment, then the `.env` file at the vault root), say: "Granola isn't connected yet — run `/granola-setup` to add your Granola API key (requires a Granola Business plan)." and continue with any meetings already synced.
+Read `meeting_sources` in `System/user-profile.yaml` before assuming a recorder.
+The configured `primary` is provenance, not permission or tool access. A valid
+vault-relative `notes_folder` outranks the default landing zone. Missing or
+malformed config, an invalid primary, an absolute path, `..`, the vault root, or
+a symlink escape must be reported and ignored; continue with safe local notes.
+Never widen into an external service just because the profile names it.
+
+For `primary: granola`, Granola sync uses the official public API. If
+`GRANOLA_API_KEY` is absent, offer `/granola-setup` and continue with local
+notes. Other primaries do not inherit a direct reader from this setting.
 
 ---
 
 ## Process
 
-### Step 1: Check Background Sync Status
+### Step 1: Check Source and Sync Status
 
-First, check if background sync is set up:
+Resolve the configured local folder using the rules above. Then check whether
+Granola background sync has left its optional state file:
 
 ```bash
 # Check for state file (indicates sync has run)
 ls .scripts/meeting-intel/processed-meetings.json
 ```
 
-**If state file exists:** Background sync is working. Continue to Step 2.
+**If the state file exists:** Granola background sync has run. Continue to Step 2.
 
-**If state file doesn't exist:**
+**If it does not exist and Granola is the configured source:** offer setup, but
+continue with local notes. The missing file is not a gate for an
+`exported-folder`, Zoom, Teams, manual note, or provider-neutral local source.
+
+For Granola setup guidance:
 > "Background meeting sync isn't set up yet. This runs automatically every 30 minutes so `/process-meetings` doesn't need terminal commands.
 >
 > **To set up (one-time, takes 30 seconds):**
@@ -155,24 +169,32 @@ cd .scripts/meeting-intel && ./install-automation.sh
 
 ### Step 2: Find Waiting Meetings
 
-Read the processed meetings state:
+Read the processed meetings state when it exists:
 ```javascript
 const state = JSON.parse(fs.readFileSync('.scripts/meeting-intel/processed-meetings.json'));
 ```
 
-List meeting files in `00-Inbox/Meetings/`:
+Search the valid configured folder first, then `00-Inbox/Meetings/`. If neither
+contains a candidate, use bounded provider-neutral Markdown discovery in the
+vault by date plus title, attendee, or meeting frontmatter. Exclude Dex
+internals, dependencies, binaries, and archives outside the requested window;
+never treat arbitrary Markdown as a meeting. For the default folder:
 ```bash
 find 00-Inbox/Meetings -name "*.md" -mtime -7 | head -50
 ```
 
-This includes Granola-synced notes in day directories and flat `*.md` notes in
-the `00-Inbox/Meetings/` folder root. Root-level notes are manually captured
-meetings with no `granola_id`; process and stamp them with the same
-`tasks-extracted` marker as any other meeting note. The `queue/` subfolder is
-handled in Step 2.5.
+This includes synced notes in day directories and flat `*.md` notes in the
+folder root. A manual note with no capture id is valid; process and stamp it
+with the same `tasks-extracted` marker as any other meeting note. The `queue/`
+subfolder is handled in Step 2.5.
 
 For each meeting file, skip notes containing `<!-- dex:skip-processing -->`:
-1. Read frontmatter to get `granola_id`, `participants`, `company`, `date`
+1. Preserve the actual vault-relative source path. Read `participants`,
+   `company`, `date`, and any non-empty scalar key ending in `_id`. Prefer the
+   key matching a string `source`; if that key is absent, report the mismatch
+   and use the note path. When `source` is absent, use an id only when exactly
+   one non-empty scalar candidate is present. `granola_id` and `wispr_id` are
+   examples, not a closed list. Multiple ids fall back to note-path identity
 2. Check if person/company pages need updating
 3. Check if tasks need extracting (look for unchecked items in "For Me" section)
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -148,8 +148,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/process-meetings/SKILL.md",
-        "sha256": "ec8f4eb16e78177cfdeed98220e699439f624e160dae262d1ea2b74981c0aa21",
-        "byte_size": 20372
+        "sha256": "0045bf71138a158cb2727d321b73fcb52c686edc5885f11bbb9c37e8125369e0",
+        "byte_size": 20529
       },
       "value": "Turns meeting material into people context and follow-up tasks, reducing the chance that decisions or promises disappear after the call.",
       "jobs_served": ["process-meetings", "keep-relationships-warm"],

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -148,8 +148,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/process-meetings/SKILL.md",
-        "sha256": "eb7e819ed4c4e32fb5ec1f5477b249ec4bd6d8805870360107098d893a04642c",
-        "byte_size": 19094
+        "sha256": "ec8f4eb16e78177cfdeed98220e699439f624e160dae262d1ea2b74981c0aa21",
+        "byte_size": 20372
       },
       "value": "Turns meeting material into people context and follow-up tasks, reducing the chance that decisions or promises disappear after the call.",
       "jobs_served": ["process-meetings", "keep-relationships-warm"],

--- a/core/tests/test_meeting_source_instruction_contract.py
+++ b/core/tests/test_meeting_source_instruction_contract.py
@@ -52,6 +52,8 @@ def _assert_local_source_contract(body: str) -> None:
         "granola_id",
         "wispr_id",
         "multiple",
+        "mismatch",
+        "non-scalar",
         "manual note",
     ):
         assert required in body
@@ -77,12 +79,12 @@ def test_meeting_source_instruction_journey_matches_the_profile_contract() -> No
 
     process_step = _section(
         PROCESS_AGENT.read_text(encoding="utf-8"),
-        "## Step 1: Check Background Sync Status",
+        "## Step 1:",
         "## Step 3: Update Person Pages",
     )
     adapter_step = _section(
         PROCESS_ADAPTER.read_text(encoding="utf-8"),
-        "### Step 1: Check Background Sync Status",
+        "### Step 1:",
         "### Step 3: Update Person Pages",
     )
     _assert_local_source_contract(process_step)
@@ -105,7 +107,8 @@ def test_contract_helper_rejects_removed_configured_source_lookup() -> None:
     valid = (
         "meeting_sources notes_folder vault-relative provider-neutral "
         "00-Inbox/Meetings missing malformed absolute symlink external service "
-        "non-empty scalar ending in `_id` granola_id wispr_id multiple manual note"
+        "non-empty scalar ending in `_id` granola_id wispr_id multiple mismatch "
+        "non-scalar manual note"
     )
     without_lookup = valid.replace("meeting_sources", "")
 
@@ -123,7 +126,8 @@ def test_contract_helper_rejects_removed_provider_neutral_capture_ids() -> None:
     valid = (
         "meeting_sources notes_folder vault-relative provider-neutral "
         "00-Inbox/Meetings missing malformed absolute symlink external service "
-        "non-empty scalar ending in `_id` granola_id wispr_id multiple manual note"
+        "non-empty scalar ending in `_id` granola_id wispr_id multiple mismatch "
+        "non-scalar manual note"
     )
     granola_only = valid.replace("ending in `_id`", "fixed key").replace(
         "wispr_id", ""

--- a/core/tests/test_meeting_source_instruction_contract.py
+++ b/core/tests/test_meeting_source_instruction_contract.py
@@ -1,0 +1,137 @@
+"""Instruction contract for provider-neutral meeting-source discovery.
+
+This is an instruction-contract and journey-order test. It reads the shipped
+profile and prompt surfaces together; it does not execute an AI agent, query a
+recorder, or claim that a live meeting-processing run succeeded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from core.utils.validators import validate_user_profile_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILE = REPO_ROOT / "System/user-profile-template.yaml"
+CLOSEOUT = REPO_ROOT / ".claude/skills/meeting-closeout/SKILL.md"
+PROCESS_AGENT = REPO_ROOT / ".claude/skills/process-meetings/AGENT_INSTRUCTIONS.md"
+PROCESS_ADAPTER = REPO_ROOT / ".agents/skills/process-meetings/SKILL.md"
+DAILY_AGENT = REPO_ROOT / ".claude/skills/daily-review/AGENT_INSTRUCTIONS.md"
+
+
+def _section(body: str, start: str, end: str) -> str:
+    return body.split(start, 1)[1].split(end, 1)[0]
+
+
+def _assert_local_source_contract(body: str) -> None:
+    """A processing prompt resolves safe local sources without tool fiction."""
+
+    for required in (
+        "meeting_sources",
+        "notes_folder",
+        "vault-relative",
+        "provider-neutral",
+        "00-Inbox/Meetings",
+        "missing",
+        "malformed",
+        "absolute",
+        "symlink",
+        "external service",
+    ):
+        assert required in body
+
+    # Configuration is read before the default landing zone is searched.
+    assert body.index("meeting_sources") < body.index("00-Inbox/Meetings")
+
+    # Recorder provenance is provider-neutral and never excludes manual notes.
+    for required in (
+        "non-empty scalar",
+        "ending in `_id`",
+        "granola_id",
+        "wispr_id",
+        "multiple",
+        "manual note",
+    ):
+        assert required in body
+
+
+def test_meeting_source_instruction_journey_matches_the_profile_contract() -> None:
+    """All shipped prompt surfaces share one safe source-selection ladder."""
+
+    profile = yaml.safe_load(PROFILE.read_text(encoding="utf-8"))
+    assert validate_user_profile_config(profile) == []
+    assert profile["meeting_sources"] == {"primary": "none", "notes_folder": ""}
+
+    closeout_step = _section(
+        CLOSEOUT.read_text(encoding="utf-8"),
+        "## Step 1 — Get the meeting",
+        "## Step 2 — Extract",
+    )
+    assert closeout_step.index("configured meeting source") < closeout_step.index(
+        "provider-neutral source note"
+    )
+    assert "Never go looking in external services" in closeout_step
+    assert "ask for\nthe notes" in closeout_step
+
+    process_step = _section(
+        PROCESS_AGENT.read_text(encoding="utf-8"),
+        "## Step 1: Check Background Sync Status",
+        "## Step 3: Update Person Pages",
+    )
+    adapter_step = _section(
+        PROCESS_ADAPTER.read_text(encoding="utf-8"),
+        "### Step 1: Check Background Sync Status",
+        "### Step 3: Update Person Pages",
+    )
+    _assert_local_source_contract(process_step)
+    _assert_local_source_contract(adapter_step)
+
+    daily_catch_up = _section(
+        DAILY_AGENT.read_text(encoding="utf-8"),
+        "## Step 0: Meeting Catch-Up",
+        "## Step 1: File Discovery",
+    )
+    assert "meeting_sources" in daily_catch_up
+    assert "process-meetings/AGENT_INSTRUCTIONS.md" in daily_catch_up
+    assert "does not grant access" in daily_catch_up
+    assert "vault" in daily_catch_up
+
+
+def test_contract_helper_rejects_removed_configured_source_lookup() -> None:
+    """The gate has signal when the configured-source lookup disappears."""
+
+    valid = (
+        "meeting_sources notes_folder vault-relative provider-neutral "
+        "00-Inbox/Meetings missing malformed absolute symlink external service "
+        "non-empty scalar ending in `_id` granola_id wispr_id multiple manual note"
+    )
+    without_lookup = valid.replace("meeting_sources", "")
+
+    try:
+        _assert_local_source_contract(without_lookup)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("contract accepted removal of meeting_sources lookup")
+
+
+def test_contract_helper_rejects_removed_provider_neutral_capture_ids() -> None:
+    """The gate has signal when provider-neutral capture IDs disappear."""
+
+    valid = (
+        "meeting_sources notes_folder vault-relative provider-neutral "
+        "00-Inbox/Meetings missing malformed absolute symlink external service "
+        "non-empty scalar ending in `_id` granola_id wispr_id multiple manual note"
+    )
+    granola_only = valid.replace("ending in `_id`", "fixed key").replace(
+        "wispr_id", ""
+    )
+
+    try:
+        _assert_local_source_contract(granola_only)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("contract accepted a provider-specific capture ID")

--- a/core/tests/test_meeting_source_instruction_contract.py
+++ b/core/tests/test_meeting_source_instruction_contract.py
@@ -55,6 +55,9 @@ def _assert_local_source_contract(body: str) -> None:
         "mismatch",
         "non-scalar",
         "manual note",
+        "normalized vault-relative Markdown path",
+        "`.md`",
+        "basename",
     ):
         assert required in body
 
@@ -108,7 +111,7 @@ def test_contract_helper_rejects_removed_configured_source_lookup() -> None:
         "meeting_sources notes_folder vault-relative provider-neutral "
         "00-Inbox/Meetings missing malformed absolute symlink external service "
         "non-empty scalar ending in `_id` granola_id wispr_id multiple mismatch "
-        "non-scalar manual note"
+        "non-scalar manual note normalized vault-relative Markdown path `.md` basename"
     )
     without_lookup = valid.replace("meeting_sources", "")
 
@@ -127,7 +130,7 @@ def test_contract_helper_rejects_removed_provider_neutral_capture_ids() -> None:
         "meeting_sources notes_folder vault-relative provider-neutral "
         "00-Inbox/Meetings missing malformed absolute symlink external service "
         "non-empty scalar ending in `_id` granola_id wispr_id multiple mismatch "
-        "non-scalar manual note"
+        "non-scalar manual note normalized vault-relative Markdown path `.md` basename"
     )
     granola_only = valid.replace("ending in `_id`", "fixed key").replace(
         "wispr_id", ""


### PR DESCRIPTION
## Summary

- preserves Chris Jackson's exact authored commit from #510
- adds an instruction-contract test that failed on clean v1.96.2 when configured-source lookup was absent
- makes configured local folders outrank the default without letting missing Granola state block exported or manual notes
- keeps actual note paths through daily review, delegated processing, and the shipped cross-harness adapter
- teaches the executable person-update hook to accept one unambiguous provider-neutral capture ID and to fall back to note-path identity on missing, empty, non-scalar, multiple, or provider-mismatched IDs
- defines that fallback as the normalized vault-relative Markdown path, including `.md`, so same-basename notes in configured and default folders cannot collide

## Root cause

PR #510 updates two delegated prompt files, but the surrounding journey still stops on Granola-only state, reconstructs links under the default meeting folder, leaves the cross-harness adapter unchanged, and has a post-write hook that reads only `granola_id`. `meeting_sources.primary` records provenance; it does not grant a Zoom, Teams, Wispr, Drive, email, or Notion reader.

## Red proof

- On clean v1.96.2: `python3 -m pytest -q core/tests/test_meeting_source_instruction_contract.py` → 1 failed, 2 passed because process-meetings did not read `meeting_sources` before its default path.
- On the current-main merged tree, replacing the provider-neutral resolver with `granola_id` only and running `node --test --test-name-pattern="provider-neutral capture id" .claude/hooks/tests/post-meeting-person-update.test.cjs` → failed, actual `00-Inbox/Meetings/roadmap.md`, expected `wispr-meeting-456`.
- On the current-main merged tree, reducing fallback identity to a basename and running `node --test --test-name-pattern="same-basename notes" .claude/hooks/tests/post-meeting-person-update.test.cjs` → failed because both `00-Inbox/Meetings/roadmap.md` and `00-Inbox/ClickUp/roadmap.md` produced `roadmap`.

The Python test is an instruction-contract and journey-order check; it does not claim to execute an AI workflow. The Node hook tests are executable behavior.

## Green proof

- 93 focused instruction/configuration and meeting-overlap tests passed
- all 206 hook tests passed
- 150 analytics receipt/event, work-server, transaction, and journey tests passed
- Ruff passed
- instructed-tool existence, architecture inventory, test-delta, PII, founder-content, Lens catalogue generation, and diff gates passed
- exact merge head `cfc630f69a14eaa1c89a784bd0ec62c86f089277` has two parents: previous PR head `90890dcc49aa038a68913aef5e57f8f3a2acf0e5` and live `origin/main` `7778ee1df949dd84334e1ead4426cc2339f7cb73`
- fresh Mac CI passed on that exact head: 7 applicable jobs green (quality, three test shards, aggregate results/coverage, Lens dry-run, PR report); release-only jobs skipped: https://github.com/davekilleen/Dex/actions/runs/31709828528

## Overlap

Merged PR #514's Calendar-confidence instructions and merged PR #515's privacy-safe analytics receipts are both present. The combined process-meetings skill retains #515's singular `meeting_processed` event plus this PR's configured provider-neutral source contract. `core/mcp/work_server.py` and all analytics receipt/event source and tests are byte-identical to current main; only the generated Lens source fingerprint needed conflict resolution.

## Attribution and ownership

Commit `f5963b02` preserves Chris Jackson as author and retains his original commit message and co-author credit. The surrounding test and hardening commits are maintainer-owned. This PR is intentionally draft; the parent review thread owns merge, release, public comments, and any contact with Chris.
