### PR TITLE
fleet: reject a non-canonical archived start at discovery, not hours later

### DIFF
--- a/core/tests/test_release_fleet.py
+++ b/core/tests/test_release_fleet.py
@@ -101,6 +101,52 @@ def test_discovers_archived_distribution_tree_when_the_canonical_tag_is_absent(
     assert [release.tag for release in releases] == [archive_tag]
 
 
+def test_rejects_archived_start_the_executor_would_refuse_mid_run(
+    tmp_path: Path,
+) -> None:
+    """A non-canonical archived start must fail discovery, not journey 191 of 202.
+
+    The executor accepts archived starts only in the canonical seven-character
+    form. Discovery is deliberately wider, so before this guard a hand-made tag
+    with a longer short sha was admitted here and then refused hours later,
+    aborting the whole fleet. Reproduces dist/archive/v1.81.12-3a8245ab.
+    """
+
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.81.12", "historic release")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    oversized = f"dist/archive/v1.81.12-{commit[:8]}"
+    _git(repo, "tag", "-a", oversized, commit, "-m", oversized)
+    _git(repo, "tag", "-d", tag)
+
+    with pytest.raises(release_fleet.FleetError, match="canonical"):
+        release_fleet.discover_distribution_releases(repo)
+
+
+def test_canonical_archived_start_supersedes_its_oversized_twin(
+    tmp_path: Path,
+) -> None:
+    """Adding the canonical tag is enough; the oversized one needs no deletion.
+
+    Discovery keeps one start per tree and sorts by tag, so the shorter tag wins
+    and its oversized twin is skipped as a duplicate tree. This is the property
+    the dist/archive/v1.81.12-3a8245a fix relies on.
+    """
+
+    repo = _repository(tmp_path)
+    tag = _tag_release(repo, "1.81.12", "historic release")
+    commit = _git(repo, "rev-parse", f"{tag}^{{commit}}")
+    oversized = f"dist/archive/v1.81.12-{commit[:8]}"
+    canonical = f"dist/archive/v1.81.12-{commit[:7]}"
+    _git(repo, "tag", "-a", oversized, commit, "-m", oversized)
+    _git(repo, "tag", "-a", canonical, commit, "-m", canonical)
+    _git(repo, "tag", "-d", tag)
+
+    releases = release_fleet.discover_distribution_releases(repo)
+
+    assert [release.tag for release in releases] == [canonical]
+
+
 def test_discovers_exact_v164_archived_starting_tree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     tag = "dist/archive/v1.64.0-366c168"
     commit = "366c168af61c50ee7157976a9eb8a154ca0fd7f4"

--- a/core/update/journey-protocol-v1.json
+++ b/core/update/journey-protocol-v1.json
@@ -51,7 +51,7 @@
     "darwin"
   ],
   "runner": {
-    "sha256": "43e8631bbe31557750a04ca059e17e1f6ba6a774b0bf6a409a0a05cdc856b789",
+    "sha256": "56b3b9cfcd6dd02ab84c76382c8364d51d3cb0463562c55323caedf8cc7cdba8",
     "source_path": "scripts/release_fleet.py"
   },
   "schema_version": 1

--- a/scripts/release_fleet.py
+++ b/scripts/release_fleet.py
@@ -40,6 +40,14 @@ RELEASE_TAG = re.compile(
 ARCHIVE_RELEASE_TAG = re.compile(
     r"^dist/archive/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7,64})$"
 )
+# The journey executor accepts an archived start only in the canonical
+# seven-character form (`_ARCHIVE_RELEASE_TAG` in scripts/release_fleet_executor.py).
+# Discovery above is deliberately wider so a non-canonical tag is still seen rather
+# than silently ignored; this pattern is what lets discovery reject it up front
+# instead of letting the fleet refuse it hours later, mid-run.
+EXECUTOR_ARCHIVE_RELEASE_TAG = re.compile(
+    r"^dist/archive/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-(?P<short>[0-9a-f]{7})$"
+)
 LEGACY_RELEASE_TAG = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 USER_FIXTURES = {
     str(INBOX_DIR.relative_to(VAULT_ROOT) / "keep.md"): b"# User note\nThis must survive updates.\n",
@@ -1052,6 +1060,18 @@ def discover_distribution_releases(repo: Path) -> tuple[DistributionRelease, ...
                 commit=commit,
                 tree=tree,
             )
+        )
+    for release in discovered:
+        if not release.tag.startswith("dist/archive/"):
+            continue
+        if EXECUTOR_ARCHIVE_RELEASE_TAG.fullmatch(release.tag) is not None:
+            continue
+        raise FleetError(
+            f"{release.tag}: archived start tag is not in the canonical "
+            f"seven-character form, so the journey executor would refuse it "
+            f"part-way through a run. Add the canonical tag for commit "
+            f"{release.commit} alongside it; nothing needs deleting, because "
+            f"discovery keeps one start per tree and prefers the shorter tag."
         )
     return tuple(sorted(discovered, key=lambda item: (_version_key(item.version), item.tag)))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebase of [#472](https://github.com/davekilleen/Dex/pull/472) onto current `main`. #472 is still open, conflicts with `main`, and its canary is red on a stale August 12 snapshot. This copy is the one to land.

**CI:** quality, all three test shards, and `historic-fleet-darwin-pr-canary` are green (canary 19m29s). Merge state is CLEAN.

## Why this is still wanted

The quality-gate successor ([#541](https://github.com/davekilleen/Dex/pull/541) / original #480) catches a lone bad archive tag in the short CI job. This PR is the complementary fail-fast **inside discovery**: if a non-canonical archived start would survive tree de-duplication, the fleet refuses it immediately instead of hours later at journey 191 of 202.

It is silent against today's tag set, because `dist/archive/v1.81.12-3a8245ab` already has its canonical twin. Merge order with the quality-gate PR does not matter.

## What

Discovery validates each surviving start against the executor's own seven-character rule and fails immediately, naming the tag, its commit, and the additive remedy. The executor is deliberately not widened.

`core/update/journey-protocol-v1.json` is regenerated because it pins the runner source by hash. Only that one hash line changes.

## About the old canary failure

#472's canary failed with `FAIL: v1.51.0: follow-up Doctor is unhealthy or incomplete`. That was a follow-up Doctor result on an August 12 head, not this guard. Rebase onto current `main` made the canary pass.

## Out of scope

- No changelog and no version bump
- Does not cut a 1.96.6 release
- Does not widen the executor
- Nothing on a user's screen except fewer broken archive starts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fdfd97a-fbc3-46ab-9f79-af914d6b29f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fdfd97a-fbc3-46ab-9f79-af914d6b29f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

