### PR TITLE
release: restore approved cutoff and publish v1.96.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,96 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.3] — 🩺 Honest checkups, safer meetings, and releases you can verify (2026-08-13)
+
+This is a reliability release built from ten fixes that were tested together. The theme is
+simple: Dex should not guess when evidence is missing, call a broken connection “empty,” or
+claim a release identity that does not exist.
+
+### 🩺 Checkups now preserve the useful diagnosis
+
+Several health checks were flattening very different problems into the same generic answer.
+A missing Dex module could become package-reinstall advice, a slow semantic-search probe could
+make the whole checkup look broken, and Apple Mail list/read could look healthy while its
+separate search index was absent or stale.
+
+**What this fixes for you:**
+
+* **The original diagnosis survives.** Missing Dex files, missing third-party packages, and
+  optional components now get different explanations and different repair steps.
+* **“Could not tell” stays different from “broken.”** A timed-out search probe is reported as
+  unknown without contaminating the rest of the checkup.
+* **Apple Mail search is checked where search really lives.** Dex validates the configured
+  index, its searchable structure, every indexed mailbox's freshness, and safe file
+  permissions. The health check reads structural metadata, not message text.
+
+### 📅 Meeting work uses evidence instead of assumptions
+
+Four related faults could make meeting preparation and follow-up look confident while using
+the wrong attendee, recorder, calendar state, or event. The fixes now meet at the real
+execution seams instead of repeating hopeful instructions in several prompts.
+
+**What this fixes for you:**
+
+* **Meeting prep reads the calendar invite first.** Structured attendee identity is preserved
+  through delegated research, so two people with similar names are not silently collapsed.
+* **A broken calendar is never presented as an empty day.** Optional absence degrades calmly;
+  missing installation, permission failure, and unknown tool errors keep their real guidance.
+* **Configured meeting sources are honoured.** Granola is no longer assumed. Provider-neutral
+  capture IDs are used when safe, with the full vault-relative Markdown path as the
+  collision-safe fallback when two notes share a filename.
+* **Capture-to-calendar matching is deterministic and conservative.** A capture can inherit a
+  calendar identity only inside the five-minute window, with timezone-aware timestamps and
+  title/participant corroboration. Ties, naive timestamps, and events beyond the boundary stay
+  unmatched. Join links, dial-ins, access codes, locations, descriptions, conferencing data,
+  notes, and raw payloads never cross that boundary.
+
+### 🔒 Local receipts stay private, and malformed tasks stop at the door
+
+Dex can keep a small local record that a capability was attempted, but the helper doing that
+work could hang beyond the session-start budget. Separately, a leaked tool-call delimiter could
+be accepted as ordinary task text and saved as a corrupted task.
+
+**What this fixes for you:**
+
+* **Usage-attempt receipts are local, bounded, and content-free.** The complete helper process
+  is stopped after three seconds, including child processes. Its output is never relayed, it
+  does not retry, and this adds no endpoint, token, consent screen, or data collection.
+* **Corrupted task payloads are refused before any write.** Known delimiter shapes are rejected
+  at the Work tool boundary, while normal task text still round-trips unchanged.
+
+### 🧭 Fresh installs use the right capability identities
+
+The recent brain/vault split left three first-install checks looking for capability sources
+under their old identity. Existing upgraded vaults could work while a clean install stopped
+before Career, Companies, or Quarter Goals was provisioned.
+
+**What this fixes for you:**
+
+* **A brand-new install completes against the exact current vault sources.** The repair updates
+  the identities without weakening provenance checks or accepting a merely similar file.
+
+### 🧾 The permanent release name is finally honest
+
+Dex 1.96.2's catalog promised a permanent download tag derived from the source commit, but the
+release is built into a later sanitized commit. The promised name could not exist, and changing
+the real tag would have broken older updaters that correctly require the suffix to match the
+released commit.
+
+**What this fixes for you:**
+
+* **Published catalog v1 stays frozen and readable.** Existing installations keep the exact
+  contract they already understand.
+* **New releases use catalog v2's honest pattern.** The exact permanent tag is derived only
+  after the release commit exists, then checked locally and again after it is pushed.
+* **An empty or unreadable tag observation fails closed.** A release cannot pass merely because
+  the remote returned no evidence.
+* **Old update paths were tested, not assumed.** Twelve historic Dex versions completed the
+  release-shaped Mac journey against this change before it merged.
+
+Thanks to Chris Jackson for the detailed Doctor, Mail, Calendar, and meeting reports and source
+patches that exposed most of these trust failures.
+
 ## [1.96.2] — 🛡️ Your history saves again, and company networks get an honest answer (2026-08-13)
 
 If you're on a corporate network that intercepts secure connections — Zscaler, Netskope, most large enterprises — or on a hotel or airport captive portal, Dex's daily update check could fail and report that the release evidence was **invalid**. That wording means something specific and alarming: that the version of Dex being offered looks tampered with. It was never true. What had actually happened is that Dex couldn't verify it was really talking to GitHub, because something on your network was sitting in the middle of the connection. Worse, Dex treated it as a permanent verdict and didn't try again, so the check stayed broken for exactly the people most likely to hit it.

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -521,6 +521,7 @@
 .claude/skills/anthropic-xlsx/LICENSE.txt
 .claude/skills/anthropic-xlsx/SKILL.md
 .claude/skills/anthropic-xlsx/recalc.py
+.claude/skills/apple-mail-setup/SKILL.md
 .claude/skills/atlassian-setup/SKILL.md
 .claude/skills/backup-now/SKILL.md
 .claude/skills/backup-restore/SKILL.md
@@ -641,6 +642,7 @@
 .scripts/lib/tests/entity-identity.test.cjs
 .scripts/lib/tests/entity-pages.test.cjs
 .scripts/lib/tests/provision.test.cjs
+.scripts/meeting-intel/__tests__/capture-calendar-identity.test.cjs
 .scripts/meeting-intel/__tests__/company-domains.test.cjs
 .scripts/meeting-intel/__tests__/contacts-state.test.cjs
 .scripts/meeting-intel/__tests__/entity-creation.test.cjs
@@ -740,6 +742,7 @@ System/trusted-mcps.example.yaml
 System/usage_log.md
 System/user-profile-template.yaml
 core/__init__.py
+core/analytics_events.py
 core/backup/__init__.py
 core/backup/backup_vault.py
 core/backup/install_backup_job.py
@@ -852,11 +855,13 @@ core/lifecycle/preview.py
 core/lifecycle/retention.py
 core/lifecycle/runtime_evidence.py
 core/lifecycle/schemas/release-catalog-v1.schema.json
+core/lifecycle/schemas/release-catalog-v2.schema.json
 core/lifecycle/secrets.py
 core/lifecycle/service.py
 core/lifecycle/sqlite_snapshot.py
 core/mcp/CAREER_MCP_README.md
 core/mcp/analytics_helper.py
+core/mcp/analytics_receipts.py
 core/mcp/analytics_server.py
 core/mcp/calendar_server.py
 core/mcp/career_parser.py
@@ -887,6 +892,7 @@ core/mcp/tests/test_onboarding_entity_offer.py
 core/mcp/tests/test_onboarding_server.py
 core/mcp/update_checker.py
 core/mcp/work_server.py
+core/meeting_capture_match.py
 core/migrations/README.md
 core/migrations/__init__.py
 core/migrations/migrate_v1_to_v2.py
@@ -963,6 +969,9 @@ core/tests/fixtures/entity_pages/render-company.expected.md
 core/tests/fixtures/entity_pages/render-company.input.json
 core/tests/fixtures/entity_pages/render-person.expected.md
 core/tests/fixtures/entity_pages/render-person.input.json
+core/tests/fixtures/release-catalog-v1.96.2-historic-shape.json
+core/tests/fixtures/release-catalog-v1.96.2-installed-files.manifest
+core/tests/fixtures/release-catalog-v1.96.2-tag-split.json
 core/tests/fixtures/releases-feed.md
 core/tests/fixtures/sync-folder-vectors.json
 core/tests/fixtures/vault/00-Inbox/Daily_Plans/.gitkeep
@@ -1019,12 +1028,17 @@ core/tests/test_adoption_rule_mutations.py
 core/tests/test_adoption_runtime_evidence.py
 core/tests/test_adoption_sqlite_snapshot.py
 core/tests/test_adoption_transaction.py
+core/tests/test_analytics_attempt_receipts.py
+core/tests/test_analytics_event_wiring.py
+core/tests/test_apple_mail_health.py
+core/tests/test_apple_mail_runtime_macos.py
 core/tests/test_apply_update.py
 core/tests/test_architecture_inventory.py
 core/tests/test_backup_vault.py
 core/tests/test_branch_protection_script.py
 core/tests/test_calendar_eventkit_script.py
 core/tests/test_calendar_server.py
+core/tests/test_calendar_skill_degradation_instruction_contract.py
 core/tests/test_capabilities.py
 core/tests/test_ci_concurrency_never_cancels_main.py
 core/tests/test_ci_shard_durations.py
@@ -1118,7 +1132,10 @@ core/tests/test_mcp_registration_lifecycle.py
 core/tests/test_mcp_servers.py
 core/tests/test_mcp_stdio_startup.py
 core/tests/test_mcp_tool_behavior.py
+core/tests/test_meeting_capture_calendar_match.py
 core/tests/test_meeting_closeout_skill.py
+core/tests/test_meeting_prep_calendar_journey.py
+core/tests/test_meeting_source_instruction_contract.py
 core/tests/test_messy_vault_parsers.py
 core/tests/test_no_deprecated_models.py
 core/tests/test_nudge_calendar.py
@@ -1132,6 +1149,7 @@ core/tests/test_pipedrive_server.py
 core/tests/test_portable_contract.py
 core/tests/test_pr_report.py
 core/tests/test_preflight_paths.py
+core/tests/test_process_meetings_capture_calendar_wiring.py
 core/tests/test_process_meetings_soft_commitment_wiring.py
 core/tests/test_provision_parity.py
 core/tests/test_provision_transaction.py
@@ -1141,6 +1159,7 @@ core/tests/test_relationships_feed.py
 core/tests/test_release_asset_prober.py
 core/tests/test_release_catalog.py
 core/tests/test_release_catalog_generation.py
+core/tests/test_release_catalog_tag_identity.py
 core/tests/test_release_channel.py
 core/tests/test_release_feed.py
 core/tests/test_release_fleet.py
@@ -1205,6 +1224,7 @@ core/update/apply_update.py
 core/update/journey-protocol-v1.json
 core/update/journey_protocol.py
 core/utils/__init__.py
+core/utils/apple_mail_health.py
 core/utils/company_domains.py
 core/utils/credential_migration_exceptions.json
 core/utils/credential_remediation.py
@@ -1308,6 +1328,7 @@ packages/dex-contracts/dist/paths.schema.json
 packages/dex-contracts/dist/portable-vault.contract.json
 packages/dex-contracts/dist/portable-vault.schema.json
 packages/dex-contracts/dist/release-catalog-v1.schema.json
+packages/dex-contracts/dist/release-catalog-v2.schema.json
 packages/dex-contracts/fixtures/connections/status.connected.json
 packages/dex-contracts/fixtures/connections/status.expired.json
 packages/dex-contracts/fixtures/connections/status.expiring.json
@@ -1339,6 +1360,7 @@ scripts/check-path-contract-usage.sh
 scripts/check-pii.sh
 scripts/check-portable-contract.py
 scripts/check-portable-contract.sh
+scripts/check-release-catalog-tag-identity.py
 scripts/check-release-tag-reachability.sh
 scripts/check-release-tag-uniqueness.sh
 scripts/check-release-tree-matches-tag.sh

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.2"
+  "release_version": "1.96.3"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.2",
+  "release_version": "1.96.3",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.2","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.3","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.2 release,
+Download the versioned bridge and its checksum from the public v1.96.3 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.2/dex-update-bridge-v1.96.2.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.3/dex-update-bridge-v1.96.3.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.2/dex-update-bridge-v1.96.2.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.3/dex-update-bridge-v1.96.3.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.2.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.3.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.2.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.2",
+  "version": "1.96.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.2",
+      "version": "1.96.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.2",
+  "version": "1.96.3",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Why

A competing Cursor background agent merged PR #529 after the approved reliability cutoff and created an unpublished v1.97.0 tag/draft containing explicitly excluded work. Public latest remains v1.96.2 and the draft has zero assets.

This PR preserves history. Commit 58ed8df0 normally reverts merge 2433886e, then commit 3ff47211 applies only the reviewed v1.96.3 release metadata to the approved cutoff.

## Exact tree proof

- Approved cutoff: d8459ef9fcd30544174cf1c3165ad47011d56079
- Accidental merge: 2433886e7be0473bc5e7e5c3e449e580b70cd0f3
- Revert: 58ed8df0; its tree is byte-identical to d8459ef9
- Isolated release candidate: e38061c1650fbd80fc4d964e2584729b56c4e14e
- Corrective head: 3ff47211; its tree is byte-identical to e38061c1
- Final diff from d8459ef9 is exactly eight release metadata/changelog files

The product tree therefore contains only the accepted PRs #513-#522 for this release. PRs #523-#530 remain absent from the final tree.

## Proof before push

- 181 focused release/catalog/distribution tests passed
- 167 script tests passed with the explicit project Python
- distribution verifier passed with zero errors
- git diff --check passed
- v1.96.3 does not exist remotely
- v1.97.0 remains hidden, unpublished, and asset-free

## Required before merge

- exact-head macOS CI green
- historic twelve-version update canary green
- independent fixed-head review
- public latest still v1.96.2

After those checks, the unpublished v1.97.0 draft/tag will be removed and verified absent before this correction merges. The normal draft-first v1.96.3 route then owns asset creation, checksum read-back, publication, and clean-install/update proof.

No force push, shared-history rewrite, reporter contact, or public comment is part of this correction.

## Verified review-base route

The first run against accidental main passed all three Mac shards but the aggregate coverage calculation treated restored approved-cutoff code as newly added code. No coverage rule is waived and the head is unchanged.

For authoritative review, this PR now targets temporary base `bb/v1.96.3-review-base-thr_gz4arpvp2j` at exact revert commit `58ed8df0e1d3e35ee40d9455a437519631a77f6a`. That base tree is byte-identical to approved cutoff `d8459ef9`, so fresh CI judges only the eight genuine v1.96.3 release files. Once green and after the hidden v1.97.0 tag/draft are removed, shared main will advance from `2433886e` to this exact head by normal fast-forward only—never reset or force-push.