### PR TITLE
ci: catch non-canonical dist/archive tags in the quality job, not hours into a fleet run

### DIFF
--- a/core/tests/test_release_tag_uniqueness.py
+++ b/core/tests/test_release_tag_uniqueness.py
@@ -160,6 +160,57 @@ def test_uniqueness_gate_rejects_an_empty_remote_observation(tmp_path: Path) -> 
     assert "uniqueness cannot be verified" in result.stderr
 
 
+def test_gate_rejects_non_canonical_archive_tag_without_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # The executor requires exactly 7 hex characters in a dist/archive tag and
+    # only says so per-journey, hours into historic-fleet-darwin. A lone
+    # non-canonical start must fail here instead. Include one unique
+    # dist/release tag so the uniqueness empty-check does not fire first.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.99.0-1111111",
+        "dist/archive/v1.81.12-3a8245ab",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "dist/archive/v1.81.12-3a8245ab" in result.stderr
+    assert "no canonical twin" in result.stderr
+    assert "Remedy: create dist/archive/v1.81.12-" in result.stderr
+    assert "Delete nothing" in result.stderr
+
+
+def test_gate_accepts_non_canonical_archive_tag_with_a_canonical_twin(
+    tmp_path: Path,
+) -> None:
+    # Discovery de-duplicates journeys by tree, so a canonical tag at the same
+    # commit already shadows the non-canonical one. That is today's tag set.
+    repository = _repository_with_remote_tags(
+        tmp_path,
+        "dist/release/v1.99.0-1111111",
+        "dist/archive/v1.81.12-3a8245ab",
+        "dist/archive/v1.81.12-3a8245a",
+    )
+
+    result = subprocess.run(
+        ["bash", str(GATE)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def _newer_release_tags(count: int) -> tuple[str, ...]:
     return tuple(
         f"dist/release/v1.{minor}.0-{minor:07x}"

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -1080,36 +1080,26 @@ def test_hanging_journey_timeout_survives_killpg_permission_error(
     # Observed on macOS CI (PR 541 tests (1)): killpg raised
     # PermissionError(1, "Operation not permitted") and the hanging-journey
     # test then saw "journey harness failed: [Errno 1] Operation not permitted"
-    # instead of a timeout. Unrelated to archive-tag checks; this keeps a
-    # timeout a timeout when the runner denies process-group signals.
-    vault = _write_valid_vault(tmp_path)
-
+    # instead of a timeout. Drive the JSON process helper directly so a
+    # missing vault .venv cannot hide the kill path.
     def deny_killpg(_process_group_id: int, _requested_signal: int) -> None:
         raise PermissionError(1, "Operation not permitted")
 
     monkeypatch.setattr(smoke.os, "killpg", deny_killpg)
-    monkeypatch.setattr(
-        smoke,
-        "_journey_command",
-        lambda *_args: [
-            sys.executable,
-            "-c",
-            "import time; time.sleep(60)",
-        ],
-    )
     started = time.monotonic()
-    run = smoke.run_smoke(
-        vault_root=vault,
-        repo_root=REPO_ROOT,
-        journey_definitions=(_definition("configs", 0.5),),
+    result, failed = smoke._run_json_process(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        cwd=tmp_path,
+        env=os.environ,
+        timeout_seconds=0.5,
+        label="journey",
     )
 
     assert time.monotonic() - started < 30
-    assert run.exit_code == 2
-    assert run.harness_failed is True
-    assert run.report["journeys"][0]["verdict"] == "UNKNOWN"
-    assert "timed out" in run.report["journeys"][0]["detail"]
-    assert "Operation not permitted" not in run.report["journeys"][0]["detail"]
+    assert failed is True
+    assert result["verdict"] == "UNKNOWN"
+    assert "timed out" in result["detail"]
+    assert "Operation not permitted" not in result["detail"]
 
 
 def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path) -> None:

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -1039,6 +1039,7 @@ def test_all_journeys_share_one_runner_generation(monkeypatch, tmp_path: Path) -
     assert [journey["verdict"] for journey in run.report["journeys"]] == ["OK", "OK"]
 
 
+@pytest.mark.xdist_group("serial_sensitive")
 def test_hanging_journey_is_killed_and_returns_exit_two(monkeypatch, tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
 
@@ -1070,6 +1071,45 @@ def test_hanging_journey_is_killed_and_returns_exit_two(monkeypatch, tmp_path: P
     # depends on host load. Both are the same correct kill behavior (UNKNOWN + exit 2),
     # so assert the shared core of the message.
     assert "timed out" in run.report["journeys"][0]["detail"]
+
+
+@pytest.mark.xdist_group("serial_sensitive")
+def test_hanging_journey_timeout_survives_killpg_permission_error(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Observed on macOS CI (PR 541 tests (1)): killpg raised
+    # PermissionError(1, "Operation not permitted") and the hanging-journey
+    # test then saw "journey harness failed: [Errno 1] Operation not permitted"
+    # instead of a timeout. Unrelated to archive-tag checks; this keeps a
+    # timeout a timeout when the runner denies process-group signals.
+    vault = _write_valid_vault(tmp_path)
+
+    def deny_killpg(_process_group_id: int, _requested_signal: int) -> None:
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(smoke.os, "killpg", deny_killpg)
+    monkeypatch.setattr(
+        smoke,
+        "_journey_command",
+        lambda *_args: [
+            sys.executable,
+            "-c",
+            "import time; time.sleep(60)",
+        ],
+    )
+    started = time.monotonic()
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs", 0.5),),
+    )
+
+    assert time.monotonic() - started < 30
+    assert run.exit_code == 2
+    assert run.harness_failed is True
+    assert run.report["journeys"][0]["verdict"] == "UNKNOWN"
+    assert "timed out" in run.report["journeys"][0]["detail"]
+    assert "Operation not permitted" not in run.report["journeys"][0]["detail"]
 
 
 def test_timed_out_journey_kills_delayed_descendants(monkeypatch, tmp_path: Path) -> None:

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -1232,11 +1232,31 @@ def _preparation_command(
     return command
 
 
+def _kill_process_handle(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.kill()
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _terminate_process_group(process: subprocess.Popen[str]) -> None:
     if os.name == "posix":
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
+            return
+        except PermissionError:
+            # macOS CI can deny killpg with EPERM while the child is still
+            # ours to kill, or while the group is already being reaped.
+            # Fall back to the process handle so a timeout stays a timeout
+            # instead of "journey harness failed: Operation not permitted".
+            _kill_process_handle(process)
             return
         if process.poll() is None:
             try:
@@ -1245,13 +1265,7 @@ def _terminate_process_group(process: subprocess.Popen[str]) -> None:
                 pass
         return
 
-    if process.poll() is not None:
-        return
-    process.kill()
-    try:
-        process.wait(timeout=0.2)
-    except subprocess.TimeoutExpired:
-        pass
+    _kill_process_handle(process)
 
 
 def _decode_child_result(stdout: str) -> dict[str, str]:
@@ -1292,7 +1306,10 @@ def _run_json_process(
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
         except subprocess.TimeoutExpired:
-            _terminate_process_group(process)
+            try:
+                _terminate_process_group(process)
+            except OSError:
+                _kill_process_handle(process)
             if process.stdout is not None:
                 process.stdout.close()
             if process.stderr is not None:
@@ -1314,7 +1331,10 @@ def _run_json_process(
         return _decode_child_result(stdout), False
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         if process is not None:
-            _terminate_process_group(process)
+            try:
+                _terminate_process_group(process)
+            except OSError:
+                _kill_process_handle(process)
         return {"verdict": "UNKNOWN", "detail": f"{label} harness failed: {_one_line(exc)}"}, True
 
 

--- a/scripts/check-release-tag-uniqueness.sh
+++ b/scripts/check-release-tag-uniqueness.sh
@@ -49,4 +49,78 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
+# dist/archive tags are the historic fleet's starting points. Discovery
+# (scripts/release_fleet.py ARCHIVE_RELEASE_TAG) accepts a 7-64 hex suffix, but
+# the executor (scripts/release_fleet_executor.py _ARCHIVE_RELEASE_TAG) requires
+# exactly 7 and raises "starting release identity is malformed" per journey,
+# hours into the 4.5h historic-fleet-darwin run. Catch it here in seconds.
+#
+# Discovery de-duplicates journeys by tree, so a non-canonical tag that has a
+# canonical twin at the same commit is already shadowed and can never be picked
+# as a starting point. Fail only on a lone non-canonical tag.
+if ! ARCHIVE_TAGS="$(
+  git ls-remote --tags origin 'refs/tags/dist/archive/v*'
+)"; then
+  echo "❌ Release-tag uniqueness gate failed: could not read dist/archive tags from origin; git ls-remote failed." >&2
+  exit 1
+fi
+
+UNTWINNED_ARCHIVE_TAGS="$(
+  printf '%s\n' "$ARCHIVE_TAGS" |
+    awk '
+      # An annotated tags peeled ^{} ref carries the commit the tag resolves
+      # to; the bare ref carries the tag object. Prefer the peeled value so
+      # twins pointing at one commit compare equal.
+      {
+        ref = $2
+        peeled = (ref ~ /\^\{\}$/)
+        sub(/\^\{\}$/, "", ref)
+        if (ref !~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/) {
+          next
+        }
+        if (peeled || !(ref in commit)) {
+          commit[ref] = $1
+        }
+      }
+      END {
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            canonical[commit[ref]] = 1
+          }
+        }
+        for (ref in commit) {
+          if (ref ~ /^refs\/tags\/dist\/archive\/v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7}$/) {
+            continue
+          }
+          if (commit[ref] in canonical) {
+            continue
+          }
+          tag = ref
+          sub(/^refs\/tags\//, "", tag)
+          print tag, commit[ref]
+        }
+      }
+    ' |
+    sort
+)"
+
+ARCHIVE_FAILED=0
+while read -r TAG COMMIT; do
+  [ -n "${TAG:-}" ] || continue
+  ARCHIVE_VERSION="${TAG#dist/archive/v}"
+  ARCHIVE_VERSION="${ARCHIVE_VERSION%%-*}"
+  CANONICAL_SHORT="$(printf '%s' "$COMMIT" | cut -c1-7)"
+  echo "❌ $TAG (commit $COMMIT) is a non-canonical dist/archive tag with no canonical twin at that commit." >&2
+  echo "The fleet executor requires exactly 7 hex characters in a dist/archive tag, so this start fails hours into historic-fleet-darwin." >&2
+  echo "Remedy: create dist/archive/v$ARCHIVE_VERSION-$CANONICAL_SHORT at $COMMIT. Delete nothing — the existing tag stays, and discovery's tree de-duplication will shadow it." >&2
+  ARCHIVE_FAILED=1
+done <<EOF
+$UNTWINNED_ARCHIVE_TAGS
+EOF
+
+if [ "$ARCHIVE_FAILED" -ne 0 ]; then
+  echo "❌ Release-tag uniqueness gate failed: one or more dist/archive tags are non-canonical with no canonical twin." >&2
+  exit 1
+fi
+
 echo "Release-tag uniqueness gate passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes draft [#541](https://github.com/davekilleen/Dex/pull/541) (rebase of [#480](https://github.com/davekilleen/Dex/pull/480)) onto current `main`. #541 is still open but was blocked on an unrelated smoke flake. No product change and no release.

## Linked Issue
- None (CI / release-harness only; continues #541 / #480)

## What Changed
- Appends an archive-canonicality check to `scripts/check-release-tag-uniqueness.sh`, which the quality job already runs.
- **The rule:** fail only when a non-canonical `dist/archive/` tag has **no canonical twin** at the same commit. Today's tag set stays green. The remedy is additive: create the canonical tag. Delete nothing.
- Hardens the smoke kill path so a macOS `killpg` `EPERM` (`Operation not permitted`) stays a timeout instead of a harness failure. That was the flake that kept #541 red.

## Why

A historic fleet run burned hours of macOS time and then failed with:

```
dist/archive/v1.81.12-3a8245ab: platform infrastructure or integrity failure:
starting release identity is malformed
```

That is a tag-naming mismatch, not an upgrade regression. This moves that check into the short quality job.

Sibling [#542](https://github.com/davekilleen/Dex/pull/542) already landed the fail-fast at discovery. This is the complementary quality-job gate.

## Flake diagnosis (#541 `tests (1)`)

#541's required `tests (1)` shard failed with:

```
FAILED core/tests/test_smoke.py::test_hanging_journey_is_killed_and_returns_exit_two
AssertionError: assert 'timed out' in 'journey harness failed: [Errno 1] Operation not permitted'
```

That test does not touch archive tags. The smoke harness calls `os.killpg` after `start_new_session=True`. On the macOS runner, `killpg` can raise `PermissionError(1, "Operation not permitted")` — the same class of reaping/permission noise `release_fleet.py` already handles. The exception escaped the timeout path and was reported as a harness failure.

This PR catches that `PermissionError`, falls back to the process handle, and adds a regression that forces the denied-`killpg` case on `_run_json_process` directly.

## Proof

- Local: uniqueness tests + isolated killpg regression passed; live `bash scripts/check-release-tag-uniqueness.sh` exits 0
- CI on this PR: **quality**, **tests (1)**, **tests (2)**, **tests (3)**, and **test-results** are all green
- `tests (1)` is the shard that flaked on #541; it is green here

## Test Plan
- Unit/integration tests added or updated:
  - `test_gate_rejects_non_canonical_archive_tag_without_a_canonical_twin`
  - `test_gate_accepts_non_canonical_archive_tag_with_a_canonical_twin`
  - `test_hanging_journey_timeout_survives_killpg_permission_error`
- Negative/error-path tests added or updated: lone non-canonical archive tag; denied `killpg`
- Commands run locally:
  - `python3 -m pytest core/tests/test_release_tag_uniqueness.py` plus the isolated killpg test — passed
  - `bash scripts/check-release-tag-uniqueness.sh` against live origin — passed
  - `ruff check` on the touched Python files — passed

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert the PR. No tags are created, deleted, moved, or force-updated. No changelog and no version bump.

## Docs Impact
- Files updated: none
- If none, reason: release-harness CI only; no user-facing Dex behavior.

## Out of scope
- No tag created, deleted, moved, or force-updated
- No changelog and no version bump
- Does not cut a 1.96.6 release
- Wispr equal-footing, Solo signing, Studio UI, SES Amazon approval

## Merge path
Ready to merge. After it lands, close #541 and #480 as superseded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee1d0c79-53be-4af9-a01c-732d273c86bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee1d0c79-53be-4af9-a01c-732d273c86bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

