### PR TITLE
Stop shard-2 tests from leaking executor process state (#443)

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -26,6 +26,8 @@ shutil.copytree(SOURCE_FIXTURE_VAULT, RUNTIME_FIXTURE_VAULT)
 # disposable copy here before collection imports any product modules.
 os.environ["VAULT_PATH"] = str(RUNTIME_FIXTURE_VAULT)
 
+from core.tests import process_isolation
+
 for relative in (
     "05-Areas/Meetings",
     "05-Areas/Meetings/Daily_Log",
@@ -72,3 +74,13 @@ def pytest_unconfigure(config: pytest.Config) -> None:
     if os.getpid() != _CREATOR_PID:
         return
     shutil.rmtree(_RUNTIME_ROOT, ignore_errors=True)
+
+
+def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:
+    """Remember the test that just finished on this worker.
+
+    Isolation assertions in the shard-sensitive suites name this nodeid when a
+    later test finds leftover process or executor state.
+    """
+    del nextitem
+    process_isolation.note_completed(item.nodeid)

--- a/core/tests/process_isolation.py
+++ b/core/tests/process_isolation.py
@@ -1,0 +1,165 @@
+"""Process-wide state that shard workers reuse across tests.
+
+CI shard 2 runs pytest-xdist workers. A test that substitutes ``time.sleep``,
+``subprocess.Popen``, ``tempfile.tempdir``, or the executor's controller bridge
+leaves that binding for every later test on the same worker. The shard-2
+alternating failures in #443 were this class of leak, not a slow assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any
+
+# Filled by the pytest_runtest_teardown hook in conftest so a failed isolation
+# check can name the test that just finished on this worker.
+last_completed_nodeid = "session-start"
+
+
+_WATCHED_ENV = (
+    "VAULT_PATH",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "DEX_MCP_HANDSHAKE_TIMEOUT",
+    "DEX_SMOKE_RUN_TOKEN",
+)
+
+
+def note_completed(nodeid: str) -> None:
+    global last_completed_nodeid
+    last_completed_nodeid = nodeid
+
+
+def _env_snapshot() -> dict[str, str | None]:
+    return {name: os.environ.get(name) for name in _WATCHED_ENV}
+
+
+@dataclass(frozen=True)
+class ProcessBaseline:
+    sleep: Any
+    time_fn: Any
+    time_ns: Any
+    popen: Any
+    os_open: Any
+    os_rename: Any
+    os_killpg: Any
+    os_fsync: Any
+    tempdir: str | None
+    stdin: Any
+    stdout: Any
+    env: dict[str, str | None]
+
+    @classmethod
+    def capture(cls) -> ProcessBaseline:
+        return cls(
+            sleep=time.sleep,
+            time_fn=time.time,
+            time_ns=time.time_ns,
+            popen=subprocess.Popen,
+            os_open=os.open,
+            os_rename=os.rename,
+            os_killpg=getattr(os, "killpg", None),
+            os_fsync=os.fsync,
+            tempdir=tempfile.tempdir,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            env=_env_snapshot(),
+        )
+
+    def differences(self) -> list[str]:
+        current = ProcessBaseline.capture()
+        mismatches: list[str] = []
+        identity_fields = (
+            "sleep",
+            "time_fn",
+            "time_ns",
+            "popen",
+            "os_open",
+            "os_rename",
+            "os_killpg",
+            "os_fsync",
+            "stdin",
+            "stdout",
+        )
+        for field in identity_fields:
+            if getattr(current, field) is not getattr(self, field):
+                mismatches.append(field)
+        if current.tempdir != self.tempdir:
+            mismatches.append("tempdir")
+        if current.env != self.env:
+            changed = [
+                name
+                for name in _WATCHED_ENV
+                if current.env.get(name) != self.env.get(name)
+            ]
+            mismatches.append("env:" + ",".join(changed))
+        return mismatches
+
+
+_BASELINE: ProcessBaseline | None = None
+
+
+def session_baseline() -> ProcessBaseline:
+    global _BASELINE
+    if _BASELINE is None:
+        _BASELINE = ProcessBaseline.capture()
+    return _BASELINE
+
+
+def assert_process_isolation(when: str) -> None:
+    mismatches = session_baseline().differences()
+    if not mismatches:
+        return
+    raise AssertionError(
+        f"process state leaked {when}; leftover={mismatches}; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+
+
+def assert_executor_isolation(executor_module: ModuleType, when: str) -> None:
+    assert_process_isolation(when)
+    from scripts import dex_update_bridge as controller_bridge
+
+    assert executor_module.dex_update_bridge is controller_bridge, (
+        f"{when}: executor.dex_update_bridge is not the controller module; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+    assert not hasattr(executor_module, "_production_authority_intact"), (
+        f"{when}: _production_authority_intact was left on the executor module; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+    assert not hasattr(executor_module, "_EXECUTOR_AUTHORITY"), (
+        f"{when}: _EXECUTOR_AUTHORITY was left on the executor module; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+    assert executor_module._transient_delivery_backoff is session_baseline_backoff(
+        executor_module
+    ), (
+        f"{when}: _transient_delivery_backoff was left substituted; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+    released_name = getattr(
+        executor_module, "_RELEASED_BRIDGE_MODULE_NAME", "dex_released_update_bridge"
+    )
+    released = sys.modules.get(released_name)
+    assert released is None or released is controller_bridge, (
+        f"{when}: {released_name} was left in sys.modules; "
+        f"previous test on this worker={last_completed_nodeid!r}"
+    )
+
+
+_BACKOFF_BY_MODULE: dict[int, Any] = {}
+
+
+def session_baseline_backoff(executor_module: ModuleType) -> Any:
+    key = id(executor_module)
+    if key not in _BACKOFF_BY_MODULE:
+        _BACKOFF_BY_MODULE[key] = executor_module._transient_delivery_backoff
+    return _BACKOFF_BY_MODULE[key]

--- a/core/tests/test_release_fleet_executor.py
+++ b/core/tests/test_release_fleet_executor.py
@@ -8,15 +8,31 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from core.tests.process_isolation import (
+    assert_executor_isolation,
+    last_completed_nodeid,
+    session_baseline_backoff,
+)
 from core.update.journey_protocol import load_update_journey_protocol
+from scripts import dex_update_bridge as controller_bridge
 from scripts import release_fleet
 from scripts import release_fleet_executor as executor
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _executor_process_isolation() -> None:
+    """Fail if a shard neighbor left executor or process bindings behind."""
+
+    assert_executor_isolation(executor, "before test")
+    yield
+    assert_executor_isolation(executor, "after test")
 
 
 def _production_runtime() -> executor._ProductionRuntime:
@@ -859,13 +875,18 @@ def test_runtime_loads_the_verified_asset_instead_of_the_controller_module(
 
     monkeypatch.setattr(Path, "read_bytes", replace_after_read)
 
-    loaded = executor._load_released_bridge(asset, digest)
+    try:
+        loaded = executor._load_released_bridge(asset, digest)
 
-    assert loaded is not executor.dex_update_bridge
-    assert Path(loaded.__file__).resolve() == asset.resolve()
-    assert loaded.MARKER == "verified"
-    with pytest.raises(executor.ExecutorError, match="changed before execution"):
-        executor._load_released_bridge(asset, digest)
+        assert loaded is not executor.dex_update_bridge
+        assert Path(loaded.__file__).resolve() == asset.resolve()
+        assert loaded.MARKER == "verified"
+        with pytest.raises(executor.ExecutorError, match="changed before execution"):
+            executor._load_released_bridge(asset, digest)
+    finally:
+        if sys.modules.get(executor._RELEASED_BRIDGE_MODULE_NAME) is not controller_bridge:
+            sys.modules.pop(executor._RELEASED_BRIDGE_MODULE_NAME, None)
+        assert executor.dex_update_bridge is controller_bridge
 
 
 def test_executor_accepts_an_exact_legacy_starting_tag_without_widening_targets(
@@ -1672,3 +1693,87 @@ def test_fixture_runtime_server_exposes_only_fixed_bridge_and_lifecycle_messages
         else [{}]
     )
     assert cleaned == expected_cleaned
+
+
+def test_runtime_server_restores_controller_bridge_when_released_asset_cannot_serve(
+    tmp_path: Path,
+) -> None:
+    """In-process fixture runtime must not leave a released copy bound on the module."""
+
+    asset = tmp_path / "dex-update-bridge.py"
+    asset.write_bytes(b"MARKER = 'incomplete-released-copy'\n")
+    digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+
+    with pytest.raises(AttributeError):
+        executor._runtime_server(
+            tmp_path / "vault",
+            bridge_asset=asset,
+            bridge_sha256=digest,
+        )
+
+    assert executor.dex_update_bridge is controller_bridge
+    assert executor._RELEASED_BRIDGE_MODULE_NAME not in sys.modules
+    assert_executor_isolation(executor, "after incomplete runtime-server load")
+
+
+def test_non_network_delivery_is_not_retried_after_a_retrying_neighbor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shard workers reuse a process; a retry test must not arm backoff for the next one."""
+
+    source_repo, source_commit = _executor_source_commit(tmp_path)
+    slept = _recorded_backoff(monkeypatch)
+
+    class BlippedDeliveryRuntime(_Runtime):
+        delivery_attempts = 0
+
+        def deliver_latest_release(self, vault: Path) -> dict[str, object]:
+            self.delivery_attempts += 1
+            if self.delivery_attempts < 3:
+                return {
+                    "status": "not-delivered",
+                    "evidence": {"reason": "network-unavailable"},
+                }
+            return super().deliver_latest_release(vault)
+
+    retry_run = _execute(
+        tmp_path / "retry",
+        BlippedDeliveryRuntime(_identity("1.81.0", "b")),
+        source_repo=source_repo,
+        source_commit=source_commit,
+    )
+    assert retry_run.case["reached_follow_up"] is True
+    assert slept == list(executor._TRANSIENT_DELIVERY_BACKOFF_SECONDS)
+
+    monkeypatch.undo()
+    assert (
+        executor._transient_delivery_backoff is session_baseline_backoff(executor)
+    ), last_completed_nodeid
+    _forbid_backoff(monkeypatch, "a non-network delivery failure must not back off")
+
+    class BrokenDeliveryRuntime(_Runtime):
+        def deliver_latest_release(self, vault: Path) -> dict[str, object]:
+            self.calls.append("deliver_latest_release")
+            return {
+                "status": "not-delivered",
+                "evidence": {"reason": "evidence-invalid"},
+            }
+
+    runtime = BrokenDeliveryRuntime(_identity("1.81.0", "b"))
+    with pytest.raises(executor.ExecutorError, match="did not prove"):
+        _execute(
+            tmp_path / "non-network",
+            runtime,
+            source_repo=source_repo,
+            source_commit=source_commit,
+        )
+
+    assert runtime.calls.count("deliver_latest_release") == 1
+
+
+def test_executor_module_state_is_the_controller_baseline() -> None:
+    """Named proof that this worker has no leftover executor or env substitutions."""
+
+    assert_executor_isolation(executor, "named isolation check")
+    assert executor._transient_delivery_backoff is session_baseline_backoff(executor)

--- a/core/tests/test_release_fleet_failure_diagnostics.py
+++ b/core/tests/test_release_fleet_failure_diagnostics.py
@@ -10,10 +10,20 @@ from pathlib import Path
 
 import pytest
 
+from core.tests.process_isolation import assert_executor_isolation
 from core.update.journey_protocol import load_update_journey_protocol
 from scripts import release_fleet_executor as executor
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _executor_process_isolation() -> None:
+    """Fail if a shard neighbor left executor or process bindings behind."""
+
+    assert_executor_isolation(executor, "before test")
+    yield
+    assert_executor_isolation(executor, "after test")
 
 
 def _identity(version: str, fill: str) -> dict[str, str]:

--- a/core/tests/test_trusted_mcp_safety.py
+++ b/core/tests/test_trusted_mcp_safety.py
@@ -15,6 +15,7 @@ from types import ModuleType
 
 import pytest
 
+from core.tests.process_isolation import assert_process_isolation
 from core.utils import doctor, mcp_handshake, smoke, trust_registry
 from core.utils.mcp_handshake import mcp_stdio_handshake
 from core.utils.trust_registry import (
@@ -23,6 +24,19 @@ from core.utils.trust_registry import (
     load_trusted_mcp_registry,
     snapshot_trusted_mcp,
 )
+
+
+@pytest.fixture(autouse=True)
+def _trusted_mcp_process_isolation() -> None:
+    """Fail if a shard neighbor left sleep, Popen, tempdir, or env bindings behind."""
+
+    assert_process_isolation("before test")
+    yield
+    assert_process_isolation("after test")
+
+
+def test_process_state_is_isolated_from_shard_neighbors() -> None:
+    assert_process_isolation("named isolation check")
 
 
 def _valid_vault(tmp_path: Path, *, initialize_git: bool = True) -> Path:
@@ -834,7 +848,12 @@ def test_f4_one_off_without_consent_token_refuses_without_execution(
     assert not marker.exists()
 
 
-def test_f4_one_off_token_is_single_use_and_runs_in_temp_vault(tmp_path: Path) -> None:
+def test_f4_one_off_token_is_single_use_and_runs_in_temp_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frozen = 1_700_000_000.0
+    monkeypatch.setattr(smoke.time, "time", lambda: frozen)
     vault = _valid_vault(tmp_path)
     marker = tmp_path / "one-off-context.jsonl"
     script = vault / "custom-mcp" / "server.py"
@@ -853,7 +872,7 @@ def test_f4_one_off_token_is_single_use_and_runs_in_temp_vault(tmp_path: Path) -
     first = smoke.check_custom_mcp_once(vault, "custom-once", consent_token=token)
     second = smoke.check_custom_mcp_once(vault, "custom-once", consent_token=token)
 
-    assert first["verdict"] == "OK"
+    assert first["verdict"] == "OK", first
     assert second == {
         "verdict": "UNKNOWN",
         "detail": "valid fresh single-use consent token is required",

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -13,7 +13,7 @@
     "follow-up-smoke"
   ],
   "executor": {
-    "sha256": "e87f38fcd9b0154b10cf8b94746f5d09c450eafe557dcd09306e4ce8bb2ecf39",
+    "sha256": "c70293ce9e3c217cd4e8507929116de63e2e0acb4f4a3ce95485b195b20cf2c8",
     "source_path": "scripts/release_fleet_executor.py"
   },
   "foundation_to_follow_up": {

--- a/scripts/release_fleet_executor.py
+++ b/scripts/release_fleet_executor.py
@@ -914,6 +914,18 @@ def _runtime_server_answer(prompt: str) -> str:
     return response["answer"]
 
 
+_RELEASED_BRIDGE_MODULE_NAME = "dex_released_update_bridge"
+
+
+def _restore_released_bridge_module(previous: ModuleType | None) -> None:
+    """Put the process-wide released-bridge slot back after an in-process load."""
+
+    if previous is None:
+        sys.modules.pop(_RELEASED_BRIDGE_MODULE_NAME, None)
+        return
+    sys.modules[_RELEASED_BRIDGE_MODULE_NAME] = previous
+
+
 def _load_released_bridge(bridge_asset: Path, bridge_sha256: str):
     """Load only the standalone bridge bytes already bound to the release."""
 
@@ -922,13 +934,18 @@ def _load_released_bridge(bridge_asset: Path, bridge_sha256: str):
     bridge_bytes = bridge_asset.read_bytes()
     if hashlib.sha256(bridge_bytes).hexdigest() != bridge_sha256:
         raise ExecutorError("standalone released bridge asset changed before execution")
-    module_name = "dex_released_update_bridge"
+    module_name = _RELEASED_BRIDGE_MODULE_NAME
     released_bridge = ModuleType(module_name)
     released_bridge.__file__ = str(bridge_asset)
     released_bridge.__package__ = ""
+    previous = sys.modules.get(module_name)
     sys.modules[module_name] = released_bridge
-    code = compile(bridge_bytes, str(bridge_asset), "exec", dont_inherit=True)
-    exec(code, released_bridge.__dict__)
+    try:
+        code = compile(bridge_bytes, str(bridge_asset), "exec", dont_inherit=True)
+        exec(code, released_bridge.__dict__)
+    except Exception:
+        _restore_released_bridge_module(previous)
+        raise
     return released_bridge
 
 
@@ -944,25 +961,26 @@ def _runtime_server(
     """Serve the fixed lifecycle vocabulary from the fixture virtualenv."""
 
     global dex_update_bridge
+    previous_bridge = dex_update_bridge
+    previous_released = sys.modules.get(_RELEASED_BRIDGE_MODULE_NAME)
     dex_update_bridge = _load_released_bridge(bridge_asset, bridge_sha256)
-
-    if (follow_up_cache is None) != (follow_up_release is None):
-        raise ExecutorError(
-            "follow-up cache and release identity must be supplied together"
-        )
-    verified_follow_up_cache = (
-        _validate_follow_up_cache(follow_up_cache, follow_up_release)
-        if follow_up_cache is not None and follow_up_release is not None
-        else None
-    )
-
-    root = dex_update_bridge._validate_vault(vault)
     temporary: tempfile.TemporaryDirectory[str] | None = None
-    cached_fetch: Callable[
-        [Path, dex_update_bridge.ReleasePin],
-        None,
-    ] | None = None
     try:
+        if (follow_up_cache is None) != (follow_up_release is None):
+            raise ExecutorError(
+                "follow-up cache and release identity must be supplied together"
+            )
+        verified_follow_up_cache = (
+            _validate_follow_up_cache(follow_up_cache, follow_up_release)
+            if follow_up_cache is not None and follow_up_release is not None
+            else None
+        )
+
+        root = dex_update_bridge._validate_vault(vault)
+        cached_fetch: Callable[
+            [Path, dex_update_bridge.ReleasePin],
+            None,
+        ] | None = None
         if dex_update_bridge._foundation_is_installed(
             root,
             dex_update_bridge.FOUNDATION,
@@ -1065,6 +1083,8 @@ def _runtime_server(
             except Exception as error:  # noqa: BLE001
                 _runtime_server_emit({"kind": "error", "message": str(error)})
     finally:
+        dex_update_bridge = previous_bridge
+        _restore_released_bridge_module(previous_released)
         if temporary is not None:
             temporary.cleanup()
     return 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Fixes #443
- Does not duplicate #477 (EPERM smoke-harness sandbox) or #487 (release-tree / descendant-kill flake)

## What Changed

Shard 2 was failing a *different* test on the same head because xdist workers reuse a process. Two leaks were real, not slow assertions:

1. **`_runtime_server` replaced `executor.dex_update_bridge` globally and never restored it.** An in-process fixture-runtime call left the next test on that worker with a swapped bridge (or a leftover `dex_released_update_bridge` in `sys.modules`).
2. **No test proved isolation.** The F10 sleep-watch fix from #457 is already on main and is kept. This PR adds a worker-local baseline for `time.sleep`, `subprocess.Popen`, `tempfile.tempdir`, watched env vars, and executor predicates (`_production_authority_intact`, `_transient_delivery_backoff`). If a neighbor leaves any of those behind, the next shard-sensitive test fails and names the previous nodeid.

Also: F4 now freezes `time.time` so the 120s consent window cannot go negative or expire under a stalled clock, and the OK assertion prints the full result so a future UNKNOWN is diagnosable instead of `assert 'UNKNOWN' == 'OK'`.

The journey protocol hash was regenerated because the executor bytes changed. That is the generator output, not a hand edit.

## Test Plan
- Unit/integration tests added or updated: `test_runtime_server_restores_controller_bridge_when_released_asset_cannot_serve`, `test_non_network_delivery_is_not_retried_after_a_retrying_neighbor`, `test_executor_module_state_is_the_controller_baseline`, `test_process_state_is_isolated_from_shard_neighbors`; autouse isolation in the fleet executor, fleet diagnostics, and trusted-MCP suites
- Negative/error-path tests added or updated: non-network delivery after a retrying neighbor must still fail on the first attempt with backoff forbidden
- Commands run locally:
  - `python3 -m pytest core/tests/test_release_fleet_executor.py core/tests/test_release_fleet_failure_diagnostics.py core/tests/test_trusted_mcp_safety.py::test_f4_one_off_token_is_single_use_and_runs_in_temp_vault` — 65 passed
  - same set under `-n auto --dist loadgroup` — 3/3 repeats, 69 passed including journey-protocol tests

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert the PR. Production fixture runtime is a dedicated process, so restoring the controller binding is belt-and-suspenders there; the test isolation is the shard-2 fix.

## Docs Impact
- Files updated: none
- If none, reason: CI test isolation and an in-process executor restore. No user-facing behaviour change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd08adc3-a756-49bc-ba3f-7e90ff5f7ae8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd08adc3-a756-49bc-ba3f-7e90ff5f7ae8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

