### PR TITLE
Lock the documented post-update canary door for #499

### DIFF
--- a/core/tests/test_health_promises.py
+++ b/core/tests/test_health_promises.py
@@ -162,6 +162,34 @@ def test_post_update_canary_reports_a_torn_install_instead_of_raising(tmp_path: 
     assert stored["ok"] is False
 
 
+def test_canary_cli_succeeds_when_invoked_by_the_documented_file_path(tmp_path: Path) -> None:
+    """The /dex-update door: `python3 core/health/post_update.py --vault .`.
+
+    Running a script by path puts the script directory on sys.path[0], not the
+    vault or repo root. The canary must still find Dex's own code without an
+    installed `core` package and without PYTHONPATH. cwd is the vault, so a
+    working-directory import cannot accidentally save the command.
+    """
+    vault = _activation_fixture(tmp_path)
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    completed = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "core" / "health" / "post_update.py"), "--vault", str(vault)],
+        capture_output=True,
+        text=True,
+        cwd=vault,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "Post-update check passed" in completed.stdout
+    assert "Traceback" not in completed.stdout + completed.stderr
+    stored = json.loads((vault / RECEIPT_RELATIVE).read_text(encoding="utf-8"))
+    assert stored["ok"] is True
+
+
 def test_canary_cli_reports_a_torn_install_plainly_without_a_traceback(tmp_path: Path) -> None:
     """The CLI contract: even a failed canary speaks one plain line and exits 1."""
     vault = _activation_fixture(tmp_path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- GitHub issue: #499

## What this is

#499 reported three Doctor/canary false alarms on a healthy install. Those three code fixes are already on `main` via #501 and #513. This PR does **not** re-implement them. It adds the one missing success-path test the issue asked for: the exact `/dex-update` command must be able to pass.

The other two requested tests are already on `main`:

- live PID + last exit `-15` is not BROKEN (`test_jobs_loaded_treats_a_live_pid_as_authoritative_over_a_previous_exit`)
- a missing `core` module is not called “missing requirements” (`test_smoke_journey_names_a_missing_dex_module_truthfully` and `test_collect_preserves_smokes_missing_dex_module_diagnosis`)

## What Changed
- Added `test_canary_cli_succeeds_when_invoked_by_the_documented_file_path`.
- Invokes `python3 core/health/post_update.py --vault <vault>` by file path, from the vault working directory, with `PYTHONPATH` removed.
- Keeps the existing torn-install negative CLI test.

## Test Plan
- Focused local run: 23 related Doctor / smoke / canary checks passed, including the new documented-path success test and the existing torn-install negative test.
- CI quality: green.
- CI tests (1) and (2): green.
- CI tests (3): failed on an unrelated check, `test_f4_one_off_token_is_single_use_and_runs_in_temp_vault` (`UNKNOWN` instead of `OK`). That test is not in this diff. Same `main` HEAD later went green. Please re-run the shard if needed.

## Quality Gates
- No product code, changelog, or version bump. This is a test lock only.
- Does not claim LIVE or shipped.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this commit; no runtime behavior changes

## Docs Impact
- None. The `/dex-update` command text is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-225198ca-edfe-4b37-8ebe-d82d50859b28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-225198ca-edfe-4b37-8ebe-d82d50859b28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

