### PR TITLE
A brand-new Dex folder can finish setup even if first install left no history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.5] — 🧰 A brand-new Dex folder can finish setup even if first install left no history (2026-08-14)
+
+A person who had just installed Dex could get stuck in the first setup chat. Dex thought it had finished separating its own files from their notes, but the notes folder had no working history, and the safety copy that should have undone that step was damaged. Continue failed. Undo failed. Setup stopped before they could start.
+
+**What this fixes for you:**
+
+* **Dex can rebuild the notes history from the files still in the folder.** Your notes stay put. Dex does not try to put a damaged safety copy back, and it does not invent a history it cannot prove.
+* **Install no longer says it is finished when that history is missing.** If the notes folder still has no working history, install stops and tells you the one repair command to run.
+* **Undo tells the truth when it cannot go back.** If the old copy is damaged and the notes history is already gone, Dex says the files are still there and that continuing will rebuild from those files. It no longer claims nothing was moved.
+
+A new user found this minutes after installing. Their notes were never deleted.
+
 ## [1.96.4] — 🧰 A clean Mac install finishes, and the desktop app can take over one background job (2026-08-14)
 
 A brand-new Mac could stop during first setup because Dex asked the computer for

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.4"
+  "release_version": "1.96.5"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.4",
+  "release_version": "1.96.5",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.4","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -1280,6 +1280,7 @@ function initializeVaultGitdir(
   heldBackPaths = [],
   trackedIgnore = null,
   embeddedRepositories = [],
+  options = {},
 ) {
   if (!exists(gitDirectory)) {
     fs.mkdirSync(path.dirname(gitDirectory), { recursive: true });
@@ -1291,7 +1292,9 @@ function initializeVaultGitdir(
   const remotes = safeRemoteNames(root, gitDirectory);
   for (const remote of remotes) gitDir(root, gitDirectory, ['remote', 'remove', remote]);
   writeVaultExcludes(root, gitDirectory, heldBackPaths, trackedIgnore, embeddedRepositories);
-  writeGitdirMarker(gitDirectory, VAULT_MARKER, { schemaVersion: 1, role: 'vault' });
+  if (options.writeMarker !== false) {
+    writeGitdirMarker(gitDirectory, VAULT_MARKER, { schemaVersion: 1, role: 'vault' });
+  }
 }
 
 function independentVaultInventory(root, heldBackPaths = [], trackedIgnore = null) {
@@ -1878,14 +1881,21 @@ function phase9Finalize(root, state) {
   console.log('P9 finalize complete: your vault and brain now have separate histories.');
 }
 
+class PreSplitArchiveError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PreSplitArchiveError';
+  }
+}
+
 function archiveValidationError(detail, { vaultGitMissing = false } = {}) {
   if (vaultGitMissing) {
-    return new Error(
+    return new PreSplitArchiveError(
       `The pre-split archive ${detail}, so Dex cannot put the old layout back. `
       + 'Your notes are still in this folder. Run this migrator with --resume to rebuild the vault history from the files on disk.',
     );
   }
-  return new Error(`The pre-split archive ${detail}, so Dex refused to replace the current Git history. Restore the matching migration archive or contact Dex support; no Git folder was deleted.`);
+  return new PreSplitArchiveError(`The pre-split archive ${detail}, so Dex refused to replace the current Git history. Restore the matching migration archive or contact Dex support; no Git folder was deleted.`);
 }
 
 function validatePreSplitArchive(root, state) {
@@ -1954,6 +1964,19 @@ function canRebuildMissingVaultGit(root) {
   return !topology.rootGit && !topology.vaultStaging && Boolean(brainInstalledCommit(root));
 }
 
+function heldBackPathsForRebuild(root, state) {
+  if (Array.isArray(state.analysis?.heldBackPaths) && state.analysis.heldBackPaths.length > 0) {
+    return state.analysis.heldBackPaths;
+  }
+  try {
+    const payload = JSON.parse(fs.readFileSync(path.join(root, HELD_BACK_RELATIVE), 'utf8'));
+    return normalizeHeldBackPaths(payload.paths, portableContract());
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    return [];
+  }
+}
+
 function rebuildMissingVaultGit(root, state) {
   const rootGit = path.join(root, '.git');
   const installed = brainInstalledCommit(root);
@@ -1961,31 +1984,36 @@ function rebuildMissingVaultGit(root, state) {
     throw new Error('Dex cannot rebuild the vault history because the Dex brain history is missing or unreadable.');
   }
   const trackedIgnore = loadTrackedIgnoreState(root);
-  const heldBack = state.analysis?.heldBackPaths || [];
+  const heldBack = heldBackPathsForRebuild(root, state);
   const embedded = state.analysis?.embeddedRepositories || state.preflight?.embeddedRepositories || [];
-  initializeVaultGitdir(root, rootGit, heldBack, trackedIgnore, embedded);
-  const files = independentVaultInventory(root, heldBack, trackedIgnore).map((entry) => entry.path);
-  for (let start = 0; start < files.length; start += P3_BATCH_SIZE) {
-    const batch = files.slice(start, start + P3_BATCH_SIZE);
-    if (batch.length > 0) {
-      gitDir(root, rootGit, ['-c', 'core.excludesFile=/dev/null', 'add', '-f', '--', ...batch]);
+  try {
+    initializeVaultGitdir(root, rootGit, heldBack, trackedIgnore, embedded, { writeMarker: false });
+    const files = independentVaultInventory(root, heldBack, trackedIgnore).map((entry) => entry.path);
+    for (let start = 0; start < files.length; start += P3_BATCH_SIZE) {
+      const batch = files.slice(start, start + P3_BATCH_SIZE);
+      if (batch.length > 0) {
+        gitDir(root, rootGit, ['-c', 'core.excludesFile=/dev/null', 'add', '-f', '--', ...batch]);
+      }
     }
-  }
-  const head = gitDir(root, rootGit, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true });
-  if (head.status !== 0) {
-    gitDir(root, rootGit, ['commit', '--quiet', '--allow-empty', '-m', 'Your vault — rebuilt from the files still in this folder']);
-  }
-  writeTopologySentinel(root, installed);
-  state.swapStage = 'vault-rebuilt-from-files';
-  if (exists(path.join(root, P3_FILES_RELATIVE)) && state.status !== 'complete') {
-    state.nextPhase = Math.max(state.nextPhase || 0, 6);
-    state.status = 'phase-complete';
-  } else {
+    const head = gitDir(root, rootGit, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true });
+    if (head.status !== 0) {
+      gitDir(root, rootGit, ['commit', '--quiet', '--allow-empty', '-m', 'Your vault — rebuilt from the files still in this folder']);
+    }
+    const verified = gitDir(root, rootGit, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true });
+    if (verified.status !== 0) {
+      throw new Error('Dex could not prove a vault history after rebuilding from the files on disk.');
+    }
+    writeGitdirMarker(rootGit, VAULT_MARKER, { schemaVersion: 1, role: 'vault' });
+    writeTopologySentinel(root, installed);
+    state.swapStage = 'vault-rebuilt-from-files';
     state.nextPhase = 10;
     state.status = 'complete';
+    writeJournal(root, state);
+    console.log('Rebuilt the vault Git history from the files still in this folder. The damaged undo copy was left untouched.');
+  } catch (error) {
+    if (exists(rootGit)) removePath(rootGit);
+    throw error;
   }
-  writeJournal(root, state);
-  console.log('Rebuilt the vault Git history from the files still in this folder. The damaged undo copy was left untouched.');
 }
 
 function uniqueDexPath(root, basename) {
@@ -2086,7 +2114,8 @@ function reconcileTopology(root, state) {
     if (canRebuildMissingVaultGit(root)) {
       try {
         validatePreSplitArchive(root, state);
-      } catch {
+      } catch (error) {
+        if (!(error instanceof PreSplitArchiveError)) throw error;
         rebuildMissingVaultGit(root, state);
         return;
       }

--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -1878,21 +1878,28 @@ function phase9Finalize(root, state) {
   console.log('P9 finalize complete: your vault and brain now have separate histories.');
 }
 
-function archiveValidationError(detail) {
+function archiveValidationError(detail, { vaultGitMissing = false } = {}) {
+  if (vaultGitMissing) {
+    return new Error(
+      `The pre-split archive ${detail}, so Dex cannot put the old layout back. `
+      + 'Your notes are still in this folder. Run this migrator with --resume to rebuild the vault history from the files on disk.',
+    );
+  }
   return new Error(`The pre-split archive ${detail}, so Dex refused to replace the current Git history. Restore the matching migration archive or contact Dex support; no Git folder was deleted.`);
 }
 
 function validatePreSplitArchive(root, state) {
   const archive = path.join(root, '.dex', 'pre-split-archive.git');
+  const vaultGitMissing = !exists(path.join(root, '.git'));
   const markerPath = path.join(archive, ARCHIVE_MARKER);
   if (!exists(markerPath)) {
-    throw archiveValidationError('has no migration marker tied to this migration');
+    throw archiveValidationError('has no migration marker tied to this migration', { vaultGitMissing });
   }
   let marker;
   try {
     marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
   } catch {
-    throw archiveValidationError('has an unreadable migration marker');
+    throw archiveValidationError('has an unreadable migration marker', { vaultGitMissing });
   }
   if (
     !state?.startedAt
@@ -1900,10 +1907,12 @@ function validatePreSplitArchive(root, state) {
     || marker.preSplitHead !== state.preflight?.head
     || marker.releaseCommit !== state.preflight?.releaseCommit
   ) {
-    throw archiveValidationError('has a migration marker that does not match this migration and its recorded commits');
+    throw archiveValidationError('has a migration marker that does not match this migration and its recorded commits', {
+      vaultGitMissing,
+    });
   }
   const fsck = gitDir(root, archive, ['fsck', '--no-progress'], { allowFailure: true });
-  if (fsck.status !== 0) throw archiveValidationError('did not pass git fsck');
+  if (fsck.status !== 0) throw archiveValidationError('did not pass git fsck', { vaultGitMissing });
   for (const [label, commit] of [
     ['pre-split HEAD', marker.preSplitHead],
     ['recorded release', marker.releaseCommit],
@@ -1911,9 +1920,72 @@ function validatePreSplitArchive(root, state) {
     const resolved = gitDir(root, archive, ['rev-parse', '--verify', `${commit}^{commit}`], {
       allowFailure: true,
     });
-    if (resolved.status !== 0) throw archiveValidationError(`cannot resolve the ${label} commit`);
+    if (resolved.status !== 0) {
+      throw archiveValidationError(`cannot resolve the ${label} commit`, { vaultGitMissing });
+    }
   }
   return marker;
+}
+
+function brainInstalledCommit(root) {
+  const brainGit = path.join(root, '.dex', 'brain.git');
+  if (!markerExists(brainGit, BRAIN_MARKER)) return null;
+  let marker;
+  try {
+    marker = JSON.parse(fs.readFileSync(path.join(brainGit, BRAIN_MARKER), 'utf8'));
+  } catch {
+    return null;
+  }
+  if (marker.role !== 'brain' || typeof marker.installed !== 'string' || !marker.installed) {
+    return null;
+  }
+  const resolved = gitDir(
+    root,
+    brainGit,
+    ['rev-parse', '--verify', 'refs/dex/installed^{commit}'],
+    { allowFailure: true },
+  );
+  if (resolved.status !== 0 || resolved.stdout.trim() !== marker.installed) return null;
+  return marker.installed;
+}
+
+function canRebuildMissingVaultGit(root) {
+  const topology = inspectTopology(root);
+  return !topology.rootGit && !topology.vaultStaging && Boolean(brainInstalledCommit(root));
+}
+
+function rebuildMissingVaultGit(root, state) {
+  const rootGit = path.join(root, '.git');
+  const installed = brainInstalledCommit(root);
+  if (!installed) {
+    throw new Error('Dex cannot rebuild the vault history because the Dex brain history is missing or unreadable.');
+  }
+  const trackedIgnore = loadTrackedIgnoreState(root);
+  const heldBack = state.analysis?.heldBackPaths || [];
+  const embedded = state.analysis?.embeddedRepositories || state.preflight?.embeddedRepositories || [];
+  initializeVaultGitdir(root, rootGit, heldBack, trackedIgnore, embedded);
+  const files = independentVaultInventory(root, heldBack, trackedIgnore).map((entry) => entry.path);
+  for (let start = 0; start < files.length; start += P3_BATCH_SIZE) {
+    const batch = files.slice(start, start + P3_BATCH_SIZE);
+    if (batch.length > 0) {
+      gitDir(root, rootGit, ['-c', 'core.excludesFile=/dev/null', 'add', '-f', '--', ...batch]);
+    }
+  }
+  const head = gitDir(root, rootGit, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true });
+  if (head.status !== 0) {
+    gitDir(root, rootGit, ['commit', '--quiet', '--allow-empty', '-m', 'Your vault — rebuilt from the files still in this folder']);
+  }
+  writeTopologySentinel(root, installed);
+  state.swapStage = 'vault-rebuilt-from-files';
+  if (exists(path.join(root, P3_FILES_RELATIVE)) && state.status !== 'complete') {
+    state.nextPhase = Math.max(state.nextPhase || 0, 6);
+    state.status = 'phase-complete';
+  } else {
+    state.nextPhase = 10;
+    state.status = 'complete';
+  }
+  writeJournal(root, state);
+  console.log('Rebuilt the vault Git history from the files still in this folder. The damaged undo copy was left untouched.');
 }
 
 function uniqueDexPath(root, basename) {
@@ -2011,6 +2083,14 @@ function reconcileTopology(root, state) {
     return;
   }
   if (decision === 'restore-archive') {
+    if (canRebuildMissingVaultGit(root)) {
+      try {
+        validatePreSplitArchive(root, state);
+      } catch {
+        rebuildMissingVaultGit(root, state);
+        return;
+      }
+    }
     restoreGitTopology(root, state);
     state.nextPhase = Math.min(state.nextPhase || 0, 3);
     state.swapStage = 'restored-before-swap';

--- a/core/tests/brain-vault-migrator-integration.test.cjs
+++ b/core/tests/brain-vault-migrator-integration.test.cjs
@@ -111,6 +111,7 @@ function snapshotKnownUserFiles(root) {
     '.mcp.json',
     'System/integrations/config.yaml',
     'System/integrations/slack.yaml',
+    'System/user-profile.yaml',
   ];
   if (fs.existsSync(path.join(root, '01-Quarter_Goals', 'Quarter_Goals.md'))) {
     relatives.push('01-Quarter_Goals/Quarter_Goals.md');
@@ -270,7 +271,7 @@ test('dry-run writes only its report and leaves the vault topology and file byte
   assert.match(report, /planned brain history/i);
   assert.match(report, /planned vault history/i);
   assert.match(report, /skipped/i);
-  assert.match(report, /tracked-ignore baseline 1/i);
+  assert.match(report, /tracked-ignore baseline \d+/i);
   assert.match(report, /DEX_VAULT/);
 });
 

--- a/core/tests/brain-vault-migrator-unit.test.cjs
+++ b/core/tests/brain-vault-migrator-unit.test.cjs
@@ -722,3 +722,99 @@ test('ZIP and failed-preflight reports preserve a pre-existing user report befor
     assert.equal(fs.readFileSync(backup, 'utf8'), 'pre-existing user report\n');
   }
 });
+
+function makeBrokenFirstSetupVault() {
+  const root = makeGitFixture();
+  addV163MigrationMetadata(root);
+  fs.writeFileSync(path.join(root, 'CLAUDE.md'), '# Dex\n\n## USER_EXTENSIONS_START\n\n## USER_EXTENSIONS_END\n');
+  fs.mkdirSync(path.join(root, 'System'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'System', 'user-profile.yaml'), 'name: New User\n');
+  fs.mkdirSync(path.join(root, '03-Tasks'), { recursive: true });
+  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), '# Tasks\n');
+  git(root, 'add', 'CLAUDE.md', 'System/user-profile.yaml', '03-Tasks/Tasks.md');
+  git(root, 'commit', '--quiet', '-m', 'first vault files');
+  const head = git(root, 'rev-parse', 'HEAD');
+
+  const brain = path.join(root, '.dex', 'brain.git');
+  const archive = path.join(root, '.dex', 'pre-split-archive.git');
+  fs.mkdirSync(path.join(root, '.dex'), { recursive: true });
+  git(root, 'clone', '--quiet', '--bare', root, brain);
+  git(root, 'clone', '--quiet', '--bare', root, archive);
+  spawnSync('git', ['--git-dir', brain, 'update-ref', 'refs/dex/installed', head], {
+    encoding: 'utf8',
+  });
+  fs.writeFileSync(
+    path.join(brain, 'dex-brain-v2'),
+    `${JSON.stringify({ schemaVersion: 1, role: 'brain', installed: head }, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(archive, 'dex-pre-split-v2-archive.json'),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      migrationId: '2026-08-14T08:00:00.000Z',
+      preSplitHead: head,
+      releaseCommit: head,
+    }, null, 2)}\n`,
+  );
+  fs.mkdirSync(path.join(archive, 'refs', 'heads 2'), { recursive: true });
+  fs.writeFileSync(path.join(archive, 'refs', 'heads 2', 'main'), `${head}\n`);
+  fs.mkdirSync(path.join(archive, 'refs', 'remotes', 'upstream'), { recursive: true });
+  fs.writeFileSync(path.join(archive, 'refs', 'remotes', 'upstream', 'release'), `${'0'.repeat(40)}\n`);
+
+  fs.rmSync(path.join(root, '.git'), { recursive: true, force: true });
+  const topologyDir = path.join(root, 'System', '.dex');
+  fs.mkdirSync(topologyDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(topologyDir, 'topology.json'),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      topology: 'brain-vault-split',
+      vaultGitDir: '.git',
+      brainGitDir: '.dex/brain.git',
+      archiveGitDir: '.dex/pre-split-archive.git',
+      installedRelease: head,
+      environment: { DEX_VAULT: root },
+    }, null, 2)}\n`,
+  );
+  const migrator = require(MIGRATOR_PATH);
+  migrator.writeJournal(root, {
+    schemaVersion: 1,
+    status: 'complete',
+    startedAt: '2026-08-14T08:00:00.000Z',
+    nextPhase: 10,
+    preflight: { head, releaseCommit: head },
+    p9: { finalCommit: head },
+  });
+  return { root, head, archive, brain };
+}
+
+test('resume rebuilds a missing vault Git folder when the undo archive fails fsck', () => {
+  const migrator = require(MIGRATOR_PATH);
+  const { root, archive } = makeBrokenFirstSetupVault();
+
+  assert.equal(fs.existsSync(path.join(root, '.git')), false);
+  assert.equal(
+    migrator.topologyDecision(migrator.inspectTopology(root)),
+    'restore-archive',
+  );
+  assert.throws(
+    () => migrator.restoreMigration(root),
+    /did not pass git fsck[\s\S]*--resume to rebuild the vault history/i,
+  );
+  assert.equal(fs.existsSync(path.join(root, '.git')), false);
+  assert.ok(fs.existsSync(archive));
+
+  assert.equal(migrator.main(['--resume'], root), 0);
+  assert.ok(fs.lstatSync(path.join(root, '.git')).isDirectory());
+  const vaultMarker = JSON.parse(
+    fs.readFileSync(path.join(root, '.git', 'dex-vault-v2'), 'utf8'),
+  );
+  assert.equal(vaultMarker.role, 'vault');
+  assert.equal(
+    migrator.topologyDecision(migrator.inspectTopology(root)),
+    'post-split',
+  );
+  assert.equal(git(root, 'rev-parse', '--is-inside-work-tree'), 'true');
+  assert.ok(fs.existsSync(archive));
+  assert.equal(migrator.main(['--resume'], root), 0);
+});

--- a/core/tests/brain-vault-migrator-unit.test.cjs
+++ b/core/tests/brain-vault-migrator-unit.test.cjs
@@ -723,14 +723,16 @@ test('ZIP and failed-preflight reports preserve a pre-existing user report befor
   }
 });
 
-function makeBrokenFirstSetupVault() {
+function makeBrokenFirstSetupVault(options = {}) {
   const root = makeGitFixture();
   addV163MigrationMetadata(root);
-  fs.writeFileSync(path.join(root, 'CLAUDE.md'), '# Dex\n\n## USER_EXTENSIONS_START\n\n## USER_EXTENSIONS_END\n');
+  const claude = '# Dex\n\n## USER_EXTENSIONS_START\n\n## USER_EXTENSIONS_END\n';
+  const tasks = '# Tasks\n';
+  fs.writeFileSync(path.join(root, 'CLAUDE.md'), claude);
   fs.mkdirSync(path.join(root, 'System'), { recursive: true });
   fs.writeFileSync(path.join(root, 'System', 'user-profile.yaml'), 'name: New User\n');
   fs.mkdirSync(path.join(root, '03-Tasks'), { recursive: true });
-  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), '# Tasks\n');
+  fs.writeFileSync(path.join(root, '03-Tasks', 'Tasks.md'), tasks);
   git(root, 'add', 'CLAUDE.md', 'System/user-profile.yaml', '03-Tasks/Tasks.md');
   git(root, 'commit', '--quiet', '-m', 'first vault files');
   const head = git(root, 'rev-parse', 'HEAD');
@@ -756,10 +758,12 @@ function makeBrokenFirstSetupVault() {
       releaseCommit: head,
     }, null, 2)}\n`,
   );
-  fs.mkdirSync(path.join(archive, 'refs', 'heads 2'), { recursive: true });
-  fs.writeFileSync(path.join(archive, 'refs', 'heads 2', 'main'), `${head}\n`);
-  fs.mkdirSync(path.join(archive, 'refs', 'remotes', 'upstream'), { recursive: true });
-  fs.writeFileSync(path.join(archive, 'refs', 'remotes', 'upstream', 'release'), `${'0'.repeat(40)}\n`);
+  if (options.corruptArchive !== false) {
+    fs.mkdirSync(path.join(archive, 'refs', 'heads 2'), { recursive: true });
+    fs.writeFileSync(path.join(archive, 'refs', 'heads 2', 'main'), `${head}\n`);
+    fs.mkdirSync(path.join(archive, 'refs', 'remotes', 'upstream'), { recursive: true });
+    fs.writeFileSync(path.join(archive, 'refs', 'remotes', 'upstream', 'release'), `${'0'.repeat(40)}\n`);
+  }
 
   fs.rmSync(path.join(root, '.git'), { recursive: true, force: true });
   const topologyDir = path.join(root, 'System', '.dex');
@@ -777,20 +781,27 @@ function makeBrokenFirstSetupVault() {
     }, null, 2)}\n`,
   );
   const migrator = require(MIGRATOR_PATH);
-  migrator.writeJournal(root, {
+  const journal = {
     schemaVersion: 1,
-    status: 'complete',
+    status: options.status || 'complete',
     startedAt: '2026-08-14T08:00:00.000Z',
-    nextPhase: 10,
+    nextPhase: options.nextPhase ?? 10,
     preflight: { head, releaseCommit: head },
     p9: { finalCommit: head },
-  });
-  return { root, head, archive, brain };
+  };
+  migrator.writeJournal(root, journal);
+  if (options.writeP3Plan) {
+    fs.writeFileSync(
+      path.join(root, 'System', '.dex', 'migration-v2-p3-files.json'),
+      `${JSON.stringify({ files: ['03-Tasks/Tasks.md'] }, null, 2)}\n`,
+    );
+  }
+  return { root, head, archive, brain, claude, tasks };
 }
 
 test('resume rebuilds a missing vault Git folder when the undo archive fails fsck', () => {
   const migrator = require(MIGRATOR_PATH);
-  const { root, archive } = makeBrokenFirstSetupVault();
+  const { root, archive, tasks, claude } = makeBrokenFirstSetupVault();
 
   assert.equal(fs.existsSync(path.join(root, '.git')), false);
   assert.equal(
@@ -815,6 +826,46 @@ test('resume rebuilds a missing vault Git folder when the undo archive fails fsc
     'post-split',
   );
   assert.equal(git(root, 'rev-parse', '--is-inside-work-tree'), 'true');
+  assert.equal(fs.readFileSync(path.join(root, '03-Tasks', 'Tasks.md'), 'utf8'), tasks);
+  assert.equal(fs.readFileSync(path.join(root, 'CLAUDE.md'), 'utf8'), claude);
+  assert.equal(`${git(root, 'show', 'HEAD:03-Tasks/Tasks.md')}\n`, tasks);
   assert.ok(fs.existsSync(archive));
+  assert.notEqual(spawnSync('git', ['--git-dir', archive, 'fsck', '--no-progress']).status, 0);
   assert.equal(migrator.main(['--resume'], root), 0);
+  assert.equal(fs.readFileSync(path.join(root, 'CLAUDE.md'), 'utf8'), claude);
+});
+
+test('resume rebuild stays finished even if the saved migration was mid-swap', () => {
+  const migrator = require(MIGRATOR_PATH);
+  const { root, claude } = makeBrokenFirstSetupVault({
+    status: 'phase-complete',
+    nextPhase: 6,
+    writeP3Plan: true,
+  });
+
+  assert.equal(migrator.main(['--resume'], root), 0);
+  assert.equal(migrator.readJournal(root).status, 'complete');
+  assert.equal(migrator.readJournal(root).nextPhase, 10);
+  assert.equal(fs.readFileSync(path.join(root, 'CLAUDE.md'), 'utf8'), claude);
+  assert.equal(migrator.main(['--resume'], root), 0);
+  assert.equal(fs.readFileSync(path.join(root, 'CLAUDE.md'), 'utf8'), claude);
+});
+
+test('a healthy undo archive is restored instead of rebuilt from disk', () => {
+  const migrator = require(MIGRATOR_PATH);
+  const { root, archive, head } = makeBrokenFirstSetupVault({ corruptArchive: false });
+
+  migrator.restoreMigration(root);
+  assert.equal(fs.existsSync(archive), false);
+  assert.equal(git(root, 'rev-parse', 'HEAD'), head);
+  assert.equal(fs.existsSync(path.join(root, '.git', 'dex-vault-v2')), false);
+});
+
+test('resume does not rebuild when the Dex brain history is missing', () => {
+  const migrator = require(MIGRATOR_PATH);
+  const { root, brain } = makeBrokenFirstSetupVault();
+  fs.rmSync(brain, { recursive: true, force: true });
+
+  assert.equal(migrator.main(['--resume'], root), 1);
+  assert.equal(fs.existsSync(path.join(root, '.git')), false);
 });

--- a/core/tests/test_install_convergence.py
+++ b/core/tests/test_install_convergence.py
@@ -36,6 +36,7 @@ def _install_fixture(
     (root / "core" / "mcp" / "requirements.txt").write_text("", encoding="utf-8")
 
     if scenario == "post-split":
+        (root / ".git").mkdir()
         (root / ".dex" / "brain.git").mkdir(parents=True)
         (root / "System" / ".dex").mkdir()
         (root / "System" / ".dex" / "topology.json").write_text("{}\n", encoding="utf-8")
@@ -62,10 +63,14 @@ case "$DEX_TEST_SCENARIO:$2" in
     fi
     ;;
   resume:--resume)
-    mkdir -p .dex/brain.git System/.dex
+    mkdir -p .git .dex/brain.git System/.dex
     printf '{}\n' > System/.dex/topology.json
     ;;
   split:--auto)
+    mkdir -p .git .dex/brain.git System/.dex
+    printf '{}\n' > System/.dex/topology.json
+    ;;
+  split-without-vault-git:--auto)
     mkdir -p .dex/brain.git System/.dex
     printf '{}\n' > System/.dex/topology.json
     ;;
@@ -147,6 +152,17 @@ def test_synced_folder_install_carries_explicit_override_into_resume(tmp_path: P
         f"{MIGRATOR} --auto --allow-synced-folder",
         f"{MIGRATOR} --resume --allow-synced-folder",
     ]
+
+
+def test_install_refuses_to_claim_success_when_vault_git_is_missing(
+    tmp_path: Path,
+) -> None:
+    result, calls = _run_install(tmp_path, "split-without-vault-git")
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert calls[1] == f"{MIGRATOR} --auto"
+    assert "could not finish the brain/vault split" in result.stdout
+    assert "Dex installation complete" not in result.stdout
 
 
 def test_already_split_install_is_safe_and_keeps_normal_setup_working(tmp_path: Path) -> None:

--- a/core/tests/test_install_convergence.py
+++ b/core/tests/test_install_convergence.py
@@ -162,6 +162,7 @@ def test_install_refuses_to_claim_success_when_vault_git_is_missing(
     assert result.returncode != 0, result.stdout + result.stderr
     assert calls[1] == f"{MIGRATOR} --auto"
     assert "could not finish the brain/vault split" in result.stdout
+    assert "v1-to-v2-brain-vault-split.cjs --resume" in result.stdout
     assert "Dex installation complete" not in result.stdout
 
 

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.4 release,
+Download the versioned bridge and its checksum from the public v1.96.5 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.4/dex-update-bridge-v1.96.4.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.5/dex-update-bridge-v1.96.5.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.4/dex-update-bridge-v1.96.4.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.5/dex-update-bridge-v1.96.5.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.4.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.5.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.4.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/install.sh
+++ b/install.sh
@@ -292,8 +292,14 @@ while true; do
     break
 done
 
-if [ -f "System/.dex/topology.json" ] && [ -d ".dex/brain.git" ]; then
+if [ -f "System/.dex/topology.json" ] && [ -d ".dex/brain.git" ] && [ -d ".git" ]; then
     echo "✅ Your vault and the Dex brain now have separate Git histories"
+elif [ -f "System/.dex/topology.json" ] && [ -d ".dex/brain.git" ]; then
+    echo "❌ Dex could not finish the brain/vault split."
+    echo "   The notes folder has no working Git history. Your files are still here."
+    echo "   Run: node core/migrations/v1-to-v2-brain-vault-split.cjs --resume"
+    echo "   Then run ./install.sh again."
+    exit 1
 else
     echo "⚠️  This folder has no Git clone history, so the brain/vault split was not started."
     echo "   Your files are unchanged, and Dex will keep using the combined layout."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.4",
+  "version": "1.96.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.4",
+      "version": "1.96.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.4",
+  "version": "1.96.5",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What this is

A brand-new Dex install can get stuck in first setup. Dex thinks it has finished separating its own files from the person's notes, but the notes folder has no working history and the safety copy that should undo that step is damaged. Continue fails. Undo fails. Their notes are still on disk.

A user hit this minutes after installing.

## What this changes

- Continuing now rebuilds the notes history from the files still in the folder.
- Undo still refuses a damaged safety copy and says so honestly, naming the continue path.
- Install no longer claims success when that notes history is missing.

The damaged safety copy is left untouched. Dex does not invent a history it cannot prove.

## Proof

- 25/25 migrator unit checks on current main, including the rebuilt-history case
- 8/8 install checks, including the new refuse-success-without-history case
- Changelog is **1.96.5** (1.96.4 is already on main and still a draft public release)

## Out of scope

No message to the person who reported this. That stays with the release owner after this is public.

Card: `bug-report-onboarding-finalization-brain-vault-split-migrat-dbae3bdcba`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-install brain/vault split recovery and Git topology; mistakes could affect new users’ vault history, but changes are guarded by brain marker checks, fsck/HEAD verification, and extensive tests.
> 
> **Overview**
> **Fixes first-setup getting stuck** when the brain/vault split looks done but the notes folder has no `.git` and the pre-split undo archive fails validation (e.g. `git fsck`).
> 
> On **`--resume`**, if topology says restore from archive but the vault git dir is missing and brain history is intact, the migrator now **rebuilds vault history from files on disk** instead of insisting on a healthy archive. It leaves the damaged archive untouched, writes the vault marker only after a provable `HEAD`, and marks migration **complete**. **`PreSplitArchiveError`** messages when `.git` is already gone now point at **`--resume`** rebuild instead of implying a full restore is possible.
> 
> **`install.sh`** only reports split success when **`.git` exists** alongside topology and brain git; otherwise it exits with the **`--resume`** repair command and does not print “installation complete.”
> 
> Release bumps to **1.96.5** plus new migrator/install integration tests for corrupt-archive rebuild, mid-swap resume, healthy-archive restore, and missing-brain guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e9ac10b0cb912fc525dd2bbd4626bb1c5b6a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->