### PR TITLE
Fix fresh installs after the brain/vault split

### DIFF
--- a/core/lens_catalog_sources.py
+++ b/core/lens_catalog_sources.py
@@ -18,9 +18,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
+try:
+    from core.utils.local_git import git_result
+except ModuleNotFoundError:  # Script entrypoints execute with core/ on sys.path.
+    from utils.local_git import git_result  # type: ignore[no-redef]
+
 DEFAULT_LIFECYCLE_CATALOG = Path("core/lifecycle/catalog/official-capabilities.json")
 DEFAULT_PORTABLE_CONTRACT = Path("packages/dex-contracts/dist/portable-vault.contract.json")
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+HEX_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 RELEASE_VERSION = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 
 
@@ -176,24 +182,155 @@ def _release_file(release_root: Path, relative: str, *, context: str) -> Path:
     return candidate
 
 
+def _regular_json_mapping(path: Path, *, context: str) -> Mapping[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise SkillSourceError(f"{context} is missing or not a regular file")
+    return _mapping(_strict_json(path, context=context), context=context)
+
+
+def _split_release_identity(
+    release_root: Path,
+    *,
+    context: str,
+) -> tuple[Path, str] | None:
+    """Return the exact installed brain tree for a sound post-split vault.
+
+    A split leaves release-owned bytes in the vault directory but moves their
+    Git authority to ``.dex/brain.git``. The new ``.git`` belongs only to the
+    user's vault, so it must never be used to prove shipped source identity.
+    """
+    root = release_root.resolve()
+    topology_path = root / "System/.dex/topology.json"
+    brain_git = root / ".dex/brain.git"
+    split_signal = any(
+        candidate.is_symlink() or candidate.exists()
+        for candidate in (topology_path, brain_git)
+    )
+    if not split_signal:
+        return None
+
+    for relative in (".git", ".dex", ".dex/brain.git", "System", "System/.dex"):
+        candidate = root / relative
+        if candidate.is_symlink():
+            raise SkillSourceError(f"cannot prove {context}: split path {relative} is a symlink")
+    if not (root / ".git").is_dir() or not brain_git.is_dir():
+        raise SkillSourceError(f"cannot prove {context}: split Git directories are incomplete")
+
+    topology = _regular_json_mapping(topology_path, context="split topology marker")
+    vault_marker = _regular_json_mapping(root / ".git/dex-vault-v2", context="vault Git marker")
+    brain_marker = _regular_json_mapping(brain_git / "dex-brain-v2", context="brain Git marker")
+    environment = topology.get("environment")
+    if (
+        topology.get("schemaVersion") != 1
+        or topology.get("topology") != "brain-vault-split"
+        or topology.get("vaultGitDir") != ".git"
+        or topology.get("brainGitDir") != ".dex/brain.git"
+        or not isinstance(environment, Mapping)
+        or not isinstance(environment.get("DEX_VAULT"), str)
+        or not environment.get("DEX_VAULT")
+        or vault_marker.get("schemaVersion") != 1
+        or vault_marker.get("role") != "vault"
+        or brain_marker.get("schemaVersion") != 1
+        or brain_marker.get("role") != "brain"
+    ):
+        raise SkillSourceError(f"cannot prove {context}: brain/vault split identity is inconsistent")
+
+    installed = topology.get("installedRelease")
+    brain_installed = brain_marker.get("installed")
+    if (
+        not isinstance(installed, str)
+        or HEX_COMMIT.fullmatch(installed) is None
+        or brain_installed != installed
+    ):
+        raise SkillSourceError(
+            f"cannot prove {context}: brain installed identity does not match split topology"
+        )
+    try:
+        installed_ref = git_result(
+            root,
+            f"--git-dir={brain_git}",
+            "rev-parse",
+            "--verify",
+            "refs/dex/installed^{commit}",
+            profile="read-only",
+            timeout=3,
+        )
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+        raise SkillSourceError(f"cannot prove {context} from the installed brain ref") from error
+    if installed_ref.returncode != 0 or installed_ref.stdout.decode("ascii", errors="ignore").strip() != installed:
+        raise SkillSourceError(
+            f"cannot prove {context}: installed brain ref does not match split topology"
+        )
+    return brain_git, installed
+
+
 def _require_tracked(release_root: Path, relative: str, *, context: str) -> None:
-    if not (release_root / ".git").exists():
+    root = release_root.resolve()
+    split_identity = _split_release_identity(root, context=context)
+    if split_identity is not None:
+        brain_git, installed = split_identity
+        try:
+            result = git_result(
+                root,
+                f"--git-dir={brain_git}",
+                "ls-tree",
+                "-z",
+                "--full-tree",
+                installed,
+                "--",
+                relative,
+                profile="read-only",
+                timeout=3,
+            )
+        except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+            raise SkillSourceError(f"cannot prove {context} from the installed brain tree") from error
+        records = tuple(record for record in result.stdout.split(b"\0") if record)
+        if result.returncode != 0 or not records:
+            raise SkillSourceError(
+                f"{context} is not tracked by the installed release tree: {relative}"
+            )
+        try:
+            metadata, raw_path = records[0].split(b"\t", 1)
+            mode, object_type, object_id = metadata.decode("ascii").split(" ")
+            tracked_path = raw_path.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as error:
+            raise SkillSourceError(f"cannot prove {context}: installed release entry is malformed") from error
+        if (
+            len(records) != 1
+            or mode not in {"100644", "100755"}
+            or object_type != "blob"
+            or tracked_path != relative
+        ):
+            raise SkillSourceError(f"cannot prove {context}: installed release entry is unsafe")
+        try:
+            blob = git_result(
+                root,
+                f"--git-dir={brain_git}",
+                "cat-file",
+                "blob",
+                object_id,
+                profile="read-only",
+                timeout=3,
+            )
+            physical = (root / relative).read_bytes()
+        except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+            raise SkillSourceError(f"cannot prove {context}: installed release bytes are unreadable") from error
+        if blob.returncode != 0 or blob.stdout != physical:
+            raise SkillSourceError(f"{context} differs from the installed release tree: {relative}")
+        return
+
+    if not (root / ".git").exists():
         return
     try:
-        result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(release_root),
-                "ls-files",
-                "--error-unmatch",
-                relative,
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
+        result = git_result(
+            root,
+            "ls-files",
+            "--error-unmatch",
+            relative,
+            profile="read-only",
+            timeout=3,
         )
-    except OSError as error:
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
         raise SkillSourceError(f"cannot prove {context} is tracked: {error}") from error
     if result.returncode != 0:
         raise SkillSourceError(f"{context} is not tracked by the release tree: {relative}")

--- a/core/tests/test_lens_catalog_sources.py
+++ b/core/tests/test_lens_catalog_sources.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -24,6 +26,65 @@ def _write(path: Path, content: bytes | str) -> bytes:
 
 def _pin(payload: bytes) -> tuple[str, int]:
     return hashlib.sha256(payload).hexdigest(), len(payload)
+
+
+def _git(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _split_release_tree(root: Path, *, source_tracked: bool = True) -> str:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "tests@example.invalid")
+    _git(root, "config", "user.name", "Dex tests")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "release")
+
+    source = root / ".claude/skills/_available/capabilities/career/skills/career-setup/SKILL.md"
+    if not source_tracked:
+        payload = source.read_bytes()
+        _git(root, "rm", "-q", source.relative_to(root).as_posix())
+        _git(root, "commit", "-qm", "release without room source")
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(payload)
+
+    installed = _git(root, "rev-parse", "HEAD")
+    brain = root / ".dex/brain.git"
+    brain.parent.mkdir()
+    shutil.move(str(root / ".git"), brain)
+    _git(root, f"--git-dir={brain}", "update-ref", "refs/dex/installed", installed)
+    (brain / "dex-brain-v2").write_text(
+        json.dumps({"schemaVersion": 1, "role": "brain", "installed": installed}),
+        encoding="utf-8",
+    )
+
+    _git(root, "init", "-q")
+    (root / ".git/dex-vault-v2").write_text(
+        json.dumps({"schemaVersion": 1, "role": "vault"}),
+        encoding="utf-8",
+    )
+    topology = root / "System/.dex/topology.json"
+    topology.parent.mkdir(parents=True)
+    topology.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "topology": "brain-vault-split",
+                "vaultGitDir": ".git",
+                "brainGitDir": ".dex/brain.git",
+                "installedRelease": installed,
+                "environment": {"DEX_VAULT": str(root)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return installed
 
 
 def _fixture(root: Path) -> dict[str, object]:
@@ -142,6 +203,35 @@ def test_closed_source_kinds_resolve_to_one_verified_pin(tmp_path: Path) -> None
         ".claude/skills/career-setup/SKILL.md",
     )
     assert all(pin.path.read_bytes() for pin in (active, lifecycle, room))
+
+
+def test_split_vault_uses_installed_brain_tree_for_source_identity(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    _split_release_tree(tmp_path)
+
+    room = _resolve(tmp_path, fixture["room"], fixture)
+
+    assert room.path.read_bytes()
+
+
+def test_split_vault_rejects_source_missing_from_installed_brain_tree(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    _split_release_tree(tmp_path, source_tracked=False)
+
+    with pytest.raises(SkillSourceError, match="not tracked.*installed.*tree"):
+        _resolve(tmp_path, fixture["room"], fixture)
+
+
+def test_split_vault_rejects_inconsistent_brain_identity(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    _split_release_tree(tmp_path)
+    marker = tmp_path / ".dex/brain.git/dex-brain-v2"
+    document = json.loads(marker.read_text(encoding="utf-8"))
+    document["installed"] = "0" * 40
+    marker.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(SkillSourceError, match="brain.*installed.*does not match"):
+        _resolve(tmp_path, fixture["room"], fixture)
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_lens_catalog_sources.py
+++ b/core/tests/test_lens_catalog_sources.py
@@ -41,7 +41,7 @@ def _git(root: Path, *arguments: str) -> str:
 
 def _split_release_tree(root: Path, *, source_tracked: bool = True) -> str:
     _git(root, "init", "-q")
-    _git(root, "config", "user.email", "tests@example.invalid")
+    _git(root, "config", "user.email", "tests@example.com")
     _git(root, "config", "user.name", "Dex tests")
     _git(root, "add", ".")
     _git(root, "commit", "-qm", "release")


### PR DESCRIPTION
## What broke

A clean install reaches the brain/vault split, then capability provisioning asks the new user-vault Git history to prove the identity of release-owned dormant skills. The Career room fails first even though its skill is tracked in the installed release.

## Fix

- recognize only the fixed, fully validated post-split topology
- require the topology marker, brain marker, and `refs/dex/installed` to agree on the exact commit
- prove each source is one safe regular blob in that installed brain tree
- compare the physical source byte-for-byte with the installed release blob
- keep pre-split source tracking on the existing closed path, now through the sanitized Git runner

## Failure-first proof

Before the fix, the unchanged v1.96.2 release clone ran `bash install.sh` and exited 1 with:

`Dormant skill source identity failed for career: ... career-coach ... is not tracked by the release tree`

The new split regression test failed with that same false provenance refusal before the implementation changed.

## Verification

- exact current head `051397de456983f4ace39ae916488fd41dfdae29` includes live `main` commit `ec640750a0f9c0af09be8d5296de5cd1d5168f15` as a parent
- CI run `31711176489` is terminal green: all seven applicable jobs passed, including quality, all three macOS test shards, aggregate results, PR report, and Lens release dry run
- no code changed after that CI run
- `python3 -m pytest -q --basetemp=/tmp/dex-capability-fix-pytest-thr3m62-merge core/tests/test_lens_catalog_sources.py core/tests/test_capabilities.py core/tests/test_install_convergence.py` — 80 passed
- exact failed release vault replay — Career, Companies, and Quarter Goals preflight all pass
- `python3 -m ruff check core/lens_catalog_sources.py core/tests/test_lens_catalog_sources.py` — passed
- `python3 -m py_compile core/lens_catalog_sources.py core/tests/test_lens_catalog_sources.py` — passed
- independent specification and standards reviews found no correctness, security, or provenance-boundary defects
- repository-wide local run reached 2,439 passes before its shared pytest temp root disappeared, causing unrelated setup cascades; CI clean runners provide the completed full gate

Mission Control: `dex-fresh-install-capability-source-identity`