### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "dex-core",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Cloud Agent development environment setup for dex-core.
+#
+# Idempotent: safe to run repeatedly and on top of a prebuilt snapshot. It
+# reproduces exactly what the CI workflow (.github/workflows/ci.yml) expects:
+# Python 3.12 dev + runtime dependencies, Node dependencies, and the generated
+# vault/path state, plus a few Cloud-Agent-specific fixes the macOS CI runners
+# do not need.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- System packages ---------------------------------------------------------
+# python3.12-venv: several tests build real virtualenvs and need ensurepip.
+# rsync: scripts/build-vault-bundle.sh stages the release tree with it.
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends python3.12-venv rsync
+
+# --- Trusted Node.js ---------------------------------------------------------
+# scripts/dex_update_bridge.py only trusts executables found under /usr/bin,
+# /bin, /usr/local/bin or /opt/homebrew/bin. Cloud Agents ship Node under
+# /exec-daemon and ~/.nvm, so expose it in a trusted directory via symlink.
+for bin in node npm npx; do
+  target="$(command -v "$bin" || true)"
+  [ -n "$target" ] && sudo ln -sf "$target" "/usr/local/bin/$bin"
+done
+
+# --- Python dependencies (global site) --------------------------------------
+# Installed into the global interpreter (not --user) so that subprocesses which
+# scrub HOME can still import them. --ignore-installed steps over the
+# Debian-managed packages (PyJWT, cryptography) that pip cannot uninstall.
+sudo pip install --break-system-packages --ignore-installed -r requirements-dev.txt
+sudo pip install --break-system-packages --ignore-installed \
+  "mcp>=1.0.0,<2.0.0" pyyaml python-dateutil requests
+
+# --- Node dependencies -------------------------------------------------------
+npm ci
+
+# --- Developer environment defaults -----------------------------------------
+# Match CI: point the vault at the test fixture, and pin an absolute interpreter
+# for the Node script suite (dex-python.cjs rejects bare names like `python3`).
+sudo tee /etc/profile.d/dex-dev.sh >/dev/null <<EOF
+export VAULT_PATH="$REPO_ROOT/core/tests/fixtures/vault"
+export DEX_PYTHON="/usr/bin/python3"
+EOF
+
+# --- Source-derived state ----------------------------------------------------
+export VAULT_PATH="$REPO_ROOT/core/tests/fixtures/vault"
+python3 -c "from core import paths; from pathlib import Path; [getattr(paths, n).mkdir(parents=True, exist_ok=True) for n in dir(paths) if n.endswith('_DIR') and isinstance(getattr(paths, n), Path)]"
+python3 core/paths.py
+
+echo "dex-core Cloud Agent environment ready."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Linear issue: `DEX-XX` (n/a — Cloud Agent environment enablement)

## What Changed
Makes `dex-core` fully usable in Cursor Cloud Agents, as a repo-managed environment (versioned with the code, like this repo's CI):

- **`.cursor/environment.json`** — repo-managed config that runs `bash .cursor/install.sh` on provision. Being committed, it is the highest-precedence environment source, so every Cloud Agent on this repo provisions itself automatically once this merges — no dashboard Save step.
- **`.cursor/install.sh`** — idempotent bootstrap that reproduces the CI toolchain and adds the Linux/Cloud-Agent-specific fixes the macOS CI runners never need:
  - installs `python3.12-venv` and `rsync` (the venv-building tests need `ensurepip`; `scripts/build-vault-bundle.sh` stages the release tree with `rsync`)
  - symlinks `node`/`npm`/`npx` into `/usr/local/bin` so `scripts/dex_update_bridge.py`'s trusted-executable check (only `/usr/bin`, `/bin`, `/usr/local/bin`, `/opt/homebrew/bin`) can find Node, which Cloud Agents ship under `/exec-daemon` and `~/.nvm`
  - installs the Python dev + runtime dependencies into the **global** interpreter site (not `--user`), so subprocess tests that scrub `HOME` can still import `mcp` et al; uses `--ignore-installed` to step over the Debian-managed `PyJWT`/`cryptography` packages pip cannot uninstall
  - installs Node deps (`npm ci`) and regenerates the source-derived vault/path state (`core/paths.py`)
  - writes `VAULT_PATH` and `DEX_PYTHON` defaults to `/etc/profile.d/dex-dev.sh`, mirroring CI

No application code is changed.

## Test Plan
Commands run locally in the Cloud Agent VM:
- `bash .cursor/install.sh` — ran twice, idempotent, working tree stays clean
- `ruff check core/` — all checks passed
- `npm run test:hooks` — 206 passed
- `npm run test:scripts` — 165 passed
- `npm run test:integrations` — 224 passed, 1 skipped
- `npm run check:connections-contract` — contract + vendoring manifest verified
- `pytest core/tests/ core/mcp/tests/ core/migrations/tests/ -m "not fuzz" -n auto` — **4297 passed, 2 skipped, 5 failed** (see below)
- End-to-end product action: booted the Work MCP server over stdio, created a task via `create_task`, confirmed it persisted to `03-Tasks/Tasks.md` (`^task-20260813-002`)

Environment builds validated:
- Prebuilt-snapshot build **SUCCEEDED**, then verified in a fresh Cloud Agent booted from that exact build: toolchain versions, HOME-scrubbed global imports, `python3 -m venv`, node trusted symlink, `profile.d` defaults, `ruff`, all Node suites, previously-env-broken Python tests (84 passed), and the end-to-end Work MCP task create/persist — all green.
- Cold build from the **default base image** (no snapshot) **SUCCEEDED**, proving `.cursor/install.sh` provisions from scratch exactly as the committed `.cursor/environment.json` will (`rsync` + `python3.12-venv` installed → `core/paths.json` generated → `dex-core Cloud Agent environment ready.` → exit 0).

### Note on the 5 Python failures
All five are intrinsic to running on a Linux Cloud Agent VM (CI runs exclusively on `macos-latest`) and are unrelated to this change:
- 4 are macOS-only by design: `test_doctor.py::test_launchctl_domain_failure_is_an_unknown_instrument` (needs macOS `plutil`) and 3 `test_release_fleet_acceptance.py` cases that hard-require `sys.platform == "darwin"`.
- 1 (`test_lifecycle_topology_migration.py::test_real_migrator_completes_the_service_guided_journey`) fails because the Cloud Agent authenticates to GitHub via a global git `insteadOf` rewrite that injects the access token into `https://github.com/...` URLs; the migrator's official-upstream regex only accepts a bare `git@`/clean URL, so the fixture's rewritten `upstream` remote no longer matches. Neutralizing that rewrite would break authenticated git operations (including this PR's push), so it is intentionally left in place.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed. (Environment tooling; no product code changed.)
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases. (Ran install twice for idempotence; verified HOME-scrubbed global imports; cold + snapshot builds.)
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass. (No product code changed; the added files are Cloud-Agent-only setup config.)

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: delete `.cursor/environment.json` and `.cursor/install.sh`; neither is referenced by CI or any product code path.

## Docs Impact
- Files updated: none
- If none, reason: This adds Cloud Agent setup config only; product behavior and contributor docs are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0303bf19-b6b2-41ba-b908-3707456a6348?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0303bf19-b6b2-41ba-b908-3707456a6348&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

