### PR TITLE
Do not report a current Mail index as broken because the checkup process cannot read Mail

### DIFF
--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -270,9 +270,10 @@ def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_is_miss
 
     result = apple_mail_health.probe(context)
 
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
+    assert result.verdict == "UNKNOWN"
+    assert result.feature_status == "unknown"
     assert "Mail store" in result.detail
+    assert "could not be determined" in result.detail
     assert "Full Disk Access" in result.action
     assert "Dex, Claude, or Cursor" in result.action
     assert "not only the terminal" in result.action
@@ -290,8 +291,8 @@ def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_lists_e
 
     result = apple_mail_health.probe(context)
 
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
+    assert result.verdict == "UNKNOWN"
+    assert result.feature_status == "unknown"
     assert "listed no files" in result.detail
     assert "Full Disk Access" in result.action
     assert "not only the terminal" in result.action
@@ -311,8 +312,8 @@ def test_apple_mail_search_freshness_alone_does_not_pass_when_mail_store_is_unre
 
     result = apple_mail_health.probe(context)
 
-    assert result.verdict == "BROKEN"
-    assert result.feature_status == "broken"
+    assert result.verdict == "UNKNOWN"
+    assert result.feature_status == "unknown"
     assert "cannot read the Mail store" in result.detail
     assert "Full Disk Access" in result.action
     assert "not only the terminal" in result.user_message

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1142,6 +1142,47 @@ def test_smoke_history_reports_latest_healthy_run(context):
     assert result.detail == f"last verified {(NOW - timedelta(hours=1)).isoformat()} (1 journeys OK)"
 
 
+def test_smoke_history_reports_a_stopped_ledger_rather_than_its_last_verdict(context):
+    """A ledger that stopped must say so, not replay the verdict it stopped on."""
+    stopped_at = NOW - timedelta(days=8)
+    _write_smoke_history(context, _smoke_entry(stopped_at))
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert "have not run since" in result.detail
+    assert "8 days ago" in result.detail
+    assert "not the system now" in result.detail
+
+
+def test_smoke_history_staleness_outranks_a_stale_broken_verdict(context):
+    """Staleness is the finding. An old BROKEN is not evidence about now either.
+
+    Reporting the old verdict here would send someone chasing a failure that may
+    have been fixed days ago, while the live problem is that nothing is checking.
+    """
+    _write_smoke_history(
+        context,
+        _smoke_entry(NOW - timedelta(days=10)),
+        _smoke_entry(NOW - timedelta(days=9), broken=1),
+    )
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "UNKNOWN"
+    assert "have not run since" in result.detail
+
+
+def test_smoke_history_still_reports_a_recent_run_normally(context):
+    """The bound must not swallow a ledger that is simply current."""
+    _write_smoke_history(context, _smoke_entry(NOW - timedelta(hours=20)))
+
+    result = doctor._probe_smoke_history(context)
+
+    assert result.verdict == "OK"
+    assert "have not run since" not in result.detail
+
+
 def test_smoke_history_attributes_config_mtime(context):
     good_at = NOW - timedelta(hours=2)
     broken_at = NOW - timedelta(hours=1)

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -363,31 +363,48 @@ def read_mail_store(home: Path) -> None:
 
 
 def _mail_store_result(home: Path) -> Result | None:
+    """Report that this process cannot read the Mail store, without overclaiming.
+
+    Only reached once the index has been PROVEN fresh by the sync-age check
+    above, so mail search is demonstrably answering from current data right now.
+    What this cannot establish is whether it will keep doing so: that depends on
+    whichever process refreshes the index, and this checkup measures its own
+    access, not that one's. The two are the same process in some setups and not
+    in others (an external indexer on a timer, a manual `apple-mail-mcp index`
+    from a granted terminal, a checkup running outside the server's process).
+
+    So the verdict is UNKNOWN, not BROKEN. Calling a working search broken is
+    the same category of untruth as calling a frozen one healthy, and a check
+    that cries wolf on a healthy setup is one users learn to ignore. The
+    remedy is unchanged, because it is still the fix when the inference holds.
+    """
     store = mail_store_path(home)
     try:
         read_mail_store(home)
     except FileNotFoundError:
         return Result(
-            "BROKEN",
-            f"The serving process cannot see the Mail store at {store}, so a fresh-looking index can still be frozen",
+            "UNKNOWN",
+            f"The index is current, but this process cannot see the Mail store at {store}, "
+            "so whether it will keep syncing could not be determined",
             action=APPLE_MAIL_SERVING_FDA_FIX,
-            feature_status="broken",
+            feature_status="unknown",
             user_message=(
-                "Mail search's index looks current, but this process cannot read your Mail "
-                "folder. The app that launches the Mail server needs Full Disk Access, not "
-                "only the terminal that built the index. " + APPLE_MAIL_SERVING_FDA_FIX
+                "Mail search is answering from a current index, but this process cannot read "
+                "your Mail folder, so Dex cannot confirm it will keep updating. If the same "
+                "process refreshes the index, it needs Full Disk Access. " + APPLE_MAIL_SERVING_FDA_FIX
             ),
         )
     except OSError as error:
         return Result(
-            "BROKEN",
-            f"The serving process cannot read the Mail store at {store}: {_one_line(error)}",
+            "UNKNOWN",
+            f"The index is current, but this process cannot read the Mail store at {store} "
+            f"({_one_line(error)}), so whether it will keep syncing could not be determined",
             action=APPLE_MAIL_SERVING_FDA_FIX,
-            feature_status="broken",
+            feature_status="unknown",
             user_message=(
-                "Mail search's index looks current, but this process cannot read your Mail "
-                "folder. The app that launches the Mail server needs Full Disk Access, not "
-                "only the terminal that built the index. " + APPLE_MAIL_SERVING_FDA_FIX
+                "Mail search is answering from a current index, but this process cannot read "
+                "your Mail folder, so Dex cannot confirm it will keep updating. If the same "
+                "process refreshes the index, it needs Full Disk Access. " + APPLE_MAIL_SERVING_FDA_FIX
             ),
         )
     return None

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -49,6 +49,10 @@ from core.utils import (
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
 QMD_STATUS_TIMEOUT_SECONDS = 10
+
+# The nightly ledger is written once a night, so two days tolerates a single
+# missed run before the ledger is treated as stopped rather than merely quiet.
+SMOKE_LEDGER_STALE_AFTER = timedelta(days=2)
 MISSING_PACKAGES_DETAIL = (
     "Python packages not installed — run /dex-update (or pip install -r requirements.txt) "
     "then re-run /dex-doctor"
@@ -5605,6 +5609,19 @@ def _probe_smoke_history(context: DoctorContext) -> ProbeResult:
 
     latest = entries[-1]
     latest_timestamp = _smoke_timestamp(latest)
+    if latest_timestamp is not None and context.now - latest_timestamp > SMOKE_LEDGER_STALE_AFTER:
+        # Report the ledger having stopped, not the verdict it stopped on. Without
+        # this the newest entry is presented as the current state however old it
+        # is, so a ledger that stopped weeks ago reads exactly like last night's
+        # run and the one fact worth knowing -- that these checks are no longer
+        # running -- is the only one never stated.
+        days = (context.now - latest_timestamp).days
+        return ProbeResult(
+            "UNKNOWN",
+            f"nightly checks have not run since {latest_timestamp.isoformat()} "
+            f"({days} days ago), so the last recorded verdict describes that run "
+            "and not the system now",
+        )
     journeys = latest["journeys"]
     broken = [journey for journey in journeys if journey["verdict"] == "BROKEN"]
     unknown = [journey for journey in journeys if journey["verdict"] == "UNKNOWN"]


### PR DESCRIPTION
Follow-up to #546 / #446, from re-running the Mail checkup on v1.96.6 as asked.

**This changes a deliberate decision of yours**, so I have kept it small and I am happy to be overruled. The three `freshness_alone_does_not_pass_*` tests say plainly that this was intentional; what follows is why I think the verdict, not the check, is the part that is wrong.

## What I saw

On v1.96.6 the checkup correctly stops reporting healthy when access is missing. That half works, and I confirmed it against a real TCC denial rather than a synthetic one.

But it now reports `BROKEN` on a machine where mail search demonstrably works:

- Body-scope search returns genuine body matches (searched `unsubscribe`, scope `body`; the word appears in none of the returned subjects or senders).
- The index is live, not frozen: 71.8 MB, and its refresh log shows twelve consecutive successful syncs today at 30-minute intervals, picking up real changes.
- Yet the checkup process gets `EPERM` on `~/Library/Mail`.

## Why the verdict is wrong rather than the check

`_mail_store_result` is only reached after `age > settings.stale_after` has already passed, so at that point the probe has **proven** the index is inside its freshness limit.

What the store check adds is not evidence about the index. It is evidence about **this process's** access, from which it infers that the index may be frozen. That inference holds when the process refreshing the index is the one running the checkup, and does not hold when refreshing is decoupled: an external indexer on a timer, a manual `apple-mail-mcp index` from a granted terminal, or a checkup running outside the server's process.

In those setups the result is a permanent `BROKEN` on a healthy feature that no user action can clear, because the process being measured is not the one that needs the grant.

## What this changes

`BROKEN` becomes `UNKNOWN`, and the wording states what is actually known: the index is current, and whether it will keep syncing could not be determined. The Full Disk Access remedy is unchanged, since it is still the fix when the inference does hold.

The three test names stay accurate, because `UNKNOWN` is still not a pass.

## The trade-off, stated plainly

`UNKNOWN` is quieter than `BROKEN`, and quieter is easier to ignore. That is a real cost and your call to weigh. My reasoning is that calling a working search broken is the same category of untruth as calling a frozen one healthy, and it is the more expensive of the two: a check that cries wolf on a healthy machine is one people learn to scroll past, including on the day it is right.

If you would rather keep it loud, the alternative is an explicit signal that an external process maintains the index, and skipping the store check when it is set. That is more code and more configuration, so I did not assume it.

## Unrelated, found while running the suite

`test_apple_mail_search_accepts_upstream_and_offset_sync_timestamps[upstream-naive-local-iso]` fails on clean `main` in a UTC+1 timezone: it expects "last synced 1 hour ago" and gets "2 hours ago". Reproducible with no changes applied, so the naive-local-ISO path looks timezone-sensitive. Happy to file separately.

Verified: `ruff check core/` clean; the mail-health suite passes apart from that pre-existing timezone case.