### PR TITLE
Lock career scores so a real skills folder cannot hide the dummy 15

### DIFF
--- a/core/tests/test_career_promotion_readiness.py
+++ b/core/tests/test_career_promotion_readiness.py
@@ -47,6 +47,12 @@ Company ladder used by career-setup.
 - Run an exec review
 """
 
+COMPETENCY_HEADINGS = [
+    "Product Strategy",
+    "Technical Depth",
+    "Stakeholder Leadership",
+]
+
 
 def _decode(result) -> dict:
     return json.loads(result[0].text)
@@ -79,6 +85,18 @@ def _write_evidence(path: Path, title: str) -> None:
     )
 
 
+def _write_mapped_evidence(path: Path, title: str, competency: str) -> None:
+    path.write_text(
+        f"# {title}\n\n"
+        "**Category:** Achievements\n\n"
+        "## Skills Demonstrated\n"
+        f"- {competency}\n\n"
+        "## Ladder Alignment\n\n"
+        f"**Maps to:** {competency}\n",
+        encoding="utf-8",
+    )
+
+
 def _score(arguments: dict | None = None) -> dict:
     return _decode(
         asyncio.run(
@@ -98,6 +116,20 @@ def _skills_gap(arguments: dict | None = None) -> dict:
                 arguments or {"target_level": "Senior PM"},
             )
         )
+    )
+
+
+def _parse_ladder() -> dict:
+    return _decode(
+        asyncio.run(career_server.handle_call_tool("parse_ladder", {}))
+    )
+
+
+def _required_skill_names(payload: dict) -> list[str]:
+    return (
+        list(payload.get("skills_gap") or [])
+        + [item["skill"] for item in payload.get("actively_developed") or []]
+        + [item["skill"] for item in payload.get("stale_skills") or []]
     )
 
 
@@ -144,6 +176,40 @@ def test_promotion_score_counts_evidence_files_sitting_in_the_evidence_folder(
     assert coverage["score"] == 3
 
 
+def test_promotion_score_uses_real_coverage_for_a_populated_skills_folder(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    (career_dir / "Career_Ladder.md").write_text(STRUCTURED_LADDER, encoding="utf-8")
+    _write_mapped_evidence(
+        evidence_dir / "2026-01-10 - Strategy memo.md",
+        "Strategy memo",
+        "Product Strategy",
+    )
+    _write_mapped_evidence(
+        evidence_dir / "2026-02-11 - Design review.md",
+        "Design review",
+        "Technical Depth",
+    )
+    _write_mapped_evidence(
+        evidence_dir / "2026-03-12 - Exec review.md",
+        "Exec review",
+        "Stakeholder Leadership",
+    )
+
+    payload = _score()
+    skills = payload["score_breakdown"]["skills_coverage"]
+
+    # One matching file per competency is "weak" coverage: 0.3 * 25 = 8.
+    # A leftover placeholder would still return 15 here.
+    assert skills["score"] != 15
+    assert skills["score"] == 8
+    assert skills["required_competencies"] == 3
+    assert skills["coverage"] == {"weak": 3}
+
+
 def test_skills_gap_reads_a_career_setup_ladder_with_competency_subheadings(
     tmp_path, monkeypatch
 ):
@@ -155,13 +221,22 @@ def test_skills_gap_reads_a_career_setup_ladder_with_competency_subheadings(
 
     assert payload["required_skills_count"] == 3
     assert payload["success"] is True
-    required = (
-        payload["skills_gap"]
-        + [item["skill"] for item in payload.get("actively_developed", [])]
-        + [item["skill"] for item in payload.get("stale_skills", [])]
-    )
-    assert required == [
-        "Product Strategy",
-        "Technical Depth",
-        "Stakeholder Leadership",
+    assert _required_skill_names(payload) == COMPETENCY_HEADINGS
+
+
+def test_skills_gap_and_parse_ladder_agree_on_heading_names(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    ladder = vault / "05-Areas" / "Career" / "Career_Ladder.md"
+    ladder.write_text(STRUCTURED_LADDER, encoding="utf-8")
+
+    gap = _skills_gap()
+    parsed = _parse_ladder()
+
+    assert parsed["success"] is True
+    assert parsed["target_level"] == "Senior PM"
+    assert [item["category"] for item in parsed["competencies"]] == COMPETENCY_HEADINGS
+    assert _required_skill_names(gap) == [
+        item["category"] for item in parsed["competencies"]
     ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Locks #539 after the product fix already on `main` via #543. Opens the stuck test-lock branch that had no PR (`cursor/career-score-honest-coverage-539-763f`).

## What Changed
- The dummy 15 / dummy 5 / subfolder-only evidence count are already gone on `main`.
- This PR adds tests only: a populated ladder plus mapped evidence must score real coverage (weak = 8, not the leftover placeholder 15), and `skills_gap_analysis` must agree with `parse_ladder` on the same competency headings.

## What this does not do
- Does not change scoring code. Product fix is already on `main`.
- Does not publish a new Dex version.
- Does not invent LIVE.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_career_promotion_readiness.py`
- Negative/error-path tests added or updated: populated folder must not return the placeholder 15
- Commands run locally: `pytest core/tests/test_career_promotion_readiness.py -q` → **6 passed**
- First CI shard 2 failed on `test_repo_fsmonitor_command_is_never_executed`, which this branch does not touch. Empty commit retriggered checks.

## Quality Gates
- Honest-health lock only. No product feature work.

## Risk & Rollback
- Risk level: low — tests only.
- Rollback plan: revert this PR.

## Docs Impact
- None. Test lock only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-895fcf51-453a-4f89-a24e-395c2c7d13fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-895fcf51-453a-4f89-a24e-395c2c7d13fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

