### PR TITLE
Add Dex Solo automation ownership handoff

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -406,8 +406,19 @@ fi
 # (core/health/promises.py), which Doctor and Proactive Health audit.
 {
     DEX_LAUNCH_AGENTS_DIR="${DEX_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+    AUTOMATION_OWNER_PYTHON="python3"
+    if [[ -f "$CLAUDE_DIR/.venv/bin/python" ]]; then
+        AUTOMATION_OWNER_PYTHON="$CLAUDE_DIR/.venv/bin/python"
+    fi
     while IFS='|' read -r JOB_NAME JOB_LOG_RELATIVE_PATH JOB_MAX_AGE_SECONDS JOB_EXPECTED_CADENCE JOB_LABEL JOB_MODE; do
         [[ -f "$DEX_LAUNCH_AGENTS_DIR/$JOB_NAME.plist" ]] || continue
+        if [[ -f "$CLAUDE_DIR/core/utils/launch_agents.py" ]] && (
+            cd "$CLAUDE_DIR" && "$AUTOMATION_OWNER_PYTHON" -m core.utils.launch_agents \
+                --offloaded-check --vault "$CLAUDE_DIR" \
+                --plist-relative "Library/LaunchAgents/$JOB_NAME.plist"
+        ) >/dev/null 2>&1; then
+            continue
+        fi
 
         JOB_LOG="$CLAUDE_DIR/$JOB_LOG_RELATIVE_PATH"
         if [[ ! -f "$JOB_LOG" ]]; then

--- a/.claude/hooks/tests/data-safety-instructions.test.cjs
+++ b/.claude/hooks/tests/data-safety-instructions.test.cjs
@@ -237,7 +237,7 @@ test('update mutation follows the immutable preview, approval, execute service r
   assertOnlyServiceOperations(UPDATE_SKILL, UPDATE_SERVICE_OPERATIONS, 'dex-update');
   assert.match(
     UPDATE_SKILL,
-    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.4\.0\./,
+    /Every lifecycle operation goes through `core\.lifecycle\.service` version 1\.5\.0\./,
   );
   assert.match(UPDATE_SKILL, /Execution requires an explicit yes to that exact preview\./);
   // execute is gated on an UNCHANGED preview + token for BOTH the adoption route and the

--- a/.claude/hooks/tests/session-staleness.test.cjs
+++ b/.claude/hooks/tests/session-staleness.test.cjs
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const crypto = require('node:crypto');
 const os = require('node:os');
 const path = require('node:path');
 
@@ -69,11 +70,31 @@ function installStaleJobHelper(sandbox) {
     path.join('core', '__init__.py'),
     path.join('core', 'utils', '__init__.py'),
     path.join('core', 'utils', 'launch_agents.py'),
+    path.join('core', 'utils', 'automation_ownership.py'),
+    path.join('core', 'portable_contract.py'),
+    path.join('core', 'path_safety.py'),
   ]) {
     const target = path.join(sandbox.vault, relative);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.copyFileSync(path.join(repoRoot, relative), target);
   }
+}
+
+function installSoloClaim(sandbox, label, plistContent) {
+  installStaleJobHelper(sandbox);
+  sandbox.launchAgents = path.join(sandbox.home, 'Library', 'LaunchAgents');
+  fs.mkdirSync(sandbox.launchAgents, { recursive: true });
+  const plistName = `${label}.plist`;
+  const plist = path.join(sandbox.launchAgents, plistName);
+  fs.writeFileSync(plist, plistContent);
+  const digest = crypto.createHash('sha256').update(fs.readFileSync(plist)).digest('hex');
+  const sidecar = path.join(sandbox.vault, 'System', '.dex', 'automation-ownership.json');
+  fs.mkdirSync(path.dirname(sidecar), { recursive: true });
+  fs.writeFileSync(
+    sidecar,
+    `{"claims":[{"automation_id":"${label}","owner_id":"dex-solo","plist_relative_path":"Library/LaunchAgents/${plistName}","plist_sha256":"${digest}"}],"schema_version":1}\n`,
+  );
+  return plist;
 }
 
 function installMovedVaultConflict(sandbox, plistName, oldVaultName = 'old-vault') {
@@ -185,6 +206,20 @@ test('session start warns when an installed meeting sync has never run', (t) => 
   );
 });
 
+test('session start suppresses Core freshness warnings for a valid Dex Solo claim', (t) => {
+  const sandbox = createSandbox(t);
+  installSoloClaim(
+    sandbox,
+    'com.dex.meeting-intel',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>Label</key><string>com.dex.meeting-intel</string></dict></plist>\n`,
+  );
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /⏰ Meeting sync/);
+});
+
 test('session start warns when meeting sync keeps running but has never succeeded', (t) => {
   const sandbox = createSandbox(t);
   installMeetingIntel(sandbox);
@@ -288,6 +323,28 @@ test('session start stays silent when no plist points to the stored former vault
 
   assert.doesNotMatch(stdout, /still points to this vault's old location/);
   assert.equal(fs.readFileSync(conflict.breadcrumb, 'utf8'), `${conflict.oldVault}\n`);
+});
+
+test('session start suppresses moved-vault warnings for a valid Dex Solo claim', (t) => {
+  const sandbox = createSandbox(t);
+  completeOnboarding(sandbox);
+  const oldVault = path.join(path.dirname(sandbox.vault), 'old-vault');
+  const breadcrumb = path.join(sandbox.home, '.config', 'dex', 'vault-path');
+  fs.mkdirSync(path.dirname(breadcrumb), { recursive: true });
+  fs.writeFileSync(breadcrumb, `${oldVault}\n`);
+  installSoloClaim(
+    sandbox,
+    'com.dex.meeting-intel',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>Label</key><string>com.dex.meeting-intel</string>
+<key>ProgramArguments</key><array><string>/bin/bash</string><string>${oldVault}/run.sh</string></array>
+</dict></plist>\n`,
+  );
+
+  const stdout = runSessionStart(sandbox);
+
+  assert.doesNotMatch(stdout, /still points to this vault's old location/);
 });
 
 test('session start stays silent when a plist references a sibling of the former vault', (t) => {

--- a/.claude/skills/dex-update/SKILL.md
+++ b/.claude/skills/dex-update/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when someone wants the latest Dex capabilities or asks what an up
 
 ## The one route
 
-Every lifecycle operation goes through `core.lifecycle.service` version 1.4.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
+Every lifecycle operation goes through `core.lifecycle.service` version 1.5.0. Treat its response as authoritative. Do not fall back to direct file operations, Git mutation, an update script, or a hand-built repair when the service refuses.
 
 Use the service operations in this order:
 

--- a/core/capabilities.py
+++ b/core/capabilities.py
@@ -20,8 +20,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-import yaml
-
 try:
     from core.lens_catalog_sources import (
         SkillSourceError,
@@ -86,6 +84,8 @@ def _read_profile(
     *,
     strict: bool = False,
 ) -> dict[str, Any]:
+    import yaml
+
     path = Path(profile_path)
     if not path.exists():
         return {}
@@ -145,11 +145,7 @@ def _within(root: Path, relative_path: str) -> Path:
 def _lexical_target(root: Path, relative_path: str, *, kind: str) -> Path:
     """Resolve a vault-relative target without following any path component."""
     relative = Path(relative_path)
-    if (
-        relative.is_absolute()
-        or not relative.parts
-        or any(part in {"", ".", ".."} for part in relative.parts)
-    ):
+    if relative.is_absolute() or not relative.parts or any(part in {"", ".", ".."} for part in relative.parts):
         raise CapabilityError(f"Capability path is not a safe relative path: {relative_path}")
     target = root.joinpath(*relative.parts)
     cursor = root
@@ -162,9 +158,7 @@ def _lexical_target(root: Path, relative_path: str, *, kind: str) -> Path:
             continue
         expects_directory = not final or kind == "directory"
         if expects_directory and not cursor.is_dir():
-            raise CapabilityError(
-                f"Capability target ancestor is not a directory: {relative.as_posix()}"
-            )
+            raise CapabilityError(f"Capability target ancestor is not a directory: {relative.as_posix()}")
         if final and kind == "file" and not cursor.is_file():
             raise CapabilityError(f"Capability target is not a regular file: {relative.as_posix()}")
     return target
@@ -249,9 +243,7 @@ class _MutationJournal:
 
     def removed_skill(self, target: Path, payload: bytes) -> None:
         # Rollback runs in reverse: restore the directory, then its one pinned file.
-        self._actions.append(
-            _UndoMutation("restore-file", target / "SKILL.md", payload=payload)
-        )
+        self._actions.append(_UndoMutation("restore-file", target / "SKILL.md", payload=payload))
         self._actions.append(_UndoMutation("restore-directory", target))
 
     def rollback(self) -> None:
@@ -562,23 +554,16 @@ def _active_room_skill_target(root: Path, pin: SkillSourcePin) -> _ActiveRoomSki
     except OSError as error:
         raise CapabilityError(f"Active room skill target cannot be inspected: {relative.as_posix()}") from error
     if len(entries) != 1 or any(
-        entry.name != "SKILL.md" or entry.is_symlink() or not entry.is_file()
-        for entry in entries
+        entry.name != "SKILL.md" or entry.is_symlink() or not entry.is_file() for entry in entries
     ):
-        raise CapabilityError(
-            f"Active room skill target contains unpinned or unsafe entries: {relative.as_posix()}"
-        )
+        raise CapabilityError(f"Active room skill target contains unpinned or unsafe entries: {relative.as_posix()}")
     try:
         payload = entries[0].read_bytes()
     except OSError as error:
-        raise CapabilityError(
-            f"Active room skill target cannot be read: {relative.as_posix()}"
-        ) from error
+        raise CapabilityError(f"Active room skill target cannot be read: {relative.as_posix()}") from error
     identity = pin.identify_payload(payload)
     if identity is None:
-        raise CapabilityError(
-            f"Active room skill target does not match its authoritative pin: {relative.as_posix()}"
-        )
+        raise CapabilityError(f"Active room skill target does not match its authoritative pin: {relative.as_posix()}")
     return _ActiveRoomSkill(target, identity, payload)
 
 
@@ -700,14 +685,10 @@ def reconcile_room(
                 active = active_skills[skill_id]
                 observed = _active_room_skill_target(root, pin)
                 if observed.identity != active.identity or observed.payload != active.payload:
-                    raise CapabilityError(
-                        f"Active room skill changed after preflight: {pin.target_path}"
-                    )
+                    raise CapabilityError(f"Active room skill changed after preflight: {pin.target_path}")
                 if active.identity != "missing":
                     if active.payload is None:
-                        raise CapabilityError(
-                            f"Active room skill payload is unavailable: {pin.target_path}"
-                        )
+                        raise CapabilityError(f"Active room skill payload is unavailable: {pin.target_path}")
                     journal.removed_skill(active.target, active.payload)
                     skill_file = active.target / "SKILL.md"
                     skill_file.unlink()
@@ -727,9 +708,7 @@ def reconcile_room(
                 raise CapabilityError(
                     f"Room {room} reconciliation failed and rollback was incomplete: {rollback_error}"
                 ) from error
-            raise CapabilityError(
-                f"Room {room} reconciliation failed and was rolled back: {error}"
-            ) from error
+            raise CapabilityError(f"Room {room} reconciliation failed and was rolled back: {error}") from error
         raise CapabilityError(f"Room {room} reconciliation failed: {error}") from error
 
     return {
@@ -834,15 +813,11 @@ def preflight_mutation_targets(
     seen: set[tuple[str, str]] = set()
     for index, raw in enumerate(targets):
         if not isinstance(raw, Mapping) or set(raw) != {"path", "kind"}:
-            raise CapabilityError(
-                f"Provision mutation target {index} must contain only path and kind"
-            )
+            raise CapabilityError(f"Provision mutation target {index} must contain only path and kind")
         relative_path = raw["path"]
         kind = raw["kind"]
         if not isinstance(relative_path, str) or kind not in {"file", "directory"}:
-            raise CapabilityError(
-                f"Provision mutation target {index} has an invalid path or kind"
-            )
+            raise CapabilityError(f"Provision mutation target {index} has an invalid path or kind")
         identity = (relative_path, kind)
         if identity in seen:
             continue
@@ -949,21 +924,16 @@ def reconcile_all(
             for room in rooms
         ]
         if profile_mutation_paths and results:
-            results[0]["mutation_paths"] = sorted(
-                set(results[0]["mutation_paths"]) | set(profile_mutation_paths)
-            )
+            results[0]["mutation_paths"] = sorted(set(results[0]["mutation_paths"]) | set(profile_mutation_paths))
         return results
     except Exception as error:
         try:
             journal.rollback()
         except Exception as rollback_error:
             raise CapabilityError(
-                "All-room reconciliation failed and aggregate rollback was incomplete: "
-                f"{rollback_error}"
+                f"All-room reconciliation failed and aggregate rollback was incomplete: {rollback_error}"
             ) from error
-        raise CapabilityError(
-            f"All-room reconciliation failed and aggregate rollback completed: {error}"
-        ) from error
+        raise CapabilityError(f"All-room reconciliation failed and aggregate rollback completed: {error}") from error
 
 
 def _atomic_text_write(path: Path, content: str) -> None:
@@ -1045,6 +1015,8 @@ def render_missing_companies_compatibility_pin(
     *,
     contract_path: Path | str | None = None,
 ) -> str | None:
+    import yaml
+
     """Render the one-time Companies compatibility pin without rewriting profile prose.
 
     ``None`` means the profile already has an explicit or legacy opinion.
@@ -1135,6 +1107,8 @@ def set_enabled(
     profile_path: Path | str | None = None,
     contract_path: Path | str | None = None,
 ) -> dict[str, Any]:
+    import yaml
+
     """Persist one room state and immediately reconcile its surfaced assets."""
     if not isinstance(room_enabled, bool):
         raise CapabilityError("enabled state must be true or false")
@@ -1214,13 +1188,8 @@ def set_enabled(
             try:
                 profile_journal.rollback()
             except Exception as rollback_error:
-                raise CapabilityError(
-                    "profile write failed and rollback was incomplete: "
-                    f"{rollback_error}"
-                ) from error
-            raise CapabilityError(
-                f"profile write failed before room reconciliation: {error}"
-            ) from error
+                raise CapabilityError(f"profile write failed and rollback was incomplete: {rollback_error}") from error
+            raise CapabilityError(f"profile write failed before room reconciliation: {error}") from error
     try:
         result = reconcile_room(
             room,
@@ -1228,23 +1197,18 @@ def set_enabled(
             vault_root=root,
             contract_path=contract_path,
         )
-        result["mutation_paths"] = sorted(
-            set(result["mutation_paths"]) | set(profile_mutation_paths)
-        )
+        result["mutation_paths"] = sorted(set(result["mutation_paths"]) | set(profile_mutation_paths))
         return result
     except Exception as error:
         try:
             profile_journal.rollback()
         except Exception as rollback_error:
             raise CapabilityError(
-                f"Room {room} reconciliation failed and profile rollback was incomplete: "
-                f"{rollback_error}"
+                f"Room {room} reconciliation failed and profile rollback was incomplete: {rollback_error}"
             ) from error
         if isinstance(error, CapabilityError):
             raise
-        raise CapabilityError(
-            f"Room {room} reconciliation failed and was rolled back: {error}"
-        ) from error
+        raise CapabilityError(f"Room {room} reconciliation failed and was rolled back: {error}") from error
 
 
 def _main() -> int:

--- a/core/capabilities.py
+++ b/core/capabilities.py
@@ -145,7 +145,11 @@ def _within(root: Path, relative_path: str) -> Path:
 def _lexical_target(root: Path, relative_path: str, *, kind: str) -> Path:
     """Resolve a vault-relative target without following any path component."""
     relative = Path(relative_path)
-    if relative.is_absolute() or not relative.parts or any(part in {"", ".", ".."} for part in relative.parts):
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
         raise CapabilityError(f"Capability path is not a safe relative path: {relative_path}")
     target = root.joinpath(*relative.parts)
     cursor = root
@@ -158,7 +162,9 @@ def _lexical_target(root: Path, relative_path: str, *, kind: str) -> Path:
             continue
         expects_directory = not final or kind == "directory"
         if expects_directory and not cursor.is_dir():
-            raise CapabilityError(f"Capability target ancestor is not a directory: {relative.as_posix()}")
+            raise CapabilityError(
+                f"Capability target ancestor is not a directory: {relative.as_posix()}"
+            )
         if final and kind == "file" and not cursor.is_file():
             raise CapabilityError(f"Capability target is not a regular file: {relative.as_posix()}")
     return target
@@ -243,7 +249,9 @@ class _MutationJournal:
 
     def removed_skill(self, target: Path, payload: bytes) -> None:
         # Rollback runs in reverse: restore the directory, then its one pinned file.
-        self._actions.append(_UndoMutation("restore-file", target / "SKILL.md", payload=payload))
+        self._actions.append(
+            _UndoMutation("restore-file", target / "SKILL.md", payload=payload)
+        )
         self._actions.append(_UndoMutation("restore-directory", target))
 
     def rollback(self) -> None:
@@ -554,16 +562,23 @@ def _active_room_skill_target(root: Path, pin: SkillSourcePin) -> _ActiveRoomSki
     except OSError as error:
         raise CapabilityError(f"Active room skill target cannot be inspected: {relative.as_posix()}") from error
     if len(entries) != 1 or any(
-        entry.name != "SKILL.md" or entry.is_symlink() or not entry.is_file() for entry in entries
+        entry.name != "SKILL.md" or entry.is_symlink() or not entry.is_file()
+        for entry in entries
     ):
-        raise CapabilityError(f"Active room skill target contains unpinned or unsafe entries: {relative.as_posix()}")
+        raise CapabilityError(
+            f"Active room skill target contains unpinned or unsafe entries: {relative.as_posix()}"
+        )
     try:
         payload = entries[0].read_bytes()
     except OSError as error:
-        raise CapabilityError(f"Active room skill target cannot be read: {relative.as_posix()}") from error
+        raise CapabilityError(
+            f"Active room skill target cannot be read: {relative.as_posix()}"
+        ) from error
     identity = pin.identify_payload(payload)
     if identity is None:
-        raise CapabilityError(f"Active room skill target does not match its authoritative pin: {relative.as_posix()}")
+        raise CapabilityError(
+            f"Active room skill target does not match its authoritative pin: {relative.as_posix()}"
+        )
     return _ActiveRoomSkill(target, identity, payload)
 
 
@@ -685,10 +700,14 @@ def reconcile_room(
                 active = active_skills[skill_id]
                 observed = _active_room_skill_target(root, pin)
                 if observed.identity != active.identity or observed.payload != active.payload:
-                    raise CapabilityError(f"Active room skill changed after preflight: {pin.target_path}")
+                    raise CapabilityError(
+                        f"Active room skill changed after preflight: {pin.target_path}"
+                    )
                 if active.identity != "missing":
                     if active.payload is None:
-                        raise CapabilityError(f"Active room skill payload is unavailable: {pin.target_path}")
+                        raise CapabilityError(
+                            f"Active room skill payload is unavailable: {pin.target_path}"
+                        )
                     journal.removed_skill(active.target, active.payload)
                     skill_file = active.target / "SKILL.md"
                     skill_file.unlink()
@@ -708,7 +727,9 @@ def reconcile_room(
                 raise CapabilityError(
                     f"Room {room} reconciliation failed and rollback was incomplete: {rollback_error}"
                 ) from error
-            raise CapabilityError(f"Room {room} reconciliation failed and was rolled back: {error}") from error
+            raise CapabilityError(
+                f"Room {room} reconciliation failed and was rolled back: {error}"
+            ) from error
         raise CapabilityError(f"Room {room} reconciliation failed: {error}") from error
 
     return {
@@ -813,11 +834,15 @@ def preflight_mutation_targets(
     seen: set[tuple[str, str]] = set()
     for index, raw in enumerate(targets):
         if not isinstance(raw, Mapping) or set(raw) != {"path", "kind"}:
-            raise CapabilityError(f"Provision mutation target {index} must contain only path and kind")
+            raise CapabilityError(
+                f"Provision mutation target {index} must contain only path and kind"
+            )
         relative_path = raw["path"]
         kind = raw["kind"]
         if not isinstance(relative_path, str) or kind not in {"file", "directory"}:
-            raise CapabilityError(f"Provision mutation target {index} has an invalid path or kind")
+            raise CapabilityError(
+                f"Provision mutation target {index} has an invalid path or kind"
+            )
         identity = (relative_path, kind)
         if identity in seen:
             continue
@@ -924,16 +949,21 @@ def reconcile_all(
             for room in rooms
         ]
         if profile_mutation_paths and results:
-            results[0]["mutation_paths"] = sorted(set(results[0]["mutation_paths"]) | set(profile_mutation_paths))
+            results[0]["mutation_paths"] = sorted(
+                set(results[0]["mutation_paths"]) | set(profile_mutation_paths)
+            )
         return results
     except Exception as error:
         try:
             journal.rollback()
         except Exception as rollback_error:
             raise CapabilityError(
-                f"All-room reconciliation failed and aggregate rollback was incomplete: {rollback_error}"
+                "All-room reconciliation failed and aggregate rollback was incomplete: "
+                f"{rollback_error}"
             ) from error
-        raise CapabilityError(f"All-room reconciliation failed and aggregate rollback completed: {error}") from error
+        raise CapabilityError(
+            f"All-room reconciliation failed and aggregate rollback completed: {error}"
+        ) from error
 
 
 def _atomic_text_write(path: Path, content: str) -> None:
@@ -1188,8 +1218,13 @@ def set_enabled(
             try:
                 profile_journal.rollback()
             except Exception as rollback_error:
-                raise CapabilityError(f"profile write failed and rollback was incomplete: {rollback_error}") from error
-            raise CapabilityError(f"profile write failed before room reconciliation: {error}") from error
+                raise CapabilityError(
+                    "profile write failed and rollback was incomplete: "
+                    f"{rollback_error}"
+                ) from error
+            raise CapabilityError(
+                f"profile write failed before room reconciliation: {error}"
+            ) from error
     try:
         result = reconcile_room(
             room,
@@ -1197,18 +1232,23 @@ def set_enabled(
             vault_root=root,
             contract_path=contract_path,
         )
-        result["mutation_paths"] = sorted(set(result["mutation_paths"]) | set(profile_mutation_paths))
+        result["mutation_paths"] = sorted(
+            set(result["mutation_paths"]) | set(profile_mutation_paths)
+        )
         return result
     except Exception as error:
         try:
             profile_journal.rollback()
         except Exception as rollback_error:
             raise CapabilityError(
-                f"Room {room} reconciliation failed and profile rollback was incomplete: {rollback_error}"
+                f"Room {room} reconciliation failed and profile rollback was incomplete: "
+                f"{rollback_error}"
             ) from error
         if isinstance(error, CapabilityError):
             raise
-        raise CapabilityError(f"Room {room} reconciliation failed and was rolled back: {error}") from error
+        raise CapabilityError(
+            f"Room {room} reconciliation failed and was rolled back: {error}"
+        ) from error
 
 
 def _main() -> int:

--- a/core/capabilities.py
+++ b/core/capabilities.py
@@ -1045,8 +1045,6 @@ def render_missing_companies_compatibility_pin(
     *,
     contract_path: Path | str | None = None,
 ) -> str | None:
-    import yaml
-
     """Render the one-time Companies compatibility pin without rewriting profile prose.
 
     ``None`` means the profile already has an explicit or legacy opinion.
@@ -1055,6 +1053,8 @@ def render_missing_companies_compatibility_pin(
     map also retain the earlier Career/Quarter bridge defaults in the same
     transaction; partial maps gain only the Companies pin.
     """
+    import yaml
+
     try:
         profile = yaml.safe_load(original) or {}
     except yaml.YAMLError as exc:
@@ -1137,9 +1137,9 @@ def set_enabled(
     profile_path: Path | str | None = None,
     contract_path: Path | str | None = None,
 ) -> dict[str, Any]:
+    """Persist one room state and immediately reconcile its surfaced assets."""
     import yaml
 
-    """Persist one room state and immediately reconcile its surfaced assets."""
     if not isinstance(room_enabled, bool):
         raise CapabilityError("enabled state must be true or false")
     surfaces = surfaces_for(room, contract_path=contract_path)

--- a/core/lifecycle/bridge.py
+++ b/core/lifecycle/bridge.py
@@ -24,7 +24,7 @@ ACTIVATION_VERSION = 1
 BRIDGE_RELEASE_RELATIVE = Path("core/lifecycle/catalog/bridge-release.json")
 ACTIVATION_RELATIVE = Path("System/.dex/lifecycle/activation.json")
 CATALOG_RELATIVE = Path("System/.release-catalog.json")
-COMPATIBLE_ACTIVATION_API_VERSIONS = frozenset({"1.2.0", "1.3.0"})
+COMPATIBLE_ACTIVATION_API_VERSIONS = frozenset({"1.2.0", "1.3.0", "1.4.0"})
 
 
 class BridgeError(RuntimeError):

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -162,7 +162,7 @@
       "properties": {
         "automation_id": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"},
         "owner_id": {"const": "dex-solo"},
-        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"},
+        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?\\.plist$"},
         "plist_sha256": {"$ref": "#/$defs/sha256"}
       }
     },
@@ -173,7 +173,7 @@
       "properties": {
         "automation_id": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"},
         "owner_id": {"const": "dex-solo"},
-        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"},
+        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?\\.plist$"},
         "plist_sha256": {"$ref": "#/$defs/sha256"},
         "launchd_state": {"const": "unloaded"}
       }

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -206,19 +206,37 @@
         "release": {"$ref": "#/$defs/automationReleaseRequest"}
       }
     },
-    "automationPreview": {
+    "automationClaimPreview": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["automation_ownership_version", "operation", "claim", "current_sidecar_sha256", "next_sidecar_sha256"],
+      "required": ["automation_ownership_version", "operation", "claim", "launchd_state", "current_sidecar_sha256", "next_sidecar_sha256"],
       "properties": {
         "automation_ownership_version": {"const": 1},
-        "operation": {"type": "string", "enum": ["claim", "release"]},
+        "operation": {"const": "claim"},
         "claim": {"$ref": "#/$defs/automationClaim"},
         "launchd_state": {"const": "unloaded"},
+        "current_sidecar_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "next_sidecar_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "automationReleasePreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_ownership_version", "operation", "claim", "scheduler_state", "current_sidecar_sha256", "next_sidecar_sha256"],
+      "properties": {
+        "automation_ownership_version": {"const": 1},
+        "operation": {"const": "release"},
+        "claim": {"$ref": "#/$defs/automationClaim"},
         "scheduler_state": {"const": "stopped"},
         "current_sidecar_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
         "next_sidecar_sha256": {"$ref": "#/$defs/sha256"}
       }
+    },
+    "automationPreview": {
+      "anyOf": [
+        {"$ref": "#/$defs/automationClaimPreview"},
+        {"$ref": "#/$defs/automationReleasePreview"}
+      ]
     },
     "automationPreviewResponse": {
       "anyOf": [

--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["api_version", "x-operations"],
   "properties": {
-    "api_version": {"const": "1.4.0"},
+    "api_version": {"const": "1.5.0"},
     "x-operations": {"type": "object"}
   },
   "x-operations": {
@@ -62,6 +62,22 @@
     "execute_approved_onboarding_context": {
       "request": {"$ref": "#/$defs/onboardingContextExecuteRequest"},
       "response": {"$ref": "#/$defs/onboardingContextExecuteResponse"}
+    },
+    "build_and_preview_automation_claim": {
+      "request": {"$ref": "#/$defs/automationClaimPreviewRequest"},
+      "response": {"$ref": "#/$defs/automationPreviewResponse"}
+    },
+    "execute_approved_automation_claim": {
+      "request": {"$ref": "#/$defs/automationExecuteRequest"},
+      "response": {"$ref": "#/$defs/automationExecuteResponse"}
+    },
+    "build_and_preview_automation_release": {
+      "request": {"$ref": "#/$defs/automationReleasePreviewRequest"},
+      "response": {"$ref": "#/$defs/automationPreviewResponse"}
+    },
+    "execute_approved_automation_release": {
+      "request": {"$ref": "#/$defs/automationExecuteRequest"},
+      "response": {"$ref": "#/$defs/automationExecuteResponse"}
     },
     "build_and_preview_conflict_resolution": {
       "request": {"$ref": "#/$defs/resolutionsRequest"},
@@ -131,13 +147,135 @@
     "apiEnvelope": {
       "type": "object",
       "required": ["api_version"],
-      "properties": {"api_version": {"const": "1.4.0"}}
+      "properties": {"api_version": {"const": "1.5.0"}}
     },
     "vaultRequest": {
       "type": "object",
       "additionalProperties": false,
       "required": ["vault_root"],
       "properties": {"vault_root": {"$ref": "#/$defs/path"}}
+    },
+    "automationClaim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_id", "owner_id", "plist_relative_path", "plist_sha256"],
+      "properties": {
+        "automation_id": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"},
+        "owner_id": {"const": "dex-solo"},
+        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"},
+        "plist_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "automationClaimRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_id", "owner_id", "plist_relative_path", "plist_sha256", "launchd_state"],
+      "properties": {
+        "automation_id": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"},
+        "owner_id": {"const": "dex-solo"},
+        "plist_relative_path": {"type": "string", "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"},
+        "plist_sha256": {"$ref": "#/$defs/sha256"},
+        "launchd_state": {"const": "unloaded"}
+      }
+    },
+    "automationReleaseRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_id", "owner_id", "scheduler_state"],
+      "properties": {
+        "automation_id": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"},
+        "owner_id": {"const": "dex-solo"},
+        "scheduler_state": {"const": "stopped"}
+      }
+    },
+    "automationClaimPreviewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "claim"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "claim": {"$ref": "#/$defs/automationClaimRequest"}
+      }
+    },
+    "automationReleasePreviewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "release"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "release": {"$ref": "#/$defs/automationReleaseRequest"}
+      }
+    },
+    "automationPreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_ownership_version", "operation", "claim", "current_sidecar_sha256", "next_sidecar_sha256"],
+      "properties": {
+        "automation_ownership_version": {"const": 1},
+        "operation": {"type": "string", "enum": ["claim", "release"]},
+        "claim": {"$ref": "#/$defs/automationClaim"},
+        "launchd_state": {"const": "unloaded"},
+        "scheduler_state": {"const": "stopped"},
+        "current_sidecar_sha256": {"anyOf": [{"$ref": "#/$defs/sha256"}, {"type": "null"}]},
+        "next_sidecar_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "automationPreviewResponse": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "needed", "preview", "approval_token"],
+          "properties": {
+            "api_version": {"const": "1.5.0"},
+            "needed": {"const": true},
+            "preview": {"$ref": "#/$defs/automationPreview"},
+            "approval_token": {"$ref": "#/$defs/sha256"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["api_version", "needed", "preview", "approval_token"],
+          "properties": {
+            "api_version": {"const": "1.5.0"},
+            "needed": {"const": false},
+            "preview": {"type": "null"},
+            "approval_token": {"type": "null"}
+          }
+        }
+      ]
+    },
+    "automationExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/automationPreview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "automationExecuteResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.5.0"},
+        "receipt": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operation", "status", "automation_id", "owner_id", "transaction_id", "sidecar_sha256"],
+          "properties": {
+            "operation": {"type": "string", "enum": ["claim", "release"]},
+            "status": {"type": "string", "enum": ["claimed", "already-claimed", "released", "already-released"]},
+            "automation_id": {"type": "string"},
+            "owner_id": {"const": "dex-solo"},
+            "transaction_id": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            "sidecar_sha256": {"$ref": "#/$defs/sha256"}
+          }
+        }
+      }
     },
     "releaseDeliveryResponse": {
       "anyOf": [
@@ -146,7 +284,7 @@
           "additionalProperties": false,
           "required": ["api_version", "status", "evidence"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "status": {"const": "not-delivered"},
             "evidence": {"type": "object"}
           }
@@ -156,7 +294,7 @@
           "additionalProperties": false,
           "required": ["api_version", "status", "release"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "status": {"const": "delivered"},
             "release": {"$ref": "#/$defs/releaseIdentity"}
           }
@@ -216,7 +354,7 @@
           "additionalProperties": false,
           "required": ["api_version", "preview", "approval_token"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "preview": {"$ref": "#/$defs/deliveredReleasePreview"},
             "approval_token": {"$ref": "#/$defs/sha256"}
           }
@@ -241,7 +379,7 @@
           "additionalProperties": false,
           "required": ["api_version", "receipt", "release"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "receipt": {"type": "object"},
             "release": {"$ref": "#/$defs/releaseIdentity"}
           }
@@ -273,7 +411,7 @@
           "additionalProperties": false,
           "required": ["api_version", "needed", "preview", "approval_token"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "needed": {"const": true},
             "preview": {"$ref": "#/$defs/mcpRegistrationPreview"},
             "approval_token": {"$ref": "#/$defs/sha256"}
@@ -284,7 +422,7 @@
           "additionalProperties": false,
           "required": ["api_version", "needed", "preview", "approval_token"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "needed": {"const": false},
             "preview": {"type": "null"},
             "approval_token": {"type": "null"}
@@ -307,7 +445,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"type": "object"}
       }
     },
@@ -336,7 +474,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "preview": {"$ref": "#/$defs/onboardingContext"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -356,7 +494,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"type": "object"}
       }
     },
@@ -405,7 +543,7 @@
           "additionalProperties": false,
           "required": ["api_version", "inventory", "plan"],
           "properties": {
-            "api_version": {"const": "1.4.0"},
+            "api_version": {"const": "1.5.0"},
             "inventory": {"$ref": "#/$defs/inventory"},
             "plan": {"$ref": "#/$defs/plan"}
           }
@@ -452,7 +590,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "preview": {"$ref": "#/$defs/preview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -537,7 +675,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "preview": {"$ref": "#/$defs/conflictResolutionPreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -584,7 +722,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "rewind_acknowledgement_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/adoptionReceipt"},
         "rewind_acknowledgement_token": {"$ref": "#/$defs/sha256"}
       }
@@ -630,7 +768,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "rewind_receipt": {"$ref": "#/$defs/rewindReceipt"}
       }
     },
@@ -675,7 +813,7 @@
       "additionalProperties": false,
       "required": ["api_version", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "preview": {"$ref": "#/$defs/archivePreview"},
         "approval_token": {"$ref": "#/$defs/sha256"}
       }
@@ -710,7 +848,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/archiveReceipt"}
       }
     },
@@ -719,7 +857,7 @@
       "additionalProperties": false,
       "required": ["api_version", "ledger_state", "retention"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "ledger_state": {"$ref": "#/$defs/ledgerState"},
         "retention": {"$ref": "#/$defs/retention"}
       }
@@ -768,7 +906,7 @@
       "additionalProperties": false,
       "required": ["api_version", "topology", "preview", "approval_token"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "topology": {"type": "string", "minLength": 1},
         "preview": {"$ref": "#/$defs/topologyPreview"},
         "approval_token": {
@@ -850,7 +988,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt", "receipt_path"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/topologyReceipt"},
         "receipt_path": {"$ref": "#/$defs/path"}
       }
@@ -898,7 +1036,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/rebuildCapsuleReceipt"}
       }
     },
@@ -929,7 +1067,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/rebuildStagingReceipt"}
       }
     },
@@ -976,7 +1114,7 @@
       "additionalProperties": false,
       "required": ["api_version", "receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/rebuildVerificationReceipt"}
       }
     },
@@ -1032,7 +1170,7 @@
         "rewind_acknowledgement_token"
       ],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "receipt": {"$ref": "#/$defs/rebuildActivationReceipt"},
         "rewind_acknowledgement_token": {
           "anyOf": [
@@ -1129,7 +1267,7 @@
       "additionalProperties": false,
       "required": ["api_version", "rewind_receipt"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "rewind_receipt": {"$ref": "#/$defs/rebuildRewindReceipt"}
       }
     },
@@ -1147,7 +1285,7 @@
       "additionalProperties": false,
       "required": ["api_version", "capsule_id", "abandoned"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "capsule_id": {"$ref": "#/$defs/capsuleId"},
         "abandoned": {"const": true}
       }
@@ -1157,7 +1295,7 @@
       "additionalProperties": false,
       "required": ["api_version", "outcomes"],
       "properties": {
-        "api_version": {"const": "1.4.0"},
+        "api_version": {"const": "1.5.0"},
         "outcomes": {
           "type": "array",
           "items": {"type": "object"}

--- a/core/lifecycle/schemas/automation-ownership-v1.schema.json
+++ b/core/lifecycle/schemas/automation-ownership-v1.schema.json
@@ -27,7 +27,7 @@
           "owner_id": {"const": "dex-solo"},
           "plist_relative_path": {
             "type": "string",
-            "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"
+            "pattern": "^Library/LaunchAgents/[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?\\.plist$"
           },
           "plist_sha256": {
             "type": "string",

--- a/core/lifecycle/schemas/automation-ownership-v1.schema.json
+++ b/core/lifecycle/schemas/automation-ownership-v1.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dex/contracts/automation-ownership-v1.schema.json",
+  "title": "Dex Solo launchd automation ownership sidecar v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "claims"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "claims": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "automation_id",
+          "owner_id",
+          "plist_relative_path",
+          "plist_sha256"
+        ],
+        "properties": {
+          "automation_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"
+          },
+          "owner_id": {"const": "dex-solo"},
+          "plist_relative_path": {
+            "type": "string",
+            "pattern": "^Library/LaunchAgents/[^/]+\\.plist$"
+          },
+          "plist_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -77,10 +77,16 @@ _ANALYTICS_RECEIPT_REASONS = frozenset(
     }
 )
 _ANALYTICS_EVENT_NAME = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
-_MAX_ANALYTICS_RECEIPT_INPUT_BYTES = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
-_MAX_RETAINED_ANALYTICS_RECEIPT_BYTES = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+_MAX_ANALYTICS_RECEIPT_INPUT_BYTES = (
+    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+)
+_MAX_RETAINED_ANALYTICS_RECEIPT_BYTES = (
+    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+)
 _ANALYTICS_RECEIPT_APPEND_ATTEMPTS = 2
-_ANALYTICS_RECEIPT_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
+_ANALYTICS_RECEIPT_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$"
+)
 _REBUILD_TRANSACTION_PATH = re.compile(
     r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
     r"receipts/(?:capsule|activation|rewind)\.json|"
@@ -125,10 +131,18 @@ def _transaction_preview_document(
 
 
 def _internal_transaction_read_limits(operation: str) -> dict[str, int]:
-    """Return the one service-owned cap required by a private receipt operation."""
-    if operation != "analytics-receipt":
-        return {}
-    return {_ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES)}
+    """Return service-owned caps for bounded private runtime files."""
+    if operation == "analytics-receipt":
+        return {
+            _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
+                portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+            )
+        }
+    if operation == "automation-ownership":
+        return {
+            automation_ownership.SIDECAR_RELATIVE: automation_ownership.SIDECAR_MAX_BYTES,
+        }
+    return {}
 
 
 def _transaction_preview_document_with_bounded_reads(
@@ -169,7 +183,9 @@ def _transaction_preview_document_with_bounded_reads(
             operation=operation,
         )
         if not verdict.allowed:
-            raise PlanRejected(f"the ownership contract forbids writing: {entry.relative} [{verdict.action}]")
+            raise PlanRejected(
+                f"the ownership contract forbids writing: {entry.relative} [{verdict.action}]"
+            )
         current: dict[str, object]
         if target.exists():
             if target.is_symlink() or not target.is_file():
@@ -285,7 +301,11 @@ def _execute_approved_transaction(
         before_commit=before_commit,
     )
     tx_paths_after = _tree_paths(root, tx_root_relative)
-    declared_paths = set(targets) | missing_ancestors | (tx_paths_before ^ tx_paths_after)
+    declared_paths = (
+        set(targets)
+        | missing_ancestors
+        | (tx_paths_before ^ tx_paths_after)
+    )
     files_written = [
         {
             "path": entry.relative,
@@ -447,7 +467,10 @@ def _append_analytics_attempt_receipt(
     }
     _validate_analytics_receipt_record(record)
     record_bytes = _canonical(record)
-    if len(record_bytes) > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES:
+    if (
+        len(record_bytes)
+        > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+    ):
         raise PlanRejected("analytics receipt record exceeds its bounded size")
 
     root = Path(vault_root)
@@ -477,7 +500,9 @@ def _append_analytics_attempt_receipt(
             _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
             _retain_newest_analytics_receipt_records(prefix, record_bytes),
             mode=0o600,
-            expected_current_sha256=(hashlib.sha256(existing).hexdigest() if target_exists else None),
+            expected_current_sha256=(
+                hashlib.sha256(existing).hexdigest() if target_exists else None
+            ),
             expected_absent=not target_exists,
         )
         plan = [entry]
@@ -496,7 +521,10 @@ def _append_analytics_attempt_receipt(
                 approved_token=str(preview["approval_token"]),
             )
         except PlanRejected as error:
-            if attempt + 1 < _ANALYTICS_RECEIPT_APPEND_ATTEMPTS and _is_stale_analytics_receipt_plan(error):
+            if (
+                attempt + 1 < _ANALYTICS_RECEIPT_APPEND_ATTEMPTS
+                and _is_stale_analytics_receipt_plan(error)
+            ):
                 continue
             raise
     raise RuntimeError("analytics receipt retry loop ended unexpectedly")
@@ -686,7 +714,10 @@ def _missing_companies_default_plan(
         for room, state in after_capabilities.items()
         if isinstance(state, Mapping)
         and isinstance(state.get("enabled"), bool)
-        and (not isinstance(before_capabilities, Mapping) or before_capabilities.get(room) != state)
+        and (
+            not isinstance(before_capabilities, Mapping)
+            or before_capabilities.get(room) != state
+        )
     }
 
     raw = original.encode("utf-8")
@@ -695,7 +726,9 @@ def _missing_companies_default_plan(
             "System/user-profile.yaml",
             rendered.encode("utf-8"),
             mode=(profile.stat().st_mode & 0o777) if exists else 0o644,
-            expected_current_sha256=(hashlib.sha256(raw).hexdigest() if exists else None),
+            expected_current_sha256=(
+                hashlib.sha256(raw).hexdigest() if exists else None
+            ),
             expected_absent=not exists,
         )
     ], states
@@ -896,7 +929,8 @@ def _prepare(vault_root: str | Path, release_root: str | Path | None = None) -> 
         prepare_vault(vault_root, release_root=release_root)
     except BridgeActivationError:
         raise PlanRejected(
-            "this Dex copy's update engine doesn't match its release information — run /dex-doctor"
+            "this Dex copy's update engine doesn't match its release information "
+            "— run /dex-doctor"
         ) from None
 
 
@@ -954,7 +988,9 @@ def _write_archive_receipt(path: Path, receipt: dict[str, object]) -> None:
         os.close(descriptor)
 
 
-def execute_approved_archive_removal(vault_root: str | Path, approved_token: str) -> dict[str, object]:
+def execute_approved_archive_removal(
+    vault_root: str | Path, approved_token: str
+) -> dict[str, object]:
     """Remove the exact archive previewed by the user while holding the shared lock."""
     root = Path(vault_root)
     preview = _archive_inventory(root)
@@ -969,7 +1005,6 @@ def execute_approved_archive_removal(vault_root: str | Path, approved_token: str
     receipt_path = root / receipt_relative
     moved = False
     try:
-
         def remove_archive() -> None:
             nonlocal moved
             os.replace(archive, quarantined)
@@ -1192,11 +1227,9 @@ def execute_approved_delivered_release(
         raise PlanRejected("delivered-release preview is not canonical JSON") from error
     expected_bytes = _canonical(expected_preview)
     expected_token = hashlib.sha256(expected_bytes).hexdigest()
-    if (
-        not hmac.compare_digest(supplied_bytes, expected_bytes)
-        or not isinstance(approved_token, str)
-        or not hmac.compare_digest(approved_token, expected_token)
-    ):
+    if not hmac.compare_digest(supplied_bytes, expected_bytes) or not isinstance(
+        approved_token, str
+    ) or not hmac.compare_digest(approved_token, expected_token):
         raise PlanRejected("delivered-release approval does not match the current exact preview")
 
     transaction_token = _preview_transaction(
@@ -1262,7 +1295,9 @@ def _mcp_registration_preview(
 
     rendered = json.loads(json.dumps(registration).replace("{{VAULT_PATH}}", str(root)))
     if os.name == "nt":
-        rendered = json.loads(json.dumps(rendered).replace(".venv/bin/python", ".venv/Scripts/python.exe"))
+        rendered = json.loads(
+            json.dumps(rendered).replace(".venv/bin/python", ".venv/Scripts/python.exe")
+        )
     updated = dict(existing)
     updated_servers = dict(servers)
     updated_servers[_MCP_REGISTRATION_NAME] = rendered
@@ -1322,11 +1357,7 @@ def execute_approved_mcp_registration(
         raise PlanRejected("the customization migration MCP registration is already present")
     expected = _canonical(expected_preview)
     token = hashlib.sha256(expected).hexdigest()
-    if (
-        not isinstance(approved_token, str)
-        or not hmac.compare_digest(supplied, expected)
-        or not hmac.compare_digest(approved_token, token)
-    ):
+    if not isinstance(approved_token, str) or not hmac.compare_digest(supplied, expected) or not hmac.compare_digest(approved_token, token):
         raise PlanRejected("MCP registration approval does not match the current exact preview")
     transaction = _preview_transaction(
         vault_root,
@@ -1384,7 +1415,9 @@ def execute_approved_conflict_resolution(
     """Execute one exactly approved conflict-resolution preview."""
     _prepare(vault_root, release_root)
     modeled = (
-        preview if isinstance(preview, ConflictResolutionPreview) else ConflictResolutionPreview.from_dict(preview)
+        preview
+        if isinstance(preview, ConflictResolutionPreview)
+        else ConflictResolutionPreview.from_dict(preview)
     )
     receipt = execute_conflict_resolution(
         Path(vault_root),
@@ -1403,7 +1436,9 @@ def build_and_preview_topology_migration(
     vault_root: str | Path,
 ) -> dict[str, object]:
     """Detect topology and preview the one-time split without converting it."""
-    topology, preview, approval_token = build_topology_migration_preview(Path(vault_root))
+    topology, preview, approval_token = build_topology_migration_preview(
+        Path(vault_root)
+    )
     return _envelope(
         topology=topology,
         preview=preview,
@@ -1476,8 +1511,12 @@ def execute_approved_rebuild_verification(
             {
                 "capsule_id": capsule_id,
                 "proposal_id": proposal_id,
-                "staging_receipt_sha256": hashlib.sha256(staging_receipt.canonical_bytes()).hexdigest(),
-                "report_sha256": hashlib.sha256(report.canonical_bytes()).hexdigest(),
+                "staging_receipt_sha256": hashlib.sha256(
+                    staging_receipt.canonical_bytes()
+                ).hexdigest(),
+                "report_sha256": hashlib.sha256(
+                    report.canonical_bytes()
+                ).hexdigest(),
             }
         )
     ).hexdigest()
@@ -1485,7 +1524,9 @@ def execute_approved_rebuild_verification(
         approved_token,
         expected_token,
     ):
-        raise VerificationError("verification confirmation token does not match staging")
+        raise VerificationError(
+            "verification confirmation token does not match staging"
+        )
     receipt = write_verification_report(
         Path(vault_root),
         capsule_id,
@@ -1507,7 +1548,9 @@ def execute_approved_rebuild_activation(
     receipt = activation.activate(root, preview, approved_token)
     return _envelope(
         receipt=receipt.to_dict(),
-        rewind_acknowledgement_token=(activation._rewind_acknowledgement_token(receipt)),
+        rewind_acknowledgement_token=(
+            activation._rewind_acknowledgement_token(receipt)
+        ),
     )
 
 
@@ -1522,7 +1565,11 @@ def rewind_rebuild_activation_by_receipt(
         rewind,
     )
 
-    modeled = receipt if isinstance(receipt, ActivationReceipt) else ActivationReceipt.from_dict(receipt)
+    modeled = (
+        receipt
+        if isinstance(receipt, ActivationReceipt)
+        else ActivationReceipt.from_dict(receipt)
+    )
     rewind_receipt = rewind(
         Path(vault_root),
         modeled,
@@ -1566,9 +1613,14 @@ def _rebuild_transaction_ids(root: Path) -> frozenset[str]:
         plan = begin.payload.get("plan")
         if not isinstance(plan, list):
             continue
-        relatives = (item.get("relative") for item in plan if isinstance(item, Mapping))
+        relatives = (
+            item.get("relative")
+            for item in plan
+            if isinstance(item, Mapping)
+        )
         if any(
-            isinstance(relative, str) and _REBUILD_TRANSACTION_PATH.fullmatch(relative) is not None
+            isinstance(relative, str)
+            and _REBUILD_TRANSACTION_PATH.fullmatch(relative) is not None
             for relative in relatives
         ):
             transaction_ids.add(tx_dir.name)

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -50,8 +50,9 @@ from core.lifecycle.preview import AdoptionPreview, build_adoption_preview
 from core.lifecycle.retention import compute_retention_report
 from core.path_safety import unsafe_existing_parent
 from core.transaction.engine import PlanEntry, PlanRejected, Transaction
+from core.utils import automation_ownership
 
-api_version = "1.4.0"
+api_version = "1.5.0"
 
 _CATALOG_RELATIVE = "System/.release-catalog.json"
 _PURPOSE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -76,16 +77,10 @@ _ANALYTICS_RECEIPT_REASONS = frozenset(
     }
 )
 _ANALYTICS_EVENT_NAME = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
-_MAX_ANALYTICS_RECEIPT_INPUT_BYTES = (
-    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
-)
-_MAX_RETAINED_ANALYTICS_RECEIPT_BYTES = (
-    portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
-)
+_MAX_ANALYTICS_RECEIPT_INPUT_BYTES = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+_MAX_RETAINED_ANALYTICS_RECEIPT_BYTES = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
 _ANALYTICS_RECEIPT_APPEND_ATTEMPTS = 2
-_ANALYTICS_RECEIPT_TIMESTAMP = re.compile(
-    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$"
-)
+_ANALYTICS_RECEIPT_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
 _REBUILD_TRANSACTION_PATH = re.compile(
     r"^System/\.dex/customization-migrations/cap-[0-9a-f]{16}/(?:"
     r"receipts/(?:capsule|activation|rewind)\.json|"
@@ -133,11 +128,7 @@ def _internal_transaction_read_limits(operation: str) -> dict[str, int]:
     """Return the one service-owned cap required by a private receipt operation."""
     if operation != "analytics-receipt":
         return {}
-    return {
-        _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
-            portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
-        )
-    }
+    return {_ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES)}
 
 
 def _transaction_preview_document_with_bounded_reads(
@@ -178,9 +169,7 @@ def _transaction_preview_document_with_bounded_reads(
             operation=operation,
         )
         if not verdict.allowed:
-            raise PlanRejected(
-                f"the ownership contract forbids writing: {entry.relative} [{verdict.action}]"
-            )
+            raise PlanRejected(f"the ownership contract forbids writing: {entry.relative} [{verdict.action}]")
         current: dict[str, object]
         if target.exists():
             if target.is_symlink() or not target.is_file():
@@ -296,11 +285,7 @@ def _execute_approved_transaction(
         before_commit=before_commit,
     )
     tx_paths_after = _tree_paths(root, tx_root_relative)
-    declared_paths = (
-        set(targets)
-        | missing_ancestors
-        | (tx_paths_before ^ tx_paths_after)
-    )
+    declared_paths = set(targets) | missing_ancestors | (tx_paths_before ^ tx_paths_after)
     files_written = [
         {
             "path": entry.relative,
@@ -462,10 +447,7 @@ def _append_analytics_attempt_receipt(
     }
     _validate_analytics_receipt_record(record)
     record_bytes = _canonical(record)
-    if (
-        len(record_bytes)
-        > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
-    ):
+    if len(record_bytes) > portable_contract.ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES:
         raise PlanRejected("analytics receipt record exceeds its bounded size")
 
     root = Path(vault_root)
@@ -495,9 +477,7 @@ def _append_analytics_attempt_receipt(
             _ANALYTICS_ATTEMPT_RECEIPT_RELATIVE,
             _retain_newest_analytics_receipt_records(prefix, record_bytes),
             mode=0o600,
-            expected_current_sha256=(
-                hashlib.sha256(existing).hexdigest() if target_exists else None
-            ),
+            expected_current_sha256=(hashlib.sha256(existing).hexdigest() if target_exists else None),
             expected_absent=not target_exists,
         )
         plan = [entry]
@@ -516,10 +496,7 @@ def _append_analytics_attempt_receipt(
                 approved_token=str(preview["approval_token"]),
             )
         except PlanRejected as error:
-            if (
-                attempt + 1 < _ANALYTICS_RECEIPT_APPEND_ATTEMPTS
-                and _is_stale_analytics_receipt_plan(error)
-            ):
+            if attempt + 1 < _ANALYTICS_RECEIPT_APPEND_ATTEMPTS and _is_stale_analytics_receipt_plan(error):
                 continue
             raise
     raise RuntimeError("analytics receipt retry loop ended unexpectedly")
@@ -709,10 +686,7 @@ def _missing_companies_default_plan(
         for room, state in after_capabilities.items()
         if isinstance(state, Mapping)
         and isinstance(state.get("enabled"), bool)
-        and (
-            not isinstance(before_capabilities, Mapping)
-            or before_capabilities.get(room) != state
-        )
+        and (not isinstance(before_capabilities, Mapping) or before_capabilities.get(room) != state)
     }
 
     raw = original.encode("utf-8")
@@ -721,9 +695,7 @@ def _missing_companies_default_plan(
             "System/user-profile.yaml",
             rendered.encode("utf-8"),
             mode=(profile.stat().st_mode & 0o777) if exists else 0o644,
-            expected_current_sha256=(
-                hashlib.sha256(raw).hexdigest() if exists else None
-            ),
+            expected_current_sha256=(hashlib.sha256(raw).hexdigest() if exists else None),
             expected_absent=not exists,
         )
     ], states
@@ -773,6 +745,120 @@ def _pin_missing_companies_default(vault_root: str | Path) -> dict[str, object]:
     return _envelope(pinned=True, receipt=executed["receipt"], states=states)
 
 
+def build_and_preview_automation_claim(
+    vault_root: str | Path,
+    claim: Mapping[str, object],
+) -> dict[str, object]:
+    """Preview Dex Solo claiming one unloaded, plist-bound launchd automation."""
+    try:
+        preview = automation_ownership.build_claim_preview(vault_root, claim)
+    except automation_ownership.AutomationOwnershipError as error:
+        raise PlanRejected(str(error)) from error
+    if preview is None:
+        return _envelope(needed=False, preview=None, approval_token=None)
+    return _envelope(
+        needed=True,
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def _execute_approved_automation_ownership(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    expected = hashlib.sha256(_canonical(preview)).hexdigest()
+    if not isinstance(approved_token, str) or not hmac.compare_digest(
+        approved_token,
+        expected,
+    ):
+        raise PlanRejected("automation ownership approval token does not match preview")
+    try:
+        entry, status = automation_ownership.execution_plan(vault_root, preview)
+    except automation_ownership.AutomationOwnershipError as error:
+        raise PlanRejected(str(error)) from error
+    claim = preview.get("claim")
+    if not isinstance(claim, Mapping):
+        raise PlanRejected("automation ownership preview claim must be an object")
+    if entry is None:
+        return _envelope(
+            receipt={
+                "operation": preview.get("operation"),
+                "status": status,
+                "automation_id": claim.get("automation_id"),
+                "owner_id": claim.get("owner_id"),
+                "transaction_id": None,
+                "sidecar_sha256": preview.get("next_sidecar_sha256"),
+            }
+        )
+    plan = [entry]
+    internal = _preview_transaction(
+        vault_root,
+        plan,
+        purpose="automation-ownership",
+        operation="automation-ownership",
+    )
+    executed = _execute_approved_transaction(
+        vault_root,
+        plan,
+        purpose="automation-ownership",
+        operation="automation-ownership",
+        approved_token=str(internal["approval_token"]),
+    )
+    transaction_receipt = executed["receipt"]
+    return _envelope(
+        receipt={
+            "operation": preview.get("operation"),
+            "status": status,
+            "automation_id": claim.get("automation_id"),
+            "owner_id": claim.get("owner_id"),
+            "transaction_id": transaction_receipt["transaction_id"],
+            "sidecar_sha256": preview.get("next_sidecar_sha256"),
+        }
+    )
+
+
+def execute_approved_automation_claim(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Record one exact approved claim through the lifecycle transaction door."""
+    if preview.get("operation") != "claim":
+        raise PlanRejected("automation claim execution requires a claim preview")
+    return _execute_approved_automation_ownership(vault_root, preview, approved_token)
+
+
+def build_and_preview_automation_release(
+    vault_root: str | Path,
+    release: Mapping[str, object],
+) -> dict[str, object]:
+    """Preview release after the Dex Solo scheduler has stopped."""
+    try:
+        preview = automation_ownership.build_release_preview(vault_root, release)
+    except automation_ownership.AutomationOwnershipError as error:
+        raise PlanRejected(str(error)) from error
+    if preview is None:
+        return _envelope(needed=False, preview=None, approval_token=None)
+    return _envelope(
+        needed=True,
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def execute_approved_automation_release(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Record one exact approved release through the lifecycle transaction door."""
+    if preview.get("operation") != "release":
+        raise PlanRejected("automation release execution requires a release preview")
+    return _execute_approved_automation_ownership(vault_root, preview, approved_token)
+
+
 def _inventory_and_plan_models(vault_root: str | Path):
     root = Path(vault_root)
     catalog = load_catalog(root / _CATALOG_RELATIVE, release_root=root)
@@ -810,8 +896,7 @@ def _prepare(vault_root: str | Path, release_root: str | Path | None = None) -> 
         prepare_vault(vault_root, release_root=release_root)
     except BridgeActivationError:
         raise PlanRejected(
-            "this Dex copy's update engine doesn't match its release information "
-            "— run /dex-doctor"
+            "this Dex copy's update engine doesn't match its release information — run /dex-doctor"
         ) from None
 
 
@@ -869,9 +954,7 @@ def _write_archive_receipt(path: Path, receipt: dict[str, object]) -> None:
         os.close(descriptor)
 
 
-def execute_approved_archive_removal(
-    vault_root: str | Path, approved_token: str
-) -> dict[str, object]:
+def execute_approved_archive_removal(vault_root: str | Path, approved_token: str) -> dict[str, object]:
     """Remove the exact archive previewed by the user while holding the shared lock."""
     root = Path(vault_root)
     preview = _archive_inventory(root)
@@ -886,6 +969,7 @@ def execute_approved_archive_removal(
     receipt_path = root / receipt_relative
     moved = False
     try:
+
         def remove_archive() -> None:
             nonlocal moved
             os.replace(archive, quarantined)
@@ -1108,9 +1192,11 @@ def execute_approved_delivered_release(
         raise PlanRejected("delivered-release preview is not canonical JSON") from error
     expected_bytes = _canonical(expected_preview)
     expected_token = hashlib.sha256(expected_bytes).hexdigest()
-    if not hmac.compare_digest(supplied_bytes, expected_bytes) or not isinstance(
-        approved_token, str
-    ) or not hmac.compare_digest(approved_token, expected_token):
+    if (
+        not hmac.compare_digest(supplied_bytes, expected_bytes)
+        or not isinstance(approved_token, str)
+        or not hmac.compare_digest(approved_token, expected_token)
+    ):
         raise PlanRejected("delivered-release approval does not match the current exact preview")
 
     transaction_token = _preview_transaction(
@@ -1176,9 +1262,7 @@ def _mcp_registration_preview(
 
     rendered = json.loads(json.dumps(registration).replace("{{VAULT_PATH}}", str(root)))
     if os.name == "nt":
-        rendered = json.loads(
-            json.dumps(rendered).replace(".venv/bin/python", ".venv/Scripts/python.exe")
-        )
+        rendered = json.loads(json.dumps(rendered).replace(".venv/bin/python", ".venv/Scripts/python.exe"))
     updated = dict(existing)
     updated_servers = dict(servers)
     updated_servers[_MCP_REGISTRATION_NAME] = rendered
@@ -1238,7 +1322,11 @@ def execute_approved_mcp_registration(
         raise PlanRejected("the customization migration MCP registration is already present")
     expected = _canonical(expected_preview)
     token = hashlib.sha256(expected).hexdigest()
-    if not isinstance(approved_token, str) or not hmac.compare_digest(supplied, expected) or not hmac.compare_digest(approved_token, token):
+    if (
+        not isinstance(approved_token, str)
+        or not hmac.compare_digest(supplied, expected)
+        or not hmac.compare_digest(approved_token, token)
+    ):
         raise PlanRejected("MCP registration approval does not match the current exact preview")
     transaction = _preview_transaction(
         vault_root,
@@ -1296,9 +1384,7 @@ def execute_approved_conflict_resolution(
     """Execute one exactly approved conflict-resolution preview."""
     _prepare(vault_root, release_root)
     modeled = (
-        preview
-        if isinstance(preview, ConflictResolutionPreview)
-        else ConflictResolutionPreview.from_dict(preview)
+        preview if isinstance(preview, ConflictResolutionPreview) else ConflictResolutionPreview.from_dict(preview)
     )
     receipt = execute_conflict_resolution(
         Path(vault_root),
@@ -1317,9 +1403,7 @@ def build_and_preview_topology_migration(
     vault_root: str | Path,
 ) -> dict[str, object]:
     """Detect topology and preview the one-time split without converting it."""
-    topology, preview, approval_token = build_topology_migration_preview(
-        Path(vault_root)
-    )
+    topology, preview, approval_token = build_topology_migration_preview(Path(vault_root))
     return _envelope(
         topology=topology,
         preview=preview,
@@ -1392,12 +1476,8 @@ def execute_approved_rebuild_verification(
             {
                 "capsule_id": capsule_id,
                 "proposal_id": proposal_id,
-                "staging_receipt_sha256": hashlib.sha256(
-                    staging_receipt.canonical_bytes()
-                ).hexdigest(),
-                "report_sha256": hashlib.sha256(
-                    report.canonical_bytes()
-                ).hexdigest(),
+                "staging_receipt_sha256": hashlib.sha256(staging_receipt.canonical_bytes()).hexdigest(),
+                "report_sha256": hashlib.sha256(report.canonical_bytes()).hexdigest(),
             }
         )
     ).hexdigest()
@@ -1405,9 +1485,7 @@ def execute_approved_rebuild_verification(
         approved_token,
         expected_token,
     ):
-        raise VerificationError(
-            "verification confirmation token does not match staging"
-        )
+        raise VerificationError("verification confirmation token does not match staging")
     receipt = write_verification_report(
         Path(vault_root),
         capsule_id,
@@ -1429,9 +1507,7 @@ def execute_approved_rebuild_activation(
     receipt = activation.activate(root, preview, approved_token)
     return _envelope(
         receipt=receipt.to_dict(),
-        rewind_acknowledgement_token=(
-            activation._rewind_acknowledgement_token(receipt)
-        ),
+        rewind_acknowledgement_token=(activation._rewind_acknowledgement_token(receipt)),
     )
 
 
@@ -1446,11 +1522,7 @@ def rewind_rebuild_activation_by_receipt(
         rewind,
     )
 
-    modeled = (
-        receipt
-        if isinstance(receipt, ActivationReceipt)
-        else ActivationReceipt.from_dict(receipt)
-    )
+    modeled = receipt if isinstance(receipt, ActivationReceipt) else ActivationReceipt.from_dict(receipt)
     rewind_receipt = rewind(
         Path(vault_root),
         modeled,
@@ -1494,14 +1566,9 @@ def _rebuild_transaction_ids(root: Path) -> frozenset[str]:
         plan = begin.payload.get("plan")
         if not isinstance(plan, list):
             continue
-        relatives = (
-            item.get("relative")
-            for item in plan
-            if isinstance(item, Mapping)
-        )
+        relatives = (item.get("relative") for item in plan if isinstance(item, Mapping))
         if any(
-            isinstance(relative, str)
-            and _REBUILD_TRANSACTION_PATH.fullmatch(relative) is not None
+            isinstance(relative, str) and _REBUILD_TRANSACTION_PATH.fullmatch(relative) is not None
             for relative in relatives
         ):
             transaction_ids.add(tx_dir.name)
@@ -1534,6 +1601,10 @@ __all__ = [
     "execute_approved_mcp_registration",
     "build_and_preview_onboarding_context",
     "execute_approved_onboarding_context",
+    "build_and_preview_automation_claim",
+    "execute_approved_automation_claim",
+    "build_and_preview_automation_release",
+    "execute_approved_automation_release",
     "deliver_and_apply_latest_release",
     "build_and_preview_conflict_resolution",
     "execute_approved_conflict_resolution",

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -50,7 +50,8 @@ AUTOMATION_OWNERSHIP_RELATIVE = "System/.dex/automation-ownership.json"
 ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES = 256 * 1024
 ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES = 256
 ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES = (
-    ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES + ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+    ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
+    + ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
 )
 
 OWNERSHIP_CLASSES = ("brain", "vault", "seed", "generated", "runtime")
@@ -130,51 +131,51 @@ RULES: tuple[Rule, ...] = (
     _r("brain-core", "core", "dir", "brain"),
     _r("brain-scripts", "scripts", "dir", "brain"),
     _r("brain-dot-scripts", ".scripts", "dir", "brain"),
-    _r(
-        "brain-packages",
-        "packages",
-        "dir",
-        "brain",
-        "package sources are brain; the committed dist/ views are generated (below)",
-    ),
-    _r(
-        "brain-claude",
-        ".claude",
-        "dir",
-        "brain",
-        "shipped skills/hooks/flows; user skills belong in .claude/skills-custom/ (vault)",
-    ),
+    _r("brain-packages", "packages", "dir", "brain",
+       "package sources are brain; the committed dist/ views are generated (below)"),
+    _r("brain-claude", ".claude", "dir", "brain",
+       "shipped skills/hooks/flows; user skills belong in .claude/skills-custom/ (vault)"),
     _r("brain-agents", ".agents", "dir", "brain"),
     _r("brain-cursor", ".cursor", "dir", "brain"),
-    _r(
-        "brain-obsidian",
-        ".obsidian",
-        "dir",
-        "brain",
-        "shipped Obsidian defaults; a user's live workspace state is untracked",
-    ),
+    _r("brain-obsidian", ".obsidian", "dir", "brain",
+       "shipped Obsidian defaults; a user's live workspace state is untracked"),
     _r("brain-github", ".github", "dir", "brain"),
-    _r("brain-ci", ".ci", "dir", "brain", "CI shard-balance data; dev-only, stripped from releases via .distignore"),
+    _r("brain-ci", ".ci", "dir", "brain",
+       "CI shard-balance data; dev-only, stripped from releases via .distignore"),
     _r("brain-docs", "docs", "dir", "brain"),
     # System docs shipped inside the user's Resources region: enumerated file by
     # file (mirroring the PARA seed pattern) so a USER note or edit added under
     # 06-Resources/Dex_System/ falls through to the vault region rule and can
     # never be clobbered by an update. Relocate to docs/ per Vault_Contract
     # §10.1; until then updates may replace exactly these shipped files.
-    _r("brain-doc-background-processing", "06-Resources/Dex_System/Background_Processing_Guide.md", "file", "brain"),
-    _r("brain-doc-calendar-setup", "06-Resources/Dex_System/Calendar_Setup.md", "file", "brain"),
-    _r("brain-doc-jobs-to-be-done", "06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md", "file", "brain"),
-    _r("brain-doc-system-guide", "06-Resources/Dex_System/Dex_System_Guide.md", "file", "brain"),
-    _r("brain-doc-technical-guide", "06-Resources/Dex_System/Dex_Technical_Guide.md", "file", "brain"),
-    _r("brain-doc-distribution-checklist", "06-Resources/Dex_System/Distribution_Checklist.md", "file", "brain"),
-    _r("brain-doc-distribution-strategy", "06-Resources/Dex_System/Distribution_Strategy.md", "file", "brain"),
-    _r("brain-doc-folder-structure", "06-Resources/Dex_System/Folder_Structure.md", "file", "brain"),
-    _r("brain-doc-memory-ownership", "06-Resources/Dex_System/Memory_Ownership.md", "file", "brain"),
-    _r("brain-doc-named-sessions", "06-Resources/Dex_System/Named_Sessions_Guide.md", "file", "brain"),
-    _r("brain-doc-obsidian-guide", "06-Resources/Dex_System/Obsidian_Guide.md", "file", "brain"),
-    _r("brain-doc-dex-system-readme", "06-Resources/Dex_System/README.md", "file", "brain"),
-    _r("brain-doc-updating-dex", "06-Resources/Dex_System/Updating_Dex.md", "file", "brain"),
-    _r("brain-staging", "staging", "dir", "brain", "dev-only staging scaffolding; excluded from releases"),
+    _r("brain-doc-background-processing",
+       "06-Resources/Dex_System/Background_Processing_Guide.md", "file", "brain"),
+    _r("brain-doc-calendar-setup", "06-Resources/Dex_System/Calendar_Setup.md",
+       "file", "brain"),
+    _r("brain-doc-jobs-to-be-done", "06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md",
+       "file", "brain"),
+    _r("brain-doc-system-guide", "06-Resources/Dex_System/Dex_System_Guide.md",
+       "file", "brain"),
+    _r("brain-doc-technical-guide", "06-Resources/Dex_System/Dex_Technical_Guide.md",
+       "file", "brain"),
+    _r("brain-doc-distribution-checklist",
+       "06-Resources/Dex_System/Distribution_Checklist.md", "file", "brain"),
+    _r("brain-doc-distribution-strategy",
+       "06-Resources/Dex_System/Distribution_Strategy.md", "file", "brain"),
+    _r("brain-doc-folder-structure", "06-Resources/Dex_System/Folder_Structure.md",
+       "file", "brain"),
+    _r("brain-doc-memory-ownership", "06-Resources/Dex_System/Memory_Ownership.md",
+       "file", "brain"),
+    _r("brain-doc-named-sessions", "06-Resources/Dex_System/Named_Sessions_Guide.md",
+       "file", "brain"),
+    _r("brain-doc-obsidian-guide", "06-Resources/Dex_System/Obsidian_Guide.md",
+       "file", "brain"),
+    _r("brain-doc-dex-system-readme", "06-Resources/Dex_System/README.md",
+       "file", "brain"),
+    _r("brain-doc-updating-dex", "06-Resources/Dex_System/Updating_Dex.md",
+       "file", "brain"),
+    _r("brain-staging", "staging", "dir", "brain",
+       "dev-only staging scaffolding; excluded from releases"),
     _r("brain-agents-md", "AGENTS.md", "file", "brain"),
     _r("brain-readme", "README.md", "file", "brain"),
     _r("brain-changelog", "CHANGELOG.md", "file", "brain"),
@@ -192,66 +193,31 @@ RULES: tuple[Rule, ...] = (
     _r("brain-gitignore", ".gitignore", "file", "brain"),
     _r("brain-gitattributes", ".gitattributes", "file", "brain"),
     _r("brain-distignore", ".distignore", "file", "brain"),
-    _r(
-        "brain-beta-communications",
-        "System/Beta_Communications",
-        "dir",
-        "brain",
-        "release-doc retained until the schema-2 baseline-reduction follow-up",
-    ),
+    _r("brain-beta-communications", "System/Beta_Communications", "dir", "brain",
+       "release-doc retained until the schema-2 baseline-reduction follow-up"),
     _r("brain-system-readme", "System/README.md", "file", "brain"),
     # --- seed: shipped once, then the user's; update writes only if absent -
     _r("seed-templates", "System/Templates", "dir", "seed"),
-    _r(
-        "seed-user-profile-live",
-        "System/user-profile.yaml",
-        "file",
-        "seed",
-        "created from the tracked template at install; user VALUES live here and are never released or overwritten",
-    ),
-    _r(
-        "seed-user-profile-template",
-        "System/user-profile-template.yaml",
-        "file",
-        "seed",
-        "canonical shipped template (the ratified doc names user-profile.example.yaml; "
-        "the repo consolidated on -template — deliberate deviation)",
-    ),
-    _r(
-        "seed-user-profile-example",
-        "System/user-profile.example.yaml",
-        "file",
-        "seed",
-        "legacy duplicate template; removal in flight (portability hygiene PR)",
-    ),
-    _r(
-        "seed-pillars-live",
-        "System/pillars.yaml",
-        "file",
-        "seed",
-        "shipped empty; user pillar registry — never overwritten",
-    ),
+    _r("seed-user-profile-live", "System/user-profile.yaml", "file", "seed",
+       "created from the tracked template at install; user VALUES live here and are never released or overwritten"),
+    _r("seed-user-profile-template", "System/user-profile-template.yaml", "file", "seed",
+       "canonical shipped template (the ratified doc names user-profile.example.yaml; "
+       "the repo consolidated on -template — deliberate deviation)"),
+    _r("seed-user-profile-example", "System/user-profile.example.yaml", "file", "seed",
+       "legacy duplicate template; removal in flight (portability hygiene PR)"),
+    _r("seed-pillars-live", "System/pillars.yaml", "file", "seed",
+       "shipped empty; user pillar registry — never overwritten"),
     _r("seed-pillars-example", "System/pillars.example.yaml", "file", "seed"),
     _r("seed-trusted-mcps-example", "System/trusted-mcps.example.yaml", "file", "seed"),
     _r("seed-mcp-example", "System/.mcp.json.example", "file", "seed"),
     _r("seed-env-example", "env.example", "file", "seed"),
-    _r(
-        "seed-integrations",
-        "System/integrations",
-        "dir",
-        "seed",
-        "SR1 #150: tracked reference-schema templates carrying env-var references; "
-        "installed if absent, never overwritten once user-owned",
-    ),
+    _r("seed-integrations", "System/integrations", "dir", "seed",
+       "SR1 #150: tracked reference-schema templates carrying env-var references; "
+       "installed if absent, never overwritten once user-owned"),
     _r("seed-dex-backlog", "System/Dex_Backlog.md", "file", "seed"),
     _r("seed-session-learnings-readme", "System/Session_Learnings/README.md", "file", "seed"),
-    _r(
-        "seed-dex-ideas",
-        "System/Dex_Ideas.md",
-        "file",
-        "seed",
-        "legacy duplicate of Dex_Backlog.md; removal in flight (portability hygiene PR)",
-    ),
+    _r("seed-dex-ideas", "System/Dex_Ideas.md", "file", "seed",
+       "legacy duplicate of Dex_Backlog.md; removal in flight (portability hygiene PR)"),
     # PARA starters: the EXACT shipped scaffolding files, enumerated one by one.
     # The regions themselves are vault (below); an update may seed precisely
     # these paths when absent and nothing else. Adding a tracked file under a
@@ -260,218 +226,125 @@ RULES: tuple[Rule, ...] = (
     _r("seed-inbox-daily-plans-readme", "00-Inbox/Daily_Plans/README.md", "file", "seed"),
     _r("seed-inbox-ideas-readme", "00-Inbox/Ideas/README.md", "file", "seed"),
     _r("seed-inbox-meetings-readme", "00-Inbox/Meetings/README.md", "file", "seed"),
-    _r(
-        "seed-quarter-goals-file",
-        "01-Quarter_Goals/Quarter_Goals.md",
-        "file",
-        "seed",
-        "capability-gated room (quarter_goals)",
-    ),
-    _r("seed-week-priorities-file", "02-Week_Priorities/Week_Priorities.md", "file", "seed"),
+    _r("seed-quarter-goals-file", "01-Quarter_Goals/Quarter_Goals.md", "file", "seed",
+       "capability-gated room (quarter_goals)"),
+    _r("seed-week-priorities-file", "02-Week_Priorities/Week_Priorities.md", "file",
+       "seed"),
     _r("seed-tasks-file", "03-Tasks/Tasks.md", "file", "seed"),
     _r("seed-projects-readme", "04-Projects/README.md", "file", "seed"),
     _r("seed-areas-readme", "05-Areas/README.md", "file", "seed"),
-    _r(
-        "seed-career-evidence-readme",
-        "05-Areas/Career/Evidence/README.md",
-        "file",
-        "seed",
-        "capability-gated room (career)",
-    ),
-    _r("seed-companies-readme", "05-Areas/Companies/README.md", "file", "seed", "capability-gated room (companies)"),
+    _r("seed-career-evidence-readme", "05-Areas/Career/Evidence/README.md", "file",
+       "seed", "capability-gated room (career)"),
+    _r("seed-companies-readme", "05-Areas/Companies/README.md", "file", "seed",
+       "capability-gated room (companies)"),
     _r("seed-people-readme", "05-Areas/People/README.md", "file", "seed"),
-    _r("seed-people-internal-readme", "05-Areas/People/Internal/README.md", "file", "seed"),
-    _r("seed-people-external-readme", "05-Areas/People/External/README.md", "file", "seed"),
+    _r("seed-people-internal-readme", "05-Areas/People/Internal/README.md", "file",
+       "seed"),
+    _r("seed-people-external-readme", "05-Areas/People/External/README.md", "file",
+       "seed"),
     _r("seed-resources-readme", "06-Resources/README.md", "file", "seed"),
     _r("seed-intel-gitkeep", "06-Resources/Intel/.gitkeep", "file", "seed"),
-    _r("seed-meeting-intel-gitkeep", "06-Resources/Intel/Meeting_Intel/.gitkeep", "file", "seed"),
+    _r("seed-meeting-intel-gitkeep", "06-Resources/Intel/Meeting_Intel/.gitkeep",
+       "file", "seed"),
     _r("seed-learnings-readme", "06-Resources/Learnings/README.md", "file", "seed"),
-    _r("seed-mistake-patterns", "06-Resources/Learnings/Mistake_Patterns.md", "file", "seed"),
-    _r("seed-working-preferences", "06-Resources/Learnings/Working_Preferences.md", "file", "seed"),
-    _r("seed-quarterly-reviews-readme", "06-Resources/Quarterly_Reviews/README.md", "file", "seed"),
+    _r("seed-mistake-patterns", "06-Resources/Learnings/Mistake_Patterns.md", "file",
+       "seed"),
+    _r("seed-working-preferences", "06-Resources/Learnings/Working_Preferences.md",
+       "file", "seed"),
+    _r("seed-quarterly-reviews-readme", "06-Resources/Quarterly_Reviews/README.md",
+       "file", "seed"),
     _r("seed-archives-readme", "07-Archives/README.md", "file", "seed"),
     _r("seed-archives-plans-readme", "07-Archives/Plans/README.md", "file", "seed"),
-    _r("seed-archives-projects-readme", "07-Archives/Projects/README.md", "file", "seed"),
+    _r("seed-archives-projects-readme", "07-Archives/Projects/README.md", "file",
+       "seed"),
     _r("seed-archives-reviews-readme", "07-Archives/Reviews/README.md", "file", "seed"),
+
     # --- generated: machine-derived, regenerated ---------------------------
-    _r(
-        "generated-claude-md",
-        "CLAUDE.md",
-        "file",
-        "generated",
-        "composed from the shipped template plus vault-owned CLAUDE-custom.md",
-    ),
-    _r(
-        "generated-contracts-dist",
-        "packages/dex-contracts/dist",
-        "dir",
-        "generated",
-        "committed for cross-repo consumption; regenerated by scripts/generate-*.py; drift is CI-gated",
-    ),
-    _r(
-        "generated-architecture-inventory",
-        "docs/architecture/INVENTORY.md",
-        "file",
-        "generated",
-        "code-derived grounding document; drift is CI-gated",
-    ),
+    _r("generated-claude-md", "CLAUDE.md", "file", "generated",
+       "composed from the shipped template plus vault-owned CLAUDE-custom.md"),
+    _r("generated-contracts-dist", "packages/dex-contracts/dist", "dir", "generated",
+       "committed for cross-repo consumption; regenerated by scripts/generate-*.py; "
+       "drift is CI-gated"),
+    _r("generated-architecture-inventory", "docs/architecture/INVENTORY.md", "file",
+       "generated", "code-derived grounding document; drift is CI-gated"),
     _r("generated-manifest", "System/.installed-files.manifest", "file", "generated"),
     _r("generated-release-catalog", "System/.release-catalog.json", "file", "generated"),
-    _r("generated-evidence-profile", "System/.release-evidence-profile.json", "file", "generated"),
-    _r(
-        "generated-health-state",
-        "System/.dex/health",
-        "dir",
-        "generated",
-        "vault-local proactive-health snapshots and refresh outcomes; regenerated "
-        "by the health lifecycle and never shipped",
-    ),
-    _r(
-        "generated-doctor-last-run",
-        "System/.doctor-last-run.json",
-        "file",
-        "generated",
-        "Doctor's rendered cache; every refresh is transaction-owned",
-    ),
-    _r(
-        "generated-local-only-transition",
-        "System/.local-only-preservation-transition.json",
-        "file",
-        "generated",
-        "SR1 #148 phase marker; owned by the local-only preservation machinery",
-    ),
+    _r("generated-evidence-profile", "System/.release-evidence-profile.json", "file",
+       "generated"),
+    _r("generated-health-state", "System/.dex/health", "dir", "generated",
+       "vault-local proactive-health snapshots and refresh outcomes; regenerated "
+       "by the health lifecycle and never shipped"),
+    _r("generated-doctor-last-run", "System/.doctor-last-run.json", "file", "generated",
+       "Doctor's rendered cache; every refresh is transaction-owned"),
+    _r("generated-local-only-transition", "System/.local-only-preservation-transition.json",
+       "file", "generated",
+       "SR1 #148 phase marker; owned by the local-only preservation machinery"),
+
     # --- runtime: local machine state ---------------------------------------
-    _r(
-        "runtime-session-learnings",
-        "System/Session_Learnings",
-        "dir",
-        "runtime",
-        "user-machine session state; historical learning files become local-only in "
-        "the untrack-v1 transition, while the shipped README remains a seed",
-    ),
+    _r("runtime-session-learnings", "System/Session_Learnings", "dir", "runtime",
+       "user-machine session state; historical learning files become local-only in "
+       "the untrack-v1 transition, while the shipped README remains a seed"),
     _r("runtime-session-memory", "System/Session_Memory", "dir", "runtime"),
-    _r(
-        "runtime-usage-log",
-        "System/usage_log.md",
-        "file",
-        "runtime",
-        "shipped blank starter, then per-machine usage state; legacy-tracked",
-    ),
-    _r("runtime-claude-state", "System/claude-code-state.json", "file", "runtime", "legacy-tracked runtime state"),
-    _r(
-        "runtime-last-learning-check", "System/.last-learning-check", "file", "runtime", "legacy-tracked runtime marker"
-    ),
-    _r(
-        "runtime-adoption-receipts",
-        "System/.dex/adoptions",
-        "dir",
-        "runtime",
-        "post-commit lifecycle receipts; local runtime evidence, never shipped",
-    ),
-    _r(
-        "runtime-lifecycle-ledger",
-        "System/.dex/ledger",
-        "dir",
-        "runtime",
-        "immutable local lifecycle events and rebuildable state; never shipped or updated",
-    ),
-    _r(
-        "runtime-lifecycle-activation",
-        "System/.dex/lifecycle/activation.json",
-        "file",
-        "runtime",
-        "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped",
-    ),
-    _r(
-        "runtime-automation-ownership",
-        "System/.dex/automation-ownership.json",
-        "file",
-        "runtime",
-        "closed Dex Solo scheduler handoff state; transaction-owned and never shipped",
-    ),
-    _r(
-        "runtime-onboarding-session",
-        "System/.onboarding-session.json",
-        "file",
-        "runtime",
-        "pre-engine onboarding scratch; deleted by receipt-declared finalization",
-    ),
+    _r("runtime-usage-log", "System/usage_log.md", "file", "runtime",
+       "shipped blank starter, then per-machine usage state; legacy-tracked"),
+    _r("runtime-claude-state", "System/claude-code-state.json", "file", "runtime",
+       "legacy-tracked runtime state"),
+    _r("runtime-last-learning-check", "System/.last-learning-check", "file", "runtime",
+       "legacy-tracked runtime marker"),
+    _r("runtime-adoption-receipts", "System/.dex/adoptions", "dir", "runtime",
+       "post-commit lifecycle receipts; local runtime evidence, never shipped"),
+    _r("runtime-lifecycle-ledger", "System/.dex/ledger", "dir", "runtime",
+       "immutable local lifecycle events and rebuildable state; never shipped or updated"),
+    _r("runtime-lifecycle-activation", "System/.dex/lifecycle/activation.json", "file", "runtime",
+       "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped"),
+    _r("runtime-automation-ownership", "System/.dex/automation-ownership.json", "file", "runtime",
+       "closed Dex Solo scheduler handoff state; transaction-owned and never shipped"),
+    _r("runtime-onboarding-session", "System/.onboarding-session.json", "file", "runtime",
+       "pre-engine onboarding scratch; deleted by receipt-declared finalization"),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
-    _r(
-        "runtime-backup-logs",
-        "System/backup",
-        "dir",
-        "runtime",
-        "the backup engine's own logs, plus the restore runbook that a restored "
-        "archive unpacks here; nothing under this path is shipped by a release, "
-        "because no released contract before v1.95 can classify it",
-    ),
+    _r("runtime-backup-logs", "System/backup", "dir", "runtime",
+       "the backup engine's own logs, plus the restore runbook that a restored "
+       "archive unpacks here; nothing under this path is shipped by a release, "
+       "because no released contract before v1.95 can classify it"),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),
     _r("runtime-logs", ".logs", "dir", "runtime"),
+
     # --- vault: the user's content and values (mostly untracked in-repo) ----
     # The PARA regions: user-owned. Updates never write inside them except to
     # place the exact seed files enumerated above, and only when absent.
     _r("vault-inbox", "00-Inbox", "dir", "vault"),
-    _r(
-        "vault-quarter-goals",
-        "01-Quarter_Goals",
-        "dir",
-        "vault",
-        "capability-gated room (quarter_goals); absence is a valid state",
-    ),
+    _r("vault-quarter-goals", "01-Quarter_Goals", "dir", "vault",
+       "capability-gated room (quarter_goals); absence is a valid state"),
     _r("vault-week-priorities", "02-Week_Priorities", "dir", "vault"),
     _r("vault-tasks", "03-Tasks", "dir", "vault"),
     _r("vault-projects", "04-Projects", "dir", "vault"),
-    _r(
-        "vault-areas",
-        "05-Areas",
-        "dir",
-        "vault",
-        "Career and Companies subtrees are capability-gated rooms; absence is a valid state",
-    ),
-    _r(
-        "vault-resources",
-        "06-Resources",
-        "dir",
-        "vault",
-        "fully user-owned per Vault_Contract §10.1; the brain docs still shipped "
-        "under 06-Resources/Dex_System carry their own brain rule until they "
-        "relocate to docs/",
-    ),
+    _r("vault-areas", "05-Areas", "dir", "vault",
+       "Career and Companies subtrees are capability-gated rooms; absence is a "
+       "valid state"),
+    _r("vault-resources", "06-Resources", "dir", "vault",
+       "fully user-owned per Vault_Contract §10.1; the brain docs still shipped "
+       "under 06-Resources/Dex_System carry their own brain rule until they "
+       "relocate to docs/"),
     _r("vault-archives", "07-Archives", "dir", "vault"),
     # Secrets: hard-denied for writes AND vault-owned (deny is orthogonal to
     # ownership — these rules give denied paths their owner).
     _r("vault-env", ".env", "file", "vault", "raw secret authority (SR1 #150 model)"),
     _r("vault-credentials", "System/credentials", "dir", "vault", "secrets; hard-denied"),
-    _r(
-        "vault-mcp-json",
-        ".mcp.json",
-        "file",
-        "vault",
-        "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
-        "mcp-registration lifecycle transaction and the sole bridge-only "
-        "legacy-qmd-reconciliation exception for an exact v1.20-compatible "
-        "install, exact dormant qmd entry, absent qmd executable, and explicit "
-        "removal approval",
-    ),
-    _r(
-        "vault-claude-custom",
-        "CLAUDE-custom.md",
-        "file",
-        "vault",
-        "the one canonical home for user instructions (Vault_Contract §5)",
-    ),
+    _r("vault-mcp-json", ".mcp.json", "file", "vault",
+       "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
+       "mcp-registration lifecycle transaction and the sole bridge-only "
+       "legacy-qmd-reconciliation exception for an exact v1.20-compatible "
+       "install, exact dormant qmd entry, absent qmd executable, and explicit "
+       "removal approval"),
+    _r("vault-claude-custom", "CLAUDE-custom.md", "file", "vault",
+       "the one canonical home for user instructions (Vault_Contract §5)"),
     _r("vault-skills-custom", ".claude/skills-custom", "dir", "vault"),
     _r("vault-mcp-custom", "core/mcp-custom", "dir", "vault"),
     _r("vault-mcp-premium", "core/mcp-premium", "dir", "vault"),
-    _r(
-        "vault-folder-paths",
-        "System/folder-paths.yaml",
-        "file",
-        "vault",
-        "the user's folder remapping (Vault_Contract §2a); vault-owned, travels with content",
-    ),
+    _r("vault-folder-paths", "System/folder-paths.yaml", "file", "vault",
+       "the user's folder remapping (Vault_Contract §2a); vault-owned, travels "
+       "with content"),
     _r("vault-trusted-mcps", "System/trusted-mcps.yaml", "file", "vault"),
 )
 
@@ -480,7 +353,11 @@ def brain_paths_inside_vault_regions() -> tuple[str, ...]:
     """Release-owned paths nested inside otherwise user-owned vault regions."""
     region_prefixes = tuple(f"{region}/" for region in VAULT_REGIONS)
     return tuple(
-        sorted(rule.path for rule in RULES if rule.ownership == "brain" and rule.path.startswith(region_prefixes))
+        sorted(
+            rule.path
+            for rule in RULES
+            if rule.ownership == "brain" and rule.path.startswith(region_prefixes)
+        )
     )
 
 
@@ -505,7 +382,9 @@ def _room_skill_source(
     return {
         "room": room,
         "skill": skill,
-        "source_path": (f".claude/skills/_available/capabilities/{room}/skills/{skill}/SKILL.md"),
+        "source_path": (
+            f".claude/skills/_available/capabilities/{room}/skills/{skill}/SKILL.md"
+        ),
         "target_path": f".claude/skills/{skill}/SKILL.md",
         "sha256": sha256,
         "byte_size": byte_size,
@@ -571,13 +450,11 @@ CAPABILITIES: dict[str, dict[str, object]] = {
                 "resume-builder",
                 "383ad20bca80a5594d09b36f5ea0cfaf84d03de3d9da51b78f569b8d56fb8444",
                 34352,
-                previous_payloads=(
-                    (
-                        "v1.95.2",
-                        "f759f12154a6b928ad4e16bf2bf82c363d6e9baf9cd9ddfedd639b60fc51d5de",
-                        29649,
-                    ),
-                ),
+                previous_payloads=((
+                    "v1.95.2",
+                    "f759f12154a6b928ad4e16bf2bf82c363d6e9baf9cd9ddfedd639b60fc51d5de",
+                    29649,
+                ),),
             ),
         ),
         "mcp": ("career_server", "resume_server"),
@@ -599,26 +476,22 @@ CAPABILITIES: dict[str, dict[str, object]] = {
                 "quarter-plan",
                 "330b61f5e0d7c5a1eecbb3453b102fcdc795e7eaf13adf8a361a93bd0a06dc94",
                 14097,
-                previous_payloads=(
-                    (
-                        "v1.95.2",
-                        "08679c722b1555563e125a7bbc67ef1ccf1dfa367f522a5eb8565cea77fd937f",
-                        9406,
-                    ),
-                ),
+                previous_payloads=((
+                    "v1.95.2",
+                    "08679c722b1555563e125a7bbc67ef1ccf1dfa367f522a5eb8565cea77fd937f",
+                    9406,
+                ),),
             ),
             _room_skill_source(
                 "quarter_goals",
                 "quarter-review",
                 "a55db8afede1a60e7de564610a6110fc418a53a434e5ece59a3fab1074bd4fb1",
                 19152,
-                previous_payloads=(
-                    (
-                        "v1.95.2",
-                        "069b339f63aa436b8ae01b16d97756b14f003f9069eb10c11827ed9abf5df794",
-                        12851,
-                    ),
-                ),
+                previous_payloads=((
+                    "v1.95.2",
+                    "069b339f63aa436b8ae01b16d97756b14f003f9069eb10c11827ed9abf5df794",
+                    12851,
+                ),),
             ),
         ),
         "config": "quarterly_planning",
@@ -633,11 +506,11 @@ CAPABILITIES: dict[str, dict[str, object]] = {
 # must use instead of re-deriving it from prose. It travels in the frozen JSON.
 # ---------------------------------------------------------------------------
 MUTATION_POLICY: dict[str, str] = {
-    "brain": "replace",  # replaced wholesale from the release
-    "seed": "write-if-absent",  # seeded once; an existing user file always wins
-    "generated": "regenerate",  # machine-derived; safe to rewrite
-    "vault": "never",  # the user's; updates never write
-    "runtime": "never",  # local machine state; updates never write
+    "brain": "replace",           # replaced wholesale from the release
+    "seed": "write-if-absent",    # seeded once; an existing user file always wins
+    "generated": "regenerate",    # machine-derived; safe to rewrite
+    "vault": "never",             # the user's; updates never write
+    "runtime": "never",           # local machine state; updates never write
 }
 
 # First-run setup is a narrower authority than an update.  These are the only
@@ -659,7 +532,11 @@ ONBOARDING_PROVISION_PATHS = frozenset(
         "05-Areas/Career/Evidence/README.md",
         "05-Areas/Companies/README.md",
     }
-    | {str(source["target_path"]) for room in CAPABILITIES.values() for source in room.get("skill_sources", ())}
+    | {
+        str(source["target_path"])
+        for room in CAPABILITIES.values()
+        for source in room.get("skill_sources", ())
+    }
 )
 
 CUSTOMIZATION_MIGRATION_SEAMS_VERSION = 0
@@ -990,7 +867,8 @@ def update_write_verdict(
             )
 
         if candidate in CUSTOMIZATION_MIGRATION_SEAM_PATHS or any(
-            candidate.startswith(prefix) for prefix in CUSTOMIZATION_MIGRATION_SEAM_PREFIXES
+            candidate.startswith(prefix)
+            for prefix in CUSTOMIZATION_MIGRATION_SEAM_PREFIXES
         ):
             return WriteVerdict(
                 candidate,
@@ -1013,13 +891,21 @@ def update_write_verdict(
     except ContractViolation:
         return WriteVerdict(str(path), False, "unclassified-never-write", None, None)
     if resolution.denied:
-        return WriteVerdict(resolution.path, False, "deny", resolution.ownership, resolution.rule_id)
+        return WriteVerdict(
+            resolution.path, False, "deny", resolution.ownership, resolution.rule_id
+        )
     action = MUTATION_POLICY[resolution.ownership]
     if action == "never":
-        return WriteVerdict(resolution.path, False, "never", resolution.ownership, resolution.rule_id)
+        return WriteVerdict(
+            resolution.path, False, "never", resolution.ownership, resolution.rule_id
+        )
     if action == "write-if-absent" and exists:
-        return WriteVerdict(resolution.path, False, action, resolution.ownership, resolution.rule_id)
-    return WriteVerdict(resolution.path, True, action, resolution.ownership, resolution.rule_id)
+        return WriteVerdict(
+            resolution.path, False, action, resolution.ownership, resolution.rule_id
+        )
+    return WriteVerdict(
+        resolution.path, True, action, resolution.ownership, resolution.rule_id
+    )
 
 
 class ContractViolation(ValueError):
@@ -1048,7 +934,9 @@ def is_denied(path: str) -> bool:
         pattern = raw_pattern.lower()
         if fnmatch.fnmatch(candidate, pattern):
             return True
-        if "/" not in pattern and any(fnmatch.fnmatch(segment, pattern) for segment in segments):
+        if "/" not in pattern and any(
+            fnmatch.fnmatch(segment, pattern) for segment in segments
+        ):
             return True
     return False
 
@@ -1121,7 +1009,11 @@ def legacy_shipped_runtime(paths: Iterable[str]) -> list[str]:
     tree is a standing contradiction the transition baseline currently
     grandfathers (usage log and legacy state markers).
     """
-    return [resolution.path for resolution in (resolve(path) for path in paths) if resolution.ownership == "runtime"]
+    return [
+        resolution.path
+        for resolution in (resolve(path) for path in paths)
+        if resolution.ownership == "runtime"
+    ]
 
 
 def build_contract_schema(

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -42,6 +42,7 @@ CONTRACT_VERSION = 2
 SUPPORTED_CONTRACT_VERSIONS = (1, CONTRACT_VERSION)
 VAULT_SCHEMA_SUPPORTED = ">=1 <2"
 ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = "System/.dex/analytics-attempts.jsonl"
+AUTOMATION_OWNERSHIP_RELATIVE = "System/.dex/automation-ownership.json"
 # A receipt retains a bounded rolling history. A prior release could write one
 # safe record beyond the retained cap, so the transaction has exactly that
 # extra recovery room to validate the full existing file before it keeps whole
@@ -49,8 +50,7 @@ ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = "System/.dex/analytics-attempts.jsonl"
 ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES = 256 * 1024
 ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES = 256
 ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES = (
-    ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES
-    + ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
+    ANALYTICS_ATTEMPT_RECEIPT_MAX_EXISTING_BYTES + ANALYTICS_ATTEMPT_RECEIPT_MAX_RECORD_BYTES
 )
 
 OWNERSHIP_CLASSES = ("brain", "vault", "seed", "generated", "runtime")
@@ -130,51 +130,51 @@ RULES: tuple[Rule, ...] = (
     _r("brain-core", "core", "dir", "brain"),
     _r("brain-scripts", "scripts", "dir", "brain"),
     _r("brain-dot-scripts", ".scripts", "dir", "brain"),
-    _r("brain-packages", "packages", "dir", "brain",
-       "package sources are brain; the committed dist/ views are generated (below)"),
-    _r("brain-claude", ".claude", "dir", "brain",
-       "shipped skills/hooks/flows; user skills belong in .claude/skills-custom/ (vault)"),
+    _r(
+        "brain-packages",
+        "packages",
+        "dir",
+        "brain",
+        "package sources are brain; the committed dist/ views are generated (below)",
+    ),
+    _r(
+        "brain-claude",
+        ".claude",
+        "dir",
+        "brain",
+        "shipped skills/hooks/flows; user skills belong in .claude/skills-custom/ (vault)",
+    ),
     _r("brain-agents", ".agents", "dir", "brain"),
     _r("brain-cursor", ".cursor", "dir", "brain"),
-    _r("brain-obsidian", ".obsidian", "dir", "brain",
-       "shipped Obsidian defaults; a user's live workspace state is untracked"),
+    _r(
+        "brain-obsidian",
+        ".obsidian",
+        "dir",
+        "brain",
+        "shipped Obsidian defaults; a user's live workspace state is untracked",
+    ),
     _r("brain-github", ".github", "dir", "brain"),
-    _r("brain-ci", ".ci", "dir", "brain",
-       "CI shard-balance data; dev-only, stripped from releases via .distignore"),
+    _r("brain-ci", ".ci", "dir", "brain", "CI shard-balance data; dev-only, stripped from releases via .distignore"),
     _r("brain-docs", "docs", "dir", "brain"),
     # System docs shipped inside the user's Resources region: enumerated file by
     # file (mirroring the PARA seed pattern) so a USER note or edit added under
     # 06-Resources/Dex_System/ falls through to the vault region rule and can
     # never be clobbered by an update. Relocate to docs/ per Vault_Contract
     # §10.1; until then updates may replace exactly these shipped files.
-    _r("brain-doc-background-processing",
-       "06-Resources/Dex_System/Background_Processing_Guide.md", "file", "brain"),
-    _r("brain-doc-calendar-setup", "06-Resources/Dex_System/Calendar_Setup.md",
-       "file", "brain"),
-    _r("brain-doc-jobs-to-be-done", "06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md",
-       "file", "brain"),
-    _r("brain-doc-system-guide", "06-Resources/Dex_System/Dex_System_Guide.md",
-       "file", "brain"),
-    _r("brain-doc-technical-guide", "06-Resources/Dex_System/Dex_Technical_Guide.md",
-       "file", "brain"),
-    _r("brain-doc-distribution-checklist",
-       "06-Resources/Dex_System/Distribution_Checklist.md", "file", "brain"),
-    _r("brain-doc-distribution-strategy",
-       "06-Resources/Dex_System/Distribution_Strategy.md", "file", "brain"),
-    _r("brain-doc-folder-structure", "06-Resources/Dex_System/Folder_Structure.md",
-       "file", "brain"),
-    _r("brain-doc-memory-ownership", "06-Resources/Dex_System/Memory_Ownership.md",
-       "file", "brain"),
-    _r("brain-doc-named-sessions", "06-Resources/Dex_System/Named_Sessions_Guide.md",
-       "file", "brain"),
-    _r("brain-doc-obsidian-guide", "06-Resources/Dex_System/Obsidian_Guide.md",
-       "file", "brain"),
-    _r("brain-doc-dex-system-readme", "06-Resources/Dex_System/README.md",
-       "file", "brain"),
-    _r("brain-doc-updating-dex", "06-Resources/Dex_System/Updating_Dex.md",
-       "file", "brain"),
-    _r("brain-staging", "staging", "dir", "brain",
-       "dev-only staging scaffolding; excluded from releases"),
+    _r("brain-doc-background-processing", "06-Resources/Dex_System/Background_Processing_Guide.md", "file", "brain"),
+    _r("brain-doc-calendar-setup", "06-Resources/Dex_System/Calendar_Setup.md", "file", "brain"),
+    _r("brain-doc-jobs-to-be-done", "06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md", "file", "brain"),
+    _r("brain-doc-system-guide", "06-Resources/Dex_System/Dex_System_Guide.md", "file", "brain"),
+    _r("brain-doc-technical-guide", "06-Resources/Dex_System/Dex_Technical_Guide.md", "file", "brain"),
+    _r("brain-doc-distribution-checklist", "06-Resources/Dex_System/Distribution_Checklist.md", "file", "brain"),
+    _r("brain-doc-distribution-strategy", "06-Resources/Dex_System/Distribution_Strategy.md", "file", "brain"),
+    _r("brain-doc-folder-structure", "06-Resources/Dex_System/Folder_Structure.md", "file", "brain"),
+    _r("brain-doc-memory-ownership", "06-Resources/Dex_System/Memory_Ownership.md", "file", "brain"),
+    _r("brain-doc-named-sessions", "06-Resources/Dex_System/Named_Sessions_Guide.md", "file", "brain"),
+    _r("brain-doc-obsidian-guide", "06-Resources/Dex_System/Obsidian_Guide.md", "file", "brain"),
+    _r("brain-doc-dex-system-readme", "06-Resources/Dex_System/README.md", "file", "brain"),
+    _r("brain-doc-updating-dex", "06-Resources/Dex_System/Updating_Dex.md", "file", "brain"),
+    _r("brain-staging", "staging", "dir", "brain", "dev-only staging scaffolding; excluded from releases"),
     _r("brain-agents-md", "AGENTS.md", "file", "brain"),
     _r("brain-readme", "README.md", "file", "brain"),
     _r("brain-changelog", "CHANGELOG.md", "file", "brain"),
@@ -192,31 +192,66 @@ RULES: tuple[Rule, ...] = (
     _r("brain-gitignore", ".gitignore", "file", "brain"),
     _r("brain-gitattributes", ".gitattributes", "file", "brain"),
     _r("brain-distignore", ".distignore", "file", "brain"),
-    _r("brain-beta-communications", "System/Beta_Communications", "dir", "brain",
-       "release-doc retained until the schema-2 baseline-reduction follow-up"),
+    _r(
+        "brain-beta-communications",
+        "System/Beta_Communications",
+        "dir",
+        "brain",
+        "release-doc retained until the schema-2 baseline-reduction follow-up",
+    ),
     _r("brain-system-readme", "System/README.md", "file", "brain"),
     # --- seed: shipped once, then the user's; update writes only if absent -
     _r("seed-templates", "System/Templates", "dir", "seed"),
-    _r("seed-user-profile-live", "System/user-profile.yaml", "file", "seed",
-       "created from the tracked template at install; user VALUES live here and are never released or overwritten"),
-    _r("seed-user-profile-template", "System/user-profile-template.yaml", "file", "seed",
-       "canonical shipped template (the ratified doc names user-profile.example.yaml; "
-       "the repo consolidated on -template — deliberate deviation)"),
-    _r("seed-user-profile-example", "System/user-profile.example.yaml", "file", "seed",
-       "legacy duplicate template; removal in flight (portability hygiene PR)"),
-    _r("seed-pillars-live", "System/pillars.yaml", "file", "seed",
-       "shipped empty; user pillar registry — never overwritten"),
+    _r(
+        "seed-user-profile-live",
+        "System/user-profile.yaml",
+        "file",
+        "seed",
+        "created from the tracked template at install; user VALUES live here and are never released or overwritten",
+    ),
+    _r(
+        "seed-user-profile-template",
+        "System/user-profile-template.yaml",
+        "file",
+        "seed",
+        "canonical shipped template (the ratified doc names user-profile.example.yaml; "
+        "the repo consolidated on -template — deliberate deviation)",
+    ),
+    _r(
+        "seed-user-profile-example",
+        "System/user-profile.example.yaml",
+        "file",
+        "seed",
+        "legacy duplicate template; removal in flight (portability hygiene PR)",
+    ),
+    _r(
+        "seed-pillars-live",
+        "System/pillars.yaml",
+        "file",
+        "seed",
+        "shipped empty; user pillar registry — never overwritten",
+    ),
     _r("seed-pillars-example", "System/pillars.example.yaml", "file", "seed"),
     _r("seed-trusted-mcps-example", "System/trusted-mcps.example.yaml", "file", "seed"),
     _r("seed-mcp-example", "System/.mcp.json.example", "file", "seed"),
     _r("seed-env-example", "env.example", "file", "seed"),
-    _r("seed-integrations", "System/integrations", "dir", "seed",
-       "SR1 #150: tracked reference-schema templates carrying env-var references; "
-       "installed if absent, never overwritten once user-owned"),
+    _r(
+        "seed-integrations",
+        "System/integrations",
+        "dir",
+        "seed",
+        "SR1 #150: tracked reference-schema templates carrying env-var references; "
+        "installed if absent, never overwritten once user-owned",
+    ),
     _r("seed-dex-backlog", "System/Dex_Backlog.md", "file", "seed"),
     _r("seed-session-learnings-readme", "System/Session_Learnings/README.md", "file", "seed"),
-    _r("seed-dex-ideas", "System/Dex_Ideas.md", "file", "seed",
-       "legacy duplicate of Dex_Backlog.md; removal in flight (portability hygiene PR)"),
+    _r(
+        "seed-dex-ideas",
+        "System/Dex_Ideas.md",
+        "file",
+        "seed",
+        "legacy duplicate of Dex_Backlog.md; removal in flight (portability hygiene PR)",
+    ),
     # PARA starters: the EXACT shipped scaffolding files, enumerated one by one.
     # The regions themselves are vault (below); an update may seed precisely
     # these paths when absent and nothing else. Adding a tracked file under a
@@ -225,123 +260,218 @@ RULES: tuple[Rule, ...] = (
     _r("seed-inbox-daily-plans-readme", "00-Inbox/Daily_Plans/README.md", "file", "seed"),
     _r("seed-inbox-ideas-readme", "00-Inbox/Ideas/README.md", "file", "seed"),
     _r("seed-inbox-meetings-readme", "00-Inbox/Meetings/README.md", "file", "seed"),
-    _r("seed-quarter-goals-file", "01-Quarter_Goals/Quarter_Goals.md", "file", "seed",
-       "capability-gated room (quarter_goals)"),
-    _r("seed-week-priorities-file", "02-Week_Priorities/Week_Priorities.md", "file",
-       "seed"),
+    _r(
+        "seed-quarter-goals-file",
+        "01-Quarter_Goals/Quarter_Goals.md",
+        "file",
+        "seed",
+        "capability-gated room (quarter_goals)",
+    ),
+    _r("seed-week-priorities-file", "02-Week_Priorities/Week_Priorities.md", "file", "seed"),
     _r("seed-tasks-file", "03-Tasks/Tasks.md", "file", "seed"),
     _r("seed-projects-readme", "04-Projects/README.md", "file", "seed"),
     _r("seed-areas-readme", "05-Areas/README.md", "file", "seed"),
-    _r("seed-career-evidence-readme", "05-Areas/Career/Evidence/README.md", "file",
-       "seed", "capability-gated room (career)"),
-    _r("seed-companies-readme", "05-Areas/Companies/README.md", "file", "seed",
-       "capability-gated room (companies)"),
+    _r(
+        "seed-career-evidence-readme",
+        "05-Areas/Career/Evidence/README.md",
+        "file",
+        "seed",
+        "capability-gated room (career)",
+    ),
+    _r("seed-companies-readme", "05-Areas/Companies/README.md", "file", "seed", "capability-gated room (companies)"),
     _r("seed-people-readme", "05-Areas/People/README.md", "file", "seed"),
-    _r("seed-people-internal-readme", "05-Areas/People/Internal/README.md", "file",
-       "seed"),
-    _r("seed-people-external-readme", "05-Areas/People/External/README.md", "file",
-       "seed"),
+    _r("seed-people-internal-readme", "05-Areas/People/Internal/README.md", "file", "seed"),
+    _r("seed-people-external-readme", "05-Areas/People/External/README.md", "file", "seed"),
     _r("seed-resources-readme", "06-Resources/README.md", "file", "seed"),
     _r("seed-intel-gitkeep", "06-Resources/Intel/.gitkeep", "file", "seed"),
-    _r("seed-meeting-intel-gitkeep", "06-Resources/Intel/Meeting_Intel/.gitkeep",
-       "file", "seed"),
+    _r("seed-meeting-intel-gitkeep", "06-Resources/Intel/Meeting_Intel/.gitkeep", "file", "seed"),
     _r("seed-learnings-readme", "06-Resources/Learnings/README.md", "file", "seed"),
-    _r("seed-mistake-patterns", "06-Resources/Learnings/Mistake_Patterns.md", "file",
-       "seed"),
-    _r("seed-working-preferences", "06-Resources/Learnings/Working_Preferences.md",
-       "file", "seed"),
-    _r("seed-quarterly-reviews-readme", "06-Resources/Quarterly_Reviews/README.md",
-       "file", "seed"),
+    _r("seed-mistake-patterns", "06-Resources/Learnings/Mistake_Patterns.md", "file", "seed"),
+    _r("seed-working-preferences", "06-Resources/Learnings/Working_Preferences.md", "file", "seed"),
+    _r("seed-quarterly-reviews-readme", "06-Resources/Quarterly_Reviews/README.md", "file", "seed"),
     _r("seed-archives-readme", "07-Archives/README.md", "file", "seed"),
     _r("seed-archives-plans-readme", "07-Archives/Plans/README.md", "file", "seed"),
-    _r("seed-archives-projects-readme", "07-Archives/Projects/README.md", "file",
-       "seed"),
+    _r("seed-archives-projects-readme", "07-Archives/Projects/README.md", "file", "seed"),
     _r("seed-archives-reviews-readme", "07-Archives/Reviews/README.md", "file", "seed"),
-
     # --- generated: machine-derived, regenerated ---------------------------
-    _r("generated-claude-md", "CLAUDE.md", "file", "generated",
-       "composed from the shipped template plus vault-owned CLAUDE-custom.md"),
-    _r("generated-contracts-dist", "packages/dex-contracts/dist", "dir", "generated",
-       "committed for cross-repo consumption; regenerated by scripts/generate-*.py; "
-       "drift is CI-gated"),
-    _r("generated-architecture-inventory", "docs/architecture/INVENTORY.md", "file",
-       "generated", "code-derived grounding document; drift is CI-gated"),
+    _r(
+        "generated-claude-md",
+        "CLAUDE.md",
+        "file",
+        "generated",
+        "composed from the shipped template plus vault-owned CLAUDE-custom.md",
+    ),
+    _r(
+        "generated-contracts-dist",
+        "packages/dex-contracts/dist",
+        "dir",
+        "generated",
+        "committed for cross-repo consumption; regenerated by scripts/generate-*.py; drift is CI-gated",
+    ),
+    _r(
+        "generated-architecture-inventory",
+        "docs/architecture/INVENTORY.md",
+        "file",
+        "generated",
+        "code-derived grounding document; drift is CI-gated",
+    ),
     _r("generated-manifest", "System/.installed-files.manifest", "file", "generated"),
     _r("generated-release-catalog", "System/.release-catalog.json", "file", "generated"),
-    _r("generated-evidence-profile", "System/.release-evidence-profile.json", "file",
-       "generated"),
-    _r("generated-health-state", "System/.dex/health", "dir", "generated",
-       "vault-local proactive-health snapshots and refresh outcomes; regenerated "
-       "by the health lifecycle and never shipped"),
-    _r("generated-doctor-last-run", "System/.doctor-last-run.json", "file", "generated",
-       "Doctor's rendered cache; every refresh is transaction-owned"),
-    _r("generated-local-only-transition", "System/.local-only-preservation-transition.json",
-       "file", "generated",
-       "SR1 #148 phase marker; owned by the local-only preservation machinery"),
-
+    _r("generated-evidence-profile", "System/.release-evidence-profile.json", "file", "generated"),
+    _r(
+        "generated-health-state",
+        "System/.dex/health",
+        "dir",
+        "generated",
+        "vault-local proactive-health snapshots and refresh outcomes; regenerated "
+        "by the health lifecycle and never shipped",
+    ),
+    _r(
+        "generated-doctor-last-run",
+        "System/.doctor-last-run.json",
+        "file",
+        "generated",
+        "Doctor's rendered cache; every refresh is transaction-owned",
+    ),
+    _r(
+        "generated-local-only-transition",
+        "System/.local-only-preservation-transition.json",
+        "file",
+        "generated",
+        "SR1 #148 phase marker; owned by the local-only preservation machinery",
+    ),
     # --- runtime: local machine state ---------------------------------------
-    _r("runtime-session-learnings", "System/Session_Learnings", "dir", "runtime",
-       "user-machine session state; historical learning files become local-only in "
-       "the untrack-v1 transition, while the shipped README remains a seed"),
+    _r(
+        "runtime-session-learnings",
+        "System/Session_Learnings",
+        "dir",
+        "runtime",
+        "user-machine session state; historical learning files become local-only in "
+        "the untrack-v1 transition, while the shipped README remains a seed",
+    ),
     _r("runtime-session-memory", "System/Session_Memory", "dir", "runtime"),
-    _r("runtime-usage-log", "System/usage_log.md", "file", "runtime",
-       "shipped blank starter, then per-machine usage state; legacy-tracked"),
-    _r("runtime-claude-state", "System/claude-code-state.json", "file", "runtime",
-       "legacy-tracked runtime state"),
-    _r("runtime-last-learning-check", "System/.last-learning-check", "file", "runtime",
-       "legacy-tracked runtime marker"),
-    _r("runtime-adoption-receipts", "System/.dex/adoptions", "dir", "runtime",
-       "post-commit lifecycle receipts; local runtime evidence, never shipped"),
-    _r("runtime-lifecycle-ledger", "System/.dex/ledger", "dir", "runtime",
-       "immutable local lifecycle events and rebuildable state; never shipped or updated"),
-    _r("runtime-lifecycle-activation", "System/.dex/lifecycle/activation.json", "file", "runtime",
-       "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped"),
-    _r("runtime-onboarding-session", "System/.onboarding-session.json", "file", "runtime",
-       "pre-engine onboarding scratch; deleted by receipt-declared finalization"),
+    _r(
+        "runtime-usage-log",
+        "System/usage_log.md",
+        "file",
+        "runtime",
+        "shipped blank starter, then per-machine usage state; legacy-tracked",
+    ),
+    _r("runtime-claude-state", "System/claude-code-state.json", "file", "runtime", "legacy-tracked runtime state"),
+    _r(
+        "runtime-last-learning-check", "System/.last-learning-check", "file", "runtime", "legacy-tracked runtime marker"
+    ),
+    _r(
+        "runtime-adoption-receipts",
+        "System/.dex/adoptions",
+        "dir",
+        "runtime",
+        "post-commit lifecycle receipts; local runtime evidence, never shipped",
+    ),
+    _r(
+        "runtime-lifecycle-ledger",
+        "System/.dex/ledger",
+        "dir",
+        "runtime",
+        "immutable local lifecycle events and rebuildable state; never shipped or updated",
+    ),
+    _r(
+        "runtime-lifecycle-activation",
+        "System/.dex/lifecycle/activation.json",
+        "file",
+        "runtime",
+        "old-engine bridge baseline marker; created locally on first lifecycle-engine run, never shipped",
+    ),
+    _r(
+        "runtime-automation-ownership",
+        "System/.dex/automation-ownership.json",
+        "file",
+        "runtime",
+        "closed Dex Solo scheduler handoff state; transaction-owned and never shipped",
+    ),
+    _r(
+        "runtime-onboarding-session",
+        "System/.onboarding-session.json",
+        "file",
+        "runtime",
+        "pre-engine onboarding scratch; deleted by receipt-declared finalization",
+    ),
     _r("runtime-dex-dir", "System/.dex", "dir", "runtime"),
-    _r("runtime-backup-logs", "System/backup", "dir", "runtime",
-       "the backup engine's own logs, plus the restore runbook that a restored "
-       "archive unpacks here; nothing under this path is shipped by a release, "
-       "because no released contract before v1.95 can classify it"),
+    _r(
+        "runtime-backup-logs",
+        "System/backup",
+        "dir",
+        "runtime",
+        "the backup engine's own logs, plus the restore runbook that a restored "
+        "archive unpacks here; nothing under this path is shipped by a release, "
+        "because no released contract before v1.95 can classify it",
+    ),
     _r("runtime-onboarding", "System/.onboarding", "dir", "runtime"),
     _r("runtime-onboarding-marker", "System/.onboarding-complete", "file", "runtime"),
     _r("runtime-logs", ".logs", "dir", "runtime"),
-
     # --- vault: the user's content and values (mostly untracked in-repo) ----
     # The PARA regions: user-owned. Updates never write inside them except to
     # place the exact seed files enumerated above, and only when absent.
     _r("vault-inbox", "00-Inbox", "dir", "vault"),
-    _r("vault-quarter-goals", "01-Quarter_Goals", "dir", "vault",
-       "capability-gated room (quarter_goals); absence is a valid state"),
+    _r(
+        "vault-quarter-goals",
+        "01-Quarter_Goals",
+        "dir",
+        "vault",
+        "capability-gated room (quarter_goals); absence is a valid state",
+    ),
     _r("vault-week-priorities", "02-Week_Priorities", "dir", "vault"),
     _r("vault-tasks", "03-Tasks", "dir", "vault"),
     _r("vault-projects", "04-Projects", "dir", "vault"),
-    _r("vault-areas", "05-Areas", "dir", "vault",
-       "Career and Companies subtrees are capability-gated rooms; absence is a "
-       "valid state"),
-    _r("vault-resources", "06-Resources", "dir", "vault",
-       "fully user-owned per Vault_Contract §10.1; the brain docs still shipped "
-       "under 06-Resources/Dex_System carry their own brain rule until they "
-       "relocate to docs/"),
+    _r(
+        "vault-areas",
+        "05-Areas",
+        "dir",
+        "vault",
+        "Career and Companies subtrees are capability-gated rooms; absence is a valid state",
+    ),
+    _r(
+        "vault-resources",
+        "06-Resources",
+        "dir",
+        "vault",
+        "fully user-owned per Vault_Contract §10.1; the brain docs still shipped "
+        "under 06-Resources/Dex_System carry their own brain rule until they "
+        "relocate to docs/",
+    ),
     _r("vault-archives", "07-Archives", "dir", "vault"),
     # Secrets: hard-denied for writes AND vault-owned (deny is orthogonal to
     # ownership — these rules give denied paths their owner).
     _r("vault-env", ".env", "file", "vault", "raw secret authority (SR1 #150 model)"),
     _r("vault-credentials", "System/credentials", "dir", "vault", "secrets; hard-denied"),
-    _r("vault-mcp-json", ".mcp.json", "file", "vault",
-       "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
-       "mcp-registration lifecycle transaction and the sole bridge-only "
-       "legacy-qmd-reconciliation exception for an exact v1.20-compatible "
-       "install, exact dormant qmd entry, absent qmd executable, and explicit "
-       "removal approval"),
-    _r("vault-claude-custom", "CLAUDE-custom.md", "file", "vault",
-       "the one canonical home for user instructions (Vault_Contract §5)"),
+    _r(
+        "vault-mcp-json",
+        ".mcp.json",
+        "file",
+        "vault",
+        "REPORT-ONLY except the explicitly previewed, user-approved, add-only "
+        "mcp-registration lifecycle transaction and the sole bridge-only "
+        "legacy-qmd-reconciliation exception for an exact v1.20-compatible "
+        "install, exact dormant qmd entry, absent qmd executable, and explicit "
+        "removal approval",
+    ),
+    _r(
+        "vault-claude-custom",
+        "CLAUDE-custom.md",
+        "file",
+        "vault",
+        "the one canonical home for user instructions (Vault_Contract §5)",
+    ),
     _r("vault-skills-custom", ".claude/skills-custom", "dir", "vault"),
     _r("vault-mcp-custom", "core/mcp-custom", "dir", "vault"),
     _r("vault-mcp-premium", "core/mcp-premium", "dir", "vault"),
-    _r("vault-folder-paths", "System/folder-paths.yaml", "file", "vault",
-       "the user's folder remapping (Vault_Contract §2a); vault-owned, travels "
-       "with content"),
+    _r(
+        "vault-folder-paths",
+        "System/folder-paths.yaml",
+        "file",
+        "vault",
+        "the user's folder remapping (Vault_Contract §2a); vault-owned, travels with content",
+    ),
     _r("vault-trusted-mcps", "System/trusted-mcps.yaml", "file", "vault"),
 )
 
@@ -350,11 +480,7 @@ def brain_paths_inside_vault_regions() -> tuple[str, ...]:
     """Release-owned paths nested inside otherwise user-owned vault regions."""
     region_prefixes = tuple(f"{region}/" for region in VAULT_REGIONS)
     return tuple(
-        sorted(
-            rule.path
-            for rule in RULES
-            if rule.ownership == "brain" and rule.path.startswith(region_prefixes)
-        )
+        sorted(rule.path for rule in RULES if rule.ownership == "brain" and rule.path.startswith(region_prefixes))
     )
 
 
@@ -379,9 +505,7 @@ def _room_skill_source(
     return {
         "room": room,
         "skill": skill,
-        "source_path": (
-            f".claude/skills/_available/capabilities/{room}/skills/{skill}/SKILL.md"
-        ),
+        "source_path": (f".claude/skills/_available/capabilities/{room}/skills/{skill}/SKILL.md"),
         "target_path": f".claude/skills/{skill}/SKILL.md",
         "sha256": sha256,
         "byte_size": byte_size,
@@ -447,11 +571,13 @@ CAPABILITIES: dict[str, dict[str, object]] = {
                 "resume-builder",
                 "383ad20bca80a5594d09b36f5ea0cfaf84d03de3d9da51b78f569b8d56fb8444",
                 34352,
-                previous_payloads=((
-                    "v1.95.2",
-                    "f759f12154a6b928ad4e16bf2bf82c363d6e9baf9cd9ddfedd639b60fc51d5de",
-                    29649,
-                ),),
+                previous_payloads=(
+                    (
+                        "v1.95.2",
+                        "f759f12154a6b928ad4e16bf2bf82c363d6e9baf9cd9ddfedd639b60fc51d5de",
+                        29649,
+                    ),
+                ),
             ),
         ),
         "mcp": ("career_server", "resume_server"),
@@ -473,22 +599,26 @@ CAPABILITIES: dict[str, dict[str, object]] = {
                 "quarter-plan",
                 "330b61f5e0d7c5a1eecbb3453b102fcdc795e7eaf13adf8a361a93bd0a06dc94",
                 14097,
-                previous_payloads=((
-                    "v1.95.2",
-                    "08679c722b1555563e125a7bbc67ef1ccf1dfa367f522a5eb8565cea77fd937f",
-                    9406,
-                ),),
+                previous_payloads=(
+                    (
+                        "v1.95.2",
+                        "08679c722b1555563e125a7bbc67ef1ccf1dfa367f522a5eb8565cea77fd937f",
+                        9406,
+                    ),
+                ),
             ),
             _room_skill_source(
                 "quarter_goals",
                 "quarter-review",
                 "a55db8afede1a60e7de564610a6110fc418a53a434e5ece59a3fab1074bd4fb1",
                 19152,
-                previous_payloads=((
-                    "v1.95.2",
-                    "069b339f63aa436b8ae01b16d97756b14f003f9069eb10c11827ed9abf5df794",
-                    12851,
-                ),),
+                previous_payloads=(
+                    (
+                        "v1.95.2",
+                        "069b339f63aa436b8ae01b16d97756b14f003f9069eb10c11827ed9abf5df794",
+                        12851,
+                    ),
+                ),
             ),
         ),
         "config": "quarterly_planning",
@@ -503,11 +633,11 @@ CAPABILITIES: dict[str, dict[str, object]] = {
 # must use instead of re-deriving it from prose. It travels in the frozen JSON.
 # ---------------------------------------------------------------------------
 MUTATION_POLICY: dict[str, str] = {
-    "brain": "replace",           # replaced wholesale from the release
-    "seed": "write-if-absent",    # seeded once; an existing user file always wins
-    "generated": "regenerate",    # machine-derived; safe to rewrite
-    "vault": "never",             # the user's; updates never write
-    "runtime": "never",           # local machine state; updates never write
+    "brain": "replace",  # replaced wholesale from the release
+    "seed": "write-if-absent",  # seeded once; an existing user file always wins
+    "generated": "regenerate",  # machine-derived; safe to rewrite
+    "vault": "never",  # the user's; updates never write
+    "runtime": "never",  # local machine state; updates never write
 }
 
 # First-run setup is a narrower authority than an update.  These are the only
@@ -529,11 +659,7 @@ ONBOARDING_PROVISION_PATHS = frozenset(
         "05-Areas/Career/Evidence/README.md",
         "05-Areas/Companies/README.md",
     }
-    | {
-        str(source["target_path"])
-        for room in CAPABILITIES.values()
-        for source in room.get("skill_sources", ())
-    }
+    | {str(source["target_path"]) for room in CAPABILITIES.values() for source in room.get("skill_sources", ())}
 )
 
 CUSTOMIZATION_MIGRATION_SEAMS_VERSION = 0
@@ -592,6 +718,7 @@ def update_write_verdict(
         "onboarding-context",
         "onboarding-provision",
         "analytics-receipt",
+        "automation-ownership",
     ):
         raise ValueError(f"unknown write operation: {operation}")
 
@@ -715,6 +842,46 @@ def update_write_verdict(
             resolution.rule_id if resolution is not None else None,
         )
 
+    if operation == "automation-ownership":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+        except ContractViolation:
+            return WriteVerdict(
+                str(path),
+                False,
+                "outside-automation-ownership",
+                None,
+                None,
+            )
+        try:
+            resolution = resolve(candidate)
+        except ContractViolation:
+            resolution = None
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        if candidate == AUTOMATION_OWNERSHIP_RELATIVE:
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-automation-ownership",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-automation-ownership",
+            resolution.ownership if resolution is not None else None,
+            resolution.rule_id if resolution is not None else None,
+        )
+
     if operation == "analytics-receipt":
         try:
             denied = is_denied(path)
@@ -823,8 +990,7 @@ def update_write_verdict(
             )
 
         if candidate in CUSTOMIZATION_MIGRATION_SEAM_PATHS or any(
-            candidate.startswith(prefix)
-            for prefix in CUSTOMIZATION_MIGRATION_SEAM_PREFIXES
+            candidate.startswith(prefix) for prefix in CUSTOMIZATION_MIGRATION_SEAM_PREFIXES
         ):
             return WriteVerdict(
                 candidate,
@@ -847,21 +1013,13 @@ def update_write_verdict(
     except ContractViolation:
         return WriteVerdict(str(path), False, "unclassified-never-write", None, None)
     if resolution.denied:
-        return WriteVerdict(
-            resolution.path, False, "deny", resolution.ownership, resolution.rule_id
-        )
+        return WriteVerdict(resolution.path, False, "deny", resolution.ownership, resolution.rule_id)
     action = MUTATION_POLICY[resolution.ownership]
     if action == "never":
-        return WriteVerdict(
-            resolution.path, False, "never", resolution.ownership, resolution.rule_id
-        )
+        return WriteVerdict(resolution.path, False, "never", resolution.ownership, resolution.rule_id)
     if action == "write-if-absent" and exists:
-        return WriteVerdict(
-            resolution.path, False, action, resolution.ownership, resolution.rule_id
-        )
-    return WriteVerdict(
-        resolution.path, True, action, resolution.ownership, resolution.rule_id
-    )
+        return WriteVerdict(resolution.path, False, action, resolution.ownership, resolution.rule_id)
+    return WriteVerdict(resolution.path, True, action, resolution.ownership, resolution.rule_id)
 
 
 class ContractViolation(ValueError):
@@ -890,9 +1048,7 @@ def is_denied(path: str) -> bool:
         pattern = raw_pattern.lower()
         if fnmatch.fnmatch(candidate, pattern):
             return True
-        if "/" not in pattern and any(
-            fnmatch.fnmatch(segment, pattern) for segment in segments
-        ):
+        if "/" not in pattern and any(fnmatch.fnmatch(segment, pattern) for segment in segments):
             return True
     return False
 
@@ -965,11 +1121,7 @@ def legacy_shipped_runtime(paths: Iterable[str]) -> list[str]:
     tree is a standing contradiction the transition baseline currently
     grandfathers (usage log and legacy state markers).
     """
-    return [
-        resolution.path
-        for resolution in (resolve(path) for path in paths)
-        if resolution.ownership == "runtime"
-    ]
+    return [resolution.path for resolution in (resolve(path) for path in paths) if resolution.ownership == "runtime"]
 
 
 def build_contract_schema(

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -43,6 +43,7 @@ SUPPORTED_CONTRACT_VERSIONS = (1, CONTRACT_VERSION)
 VAULT_SCHEMA_SUPPORTED = ">=1 <2"
 ANALYTICS_ATTEMPT_RECEIPT_RELATIVE = "System/.dex/analytics-attempts.jsonl"
 AUTOMATION_OWNERSHIP_RELATIVE = "System/.dex/automation-ownership.json"
+AUTOMATION_OWNERSHIP_TRANSACTION_MAX_BYTES = 64 * 1024
 # A receipt retains a bounded rolling history. A prior release could write one
 # safe record beyond the retained cap, so the transaction has exactly that
 # extra recovery room to validate the full existing file before it keeps whole

--- a/core/tests/test_automation_ownership_contract.py
+++ b/core/tests/test_automation_ownership_contract.py
@@ -125,6 +125,12 @@ def test_public_preview_schema_keeps_claim_and_release_shapes_closed(
     assert list(validator.iter_errors({**preview, "scheduler_state": "stopped"}))
     assert list(validator.iter_errors({key: value for key, value in preview.items() if key != "launchd_state"}))
 
+    noncanonical = {
+        **preview,
+        "claim": {**preview["claim"], "plist_relative_path": "Library/LaunchAgents/..plist"},
+    }
+    assert list(validator.iter_errors(noncanonical))
+
 
 def test_claim_executes_only_through_transaction_and_is_idempotent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -152,7 +158,12 @@ def test_claim_executes_only_through_transaction_and_is_idempotent(
     }
     schema = json.loads(SIDECAR_SCHEMA.read_text(encoding="utf-8"))
     Draft202012Validator.check_schema(schema)
-    assert list(Draft202012Validator(schema).iter_errors(json.loads(sidecar.read_text()))) == []
+    sidecar_validator = Draft202012Validator(schema)
+    sidecar_state = json.loads(sidecar.read_text())
+    assert list(sidecar_validator.iter_errors(sidecar_state)) == []
+    noncanonical_sidecar = json.loads(sidecar.read_text())
+    noncanonical_sidecar["claims"][0]["plist_relative_path"] = "Library/LaunchAgents/..plist"
+    assert list(sidecar_validator.iter_errors(noncanonical_sidecar))
     assert executed["receipt"]["status"] == "claimed"
     assert executed["receipt"]["transaction_id"]
     assert not (vault / "System/.dex/ledger").exists()
@@ -245,6 +256,32 @@ def test_claim_rejects_sidecar_state_that_appears_after_preview(
     assert json.loads(sidecar.read_text()) == {"schema_version": 1, "claims": []}
 
 
+def test_claim_idempotent_replay_rejects_unrelated_sidecar_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    service.execute_approved_automation_claim(vault, previewed["preview"], previewed["approval_token"])
+    sidecar = vault / automation_ownership.SIDECAR_RELATIVE
+    state = json.loads(sidecar.read_text())
+    state["claims"].append(
+        {
+            "automation_id": "com.dex.zzz",
+            "owner_id": "dex-solo",
+            "plist_relative_path": "Library/LaunchAgents/com.dex.zzz.plist",
+            "plist_sha256": "0" * 64,
+        }
+    )
+    sidecar.write_bytes(_canonical(state))
+
+    with pytest.raises(PlanRejected, match="state changed since preview"):
+        service.execute_approved_automation_claim(
+            vault,
+            previewed["preview"],
+            previewed["approval_token"],
+        )
+
+
 def test_claim_obeys_transaction_lock_and_rolls_back_commit_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -299,6 +336,43 @@ def test_release_requires_stopped_scheduler_and_is_idempotent(tmp_path: Path, mo
 
     with pytest.raises(PlanRejected, match="stopped"):
         service.build_and_preview_automation_release(vault, {**release_request, "scheduler_state": "running"})
+
+
+def test_release_idempotent_replay_rejects_unrelated_sidecar_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    _claim(vault, request)
+    release_request = {
+        "automation_id": LABEL,
+        "owner_id": "dex-solo",
+        "scheduler_state": "stopped",
+    }
+    previewed = service.build_and_preview_automation_release(vault, release_request)
+    service.execute_approved_automation_release(vault, previewed["preview"], previewed["approval_token"])
+    sidecar = vault / automation_ownership.SIDECAR_RELATIVE
+    sidecar.write_bytes(
+        _canonical(
+            {
+                "schema_version": 1,
+                "claims": [
+                    {
+                        "automation_id": "com.dex.zzz",
+                        "owner_id": "dex-solo",
+                        "plist_relative_path": "Library/LaunchAgents/com.dex.zzz.plist",
+                        "plist_sha256": "0" * 64,
+                    }
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(PlanRejected, match="state changed since preview"):
+        service.execute_approved_automation_release(
+            vault,
+            previewed["preview"],
+            previewed["approval_token"],
+        )
 
 
 def test_release_rejects_foreign_owner_and_tampered_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/core/tests/test_automation_ownership_contract.py
+++ b/core/tests/test_automation_ownership_contract.py
@@ -1,0 +1,290 @@
+"""Frozen lifecycle contract for handing one launchd automation to Dex Solo."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import plistlib
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from core.lifecycle import service
+from core.transaction.engine import PlanRejected, Transaction
+from core.transaction.lock import LockBusyError, acquire_owned_lock
+from core.utils import automation_ownership
+
+LABEL = "com.dex.smoke-nightly"
+PLIST_RELATIVE = f"Library/LaunchAgents/{LABEL}.plist"
+SIDECAR_SCHEMA = Path(__file__).resolve().parents[1] / "lifecycle/schemas/automation-ownership-v1.schema.json"
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+
+
+def _fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, dict[str, object]]:
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    home = tmp_path / "home"
+    plist = home / PLIST_RELATIVE
+    plist.parent.mkdir(parents=True)
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": LABEL,
+                "ProgramArguments": ["/bin/bash", str(vault / ".scripts/smoke-nightly.sh")],
+            },
+            handle,
+        )
+    monkeypatch.setattr(automation_ownership, "_home_root", lambda: home)
+    claim = {
+        "automation_id": LABEL,
+        "owner_id": "dex-solo",
+        "plist_relative_path": PLIST_RELATIVE,
+        "plist_sha256": hashlib.sha256(plist.read_bytes()).hexdigest(),
+        "launchd_state": "unloaded",
+    }
+    return vault, claim
+
+
+def _claim(vault: Path, request: dict[str, object]) -> dict[str, object]:
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    return service.execute_approved_automation_claim(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+
+def test_claim_preview_binds_exact_plist_and_sidecar_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+
+    response = service.build_and_preview_automation_claim(vault, request)
+
+    assert response["api_version"] == "1.5.0"
+    assert response["needed"] is True
+    assert response["preview"] == {
+        "automation_ownership_version": 1,
+        "operation": "claim",
+        "claim": {
+            "automation_id": LABEL,
+            "owner_id": "dex-solo",
+            "plist_relative_path": PLIST_RELATIVE,
+            "plist_sha256": request["plist_sha256"],
+        },
+        "launchd_state": "unloaded",
+        "current_sidecar_sha256": None,
+        "next_sidecar_sha256": hashlib.sha256(
+            _canonical(
+                {
+                    "schema_version": 1,
+                    "claims": [
+                        {
+                            "automation_id": LABEL,
+                            "owner_id": "dex-solo",
+                            "plist_relative_path": PLIST_RELATIVE,
+                            "plist_sha256": request["plist_sha256"],
+                        }
+                    ],
+                }
+            )
+        ).hexdigest(),
+    }
+    expected_token = hashlib.sha256(_canonical(response["preview"])).hexdigest()
+    assert response["approval_token"] == expected_token
+    assert not (vault / automation_ownership.SIDECAR_RELATIVE).exists()
+
+
+def test_claim_executes_only_through_transaction_and_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    executed = service.execute_approved_automation_claim(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    sidecar = vault / automation_ownership.SIDECAR_RELATIVE
+    assert json.loads(sidecar.read_text()) == {
+        "schema_version": 1,
+        "claims": [
+            {
+                "automation_id": LABEL,
+                "owner_id": "dex-solo",
+                "plist_relative_path": PLIST_RELATIVE,
+                "plist_sha256": request["plist_sha256"],
+            }
+        ],
+    }
+    schema = json.loads(SIDECAR_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    assert list(Draft202012Validator(schema).iter_errors(json.loads(sidecar.read_text()))) == []
+    assert executed["receipt"]["status"] == "claimed"
+    assert executed["receipt"]["transaction_id"]
+    assert not (vault / "System/.dex/ledger").exists()
+
+    repeated_execution = service.execute_approved_automation_claim(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+    assert repeated_execution["receipt"]["status"] == "already-claimed"
+    assert repeated_execution["receipt"]["transaction_id"] is None
+
+    repeated = service.build_and_preview_automation_claim(vault, request)
+    assert repeated == {
+        "api_version": "1.5.0",
+        "needed": False,
+        "preview": None,
+        "approval_token": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("automation_id", "../smoke", "automation_id"),
+        ("owner_id", "another-app", "Dex Solo"),
+        ("plist_relative_path", "/Library/LaunchAgents/x.plist", "relative"),
+        ("plist_sha256", "A" * 64, "sha256"),
+        ("launchd_state", "loaded", "unloaded"),
+    ],
+)
+def test_claim_validation_is_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    request[field] = value
+
+    with pytest.raises(PlanRejected, match=message):
+        service.build_and_preview_automation_claim(vault, request)
+
+    assert not (vault / automation_ownership.SIDECAR_RELATIVE).exists()
+
+
+def test_claim_rejects_unknown_fields_and_conflicting_reuse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    with pytest.raises(PlanRejected, match="unsupported fields"):
+        service.build_and_preview_automation_claim(vault, {**request, "extra": True})
+
+    _claim(vault, request)
+    conflict = dict(request)
+    conflict["plist_relative_path"] = "Library/LaunchAgents/other.plist"
+    with pytest.raises(PlanRejected, match="conflicting reuse"):
+        service.build_and_preview_automation_claim(vault, conflict)
+
+
+def test_claim_recomputes_token_and_rejects_plist_or_sidecar_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    plist = automation_ownership._home_root() / PLIST_RELATIVE
+    plist.write_bytes(plist.read_bytes() + b"\n")
+
+    with pytest.raises(PlanRejected, match="plist evidence changed"):
+        service.execute_approved_automation_claim(vault, previewed["preview"], previewed["approval_token"])
+
+    assert not (vault / automation_ownership.SIDECAR_RELATIVE).exists()
+
+
+def test_claim_rejects_sidecar_state_that_appears_after_preview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    sidecar = vault / automation_ownership.SIDECAR_RELATIVE
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_bytes(_canonical({"schema_version": 1, "claims": []}))
+
+    with pytest.raises(PlanRejected, match="state changed since preview"):
+        service.execute_approved_automation_claim(
+            vault,
+            previewed["preview"],
+            previewed["approval_token"],
+        )
+
+    assert json.loads(sidecar.read_text()) == {"schema_version": 1, "claims": []}
+
+
+def test_claim_obeys_transaction_lock_and_rolls_back_commit_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    previewed = service.build_and_preview_automation_claim(vault, request)
+    release = acquire_owned_lock(vault, "test-owner")
+    try:
+        with pytest.raises(LockBusyError):
+            service.execute_approved_automation_claim(vault, previewed["preview"], previewed["approval_token"])
+    finally:
+        release()
+
+    def fail_commit(_transaction: Transaction) -> dict[str, object]:
+        raise RuntimeError("deliberate commit failure")
+
+    monkeypatch.setattr(Transaction, "_commit_phase", fail_commit)
+    with pytest.raises(RuntimeError, match="deliberate commit failure"):
+        service.execute_approved_automation_claim(vault, previewed["preview"], previewed["approval_token"])
+    assert not (vault / automation_ownership.SIDECAR_RELATIVE).exists()
+
+
+def test_release_requires_stopped_scheduler_and_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    _claim(vault, request)
+    release_request = {
+        "automation_id": LABEL,
+        "owner_id": "dex-solo",
+        "scheduler_state": "stopped",
+    }
+
+    previewed = service.build_and_preview_automation_release(vault, release_request)
+    assert previewed["preview"]["scheduler_state"] == "stopped"
+    released = service.execute_approved_automation_release(vault, previewed["preview"], previewed["approval_token"])
+    assert released["receipt"]["status"] == "released"
+    assert json.loads((vault / automation_ownership.SIDECAR_RELATIVE).read_text()) == {
+        "schema_version": 1,
+        "claims": [],
+    }
+    repeated_release = service.execute_approved_automation_release(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+    assert repeated_release["receipt"]["status"] == "already-released"
+    assert repeated_release["receipt"]["transaction_id"] is None
+    assert service.build_and_preview_automation_release(vault, release_request) == {
+        "api_version": "1.5.0",
+        "needed": False,
+        "preview": None,
+        "approval_token": None,
+    }
+
+    with pytest.raises(PlanRejected, match="stopped"):
+        service.build_and_preview_automation_release(vault, {**release_request, "scheduler_state": "running"})
+
+
+def test_release_rejects_foreign_owner_and_tampered_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    _claim(vault, request)
+    release_request = {
+        "automation_id": LABEL,
+        "owner_id": "dex-solo",
+        "scheduler_state": "stopped",
+    }
+    previewed = service.build_and_preview_automation_release(vault, release_request)
+
+    with pytest.raises(PlanRejected, match="approval token"):
+        service.execute_approved_automation_release(vault, previewed["preview"], "0" * 64)
+    with pytest.raises(PlanRejected, match="Dex Solo"):
+        service.build_and_preview_automation_release(vault, {**release_request, "owner_id": "foreign-owner"})

--- a/core/tests/test_automation_ownership_contract.py
+++ b/core/tests/test_automation_ownership_contract.py
@@ -99,6 +99,12 @@ def test_claim_preview_binds_exact_plist_and_sidecar_state(tmp_path: Path, monke
     assert not (vault / automation_ownership.SIDECAR_RELATIVE).exists()
 
 
+def test_transaction_rereads_the_sidecar_with_the_closed_size_bound() -> None:
+    assert service._internal_transaction_read_limits("automation-ownership") == {
+        automation_ownership.SIDECAR_RELATIVE: automation_ownership.SIDECAR_MAX_BYTES,
+    }
+
+
 def test_claim_executes_only_through_transaction_and_is_idempotent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/core/tests/test_automation_ownership_contract.py
+++ b/core/tests/test_automation_ownership_contract.py
@@ -191,6 +191,7 @@ def test_claim_executes_only_through_transaction_and_is_idempotent(
         ("automation_id", "../smoke", "automation_id"),
         ("owner_id", "another-app", "Dex Solo"),
         ("plist_relative_path", "/Library/LaunchAgents/x.plist", "relative"),
+        ("plist_relative_path", "Library/LaunchAgents/..plist", "canonical"),
         ("plist_sha256", "A" * 64, "sha256"),
         ("launchd_state", "loaded", "unloaded"),
     ],

--- a/core/tests/test_automation_ownership_contract.py
+++ b/core/tests/test_automation_ownership_contract.py
@@ -18,6 +18,7 @@ from core.utils import automation_ownership
 LABEL = "com.dex.smoke-nightly"
 PLIST_RELATIVE = f"Library/LaunchAgents/{LABEL}.plist"
 SIDECAR_SCHEMA = Path(__file__).resolve().parents[1] / "lifecycle/schemas/automation-ownership-v1.schema.json"
+API_SCHEMA = Path(__file__).resolve().parents[1] / "lifecycle/contracts/api.schema.json"
 
 
 def _canonical(value: object) -> bytes:
@@ -103,6 +104,26 @@ def test_transaction_rereads_the_sidecar_with_the_closed_size_bound() -> None:
     assert service._internal_transaction_read_limits("automation-ownership") == {
         automation_ownership.SIDECAR_RELATIVE: automation_ownership.SIDECAR_MAX_BYTES,
     }
+
+
+def test_public_preview_schema_keeps_claim_and_release_shapes_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault, request = _fixture(tmp_path, monkeypatch)
+    preview = service.build_and_preview_automation_claim(vault, request)["preview"]
+    document = json.loads(API_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(document)
+    preview_schema = {
+        "$schema": document["$schema"],
+        "$ref": "#/$defs/automationPreview",
+        "$defs": document["$defs"],
+    }
+    validator = Draft202012Validator(preview_schema)
+
+    assert list(validator.iter_errors(preview)) == []
+    assert list(validator.iter_errors({**preview, "scheduler_state": "stopped"}))
+    assert list(validator.iter_errors({key: value for key, value in preview.items() if key != "launchd_state"}))
 
 
 def test_claim_executes_only_through_transaction_and_is_idempotent(

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -28,7 +28,7 @@ from core.tests.lifecycle_test_helpers import (
     write_manifest,
 )
 from core.transaction.engine import PlanRejected
-from core.utils import doctor, release_channel
+from core.utils import automation_ownership, doctor, release_channel
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCTOR_PATH = Path(__file__).resolve().parents[1] / "utils" / "doctor.py"
@@ -93,9 +93,7 @@ def foreign_launch_agents(context):
     agents.mkdir(parents=True, exist_ok=True)
     definitions = {
         "com.dex.research-scan": ".scripts/research-scan.py",
-        "com.dex.other-product": str(
-            context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"
-        ),
+        "com.dex.other-product": str(context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"),
     }
     plists = []
     for label, script in definitions.items():
@@ -175,24 +173,66 @@ def _write_plist(context, label):
     return plist
 
 
+def _write_solo_automation_claim(context, plist, label):
+    relative = plist.relative_to(context.home).as_posix()
+    sidecar = context.vault_root / automation_ownership.SIDECAR_RELATIVE
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "claims": [
+                    {
+                        "automation_id": label,
+                        "owner_id": "dex-solo",
+                        "plist_relative_path": relative,
+                        "plist_sha256": hashlib.sha256(plist.read_bytes()).hexdigest(),
+                    }
+                ],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return sidecar
+
+
 def _write_entity_probe_files(context, *, mode="auto", unresolved=None):
     runtime = context.vault_root / "System" / ".dex"
     runtime.mkdir(parents=True, exist_ok=True)
-    (runtime / "contacts.json").write_text(json.dumps({
-        "contacts": {"one": {}}, "observations": {"m1": {}, "m2": {}},
-    }))
-    (runtime / "entity-suggestions.json").write_text(json.dumps({
-        "suggestions": [{"status": "suggested"}],
-    }))
-    (runtime / "entity-verification.json").write_text(json.dumps({
-        "generated_at": NOW.isoformat(), "unresolved": unresolved or [],
-    }))
-    (context.vault_root / "System" / "user-profile.yaml").write_text(
-        f"entity_creation:\n  mode: {mode}\n"
+    (runtime / "contacts.json").write_text(
+        json.dumps(
+            {
+                "contacts": {"one": {}},
+                "observations": {"m1": {}, "m2": {}},
+            }
+        )
     )
-    (context.vault_root / "System" / "People_Index.json").write_text(json.dumps({
-        "built_at": NOW.isoformat(),
-    }))
+    (runtime / "entity-suggestions.json").write_text(
+        json.dumps(
+            {
+                "suggestions": [{"status": "suggested"}],
+            }
+        )
+    )
+    (runtime / "entity-verification.json").write_text(
+        json.dumps(
+            {
+                "generated_at": NOW.isoformat(),
+                "unresolved": unresolved or [],
+            }
+        )
+    )
+    (context.vault_root / "System" / "user-profile.yaml").write_text(f"entity_creation:\n  mode: {mode}\n")
+    (context.vault_root / "System" / "People_Index.json").write_text(
+        json.dumps(
+            {
+                "built_at": NOW.isoformat(),
+            }
+        )
+    )
 
 
 def _write_release_catalog(context, *, content=b"release skill\n", catalog_version=2):
@@ -200,20 +240,18 @@ def _write_release_catalog(context, *, content=b"release skill\n", catalog_versi
     manifest = write_manifest(context.vault_root, [item_path])
     write_file(context.vault_root, item_path, content)
     release_identity = {
-                "version": "1.64.0",
-                "channel": "release",
-                "source_commit": SOURCE_COMMIT,
-                "manifest": {
-                    "path": "System/.installed-files.manifest",
-                    "sha256": hashlib.sha256(manifest).hexdigest(),
-                },
-            }
+        "version": "1.64.0",
+        "channel": "release",
+        "source_commit": SOURCE_COMMIT,
+        "manifest": {
+            "path": "System/.installed-files.manifest",
+            "sha256": hashlib.sha256(manifest).hexdigest(),
+        },
+    }
     if catalog_version == 1:
         release_identity["immutable_distribution_tag"] = "dist/release/v1.64.0-0123456"
     else:
-        release_identity["immutable_distribution_tag_pattern"] = (
-            "dist/release/v1.64.0-<release-commit-prefix>"
-        )
+        release_identity["immutable_distribution_tag_pattern"] = "dist/release/v1.64.0-<release-commit-prefix>"
     document = with_catalog_identity(
         {
             "catalog_version": catalog_version,
@@ -291,11 +329,7 @@ def _drift_context(tmp_path, *, release_ref=True, channel=None):
     (vault / "core").mkdir()
     (vault / "core" / "shipped.py").write_text("SHIPPED = 1\n")
     (vault / "CLAUDE.md").write_text(
-        "# Dex\n\n"
-        "## USER_EXTENSIONS_START\n"
-        "<!-- personal instructions -->\n"
-        "## USER_EXTENSIONS_END\n\n"
-        "Shipped tail.\n"
+        "# Dex\n\n## USER_EXTENSIONS_START\n<!-- personal instructions -->\n## USER_EXTENSIONS_END\n\nShipped tail.\n"
     )
     (vault / ".mcp.json").write_text(
         json.dumps(
@@ -372,9 +406,14 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     _write_entity_probe_files(context)
     (context.vault_root / "System" / "user-profile.yaml").write_text("name: Test\n")
     verification = context.vault_root / "System" / ".dex" / "entity-verification.json"
-    verification.write_text(json.dumps({
-        "generated_at": (NOW - timedelta(hours=49)).isoformat(), "unresolved": [],
-    }))
+    verification.write_text(
+        json.dumps(
+            {
+                "generated_at": (NOW - timedelta(hours=49)).isoformat(),
+                "unresolved": [],
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert result.verdict == "OK"
     assert "suggest (default — key missing)" in result.detail
@@ -392,10 +431,7 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
                 "meeting_id": "meeting-1",
                 "meeting_ids": ["meeting-1"],
                 "op_type": "mutate",
-                "entity_path": (
-                    str(context.vault_root)
-                    + "/05-Areas/People/External/Jane_Example.md"
-                ),
+                "entity_path": (str(context.vault_root) + "/05-Areas/People/External/Jane_Example.md"),
                 "entity_identity": {
                     "kind": "person",
                     "name": "Jane Example",
@@ -420,9 +456,7 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
         action="Re-queue the dead-lettered entity write with retry counters reset.",
         applied=False,
     )
-    definition = next(
-        item for item in doctor.QUICK_CHECKS if item.id == "entity.engine"
-    )
+    definition = next(item for item in doctor.QUICK_CHECKS if item.id == "entity.engine")
     rendered = doctor._result_json(definition, result)
     assert rendered["feature_status"] == "broken"
     assert rendered["user_message"] == result.user_message
@@ -441,10 +475,13 @@ def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
     monkeypatch.setattr(
         doctor,
         "_requeue_entity_dead_letters",
-        lambda candidate: calls.append(candidate) or {
-            "requeued": 1,
-            "dead_letter_ids": ["example-dead-letter"],
-        },
+        lambda candidate: (
+            calls.append(candidate)
+            or {
+                "requeued": 1,
+                "dead_letter_ids": ["example-dead-letter"],
+            }
+        ),
     )
 
     actions, errors = doctor._apply_t1_heals(context)
@@ -460,13 +497,7 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
     _write_entity_probe_files(context)
     operation = {
         "op": "create",
-        "path": str(
-            context.vault_root
-            / "05-Areas"
-            / "People"
-            / "External"
-            / "Jane_Example.md"
-        ),
+        "path": str(context.vault_root / "05-Areas" / "People" / "External" / "Jane_Example.md"),
         "content": "# Jane Example\n",
         "allowed_root": str(context.vault_root),
     }
@@ -495,9 +526,7 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
 
     assert healed["requeued"] == 1
     assert not dead_letter.exists()
-    pending = json.loads(
-        (context.vault_root / "System" / ".dex" / "entity-pending.json").read_text()
-    )
+    pending = json.loads((context.vault_root / "System" / ".dex" / "entity-pending.json").read_text())
     assert pending["batches"][0]["ops"] == [operation]
     assert doctor._probe_entity_engine(context).verdict == "OK"
 
@@ -511,10 +540,17 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(json.dumps({"version": 2, "pages": {
-        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-        "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "pages": {
+                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+                    "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
+                },
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert "gardener on (2 pages maintained), 1 user-owned summary" in result.detail
 
@@ -523,9 +559,16 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     result = doctor._probe_entity_engine(context)
     assert "gardener off (disabled), 1 user-owned summary" in result.detail
 
-    gardener.write_text(json.dumps({"version": 1, "pages": {
-        "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "pages": {
+                    "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
+                },
+            }
+        )
+    )
     result = doctor._probe_entity_engine(context)
     assert "1 legacy lock pending migration" in result.detail
 
@@ -535,9 +578,16 @@ def test_entity_engine_probe_reads_llm_key_from_vault_env_file(monkeypatch, cont
         monkeypatch.delenv(key, raising=False)
     _write_entity_probe_files(context)
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(json.dumps({"version": 2, "pages": {
-        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-    }}))
+    gardener.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "pages": {
+                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+                },
+            }
+        )
+    )
     env_path = context.vault_root / ".env"
     env_path.write_text("# local keys\nexport GEMINI_API_KEY='test-placeholder-key'\n")
 
@@ -777,9 +827,7 @@ def test_release_catalog_probe_is_calmly_off_for_older_installs(context):
 
 
 @pytest.mark.parametrize("catalog_version", (1, 2))
-def test_release_catalog_probe_reports_valid_version_without_writing(
-    context, catalog_version
-):
+def test_release_catalog_probe_reports_valid_version_without_writing(context, catalog_version):
     _write_release_catalog(context, catalog_version=catalog_version)
     before = _tree_snapshot(context.vault_root)
 
@@ -914,9 +962,7 @@ def test_adoption_plan_probe_is_broken_on_a_real_bridge_pin_mismatch(context):
 
 
 def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
-    (context.vault_root / "System/.release-catalog.json").write_text(
-        "{not json", encoding="utf-8"
-    )
+    (context.vault_root / "System/.release-catalog.json").write_text("{not json", encoding="utf-8")
     _stub_probes(monkeypatch, exclude={"release.catalog", "adoption.plan"})
 
     report = doctor.collect(context=context)
@@ -945,9 +991,7 @@ def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
         ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
         check=True,
     )
-    (brain / "dex-brain-v2").write_text(
-        json.dumps({"role": "brain", "installed": commit}) + "\n"
-    )
+    (brain / "dex-brain-v2").write_text(json.dumps({"role": "brain", "installed": commit}) + "\n")
     topology = context.vault_root / "System/.dex/topology.json"
     topology.parent.mkdir(parents=True, exist_ok=True)
     topology.write_text(
@@ -970,10 +1014,7 @@ def test_topology_probe_distinguishes_combined_split_and_invalid(context):
     assert doctor._topology_state(context) == "combined"
     assert doctor._probe_migration_pending(context).verdict == "OFF"
 
-    migrator = (
-        context.vault_root
-        / "core/migrations/v1-to-v2-brain-vault-split.cjs"
-    )
+    migrator = context.vault_root / "core/migrations/v1-to-v2-brain-vault-split.cjs"
     migrator.parent.mkdir(parents=True)
     migrator.write_text("'use strict';\n", encoding="utf-8")
     assert doctor._topology_state(context) == "migration-pending"
@@ -1280,9 +1321,7 @@ def test_raising_probe_becomes_unknown_and_main_still_returns_valid_json(monkeyp
         ),
     ],
 )
-def test_missing_modules_have_truthful_actionable_unknown_detail(
-    monkeypatch, context, error, guidance
-):
+def test_missing_modules_have_truthful_actionable_unknown_detail(monkeypatch, context, error, guidance):
     _stub_probes(monkeypatch)
 
     def missing_dependency(_context):
@@ -1383,10 +1422,7 @@ def test_heal_applies_all_t1_actions_and_leaves_t2_suggestion_untouched(
     assert "Missing standard PARA directories: 00-Inbox" in structure["detail"]
     assert structure["heal"] == {
         "tier": 1,
-        "action": (
-            "regenerated core/paths.json; restored executable permission on "
-            ".scripts/repo-tool.sh."
-        ),
+        "action": ("regenerated core/paths.json; restored executable permission on .scripts/repo-tool.sh."),
         "applied": True,
     }
     assert _check(report, "mcp.registered")["heal"] == {
@@ -1416,9 +1452,7 @@ def test_quick_mode_does_not_apply_t1_without_heal(monkeypatch, context):
     assert not script.stat().st_mode & stat.S_IXUSR
 
 
-def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(
-    monkeypatch, context
-):
+def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(monkeypatch, context):
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     script = context.vault_root / ".scripts" / "repair-me.sh"
@@ -1490,9 +1524,7 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
     structure = _check(report, "vault.structure")
     assert structure["verdict"] == "UNKNOWN"
     assert structure["heal"]["applied"] is True
-    assert report["instruments"]["failed"] == [
-        {"id": "vault.structure", "error": "structure probe exploded"}
-    ]
+    assert report["instruments"]["failed"] == [{"id": "vault.structure", "error": "structure probe exploded"}]
 
 
 def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, capsys):
@@ -1598,10 +1630,7 @@ def test_capability_rooms_probe_detects_missing_on_assets_and_live_off_skills(
     assert "quarter-plan" in result.detail
     assert result.heal == doctor.Heal(
         tier=1,
-        action=(
-            "Reconcile capability room folders and shipped skills without "
-            "deleting user content."
-        ),
+        action=("Reconcile capability room folders and shipped skills without deleting user content."),
         applied=False,
     )
 
@@ -1624,9 +1653,7 @@ def test_capability_seed_probe_advises_update_only_for_enabled_rooms(
     )
     career = context.vault_root / "05-Areas/Career"
     career.mkdir(parents=True)
-    dormant = (
-        REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
-    )
+    dormant = REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
     for skill in ("career-setup", "career-coach", "resume-builder"):
         shutil.copytree(dormant / skill, context.vault_root / ".claude/skills" / skill)
 
@@ -1661,8 +1688,7 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     (context.vault_root / "System/user-profile.yaml").write_text(
-        "name: Legacy User\n"
-        "role: Founder\n",
+        "name: Legacy User\nrole: Founder\n",
         encoding="utf-8",
     )
     user_note = context.vault_root / "05-Areas/Career/private-review.md"
@@ -1671,8 +1697,7 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     existing_skill = context.vault_root / ".claude/skills/quarter-plan/SKILL.md"
     existing_skill.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(
-        REPO_ROOT
-        / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
+        REPO_ROOT / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
         existing_skill,
     )
     context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1693,13 +1718,9 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "applied": True,
     }
     assert user_note.read_text(encoding="utf-8") == "Keep this forever.\n"
-    assert (
-        context.vault_root / "05-Areas/Career/Evidence/README.md"
-    ).is_file()
+    assert (context.vault_root / "05-Areas/Career/Evidence/README.md").is_file()
     for skill in ("career-setup", "career-coach", "resume-builder"):
-        assert (
-            context.vault_root / ".claude/skills" / skill / "SKILL.md"
-        ).is_file()
+        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
     for skill in (
         "career-setup",
         "career-coach",
@@ -1707,12 +1728,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "quarter-plan",
         "quarter-review",
     ):
-        assert (
-            context.vault_root / ".claude/skills" / skill / "SKILL.md"
-        ).is_file()
-    profile = (
-        context.vault_root / "System/user-profile.yaml"
-    ).read_text(encoding="utf-8")
+        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
+    profile = (context.vault_root / "System/user-profile.yaml").read_text(encoding="utf-8")
     assert "companies:\n    enabled: true" in profile
 
 
@@ -1830,11 +1847,7 @@ def test_mcp_probes_read_legacy_config_without_moving_it(context):
     server = mcp_dir / "alpha_server.py"
     server.touch()
     legacy = context.vault_root / "System" / ".mcp.json"
-    legacy.write_text(
-        json.dumps(
-            {"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}
-        )
-    )
+    legacy.write_text(json.dumps({"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}))
 
     before = _tree_snapshot(context.vault_root)
     registered = doctor._probe_mcp_registered(context)
@@ -1903,9 +1916,7 @@ def test_hooks_wired_detects_dangling_hook_files(context):
         json.dumps(
             {
                 "hooks": {
-                    "SessionStart": [
-                        {"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}
-                    ]
+                    "SessionStart": [{"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}]
                 }
             }
         )
@@ -1962,6 +1973,67 @@ def test_jobs_loaded_distinguishes_not_installed_from_unloaded(monkeypatch, cont
     assert result.heal.tier == 2
 
 
+def test_doctor_treats_valid_solo_claim_as_app_owned_and_offloaded(monkeypatch, context):
+    plist = _write_plist(context, "com.dex.meeting-intel")
+    _write_solo_automation_claim(context, plist, "com.dex.meeting-intel")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    def launchctl_must_not_run(*_args, **_kwargs):
+        raise AssertionError("Core must not inspect launchd state for an offloaded job")
+
+    monkeypatch.setattr(doctor, "_launchctl_status", launchctl_must_not_run)
+
+    loaded = doctor._probe_jobs_loaded(context)
+    fresh = doctor._probe_jobs_fresh(context)
+
+    assert loaded.verdict == "OK"
+    assert "owned by Dex Solo and offloaded from Core" in loaded.detail
+    assert fresh.verdict == "OFF"
+    assert "owned by Dex Solo and offloaded from Core" in fresh.detail
+
+
+def test_doctor_does_not_call_valid_solo_claim_broken_or_stale(monkeypatch, context):
+    former_vault = context.home.parent / "old-vault"
+    _write_breadcrumb(context, former_vault)
+    plist = _write_plist(context, "com.dex.example-job")
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.dex.example-job",
+                "ProgramArguments": ["/bin/bash", str(former_vault / ".scripts/job.sh")],
+            },
+            handle,
+        )
+    _write_solo_automation_claim(context, plist, "com.dex.example-job")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "OK"
+    assert "offloaded" in result.detail
+    assert "old location" not in result.detail
+
+
+def test_doctor_rejects_stale_solo_plist_evidence(monkeypatch, context):
+    plist = _write_plist(context, "com.dex.meeting-intel")
+    _write_solo_automation_claim(context, plist, "com.dex.meeting-intel")
+    plist.write_bytes(plist.read_bytes() + b"\n")
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda _plist: "/bin/bash")
+    monkeypatch.setattr(
+        doctor,
+        "_launchctl_status",
+        lambda _label: {"loaded": False, "last_exit_status": None},
+    )
+
+    result = doctor._probe_jobs_loaded(context)
+
+    assert result.verdict == "BROKEN"
+    assert "not loaded" in result.detail
+    assert "offloaded" not in result.detail
+
+
 def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_launch_agents):
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
 
@@ -1969,8 +2041,7 @@ def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "2 Dex launch agents from other Dex products were skipped"
+        "No launch agents for this vault are installed; 2 Dex launch agents from other Dex products were skipped"
     )
     assert "research-scan.py" not in result.detail
 
@@ -1998,8 +2069,7 @@ def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypa
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2027,8 +2097,7 @@ def test_shipped_job_from_another_worktree_vault_is_not_a_failure(monkeypatch, c
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2210,8 +2279,13 @@ def test_jobs_loaded_reports_missing_program_script_as_broken_t2(monkeypatch, co
 
 
 def test_launchctl_domain_failure_is_an_unknown_instrument(monkeypatch, context):
-    _write_plist(context, "com.dex.meeting-intel")
+    plist = _write_plist(context, "com.dex.meeting-intel")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(
+        doctor,
+        "_plist_interpreter",
+        lambda candidate: "/bin/bash" if candidate == plist else None,
+    )
     monkeypatch.setattr(
         doctor,
         "_launchctl_domain_check",
@@ -2390,9 +2464,7 @@ def _write_breadcrumb(context, former_vault):
     return breadcrumb
 
 
-def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkeypatch, context):
     """A job left behind by a vault move is owned-and-stale, never foreign (#364)."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2423,9 +2495,7 @@ def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
     assert str(context.vault_root) in result.heal.action
 
 
-def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(monkeypatch, context):
     """The hook and the doctor must agree: any label pointing at the former root."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2466,12 +2536,7 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
                 "Label": "com.dex.sibling-product",
                 "ProgramArguments": [
                     "/bin/bash",
-                    str(
-                        context.home.parent
-                        / "old-vault-other"
-                        / ".scripts"
-                        / "run.sh"
-                    ),
+                    str(context.home.parent / "old-vault-other" / ".scripts" / "run.sh"),
                 ],
             },
             handle,
@@ -2485,9 +2550,7 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
     assert "was skipped" in result.detail
 
 
-def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
-    monkeypatch, context
-):
+def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch, context):
     """User-installed com.<user>.dex.* jobs get real monitoring coverage (#253)."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2510,16 +2573,12 @@ def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
     assert str(missing_script) in result.detail
 
 
-def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
-    monkeypatch, context
-):
+def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkeypatch, context):
     """Ownership is path evidence, not the label: any plist into this vault counts."""
     plist = _write_plist(context, "com.mycompany.sync")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(
-        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
-    )
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2532,9 +2591,7 @@ def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
     assert "All 1 installed launch agents for this vault are loaded" in result.detail
 
 
-def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(
-    monkeypatch, context
-):
+def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(monkeypatch, context):
     """com.dexcom.* / com.samsung.dex.* / com.fedex.* are other products."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2585,9 +2642,7 @@ def test_corrupt_third_party_plists_never_degrade_job_monitoring(monkeypatch, co
     plist = _write_plist(context, "com.dex.smoke-nightly")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(
-        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
-    )
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2609,9 +2664,7 @@ def test_truncated_shipped_plist_is_unknown_not_a_probe_crash(monkeypatch, conte
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
     plist = agents / "com.dex.meeting-intel.plist"
-    plist.write_bytes(
-        b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>'
-    )
+    plist.write_bytes(b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>')
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
 
     loaded = doctor._probe_jobs_loaded(context)
@@ -2634,9 +2687,7 @@ def test_legacy_claudesidian_jobs_get_real_freshness_audits(context):
     assert "checked for loading only" not in result.detail
 
 
-def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(
-    monkeypatch, context
-):
+def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(monkeypatch, context):
     """A partially repointed job (invocation current, other keys stale) is surfaced.
 
     The session-start hook greps raw bytes and keeps warning about the
@@ -2760,9 +2811,7 @@ def test_stored_former_vault_root_rejects_current_and_degenerate_roots(context):
     assert doctor._stored_former_vault_root(context) == former
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
-    monkeypatch, context
-):
+def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch, context):
     """A worktree path is foreign unless it is this vault's path evidence."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2783,14 +2832,11 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(
-    monkeypatch, context
-):
+def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(monkeypatch, context):
     checkout = context.home.parent / "checkouts" / "dex-copy"
     (checkout / ".scripts").mkdir(parents=True)
     (checkout / ".git").write_text("gitdir: /somewhere/else\n", encoding="utf-8")
@@ -2814,8 +2860,7 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checko
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; "
-        "1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
     )
 
 
@@ -3024,8 +3069,7 @@ def test_customization_mcp_compiles_custom_python_without_running_or_littering(c
     target = context.vault_root / "custom-mcp" / "server.py"
     target.parent.mkdir()
     target.write_text(
-        "from pathlib import Path\n"
-        f"Path({str(sentinel)!r}).write_text('executed')\n",
+        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
         encoding="utf-8",
     )
     _write_mcp_config(
@@ -3202,8 +3246,7 @@ def test_worktree_blob_ids_hash_large_release_trees_in_pipe_safe_batches(
 ) -> None:
     relatives = [f"core/release-file-{index:04d}.py" for index in range(600)]
     expected = {
-        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest()
-        for relative in relatives
+        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest() for relative in relatives
     }
     observed_batches: list[list[str]] = []
 
@@ -3407,8 +3450,7 @@ def test_repository_credential_named_release_files_match_head_without_python_rea
     credential_paths = sorted(
         relative
         for relative in release_entries
-        if "credential" in relative.casefold()
-        and not relative.startswith("core/tests/")
+        if "credential" in relative.casefold() and not relative.startswith("core/tests/")
     )
     assert credential_paths == [
         "core/utils/credential_migration_exceptions.json",
@@ -3733,9 +3775,7 @@ def test_smoke_journeys_roll_up_broken_from_exit_one(monkeypatch, context):
     payload = {
         "schema_version": 1,
         "generated_at": NOW.isoformat(),
-        "journeys": [
-            {"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}
-        ],
+        "journeys": [{"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}],
         "summary": {"ok": 0, "broken": 1, "unknown": 0, "off": 0},
     }
     monkeypatch.setattr(
@@ -3836,20 +3876,14 @@ def test_granola_no_key_is_off_and_api_400_is_broken(monkeypatch, context):
     result = doctor._probe_granola_query_path(context)
     assert result.verdict == "BROKEN"
     assert result.detail == (
-        "Granola query failed (HTTP 400) — the connector may need updating. "
-        "Response: created_after is invalid"
+        "Granola query failed (HTTP 400) — the connector may need updating. Response: created_after is invalid"
     )
 
 
 def _write_backup_config(context, *, enabled=True):
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir(parents=True, exist_ok=True)
-    config.write_text(
-        "backup:\n"
-        f"  enabled: {str(enabled).lower()}\n"
-        "  backend: folder\n"
-        "  destination: /backups\n"
-    )
+    config.write_text(f"backup:\n  enabled: {str(enabled).lower()}\n  backend: folder\n  destination: /backups\n")
 
 
 def _write_backup_stamp(context, *, ok, timestamp, error=None, warnings=None):
@@ -3876,9 +3910,11 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
         context,
         ok=True,
         timestamp="2026-07-10T02:00:00+00:00",
-        warnings=["the vault's version history could not be bundled, so this "
-                  "set holds the notes archive only: fatal: Refusing to create "
-                  "empty bundle."],
+        warnings=[
+            "the vault's version history could not be bundled, so this "
+            "set holds the notes archive only: fatal: Refusing to create "
+            "empty bundle."
+        ],
     )
     result = doctor._probe_backup_freshness(context)
     assert result.verdict == "BROKEN"
@@ -3889,8 +3925,7 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
 
 def test_backup_freshness_stays_ok_when_the_run_recorded_no_warnings(context):
     _write_backup_config(context)
-    _write_backup_stamp(
-        context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
+    _write_backup_stamp(context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
     assert doctor._probe_backup_freshness(context).verdict == "OK"
 
 
@@ -3999,9 +4034,7 @@ def test_calendar_permission_boundaries_and_configured_name(monkeypatch, context
     )
     assert doctor._probe_calendar_access(context).verdict == "OFF"
 
-    (context.vault_root / "System" / "user-profile.yaml").write_text(
-        "calendar:\n  work_calendar: Team Calendar\n"
-    )
+    (context.vault_root / "System" / "user-profile.yaml").write_text("calendar:\n  work_calendar: Team Calendar\n")
     assert doctor._probe_calendar_access(context).verdict == "BROKEN"
 
     monkeypatch.setattr(doctor, "_calendar_permission_status", lambda _context: "denied")
@@ -4196,9 +4229,7 @@ def test_qmd_unexpected_exception_still_breaks_doctor_self(monkeypatch, context)
     report = doctor.collect(deep=True, context=context)
 
     assert _check(report, "qmd.live")["verdict"] == "UNKNOWN"
-    assert report["instruments"]["failed"] == [
-        {"id": "qmd.live", "error": "unexpected qmd adapter failure"}
-    ]
+    assert report["instruments"]["failed"] == [{"id": "qmd.live", "error": "unexpected qmd adapter failure"}]
     assert _check(report, "doctor.self")["verdict"] == "BROKEN"
 
 
@@ -4251,12 +4282,7 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir()
     config.write_text(
-        "todoist:\n"
-        "  enabled: true\n"
-        "  task_sync: true\n"
-        "  api_key_env_var: TODOIST_API_KEY\n"
-        "notion:\n"
-        "  enabled: true\n"
+        "todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\nnotion:\n  enabled: true\n"
     )
     (context.vault_root / ".env").write_text('TODOIST_API_KEY="secret"\n')
     (context.vault_root / ".env").chmod(0o600)
@@ -4299,12 +4325,7 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     assert with_unverifiable.verdict == "UNKNOWN"
     assert "notion" in with_unverifiable.detail
 
-    config.write_text(
-        "todoist:\n"
-        "  enabled: true\n"
-        "  task_sync: true\n"
-        "  api_key_env_var: TODOIST_API_KEY\n"
-    )
+    config.write_text("todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\n")
     assert doctor._probe_integrations_enabled(context).verdict == "OK"
 
 
@@ -4374,11 +4395,7 @@ def test_integrations_engine_stored_but_unverified_rows_are_unknown(monkeypatch,
         lambda command, **_kwargs: subprocess.CompletedProcess(
             command,
             0,
-            stdout=(
-                '{"connections":[{"service":"google","status":"'
-                + status
-                + '","verified":false}]}\n'
-            ),
+            stdout=('{"connections":[{"service":"google","status":"' + status + '","verified":false}]}\n'),
             stderr="",
         ),
     )
@@ -4578,7 +4595,7 @@ def test_post_update_canary_probe_reads_the_receipt(context):
 
 def test_meeting_sources_probe_is_ok_for_api_sources_without_folders(context):
     profile = context.vault_root / "System" / "user-profile.yaml"
-    profile.write_text("meeting_sources:\n  primary: granola\n  notes_folder: \"\"\n", encoding="utf-8")
+    profile.write_text('meeting_sources:\n  primary: granola\n  notes_folder: ""\n', encoding="utf-8")
     result = doctor._probe_meeting_sources(context)
     assert result.verdict == "OK"
     assert "granola" in result.detail

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -93,7 +93,9 @@ def foreign_launch_agents(context):
     agents.mkdir(parents=True, exist_ok=True)
     definitions = {
         "com.dex.research-scan": ".scripts/research-scan.py",
-        "com.dex.other-product": str(context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"),
+        "com.dex.other-product": str(
+            context.home.parent / "other-dex-vault" / ".scripts" / "other-product.py"
+        ),
     }
     plists = []
     for label, script in definitions.items():
@@ -202,37 +204,21 @@ def _write_solo_automation_claim(context, plist, label):
 def _write_entity_probe_files(context, *, mode="auto", unresolved=None):
     runtime = context.vault_root / "System" / ".dex"
     runtime.mkdir(parents=True, exist_ok=True)
-    (runtime / "contacts.json").write_text(
-        json.dumps(
-            {
-                "contacts": {"one": {}},
-                "observations": {"m1": {}, "m2": {}},
-            }
-        )
+    (runtime / "contacts.json").write_text(json.dumps({
+        "contacts": {"one": {}}, "observations": {"m1": {}, "m2": {}},
+    }))
+    (runtime / "entity-suggestions.json").write_text(json.dumps({
+        "suggestions": [{"status": "suggested"}],
+    }))
+    (runtime / "entity-verification.json").write_text(json.dumps({
+        "generated_at": NOW.isoformat(), "unresolved": unresolved or [],
+    }))
+    (context.vault_root / "System" / "user-profile.yaml").write_text(
+        f"entity_creation:\n  mode: {mode}\n"
     )
-    (runtime / "entity-suggestions.json").write_text(
-        json.dumps(
-            {
-                "suggestions": [{"status": "suggested"}],
-            }
-        )
-    )
-    (runtime / "entity-verification.json").write_text(
-        json.dumps(
-            {
-                "generated_at": NOW.isoformat(),
-                "unresolved": unresolved or [],
-            }
-        )
-    )
-    (context.vault_root / "System" / "user-profile.yaml").write_text(f"entity_creation:\n  mode: {mode}\n")
-    (context.vault_root / "System" / "People_Index.json").write_text(
-        json.dumps(
-            {
-                "built_at": NOW.isoformat(),
-            }
-        )
-    )
+    (context.vault_root / "System" / "People_Index.json").write_text(json.dumps({
+        "built_at": NOW.isoformat(),
+    }))
 
 
 def _write_release_catalog(context, *, content=b"release skill\n", catalog_version=2):
@@ -240,18 +226,20 @@ def _write_release_catalog(context, *, content=b"release skill\n", catalog_versi
     manifest = write_manifest(context.vault_root, [item_path])
     write_file(context.vault_root, item_path, content)
     release_identity = {
-        "version": "1.64.0",
-        "channel": "release",
-        "source_commit": SOURCE_COMMIT,
-        "manifest": {
-            "path": "System/.installed-files.manifest",
-            "sha256": hashlib.sha256(manifest).hexdigest(),
-        },
-    }
+                "version": "1.64.0",
+                "channel": "release",
+                "source_commit": SOURCE_COMMIT,
+                "manifest": {
+                    "path": "System/.installed-files.manifest",
+                    "sha256": hashlib.sha256(manifest).hexdigest(),
+                },
+            }
     if catalog_version == 1:
         release_identity["immutable_distribution_tag"] = "dist/release/v1.64.0-0123456"
     else:
-        release_identity["immutable_distribution_tag_pattern"] = "dist/release/v1.64.0-<release-commit-prefix>"
+        release_identity["immutable_distribution_tag_pattern"] = (
+            "dist/release/v1.64.0-<release-commit-prefix>"
+        )
     document = with_catalog_identity(
         {
             "catalog_version": catalog_version,
@@ -329,7 +317,11 @@ def _drift_context(tmp_path, *, release_ref=True, channel=None):
     (vault / "core").mkdir()
     (vault / "core" / "shipped.py").write_text("SHIPPED = 1\n")
     (vault / "CLAUDE.md").write_text(
-        "# Dex\n\n## USER_EXTENSIONS_START\n<!-- personal instructions -->\n## USER_EXTENSIONS_END\n\nShipped tail.\n"
+        "# Dex\n\n"
+        "## USER_EXTENSIONS_START\n"
+        "<!-- personal instructions -->\n"
+        "## USER_EXTENSIONS_END\n\n"
+        "Shipped tail.\n"
     )
     (vault / ".mcp.json").write_text(
         json.dumps(
@@ -406,14 +398,9 @@ def test_entity_engine_probe_reports_default_mode_and_stale_verification(context
     _write_entity_probe_files(context)
     (context.vault_root / "System" / "user-profile.yaml").write_text("name: Test\n")
     verification = context.vault_root / "System" / ".dex" / "entity-verification.json"
-    verification.write_text(
-        json.dumps(
-            {
-                "generated_at": (NOW - timedelta(hours=49)).isoformat(),
-                "unresolved": [],
-            }
-        )
-    )
+    verification.write_text(json.dumps({
+        "generated_at": (NOW - timedelta(hours=49)).isoformat(), "unresolved": [],
+    }))
     result = doctor._probe_entity_engine(context)
     assert result.verdict == "OK"
     assert "suggest (default — key missing)" in result.detail
@@ -431,7 +418,10 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
                 "meeting_id": "meeting-1",
                 "meeting_ids": ["meeting-1"],
                 "op_type": "mutate",
-                "entity_path": (str(context.vault_root) + "/05-Areas/People/External/Jane_Example.md"),
+                "entity_path": (
+                    str(context.vault_root)
+                    + "/05-Areas/People/External/Jane_Example.md"
+                ),
                 "entity_identity": {
                     "kind": "person",
                     "name": "Jane Example",
@@ -456,7 +446,9 @@ def test_entity_engine_probe_surfaces_dead_letters_through_feature_status(contex
         action="Re-queue the dead-lettered entity write with retry counters reset.",
         applied=False,
     )
-    definition = next(item for item in doctor.QUICK_CHECKS if item.id == "entity.engine")
+    definition = next(
+        item for item in doctor.QUICK_CHECKS if item.id == "entity.engine"
+    )
     rendered = doctor._result_json(definition, result)
     assert rendered["feature_status"] == "broken"
     assert rendered["user_message"] == result.user_message
@@ -475,13 +467,10 @@ def test_t1_heal_requeues_dead_lettered_entity_writes(monkeypatch, context):
     monkeypatch.setattr(
         doctor,
         "_requeue_entity_dead_letters",
-        lambda candidate: (
-            calls.append(candidate)
-            or {
-                "requeued": 1,
-                "dead_letter_ids": ["example-dead-letter"],
-            }
-        ),
+        lambda candidate: calls.append(candidate) or {
+            "requeued": 1,
+            "dead_letter_ids": ["example-dead-letter"],
+        },
     )
 
     actions, errors = doctor._apply_t1_heals(context)
@@ -497,7 +486,13 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
     _write_entity_probe_files(context)
     operation = {
         "op": "create",
-        "path": str(context.vault_root / "05-Areas" / "People" / "External" / "Jane_Example.md"),
+        "path": str(
+            context.vault_root
+            / "05-Areas"
+            / "People"
+            / "External"
+            / "Jane_Example.md"
+        ),
         "content": "# Jane Example\n",
         "allowed_root": str(context.vault_root),
     }
@@ -526,7 +521,9 @@ def test_entity_dead_letter_heal_round_trip_returns_probe_to_ok(context):
 
     assert healed["requeued"] == 1
     assert not dead_letter.exists()
-    pending = json.loads((context.vault_root / "System" / ".dex" / "entity-pending.json").read_text())
+    pending = json.loads(
+        (context.vault_root / "System" / ".dex" / "entity-pending.json").read_text()
+    )
     assert pending["batches"][0]["ops"] == [operation]
     assert doctor._probe_entity_engine(context).verdict == "OK"
 
@@ -540,17 +537,10 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 2,
-                "pages": {
-                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-                    "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 2, "pages": {
+        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+        "two.md": {"output_hash": "two", "blocks": {"context-summary": {"owner": "user"}}},
+    }}))
     result = doctor._probe_entity_engine(context)
     assert "gardener on (2 pages maintained), 1 user-owned summary" in result.detail
 
@@ -559,16 +549,9 @@ def test_entity_engine_probe_reports_gardener_statuses(monkeypatch, context):
     result = doctor._probe_entity_engine(context)
     assert "gardener off (disabled), 1 user-owned summary" in result.detail
 
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "pages": {
-                    "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 1, "pages": {
+        "legacy.md": {"output_hash": "old", "locked": True, "locked_reason": "user-edited"},
+    }}))
     result = doctor._probe_entity_engine(context)
     assert "1 legacy lock pending migration" in result.detail
 
@@ -578,16 +561,9 @@ def test_entity_engine_probe_reads_llm_key_from_vault_env_file(monkeypatch, cont
         monkeypatch.delenv(key, raising=False)
     _write_entity_probe_files(context)
     gardener = context.core_path("GARDENER_STATE_FILE")
-    gardener.write_text(
-        json.dumps(
-            {
-                "version": 2,
-                "pages": {
-                    "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
-                },
-            }
-        )
-    )
+    gardener.write_text(json.dumps({"version": 2, "pages": {
+        "one.md": {"output_hash": "one", "blocks": {"context-summary": {"owner": "dex"}}},
+    }}))
     env_path = context.vault_root / ".env"
     env_path.write_text("# local keys\nexport GEMINI_API_KEY='test-placeholder-key'\n")
 
@@ -827,7 +803,9 @@ def test_release_catalog_probe_is_calmly_off_for_older_installs(context):
 
 
 @pytest.mark.parametrize("catalog_version", (1, 2))
-def test_release_catalog_probe_reports_valid_version_without_writing(context, catalog_version):
+def test_release_catalog_probe_reports_valid_version_without_writing(
+    context, catalog_version
+):
     _write_release_catalog(context, catalog_version=catalog_version)
     before = _tree_snapshot(context.vault_root)
 
@@ -962,7 +940,9 @@ def test_adoption_plan_probe_is_broken_on_a_real_bridge_pin_mismatch(context):
 
 
 def test_corrupt_catalog_never_raises_out_of_doctor(monkeypatch, context):
-    (context.vault_root / "System/.release-catalog.json").write_text("{not json", encoding="utf-8")
+    (context.vault_root / "System/.release-catalog.json").write_text(
+        "{not json", encoding="utf-8"
+    )
     _stub_probes(monkeypatch, exclude={"release.catalog", "adoption.plan"})
 
     report = doctor.collect(context=context)
@@ -991,7 +971,9 @@ def _write_split_topology(context, *, installed: str = "a" * 40) -> Path:
         ["git", f"--git-dir={brain}", "remote", "add", "origin", "https://github.com/davekilleen/Dex.git"],
         check=True,
     )
-    (brain / "dex-brain-v2").write_text(json.dumps({"role": "brain", "installed": commit}) + "\n")
+    (brain / "dex-brain-v2").write_text(
+        json.dumps({"role": "brain", "installed": commit}) + "\n"
+    )
     topology = context.vault_root / "System/.dex/topology.json"
     topology.parent.mkdir(parents=True, exist_ok=True)
     topology.write_text(
@@ -1014,7 +996,10 @@ def test_topology_probe_distinguishes_combined_split_and_invalid(context):
     assert doctor._topology_state(context) == "combined"
     assert doctor._probe_migration_pending(context).verdict == "OFF"
 
-    migrator = context.vault_root / "core/migrations/v1-to-v2-brain-vault-split.cjs"
+    migrator = (
+        context.vault_root
+        / "core/migrations/v1-to-v2-brain-vault-split.cjs"
+    )
     migrator.parent.mkdir(parents=True)
     migrator.write_text("'use strict';\n", encoding="utf-8")
     assert doctor._topology_state(context) == "migration-pending"
@@ -1321,7 +1306,9 @@ def test_raising_probe_becomes_unknown_and_main_still_returns_valid_json(monkeyp
         ),
     ],
 )
-def test_missing_modules_have_truthful_actionable_unknown_detail(monkeypatch, context, error, guidance):
+def test_missing_modules_have_truthful_actionable_unknown_detail(
+    monkeypatch, context, error, guidance
+):
     _stub_probes(monkeypatch)
 
     def missing_dependency(_context):
@@ -1422,7 +1409,10 @@ def test_heal_applies_all_t1_actions_and_leaves_t2_suggestion_untouched(
     assert "Missing standard PARA directories: 00-Inbox" in structure["detail"]
     assert structure["heal"] == {
         "tier": 1,
-        "action": ("regenerated core/paths.json; restored executable permission on .scripts/repo-tool.sh."),
+        "action": (
+            "regenerated core/paths.json; restored executable permission on "
+            ".scripts/repo-tool.sh."
+        ),
         "applied": True,
     }
     assert _check(report, "mcp.registered")["heal"] == {
@@ -1452,7 +1442,9 @@ def test_quick_mode_does_not_apply_t1_without_heal(monkeypatch, context):
     assert not script.stat().st_mode & stat.S_IXUSR
 
 
-def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(monkeypatch, context):
+def test_t1_authorized_repairs_preview_and_execute_through_lifecycle_service(
+    monkeypatch, context
+):
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     script = context.vault_root / ".scripts" / "repair-me.sh"
@@ -1524,7 +1516,9 @@ def test_heal_does_not_overwrite_a_raising_structure_probe_with_ok(monkeypatch, 
     structure = _check(report, "vault.structure")
     assert structure["verdict"] == "UNKNOWN"
     assert structure["heal"]["applied"] is True
-    assert report["instruments"]["failed"] == [{"id": "vault.structure", "error": "structure probe exploded"}]
+    assert report["instruments"]["failed"] == [
+        {"id": "vault.structure", "error": "structure probe exploded"}
+    ]
 
 
 def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, capsys):
@@ -1630,7 +1624,10 @@ def test_capability_rooms_probe_detects_missing_on_assets_and_live_off_skills(
     assert "quarter-plan" in result.detail
     assert result.heal == doctor.Heal(
         tier=1,
-        action=("Reconcile capability room folders and shipped skills without deleting user content."),
+        action=(
+            "Reconcile capability room folders and shipped skills without "
+            "deleting user content."
+        ),
         applied=False,
     )
 
@@ -1653,7 +1650,9 @@ def test_capability_seed_probe_advises_update_only_for_enabled_rooms(
     )
     career = context.vault_root / "05-Areas/Career"
     career.mkdir(parents=True)
-    dormant = REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
+    dormant = (
+        REPO_ROOT / ".claude/skills/_available/capabilities/career/skills"
+    )
     for skill in ("career-setup", "career-coach", "resume-builder"):
         shutil.copytree(dormant / skill, context.vault_root / ".claude/skills" / skill)
 
@@ -1688,7 +1687,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     for name in doctor.PARA_PATH_NAMES:
         context.core_path(name).mkdir(parents=True, exist_ok=True)
     (context.vault_root / "System/user-profile.yaml").write_text(
-        "name: Legacy User\nrole: Founder\n",
+        "name: Legacy User\n"
+        "role: Founder\n",
         encoding="utf-8",
     )
     user_note = context.vault_root / "05-Areas/Career/private-review.md"
@@ -1697,7 +1697,8 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
     existing_skill = context.vault_root / ".claude/skills/quarter-plan/SKILL.md"
     existing_skill.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(
-        REPO_ROOT / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
+        REPO_ROOT
+        / ".claude/skills/_available/capabilities/quarter_goals/skills/quarter-plan/SKILL.md",
         existing_skill,
     )
     context.paths_json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1718,9 +1719,13 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "applied": True,
     }
     assert user_note.read_text(encoding="utf-8") == "Keep this forever.\n"
-    assert (context.vault_root / "05-Areas/Career/Evidence/README.md").is_file()
+    assert (
+        context.vault_root / "05-Areas/Career/Evidence/README.md"
+    ).is_file()
     for skill in ("career-setup", "career-coach", "resume-builder"):
-        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
+        assert (
+            context.vault_root / ".claude/skills" / skill / "SKILL.md"
+        ).is_file()
     for skill in (
         "career-setup",
         "career-coach",
@@ -1728,8 +1733,12 @@ def test_doctor_heal_reconciles_room_assets_and_preserves_user_content(
         "quarter-plan",
         "quarter-review",
     ):
-        assert (context.vault_root / ".claude/skills" / skill / "SKILL.md").is_file()
-    profile = (context.vault_root / "System/user-profile.yaml").read_text(encoding="utf-8")
+        assert (
+            context.vault_root / ".claude/skills" / skill / "SKILL.md"
+        ).is_file()
+    profile = (
+        context.vault_root / "System/user-profile.yaml"
+    ).read_text(encoding="utf-8")
     assert "companies:\n    enabled: true" in profile
 
 
@@ -1847,7 +1856,11 @@ def test_mcp_probes_read_legacy_config_without_moving_it(context):
     server = mcp_dir / "alpha_server.py"
     server.touch()
     legacy = context.vault_root / "System" / ".mcp.json"
-    legacy.write_text(json.dumps({"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}))
+    legacy.write_text(
+        json.dumps(
+            {"mcpServers": {"alpha": {"command": sys.executable, "args": [str(server)]}}}
+        )
+    )
 
     before = _tree_snapshot(context.vault_root)
     registered = doctor._probe_mcp_registered(context)
@@ -1916,7 +1929,9 @@ def test_hooks_wired_detects_dangling_hook_files(context):
         json.dumps(
             {
                 "hooks": {
-                    "SessionStart": [{"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}]
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": "bash .claude/hooks/session-start.sh"}]}
+                    ]
                 }
             }
         )
@@ -2041,7 +2056,8 @@ def test_jobs_loaded_skips_foreign_product_plists(monkeypatch, context, foreign_
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 2 Dex launch agents from other Dex products were skipped"
+        "No launch agents for this vault are installed; "
+        "2 Dex launch agents from other Dex products were skipped"
     )
     assert "research-scan.py" not in result.detail
 
@@ -2069,7 +2085,8 @@ def test_shipped_job_from_another_vault_is_not_attributed_to_this_vault(monkeypa
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2097,7 +2114,8 @@ def test_shipped_job_from_another_worktree_vault_is_not_a_failure(monkeypatch, c
 
     assert loaded.verdict == "OFF"
     assert loaded.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
     assert fresh.verdict == "OFF"
 
@@ -2281,11 +2299,7 @@ def test_jobs_loaded_reports_missing_program_script_as_broken_t2(monkeypatch, co
 def test_launchctl_domain_failure_is_an_unknown_instrument(monkeypatch, context):
     plist = _write_plist(context, "com.dex.meeting-intel")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
-    monkeypatch.setattr(
-        doctor,
-        "_plist_interpreter",
-        lambda candidate: "/bin/bash" if candidate == plist else None,
-    )
+    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
     monkeypatch.setattr(
         doctor,
         "_launchctl_domain_check",
@@ -2464,7 +2478,9 @@ def _write_breadcrumb(context, former_vault):
     return breadcrumb
 
 
-def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkeypatch, context):
+def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(
+    monkeypatch, context
+):
     """A job left behind by a vault move is owned-and-stale, never foreign (#364)."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2495,7 +2511,9 @@ def test_jobs_loaded_flags_agent_pointing_at_the_stored_former_vault_root(monkey
     assert str(context.vault_root) in result.heal.action
 
 
-def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(monkeypatch, context):
+def test_jobs_loaded_flags_user_labeled_stale_agent_the_hook_warns_about(
+    monkeypatch, context
+):
     """The hook and the doctor must agree: any label pointing at the former root."""
     former_vault = context.home.parent / "old-vault"
     _write_breadcrumb(context, former_vault)
@@ -2536,7 +2554,12 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
                 "Label": "com.dex.sibling-product",
                 "ProgramArguments": [
                     "/bin/bash",
-                    str(context.home.parent / "old-vault-other" / ".scripts" / "run.sh"),
+                    str(
+                        context.home.parent
+                        / "old-vault-other"
+                        / ".scripts"
+                        / "run.sh"
+                    ),
                 ],
             },
             handle,
@@ -2550,7 +2573,9 @@ def test_jobs_loaded_stale_matching_requires_a_path_boundary(monkeypatch, contex
     assert "was skipped" in result.detail
 
 
-def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch, context):
+def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(
+    monkeypatch, context
+):
     """User-installed com.<user>.dex.* jobs get real monitoring coverage (#253)."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2573,12 +2598,16 @@ def test_jobs_loaded_discovers_user_labeled_dex_agent_for_this_vault(monkeypatch
     assert str(missing_script) in result.detail
 
 
-def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkeypatch, context):
+def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(
+    monkeypatch, context
+):
     """Ownership is path evidence, not the label: any plist into this vault counts."""
     plist = _write_plist(context, "com.mycompany.sync")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
+    monkeypatch.setattr(
+        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
+    )
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2591,7 +2620,9 @@ def test_jobs_loaded_discovers_vault_job_under_any_label_by_path_evidence(monkey
     assert "All 1 installed launch agents for this vault are loaded" in result.detail
 
 
-def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(monkeypatch, context):
+def test_jobs_loaded_ignores_unrelated_products_whose_names_contain_dex(
+    monkeypatch, context
+):
     """com.dexcom.* / com.samsung.dex.* / com.fedex.* are other products."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2642,7 +2673,9 @@ def test_corrupt_third_party_plists_never_degrade_job_monitoring(monkeypatch, co
     plist = _write_plist(context, "com.dex.smoke-nightly")
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
     monkeypatch.setattr(doctor, "_launchctl_domain_check", lambda: None)
-    monkeypatch.setattr(doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None)
+    monkeypatch.setattr(
+        doctor, "_plist_interpreter", lambda candidate: "/bin/bash" if candidate == plist else None
+    )
     monkeypatch.setattr(
         doctor,
         "_launchctl_status",
@@ -2664,7 +2697,9 @@ def test_truncated_shipped_plist_is_unknown_not_a_probe_crash(monkeypatch, conte
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
     plist = agents / "com.dex.meeting-intel.plist"
-    plist.write_bytes(b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>')
+    plist.write_bytes(
+        b'<?xml version="1.0"?><plist version="1.0"><dict><key>Label</key>'
+    )
     monkeypatch.setattr(doctor, "_is_macos", lambda: True)
 
     loaded = doctor._probe_jobs_loaded(context)
@@ -2687,7 +2722,9 @@ def test_legacy_claudesidian_jobs_get_real_freshness_audits(context):
     assert "checked for loading only" not in result.detail
 
 
-def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(monkeypatch, context):
+def test_jobs_loaded_flags_owned_agent_with_leftover_former_root_references(
+    monkeypatch, context
+):
     """A partially repointed job (invocation current, other keys stale) is surfaced.
 
     The session-start hook greps raw bytes and keeps warning about the
@@ -2811,7 +2848,9 @@ def test_stored_former_vault_root_rejects_current_and_degenerate_roots(context):
     assert doctor._stored_former_vault_root(context) == former
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch, context):
+def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(
+    monkeypatch, context
+):
     """A worktree path is foreign unless it is this vault's path evidence."""
     agents = context.home / "Library" / "LaunchAgents"
     agents.mkdir(parents=True, exist_ok=True)
@@ -2832,11 +2871,14 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_at_another_worktree(monkeypatch,
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
 
 
-def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(monkeypatch, context):
+def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checkout(
+    monkeypatch, context
+):
     checkout = context.home.parent / "checkouts" / "dex-copy"
     (checkout / ".scripts").mkdir(parents=True)
     (checkout / ".git").write_text("gitdir: /somewhere/else\n", encoding="utf-8")
@@ -2860,7 +2902,8 @@ def test_jobs_loaded_skips_a_dex_plist_pointing_into_another_git_worktree_checko
 
     assert result.verdict == "OFF"
     assert result.detail == (
-        "No launch agents for this vault are installed; 1 Dex launch agent from another Dex product was skipped"
+        "No launch agents for this vault are installed; "
+        "1 Dex launch agent from another Dex product was skipped"
     )
 
 
@@ -3069,7 +3112,8 @@ def test_customization_mcp_compiles_custom_python_without_running_or_littering(c
     target = context.vault_root / "custom-mcp" / "server.py"
     target.parent.mkdir()
     target.write_text(
-        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
+        "from pathlib import Path\n"
+        f"Path({str(sentinel)!r}).write_text('executed')\n",
         encoding="utf-8",
     )
     _write_mcp_config(
@@ -3246,7 +3290,8 @@ def test_worktree_blob_ids_hash_large_release_trees_in_pipe_safe_batches(
 ) -> None:
     relatives = [f"core/release-file-{index:04d}.py" for index in range(600)]
     expected = {
-        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest() for relative in relatives
+        relative: hashlib.sha1(relative.encode("utf-8"), usedforsecurity=False).hexdigest()
+        for relative in relatives
     }
     observed_batches: list[list[str]] = []
 
@@ -3450,7 +3495,8 @@ def test_repository_credential_named_release_files_match_head_without_python_rea
     credential_paths = sorted(
         relative
         for relative in release_entries
-        if "credential" in relative.casefold() and not relative.startswith("core/tests/")
+        if "credential" in relative.casefold()
+        and not relative.startswith("core/tests/")
     )
     assert credential_paths == [
         "core/utils/credential_migration_exceptions.json",
@@ -3775,7 +3821,9 @@ def test_smoke_journeys_roll_up_broken_from_exit_one(monkeypatch, context):
     payload = {
         "schema_version": 1,
         "generated_at": NOW.isoformat(),
-        "journeys": [{"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}],
+        "journeys": [
+            {"id": "task_lifecycle", "verdict": "BROKEN", "detail": "Tasks.md changed", "duration_ms": 3}
+        ],
         "summary": {"ok": 0, "broken": 1, "unknown": 0, "off": 0},
     }
     monkeypatch.setattr(
@@ -3876,14 +3924,20 @@ def test_granola_no_key_is_off_and_api_400_is_broken(monkeypatch, context):
     result = doctor._probe_granola_query_path(context)
     assert result.verdict == "BROKEN"
     assert result.detail == (
-        "Granola query failed (HTTP 400) — the connector may need updating. Response: created_after is invalid"
+        "Granola query failed (HTTP 400) — the connector may need updating. "
+        "Response: created_after is invalid"
     )
 
 
 def _write_backup_config(context, *, enabled=True):
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir(parents=True, exist_ok=True)
-    config.write_text(f"backup:\n  enabled: {str(enabled).lower()}\n  backend: folder\n  destination: /backups\n")
+    config.write_text(
+        "backup:\n"
+        f"  enabled: {str(enabled).lower()}\n"
+        "  backend: folder\n"
+        "  destination: /backups\n"
+    )
 
 
 def _write_backup_stamp(context, *, ok, timestamp, error=None, warnings=None):
@@ -3910,11 +3964,9 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
         context,
         ok=True,
         timestamp="2026-07-10T02:00:00+00:00",
-        warnings=[
-            "the vault's version history could not be bundled, so this "
-            "set holds the notes archive only: fatal: Refusing to create "
-            "empty bundle."
-        ],
+        warnings=["the vault's version history could not be bundled, so this "
+                  "set holds the notes archive only: fatal: Refusing to create "
+                  "empty bundle."],
     )
     result = doctor._probe_backup_freshness(context)
     assert result.verdict == "BROKEN"
@@ -3925,7 +3977,8 @@ def test_backup_freshness_broken_when_a_recent_run_stored_less_than_asked(contex
 
 def test_backup_freshness_stays_ok_when_the_run_recorded_no_warnings(context):
     _write_backup_config(context)
-    _write_backup_stamp(context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
+    _write_backup_stamp(
+        context, ok=True, timestamp="2026-07-10T02:00:00+00:00", warnings=[])
     assert doctor._probe_backup_freshness(context).verdict == "OK"
 
 
@@ -4034,7 +4087,9 @@ def test_calendar_permission_boundaries_and_configured_name(monkeypatch, context
     )
     assert doctor._probe_calendar_access(context).verdict == "OFF"
 
-    (context.vault_root / "System" / "user-profile.yaml").write_text("calendar:\n  work_calendar: Team Calendar\n")
+    (context.vault_root / "System" / "user-profile.yaml").write_text(
+        "calendar:\n  work_calendar: Team Calendar\n"
+    )
     assert doctor._probe_calendar_access(context).verdict == "BROKEN"
 
     monkeypatch.setattr(doctor, "_calendar_permission_status", lambda _context: "denied")
@@ -4229,7 +4284,9 @@ def test_qmd_unexpected_exception_still_breaks_doctor_self(monkeypatch, context)
     report = doctor.collect(deep=True, context=context)
 
     assert _check(report, "qmd.live")["verdict"] == "UNKNOWN"
-    assert report["instruments"]["failed"] == [{"id": "qmd.live", "error": "unexpected qmd adapter failure"}]
+    assert report["instruments"]["failed"] == [
+        {"id": "qmd.live", "error": "unexpected qmd adapter failure"}
+    ]
     assert _check(report, "doctor.self")["verdict"] == "BROKEN"
 
 
@@ -4282,7 +4339,12 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     config = context.vault_root / "System" / "integrations" / "config.yaml"
     config.parent.mkdir()
     config.write_text(
-        "todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\nnotion:\n  enabled: true\n"
+        "todoist:\n"
+        "  enabled: true\n"
+        "  task_sync: true\n"
+        "  api_key_env_var: TODOIST_API_KEY\n"
+        "notion:\n"
+        "  enabled: true\n"
     )
     (context.vault_root / ".env").write_text('TODOIST_API_KEY="secret"\n')
     (context.vault_root / ".env").chmod(0o600)
@@ -4325,7 +4387,12 @@ def test_integrations_check_only_task_sync_entries_through_adapter_runner(monkey
     assert with_unverifiable.verdict == "UNKNOWN"
     assert "notion" in with_unverifiable.detail
 
-    config.write_text("todoist:\n  enabled: true\n  task_sync: true\n  api_key_env_var: TODOIST_API_KEY\n")
+    config.write_text(
+        "todoist:\n"
+        "  enabled: true\n"
+        "  task_sync: true\n"
+        "  api_key_env_var: TODOIST_API_KEY\n"
+    )
     assert doctor._probe_integrations_enabled(context).verdict == "OK"
 
 
@@ -4395,7 +4462,11 @@ def test_integrations_engine_stored_but_unverified_rows_are_unknown(monkeypatch,
         lambda command, **_kwargs: subprocess.CompletedProcess(
             command,
             0,
-            stdout=('{"connections":[{"service":"google","status":"' + status + '","verified":false}]}\n'),
+            stdout=(
+                '{"connections":[{"service":"google","status":"'
+                + status
+                + '","verified":false}]}\n'
+            ),
             stderr="",
         ),
     )
@@ -4595,7 +4666,7 @@ def test_post_update_canary_probe_reads_the_receipt(context):
 
 def test_meeting_sources_probe_is_ok_for_api_sources_without_folders(context):
     profile = context.vault_root / "System" / "user-profile.yaml"
-    profile.write_text('meeting_sources:\n  primary: granola\n  notes_folder: ""\n', encoding="utf-8")
+    profile.write_text("meeting_sources:\n  primary: granola\n  notes_folder: \"\"\n", encoding="utf-8")
     result = doctor._probe_meeting_sources(context)
     assert result.verdict == "OK"
     assert "granola" in result.detail

--- a/core/tests/test_launch_agents.py
+++ b/core/tests/test_launch_agents.py
@@ -1,0 +1,65 @@
+"""Direct coverage for the shared launch-agent ownership helper."""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from core.utils import automation_ownership, launch_agents
+
+
+def test_former_root_scan_skips_a_valid_solo_owned_plist(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    home = tmp_path / "home"
+    former = tmp_path / "former-vault"
+    breadcrumb = home / ".config/dex/vault-path"
+    breadcrumb.parent.mkdir(parents=True)
+    breadcrumb.write_text(f"{former}\n", encoding="utf-8")
+    plist = home / "Library/LaunchAgents/com.dex.example.plist"
+    plist.parent.mkdir(parents=True)
+    with plist.open("wb") as handle:
+        plistlib.dump({"ProgramArguments": [str(former / "run.sh")]}, handle)
+    observed: list[tuple[Path, str, Path]] = []
+
+    def is_offloaded(root: Path, relative: str, *, home_root: Path) -> bool:
+        observed.append((root, relative, home_root))
+        return True
+
+    monkeypatch.setattr(automation_ownership, "is_plist_offloaded", is_offloaded)
+
+    assert launch_agents.any_agent_references_former_root(vault, home) is False
+    assert observed == [
+        (vault, "Library/LaunchAgents/com.dex.example.plist", home),
+    ]
+
+
+def test_offloaded_check_cli_returns_the_claim_status(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(
+        automation_ownership,
+        "is_plist_offloaded",
+        lambda root, relative, *, home_root: (
+            root == vault
+            and relative == "Library/LaunchAgents/com.dex.example.plist"
+            and home_root == home
+        ),
+    )
+
+    args = [
+        "--offloaded-check",
+        "--vault",
+        str(vault),
+        "--plist-relative",
+        "Library/LaunchAgents/com.dex.example.plist",
+    ]
+    assert launch_agents.main(args) == 0
+    assert launch_agents.main([*args[:-1], "Library/LaunchAgents/com.dex.other.plist"]) == 1

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -463,7 +463,7 @@ def test_lifecycle_1_2_callers_resolve_unchanged_operations() -> None:
         ),
     }
 
-    assert service.api_version == "1.4.0"
+    assert service.api_version == "1.5.0"
     assert {
         name: str(inspect.signature(getattr(service, name)))
         for name in expected_signatures

--- a/core/tests/test_lifecycle_bridge.py
+++ b/core/tests/test_lifecycle_bridge.py
@@ -121,6 +121,10 @@ def test_reactivation_is_idempotent_but_invalid_existing_record_is_refused(
     activation_path.write_bytes(_canonical(previous_api))
     assert activate_vault(vault) == previous_api
 
+    previous_api = {**first, "api_version": "1.4.0"}
+    activation_path.write_bytes(_canonical(previous_api))
+    assert activate_vault(vault) == previous_api
+
     activation_path.write_text('{"activation_version":999}\n', encoding="utf-8")
     with pytest.raises(BridgeActivationError, match="existing activation"):
         activate_vault(vault)

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import plistlib
 import re
 import shutil
 from collections.abc import Mapping
@@ -21,13 +22,9 @@ from core.lifecycle.engine import (
 from core.tests.test_adoption_transaction import _setup
 from core.tests.test_lifecycle_bridge import _write_bridge_release
 from core.update import apply_update
+from core.utils import automation_ownership
 
-SCHEMA_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "lifecycle"
-    / "contracts"
-    / "api.schema.json"
-)
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "lifecycle" / "contracts" / "api.schema.json"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -96,18 +93,17 @@ def _validate(schema: dict[str, object], node: object, value: object, path: str 
                 _validate(schema, child, value[field], f"{path}.{field}")
 
 
-def _assert_conforms(
-    schema: dict[str, object], operation: str, request: dict[str, object], response: object
-) -> None:
+def _assert_conforms(schema: dict[str, object], operation: str, request: dict[str, object], response: object) -> None:
     operation_schema = schema["x-operations"][operation]
     _validate(schema, operation_schema["request"], request)
     _validate(schema, operation_schema["response"], response)
 
 
-def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> None:
-    vault, _document, _catalog, _inventory, _plan, _loader = _setup(
-        tmp_path, item_ids=("alpha",)
-    )
+def test_frozen_service_inputs_and_outputs_conform_to_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault, _document, _catalog, _inventory, _plan, _loader = _setup(tmp_path, item_ids=("alpha",))
     _write_bridge_release(vault)
     release_root = tmp_path / "release"
     shutil.copytree(vault, release_root)
@@ -194,14 +190,82 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
         onboarding_execute_response,
     )
 
+    automation_vault = tmp_path / "automation-vault"
+    (automation_vault / "System").mkdir(parents=True)
+    home = tmp_path / "automation-home"
+    label = "com.dex.smoke-nightly"
+    plist_relative = f"Library/LaunchAgents/{label}.plist"
+    plist = home / plist_relative
+    plist.parent.mkdir(parents=True)
+    with plist.open("wb") as handle:
+        plistlib.dump({"Label": label, "ProgramArguments": ["/bin/bash"]}, handle)
+    monkeypatch.setattr(automation_ownership, "_home_root", lambda: home)
+    claim = {
+        "automation_id": label,
+        "owner_id": "dex-solo",
+        "plist_relative_path": plist_relative,
+        "plist_sha256": hashlib.sha256(plist.read_bytes()).hexdigest(),
+        "launchd_state": "unloaded",
+    }
+    claim_preview = service.build_and_preview_automation_claim(automation_vault, claim)
+    _assert_conforms(
+        schema,
+        "build_and_preview_automation_claim",
+        {"vault_root": str(automation_vault), "claim": claim},
+        claim_preview,
+    )
+    claim_execute = service.execute_approved_automation_claim(
+        automation_vault,
+        claim_preview["preview"],
+        claim_preview["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_automation_claim",
+        {
+            "vault_root": str(automation_vault),
+            "preview": claim_preview["preview"],
+            "approved_token": claim_preview["approval_token"],
+        },
+        claim_execute,
+    )
+    release = {
+        "automation_id": label,
+        "owner_id": "dex-solo",
+        "scheduler_state": "stopped",
+    }
+    release_preview = service.build_and_preview_automation_release(
+        automation_vault,
+        release,
+    )
+    _assert_conforms(
+        schema,
+        "build_and_preview_automation_release",
+        {"vault_root": str(automation_vault), "release": release},
+        release_preview,
+    )
+    release_execute = service.execute_approved_automation_release(
+        automation_vault,
+        release_preview["preview"],
+        release_preview["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_automation_release",
+        {
+            "vault_root": str(automation_vault),
+            "preview": release_preview["preview"],
+            "approved_token": release_preview["approval_token"],
+        },
+        release_execute,
+    )
+
     preview_request = {
         "vault_root": str(vault),
         "release_root": str(release_root),
         "requested_item_ids": ["alpha"],
     }
-    preview_response = service.build_and_preview_adoption(
-        vault, release_root, ("alpha",)
-    )
+    preview_response = service.build_and_preview_adoption(vault, release_root, ("alpha",))
     _assert_conforms(
         schema,
         "build_and_preview_adoption",
@@ -314,9 +378,7 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(tmp_path: Path) -> 
 
 
 def test_service_recovery_refuses_damage_before_activation_mutates(tmp_path: Path) -> None:
-    vault, _document, _catalog, _inventory, _plan, _loader = _setup(
-        tmp_path, item_ids=("alpha",)
-    )
+    vault, _document, _catalog, _inventory, _plan, _loader = _setup(tmp_path, item_ids=("alpha",))
     _write_bridge_release(vault)
     journal = vault / "System/.dex/tx/damaged/journal.jsonl"
     journal.parent.mkdir(parents=True)
@@ -334,7 +396,7 @@ def test_service_recovery_refuses_damage_before_activation_mutates(tmp_path: Pat
 def test_api_version_is_present_and_frozen_in_schema() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
-    assert service.api_version == "1.4.0"
+    assert service.api_version == "1.5.0"
     assert schema["properties"]["api_version"] == {"const": service.api_version}
 
 
@@ -353,6 +415,10 @@ def test_additive_public_surface_preserves_every_existing_operation() -> None:
         "execute_approved_mcp_registration",
         "build_and_preview_onboarding_context",
         "execute_approved_onboarding_context",
+        "build_and_preview_automation_claim",
+        "execute_approved_automation_claim",
+        "build_and_preview_automation_release",
+        "execute_approved_automation_release",
         "deliver_and_apply_latest_release",
         "build_and_preview_conflict_resolution",
         "execute_approved_conflict_resolution",
@@ -387,11 +453,25 @@ def test_onboarding_context_operations_have_frozen_signatures() -> None:
         "calendar_source: 'Mapping[str, object]') -> 'dict[str, object]'"
     )
     assert str(inspect.signature(service.execute_approved_onboarding_context)) == (
-        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', "
-        "approved_token: 'str') -> 'dict[str, object]'"
+        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', approved_token: 'str') -> 'dict[str, object]'"
     )
     assert "version bump" in service.__doc__.lower()
     assert "bridge" in service.__doc__.lower()
+
+
+def test_automation_ownership_operations_have_frozen_signatures() -> None:
+    assert str(inspect.signature(service.build_and_preview_automation_claim)) == (
+        "(vault_root: 'str | Path', claim: 'Mapping[str, object]') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.execute_approved_automation_claim)) == (
+        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', approved_token: 'str') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.build_and_preview_automation_release)) == (
+        "(vault_root: 'str | Path', release: 'Mapping[str, object]') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.execute_approved_automation_release)) == (
+        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', approved_token: 'str') -> 'dict[str, object]'"
+    )
 
 
 def test_release_delivery_is_non_mutating_and_exposed_only_through_the_lifecycle_service(
@@ -505,7 +585,7 @@ def test_archive_removal_is_previewed_approved_and_receipted(tmp_path: Path) -> 
 
     preview = service.build_archive_removal_preview(vault)
 
-    assert preview["api_version"] == "1.4.0"
+    assert preview["api_version"] == "1.5.0"
     assert preview["preview"]["archive_relative"] == ".dex/pre-split-archive.git"
     assert preview["preview"]["size_bytes"] == len(b"ref: refs/heads/main\narchive bytes")
     assert preview["preview"]["retention"] == "one full release cycle after conversion"

--- a/core/tests/test_lifecycle_topology_migration.py
+++ b/core/tests/test_lifecycle_topology_migration.py
@@ -101,7 +101,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
 
     previewed = service.build_and_preview_topology_migration(vault)
 
-    assert previewed["api_version"] == "1.4.0"
+    assert previewed["api_version"] == "1.5.0"
     assert previewed["topology"] == "combined"
     assert previewed["preview"]["operation"] == "brain-vault-topology-migration"
     assert [
@@ -125,7 +125,7 @@ def test_combined_topology_previews_approval_converts_and_receipts(
     )
 
     assert (vault / "System/.dex/topology.json").is_file()
-    assert executed["api_version"] == "1.4.0"
+    assert executed["api_version"] == "1.5.0"
     assert executed["receipt"]["operation"] == "brain-vault-topology-migration"
     assert executed["receipt"]["topology_before"] == "combined"
     assert executed["receipt"]["topology_after"] == "post-split"

--- a/core/tests/test_lifecycle_topology_migration.py
+++ b/core/tests/test_lifecycle_topology_migration.py
@@ -221,7 +221,7 @@ def test_dex_update_skill_routes_the_guided_migration_through_service() -> None:
         REPO_ROOT / ".claude/skills/dex-update/SKILL.md"
     ).read_text(encoding="utf-8")
 
-    assert "version 1.4.0" in instructions
+    assert "version 1.5.0" in instructions
     assert "build_and_preview_topology_migration" in instructions
     assert "execute_approved_topology_migration" in instructions
     assert "dry-run" in instructions

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -99,8 +99,7 @@ def test_room_upgrade_ledger_preserves_all_published_payload_identities() -> Non
     document = portable_contract.build_contract_document(contract_version=2)
     observed = {
         pin["skill"]: {
-            (previous["release"], previous["sha256"], previous["byte_size"])
-            for previous in pin["previous_payloads"]
+            (previous["release"], previous["sha256"], previous["byte_size"]) for previous in pin["previous_payloads"]
         }
         for room in document["capabilities"].values()
         for pin in room["skill_sources"]
@@ -124,6 +123,7 @@ def _tracked_paths() -> list[str]:
 # ---------------------------------------------------------------------------
 # Resolution semantics
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     ("path", "ownership", "denied"),
@@ -157,6 +157,7 @@ def _tracked_paths() -> list[str]:
         ("System/.installed-files.manifest", "generated", False),
         ("packages/dex-contracts/dist/paths.contract.json", "generated", False),
         ("System/.dex/gardener.json", "runtime", False),
+        (portable_contract.AUTOMATION_OWNERSHIP_RELATIVE, "runtime", False),
         ("System/.onboarding-session.json", "runtime", False),
         ("System/Session_Learnings/2026-05-01.md", "runtime", False),
     ],
@@ -171,10 +172,7 @@ def test_exact_seed_beats_region_and_specificity_orders_directories() -> None:
     # Exact starter file wins over its vault region.
     assert portable_contract.resolve("03-Tasks/Tasks.md").rule_id == "seed-tasks-file"
     # Shipped system docs are enumerated file-by-file as brain…
-    assert (
-        portable_contract.resolve("06-Resources/Dex_System/README.md").rule_id
-        == "brain-doc-dex-system-readme"
-    )
+    assert portable_contract.resolve("06-Resources/Dex_System/README.md").rule_id == "brain-doc-dex-system-readme"
 
 
 def test_user_file_next_to_shipped_docs_is_vault_not_brain() -> None:
@@ -183,9 +181,7 @@ def test_user_file_next_to_shipped_docs_is_vault_not_brain() -> None:
     resolution = portable_contract.resolve("06-Resources/Dex_System/my-notes.md")
     assert resolution.ownership == "vault"
     assert resolution.rule_id == "vault-resources"
-    verdict = portable_contract.update_write_verdict(
-        "06-Resources/Dex_System/my-notes.md", exists=True
-    )
+    verdict = portable_contract.update_write_verdict("06-Resources/Dex_System/my-notes.md", exists=True)
     assert verdict.allowed is False
 
 
@@ -387,6 +383,25 @@ def test_onboarding_context_operation_only_authorizes_the_live_profile() -> None
     assert refused.action == "outside-onboarding-context"
 
 
+def test_automation_ownership_operation_only_authorizes_its_sidecar() -> None:
+    allowed = portable_contract.update_write_verdict(
+        portable_contract.AUTOMATION_OWNERSHIP_RELATIVE,
+        exists=True,
+        operation="automation-ownership",
+    )
+    refused = portable_contract.update_write_verdict(
+        "System/.dex/ledger/automation.jsonl",
+        exists=False,
+        operation="automation-ownership",
+    )
+
+    assert allowed.allowed is True
+    assert allowed.action == "write-automation-ownership"
+    assert allowed.rule_id == "runtime-automation-ownership"
+    assert refused.allowed is False
+    assert refused.action == "outside-automation-ownership"
+
+
 @pytest.mark.parametrize(
     "path",
     [
@@ -463,9 +478,7 @@ def test_customization_migration_hard_deny_survives_unclassified_resolution(
     assert portable_contract.is_denied(path) is True
 
     def unclassified(candidate: str) -> portable_contract.Resolution:
-        raise portable_contract.ContractViolation(
-            f"no ownership rule classifies: {candidate}"
-        )
+        raise portable_contract.ContractViolation(f"no ownership rule classifies: {candidate}")
 
     monkeypatch.setattr(portable_contract, "resolve", unclassified)
     with pytest.raises(portable_contract.ContractViolation):
@@ -544,14 +557,13 @@ def test_traversal_and_empty_paths_are_rejected() -> None:
 def test_unknown_path_raises_and_unclassified_reports_it() -> None:
     with pytest.raises(portable_contract.ContractViolation):
         portable_contract.resolve("totally/unknown/path.xyz")
-    assert portable_contract.unclassified(["totally/unknown/path.xyz"]) == [
-        "totally/unknown/path.xyz"
-    ]
+    assert portable_contract.unclassified(["totally/unknown/path.xyz"]) == ["totally/unknown/path.xyz"]
 
 
 # ---------------------------------------------------------------------------
 # Whole-tree invariants (the gate's substance, asserted directly)
 # ---------------------------------------------------------------------------
+
 
 def test_every_tracked_path_classifies() -> None:
     missing = portable_contract.unclassified(_tracked_paths())
@@ -563,9 +575,7 @@ def test_no_tracked_path_is_release_forbidden() -> None:
 
 
 def test_release_forbidden_flags_vault_and_denied_content() -> None:
-    forbidden = portable_contract.release_forbidden(
-        ["04-Projects/private-notes.md", ".env", "core/utils/doctor.py"]
-    )
+    forbidden = portable_contract.release_forbidden(["04-Projects/private-notes.md", ".env", "core/utils/doctor.py"])
     assert "04-Projects/private-notes.md" in forbidden
     assert ".env" in forbidden
     assert "core/utils/doctor.py" not in forbidden
@@ -574,9 +584,7 @@ def test_release_forbidden_flags_vault_and_denied_content() -> None:
 def test_capability_rooms_cover_gated_regions() -> None:
     capabilities = portable_contract.CAPABILITIES
     assert set(capabilities) == {"career", "companies", "quarter_goals"}
-    gated_folders = {
-        folder for spec in capabilities.values() for folder in spec["folders"]
-    }
+    gated_folders = {folder for spec in capabilities.values() for folder in spec["folders"]}
     assert gated_folders == {
         "05-Areas/Career",
         "05-Areas/Companies",
@@ -593,13 +601,11 @@ def test_capability_rooms_cover_gated_regions() -> None:
 
 def test_committed_dist_matches_source_of_truth() -> None:
     committed = json.loads(
-        (REPO_ROOT / "packages/dex-contracts/dist/portable-vault.contract.json")
-        .read_text(encoding="utf-8")
+        (REPO_ROOT / "packages/dex-contracts/dist/portable-vault.contract.json").read_text(encoding="utf-8")
     )
     assert committed == portable_contract.build_contract_document()
     committed_schema = json.loads(
-        (REPO_ROOT / "packages/dex-contracts/dist/portable-vault.schema.json")
-        .read_text(encoding="utf-8")
+        (REPO_ROOT / "packages/dex-contracts/dist/portable-vault.schema.json").read_text(encoding="utf-8")
     )
     assert committed_schema == portable_contract.build_contract_schema()
 
@@ -607,9 +613,7 @@ def test_committed_dist_matches_source_of_truth() -> None:
 def test_rule_ids_are_unique_and_document_is_deterministic() -> None:
     ids = [rule.rule_id for rule in portable_contract.RULES]
     assert len(ids) == len(set(ids))
-    assert portable_contract.build_contract_document() == (
-        portable_contract.build_contract_document()
-    )
+    assert portable_contract.build_contract_document() == (portable_contract.build_contract_document())
 
 
 def test_sync_folder_marker_data_is_explicitly_release_owned() -> None:
@@ -623,6 +627,7 @@ def test_sync_folder_marker_data_is_explicitly_release_owned() -> None:
 # ---------------------------------------------------------------------------
 # The gate script: red-when-removed proofs in an isolated fixture repo
 # ---------------------------------------------------------------------------
+
 
 def _gate_fixture(tmp_path: Path) -> Path:
     """A minimal repo the real gate script runs against."""
@@ -645,13 +650,9 @@ def _gate_fixture(tmp_path: Path) -> Path:
     dist = root / "packages/dex-contracts/dist"
     dist.mkdir(parents=True)
     for name in ("portable-vault.contract.json", "portable-vault.schema.json"):
-        (dist / name).write_bytes(
-            (REPO_ROOT / "packages/dex-contracts/dist" / name).read_bytes()
-        )
+        (dist / name).write_bytes((REPO_ROOT / "packages/dex-contracts/dist" / name).read_bytes())
     subprocess.run(["git", "add", "."], cwd=root, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "fixture"], cwd=root, check=True, capture_output=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=root, check=True, capture_output=True)
     return root
 
 

--- a/core/tests/test_provision_parity.py
+++ b/core/tests/test_provision_parity.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -129,6 +130,36 @@ def test_installer_routes_bootstrap_config_to_sanctioned_provision_contract() ->
     assert "mcp_path.write_text" not in installer
 
 
+def test_install_config_preflight_needs_no_global_pyyaml(tmp_path: Path) -> None:
+    """The pre-venv installer seam must run on the standard library alone."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            str(REPO_ROOT / "core/capabilities.py"),
+            "--preflight-mutation-targets",
+            "--vault",
+            str(vault),
+            "--contract",
+            str(CONTRACT_PATH),
+            "--mutation-targets-json",
+            '[{"path":".mcp.json","kind":"file"}]',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "mutation_targets": [{"kind": "file", "path": ".mcp.json"}],
+        "preflight": "passed",
+    }
+
+
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
 def test_adopt_preserves_existing_content_while_routing_lifecycle(tmp_path: Path) -> None:
     vault = _prepare_provision_vault(
@@ -157,11 +188,14 @@ def test_fresh_provision_enables_companies_and_creates_its_room(tmp_path: Path) 
     profile_path = vault / "System/user-profile.yaml"
     profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
     assert profile["capabilities"]["companies"]["enabled"] is True
-    assert capabilities.enabled(
-        "companies",
-        profile_path=profile_path,
-        contract_path=CONTRACT_PATH,
-    ) is True
+    assert (
+        capabilities.enabled(
+            "companies",
+            profile_path=profile_path,
+            contract_path=CONTRACT_PATH,
+        )
+        is True
+    )
     assert (vault / "05-Areas/Companies").is_dir()
 
 
@@ -238,22 +272,12 @@ def test_onboarding_rolls_back_every_write_when_a_late_target_fails(
     assert failed["terminal"] is True
     assert failed["transaction_ids"]
     declared = set(summary["mutation_receipt"]["declared_paths"])
-    changed = {
-        path
-        for path in set(before) | set(after)
-        if before.get(path) != after.get(path)
-    }
+    changed = {path for path in set(before) | set(after) if before.get(path) != after.get(path)}
     assert changed
     assert changed <= declared
     assert all(path == "System/.dex" or path.startswith("System/.dex/tx") for path in changed)
-    assert {
-        path: value
-        for path, value in after.items()
-        if not path.startswith("System/.dex")
-    } == {
-        path: value
-        for path, value in before.items()
-        if not path.startswith("System/.dex")
+    assert {path: value for path, value in after.items() if not path.startswith("System/.dex")} == {
+        path: value for path, value in before.items() if not path.startswith("System/.dex")
     }
 
 
@@ -322,7 +346,8 @@ def test_real_onboarding_recovers_every_direct_transaction_crash_seam(
     assert all(
         index < marker_index
         for index, relative in enumerate(plan_paths)
-        if relative not in {
+        if relative
+        not in {
             "System/.onboarding-complete",
             "System/.onboarding-session.json",
         }
@@ -348,10 +373,7 @@ def test_real_onboarding_recovers_every_direct_transaction_crash_seam(
 
     committed: set[str] = set()
     for journal in sorted((vault / "System/.dex/tx").glob("*/journal.jsonl")):
-        events = {
-            json.loads(line)["event"]
-            for line in journal.read_text(encoding="utf-8").splitlines()
-        }
+        events = {json.loads(line)["event"] for line in journal.read_text(encoding="utf-8").splitlines()}
         assert len(events & {"COMMITTED", "ROLLED-BACK"}) == 1
         if "COMMITTED" in events:
             committed.add(journal.parent.name)
@@ -416,9 +438,7 @@ def test_real_adopt_recovers_a_lifecycle_commit_after_its_receipt_is_lost(
     assert summary["ok"] is True
     assert (vault / "System/.onboarding-complete").is_file()
     assert not session.exists()
-    profile = yaml.safe_load(
-        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
-    )
+    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
     assert profile["capabilities"]["companies"]["enabled"] is True
     assert committed <= set(summary["mutation_receipt"]["transaction_ids"])
 
@@ -574,7 +594,7 @@ def test_onboarding_refuses_symlinked_mutation_targets_before_any_write(
     target_kind: str,
 ) -> None:
     vault = _prepare_provision_vault(tmp_path)
-    outside = tmp_path / f"outside-{unsafe_target.replace('/', '-') }"
+    outside = tmp_path / f"outside-{unsafe_target.replace('/', '-')}"
     target = vault / unsafe_target
     if target_kind == "directory":
         target.rename(outside)
@@ -701,11 +721,14 @@ def test_adopt_gives_an_existing_vault_without_a_company_opinion_the_room_idempo
     first = profile_path.read_text(encoding="utf-8")
     profile = yaml.safe_load(first)
     assert profile["capabilities"]["companies"]["enabled"] is True
-    assert capabilities.enabled(
-        "companies",
-        profile_path=profile_path,
-        contract_path=CONTRACT_PATH,
-    ) is True
+    assert (
+        capabilities.enabled(
+            "companies",
+            profile_path=profile_path,
+            contract_path=CONTRACT_PATH,
+        )
+        is True
+    )
     assert (vault / "05-Areas/Companies").exists()
 
     _run_provision(vault, "--adopt")
@@ -763,9 +786,7 @@ def test_lifecycle_only_dry_run_previews_the_exact_compatibility_pin(
         "companies": True,
         "quarter_goals": True,
     }
-    assert summary["mutation_receipt"]["declared_paths"] == [
-        "System/user-profile.yaml"
-    ]
+    assert summary["mutation_receipt"]["declared_paths"] == ["System/user-profile.yaml"]
     assert summary["mutation_receipt"]["lifecycle_transaction_ids"] == []
 
 
@@ -826,9 +847,7 @@ def test_lifecycle_only_update_adds_only_companies_to_a_partial_capability_map(
 
     _run_provision(vault, "--adopt", "--lifecycle-only")
 
-    profile = yaml.safe_load(
-        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
-    )
+    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
     assert profile["capabilities"] == {
         # Companies is added because this vault never said otherwise; the
         # explicit career: false above is a real choice and is preserved.
@@ -862,9 +881,7 @@ def test_adopt_preserves_an_existing_explicit_company_choice(
 
     _run_provision(vault, "--adopt")
 
-    profile = yaml.safe_load(
-        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
-    )
+    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
     assert profile["capabilities"]["companies"] == {
         "enabled": company_enabled,
         "custom": "keep",
@@ -896,20 +913,13 @@ def test_lifecycle_only_update_preserves_an_explicit_company_choice(
 def test_adopt_preserves_a_legacy_capability_opinion(tmp_path: Path) -> None:
     vault = _prepare_provision_vault(
         tmp_path,
-        profile_text=(
-            "name: Existing User\n"
-            "quarterly_planning:\n"
-            "  enabled: true\n"
-            "  q1_start_month: 4\n"
-        ),
+        profile_text=("name: Existing User\nquarterly_planning:\n  enabled: true\n  q1_start_month: 4\n"),
         companies_default=True,
     )
 
     _run_provision(vault, "--adopt")
 
-    profile = yaml.safe_load(
-        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
-    )
+    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
     assert profile["capabilities"]["companies"]["enabled"] is True
     assert profile["capabilities"]["quarter_goals"]["enabled"] is True
     assert profile["quarterly_planning"]["enabled"] is True

--- a/core/tests/test_provision_parity.py
+++ b/core/tests/test_provision_parity.py
@@ -188,14 +188,11 @@ def test_fresh_provision_enables_companies_and_creates_its_room(tmp_path: Path) 
     profile_path = vault / "System/user-profile.yaml"
     profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
     assert profile["capabilities"]["companies"]["enabled"] is True
-    assert (
-        capabilities.enabled(
-            "companies",
-            profile_path=profile_path,
-            contract_path=CONTRACT_PATH,
-        )
-        is True
-    )
+    assert capabilities.enabled(
+        "companies",
+        profile_path=profile_path,
+        contract_path=CONTRACT_PATH,
+    ) is True
     assert (vault / "05-Areas/Companies").is_dir()
 
 
@@ -272,12 +269,22 @@ def test_onboarding_rolls_back_every_write_when_a_late_target_fails(
     assert failed["terminal"] is True
     assert failed["transaction_ids"]
     declared = set(summary["mutation_receipt"]["declared_paths"])
-    changed = {path for path in set(before) | set(after) if before.get(path) != after.get(path)}
+    changed = {
+        path
+        for path in set(before) | set(after)
+        if before.get(path) != after.get(path)
+    }
     assert changed
     assert changed <= declared
     assert all(path == "System/.dex" or path.startswith("System/.dex/tx") for path in changed)
-    assert {path: value for path, value in after.items() if not path.startswith("System/.dex")} == {
-        path: value for path, value in before.items() if not path.startswith("System/.dex")
+    assert {
+        path: value
+        for path, value in after.items()
+        if not path.startswith("System/.dex")
+    } == {
+        path: value
+        for path, value in before.items()
+        if not path.startswith("System/.dex")
     }
 
 
@@ -346,8 +353,7 @@ def test_real_onboarding_recovers_every_direct_transaction_crash_seam(
     assert all(
         index < marker_index
         for index, relative in enumerate(plan_paths)
-        if relative
-        not in {
+        if relative not in {
             "System/.onboarding-complete",
             "System/.onboarding-session.json",
         }
@@ -373,7 +379,10 @@ def test_real_onboarding_recovers_every_direct_transaction_crash_seam(
 
     committed: set[str] = set()
     for journal in sorted((vault / "System/.dex/tx").glob("*/journal.jsonl")):
-        events = {json.loads(line)["event"] for line in journal.read_text(encoding="utf-8").splitlines()}
+        events = {
+            json.loads(line)["event"]
+            for line in journal.read_text(encoding="utf-8").splitlines()
+        }
         assert len(events & {"COMMITTED", "ROLLED-BACK"}) == 1
         if "COMMITTED" in events:
             committed.add(journal.parent.name)
@@ -438,7 +447,9 @@ def test_real_adopt_recovers_a_lifecycle_commit_after_its_receipt_is_lost(
     assert summary["ok"] is True
     assert (vault / "System/.onboarding-complete").is_file()
     assert not session.exists()
-    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
     assert profile["capabilities"]["companies"]["enabled"] is True
     assert committed <= set(summary["mutation_receipt"]["transaction_ids"])
 
@@ -594,7 +605,7 @@ def test_onboarding_refuses_symlinked_mutation_targets_before_any_write(
     target_kind: str,
 ) -> None:
     vault = _prepare_provision_vault(tmp_path)
-    outside = tmp_path / f"outside-{unsafe_target.replace('/', '-')}"
+    outside = tmp_path / f"outside-{unsafe_target.replace('/', '-') }"
     target = vault / unsafe_target
     if target_kind == "directory":
         target.rename(outside)
@@ -721,14 +732,11 @@ def test_adopt_gives_an_existing_vault_without_a_company_opinion_the_room_idempo
     first = profile_path.read_text(encoding="utf-8")
     profile = yaml.safe_load(first)
     assert profile["capabilities"]["companies"]["enabled"] is True
-    assert (
-        capabilities.enabled(
-            "companies",
-            profile_path=profile_path,
-            contract_path=CONTRACT_PATH,
-        )
-        is True
-    )
+    assert capabilities.enabled(
+        "companies",
+        profile_path=profile_path,
+        contract_path=CONTRACT_PATH,
+    ) is True
     assert (vault / "05-Areas/Companies").exists()
 
     _run_provision(vault, "--adopt")
@@ -786,7 +794,9 @@ def test_lifecycle_only_dry_run_previews_the_exact_compatibility_pin(
         "companies": True,
         "quarter_goals": True,
     }
-    assert summary["mutation_receipt"]["declared_paths"] == ["System/user-profile.yaml"]
+    assert summary["mutation_receipt"]["declared_paths"] == [
+        "System/user-profile.yaml"
+    ]
     assert summary["mutation_receipt"]["lifecycle_transaction_ids"] == []
 
 
@@ -847,7 +857,9 @@ def test_lifecycle_only_update_adds_only_companies_to_a_partial_capability_map(
 
     _run_provision(vault, "--adopt", "--lifecycle-only")
 
-    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
     assert profile["capabilities"] == {
         # Companies is added because this vault never said otherwise; the
         # explicit career: false above is a real choice and is preserved.
@@ -881,7 +893,9 @@ def test_adopt_preserves_an_existing_explicit_company_choice(
 
     _run_provision(vault, "--adopt")
 
-    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
     assert profile["capabilities"]["companies"] == {
         "enabled": company_enabled,
         "custom": "keep",
@@ -913,13 +927,20 @@ def test_lifecycle_only_update_preserves_an_explicit_company_choice(
 def test_adopt_preserves_a_legacy_capability_opinion(tmp_path: Path) -> None:
     vault = _prepare_provision_vault(
         tmp_path,
-        profile_text=("name: Existing User\nquarterly_planning:\n  enabled: true\n  q1_start_month: 4\n"),
+        profile_text=(
+            "name: Existing User\n"
+            "quarterly_planning:\n"
+            "  enabled: true\n"
+            "  q1_start_month: 4\n"
+        ),
         companies_default=True,
     )
 
     _run_provision(vault, "--adopt")
 
-    profile = yaml.safe_load((vault / "System/user-profile.yaml").read_text(encoding="utf-8"))
+    profile = yaml.safe_load(
+        (vault / "System/user-profile.yaml").read_text(encoding="utf-8")
+    )
     assert profile["capabilities"]["companies"]["enabled"] is True
     assert profile["capabilities"]["quarter_goals"]["enabled"] is True
     assert profile["quarterly_planning"]["enabled"] is True

--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -770,6 +770,64 @@ def test_resume_quarantines_analytics_receipt_without_a_persisted_read_limit(
     assert target.read_bytes() == b"private bytes must not be read"
 
 
+def test_engine_automation_ownership_requires_its_exact_bounded_read_limit(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path)
+    relative = portable_contract.AUTOMATION_OWNERSHIP_RELATIVE
+
+    with pytest.raises(PlanRejected, match="required bounded-read limit"):
+        Transaction.begin(
+            vault,
+            [PlanEntry(relative, b'{"claims":[],"schema_version":1}\n', expected_absent=True)],
+            operation="automation-ownership",
+        )
+
+
+def test_resume_quarantines_automation_ownership_without_a_persisted_read_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path)
+    tx_id = "20260813T000000-automation-ownership"
+    relative = portable_contract.AUTOMATION_OWNERSHIP_RELATIVE
+    target = vault / relative
+    target.write_bytes(b"private bytes must not be read")
+    journal = Journal(vault / "System/.dex/tx" / tx_id / "journal.jsonl")
+    journal.append(
+        "BEGIN",
+        {
+            "tx_id": tx_id,
+            "operation": "automation-ownership",
+            "plan": [
+                {
+                    "relative": relative,
+                    "sha256": hashlib.sha256(b"{}\n").hexdigest(),
+                    "size": 3,
+                    "expected_absent": True,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        Transaction,
+        "_target_matches_planned_content",
+        staticmethod(lambda *_args, **_kwargs: pytest.fail("automation ownership target was read")),
+    )
+
+    outcomes = Transaction.resume(vault)
+
+    assert outcomes == [
+        {
+            "tx_id": tx_id,
+            "committed": False,
+            "resumed": True,
+            "quarantined": "automation ownership transaction lacks the required bounded-read limit",
+        }
+    ]
+    assert target.read_bytes() == b"private bytes must not be read"
+
+
 def test_resume_preserves_expected_absent_user_file_matching_plan_when_temp_inode_differs(
     tmp_path: Path,
 ) -> None:

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -168,16 +168,24 @@ class Transaction:
             for relative, max_bytes in read_limits.items()
         ):
             raise PlanRejected("transaction bounded-read limits are invalid")
+        required_limit = None
         if operation == "analytics-receipt":
-            expected_receipt_limit = {
+            required_limit = {
                 portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
                     portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
                 )
             }
-            if read_limits != expected_receipt_limit:
-                raise PlanRejected(
-                    "analytics receipt transaction lacks the required bounded-read limit"
+        elif operation == "automation-ownership":
+            required_limit = {
+                portable_contract.AUTOMATION_OWNERSHIP_RELATIVE: (
+                    portable_contract.AUTOMATION_OWNERSHIP_TRANSACTION_MAX_BYTES
                 )
+            }
+        if required_limit is not None and read_limits != required_limit:
+            operation_name = operation.replace("-", " ")
+            raise PlanRejected(
+                f"{operation_name} transaction lacks the required bounded-read limit"
+            )
 
         # Target modes are bounded: no setuid/setgid/sticky, no bits beyond
         # permissions. A buggy or hostile plan must not mint a 4777 file.
@@ -789,16 +797,25 @@ class Transaction:
         ):
             raise TransactionError("transaction bounded-read limits are invalid")
         read_limits = dict(raw_limits)
-        if payload.get("operation", "update") == "analytics-receipt":
-            expected_receipt_limit = {
+        operation = payload.get("operation", "update")
+        required_limit = None
+        if operation == "analytics-receipt":
+            required_limit = {
                 portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE: (
                     portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
                 )
             }
-            if read_limits != expected_receipt_limit:
-                raise TransactionError(
-                    "analytics receipt transaction lacks the required bounded-read limit"
+        elif operation == "automation-ownership":
+            required_limit = {
+                portable_contract.AUTOMATION_OWNERSHIP_RELATIVE: (
+                    portable_contract.AUTOMATION_OWNERSHIP_TRANSACTION_MAX_BYTES
                 )
+            }
+        if required_limit is not None and read_limits != required_limit:
+            operation_name = operation.replace("-", " ")
+            raise TransactionError(
+                f"{operation_name} transaction lacks the required bounded-read limit"
+            )
         return read_limits
 
     @classmethod

--- a/core/utils/automation_ownership.py
+++ b/core/utils/automation_ownership.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 SIDECAR_RELATIVE = portable_contract.AUTOMATION_OWNERSHIP_RELATIVE
 SIDECAR_SCHEMA_VERSION = 1
-SIDECAR_MAX_BYTES = 64 * 1024
+SIDECAR_MAX_BYTES = portable_contract.AUTOMATION_OWNERSHIP_TRANSACTION_MAX_BYTES
 OWNER_ID = "dex-solo"
 
 _CLAIM_FIELDS = frozenset({"automation_id", "owner_id", "plist_relative_path", "plist_sha256"})
@@ -261,6 +261,8 @@ def _plan(
 ) -> tuple[PlanEntry | None, str]:
     from core.transaction.engine import PlanEntry
 
+    if preview.get("automation_ownership_version") != 1:
+        raise AutomationOwnershipError("automation ownership preview version is unsupported")
     operation = preview.get("operation")
     claim = preview.get("claim")
     if operation == "claim":
@@ -278,6 +280,9 @@ def _plan(
             {**dict(_claim(claim)), "launchd_state": preview.get("launchd_state")},
         )
         if rebuilt is None:
+            _state_now, current_sha = read_state(vault_root)
+            if current_sha != preview.get("next_sidecar_sha256"):
+                raise AutomationOwnershipError("automation ownership state changed since preview")
             return None, "already-claimed"
         status = "claimed"
     elif operation == "release":
@@ -300,12 +305,13 @@ def _plan(
             },
         )
         if rebuilt is None:
+            _state_now, current_sha = read_state(vault_root)
+            if current_sha != preview.get("next_sidecar_sha256"):
+                raise AutomationOwnershipError("automation ownership state changed since preview")
             return None, "already-released"
         status = "released"
     else:
         raise AutomationOwnershipError("automation ownership preview operation is invalid")
-    if preview.get("automation_ownership_version") != 1:
-        raise AutomationOwnershipError("automation ownership preview version is unsupported")
     if dict(preview) != rebuilt:
         raise AutomationOwnershipError("automation ownership state changed since preview")
 

--- a/core/utils/automation_ownership.py
+++ b/core/utils/automation_ownership.py
@@ -79,6 +79,7 @@ def _plist_relative(value: object) -> str:
         or candidate.parts[:2] != ("Library", "LaunchAgents")
         or any(part in {"", ".", ".."} for part in candidate.parts)
         or not candidate.name.endswith(".plist")
+        or _ID.fullmatch(candidate.name.removesuffix(".plist")) is None
     ):
         raise AutomationOwnershipError("automation plist path must be a canonical relative Library/LaunchAgents path")
     return value

--- a/core/utils/automation_ownership.py
+++ b/core/utils/automation_ownership.py
@@ -1,0 +1,386 @@
+"""Closed runtime state for handing launchd jobs between Core and Dex Solo.
+
+The sidecar is intentionally separate from the lifecycle ledger. Releases
+predating this contract reject unknown ledger events, while this runtime file
+can be ignored safely by old readers. Mutation remains owned by the lifecycle
+service and transaction engine; this module only validates and models bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import plistlib
+import re
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from core import portable_contract
+from core.path_safety import unsafe_existing_parent
+
+if TYPE_CHECKING:
+    from core.transaction.engine import PlanEntry
+
+SIDECAR_RELATIVE = portable_contract.AUTOMATION_OWNERSHIP_RELATIVE
+SIDECAR_SCHEMA_VERSION = 1
+SIDECAR_MAX_BYTES = 64 * 1024
+OWNER_ID = "dex-solo"
+
+_CLAIM_FIELDS = frozenset({"automation_id", "owner_id", "plist_relative_path", "plist_sha256"})
+_CLAIM_REQUEST_FIELDS = _CLAIM_FIELDS | {"launchd_state"}
+_RELEASE_REQUEST_FIELDS = frozenset({"automation_id", "owner_id", "scheduler_state"})
+_ID = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class AutomationOwnershipError(ValueError):
+    """The sidecar request or evidence is unsafe or non-canonical."""
+
+
+def _home_root() -> Path:
+    return Path.home()
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _canonical_id(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or _ID.fullmatch(value) is None:
+        raise AutomationOwnershipError(f"automation ownership {field} is not canonical")
+    return value
+
+
+def _owner(value: object) -> str:
+    owner = _canonical_id(value, field="owner_id")
+    if owner != OWNER_ID:
+        raise AutomationOwnershipError("automation ownership is reserved for Dex Solo")
+    return owner
+
+
+def _plist_relative(value: object) -> str:
+    if not isinstance(value, str):
+        raise AutomationOwnershipError("automation plist path must be a canonical relative path")
+    candidate = PurePosixPath(value)
+    if (
+        candidate.is_absolute()
+        or candidate.as_posix() != value
+        or len(candidate.parts) != 3
+        or candidate.parts[:2] != ("Library", "LaunchAgents")
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+        or not candidate.name.endswith(".plist")
+    ):
+        raise AutomationOwnershipError("automation plist path must be a canonical relative Library/LaunchAgents path")
+    return value
+
+
+def _sha256(value: object) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise AutomationOwnershipError("automation plist sha256 must be lowercase hexadecimal")
+    return value
+
+
+def _claim(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping) or set(value) != _CLAIM_FIELDS:
+        raise AutomationOwnershipError("automation claim has unsupported fields")
+    return {
+        "automation_id": _canonical_id(value.get("automation_id"), field="automation_id"),
+        "owner_id": _owner(value.get("owner_id")),
+        "plist_relative_path": _plist_relative(value.get("plist_relative_path")),
+        "plist_sha256": _sha256(value.get("plist_sha256")),
+    }
+
+
+def _claim_request(value: object) -> tuple[dict[str, str], str]:
+    if not isinstance(value, Mapping) or set(value) != _CLAIM_REQUEST_FIELDS:
+        raise AutomationOwnershipError("automation claim request has unsupported fields")
+    claim = _claim({field: value[field] for field in _CLAIM_FIELDS})
+    state = value.get("launchd_state")
+    if state != "unloaded":
+        raise AutomationOwnershipError("launchd must be unloaded before Dex Solo records a claim")
+    return claim, state
+
+
+def _release_request(value: object) -> tuple[str, str, str]:
+    if not isinstance(value, Mapping) or set(value) != _RELEASE_REQUEST_FIELDS:
+        raise AutomationOwnershipError("automation release request has unsupported fields")
+    automation_id = _canonical_id(value.get("automation_id"), field="automation_id")
+    owner_id = _owner(value.get("owner_id"))
+    scheduler_state = value.get("scheduler_state")
+    if scheduler_state != "stopped":
+        raise AutomationOwnershipError("Dex Solo scheduler must be stopped before release")
+    return automation_id, owner_id, scheduler_state
+
+
+def _state(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping) or set(value) != {"schema_version", "claims"}:
+        raise AutomationOwnershipError("automation ownership sidecar has unsupported fields")
+    if value.get("schema_version") != SIDECAR_SCHEMA_VERSION:
+        raise AutomationOwnershipError("automation ownership sidecar schema version is unsupported")
+    raw_claims = value.get("claims")
+    if not isinstance(raw_claims, list):
+        raise AutomationOwnershipError("automation ownership sidecar claims must be an array")
+    claims = [_claim(item) for item in raw_claims]
+    if claims != sorted(claims, key=lambda item: item["automation_id"]):
+        raise AutomationOwnershipError("automation ownership claims are not in canonical order")
+    ids = [item["automation_id"] for item in claims]
+    paths = [item["plist_relative_path"] for item in claims]
+    if len(ids) != len(set(ids)) or len(paths) != len(set(paths)):
+        raise AutomationOwnershipError("automation ownership sidecar contains conflicting reuse")
+    return {"schema_version": SIDECAR_SCHEMA_VERSION, "claims": claims}
+
+
+def read_state(vault_root: str | Path) -> tuple[dict[str, object], str | None]:
+    root = Path(vault_root)
+    unsafe = unsafe_existing_parent(root, SIDECAR_RELATIVE)
+    if unsafe is not None:
+        raise AutomationOwnershipError(f"automation ownership sidecar: {unsafe}")
+    target = root / SIDECAR_RELATIVE
+    if not target.exists() and not target.is_symlink():
+        return {"schema_version": SIDECAR_SCHEMA_VERSION, "claims": []}, None
+    if target.is_symlink() or not target.is_file():
+        raise AutomationOwnershipError("automation ownership sidecar must be a regular file")
+    raw = target.read_bytes()
+    if len(raw) > SIDECAR_MAX_BYTES:
+        raise AutomationOwnershipError("automation ownership sidecar exceeds its size limit")
+    try:
+        parsed = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AutomationOwnershipError("automation ownership sidecar is invalid JSON") from error
+    state = _state(parsed)
+    if raw != _canonical(state):
+        raise AutomationOwnershipError("automation ownership sidecar is not canonical JSON")
+    return state, hashlib.sha256(raw).hexdigest()
+
+
+def _verified_plist(
+    claim: Mapping[str, str],
+    *,
+    home_root: Path | None = None,
+) -> None:
+    home = home_root or _home_root()
+    relative = claim["plist_relative_path"]
+    unsafe = unsafe_existing_parent(home, relative)
+    if unsafe is not None:
+        raise AutomationOwnershipError(f"automation plist evidence is unsafe: {unsafe}")
+    plist = home / relative
+    if plist.is_symlink() or not plist.is_file():
+        raise AutomationOwnershipError("automation plist evidence is missing or not a regular file")
+    raw = plist.read_bytes()
+    if hashlib.sha256(raw).hexdigest() != claim["plist_sha256"]:
+        raise AutomationOwnershipError("automation plist evidence changed since preview")
+    try:
+        payload = plistlib.loads(raw)
+    except Exception as error:  # plistlib exposes several parse error types
+        raise AutomationOwnershipError("automation plist evidence is unreadable") from error
+    if not isinstance(payload, Mapping) or payload.get("Label") != claim["automation_id"]:
+        raise AutomationOwnershipError("automation plist Label does not match automation_id")
+    if not claim["automation_id"].startswith(("com.dex.", "com.claudesidian.")):
+        raise AutomationOwnershipError("automation claim is not for a shipped Dex launchd label")
+
+
+def _sidecar_sha(state: Mapping[str, object]) -> str:
+    return hashlib.sha256(_canonical(state)).hexdigest()
+
+
+def build_claim_preview(
+    vault_root: str | Path,
+    request: object,
+) -> dict[str, object] | None:
+    claim, launchd_state = _claim_request(request)
+    state, current_sha = read_state(vault_root)
+    claims = list(state["claims"])
+    for existing in claims:
+        if existing == claim:
+            _verified_plist(claim)
+            return None
+        if (
+            existing["automation_id"] == claim["automation_id"]
+            or existing["plist_relative_path"] == claim["plist_relative_path"]
+        ):
+            raise AutomationOwnershipError("automation ownership claim has conflicting reuse")
+    _verified_plist(claim)
+    next_state = _state(
+        {
+            "schema_version": SIDECAR_SCHEMA_VERSION,
+            "claims": sorted([*claims, claim], key=lambda item: item["automation_id"]),
+        }
+    )
+    return {
+        "automation_ownership_version": 1,
+        "operation": "claim",
+        "claim": claim,
+        "launchd_state": launchd_state,
+        "current_sidecar_sha256": current_sha,
+        "next_sidecar_sha256": _sidecar_sha(next_state),
+    }
+
+
+def build_release_preview(
+    vault_root: str | Path,
+    request: object,
+) -> dict[str, object] | None:
+    automation_id, owner_id, scheduler_state = _release_request(request)
+    state, current_sha = read_state(vault_root)
+    claims = list(state["claims"])
+    existing = next((item for item in claims if item["automation_id"] == automation_id), None)
+    if existing is None:
+        return None
+    if existing["owner_id"] != owner_id:
+        raise AutomationOwnershipError("automation ownership release names a foreign owner")
+    _verified_plist(existing)
+    next_state = _state(
+        {
+            "schema_version": SIDECAR_SCHEMA_VERSION,
+            "claims": [item for item in claims if item["automation_id"] != automation_id],
+        }
+    )
+    return {
+        "automation_ownership_version": 1,
+        "operation": "release",
+        "claim": existing,
+        "scheduler_state": scheduler_state,
+        "current_sidecar_sha256": current_sha,
+        "next_sidecar_sha256": _sidecar_sha(next_state),
+    }
+
+
+def _plan(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+) -> tuple[PlanEntry | None, str]:
+    from core.transaction.engine import PlanEntry
+
+    operation = preview.get("operation")
+    claim = preview.get("claim")
+    if operation == "claim":
+        if set(preview) != {
+            "automation_ownership_version",
+            "operation",
+            "claim",
+            "launchd_state",
+            "current_sidecar_sha256",
+            "next_sidecar_sha256",
+        }:
+            raise AutomationOwnershipError("automation claim preview has unsupported fields")
+        rebuilt = build_claim_preview(
+            vault_root,
+            {**dict(_claim(claim)), "launchd_state": preview.get("launchd_state")},
+        )
+        if rebuilt is None:
+            return None, "already-claimed"
+        status = "claimed"
+    elif operation == "release":
+        if set(preview) != {
+            "automation_ownership_version",
+            "operation",
+            "claim",
+            "scheduler_state",
+            "current_sidecar_sha256",
+            "next_sidecar_sha256",
+        }:
+            raise AutomationOwnershipError("automation release preview has unsupported fields")
+        modeled = _claim(claim)
+        rebuilt = build_release_preview(
+            vault_root,
+            {
+                "automation_id": modeled["automation_id"],
+                "owner_id": modeled["owner_id"],
+                "scheduler_state": preview.get("scheduler_state"),
+            },
+        )
+        if rebuilt is None:
+            return None, "already-released"
+        status = "released"
+    else:
+        raise AutomationOwnershipError("automation ownership preview operation is invalid")
+    if preview.get("automation_ownership_version") != 1:
+        raise AutomationOwnershipError("automation ownership preview version is unsupported")
+    if dict(preview) != rebuilt:
+        raise AutomationOwnershipError("automation ownership state changed since preview")
+
+    state, current_sha = read_state(vault_root)
+    modeled_claim = _claim(claim)
+    claims = list(state["claims"])
+    next_claims = (
+        sorted([*claims, modeled_claim], key=lambda item: item["automation_id"])
+        if operation == "claim"
+        else [item for item in claims if item["automation_id"] != modeled_claim["automation_id"]]
+    )
+    content = _canonical(_state({"schema_version": SIDECAR_SCHEMA_VERSION, "claims": next_claims}))
+    return (
+        PlanEntry(
+            SIDECAR_RELATIVE,
+            content,
+            mode=0o600,
+            expected_current_sha256=current_sha,
+            expected_absent=current_sha is None,
+        ),
+        status,
+    )
+
+
+def execution_plan(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+) -> tuple[PlanEntry | None, str]:
+    if not isinstance(preview, Mapping):
+        raise AutomationOwnershipError("automation ownership preview must be an object")
+    return _plan(vault_root, preview)
+
+
+def valid_claims(
+    vault_root: str | Path,
+    *,
+    home_root: Path | None = None,
+) -> tuple[dict[str, str], ...]:
+    """Return only claims whose current plist still matches the sealed evidence."""
+    try:
+        state, _sha = read_state(vault_root)
+    except AutomationOwnershipError:
+        return ()
+    valid: list[dict[str, str]] = []
+    for claim in state["claims"]:
+        try:
+            _verified_plist(claim, home_root=home_root)
+        except AutomationOwnershipError:
+            continue
+        valid.append(claim)
+    return tuple(valid)
+
+
+def is_plist_offloaded(
+    vault_root: str | Path,
+    plist_relative_path: str,
+    *,
+    home_root: Path | None = None,
+) -> bool:
+    try:
+        relative = _plist_relative(plist_relative_path)
+    except AutomationOwnershipError:
+        return False
+    return any(claim["plist_relative_path"] == relative for claim in valid_claims(vault_root, home_root=home_root))
+
+
+__all__ = [
+    "AutomationOwnershipError",
+    "OWNER_ID",
+    "SIDECAR_RELATIVE",
+    "SIDECAR_SCHEMA_VERSION",
+    "build_claim_preview",
+    "build_release_preview",
+    "execution_plan",
+    "is_plist_offloaded",
+    "read_state",
+    "valid_claims",
+]

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -37,14 +37,13 @@ from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
 from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry, PlanRejected
 from core.transaction.journal import Journal, JournalCorruptError
-from core.utils import apple_mail_health, dex_logger, launch_agents, preflight, release_channel
+from core.utils import apple_mail_health, automation_ownership, dex_logger, launch_agents, preflight, release_channel
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
 QMD_STATUS_TIMEOUT_SECONDS = 10
 MISSING_PACKAGES_DETAIL = (
-    "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
-    "then re-run /dex-doctor"
+    "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor"
 )
 RELEASE_CATALOG_PATH = "System/.release-catalog.json"
 KNOWN_SKILL_CONTAINER_DIRECTORIES = frozenset({"_available", "integrations"})
@@ -61,20 +60,13 @@ ADOPTION_STATUSES = frozenset(state.value for state in AdoptionState)
 ADOPTION_REASON_CODES = frozenset(reason.value for reason in ReasonCode)
 INSTALLER_STRIPPED_PACKAGE_SCRIPTS = {
     "test:hooks": "node --test .claude/hooks/tests/*.test.cjs",
-    "test:scripts": (
-        "node --test .scripts/lib/tests/*.test.cjs "
-        ".scripts/meeting-intel/__tests__/*.test.cjs"
-    ),
-    "test:integrations": (
-        "node --test core/integrations/connection-manager/*.test.cjs"
-    ),
+    "test:scripts": ("node --test .scripts/lib/tests/*.test.cjs .scripts/meeting-intel/__tests__/*.test.cjs"),
+    "test:integrations": ("node --test core/integrations/connection-manager/*.test.cjs"),
     "check:connections-contract": (
-        "node scripts/check-connections-contract.mjs && "
-        "node scripts/build-connections-engine-manifest.mjs --check"
+        "node scripts/check-connections-contract.mjs && node scripts/build-connections-engine-manifest.mjs --check"
     ),
     "test:connections-consumer-smoke": (
-        "node --test "
-        "core/integrations/connection-manager/connections-contract.test.cjs"
+        "node --test core/integrations/connection-manager/connections-contract.test.cjs"
     ),
 }
 
@@ -82,9 +74,7 @@ INSTALLER_STRIPPED_PACKAGE_SCRIPTS = {
 def _validate_authority_item(item_id: object, item_version: object) -> None:
     if not isinstance(item_id, str) or ITEM_ID.fullmatch(item_id) is None:
         raise ValueError("Adoption authority item_id is not canonical")
-    if item_version is not None and (
-        not isinstance(item_version, str) or SEMVER.fullmatch(item_version) is None
-    ):
+    if item_version is not None and (not isinstance(item_version, str) or SEMVER.fullmatch(item_version) is None):
         raise ValueError("Adoption authority item_version is not strict SemVer")
 
 
@@ -234,9 +224,7 @@ class AdoptionReviewItem:
             or any(reason not in ADOPTION_REASON_CODES for reason in self.reasons)
         ):
             raise ValueError("Adoption review reasons use an invalid authority value")
-        if not isinstance(self.files, tuple) or any(
-            type(entry) is not AdoptionReviewFile for entry in self.files
-        ):
+        if not isinstance(self.files, tuple) or any(type(entry) is not AdoptionReviewFile for entry in self.files):
             raise ValueError("Adoption review files must be AdoptionReviewFile records")
 
     def to_dict(self) -> dict[str, object]:
@@ -443,11 +431,7 @@ class ReceiptsAndRewindGroup:
 
 
 AdoptionGroup = (
-    NewAndSafeGroup
-    | NeedsReviewGroup
-    | PreservedForNowGroup
-    | ContinueOrRecoverGroup
-    | ReceiptsAndRewindGroup
+    NewAndSafeGroup | NeedsReviewGroup | PreservedForNowGroup | ContinueOrRecoverGroup | ReceiptsAndRewindGroup
 )
 
 
@@ -490,9 +474,7 @@ class AdoptionReport:
                 raise ValueError("Adoption group count must be a non-negative integer")
             _validate_surface(group.surface)
         new_group, review_group, preserved_group, recovery_group, receipt_group = self.groups
-        if not isinstance(new_group.items, tuple) or any(
-            type(item) is not AdoptionItem for item in new_group.items
-        ):
+        if not isinstance(new_group.items, tuple) or any(type(item) is not AdoptionItem for item in new_group.items):
             raise ValueError("new-and-safe items must be AdoptionItem records")
         if any(item.action != PlannedAction.ADOPT.value for item in new_group.items):
             raise ValueError("new-and-safe items must have action adopt")
@@ -504,35 +486,25 @@ class AdoptionReport:
             type(item) is not AdoptionItem for item in preserved_group.held_back_items
         ):
             raise ValueError("preserved held-back items must be AdoptionItem records")
-        if any(
-            item.action != PlannedAction.SKIP_HELD_BACK.value
-            for item in preserved_group.held_back_items
-        ):
+        if any(item.action != PlannedAction.SKIP_HELD_BACK.value for item in preserved_group.held_back_items):
             raise ValueError("preserved held-back items must have action skip-held-back")
         if not isinstance(preserved_group.customized_files, tuple) or any(
-            type(item) is not PreservedCustomization
-            for item in preserved_group.customized_files
+            type(item) is not PreservedCustomization for item in preserved_group.customized_files
         ):
             raise ValueError("preserved customized files must be strict authority records")
         if not isinstance(recovery_group.transactions, tuple) or any(
-            type(item) is not InterruptedTransaction
-            for item in recovery_group.transactions
+            type(item) is not InterruptedTransaction for item in recovery_group.transactions
         ):
             raise ValueError("recovery transactions must be strict authority records")
         if recovery_group.ledger is not None and type(recovery_group.ledger) is not LedgerRecovery:
             raise ValueError("recovery ledger must be a LedgerRecovery record or null")
-        if recovery_group.inspection_error is not None and not isinstance(
-            recovery_group.inspection_error, str
-        ):
+        if recovery_group.inspection_error is not None and not isinstance(recovery_group.inspection_error, str):
             raise ValueError("recovery inspection_error must be a string or null")
         if not isinstance(receipt_group.receipts, tuple) or any(
             type(item) is not AdoptionReceiptSummary for item in receipt_group.receipts
         ):
             raise ValueError("receipt summaries must be strict authority records")
-        if any(
-            item.status != AdoptionState.ADOPTED.value
-            for item in receipt_group.receipts
-        ):
+        if any(item.status != AdoptionState.ADOPTED.value for item in receipt_group.receipts):
             raise ValueError("receipt summaries must have status adopted")
         expected_counts = (
             len(new_group.items),
@@ -852,11 +824,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             pass
         if current_paths != expected_paths:
             relative = context.paths_json_path.relative_to(context.vault_root).as_posix()
-            mode = (
-                context.paths_json_path.stat().st_mode & 0o777
-                if context.paths_json_path.is_file()
-                else 0o644
-            )
+            mode = context.paths_json_path.stat().st_mode & 0o777 if context.paths_json_path.is_file() else 0o644
             planned.append(
                 PlanEntry(
                     relative,
@@ -880,9 +848,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             try:
                 relative = script.relative_to(context.vault_root).as_posix()
             except ValueError:
-                errors.append(
-                    f"Executable-mode repair requires user action outside the vault: {script}"
-                )
+                errors.append(f"Executable-mode repair requires user action outside the vault: {script}")
                 continue
             planned.append(
                 PlanEntry(
@@ -903,9 +869,7 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             # Findings that cannot be auto-tightened (foreign owner, symlink)
             # carry their own Tier-3 guidance and are never attempted here.
             _tighten_env_permissions(context)
-            actions.setdefault("vault.configs", []).append(
-                "tightened .env to owner-only permissions"
-            )
+            actions.setdefault("vault.configs", []).append("tightened .env to owner-only permissions")
     except OSError as error:
         errors.append(f".env permission heal failed: {_one_line(error)}")
 
@@ -926,19 +890,13 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
         acknowledged = _acknowledge_resolved_preflight_errors(context)
         if acknowledged:
             noun = "error" if acknowledged == 1 else "errors"
-            actions.setdefault("preflight.queue", []).append(
-                f"acknowledged {acknowledged} resolved preflight {noun}"
-            )
+            actions.setdefault("preflight.queue", []).append(f"acknowledged {acknowledged} resolved preflight {noun}")
     except Exception as error:
         errors.append(f"Preflight-queue heal failed: {_one_line(error)}")
 
     try:
         room_health = _probe_capability_rooms(context)
-        if (
-            room_health.verdict == "BROKEN"
-            and room_health.heal is not None
-            and room_health.heal.tier == 1
-        ):
+        if room_health.verdict == "BROKEN" and room_health.heal is not None and room_health.heal.tier == 1:
             from core import capabilities
 
             reconciled = capabilities.reconcile_all(
@@ -1046,10 +1004,7 @@ def collect(
             truthful_missing_diagnosis = bool(
                 missing_module
                 and (
-                    (
-                        dex_logger.is_dex_module(missing_module)
-                        and "Dex checkup fault" in result.detail
-                    )
+                    (dex_logger.is_dex_module(missing_module) and "Dex checkup fault" in result.detail)
                     or (
                         not dex_logger.is_dex_module(missing_module)
                         and f"missing module {missing_module!r}" in result.detail
@@ -1098,8 +1053,7 @@ def collect(
                     result = replace(
                         result,
                         detail=(
-                            f"{result.detail.rstrip('.')}; a safe Tier-1 repair separately "
-                            + "; ".join(check_actions)
+                            f"{result.detail.rstrip('.')}; a safe Tier-1 repair separately " + "; ".join(check_actions)
                         ),
                     )
             if definition.id == "capabilities.rooms" and check_actions:
@@ -1141,19 +1095,11 @@ def collect(
     }
     if deep:
         assessment_result = results.get("customizations.assessment")
-        if (
-            assessment_result is not None
-            and assessment_result.structured_detail is not None
-        ):
+        if assessment_result is not None and assessment_result.structured_detail is not None:
             report["customization_assessment"] = assessment_result.structured_detail
         migration_status_result = results.get("customizations.migration-status")
-        if (
-            migration_status_result is not None
-            and migration_status_result.structured_detail is not None
-        ):
-            report["customization_migration_status"] = (
-                migration_status_result.structured_detail
-            )
+        if migration_status_result is not None and migration_status_result.structured_detail is not None:
+            report["customization_migration_status"] = migration_status_result.structured_detail
 
     try:
         _write_last_run(report, context)
@@ -1353,11 +1299,7 @@ def _empty_adoption_report(
     inspection_error: str | None = None,
 ) -> AdoptionReport:
     recovery_count = len(transactions) + int(ledger is not None) + int(inspection_error is not None)
-    recovery_surface = (
-        _recovery_surface(transactions, ledger, inspection_error)
-        if recovery_count
-        else surface
-    )
+    recovery_surface = _recovery_surface(transactions, ledger, inspection_error) if recovery_count else surface
     return AdoptionReport(
         ADOPTION_REPORT_VERSION,
         verdict,
@@ -1401,14 +1343,10 @@ def _inspect_interrupted_transactions(
         return (), f"Transaction store could not be inspected: {_one_line(error)}"
     for tx_dir in candidates:
         if lifecycle_engine.TRANSACTION_ID.fullmatch(tx_dir.name) is None:
-            inspection_errors.append(
-                f"Transaction store contains a non-canonical entry: {tx_dir.name}"
-            )
+            inspection_errors.append(f"Transaction store contains a non-canonical entry: {tx_dir.name}")
             continue
         if tx_dir.is_symlink() or not tx_dir.is_dir():
-            interrupted.append(
-                InterruptedTransaction(tx_dir.name, "UNKNOWN", None, False)
-            )
+            interrupted.append(InterruptedTransaction(tx_dir.name, "UNKNOWN", None, False))
             continue
         try:
             entries = Journal(tx_dir / "journal.jsonl").read()
@@ -1580,11 +1518,7 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
         plan = build_adoption_plan(
             catalog,
             inventory,
-            adoption_states={
-                item_id: AdoptionState.ADOPTED
-                for item_id in adopted
-                if item_id in catalog_ids
-            },
+            adoption_states={item_id: AdoptionState.ADOPTED for item_id in adopted if item_id in catalog_ids},
             held_back=frozenset(held_back & catalog_ids),
         )
     except Exception as error:
@@ -1606,11 +1540,7 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
             item.item_version,
             item.action.value,
             tuple(reason.code.value for reason in item.reasons),
-            tuple(
-                AdoptionReviewFile(path, reason.code.value)
-                for reason in item.reasons
-                for path in reason.paths
-            ),
+            tuple(AdoptionReviewFile(path, reason.code.value) for reason in item.reasons for path in reason.paths),
         )
         for item in plan.items
         if item.action in {PlannedAction.CONFLICT, PlannedAction.UNKNOWN}
@@ -1659,22 +1589,18 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
     recovery_verdict = (
         "UNKNOWN"
         if inspection_error is not None or any(tx.verdict == "UNKNOWN" for tx in transactions)
-        else "BROKEN" if transactions else "OK"
-    )
-    review_verdict = (
-        "UNKNOWN"
-        if any(item.action is PlannedAction.UNKNOWN for item in plan.items)
+        else "BROKEN"
+        if transactions
         else "OK"
     )
-    receipts_verdict = (
-        "UNKNOWN"
-        if any(receipt.rewind_verdict == "UNKNOWN" for receipt in receipts)
-        else "OK"
-    )
+    review_verdict = "UNKNOWN" if any(item.action is PlannedAction.UNKNOWN for item in plan.items) else "OK"
+    receipts_verdict = "UNKNOWN" if any(receipt.rewind_verdict == "UNKNOWN" for receipt in receipts) else "OK"
     report_verdict = (
         "UNKNOWN"
         if "UNKNOWN" in {recovery_verdict, review_verdict, receipts_verdict}
-        else "BROKEN" if recovery_verdict == "BROKEN" else "OK"
+        else "BROKEN"
+        if recovery_verdict == "BROKEN"
+        else "OK"
     )
     return AdoptionReport(
         ADOPTION_REPORT_VERSION,
@@ -1757,8 +1683,7 @@ def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
     counts = result["plan"]["counts"]
     return ProbeResult(
         "OK",
-        f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / "
-        f"{counts['conflict']} conflicts",
+        f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / {counts['conflict']} conflicts",
     )
 
 
@@ -1787,9 +1712,7 @@ def _probe_customization_assessment(context: DoctorContext) -> ProbeResult:
     from core.customization_migration.service import assess
 
     assessment = assess(context.vault_root)
-    authority = _customization_persistence_detail(
-        assessment_report(assessment)
-    )
+    authority = _customization_persistence_detail(assessment_report(assessment))
     catalog_path = _release_catalog_path(context)
     if os.path.lexists(catalog_path):
         try:
@@ -1803,8 +1726,7 @@ def _probe_customization_assessment(context: DoctorContext) -> ProbeResult:
     if assessment.baseline_identity_state != "VERIFIED":
         return ProbeResult(
             "UNKNOWN",
-            "I couldn't verify which Dex version is installed, so I can't tell you "
-            "what you've changed.",
+            "I couldn't verify which Dex version is installed, so I can't tell you what you've changed.",
             structured_detail=authority,
         )
     if assessment.completeness == "UNKNOWN":
@@ -1848,9 +1770,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
         from core.customization_migration.service import migration_status_to_dict
     except ModuleNotFoundError as error:
         missing = error.name or ""
-        if missing == "core.customization_migration" or missing.startswith(
-            "core.customization_migration."
-        ):
+        if missing == "core.customization_migration" or missing.startswith("core.customization_migration."):
             return ProbeResult(
                 "OFF",
                 "Customization migration status is unavailable on this older Dex release",
@@ -1885,13 +1805,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
     recovery_token = authority.get("recovery_token")
     if (
         not isinstance(recovery_actions, list)
-        or (
-            recovery_actions
-            and (
-                not isinstance(recovery_token, str)
-                or len(recovery_token) != 64
-            )
-        )
+        or (recovery_actions and (not isinstance(recovery_token, str) or len(recovery_token) != 64))
         or (not recovery_actions and recovery_token is not None)
     ):
         return ProbeResult(
@@ -1899,8 +1813,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             "The customization recovery status is structurally incomplete",
         )
     expected_recovery_action = (
-        "python3 -m core.customization_migration.cli recover "
-        f"--confirm-token {recovery_token}"
+        f"python3 -m core.customization_migration.cli recover --confirm-token {recovery_token}"
         if isinstance(recovery_token, str)
         else None
     )
@@ -1925,10 +1838,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 "rewind",
             }
             or not isinstance(recovery["capsule_id"], str)
-            or (
-                recovery["proposal_id"] is not None
-                and not isinstance(recovery["proposal_id"], str)
-            )
+            or (recovery["proposal_id"] is not None and not isinstance(recovery["proposal_id"], str))
             or recovery["action"] != expected_recovery_action
         ):
             return ProbeResult(
@@ -1949,19 +1859,17 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
         capsule_id = capsule.get("capsule_id")
         state = capsule.get("state")
         validation = capsule.get("validation")
-        if (
-            not isinstance(capsule_id, str)
-            or not isinstance(state, str)
-            or not isinstance(validation, dict)
-        ):
+        if not isinstance(capsule_id, str) or not isinstance(state, str) or not isinstance(validation, dict):
             return ProbeResult(
                 "UNKNOWN",
                 "The customization migration status contains incomplete capsule authority",
             )
         status = validation.get("status")
         mismatches = validation.get("mismatches")
-        if not isinstance(status, str) or not isinstance(mismatches, list) or any(
-            not isinstance(item, str) for item in mismatches
+        if (
+            not isinstance(status, str)
+            or not isinstance(mismatches, list)
+            or any(not isinstance(item, str) for item in mismatches)
         ):
             return ProbeResult(
                 "UNKNOWN",
@@ -1972,9 +1880,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             verification_verdicts = capsule.get("verification_verdicts")
             pending_rebuild = capsule.get("pending_rebuild")
             activation = capsule.get("activation")
-            activation_receipt_present = capsule.get(
-                "activation_receipt_present"
-            )
+            activation_receipt_present = capsule.get("activation_receipt_present")
             rewindable = capsule.get("rewindable")
             if (
                 not isinstance(staging, dict)
@@ -1996,8 +1902,7 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 or type(staging_truncated) is not bool
                 or set(verification_verdicts) != {"OK", "BLOCKED", "UNKNOWN"}
                 or any(
-                    type(verification_verdicts[key]) is not int
-                    or verification_verdicts[key] < 0
+                    type(verification_verdicts[key]) is not int or verification_verdicts[key] < 0
                     for key in ("OK", "BLOCKED", "UNKNOWN")
                 )
             ):
@@ -2011,17 +1916,14 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                     not isinstance(proposal, dict)
                     or not isinstance(proposal.get("proposal_id"), str)
                     or not isinstance(proposal.get("state"), str)
-                    or proposal.get("verification_verdict")
-                    not in counted_verdicts
+                    or proposal.get("verification_verdict") not in counted_verdicts
                 ):
                     return ProbeResult(
                         "UNKNOWN",
                         "The customization staging status contains a malformed proposal",
                     )
                 counted_verdicts[proposal["verification_verdict"]] += 1
-                rebuild_broken = rebuild_broken or (
-                    proposal["state"] == "recovery-required"
-                )
+                rebuild_broken = rebuild_broken or (proposal["state"] == "recovery-required")
             if counted_verdicts != verification_verdicts:
                 return ProbeResult(
                     "UNKNOWN",
@@ -2038,16 +1940,12 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             if (
                 set(activation) != activation_required
                 or activation.get("capsule_id") != capsule_id
-                or (
-                    activation.get("proposal_id") is not None
-                    and not isinstance(activation.get("proposal_id"), str)
-                )
+                or (activation.get("proposal_id") is not None and not isinstance(activation.get("proposal_id"), str))
                 or not isinstance(activation.get("state"), str)
                 or not isinstance(activation.get("reason"), str)
                 or type(activation.get("activation_receipt_present")) is not bool
                 or type(activation.get("rewindable")) is not bool
-                or activation_receipt_present
-                != activation["activation_receipt_present"]
+                or activation_receipt_present != activation["activation_receipt_present"]
                 or rewindable != activation["rewindable"]
             ):
                 return ProbeResult(
@@ -2056,17 +1954,12 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 )
             pending = pending or pending_rebuild
             rebuild_broken = rebuild_broken or (
-                verification_verdicts["BLOCKED"] > 0
-                or activation["state"] == "recovery-required"
+                verification_verdicts["BLOCKED"] > 0 or activation["state"] == "recovery-required"
             )
             rebuild_unknown = rebuild_unknown or (
                 staging_truncated
                 or verification_verdicts["UNKNOWN"] > 0
-                or (
-                    activation_receipt_present
-                    and activation["state"]
-                    not in {"activated", "rewound"}
-                )
+                or (activation_receipt_present and activation["state"] not in {"activated", "rewound"})
             )
         else:
             pending = pending or state == "capsule-created"
@@ -2120,11 +2013,7 @@ def _mcp_config_path(context: DoctorContext) -> Path:
 
 def _load_mcp_config(context: DoctorContext) -> dict[str, Any]:
     loaded = json.loads(_mcp_config_path(context).read_text())
-    if (
-        not isinstance(loaded, dict)
-        or "mcpServers" not in loaded
-        or not isinstance(loaded["mcpServers"], dict)
-    ):
+    if not isinstance(loaded, dict) or "mcpServers" not in loaded or not isinstance(loaded["mcpServers"], dict):
         raise ValueError(".mcp.json must contain an mcpServers object")
     return loaded
 
@@ -2258,9 +2147,7 @@ def _probe_mcp_orphans(context: DoctorContext) -> ProbeResult:
     except FileNotFoundError:
         config = {"mcpServers": {}}
     registered = {
-        target.resolve()
-        for entry in config["mcpServers"].values()
-        for target in _entry_targets(entry, context)
+        target.resolve() for entry in config["mcpServers"].values() for target in _entry_targets(entry, context)
     }
     orphans = [path.name for resolved, path in shipped.items() if resolved not in registered]
     if orphans:
@@ -2403,10 +2290,7 @@ def _installed_launch_agents(context: DoctorContext) -> list[tuple[Path, bool]]:
     directory = context.launch_agents_dir
     if not directory.is_dir():
         return []
-    return sorted(
-        (path, launch_agents.is_dex_named(path.name))
-        for path in directory.glob("*.plist")
-    )
+    return sorted((path, launch_agents.is_dex_named(path.name)) for path in directory.glob("*.plist"))
 
 
 def _stored_former_vault_root(context: DoctorContext) -> Path | None:
@@ -2494,10 +2378,7 @@ def _with_skipped_launch_agents(detail: str, skipped_count: int) -> str:
 
 
 def _unattributable_launch_agent_detail(plist: Path, error: Exception) -> str:
-    return (
-        f"Could not determine whether {plist.name} belongs to this vault "
-        f"({_one_line(error)})"
-    )
+    return f"Could not determine whether {plist.name} belongs to this vault ({_one_line(error)})"
 
 
 def _plist_configuration_issue(plist: Path, data: dict[str, Any], context: DoctorContext) -> str | None:
@@ -2586,6 +2467,7 @@ def _resolved_interpreter(raw: str, context: DoctorContext) -> str | None:
 
 
 _OWNED = "owned"
+_OFFLOADED = "offloaded"
 _STALE = "stale"
 _FOREIGN = "foreign"
 _UNREADABLE = "unreadable"
@@ -2596,7 +2478,7 @@ class LaunchAgentRecord:
     """One launch agent's classification, computed once per doctor run."""
 
     plist: Path
-    classification: str  # "owned" | "stale" | "foreign" | "unreadable"
+    classification: str  # "owned" | "offloaded" | "stale" | "foreign" | "unreadable"
     label: str
     data: dict[str, Any] | None = None
     error_detail: str | None = None  # unreadable only
@@ -2627,7 +2509,28 @@ def _classify_launch_agents(context: DoctorContext) -> LaunchAgentScan:
     except (OSError, RuntimeError):
         vault_root = context.vault_root
     records: list[LaunchAgentRecord] = []
+    offloaded = {
+        claim["plist_relative_path"]: claim
+        for claim in automation_ownership.valid_claims(
+            context.vault_root,
+            home_root=context.home,
+        )
+    }
     for plist, dex_named in _installed_launch_agents(context):
+        try:
+            plist_relative = plist.relative_to(context.home).as_posix()
+        except ValueError:
+            plist_relative = ""
+        offloaded_claim = offloaded.get(plist_relative)
+        if offloaded_claim is not None:
+            records.append(
+                LaunchAgentRecord(
+                    plist=plist,
+                    classification=_OFFLOADED,
+                    label=offloaded_claim["automation_id"],
+                )
+            )
+            continue
         try:
             data = _plist_data(plist)
         except PermissionError:
@@ -2664,11 +2567,7 @@ def _classify_launch_agents(context: DoctorContext) -> LaunchAgentScan:
             # The agent points at this vault's stored former location. That
             # is this vault's job left behind by a move or rename —
             # owned-and-stale, never another product's (issue #364).
-            records.append(
-                LaunchAgentRecord(
-                    plist=plist, classification=_STALE, label=label, data=data
-                )
-            )
+            records.append(LaunchAgentRecord(plist=plist, classification=_STALE, label=label, data=data))
         elif dex_named:
             records.append(
                 LaunchAgentRecord(
@@ -2717,9 +2616,13 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     unknowns = []
     runtime_labels = []
     skipped_count = 0
+    offloaded_count = 0
     owned_count = 0
     stale_count = 0
     for record in scan.records:
+        if record.classification == _OFFLOADED:
+            offloaded_count += 1
+            continue
         if record.classification == _UNREADABLE:
             # A corrupt plist could belong to this vault, but a filename alone
             # cannot establish that safely. Surface the uncertainty instead of
@@ -2794,12 +2697,20 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
                     unknowns.append(f"{label} is loaded but has no observable LastExitStatus")
                 elif status["last_exit_status"] != 0:
                     issues.append((2, f"{label} last exited with status {status['last_exit_status']}"))
+    offloaded_note = (
+        f"{offloaded_count} launch agent{' is' if offloaded_count == 1 else 's are'} "
+        "owned by Dex Solo and offloaded from Core"
+        if offloaded_count
+        else ""
+    )
     if not owned_count and not issues:
         if unknowns:
             return ProbeResult(
                 "UNKNOWN",
                 _with_skipped_launch_agents("; ".join(unknowns), skipped_count),
             )
+        if offloaded_note:
+            return ProbeResult("OK", _with_skipped_launch_agents(offloaded_note, skipped_count))
         return ProbeResult(
             "OFF",
             _with_skipped_launch_agents("No launch agents for this vault are installed", skipped_count),
@@ -2819,6 +2730,8 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
         if sum(1 for issue_tier, _detail in issues if issue_tier == 2) > stale_count:
             action_parts.append("repair or reload the named launch agent only after explicit approval")
         detail_parts = [detail for _tier, detail in issues]
+        if offloaded_note:
+            detail_parts.append(offloaded_note)
         detail_parts.extend(unknowns)
         return ProbeResult(
             "BROKEN",
@@ -2833,7 +2746,14 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     return ProbeResult(
         "OK",
         _with_skipped_launch_agents(
-            f"All {owned_count} installed launch agents for this vault are loaded with valid interpreters",
+            "; ".join(
+                part
+                for part in (
+                    f"All {owned_count} installed launch agents for this vault are loaded with valid interpreters",
+                    offloaded_note,
+                )
+                if part
+            ),
             skipped_count,
         ),
     )
@@ -2860,13 +2780,14 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
         return None
 
     scan = _scan_launch_agents(context)
-    unknowns = [
-        record.error_detail
-        for record in scan.records
-        if record.classification == _UNREADABLE
-    ]
-    installed = sorted(
-        {record.label for record in scan.records if record.classification == _OWNED}
+    unknowns = [record.error_detail for record in scan.records if record.classification == _UNREADABLE]
+    installed = sorted({record.label for record in scan.records if record.classification == _OWNED})
+    offloaded = sorted({record.label for record in scan.records if record.classification == _OFFLOADED})
+    offloaded_note = (
+        f"{len(offloaded)} launch agent{' is' if len(offloaded) == 1 else 's are'} "
+        "owned by Dex Solo and offloaded from Core"
+        if offloaded
+        else ""
     )
     monitored = []
     monitored_ids = set()
@@ -2900,7 +2821,8 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
         if unknowns:
             return ProbeResult("UNKNOWN", _with_coverage_note("; ".join(unknowns)))
         return ProbeResult(
-            "OFF", _with_coverage_note("No shipped Dex freshness jobs are installed")
+            "OFF",
+            _with_coverage_note(offloaded_note or "No shipped Dex freshness jobs are installed"),
         )
 
     stale = []
@@ -2919,7 +2841,14 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     return ProbeResult(
         "OK",
         _with_coverage_note(
-            f"All {len(monitored)} installed job promises are within their promised cadence"
+            "; ".join(
+                part
+                for part in (
+                    f"All {len(monitored)} installed job promises are within their promised cadence",
+                    offloaded_note,
+                )
+                if part
+            )
         ),
     )
 
@@ -2985,11 +2914,7 @@ def _acknowledge_resolved_preflight_errors(context: DoctorContext) -> int:
             return 0
         acknowledged = 0
         for entry in entries:
-            if (
-                isinstance(entry, dict)
-                and entry.get("id") in resolved
-                and not entry.get("acknowledged", False)
-            ):
+            if isinstance(entry, dict) and entry.get("id") in resolved and not entry.get("acknowledged", False):
                 entry["acknowledged"] = True
                 entry["acknowledgedAt"] = context.now.astimezone(timezone.utc).isoformat()
                 acknowledged += 1
@@ -3037,28 +2962,13 @@ def _historical_error_summary(
     count = len(entries)
     subject = "1 earlier error" if count == 1 else f"{count} earlier errors"
     if previous_version_count == count:
-        reason = (
-            " from a previous Dex version"
-            if count == 1
-            else " from previous Dex versions"
-        )
+        reason = " from a previous Dex version" if count == 1 else " from previous Dex versions"
     elif previous_version_count:
-        reason = (
-            " from previous Dex versions or more than "
-            f"{dex_logger.STALE_ERROR_DAYS} days ago"
-        )
+        reason = f" from previous Dex versions or more than {dex_logger.STALE_ERROR_DAYS} days ago"
     else:
-        reason = (
-            " that is old enough to count as history"
-            if count == 1
-            else " that are old enough to count as history"
-        )
+        reason = " that is old enough to count as history" if count == 1 else " that are old enough to count as history"
 
-    dated = [
-        _queued_error_date(entry)
-        for entry in entries
-        if _queued_error_date(entry) != "date unavailable"
-    ]
+    dated = [_queued_error_date(entry) for entry in entries if _queued_error_date(entry) != "date unavailable"]
     if dated:
         return f"{subject}{reason}, last on {max(dated)}"
     return f"{subject}{reason}, dates unavailable"
@@ -3077,10 +2987,7 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
     resolved_heal = (
         Heal(
             tier=1,
-            action=(
-                f"Acknowledge {resolved_count} resolved preflight "
-                f"{'error' if resolved_count == 1 else 'errors'}."
-            ),
+            action=(f"Acknowledge {resolved_count} resolved preflight {'error' if resolved_count == 1 else 'errors'}."),
             applied=False,
         )
         if resolved_count
@@ -3129,9 +3036,7 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
     detail = "Preflight completed with no server or current queued errors"
     if resolved_count:
         noun = "error has" if resolved_count == 1 else "errors have"
-        detail += (
-            f"; {resolved_count} queued {noun} a newer successful check"
-        )
+        detail += f"; {resolved_count} queued {noun} a newer successful check"
     if historical_summary:
         detail += f"; {historical_summary}"
     return ProbeResult("OK", detail, resolved_heal)
@@ -3140,20 +3045,14 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
 def _capability_seed_paths(room: str) -> tuple[str, ...]:
     from core import capabilities
 
-    folders = tuple(
-        str(folder).rstrip("/")
-        for folder in capabilities.surfaces_for(room).get("folders", [])
-    )
+    folders = tuple(str(folder).rstrip("/") for folder in capabilities.surfaces_for(room).get("folders", []))
     return tuple(
         sorted(
             rule.path
             for rule in portable_contract.RULES
             if rule.ownership == "seed"
             and rule.kind == "file"
-            and any(
-                rule.path == folder or rule.path.startswith(f"{folder}/")
-                for folder in folders
-            )
+            and any(rule.path == folder or rule.path.startswith(f"{folder}/") for folder in folders)
         )
     )
 
@@ -3186,12 +3085,7 @@ def _probe_capability_rooms(context: DoctorContext) -> ProbeResult:
             for skill in surfaces.get("skills", []):
                 path = context.vault_root / ".claude/skills" / str(skill)
                 skill_file = path / "SKILL.md"
-                if (
-                    path.is_symlink()
-                    or not path.is_dir()
-                    or skill_file.is_symlink()
-                    or not skill_file.is_file()
-                ):
+                if path.is_symlink() or not path.is_dir() or skill_file.is_symlink() or not skill_file.is_file():
                     missing_skills.append(f"{room}: {skill}")
             for relative in _capability_seed_paths(room):
                 path = context.vault_root / relative
@@ -3205,32 +3099,20 @@ def _probe_capability_rooms(context: DoctorContext) -> ProbeResult:
 
     findings: list[str] = []
     if missing_folders:
-        findings.append(
-            f"Enabled room folders are missing: {', '.join(missing_folders)}"
-        )
+        findings.append(f"Enabled room folders are missing: {', '.join(missing_folders)}")
     if missing_skills:
-        findings.append(
-            f"Enabled room skills are missing: {', '.join(missing_skills)}"
-        )
+        findings.append(f"Enabled room skills are missing: {', '.join(missing_skills)}")
     if stale_skills:
-        findings.append(
-            f"Disabled room skills are still live: {', '.join(stale_skills)}"
-        )
+        findings.append(f"Disabled room skills are still live: {', '.join(stale_skills)}")
     if missing_seeds:
-        findings.append(
-            "Missing enabled-room seed files: "
-            f"{', '.join(missing_seeds)} — run /dex-update to restore"
-        )
+        findings.append(f"Missing enabled-room seed files: {', '.join(missing_seeds)} — run /dex-update to restore")
     if findings:
         return ProbeResult(
             "BROKEN",
             "; ".join(findings),
             Heal(
                 tier=1,
-                action=(
-                    "Reconcile capability room folders and shipped skills "
-                    "without deleting user content."
-                ),
+                action=("Reconcile capability room folders and shipped skills without deleting user content."),
                 applied=False,
             ),
         )
@@ -3256,9 +3138,7 @@ def _unsafe_customization_path(context: DoctorContext, path: Path) -> str | None
     if any(part in {"", ".", ".."} for part in relative.parts):
         return "contains an unsafe path component"
     if any(
-        part.lower() == ".env"
-        or part.lower().startswith(".env.")
-        or "credential" in part.lower()
+        part.lower() == ".env" or part.lower().startswith(".env.") or "credential" in part.lower()
         for part in relative.parts
     ):
         return "is credential-sensitive"
@@ -3281,18 +3161,19 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
             "UNKNOWN",
             f"{relative} {root_safety} and was not read for safety; fix or remove {relative}",
         )
-    skill_directories = sorted(
-        (
-            path
-            for path in skills_root.iterdir()
-            if path.name not in KNOWN_SKILL_CONTAINER_DIRECTORIES
-            and (
-                path.is_symlink()
-                or (path.is_dir() and any(path.iterdir()))
-            )
-        ),
-        key=lambda path: path.name,
-    ) if skills_root.is_dir() else []
+    skill_directories = (
+        sorted(
+            (
+                path
+                for path in skills_root.iterdir()
+                if path.name not in KNOWN_SKILL_CONTAINER_DIRECTORIES
+                and (path.is_symlink() or (path.is_dir() and any(path.iterdir())))
+            ),
+            key=lambda path: path.name,
+        )
+        if skills_root.is_dir()
+        else []
+    )
     catalogued_paths: frozenset[str] | None = None
     catalog_path = _release_catalog_path(context)
     if catalog_path.is_file():
@@ -3301,11 +3182,7 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
         except (CatalogError, OSError, UnicodeError):
             pass
         else:
-            catalogued_paths = frozenset(
-                file.path
-                for item in catalog.items
-                for file in item.files
-            )
+            catalogued_paths = frozenset(file.path for item in catalog.items for file in item.files)
     failures = []
     safety_findings = []
     custom_count = 0
@@ -3316,11 +3193,7 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
         custom_count += int(is_custom)
         release_carries_skill = catalogued_paths is None or relative in catalogued_paths
         shipped_label = "shipped skill" if release_carries_skill else "skill"
-        guidance = (
-            f"run /dex-update to restore {relative}"
-            if release_carries_skill
-            else f"fix or remove {relative}"
-        )
+        guidance = f"run /dex-update to restore {relative}" if release_carries_skill else f"fix or remove {relative}"
         safety_reason = _unsafe_customization_path(context, skill_path)
         if safety_reason:
             if is_custom:
@@ -3330,8 +3203,7 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
                 )
             else:
                 safety_findings.append(
-                    f"{shipped_label} {relative} {safety_reason} and was not read for safety; "
-                    f"{guidance}"
+                    f"{shipped_label} {relative} {safety_reason} and was not read for safety; {guidance}"
                 )
             continue
         errors = validate_skill_frontmatter(skill_path)
@@ -3339,13 +3211,9 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
             continue
         issue = "; ".join(_one_line(error) for error in errors)
         if is_custom:
-            failures.append(
-                f"user customization {relative} is invalid ({issue}); fix or remove {relative}"
-            )
+            failures.append(f"user customization {relative} is invalid ({issue}); fix or remove {relative}")
         else:
-            failures.append(
-                f"{shipped_label} {relative} is invalid ({issue}); {guidance}"
-            )
+            failures.append(f"{shipped_label} {relative} is invalid ({issue}); {guidance}")
 
     findings = [*failures, *safety_findings]
     if findings:
@@ -3399,9 +3267,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
     if config_safety:
         relative = _display_vault_path(context, config_path)
         guidance = (
-            f"run /dex-update to restore {relative}"
-            if shipped_example
-            else f"fix your customization in {relative}"
+            f"run /dex-update to restore {relative}" if shipped_example else f"fix your customization in {relative}"
         )
         return ProbeResult(
             "UNKNOWN",
@@ -3420,9 +3286,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
 
     structural_errors = validate_mcp_config(config)
     if shipped_example:
-        structural_errors = [
-            error for error in structural_errors if "unresolved placeholder" not in error
-        ]
+        structural_errors = [error for error in structural_errors if "unresolved placeholder" not in error]
     if structural_errors:
         return _mcp_customization_failure(
             context,
@@ -3433,9 +3297,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
 
     servers = config["mcpServers"]
     custom_entries = [
-        (name, entry)
-        for name, entry in servers.items()
-        if isinstance(name, str) and name.startswith("custom-")
+        (name, entry) for name, entry in servers.items() if isinstance(name, str) and name.startswith("custom-")
     ]
     compile_failures = []
     safety_findings = []
@@ -3446,9 +3308,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
         compile_index = 0
         for name, entry in custom_entries:
             if trust_registry.invalid_reason is not None:
-                safety_findings.append(
-                    f"{name} trusted MCP registry is invalid ({trust_registry.invalid_reason})"
-                )
+                safety_findings.append(f"{name} trusted MCP registry is invalid ({trust_registry.invalid_reason})")
                 continue
             trusted_target: Path | None = None
             if name in trust_registry.entries:
@@ -3469,11 +3329,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                     "(nightly and in deep scans), and trusts whatever it imports"
                 )
             python_targets = sorted(
-                {trusted_target} if trusted_target is not None else {
-                    target
-                    for target in _entry_targets(entry, context)
-                    if target.suffix == ".py"
-                },
+                {trusted_target}
+                if trusted_target is not None
+                else {target for target in _entry_targets(entry, context) if target.suffix == ".py"},
                 key=str,
             )
             for target in python_targets:
@@ -3485,8 +3343,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                     safety_reason = _unsafe_customization_path(context, target)
                 if safety_reason:
                     safety_findings.append(
-                        f"{name} target {relative_target} {safety_reason} and was not compiled or "
-                        "executed for safety"
+                        f"{name} target {relative_target} {safety_reason} and was not compiled or executed for safety"
                     )
                     continue
                 if not target.is_file():
@@ -3501,9 +3358,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                         doraise=True,
                     )
                 except (OSError, py_compile.PyCompileError) as error:
-                    compile_failures.append(
-                        f"{name} target {relative_target} does not compile ({_one_line(error)})"
-                    )
+                    compile_failures.append(f"{name} target {relative_target} does not compile ({_one_line(error)})")
 
     if compile_failures:
         issues = [*compile_failures, *safety_findings]
@@ -3517,9 +3372,7 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
     if safety_findings:
         relative = _display_vault_path(context, config_path)
         guidance = (
-            f"run /dex-update to restore {relative}"
-            if shipped_example
-            else f"fix your customization in {relative}"
+            f"run /dex-update to restore {relative}" if shipped_example else f"fix your customization in {relative}"
         )
         return ProbeResult(
             "UNKNOWN",
@@ -3626,28 +3479,20 @@ def _probe_vault_git(context: DoctorContext) -> ProbeResult:
             "The separate vault history is not active; the topology check reports the current layout",
         )
     git_directory = context.vault_root / ".git"
-    healthy = _git_result(
-        context, "rev-parse", "--git-dir", git_directory=git_directory
-    )
+    healthy = _git_result(context, "rev-parse", "--git-dir", git_directory=git_directory)
     if healthy.returncode != 0:
         return ProbeResult(
             "BROKEN",
             "The vault Git repository cannot be opened — your files remain on disk, but history needs repair",
         )
-    integrity = _git_result(
-        context, "fsck", "--no-progress", git_directory=git_directory
-    )
+    integrity = _git_result(context, "fsck", "--no-progress", git_directory=git_directory)
     if integrity.returncode != 0:
         return ProbeResult(
             "BROKEN",
             "The vault Git repository failed its integrity check — do not push it; repair the local history",
         )
     remotes = _git_result(context, "remote", git_directory=git_directory)
-    remote_count = (
-        len([line for line in remotes.stdout.splitlines() if line.strip()])
-        if remotes.returncode == 0
-        else 0
-    )
+    remote_count = len([line for line in remotes.stdout.splitlines() if line.strip()]) if remotes.returncode == 0 else 0
     suffix = (
         "no private backup remote configured"
         if remote_count == 0
@@ -3688,12 +3533,8 @@ def _probe_brain_git(context: DoctorContext) -> ProbeResult:
             "BROKEN",
             "The Dex brain release identity disagrees across its installed ref and topology markers — rerun /dex-update",
         )
-    configured = _git_result(
-        context, "config", "--get", "remote.origin.url", git_directory=brain
-    )
-    effective = _git_result(
-        context, "remote", "get-url", "origin", git_directory=brain
-    )
+    configured = _git_result(context, "config", "--get", "remote.origin.url", git_directory=brain)
+    effective = _git_result(context, "remote", "get-url", "origin", git_directory=brain)
     official = re.compile(
         r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)"
         r"davekilleen/Dex(?:\.git)?/?$",
@@ -3717,9 +3558,7 @@ def _probe_brain_git(context: DoctorContext) -> ProbeResult:
         )
     archive = context.vault_root / ".dex/pre-split-archive.git"
     archive_note = (
-        " The pre-split restore archive is still present."
-        if archive.is_dir() and not archive.is_symlink()
-        else ""
+        " The pre-split restore archive is still present." if archive.is_dir() and not archive.is_symlink() else ""
     )
     return ProbeResult(
         "OK",
@@ -3735,11 +3574,7 @@ def _probe_pre_split_archive(context: DoctorContext) -> ProbeResult:
     if archive.is_symlink() or not archive.is_dir():
         return ProbeResult("BROKEN", "The pre-split undo archive is not a safe directory")
     try:
-        size_bytes = sum(
-            path.stat().st_size
-            for path in archive.rglob("*")
-            if path.is_file() and not path.is_symlink()
-        )
+        size_bytes = sum(path.stat().st_size for path in archive.rglob("*") if path.is_file() and not path.is_symlink())
         age_days = max(0, int((context.now.timestamp() - archive.stat().st_mtime) // 86_400))
     except OSError as error:
         return ProbeResult("UNKNOWN", f"Could not inspect the pre-split undo archive: {_one_line(str(error))}")
@@ -3764,26 +3599,17 @@ def _probe_vault_auto_commit(context: DoctorContext) -> ProbeResult:
     except FileNotFoundError:
         profile = {}
     if not isinstance(profile, dict):
-        return ProbeResult(
-            "BROKEN", "Vault auto-commit cannot read user-profile.yaml as a mapping"
-        )
+        return ProbeResult("BROKEN", "Vault auto-commit cannot read user-profile.yaml as a mapping")
     vault_settings = profile.get("vault")
-    enabled = (
-        isinstance(vault_settings, dict)
-        and vault_settings.get("auto_commit") is True
-    )
+    enabled = isinstance(vault_settings, dict) and vault_settings.get("auto_commit") is True
     if not enabled:
-        return ProbeResult(
-            "OFF", "Vault auto-commit is off by default; local files remain untouched"
-        )
+        return ProbeResult("OFF", "Vault auto-commit is off by default; local files remain untouched")
     if _topology_state(context) != "post-split":
         return ProbeResult(
             "BROKEN",
             "Vault auto-commit is enabled before the split topology is ready — run /dex-update",
         )
-    return ProbeResult(
-        "OK", "Vault auto-commit is enabled for local snapshots and never pushes"
-    )
+    return ProbeResult("OK", "Vault auto-commit is enabled for local snapshots and never pushes")
 
 
 def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
@@ -3793,8 +3619,7 @@ def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
     if topology == "migration-pending":
         return ProbeResult(
             "OFF",
-            "Optional one-time upgrade available — run /dex-update when you want it; "
-            "notes stay in place either way",
+            "Optional one-time upgrade available — run /dex-update when you want it; notes stay in place either way",
         )
     if topology == "migration-in-progress":
         return ProbeResult(
@@ -3811,12 +3636,8 @@ def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
             "to return to the pre-split layout. Do not reinstall, restore backups, or run raw Git commands.",
         )
     if topology == "zip-or-manual":
-        return ProbeResult(
-            "OFF", "This ZIP/manual install has no Git topology; use the manual update path"
-        )
-    return ProbeResult(
-        "OFF", "This is the older combined topology; updates keep using the merge path"
-    )
+        return ProbeResult("OFF", "This ZIP/manual install has no Git topology; use the manual update path")
+    return ProbeResult("OFF", "This is the older combined topology; updates keep using the merge path")
 
 
 def _upstream_release_ref(context: DoctorContext, channel: str | None = None) -> str | None:
@@ -3859,17 +3680,9 @@ def _sanctioned_customization_path(relative: str) -> bool:
     if relative in {"System/user-profile.yaml", "System/pillars.yaml"}:
         return True
     parts = relative.split("/")
-    if (
-        len(parts) >= 3
-        and parts[:2] == [".claude", "skills"]
-        and parts[2].endswith("-custom")
-    ):
+    if len(parts) >= 3 and parts[:2] == [".claude", "skills"] and parts[2].endswith("-custom"):
         return True
-    return (
-        len(parts) == 3
-        and parts[:2] == ["System", "integrations"]
-        and Path(relative).suffix == ".yaml"
-    )
+    return len(parts) == 3 and parts[:2] == ["System", "integrations"] and Path(relative).suffix == ".yaml"
 
 
 def _git_file(
@@ -3984,9 +3797,9 @@ def _only_sanctioned_file_changes(
     if relative == "CLAUDE.md":
         return _strip_user_extensions(baseline_text) == _strip_user_extensions(working_text)
     if relative == ".gitignore":
-        return _without_vault_mode_gitignore_section(
-            baseline_text
-        ) == _without_vault_mode_gitignore_section(working_text)
+        return _without_vault_mode_gitignore_section(baseline_text) == _without_vault_mode_gitignore_section(
+            working_text
+        )
     if relative == ".mcp.json":
         baseline_config = _mcp_without_custom_entries(baseline_text)
         working_config = _mcp_without_custom_entries(working_text)
@@ -4033,12 +3846,7 @@ def _worktree_blob_mode_matches(
     mode: str,
 ) -> bool:
     parts = Path(relative).parts
-    if (
-        not parts
-        or "\n" in relative
-        or "\r" in relative
-        or any(part in {"", ".", ".."} for part in parts)
-    ):
+    if not parts or "\n" in relative or "\r" in relative or any(part in {"", ".", ".."} for part in parts):
         return False
     current = context.repo_root
     for part in parts[:-1]:
@@ -4088,13 +3896,7 @@ def _worktree_blob_ids(
 
 
 def _symlink_matches_release_blob(path: Path, object_id: str) -> bool:
-    algorithm = (
-        "sha1"
-        if len(object_id) == 40
-        else "sha256"
-        if len(object_id) == 64
-        else None
-    )
+    algorithm = "sha1" if len(object_id) == 40 else "sha256" if len(object_id) == 64 else None
     if algorithm is None:
         return False
     try:
@@ -4114,8 +3916,7 @@ def _mismatched_release_blobs(
     hashable = [
         relative
         for relative, (mode, _object_id) in entries.items()
-        if mode != "120000"
-        and _worktree_blob_mode_matches(context, relative, mode)
+        if mode != "120000" and _worktree_blob_mode_matches(context, relative, mode)
     ]
     worktree_ids = _worktree_blob_ids(context, hashable)
     return {
@@ -4174,9 +3975,7 @@ def _brain_paths_from_installed_release(
         try:
             resolution = portable_contract.resolve(relative)
         except portable_contract.ContractViolation as error:
-            raise RuntimeError(
-                f"installed brain release has an unclassified path: {relative}"
-            ) from error
+            raise RuntimeError(f"installed brain release has an unclassified path: {relative}") from error
         if resolution.ownership == "brain":
             paths.add(relative)
     return paths
@@ -4232,9 +4031,7 @@ def _installer_normalized_package_metadata(
     if relative == "package.json":
         baseline_scripts = baseline_value.get("scripts")
         current_scripts = current_value.get("scripts")
-        if not isinstance(baseline_scripts, Mapping) or not isinstance(
-            current_scripts, Mapping
-        ):
+        if not isinstance(baseline_scripts, Mapping) or not isinstance(current_scripts, Mapping):
             return False
         for name, command in baseline_scripts.items():
             if current_scripts.get(name) != command:
@@ -4252,15 +4049,11 @@ def _installer_normalized_package_metadata(
 
     baseline_packages = baseline_value.get("packages")
     current_packages = current_value.get("packages")
-    if not isinstance(baseline_packages, Mapping) or not isinstance(
-        current_packages, Mapping
-    ):
+    if not isinstance(baseline_packages, Mapping) or not isinstance(current_packages, Mapping):
         return False
     baseline_root = baseline_packages.get("")
     current_root = current_packages.get("")
-    if not isinstance(baseline_root, Mapping) or not isinstance(
-        current_root, Mapping
-    ):
+    if not isinstance(baseline_root, Mapping) or not isinstance(current_root, Mapping):
         return False
     package_version = current_package["version"]
     if (
@@ -4296,15 +4089,9 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
                 "UNKNOWN",
                 "the brain Git store cannot resolve refs/dex/installed — rerun /dex-update",
             )
-        release_entries = _release_tree_entries(
-            context, baseline, git_directory=brain
-        )
+        release_entries = _release_tree_entries(context, baseline, git_directory=brain)
         brain_paths = _brain_paths_from_installed_release(context, baseline, brain)
-        brain_entries = {
-            relative: release_entries[relative]
-            for relative in brain_paths
-            if relative in release_entries
-        }
+        brain_entries = {relative: release_entries[relative] for relative in brain_paths if relative in release_entries}
         mismatched = _mismatched_release_blobs(
             context,
             brain_entries,
@@ -4329,13 +4116,10 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
             )
         )
         if not drifted:
-            return ProbeResult(
-                "OK", "No shipped brain files differ from refs/dex/installed"
-            )
+            return ProbeResult("OK", "No shipped brain files differ from refs/dex/installed")
         return ProbeResult(
             "UNKNOWN",
-            "Modified shipped brain files: "
-            f"{', '.join(drifted)}; the updater snapshots them before replacement",
+            f"Modified shipped brain files: {', '.join(drifted)}; the updater snapshots them before replacement",
         )
 
     channel = release_channel.read_channel(context.vault_root)
@@ -4372,14 +4156,12 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
     candidates = sorted(
         relative
         for relative in mismatched
-        if _is_shipped_drift_candidate(relative)
-        and not _sanctioned_customization_path(relative)
+        if _is_shipped_drift_candidate(relative) and not _sanctioned_customization_path(relative)
     )
     drifted = [
         relative
         for relative in candidates
-        if relative not in COMPOSED_SHIPPED_PATHS
-        or not _only_sanctioned_file_changes(context, baseline, relative)
+        if relative not in COMPOSED_SHIPPED_PATHS or not _only_sanctioned_file_changes(context, baseline, relative)
     ]
     if not drifted:
         return ProbeResult("OK", "No tracked shipped files differ from the installed release")
@@ -4403,9 +4185,7 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         people_dir = context.core_path("PEOPLE_DIR")
         companies_dir = context.core_path("COMPANIES_DIR")
         people_index_path = context.core_path("PEOPLE_INDEX_FILE")
-        dead_letter_path = (
-            context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
-        )
+        dead_letter_path = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
 
         contacts = json.loads(contacts_path.read_text()) if contacts_path.exists() else {}
         suggestions = json.loads(suggestions_path.read_text()) if suggestions_path.exists() else {}
@@ -4475,10 +4255,14 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
                 if page.name != "README.md" and parse_entity_page(page).get("quarantined"):
                     quarantined_paths.append(str(page.relative_to(context.vault_root)))
 
-        newest_people_mtime = max(
-            (page.stat().st_mtime for page in people_dir.rglob("*.md") if page.name != "README.md"),
-            default=0.0,
-        ) if people_dir.exists() else 0.0
+        newest_people_mtime = (
+            max(
+                (page.stat().st_mtime for page in people_dir.rglob("*.md") if page.name != "README.md"),
+                default=0.0,
+            )
+            if people_dir.exists()
+            else 0.0
+        )
         index_freshness = "missing"
         if people_index_path.exists():
             people_index = json.loads(people_index_path.read_text())
@@ -4890,18 +4674,14 @@ def _probe_backup_freshness(context: DoctorContext) -> ProbeResult:
     warnings = stamp.get("warnings")
     if isinstance(warnings, list) and warnings:
         detail = "; ".join(_one_line(str(item)) for item in warnings[:3])
-        return ProbeResult("BROKEN", f"{summary}, but it stored less than a full "
-                                     f"backup: {detail}", _BACKUP_HEAL)
+        return ProbeResult("BROKEN", f"{summary}, but it stored less than a full backup: {detail}", _BACKUP_HEAL)
     return ProbeResult("OK", summary)
 
 
 def _calendar_permission_status(_context: DoctorContext) -> str:
     if not _is_macos():
         return "unsupported"
-    code = (
-        "import EventKit; "
-        "print(EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeEvent))"
-    )
+    code = "import EventKit; print(EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeEvent))"
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
@@ -5045,7 +4825,11 @@ def _qmd_registered(config: dict[str, Any]) -> bool:
             continue
         command = str(entry.get("command", ""))
         args = [str(argument) for argument in entry.get("args", []) if isinstance(argument, str)]
-        if "qmd" in name.lower() or Path(command).name == "qmd" or any(Path(argument).name == "qmd" for argument in args):
+        if (
+            "qmd" in name.lower()
+            or Path(command).name == "qmd"
+            or any(Path(argument).name == "qmd" for argument in args)
+        ):
             return True
     return False
 
@@ -5245,9 +5029,7 @@ def _probe_integrations_enabled(context: DoctorContext) -> ProbeResult:
         if status in {"needs_reauth", "not_connected"}:
             failures.append(f"{service}: {status}")
         elif row.get("verified") is not True:
-            unknowns.append(
-                f"{service}: stored credential has not been live-verified"
-            )
+            unknowns.append(f"{service}: stored credential has not been live-verified")
     if failures:
         detail_parts = [f"failed: {'; '.join(failures)}"]
         if unknowns:
@@ -5324,10 +5106,7 @@ def _probe_mcp_importable(context: DoctorContext) -> ProbeResult:
         if missing_dependencies:
             noun = "dependency" if len(missing_dependencies) == 1 else "dependencies"
             named = ", ".join(repr(name) for name in sorted(missing_dependencies))
-            remedies.append(
-                f"Reinstall missing MCP {noun} {named} into the vault .venv, "
-                "then re-run /dex-doctor."
-            )
+            remedies.append(f"Reinstall missing MCP {noun} {named} into the vault .venv, then re-run /dex-doctor.")
         if unclassified_failure:
             remedies.append("Reinstall the missing MCP dependencies into the vault .venv.")
         return ProbeResult(
@@ -5408,10 +5187,7 @@ def _smoke_attribution_paths(context: DoctorContext) -> list[Path]:
     paths_to_check.extend(sorted((system / "integrations").glob("*.yaml")))
     custom_skills = context.vault_root / ".claude" / "skills"
     paths_to_check.extend(
-        path
-        for root in sorted(custom_skills.glob("*-custom"))
-        for path in sorted(root.rglob("*"))
-        if path.is_file()
+        path for root in sorted(custom_skills.glob("*-custom")) for path in sorted(root.rglob("*")) if path.is_file()
     )
     return paths_to_check
 
@@ -5455,11 +5231,7 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         )
 
     prior_good_index = next(
-        (
-            index
-            for index in range(len(entries) - 2, -1, -1)
-            if entries[index]["summary"].get("broken") == 0
-        ),
+        (index for index in range(len(entries) - 2, -1, -1) if entries[index]["summary"].get("broken") == 0),
         None,
     )
     broken_ids = ", ".join(journey["id"] for journey in broken)
@@ -5470,11 +5242,7 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         )
 
     good_entry = entries[prior_good_index]
-    first_broken = next(
-        entry
-        for entry in entries[prior_good_index + 1 :]
-        if entry["summary"].get("broken", 0) > 0
-    )
+    first_broken = next(entry for entry in entries[prior_good_index + 1 :] if entry["summary"].get("broken", 0) > 0)
     window_start = _smoke_timestamp(good_entry)
     window_end = _smoke_timestamp(first_broken)
     facts = []
@@ -5484,9 +5252,7 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         except OSError:
             continue
         if window_start < modified <= window_end:
-            facts.append(
-                f"{_smoke_attribution_name(path, context)} modified {modified.isoformat()}"
-            )
+            facts.append(f"{_smoke_attribution_name(path, context)} modified {modified.isoformat()}")
     old_version = good_entry.get("dex_version")
     new_version = first_broken.get("dex_version")
     if isinstance(old_version, str) and isinstance(new_version, str) and old_version != new_version:
@@ -5507,16 +5273,8 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
 def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
     smoke_path = context.repo_root / "core" / "utils" / "smoke.py"
     vault_python = context.vault_root / ".venv" / "bin" / "python"
-    interpreter = (
-        str(vault_python)
-        if vault_python.is_file() and os.access(vault_python, os.X_OK)
-        else sys.executable
-    )
-    env = {
-        name: os.environ[name]
-        for name in ("PATH", "PYTHONPATH")
-        if name in os.environ
-    }
+    interpreter = str(vault_python) if vault_python.is_file() and os.access(vault_python, os.X_OK) else sys.executable
+    env = {name: os.environ[name] for name in ("PATH", "PYTHONPATH") if name in os.environ}
     env.update(
         {
             "VAULT_PATH": str(context.vault_root),
@@ -5572,9 +5330,7 @@ def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
     else:
         worst = "OFF"
     if (result.returncode == 1) != (worst == "BROKEN"):
-        raise RuntimeError(
-            f"smoke harness exit {result.returncode} did not match its {worst} journey roll-up"
-        )
+        raise RuntimeError(f"smoke harness exit {result.returncode} did not match its {worst} journey roll-up")
     return ProbeResult(worst, " | ".join(rendered))
 
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -37,13 +37,21 @@ from core.lifecycle.model import ITEM_ID, SEMVER, AdoptionState
 from core.lifecycle.plan import PlannedAction, ReasonCode, build_adoption_plan
 from core.transaction.engine import TX_ROOT_RELATIVE, PlanEntry, PlanRejected
 from core.transaction.journal import Journal, JournalCorruptError
-from core.utils import apple_mail_health, automation_ownership, dex_logger, launch_agents, preflight, release_channel
+from core.utils import (
+    apple_mail_health,
+    automation_ownership,
+    dex_logger,
+    launch_agents,
+    preflight,
+    release_channel,
+)
 
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
 QMD_STATUS_TIMEOUT_SECONDS = 10
 MISSING_PACKAGES_DETAIL = (
-    "Python packages not installed — run /dex-update (or pip install -r requirements.txt) then re-run /dex-doctor"
+    "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
+    "then re-run /dex-doctor"
 )
 RELEASE_CATALOG_PATH = "System/.release-catalog.json"
 KNOWN_SKILL_CONTAINER_DIRECTORIES = frozenset({"_available", "integrations"})
@@ -60,13 +68,20 @@ ADOPTION_STATUSES = frozenset(state.value for state in AdoptionState)
 ADOPTION_REASON_CODES = frozenset(reason.value for reason in ReasonCode)
 INSTALLER_STRIPPED_PACKAGE_SCRIPTS = {
     "test:hooks": "node --test .claude/hooks/tests/*.test.cjs",
-    "test:scripts": ("node --test .scripts/lib/tests/*.test.cjs .scripts/meeting-intel/__tests__/*.test.cjs"),
-    "test:integrations": ("node --test core/integrations/connection-manager/*.test.cjs"),
+    "test:scripts": (
+        "node --test .scripts/lib/tests/*.test.cjs "
+        ".scripts/meeting-intel/__tests__/*.test.cjs"
+    ),
+    "test:integrations": (
+        "node --test core/integrations/connection-manager/*.test.cjs"
+    ),
     "check:connections-contract": (
-        "node scripts/check-connections-contract.mjs && node scripts/build-connections-engine-manifest.mjs --check"
+        "node scripts/check-connections-contract.mjs && "
+        "node scripts/build-connections-engine-manifest.mjs --check"
     ),
     "test:connections-consumer-smoke": (
-        "node --test core/integrations/connection-manager/connections-contract.test.cjs"
+        "node --test "
+        "core/integrations/connection-manager/connections-contract.test.cjs"
     ),
 }
 
@@ -74,7 +89,9 @@ INSTALLER_STRIPPED_PACKAGE_SCRIPTS = {
 def _validate_authority_item(item_id: object, item_version: object) -> None:
     if not isinstance(item_id, str) or ITEM_ID.fullmatch(item_id) is None:
         raise ValueError("Adoption authority item_id is not canonical")
-    if item_version is not None and (not isinstance(item_version, str) or SEMVER.fullmatch(item_version) is None):
+    if item_version is not None and (
+        not isinstance(item_version, str) or SEMVER.fullmatch(item_version) is None
+    ):
         raise ValueError("Adoption authority item_version is not strict SemVer")
 
 
@@ -224,7 +241,9 @@ class AdoptionReviewItem:
             or any(reason not in ADOPTION_REASON_CODES for reason in self.reasons)
         ):
             raise ValueError("Adoption review reasons use an invalid authority value")
-        if not isinstance(self.files, tuple) or any(type(entry) is not AdoptionReviewFile for entry in self.files):
+        if not isinstance(self.files, tuple) or any(
+            type(entry) is not AdoptionReviewFile for entry in self.files
+        ):
             raise ValueError("Adoption review files must be AdoptionReviewFile records")
 
     def to_dict(self) -> dict[str, object]:
@@ -431,7 +450,11 @@ class ReceiptsAndRewindGroup:
 
 
 AdoptionGroup = (
-    NewAndSafeGroup | NeedsReviewGroup | PreservedForNowGroup | ContinueOrRecoverGroup | ReceiptsAndRewindGroup
+    NewAndSafeGroup
+    | NeedsReviewGroup
+    | PreservedForNowGroup
+    | ContinueOrRecoverGroup
+    | ReceiptsAndRewindGroup
 )
 
 
@@ -474,7 +497,9 @@ class AdoptionReport:
                 raise ValueError("Adoption group count must be a non-negative integer")
             _validate_surface(group.surface)
         new_group, review_group, preserved_group, recovery_group, receipt_group = self.groups
-        if not isinstance(new_group.items, tuple) or any(type(item) is not AdoptionItem for item in new_group.items):
+        if not isinstance(new_group.items, tuple) or any(
+            type(item) is not AdoptionItem for item in new_group.items
+        ):
             raise ValueError("new-and-safe items must be AdoptionItem records")
         if any(item.action != PlannedAction.ADOPT.value for item in new_group.items):
             raise ValueError("new-and-safe items must have action adopt")
@@ -486,25 +511,35 @@ class AdoptionReport:
             type(item) is not AdoptionItem for item in preserved_group.held_back_items
         ):
             raise ValueError("preserved held-back items must be AdoptionItem records")
-        if any(item.action != PlannedAction.SKIP_HELD_BACK.value for item in preserved_group.held_back_items):
+        if any(
+            item.action != PlannedAction.SKIP_HELD_BACK.value
+            for item in preserved_group.held_back_items
+        ):
             raise ValueError("preserved held-back items must have action skip-held-back")
         if not isinstance(preserved_group.customized_files, tuple) or any(
-            type(item) is not PreservedCustomization for item in preserved_group.customized_files
+            type(item) is not PreservedCustomization
+            for item in preserved_group.customized_files
         ):
             raise ValueError("preserved customized files must be strict authority records")
         if not isinstance(recovery_group.transactions, tuple) or any(
-            type(item) is not InterruptedTransaction for item in recovery_group.transactions
+            type(item) is not InterruptedTransaction
+            for item in recovery_group.transactions
         ):
             raise ValueError("recovery transactions must be strict authority records")
         if recovery_group.ledger is not None and type(recovery_group.ledger) is not LedgerRecovery:
             raise ValueError("recovery ledger must be a LedgerRecovery record or null")
-        if recovery_group.inspection_error is not None and not isinstance(recovery_group.inspection_error, str):
+        if recovery_group.inspection_error is not None and not isinstance(
+            recovery_group.inspection_error, str
+        ):
             raise ValueError("recovery inspection_error must be a string or null")
         if not isinstance(receipt_group.receipts, tuple) or any(
             type(item) is not AdoptionReceiptSummary for item in receipt_group.receipts
         ):
             raise ValueError("receipt summaries must be strict authority records")
-        if any(item.status != AdoptionState.ADOPTED.value for item in receipt_group.receipts):
+        if any(
+            item.status != AdoptionState.ADOPTED.value
+            for item in receipt_group.receipts
+        ):
             raise ValueError("receipt summaries must have status adopted")
         expected_counts = (
             len(new_group.items),
@@ -824,7 +859,11 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             pass
         if current_paths != expected_paths:
             relative = context.paths_json_path.relative_to(context.vault_root).as_posix()
-            mode = context.paths_json_path.stat().st_mode & 0o777 if context.paths_json_path.is_file() else 0o644
+            mode = (
+                context.paths_json_path.stat().st_mode & 0o777
+                if context.paths_json_path.is_file()
+                else 0o644
+            )
             planned.append(
                 PlanEntry(
                     relative,
@@ -848,7 +887,9 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             try:
                 relative = script.relative_to(context.vault_root).as_posix()
             except ValueError:
-                errors.append(f"Executable-mode repair requires user action outside the vault: {script}")
+                errors.append(
+                    f"Executable-mode repair requires user action outside the vault: {script}"
+                )
                 continue
             planned.append(
                 PlanEntry(
@@ -869,7 +910,9 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
             # Findings that cannot be auto-tightened (foreign owner, symlink)
             # carry their own Tier-3 guidance and are never attempted here.
             _tighten_env_permissions(context)
-            actions.setdefault("vault.configs", []).append("tightened .env to owner-only permissions")
+            actions.setdefault("vault.configs", []).append(
+                "tightened .env to owner-only permissions"
+            )
     except OSError as error:
         errors.append(f".env permission heal failed: {_one_line(error)}")
 
@@ -890,13 +933,19 @@ def _apply_t1_heals(context: DoctorContext) -> tuple[dict[str, list[str]], list[
         acknowledged = _acknowledge_resolved_preflight_errors(context)
         if acknowledged:
             noun = "error" if acknowledged == 1 else "errors"
-            actions.setdefault("preflight.queue", []).append(f"acknowledged {acknowledged} resolved preflight {noun}")
+            actions.setdefault("preflight.queue", []).append(
+                f"acknowledged {acknowledged} resolved preflight {noun}"
+            )
     except Exception as error:
         errors.append(f"Preflight-queue heal failed: {_one_line(error)}")
 
     try:
         room_health = _probe_capability_rooms(context)
-        if room_health.verdict == "BROKEN" and room_health.heal is not None and room_health.heal.tier == 1:
+        if (
+            room_health.verdict == "BROKEN"
+            and room_health.heal is not None
+            and room_health.heal.tier == 1
+        ):
             from core import capabilities
 
             reconciled = capabilities.reconcile_all(
@@ -1004,7 +1053,10 @@ def collect(
             truthful_missing_diagnosis = bool(
                 missing_module
                 and (
-                    (dex_logger.is_dex_module(missing_module) and "Dex checkup fault" in result.detail)
+                    (
+                        dex_logger.is_dex_module(missing_module)
+                        and "Dex checkup fault" in result.detail
+                    )
                     or (
                         not dex_logger.is_dex_module(missing_module)
                         and f"missing module {missing_module!r}" in result.detail
@@ -1053,7 +1105,8 @@ def collect(
                     result = replace(
                         result,
                         detail=(
-                            f"{result.detail.rstrip('.')}; a safe Tier-1 repair separately " + "; ".join(check_actions)
+                            f"{result.detail.rstrip('.')}; a safe Tier-1 repair separately "
+                            + "; ".join(check_actions)
                         ),
                     )
             if definition.id == "capabilities.rooms" and check_actions:
@@ -1095,11 +1148,19 @@ def collect(
     }
     if deep:
         assessment_result = results.get("customizations.assessment")
-        if assessment_result is not None and assessment_result.structured_detail is not None:
+        if (
+            assessment_result is not None
+            and assessment_result.structured_detail is not None
+        ):
             report["customization_assessment"] = assessment_result.structured_detail
         migration_status_result = results.get("customizations.migration-status")
-        if migration_status_result is not None and migration_status_result.structured_detail is not None:
-            report["customization_migration_status"] = migration_status_result.structured_detail
+        if (
+            migration_status_result is not None
+            and migration_status_result.structured_detail is not None
+        ):
+            report["customization_migration_status"] = (
+                migration_status_result.structured_detail
+            )
 
     try:
         _write_last_run(report, context)
@@ -1299,7 +1360,11 @@ def _empty_adoption_report(
     inspection_error: str | None = None,
 ) -> AdoptionReport:
     recovery_count = len(transactions) + int(ledger is not None) + int(inspection_error is not None)
-    recovery_surface = _recovery_surface(transactions, ledger, inspection_error) if recovery_count else surface
+    recovery_surface = (
+        _recovery_surface(transactions, ledger, inspection_error)
+        if recovery_count
+        else surface
+    )
     return AdoptionReport(
         ADOPTION_REPORT_VERSION,
         verdict,
@@ -1343,10 +1408,14 @@ def _inspect_interrupted_transactions(
         return (), f"Transaction store could not be inspected: {_one_line(error)}"
     for tx_dir in candidates:
         if lifecycle_engine.TRANSACTION_ID.fullmatch(tx_dir.name) is None:
-            inspection_errors.append(f"Transaction store contains a non-canonical entry: {tx_dir.name}")
+            inspection_errors.append(
+                f"Transaction store contains a non-canonical entry: {tx_dir.name}"
+            )
             continue
         if tx_dir.is_symlink() or not tx_dir.is_dir():
-            interrupted.append(InterruptedTransaction(tx_dir.name, "UNKNOWN", None, False))
+            interrupted.append(
+                InterruptedTransaction(tx_dir.name, "UNKNOWN", None, False)
+            )
             continue
         try:
             entries = Journal(tx_dir / "journal.jsonl").read()
@@ -1518,7 +1587,11 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
         plan = build_adoption_plan(
             catalog,
             inventory,
-            adoption_states={item_id: AdoptionState.ADOPTED for item_id in adopted if item_id in catalog_ids},
+            adoption_states={
+                item_id: AdoptionState.ADOPTED
+                for item_id in adopted
+                if item_id in catalog_ids
+            },
             held_back=frozenset(held_back & catalog_ids),
         )
     except Exception as error:
@@ -1540,7 +1613,11 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
             item.item_version,
             item.action.value,
             tuple(reason.code.value for reason in item.reasons),
-            tuple(AdoptionReviewFile(path, reason.code.value) for reason in item.reasons for path in reason.paths),
+            tuple(
+                AdoptionReviewFile(path, reason.code.value)
+                for reason in item.reasons
+                for path in reason.paths
+            ),
         )
         for item in plan.items
         if item.action in {PlannedAction.CONFLICT, PlannedAction.UNKNOWN}
@@ -1589,18 +1666,22 @@ def collect_adoption_report(context: DoctorContext) -> AdoptionReport:
     recovery_verdict = (
         "UNKNOWN"
         if inspection_error is not None or any(tx.verdict == "UNKNOWN" for tx in transactions)
-        else "BROKEN"
-        if transactions
+        else "BROKEN" if transactions else "OK"
+    )
+    review_verdict = (
+        "UNKNOWN"
+        if any(item.action is PlannedAction.UNKNOWN for item in plan.items)
         else "OK"
     )
-    review_verdict = "UNKNOWN" if any(item.action is PlannedAction.UNKNOWN for item in plan.items) else "OK"
-    receipts_verdict = "UNKNOWN" if any(receipt.rewind_verdict == "UNKNOWN" for receipt in receipts) else "OK"
+    receipts_verdict = (
+        "UNKNOWN"
+        if any(receipt.rewind_verdict == "UNKNOWN" for receipt in receipts)
+        else "OK"
+    )
     report_verdict = (
         "UNKNOWN"
         if "UNKNOWN" in {recovery_verdict, review_verdict, receipts_verdict}
-        else "BROKEN"
-        if recovery_verdict == "BROKEN"
-        else "OK"
+        else "BROKEN" if recovery_verdict == "BROKEN" else "OK"
     )
     return AdoptionReport(
         ADOPTION_REPORT_VERSION,
@@ -1683,7 +1764,8 @@ def _probe_adoption_plan(context: DoctorContext) -> ProbeResult:
     counts = result["plan"]["counts"]
     return ProbeResult(
         "OK",
-        f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / {counts['conflict']} conflicts",
+        f"{counts['adopt']} adoptable / {counts['already-adopted']} adopted / "
+        f"{counts['conflict']} conflicts",
     )
 
 
@@ -1712,7 +1794,9 @@ def _probe_customization_assessment(context: DoctorContext) -> ProbeResult:
     from core.customization_migration.service import assess
 
     assessment = assess(context.vault_root)
-    authority = _customization_persistence_detail(assessment_report(assessment))
+    authority = _customization_persistence_detail(
+        assessment_report(assessment)
+    )
     catalog_path = _release_catalog_path(context)
     if os.path.lexists(catalog_path):
         try:
@@ -1726,7 +1810,8 @@ def _probe_customization_assessment(context: DoctorContext) -> ProbeResult:
     if assessment.baseline_identity_state != "VERIFIED":
         return ProbeResult(
             "UNKNOWN",
-            "I couldn't verify which Dex version is installed, so I can't tell you what you've changed.",
+            "I couldn't verify which Dex version is installed, so I can't tell you "
+            "what you've changed.",
             structured_detail=authority,
         )
     if assessment.completeness == "UNKNOWN":
@@ -1770,7 +1855,9 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
         from core.customization_migration.service import migration_status_to_dict
     except ModuleNotFoundError as error:
         missing = error.name or ""
-        if missing == "core.customization_migration" or missing.startswith("core.customization_migration."):
+        if missing == "core.customization_migration" or missing.startswith(
+            "core.customization_migration."
+        ):
             return ProbeResult(
                 "OFF",
                 "Customization migration status is unavailable on this older Dex release",
@@ -1805,7 +1892,13 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
     recovery_token = authority.get("recovery_token")
     if (
         not isinstance(recovery_actions, list)
-        or (recovery_actions and (not isinstance(recovery_token, str) or len(recovery_token) != 64))
+        or (
+            recovery_actions
+            and (
+                not isinstance(recovery_token, str)
+                or len(recovery_token) != 64
+            )
+        )
         or (not recovery_actions and recovery_token is not None)
     ):
         return ProbeResult(
@@ -1813,7 +1906,8 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             "The customization recovery status is structurally incomplete",
         )
     expected_recovery_action = (
-        f"python3 -m core.customization_migration.cli recover --confirm-token {recovery_token}"
+        "python3 -m core.customization_migration.cli recover "
+        f"--confirm-token {recovery_token}"
         if isinstance(recovery_token, str)
         else None
     )
@@ -1838,7 +1932,10 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 "rewind",
             }
             or not isinstance(recovery["capsule_id"], str)
-            or (recovery["proposal_id"] is not None and not isinstance(recovery["proposal_id"], str))
+            or (
+                recovery["proposal_id"] is not None
+                and not isinstance(recovery["proposal_id"], str)
+            )
             or recovery["action"] != expected_recovery_action
         ):
             return ProbeResult(
@@ -1859,17 +1956,19 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
         capsule_id = capsule.get("capsule_id")
         state = capsule.get("state")
         validation = capsule.get("validation")
-        if not isinstance(capsule_id, str) or not isinstance(state, str) or not isinstance(validation, dict):
+        if (
+            not isinstance(capsule_id, str)
+            or not isinstance(state, str)
+            or not isinstance(validation, dict)
+        ):
             return ProbeResult(
                 "UNKNOWN",
                 "The customization migration status contains incomplete capsule authority",
             )
         status = validation.get("status")
         mismatches = validation.get("mismatches")
-        if (
-            not isinstance(status, str)
-            or not isinstance(mismatches, list)
-            or any(not isinstance(item, str) for item in mismatches)
+        if not isinstance(status, str) or not isinstance(mismatches, list) or any(
+            not isinstance(item, str) for item in mismatches
         ):
             return ProbeResult(
                 "UNKNOWN",
@@ -1880,7 +1979,9 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             verification_verdicts = capsule.get("verification_verdicts")
             pending_rebuild = capsule.get("pending_rebuild")
             activation = capsule.get("activation")
-            activation_receipt_present = capsule.get("activation_receipt_present")
+            activation_receipt_present = capsule.get(
+                "activation_receipt_present"
+            )
             rewindable = capsule.get("rewindable")
             if (
                 not isinstance(staging, dict)
@@ -1902,7 +2003,8 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 or type(staging_truncated) is not bool
                 or set(verification_verdicts) != {"OK", "BLOCKED", "UNKNOWN"}
                 or any(
-                    type(verification_verdicts[key]) is not int or verification_verdicts[key] < 0
+                    type(verification_verdicts[key]) is not int
+                    or verification_verdicts[key] < 0
                     for key in ("OK", "BLOCKED", "UNKNOWN")
                 )
             ):
@@ -1916,14 +2018,17 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                     not isinstance(proposal, dict)
                     or not isinstance(proposal.get("proposal_id"), str)
                     or not isinstance(proposal.get("state"), str)
-                    or proposal.get("verification_verdict") not in counted_verdicts
+                    or proposal.get("verification_verdict")
+                    not in counted_verdicts
                 ):
                     return ProbeResult(
                         "UNKNOWN",
                         "The customization staging status contains a malformed proposal",
                     )
                 counted_verdicts[proposal["verification_verdict"]] += 1
-                rebuild_broken = rebuild_broken or (proposal["state"] == "recovery-required")
+                rebuild_broken = rebuild_broken or (
+                    proposal["state"] == "recovery-required"
+                )
             if counted_verdicts != verification_verdicts:
                 return ProbeResult(
                     "UNKNOWN",
@@ -1940,12 +2045,16 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
             if (
                 set(activation) != activation_required
                 or activation.get("capsule_id") != capsule_id
-                or (activation.get("proposal_id") is not None and not isinstance(activation.get("proposal_id"), str))
+                or (
+                    activation.get("proposal_id") is not None
+                    and not isinstance(activation.get("proposal_id"), str)
+                )
                 or not isinstance(activation.get("state"), str)
                 or not isinstance(activation.get("reason"), str)
                 or type(activation.get("activation_receipt_present")) is not bool
                 or type(activation.get("rewindable")) is not bool
-                or activation_receipt_present != activation["activation_receipt_present"]
+                or activation_receipt_present
+                != activation["activation_receipt_present"]
                 or rewindable != activation["rewindable"]
             ):
                 return ProbeResult(
@@ -1954,12 +2063,17 @@ def _probe_customization_migration_status(context: DoctorContext) -> ProbeResult
                 )
             pending = pending or pending_rebuild
             rebuild_broken = rebuild_broken or (
-                verification_verdicts["BLOCKED"] > 0 or activation["state"] == "recovery-required"
+                verification_verdicts["BLOCKED"] > 0
+                or activation["state"] == "recovery-required"
             )
             rebuild_unknown = rebuild_unknown or (
                 staging_truncated
                 or verification_verdicts["UNKNOWN"] > 0
-                or (activation_receipt_present and activation["state"] not in {"activated", "rewound"})
+                or (
+                    activation_receipt_present
+                    and activation["state"]
+                    not in {"activated", "rewound"}
+                )
             )
         else:
             pending = pending or state == "capsule-created"
@@ -2013,7 +2127,11 @@ def _mcp_config_path(context: DoctorContext) -> Path:
 
 def _load_mcp_config(context: DoctorContext) -> dict[str, Any]:
     loaded = json.loads(_mcp_config_path(context).read_text())
-    if not isinstance(loaded, dict) or "mcpServers" not in loaded or not isinstance(loaded["mcpServers"], dict):
+    if (
+        not isinstance(loaded, dict)
+        or "mcpServers" not in loaded
+        or not isinstance(loaded["mcpServers"], dict)
+    ):
         raise ValueError(".mcp.json must contain an mcpServers object")
     return loaded
 
@@ -2147,7 +2265,9 @@ def _probe_mcp_orphans(context: DoctorContext) -> ProbeResult:
     except FileNotFoundError:
         config = {"mcpServers": {}}
     registered = {
-        target.resolve() for entry in config["mcpServers"].values() for target in _entry_targets(entry, context)
+        target.resolve()
+        for entry in config["mcpServers"].values()
+        for target in _entry_targets(entry, context)
     }
     orphans = [path.name for resolved, path in shipped.items() if resolved not in registered]
     if orphans:
@@ -2290,7 +2410,10 @@ def _installed_launch_agents(context: DoctorContext) -> list[tuple[Path, bool]]:
     directory = context.launch_agents_dir
     if not directory.is_dir():
         return []
-    return sorted((path, launch_agents.is_dex_named(path.name)) for path in directory.glob("*.plist"))
+    return sorted(
+        (path, launch_agents.is_dex_named(path.name))
+        for path in directory.glob("*.plist")
+    )
 
 
 def _stored_former_vault_root(context: DoctorContext) -> Path | None:
@@ -2378,7 +2501,10 @@ def _with_skipped_launch_agents(detail: str, skipped_count: int) -> str:
 
 
 def _unattributable_launch_agent_detail(plist: Path, error: Exception) -> str:
-    return f"Could not determine whether {plist.name} belongs to this vault ({_one_line(error)})"
+    return (
+        f"Could not determine whether {plist.name} belongs to this vault "
+        f"({_one_line(error)})"
+    )
 
 
 def _plist_configuration_issue(plist: Path, data: dict[str, Any], context: DoctorContext) -> str | None:
@@ -2567,7 +2693,11 @@ def _classify_launch_agents(context: DoctorContext) -> LaunchAgentScan:
             # The agent points at this vault's stored former location. That
             # is this vault's job left behind by a move or rename —
             # owned-and-stale, never another product's (issue #364).
-            records.append(LaunchAgentRecord(plist=plist, classification=_STALE, label=label, data=data))
+            records.append(
+                LaunchAgentRecord(
+                    plist=plist, classification=_STALE, label=label, data=data
+                )
+            )
         elif dex_named:
             records.append(
                 LaunchAgentRecord(
@@ -2780,9 +2910,17 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
         return None
 
     scan = _scan_launch_agents(context)
-    unknowns = [record.error_detail for record in scan.records if record.classification == _UNREADABLE]
-    installed = sorted({record.label for record in scan.records if record.classification == _OWNED})
-    offloaded = sorted({record.label for record in scan.records if record.classification == _OFFLOADED})
+    unknowns = [
+        record.error_detail
+        for record in scan.records
+        if record.classification == _UNREADABLE
+    ]
+    installed = sorted(
+        {record.label for record in scan.records if record.classification == _OWNED}
+    )
+    offloaded = sorted(
+        {record.label for record in scan.records if record.classification == _OFFLOADED}
+    )
     offloaded_note = (
         f"{len(offloaded)} launch agent{' is' if len(offloaded) == 1 else 's are'} "
         "owned by Dex Solo and offloaded from Core"
@@ -2914,7 +3052,11 @@ def _acknowledge_resolved_preflight_errors(context: DoctorContext) -> int:
             return 0
         acknowledged = 0
         for entry in entries:
-            if isinstance(entry, dict) and entry.get("id") in resolved and not entry.get("acknowledged", False):
+            if (
+                isinstance(entry, dict)
+                and entry.get("id") in resolved
+                and not entry.get("acknowledged", False)
+            ):
                 entry["acknowledged"] = True
                 entry["acknowledgedAt"] = context.now.astimezone(timezone.utc).isoformat()
                 acknowledged += 1
@@ -2962,13 +3104,28 @@ def _historical_error_summary(
     count = len(entries)
     subject = "1 earlier error" if count == 1 else f"{count} earlier errors"
     if previous_version_count == count:
-        reason = " from a previous Dex version" if count == 1 else " from previous Dex versions"
+        reason = (
+            " from a previous Dex version"
+            if count == 1
+            else " from previous Dex versions"
+        )
     elif previous_version_count:
-        reason = f" from previous Dex versions or more than {dex_logger.STALE_ERROR_DAYS} days ago"
+        reason = (
+            " from previous Dex versions or more than "
+            f"{dex_logger.STALE_ERROR_DAYS} days ago"
+        )
     else:
-        reason = " that is old enough to count as history" if count == 1 else " that are old enough to count as history"
+        reason = (
+            " that is old enough to count as history"
+            if count == 1
+            else " that are old enough to count as history"
+        )
 
-    dated = [_queued_error_date(entry) for entry in entries if _queued_error_date(entry) != "date unavailable"]
+    dated = [
+        _queued_error_date(entry)
+        for entry in entries
+        if _queued_error_date(entry) != "date unavailable"
+    ]
     if dated:
         return f"{subject}{reason}, last on {max(dated)}"
     return f"{subject}{reason}, dates unavailable"
@@ -2987,7 +3144,10 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
     resolved_heal = (
         Heal(
             tier=1,
-            action=(f"Acknowledge {resolved_count} resolved preflight {'error' if resolved_count == 1 else 'errors'}."),
+            action=(
+                f"Acknowledge {resolved_count} resolved preflight "
+                f"{'error' if resolved_count == 1 else 'errors'}."
+            ),
             applied=False,
         )
         if resolved_count
@@ -3036,7 +3196,9 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
     detail = "Preflight completed with no server or current queued errors"
     if resolved_count:
         noun = "error has" if resolved_count == 1 else "errors have"
-        detail += f"; {resolved_count} queued {noun} a newer successful check"
+        detail += (
+            f"; {resolved_count} queued {noun} a newer successful check"
+        )
     if historical_summary:
         detail += f"; {historical_summary}"
     return ProbeResult("OK", detail, resolved_heal)
@@ -3045,14 +3207,20 @@ def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:
 def _capability_seed_paths(room: str) -> tuple[str, ...]:
     from core import capabilities
 
-    folders = tuple(str(folder).rstrip("/") for folder in capabilities.surfaces_for(room).get("folders", []))
+    folders = tuple(
+        str(folder).rstrip("/")
+        for folder in capabilities.surfaces_for(room).get("folders", [])
+    )
     return tuple(
         sorted(
             rule.path
             for rule in portable_contract.RULES
             if rule.ownership == "seed"
             and rule.kind == "file"
-            and any(rule.path == folder or rule.path.startswith(f"{folder}/") for folder in folders)
+            and any(
+                rule.path == folder or rule.path.startswith(f"{folder}/")
+                for folder in folders
+            )
         )
     )
 
@@ -3085,7 +3253,12 @@ def _probe_capability_rooms(context: DoctorContext) -> ProbeResult:
             for skill in surfaces.get("skills", []):
                 path = context.vault_root / ".claude/skills" / str(skill)
                 skill_file = path / "SKILL.md"
-                if path.is_symlink() or not path.is_dir() or skill_file.is_symlink() or not skill_file.is_file():
+                if (
+                    path.is_symlink()
+                    or not path.is_dir()
+                    or skill_file.is_symlink()
+                    or not skill_file.is_file()
+                ):
                     missing_skills.append(f"{room}: {skill}")
             for relative in _capability_seed_paths(room):
                 path = context.vault_root / relative
@@ -3099,20 +3272,32 @@ def _probe_capability_rooms(context: DoctorContext) -> ProbeResult:
 
     findings: list[str] = []
     if missing_folders:
-        findings.append(f"Enabled room folders are missing: {', '.join(missing_folders)}")
+        findings.append(
+            f"Enabled room folders are missing: {', '.join(missing_folders)}"
+        )
     if missing_skills:
-        findings.append(f"Enabled room skills are missing: {', '.join(missing_skills)}")
+        findings.append(
+            f"Enabled room skills are missing: {', '.join(missing_skills)}"
+        )
     if stale_skills:
-        findings.append(f"Disabled room skills are still live: {', '.join(stale_skills)}")
+        findings.append(
+            f"Disabled room skills are still live: {', '.join(stale_skills)}"
+        )
     if missing_seeds:
-        findings.append(f"Missing enabled-room seed files: {', '.join(missing_seeds)} — run /dex-update to restore")
+        findings.append(
+            "Missing enabled-room seed files: "
+            f"{', '.join(missing_seeds)} — run /dex-update to restore"
+        )
     if findings:
         return ProbeResult(
             "BROKEN",
             "; ".join(findings),
             Heal(
                 tier=1,
-                action=("Reconcile capability room folders and shipped skills without deleting user content."),
+                action=(
+                    "Reconcile capability room folders and shipped skills "
+                    "without deleting user content."
+                ),
                 applied=False,
             ),
         )
@@ -3138,7 +3323,9 @@ def _unsafe_customization_path(context: DoctorContext, path: Path) -> str | None
     if any(part in {"", ".", ".."} for part in relative.parts):
         return "contains an unsafe path component"
     if any(
-        part.lower() == ".env" or part.lower().startswith(".env.") or "credential" in part.lower()
+        part.lower() == ".env"
+        or part.lower().startswith(".env.")
+        or "credential" in part.lower()
         for part in relative.parts
     ):
         return "is credential-sensitive"
@@ -3161,19 +3348,18 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
             "UNKNOWN",
             f"{relative} {root_safety} and was not read for safety; fix or remove {relative}",
         )
-    skill_directories = (
-        sorted(
-            (
-                path
-                for path in skills_root.iterdir()
-                if path.name not in KNOWN_SKILL_CONTAINER_DIRECTORIES
-                and (path.is_symlink() or (path.is_dir() and any(path.iterdir())))
-            ),
-            key=lambda path: path.name,
-        )
-        if skills_root.is_dir()
-        else []
-    )
+    skill_directories = sorted(
+        (
+            path
+            for path in skills_root.iterdir()
+            if path.name not in KNOWN_SKILL_CONTAINER_DIRECTORIES
+            and (
+                path.is_symlink()
+                or (path.is_dir() and any(path.iterdir()))
+            )
+        ),
+        key=lambda path: path.name,
+    ) if skills_root.is_dir() else []
     catalogued_paths: frozenset[str] | None = None
     catalog_path = _release_catalog_path(context)
     if catalog_path.is_file():
@@ -3182,7 +3368,11 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
         except (CatalogError, OSError, UnicodeError):
             pass
         else:
-            catalogued_paths = frozenset(file.path for item in catalog.items for file in item.files)
+            catalogued_paths = frozenset(
+                file.path
+                for item in catalog.items
+                for file in item.files
+            )
     failures = []
     safety_findings = []
     custom_count = 0
@@ -3193,7 +3383,11 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
         custom_count += int(is_custom)
         release_carries_skill = catalogued_paths is None or relative in catalogued_paths
         shipped_label = "shipped skill" if release_carries_skill else "skill"
-        guidance = f"run /dex-update to restore {relative}" if release_carries_skill else f"fix or remove {relative}"
+        guidance = (
+            f"run /dex-update to restore {relative}"
+            if release_carries_skill
+            else f"fix or remove {relative}"
+        )
         safety_reason = _unsafe_customization_path(context, skill_path)
         if safety_reason:
             if is_custom:
@@ -3203,7 +3397,8 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
                 )
             else:
                 safety_findings.append(
-                    f"{shipped_label} {relative} {safety_reason} and was not read for safety; {guidance}"
+                    f"{shipped_label} {relative} {safety_reason} and was not read for safety; "
+                    f"{guidance}"
                 )
             continue
         errors = validate_skill_frontmatter(skill_path)
@@ -3211,9 +3406,13 @@ def _probe_customization_skills(context: DoctorContext) -> ProbeResult:
             continue
         issue = "; ".join(_one_line(error) for error in errors)
         if is_custom:
-            failures.append(f"user customization {relative} is invalid ({issue}); fix or remove {relative}")
+            failures.append(
+                f"user customization {relative} is invalid ({issue}); fix or remove {relative}"
+            )
         else:
-            failures.append(f"{shipped_label} {relative} is invalid ({issue}); {guidance}")
+            failures.append(
+                f"{shipped_label} {relative} is invalid ({issue}); {guidance}"
+            )
 
     findings = [*failures, *safety_findings]
     if findings:
@@ -3267,7 +3466,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
     if config_safety:
         relative = _display_vault_path(context, config_path)
         guidance = (
-            f"run /dex-update to restore {relative}" if shipped_example else f"fix your customization in {relative}"
+            f"run /dex-update to restore {relative}"
+            if shipped_example
+            else f"fix your customization in {relative}"
         )
         return ProbeResult(
             "UNKNOWN",
@@ -3286,7 +3487,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
 
     structural_errors = validate_mcp_config(config)
     if shipped_example:
-        structural_errors = [error for error in structural_errors if "unresolved placeholder" not in error]
+        structural_errors = [
+            error for error in structural_errors if "unresolved placeholder" not in error
+        ]
     if structural_errors:
         return _mcp_customization_failure(
             context,
@@ -3297,7 +3500,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
 
     servers = config["mcpServers"]
     custom_entries = [
-        (name, entry) for name, entry in servers.items() if isinstance(name, str) and name.startswith("custom-")
+        (name, entry)
+        for name, entry in servers.items()
+        if isinstance(name, str) and name.startswith("custom-")
     ]
     compile_failures = []
     safety_findings = []
@@ -3308,7 +3513,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
         compile_index = 0
         for name, entry in custom_entries:
             if trust_registry.invalid_reason is not None:
-                safety_findings.append(f"{name} trusted MCP registry is invalid ({trust_registry.invalid_reason})")
+                safety_findings.append(
+                    f"{name} trusted MCP registry is invalid ({trust_registry.invalid_reason})"
+                )
                 continue
             trusted_target: Path | None = None
             if name in trust_registry.entries:
@@ -3329,9 +3536,11 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                     "(nightly and in deep scans), and trusts whatever it imports"
                 )
             python_targets = sorted(
-                {trusted_target}
-                if trusted_target is not None
-                else {target for target in _entry_targets(entry, context) if target.suffix == ".py"},
+                {trusted_target} if trusted_target is not None else {
+                    target
+                    for target in _entry_targets(entry, context)
+                    if target.suffix == ".py"
+                },
                 key=str,
             )
             for target in python_targets:
@@ -3343,7 +3552,8 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                     safety_reason = _unsafe_customization_path(context, target)
                 if safety_reason:
                     safety_findings.append(
-                        f"{name} target {relative_target} {safety_reason} and was not compiled or executed for safety"
+                        f"{name} target {relative_target} {safety_reason} and was not compiled or "
+                        "executed for safety"
                     )
                     continue
                 if not target.is_file():
@@ -3358,7 +3568,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
                         doraise=True,
                     )
                 except (OSError, py_compile.PyCompileError) as error:
-                    compile_failures.append(f"{name} target {relative_target} does not compile ({_one_line(error)})")
+                    compile_failures.append(
+                        f"{name} target {relative_target} does not compile ({_one_line(error)})"
+                    )
 
     if compile_failures:
         issues = [*compile_failures, *safety_findings]
@@ -3372,7 +3584,9 @@ def _probe_customization_mcp(context: DoctorContext) -> ProbeResult:
     if safety_findings:
         relative = _display_vault_path(context, config_path)
         guidance = (
-            f"run /dex-update to restore {relative}" if shipped_example else f"fix your customization in {relative}"
+            f"run /dex-update to restore {relative}"
+            if shipped_example
+            else f"fix your customization in {relative}"
         )
         return ProbeResult(
             "UNKNOWN",
@@ -3479,20 +3693,28 @@ def _probe_vault_git(context: DoctorContext) -> ProbeResult:
             "The separate vault history is not active; the topology check reports the current layout",
         )
     git_directory = context.vault_root / ".git"
-    healthy = _git_result(context, "rev-parse", "--git-dir", git_directory=git_directory)
+    healthy = _git_result(
+        context, "rev-parse", "--git-dir", git_directory=git_directory
+    )
     if healthy.returncode != 0:
         return ProbeResult(
             "BROKEN",
             "The vault Git repository cannot be opened — your files remain on disk, but history needs repair",
         )
-    integrity = _git_result(context, "fsck", "--no-progress", git_directory=git_directory)
+    integrity = _git_result(
+        context, "fsck", "--no-progress", git_directory=git_directory
+    )
     if integrity.returncode != 0:
         return ProbeResult(
             "BROKEN",
             "The vault Git repository failed its integrity check — do not push it; repair the local history",
         )
     remotes = _git_result(context, "remote", git_directory=git_directory)
-    remote_count = len([line for line in remotes.stdout.splitlines() if line.strip()]) if remotes.returncode == 0 else 0
+    remote_count = (
+        len([line for line in remotes.stdout.splitlines() if line.strip()])
+        if remotes.returncode == 0
+        else 0
+    )
     suffix = (
         "no private backup remote configured"
         if remote_count == 0
@@ -3533,8 +3755,12 @@ def _probe_brain_git(context: DoctorContext) -> ProbeResult:
             "BROKEN",
             "The Dex brain release identity disagrees across its installed ref and topology markers — rerun /dex-update",
         )
-    configured = _git_result(context, "config", "--get", "remote.origin.url", git_directory=brain)
-    effective = _git_result(context, "remote", "get-url", "origin", git_directory=brain)
+    configured = _git_result(
+        context, "config", "--get", "remote.origin.url", git_directory=brain
+    )
+    effective = _git_result(
+        context, "remote", "get-url", "origin", git_directory=brain
+    )
     official = re.compile(
         r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)"
         r"davekilleen/Dex(?:\.git)?/?$",
@@ -3558,7 +3784,9 @@ def _probe_brain_git(context: DoctorContext) -> ProbeResult:
         )
     archive = context.vault_root / ".dex/pre-split-archive.git"
     archive_note = (
-        " The pre-split restore archive is still present." if archive.is_dir() and not archive.is_symlink() else ""
+        " The pre-split restore archive is still present."
+        if archive.is_dir() and not archive.is_symlink()
+        else ""
     )
     return ProbeResult(
         "OK",
@@ -3574,7 +3802,11 @@ def _probe_pre_split_archive(context: DoctorContext) -> ProbeResult:
     if archive.is_symlink() or not archive.is_dir():
         return ProbeResult("BROKEN", "The pre-split undo archive is not a safe directory")
     try:
-        size_bytes = sum(path.stat().st_size for path in archive.rglob("*") if path.is_file() and not path.is_symlink())
+        size_bytes = sum(
+            path.stat().st_size
+            for path in archive.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        )
         age_days = max(0, int((context.now.timestamp() - archive.stat().st_mtime) // 86_400))
     except OSError as error:
         return ProbeResult("UNKNOWN", f"Could not inspect the pre-split undo archive: {_one_line(str(error))}")
@@ -3599,17 +3831,26 @@ def _probe_vault_auto_commit(context: DoctorContext) -> ProbeResult:
     except FileNotFoundError:
         profile = {}
     if not isinstance(profile, dict):
-        return ProbeResult("BROKEN", "Vault auto-commit cannot read user-profile.yaml as a mapping")
+        return ProbeResult(
+            "BROKEN", "Vault auto-commit cannot read user-profile.yaml as a mapping"
+        )
     vault_settings = profile.get("vault")
-    enabled = isinstance(vault_settings, dict) and vault_settings.get("auto_commit") is True
+    enabled = (
+        isinstance(vault_settings, dict)
+        and vault_settings.get("auto_commit") is True
+    )
     if not enabled:
-        return ProbeResult("OFF", "Vault auto-commit is off by default; local files remain untouched")
+        return ProbeResult(
+            "OFF", "Vault auto-commit is off by default; local files remain untouched"
+        )
     if _topology_state(context) != "post-split":
         return ProbeResult(
             "BROKEN",
             "Vault auto-commit is enabled before the split topology is ready — run /dex-update",
         )
-    return ProbeResult("OK", "Vault auto-commit is enabled for local snapshots and never pushes")
+    return ProbeResult(
+        "OK", "Vault auto-commit is enabled for local snapshots and never pushes"
+    )
 
 
 def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
@@ -3619,7 +3860,8 @@ def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
     if topology == "migration-pending":
         return ProbeResult(
             "OFF",
-            "Optional one-time upgrade available — run /dex-update when you want it; notes stay in place either way",
+            "Optional one-time upgrade available — run /dex-update when you want it; "
+            "notes stay in place either way",
         )
     if topology == "migration-in-progress":
         return ProbeResult(
@@ -3636,8 +3878,12 @@ def _probe_migration_pending(context: DoctorContext) -> ProbeResult:
             "to return to the pre-split layout. Do not reinstall, restore backups, or run raw Git commands.",
         )
     if topology == "zip-or-manual":
-        return ProbeResult("OFF", "This ZIP/manual install has no Git topology; use the manual update path")
-    return ProbeResult("OFF", "This is the older combined topology; updates keep using the merge path")
+        return ProbeResult(
+            "OFF", "This ZIP/manual install has no Git topology; use the manual update path"
+        )
+    return ProbeResult(
+        "OFF", "This is the older combined topology; updates keep using the merge path"
+    )
 
 
 def _upstream_release_ref(context: DoctorContext, channel: str | None = None) -> str | None:
@@ -3680,9 +3926,17 @@ def _sanctioned_customization_path(relative: str) -> bool:
     if relative in {"System/user-profile.yaml", "System/pillars.yaml"}:
         return True
     parts = relative.split("/")
-    if len(parts) >= 3 and parts[:2] == [".claude", "skills"] and parts[2].endswith("-custom"):
+    if (
+        len(parts) >= 3
+        and parts[:2] == [".claude", "skills"]
+        and parts[2].endswith("-custom")
+    ):
         return True
-    return len(parts) == 3 and parts[:2] == ["System", "integrations"] and Path(relative).suffix == ".yaml"
+    return (
+        len(parts) == 3
+        and parts[:2] == ["System", "integrations"]
+        and Path(relative).suffix == ".yaml"
+    )
 
 
 def _git_file(
@@ -3797,9 +4051,9 @@ def _only_sanctioned_file_changes(
     if relative == "CLAUDE.md":
         return _strip_user_extensions(baseline_text) == _strip_user_extensions(working_text)
     if relative == ".gitignore":
-        return _without_vault_mode_gitignore_section(baseline_text) == _without_vault_mode_gitignore_section(
-            working_text
-        )
+        return _without_vault_mode_gitignore_section(
+            baseline_text
+        ) == _without_vault_mode_gitignore_section(working_text)
     if relative == ".mcp.json":
         baseline_config = _mcp_without_custom_entries(baseline_text)
         working_config = _mcp_without_custom_entries(working_text)
@@ -3846,7 +4100,12 @@ def _worktree_blob_mode_matches(
     mode: str,
 ) -> bool:
     parts = Path(relative).parts
-    if not parts or "\n" in relative or "\r" in relative or any(part in {"", ".", ".."} for part in parts):
+    if (
+        not parts
+        or "\n" in relative
+        or "\r" in relative
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
         return False
     current = context.repo_root
     for part in parts[:-1]:
@@ -3896,7 +4155,13 @@ def _worktree_blob_ids(
 
 
 def _symlink_matches_release_blob(path: Path, object_id: str) -> bool:
-    algorithm = "sha1" if len(object_id) == 40 else "sha256" if len(object_id) == 64 else None
+    algorithm = (
+        "sha1"
+        if len(object_id) == 40
+        else "sha256"
+        if len(object_id) == 64
+        else None
+    )
     if algorithm is None:
         return False
     try:
@@ -3916,7 +4181,8 @@ def _mismatched_release_blobs(
     hashable = [
         relative
         for relative, (mode, _object_id) in entries.items()
-        if mode != "120000" and _worktree_blob_mode_matches(context, relative, mode)
+        if mode != "120000"
+        and _worktree_blob_mode_matches(context, relative, mode)
     ]
     worktree_ids = _worktree_blob_ids(context, hashable)
     return {
@@ -3975,7 +4241,9 @@ def _brain_paths_from_installed_release(
         try:
             resolution = portable_contract.resolve(relative)
         except portable_contract.ContractViolation as error:
-            raise RuntimeError(f"installed brain release has an unclassified path: {relative}") from error
+            raise RuntimeError(
+                f"installed brain release has an unclassified path: {relative}"
+            ) from error
         if resolution.ownership == "brain":
             paths.add(relative)
     return paths
@@ -4031,7 +4299,9 @@ def _installer_normalized_package_metadata(
     if relative == "package.json":
         baseline_scripts = baseline_value.get("scripts")
         current_scripts = current_value.get("scripts")
-        if not isinstance(baseline_scripts, Mapping) or not isinstance(current_scripts, Mapping):
+        if not isinstance(baseline_scripts, Mapping) or not isinstance(
+            current_scripts, Mapping
+        ):
             return False
         for name, command in baseline_scripts.items():
             if current_scripts.get(name) != command:
@@ -4049,11 +4319,15 @@ def _installer_normalized_package_metadata(
 
     baseline_packages = baseline_value.get("packages")
     current_packages = current_value.get("packages")
-    if not isinstance(baseline_packages, Mapping) or not isinstance(current_packages, Mapping):
+    if not isinstance(baseline_packages, Mapping) or not isinstance(
+        current_packages, Mapping
+    ):
         return False
     baseline_root = baseline_packages.get("")
     current_root = current_packages.get("")
-    if not isinstance(baseline_root, Mapping) or not isinstance(current_root, Mapping):
+    if not isinstance(baseline_root, Mapping) or not isinstance(
+        current_root, Mapping
+    ):
         return False
     package_version = current_package["version"]
     if (
@@ -4089,9 +4363,15 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
                 "UNKNOWN",
                 "the brain Git store cannot resolve refs/dex/installed — rerun /dex-update",
             )
-        release_entries = _release_tree_entries(context, baseline, git_directory=brain)
+        release_entries = _release_tree_entries(
+            context, baseline, git_directory=brain
+        )
         brain_paths = _brain_paths_from_installed_release(context, baseline, brain)
-        brain_entries = {relative: release_entries[relative] for relative in brain_paths if relative in release_entries}
+        brain_entries = {
+            relative: release_entries[relative]
+            for relative in brain_paths
+            if relative in release_entries
+        }
         mismatched = _mismatched_release_blobs(
             context,
             brain_entries,
@@ -4116,10 +4396,13 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
             )
         )
         if not drifted:
-            return ProbeResult("OK", "No shipped brain files differ from refs/dex/installed")
+            return ProbeResult(
+                "OK", "No shipped brain files differ from refs/dex/installed"
+            )
         return ProbeResult(
             "UNKNOWN",
-            f"Modified shipped brain files: {', '.join(drifted)}; the updater snapshots them before replacement",
+            "Modified shipped brain files: "
+            f"{', '.join(drifted)}; the updater snapshots them before replacement",
         )
 
     channel = release_channel.read_channel(context.vault_root)
@@ -4156,12 +4439,14 @@ def _probe_core_drift(context: DoctorContext) -> ProbeResult:
     candidates = sorted(
         relative
         for relative in mismatched
-        if _is_shipped_drift_candidate(relative) and not _sanctioned_customization_path(relative)
+        if _is_shipped_drift_candidate(relative)
+        and not _sanctioned_customization_path(relative)
     )
     drifted = [
         relative
         for relative in candidates
-        if relative not in COMPOSED_SHIPPED_PATHS or not _only_sanctioned_file_changes(context, baseline, relative)
+        if relative not in COMPOSED_SHIPPED_PATHS
+        or not _only_sanctioned_file_changes(context, baseline, relative)
     ]
     if not drifted:
         return ProbeResult("OK", "No tracked shipped files differ from the installed release")
@@ -4185,7 +4470,9 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
         people_dir = context.core_path("PEOPLE_DIR")
         companies_dir = context.core_path("COMPANIES_DIR")
         people_index_path = context.core_path("PEOPLE_INDEX_FILE")
-        dead_letter_path = context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+        dead_letter_path = (
+            context.vault_root / "System" / ".dex" / "entity-dead-letter.jsonl"
+        )
 
         contacts = json.loads(contacts_path.read_text()) if contacts_path.exists() else {}
         suggestions = json.loads(suggestions_path.read_text()) if suggestions_path.exists() else {}
@@ -4255,14 +4542,10 @@ def _probe_entity_engine(context: DoctorContext) -> ProbeResult:
                 if page.name != "README.md" and parse_entity_page(page).get("quarantined"):
                     quarantined_paths.append(str(page.relative_to(context.vault_root)))
 
-        newest_people_mtime = (
-            max(
-                (page.stat().st_mtime for page in people_dir.rglob("*.md") if page.name != "README.md"),
-                default=0.0,
-            )
-            if people_dir.exists()
-            else 0.0
-        )
+        newest_people_mtime = max(
+            (page.stat().st_mtime for page in people_dir.rglob("*.md") if page.name != "README.md"),
+            default=0.0,
+        ) if people_dir.exists() else 0.0
         index_freshness = "missing"
         if people_index_path.exists():
             people_index = json.loads(people_index_path.read_text())
@@ -4674,14 +4957,18 @@ def _probe_backup_freshness(context: DoctorContext) -> ProbeResult:
     warnings = stamp.get("warnings")
     if isinstance(warnings, list) and warnings:
         detail = "; ".join(_one_line(str(item)) for item in warnings[:3])
-        return ProbeResult("BROKEN", f"{summary}, but it stored less than a full backup: {detail}", _BACKUP_HEAL)
+        return ProbeResult("BROKEN", f"{summary}, but it stored less than a full "
+                                     f"backup: {detail}", _BACKUP_HEAL)
     return ProbeResult("OK", summary)
 
 
 def _calendar_permission_status(_context: DoctorContext) -> str:
     if not _is_macos():
         return "unsupported"
-    code = "import EventKit; print(EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeEvent))"
+    code = (
+        "import EventKit; "
+        "print(EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeEvent))"
+    )
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
@@ -4825,11 +5112,7 @@ def _qmd_registered(config: dict[str, Any]) -> bool:
             continue
         command = str(entry.get("command", ""))
         args = [str(argument) for argument in entry.get("args", []) if isinstance(argument, str)]
-        if (
-            "qmd" in name.lower()
-            or Path(command).name == "qmd"
-            or any(Path(argument).name == "qmd" for argument in args)
-        ):
+        if "qmd" in name.lower() or Path(command).name == "qmd" or any(Path(argument).name == "qmd" for argument in args):
             return True
     return False
 
@@ -5029,7 +5312,9 @@ def _probe_integrations_enabled(context: DoctorContext) -> ProbeResult:
         if status in {"needs_reauth", "not_connected"}:
             failures.append(f"{service}: {status}")
         elif row.get("verified") is not True:
-            unknowns.append(f"{service}: stored credential has not been live-verified")
+            unknowns.append(
+                f"{service}: stored credential has not been live-verified"
+            )
     if failures:
         detail_parts = [f"failed: {'; '.join(failures)}"]
         if unknowns:
@@ -5106,7 +5391,10 @@ def _probe_mcp_importable(context: DoctorContext) -> ProbeResult:
         if missing_dependencies:
             noun = "dependency" if len(missing_dependencies) == 1 else "dependencies"
             named = ", ".join(repr(name) for name in sorted(missing_dependencies))
-            remedies.append(f"Reinstall missing MCP {noun} {named} into the vault .venv, then re-run /dex-doctor.")
+            remedies.append(
+                f"Reinstall missing MCP {noun} {named} into the vault .venv, "
+                "then re-run /dex-doctor."
+            )
         if unclassified_failure:
             remedies.append("Reinstall the missing MCP dependencies into the vault .venv.")
         return ProbeResult(
@@ -5187,7 +5475,10 @@ def _smoke_attribution_paths(context: DoctorContext) -> list[Path]:
     paths_to_check.extend(sorted((system / "integrations").glob("*.yaml")))
     custom_skills = context.vault_root / ".claude" / "skills"
     paths_to_check.extend(
-        path for root in sorted(custom_skills.glob("*-custom")) for path in sorted(root.rglob("*")) if path.is_file()
+        path
+        for root in sorted(custom_skills.glob("*-custom"))
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
     )
     return paths_to_check
 
@@ -5231,7 +5522,11 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         )
 
     prior_good_index = next(
-        (index for index in range(len(entries) - 2, -1, -1) if entries[index]["summary"].get("broken") == 0),
+        (
+            index
+            for index in range(len(entries) - 2, -1, -1)
+            if entries[index]["summary"].get("broken") == 0
+        ),
         None,
     )
     broken_ids = ", ".join(journey["id"] for journey in broken)
@@ -5242,7 +5537,11 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         )
 
     good_entry = entries[prior_good_index]
-    first_broken = next(entry for entry in entries[prior_good_index + 1 :] if entry["summary"].get("broken", 0) > 0)
+    first_broken = next(
+        entry
+        for entry in entries[prior_good_index + 1 :]
+        if entry["summary"].get("broken", 0) > 0
+    )
     window_start = _smoke_timestamp(good_entry)
     window_end = _smoke_timestamp(first_broken)
     facts = []
@@ -5252,7 +5551,9 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
         except OSError:
             continue
         if window_start < modified <= window_end:
-            facts.append(f"{_smoke_attribution_name(path, context)} modified {modified.isoformat()}")
+            facts.append(
+                f"{_smoke_attribution_name(path, context)} modified {modified.isoformat()}"
+            )
     old_version = good_entry.get("dex_version")
     new_version = first_broken.get("dex_version")
     if isinstance(old_version, str) and isinstance(new_version, str) and old_version != new_version:
@@ -5273,8 +5574,16 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
 def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
     smoke_path = context.repo_root / "core" / "utils" / "smoke.py"
     vault_python = context.vault_root / ".venv" / "bin" / "python"
-    interpreter = str(vault_python) if vault_python.is_file() and os.access(vault_python, os.X_OK) else sys.executable
-    env = {name: os.environ[name] for name in ("PATH", "PYTHONPATH") if name in os.environ}
+    interpreter = (
+        str(vault_python)
+        if vault_python.is_file() and os.access(vault_python, os.X_OK)
+        else sys.executable
+    )
+    env = {
+        name: os.environ[name]
+        for name in ("PATH", "PYTHONPATH")
+        if name in os.environ
+    }
     env.update(
         {
             "VAULT_PATH": str(context.vault_root),
@@ -5330,7 +5639,9 @@ def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
     else:
         worst = "OFF"
     if (result.returncode == 1) != (worst == "BROKEN"):
-        raise RuntimeError(f"smoke harness exit {result.returncode} did not match its {worst} journey roll-up")
+        raise RuntimeError(
+            f"smoke harness exit {result.returncode} did not match its {worst} journey roll-up"
+        )
     return ProbeResult(worst, " | ".join(rendered))
 
 

--- a/core/utils/launch_agents.py
+++ b/core/utils/launch_agents.py
@@ -138,6 +138,8 @@ def any_agent_references_former_root(
     launch_agents_dir: Path | None = None,
 ) -> bool:
     """Return whether any launch agent still references the former vault root."""
+    from core.utils import automation_ownership
+
     former_root = stored_former_vault_root(vault_root, home)
     if former_root is None:
         return False
@@ -149,6 +151,16 @@ def any_agent_references_former_root(
     except OSError:
         return False
     for plist in plists:
+        try:
+            relative = plist.relative_to(home).as_posix()
+        except ValueError:
+            relative = ""
+        if automation_ownership.is_plist_offloaded(
+            vault_root,
+            relative,
+            home_root=home,
+        ):
+            continue
         payload = load_plist_payload(plist)
         if payload is not None and payload_references_root(payload, former_root):
             return True
@@ -157,9 +169,26 @@ def any_agent_references_former_root(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--stale-check", action="store_true", required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--stale-check", action="store_true")
+    mode.add_argument("--offloaded-check", action="store_true")
     parser.add_argument("--vault", type=Path, required=True)
+    parser.add_argument("--plist-relative")
     args = parser.parse_args(argv)
+    if args.offloaded_check:
+        from core.utils import automation_ownership
+
+        if not isinstance(args.plist_relative, str):
+            parser.error("--offloaded-check requires --plist-relative")
+        return (
+            0
+            if automation_ownership.is_plist_offloaded(
+                args.vault,
+                args.plist_relative,
+                home_root=Path.home(),
+            )
+            else 1
+        )
     if any_agent_references_former_root(args.vault, Path.home()):
         print(STALE_JOB_SENTINEL)
     return 0

--- a/docs/architecture/INVENTORY.md
+++ b/docs/architecture/INVENTORY.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE — DO NOT EDIT BY HAND. -->
 <!-- Generator: scripts/generate-architecture-inventory.py -->
-<!-- Content SHA-256: 6672cd77e728d5e48d9ca33f1c8aebd1db91101c6bdf8d61707e38e71fcba74a -->
+<!-- Content SHA-256: dd9818642b133e90d8c327eb4d9932c3d452fd96737126d36f1a9162fd25b536 -->
 
 # Architecture Inventory
 
@@ -155,7 +155,7 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 | `seed` | 38 | `write-if-absent` |
 | `generated` | 9 | `regenerate` |
 | `vault` | 17 | `never` |
-| `runtime` | 14 | `never` |
+| `runtime` | 15 | `never` |
 
 <details><summary><code>brain</code> declared paths (45)</summary>
 
@@ -286,11 +286,12 @@ Derived from `core/portable_contract.py` `RULES` and `MUTATION_POLICY`.
 
 </details>
 
-<details><summary><code>runtime</code> declared paths (14)</summary>
+<details><summary><code>runtime</code> declared paths (15)</summary>
 
 - `.logs` (dir; `runtime-logs`)
 - `System/.dex` (dir; `runtime-dex-dir`)
 - `System/.dex/adoptions` (dir; `runtime-adoption-receipts`)
+- `System/.dex/automation-ownership.json` (file; `runtime-automation-ownership`)
 - `System/.dex/ledger` (dir; `runtime-lifecycle-ledger`)
 - `System/.dex/lifecycle/activation.json` (file; `runtime-lifecycle-activation`)
 - `System/.last-learning-check` (file; `runtime-last-learning-check`)

--- a/docs/automation-ownership-contract.md
+++ b/docs/automation-ownership-contract.md
@@ -1,0 +1,63 @@
+# Dex Solo automation ownership contract
+
+**Summary:** Dex Solo may take over one existing Dex launchd job only after it
+has unloaded that job and verified it is no longer loaded. Core then seals the
+exact plist bytes and owner in a transaction-written runtime sidecar. To give
+the job back, Solo stops its own scheduler before recording the release.
+
+## Frozen lifecycle API (v1.5.0)
+
+Claim preview:
+
+```python
+previewed = service.build_and_preview_automation_claim(vault_root, {
+    "automation_id": "com.dex.smoke-nightly",
+    "owner_id": "dex-solo",
+    "plist_relative_path": "Library/LaunchAgents/com.dex.smoke-nightly.plist",
+    "plist_sha256": "<lowercase SHA-256 of the current plist bytes>",
+    "launchd_state": "unloaded",
+})
+```
+
+Claim execution:
+
+```python
+claimed = service.execute_approved_automation_claim(
+    vault_root,
+    previewed["preview"],
+    previewed["approval_token"],
+)
+```
+
+Release preview and execution:
+
+```python
+previewed = service.build_and_preview_automation_release(vault_root, {
+    "automation_id": "com.dex.smoke-nightly",
+    "owner_id": "dex-solo",
+    "scheduler_state": "stopped",
+})
+released = service.execute_approved_automation_release(
+    vault_root,
+    previewed["preview"],
+    previewed["approval_token"],
+)
+```
+
+The caller must treat `needed: false` as success: the requested claim or
+release is already in effect. Re-executing an approved preview is also safe and
+returns `already-claimed` or `already-released` without another transaction.
+
+## Safety boundary
+
+- Core accepts only `dex-solo`, canonical launchd ids, a home-relative
+  `Library/LaunchAgents/*.plist` path, and lowercase SHA-256 evidence.
+- Claim execution re-reads the plist and sidecar, then recomputes the approval
+  binding. Changed plist bytes or ownership state require a new preview.
+- The only writable path is
+  `System/.dex/automation-ownership.json`, allowlisted specifically for the
+  `automation-ownership` transaction operation. The legacy lifecycle ledger is
+  not touched.
+- Doctor and SessionStart ignore a Core launchd job only while its Dex Solo
+  claim is structurally valid and its current plist still matches the sealed
+  hash. Invalid or stale evidence fails closed to Core's normal checks.

--- a/docs/automation-ownership-contract.md
+++ b/docs/automation-ownership-contract.md
@@ -52,6 +52,10 @@ returns `already-claimed` or `already-released` without another transaction.
 
 - Core accepts only `dex-solo`, canonical launchd ids, a home-relative
   `Library/LaunchAgents/*.plist` path, and lowercase SHA-256 evidence.
+- The unload and stop fields are caller attestations at this cross-repository
+  boundary. Dex Solo must perform and verify each action before making the
+  corresponding call; Core rejects every other state literal but does not
+  control or inspect Solo's scheduler process.
 - Claim execution re-reads the plist and sidecar, then recomputes the approval
   binding. Changed plist bytes or ownership state require a new preview.
 - The only writable path is

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -489,6 +489,13 @@
       "note": "post-commit lifecycle receipts; local runtime evidence, never shipped"
     },
     {
+      "id": "runtime-automation-ownership",
+      "path": "System/.dex/automation-ownership.json",
+      "kind": "file",
+      "ownership": "runtime",
+      "note": "closed Dex Solo scheduler handoff state; transaction-owned and never shipped"
+    },
+    {
       "id": "generated-health-state",
       "path": "System/.dex/health",
       "kind": "dir",


### PR DESCRIPTION
## Summary
- add frozen lifecycle v1.5 preview/execute APIs for Dex Solo claim and release of one existing launchd job
- persist a closed transaction-only runtime sidecar outside the legacy ledger, with canonical ids/paths/SHA-256, stale binding, idempotency, and conflict rejection
- make Doctor and SessionStart treat valid Solo claims as app-owned/offloaded
- make the pre-venv installer capability preflight independent of globally installed PyYAML

## Ordering contract
- claim: Solo unloads and verifies launchd first, then previews/executes the claim
- release: Solo stops its scheduler first, then previews/executes the release

## Verification
- deliberate portable-contract break made the new gate fail, then passed after restoration
- 4,374 Python tests passed; 2 skipped; three macOS-only historic-fleet tests excluded on Linux and left to macOS CI
- focused post-diff-read suite: 397 passed; SessionStart 21/21
- Node hooks 208/208; scripts parity green with DEX_PYTHON; integrations 224 passed/1 skipped; connections contract green
- generated contract/inventory, Ruff, shell syntax, JSON schemas, and diff checks green

No Dex Core release is published by this PR.