### PR TITLE
ci: catch non-canonical dist/archive tags in the quality job, not hours into a fleet run

### DIFF
--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -160,6 +160,57 @@ def test_uniqueness_gate_rejects_an_empty_remote_observation(tmp_path: Path) -> 
     assert "uniqueness cannot be verified" in result.stderr
 
 
+def test_gate_rejects_non_canonical_archive_tag_without_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # The executor requires exactly 7 hex characters in a dist/archive tag and
+    # only says so per-journey, hours into historic-fleet-darwin. A lone
+    # non-canonical start must fail here instead. Include one unique
+    # dist/release tag so the uniqueness empty-check does not fire first.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.99.0-1111111",
+        "dist/archive/v1.81.12-3a8245ab",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "dist/archive/v1.81.12-3a8245ab" in result.stderr
+    assert "no canonical twin" in result.stderr
+    assert "Remedy: create dist/archive/v1.81.12-" in result.stderr
+    assert "Delete nothing" in result.stderr
+
+
+def test_gate_accepts_non_canonical_archive_tag_with_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # Discovery de-duplicates journeys by tree, so a canonical tag at the same
+    # commit already shadows the non-canonical one. That is today's tag set.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.99.0-1111111",
+        "dist/archive/v1.81.12-3a8245ab",
+        "dist/archive/v1.81.12-3a8245a",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def _newer_release_tags(count: int) -> tuple[str, ...]:
     return tuple(
         f"dist/release/v1.{minor}.0-{minor:07x}"

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -49,4 +49,78 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
+# dist/archive tags are the historic fleet's starting points. Discovery
+# (scripts/release_fleet.py ARCHIVE_RELEASE_TAG) accepts a 7-64 hex suffix, but
+# the executor (scripts/release_fleet_executor.py _ARCHIVE_RELEASE_TAG) requires
+# exactly 7 and raises "starting release identity is malformed" per journey,
+# hours into the 4.5h historic-fleet-darwin run. Catch it here in seconds.
+#
+# Discovery de-duplicates journeys by tree, so a non-canonical tag that has a
+# canonical twin at the same commit is already shadowed and can never be picked
+# as a starting point. Fail only on a lone non-canonical tag.
+if ! ARCHIVE_TAGS="$(
+  git ls-remote --tags origin 'refs/tags/dist/archive/v*'
+)"; then
+  echo "❌ Release-tag uniqueness gate failed: could not read dist/archive tags from origin; git ls-remote failed." >&2
+  exit 1
+fi
+
+UNTWINNED_ARCHIVE_TAGS="$(
+  printf '%s\n' "$ARCHIVE_TAGS" |
+    awk '
+      # An annotated tag's peeled ^{} ref carries the commit the tag resolves
+      # to; the bare ref carries the tag object. Prefer the peeled value so
+      # twins pointing at one commit compare equal.
+      {
+        ref = $2
+        peeled = (ref ~ /\^\{\}$/)
+        sub(/\^\{\}$/, "", ref)
+        if (ref !~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/) {
+          next
+        }
+        if (peeled || !(ref in commit)) {
+          commit[ref] = $1
+        }
+      }
+      END {
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            canonical[commit[ref]] = 1
+          }
+        }
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            continue
+          }
+          if (commit[ref] in canonical) {
+            continue
+          }
+          tag = ref
+          sub(/^refs\/tags\//, "", tag)
+          print tag, commit[ref]
+        }
+      }
+    ' |
+    sort
+)"
+
+ARCHIVE_FAILED=0
+while read -r TAG COMMIT; do
+  [ -n "${TAG:-}" ] || continue
+  ARCHIVE_VERSION="${TAG#dist/archive/v}"
+  ARCHIVE_VERSION="${ARCHIVE_VERSION%%-*}"
+  CANONICAL_SHORT="$(printf '%s' "$COMMIT" | cut -c1-7)"
+  echo "❌ $TAG (commit $COMMIT) is a non-canonical dist/archive tag with no canonical twin at that commit." >&2
+  echo "The fleet executor requires exactly 7 hex characters in a dist/archive tag, so this start fails hours into historic-fleet-darwin." >&2
+  echo "Remedy: create dist/archive/v$ARCHIVE_VERSION-$CANONICAL_SHORT at $COMMIT. Delete nothing — the existing tag stays, and discovery's tree de-duplication will shadow it." >&2
+  ARCHIVE_FAILED=1
+done <<EOF
+$UNTWINNED_ARCHIVE_TAGS
+EOF
+
+if [ "$ARCHIVE_FAILED" -ne 0 ]; then
+  echo "❌ Release-tag uniqueness gate failed: one or more dist/archive tags are non-canonical with no canonical twin." >&2
+  exit 1
+fi
+
 echo "Release-tag uniqueness gate passed."

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -68,7 +68,7 @@ fi
 UNTWINNED_ARCHIVE_TAGS="$(
   printf '%s\n' "$ARCHIVE_TAGS" |
     awk '
-      # An annotated tag's peeled ^{} ref carries the commit the tag resolves
+      # An annotated tags peeled ^{} ref carries the commit the tag resolves
       # to; the bare ref carries the tag object. Prefer the peeled value so
       # twins pointing at one commit compare equal.
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebase of [#480](https://github.com/davekilleen/Dex/pull/480) onto current `main`. #480 is still open but conflicts; this is the rebased copy. No product change and no release.

## Why

A historic fleet run burned hours of macOS time and then failed with:

```
dist/archive/v1.81.12-3a8245ab: platform infrastructure or integrity failure:
starting release identity is malformed
```

That is a tag-naming mismatch, not an upgrade regression. This moves that check into the short quality job.

## What

Appends an archive-canonicality check to `scripts/check-release-tag-uniqueness.sh`.

**The rule:** fail only when a non-canonical `dist/archive/` tag has **no canonical twin** at the same commit. Today's tag set stays green. The remedy is additive: create the canonical tag. Delete nothing.

## Proof

- Local: `python3 -m pytest core/tests/test_release_tag_uniqueness.py` — 18 passed
- Live origin tags: `bash scripts/check-release-tag-uniqueness.sh` exits 0
- CI **quality** job (the job that runs this gate): green on every run

Required `tests (*)` shards have been flaking on unrelated smoke tests this branch does not touch (`fsmonitor`, hanging-journey timeouts, `Operation not permitted`). Sibling [#542](https://github.com/davekilleen/Dex/pull/542) is fully green, including those shards.

## Relationship to #472 / #542

Complementary, not a replacement. #542 is the fail-fast at discovery and is CLEAN with a green canary.

## Out of scope

- No tag created, deleted, moved, or force-updated
- No changelog and no version bump
- Does not cut a 1.96.6 release

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fdfd97a-fbc3-46ab-9f79-af914d6b29f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fdfd97a-fbc3-46ab-9f79-af914d6b29f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

