### PR TITLE
The promotion score now uses your real evidence

### DIFF
--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -811,6 +811,64 @@ async def handle_scan_work_for_evidence(arguments: dict) -> list[types.TextConte
     )]
 
 
+def _required_skills_from_ladder() -> list[str]:
+    """Read required skills with the same ladder parser the rest of Dex uses."""
+    ladder_data = parse_ladder_file(LADDER_FILE)
+    required_skills = []
+    seen = set()
+    for competency in ladder_data.get("competencies") or []:
+        for skill in [competency.get("category"), *(competency.get("target_level_requirements") or [])]:
+            if not skill or skill in seen:
+                continue
+            seen.add(skill)
+            required_skills.append(skill)
+    return required_skills
+
+
+def _score_evidence_count(evidence_count: int) -> int:
+    if evidence_count >= 21:
+        return 25
+    if evidence_count >= 16:
+        return 20
+    if evidence_count >= 11:
+        return 15
+    if evidence_count >= 6:
+        return 10
+    return evidence_count
+
+
+def _score_skills_from_coverage(coverage_analysis: dict, competency_count: int) -> int:
+    if competency_count <= 0:
+        return 0
+    weights = {"strong": 1.0, "moderate": 0.6, "weak": 0.3, "none": 0.0}
+    items = coverage_analysis.get("coverage_by_competency") or []
+    if not items:
+        return 0
+    fraction = sum(weights.get(item.get("coverage_level"), 0.0) for item in items) / len(items)
+    return round(fraction * 25)
+
+
+def _score_growth_velocity(growth: dict, period_data: list) -> int:
+    if not period_data or growth.get("trend") == "no_data":
+        return 0
+    average = float(growth.get("average_monthly") or 0)
+    if average >= 4:
+        score = 10
+    elif average >= 2:
+        score = 8
+    elif average >= 1:
+        score = 6
+    elif average > 0:
+        score = 4
+    else:
+        return 0
+    if growth.get("trend") == "accelerating":
+        return min(10, score + 1)
+    if growth.get("trend") == "decelerating":
+        return max(0, score - 1)
+    return score
+
+
 async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]:
     """Analyze skills gap by comparing career ladder to active work"""
     target_level = arguments.get('target_level')
@@ -818,26 +876,7 @@ async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]
     stale_threshold_days = arguments.get('stale_threshold_days', 42)
     
     # 1. Parse career ladder to get required skills
-    ladder_file = CAREER_DIR / 'Career_Ladder.md'
-    required_skills = []
-    
-    if ladder_file.exists():
-        content = ladder_file.read_text()
-        # Simple skill extraction - look for skills in target level section
-        # This is basic - real implementation would parse more sophisticatedly
-        lines = content.split('\n')
-        in_target_section = False
-        
-        for line in lines:
-            if target_level and target_level in line and line.startswith('#'):
-                in_target_section = True
-            elif line.startswith('#') and in_target_section:
-                break  # Moved to next section
-            elif in_target_section and ('- ' in line or '* ' in line):
-                # Extract skill mentions
-                skill_match = re.search(r'[-*]\s*(.+)', line)
-                if skill_match:
-                    required_skills.append(skill_match.group(1).strip())
+    required_skills = _required_skills_from_ladder()
     
     # 2. Scan work data for skills being developed
     active_skills = {}
@@ -1093,24 +1132,10 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
     score_breakdown = {}
     
     # 1. Evidence Coverage (0-25 points)
-    # Count evidence files in last 12 months
-    evidence_count = 0
-    if EVIDENCE_DIR.exists():
-        for category_dir in EVIDENCE_DIR.iterdir():
-            if category_dir.is_dir():
-                evidence_count += len(list(category_dir.glob('*.md')))
-    
-    # Scoring: 0-5 files=5pts, 6-10=10pts, 11-15=15pts, 16-20=20pts, 21+=25pts
-    if evidence_count >= 21:
-        evidence_score = 25
-    elif evidence_count >= 16:
-        evidence_score = 20
-    elif evidence_count >= 11:
-        evidence_score = 15
-    elif evidence_count >= 6:
-        evidence_score = 10
-    else:
-        evidence_score = evidence_count
+    # Same whole-folder scanner used by scan_evidence / timeline_analysis.
+    evidence_files = scan_evidence_directory(EVIDENCE_DIR) if EVIDENCE_DIR.exists() else []
+    evidence_count = len(evidence_files)
+    evidence_score = _score_evidence_count(evidence_count)
     
     score_breakdown['evidence_coverage'] = {
         'score': evidence_score,
@@ -1149,13 +1174,16 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
     }
     
     # 3. Skills Coverage (0-25 points)
-    # Use skills_gap_analysis to check coverage
-    # Simplified for now - would call skills_gap_analysis tool
-    skills_score = 15  # Placeholder
+    ladder_data = parse_ladder_file(LADDER_FILE)
+    competencies = ladder_data.get("competencies") or []
+    coverage_analysis = analyze_competency_coverage(evidence_files, competencies) if competencies else {}
+    skills_score = _score_skills_from_coverage(coverage_analysis, len(competencies))
     score_breakdown['skills_coverage'] = {
         'score': skills_score,
         'max': 25,
-        'notes': 'Skills demonstrated vs required (use skills_gap_analysis for details)'
+        'required_competencies': len(competencies),
+        'coverage': coverage_analysis.get('overall_coverage', {}),
+        'notes': 'Skills demonstrated vs required, from career ladder and evidence'
     }
     
     # 4. Time in Role (0-10 points)
@@ -1175,12 +1203,17 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
     }
     
     # 5. Growth Velocity (0-10 points)
-    # Evidence accumulation over time
-    velocity_score = 5  # Placeholder
+    recent_range = parse_date_range("last-12-months")
+    recent_evidence = scan_evidence_directory(EVIDENCE_DIR, recent_range) if EVIDENCE_DIR.exists() else []
+    period_data = group_evidence_by_period(recent_evidence, group_by="month")
+    growth = calculate_growth_velocity(period_data)
+    velocity_score = _score_growth_velocity(growth, period_data)
     score_breakdown['growth_velocity'] = {
         'score': velocity_score,
         'max': 10,
-        'notes': 'Consistent evidence accumulation (use timeline_analysis for details)'
+        'average_monthly': growth.get('average_monthly', 0),
+        'trend': growth.get('trend', 'no_data'),
+        'notes': 'Evidence accumulation over the last 12 months'
     }
     
     # Total Score

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -817,11 +817,11 @@ def _required_skills_from_ladder() -> list[str]:
     required_skills = []
     seen = set()
     for competency in ladder_data.get("competencies") or []:
-        for skill in [competency.get("category"), *(competency.get("target_level_requirements") or [])]:
-            if not skill or skill in seen:
-                continue
-            seen.add(skill)
-            required_skills.append(skill)
+        skill = competency.get("category")
+        if not skill or skill in seen:
+            continue
+        seen.add(skill)
+        required_skills.append(skill)
     return required_skills
 
 

--- a/core/tests/test_career_promotion_readiness.py
+++ b/core/tests/test_career_promotion_readiness.py
@@ -1,0 +1,163 @@
+"""Promotion-readiness score must use real career readers, not dummy points."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from core.mcp import career_server
+
+STRUCTURED_LADDER = """# Career Ladder
+
+**Company:** Acme
+**Current Level:** PM
+**Target Level:** Senior PM
+**Last Updated:** 2026-08-01
+
+---
+
+## Career Framework
+
+Company ladder used by career-setup.
+
+---
+
+## Current Level: PM
+
+**Expectations:**
+- Ship assigned features
+
+---
+
+## Target Level: Senior PM
+
+**Requirements for Promotion:**
+
+### Product Strategy
+- Set multi-quarter product direction
+- Align the roadmap to company outcomes
+
+### Technical Depth
+- Lead a system design review
+- Debug a production incident
+
+### Stakeholder Leadership
+- Influence without authority
+- Run an exec review
+"""
+
+
+def _decode(result) -> dict:
+    return json.loads(result[0].text)
+
+
+def _enable_career_room(tmp_path: Path, monkeypatch) -> Path:
+    vault = tmp_path / "vault"
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    ladder_file = career_dir / "Career_Ladder.md"
+    profile_file = vault / "System" / "user-profile.yaml"
+    profile_file.parent.mkdir(parents=True, exist_ok=True)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    profile_file.write_text(
+        "capabilities:\n  career:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(career_server, "BASE_DIR", vault)
+    monkeypatch.setattr(career_server, "CAREER_DIR", career_dir)
+    monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
+    monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
+    monkeypatch.setattr(career_server, "USER_PROFILE_FILE", profile_file)
+    return vault
+
+
+def _write_evidence(path: Path, title: str) -> None:
+    path.write_text(
+        f"# {title}\n\n**Category:** Achievements\n\nA captured career win.\n",
+        encoding="utf-8",
+    )
+
+
+def _score(arguments: dict | None = None) -> dict:
+    return _decode(
+        asyncio.run(
+            career_server.handle_call_tool(
+                "promotion_readiness_score",
+                arguments or {"time_in_role_months": 3},
+            )
+        )
+    )
+
+
+def _skills_gap(arguments: dict | None = None) -> dict:
+    return _decode(
+        asyncio.run(
+            career_server.handle_call_tool(
+                "skills_gap_analysis",
+                arguments or {"target_level": "Senior PM"},
+            )
+        )
+    )
+
+
+def test_promotion_score_does_not_invent_skills_points_when_ladder_is_empty(
+    tmp_path, monkeypatch
+):
+    _enable_career_room(tmp_path, monkeypatch)
+
+    payload = _score()
+    skills = payload["score_breakdown"]["skills_coverage"]
+
+    assert skills["score"] != 15
+    assert skills["score"] == 0
+    assert skills["max"] == 25
+
+
+def test_promotion_score_does_not_invent_growth_velocity_when_evidence_is_empty(
+    tmp_path, monkeypatch
+):
+    _enable_career_room(tmp_path, monkeypatch)
+
+    payload = _score()
+    velocity = payload["score_breakdown"]["growth_velocity"]
+
+    assert velocity["score"] != 5
+    assert velocity["score"] == 0
+    assert velocity["max"] == 10
+
+
+def test_promotion_score_counts_evidence_files_sitting_in_the_evidence_folder(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    evidence_dir = vault / "05-Areas" / "Career" / "Evidence"
+    _write_evidence(evidence_dir / "2026-01-10 - Led API migration.md", "Led API migration")
+    _write_evidence(evidence_dir / "2026-03-04 - Ran exec review.md", "Ran exec review")
+    _write_evidence(evidence_dir / "2026-06-18 - Closed churn gap.md", "Closed churn gap")
+    (evidence_dir / "README.md").write_text("# Career Evidence\n", encoding="utf-8")
+
+    payload = _score()
+    coverage = payload["score_breakdown"]["evidence_coverage"]
+
+    assert coverage["evidence_count"] == 3
+    assert coverage["score"] == 3
+
+
+def test_skills_gap_reads_a_career_setup_ladder_with_competency_subheadings(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    ladder = vault / "05-Areas" / "Career" / "Career_Ladder.md"
+    ladder.write_text(STRUCTURED_LADDER, encoding="utf-8")
+
+    payload = _skills_gap()
+
+    assert payload["required_skills_count"] > 0
+    assert payload["success"] is True
+    joined = " ".join(payload["skills_gap"] + [
+        item["skill"] for item in payload.get("actively_developed", [])
+    ] + [
+        item["skill"] for item in payload.get("stale_skills", [])
+    ])
+    assert "Product Strategy" in joined or "Set multi-quarter product direction" in joined

--- a/core/tests/test_career_promotion_readiness.py
+++ b/core/tests/test_career_promotion_readiness.py
@@ -153,11 +153,15 @@ def test_skills_gap_reads_a_career_setup_ladder_with_competency_subheadings(
 
     payload = _skills_gap()
 
-    assert payload["required_skills_count"] > 0
+    assert payload["required_skills_count"] == 3
     assert payload["success"] is True
-    joined = " ".join(payload["skills_gap"] + [
-        item["skill"] for item in payload.get("actively_developed", [])
-    ] + [
-        item["skill"] for item in payload.get("stale_skills", [])
-    ])
-    assert "Product Strategy" in joined or "Set multi-quarter product direction" in joined
+    required = (
+        payload["skills_gap"]
+        + [item["skill"] for item in payload.get("actively_developed", [])]
+        + [item["skill"] for item in payload.get("stale_skills", [])]
+    )
+    assert required == [
+        "Product Strategy",
+        "Technical Depth",
+        "Stakeholder Leadership",
+    ]


### PR DESCRIPTION
## What this is

Dex's promotion-readiness score was inventing 20 of its 100 points on every run. Skills were always 15. Growth was always 5. Evidence files sitting in the Evidence folder — the layout the career setup itself describes — counted as zero. The skills-gap tool also used a cruder reader than the rest of Dex and stopped at the first subheading, so a properly structured ladder looked empty.

## What this changes

- The score now uses the same evidence scanner, ladder parser, coverage reader, and growth-velocity reader the rest of Dex already uses.
- Evidence files in the Evidence folder itself count. README files still do not.
- Skills and growth score from that real data. An empty folder scores 0, not 15 or 5.
- The skills-gap tool reads the same structured ladder the career setup writes.

## What this does not do

- It does not publish a new Dex version. `package.json` stays 1.96.5. Merging this will not put a new download on the site.
- It does not invent a new career product.

## Proof

The new tests failed on the dummy 15, the dummy 5, the subfolder-only evidence count, and the empty structured ladder. They pass after this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible readiness scores will drop where placeholders inflated them; logic now depends on shared parsers and evidence layout, but changes are covered by new tests and reuse existing career tooling.
> 
> **Overview**
> **Promotion readiness** and **skills gap** now derive scores from the same career parsers and scanners as the rest of Dex, instead of fixed placeholders and a brittle markdown scrape.
> 
> The promotion score’s **evidence coverage** uses `scan_evidence_directory` (files directly in Evidence count; READMEs excluded). **Skills coverage** comes from `parse_ladder_file` + `analyze_competency_coverage` with weighted coverage levels (0 when the ladder has no competencies). **Growth velocity** uses last-12-month evidence grouped by month and `calculate_growth_velocity`, scoring 0 when there’s no data instead of always 5. Shared helpers (`_score_evidence_count`, `_score_skills_from_coverage`, `_score_growth_velocity`) centralize the rubrics.
> 
> **Skills gap** required skills are loaded via `_required_skills_from_ladder()` and `parse_ladder_file`, so career-setup competency subheadings (e.g. Product Strategy) are all recognized—not just the first section under a target-level heading.
> 
> New tests in `test_career_promotion_readiness.py` lock in zero skills/growth when data is empty, evidence counting in the Evidence folder, and structured ladder parsing for skills gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d12240d2d0bf1b7411deca0e163c0b8a81d98eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->