### PR TITLE
Fail closed when Mail search is not honestly indexed (#446)

### DIFF
--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -203,6 +203,93 @@ def test_apple_mail_search_is_broken_when_the_index_was_never_built(monkeypatch,
     assert "returns nothing" in result.user_message
 
 
+_MAIL_CONTENT_MARKERS = (
+    "Fixture subject",
+    "fixture@example.com",
+    "Fixture body",
+    "Searchable body",
+)
+
+
+def _assert_fail_closed_flow(state, *, status="broken"):
+    encoded = json.dumps(state)
+    assert state["feature_status"] == status
+    assert state["usable"] is False
+    assert state["search"] == "blocked"
+    if status != "off":
+        assert state["visible"].startswith(apple_mail_health.EMAIL_CONTEXT_OMITTED_PREFIX)
+    for key in apple_mail_health._SEARCH_RESULT_KEYS:
+        assert key not in state
+        assert f'"{key}": []' not in encoded
+    for marker in _MAIL_CONTENT_MARKERS:
+        assert marker not in encoded
+
+
+def test_email_aware_path_with_no_index_is_visible_not_empty(context):
+    """Linux contract: a missing index is a visible broken state, never []."""
+    _register_apple_mail_user_scope(context)
+
+    state = apple_mail_health.flow_status(context)
+
+    _assert_fail_closed_flow(state)
+    assert "never been built" in state["user_message"]
+    assert "apple-mail-mcp index" in state["action"]
+
+
+def test_email_aware_path_with_index_still_allows_existing_search(context):
+    """Linux contract: a fresh index keeps the existing Mail search path open."""
+    _register_apple_mail_user_scope(context)
+    _write_apple_mail_index(context, age_days=1)
+
+    state = apple_mail_health.flow_status(context)
+    encoded = json.dumps(state)
+
+    assert state["feature_status"] == "ok"
+    assert state["usable"] is True
+    assert state["search"] == "allowed"
+    assert "visible" not in state
+    assert "user_message" not in state
+    for key in apple_mail_health._SEARCH_RESULT_KEYS:
+        assert key not in state
+        assert f'"{key}": []' not in encoded
+    for marker in _MAIL_CONTENT_MARKERS:
+        assert marker not in encoded
+
+
+def test_email_aware_path_omits_unconnected_mail_without_noise(context):
+    state = apple_mail_health.flow_status(context)
+
+    _assert_fail_closed_flow(state, status="off")
+    assert "visible" not in state
+
+
+@pytest.mark.parametrize(
+    "broken_shape",
+    ["empty-file", "dummy-bytes", "empty-schema", "empty-fts", "stale"],
+)
+def test_email_aware_path_dummy_or_unusable_index_is_visible_not_empty(context, broken_shape):
+    """Dummy or silent-empty indexes must not look like search worked."""
+    _register_apple_mail_user_scope(context)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    if broken_shape == "empty-file":
+        _write_apple_mail_index(context, size=0)
+    elif broken_shape == "dummy-bytes":
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_bytes(b"not a sqlite database")
+        index.chmod(0o600)
+    elif broken_shape == "empty-schema":
+        _write_real_apple_mail_index(index, email_count=0)
+    elif broken_shape == "empty-fts":
+        _write_real_apple_mail_index(index, fts_searchable=False)
+    else:
+        _write_apple_mail_index(context, age_days=30)
+
+    state = apple_mail_health.flow_status(context)
+
+    _assert_fail_closed_flow(state)
+    assert state["feature_status"] != "ok"
+
+
 def test_apple_mail_search_is_broken_when_the_index_is_empty(monkeypatch, context):
     _register_apple_mail_user_scope(context)
     _write_apple_mail_index(context, size=0)

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -57,6 +57,7 @@ QUICK_IDS = [
     "customizations.skills",
     "customizations.mcp",
     "core.drift",
+    "mail.apple-search",
     "doctor.self",
 ]
 
@@ -69,7 +70,6 @@ DEEP_IDS = [
     "config.claude_composition",
     "update.post-canary",
     "calendar.access",
-    "mail.apple-search",
     "qmd.live",
     "integrations.enabled",
     "mcp.importable",
@@ -4126,12 +4126,12 @@ def test_calendar_sandbox_failure_is_unknown(monkeypatch, context):
     assert doctor._probe_calendar_access(context).verdict == "UNKNOWN"
 
 
-def test_apple_mail_search_is_a_deep_check_and_adapts_the_focused_probe(
+def test_apple_mail_search_is_a_quick_check_and_adapts_the_focused_probe(
     monkeypatch,
     context,
 ):
-    assert "mail.apple-search" in DEEP_IDS
-    definition = next(check for check in doctor.DEEP_CHECKS if check.id == "mail.apple-search")
+    assert "mail.apple-search" in QUICK_IDS
+    definition = next(check for check in doctor.QUICK_CHECKS if check.id == "mail.apple-search")
     assert definition.probe == "_probe_apple_mail_search"
 
     observed = {}
@@ -4162,6 +4162,136 @@ def test_apple_mail_search_is_a_deep_check_and_adapts_the_focused_probe(
     assert observed["context"].project_config_path == context.vault_root / ".mcp.json"
     assert observed["context"].macos is True
     assert observed["context"].cli_present is True
+
+
+def test_focused_mail_check_does_not_run_the_deep_registry_or_write_last_run(
+    monkeypatch,
+    context,
+):
+    deep_calls = []
+
+    def mark(name):
+        def probe(_context, *, _name=name):
+            deep_calls.append(_name)
+            return doctor.ProbeResult("OK", f"{_name} should not have run.")
+
+        return probe
+
+    _stub_probes(monkeypatch)
+    for definition in doctor.DEEP_CHECKS:
+        monkeypatch.setattr(doctor, definition.probe, mark(definition.id))
+
+    report = doctor.collect(check_id="mail.apple-search", context=context)
+
+    assert report["mode"] == "focused"
+    assert "adoption" not in report
+    assert [check["id"] for check in report["checks"]] == [
+        "mail.apple-search",
+        "doctor.self",
+    ]
+    assert deep_calls == []
+    assert not context.last_run_path.exists()
+
+
+def test_focused_mail_check_cli_returns_honest_broken_status(
+    monkeypatch,
+    context,
+    capsys,
+):
+    _stub_probes(
+        monkeypatch,
+        overrides={
+            "mail.apple-search": doctor.ProbeResult(
+                "BROKEN",
+                "Apple Mail search has no index, so every mail search returns nothing",
+                heal=doctor.Heal(tier=3, action="Run apple-mail-mcp index.", applied=False),
+                feature_status="broken",
+                user_message="Mail search has never been built, so it silently returns nothing.",
+            )
+        },
+    )
+
+    assert doctor.main(["--check", "mail.apple-search"], context=context) == 0
+    report = json.loads(capsys.readouterr().out)
+    mail = _check(report, "mail.apple-search")
+
+    assert report["mode"] == "focused"
+    assert mail["feature_status"] == "broken"
+    assert mail["user_message"]
+    assert "returns nothing" in mail["user_message"]
+    assert mail.get("emails") is None
+    assert "granola.query_path" not in {check["id"] for check in report["checks"]}
+
+
+def test_focused_check_rejects_an_unknown_id(context):
+    with pytest.raises(ValueError, match="Unknown doctor check"):
+        doctor.collect(check_id="mail.not-a-real-check", context=context)
+
+
+def test_focused_check_cannot_run_the_deep_registry(context):
+    with pytest.raises(ValueError, match="focused check cannot run the full deep registry"):
+        doctor.collect(deep=True, check_id="mail.apple-search", context=context)
+
+
+def _register_apple_mail_for_doctor(context):
+    (context.home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"user-apple-mail": {"command": "apple-mail-mcp", "args": ["serve"]}}})
+    )
+
+
+def _assert_doctor_mail_is_fail_closed(mail):
+    encoded = json.dumps(mail)
+    assert mail["feature_status"] == "broken"
+    assert mail["verdict"] == "BROKEN"
+    assert mail.get("user_message")
+    assert mail.get("emails") is None
+    for key in ("emails", "results", "messages", "matches"):
+        assert key not in mail
+        assert f'"{key}": []' not in encoded
+    for marker in ("Fixture subject", "fixture@example.com", "Fixture body"):
+        assert marker not in encoded
+
+
+def test_public_download_quick_doctor_fail_closes_a_missing_mail_index(
+    monkeypatch,
+    context,
+):
+    """Default /dex-doctor (no --deep) is the public download path. Missing index is broken, never []."""
+    _stub_probes(monkeypatch, exclude={"mail.apple-search"})
+    _register_apple_mail_for_doctor(context)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+
+    report = doctor.collect(context=context)
+    mail = _check(report, "mail.apple-search")
+
+    assert report["mode"] == "quick"
+    assert "mail.apple-search" in [check["id"] for check in report["checks"]]
+    _assert_doctor_mail_is_fail_closed(mail)
+    assert "never been built" in mail["user_message"]
+    assert "returns nothing" in mail["user_message"]
+
+
+def test_public_download_quick_doctor_fail_closes_a_dummy_mail_index(
+    monkeypatch,
+    context,
+):
+    """A dummy index file must not look like search worked on the public download path."""
+    _stub_probes(monkeypatch, exclude={"mail.apple-search"})
+    _register_apple_mail_for_doctor(context)
+    index = context.home / ".apple-mail-mcp" / "index.db"
+    index.parent.mkdir(parents=True)
+    index.write_bytes(b"not a sqlite database")
+    index.chmod(0o600)
+    monkeypatch.setattr(doctor, "_is_macos", lambda: True)
+    monkeypatch.setattr(doctor, "_apple_mail_cli_present", lambda: True)
+
+    report = doctor.collect(context=context)
+    mail = _check(report, "mail.apple-search")
+
+    assert report["mode"] == "quick"
+    _assert_doctor_mail_is_fail_closed(mail)
+    assert mail["feature_status"] != "ok"
 
 
 def test_calendar_permission_adapter_preserves_eventkit_status(monkeypatch, context):

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -101,6 +101,44 @@ class Result:
     user_message: str | None = None
 
 
+# Keys a silent-empty search would use. Email-aware flows must never treat a
+# missing or unusable index as "no matching mail."
+_SEARCH_RESULT_KEYS = ("emails", "results", "messages", "matches")
+EMAIL_CONTEXT_OMITTED_PREFIX = "Email context omitted"
+
+
+def omission_line(result: Result) -> str:
+    """Return the one visible line a daily plan / week review must show."""
+    message = result.user_message or result.detail
+    return f"{EMAIL_CONTEXT_OMITTED_PREFIX} — {message}"
+
+
+def flow_status(context: Context) -> dict[str, object]:
+    """Fail-closed readiness for email-aware flows.
+
+    A missing or unusable index is a visible broken state, never an empty
+    search result. Only ``feature_status: ok`` allows the existing Mail MCP
+    search path to run.
+    """
+    result = probe(context)
+    status = result.feature_status or "unknown"
+    usable = status == "ok"
+    payload: dict[str, object] = {
+        "feature_status": status,
+        "verdict": result.verdict,
+        "usable": usable,
+        "search": "allowed" if usable else "blocked",
+        "detail": result.detail,
+    }
+    if result.user_message:
+        payload["user_message"] = result.user_message
+    if result.action:
+        payload["action"] = result.action
+    if not usable and status != "off":
+        payload["visible"] = omission_line(result)
+    return payload
+
+
 def _one_line(error: BaseException) -> str:
     return " ".join(str(error).split())
 

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -635,6 +635,7 @@ QUICK_CHECKS = (
         "_probe_customization_mcp",
     ),
     CheckDefinition("core.drift", "Shipped-file drift", "_probe_core_drift"),
+    CheckDefinition("mail.apple-search", "Apple Mail search", "_probe_apple_mail_search"),
     CheckDefinition("doctor.self", "Doctor instruments", "_probe_doctor_self"),
 )
 
@@ -655,7 +656,6 @@ DEEP_CHECKS = (
     CheckDefinition("config.claude_composition", "CLAUDE customisations live", "_probe_claude_composition"),
     CheckDefinition("update.post-canary", "Post-update canary", "_probe_post_update_canary"),
     CheckDefinition("calendar.access", "Calendar access", "_probe_calendar_access"),
-    CheckDefinition("mail.apple-search", "Apple Mail search", "_probe_apple_mail_search"),
     CheckDefinition("qmd.live", "Semantic search", "_probe_qmd_live"),
     CheckDefinition("integrations.enabled", "Enabled integrations", "_probe_integrations_enabled"),
     CheckDefinition("mcp.importable", "MCP imports", "_probe_mcp_importable"),
@@ -1017,15 +1017,35 @@ def _write_last_run(report: dict[str, Any], context: DoctorContext) -> None:
     )
 
 
+def _check_definition(check_id: str) -> CheckDefinition:
+    for definition in (*QUICK_CHECKS, *DEEP_CHECKS):
+        if definition.id == check_id:
+            return definition
+    raise ValueError(f"Unknown doctor check {check_id!r}")
+
+
 def collect(
     *,
     deep: bool = False,
     heal: bool = False,
     context: DoctorContext | None = None,
+    check_id: str | None = None,
 ) -> dict[str, Any]:
     """Run the selected registry and return its JSON-serializable report."""
     context = context or DoctorContext.from_environment()
-    definitions = [*QUICK_CHECKS, *DEEP_CHECKS] if deep else list(QUICK_CHECKS)
+    focused = check_id is not None
+    if focused and deep:
+        raise ValueError("A focused check cannot run the full deep registry")
+    if focused:
+        assert check_id is not None
+        target = _check_definition(check_id)
+        definitions = [target]
+        if target.id != "doctor.self":
+            definitions.append(_check_definition("doctor.self"))
+    elif deep:
+        definitions = [*QUICK_CHECKS, *DEEP_CHECKS]
+    else:
+        definitions = list(QUICK_CHECKS)
     results: dict[str, ProbeResult] = {}
     failed: list[dict[str, str]] = []
 
@@ -1147,10 +1167,9 @@ def collect(
     results["doctor.self"] = self_result
 
     checks = [_result_json(definition, results[definition.id]) for definition in definitions]
-    adoption = collect_adoption_report(context)
     report = {
         "generated_at": context.now.isoformat(),
-        "mode": "deep" if deep else "quick",
+        "mode": "focused" if focused else ("deep" if deep else "quick"),
         "instruments": {
             "attempted": len(definitions),
             "completed": len(definitions) - len(failed),
@@ -1158,8 +1177,9 @@ def collect(
         },
         "checks": checks,
         "summary": _summary(checks),
-        "adoption": adoption.to_dict(),
     }
+    if not focused:
+        report["adoption"] = collect_adoption_report(context).to_dict()
     if deep:
         assessment_result = results.get("customizations.assessment")
         if (
@@ -1175,6 +1195,9 @@ def collect(
             report["customization_migration_status"] = (
                 migration_status_result.structured_detail
             )
+
+    if focused:
+        return report
 
     try:
         _write_last_run(report, context)
@@ -5747,6 +5770,11 @@ def _probe_smoke_journeys(context: DoctorContext) -> ProbeResult:
 def main(argv: list[str] | None = None, *, context: DoctorContext | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--deep", action="store_true", help="Run live service probes.")
+    parser.add_argument(
+        "--check",
+        metavar="ID",
+        help="Run one named check. Email-aware flows use --check mail.apple-search instead of --deep.",
+    )
     parser.add_argument("--heal", action="store_true", help="Apply safe Tier-1 repairs before checking.")
     parser.add_argument("--credential-scan", action="store_true", help="Run the bounded local credential scan.")
     parser.add_argument("--credential-migrate", action="store_true", help="Run safe local credential migration.")
@@ -5772,7 +5800,14 @@ def main(argv: list[str] | None = None, *, context: DoctorContext | None = None)
             credential_report = run_credential_workflow(root, action, journal_id=journal_id)
             print(json.dumps(credential_report, indent=2))
             return 2 if credential_report.get("migration_state") == "refused" and action != "status" else 0
-        report = collect(deep=args.deep, heal=args.heal, context=context)
+        if args.check and args.deep:
+            parser.error("--check cannot be combined with --deep")
+        report = collect(
+            deep=args.deep,
+            heal=args.heal,
+            context=context,
+            check_id=args.check,
+        )
         output = json.dumps(report, indent=2)
     except Exception as error:
         print(f"dex-doctor could not produce JSON: {_one_line(error)}", file=sys.stderr)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #446.

This is the remaining honesty gap on the existing email-aware path. It does not invent a Mail product. It lands the fail-closed wall from PR 552 on the path the public folder download actually runs: default `/dex-doctor` (quick, no `--deep`).

## Linked Issue
- GitHub: #446
- Linear issue: none (public user report)
- Related draft: #552 (same wall; this pot does not rewrite `.claude/*` and tightens evidence on the public download path)

## What Changed
Community Apple Mail can list and read messages while its search index was never built, is dummy, or cannot answer searches. Search then comes back empty. Daily plan and week review were told to run a full deep Doctor scan first, which looks frozen, and a missing index still read as “no mail.” The public download checkup (`/dex-doctor` without `--deep`) did not run Mail search at all.

This PR:
- Adds a fail-closed `flow_status` for email-aware flows: no usable index → visible broken state, never an empty result list; fresh index → existing search path still allowed
- Adds `python3 core/utils/doctor.py --check mail.apple-search` so those flows do not run `--deep`
- Moves `mail.apple-search` into the regular (quick) checkup so the public download path sees a missing or dummy index without a live-service scan
- Tightens tests: dummy/empty/unusable indexes are visible-broken, never `[]`; payloads carry no message content or identity

## What Maya sees when Mail has no honest index
One calm line, then the plan continues without pretending the inbox is empty:

> Email context omitted — Mail search has never been built, so it silently returns nothing. Run `umask 077; apple-mail-mcp index --verbose` from a terminal app granted Full Disk Access: System Settings > Privacy & Security > Full Disk Access. Quit and reopen that terminal before building. The app that launches the Mail server (Dex, Claude, or Cursor) also needs Full Disk Access — background sync reads ~/Library/Mail, and a fresh-looking index can still be frozen if that grant is missing.

If Mail is not connected, that section stays off with no noise.

## What this does not do
- Does not rewrite `.claude/*`
- Does not invent LIVE or stamp a release
- Does not add a vendor mail key
- Does not change the Dex.dmg first screen

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_apple_mail_health.py`, `core/tests/test_doctor.py`
- Negative/error-path tests added or updated: no index / dummy / empty / unusable → `feature_status: broken` and a visible omission line; default quick Doctor (public download path) fail-closes; unknown `--check` id rejected; focused check does not run the deep registry
- Commands run locally (Linux):
  - Targeted fail-closed + Doctor contract tests: **92 passed**
  - `python3 -m pytest core/tests/test_doctor.py -q`: **213 passed**; 9 failures are missing local `mcp` / `js-yaml` modules, not this change

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this branch. Mail search stays opt-in; the existing probe still reports broken when the index is missing.

## Docs Impact
- Files updated: none (skill copy left as-is)
- Changelog / package version not bumped — this is not LIVE and should not be treated as a release.

Not LIVE. Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e3ae39a-c4a9-43e1-bf96-f6c7a4d7e4d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e3ae39a-c4a9-43e1-bf96-f6c7a4d7e4d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

