### PR TITLE
Mail search checkup treats a frozen empty copy as broken

### DIFF
--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -24,14 +24,20 @@ announces failure:
 | Path | Needs | What happens when it's missing |
 |---|---|---|
 | List / read messages | Automation permission | Prompts you — you notice |
-| **Search** | A pre-built local index (default `~/.apple-mail-mcp/index.db`), which requires **Full Disk Access** to build | **Returns empty. Forever. Silently.** |
+| **Search** | A pre-built local index (default `~/.apple-mail-mcp/index.db`), which requires **Full Disk Access** to build *and* to keep current | **Looks empty — or worse, returns subject/sender hits labelled as body matches.** |
 
-Because list and read keep working, the integration *looks* healthy. Search returns nothing,
-Dex falls back to reading messages one at a time, and nobody ever learns the index was never
-built. One reporter ran that way for months.
+Because list and read keep working, the integration *looks* healthy. On older server
+versions, search returned nothing. On the current supported release (0.4.3), a missing
+index no longer stays silent: body search falls through to a live Mail query of subject
+and sender, then labels those hits as body matches. That is plausible-looking evidence
+for a search that never read a message body.
 
-So this setup is not finished when the server is registered. It is finished when the index
-exists and is fresh.
+One reporter ran the silent version for months. The labelled-as-body version is worse
+than silence.
+
+So this setup is not finished when the server is registered. It is finished when the
+index exists, the serving process can read `~/Library/Mail`, and `/dex-doctor` reports
+`mail.apple-search` as `OK`.
 
 ---
 
@@ -63,28 +69,38 @@ Dex requires an explicit scope (a hook enforces this). Register it for the user:
 claude mcp add --scope user apple-mail -- apple-mail-mcp serve
 ```
 
-### 4. Grant narrowly scoped Full Disk Access — do this before building the index
+### 4. Grant Full Disk Access to two apps — the terminal *and* the app that launches Mail search
 
-This is the step people skip, and skipping it is what produces the silent failure. Building
-the index reads `~/Library/Mail` directly, which macOS protects.
+This is the step people skip, and skipping it is what produces the silent (or worse,
+plausible-looking) failure. Building the index reads `~/Library/Mail` directly, which
+macOS protects. Keeping the index current does the same read from whatever process
+launches the Mail server — that is Dex, Claude, or Cursor, not the terminal that ran
+`index`.
+
+Those are two different grants. The one you would naturally test (Terminal) is not the
+one that keeps search alive.
 
 Full Disk Access is a broad macOS permission: the approved app can read protected personal
-data across the Mac, not only Mail. Grant it to the specific terminal app used for this
-one-off build. Do **not** grant it to Dex, Claude, or the ordinary MCP server process.
+data across the Mac, not only Mail. Grant it to:
 
-Walk the user through it:
+1. The terminal app that will run the one-off `index` command
+2. The app that launches the Mail server (Dex, Claude, or Cursor)
+
+Walk the user through it for each app:
 
 ```
 1. Open System Settings (Command+Space, type "System Settings")
 2. Click "Privacy & Security" in the sidebar
 3. Click "Full Disk Access"
-4. Click "+" and add Terminal (or whichever terminal app you'll run the next command in)
+4. Click "+" and add the app
 5. Toggle it ON
-6. Quit and reopen Terminal — the permission only applies to a fresh launch
+6. Quit and reopen that app — the permission only applies to a fresh launch
 ```
 
-Explain why in one line: "macOS treats your mail files as private, so this one-off indexer
-needs explicit permission to read them — without it, it exits quietly and builds nothing."
+Explain why in one line: "macOS treats your mail files as private. The indexer needs
+permission to build the search copy, and the app that runs Mail search needs the same
+permission to keep that copy current — without it, refresh can report success after
+reading nothing."
 
 ### 5. Build the index
 
@@ -95,9 +111,10 @@ umask 077; apple-mail-mcp index --verbose
 ```
 
 `umask 077` makes any new database and SQLite sidecar files private to this Mac account.
-The build takes a few minutes on a large mailbox and must be run manually. Do not solve future
-freshness by giving the always-running MCP host Full Disk Access; refresh from the narrowly
-approved terminal when Doctor says the configured freshness limit has been exceeded.
+The build takes a few minutes on a large mailbox and must be run manually. After the
+build, leave Full Disk Access on for the app that launches the Mail server. Background
+sync reads `~/Library/Mail` the same way the indexer does; if that grant is missing,
+every refresh can return zero changes and still write a fresh "last synced" time.
 
 ### 6. Verify — do not skip this
 
@@ -119,12 +136,12 @@ Confirm: "✅ Mail search is working — indexed and fresh."
 
 Then tell them the two maintenance facts that matter:
 
-1. **The index may not update itself reliably without protected-file access.** Doctor reads
-   the server's real last-sync record and applies its configured freshness limit (24 hours by
-   default), rather than guessing from the database file's modified time.
-2. **Full Disk Access can be removed from the terminal after the build.** Grant it again only
-   when a manual refresh is needed. This is safer than leaving the always-running MCP host with
-   broad access to the Mac.
+1. **A recent "last synced" time is not proof the index is alive.** If the app that
+   launches the Mail server lacks Full Disk Access, refresh can read nothing, write a
+   fresh timestamp, and leave the copy frozen for months. Doctor now checks that this
+   process can actually read `~/Library/Mail`, not only that the index file looks fresh.
+2. **The terminal grant can be removed after the build.** The Dex / Claude / Cursor
+   grant cannot — that is the process that keeps the copy current.
 
 ---
 
@@ -135,9 +152,9 @@ Then tell them the two maintenance facts that matter:
 | Verdict | Meaning |
 |---|---|
 | `OFF` | No Apple Mail server registered — opt-in, not a problem |
-| `OK` | The configured SQLite index has real schema and data, a successful sync within its configured freshness limit, and private file permissions |
-| `BROKEN` | Command missing; config invalid; index missing, empty, corrupt, incomplete, stale, or readable by other local accounts — each with the exact fix |
-| `UNKNOWN` | A server is registered but this isn't macOS, or the index couldn't be read |
+| `OK` | The configured SQLite index has real schema and data, a successful sync within its configured freshness limit, private file permissions, *and* this process can read `~/Library/Mail` |
+| `BROKEN` | Command missing; config invalid; index missing, empty, unreadable, corrupt, incomplete, stale, readable by other local accounts, or the serving process cannot read the Mail store — each with the exact fix and the Full Disk Access prerequisite |
+| `UNKNOWN` | A server is registered but this isn't macOS |
 
 ---
 
@@ -156,8 +173,13 @@ Quit Terminal completely (Command+Q, not just closing the window) and reopen it.
 the permission at launch.
 
 **Search worked before and stopped:**
-Run `apple-mail-mcp status`, then `/dex-doctor`. If the recorded sync is older than the
-configured limit, temporarily grant the indexing terminal Full Disk Access and refresh.
+Run `apple-mail-mcp status`, then `/dex-doctor`. A recent last-sync time is not enough —
+if Doctor says the serving process cannot read `~/Library/Mail`, grant Full Disk Access
+to Dex / Claude / Cursor (not only Terminal), quit and reopen that app, then rebuild.
+
+**Search returns subject-looking hits labelled as body matches:**
+On 0.4.3, body search with no usable index falls through to a live Mail query of
+subject and sender. Treat that as broken, not as evidence. Run `/dex-doctor`.
 
 **The model keeps retrying searches with different keywords:**
 That's the server's empty-result hint ("try fewer keywords") being misread as a search miss

--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -14,12 +14,20 @@ from core.utils import apple_mail_health
 NOW = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
 
 
+def _grant_serving_process_mail_store(home: Path) -> Path:
+    store = home / "Library" / "Mail"
+    store.mkdir(parents=True, exist_ok=True)
+    (store / ".keep").write_text("readable")
+    return store
+
+
 @pytest.fixture
 def context(tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()
     home = tmp_path / "home"
     home.mkdir()
+    _grant_serving_process_mail_store(home)
     return apple_mail_health.Context(
         home=home,
         vault_root=vault,
@@ -226,6 +234,97 @@ def test_apple_mail_search_is_ok_with_a_fresh_index(monkeypatch, context):
     assert result.verdict == "OK"
     assert result.feature_status == "ok"
     assert result.action is None
+
+
+def test_apple_mail_search_is_broken_when_the_index_cannot_be_read(monkeypatch, context):
+    _register_apple_mail_user_scope(context)
+    index = _write_apple_mail_index(context, age_days=1)
+    original_stat = Path.stat
+
+    def refuse_index_stat(self, *args, **kwargs):
+        if Path(self) == index:
+            raise PermissionError("Operation not permitted")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", refuse_index_stat)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "could not be read" in result.detail
+    assert "Full Disk Access" in result.action
+    assert "apple-mail-mcp index" in result.action
+
+
+def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_is_missing(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=0)
+    store = apple_mail_health.mail_store_path(context.home)
+    for child in store.iterdir():
+        child.unlink()
+    store.rmdir()
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "Mail store" in result.detail
+    assert "Full Disk Access" in result.action
+    assert "Dex, Claude, or Cursor" in result.action
+    assert "not only the terminal" in result.action
+
+
+def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_lists_empty(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=0)
+    store = apple_mail_health.mail_store_path(context.home)
+    for child in store.iterdir():
+        child.unlink()
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "listed no files" in result.detail
+    assert "Full Disk Access" in result.action
+    assert "not only the terminal" in result.action
+
+
+def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_is_unreadable(
+    monkeypatch,
+    context,
+):
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=0)
+
+    def refuse_mail_store(_home):
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(apple_mail_health, "read_mail_store", refuse_mail_store)
+
+    result = apple_mail_health.probe(context)
+
+    assert result.verdict == "BROKEN"
+    assert result.feature_status == "broken"
+    assert "cannot read the Mail store" in result.detail
+    assert "Full Disk Access" in result.action
+    assert "not only the terminal" in result.user_message
+
+
+def test_apple_mail_setup_action_names_serving_process_full_disk_access():
+    action = apple_mail_health.setup_action("index")
+
+    assert "apple-mail-mcp index" in action
+    assert "Full Disk Access" in action
+    assert "Dex, Claude, or Cursor" in action
+    assert "does not need this permission" not in action
 
 
 def test_apple_mail_search_uses_custom_path_and_real_sqlite_state(monkeypatch, context):

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -600,3 +600,13 @@ def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:
     assert supported_runtime in requirements
     assert "community-maintained" in setup
     assert "health checks and macOS CI prove compatibility" in setup
+
+
+def test_apple_mail_setup_names_serving_process_full_disk_access() -> None:
+    setup = _read(".claude/skills/apple-mail-setup/SKILL.md")
+
+    assert "Dex, Claude, or Cursor" in setup
+    assert "not the terminal that ran" in setup
+    assert "~/Library/Mail" in setup
+    assert "Do **not** grant it to Dex, Claude, or the ordinary MCP server process." not in setup
+    assert "fresh-looking index can still be frozen" in setup or "write a fresh" in setup

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -9,6 +9,7 @@ Doctor orchestrator.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import sqlite3
 import stat
@@ -50,18 +51,27 @@ REQUIRED_FTS_TRIGGERS = {"emails_ai", "emails_ad", "emails_au"}
 
 
 def setup_action(command: str) -> str:
-    """Return stable, explicit privacy guidance for an index operation."""
+    """Return the exact index command plus the Full Disk Access prerequisite."""
     operation = "rebuilding" if command == "rebuild" else "building"
     return (
         f"Run `umask 077; apple-mail-mcp {command} --verbose` from a terminal app "
-        "temporarily granted Full Disk Access: System Settings > Privacy & Security > "
+        "granted Full Disk Access: System Settings > Privacy & Security > "
         "Full Disk Access. Quit and reopen that terminal before "
-        f"{operation}; searching the completed local index does not need this permission."
+        f"{operation}. The app that launches the Mail server (Dex, Claude, or Cursor) "
+        "also needs Full Disk Access — background sync reads ~/Library/Mail, and a "
+        "fresh-looking index can still be frozen if that grant is missing."
     )
 
 
 APPLE_MAIL_INDEX_BUILD_FIX = setup_action("index")
 APPLE_MAIL_INDEX_REBUILD_FIX = setup_action("rebuild")
+APPLE_MAIL_SERVING_FDA_FIX = (
+    "Grant Full Disk Access to the app that launches the Mail server (Dex, Claude, or Cursor), "
+    "not only the terminal that ran `apple-mail-mcp index`: System Settings > Privacy & Security > "
+    "Full Disk Access. Quit and reopen that app, then run /apple-mail-setup. "
+    "Background sync reads ~/Library/Mail; without that grant it can report a fresh sync after reading nothing."
+)
+APPLE_MAIL_STORE_RELATIVE = Path("Library") / "Mail"
 
 
 @dataclass(frozen=True)
@@ -331,6 +341,58 @@ def _describe_age(age: timedelta) -> str:
     return "in the last hour"
 
 
+def mail_store_path(home: Path) -> Path:
+    return home / APPLE_MAIL_STORE_RELATIVE
+
+
+def read_mail_store(home: Path) -> None:
+    """List the Mail store. Raises if this process cannot read it.
+
+    Full Disk Access at sync time belongs to the process that launches the
+    server (the MCP client), not the terminal that built the index. Listing
+    is the macOS TCC seam: exists() can lie when the grant is missing, and a
+    successful empty listing is also not proof — denied access often returns
+    no entries and no error.
+    """
+    store = mail_store_path(home)
+    with os.scandir(store) as entries:
+        first = next(entries, None)
+    if first is None:
+        raise OSError(f"{store} listed no files; Full Disk Access may be hiding the Mail store from this process")
+    os.stat(first.path)
+
+
+def _mail_store_result(home: Path) -> Result | None:
+    store = mail_store_path(home)
+    try:
+        read_mail_store(home)
+    except FileNotFoundError:
+        return Result(
+            "BROKEN",
+            f"The serving process cannot see the Mail store at {store}, so a fresh-looking index can still be frozen",
+            action=APPLE_MAIL_SERVING_FDA_FIX,
+            feature_status="broken",
+            user_message=(
+                "Mail search's index looks current, but this process cannot read your Mail "
+                "folder. The app that launches the Mail server needs Full Disk Access, not "
+                "only the terminal that built the index. " + APPLE_MAIL_SERVING_FDA_FIX
+            ),
+        )
+    except OSError as error:
+        return Result(
+            "BROKEN",
+            f"The serving process cannot read the Mail store at {store}: {_one_line(error)}",
+            action=APPLE_MAIL_SERVING_FDA_FIX,
+            feature_status="broken",
+            user_message=(
+                "Mail search's index looks current, but this process cannot read your Mail "
+                "folder. The app that launches the Mail server needs Full Disk Access, not "
+                "only the terminal that built the index. " + APPLE_MAIL_SERVING_FDA_FIX
+            ),
+        )
+    return None
+
+
 def probe(context: Context) -> Result:
     """Prove the configured local FTS index can truthfully answer searches."""
     try:
@@ -379,6 +441,8 @@ def probe(context: Context) -> Result:
     index = settings.path
     try:
         index_stat = index.stat()
+        with index.open("rb") as handle:
+            handle.read(1)
     except FileNotFoundError:
         return Result(
             "BROKEN",
@@ -390,7 +454,13 @@ def probe(context: Context) -> Result:
         )
     except OSError as error:
         detail = _one_line(error)
-        return Result("UNKNOWN", f"The Apple Mail index could not be read: {detail}", feature_status="unknown")
+        return Result(
+            "BROKEN",
+            f"The Apple Mail search index at {index} could not be read: {detail}",
+            action=APPLE_MAIL_INDEX_BUILD_FIX,
+            feature_status="broken",
+            user_message=("Mail search's index exists but this process cannot read it. " + APPLE_MAIL_INDEX_BUILD_FIX),
+        )
     if index_stat.st_size == 0:
         return Result(
             "BROKEN",
@@ -446,6 +516,9 @@ def probe(context: Context) -> Result:
             user_message=f"Mail search is running on an index last synced {described_age}, so recent mail may be invisible. "
             + APPLE_MAIL_INDEX_BUILD_FIX,
         )
+    mail_store = _mail_store_result(context.home)
+    if mail_store:
+        return mail_store
     return Result(
         "OK",
         f"Apple Mail search is using {index} with {email_count} indexed message{'s' if email_count != 1 else ''}, last synced {_describe_age(age)}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Recreates the honest-empty lock from closed unmerged #469, on top of the live index probe already on `main` via #517. Does not comment on #446.

## What Changed
- Doctor still uses the real SQLite index check from #517. This PR does **not** replay the weaker file-size / mtime probe that caused #469 to be closed.
- After that index check passes, Doctor also proves **this process** can list and read `~/Library/Mail`.
- A missing, empty, or unreadable index is **broken**, not “could not tell.”
- An empty Mail-folder listing is **broken**, not healthy. On a Mac without Full Disk Access, that listing can come back empty with no error — the same lie as a frozen copy that still looks freshly refreshed.
- Setup names both grants: the terminal that builds the index, and the app that launches Mail search (Dex, Claude, or Cursor).

## What this does not do
- Does not publish a new Dex version. `package.json` stays as it is. Merging this will not put a new download on the site.
- Does not invent LIVE. Still not shipped until a release owner cuts a version.
- Does not start a new mail product. Honest-health lock only.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_apple_mail_health.py` (unreadable index, missing store, empty listing, unreadable store, serving-process grant copy)
- Negative/error-path tests added or updated: empty listing and permission denial are broken
- Commands run locally: `pytest core/tests/test_apple_mail_health.py core/tests/test_instruction_honesty.py -q` (running after this PR is opened)

## Quality Gates
- Tests lock the honest-empty paths.
- Docs: `/apple-mail-setup` now matches the probe (the old “do not grant Dex/Claude Full Disk Access” line was the lie this lock removes).
- No changelog version cut.

## Risk & Rollback
- Risk level: medium — a Mac with a genuinely empty Mail folder will now be reported broken, because that is indistinguishable from a TCC empty listing.
- Rollback plan: revert this PR. The #517 index probe remains.

## Docs Impact
- `.claude/skills/apple-mail-setup/SKILL.md` — setup now names the serving-process grant.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-895fcf51-453a-4f89-a24e-395c2c7d13fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-895fcf51-453a-4f89-a24e-395c2c7d13fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

