### PR TITLE
Install pending session learnings instead of only capturing them

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -25,10 +25,11 @@ These commands are wired in `.claude/settings.json` and run independently of any
 | `PreToolUse` | `Bash` | `bash .claude/hooks/dex-safety-guard.sh` | Block unsafe shell commands and redirect disallowed MCP usage. |
 | `PreToolUse` | `Bash` | `node .claude/hooks/ensure-mcp-user-scope.cjs` | Require an explicit scope for `claude mcp add`. |
 | `PreToolUse` | `mcp__.*` | `bash .claude/hooks/dex-safety-guard.sh` | Apply the MCP safety rules before MCP calls. |
+| `Stop` | all | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/install-learnings.sh"` | When unused session learnings have piled up (8 pending and the oldest is at least 14 days), block Stop once per day so they get installed or honestly dropped. Capture stays separate. |
 | `SessionEnd` | all | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/session-end.sh "$transcript_path"` | Record the session-end marker and transcript reference. |
 | `SessionEnd` | all | `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/vault-autocommit.cjs` | Safely checkpoint eligible vault changes when no mutation is active. |
 
-Settings also uses the macOS system ping for `Stop` and permission/elicitation `Notification` events. Those entries do not invoke repository hook files.
+Settings also uses the macOS system ping for `Stop` and permission/elicitation `Notification` events. The ping entries do not invoke repository hook files. The `Stop` install-learnings wrapper above does.
 
 ## Skill-scoped wiring
 

--- a/.claude/hooks/install-learnings.py
+++ b/.claude/hooks/install-learnings.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Stop hook: force one install pass when unused session learnings pile up.
 
-Capture stays in `/daily-review` and session-end. This hook never writes a
-learning. When the pending pile crosses the shipped volume+age threshold, it
-blocks Stop once per UTC day so the model routes existing entries (or honestly
-drops them) instead of only archiving them.
+Capture stays in `/daily-review` and session-end. This hook never writes a learning.
+When the pending pile crosses the shipped volume+age threshold, it blocks Stop
+once per UTC day so the model routes existing entries (or honestly drops them)
+instead of only archiving them.
 
 Fail-open: invalid stdin, missing Python deps, unwritable vault, or a missing
 interpreter all exit 0 with no output. Unwritable dedup degrades to silence,
@@ -18,7 +18,6 @@ import os
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
-
 
 _HOOK_REPO = Path(__file__).resolve().parents[2]
 

--- a/.claude/hooks/install-learnings.py
+++ b/.claude/hooks/install-learnings.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Stop hook: force one install pass when unused session learnings pile up.
+
+Capture stays in `/daily-review` and session-end. This hook never writes a
+learning. When the pending pile crosses the shipped volume+age threshold, it
+blocks Stop once per UTC day so the model routes existing entries (or honestly
+drops them) instead of only archiving them.
+
+Fail-open: invalid stdin, missing Python deps, unwritable vault, or a missing
+interpreter all exit 0 with no output. Unwritable dedup degrades to silence,
+never to a nag on every Stop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+
+_HOOK_REPO = Path(__file__).resolve().parents[2]
+
+
+def _vault_root() -> Path:
+    configured = os.environ.get("CLAUDE_PROJECT_DIR")
+    if configured:
+        return Path(configured)
+    return _HOOK_REPO
+
+
+def _dedup_path(vault: Path) -> Path:
+    override = os.environ.get("DEX_INSTALL_LEARNINGS_DEDUP_FILE")
+    if override:
+        return Path(override)
+    return vault / "System" / ".dex" / "install-learnings-dedup"
+
+
+def _today() -> date:
+    override = os.environ.get("DEX_INSTALL_LEARNINGS_TODAY")
+    if override:
+        return datetime.strptime(override, "%Y-%m-%d").date()
+    return datetime.now(timezone.utc).date()
+
+
+def _claim_today(vault: Path, today: date) -> bool:
+    """Return True only after today's prompt marker is known to persist."""
+    path = _dedup_path(vault)
+    marker = f"prompted:{today.isoformat()}"
+    try:
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        if marker in existing.splitlines():
+            return False
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(marker + "\n")
+        persisted = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return marker in persisted.splitlines()
+
+
+def _reason(pending_count: int, oldest_age_days: int) -> str:
+    return (
+        "<install_learnings>\n"
+        f"Pending session learnings crossed the install threshold: "
+        f"{pending_count} unused, oldest {oldest_age_days} days.\n"
+        "\n"
+        "Capture and apply stay separate — do not extract new learnings in this pass.\n"
+        "Read `.claude/skills/install-learnings/SKILL.md` and "
+        "`.claude/reference/session-learnings-routing.md`, then follow that contract:\n"
+        "1. Cluster related pending entries; prefer one rule covering several.\n"
+        "2. Route each cluster into the file that changes next-session behaviour, "
+        "or mark dropped with the date and reason.\n"
+        "3. Never fabricate an edit to make the count drop. Never delete an entry "
+        "to hide it.\n"
+        "4. After routing, read the changed files back, then stop.\n"
+        "Do this once (typically 1–4 clusters), then stop. If the last user message "
+        "was clearly mid-task, still route one highest-value cluster, then stop.\n"
+        "</install_learnings>\n"
+    )
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+        if not isinstance(payload, dict):
+            return 0
+        if payload.get("stop_hook_active") is True:
+            return 0
+
+        vault = _vault_root()
+        if str(_HOOK_REPO) not in sys.path:
+            sys.path.insert(0, str(_HOOK_REPO))
+        from core.utils.session_learnings import install_prompt_stats
+
+        today = _today()
+        stats = install_prompt_stats(vault, today=today)
+        if not stats.should_prompt_install:
+            return 0
+        if stats.oldest_age_days is None:
+            return 0
+        if not _claim_today(vault, today):
+            return 0
+
+        output = {
+            "decision": "block",
+            "reason": _reason(stats.pending_count, stats.oldest_age_days),
+        }
+        print(json.dumps(output))
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/install-learnings.sh
+++ b/.claude/hooks/install-learnings.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Stop-hook wrapper for pending session-learning install.
+# Fail-open when python3 is missing (Linux replica / stripped PATH).
+# The Python program owns stdin, threshold detection, and the Stop block.
+# Run the sibling .py next to this wrapper (shipped tree), not a copy
+# under the vault path — harness tests point CLAUDE_PROJECT_DIR at a
+# sandbox that has the notes, not the hook files.
+
+command -v python3 >/dev/null 2>&1 || exit 0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/install-learnings.py"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -230,6 +230,7 @@ if [[ -f "$LEARNING_PENDING" ]]; then
         echo "--- 📚 Pending Learnings Review ($LEARNING_COUNT) ---"
         echo "Session learnings ready for review"
         echo "Run: /dex-whats-new --learnings"
+        echo "To apply them so the next session changes: /install-learnings"
         echo "---"
         echo ""
     fi

--- a/.claude/hooks/tests/hook-command-paths.test.cjs
+++ b/.claude/hooks/tests/hook-command-paths.test.cjs
@@ -74,10 +74,13 @@ test('notification hooks survive a platform without afplay', () => {
     'fixture PATH must not expose afplay',
   );
 
+  // Claude Code always sets CLAUDE_PROJECT_DIR. Keep it here so Stop hooks
+  // that live in the vault can no-op on missing afplay/python3 instead of
+  // dying on an empty project path.
   for (const command of commands) {
     const result = spawnSync('/bin/bash', ['-c', command], {
       encoding: 'utf8',
-      env: { ...process.env, PATH: linuxLikeBin },
+      env: { ...process.env, PATH: linuxLikeBin, CLAUDE_PROJECT_DIR: ROOT },
     });
     assert.equal(
       result.status,

--- a/.claude/reference/README.md
+++ b/.claude/reference/README.md
@@ -76,6 +76,7 @@ Reference docs should:
 
 - **mcp-servers.md** - MCP setup, troubleshooting, and integration patterns
 - **meeting-intel.md** - Meeting processing pipeline details
+- **session-learnings-routing.md** - Where a pending session learning has to go so the next session actually changes
 
 ## Related
 

--- a/.claude/reference/mcp-servers.md
+++ b/.claude/reference/mcp-servers.md
@@ -376,8 +376,10 @@ node .scripts/check-anthropic-changelog.cjs --dry-run  # Preview mode
 2. Counts learnings with `**Status:** pending`
 3. If 5+ pending learnings:
    - Writes reminder to `System/learning-review-pending.md`
-   - Session start hook displays count and suggests `/dex-whats-new --learnings`
+   - Session start hook displays count and suggests `/dex-whats-new --learnings` to review, and `/install-learnings` to apply
 4. If <5 pending, removes any existing reminder file
+
+Installing is a separate path from this reminder. `/install-learnings` and the Stop hook (8 pending, oldest at least 14 days) route unused entries into the file that changes next-session behaviour. Routing table: `.claude/reference/session-learnings-routing.md`.
 
 **Manual testing:**
 ```bash

--- a/.claude/reference/session-learnings-routing.md
+++ b/.claude/reference/session-learnings-routing.md
@@ -1,0 +1,80 @@
+# Session-learnings routing
+
+How a **pending** session learning becomes a change that affects the next
+session — or an honest `dropped` with a reason. Capture (`/daily-review`,
+session-end, the learning-review reminder) stays a separate concern. This
+file is the routing table `/install-learnings` and the Stop hook point at.
+Edit the destinations here without touching hook code.
+
+## Shipped trigger defaults
+
+The Stop hook fires when **both** are true:
+
+- **Volume:** 8 pending entries or more
+- **Age floor:** the oldest pending entry is at least 14 days old
+
+Empty and new vaults stay silent. A busy first week of captures does not
+fire. Three old notes also do not fire — `/install-learnings` can still be
+run by hand. A vault that is keeping up never sees the hook.
+
+The hook asks for one routing pass (typically 1–4 clusters), then stops. It
+does not try to clear an 80-entry pile in one session.
+
+## Status values
+
+Leave capture as:
+
+```markdown
+**Status:** pending
+```
+
+After a real routing decision, rewrite that line in place. Do not delete the
+entry.
+
+```markdown
+**Status:** implemented (YYYY-MM-DD — where it went)
+**Status:** dropped (YYYY-MM-DD — reason)
+```
+
+`dropped` is the third state for wrong, obsolete, or already-covered notes.
+Without it, stale entries either linger forever or get quietly deleted.
+
+Do not fabricate an edit to make the count drop. Do not delete an obsolete
+entry to hide it.
+
+## Routing table
+
+Prefer **one rule covering a cluster** of related entries over eight tiny
+edits. The clusters are where the value is.
+
+| Kind of learning | Where it has to go |
+|---|---|
+| Behavioural — how the assistant should work | `CLAUDE.md` user-extensions block (`## USER_EXTENSIONS_START` … `## USER_EXTENSIONS_END`). If the same rule belongs in a standing memory note, add it there too and keep the user-extensions line as the session-visible copy. |
+| A defect in a skill | That skill's `SKILL.md`, as a real numbered step — not prose in a "notes" section. |
+| A small, safe defect in code or config | Fix it in place. If it is not small and safe, capture it as a backlog idea with `capture_idea` and mark the learning implemented to that idea id, or dropped if it is not an idea either. |
+| An environment or platform fact | The matching file in `.claude/reference/` |
+
+Do not put preferences that Claude's built-in memory already owns into
+session learnings or user-extensions. See [Memory_Ownership.md](../../docs/Dex_System/Memory_Ownership.md).
+
+## Clustering
+
+1. Read pending entries across `System/Session_Learnings/*.md` (skip `README.md` and session-end markers that have no status).
+2. Group by the file that would change next-session behaviour, not by the day they were captured.
+3. Write one durable rule per cluster. Mark every covered entry `implemented` pointing at that same destination.
+4. Leave unrelated pending entries pending. Another pass will take them.
+
+## Quality bar
+
+A good pass leaves behind a behaviour change the next session will actually
+follow, and a status line that says where each routed entry went. A dropped
+entry names why. The pending count falls because something was installed or
+honestly declined — not because notes were deleted or rewritten as done
+without a matching file change.
+
+## Related
+
+- Skill: `/install-learnings` (`.claude/skills/install-learnings/SKILL.md`)
+- Capture: `/daily-review`
+- Review without applying: `/dex-whats-new --learnings`
+- Product ideas (not session-learning routing): `/dex-backlog`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,10 @@
           {
             "type": "command",
             "command": "sh -c 'command -v afplay >/dev/null 2>&1 || exit 0; exec afplay /System/Library/Sounds/Ping.aiff'"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/install-learnings.sh\""
           }
         ]
       }

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -249,6 +249,7 @@ Built specifically for personal knowledge management and productivity workflows 
 - `/dex-backlog` - AI-powered idea ranking
 - `/dex-improve` - Workshop improvement ideas
 - `/dex-whats-new` - Check for system improvements (learnings + Claude updates)
+- `/install-learnings` - Route unused session learnings into next-session behaviour, or drop them with a reason
 - `/dex-update` - Update Dex automatically (shows what's new, updates if confirmed, no technical knowledge needed)
 - `/dex-rollback` - Undo last update if something went wrong
 - `/dex-obsidian-setup` - Enable Obsidian integration and migrate vault to wiki links

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -323,7 +323,7 @@ Scan today's conversation for learnings:
 3. **Documentation gaps** — Were there questions about how the system works?
 4. **Workflow inefficiencies** — Did any task take longer than it should?
 
-Write to `System/Session_Learnings/YYYY-MM-DD.md`.
+Write to `System/Session_Learnings/YYYY-MM-DD.md` with `**Status:** pending`. Capture only — do not install, rewrite skills, or edit `CLAUDE.md` in this step. Applying pending learnings is `/install-learnings`.
 
 Then ask: "I captured [N] learnings from today's session. Anything else you'd like to add?"
 

--- a/.claude/skills/dex-whats-new/SKILL.md
+++ b/.claude/skills/dex-whats-new/SKILL.md
@@ -78,6 +78,8 @@ Based on what you've learned, here's how to improve Dex:
 Want me to implement any of these? (Enter number)
 ```
 
+**Applying is a separate step.** Reviewing here does not install anything. If the user wants pending learnings to change next-session behaviour, run `/install-learnings` (routing table: `.claude/reference/session-learnings-routing.md`). Do not extract new learnings in that pass.
+
 **If no learnings:**
 Skip this section or show: "No session learnings captured yet. The system will learn as you use it."
 

--- a/.claude/skills/install-learnings/SKILL.md
+++ b/.claude/skills/install-learnings/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: install-learnings
+description: "Turn unused session learnings into changes that affect the next session — or honestly drop them with a reason. Use when the user says 'install the learnings', 'apply pending learnings', 'the learnings never get used', 'session learnings are piling up', or when a session-end notice reports the unused pile crossed the install threshold. Also use proactively when `/dex-whats-new` finds pending learnings the user wants applied. Not for capturing a new learning from today's work; use `daily-review`. Not for ranking product ideas; use `dex-backlog`."
+---
+
+# /install-learnings
+
+Pending session learnings are an archive until they change a file the next session will follow. This skill is the **apply** half. Capture stays in `/daily-review`. Do not extract new learnings here.
+
+Governing rule: **route into the place that changes behaviour, then record where it went.** Prefer one rule covering a cluster over eight tiny edits. Never fabricate an edit to make the count drop. Never delete an entry to hide it.
+
+Read the routing table before touching files: [session-learnings-routing.md](../../reference/session-learnings-routing.md).
+
+---
+
+## Step 1 — Load pending entries (don't capture)
+
+Read `System/Session_Learnings/*.md`. Skip `README.md` and session-end markers that have no `**Status:**` line. Collect every block whose status is exactly `pending`.
+
+If the folder is missing or there are no pending entries, say so plainly and stop. Do not invent entries.
+
+## Step 2 — Cluster, then choose a destination
+
+Group pending entries by the file that would change next-session behaviour, using the routing table:
+
+| Kind | Destination |
+|---|---|
+| How the assistant should work | `CLAUDE.md` user-extensions block, and/or a standing memory note |
+| A defect in a skill | That skill's `SKILL.md` as a **numbered step**, not prose |
+| Small safe code/config defect | Fix it; otherwise `capture_idea` and point the status at the idea id |
+| Environment/platform fact | Matching `.claude/reference/` file |
+
+Take **1–4 clusters** this pass unless the user asked to clear the pile. Leave the rest pending.
+
+## Step 3 — Install or drop (no silent deletes)
+
+For each chosen cluster:
+
+- **Install:** make the real file change, then read that file back. Only then rewrite each covered entry's status to `implemented (YYYY-MM-DD — where)`.
+- **Drop:** if the note is wrong, obsolete, or already covered, rewrite status to `dropped (YYYY-MM-DD — reason)`. Leave the entry in the file.
+- **Skip:** if the right destination is unclear, leave it `pending`.
+
+Do not mark `implemented` unless the destination file now contains the rule. Do not replace `pending` with anything other than `implemented (…)` or `dropped (…)`.
+
+## Step 4 — Inspect, then report
+
+Read back every file that changed, including the learning files whose status lines moved. Report:
+
+- how many entries were pending at the start
+- which clusters were installed, and where
+- which were dropped, and why
+- how many remain pending
+
+Never say "installed / done" without those destinations in hand.
+
+---
+
+## Quality bar
+
+A good run changes next-session behaviour for the clusters it took, records where each routed entry went, and leaves unrelated pending entries untouched. The count falls because something was installed or honestly dropped.
+
+## Anti-patterns (do not do these)
+
+- **Capturing new learnings** during this pass — that is `/daily-review`.
+- **Fabricating an edit** so the pending count drops.
+- **Deleting** an obsolete entry instead of marking `dropped`.
+- **Prose in a skill** where a numbered step is required.
+- **Claiming implemented** without reading the destination file back.
+- Dumping personal names or vault anecdotes into the report; summarise the rule, not the original story.
+
+## Degradation
+
+- `System/Session_Learnings/` missing → say the folder is not there yet; stop.
+- Destination file missing (no `CLAUDE.md`, no matching skill) → leave those entries pending and say why; do not invent a destination.
+- A write fails or the read-back does not contain the rule → do not mark implemented; report that cluster as not installed.
+
+---
+
+## Track Usage (Silent)
+
+Update `System/usage_log.md` to mark learnings installed as used.
+
+**Analytics (Silent):** call `track_event` with event_name `learnings_installed` and properties `implemented_count`, `dropped_count` (counts only — no titles, no file contents). Fires only if the user opted into analytics; no action if it returns `analytics_disabled`.

--- a/.claude/skills/install-learnings/evals/trigger-cases.yaml
+++ b/.claude/skills/install-learnings/evals/trigger-cases.yaml
@@ -1,0 +1,38 @@
+# Trigger evals for /install-learnings.
+# Capture vs apply stay separate: positives are apply/routing; capture and
+# idea-ranking must not fire this skill.
+
+skill: install-learnings
+
+positive:
+  - utterance: "Install the pending session learnings so they actually change next time."
+    expect: fire
+  - utterance: "Those session learnings are just sitting there unused — apply them."
+    expect: fire
+  - utterance: "The learnings never get used. Route the pending pile."
+    expect: fire
+
+negative:
+  - utterance: "Wrap up my day and capture what I learned."
+    expect: no-fire
+    route_to: daily-review
+    why: capture is daily-review; this skill only installs already-pending entries.
+  - utterance: "Show my Dex improvement ideas and what we should build next."
+    expect: no-fire
+    route_to: dex-backlog
+    why: product ideas are the backlog, not session-learning routing.
+
+ambiguous:
+  - utterance: "Do something with the learnings."
+    expect: ask
+    why: could mean capture (daily-review), review (dex-whats-new), or install.
+
+missing_prerequisite:
+  - utterance: "Install the pending session learnings."
+    expect: degrade
+    why: System/Session_Learnings/ is missing — say so and stop; do not invent entries.
+
+failure_recovery:
+  - utterance: "Install the pending session learnings."
+    expect: honest-failure
+    why: destination write failed or read-back lacks the rule — do not mark implemented.

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -301,6 +301,8 @@ Review `System/Session_Learnings/` files from this week:
 > 
 > Should I add these to your pattern files?"
 
+Unaddressed pending entries are installed by `/install-learnings`, not by compiling them here. If the unused pile is large, offer that command once.
+
 ---
 
 ## Output Format

--- a/.scripts/learning-review-prompt.sh
+++ b/.scripts/learning-review-prompt.sh
@@ -81,7 +81,8 @@ You have accumulated learnings from recent sessions that haven't been reviewed y
 Run \`/dex-whats-new --learnings\` to:
 - Review patterns identified from your usage
 - See suggested system improvements
-- Mark learnings as implemented or archived
+
+Run \`/install-learnings\` to route pending entries into the file that changes next-session behaviour (or honestly drop them). Reviewing is not installing.
 
 This helps Dex evolve based on your actual workflow patterns.
 

--- a/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -130,6 +130,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 | `/week` command | Weekly pattern recognition and planning |
 | Background changelog monitor | Checks every 6 hours for Claude updates, alerts you automatically |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
+| `/install-learnings` | Routes unused session learnings into the file that changes next time, or drops them with a reason |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
 | `Working_Preferences.md` | Collaboration style captured and applied consistently |
 | Session learnings capture | Automatic logging in `System/Session_Learnings/` |
@@ -140,7 +141,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 
 During the week, you mentioned "I prefer summaries in bullet points." Dex captured this in Session_Learnings and now asks: "You've mentioned this preference 3 times. Add to Working_Preferences.md so all future summaries use bullets?"
 
-**Why automation matters**: Next week, when you start a session at 5pm, Dex notices: "📚 You have 7 pending learnings from this week" and prompts a review. You also see: "🆕 New Claude Code features detected!" because background monitoring found updates. The system improves itself quietly.
+**Why automation matters**: Next week, when you start a session at 5pm, Dex notices: "📚 You have 7 pending learnings from this week" and prompts a review. If those notes have sat unused long enough, session end asks for `/install-learnings` so they actually change next time. You also see: "🆕 New Claude Code features detected!" because background monitoring found updates. The system improves itself quietly.
 
 ---
 

--- a/06-Resources/Dex_System/Dex_System_Guide.md
+++ b/06-Resources/Dex_System/Dex_System_Guide.md
@@ -450,6 +450,9 @@ Dex checks if Anthropic has released new Claude Code features. When it finds som
 **Learning Review Prompts (daily at 5pm)**  
 As you work, Dex captures learnings in `System/Session_Learnings/`. When you accumulate 5+ learnings that haven't been reviewed yet, Dex reminds you: "📚 You have 7 pending learnings from this week. Worth reviewing?"
 
+**Learning install (when the unused pile has grown)**  
+Reviewing is not installing. When 8 or more unused notes have sat at least 14 days, Dex asks at the end of a session for `/install-learnings`: route them into the file that changes next time, or drop them with a reason. A new vault does not get that nudge.
+
 Both happen automatically with no action from you. The system stays current on its own.
 
 ### Learning Files
@@ -479,12 +482,13 @@ Every session builds on the last. The system remembers so you don't have to.
 Without automation, learning requires discipline. You have to remember to:
 - Check for Claude updates
 - Review your learnings
+- Install the ones that should change next time
 - Update your preferences
 - Apply past lessons
 
-Most people don't. The learnings sit unused.
+Most people don't. The notes sit unused unless something routes them.
 
-With automation, Dex nudges you at the right time. The system improves itself through quiet background work, and only asks for your input when it matters.
+With automation, Dex nudges you at the right time — and when the unused pile has grown, it asks for an install pass instead of another reminder to review. The system improves itself through quiet background work, and only asks for your input when it matters.
 
 ---
 
@@ -879,6 +883,7 @@ Located in `06-Resources/Learnings/` and `System/Session_Learnings/`:
 **Automatic Prompts:**
 - Daily at 5pm, Dex checks if you have 5+ pending learnings
 - Next session start: "📚 You have 7 pending learnings from this week. Worth reviewing?"
+- When 8+ unused notes are at least 14 days old, session end asks for `/install-learnings` so they are applied or honestly dropped
 
 ### Why This Matters
 

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -900,6 +900,8 @@ Focus on architecture questions, not syntax nitpicks. I trust the team on detail
    - Move to appropriate file (`Mistake_Patterns.md`, `Working_Preferences.md`, or fix immediately)
    - Mark as resolved in session learnings
 
+5. **Install (separate from capture):** `/install-learnings` routes still-pending entries into the file that changes next-session behaviour, or marks them `dropped` with a reason. A Stop hook asks for this pass when there are 8 pending entries and the oldest is at least 14 days old. Routing table: `.claude/reference/session-learnings-routing.md`. Do not fabricate an edit to make the count drop. Do not delete an obsolete entry.
+
 ### Background Automation Setup
 
 Dex runs self-learning checks automatically through two mechanisms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.3] — 📝 Unused session notes now change how Dex works next time (2026-08-13)
+
+Dex was already good at writing down what went wrong in a session. Those notes landed in a folder marked pending and stayed there. One person reached eighty-seven unused notes, the oldest ten weeks old. Every one was a real lesson. None of them changed what Dex did the next day.
+
+**What this fixes for you:**
+
+* **Dex now installs those notes instead of only filing them.** When enough unused notes have sat for two weeks, Dex takes a routing pass at the end of a session: it writes the lesson into the instructions it will follow next time, or it honestly drops the note with a date and a reason.
+* **You can run that pass yourself.** `/install-learnings` does the same routing any time, without waiting for the pile to grow.
+* **Nothing is deleted to make the pile look smaller.** Wrong or already-covered notes are marked dropped, not erased. Dex will not invent a fake edit just to lower the count.
+
+Thanks to Josh, who showed that writing the notes down is not the same as using them, and that a routing pass is what actually moves the number.
+
 ## [1.96.2] — 🛡️ Your history saves again, and company networks get an honest answer (2026-08-13)
 
 If you're on a corporate network that intercepts secure connections — Zscaler, Netskope, most large enterprises — or on a hotel or airport captive portal, Dex's daily update check could fail and report that the release evidence was **invalid**. That wording means something specific and alarming: that the version of Dex being offered looks tampered with. It was never true. What had actually happened is that Dex couldn't verify it was really talking to GitHub, because something on your network was sitting in the middle of the connection. Worse, Dex treated it as a permanent verdict and didn't try again, so the check stayed broken for exactly the people most likely to hit it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,15 @@ Learnings are captured during the daily review process. When the user runs `/dai
 
 3. **Tell the user** how many learnings you captured, then ask if they want to add more
 
+Leave status as `pending`. Applying those notes so the next session changes is a separate step: `/install-learnings`. Do not install, rewrite skills, or edit user-extensions during capture.
+
 This happens during `/daily-review` - you don't need to capture learnings silently during the session. The review process handles it systematically.
+
+### Learning Install via `/install-learnings`
+
+Pending session learnings stay an archive until they are routed into a file the next session will follow. When the unused pile is large (8 pending and the oldest is at least 14 days), a session-end hook asks for one install pass. The user can also run `/install-learnings` at any time.
+
+Follow `.claude/reference/session-learnings-routing.md`. Prefer one rule covering a cluster. Rewrite status to `implemented (YYYY-MM-DD — where)` or `dropped (YYYY-MM-DD — reason)`. Never fabricate an edit to make the count drop. Never delete an entry to hide it.
 
 ### Background Self-Learning Automation
 
@@ -449,6 +457,7 @@ Dex continuously learns from usage and external sources through automatic checks
 - Checks bounded release evidence from the pinned Dex repository (at most daily)
 - Tracks pending learnings in `System/Session_Learnings/` (daily)
 - Surfaces alerts during session start and `/daily-plan`
+- Asks for an install pass at session end when unused learnings have piled up
 - Pattern recognition during weekly reviews
 
 **Setup details:** See `06-Resources/Dex_System/Dex_Technical_Guide.md` for installation and configuration.
@@ -564,6 +573,7 @@ Skills extend Dex capabilities and are invoked with `/skill-name`. Common skills
 - `/enable-semantic-search` - Enable local AI-powered semantic search with smart collection discovery
 - `/xray` - AI education: understand what just happened under the hood (context, MCPs, hooks)
 - `/dex-level-up`, `/dex-backlog`, `/dex-improve` - System improvements
+- `/install-learnings` - Turn unused session learnings into next-session behaviour, or drop them with a reason
 - `/dex-doctor` - Full system checkup: finds what's broken, fixes what's safe, guides you through the rest
 - `/feedback` - Report a Dex bug to the Dex team with zero homework; Dex investigates, you approve, and you hear back when it's fixed
 - `/dex-update` - Update Dex automatically (shows what's new, updates if confirmed, no technical knowledge needed)

--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ The system teaches you progressively. You learn what you need, when you need it.
 The system captures learnings and improves over time:
 
 - Run `/daily-review` - captures learnings to `System/Session_Learnings/`
+- Run `/install-learnings` - routes unused notes into the place that changes next time, or drops them with a reason
 - Weekly synthesis (`/week-review`) - turns learnings into system improvements
 - Background automation - checks for new Claude Code features daily
 - Run `/dex-whats-new` - surfaces learnings and new capabilities you can use

--- a/System/README.md
+++ b/System/README.md
@@ -16,7 +16,7 @@ Configuration and system files for Dex.
 ## Subfolders
 
 - **Templates/** — Note templates for consistent formatting
-- **Session_Learnings/** — Daily learning capture from `/daily-review` sessions
+- **Session_Learnings/** — Daily learning capture from `/daily-review`; `/install-learnings` routes unused notes so the next session changes
 
 ## What to Edit
 

--- a/System/Session_Learnings/README.md
+++ b/System/Session_Learnings/README.md
@@ -17,7 +17,7 @@ Each learning includes:
 - **What happened** — Specific situation
 - **Why it matters** — Impact on system/workflow
 - **Suggested fix** — Specific action with file paths
-- **Status** — pending, implemented, or won't-fix
+- **Status** — `pending`, `implemented (YYYY-MM-DD — where)`, or `dropped (YYYY-MM-DD — reason)`
 
 ## Naming Convention
 
@@ -25,22 +25,23 @@ Each learning includes:
 
 ## Workflow
 
-1. **Capture** — Happens automatically during `/daily-review` (daily review)
-2. **Review** — Periodically check pending learnings via `/dex-whats-new`
-3. **Implement** — Fix documentation gaps or system issues
-4. **Update status** — Mark as implemented when done
+1. **Capture** — Happens during `/daily-review`. Entries are written `pending`. Session-end only logs that a session finished.
+2. **Review** — `/dex-whats-new --learnings` summarises patterns. Reviewing does not install.
+3. **Install** — `/install-learnings` routes pending entries into the file that changes next-session behaviour, or marks them `dropped` with a reason. A Stop hook asks for this pass when 8+ pending entries have sat at least 14 days. Routing table: `.claude/reference/session-learnings-routing.md`.
+4. **Do not delete** an obsolete entry to hide it. Use `dropped`.
 
 ## vs. Dex Backlog
 
-**Session Learnings** = specific bugs or doc gaps discovered  
+**Session Learnings** = specific bugs or doc gaps discovered
 **Dex Backlog** = feature ideas and improvements (in `System/Dex_Backlog.md`)
 
-Both feed into system improvements, but learnings are reactive (fixing issues) while the backlog is proactive (new capabilities).
+Both feed into system improvements, but learnings are reactive (fixing issues) while the backlog is proactive (new capabilities). A learning that is not small and safe to fix becomes a backlog idea rather than a silent skip.
 
 ## Integration
 
-- `/dex-whats-new` checks for pending learnings
-- Weekly reviews surface unaddressed learnings
-- Helps Dex evolve based on actual usage patterns
+- `/daily-review` captures (status stays `pending`)
+- `/dex-whats-new` reviews
+- `/install-learnings` installs or honestly drops
+- Weekly reviews can offer `/install-learnings` when the unused pile is large
 
 This enables Dex to learn from your usage and improve over time.

--- a/System/usage_log.md
+++ b/System/usage_log.md
@@ -59,7 +59,7 @@
 - [ ] Promotion readiness checked
 - [ ] Skills gap analysis
 
-## System Discovery & Improvement (9 features)
+## System Discovery & Improvement (10 features)
 
 - [ ] Feature discovery (`/dex-level-up`)
 - [ ] X-ray transparency (`/xray`)
@@ -70,6 +70,7 @@
 - [ ] Dex updated (`/dex-update`)
 - [ ] Dex rolled back (`/dex-rollback`)
 - [ ] Learnings reviewed (`/learnings`)
+- [ ] Learnings installed (`/install-learnings`)
 
 ## Integrations (5 features)
 

--- a/core/mcp/dex_improvements_server.py
+++ b/core/mcp/dex_improvements_server.py
@@ -79,7 +79,6 @@ BASE_DIR = Path(os.environ.get('VAULT_PATH', Path.cwd()))
 BACKLOG_FILE = BASE_DIR / 'System' / 'Dex_Backlog.md'
 SYSTEM_DIR = BASE_DIR / 'System'
 CHANGELOG_FILE = BASE_DIR / '06-Resources' / 'Claude_Code_Docs' / 'changelog-log.md'
-SESSION_LEARNINGS_DIR = BASE_DIR / 'System' / 'Session_Learnings'
 SYNTHESIS_STATE_FILE = BASE_DIR / 'System' / '.synthesis-state.json'
 
 # Valid categories for ideas
@@ -363,39 +362,11 @@ def generate_idea_title_from_feature(feature_text: str) -> str:
 
 def parse_session_learnings(since_date: Optional[str] = None) -> List[Dict[str, str]]:
     """Parse session learnings files for pending improvements"""
-    if not SESSION_LEARNINGS_DIR.exists():
-        return []
+    from core.utils.session_learnings import parse_entries, pending_entries
 
-    learnings = []
-    for filepath in sorted(SESSION_LEARNINGS_DIR.glob('*.md'), reverse=True):
-        file_date = filepath.stem
-        if since_date and file_date < since_date:
-            continue
-
-        content = filepath.read_text()
-        blocks = re.split(r'\n---\n', content)
-
-        for block in blocks:
-            status_match = re.search(r'\*\*Status:\*\*\s*(\w+)', block)
-            if not status_match or status_match.group(1) != 'pending':
-                continue
-
-            title_match = re.search(r'##\s*\[?\d{2}:\d{2}\]?\s*-?\s*(.+)', block)
-            fix_match = re.search(r'\*\*Suggested fix:\*\*\s*(.+?)(?:\n\*\*|\n---|\Z)', block, re.DOTALL)
-            what_match = re.search(r'\*\*What happened:\*\*\s*(.+?)(?:\n\*\*|\n---|\Z)', block, re.DOTALL)
-            why_match = re.search(r'\*\*Why it matters:\*\*\s*(.+?)(?:\n\*\*|\n---|\Z)', block, re.DOTALL)
-
-            if title_match:
-                learnings.append({
-                    "date": file_date,
-                    "title": title_match.group(1).strip(),
-                    "what_happened": what_match.group(1).strip() if what_match else "",
-                    "why_it_matters": why_match.group(1).strip() if why_match else "",
-                    "suggested_fix": fix_match.group(1).strip() if fix_match else "",
-                    "file": str(filepath),
-                })
-
-    return learnings
+    pending = pending_entries(parse_entries(BASE_DIR), since_date=since_date)
+    pending.sort(key=lambda entry: entry.date, reverse=True)
+    return [entry.as_synthesis_dict() for entry in pending]
 
 def enrich_idea_in_backlog(idea_id: str, evidence: str, source: str) -> Dict[str, Any]:
     """Append evidence to an existing idea's entry in the backlog"""

--- a/core/tests/test_install_learnings_hook.py
+++ b/core/tests/test_install_learnings_hook.py
@@ -1,0 +1,171 @@
+"""Stop-hook contract for installing pending session learnings.
+
+The hook is detection-only. It never writes a learning file, never dumps
+entry text (personal-data gate), and fail-opens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "install-learnings.py"
+TODAY = date(2026, 8, 13)
+
+
+def _run_hook(vault: Path, payload: dict, *, dedup: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(vault)
+    env["DEX_INSTALL_LEARNINGS_TODAY"] = TODAY.isoformat()
+    if dedup is not None:
+        env["DEX_INSTALL_LEARNINGS_DEDUP_FILE"] = str(dedup)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        cwd=vault,
+        env=env,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _pending_block(title: str) -> str:
+    return (
+        f"## [14:32] - {title}\n\n"
+        "**What happened:** A check continued after a failed command.\n"
+        "**Why it matters:** The next session repeated the same miss.\n"
+        "**Suggested fix:** Add a numbered verification step to the skill.\n"
+        "**Status:** pending\n\n"
+        "---\n"
+    )
+
+
+def _seed_backlog(vault: Path, *, count: int, oldest_age_days: int) -> None:
+    marker = vault / "System" / ".onboarding-complete"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{}\n", encoding="utf-8")
+    directory = vault / "System" / "Session_Learnings"
+    directory.mkdir(parents=True, exist_ok=True)
+    oldest = TODAY - timedelta(days=oldest_age_days)
+    for offset in range(count):
+        day = oldest + timedelta(days=offset)
+        (directory / f"{day.isoformat()}.md").write_text(
+            f"# Session Learnings - {day.isoformat()}\n\n"
+            + _pending_block(f"Clustered miss {offset}"),
+            encoding="utf-8",
+        )
+
+
+def test_hook_fails_open_for_empty_and_invalid_stdin(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+    for stdin in ("", "{not-json"):
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            cwd=tmp_path,
+            env=env,
+            input=stdin,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+
+def test_empty_and_new_vaults_are_silent(tmp_path: Path) -> None:
+    result = _run_hook(tmp_path, {"hook_event_name": "Stop"})
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+    marker = tmp_path / "System" / ".onboarding-complete"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("{}\n", encoding="utf-8")
+    directory = tmp_path / "System" / "Session_Learnings"
+    directory.mkdir(parents=True)
+    (directory / "2026-08-12.md").write_text(
+        "# Session Learnings - 2026-08-12\n\n" + _pending_block("Fresh miss"),
+        encoding="utf-8",
+    )
+    result = _run_hook(tmp_path, {"hook_event_name": "Stop"})
+    assert result.stdout == ""
+
+
+def test_threshold_blocks_stop_once_per_day_without_leaking_entry_text(
+    tmp_path: Path,
+) -> None:
+    _seed_backlog(tmp_path, count=8, oldest_age_days=70)
+    dedup = tmp_path / "dedup"
+    payload = {"hook_event_name": "Stop", "session_id": "install-learnings-test"}
+
+    first = _run_hook(tmp_path, payload, dedup=dedup)
+    assert first.returncode == 0, first.stderr
+    output = json.loads(first.stdout)
+    assert output["decision"] == "block"
+    reason = output["reason"]
+    assert "8 unused" in reason
+    assert "oldest 70 days" in reason
+    assert "install-learnings" in reason
+    assert "session-learnings-routing.md" in reason
+    assert "Clustered miss" not in reason
+    assert "failed command" not in reason
+
+    second = _run_hook(tmp_path, payload, dedup=dedup)
+    assert second.returncode == 0
+    assert second.stdout == ""
+
+
+def test_stop_hook_active_does_not_loop(tmp_path: Path) -> None:
+    _seed_backlog(tmp_path, count=8, oldest_age_days=70)
+    result = _run_hook(
+        tmp_path,
+        {"hook_event_name": "Stop", "stop_hook_active": True},
+        dedup=tmp_path / "dedup",
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_hook_never_writes_a_learning_file(tmp_path: Path) -> None:
+    _seed_backlog(tmp_path, count=8, oldest_age_days=70)
+    before = {
+        path: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "System" / "Session_Learnings").glob("*.md")
+    }
+    _run_hook(tmp_path, {"hook_event_name": "Stop"}, dedup=tmp_path / "dedup")
+    after = {
+        path: path.read_text(encoding="utf-8")
+        for path in (tmp_path / "System" / "Session_Learnings").glob("*.md")
+    }
+    assert after == before
+
+
+def test_settings_wires_the_stop_wrapper() -> None:
+    settings = json.loads(
+        (REPO_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8")
+    )
+    commands = []
+    for group in settings.get("hooks", {}).get("Stop", []):
+        for hook in group.get("hooks", []):
+            commands.append(hook.get("command", ""))
+    assert any("install-learnings.sh" in command for command in commands)
+    assert any(
+        "CLAUDE_PROJECT_DIR" in command
+        for command in commands
+        if "install-learnings" in command
+    )
+
+
+def test_hook_source_does_not_capture_or_delete() -> None:
+    source = HOOK.read_text(encoding="utf-8")
+    assert "daily-review" in source
+    assert "never writes a learning" in source
+    assert "unlink" not in source
+    assert "os.remove" not in source

--- a/core/tests/test_install_learnings_skill.py
+++ b/core/tests/test_install_learnings_skill.py
@@ -1,0 +1,83 @@
+"""Contract tests for /install-learnings.
+
+Apply is a separate concern from capture. These tests lock that split, the
+routing-table pointer, the implemented/dropped status contract, and the
+ban on fabricating edits or deleting entries.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.utils.validators import validate_skill_frontmatter
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".claude/skills/install-learnings/SKILL.md"
+EVALS = ROOT / ".claude/skills/install-learnings/evals/trigger-cases.yaml"
+ROUTING = ROOT / ".claude/reference/session-learnings-routing.md"
+
+
+def _frontmatter_description() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    fm = text.split("---\n", 2)[1]
+    for line in fm.splitlines():
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError("no description in frontmatter")
+
+
+def test_skill_exists_with_evals_and_valid_frontmatter() -> None:
+    assert SKILL.is_file()
+    assert EVALS.is_file()
+    assert ROUTING.is_file()
+    assert validate_skill_frontmatter(SKILL) == []
+
+
+def test_description_routes_apply_not_capture() -> None:
+    desc = _frontmatter_description().lower()
+    assert "when the user says" in desc
+    assert "daily-review" in desc
+    assert "dex-backlog" in desc
+    assert "capturing a new learning" in desc
+
+
+def test_body_keeps_capture_and_apply_separate() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "do not extract new learnings" in text
+    assert "daily-review" in text
+    assert "session-learnings-routing.md" in text
+
+
+def test_status_contract_and_no_silent_deletes() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "implemented (YYYY-MM-DD — where)" in text
+    assert "dropped (YYYY-MM-DD — reason)" in text
+    assert "Never delete" in text or "never delete" in text
+    assert "Never fabricate" in text or "never fabricate" in text
+
+
+def test_inspects_destination_before_claiming_implemented() -> None:
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "read that file back" in text or "read the destination file back" in text
+    assert "do not mark implemented" in text
+
+
+def test_capture_flows_do_not_install_and_review_hands_off() -> None:
+    daily = (ROOT / ".claude/skills/daily-review/SKILL.md").read_text(encoding="utf-8")
+    whats_new = (ROOT / ".claude/skills/dex-whats-new/SKILL.md").read_text(encoding="utf-8")
+    assert "Capture only" in daily or "capture only" in daily.lower()
+    assert "/install-learnings" in daily
+    assert "Reviewing here does not install" in whats_new or "does not install" in whats_new
+    assert "/install-learnings" in whats_new
+
+
+@pytest.mark.parametrize(
+    "needle",
+    ["positive:", "negative:", "ambiguous:", "missing_prerequisite:", "failure_recovery:"],
+)
+def test_evals_carry_the_canonical_case_buckets(needle: str) -> None:
+    text = EVALS.read_text(encoding="utf-8")
+    assert needle in text
+    assert "daily-review" in text
+    assert "dex-backlog" in text

--- a/core/tests/test_session_learnings.py
+++ b/core/tests/test_session_learnings.py
@@ -1,0 +1,182 @@
+"""Contract for pending session-learning detection and the install threshold.
+
+Personal-data gate: fixtures use generic titles only. No identities, no vault
+content copied from a real user.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from core.utils import session_learnings as sl
+
+TODAY = date(2026, 8, 13)
+
+
+def _write_learning(vault: Path, day: date, body: str) -> Path:
+    directory = vault / "System" / "Session_Learnings"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{day.isoformat()}.md"
+    path.write_text(
+        f"# Session Learnings - {day.isoformat()}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _pending_block(title: str, *, status: str = "pending") -> str:
+    return (
+        f"## [14:32] - {title}\n\n"
+        "**What happened:** A check continued after a failed command.\n"
+        "**Why it matters:** The next session repeated the same miss.\n"
+        "**Suggested fix:** Add a numbered verification step to the skill.\n"
+        f"**Status:** {status}\n\n"
+        "---\n"
+    )
+
+
+def _onboard(vault: Path) -> None:
+    marker = vault / "System" / ".onboarding-complete"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{}\n", encoding="utf-8")
+
+
+def test_missing_directory_is_empty_and_silent(tmp_path: Path) -> None:
+    stats = sl.install_prompt_stats(tmp_path, today=TODAY)
+    assert stats.pending_count == 0
+    assert stats.should_prompt_install is False
+
+
+def test_skips_readme_and_session_end_markers_without_status(tmp_path: Path) -> None:
+    _onboard(tmp_path)
+    directory = tmp_path / "System" / "Session_Learnings"
+    directory.mkdir(parents=True)
+    (directory / "README.md").write_text("# Session Learnings\n", encoding="utf-8")
+    (directory / "2026-08-01.md").write_text(
+        "# Session Learnings - 2026-08-01\n\n"
+        "## 09:00 - Session completed\n\n"
+        "**Session ended**\n"
+        "**Transcript:** `/tmp/example.jsonl`\n\n"
+        "_Note: Run /daily-review to extract learnings from this session._\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    entries = sl.parse_entries(tmp_path)
+    assert entries == []
+    assert sl.install_prompt_stats(tmp_path, today=TODAY).pending_count == 0
+
+
+def test_parses_pending_implemented_and_dropped_without_deleting(tmp_path: Path) -> None:
+    _onboard(tmp_path)
+    _write_learning(
+        tmp_path,
+        date(2026, 6, 1),
+        _pending_block("Guard failed open")
+        + _pending_block(
+            "Already routed",
+            status="implemented (2026-07-01 — CLAUDE.md user-extensions)",
+        )
+        + _pending_block(
+            "Wrong diagnosis",
+            status="dropped (2026-07-02 — already covered by the verification rule)",
+        )
+        + _pending_block("Legacy close", status="won't-fix"),
+    )
+
+    entries = sl.parse_entries(tmp_path)
+    statuses = {entry.title: entry.status for entry in entries}
+    assert statuses["Guard failed open"] == "pending"
+    assert statuses["Already routed"] == "implemented"
+    assert statuses["Wrong diagnosis"] == "dropped"
+    assert statuses["Legacy close"] == "won't-fix"
+    pending = sl.pending_entries(entries)
+    assert [entry.title for entry in pending] == ["Guard failed open"]
+
+
+def test_new_vault_volume_without_age_floor_stays_silent(tmp_path: Path) -> None:
+    _onboard(tmp_path)
+    for offset in range(sl.MIN_PENDING_COUNT):
+        day = TODAY - timedelta(days=offset)
+        _write_learning(tmp_path, day, _pending_block(f"Fresh miss {offset}"))
+
+    stats = sl.install_prompt_stats(tmp_path, today=TODAY)
+    assert stats.pending_count == sl.MIN_PENDING_COUNT
+    assert stats.oldest_age_days == sl.MIN_PENDING_COUNT - 1
+    assert stats.should_prompt_install is False
+
+
+def test_old_but_small_pile_stays_silent(tmp_path: Path) -> None:
+    _onboard(tmp_path)
+    oldest = TODAY - timedelta(days=70)
+    _write_learning(tmp_path, oldest, _pending_block("Ten-week-old miss"))
+    _write_learning(
+        tmp_path,
+        oldest + timedelta(days=1),
+        _pending_block("Related miss"),
+    )
+
+    stats = sl.install_prompt_stats(tmp_path, today=TODAY)
+    assert stats.pending_count == 2
+    assert stats.oldest_age_days == 70
+    assert stats.should_prompt_install is False
+
+
+def test_volume_and_age_floor_together_prompt_install(tmp_path: Path) -> None:
+    _onboard(tmp_path)
+    oldest = TODAY - timedelta(days=70)
+    for offset in range(sl.MIN_PENDING_COUNT):
+        day = oldest + timedelta(days=offset)
+        _write_learning(tmp_path, day, _pending_block(f"Clustered miss {offset}"))
+
+    stats = sl.install_prompt_stats(tmp_path, today=TODAY)
+    assert stats.pending_count == sl.MIN_PENDING_COUNT
+    assert stats.oldest_pending_date == oldest.isoformat()
+    assert stats.oldest_age_days == 70
+    assert stats.should_prompt_install is True
+
+
+def test_unonboarded_vault_never_prompts_even_with_a_large_pile(tmp_path: Path) -> None:
+    oldest = TODAY - timedelta(days=70)
+    for offset in range(sl.MIN_PENDING_COUNT):
+        _write_learning(
+            tmp_path,
+            oldest + timedelta(days=offset),
+            _pending_block(f"Pre-setup miss {offset}"),
+        )
+
+    stats = sl.install_prompt_stats(tmp_path, today=TODAY)
+    assert stats.should_prompt_install is False
+    assert stats.pending_count == 0
+
+
+def test_render_status_records_where_or_why() -> None:
+    assert (
+        sl.render_status("implemented", TODAY, "CLAUDE.md user-extensions")
+        == "implemented (2026-08-13 — CLAUDE.md user-extensions)"
+    )
+    assert (
+        sl.render_status("dropped", TODAY, "already covered by the verification rule")
+        == "dropped (2026-08-13 — already covered by the verification rule)"
+    )
+
+
+@pytest.mark.parametrize("kind", ["pending", "archived", ""])
+def test_render_status_rejects_silent_count_drops(kind: str) -> None:
+    with pytest.raises(ValueError):
+        sl.render_status(kind, TODAY, "nowhere")
+
+
+def test_routing_doc_documents_the_shipped_defaults() -> None:
+    root = Path(__file__).resolve().parents[2]
+    routing = root / sl.ROUTING_DOC_RELATIVE
+    text = routing.read_text(encoding="utf-8")
+    assert f"{sl.MIN_PENDING_COUNT} pending" in text
+    assert f"{sl.MIN_OLDEST_AGE_DAYS} days" in text
+    assert "**Status:** implemented (YYYY-MM-DD —" in text
+    assert "**Status:** dropped (YYYY-MM-DD —" in text
+    assert "Do not fabricate" in text or "do not fabricate" in text
+    assert "Do not delete" in text or "do not delete" in text or "Never delete" in text

--- a/core/utils/session_learnings.py
+++ b/core/utils/session_learnings.py
@@ -1,0 +1,204 @@
+"""Pending session-learning detection and the install-threshold policy.
+
+Capture stays elsewhere (`/daily-review`, session-end). This module only
+answers: which entries are still pending, and has the unused pile crossed
+the install threshold?
+
+Shipped defaults (documented in `.claude/reference/session-learnings-routing.md`):
+
+- Volume: at least ``MIN_PENDING_COUNT`` pending entries.
+- Age floor: the oldest pending entry is at least ``MIN_OLDEST_AGE_DAYS`` days
+  old. Empty and new vaults stay silent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+MIN_PENDING_COUNT = 8
+MIN_OLDEST_AGE_DAYS = 14
+ROUTING_DOC_RELATIVE = ".claude/reference/session-learnings-routing.md"
+ONBOARDING_MARKER = Path("System") / ".onboarding-complete"
+LEARNINGS_DIR = Path("System") / "Session_Learnings"
+
+STATUS_PENDING = "pending"
+STATUS_IMPLEMENTED = "implemented"
+STATUS_DROPPED = "dropped"
+
+_DATE_STEM = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_STATUS_LINE = re.compile(
+    r"^\*\*Status:\*\*\s*"
+    r"(pending|implemented|dropped|won't-fix|wont-fix|archived|resolved)"
+    r"(?P<detail>\s+.*)?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_HEADING = re.compile(r"^##\s+(?:\[\d{2}:\d{2}\]\s*-?\s*|\d{2}:\d{2}\s+-\s+)?(.+)$", re.MULTILINE)
+_FIELD = re.compile(
+    r"\*\*(What happened|Why it matters|Suggested fix):\*\*\s*(.+?)"
+    r"(?=\n\*\*|\n---|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class LearningEntry:
+    """One session-learning block with a status line."""
+
+    date: str
+    title: str
+    what_happened: str
+    why_it_matters: str
+    suggested_fix: str
+    status: str
+    status_detail: str
+    path: Path
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == STATUS_PENDING
+
+    def as_synthesis_dict(self) -> dict[str, str]:
+        """Shape consumed by Improvements MCP ``synthesize_learnings``."""
+        return {
+            "date": self.date,
+            "title": self.title,
+            "what_happened": self.what_happened,
+            "why_it_matters": self.why_it_matters,
+            "suggested_fix": self.suggested_fix,
+            "file": str(self.path),
+        }
+
+
+@dataclass(frozen=True)
+class BacklogStats:
+    """Install-threshold view of the pending pile. Contains no entry text."""
+
+    pending_count: int
+    oldest_pending_date: str | None
+    oldest_age_days: int | None
+    should_prompt_install: bool
+
+
+def learnings_dir(vault: Path) -> Path:
+    return vault / LEARNINGS_DIR
+
+
+def parse_entries(vault: Path) -> list[LearningEntry]:
+    """Parse dated session-learning files. Missing directories yield []."""
+    directory = learnings_dir(vault)
+    if not directory.is_dir():
+        return []
+
+    entries: list[LearningEntry] = []
+    for path in sorted(directory.glob("*.md")):
+        stem = path.stem
+        if not _DATE_STEM.fullmatch(stem):
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for block in re.split(r"\n---\n", content):
+            entry = _parse_block(path, stem, block)
+            if entry is not None:
+                entries.append(entry)
+    return entries
+
+
+def pending_entries(
+    entries: list[LearningEntry], *, since_date: str | None = None
+) -> list[LearningEntry]:
+    pending = [entry for entry in entries if entry.is_pending]
+    if since_date:
+        pending = [entry for entry in pending if entry.date >= since_date]
+    return pending
+
+
+def backlog_stats(
+    entries: list[LearningEntry],
+    *,
+    today: date | None = None,
+    onboarded: bool = True,
+) -> BacklogStats:
+    """Compute the install prompt from already-parsed entries."""
+    if not onboarded:
+        return BacklogStats(0, None, None, False)
+
+    pending = pending_entries(entries)
+    if not pending:
+        return BacklogStats(0, None, None, False)
+
+    today = today or date.today()
+    oldest = min(pending, key=lambda entry: entry.date)
+    oldest_day = _parse_iso_date(oldest.date)
+    if oldest_day is None:
+        return BacklogStats(len(pending), oldest.date, None, False)
+
+    age_days = (today - oldest_day).days
+    should_prompt = (
+        len(pending) >= MIN_PENDING_COUNT and age_days >= MIN_OLDEST_AGE_DAYS
+    )
+    return BacklogStats(len(pending), oldest.date, age_days, should_prompt)
+
+
+def install_prompt_stats(vault: Path, *, today: date | None = None) -> BacklogStats:
+    """Full vault check used by the Stop hook. Silent before onboarding."""
+    onboarded = (vault / ONBOARDING_MARKER).is_file()
+    if not onboarded:
+        return BacklogStats(0, None, None, False)
+    return backlog_stats(parse_entries(vault), today=today, onboarded=True)
+
+
+def render_status(kind: str, when: date, detail: str) -> str:
+    """Lock the status line the skill writes after a routing decision."""
+    normalized = kind.strip().casefold()
+    if normalized not in {STATUS_IMPLEMENTED, STATUS_DROPPED}:
+        raise ValueError("status kind must be implemented or dropped")
+    cleaned = " ".join(detail.split())
+    if not cleaned:
+        raise ValueError("status detail is required")
+    return f"{normalized} ({when.isoformat()} — {cleaned})"
+
+
+def _parse_block(path: Path, file_date: str, block: str) -> LearningEntry | None:
+    status_match = _STATUS_LINE.search(block)
+    if status_match is None:
+        return None
+
+    status = status_match.group(1).casefold()
+    if status in {"won't-fix", "wont-fix", "archived", "resolved"}:
+        # Legacy terminal labels: not pending, not rewritten here.
+        pass
+    detail = (status_match.group("detail") or "").strip()
+
+    heading = _HEADING.search(block)
+    if heading is None:
+        return None
+    title = heading.group(1).strip()
+    if not title:
+        return None
+
+    fields = {
+        match.group(1).casefold(): match.group(2).strip()
+        for match in _FIELD.finditer(block)
+    }
+    return LearningEntry(
+        date=file_date,
+        title=title,
+        what_happened=fields.get("what happened", ""),
+        why_it_matters=fields.get("why it matters", ""),
+        suggested_fix=fields.get("suggested fix", ""),
+        status=status,
+        status_detail=detail,
+        path=path,
+    )
+
+
+def _parse_iso_date(value: str) -> date | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None

--- a/docs/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/docs/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -130,6 +130,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 | `/week` command | Weekly pattern recognition and planning |
 | Background changelog monitor | Checks every 6 hours for Claude updates, alerts you automatically |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
+| `/install-learnings` | Routes unused session learnings into the file that changes next time, or drops them with a reason |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
 | `Working_Preferences.md` | Collaboration style captured and applied consistently |
 | Session learnings capture | Automatic logging in `System/Session_Learnings/` |
@@ -140,7 +141,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 
 During the week, you mentioned "I prefer summaries in bullet points." Dex captured this in Session_Learnings and now asks: "You've mentioned this preference 3 times. Add to Working_Preferences.md so all future summaries use bullets?"
 
-**Why automation matters**: Next week, when you start a session at 5pm, Dex notices: "📚 You have 7 pending learnings from this week" and prompts a review. You also see: "🆕 New Claude Code features detected!" because background monitoring found updates. The system improves itself quietly.
+**Why automation matters**: Next week, when you start a session at 5pm, Dex notices: "📚 You have 7 pending learnings from this week" and prompts a review. If those notes have sat unused long enough, session end asks for `/install-learnings` so they actually change next time. You also see: "🆕 New Claude Code features detected!" because background monitoring found updates. The system improves itself quietly.
 
 ---
 

--- a/docs/Dex_System/Dex_System_Guide.md
+++ b/docs/Dex_System/Dex_System_Guide.md
@@ -450,6 +450,9 @@ Dex checks if Anthropic has released new Claude Code features. When it finds som
 **Learning Review Prompts (daily at 5pm)**  
 As you work, Dex captures learnings in `System/Session_Learnings/`. When you accumulate 5+ learnings that haven't been reviewed yet, Dex reminds you: "📚 You have 7 pending learnings from this week. Worth reviewing?"
 
+**Learning install (when the unused pile has grown)**  
+Reviewing is not installing. When 8 or more unused notes have sat at least 14 days, Dex asks at the end of a session for `/install-learnings`: route them into the file that changes next time, or drop them with a reason. A new vault does not get that nudge.
+
 Both happen automatically with no action from you. The system stays current on its own.
 
 ### Learning Files
@@ -479,12 +482,13 @@ Every session builds on the last. The system remembers so you don't have to.
 Without automation, learning requires discipline. You have to remember to:
 - Check for Claude updates
 - Review your learnings
+- Install the ones that should change next time
 - Update your preferences
 - Apply past lessons
 
-Most people don't. The learnings sit unused.
+Most people don't. The notes sit unused unless something routes them.
 
-With automation, Dex nudges you at the right time. The system improves itself through quiet background work, and only asks for your input when it matters.
+With automation, Dex nudges you at the right time — and when the unused pile has grown, it asks for an install pass instead of another reminder to review. The system improves itself through quiet background work, and only asks for your input when it matters.
 
 ---
 
@@ -879,6 +883,7 @@ Located in `06-Resources/Learnings/` and `System/Session_Learnings/`:
 **Automatic Prompts:**
 - Daily at 5pm, Dex checks if you have 5+ pending learnings
 - Next session start: "📚 You have 7 pending learnings from this week. Worth reviewing?"
+- When 8+ unused notes are at least 14 days old, session end asks for `/install-learnings` so they are applied or honestly dropped
 
 ### Why This Matters
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -900,6 +900,8 @@ Focus on architecture questions, not syntax nitpicks. I trust the team on detail
    - Move to appropriate file (`Mistake_Patterns.md`, `Working_Preferences.md`, or fix immediately)
    - Mark as resolved in session learnings
 
+5. **Install (separate from capture):** `/install-learnings` routes still-pending entries into the file that changes next-session behaviour, or marks them `dropped` with a reason. A Stop hook asks for this pass when there are 8 pending entries and the oldest is at least 14 days old. Routing table: `.claude/reference/session-learnings-routing.md`. Do not fabricate an edit to make the count drop. Do not delete an obsolete entry.
+
 ### Background Automation Setup
 
 Dex runs self-learning checks automatically through two mechanisms:

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 6672cd77e728d5e48d9ca33f1c8aebd1db91101c6bdf8d61707e38e71fcba74a -->
+<!-- Content SHA-256: 4d2be43c1032ae721a9b1d7f61ef19b4af427c93bfd03530befe2e0e922fc06a -->
 
 # Architecture Inventory
 
@@ -26,7 +26,7 @@ This inventory is derived only from repository code and shipped skill files.
 
 ## Skills
 
-**Skill count:** 82<br>
+**Skill count:** 83<br>
 **Discoverability-risk count:** 4
 
 A description has a trigger when its frontmatter contains the word `when` or `whenever` (case-insensitive). Length is measured in characters.
@@ -87,6 +87,7 @@ A description has a trigger when its frontmatter contains the word `when` or `wh
 | `identity-snapshot` | `.claude/skills/identity-snapshot/SKILL.md` | Generate a living profile of the user's working patterns, decision tendencies and quality preferences from their Dex data. Use when the user says 'what are my patterns', 'how do I work', or during `week-review`. Also use proactively when the model (older than 7 days) is stale. Not for planning a week; use `week-plan`. | 319 | when |
 | `industry-truths` | `.claude/skills/industry-truths/SKILL.md` | Define time-horizoned assumptions about your industry (today / 6mo / 12mo) that ground strategic thinking. Use when the user is making roadmap, positioning or investment calls, or says 'what am I assuming about the market'. Also use proactively before a big strategic recommendation. Not for capturing a single decision; use `decision-log`. | 340 | when |
 | `initiative-kickoff` | `.claude/skills/initiative-kickoff/SKILL.md` | Turn a decision to start something new — a hire, a partnership, a go-to-market push, an internal bet — into a real initiative: the outcome and why now, what success looks like, who's involved, the first concrete steps, and a project page that ladders to your pillars and goals. Use when the user says 'let's kick off X', 'I'm starting a new initiative', 'set up a project for this', or 'we've decided to do Y'. Also use proactively when the user commits to a new effort mid-conversation. Not for spec'ing a product feature or writing a PRD; use `product-brief`. Not for checking the status of projects already underway; use `project-health`. | 641 | when |
+| `install-learnings` | `.claude/skills/install-learnings/SKILL.md` | Turn unused session learnings into changes that affect the next session — or honestly drop them with a reason. Use when the user says 'install the learnings', 'apply pending learnings', 'the learnings never get used', 'session learnings are piling up', or when a session-end notice reports the unused pile crossed the install threshold. Also use proactively when `/dex-whats-new` finds pending learnings the user wants applied. Not for capturing a new learning from today's work; use `daily-review`. Not for ranking product ideas; use `dex-backlog`. | 549 | when |
 | `integrate-mcp` | `.claude/skills/integrate-mcp/SKILL.md` | Install and wire up an existing MCP server from Smithery.ai or a GitHub repo. Use when the user names a tool that already has a server — 'add the Notion MCP', 'install this Smithery server'. Not for building a new integration from nothing; use `create-mcp`. Not for adding one already-known server safely; use `dex-add-mcp`. | 324 | when |
 | `journal` | `.claude/skills/journal/SKILL.md` | Toggle journaling or start a morning/evening/weekly journal entry. Use when the user says 'journal', 'morning pages', 'evening reflection'. Also use proactively when a journaling-enabled user starts/ends the day. Not for a structured end-of-day work review; use `daily-review`. | 277 | when |
 | `manage-capabilities` | `.claude/skills/manage-capabilities/SKILL.md` | Turn optional Dex rooms/features on or off without deleting any content. Use when the user says 'turn off X', 'enable the career room', 'hide a feature I don't use'. Not for diagnosing breakage; use `dex-doctor`. Not for a full role restructure; use `reset`. | 258 | when |
@@ -122,12 +123,12 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 | Server | Referencing skill count | Surface status | Skills (referenced tools) |
 | --- | ---: | --- | --- |
-| `dex-analytics` | 28 | **over-surfaced** | `commitments` (`track_event`); `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-closeout` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `relationship-radar` (`track_event`); `reset` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
+| `dex-analytics` | 29 | **over-surfaced** | `commitments` (`track_event`); `create-mcp` (`track_event`); `create-skill` (`track_event`); `daily-plan` (`track_event`); `daily-review` (`track_event`); `dex-add-mcp` (`track_event`); `dex-backlog` (`track_event`); `dex-improve` (`track_event`); `dex-level-up` (`track_event`); `dex-obsidian-setup` (`track_event`); `dex-whats-new` (`track_event`); `getting-started` (`track_event`); `initiative-kickoff` (`track_event`); `install-learnings` (`track_event`); `integrate-mcp` (`track_event`); `journal` (`track_event`); `meeting-closeout` (`track_event`); `meeting-prep` (`track_event`); `process-meetings` (`track_event`); `product-brief` (`track_event`); `project-health` (`track_event`); `prompt-improver` (`track_event`); `relationship-radar` (`track_event`); `reset` (`track_event`); `save-insight` (`track_event`); `triage` (`track_event`); `week-plan` (`track_event`); `week-review` (`track_event`); `xray` (`track_event`) |
 | `dex-calendar-mcp` | 6 | normal | `daily-plan` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_complete_item`, `reminders_create_item`, `reminders_ensure_lists`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `daily-review` (`calendar_get_events_with_attendees`, `calendar_get_today`, `reminders_clear_completed`, `reminders_find_and_complete`, `reminders_list_completed`, `reminders_list_items`); `meeting-prep` (`calendar_get_events_with_attendees`); `process-meetings` (`calendar_get_events_with_attendees`); `week-plan` (`calendar_get_events_with_attendees`); `week-review` (`calendar_get_events_with_attendees`, `reminders_list_items`) |
 | `dex-career-mcp` | 0 | **under-surfaced** | — |
 | `dex-customization-migration-mcp` | 1 | normal | `dex-update` (`read_customization_capsule_blob`, `read_customization_capsule_section`) |
 | `dex-granola-mcp` | 4 | normal | `daily-plan` (`granola_get_recent_meetings`); `getting-started` (`granola_check_available`, `granola_get_recent_meetings`); `week-plan` (`granola_get_today_meetings`); `zoom-setup` (`granola_check_available`) |
-| `dex-improvements-mcp` | 7 | normal | `daily-plan` (`list_ideas`, `synthesize_changelog`, `synthesize_learnings`); `daily-review` (`list_ideas`); `dex-backlog` (`capture_idea`, `mark_implemented`); `dex-doctor` (`capture_idea`); `dex-level-up` (`capture_idea`); `dex-whats-new` (`synthesize_changelog`, `synthesize_learnings`); `week-review` (`list_ideas`) |
+| `dex-improvements-mcp` | 8 | normal | `daily-plan` (`list_ideas`, `synthesize_changelog`, `synthesize_learnings`); `daily-review` (`list_ideas`); `dex-backlog` (`capture_idea`, `mark_implemented`); `dex-doctor` (`capture_idea`); `dex-level-up` (`capture_idea`); `dex-whats-new` (`synthesize_changelog`, `synthesize_learnings`); `install-learnings` (`capture_idea`); `week-review` (`list_ideas`) |
 | `dex-onboarding-mcp` | 3 | normal | `getting-started` (`check_onboarding_complete`); `reset` (`finalize_onboarding`, `start_onboarding_session`); `setup` (`start_onboarding_session`) |
 | `dex-pipedrive-mcp` | 2 | normal | `pipedrive-setup` (`pipedrive_list_stages`, `pipedrive_list_users`, `pipedrive_status`); `pipeline-sync` (`pipedrive_add_deal_activity`, `pipedrive_add_deal_note`, `pipedrive_create_deal`, `pipedrive_create_org`, `pipedrive_find_deal`, `pipedrive_find_org`, `pipedrive_get_deal`, `pipedrive_get_mapping`, `pipedrive_get_pipeline_snapshot`, `pipedrive_list_deals`, `pipedrive_save_mapping`, `pipedrive_status`, `pipedrive_update_deal`) |
 | `dex-resume-mcp` | 0 | **under-surfaced** | — |
@@ -142,7 +143,7 @@ References are exact tool-name matches in skill bodies (frontmatter excluded). U
 
 ### Over-surfaced servers
 
-- `dex-analytics` — 28 skills reference its tools.
+- `dex-analytics` — 29 skills reference its tools.
 - `dex-work-mcp` — 12 skills reference its tools.
 
 ## Portable ownership classes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #503.

## Problem

Dex already captures session learnings into `System/Session_Learnings/` with `**Status:** pending`. Capture (`/daily-review`, session-end, the daily review reminder) works. Nothing then routes those notes into a file that changes next-session behaviour, so they accumulate as an archive. The reporter reached 87 pending entries, oldest ten weeks.

## What this does

Keeps **capture and apply as separate concerns**.

- **Capture** is unchanged: `/daily-review` still writes `pending`.
- **Apply** is new: `/install-learnings` clusters related pending entries and routes them using a documented table, then records `implemented (YYYY-MM-DD — where)` or `dropped (YYYY-MM-DD — reason)`.
- A **Stop hook** asks for that pass once per day when **both** are true: 8+ pending entries **and** the oldest is at least 14 days old. Empty and new vaults stay silent.
- The hook never writes a learning, never dumps entry text, and fail-opens.

## Defaults for the open questions in #503

| Question | Default |
|---|---|
| Trigger | Volume **with** an age floor (8 pending **and** oldest ≥ 14 days). Not volume-only, so a busy first week does not fire. |
| One hook or two? | Separate. Capture stays in `/daily-review` / session-end. Apply is this Stop hook + skill. |
| Keep `dropped`? | Yes. Third state for wrong, obsolete, or already-covered notes. No silent deletes. |
| Where the routing table lives | `.claude/reference/session-learnings-routing.md` — the hook and skill point at it so destinations can be edited without hook code. |

Josh’s second Stop hook is adopted in Dex-native shape: fail-open, once-per-day dedup, `stop_hook_active` loop guard, counts-only (no vault content in the prompt).

## What this does not do

Does not expand into #504, #505, or #506. Does not soften the README self-improvement claim as a substitute for the install path.

## Tests

- Parser and threshold (`core/tests/test_session_learnings.py`)
- Stop hook fail-open, dedup, no PII leak, no learning writes (`core/tests/test_install_learnings_hook.py`)
- Skill contract, evals, capture/apply split (`core/tests/test_install_learnings_skill.py`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cdd2bdf-6c4c-479b-8383-6e214f0eebed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cdd2bdf-6c4c-479b-8383-6e214f0eebed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

