### PR TITLE
Fail closed when Apple Mail search has no index (#446)

### DIFF
--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -147,7 +147,8 @@ Then tell them the two maintenance facts that matter:
 
 ## Ongoing health
 
-`/dex-doctor` runs `mail.apple-search` as a deep check and reports:
+`/dex-doctor` runs `mail.apple-search` as a local checkup (also as
+`python3 core/utils/doctor.py --check mail.apple-search`) and reports:
 
 | Verdict | Meaning |
 |---|---|

--- a/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -116,7 +116,8 @@ from them; triage is an interactive step in the main conversation.
 
 Check `System/integrations/config.yaml`. Also treat a registered `apple-mail-mcp`
 server as connected. Before querying any connected email source, run
-`python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`python3 core/utils/doctor.py --check mail.apple-search` — a focused local check,
+not `--deep`. Apple Mail search is usable only when the
 `mail.apple-search` check reports `OK` / `feature_status: ok`.
 
 If the source is connected and healthy:

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -342,8 +342,9 @@ For each completed item:
 
 Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. Also treat a
 registered `apple-mail-mcp` server as a connected source. Before querying a connected email
-source, run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
-`mail.apple-search` check reports `OK` / `feature_status: ok`.
+source, run `python3 core/utils/doctor.py --check mail.apple-search` — a focused local check,
+not `--deep`. Apple Mail search is usable only when that check reports `OK` /
+`feature_status: ok`.
 
 If connected and healthy:
 1. Get unread count and priority emails from monitored labels

--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -123,7 +123,8 @@ Never read or change the separate analytics consent while handling this choice.
 
 ### Step 2: Offer the deep scan
 
-Quick mode checks configuration, wiring, and background-job freshness. Deep mode
+Quick mode checks configuration, wiring, background-job freshness, and the local
+Mail search index when a community Apple Mail server is registered. Deep mode
 additionally contacts live services (Granola API, Calendar via EventKit, enabled
 integrations). Ask:
 

--- a/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
@@ -75,7 +75,8 @@ follow-ups that may have slipped.
 
 Check `System/integrations/config.yaml`. Also treat a registered `apple-mail-mcp`
 server as connected. Before querying any connected email source, run
-`python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+`python3 core/utils/doctor.py --check mail.apple-search` — a focused local check,
+not `--deep`. Apple Mail search is usable only when the
 `mail.apple-search` check reports `OK` / `feature_status: ok`. If healthy, analyse
 the week's mail:
 - Total volume (received vs sent)

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -256,7 +256,8 @@ Review meeting notes from the week:
 
 Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. Also treat a
 registered `apple-mail-mcp` server as connected. Before querying a connected email source,
-run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable only when the
+run `python3 core/utils/doctor.py --check mail.apple-search` — a focused local check,
+not `--deep`. Apple Mail search is usable only when the
 `mail.apple-search` check reports `OK` / `feature_status: ok`.
 
 If connected and healthy:

--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -203,6 +203,49 @@ def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch,
     assert "returns nothing" in result.user_message
 
 
+def test_email_aware_path_with_no_index_is_visible_not_empty(context):
+    """Linux contract: a missing index is a visible broken state, never []."""
+    _register_apple_mail_user_scope(context)
+
+    state = apple_mail_health.flow_status(context)
+    encoded = json.dumps(state)
+
+    assert state["feature_status"] == "broken"
+    assert state["usable"] is False
+    assert state["search"] == "blocked"
+    assert state["visible"].startswith(apple_mail_health.EMAIL_CONTEXT_OMITTED_PREFIX)
+    assert "never been built" in state["user_message"]
+    assert "apple-mail-mcp index" in state["action"]
+    for key in apple_mail_health._SEARCH_RESULT_KEYS:
+        assert key not in state
+        assert f'"{key}": []' not in encoded
+
+
+def test_email_aware_path_with_index_still_allows_existing_search(context):
+    """Linux contract: a fresh index keeps the existing Mail search path open."""
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=1)
+
+    state = apple_mail_health.flow_status(context)
+
+    assert state["feature_status"] == "ok"
+    assert state["usable"] is True
+    assert state["search"] == "allowed"
+    assert "visible" not in state
+    assert "user_message" not in state
+    for key in apple_mail_health._SEARCH_RESULT_KEYS:
+        assert key not in state
+
+
+def test_email_aware_path_omits_unconnected_mail_without_noise(context):
+    state = apple_mail_health.flow_status(context)
+
+    assert state["feature_status"] == "off"
+    assert state["usable"] is False
+    assert state["search"] == "blocked"
+    assert "visible" not in state
+
+
 def test_apple_mail_search_is_broken_when_the_index_is_empty(monkeypatch, context):
     _register_apple_mail_user_scope(context)
     _write_apple_mail_index(context, size=0)

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -57,6 +57,7 @@ QUICK_IDS = [
     "customizations.skills",
     "customizations.mcp",
     "core.drift",
+    "mail.apple-search",
     "doctor.self",
 ]
 
@@ -69,7 +70,6 @@ DEEP_IDS = [
     "config.claude_composition",
     "update.post-canary",
     "calendar.access",
-    "mail.apple-search",
     "qmd.live",
     "integrations.enabled",
     "mcp.importable",
@@ -4126,12 +4126,12 @@ def test_calendar_sandbox_failure_is_unknown(monkeypatch, context):
     assert doctor._probe_calendar_access(context).verdict == "UNKNOWN"
 
 
-def test_apple_mail_search_is_a_deep_check_and_adapts_the_focused_probe(
+def test_apple_mail_search_is_a_quick_check_and_adapts_the_focused_probe(
     monkeypatch,
     context,
 ):
-    assert "mail.apple-search" in DEEP_IDS
-    definition = next(check for check in doctor.DEEP_CHECKS if check.id == "mail.apple-search")
+    assert "mail.apple-search" in QUICK_IDS
+    definition = next(check for check in doctor.QUICK_CHECKS if check.id == "mail.apple-search")
     assert definition.probe == "_probe_apple_mail_search"
 
     observed = {}
@@ -4162,6 +4162,70 @@ def test_apple_mail_search_is_a_deep_check_and_adapts_the_focused_probe(
     assert observed["context"].project_config_path == context.vault_root / ".mcp.json"
     assert observed["context"].macos is True
     assert observed["context"].cli_present is True
+
+
+def test_focused_mail_check_does_not_run_the_deep_registry_or_write_last_run(
+    monkeypatch,
+    context,
+):
+    deep_calls = []
+
+    def mark(name):
+        def probe(_context, *, _name=name):
+            deep_calls.append(_name)
+            return doctor.ProbeResult("OK", f"{_name} should not have run.")
+
+        return probe
+
+    _stub_probes(monkeypatch)
+    for definition in doctor.DEEP_CHECKS:
+        monkeypatch.setattr(doctor, definition.probe, mark(definition.id))
+
+    report = doctor.collect(check_id="mail.apple-search", context=context)
+
+    assert report["mode"] == "focused"
+    assert "adoption" not in report
+    assert [check["id"] for check in report["checks"]] == [
+        "mail.apple-search",
+        "doctor.self",
+    ]
+    assert deep_calls == []
+    assert not context.last_run_path.exists()
+
+
+def test_focused_mail_check_cli_returns_honest_broken_status(
+    monkeypatch,
+    context,
+    capsys,
+):
+    _stub_probes(
+        monkeypatch,
+        overrides={
+            "mail.apple-search": doctor.ProbeResult(
+                "BROKEN",
+                "Apple Mail search has no index, so every mail search returns nothing",
+                heal=doctor.Heal(tier=3, action="Run apple-mail-mcp index.", applied=False),
+                feature_status="broken",
+                user_message="Mail search has never been built, so it silently returns nothing.",
+            )
+        },
+    )
+
+    assert doctor.main(["--check", "mail.apple-search"], context=context) == 0
+    report = json.loads(capsys.readouterr().out)
+    mail = _check(report, "mail.apple-search")
+
+    assert report["mode"] == "focused"
+    assert mail["feature_status"] == "broken"
+    assert mail["user_message"]
+    assert "returns nothing" in mail["user_message"]
+    assert mail.get("emails") is None
+    assert "granola.query_path" not in {check["id"] for check in report["checks"]}
+
+
+def test_focused_check_rejects_an_unknown_id(context):
+    with pytest.raises(ValueError, match="Unknown doctor check"):
+        doctor.collect(check_id="mail.not-a-real-check", context=context)
 
 
 def test_calendar_permission_adapter_preserves_eventkit_status(monkeypatch, context):

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -588,7 +588,8 @@ def test_email_aware_plans_do_not_silently_skip_a_broken_mail_index() -> None:
         instructions = _read(relative)
         assert "mail.apple-search" in instructions, relative
         assert "do not silently skip" in instructions.lower(), relative
-        assert "python3 core/utils/doctor.py --deep" in instructions, relative
+        assert "python3 core/utils/doctor.py --check mail.apple-search" in instructions, relative
+        assert "`--deep`" in instructions, relative
 
 
 def test_apple_mail_setup_installs_only_the_runtime_mac_ci_proves() -> None:

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -101,6 +101,44 @@ class Result:
     user_message: str | None = None
 
 
+# Keys a silent-empty search would use. Email-aware flows must never treat a
+# missing index as "no matching mail."
+_SEARCH_RESULT_KEYS = ("emails", "results", "messages", "matches")
+EMAIL_CONTEXT_OMITTED_PREFIX = "Email context omitted"
+
+
+def omission_line(result: Result) -> str:
+    """Return the one visible line a daily plan / week review must show."""
+    message = result.user_message or result.detail
+    return f"{EMAIL_CONTEXT_OMITTED_PREFIX} — {message}"
+
+
+def flow_status(context: Context) -> dict[str, object]:
+    """Fail-closed readiness for email-aware flows.
+
+    A missing or unusable index is a visible broken state, never an empty
+    search result. Only ``feature_status: ok`` allows the existing Mail MCP
+    search path to run.
+    """
+    result = probe(context)
+    status = result.feature_status or "unknown"
+    usable = status == "ok"
+    payload: dict[str, object] = {
+        "feature_status": status,
+        "verdict": result.verdict,
+        "usable": usable,
+        "search": "allowed" if usable else "blocked",
+        "detail": result.detail,
+    }
+    if result.user_message:
+        payload["user_message"] = result.user_message
+    if result.action:
+        payload["action"] = result.action
+    if not usable and status != "off":
+        payload["visible"] = omission_line(result)
+    return payload
+
+
 def _one_line(error: BaseException) -> str:
     return " ".join(str(error).split())
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -635,6 +635,7 @@ QUICK_CHECKS = (
         "_probe_customization_mcp",
     ),
     CheckDefinition("core.drift", "Shipped-file drift", "_probe_core_drift"),
+    CheckDefinition("mail.apple-search", "Apple Mail search", "_probe_apple_mail_search"),
     CheckDefinition("doctor.self", "Doctor instruments", "_probe_doctor_self"),
 )
 
@@ -655,7 +656,6 @@ DEEP_CHECKS = (
     CheckDefinition("config.claude_composition", "CLAUDE customisations live", "_probe_claude_composition"),
     CheckDefinition("update.post-canary", "Post-update canary", "_probe_post_update_canary"),
     CheckDefinition("calendar.access", "Calendar access", "_probe_calendar_access"),
-    CheckDefinition("mail.apple-search", "Apple Mail search", "_probe_apple_mail_search"),
     CheckDefinition("qmd.live", "Semantic search", "_probe_qmd_live"),
     CheckDefinition("integrations.enabled", "Enabled integrations", "_probe_integrations_enabled"),
     CheckDefinition("mcp.importable", "MCP imports", "_probe_mcp_importable"),
@@ -1017,15 +1017,35 @@ def _write_last_run(report: dict[str, Any], context: DoctorContext) -> None:
     )
 
 
+def _check_definition(check_id: str) -> CheckDefinition:
+    for definition in (*QUICK_CHECKS, *DEEP_CHECKS):
+        if definition.id == check_id:
+            return definition
+    raise ValueError(f"Unknown doctor check {check_id!r}")
+
+
 def collect(
     *,
     deep: bool = False,
     heal: bool = False,
     context: DoctorContext | None = None,
+    check_id: str | None = None,
 ) -> dict[str, Any]:
     """Run the selected registry and return its JSON-serializable report."""
     context = context or DoctorContext.from_environment()
-    definitions = [*QUICK_CHECKS, *DEEP_CHECKS] if deep else list(QUICK_CHECKS)
+    focused = check_id is not None
+    if focused and deep:
+        raise ValueError("A focused check cannot run the full deep registry")
+    if focused:
+        assert check_id is not None
+        target = _check_definition(check_id)
+        definitions = [target]
+        if target.id != "doctor.self":
+            definitions.append(_check_definition("doctor.self"))
+    elif deep:
+        definitions = [*QUICK_CHECKS, *DEEP_CHECKS]
+    else:
+        definitions = list(QUICK_CHECKS)
     results: dict[str, ProbeResult] = {}
     failed: list[dict[str, str]] = []
 
@@ -1147,10 +1167,9 @@ def collect(
     results["doctor.self"] = self_result
 
     checks = [_result_json(definition, results[definition.id]) for definition in definitions]
-    adoption = collect_adoption_report(context)
     report = {
         "generated_at": context.now.isoformat(),
-        "mode": "deep" if deep else "quick",
+        "mode": "focused" if focused else ("deep" if deep else "quick"),
         "instruments": {
             "attempted": len(definitions),
             "completed": len(definitions) - len(failed),
@@ -1158,8 +1177,9 @@ def collect(
         },
         "checks": checks,
         "summary": _summary(checks),
-        "adoption": adoption.to_dict(),
     }
+    if not focused:
+        report["adoption"] = collect_adoption_report(context).to_dict()
     if deep:
         assessment_result = results.get("customizations.assessment")
         if (
@@ -1175,6 +1195,9 @@ def collect(
             report["customization_migration_status"] = (
                 migration_status_result.structured_detail
             )
+
+    if focused:
+        return report
 
     try:
         _write_last_run(report, context)
@@ -5747,6 +5770,11 @@ def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
 def main(argv: list[str] | None = None, *, context: DoctorContext | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--deep", action="store_true", help="Run live service probes.")
+    parser.add_argument(
+        "--check",
+        metavar="ID",
+        help="Run one named check. Email-aware flows use --check mail.apple-search instead of --deep.",
+    )
     parser.add_argument("--heal", action="store_true", help="Apply safe Tier-1 repairs before checking.")
     parser.add_argument("--credential-scan", action="store_true", help="Run the bounded local credential scan.")
     parser.add_argument("--credential-migrate", action="store_true", help="Run safe local credential migration.")
@@ -5772,7 +5800,14 @@ def main(argv: list[str] | None = None, *, context: DoctorContext | None = None)
             credential_report = run_credential_workflow(root, action, journal_id=journal_id)
             print(json.dumps(credential_report, indent=2))
             return 2 if credential_report.get("migration_state") == "refused" and action != "status" else 0
-        report = collect(deep=args.deep, heal=args.heal, context=context)
+        if args.check and args.deep:
+            parser.error("--check cannot be combined with --deep")
+        report = collect(
+            deep=args.deep,
+            heal=args.heal,
+            context=context,
+            check_id=args.check,
+        )
         output = json.dumps(report, indent=2)
     except Exception as error:
         print(f"dex-doctor could not produce JSON: {_one_line(error)}", file=sys.stderr)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #446.

This is the remaining honesty gap on the existing email-aware path. It does not invent a Mail product.

## Linked Issue
- GitHub: #446
- Linear issue: none (public user report)

## What Changed
Community Apple Mail can list and read messages while its search index was never built. Search then comes back empty (or, on 0.4.3, as subject/sender hits labelled as body matches). Daily plan and week review were told to run a full deep Doctor scan first, which looks frozen, and a missing index still read as “no mail.”

This PR:
- Adds a fail-closed `flow_status` for email-aware flows: no index → visible broken state, never an empty result list; fresh index → existing search path still allowed
- Adds `python3 core/utils/doctor.py --check mail.apple-search` so those flows do not run `--deep`
- Moves `mail.apple-search` into the regular (quick) checkup so `/dex-doctor` sees a missing index without a live-service scan

## What Maya sees when Mail has no index
One calm line, then the plan continues without pretending the inbox is empty:

> Email context omitted — Mail search has never been built, so it silently returns nothing. Run `umask 077; apple-mail-mcp index --verbose` from a terminal app granted Full Disk Access: System Settings > Privacy & Security > Full Disk Access. Quit and reopen that terminal before building. The app that launches the Mail server (Dex, Claude, or Cursor) also needs Full Disk Access — background sync reads ~/Library/Mail, and a fresh-looking index can still be frozen if that grant is missing.

If Mail is not connected, that section stays off with no noise.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_apple_mail_health.py`, `core/tests/test_doctor.py`, `core/tests/test_instruction_honesty.py`
- Negative/error-path tests added or updated: no index → `feature_status: broken` and a visible omission line; unknown `--check` id rejected; focused check does not run the deep registry
- Commands run locally (Linux):
  - `python3 -m pytest core/tests/test_apple_mail_health.py core/tests/test_instruction_honesty.py core/tests/test_doctor.py::test_focused_mail_check_does_not_run_the_deep_registry_or_write_last_run core/tests/test_doctor.py::test_focused_mail_check_cli_returns_honest_broken_status core/tests/test_doctor.py::test_json_contract_shape_and_last_run_file -q`

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this branch. Mail search stays opt-in; the existing probe still reports broken when the index is missing.

## Docs Impact
- Files updated: `/apple-mail-setup`, `/daily-plan`, `/week-review`, `/dex-doctor` skill instructions
- Changelog / package version not bumped — this is not LIVE and should not be treated as a release.

## Files
- `core/utils/apple_mail_health.py`
- `core/utils/doctor.py`
- `core/tests/test_apple_mail_health.py`
- `core/tests/test_doctor.py`
- `core/tests/test_instruction_honesty.py`
- `.claude/skills/daily-plan/SKILL.md`
- `.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md`
- `.claude/skills/week-review/SKILL.md`
- `.claude/skills/week-review/AGENT_INSTRUCTIONS.md`
- `.claude/skills/apple-mail-setup/SKILL.md`
- `.claude/skills/dex-doctor/SKILL.md`

Not LIVE. Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b6d42ac-63a9-432e-ba3a-60ce58c5c802?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b6d42ac-63a9-432e-ba3a-60ce58c5c802&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

