### PR TITLE
Career scores use the structured target level the download actually runs

### DIFF
--- a/.claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md
+++ b/.claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md
@@ -31,6 +31,8 @@ This command uses **Career MCP tools** for efficient data aggregation:
 - `parse_ladder()` - Extracts competency requirements from career ladder
 - `analyze_coverage()` - Maps evidence to competencies with coverage statistics
 - `timeline_analysis()` - Tracks evidence trends and growth velocity
+- `promotion_readiness_score()` - Sourced 0-100 score from real evidence. Never invent a skills score of 15.
+- `skills_gap_analysis()` - Required skills come from the structured `## Target Level` section, including `###` competency headings. Pass `target_level`.
 
 **How it works:** MCP tools provide structured data → LLM interprets and coaches. This makes assessments faster, more consistent, and enables trend tracking over time.
 
@@ -690,11 +692,13 @@ coverage.
 Before generating the assessment, use MCP tools to gather structured data:
 
 **Career MCP:**
-1. **Call `scan_evidence()`** - Get overview of all career evidence
-2. **Call `parse_ladder()`** - Get structured competency requirements
-3. **Call `analyze_coverage()`** - Get competency-to-evidence mapping
+1. **Call `scan_evidence()`** - Get overview of all career evidence, including files sitting in the Evidence folder itself
+2. **Call `parse_ladder(target_level=...)`** - Get structured competency requirements from the target-level section
+3. **Call `analyze_coverage(target_level=...)`** - Get competency-to-evidence mapping
 4. **Call `timeline_analysis()`** - Get evidence trends over time
 5. **Call `scan_work_for_evidence(date_range: "last-12-months", impact_level: "high")`** - Find uncaptured high-impact work
+6. **Call `promotion_readiness_score(target_level=...)`** - Use this sourced score. Do not invent `skills_coverage` of 15.
+7. **Call `skills_gap_analysis(target_level=...)`** - Read required skills from the structured target level. A `###` competency heading is still inside that level.
 
 **Work MCP:**
 1. **Call `get_quarterly_goals()`** for recent quarters - See what outcomes you've delivered
@@ -711,11 +715,13 @@ These tools provide consistent, structured data that you then interpret for coac
 **Example MCP workflow:**
 ```
 [Career MCP: scan_evidence() - returns [observed count] records for [selected period], with [coverage/unknowns]]
-[Career MCP: parse_ladder() - returns [observed count] sourced competencies]
-[Career MCP: analyze_coverage() - returns sourced evidence counts plus unknown mappings]
+[Career MCP: parse_ladder(target_level=...) - returns [observed count] sourced competencies]
+[Career MCP: analyze_coverage(target_level=...) - returns sourced evidence counts plus unknown mappings]
+[Career MCP: promotion_readiness_score(target_level=...) - returns the sourced score breakdown; never invent skills_coverage 15]
+[Career MCP: skills_gap_analysis(target_level=...) - required skills come from the structured target level]
 [Work MCP: get_quarterly_goals() - returns [observed count] goals and their source states]
 [Work MCP: scan_work_for_evidence() - returns [observed count] candidates requiring user validation]
-[Now interpret combined data and generate assessment below]
+[Now interpret the sourced score and gap. Do not invent a dummy 15.]
 ```
 
 Then generate:

--- a/core/mcp/career_parser.py
+++ b/core/mcp/career_parser.py
@@ -424,9 +424,48 @@ def scan_evidence_directory(evidence_dir: Path, date_range: Optional[Tuple[date,
 # LADDER FILE PARSING
 # ============================================================================
 
-def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
+def _target_level_section(content: str, target_level: Optional[str] = None) -> tuple[str, str]:
+    """
+    Read the structured target-level section from a career-setup ladder.
+
+    A well-formed ladder uses ``## Target Level: {name}`` plus ``###``
+    competency headings. Prefer an explicit target-level argument, then the
+    file's Target Level field, then any heading that names that level.
+    """
+    file_target_level = extract_field(content, "Target Level")
+    selected = (target_level or "").strip() or file_target_level
+    candidates: list[str] = []
+    if selected:
+        candidates.append(f"## Target Level: {selected}")
+    if file_target_level and file_target_level != selected:
+        candidates.append(f"## Target Level: {file_target_level}")
+    candidates.append("## Target Level")
+
+    for heading in candidates:
+        section = extract_section(content, heading)
+        if section and find_competency_headings(section, level=3):
+            return selected or file_target_level, section
+
+    if selected:
+        for line in content.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("##") and selected.lower() in stripped.lower():
+                section = extract_section(content, stripped)
+                if section and find_competency_headings(section, level=3):
+                    return selected, section
+
+    heading = candidates[0]
+    return selected or file_target_level, extract_section(content, heading)
+
+
+def parse_ladder_file(filepath: Path, target_level: Optional[str] = None) -> Dict[str, Any]:
     """
     Parse career ladder markdown and extract competency structure.
+
+    Args:
+        filepath: Career_Ladder.md
+        target_level: Optional level name. When set, read that structured
+            ``## Target Level: …`` section even if the metadata field differs.
     
     Returns:
         Dict with ladder metadata and competencies
@@ -450,12 +489,9 @@ def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
     # Extract metadata
     company = extract_field(content, "Company")
     current_level = extract_field(content, "Current Level")
-    target_level = extract_field(content, "Target Level")
+    file_target_level = extract_field(content, "Target Level")
     last_updated = extract_field(content, "Last Updated")
-    
-    # Find target level section
-    target_section_heading = f"## Target Level: {target_level}" if target_level else "## Target Level"
-    target_section = extract_section(content, target_section_heading)
+    resolved_target_level, target_section = _target_level_section(content, target_level)
     
     # Parse competencies (### headings under target level)
     competencies = []
@@ -474,7 +510,7 @@ def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
         "filepath": str(filepath),
         "company": company,
         "current_level": current_level,
-        "target_level": target_level,
+        "target_level": resolved_target_level or file_target_level,
         "last_updated": last_updated,
         "competencies": competencies,
         "competency_count": len(competencies)

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -478,8 +478,10 @@ async def handle_parse_ladder(arguments: dict) -> list[types.TextContent]:
             note="Run /career-setup to create your career ladder",
         )
     
-    # Parse the ladder
-    ladder_data = parse_ladder_file(LADDER_FILE)
+    # Parse the ladder, honoring an explicit structured target level
+    ladder_data = parse_ladder_file(
+        LADDER_FILE, target_level=arguments.get("target_level")
+    )
     
     if "error" in ladder_data:
         return _feature_response(
@@ -518,8 +520,10 @@ async def handle_analyze_coverage(arguments: dict) -> list[types.TextContent]:
             note="Run /career-setup to create your career ladder",
         )
     
-    # Parse ladder
-    ladder_data = parse_ladder_file(LADDER_FILE)
+    # Parse ladder, honoring an explicit structured target level
+    ladder_data = parse_ladder_file(
+        LADDER_FILE, target_level=arguments.get("target_level")
+    )
     if "error" in ladder_data or not ladder_data.get('competencies'):
         error = "Failed to parse career ladder or no competencies found"
         return _feature_response(
@@ -811,14 +815,16 @@ async def handle_scan_work_for_evidence(arguments: dict) -> list[types.TextConte
     )]
 
 
-def _required_skills_from_ladder() -> list[str]:
-    """Read required skills with the same ladder parser the rest of Dex uses."""
-    ladder_data = parse_ladder_file(LADDER_FILE)
+def _required_skills_from_ladder(target_level: str | None = None) -> list[str]:
+    """Read required skills from the structured target-level section."""
+    ladder_data = parse_ladder_file(LADDER_FILE, target_level=target_level)
     required_skills = []
     seen = set()
     for competency in ladder_data.get("competencies") or []:
         skill = competency.get("category")
         if not skill or skill in seen:
+            continue
+        if not competency.get("target_level_requirements"):
             continue
         seen.add(skill)
         required_skills.append(skill)
@@ -875,8 +881,8 @@ async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]
     lookback_days = arguments.get('lookback_days', 90)
     stale_threshold_days = arguments.get('stale_threshold_days', 42)
     
-    # 1. Parse career ladder to get required skills
-    required_skills = _required_skills_from_ladder()
+    # 1. Parse career ladder to get required skills from the structured target level
+    required_skills = _required_skills_from_ladder(target_level)
     
     # 2. Scan work data for skills being developed
     active_skills = {}
@@ -977,6 +983,7 @@ async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]
         'analysis_date': datetime.now().isoformat(),
         'target_level': target_level,
         'lookback_days': lookback_days,
+        'required_skills': required_skills,
         'required_skills_count': len(required_skills),
         'actively_developed': actively_developed,
         'actively_developed_count': len(actively_developed),
@@ -1174,7 +1181,7 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
     }
     
     # 3. Skills Coverage (0-25 points)
-    ladder_data = parse_ladder_file(LADDER_FILE)
+    ladder_data = parse_ladder_file(LADDER_FILE, target_level=target_level)
     competencies = ladder_data.get("competencies") or []
     coverage_analysis = analyze_competency_coverage(evidence_files, competencies) if competencies else {}
     skills_score = _score_skills_from_coverage(coverage_analysis, len(competencies))

--- a/core/portable_contract.py
+++ b/core/portable_contract.py
@@ -426,9 +426,14 @@ CAPABILITIES: dict[str, dict[str, object]] = {
             _room_skill_source(
                 "career",
                 "career-coach",
-                "ff1997a5eb4092b0993425d57b048d0c8dcf16c1d37d62b2df443eaa6f836a6c",
-                36036,
+                "43596f024ad7e10320f425170437ddffb7205bb2d1c88fd74e46c0cdb6d60e8d",
+                36981,
                 previous_payloads=(
+                    (
+                        "v1.96.6",
+                        "ff1997a5eb4092b0993425d57b048d0c8dcf16c1d37d62b2df443eaa6f836a6c",
+                        36036,
+                    ),
                     (
                         "v1.95.2",
                         "356de976657e23a399c19bd09f580e429cc0c3fc7da4a79095345b6ce8c8d352",

--- a/core/tests/test_career_promotion_readiness.py
+++ b/core/tests/test_career_promotion_readiness.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from core.mcp import career_server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CAREER_COACH = (
+    REPO_ROOT
+    / ".claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md"
+)
 
 STRUCTURED_LADDER = """# Career Ladder
 
@@ -240,3 +249,97 @@ def test_skills_gap_and_parse_ladder_agree_on_heading_names(
     assert _required_skill_names(gap) == [
         item["category"] for item in parsed["competencies"]
     ]
+
+
+def test_skills_gap_reads_structured_target_level_even_when_metadata_differs(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    ladder = vault / "05-Areas" / "Career" / "Career_Ladder.md"
+    # Metadata names a different level than the structured section the caller asks for.
+    ladder.write_text(
+        STRUCTURED_LADDER.replace("**Target Level:** Senior PM", "**Target Level:** L5"),
+        encoding="utf-8",
+    )
+
+    payload = _skills_gap({"target_level": "Senior PM"})
+
+    assert payload["required_skills_count"] != 0
+    assert payload["required_skills_count"] == 3
+    assert payload["required_skills"] == COMPETENCY_HEADINGS
+    assert _required_skill_names(payload) == COMPETENCY_HEADINGS
+
+
+def test_career_coach_live_path_must_call_score_and_gap_tools() -> None:
+    text = CAREER_COACH.read_text(encoding="utf-8")
+
+    assert "promotion_readiness_score" in text
+    assert "skills_gap_analysis" in text
+    assert "never invent" in text.lower() or "do not invent" in text.lower()
+
+
+def test_download_path_vault_path_uses_real_evidence_not_dummy_15(tmp_path) -> None:
+    """The public folder install launches career_server with VAULT_PATH set.
+
+    Monkeypatching module globals is not that path. A fresh interpreter must
+    still count Evidence-folder files, refuse the dummy 15, and read a
+    structured target level.
+    """
+    vault = tmp_path / "vault"
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    profile = vault / "System" / "user-profile.yaml"
+    evidence_dir.mkdir(parents=True)
+    profile.parent.mkdir(parents=True)
+    profile.write_text("capabilities:\n  career:\n    enabled: true\n", encoding="utf-8")
+    (career_dir / "Career_Ladder.md").write_text(STRUCTURED_LADDER, encoding="utf-8")
+    for name, competency in (
+        ("2026-01-10 - Strategy memo.md", "Product Strategy"),
+        ("2026-02-11 - Design review.md", "Technical Depth"),
+        ("2026-03-12 - Exec review.md", "Stakeholder Leadership"),
+    ):
+        (evidence_dir / name).write_text(
+            f"# {name}\n\n"
+            "**Category:** Achievements\n\n"
+            "## Skills Demonstrated\n"
+            f"- {competency}\n\n"
+            "## Ladder Alignment\n\n"
+            f"**Maps to:** {competency}\n",
+            encoding="utf-8",
+        )
+    (evidence_dir / "README.md").write_text("# Career Evidence\n", encoding="utf-8")
+
+    script = r"""
+import asyncio, json, sys
+from core.mcp import career_server
+
+def decode(result):
+    return json.loads(result[0].text)
+
+score = decode(asyncio.run(career_server.handle_call_tool(
+    "promotion_readiness_score", {"time_in_role_months": 3, "target_level": "Senior PM"}
+)))
+gap = decode(asyncio.run(career_server.handle_call_tool(
+    "skills_gap_analysis", {"target_level": "Senior PM"}
+)))
+print(json.dumps({"score": score, "gap": gap}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env={**os.environ, "VAULT_PATH": str(vault)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    skills = payload["score"]["score_breakdown"]["skills_coverage"]
+    evidence = payload["score"]["score_breakdown"]["evidence_coverage"]
+    gap = payload["gap"]
+
+    assert evidence["evidence_count"] == 3
+    assert skills["score"] != 15
+    assert skills["score"] == 8
+    assert gap["required_skills_count"] == 3
+    assert gap["required_skills"] == COMPETENCY_HEADINGS

--- a/core/tests/test_feature_status.py
+++ b/core/tests/test_feature_status.py
@@ -249,7 +249,7 @@ def test_existing_unreadable_career_ladder_reports_broken(monkeypatch, tmp_path)
     monkeypatch.setattr(
         career_server,
         "parse_ladder_file",
-        lambda _path: {"error": "Could not parse career ladder"},
+        lambda _path, target_level=None: {"error": "Could not parse career ladder"},
     )
 
     payload = _decode_tool_result(
@@ -275,7 +275,11 @@ def test_career_ladder_without_competencies_reports_broken(monkeypatch, tmp_path
     monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
     monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
     monkeypatch.setattr(career_server, "USER_PROFILE_FILE", profile_file)
-    monkeypatch.setattr(career_server, "parse_ladder_file", lambda _path: ladder_data)
+    monkeypatch.setattr(
+        career_server,
+        "parse_ladder_file",
+        lambda _path, target_level=None: ladder_data,
+    )
 
     payload = _decode_tool_result(
         asyncio.run(career_server.handle_call_tool("analyze_coverage", {}))

--- a/core/tests/test_portable_contract.py
+++ b/core/tests/test_portable_contract.py
@@ -59,6 +59,11 @@ def test_room_upgrade_ledger_preserves_all_published_payload_identities() -> Non
         },
         "career-coach": {
             (
+                "v1.96.6",
+                "ff1997a5eb4092b0993425d57b048d0c8dcf16c1d37d62b2df443eaa6f836a6c",
+                36036,
+            ),
+            (
                 "v1.95.2",
                 "356de976657e23a399c19bd09f580e429cc0c3fc7da4a79095345b6ce8c8d352",
                 29547,

--- a/packages/dex-contracts/dist/portable-vault.contract.json
+++ b/packages/dex-contracts/dist/portable-vault.contract.json
@@ -869,9 +869,14 @@
           "skill": "career-coach",
           "source_path": ".claude/skills/_available/capabilities/career/skills/career-coach/SKILL.md",
           "target_path": ".claude/skills/career-coach/SKILL.md",
-          "sha256": "ff1997a5eb4092b0993425d57b048d0c8dcf16c1d37d62b2df443eaa6f836a6c",
-          "byte_size": 36036,
+          "sha256": "43596f024ad7e10320f425170437ddffb7205bb2d1c88fd74e46c0cdb6d60e8d",
+          "byte_size": 36981,
           "previous_payloads": [
+            {
+              "release": "v1.96.6",
+              "sha256": "ff1997a5eb4092b0993425d57b048d0c8dcf16c1d37d62b2df443eaa6f836a6c",
+              "byte_size": 36036
+            },
             {
               "release": "v1.95.2",
               "sha256": "356de976657e23a399c19bd09f580e429cc0c3fc7da4a79095345b6ce8c8d352",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Fixes the three #539 faults on the path the public folder download runs (`install.sh` + `VAULT_PATH` + `/career-coach`), not only on monkeypatched unit tests.

## What Changed
- `promotion_readiness_score` and `skills_gap_analysis` now read the structured `## Target Level` section, including when the caller passes `target_level` and the metadata field names a different level.
- Files sitting in `05-Areas/Career/Evidence/` still count. README files still do not.
- `/career-coach` (the live OSS skill the download copies in) must call `promotion_readiness_score` and `skills_gap_analysis`. It must not invent a skills score of 15.

## What this does not do
- Does not invent a new career product.
- Does not publish a new Dex version. Merging this will not put a new download on the site.
- Does not touch Mac Dex.dmg, plugin 20–27, or `gtm/claude/*`.
- Not LIVE. Draft. Do not merge.

## What Maya sees on a well-formed ladder + evidence
On a career-setup ladder with `## Target Level: Senior PM` and three `###` competencies, plus three mapped evidence files sitting in the Evidence folder:

- `evidence_coverage.evidence_count` is **3** (not 0)
- `skills_coverage.score` is **8** (weak coverage), **not 15**
- `skills_gap_analysis(target_level="Senior PM")` returns **3** required skills: Product Strategy, Technical Depth, Stakeholder Leadership

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_career_promotion_readiness.py`
- Negative/error-path tests added or updated: dummy 15 is forbidden; Evidence-folder files must count; structured target level must be read even when metadata differs; VAULT_PATH subprocess locks the download launch path
- Commands run locally: `pytest core/tests/test_career_promotion_readiness.py core/tests/test_feature_status.py` plus contract pin tests → **43 passed**

## Quality Gates
- Honest-health lock for the three #539 faults. No new career product.

## Risk & Rollback
- Risk level: low — shared ladder reader + skill wiring + tests.
- Rollback plan: revert this PR.

## Docs Impact
- None beyond the career-coach skill instructions the download already ships. Contract pin updated so the skill hash matches.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9c91f1-b900-4ae0-ba0b-0965e4a66ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9c91f1-b900-4ae0-ba0b-0965e4a66ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

