### PR TITLE
Let a beta person set photo, title, and company for shared rooms

### DIFF
--- a/core/lifecycle/contracts/api.schema.json
+++ b/core/lifecycle/contracts/api.schema.json
@@ -63,6 +63,22 @@
       "request": {"$ref": "#/$defs/onboardingContextExecuteRequest"},
       "response": {"$ref": "#/$defs/onboardingContextExecuteResponse"}
     },
+    "build_and_preview_room_presence": {
+      "request": {"$ref": "#/$defs/roomPresencePreviewRequest"},
+      "response": {"$ref": "#/$defs/roomPresencePreviewResponse"}
+    },
+    "execute_approved_room_presence": {
+      "request": {"$ref": "#/$defs/roomPresenceExecuteRequest"},
+      "response": {"$ref": "#/$defs/roomPresenceExecuteResponse"}
+    },
+    "build_and_preview_room_presence_share": {
+      "request": {"$ref": "#/$defs/roomPresenceSharePreviewRequest"},
+      "response": {"$ref": "#/$defs/roomPresenceSharePreviewResponse"}
+    },
+    "execute_approved_room_presence_share": {
+      "request": {"$ref": "#/$defs/roomPresenceShareExecuteRequest"},
+      "response": {"$ref": "#/$defs/roomPresenceExecuteResponse"}
+    },
     "build_and_preview_automation_claim": {
       "request": {"$ref": "#/$defs/automationClaimPreviewRequest"},
       "response": {"$ref": "#/$defs/automationPreviewResponse"}
@@ -514,6 +530,106 @@
       "properties": {
         "api_version": {"const": "1.5.0"},
         "receipt": {"type": "object"}
+      }
+    },
+    "roomPresenceCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["photo", "title", "company"],
+      "properties": {
+        "photo": {"type": "string"},
+        "title": {"type": "string"},
+        "company": {"type": "string"}
+      }
+    },
+    "roomPresencePreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["card", "shared", "writes"],
+      "properties": {
+        "card": {"$ref": "#/$defs/roomPresenceCard"},
+        "shared": {"const": false},
+        "writes": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+      }
+    },
+    "roomPresencePreviewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "fields"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "fields": {"type": "object"}
+      }
+    },
+    "roomPresencePreviewResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "preview", "approval_token"],
+      "properties": {
+        "api_version": {"const": "1.5.0"},
+        "preview": {"$ref": "#/$defs/roomPresencePreview"},
+        "approval_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "roomPresenceExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/roomPresencePreview"},
+        "approved_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "roomPresenceExecuteResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "receipt"],
+      "properties": {
+        "api_version": {"const": "1.5.0"},
+        "receipt": {"type": "object"}
+      }
+    },
+    "roomPresenceSharePreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["room", "consent_required", "card", "visible_after_yes", "writes"],
+      "properties": {
+        "room": {"type": "string", "minLength": 1},
+        "consent_required": {"const": "yes"},
+        "card": {"$ref": "#/$defs/roomPresenceCard"},
+        "visible_after_yes": {"type": "object"},
+        "writes": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+      }
+    },
+    "roomPresenceSharePreviewRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "room_id"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "room_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "roomPresenceSharePreviewResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_version", "preview", "approval_token"],
+      "properties": {
+        "api_version": {"const": "1.5.0"},
+        "preview": {"$ref": "#/$defs/roomPresenceSharePreview"},
+        "approval_token": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "roomPresenceShareExecuteRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vault_root", "preview", "approved_token", "consent"],
+      "properties": {
+        "vault_root": {"$ref": "#/$defs/path"},
+        "preview": {"$ref": "#/$defs/roomPresenceSharePreview"},
+        "approved_token": {"$ref": "#/$defs/sha256"},
+        "consent": {"const": "yes"}
       }
     },
     "previewRequest": {

--- a/core/lifecycle/service.py
+++ b/core/lifecycle/service.py
@@ -685,6 +685,236 @@ def execute_approved_onboarding_context(
     return _envelope(receipt=executed["receipt"])
 
 
+def _load_room_presence_profile(vault_root: str | Path) -> tuple[Path, bytes, dict[str, object]]:
+    """Read the live profile once so the hash and the parse stay the same bytes."""
+    import yaml
+
+    from core.room_presence import PROFILE_RELATIVE
+
+    root = Path(vault_root)
+    profile = root / PROFILE_RELATIVE
+    if profile.is_symlink() or not profile.is_file():
+        raise PlanRejected("room presence requires a finalized regular user profile")
+    original = profile.read_bytes()
+    try:
+        current = yaml.safe_load(original.decode("utf-8")) or {}
+    except (UnicodeDecodeError, yaml.YAMLError) as error:
+        raise PlanRejected("user profile is not valid YAML") from error
+    if not isinstance(current, dict):
+        raise PlanRejected("user profile must be a YAML object")
+    return profile, original, current
+
+
+def _room_presence_profile_plan(
+    vault_root: str | Path,
+    profile: Path,
+    original: bytes,
+    updated: Mapping[str, object],
+    *,
+    purpose: str,
+) -> tuple[dict[str, object], list[PlanEntry]]:
+    """Build the exact user-profile write for a room-presence mutation."""
+    import yaml
+
+    from core.room_presence import PROFILE_RELATIVE
+
+    if not isinstance(updated, Mapping):
+        raise PlanRejected("room presence update is malformed")
+    plan = [
+        PlanEntry(
+            PROFILE_RELATIVE,
+            yaml.safe_dump(dict(updated), sort_keys=False, allow_unicode=True).encode(
+                "utf-8"
+            ),
+            mode=profile.stat().st_mode & 0o777,
+            expected_current_sha256=hashlib.sha256(original).hexdigest(),
+        )
+    ]
+    transaction = _transaction_preview_document(
+        vault_root,
+        plan,
+        purpose=purpose,
+        operation="room-presence",
+    )
+    return {"writes": transaction["writes"]}, plan
+
+
+def _room_presence_fields_preview(
+    vault_root: str | Path,
+    fields: Mapping[str, object],
+) -> tuple[dict[str, object], list[PlanEntry]]:
+    """Build the exact local card mutation. This does not share anything."""
+    from core.room_presence import apply_local_fields, local_card
+
+    profile, original, current = _load_room_presence_profile(vault_root)
+    if not isinstance(fields, Mapping):
+        raise PlanRejected("room presence fields are malformed")
+    try:
+        updated = apply_local_fields(
+            current,
+            photo=fields.get("photo", None),
+            title=fields.get("title", None),
+            company=fields.get("company", None),
+        )
+    except ValueError as error:
+        raise PlanRejected(str(error)) from error
+    document, plan = _room_presence_profile_plan(
+        vault_root,
+        profile,
+        original,
+        updated,
+        purpose="room-presence",
+    )
+    return {
+        "card": local_card(updated),
+        "shared": False,
+        "writes": document["writes"],
+    }, plan
+
+
+def build_and_preview_room_presence(
+    vault_root: str | Path,
+    fields: Mapping[str, object],
+) -> dict[str, object]:
+    """Show the local photo, title, and company save before writing anything."""
+    preview, _plan = _room_presence_fields_preview(vault_root, fields)
+    return _envelope(
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def execute_approved_room_presence(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+) -> dict[str, object]:
+    """Save only the unchanged local card. This still does not share it."""
+    if not isinstance(preview, Mapping):
+        raise PlanRejected("room presence preview is malformed")
+    fields = {
+        "photo": preview.get("card", {}).get("photo")
+        if isinstance(preview.get("card"), Mapping)
+        else None,
+        "title": preview.get("card", {}).get("title")
+        if isinstance(preview.get("card"), Mapping)
+        else None,
+        "company": preview.get("card", {}).get("company")
+        if isinstance(preview.get("card"), Mapping)
+        else None,
+    }
+    expected_preview, plan = _room_presence_fields_preview(vault_root, fields)
+    expected_bytes = _canonical(expected_preview)
+    if (
+        _canonical(dict(preview)) != expected_bytes
+        or not isinstance(approved_token, str)
+        or not hmac.compare_digest(approved_token, hashlib.sha256(expected_bytes).hexdigest())
+    ):
+        raise PlanRejected("room presence approval does not match the current exact preview")
+    executed = _execute_approved_transaction(
+        vault_root,
+        plan,
+        purpose="room-presence",
+        operation="room-presence",
+        approved_token=str(
+            _preview_transaction(
+                vault_root,
+                plan,
+                purpose="room-presence",
+                operation="room-presence",
+            )["approval_token"]
+        ),
+    )
+    return _envelope(receipt=executed["receipt"])
+
+
+def _room_presence_share_preview(
+    vault_root: str | Path,
+    room_id: str,
+) -> tuple[dict[str, object], list[PlanEntry]]:
+    """Build the exact share mutation. Audience is still closed until a yes."""
+    from core.room_presence import apply_share, local_card, normalize_room_id, room_view
+
+    profile, original, current = _load_room_presence_profile(vault_root)
+    try:
+        normalized = normalize_room_id(room_id)
+        updated = apply_share(current, normalized)
+    except ValueError as error:
+        raise PlanRejected(str(error)) from error
+    document, plan = _room_presence_profile_plan(
+        vault_root,
+        profile,
+        original,
+        updated,
+        purpose="room-presence-share",
+    )
+    visible = room_view(updated, normalized)
+    return {
+        "room": normalized,
+        "consent_required": "yes",
+        "card": local_card(updated),
+        "visible_after_yes": visible,
+        "writes": document["writes"],
+    }, plan
+
+
+def build_and_preview_room_presence_share(
+    vault_root: str | Path,
+    room_id: str,
+) -> dict[str, object]:
+    """Show what another person would see after a yes. Writes nothing."""
+    preview, _plan = _room_presence_share_preview(vault_root, room_id)
+    return _envelope(
+        preview=preview,
+        approval_token=hashlib.sha256(_canonical(preview)).hexdigest(),
+    )
+
+
+def execute_approved_room_presence_share(
+    vault_root: str | Path,
+    preview: Mapping[str, object],
+    approved_token: str,
+    consent: str,
+) -> dict[str, object]:
+    """Share the card with one room only after an unchanged preview and a yes."""
+    from core.room_presence import require_yes
+
+    if not isinstance(preview, Mapping):
+        raise PlanRejected("room presence share preview is malformed")
+    try:
+        require_yes(consent)
+    except ValueError as error:
+        raise PlanRejected(str(error)) from error
+    room_id = preview.get("room")
+    if not isinstance(room_id, str):
+        raise PlanRejected("room presence share preview is malformed")
+    expected_preview, plan = _room_presence_share_preview(vault_root, room_id)
+    expected_bytes = _canonical(expected_preview)
+    if (
+        _canonical(dict(preview)) != expected_bytes
+        or not isinstance(approved_token, str)
+        or not hmac.compare_digest(approved_token, hashlib.sha256(expected_bytes).hexdigest())
+    ):
+        raise PlanRejected(
+            "room presence share approval does not match the current exact preview"
+        )
+    executed = _execute_approved_transaction(
+        vault_root,
+        plan,
+        purpose="room-presence-share",
+        operation="room-presence",
+        approved_token=str(
+            _preview_transaction(
+                vault_root,
+                plan,
+                purpose="room-presence-share",
+                operation="room-presence",
+            )["approval_token"]
+        ),
+    )
+    return _envelope(receipt=executed["receipt"])
+
+
 def _missing_companies_default_plan(
     vault_root: str | Path,
 ) -> tuple[list[PlanEntry], dict[str, bool]]:
@@ -1653,6 +1883,10 @@ __all__ = [
     "execute_approved_mcp_registration",
     "build_and_preview_onboarding_context",
     "execute_approved_onboarding_context",
+    "build_and_preview_room_presence",
+    "execute_approved_room_presence",
+    "build_and_preview_room_presence_share",
+    "execute_approved_room_presence_share",
     "build_and_preview_automation_claim",
     "execute_approved_automation_claim",
     "build_and_preview_automation_release",

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -597,6 +597,7 @@ def update_write_verdict(
         "onboarding-provision",
         "analytics-receipt",
         "automation-ownership",
+        "room-presence",
     ):
         raise ValueError(f"unknown write operation: {operation}")
 
@@ -716,6 +717,46 @@ def update_write_verdict(
             candidate,
             False,
             "outside-onboarding-context",
+            resolution.ownership if resolution is not None else None,
+            resolution.rule_id if resolution is not None else None,
+        )
+
+    if operation == "room-presence":
+        try:
+            denied = is_denied(path)
+            candidate = _normalize(path)
+        except ContractViolation:
+            return WriteVerdict(
+                str(path),
+                False,
+                "outside-room-presence",
+                None,
+                None,
+            )
+        try:
+            resolution = resolve(candidate)
+        except ContractViolation:
+            resolution = None
+        if denied:
+            return WriteVerdict(
+                candidate,
+                False,
+                "deny",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        if candidate == "System/user-profile.yaml":
+            return WriteVerdict(
+                candidate,
+                True,
+                "write-room-presence",
+                resolution.ownership if resolution is not None else None,
+                resolution.rule_id if resolution is not None else None,
+            )
+        return WriteVerdict(
+            candidate,
+            False,
+            "outside-room-presence",
             resolution.ownership if resolution is not None else None,
             resolution.rule_id if resolution is not None else None,
         )

--- a/core/room_presence.py
+++ b/core/room_presence.py
@@ -1,0 +1,160 @@
+"""Local room-presence card: photo, title, and company.
+
+This is who a beta person is in a shared room. It is not a career product,
+not a live network, and not the Mac Dex app. Folders never grant audience —
+another person sees this card only after an explicit yes.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+PROFILE_RELATIVE = "System/user-profile.yaml"
+PRESENCE_KEY = "room_presence"
+CARD_FIELDS = ("photo", "title", "company")
+CONSENT_YES = "yes"
+_ROOM_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_PHOTO_SUFFIXES = (".gif", ".jpeg", ".jpg", ".png", ".webp")
+
+
+class RoomPresenceError(ValueError):
+    """Raised when a room-presence field or room id is not saveable."""
+
+
+def normalize_room_id(room_id: object) -> str:
+    """Return a short room id, or raise if it looks like a folder path."""
+    if not isinstance(room_id, str) or _ROOM_ID.fullmatch(room_id) is None:
+        raise RoomPresenceError(
+            "a shared room needs a short name like design-sync, not a folder path"
+        )
+    return room_id
+
+
+def normalize_text(value: object, *, field: str) -> str:
+    """Return a trimmed string. Missing or blank stays empty — never a name."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise RoomPresenceError(f"{field} must be text")
+    return value.strip()
+
+
+def normalize_photo(value: object) -> str:
+    """Return a vault-relative photo path, or empty. Empty stays empty."""
+    text = normalize_text(value, field="photo")
+    if not text:
+        return ""
+    candidate = Path(text)
+    if candidate.is_absolute() or "\\" in text or ".." in candidate.parts:
+        raise RoomPresenceError("photo must be a file inside this Dex folder")
+    if candidate.suffix.lower() not in _PHOTO_SUFFIXES:
+        raise RoomPresenceError("photo must be a .jpg, .jpeg, .png, .webp, or .gif path")
+    return candidate.as_posix()
+
+
+def empty_card() -> dict[str, str]:
+    """Return the three card fields as empty strings, not placeholder names."""
+    return {field: "" for field in CARD_FIELDS}
+
+
+def card_from_mapping(payload: Mapping[str, Any] | None) -> dict[str, str]:
+    """Read photo, title, and company only. Never invent a name from elsewhere."""
+    card = empty_card()
+    if not isinstance(payload, Mapping):
+        return card
+    card["photo"] = normalize_photo(payload.get("photo"))
+    card["title"] = normalize_text(payload.get("title"), field="title")
+    card["company"] = normalize_text(payload.get("company"), field="company")
+    return card
+
+
+def presence_block(profile: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the local presence block, ignoring career and folder state."""
+    if not isinstance(profile, Mapping):
+        return {"card": empty_card(), "shared_rooms": {}}
+    raw = profile.get(PRESENCE_KEY)
+    if not isinstance(raw, Mapping):
+        return {"card": empty_card(), "shared_rooms": {}}
+    shared = raw.get("shared_rooms")
+    rooms: dict[str, dict[str, bool]] = {}
+    if isinstance(shared, Mapping):
+        for room_id, state in shared.items():
+            if not isinstance(room_id, str) or _ROOM_ID.fullmatch(room_id) is None:
+                continue
+            if isinstance(state, Mapping) and state.get("consented") is True:
+                rooms[room_id] = {"consented": True}
+    return {"card": card_from_mapping(raw), "shared_rooms": rooms}
+
+
+def local_card(profile: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return the locally saved card. Profile name is never used as a stand-in."""
+    return presence_block(profile)["card"]
+
+
+def room_is_shared(profile: Mapping[str, Any] | None, room_id: str) -> bool:
+    """Return whether this room was shared with an explicit yes."""
+    block = presence_block(profile)
+    return block["shared_rooms"].get(normalize_room_id(room_id), {}).get("consented") is True
+
+
+def room_view(profile: Mapping[str, Any] | None, room_id: str) -> dict[str, Any]:
+    """Return what another person in this room may see.
+
+    Unshared rooms return no card. Shared rooms return photo, title, and
+    company only — never a folder tree, never a guessed name.
+    """
+    normalized = normalize_room_id(room_id)
+    if not room_is_shared(profile, normalized):
+        return {"room": normalized, "shared": False, "card": None}
+    return {"room": normalized, "shared": True, "card": local_card(profile)}
+
+
+def apply_local_fields(
+    profile: Mapping[str, Any],
+    *,
+    photo: object = None,
+    title: object = None,
+    company: object = None,
+) -> dict[str, Any]:
+    """Write photo, title, and company locally without granting any audience."""
+    if not isinstance(profile, Mapping):
+        raise RoomPresenceError("user profile must be a YAML object")
+    updated = dict(profile)
+    current = presence_block(profile)
+    card = dict(current["card"])
+    if photo is not None:
+        card["photo"] = normalize_photo(photo)
+    if title is not None:
+        card["title"] = normalize_text(title, field="title")
+    if company is not None:
+        card["company"] = normalize_text(company, field="company")
+    updated[PRESENCE_KEY] = {
+        **card,
+        "shared_rooms": current["shared_rooms"],
+    }
+    return updated
+
+
+def apply_share(profile: Mapping[str, Any], room_id: str) -> dict[str, Any]:
+    """Record that this room may see the card. Callers must already have a yes."""
+    if not isinstance(profile, Mapping):
+        raise RoomPresenceError("user profile must be a YAML object")
+    normalized = normalize_room_id(room_id)
+    updated = dict(profile)
+    current = presence_block(profile)
+    rooms = dict(current["shared_rooms"])
+    rooms[normalized] = {"consented": True}
+    updated[PRESENCE_KEY] = {
+        **current["card"],
+        "shared_rooms": rooms,
+    }
+    return updated
+
+
+def require_yes(consent: object) -> None:
+    """Sharing still requires a yes. Folders, tokens, and other words do not count."""
+    if not isinstance(consent, str) or consent.strip() != CONSENT_YES:
+        raise RoomPresenceError("sharing still requires a yes")

--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -190,6 +190,76 @@ def test_frozen_service_inputs_and_outputs_conform_to_schema(
         onboarding_execute_response,
     )
 
+    presence_vault = tmp_path / "presence-vault"
+    (presence_vault / "System").mkdir(parents=True)
+    (presence_vault / "System" / "user-profile.yaml").write_text(
+        "name: Example User\n",
+        encoding="utf-8",
+    )
+    presence_fields = {"photo": "System/maya.png", "title": "Designer", "company": ""}
+    presence_request = {
+        "vault_root": str(presence_vault),
+        "fields": presence_fields,
+    }
+    presence_response = service.build_and_preview_room_presence(
+        presence_vault,
+        presence_fields,
+    )
+    _assert_conforms(
+        schema,
+        "build_and_preview_room_presence",
+        presence_request,
+        presence_response,
+    )
+    presence_execute_request = {
+        "vault_root": str(presence_vault),
+        "preview": presence_response["preview"],
+        "approved_token": presence_response["approval_token"],
+    }
+    presence_execute_response = service.execute_approved_room_presence(
+        presence_vault,
+        presence_response["preview"],
+        presence_response["approval_token"],
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_room_presence",
+        presence_execute_request,
+        presence_execute_response,
+    )
+    share_request = {
+        "vault_root": str(presence_vault),
+        "room_id": "design-sync",
+    }
+    share_response = service.build_and_preview_room_presence_share(
+        presence_vault,
+        "design-sync",
+    )
+    _assert_conforms(
+        schema,
+        "build_and_preview_room_presence_share",
+        share_request,
+        share_response,
+    )
+    share_execute_request = {
+        "vault_root": str(presence_vault),
+        "preview": share_response["preview"],
+        "approved_token": share_response["approval_token"],
+        "consent": "yes",
+    }
+    share_execute_response = service.execute_approved_room_presence_share(
+        presence_vault,
+        share_response["preview"],
+        share_response["approval_token"],
+        "yes",
+    )
+    _assert_conforms(
+        schema,
+        "execute_approved_room_presence_share",
+        share_execute_request,
+        share_execute_response,
+    )
+
     automation_vault = tmp_path / "automation-vault"
     (automation_vault / "System").mkdir(parents=True)
     home = tmp_path / "automation-home"
@@ -415,6 +485,10 @@ def test_additive_public_surface_preserves_every_existing_operation() -> None:
         "execute_approved_mcp_registration",
         "build_and_preview_onboarding_context",
         "execute_approved_onboarding_context",
+        "build_and_preview_room_presence",
+        "execute_approved_room_presence",
+        "build_and_preview_room_presence_share",
+        "execute_approved_room_presence_share",
         "build_and_preview_automation_claim",
         "execute_approved_automation_claim",
         "build_and_preview_automation_release",
@@ -445,6 +519,22 @@ def test_additive_public_surface_preserves_every_existing_operation() -> None:
         "abandon_rebuild_capsule",
         "recover_rebuild_transactions",
     ]
+
+
+def test_room_presence_operations_have_frozen_signatures() -> None:
+    assert str(inspect.signature(service.build_and_preview_room_presence)) == (
+        "(vault_root: 'str | Path', fields: 'Mapping[str, object]') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.execute_approved_room_presence)) == (
+        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', approved_token: 'str') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.build_and_preview_room_presence_share)) == (
+        "(vault_root: 'str | Path', room_id: 'str') -> 'dict[str, object]'"
+    )
+    assert str(inspect.signature(service.execute_approved_room_presence_share)) == (
+        "(vault_root: 'str | Path', preview: 'Mapping[str, object]', approved_token: 'str', "
+        "consent: 'str') -> 'dict[str, object]'"
+    )
 
 
 def test_onboarding_context_operations_have_frozen_signatures() -> None:

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -365,6 +365,24 @@ def test_capability_state_operation_only_authorizes_the_live_profile() -> None:
     assert refused.action == "outside-capability-state"
 
 
+def test_room_presence_operation_only_authorizes_the_live_profile() -> None:
+    allowed = portable_contract.update_write_verdict(
+        "System/user-profile.yaml",
+        exists=True,
+        operation="room-presence",
+    )
+    refused = portable_contract.update_write_verdict(
+        "05-Areas/Career/Evidence/README.md",
+        exists=True,
+        operation="room-presence",
+    )
+
+    assert allowed.allowed is True
+    assert allowed.action == "write-room-presence"
+    assert refused.allowed is False
+    assert refused.action == "outside-room-presence"
+
+
 def test_onboarding_context_operation_only_authorizes_the_live_profile() -> None:
     allowed = portable_contract.update_write_verdict(
         "System/user-profile.yaml",

--- a/core/tests/test_room_presence.py
+++ b/core/tests/test_room_presence.py
@@ -1,0 +1,220 @@
+"""Room presence card: local photo/title/company, empty stays empty, share needs yes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.lifecycle import service
+from core.room_presence import local_card, room_view
+from core.transaction.engine import PlanRejected
+
+
+def _vault(tmp_path: Path, *, name: str = "Maya") -> Path:
+    vault = tmp_path / "vault"
+    system = vault / "System"
+    system.mkdir(parents=True)
+    (system / "user-profile.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": name,
+                "role": "Should not become a title",
+                "company": "Should not leak from onboarding",
+                "capabilities": {"career": {"enabled": True}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (vault / "05-Areas" / "Career" / "Evidence").mkdir(parents=True)
+    (vault / "05-Areas" / "Career" / "Evidence" / "README.md").write_text(
+        "# Career\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def _profile(vault: Path) -> dict:
+    return yaml.safe_load((vault / "System" / "user-profile.yaml").read_text(encoding="utf-8"))
+
+
+def test_profile_fields_save_locally(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    original = (vault / "System" / "user-profile.yaml").read_text(encoding="utf-8")
+
+    previewed = service.build_and_preview_room_presence(
+        vault,
+        {
+            "photo": "System/maya.png",
+            "title": "Product designer",
+            "company": "Northwind",
+        },
+    )
+
+    assert (vault / "System" / "user-profile.yaml").read_text(encoding="utf-8") == original
+    assert previewed["preview"]["shared"] is False
+    assert previewed["preview"]["card"] == {
+        "photo": "System/maya.png",
+        "title": "Product designer",
+        "company": "Northwind",
+    }
+
+    executed = service.execute_approved_room_presence(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    saved = _profile(vault)
+    assert local_card(saved) == previewed["preview"]["card"]
+    assert saved["name"] == "Maya"
+    assert executed["receipt"]["purpose"] == "room-presence"
+    assert [write["path"] for write in executed["receipt"]["files_written"]] == [
+        "System/user-profile.yaml"
+    ]
+    assert room_view(saved, "design-sync") == {
+        "room": "design-sync",
+        "shared": False,
+        "card": None,
+    }
+
+
+def test_empty_is_empty_not_a_placeholder_name(tmp_path: Path) -> None:
+    vault = _vault(tmp_path, name="Maya")
+
+    previewed = service.build_and_preview_room_presence(
+        vault,
+        {"photo": "", "title": "  ", "company": None},
+    )
+    service.execute_approved_room_presence(
+        vault,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    saved = _profile(vault)
+    card = local_card(saved)
+    assert card == {"photo": "", "title": "", "company": ""}
+    assert "Maya" not in card.values()
+    assert "Should not become a title" not in card.values()
+    assert saved["name"] == "Maya"
+
+    share = service.build_and_preview_room_presence_share(vault, "design-sync")
+    service.execute_approved_room_presence_share(
+        vault,
+        share["preview"],
+        share["approval_token"],
+        "yes",
+    )
+    visible = room_view(_profile(vault), "design-sync")
+    assert visible["shared"] is True
+    assert visible["card"] == {"photo": "", "title": "", "company": ""}
+    assert visible["card"]["title"] == ""
+    assert "Maya" not in visible["card"].values()
+
+
+def test_sharing_still_requires_a_yes(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    saved = service.build_and_preview_room_presence(
+        vault,
+        {"photo": "System/maya.png", "title": "Product designer", "company": ""},
+    )
+    service.execute_approved_room_presence(
+        vault,
+        saved["preview"],
+        saved["approval_token"],
+    )
+    share = service.build_and_preview_room_presence_share(vault, "design-sync")
+    original = (vault / "System" / "user-profile.yaml").read_bytes()
+
+    for consent in ("", "ok", "true", "05-Areas/Career", True):
+        with pytest.raises(PlanRejected, match="sharing still requires a yes"):
+            service.execute_approved_room_presence_share(
+                vault,
+                share["preview"],
+                share["approval_token"],
+                consent,  # type: ignore[arg-type]
+            )
+        assert (vault / "System" / "user-profile.yaml").read_bytes() == original
+        assert room_view(_profile(vault), "design-sync")["shared"] is False
+
+    with pytest.raises(PlanRejected, match="approval does not match"):
+        service.execute_approved_room_presence_share(
+            vault,
+            share["preview"],
+            "0" * 64,
+            "yes",
+        )
+    assert room_view(_profile(vault), "design-sync")["shared"] is False
+
+
+def test_folders_never_grant_audience(tmp_path: Path) -> None:
+    vault = _vault(tmp_path)
+    saved = service.build_and_preview_room_presence(
+        vault,
+        {"photo": "System/maya.png", "title": "Product designer", "company": ""},
+    )
+    service.execute_approved_room_presence(
+        vault,
+        saved["preview"],
+        saved["approval_token"],
+    )
+
+    profile = _profile(vault)
+    assert profile["capabilities"]["career"]["enabled"] is True
+    assert (vault / "05-Areas" / "Career" / "Evidence" / "README.md").is_file()
+    visible = room_view(profile, "career")
+    assert visible == {"room": "career", "shared": False, "card": None}
+    with pytest.raises(PlanRejected, match="not a folder path"):
+        service.build_and_preview_room_presence_share(vault, "05-Areas/Career")
+
+
+def test_maya_adds_a_photo_and_title_and_a_room_sees_the_card_not_a_folder_tree(
+    tmp_path: Path,
+) -> None:
+    maya = _vault(tmp_path, name="Maya")
+    previewed = service.build_and_preview_room_presence(
+        maya,
+        {
+            "photo": "System/maya.png",
+            "title": "Product designer",
+            "company": "",
+        },
+    )
+    service.execute_approved_room_presence(
+        maya,
+        previewed["preview"],
+        previewed["approval_token"],
+    )
+
+    before_yes = room_view(_profile(maya), "design-sync")
+    assert before_yes["shared"] is False
+    assert before_yes["card"] is None
+
+    share = service.build_and_preview_room_presence_share(maya, "design-sync")
+    assert share["preview"]["consent_required"] == "yes"
+    assert "folders" not in share["preview"]
+    assert "05-Areas" not in str(share["preview"]["visible_after_yes"])
+    service.execute_approved_room_presence_share(
+        maya,
+        share["preview"],
+        share["approval_token"],
+        "yes",
+    )
+
+    other_person_sees = room_view(_profile(maya), "design-sync")
+    assert other_person_sees == {
+        "room": "design-sync",
+        "shared": True,
+        "card": {
+            "photo": "System/maya.png",
+            "title": "Product designer",
+            "company": "",
+        },
+    }
+    assert set(other_person_sees["card"]) == {"photo", "title", "company"}
+    assert "folders" not in other_person_sees
+    assert "Career" not in other_person_sees
+    assert other_person_sees["card"]["company"] == ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- WO-044 job 47 (GTM-lab brief 404'd; this follows the job brief)

## Maya's walk

Maya is in a shared room. People there should know who she is. They should not see her Dex folders.

1. Maya adds a photo (`System/maya.png`) and a title (`Product designer`). She leaves company blank.
2. Those three fields save on her machine. Company stays empty. Dex does not fill in "Maya" or any other stand-in name.
3. She already has a Career folder. That folder does **not** share her card. Folders never grant audience.
4. Sharing still needs a yes. Until she says yes, another person in the room sees nothing.
5. After she says yes for `design-sync`, the other person sees her photo and title — not `05-Areas/Career`, not a folder tree.

This is the local card for a shared room. It is not a second Career product. It is not a live network. It is not the Mac Dex.dmg app. v1.96.6 stays as shipped.

## What Changed
- Local presence card: photo, title, company, saved through the one safe write door
- Empty fields stay empty
- Sharing one room requires an unchanged preview **and** the word `yes`
- Capability folders cannot share the card or be used as a room name

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_room_presence.py`
- Negative/error-path tests added or updated: empty stays empty; share without yes; folder path refused
- Commands run locally:
  - `python3 -m pytest core/tests/test_room_presence.py core/tests/test_portable_contract.py core/tests/test_onboarding_context_lifecycle.py core/tests/test_lifecycle_service_contract.py -q`
  - 123 passed

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: close the PR. Nothing is tagged or shipped.

## Docs Impact
- Files updated: none
- If none, reason: this is a local contract, not a shipped user-facing release. Changelog stays on v1.96.6.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-987ea206-2f28-4f4c-b778-8d5f2416aae8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-987ea206-2f28-4f4c-b778-8d5f2416aae8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

