### PR TITLE
Make revived smoke journeys deterministic under the CI sandbox

### DIFF
--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1041,6 +1041,11 @@ are started automatically. Custom commands, remote or npm servers, symlinks, and
 shipped servers remain structural-only unless a custom local Python server has the exact
 user-owned trust record described below.
 
+If the operating system refuses to isolate or stop a helper process — GitHub-hosted
+runners do this intermittently — the journey records `sandbox unavailable` together with
+the errno, the operation, and the path, and skips that journey rather than reporting the
+checkup as failed. A real product failure still fails the check.
+
 ### Trusting your own servers
 
 `/create-mcp` can optionally check a custom local Python MCP server once, then separately

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -734,6 +734,7 @@ def test_runner_fallback_is_import_complete_for_the_runner_entry(
     required = {
         Path("core/utils/smoke.py"),
         Path("core/utils/dex_logger.py"),
+        Path("core/utils/process_isolation.py"),
         Path("core/utils/release_channel.py"),
         Path("core/utils/update_verifier.py"),
     }

--- a/core/tests/test_smoke_process_lifecycle.py
+++ b/core/tests/test_smoke_process_lifecycle.py
@@ -15,8 +15,21 @@ import sys
 import time
 from pathlib import Path
 
-from core.utils import mcp_handshake, process_isolation, smoke
 from core.tests.test_smoke import REPO_ROOT, _definition, _write_valid_vault
+from core.utils import mcp_handshake, process_isolation, smoke
+
+
+def _succeed_preparation(monkeypatch) -> None:
+    """Skip vault preparation so lifecycle tests do not depend on site-packages."""
+    monkeypatch.setattr(
+        smoke,
+        "_preparation_command",
+        lambda *_args: [
+            sys.executable,
+            "-c",
+            "import json; print(json.dumps({'verdict': 'OK', 'detail': 'prepared'}))",
+        ],
+    )
 
 
 def test_format_os_error_names_errno_operation_and_path() -> None:
@@ -127,9 +140,18 @@ def test_start_new_session_eperm_is_named_skip_not_harness_failed(
     assert "errno=1 (EPERM)" in detail
 
 
-def test_broken_product_journey_still_fails_the_gate(tmp_path: Path) -> None:
+def test_broken_product_journey_still_fails_the_gate(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
-    (vault / "System" / "pillars.yaml").write_text("pillars: [\n", encoding="utf-8")
+    _succeed_preparation(monkeypatch)
+    monkeypatch.setattr(
+        smoke,
+        "_journey_command",
+        lambda *_args: [
+            sys.executable,
+            "-c",
+            "import json; print(json.dumps({'verdict': 'BROKEN', 'detail': 'config is invalid'}))",
+        ],
+    )
 
     run = smoke.run_smoke(
         vault_root=vault,
@@ -193,6 +215,7 @@ def test_killpg_eperm_still_reaps_descendants_after_normal_exit(
         "_journey_command",
         lambda *_args: [sys.executable, "-c", parent],
     )
+    _succeed_preparation(monkeypatch)
 
     def eperm_killpg(_pgid: int, _sig: int) -> None:
         raise PermissionError(errno.EPERM, "Operation not permitted")
@@ -235,6 +258,7 @@ def test_timed_out_journey_kills_descendants_when_killpg_returns_eperm(
         "_journey_command",
         lambda *_args: [sys.executable, "-c", parent],
     )
+    _succeed_preparation(monkeypatch)
 
     def eperm_killpg(_pgid: int, _sig: int) -> None:
         raise PermissionError(errno.EPERM, "Operation not permitted")
@@ -244,7 +268,7 @@ def test_timed_out_journey_kills_descendants_when_killpg_returns_eperm(
     run = smoke.run_smoke(
         vault_root=vault,
         repo_root=REPO_ROOT,
-        journey_definitions=(_definition("configs", budget)),
+        journey_definitions=(_definition("configs", budget),),
     )
     time.sleep(post_run_wait)
 

--- a/core/tests/test_smoke_process_lifecycle.py
+++ b/core/tests/test_smoke_process_lifecycle.py
@@ -1,0 +1,281 @@
+"""Harness lifecycle contracts for smoke journeys under sandbox / xdist races.
+
+#477: revived journeys failed ~1/3 of GitHub-hosted runs with a bare EPERM from
+process-group teardown (internal-journey dispatch and descendant cleanup are the
+same lifecycle). These tests pin the product choice: diagnosable OSErrors,
+named skip when the syscall is unavailable, real descendant kill when Darwin
+returns EPERM on a zombie leader, and no unfailable exit_code==0 gate.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import sys
+import time
+from pathlib import Path
+
+from core.utils import mcp_handshake, process_isolation, smoke
+from core.tests.test_smoke import REPO_ROOT, _definition, _write_valid_vault
+
+
+def test_format_os_error_names_errno_operation_and_path() -> None:
+    bare = OSError(errno.EPERM, "Operation not permitted")
+    detail = process_isolation.format_os_error(bare, operation="internal-journey")
+
+    assert "internal-journey" in detail
+    assert "errno=1 (EPERM)" in detail
+    assert "path=<none>" in detail
+    assert "Operation not permitted" in detail
+
+    with_path = OSError(errno.EPERM, "Operation not permitted", "/tmp/dex-smoke-x")
+    assert "path=/tmp/dex-smoke-x" in process_isolation.format_os_error(
+        with_path, operation="chmod"
+    )
+
+
+def test_sandbox_refused_is_only_bare_eperm() -> None:
+    assert process_isolation.sandbox_refused(OSError(errno.EPERM, "Operation not permitted"))
+    assert not process_isolation.sandbox_refused(
+        OSError(errno.EPERM, "Operation not permitted", "/tmp/vault")
+    )
+    assert not process_isolation.sandbox_refused(
+        PermissionError("internal smoke mode requires a regular parent-created run marker")
+    )
+    assert not process_isolation.sandbox_refused(OSError(errno.EACCES, "Permission denied"))
+
+
+def test_bare_eperm_in_internal_journey_is_named_skip_with_errno(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(smoke, "_authorize_internal", lambda *_args: None)
+    monkeypatch.setattr(smoke, "_block_python_network", lambda: None)
+    monkeypatch.setattr(smoke, "_internal_release_root", lambda *_args: tmp_path)
+
+    def fail_with_bare_eperm(*_args: object) -> dict[str, str]:
+        raise OSError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setitem(smoke.INTERNAL_JOURNEYS, "configs", fail_with_bare_eperm)
+
+    exit_code = smoke.main(["--_journey", "configs"])
+    result = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert result["verdict"] == "UNKNOWN"
+    assert result["detail"].startswith(process_isolation.SANDBOX_UNAVAILABLE_PREFIX)
+    assert "internal-journey" in result["detail"]
+    assert "errno=1 (EPERM)" in result["detail"]
+    assert "path=<none>" in result["detail"]
+
+
+def test_authorize_permissionerror_still_refuses_with_exit_two(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setattr(
+        smoke,
+        "_authorize_internal",
+        lambda *_args: (_ for _ in ()).throw(
+            PermissionError("internal smoke mode requires a regular parent-created run marker")
+        ),
+    )
+
+    exit_code = smoke.main(["--_journey", "configs"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "internal smoke journey refused:" in captured.err
+    assert "internal-journey" in captured.err
+    assert "requires a regular parent-created run marker" in captured.err
+    assert captured.out == ""
+
+
+def test_start_new_session_eperm_is_named_skip_not_harness_failed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    vault = _write_valid_vault(tmp_path)
+    original = smoke.subprocess.Popen
+
+    def refuse_new_session(*args: object, **kwargs: object):
+        if kwargs.get("start_new_session"):
+            raise OSError(errno.EPERM, "Operation not permitted")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(smoke.subprocess, "Popen", refuse_new_session)
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    assert run.harness_failed is False
+    assert run.exit_code == 0
+    detail = run.report["journeys"][0]["detail"]
+    assert detail.startswith(process_isolation.SANDBOX_UNAVAILABLE_PREFIX)
+    assert "start_new_session" in detail
+    assert "errno=1 (EPERM)" in detail
+
+
+def test_broken_product_journey_still_fails_the_gate(tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    (vault / "System" / "pillars.yaml").write_text("pillars: [\n", encoding="utf-8")
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    assert run.exit_code == 1
+    assert run.harness_failed is False
+    assert run.report["journeys"][0]["verdict"] == "BROKEN"
+
+
+def test_handshake_teardown_eperm_does_not_fail_a_finished_initialize(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    server = tmp_path / "fast-exit-server.py"
+    server.write_text(
+        "import json, sys\n"
+        "request = json.loads(sys.stdin.readline())\n"
+        "print(json.dumps({'jsonrpc': '2.0', 'id': request['id'], 'result': "
+        "{'capabilities': {}, 'serverInfo': {'name': 'fast-exit', 'version': '1'}}}), "
+        "flush=True)\n",
+        encoding="utf-8",
+    )
+
+    def eperm_killpg(_pgid: int, _sig: int) -> None:
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(process_isolation.os, "killpg", eperm_killpg)
+
+    result = mcp_handshake.mcp_stdio_handshake(
+        [sys.executable, str(server)],
+        timeout=5.0,
+    )
+
+    assert result.ok is True
+    assert result.error is None
+
+
+def test_killpg_eperm_still_reaps_descendants_after_normal_exit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    vault = _write_valid_vault(tmp_path)
+    sentinel = tmp_path / "eperm-orphan-survived"
+    spawned = tmp_path / "eperm-descendant-spawned"
+    descendant = (
+        "import time; from pathlib import Path; time.sleep(2.5); "
+        f"Path({str(sentinel)!r}).touch()"
+    )
+    parent = (
+        "import json, subprocess, sys; from pathlib import Path; "
+        f"subprocess.Popen([sys.executable, '-c', {descendant!r}], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        f"Path({str(spawned)!r}).touch(); "
+        "print(json.dumps({'verdict': 'OK', 'detail': 'parent exited'}))"
+    )
+    monkeypatch.setattr(
+        smoke,
+        "_journey_command",
+        lambda *_args: [sys.executable, "-c", parent],
+    )
+
+    def eperm_killpg(_pgid: int, _sig: int) -> None:
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(process_isolation.os, "killpg", eperm_killpg)
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+    time.sleep(4.0)
+
+    assert run.exit_code == 0
+    assert run.harness_failed is False
+    assert spawned.exists(), "the parent never spawned a descendant"
+    assert not sentinel.exists()
+
+
+def test_timed_out_journey_kills_descendants_when_killpg_returns_eperm(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    vault = _write_valid_vault(tmp_path)
+    sentinel = tmp_path / "eperm-timeout-orphan-survived"
+    spawned = tmp_path / "eperm-timeout-descendant-spawned"
+    budget, descendant_delay, post_run_wait = 3.0, 8.0, 10.0
+    descendant = (
+        f"import time; from pathlib import Path; time.sleep({descendant_delay}); "
+        f"Path({str(sentinel)!r}).touch()"
+    )
+    parent = (
+        "import subprocess, sys; from pathlib import Path; "
+        f"subprocess.Popen([sys.executable, '-c', {descendant!r}]); "
+        f"Path({str(spawned)!r}).touch(); "
+        "import time; time.sleep(60)"
+    )
+    monkeypatch.setattr(
+        smoke,
+        "_journey_command",
+        lambda *_args: [sys.executable, "-c", parent],
+    )
+
+    def eperm_killpg(_pgid: int, _sig: int) -> None:
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(process_isolation.os, "killpg", eperm_killpg)
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs", budget)),
+    )
+    time.sleep(post_run_wait)
+
+    assert run.exit_code == 2
+    assert "timed out" in run.report["journeys"][0]["detail"]
+    assert spawned.exists(), (
+        "the parent never spawned a descendant, so this test did not exercise the "
+        "kill path at all; it cannot pass on that basis"
+    )
+    assert not sentinel.exists()
+
+
+def test_smoke_temp_is_isolated_per_xdist_worker(monkeypatch, tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw7")
+    observed_prefixes: list[str] = []
+    original = smoke.tempfile.TemporaryDirectory
+
+    def capture_temporary_directory(*args: object, **kwargs: object):
+        prefix = kwargs.get("prefix")
+        if isinstance(prefix, str):
+            observed_prefixes.append(prefix)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(smoke.tempfile, "TemporaryDirectory", capture_temporary_directory)
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    assert run.exit_code == 0
+    assert any(prefix.startswith("dex-smoke-gw7-run-") for prefix in observed_prefixes)

--- a/core/utils/mcp_handshake.py
+++ b/core/utils/mcp_handshake.py
@@ -13,6 +13,8 @@ from queue import Empty, Queue
 from threading import Thread
 from typing import Any, Mapping, Sequence
 
+from core.utils.process_isolation import capture_process_group, terminate_process_group
+
 INITIALIZE_REQUEST = {
     "jsonrpc": "2.0",
     "id": 1,
@@ -50,38 +52,39 @@ def _response_error(response: object) -> str | None:
     return None
 
 
-def _terminate_process_group(process: subprocess.Popen[str]) -> None:
-    """Stop the server and any children, escalating when it ignores SIGTERM."""
-    if process.stdin is not None:
-        try:
-            process.stdin.close()
-        except OSError:
-            pass
-    if process.poll() is not None:
+def _close_stdin(process: subprocess.Popen[str]) -> None:
+    if process.stdin is None:
         return
-
     try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGTERM)
-        else:
-            process.terminate()
-    except ProcessLookupError:
+        process.stdin.close()
+    except OSError:
+        pass
+
+
+def _terminate_process_group(process: subprocess.Popen[str], *, pgid: int | None = None) -> None:
+    """Stop the server and any children, escalating when it ignores SIGTERM.
+
+    Darwin returns EPERM for killpg on a zombie session leader; that must not
+    unwind a successful handshake into ``internal smoke journey refused``.
+    """
+    _close_stdin(process)
+    if process.poll() is not None:
+        # Leader already reaped. Still reap any descendants that outlived it.
+        terminate_process_group(process, pgid=pgid, sig=signal.SIGKILL)
         return
 
+    terminate_process_group(process, pgid=pgid, sig=signal.SIGTERM)
     try:
         process.wait(timeout=1)
+        terminate_process_group(process, pgid=pgid, sig=signal.SIGKILL)
         return
     except subprocess.TimeoutExpired:
         pass
-
+    terminate_process_group(process, pgid=pgid, sig=signal.SIGKILL)
     try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGKILL)
-        else:
-            process.kill()
-    except ProcessLookupError:
-        return
-    process.wait(timeout=1)
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def mcp_stdio_handshake(
@@ -102,6 +105,7 @@ def mcp_stdio_handshake(
         raise ValueError("timeout must be greater than zero")
 
     process: subprocess.Popen[str] | None = None
+    pgid: int | None = None
     response: dict[str, Any] | None = None
     error: str | None = None
     stderr = ""
@@ -121,6 +125,7 @@ def mcp_stdio_handshake(
                 errors="replace",
                 start_new_session=True,
             )
+            pgid = capture_process_group(process)
             if process.stdin is None or process.stdout is None:
                 error = "could not open server stdio pipes"
             else:
@@ -154,7 +159,7 @@ def mcp_stdio_handshake(
             error = f"could not complete initialize handshake: {exc}"
         finally:
             if process is not None:
-                _terminate_process_group(process)
+                _terminate_process_group(process, pgid=pgid)
                 returncode = process.returncode
             stderr_file.flush()
             stderr_file.seek(0)

--- a/core/utils/process_isolation.py
+++ b/core/utils/process_isolation.py
@@ -1,0 +1,190 @@
+"""Process-group lifecycle helpers for smoke journeys and MCP handshakes.
+
+GitHub-hosted macOS runners (and pytest-xdist) make two syscalls unreliable:
+
+* ``os.killpg`` on a session whose leader has already exited returns ``EPERM``
+  instead of ``ESRCH`` (Darwin zombie-leader behaviour).
+* ``start_new_session=True`` can itself return ``EPERM`` when the sandbox
+  refuses a new session.
+
+Neither is a product failure. Teardown must not raise, and a genuinely
+unavailable isolation syscall degrades to a named skip rather than
+``harness_failed``.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+SANDBOX_UNAVAILABLE_PREFIX = "sandbox unavailable:"
+
+_PGREP_CANDIDATES = (Path("/usr/bin/pgrep"), Path("/bin/pgrep"))
+
+
+def format_os_error(
+    exc: BaseException,
+    *,
+    operation: str,
+    path: object | None = None,
+) -> str:
+    """Render an OSError with errno, operation, and path instead of one collapsed line."""
+    pieces = [operation]
+    err = getattr(exc, "errno", None)
+    if isinstance(err, int):
+        name = errno.errorcode.get(err, "UNKNOWN")
+        pieces.append(f"errno={err} ({name})")
+    target = path if path is not None else getattr(exc, "filename", None)
+    if target not in (None, ""):
+        pieces.append(f"path={target}")
+    else:
+        pieces.append("path=<none>")
+    second = getattr(exc, "filename2", None)
+    if second not in (None, ""):
+        pieces.append(f"path2={second}")
+    if isinstance(err, int):
+        try:
+            pieces.append(os.strerror(err))
+        except (OverflowError, ValueError):
+            pieces.append(str(exc))
+    else:
+        pieces.append(" ".join(str(exc).split()) or type(exc).__name__)
+    return " ".join(str(part) for part in pieces)
+
+
+def sandbox_refused(exc: BaseException) -> bool:
+    """True when a syscall returned bare EPERM with no filesystem path.
+
+    ``PermissionError("explicit message")`` from authorization checks has
+    ``errno is None`` and must not be treated as a sandbox skip. Path-bearing
+    EPERM is a real access failure and stays a harness/product verdict.
+    """
+    if not isinstance(exc, OSError) or exc.errno != errno.EPERM:
+        return False
+    return getattr(exc, "filename", None) in (None, "")
+
+
+def sandbox_skip_detail(exc: BaseException, *, operation: str, path: object | None = None) -> str:
+    """Named skip detail for a syscall the sandbox will not perform."""
+    return f"{SANDBOX_UNAVAILABLE_PREFIX} {format_os_error(exc, operation=operation, path=path)}"
+
+
+def capture_process_group(process: subprocess.Popen[str]) -> int:
+    """Record the session id at spawn, before the leader can be reaped."""
+    return process.pid
+
+
+def process_group_members(pgid: int) -> tuple[int, ...]:
+    """Best-effort live members of ``pgid`` (Linux ``/proc``, else ``pgrep -g``)."""
+    members = _proc_group_members(pgid)
+    if members is not None:
+        return members
+    return _pgrep_group_members(pgid)
+
+
+def terminate_process_group(
+    process: subprocess.Popen[str],
+    *,
+    pgid: int | None = None,
+    sig: int | None = None,
+) -> None:
+    """Stop a session started with ``start_new_session=True``.
+
+    Never raises for the Darwin zombie-leader ``EPERM`` or for a group that
+    has already vanished. Live descendants are signalled individually when
+    ``killpg`` is refused.
+    """
+    if os.name != "posix":
+        if process.poll() is not None:
+            return
+        process.kill()
+        _wait_briefly(process)
+        return
+
+    target = pgid if pgid is not None else process.pid
+    sent = sig if sig is not None else signal.SIGKILL
+    try:
+        os.killpg(target, sent)
+    except ProcessLookupError:
+        return
+    except OSError:
+        _kill_process_group_members(target)
+        if process.poll() is None:
+            try:
+                process.kill()
+            except OSError:
+                pass
+    _wait_briefly(process)
+
+
+def _wait_briefly(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.wait(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _kill_process_group_members(pgid: int) -> None:
+    for pid in process_group_members(pgid):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            continue
+
+
+def _proc_group_members(pgid: int) -> tuple[int, ...] | None:
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return None
+    found: list[int] = []
+    try:
+        entries = list(proc.iterdir())
+    except OSError:
+        return ()
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            status = (entry / "stat").read_text(encoding="utf-8")
+        except OSError:
+            continue
+        close = status.rfind(")")
+        if close == -1:
+            continue
+        fields = status[close + 2 :].split()
+        # After ``(comm)``: state, ppid, pgrp, ...
+        if len(fields) < 3:
+            continue
+        try:
+            group = int(fields[2])
+        except ValueError:
+            continue
+        if group == pgid:
+            found.append(int(entry.name))
+    return tuple(found)
+
+
+def _pgrep_group_members(pgid: int) -> tuple[int, ...]:
+    executable = next((candidate for candidate in _PGREP_CANDIDATES if candidate.is_file()), None)
+    if executable is None:
+        return ()
+    try:
+        result = subprocess.run(
+            [str(executable), "-g", str(pgid)],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ()
+    members: list[int] = []
+    for token in result.stdout.split():
+        if token.isdigit():
+            members.append(int(token))
+    return tuple(members)

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -12,7 +12,6 @@ import re
 import secrets
 import shlex
 import shutil
-import signal
 import stat
 import subprocess
 import sys
@@ -31,7 +30,7 @@ if str(RUNNER_ROOT) in sys.path:
     sys.path.remove(str(RUNNER_ROOT))
 sys.path.insert(0, str(RUNNER_ROOT))
 
-from core.utils import dex_logger, release_channel
+from core.utils import dex_logger, process_isolation, release_channel
 
 SCHEMA_VERSION = 1
 HISTORY_LIMIT = 120
@@ -96,6 +95,7 @@ RUNNER_FALLBACK_RELATIVES = (
     Path("core/utils/__init__.py"),
     Path("core/utils/dex_logger.py"),
     Path("core/utils/release_channel.py"),
+    Path("core/utils/process_isolation.py"),
     Path("core/utils/smoke.py"),
     Path("core/utils/trust_registry.py"),
     Path("core/utils/update_verifier.py"),
@@ -1089,7 +1089,15 @@ def _set_runtime_path_writable(path: Path, *, writable: bool) -> None:
             or stat.S_IFMT(opened_stat.st_mode) != stat.S_IFMT(path_stat.st_mode)
         ):
             raise JourneySafetySkip(f"runtime tree path changed during chmod: {path}")
-        os.fchmod(descriptor, mode)
+        try:
+            os.fchmod(descriptor, mode)
+        except OSError as exc:
+            detail = process_isolation.format_os_error(exc, operation="chmod", path=path)
+            if process_isolation.sandbox_refused(exc):
+                raise JourneySafetySkip(
+                    process_isolation.sandbox_skip_detail(exc, operation="chmod", path=path)
+                ) from exc
+            raise JourneySafetySkip(f"runtime tree path could not be chmod'd: {detail}") from exc
     finally:
         os.close(descriptor)
 
@@ -1232,26 +1240,8 @@ def _preparation_command(
     return command
 
 
-def _terminate_process_group(process: subprocess.Popen[str]) -> None:
-    if os.name == "posix":
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            return
-        if process.poll() is None:
-            try:
-                process.wait(timeout=0.2)
-            except subprocess.TimeoutExpired:
-                pass
-        return
-
-    if process.poll() is not None:
-        return
-    process.kill()
-    try:
-        process.wait(timeout=0.2)
-    except subprocess.TimeoutExpired:
-        pass
+def _terminate_process_group(process: subprocess.Popen[str], *, pgid: int | None = None) -> None:
+    process_isolation.terminate_process_group(process, pgid=pgid)
 
 
 def _decode_child_result(stdout: str) -> dict[str, str]:
@@ -1277,22 +1267,38 @@ def _run_json_process(
     label: str,
 ) -> tuple[dict[str, str], bool]:
     process: subprocess.Popen[str] | None = None
+    pgid: int | None = None
     try:
-        process = subprocess.Popen(
-            list(command),
-            cwd=cwd,
-            env=dict(env),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            start_new_session=True,
-        )
+        try:
+            process = subprocess.Popen(
+                list(command),
+                cwd=cwd,
+                env=dict(env),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                start_new_session=True,
+            )
+        except OSError as exc:
+            detail = process_isolation.format_os_error(exc, operation="start_new_session")
+            if process_isolation.sandbox_refused(exc):
+                return {
+                    "verdict": "UNKNOWN",
+                    "detail": process_isolation.sandbox_skip_detail(
+                        exc, operation="start_new_session"
+                    ),
+                }, False
+            return {
+                "verdict": "UNKNOWN",
+                "detail": f"{label} harness failed: {detail}",
+            }, True
+        pgid = process_isolation.capture_process_group(process)
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
         except subprocess.TimeoutExpired:
-            _terminate_process_group(process)
+            _terminate_process_group(process, pgid=pgid)
             if process.stdout is not None:
                 process.stdout.close()
             if process.stderr is not None:
@@ -1304,7 +1310,7 @@ def _run_json_process(
                 },
                 True,
             )
-        _terminate_process_group(process)
+        _terminate_process_group(process, pgid=pgid)
         if process.returncode != 0:
             diagnostic = _one_line(stderr or stdout or f"exit {process.returncode}")[-500:]
             return (
@@ -1314,8 +1320,18 @@ def _run_json_process(
         return _decode_child_result(stdout), False
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         if process is not None:
-            _terminate_process_group(process)
-        return {"verdict": "UNKNOWN", "detail": f"{label} harness failed: {_one_line(exc)}"}, True
+            _terminate_process_group(process, pgid=pgid)
+        if isinstance(exc, OSError) and process_isolation.sandbox_refused(exc):
+            return {
+                "verdict": "UNKNOWN",
+                "detail": process_isolation.sandbox_skip_detail(exc, operation=label),
+            }, False
+        detail = (
+            process_isolation.format_os_error(exc, operation=label)
+            if isinstance(exc, OSError)
+            else _one_line(exc)
+        )
+        return {"verdict": "UNKNOWN", "detail": f"{label} harness failed: {detail}"}, True
 
 
 def _run_journey_process(
@@ -1364,6 +1380,34 @@ def _harness_failure_run(
         },
         harness_failed=True,
     )
+
+
+def _named_skip_run(
+    journey_definitions: Sequence[JourneyDefinition],
+    error: object,
+) -> SmokeRun:
+    detail = _one_line(error)
+    journeys = [
+        {"id": definition.id, "verdict": "UNKNOWN", "detail": detail, "duration_ms": 0}
+        for definition in journey_definitions
+    ]
+    return SmokeRun(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "journeys": journeys,
+            "summary": _summary(journeys),
+        },
+        harness_failed=False,
+    )
+
+
+def _smoke_run_identity() -> str:
+    """Stable per-pytest-xdist-worker (or per-process) temp namespace."""
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if re.fullmatch(r"[A-Za-z0-9._-]{1,32}", worker):
+        return worker
+    return f"pid{os.getpid()}"
 
 
 def _safe_temporary_parent(source: Path) -> Path:
@@ -1661,6 +1705,23 @@ def _run_smoke_journeys(
                 finally:
                     if release_root is not None:
                         _set_runtime_tree_writable(release_root, writable=True)
+        except JourneySafetySkip as exc:
+            result = {"verdict": "UNKNOWN", "detail": _one_line(exc)}
+        except OSError as exc:
+            if process_isolation.sandbox_refused(exc):
+                result = {
+                    "verdict": "UNKNOWN",
+                    "detail": process_isolation.sandbox_skip_detail(exc, operation="journey-harness"),
+                }
+            else:
+                result = {
+                    "verdict": "UNKNOWN",
+                    "detail": (
+                        "journey harness failed: "
+                        f"{process_isolation.format_os_error(exc, operation='journey-harness')}"
+                    ),
+                }
+                harness_failed = True
         except Exception as exc:
             result = {"verdict": "UNKNOWN", "detail": f"journey harness failed: {_one_line(exc)}"}
             harness_failed = True
@@ -1693,24 +1754,42 @@ def run_smoke(
 
     started = time.monotonic()
     try:
+        system_temp = temporary_parent
         with tempfile.TemporaryDirectory(
-            prefix="dex-smoke-runner-",
-            dir=temporary_parent,
-        ) as temporary:
-            runner_root = _materialize_runner(Path(temporary) / "runner")
-            try:
-                _set_runtime_tree_writable(runner_root, writable=False)
-                results, harness_failed = _run_smoke_journeys(
-                    source=source,
-                    repository=repository,
-                    temporary_parent=temporary_parent,
-                    runner_root=runner_root,
-                    journey_definitions=journey_definitions,
-                    global_timeout_seconds=global_timeout_seconds,
-                    started=started,
-                )
-            finally:
-                _set_runtime_tree_writable(runner_root, writable=True)
+            prefix=f"dex-smoke-{_smoke_run_identity()}-run-",
+            dir=system_temp,
+        ) as run_home:
+            isolated_parent = Path(run_home)
+            with tempfile.TemporaryDirectory(
+                prefix="dex-smoke-runner-",
+                dir=isolated_parent,
+            ) as temporary:
+                runner_root = _materialize_runner(Path(temporary) / "runner")
+                try:
+                    _set_runtime_tree_writable(runner_root, writable=False)
+                    results, harness_failed = _run_smoke_journeys(
+                        source=source,
+                        repository=repository,
+                        temporary_parent=isolated_parent,
+                        runner_root=runner_root,
+                        journey_definitions=journey_definitions,
+                        global_timeout_seconds=global_timeout_seconds,
+                        started=started,
+                    )
+                finally:
+                    _set_runtime_tree_writable(runner_root, writable=True)
+    except JourneySafetySkip as exc:
+        return _named_skip_run(journey_definitions, exc)
+    except OSError as exc:
+        if process_isolation.sandbox_refused(exc):
+            return _named_skip_run(
+                journey_definitions,
+                process_isolation.sandbox_skip_detail(exc, operation="smoke-harness"),
+            )
+        return _harness_failure_run(
+            journey_definitions,
+            process_isolation.format_os_error(exc, operation="smoke-harness"),
+        )
     except Exception as exc:
         return _harness_failure_run(journey_definitions, exc)
 
@@ -2575,6 +2654,21 @@ INTERNAL_JOURNEYS: dict[str, Callable[[Path, Path], dict[str, str]]] = {
 }
 
 
+def _sandbox_skip_result(exc: BaseException, *, operation: str) -> dict[str, str] | None:
+    if isinstance(exc, OSError) and process_isolation.sandbox_refused(exc):
+        return {
+            "verdict": "UNKNOWN",
+            "detail": process_isolation.sandbox_skip_detail(exc, operation=operation),
+        }
+    return None
+
+
+def _internal_refusal_detail(exc: BaseException, *, operation: str) -> str:
+    if isinstance(exc, OSError):
+        return process_isolation.format_os_error(exc, operation=operation)
+    return _one_line(exc)
+
+
 def _print_human(report: Mapping[str, object]) -> None:
     for journey in report["journeys"]:
         print(
@@ -2714,8 +2808,15 @@ def main(
         except ModuleNotFoundError as error:
             result = {"verdict": "UNKNOWN", "detail": _missing_module_detail(error)}
         except (OSError, PermissionError) as exc:
-            print(f"smoke preparation refused: {_one_line(exc)}", file=sys.stderr)
-            return 2
+            skip = _sandbox_skip_result(exc, operation="smoke-preparation")
+            if skip is not None:
+                result = skip
+            else:
+                print(
+                    f"smoke preparation refused: {_internal_refusal_detail(exc, operation='smoke-preparation')}",
+                    file=sys.stderr,
+                )
+                return 2
         else:
             result = {"verdict": "OK", "detail": "journey vault prepared safely"}
         print(json.dumps(result, separators=(",", ":")))
@@ -2728,11 +2829,20 @@ def main(
             _block_python_network()
             release_root = _internal_release_root(args.run_marker, args.release_root)
             result = INTERNAL_JOURNEYS[args._journey](vault, release_root)
+        except JourneySafetySkip as exc:
+            result = {"verdict": "UNKNOWN", "detail": _one_line(exc)}
         except ModuleNotFoundError as error:
             result = {"verdict": "UNKNOWN", "detail": _missing_module_detail(error)}
         except (KeyError, OSError, PermissionError) as exc:
-            print(f"internal smoke journey refused: {_one_line(exc)}", file=sys.stderr)
-            return 2
+            skip = _sandbox_skip_result(exc, operation="internal-journey")
+            if skip is not None:
+                result = skip
+            else:
+                print(
+                    f"internal smoke journey refused: {_internal_refusal_detail(exc, operation='internal-journey')}",
+                    file=sys.stderr,
+                )
+                return 2
         print(json.dumps(result, separators=(",", ":")))
         return 0
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -1041,6 +1041,11 @@ are started automatically. Custom commands, remote or npm servers, symlinks, and
 shipped servers remain structural-only unless a custom local Python server has the exact
 user-owned trust record described below.
 
+If the operating system refuses to isolate or stop a helper process — GitHub-hosted
+runners do this intermittently — the journey records `sandbox unavailable` together with
+the errno, the operation, and the path, and skips that journey rather than reporting the
+checkup as failed. A real product failure still fails the check.
+
 ### Trusting your own servers
 
 `/create-mcp` can optionally check a custom local Python MCP server once, then separately

--- a/docs/gate-omission-audit-2026-08-11.md
+++ b/docs/gate-omission-audit-2026-08-11.md
@@ -537,6 +537,21 @@ than from 11 August.
   against the tempting non-fix (loosening the `exit_code == 0` assertion), which
   would recreate the unfailable gate #367 just removed.
 
+  **Partial fix in [#487](https://github.com/davekilleen/Dex/pull/487):** the
+  descendant-timeout test's 0.4s budget could expire before the child spawned,
+  so a run that never exercised the kill still passed. The budget now covers
+  spawn; that does not address the bare `EPERM` from process-group teardown.
+
+  **Harness lifecycle fix (issue #477):** `killpg` on a session whose leader has
+  already exited returns `EPERM` on Darwin instead of `ESRCH`. The handshake
+  `finally` and the journey runner both used that syscall and treated the
+  refusal as `harness_failed`. Teardown now swallows the zombie-leader `EPERM`
+  and signals remaining descendants individually. The next refusal logs errno,
+  operation, and path. A syscall the sandbox will not perform degrades to a
+  named `sandbox unavailable` skip (not `harness_failed`). Parallel xdist
+  workers each get their own `dex-smoke-<worker>-run-*` temp tree. The
+  `exit_code == 0` product assertion is unchanged.
+
 ---
 
 ## Smaller gaps, no action proposed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #477.

## Linked Issue
- GitHub issue: #477

## What Changed

Since #367 made release smoke journeys actually execute, GitHub-hosted CI failed about one run in three with a bare `EPERM` from process-group teardown. #487 already widened the descendant-timeout budget so the kill path is actually exercised; it did **not** fix the `EPERM` itself.

This treats the two known flakes as one harness lifecycle problem (internal-journey dispatch + descendant teardown):

- **Diagnosable refusals.** The next `OSError` logs errno, operation, and path instead of collapsing to `[Errno 1] Operation not permitted`.
- **Darwin zombie-leader `killpg`.** After a fast-exiting MCP server (the blessed-local-Python case) or a timed-out parent, `killpg` returns `EPERM` instead of `ESRCH`. Teardown swallows that and signals remaining descendants individually, so the handshake `finally` can no longer unwind a successful initialize into `harness_failed`.
- **Named skip, not a dead gate.** If the sandbox genuinely refuses `start_new_session` / a pathless `EPERM` syscall, the journey records `sandbox unavailable: …` with `harness_failed=False`. Authorization `PermissionError`s and real product `BROKEN` still fail. The `exit_code == 0` assertion in `test_blessed_local_python_executes_snapshot_with_configured_env_scrubbed` is unchanged.
- **Per-worker temp trees.** Each pytest-xdist worker (or process) gets its own `dex-smoke-<worker>-run-*` parent so parallel shards do not share a `/tmp/dex-smoke-*` root.

## Test Plan
- Unit/integration tests added: `core/tests/test_smoke_process_lifecycle.py` (diagnostics, named skip, descendant reap under forced `killpg` EPERM, timeout kill under EPERM, xdist temp isolation, product `BROKEN` still exits 1). Fallback runner list includes `process_isolation.py`.
- Negative/error-path tests: authorization `PermissionError` still exits 2; path-bearing EPERM is not a sandbox skip.
- Commands run locally:
  - `pytest core/tests/test_smoke_process_lifecycle.py` — 10 passed
  - `pytest` on hanging-preparation, runner-fallback, early-harness-failure, ambient-tmpdir, and missing-module smoke tests — passed
  - `ruff check` on the touched Python files — passed
  - Full `mcp_stdio_startup` / yaml-dependent smoke journeys were not run here (this Linux runner lacks the `mcp` package and system-site `yaml` the isolated child uses on macOS CI).

## Quality Gates
- Tests added for the regression; `exit_code == 0` on the blessed MCP smoke test is **not** loosened.
- Docs: `docs/gate-omission-audit-2026-08-11.md` F11, and the Dex technical guide (both copies kept identical).

## Risk & Rollback
- Risk level: medium (harness lifecycle under pytest-xdist / macOS CI).
- Rollback plan: revert this branch; journeys return to the previous `killpg` + collapsed `OSError` behaviour.

## Docs Impact
- `docs/gate-omission-audit-2026-08-11.md`
- `docs/Dex_System/Dex_Technical_Guide.md`
- `06-Resources/Dex_System/Dex_Technical_Guide.md` (byte-identical compatibility copy)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-899a2b94-eaa2-44ed-a244-4ebe4414ff85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-899a2b94-eaa2-44ed-a244-4ebe4414ff85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

