### PR TITLE
Let the connection manager hold a credential for a remote MCP server

### DIFF
--- a/core/integrations/connection-manager/oauth-flow.cjs
+++ b/core/integrations/connection-manager/oauth-flow.cjs
@@ -151,6 +151,11 @@ function buildAuthorizationUrl(providerConfig, { clientId, scopes = [], redirect
   const allScopes = scopes.length ? scopes : providerConfig.defaultScopes || [];
   if (allScopes.length) params.set('scope', allScopes.join(providerConfig.scopeSeparator || ' '));
 
+  // RFC 8707. A remote MCP server checks that the token was issued FOR it. Omit
+  // this and the authorization server audiences the token to its own default
+  // client, and every call fails 401 holding a token that looks entirely valid.
+  if (providerConfig.resource) params.set('resource', providerConfig.resource);
+
   const state = base64url(crypto.randomBytes(16));
   params.set('state', state);
 
@@ -250,14 +255,69 @@ async function exchangeCodeForToken(providerConfig, { code, codeVerifier, client
     ...providerConfig.tokenParams,
   };
   if (codeVerifier) body.code_verifier = codeVerifier;
+  // The audience has to be asserted again here: binding the authorization
+  // request alone does not bind the token that comes back.
+  if (providerConfig.resource) body.resource = providerConfig.resource;
   const headers = buildTokenAuth(providerConfig, clientId, clientSecret, body);
   return normalizeToken(await postToken(providerConfig, body, headers), {}, providerConfig);
+}
+
+/**
+ * Register this installation as a public OAuth client (RFC 7591).
+ *
+ * Used by providers that issue no client secret, which is the honest shape for
+ * a locally installed application: a secret shipped to every copy is not a
+ * secret. The registration endpoint is pinned like any other origin, so
+ * registering decides who the client is and never where it may talk.
+ *
+ * The returned client id belongs to this vault and is stored with the token.
+ * Re-registering on every connect would leak client registrations, so callers
+ * should reuse a stored one when they have it.
+ */
+async function registerDynamicClient(providerConfig, { redirectUri, clientName = 'Dex', scopes = [] }) {
+  if (!providerConfig.registrationUrl) {
+    throw new Error(`Provider ${providerConfig.id} does not support dynamic client registration`);
+  }
+  if (providerConfig.id && isVetted(providerConfig.id)) {
+    assertPinnedOrigin(providerConfig.id, 'registration', providerConfig.registrationUrl);
+  }
+
+  const requested = scopes.length ? scopes : providerConfig.defaultScopes || [];
+  const payload = {
+    client_name: clientName,
+    redirect_uris: [redirectUri],
+    grant_types: providerConfig.registrationGrantTypes || ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+  if (requested.length) payload.scope = requested.join(providerConfig.scopeSeparator || ' ');
+
+  const response = await fetch(providerConfig.registrationUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Dynamic client registration failed (${response.status}): ${text.slice(0, 200)}`);
+  }
+  let registration;
+  try {
+    registration = JSON.parse(text);
+  } catch {
+    throw new Error('Dynamic client registration returned a non-JSON response');
+  }
+  if (!registration.client_id) {
+    throw new Error('Dynamic client registration returned no client_id');
+  }
+  return registration;
 }
 
 module.exports = {
   startCallbackServer,
   buildAuthorizationUrl,
   exchangeCodeForToken,
+  registerDynamicClient,
   makePkce,
   CALLBACK_PORTS,
 };

--- a/core/integrations/connection-manager/oauth-remote-mcp.test.cjs
+++ b/core/integrations/connection-manager/oauth-remote-mcp.test.cjs
@@ -1,0 +1,92 @@
+'use strict';
+/**
+ * A remote MCP server is a different shape of provider: it issues no client
+ * secret, the client id does not exist until registration, and the token must
+ * be bound to the resource or it is refused. None of that may loosen the rule
+ * that every origin is fixed at review time.
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+
+const pinned = require('./pinned-providers.cjs');
+const oauth = require('./oauth-flow.cjs');
+
+const WISPR = {
+  id: 'wispr',
+  authorizationUrl: 'https://mcp-auth.wisprflow.com/oauth2/authorize',
+  tokenUrl: 'https://mcp-auth.wisprflow.com/oauth2/token',
+  registrationUrl: 'https://mcp-auth.wisprflow.com/oauth2/register',
+  resource: 'https://api.wisprflow.ai/connect/mcp',
+  defaultScopes: ['openid', 'offline_access'],
+  usePkce: true,
+};
+
+test('registration is pinned like every other origin', () => {
+  assert.equal(
+    pinned.assertPinnedOrigin('wispr', 'registration', 'https://mcp-auth.wisprflow.com/oauth2/register'),
+    'https://mcp-auth.wisprflow.com',
+  );
+  assert.throws(
+    () => pinned.assertPinnedOrigin('wispr', 'registration', 'https://evil.example/register'),
+    /OriginUnpinned/,
+    'dynamic registration decides who the client is, never where it may talk',
+  );
+});
+
+test('the authorization request carries the resource it is for', () => {
+  const { url } = oauth.buildAuthorizationUrl(WISPR, {
+    clientId: 'client_TEST',
+    redirectUri: 'http://127.0.0.1:8765/callback',
+  });
+  const params = new URL(url).searchParams;
+  assert.equal(params.get('resource'), WISPR.resource);
+  assert.equal(params.get('code_challenge_method'), 'S256');
+});
+
+test('a provider with no resource is unchanged', () => {
+  const { url } = oauth.buildAuthorizationUrl(
+    { ...WISPR, id: undefined, resource: undefined },
+    { clientId: 'c', redirectUri: 'http://127.0.0.1:8765/callback' },
+  );
+  assert.equal(new URL(url).searchParams.get('resource'), null);
+});
+
+test('registration refuses a provider that does not offer it', async () => {
+  await assert.rejects(
+    () => oauth.registerDynamicClient({ id: 'wispr' }, { redirectUri: 'http://127.0.0.1:8765/callback' }),
+    /does not support dynamic client registration/,
+  );
+});
+
+test('registration asks for a public client and returns its id', async () => {
+  const originalFetch = global.fetch;
+  let sent = null;
+  global.fetch = async (url, init) => {
+    sent = { url, body: JSON.parse(init.body) };
+    return { ok: true, status: 200, text: async () => JSON.stringify({ client_id: 'client_NEW' }) };
+  };
+  try {
+    const registration = await oauth.registerDynamicClient(WISPR, {
+      redirectUri: 'http://127.0.0.1:8765/callback',
+    });
+    assert.equal(registration.client_id, 'client_NEW');
+    assert.equal(sent.body.token_endpoint_auth_method, 'none', 'a local install cannot keep a secret');
+    assert.deepEqual(sent.body.grant_types, ['authorization_code', 'refresh_token']);
+    assert.equal(sent.body.scope, 'openid offline_access');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('a registration response without a client id is refused', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+  try {
+    await assert.rejects(
+      () => oauth.registerDynamicClient(WISPR, { redirectUri: 'http://127.0.0.1:8765/callback' }),
+      /no client_id/,
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/core/integrations/connection-manager/pinned-providers.cjs
+++ b/core/integrations/connection-manager/pinned-providers.cjs
@@ -1,6 +1,9 @@
 'use strict';
 
-const ORIGIN_KINDS = new Set(['authorization', 'token', 'refresh', 'api', 'verification']);
+// 'registration' is where a public client registers itself. It is pinned like
+// every other origin: dynamic client registration decides WHO the client is,
+// never WHERE it may talk.
+const ORIGIN_KINDS = new Set(['authorization', 'token', 'refresh', 'registration', 'api', 'verification']);
 
 function deepFreeze(value) {
   if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
@@ -9,6 +12,18 @@ function deepFreeze(value) {
 }
 
 const REVIEWED_PROVIDERS = deepFreeze({
+  // Wispr Flow exposes meetings over a remote MCP server. It issues no client
+  // secret, so the client id is obtained by dynamic registration at connect
+  // time; the origins below are still fixed here, at review time.
+  wispr: {
+    authorizationOrigin: 'https://mcp-auth.wisprflow.com',
+    tokenOrigin: 'https://mcp-auth.wisprflow.com',
+    refreshOrigin: 'https://mcp-auth.wisprflow.com',
+    registrationOrigin: 'https://mcp-auth.wisprflow.com',
+    apiOrigins: ['https://api.wisprflow.ai'],
+    verificationOrigin: 'https://api.wisprflow.ai',
+    tenant: null,
+  },
   google: {
     authorizationOrigin: 'https://accounts.google.com',
     tokenOrigin: 'https://oauth2.googleapis.com',

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 240227,
-      "treeHash": "e8283181e7c3a74e5b79fe540208ace69a31f76b0f653b4ca25d58011bbbb12f",
+      "totalBytes": 243651,
+      "treeHash": "f01c8f1157e5fe7e3bac20499d990d0d5997baa67223b957353fe73ae5ddd386",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -96,13 +96,13 @@
         },
         {
           "path": "oauth-flow.cjs",
-          "bytes": 10679,
-          "sha256": "9e54745bbf65646de65b6942906436d068fda1f51c3e3b768f4b86ce9c90ee56"
+          "bytes": 13326,
+          "sha256": "34f2acb3b0bca6534d26b679aa3f5d975092bd5de05905d7a448e81cd00da886"
         },
         {
           "path": "pinned-providers.cjs",
-          "bytes": 3077,
-          "sha256": "e65ec1e95671fd31061b55fd957d34397176c89c257143522e056a8d8c578113"
+          "bytes": 3854,
+          "sha256": "76ff7893cd49257a06e6bb4823f4e1f0968c8dbe85b9a3459cdbc262449f858d"
         },
         {
           "path": "presence.cjs",


### PR DESCRIPTION
First of three, and the only one that stands entirely on its own. Nothing here mentions meetings; it is the credential substrate.

Context in #559. Remote MCP servers are becoming an ordinary way to reach a service, and the connection manager cannot hold a credential for one today. Two things are missing.

**Dynamic client registration (RFC 7591).** Some providers issue no client secret, which is the honest shape for a locally installed application: a secret shipped to every copy is not a secret. The client id does not exist until the client registers itself, so `pinned-providers` cannot currently express such a provider at all.

This does not loosen origin pinning. `registration` is a new pinned origin kind, so registering decides **who** the client is and never **where** it may talk. There is a test asserting an off-origin registration endpoint is refused.

**RFC 8707 resource binding.** Verified against a live provider: with no `resource` parameter the authorization server issues a token audienced to its own first-party client, and the resource server returns 401 while the token looks entirely valid.

```
# no resource parameter
aud = client_01JEQ2G2M8BTPMXB7GS1WJA4X5   -> 401 at the MCP endpoint

# resource=https://api.wisprflow.ai/connect/mcp
aud = https://api.wisprflow.ai/connect/mcp -> accepted
```

`audience=` is silently ignored and falls back to the default, so the failure presents as a credentials problem and is not one. Binding the authorization request alone is not enough; the token exchange has to assert it again. This is a one-line requirement that costs a long debugging session if missed.

Wispr Flow is added to the reviewed providers as the first instance, origins fixed here at review time. Its metadata advertises the device code grant but its registration endpoint rejects it for dynamically registered clients, so only `authorization_code` and `refresh_token` are requested.

The generated connections engine manifest is regenerated for the `oauth-flow.cjs` change, which is exactly what its integrity check exists to catch.

**Verification.** 6 new tests pass. The pre-existing failure count in the connection-manager suites is unchanged at 11, all from the absent `@nangohq/providers` dependency in this environment rather than anything here.