### PR TITLE
release: v1.96.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.4] — 🧰 A clean Mac install finishes, and the desktop app can take over one background job (2026-08-14)
+
+A brand-new Mac could stop during first setup because Dex asked the computer for
+a helper it had not installed yet. Separately, the Dex Solo desktop app could not
+safely take over one existing Dex background job, so two copies of the same job
+could try to run.
+
+**What this fixes for you:**
+
+* **A clean install no longer depends on a leftover extra library.** First-time
+  setup checks its own files with tools that are already there, then installs
+  everything else in the right order.
+* **The desktop app can take over one existing background job without running it
+  twice.** It has to prove the old job is stopped first. Giving the job back
+  works the same way in reverse.
+* **Dex's own checkup stays honest about that handoff.** It ignores the
+  handed-over job only while the proof is still valid. If the proof goes stale,
+  the normal checkup takes over again.
+
 ## [1.96.3] — 🩺 Honest checkups, safer meetings, and releases you can verify (2026-08-13)
 
 This is a reliability release built from ten fixes that were tested together. The theme is

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -854,6 +854,7 @@ core/lifecycle/plan.py
 core/lifecycle/preview.py
 core/lifecycle/retention.py
 core/lifecycle/runtime_evidence.py
+core/lifecycle/schemas/automation-ownership-v1.schema.json
 core/lifecycle/schemas/release-catalog-v1.schema.json
 core/lifecycle/schemas/release-catalog-v2.schema.json
 core/lifecycle/secrets.py
@@ -1034,6 +1035,7 @@ core/tests/test_apple_mail_health.py
 core/tests/test_apple_mail_runtime_macos.py
 core/tests/test_apply_update.py
 core/tests/test_architecture_inventory.py
+core/tests/test_automation_ownership_contract.py
 core/tests/test_backup_vault.py
 core/tests/test_branch_protection_script.py
 core/tests/test_calendar_eventkit_script.py
@@ -1117,6 +1119,7 @@ core/tests/test_instructed_tools_gate.py
 core/tests/test_instruction_honesty.py
 core/tests/test_integration_credentials.py
 core/tests/test_large_vault_performance.py
+core/tests/test_launch_agents.py
 core/tests/test_learning_capture_command_name.py
 core/tests/test_lens_catalog_ci_trigger.py
 core/tests/test_lens_catalog_sources.py
@@ -1225,6 +1228,7 @@ core/update/journey-protocol-v1.json
 core/update/journey_protocol.py
 core/utils/__init__.py
 core/utils/apple_mail_health.py
+core/utils/automation_ownership.py
 core/utils/company_domains.py
 core/utils/credential_migration_exceptions.json
 core/utils/credential_remediation.py
@@ -1282,6 +1286,7 @@ docs/architecture/HEALTH-PROMISES.md
 docs/architecture/INVENTORY.md
 docs/architecture/STATE.md
 docs/assets/dex-hero.gif
+docs/automation-ownership-contract.md
 docs/backup-restore.md
 docs/calendar-performance.md
 docs/credential-remediation.md

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.3"
+  "release_version": "1.96.4"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.3",
+  "release_version": "1.96.4",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.3","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.4","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.3 release,
+Download the versioned bridge and its checksum from the public v1.96.4 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.3/dex-update-bridge-v1.96.3.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.4/dex-update-bridge-v1.96.4.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.3/dex-update-bridge-v1.96.3.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.4/dex-update-bridge-v1.96.4.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.3.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.4.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.3.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.3",
+      "version": "1.96.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Public Dex is still 1.96.3. The clean Mac install repair and the desktop-app job handoff are already on main from PR #536. This commit is the version stamp so testers actually download them.

The identity check that 1.96.2 failed is already live in 1.96.3. This cut uses that path: the catalog names a pattern, the real tag is minted from the sanitized release commit, then checked locally and again after push.

## What testers get

- A clean Mac install no longer stops because a helper was missing too early.
- Dex Solo can take over one existing Dex background job without two copies running.

## Verification already done

- Identity gate tests: 18/18, including the 1.96.2 concrete-tag-promise going red.
- Live 1.96.3 public identity verified: `v1.96.3` → `3ff47211`, `dist/release/v1.96.3-fe28238` → `fe28238`.
- Public 1.96.3 asset checksums matched.
- Clean-install preflight test and identity tests passed on this commit.

After merge: push `v1.96.4` immediately, then prove the public download is 1.96.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version strings, changelog, and rescue doc URLs; functional behavior was shipped in prior merges on main.
> 
> **Overview**
> This is a **release stamp**, not the feature work itself: it moves Dex’s published version from **1.96.3** to **1.96.4** so installers, bridges, and rescue docs point at the new cut.
> 
> **Version and release metadata** are updated in `package.json` / lockfile, `core/lifecycle/catalog/bridge-release.json`, and the System release-evidence / preservation transition JSON so lifecycle tooling agrees on **1.96.4**.
> 
> **User-facing release notes** add a **1.96.4** changelog entry for two themes already merged on main: clean Mac installs no longer fail on a missing early helper, and Dex Solo can **take over** one Dex background LaunchAgent job without double-running it (with Doctor honoring a time-bounded handoff proof).
> 
> **UPDATE-RESCUE** download URLs, filenames, and checksum commands are retargeted from the **v1.96.3** update bridge to **v1.96.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f8fbd938e43860278f7a4bf6434a6180a56d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->