### PR TITLE
Career score and gap tools compute or fail honestly (not LIVE, do not merge)

### DIFF
--- a/core/mcp/career_parser.py
+++ b/core/mcp/career_parser.py
@@ -424,9 +424,48 @@ def scan_evidence_directory(evidence_dir: Path, date_range: Optional[Tuple[date,
 # LADDER FILE PARSING
 # ============================================================================
 
-def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
+def _target_level_section(content: str, target_level: Optional[str] = None) -> tuple[str, str]:
+    """
+    Read the structured target-level section from a career-setup ladder.
+
+    A well-formed ladder uses ``## Target Level: {name}`` plus ``###``
+    competency headings. Prefer an explicit target-level argument, then the
+    file's Target Level field, then any heading that names that level.
+    """
+    file_target_level = extract_field(content, "Target Level")
+    selected = (target_level or "").strip() or file_target_level
+    candidates: list[str] = []
+    if selected:
+        candidates.append(f"## Target Level: {selected}")
+    if file_target_level and file_target_level != selected:
+        candidates.append(f"## Target Level: {file_target_level}")
+    candidates.append("## Target Level")
+
+    for heading in candidates:
+        section = extract_section(content, heading)
+        if section and find_competency_headings(section, level=3):
+            return selected or file_target_level, section
+
+    if selected:
+        for line in content.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("##") and selected.lower() in stripped.lower():
+                section = extract_section(content, stripped)
+                if section and find_competency_headings(section, level=3):
+                    return selected, section
+
+    heading = candidates[0]
+    return selected or file_target_level, extract_section(content, heading)
+
+
+def parse_ladder_file(filepath: Path, target_level: Optional[str] = None) -> Dict[str, Any]:
     """
     Parse career ladder markdown and extract competency structure.
+
+    Args:
+        filepath: Career_Ladder.md
+        target_level: Optional level name. When set, read that structured
+            ``## Target Level: …`` section even if the metadata field differs.
     
     Returns:
         Dict with ladder metadata and competencies
@@ -450,12 +489,9 @@ def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
     # Extract metadata
     company = extract_field(content, "Company")
     current_level = extract_field(content, "Current Level")
-    target_level = extract_field(content, "Target Level")
+    file_target_level = extract_field(content, "Target Level")
     last_updated = extract_field(content, "Last Updated")
-    
-    # Find target level section
-    target_section_heading = f"## Target Level: {target_level}" if target_level else "## Target Level"
-    target_section = extract_section(content, target_section_heading)
+    resolved_target_level, target_section = _target_level_section(content, target_level)
     
     # Parse competencies (### headings under target level)
     competencies = []
@@ -474,7 +510,7 @@ def parse_ladder_file(filepath: Path) -> Dict[str, Any]:
         "filepath": str(filepath),
         "company": company,
         "current_level": current_level,
-        "target_level": target_level,
+        "target_level": resolved_target_level or file_target_level,
         "last_updated": last_updated,
         "competencies": competencies,
         "competency_count": len(competencies)

--- a/core/mcp/career_server.py
+++ b/core/mcp/career_server.py
@@ -113,6 +113,11 @@ CAREER_TRACKING_OFF_MESSAGE = (
 CAREER_ROOM_OFF_MESSAGE = (
     "The Career room is off. Turn it on with /manage-capabilities when you want it."
 )
+CAREER_LADDER_UNREADABLE_MESSAGE = (
+    "I couldn't read the target level on your career ladder, so I don't have a "
+    "real promotion score. The Target Level section needs competency headings "
+    "with requirements."
+)
 
 # Initialize the MCP server
 app = Server("dex-career-mcp")
@@ -811,18 +816,48 @@ async def handle_scan_work_for_evidence(arguments: dict) -> list[types.TextConte
     )]
 
 
-def _required_skills_from_ladder() -> list[str]:
-    """Read required skills with the same ladder parser the rest of Dex uses."""
-    ladder_data = parse_ladder_file(LADDER_FILE)
+def _skill_names_from_ladder_data(ladder_data: dict) -> list[str]:
+    """Competency headings from an already-parsed ladder."""
     required_skills = []
     seen = set()
     for competency in ladder_data.get("competencies") or []:
         skill = competency.get("category")
         if not skill or skill in seen:
             continue
+        if not competency.get("target_level_requirements"):
+            continue
         seen.add(skill)
         required_skills.append(skill)
     return required_skills
+
+
+def _required_skills_from_ladder(target_level: str | None = None) -> list[str]:
+    """Read required skills from the structured target-level section."""
+    return _skill_names_from_ladder_data(
+        parse_ladder_file(LADDER_FILE, target_level=target_level)
+    )
+
+
+def _ladder_for_score_tools(target_level: str | None = None):
+    """Return parsed ladder data, or an honest fail Maya can read.
+
+    A missing ladder stays an empty compute (score 0), which existing
+    download-path locks already require. A ladder that exists but cannot
+    be read must not come back as a dummy success.
+    """
+    if not LADDER_FILE.exists():
+        return {"competencies": []}, None
+    ladder_data = parse_ladder_file(LADDER_FILE, target_level=target_level)
+    if "error" in ladder_data or not ladder_data.get("competencies"):
+        error = ladder_data.get("error") or CAREER_LADDER_UNREADABLE_MESSAGE
+        return None, _feature_response(
+            CAREER_LADDER_FEATURE,
+            "broken",
+            error,
+            error=error,
+            target_level=target_level,
+        )
+    return ladder_data, None
 
 
 def _score_evidence_count(evidence_count: int) -> int:
@@ -875,8 +910,11 @@ async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]
     lookback_days = arguments.get('lookback_days', 90)
     stale_threshold_days = arguments.get('stale_threshold_days', 42)
     
-    # 1. Parse career ladder to get required skills
-    required_skills = _required_skills_from_ladder()
+    # 1. Parse career ladder to get required skills from the structured target level
+    ladder_data, ladder_fail = _ladder_for_score_tools(target_level)
+    if ladder_fail is not None:
+        return ladder_fail
+    required_skills = _skill_names_from_ladder_data(ladder_data)
     
     # 2. Scan work data for skills being developed
     active_skills = {}
@@ -977,6 +1015,7 @@ async def handle_skills_gap_analysis(arguments: dict) -> list[types.TextContent]
         'analysis_date': datetime.now().isoformat(),
         'target_level': target_level,
         'lookback_days': lookback_days,
+        'required_skills': required_skills,
         'required_skills_count': len(required_skills),
         'actively_developed': actively_developed,
         'actively_developed_count': len(actively_developed),
@@ -1174,7 +1213,9 @@ async def handle_promotion_readiness_score(arguments: dict) -> list[types.TextCo
     }
     
     # 3. Skills Coverage (0-25 points)
-    ladder_data = parse_ladder_file(LADDER_FILE)
+    ladder_data, ladder_fail = _ladder_for_score_tools(target_level)
+    if ladder_fail is not None:
+        return ladder_fail
     competencies = ladder_data.get("competencies") or []
     coverage_analysis = analyze_competency_coverage(evidence_files, competencies) if competencies else {}
     skills_score = _score_skills_from_coverage(coverage_analysis, len(competencies))

--- a/core/tests/test_career_mcp_honest_score.py
+++ b/core/tests/test_career_mcp_honest_score.py
@@ -1,0 +1,287 @@
+"""career-mcp score and gap tools must compute or fail honestly.
+
+Locks #539 on the path the public folder actually runs (VAULT_PATH +
+career_server.py). Does not touch test_career_promotion_readiness.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from core.mcp import career_server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+STRUCTURED_LADDER = """# Career Ladder
+
+**Company:** Acme
+**Current Level:** PM
+**Target Level:** Senior PM
+**Last Updated:** 2026-08-01
+
+---
+
+## Career Framework
+
+Company ladder used by career-setup.
+
+---
+
+## Current Level: PM
+
+**Expectations:**
+- Ship assigned features
+
+---
+
+## Target Level: Senior PM
+
+**Requirements for Promotion:**
+
+### Product Strategy
+- Set multi-quarter product direction
+- Align the roadmap to company outcomes
+
+### Technical Depth
+- Lead a system design review
+- Debug a production incident
+
+### Stakeholder Leadership
+- Influence without authority
+- Run an exec review
+"""
+
+COMPETENCY_HEADINGS = [
+    "Product Strategy",
+    "Technical Depth",
+    "Stakeholder Leadership",
+]
+
+UNREADABLE_LADDER = """# Career Ladder
+
+**Company:** Acme
+**Current Level:** PM
+**Target Level:** Senior PM
+
+## Current Level: PM
+
+- Ship assigned features
+"""
+
+
+def _decode(result) -> dict:
+    return json.loads(result[0].text)
+
+
+def _enable_career_room(tmp_path: Path, monkeypatch) -> Path:
+    vault = tmp_path / "vault"
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    ladder_file = career_dir / "Career_Ladder.md"
+    profile_file = vault / "System" / "user-profile.yaml"
+    profile_file.parent.mkdir(parents=True, exist_ok=True)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    profile_file.write_text(
+        "capabilities:\n  career:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(career_server, "BASE_DIR", vault)
+    monkeypatch.setattr(career_server, "CAREER_DIR", career_dir)
+    monkeypatch.setattr(career_server, "EVIDENCE_DIR", evidence_dir)
+    monkeypatch.setattr(career_server, "LADDER_FILE", ladder_file)
+    monkeypatch.setattr(career_server, "USER_PROFILE_FILE", profile_file)
+    return vault
+
+
+def _write_mapped_evidence(path: Path, title: str, competency: str) -> None:
+    path.write_text(
+        f"# {title}\n\n"
+        "**Category:** Achievements\n\n"
+        "## Skills Demonstrated\n"
+        f"- {competency}\n\n"
+        "## Ladder Alignment\n\n"
+        f"**Maps to:** {competency}\n",
+        encoding="utf-8",
+    )
+
+
+def _score(arguments: dict | None = None) -> dict:
+    return _decode(
+        asyncio.run(
+            career_server.handle_call_tool(
+                "promotion_readiness_score",
+                arguments or {"time_in_role_months": 3, "target_level": "Senior PM"},
+            )
+        )
+    )
+
+
+def _skills_gap(arguments: dict | None = None) -> dict:
+    return _decode(
+        asyncio.run(
+            career_server.handle_call_tool(
+                "skills_gap_analysis",
+                arguments or {"target_level": "Senior PM"},
+            )
+        )
+    )
+
+
+def _write_download_vault(tmp_path: Path, *, ladder: str | None = None) -> Path:
+    vault = tmp_path / "vault"
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    profile = vault / "System" / "user-profile.yaml"
+    evidence_dir.mkdir(parents=True)
+    profile.parent.mkdir(parents=True)
+    profile.write_text("capabilities:\n  career:\n    enabled: true\n", encoding="utf-8")
+    if ladder is not None:
+        (career_dir / "Career_Ladder.md").write_text(ladder, encoding="utf-8")
+    return vault
+
+
+def _run_on_download_path(vault: Path) -> dict:
+    """Score and gap as the public folder launch does: VAULT_PATH, no monkeypatch."""
+    script = r"""
+import asyncio, json
+from core.mcp import career_server
+
+def decode(result):
+    return json.loads(result[0].text)
+
+score = decode(asyncio.run(career_server.handle_call_tool(
+    "promotion_readiness_score", {"time_in_role_months": 3, "target_level": "Senior PM"}
+)))
+gap = decode(asyncio.run(career_server.handle_call_tool(
+    "skills_gap_analysis", {"target_level": "Senior PM"}
+)))
+print(json.dumps({"score": score, "gap": gap}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env={**os.environ, "VAULT_PATH": str(vault)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def test_well_formed_ladder_and_evidence_return_computed_score_not_dummy_15(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    career_dir = vault / "05-Areas" / "Career"
+    evidence_dir = career_dir / "Evidence"
+    (career_dir / "Career_Ladder.md").write_text(STRUCTURED_LADDER, encoding="utf-8")
+    for name, competency in (
+        ("2026-01-10 - Strategy memo.md", "Product Strategy"),
+        ("2026-02-11 - Design review.md", "Technical Depth"),
+        ("2026-03-12 - Exec review.md", "Stakeholder Leadership"),
+    ):
+        _write_mapped_evidence(evidence_dir / name, name, competency)
+
+    payload = _score()
+    skills = payload["score_breakdown"]["skills_coverage"]
+    evidence = payload["score_breakdown"]["evidence_coverage"]
+
+    assert payload["success"] is True
+    assert "feature_status" not in payload or payload.get("feature_status") == "ok"
+    assert evidence["evidence_count"] == 3
+    assert skills["score"] != 15
+    assert skills["score"] == 8
+    assert skills["required_competencies"] == 3
+
+
+def test_skills_gap_returns_structured_target_level_skills(tmp_path, monkeypatch):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    (vault / "05-Areas" / "Career" / "Career_Ladder.md").write_text(
+        STRUCTURED_LADDER, encoding="utf-8"
+    )
+
+    payload = _skills_gap()
+
+    assert payload["success"] is True
+    assert payload["required_skills_count"] == 3
+    assert payload["required_skills"] == COMPETENCY_HEADINGS
+
+
+def test_target_level_argument_reads_structured_section_when_metadata_differs(
+    tmp_path, monkeypatch
+):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    ladder = vault / "05-Areas" / "Career" / "Career_Ladder.md"
+    ladder.write_text(
+        STRUCTURED_LADDER.replace("**Target Level:** Senior PM", "**Target Level:** L5"),
+        encoding="utf-8",
+    )
+
+    gap = _skills_gap({"target_level": "Senior PM"})
+    score = _score({"time_in_role_months": 3, "target_level": "Senior PM"})
+
+    assert gap["success"] is True
+    assert gap["required_skills_count"] == 3
+    assert gap["required_skills"] == COMPETENCY_HEADINGS
+    assert score["success"] is True
+    assert score["score_breakdown"]["skills_coverage"]["required_competencies"] == 3
+    assert score["score_breakdown"]["skills_coverage"]["score"] != 15
+
+
+def test_unreadable_existing_ladder_is_a_visible_honest_fail(tmp_path, monkeypatch):
+    vault = _enable_career_room(tmp_path, monkeypatch)
+    (vault / "05-Areas" / "Career" / "Career_Ladder.md").write_text(
+        UNREADABLE_LADDER, encoding="utf-8"
+    )
+
+    score = _score()
+    gap = _skills_gap()
+
+    for payload in (score, gap):
+        assert payload["success"] is False
+        assert payload["feature_status"] == "broken"
+        assert payload["user_message"]
+        assert "15" not in payload["user_message"]
+        assert "score_breakdown" not in payload or "dummy" not in json.dumps(payload)
+
+
+def test_download_path_computes_real_score_or_honest_fail(tmp_path):
+    vault = _write_download_vault(tmp_path, ladder=STRUCTURED_LADDER)
+    evidence_dir = vault / "05-Areas" / "Career" / "Evidence"
+    for name, competency in (
+        ("2026-01-10 - Strategy memo.md", "Product Strategy"),
+        ("2026-02-11 - Design review.md", "Technical Depth"),
+        ("2026-03-12 - Exec review.md", "Stakeholder Leadership"),
+    ):
+        _write_mapped_evidence(evidence_dir / name, name, competency)
+
+    payload = _run_on_download_path(vault)
+    skills = payload["score"]["score_breakdown"]["skills_coverage"]
+    evidence = payload["score"]["score_breakdown"]["evidence_coverage"]
+    gap = payload["gap"]
+
+    assert payload["score"]["success"] is True
+    assert evidence["evidence_count"] == 3
+    assert skills["score"] != 15
+    assert skills["score"] == 8
+    assert gap["success"] is True
+    assert gap["required_skills_count"] == 3
+    assert gap["required_skills"] == COMPETENCY_HEADINGS
+
+
+def test_download_path_honest_fail_when_ladder_cannot_be_read(tmp_path):
+    vault = _write_download_vault(tmp_path, ladder=UNREADABLE_LADDER)
+    payload = _run_on_download_path(vault)
+
+    assert payload["score"]["success"] is False
+    assert payload["score"]["feature_status"] == "broken"
+    assert payload["score"]["user_message"]
+    assert payload["gap"]["success"] is False
+    assert payload["gap"]["feature_status"] == "broken"
+    assert "15" not in json.dumps(payload)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- WO-044 job 46 / #539. PR #556 holds the existing test lock only — this pot is the career-mcp implementation, plus tests in a new file.

## What Changed
- `promotion_readiness_score` and `skills_gap_analysis` now read the structured `## Target Level` section, including when the caller passes `target_level` and the metadata field names a different level.
- On a well-formed ladder plus mapped evidence, both tools return a real computed result. Skills coverage is not the dummy 15.
- If a career ladder file exists but cannot be read, both tools return a visible honest fail Maya can read. They do not invent a number.

## What this does not do
- Does not invent a new career product. Job 46 is truth on the download path.
- Does not touch `core/tests/test_career_promotion_readiness.py` (PR #556).
- Does not rewrite `.claude/*`, plugin 20–27, package.json, lockfiles, mail files, or analytics walls.
- Does not publish a new Dex version. Not LIVE. Draft. Do not merge.

## What Maya sees on a well-formed ladder + evidence
On a career-setup ladder with `## Target Level: Senior PM` and three `###` competencies, plus three mapped evidence files sitting in the Evidence folder:

- `evidence_coverage.evidence_count` is **3** (not 0)
- `skills_coverage.score` is **8** (weak coverage), **not 15**
- `skills_gap_analysis(target_level="Senior PM")` returns **3** required skills: Product Strategy, Technical Depth, Stakeholder Leadership

If that ladder file is present but has no readable Target Level section, she gets a broken-status message instead of a dummy score.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_career_mcp_honest_score.py` (new file)
- Negative/error-path tests added or updated: unreadable existing ladder must fail visibly; dummy 15 is forbidden; `target_level` must still find the structured section when metadata differs; VAULT_PATH subprocess locks the download launch path
- Commands run locally: `pytest core/tests/test_career_mcp_honest_score.py core/tests/test_career_promotion_readiness.py` → **12 passed**; career-related `test_feature_status.py` / analytics wiring → **8 passed**

## Quality Gates
- Honest-health lock for the two #539 tools. No new career product.

## Risk & Rollback
- Risk level: low — shared ladder reader + score/gap wiring + new tests.
- Rollback plan: revert this PR.

## Docs Impact
- None. Implementation and test lock only. Not LIVE.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e063459-f23a-4d19-adee-36dfe109c870?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e063459-f23a-4d19-adee-36dfe109c870&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

