### PR TITLE
release: v1.96.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.6] — 🧰 Your promotion score uses real evidence, and Mail search checkup tells the truth (2026-08-17)
+
+The promotion score could look confident while using made-up points. Skills were always 15. Growth was always 5. Evidence sitting in the Evidence folder — the place career setup itself uses — counted as nothing. Separately, Mail search checkup could look healthy when it could not actually see Mail, or when the search index was missing, empty, or unreadable. And if you record meetings with Wispr, Dex already understood those notes, but settings still refused the word Wispr.
+
+**What this fixes for you:**
+
+* **The promotion score now uses your real evidence.** Files in the Evidence folder count. Skills and growth come from that same evidence, not from made-up points. An empty folder scores 0, not 15 or 5.
+* **Mail search checkup tells the truth.** If the checkup cannot see your Mail folder, or the search index is missing, empty, or unreadable, it says so. It no longer calls that healthy.
+* **You can name Wispr as where meetings come from.** If that is your recorder, you can say so in settings. This does not connect Dex to Wispr or pull meetings on its own. It only stops rejecting the name.
+
+Two people reported the score and the Mail checkup. A contributor found the Wispr name after Dex already recognised their notes.
+
 ## [1.96.5] — 🧰 A brand-new Dex folder can finish setup even if first install left no history (2026-08-14)
 
 A person who had just installed Dex could get stuck in the first setup chat. Dex thought it had finished separating its own files from their notes, but the notes folder had no working history, and the safety copy that should have undone that step was damaged. Continue failed. Undo failed. Setup stopped before they could start.

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -1042,6 +1042,7 @@ core/tests/test_calendar_eventkit_script.py
 core/tests/test_calendar_server.py
 core/tests/test_calendar_skill_degradation_instruction_contract.py
 core/tests/test_capabilities.py
+core/tests/test_career_promotion_readiness.py
 core/tests/test_ci_concurrency_never_cancels_main.py
 core/tests/test_ci_shard_durations.py
 core/tests/test_commitments_skill.py

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.5"
+  "release_version": "1.96.6"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.5",
+  "release_version": "1.96.6",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.5","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.6","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.5 release,
+Download the versioned bridge and its checksum from the public v1.96.6 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.5/dex-update-bridge-v1.96.5.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.6/dex-update-bridge-v1.96.6.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.5/dex-update-bridge-v1.96.5.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.6/dex-update-bridge-v1.96.6.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.5.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.6.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.5.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.5",
+  "version": "1.96.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.5",
+      "version": "1.96.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.5",
+  "version": "1.96.6",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public Dex is now **v1.96.6**. The career promotion-score fix, the Mail search checkup honesty fix, and the Wispr meeting-source name were already on main. This PR was the version stamp so two community reporters can download them.

Published: https://github.com/davekilleen/Dex/releases/tag/v1.96.6

## What testers get

- The promotion score uses real evidence and the shared ladder reader. Made-up 15 / made-up 5 / Evidence-folder-does-not-count are gone. Fixes #539 (merged via #543).
- Mail search checkup tells the truth when this process cannot list or read Mail, or the index is missing, empty, or unreadable. Fixes the Dex side of #446 (merged via #546, on top of #517).
- A person can name Wispr as their meeting source (#540).

#545 is a test lock only. It is not in the user notes.

## Publish proof

- PR merged to main as `17a51fc`.
- Annotated tag `v1.96.6` on that commit.
- GitHub release is public (not draft) with assets:
  - `dex-update-bridge-v1.96.6.py` + `.sha256`
  - `dex-vault-bundle-v1.96.6.tar.gz` + `.sha256`
  - `dex-lens-catalog-v1.96.6.json` + `.sha256`
- `/dex-update` and the rescue download can use this cut today.

heydex.ai/releases still showed 1.96.5 at publish time. That site is updated from the separate heydex-website repo (`./deploy-releases.sh`), not from this cut.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aa13459-4fd3-47e2-9e60-a4de2c28f2b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa13459-4fd3-47e2-9e60-a4de2c28f2b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

