### PR TITLE
Back up Claude Code project memory into the vault

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -26,6 +26,7 @@ These commands are wired in `.claude/settings.json` and run independently of any
 | `PreToolUse` | `Bash` | `node .claude/hooks/ensure-mcp-user-scope.cjs` | Require an explicit scope for `claude mcp add`. |
 | `PreToolUse` | `mcp__.*` | `bash .claude/hooks/dex-safety-guard.sh` | Apply the MCP safety rules before MCP calls. |
 | `SessionEnd` | all | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/session-end.sh "$transcript_path"` | Record the session-end marker and transcript reference. |
+| `SessionEnd` | all | `python3 "$CLAUDE_PROJECT_DIR/core/utils/memory_mirror.py" --vault "$CLAUDE_PROJECT_DIR"` | Copy Claude Code's per-project memory into `System/memory-mirror/` so it rides vault history and backups. |
 | `SessionEnd` | all | `node "$CLAUDE_PROJECT_DIR"/.claude/hooks/vault-autocommit.cjs` | Safely checkpoint eligible vault changes when no mutation is active. |
 
 Settings also uses the macOS system ping for `Stop` and permission/elicitation `Notification` events. Those entries do not invoke repository hook files.

--- a/.claude/hooks/tests/vault-autocommit.test.cjs
+++ b/.claude/hooks/tests/vault-autocommit.test.cjs
@@ -77,6 +77,15 @@ test('enabled hook commits only contract-owned vault and seed changes locally', 
   fs.writeFileSync(path.join(root, 'core', 'brain.py'), 'BRAIN = true\n');
   fs.mkdirSync(path.join(root, 'System', '.dex'), { recursive: true });
   fs.writeFileSync(path.join(root, 'System', '.dex', 'runtime.json'), '{}\n');
+  fs.mkdirSync(path.join(root, 'System', 'memory-mirror'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'System', 'memory-mirror', '_MANIFEST.md'),
+    '# fixture mirror record\n',
+  );
+  fs.writeFileSync(
+    path.join(root, 'System', 'memory-mirror', 'MEMORY.md'),
+    '# fixture project memory\n',
+  );
 
   const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
 
@@ -85,6 +94,8 @@ test('enabled hook commits only contract-owned vault and seed changes locally', 
   assert.equal(git(root, 'log', '-1', '--format=%s'), 'Dex vault 2026-07-13');
   assert.equal(git(root, 'show', 'HEAD:04-Projects/private.md'), 'private note');
   assert.equal(git(root, 'show', 'HEAD:03-Tasks/Tasks.md'), '# edited seed');
+  assert.equal(git(root, 'show', 'HEAD:System/memory-mirror/MEMORY.md'), '# fixture project memory');
+  assert.equal(git(root, 'show', 'HEAD:System/memory-mirror/_MANIFEST.md'), '# fixture mirror record');
   for (const relative of ['note.md', 'core/brain.py', 'System/.dex/runtime.json']) {
     assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
   }
@@ -255,7 +266,8 @@ test('settings wires the opt-in hook after session-end and the shipped profile d
   const settings = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, '.claude', 'settings.json'), 'utf8'));
   const commands = settings.hooks.SessionEnd[0].hooks.map((entry) => entry.command);
   assert.match(commands[0], /session-end\.sh/);
-  assert.match(commands[1], /vault-autocommit\.cjs/);
+  assert.match(commands[1], /memory_mirror\.py/);
+  assert.match(commands[2], /vault-autocommit\.cjs/);
   const profile = fs.readFileSync(path.join(REPO_ROOT, 'System', 'user-profile-template.yaml'), 'utf8');
   assert.match(profile, /^vault:\n  auto_commit: false$/m);
 });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,6 +111,10 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/core/utils/memory_mirror.py\" --vault \"$CLAUDE_PROJECT_DIR\""
+          },
+          {
+            "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/vault-autocommit.cjs"
           }
         ]

--- a/06-Resources/Dex_System/Folder_Structure.md
+++ b/06-Resources/Dex_System/Folder_Structure.md
@@ -223,6 +223,7 @@ Aim to triage weekly. If something sits 30+ days:
 System/
 ├── Templates/                # Note templates (5 core templates)
 ├── Session_Learnings/        # Auto-captured improvements during /review
+├── memory-mirror/            # Copy of Claude Code's per-project memory
 ├── pillars.yaml              # Strategic pillars (your main focus areas)
 ├── user-profile.yaml         # User preferences and settings
 ├── claude-code-state.json    # Tracks last changelog check

--- a/06-Resources/Dex_System/Memory_Ownership.md
+++ b/06-Resources/Dex_System/Memory_Ownership.md
@@ -6,6 +6,18 @@
 **How it works:** Automatically captured by Claude. Persists across all sessions and harnesses.
 **Dex action:** Don't duplicate. Don't capture preferences in learning-heartbeat.
 
+Per-project auto-memory lives outside the vault, at Claude Code's
+`~/.claude/projects/<encoded>/memory/` folder. Dex copies that folder into
+`System/memory-mirror/` at the end of a Claude Code session so it rides the
+vault's history and backups. Deletions in the live folder are mirrored; git
+history is the recovery path. A dated `_MANIFEST.md` in the copy is how a
+stopped copy becomes visible, and `/dex-doctor` flags a missing or stale copy.
+
+User-level memory — `~/.claude/CLAUDE.md` and anything else that applies to
+every project on the machine — is not copied into this vault. Dumping it here
+would mix global personal context into a tree that can be shared or backed up
+with this vault alone.
+
 ## Agent Memory (frontmatter, `memory: project`)
 **Owns:** Per-agent operational state across sessions
 **Examples:** "deal-attention flagged Acme Corp 3 times", "cracks-detector: pricing follow-up resolved"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.97.0] — 🧠 Claude's project notes now live in your vault (2026-08-13)
+
+Claude Code keeps a private notes folder outside Dex — every correction and local convention it has learned about your work. That folder was never saved with your vault. If it disappeared, nothing would error; sessions would just get quietly worse.
+
+**What this fixes for you:**
+
+* **Those notes are copied into your vault at the end of a Claude Code session.** They sit under System, with your other machine state, not in a folder you might share. Your existing vault history and backups cover them.
+* **If the copy stops, Dex can tell you.** A dated record in the vault is how you notice, and a checkup flags a missing or old copy instead of failing silently.
+* **A sudden wipe is not copied over.** If the live notes folder shrinks sharply, Dex leaves the vault copy alone so earlier files remain the recovery path.
+* **Notes that apply to every project on your machine stay out of this vault.** Only this project's learned notes are copied.
+
+Thanks to Josh, who found the gap and prototyped the copy.
+
 ## [1.96.2] — 🛡️ Your history saves again, and company networks get an honest answer (2026-08-13)
 
 If you're on a corporate network that intercepts secure connections — Zscaler, Netskope, most large enterprises — or on a hotel or airport captive portal, Dex's daily update check could fail and report that the release evidence was **invalid**. That wording means something specific and alarming: that the version of Dex being offered looks tampered with. It was never true. What had actually happened is that Dex couldn't verify it was really talking to GitHub, because something on your network was sitting in the middle of the connection. Worse, Dex treated it as a permanent verdict and didn't try again, so the check stayed broken for exactly the people most likely to hit it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ Read these files when users ask about system details, features, or setup.
 Other capability surfaces to know about (read on demand, don't preload):
 - **Hooks** — automatic behaviors (session context, person/company context injection,
   safety guards, release awareness, the mid-session health pulse, session-end
-  autocommit) are wired in `.claude/settings.json`; `.claude/hooks/README.md`
-  documents them.
+  project-memory backup, session-end autocommit) are wired in `.claude/settings.json`;
+  `.claude/hooks/README.md` documents them.
 - **Optional capability rooms** — role-specific skill packs live in
   `.claude/skills/_available/` and are switched on via `/manage-capabilities`
   (registry: `core/capabilities.py`). If a user asks for sales/product/marketing/

--- a/System/README.md
+++ b/System/README.md
@@ -17,6 +17,7 @@ Configuration and system files for Dex.
 
 - **Templates/** — Note templates for consistent formatting
 - **Session_Learnings/** — Daily learning capture from `/daily-review` sessions
+- **memory-mirror/** — Copy of this vault's Claude Code per-project memory (created automatically; do not edit)
 
 ## What to Edit
 
@@ -29,6 +30,7 @@ Configuration and system files for Dex.
 - usage_log.md — Auto-updated by system
 - .last-learning-check — Auto-updated by learning prompt system
 - claude-code-state.json — Auto-updated by changelog monitoring
+- memory-mirror/ — Auto-copied from Claude Code at session end
 
 ## Key Concepts
 

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -328,6 +328,14 @@ RULES: tuple[Rule, ...] = (
     # ownership — these rules give denied paths their owner).
     _r("vault-env", ".env", "file", "vault", "raw secret authority (SR1 #150 model)"),
     _r("vault-credentials", "System/credentials", "dir", "vault", "secrets; hard-denied"),
+    _r(
+        "vault-memory-mirror",
+        "System/memory-mirror",
+        "dir",
+        "vault",
+        "user-owned Claude Code per-project memory copy; machine state under "
+        "System/, never a shared PARA folder; updates never write it",
+    ),
     _r("vault-mcp-json", ".mcp.json", "file", "vault",
        "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
        "mcp-registration lifecycle transaction and the sole bridge-only "

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -41,6 +41,7 @@ QUICK_IDS = [
     "brain.git",
     "topology.pre-split-archive",
     "vault.auto-commit",
+    "memory.mirror",
     "topology.migration-pending",
     "release.catalog",
     "adoption.plan",

--- a/core/tests/test_health_reporter.py
+++ b/core/tests/test_health_reporter.py
@@ -45,11 +45,11 @@ def test_doctor_report_is_normalized_across_the_complete_registry():
     assert envelope.contract == "dex.health.reporter/v1"
     assert envelope.reporter == DOCTOR_REPORTER_IDENTITY
     assert envelope.refresh_id == "refresh-001"
-    # 36: Apple Mail search joined the Pipedrive CRM and backup freshness deep
-    # checks. This literal is a deliberate tripwire, and parallel branches can
-    # each bump it to the same stale value while merging cleanly — so it is set
-    # from the complete registry's measured size, not from either branch's guess.
-    assert len(envelope.results) == 36
+    # 37: Claude project memory backup joined the quick registry. This literal
+    # is a deliberate tripwire, and parallel branches can each bump it to the
+    # same stale value while merging cleanly — so it is set from the complete
+    # registry's measured size, not from either branch's guess.
+    assert len(envelope.results) == 37
     assert [result.id for result in envelope.results] == [
         f"doctor.core/{definition.id}"
         for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)

--- a/core/tests/test_memory_mirror.py
+++ b/core/tests/test_memory_mirror.py
@@ -1,0 +1,361 @@
+"""Copy Claude Code per-project memory into the vault without leaking personal data."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core.utils import doctor, memory_mirror
+
+NOW = datetime(2026, 8, 13, 15, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_config_dir(monkeypatch) -> None:
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
+def _vault(tmp_path: Path) -> tuple[Path, Path]:
+    vault = tmp_path / "fixture_vault"
+    home = tmp_path / "home"
+    vault.mkdir()
+    home.mkdir()
+    (vault / "System").mkdir()
+    return vault, home
+
+
+def _write_source(home: Path, encoded: str, files: dict[str, str]) -> Path:
+    memory_dir = home / ".claude" / "projects" / encoded / "memory"
+    memory_dir.mkdir(parents=True)
+    for name, content in files.items():
+        target = memory_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return memory_dir
+
+
+def _dest_text(vault: Path, relative: str) -> str:
+    return (vault / "System" / "memory-mirror" / relative).read_text(encoding="utf-8")
+
+
+def test_encoding_replaces_separators_and_non_alnum() -> None:
+    root = Path("/tmp/fixture_vault")
+    assert memory_mirror.encode_separators(root) == "-tmp-fixture_vault"
+    assert memory_mirror.encode_non_alnum(root) == "-tmp-fixture-vault"
+
+
+def test_manifest_round_trip_parses_the_dated_record() -> None:
+    text = memory_mirror.render_manifest(
+        mirrored_at=NOW,
+        file_count=3,
+        copied=("MEMORY.md",),
+        removed=("old.md",),
+        unchanged=1,
+        source_method="derived",
+    )
+    parsed = memory_mirror.parse_manifest(text)
+    assert parsed is not None
+    assert parsed.file_count == 3
+    assert parsed.mirrored_at == NOW
+
+
+def test_derived_source_is_preferred_when_memory_entrypoint_exists(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n", "topic-one.md": "alpha\n"})
+
+    resolution = memory_mirror.resolve_source(vault, home)
+
+    assert resolution.status == memory_mirror.STATUS_FOUND
+    assert resolution.method == "derived"
+    assert resolution.path is not None
+    assert resolution.path.name == "memory"
+
+
+def test_fallback_finds_memory_when_non_alnum_encoding_is_the_live_folder(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_non_alnum(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+
+    resolution = memory_mirror.resolve_source(vault, home)
+
+    assert resolution.status == memory_mirror.STATUS_FOUND
+    assert resolution.method in {"derived", "fallback"}
+    assert (resolution.path / "MEMORY.md").is_file()
+
+
+def test_empty_encoded_folder_without_entrypoint_fails_loudly(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    empty = home / ".claude" / "projects" / encoded / "memory"
+    empty.mkdir(parents=True)
+
+    resolution = memory_mirror.resolve_source(vault, home)
+
+    assert resolution.status == memory_mirror.STATUS_EMPTY_ENCODED
+    assert "MEMORY.md" in resolution.detail
+
+
+def test_user_level_memory_is_never_selected_as_the_source(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    user_memory = home / ".claude" / "memory"
+    user_memory.mkdir(parents=True)
+    (home / ".claude" / "CLAUDE.md").write_text("# user-level instructions\n", encoding="utf-8")
+    (user_memory / "MEMORY.md").write_text("# user-level memory\n", encoding="utf-8")
+
+    resolution = memory_mirror.resolve_source(vault, home)
+
+    assert resolution.status == memory_mirror.STATUS_MISSING
+    assert resolution.path is None
+
+
+def test_successful_copy_does_not_import_user_level_files(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "CLAUDE.md").write_text("# user-level instructions\n", encoding="utf-8")
+    user_memory = home / ".claude" / "memory"
+    user_memory.mkdir(exist_ok=True)
+    (user_memory / "MEMORY.md").write_text("# user-level memory\n", encoding="utf-8")
+
+    outcome = memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+
+    assert outcome.action == memory_mirror.ACTION_MIRRORED
+    names = {path.name for path in (vault / "System" / "memory-mirror").iterdir()}
+    assert names == {"MEMORY.md", "_MANIFEST.md"}
+    assert _dest_text(vault, "MEMORY.md") == "# fixture index\n"
+    manifest_text = (vault / "System" / "memory-mirror" / "_MANIFEST.md").read_text(encoding="utf-8")
+    assert "# user-level" not in _dest_text(vault, "MEMORY.md")
+    assert "# user-level" not in manifest_text
+
+
+def test_ambiguous_fallback_refuses_rather_than_guessing(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    projects = home / ".claude" / "projects"
+    first = memory_mirror.encode_separators(vault.resolve())
+    second = first + "-extra"
+    for name in (first, second):
+        memory_dir = projects / name / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("# fixture index\n", encoding="utf-8")
+    # Make the extra dir also match the normalized wanted set by using the
+    # non-alnum encoding as a second live folder when it differs.
+    alt = memory_mirror.encode_non_alnum(vault.resolve())
+    if alt != first:
+        memory_dir = projects / alt / "memory"
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        (memory_dir / "MEMORY.md").write_text("# fixture index\n", encoding="utf-8")
+
+    resolution = memory_mirror.resolve_source(vault, home)
+
+    assert resolution.status in {
+        memory_mirror.STATUS_AMBIGUOUS,
+        memory_mirror.STATUS_FOUND,
+    }
+    if resolution.status == memory_mirror.STATUS_FOUND:
+        assert resolution.path is not None
+        assert resolution.path.parent.name in {first, alt}
+
+
+def test_mutation_lock_skips_without_writing(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    lock = vault / "System" / ".dex" / "mutation.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("{}\n", encoding="utf-8")
+
+    outcome = memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+
+    assert outcome.action == memory_mirror.ACTION_SKIPPED
+    assert not (vault / "System" / "memory-mirror").exists()
+
+
+def test_mirror_copies_files_writes_manifest_and_is_idempotent(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(
+        home,
+        encoded,
+        {"MEMORY.md": "# fixture index\n", "topic-one.md": "alpha\n"},
+    )
+
+    first = memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+    second = memory_mirror.mirror(
+        vault_root=vault, home=home, now=NOW + timedelta(minutes=5)
+    )
+
+    assert first.action == memory_mirror.ACTION_MIRRORED
+    assert first.wrote is True
+    assert set(first.copied) == {"MEMORY.md", "topic-one.md"}
+    assert _dest_text(vault, "topic-one.md") == "alpha\n"
+    manifest = memory_mirror.read_manifest(vault)
+    assert manifest is not None
+    assert manifest.file_count == 2
+    assert second.action == memory_mirror.ACTION_NOOP
+    assert second.copied == ()
+    assert second.removed == ()
+    assert "2026-08-13T15:05:00+00:00" in memory_mirror.manifest_path(vault).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_mirror_deletes_files_removed_from_the_source(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    source = _write_source(
+        home,
+        encoded,
+        {"MEMORY.md": "# fixture index\n", "topic-one.md": "alpha\n", "topic-two.md": "beta\n"},
+    )
+    memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+    (source / "topic-two.md").unlink()
+
+    outcome = memory_mirror.mirror(
+        vault_root=vault, home=home, now=NOW + timedelta(minutes=1)
+    )
+
+    assert outcome.removed == ("topic-two.md",)
+    assert not (vault / "System" / "memory-mirror" / "topic-two.md").exists()
+    assert _dest_text(vault, "topic-one.md") == "alpha\n"
+
+
+def test_drop_guard_refuses_to_propagate_a_wipe(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    files = {f"topic-{index}.md": f"note {index}\n" for index in range(8)}
+    files["MEMORY.md"] = "# fixture index\n"
+    source = _write_source(home, encoded, files)
+    memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+    for path in source.iterdir():
+        if path.name != "MEMORY.md":
+            path.unlink()
+
+    outcome = memory_mirror.mirror(
+        vault_root=vault, home=home, now=NOW + timedelta(minutes=1)
+    )
+
+    assert outcome.action == memory_mirror.ACTION_REFUSED
+    assert outcome.wrote is False
+    assert (vault / "System" / "memory-mirror" / "topic-0.md").is_file()
+    assert memory_mirror.read_manifest(vault).mirrored_at == NOW
+
+
+def test_dry_run_reports_and_writes_nothing(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n", "topic-one.md": "alpha\n"})
+
+    outcome = memory_mirror.mirror(vault_root=vault, home=home, now=NOW, dry_run=True)
+
+    assert outcome.action == memory_mirror.ACTION_DRY_RUN
+    assert "would copy" in outcome.detail.lower() or "Dry run" in outcome.detail
+    assert not (vault / "System" / "memory-mirror").exists()
+
+
+def test_cli_dry_run_env_writes_nothing(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    env = {
+        **os.environ,
+        memory_mirror.DRY_RUN_ENV: "1",
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(vault),
+    }
+
+    exit_code = memory_mirror.main(["--vault", str(vault), "--home", str(home)], env=env)
+
+    assert exit_code == 0
+    assert not (vault / "System" / "memory-mirror").exists()
+
+
+def test_cli_refuses_empty_encoded_source(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    (home / ".claude" / "projects" / encoded / "memory").mkdir(parents=True)
+
+    exit_code = memory_mirror.main(
+        ["--vault", str(vault), "--home", str(home)],
+        env={**os.environ, "HOME": str(home)},
+    )
+
+    assert exit_code == 1
+    assert not (vault / "System" / "memory-mirror").exists()
+
+
+def test_doctor_is_off_when_there_is_nothing_to_copy(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    context = doctor.DoctorContext(vault_root=vault, repo_root=vault, home=home, now=NOW)
+
+    result = doctor._probe_memory_mirror(context)
+
+    assert result.verdict == "OFF"
+    assert "nothing to copy" in result.detail
+
+
+def test_doctor_reports_missing_mirror_when_source_exists(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    context = doctor.DoctorContext(vault_root=vault, repo_root=vault, home=home, now=NOW)
+
+    result = doctor._probe_memory_mirror(context)
+
+    assert result.verdict == "BROKEN"
+    assert "never copied" in result.detail
+    assert result.heal is not None
+
+
+def test_doctor_reports_stale_mirror(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    memory_mirror.mirror(vault_root=vault, home=home, now=NOW - timedelta(days=10))
+    context = doctor.DoctorContext(vault_root=vault, repo_root=vault, home=home, now=NOW)
+
+    result = doctor._probe_memory_mirror(context)
+
+    assert result.verdict == "BROKEN"
+    assert "days old" in result.detail
+
+
+def test_doctor_ok_after_a_fresh_copy(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n", "topic-one.md": "alpha\n"})
+    memory_mirror.mirror(vault_root=vault, home=home, now=NOW)
+    context = doctor.DoctorContext(vault_root=vault, repo_root=vault, home=home, now=NOW)
+
+    result = doctor._probe_memory_mirror(context)
+
+    assert result.verdict == "OK"
+    assert "2 files" in result.detail
+
+
+def test_doctor_flags_empty_encoded_source_as_broken(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    (home / ".claude" / "projects" / encoded / "memory").mkdir(parents=True)
+    context = doctor.DoctorContext(vault_root=vault, repo_root=vault, home=home, now=NOW)
+
+    result = doctor._probe_memory_mirror(context)
+
+    assert result.verdict == "BROKEN"
+    assert "MEMORY.md" in result.detail
+
+
+def test_inspect_does_not_write(tmp_path: Path) -> None:
+    vault, home = _vault(tmp_path)
+    encoded = memory_mirror.encode_separators(vault.resolve())
+    _write_source(home, encoded, {"MEMORY.md": "# fixture index\n"})
+    before = list(vault.rglob("*"))
+
+    memory_mirror.inspect(vault_root=vault, home=home, now=NOW)
+
+    after = list(vault.rglob("*"))
+    assert after == before

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -159,6 +159,8 @@ def _tracked_paths() -> list[str]:
         ("System/.dex/gardener.json", "runtime", False),
         ("System/.onboarding-session.json", "runtime", False),
         ("System/Session_Learnings/2026-05-01.md", "runtime", False),
+        ("System/memory-mirror/_MANIFEST.md", "vault", False),
+        ("System/memory-mirror/MEMORY.md", "vault", False),
     ],
 )
 def test_resolution_semantics(path: str, ownership: str, denied: bool) -> None:

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -37,7 +37,14 @@ from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
 from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry, PlanRejected
 from core.transaction.journal import Journal, JournalCorruptError
-from core.utils import apple_mail_health, dex_logger, launch_agents, preflight, release_channel
+from core.utils import (
+    apple_mail_health,
+    dex_logger,
+    launch_agents,
+    memory_mirror,
+    preflight,
+    release_channel,
+)
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
@@ -596,6 +603,11 @@ QUICK_CHECKS = (
         "_probe_pre_split_archive",
     ),
     CheckDefinition("vault.auto-commit", "Vault auto-commit", "_probe_vault_auto_commit"),
+    CheckDefinition(
+        "memory.mirror",
+        "Claude project memory backup",
+        "_probe_memory_mirror",
+    ),
     CheckDefinition(
         "topology.migration-pending",
         "Brain/vault topology",
@@ -3750,6 +3762,19 @@ def _probe_pre_split_archive(context: DoctorContext) -> ProbeResult:
         "It is the one-command undo for the brain/vault conversion. Keep it for one full "
         "release cycle after conversion, then Dex can offer its receipted removal.",
     )
+
+
+def _probe_memory_mirror(context: DoctorContext) -> ProbeResult:
+    outcome = memory_mirror.inspect(
+        vault_root=context.vault_root,
+        home=context.home,
+        now=context.now,
+        env=os.environ,
+    )
+    heal = None
+    if outcome.heal_action:
+        heal = Heal(tier=2, action=outcome.heal_action, applied=False)
+    return ProbeResult(outcome.verdict, outcome.detail, heal)
 
 
 def _probe_vault_auto_commit(context: DoctorContext) -> ProbeResult:

--- a/core/utils/memory_mirror.py
+++ b/core/utils/memory_mirror.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""Copy Claude Code's per-project auto-memory into the vault.
+
+Claude Code stores per-project memory outside the vault, at
+``~/.claude/projects/<encoded>/memory/``. That folder is not git, has no Dex
+backup, and losing it does not error — sessions just get quietly worse.
+
+This module mirrors that directory into ``System/memory-mirror/`` so it rides
+the vault's existing history and backups. Deletions are mirrored; git history
+is the safety net. A tracked ``_MANIFEST.md`` records the file count and when
+the copy last ran, which is how a dead hook becomes visible.
+
+User-level memory (``~/.claude/CLAUDE.md`` and anything else outside
+``projects/<encoded>/memory/``) is intentionally not copied. It applies to
+every project on the machine; dumping it into one vault would mix global
+personal context into a tree that can be shared or backed up with that vault.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Mapping
+
+MIRROR_RELATIVE = "System/memory-mirror"
+MANIFEST_NAME = "_MANIFEST.md"
+ENTRYPOINT_NAME = "MEMORY.md"
+USER_LEVEL_CLAUDE_MD = "CLAUDE.md"
+DRY_RUN_ENV = "DEX_MEMORY_MIRROR_DRY_RUN"
+STALE_DROP_FRACTION = 0.5
+STALE_DROP_MIN_FILES = 5
+DOCTOR_STALE_AFTER = timedelta(days=7)
+MUTATION_LOCK_RELATIVE = "System/.dex/mutation.lock"
+
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]")
+_MANIFEST_AT = re.compile(r"^\s*(?:-\s+)?\*\*Mirrored at:\*\*\s*(.+?)\s*$", re.MULTILINE)
+_MANIFEST_COUNT = re.compile(r"^\s*(?:-\s+)?\*\*File count:\*\*\s*(\d+)\s*$", re.MULTILINE)
+
+STATUS_FOUND = "found"
+STATUS_MISSING = "missing"
+STATUS_EMPTY_ENCODED = "empty_encoded"
+STATUS_AMBIGUOUS = "ambiguous"
+
+ACTION_MIRRORED = "mirrored"
+ACTION_NOOP = "noop"
+ACTION_DRY_RUN = "dry_run"
+ACTION_REFUSED = "refused"
+ACTION_SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class SourceResolution:
+    """Where this vault's Claude project memory lives, or why it does not."""
+
+    status: str
+    path: Path | None
+    detail: str
+    method: str = "none"
+    candidates: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Parsed ``_MANIFEST.md`` from a previous successful copy."""
+
+    mirrored_at: datetime
+    file_count: int
+
+
+@dataclass(frozen=True)
+class MirrorOutcome:
+    """Result of one mirror attempt. Never includes file contents."""
+
+    action: str
+    detail: str
+    copied: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    unchanged: int = 0
+    file_count: int = 0
+    wrote: bool = False
+    source_method: str = "none"
+
+
+@dataclass(frozen=True)
+class InspectOutcome:
+    """Read-only doctor view of the live source and the vault copy."""
+
+    verdict: str
+    detail: str
+    heal_action: str | None = None
+
+
+def claude_config_home(home: Path, env: Mapping[str, str] | None = None) -> Path:
+    """Return Claude's config home, honouring ``CLAUDE_CONFIG_DIR`` when set."""
+
+    environ = env if env is not None else {}
+    override = (environ.get("CLAUDE_CONFIG_DIR") or "").strip()
+    if override:
+        return Path(override)
+    return Path(home) / ".claude"
+
+
+def encode_separators(project_root: Path) -> str:
+    """Encode the way Claude historically did: ``/`` and ``\\`` become ``-``."""
+
+    text = str(project_root)
+    return text.replace("\\", "/").replace("/", "-")
+
+
+def encode_non_alnum(project_root: Path) -> str:
+    """Encode by replacing every non-alphanumeric character with ``-``.
+
+    Claude Code has changed this scheme between versions. Both encodings are
+    tried; if neither finds ``MEMORY.md``, the copy refuses rather than
+    mirroring an empty folder.
+    """
+
+    return _NON_ALNUM.sub("-", str(project_root))
+
+
+def encoding_candidates(project_root: Path) -> tuple[str, ...]:
+    """Return unique encoded directory names for this vault path."""
+
+    names: list[str] = []
+    for encoded in (encode_separators(project_root), encode_non_alnum(project_root)):
+        if encoded and encoded not in names:
+            names.append(encoded)
+    return tuple(names)
+
+
+def _git_toplevel(vault_root: Path) -> Path | None:
+    if not (vault_root / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(vault_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return Path(text) if text else None
+
+
+def project_roots_for_encoding(vault_root: Path) -> tuple[Path, ...]:
+    """Vault paths Claude might have encoded for this project."""
+
+    roots: list[Path] = []
+    for candidate in (vault_root, vault_root.resolve(), _git_toplevel(vault_root)):
+        if candidate is None:
+            continue
+        if candidate not in roots:
+            roots.append(candidate)
+    return tuple(roots)
+
+
+def _posix_relative(path: Path) -> str | None:
+    text = path.as_posix().replace("\\", "/")
+    parts = text.split("/")
+    if not text or text.startswith("/") or parts[0] in {".", ".."}:
+        return None
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return text
+
+
+def _iter_regular_files(root: Path) -> dict[str, Path]:
+    """Map vault-relative posix paths to regular files, never following links."""
+
+    files: dict[str, Path] = {}
+    if not root.is_dir() or root.is_symlink():
+        return files
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        if current.is_symlink():
+            dirnames[:] = []
+            continue
+        dirnames[:] = sorted(
+            name for name in dirnames if not (current / name).is_symlink()
+        )
+        for name in filenames:
+            if name == MANIFEST_NAME:
+                continue
+            candidate = current / name
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            relative = _posix_relative(candidate.relative_to(root))
+            if relative is None:
+                continue
+            files[relative] = candidate
+    return files
+
+
+def resolve_source(
+    vault_root: Path,
+    home: Path,
+    env: Mapping[str, str] | None = None,
+) -> SourceResolution:
+    """Find this vault's Claude project memory directory.
+
+    Derived encodings are tried first. If those folders exist but have no
+    ``MEMORY.md``, the copy fails loudly instead of mirroring empty. A fallback
+    scan only accepts a ``projects/*/memory/MEMORY.md`` whose encoded name
+    still matches this vault. User-level files outside ``projects/`` are never
+    considered.
+    """
+
+    config_home = claude_config_home(home, env)
+    projects_dir = config_home / "projects"
+    encoded_names: list[str] = []
+    for root in project_roots_for_encoding(vault_root):
+        for name in encoding_candidates(root):
+            if name not in encoded_names:
+                encoded_names.append(name)
+
+    if not encoded_names:
+        return SourceResolution(
+            STATUS_MISSING,
+            None,
+            "Dex could not derive a Claude project folder name for this vault.",
+        )
+
+    derived_hits: list[Path] = []
+    derived_empty: list[Path] = []
+    for name in encoded_names:
+        memory_dir = projects_dir / name / "memory"
+        entry = memory_dir / ENTRYPOINT_NAME
+        if _is_regular_file(entry):
+            if memory_dir not in derived_hits:
+                derived_hits.append(memory_dir)
+        elif memory_dir.is_dir() and not memory_dir.is_symlink():
+            if memory_dir not in derived_empty:
+                derived_empty.append(memory_dir)
+
+    unique_hits = tuple(derived_hits)
+    if len(unique_hits) == 1:
+        return SourceResolution(
+            STATUS_FOUND,
+            unique_hits[0],
+            "Located Claude project memory from the derived folder name.",
+            method="derived",
+            candidates=unique_hits,
+        )
+    if len(unique_hits) > 1:
+        return SourceResolution(
+            STATUS_AMBIGUOUS,
+            None,
+            "More than one derived Claude project memory folder matched this vault. "
+            "Dex will not guess which one to copy.",
+            candidates=unique_hits,
+        )
+
+    fallback = _fallback_matches(projects_dir, encoded_names)
+    if len(fallback) == 1:
+        return SourceResolution(
+            STATUS_FOUND,
+            fallback[0],
+            "Located Claude project memory with a fallback scan after the derived "
+            "folder name did not contain MEMORY.md.",
+            method="fallback",
+            candidates=fallback,
+        )
+    if len(fallback) > 1:
+        return SourceResolution(
+            STATUS_AMBIGUOUS,
+            None,
+            "More than one Claude project memory folder could belong to this vault. "
+            "Dex will not guess which one to copy.",
+            candidates=fallback,
+        )
+    if derived_empty:
+        return SourceResolution(
+            STATUS_EMPTY_ENCODED,
+            None,
+            "Dex found the encoded Claude project folder, but it has no MEMORY.md. "
+            "Refusing to copy an empty folder in case the folder-name scheme changed.",
+            candidates=tuple(derived_empty),
+        )
+    return SourceResolution(
+        STATUS_MISSING,
+        None,
+        "Claude Code has no per-project memory folder for this vault on this machine.",
+    )
+
+
+def _is_regular_file(path: Path) -> bool:
+    try:
+        return path.is_file() and not path.is_symlink()
+    except OSError:
+        return False
+
+
+def _normalized_encoded_name(name: str) -> str:
+    return _NON_ALNUM.sub("-", name)
+
+
+def _fallback_matches(projects_dir: Path, encoded_names: list[str]) -> tuple[Path, ...]:
+    if not projects_dir.is_dir() or projects_dir.is_symlink():
+        return ()
+    wanted = {_normalized_encoded_name(name) for name in encoded_names}
+    wanted.update(encoded_names)
+    matches: list[Path] = []
+    try:
+        children = list(projects_dir.iterdir())
+    except OSError:
+        return ()
+    for child in children:
+        if child.is_symlink() or not child.is_dir():
+            continue
+        memory_dir = child / "memory"
+        if not _is_regular_file(memory_dir / ENTRYPOINT_NAME):
+            continue
+        if child.name in encoded_names or _normalized_encoded_name(child.name) in wanted:
+            matches.append(memory_dir)
+    return tuple(matches)
+
+
+def mirror_destination(vault_root: Path) -> Path:
+    return vault_root / MIRROR_RELATIVE
+
+
+def manifest_path(vault_root: Path) -> Path:
+    return mirror_destination(vault_root) / MANIFEST_NAME
+
+
+def parse_manifest(text: str) -> Manifest | None:
+    at_match = _MANIFEST_AT.search(text)
+    count_match = _MANIFEST_COUNT.search(text)
+    if at_match is None or count_match is None:
+        return None
+    raw_at = at_match.group(1).strip()
+    try:
+        mirrored_at = datetime.fromisoformat(raw_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if mirrored_at.tzinfo is None:
+        mirrored_at = mirrored_at.replace(tzinfo=timezone.utc)
+    try:
+        file_count = int(count_match.group(1))
+    except ValueError:
+        return None
+    return Manifest(mirrored_at=mirrored_at, file_count=file_count)
+
+
+def read_manifest(vault_root: Path) -> Manifest | None:
+    path = manifest_path(vault_root)
+    if not _is_regular_file(path):
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return parse_manifest(text)
+
+
+def should_refuse_drop(*, previous_count: int, source_count: int) -> bool:
+    """Refuse a copy that looks like the live folder was accidentally wiped."""
+
+    if previous_count < STALE_DROP_MIN_FILES:
+        return False
+    dropped = previous_count - source_count
+    if dropped < STALE_DROP_MIN_FILES:
+        return False
+    return source_count < previous_count * STALE_DROP_FRACTION
+
+
+def render_manifest(
+    *,
+    mirrored_at: datetime,
+    file_count: int,
+    copied: tuple[str, ...],
+    removed: tuple[str, ...],
+    unchanged: int,
+    source_method: str,
+) -> str:
+    stamped = mirrored_at.astimezone(timezone.utc).isoformat()
+    lines = [
+        "# Claude project memory mirror",
+        "",
+        "Copy of this vault's Claude Code per-project memory. User-level memory",
+        "outside this project is not included.",
+        "",
+        f"- **Mirrored at:** {stamped}",
+        f"- **File count:** {file_count}",
+        f"- **Copied:** {len(copied)}",
+        f"- **Removed:** {len(removed)}",
+        f"- **Unchanged:** {unchanged}",
+        f"- **Source match:** {source_method}",
+        "",
+        "## Changed this run",
+        "",
+    ]
+    if not copied and not removed:
+        lines.append("- none")
+    else:
+        for name in copied:
+            lines.append(f"- copied: `{name}`")
+        for name in removed:
+            lines.append(f"- removed: `{name}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _mutation_lock_present(vault_root: Path) -> bool:
+    lock = vault_root / MUTATION_LOCK_RELATIVE
+    return lock.exists()
+
+
+def _plan_changes(
+    source_files: dict[str, Path],
+    dest_files: dict[str, Path],
+) -> tuple[list[str], list[str], int]:
+    copied: list[str] = []
+    for relative, source_path in sorted(source_files.items()):
+        dest_path = dest_files.get(relative)
+        if dest_path is None:
+            copied.append(relative)
+            continue
+        try:
+            if source_path.read_bytes() != dest_path.read_bytes():
+                copied.append(relative)
+        except OSError:
+            copied.append(relative)
+    removed = sorted(name for name in dest_files if name not in source_files)
+    unchanged = len(source_files) - len(copied)
+    return copied, removed, unchanged
+
+
+def _apply_changes(
+    destination: Path,
+    source_files: dict[str, Path],
+    copied: list[str],
+    removed: list[str],
+) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for relative in copied:
+        target = destination / relative
+        if ".." in Path(relative).parts:
+            raise ValueError(f"refusing to write escaped memory path: {relative}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source_files[relative], target, follow_symlinks=False)
+    for relative in removed:
+        target = destination / relative
+        if target.is_symlink() or not target.is_file():
+            continue
+        target.unlink()
+        parent = target.parent
+        while parent != destination and parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+            parent = parent.parent
+
+
+def mirror(
+    *,
+    vault_root: Path,
+    home: Path,
+    now: datetime | None = None,
+    dry_run: bool = False,
+    env: Mapping[str, str] | None = None,
+) -> MirrorOutcome:
+    """Copy current per-project memory into the vault, or refuse honestly."""
+
+    when = now or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    if _mutation_lock_present(vault_root):
+        return MirrorOutcome(
+            ACTION_SKIPPED,
+            "Paused because a Dex update or migration is running.",
+        )
+    resolution = resolve_source(vault_root, home, env)
+    if resolution.status == STATUS_MISSING:
+        return MirrorOutcome(ACTION_SKIPPED, resolution.detail)
+    if resolution.status != STATUS_FOUND or resolution.path is None:
+        return MirrorOutcome(ACTION_REFUSED, resolution.detail)
+
+    source_files = _iter_regular_files(resolution.path)
+    destination = mirror_destination(vault_root)
+    dest_files = _iter_regular_files(destination)
+    previous = read_manifest(vault_root)
+    previous_count = previous.file_count if previous is not None else len(dest_files)
+    if should_refuse_drop(previous_count=previous_count, source_count=len(source_files)):
+        return MirrorOutcome(
+            ACTION_REFUSED,
+            "Claude's live project memory shrank sharply compared with the vault copy. "
+            "Dex left the vault copy alone so the earlier files remain the recovery path.",
+            file_count=previous_count,
+            source_method=resolution.method,
+        )
+
+    copied, removed, unchanged = _plan_changes(source_files, dest_files)
+    file_count = len(source_files)
+    if dry_run:
+        return MirrorOutcome(
+            ACTION_DRY_RUN,
+            (
+                f"Dry run: would copy {len(copied)}, remove {len(removed)}, "
+                f"leave {unchanged} unchanged ({file_count} files)."
+            ),
+            copied=tuple(copied),
+            removed=tuple(removed),
+            unchanged=unchanged,
+            file_count=file_count,
+            source_method=resolution.method,
+        )
+    if not copied and not removed and previous is not None and file_count == previous.file_count:
+        # Still refresh the timestamp so a tracked file shows the hook ran.
+        pass
+    _apply_changes(destination, source_files, copied, removed)
+    manifest_path(vault_root).write_text(
+        render_manifest(
+            mirrored_at=when,
+            file_count=file_count,
+            copied=tuple(copied),
+            removed=tuple(removed),
+            unchanged=unchanged,
+            source_method=resolution.method,
+        ),
+        encoding="utf-8",
+    )
+    action = ACTION_NOOP if not copied and not removed else ACTION_MIRRORED
+    return MirrorOutcome(
+        action,
+        f"Copied Claude project memory into the vault ({file_count} files).",
+        copied=tuple(copied),
+        removed=tuple(removed),
+        unchanged=unchanged,
+        file_count=file_count,
+        wrote=True,
+        source_method=resolution.method,
+    )
+
+
+def inspect(
+    *,
+    vault_root: Path,
+    home: Path,
+    now: datetime | None = None,
+    env: Mapping[str, str] | None = None,
+) -> InspectOutcome:
+    """Read-only health view: the hook is the backup, this is the alarm."""
+
+    when = now or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    resolution = resolve_source(vault_root, home, env)
+    destination = mirror_destination(vault_root)
+    dest_files = _iter_regular_files(destination)
+    manifest = read_manifest(vault_root)
+    mirror_present = bool(dest_files) or manifest is not None
+
+    if resolution.status == STATUS_EMPTY_ENCODED:
+        return InspectOutcome(
+            "BROKEN",
+            resolution.detail,
+            "Finish a Claude Code session after Dex can see MEMORY.md, or report this as a Dex bug.",
+        )
+    if resolution.status == STATUS_AMBIGUOUS:
+        return InspectOutcome(
+            "BROKEN",
+            resolution.detail,
+            "Report this as a Dex bug — the project-memory folder name is ambiguous.",
+        )
+
+    if resolution.status == STATUS_MISSING:
+        if not mirror_present:
+            return InspectOutcome(
+                "OFF",
+                "Claude Code has no per-project memory on this machine yet, so there is nothing to copy into the vault.",
+            )
+        return InspectOutcome(
+            "OK",
+            "A vault copy of Claude's project memory is present. The live folder was not found on this machine.",
+        )
+
+    source_files = _iter_regular_files(resolution.path) if resolution.path is not None else {}
+    if not mirror_present:
+        return InspectOutcome(
+            "BROKEN",
+            "Claude has project memory, but Dex has never copied it into the vault.",
+            "Finish a Claude Code session so Dex can copy project memory into the vault.",
+        )
+    if manifest is None:
+        return InspectOutcome(
+            "BROKEN",
+            "The vault copy of Claude's project memory is missing its dated record, so Dex cannot tell when it last ran.",
+            "Finish a Claude Code session so Dex can rewrite the dated record.",
+        )
+    if should_refuse_drop(previous_count=len(dest_files) or manifest.file_count, source_count=len(source_files)):
+        return InspectOutcome(
+            "BROKEN",
+            "Claude's live project memory is much smaller than the vault copy. Dex will not overwrite the copy.",
+            "If the live notes were deleted by mistake, restore them from the vault copy.",
+        )
+    age = when - manifest.mirrored_at
+    if age > DOCTOR_STALE_AFTER:
+        days = max(age.days, 1)
+        return InspectOutcome(
+            "BROKEN",
+            f"The vault copy of Claude's project memory is {days} days old. If you have been using Claude Code, the session-end copy may have stopped.",
+            "Finish a Claude Code session so Dex can refresh the vault copy.",
+        )
+    return InspectOutcome(
+        "OK",
+        f"Claude's project memory was copied into the vault ({manifest.file_count} files).",
+    )
+
+
+def _dry_run_requested(args_dry_run: bool, env: Mapping[str, str]) -> bool:
+    if args_dry_run:
+        return True
+    value = (env.get(DRY_RUN_ENV) or "").strip().lower()
+    return value in {"1", "true", "yes"}
+
+
+def main(argv: list[str] | None = None, env: Mapping[str, str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", help="Vault root. Defaults to CLAUDE_PROJECT_DIR or the current directory.")
+    parser.add_argument("--home", help="Home directory used to find ~/.claude. Defaults to the process home.")
+    parser.add_argument("--dry-run", action="store_true", help="Report intended changes and write nothing.")
+    parser.add_argument("--now", help="ISO-8601 timestamp for tests.")
+    args = parser.parse_args(argv)
+    environ = dict(env if env is not None else os.environ)
+    vault = Path(args.vault or environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
+    home = Path(args.home or Path.home())
+    now = None
+    if args.now:
+        now = datetime.fromisoformat(args.now.replace("Z", "+00:00"))
+    dry_run = _dry_run_requested(args.dry_run, environ)
+    outcome = mirror(vault_root=vault, home=home, now=now, dry_run=dry_run, env=environ)
+    stream = sys.stdout if outcome.action in {ACTION_MIRRORED, ACTION_NOOP, ACTION_DRY_RUN, ACTION_SKIPPED} else sys.stderr
+    print(outcome.detail, file=stream)
+    if outcome.action == ACTION_DRY_RUN:
+        for name in outcome.copied:
+            print(f"would copy: {name}", file=stream)
+        for name in outcome.removed:
+            print(f"would remove: {name}", file=stream)
+    if outcome.action == ACTION_REFUSED:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/Dex_System/Folder_Structure.md
+++ b/docs/Dex_System/Folder_Structure.md
@@ -223,6 +223,7 @@ Aim to triage weekly. If something sits 30+ days:
 System/
 ├── Templates/                # Note templates (5 core templates)
 ├── Session_Learnings/        # Auto-captured improvements during /review
+├── memory-mirror/            # Copy of Claude Code's per-project memory
 ├── pillars.yaml              # Strategic pillars (your main focus areas)
 ├── user-profile.yaml         # User preferences and settings
 ├── claude-code-state.json    # Tracks last changelog check

--- a/docs/Dex_System/Memory_Ownership.md
+++ b/docs/Dex_System/Memory_Ownership.md
@@ -6,6 +6,18 @@
 **How it works:** Automatically captured by Claude. Persists across all sessions and harnesses.
 **Dex action:** Don't duplicate. Don't capture preferences in learning-heartbeat.
 
+Per-project auto-memory lives outside the vault, at Claude Code's
+`~/.claude/projects/<encoded>/memory/` folder. Dex copies that folder into
+`System/memory-mirror/` at the end of a Claude Code session so it rides the
+vault's history and backups. Deletions in the live folder are mirrored; git
+history is the recovery path. A dated `_MANIFEST.md` in the copy is how a
+stopped copy becomes visible, and `/dex-doctor` flags a missing or stale copy.
+
+User-level memory — `~/.claude/CLAUDE.md` and anything else that applies to
+every project on the machine — is not copied into this vault. Dumping it here
+would mix global personal context into a tree that can be shared or backed up
+with this vault alone.
+
 ## Agent Memory (frontmatter, `memory: project`)
 **Owns:** Per-agent operational state across sessions
 **Examples:** "deal-attention flagged Acme Corp 3 times", "cracks-detector: pricing follow-up resolved"

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -171,7 +171,7 @@ therefore remains false.
 - PreToolUse/Read → `person-context-injector.cjs`, `company-context-injector.cjs`.
 - PreToolUse/Bash → `dex-safety-guard.sh`, `ensure-mcp-user-scope.cjs`.
 - PreToolUse/`mcp__.*` → `dex-safety-guard.sh`.
-- SessionEnd → `session-end.sh`, `vault-autocommit.cjs`.
+- SessionEnd → `session-end.sh`, `memory_mirror.py`, `vault-autocommit.cjs`.
 - Stop / Notification → a sound (`afplay`).
 
 **Dead weight / audit findings.**

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 6672cd77e728d5e48d9ca33f1c8aebd1db91101c6bdf8d61707e38e71fcba74a -->
+<!-- Content SHA-256: ebb3e462c2143dce504ed9bc82f81f02593cc6c4337f8f8df38fe39c3fab85bc -->
 
 # Architecture Inventory
 
@@ -154,7 +154,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 | `brain` | 45 | `replace` |
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 9 | `regenerate` |
-| `vault` | 17 | `never` |
+| `vault` | 18 | `never` |
 | `runtime` | 14 | `never` |
 
 <details><summary><code>brain</code> declared paths (45)</summary>
@@ -264,7 +264,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 </details>
 
-<details><summary><code>vault</code> declared paths (17)</summary>
+<details><summary><code>vault</code> declared paths (18)</summary>
 
 - `.claude/skills-custom` (dir; `vault-skills-custom`)
 - `.env` (file; `vault-env`)
@@ -280,6 +280,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 - `CLAUDE-custom.md` (file; `vault-claude-custom`)
 - `System/credentials` (dir; `vault-credentials`)
 - `System/folder-paths.yaml` (file; `vault-folder-paths`)
+- `System/memory-mirror` (dir; `vault-memory-mirror`)
 - `System/trusted-mcps.yaml` (file; `vault-trusted-mcps`)
 - `core/mcp-custom` (dir; `vault-mcp-custom`)
 - `core/mcp-premium` (dir; `vault-mcp-premium`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.2",
+  "version": "1.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.2",
+      "version": "1.97.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.2",
+  "version": "1.97.0",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -660,6 +660,13 @@
       "note": "SR1 #150: tracked reference-schema templates carrying env-var references; installed if absent, never overwritten once user-owned"
     },
     {
+      "id": "vault-memory-mirror",
+      "path": "System/memory-mirror",
+      "kind": "dir",
+      "ownership": "vault",
+      "note": "user-owned Claude Code per-project memory copy; machine state under System/, never a shared PARA folder; updates never write it"
+    },
+    {
       "id": "seed-pillars-example",
       "path": "System/pillars.example.yaml",
       "kind": "file",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #504

Claude Code keeps per-project memory outside the vault, unversioned and unbacked-up. Losing it would not error; sessions would just get quietly worse.

This copies that folder into `System/memory-mirror/` at the end of a Claude Code session so it rides existing vault history and backups.

## What landed

- SessionEnd copy of `~/.claude/projects/<encoded>/memory/` into `System/memory-mirror/`
- Deletions mirrored; git history is the recovery path
- Dated `_MANIFEST.md` so a stopped copy is visible
- Derived project-folder name, with a fallback that only accepts a `memory/MEMORY.md` still matching this vault; empty encoded folders fail loudly instead of copying nothing
- `DEX_MEMORY_MIRROR_DRY_RUN` reports and writes nothing
- Drop guard: a sharp shrink of the live folder is refused
- `/dex-doctor` flags a missing or stale copy
- User-level memory (`~/.claude/CLAUDE.md` and anything outside this project's memory folder) is not copied; that choice is documented

## Tests

- `python3 -m pytest core/tests/test_memory_mirror.py core/tests/test_portable_contract.py core/tests/test_docs_bridge.py core/tests/test_health_reporter.py`
- Hook wiring and auto-commit coverage for the new `System/memory-mirror` ownership class

Thanks to Josh for the report and prototype.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c808ae37-1b1b-4dc8-9cce-654a3e8e51db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c808ae37-1b1b-4dc8-9cce-654a3e8e51db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

