### PR TITLE
Give meeting notes one internal record, so a source is a choice and not a fork

### DIFF
--- a/core/meeting_sources/attribution.py
+++ b/core/meeting_sources/attribution.py
@@ -1,0 +1,86 @@
+"""Resolve who was actually in a meeting, when the recorder could not say.
+
+Some sources return a capture with no attendees and no title, because they
+title and attribute from a calendar they cannot read. The summary still names
+speakers, but those names are turns in a recording, not identified people. Left
+alone that produces confident, plausible, invented commitments.
+
+Dex already ships the resolver: ``match_capture_to_calendar`` matches a capture
+to a calendar event by instant, tie-breaking on title and participant overlap,
+and returns an allowlist of meeting identity. This module is the join between
+that resolver and the meeting record, so an unattributed capture becomes an
+attributed one wherever the calendar can prove it, and stays honestly
+unattributed wherever it cannot.
+
+**A match is proof; the absence of one is not disproof.** An unmatched capture
+means the calendar could not confirm attendance, never that nobody was there.
+The reason is carried through so the note can say which it was.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from core.meeting_capture_match import match_capture_to_calendar
+from core.meeting_sources.record import Attendee, MeetingRecord
+
+
+def record_as_capture(record: MeetingRecord) -> dict[str, Any]:
+    """Present a record in the shape the shipped matcher expects.
+
+    ``start_time`` is emitted as an ISO string carrying its offset. The matcher
+    parses timestamps rather than accepting datetimes, and rejects any that does
+    not declare a timezone rather than guessing an offset. Passing a datetime
+    object here silently reads as "missing timezone" and every capture comes
+    back unmatched, which looks exactly like a genuinely absent calendar entry.
+    """
+    capture: dict[str, Any] = {
+        "start_time": record.start.isoformat(),
+        "title": "" if record.extra.get("title_was_derived") else (record.title or ""),
+    }
+    if record.attendees:
+        capture["attendees"] = [
+            {"name": person.name, "email": person.email} for person in record.attendees
+        ]
+    return capture
+
+
+def resolve(record: MeetingRecord, calendar_events: list[dict[str, Any]]) -> MeetingRecord:
+    """Return the record with attendance filled in when the calendar proves it.
+
+    A derived title is replaced by the real one on a match, because the calendar
+    knows what the meeting was called and the summary only guessed.
+    """
+    if record.attribution_is_reliable:
+        return record
+
+    outcome = match_capture_to_calendar(record_as_capture(record), calendar_events or [])
+    extra = dict(record.extra)
+    extra["attribution_match"] = outcome.get("status")
+    if outcome.get("status") != "matched":
+        # Keep the reason. "No calendar event within five minutes" and "the
+        # calendar could not be read" call for different responses from a user.
+        extra["attribution_reason"] = outcome.get("reason")
+        return replace(record, extra=extra)
+
+    identity = outcome.get("identity") or {}
+    attendees = tuple(
+        Attendee(name=person.get("name"), email=person.get("email"))
+        for person in identity.get("attendees") or []
+        if person.get("name") or person.get("email")
+    )
+    if not attendees:
+        # Matched an event that lists nobody. The match is real, the attendance
+        # is still unknown, and claiming otherwise would be the invention this
+        # module exists to prevent.
+        extra["attribution_reason"] = "matched_event_has_no_attendees"
+        return replace(record, extra=extra)
+
+    extra["attribution_delta_seconds"] = outcome.get("delta_seconds")
+    title = record.title
+    if record.extra.get("title_was_derived") and identity.get("title"):
+        title = identity["title"]
+        extra["title_was_derived"] = False
+        extra["title_from_calendar"] = True
+
+    return replace(record, attendees=attendees, title=title, extra=extra)

--- a/core/meeting_sources/calendar_lookup.py
+++ b/core/meeting_sources/calendar_lookup.py
@@ -1,0 +1,116 @@
+"""Read calendar events for attribution, from a process with no host attached.
+
+The meeting-source sweep runs on a schedule, so it cannot ask an MCP client for
+the calendar. It uses the same EventKit helper the calendar server shells to,
+which is an ordinary script and works anywhere the vault does.
+
+Calendar absence is not calendar emptiness. Every failure here returns None, and
+callers must treat that as "attendance could not be checked" rather than "nobody
+was there". Returning an empty list instead would let a machine with no calendar
+access silently mark every capture as having no attendees.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HELPER = Path("core/mcp/scripts/calendar_eventkit.py")
+TIMEOUT_SECONDS = 30
+
+
+def default_calendar_name(vault_root: Path) -> str | None:
+    """The calendar the user configured, if they configured one.
+
+    Follows the same order the calendar server uses, so a vault that works
+    there works here: ``calendar.work_calendar``, then ``work_email``, then a
+    name built from ``name`` and ``email_domain``. Unlike the server this
+    returns None rather than falling back to a guessed "Work" calendar, because
+    querying a calendar the user does not have would produce an empty result
+    that reads exactly like a meeting with nobody in it.
+    """
+    profile = vault_root / "System" / "user-profile.yaml"
+    try:
+        import yaml
+
+        data = yaml.safe_load(profile.read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001 - an unreadable profile is not a calendar fault
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    calendar = data.get("calendar")
+    if isinstance(calendar, dict):
+        configured = calendar.get("work_calendar")
+        if isinstance(configured, str) and configured.strip():
+            return configured.strip()
+
+    work_email = data.get("work_email")
+    if isinstance(work_email, str) and work_email.strip():
+        return work_email.strip()
+
+    name, domain = data.get("name"), data.get("email_domain")
+    if isinstance(name, str) and name.strip() and isinstance(domain, str) and domain.strip():
+        return f"{name.strip().lower().replace(' ', '.')}@{domain.strip()}"
+    return None
+
+
+def events_around(
+    vault_root: Path,
+    *,
+    start_offset_days: int,
+    end_offset_days: int,
+    calendar_name: str | None = None,
+) -> list[dict[str, Any]] | None:
+    """Events with attendees in the window, or None when they cannot be read."""
+    helper = vault_root / HELPER
+    if not helper.is_file():
+        logger.info("Calendar helper not present at %s; attribution will stay unresolved", helper)
+        return None
+
+    name = calendar_name or default_calendar_name(vault_root)
+    if not name:
+        logger.info("No calendar configured; attribution will stay unresolved")
+        return None
+
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(helper),
+                "attendees",
+                name,
+                str(start_offset_days),
+                str(end_offset_days),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+            env={**os.environ, "PYTHONPATH": str(vault_root)},
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        logger.warning("Calendar could not be read: %s", error)
+        return None
+
+    if completed.returncode != 0:
+        logger.warning("Calendar helper failed: %s", (completed.stderr or "").strip()[:200])
+        return None
+
+    try:
+        payload = json.loads(completed.stdout or "null")
+    except json.JSONDecodeError:
+        logger.warning("Calendar helper returned output that is not JSON")
+        return None
+
+    if isinstance(payload, dict):
+        payload = payload.get("events")
+    if not isinstance(payload, list):
+        return None
+    return [event for event in payload if isinstance(event, dict)]

--- a/core/meeting_sources/granola_adapter.py
+++ b/core/meeting_sources/granola_adapter.py
@@ -1,0 +1,98 @@
+"""Map Granola's API payloads onto the internal meeting record.
+
+Granola is the provider the record has to fit without bending, because it is
+the one already in use and its behaviour must not change. It is also usefully
+unlike Wispr, which is what makes the pair a real test of the contract rather
+than a shape drawn around a single source:
+
+- Granola supplies a title; Wispr supplies none.
+- Granola supplies attendees with emails, so attribution is resolved and
+  person-page routing works; Wispr supplies none.
+- Granola's action items are markdown checkboxes the user has already curated;
+  Wispr's are prose bullets under a heading.
+- Granola's transcript is a list of speaker turns; Wispr's is fetched separately.
+
+None of that reaches anything downstream. Both produce a MeetingRecord.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from core.meeting_sources.record import Attendee, MeetingRecord, parse_timestamp
+
+SOURCE = "granola"
+
+_CHECKBOX_PREFIXES = ("- [ ]", "* [ ]")
+
+
+def _attendees(raw: Any) -> tuple[Attendee, ...]:
+    if not isinstance(raw, list):
+        return ()
+    people: list[Attendee] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = (entry.get("name") or "").strip() or None
+        email = (entry.get("email") or "").strip() or None
+        if name or email:
+            people.append(Attendee(name=name, email=email))
+    return tuple(people)
+
+
+def extract_action_items(notes: str) -> tuple[str, ...]:
+    """Unchecked checkbox lines, which is how Granola records action items.
+
+    Only unchecked ones: a ticked box is something already done, and importing
+    it as an open task would hand the user back work they have finished.
+    """
+    items: list[str] = []
+    for line in (notes or "").splitlines():
+        stripped = line.strip()
+        for prefix in _CHECKBOX_PREFIXES:
+            if stripped.startswith(prefix):
+                text = stripped[len(prefix):].strip()
+                if text:
+                    items.append(text)
+                break
+    return tuple(items)
+
+
+def _transcript_present(detail: dict[str, Any]) -> bool:
+    transcript = detail.get("transcript")
+    if isinstance(transcript, list):
+        return any(
+            isinstance(turn, dict) and (turn.get("text") or "").strip() for turn in transcript
+        )
+    return bool(transcript)
+
+
+def to_record(detail: dict[str, Any]) -> MeetingRecord:
+    """Map one Granola note detail onto the internal record."""
+    if not isinstance(detail, dict) or not detail.get("id"):
+        raise ValueError("A Granola note detail needs an id")
+
+    start = parse_timestamp(detail.get("created_at"))
+    if start is None:
+        raise ValueError(f"Granola note {detail['id']} has no usable created_at")
+
+    notes = detail.get("summary_markdown") or detail.get("summary_text") or ""
+    title = (detail.get("title") or "").strip()
+
+    extra: dict[str, Any] = {"title_was_derived": not title}
+    if detail.get("web_url"):
+        extra["web_url"] = detail["web_url"]
+
+    return MeetingRecord(
+        source=SOURCE,
+        source_id=str(detail["id"]),
+        start=start,
+        end=parse_timestamp(detail.get("ended_at") or detail.get("end")),
+        title=title or "Untitled Meeting",
+        body=notes.strip(),
+        attendees=_attendees(detail.get("attendees")),
+        action_items=extract_action_items(notes),
+        has_transcript=_transcript_present(detail),
+        finalized=True,
+        modified_at=parse_timestamp(detail.get("updated_at")),
+        extra=extra,
+    )

--- a/core/meeting_sources/landing_zone.py
+++ b/core/meeting_sources/landing_zone.py
@@ -1,0 +1,149 @@
+"""Write meeting records into the vault's meeting landing zone.
+
+`00-Inbox/Meetings/` is where every fetcher delivers, whatever it fetched from.
+Session-start detection and `/process-meetings` already watch this folder, so a
+source that writes here needs no detection path of its own. That contract is
+the reason a new provider is additive rather than invasive.
+
+Two things this module refuses to do:
+
+**It will not invent attribution.** When a record's provider could not say who
+was present, the note says so in terms a reader and a model both act on, rather
+than presenting speaker labels as though they were people. A summary that says
+"(Speaker 1) will chase the credit" becomes a commitment attached to a real
+person two steps downstream, and nobody notices the invention.
+
+**It will not rewrite a note it has already written.** Dedup is on the
+`source`/`<source>_id` pair, which is also what the person-page touch tracking
+keys on. Re-writing would resurrect notes the user has since edited or marked
+processed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from core import paths
+from core.meeting_sources.record import MeetingRecord
+
+# Derived from the path contract rather than written out, so a vault that moves
+# its folders moves this too. Kept relative so callers can pass any root, which
+# is what makes the writer testable and lets a sweep target a scratch vault.
+MEETINGS_RELATIVE = paths.MEETINGS_DIR.relative_to(paths.VAULT_ROOT)
+_UNSAFE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_FRONTMATTER = re.compile(r"\A---\s*\n(?P<body>.*?)\n---\s*\n", re.DOTALL)
+
+
+def meetings_dir(vault_root: Path) -> Path:
+    return vault_root / MEETINGS_RELATIVE
+
+
+def _slug(title: str) -> str:
+    cleaned = _UNSAFE.sub("", title).strip().rstrip(".")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned[:60].strip() or "Meeting"
+
+
+def note_path(vault_root: Path, record: MeetingRecord) -> Path:
+    return meetings_dir(vault_root) / f"{record.local_date} - {_slug(record.title or 'Meeting')}.md"
+
+
+def existing_source_ids(vault_root: Path, source: str) -> set[str]:
+    """Every `<source>_id` already present in the landing zone.
+
+    Reads frontmatter only, and tolerates notes that have none: hand-dropped
+    files are valid here and must not break a sweep.
+    """
+    key = f"{source}_id"
+    found: set[str] = set()
+    folder = meetings_dir(vault_root)
+    if not folder.is_dir():
+        return found
+    for path in folder.rglob("*.md"):
+        try:
+            head = path.read_text(encoding="utf-8")[:2000]
+        except (OSError, UnicodeDecodeError):
+            continue
+        match = _FRONTMATTER.match(head)
+        if not match:
+            continue
+        for line in match.group("body").splitlines():
+            name, _, value = line.partition(":")
+            if name.strip() == key and value.strip():
+                found.add(value.strip().strip("\"'"))
+    return found
+
+
+def render(record: MeetingRecord) -> str:
+    """The note as it lands in the vault."""
+    lines = [
+        "---",
+        f"date: {record.local_date}",
+        "type: meeting",
+        # Two separate keys, exactly these names. Upstream dedup and person-page
+        # touch tracking run on `source` plus `<source>_id`; folding the id into
+        # the source line makes the note look new on every sweep.
+        f"source: {record.source}",
+        f"{record.source}_id: {record.source_id}",
+        f"start: {record.start.isoformat()}",
+    ]
+    if record.end:
+        lines.append(f"end: {record.end.isoformat()}")
+    if record.attendees:
+        lines.append("attendees:")
+        for person in record.attendees:
+            label = person.email or person.name
+            lines.append(f"  - {label}")
+    lines.append(f"has_transcript: {str(record.has_transcript).lower()}")
+    lines.append(f"attribution_resolved: {str(record.attribution_is_reliable).lower()}")
+    if record.extra.get("title_was_derived"):
+        lines.append("title_derived: true")
+    lines.append("ai_analyzed: false")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {record.title}")
+    lines.append("")
+
+    if not record.attribution_is_reliable:
+        lines += [
+            "> **Attendance unresolved.** This capture arrived without attendee names, so any",
+            "> speaker labels below identify turns in the recording, not people. Do not assign",
+            "> an action, a decision or a quote to anyone on the strength of this note alone.",
+            "> Match it against the calendar entry for this time first.",
+            "",
+        ]
+    if record.extra.get("title_was_derived"):
+        lines += [
+            "> Title derived from the summary, because this source supplied none.",
+            "",
+        ]
+
+    lines.append(record.body if record.body else "_This capture has no summary._")
+    lines.append("")
+
+    if record.action_items:
+        lines.append("### For Me")
+        lines.append("")
+        for item in record.action_items:
+            lines.append(f"- [ ] {item}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write(vault_root: Path, record: MeetingRecord, *, overwrite: bool = False) -> Path | None:
+    """Write one record. Returns the path, or None when it was already there."""
+    folder = meetings_dir(vault_root)
+    folder.mkdir(parents=True, exist_ok=True)
+    if not overwrite and record.source_id in existing_source_ids(vault_root, record.source):
+        return None
+
+    path = note_path(vault_root, record)
+    if path.exists() and not overwrite:
+        # Same day, same derived title, different capture. Keep both rather
+        # than silently dropping one.
+        path = path.with_name(f"{path.stem} ({record.source_id[:8]}){path.suffix}")
+
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(render(record), encoding="utf-8")
+    tmp.replace(path)
+    return path

--- a/core/meeting_sources/record.py
+++ b/core/meeting_sources/record.py
@@ -1,0 +1,92 @@
+"""The internal meeting record every source is mapped onto.
+
+The point of this contract is that nothing downstream should ever ask which
+tool a meeting came from. A provider adapter's whole job is to produce one of
+these; `/process-meetings`, person pages and task extraction consume it.
+
+Two decisions here matter more than the field list:
+
+**Absence is representable.** ``title`` and ``attendees`` are routinely empty
+from real providers: a recorder that titles and attributes from a calendar it
+cannot read returns neither. A record that forced them would push adapters into
+inventing values, and an invented attendee becomes an invented commitment two
+steps later. Empty means unknown, and callers must treat it that way.
+
+**Provenance is mandatory.** ``source`` and ``source_id`` are what dedup and
+person-page touch tracking run on. A record without them would be reprocessed
+as new on every sweep.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Attendee:
+    """Someone present. ``email`` is what person-page routing keys on."""
+
+    name: str | None = None
+    email: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name and not self.email:
+            raise ValueError("An attendee needs at least a name or an email")
+
+
+@dataclass(frozen=True)
+class MeetingRecord:
+    """One meeting, in the shape Dex works with regardless of origin."""
+
+    source: str
+    source_id: str
+    start: datetime
+    end: datetime | None = None
+    title: str | None = None
+    body: str = ""
+    attendees: tuple[Attendee, ...] = ()
+    action_items: tuple[str, ...] = ()
+    has_transcript: bool = False
+    finalized: bool = True
+    modified_at: datetime | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.source or not self.source_id:
+            raise ValueError("A meeting record must carry source and source_id")
+        if self.start.tzinfo is None:
+            raise ValueError("start must be timezone-aware")
+
+    @property
+    def attribution_is_reliable(self) -> bool:
+        """Whether anything in the body may be attributed to a named person.
+
+        False when the provider gave us no attendees. A summary from such a
+        source names speakers it cannot actually identify, so ownership,
+        commitments and quotes taken from it would be fabrications with a
+        plausible shape. Callers should resolve attendance from the calendar
+        instead, or record the meeting unattributed.
+        """
+        return bool(self.attendees)
+
+    @property
+    def local_date(self) -> str:
+        return self.start.astimezone().strftime("%Y-%m-%d")
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    """Parse a provider timestamp into an aware datetime, or None.
+
+    Providers are inconsistent about trailing Z, fractional seconds and naive
+    values. A naive timestamp is treated as UTC rather than local, because
+    every source seen so far reports UTC and guessing local would silently
+    shift meetings across day boundaries.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed

--- a/core/meeting_sources/wispr_adapter.py
+++ b/core/meeting_sources/wispr_adapter.py
@@ -1,0 +1,128 @@
+"""Map Wispr Flow's payloads onto the internal meeting record.
+
+Everything provider-specific about Wispr lives here, so nothing downstream has
+to know this source exists. Three of its traits are load-bearing:
+
+- **Titles come back empty.** Wispr titles a capture from the calendar event,
+  and its calendar sync is Google-only. A Microsoft 365 user therefore gets no
+  title at all. We derive one from the body rather than leave a note called
+  nothing, and we mark it as derived so it is never mistaken for what the
+  meeting was actually called.
+- **Attendees come back empty for the same reason.** That makes every summary
+  from this source unreliable for attribution: it names speakers it cannot
+  identify. The record carries the emptiness honestly and downstream resolves
+  attendance from Dex's own calendar.
+- **``todos`` is present but empty in practice.** Action items are prose inside
+  the summary, under a "Next Steps" heading, so they are extracted from there
+  and only from there.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from core.meeting_sources.record import Attendee, MeetingRecord, parse_timestamp  # noqa: F401
+
+SOURCE = "wispr"
+
+# Wispr writes its action items under a heading like "### Next Steps".
+_NEXT_STEPS = re.compile(r"^#{1,6}\s*next steps\s*$", re.IGNORECASE)
+_HEADING = re.compile(r"^#{1,6}\s+")
+_BULLET = re.compile(r"^\s*[-*]\s+(?P<text>.+?)\s*$")
+# "- (Ken) Add Pipedrive deal id..." — the parenthesised owner is a speaker
+# label, which for this source may be "Speaker 1" and is not a resolved person.
+_LEADING_OWNER = re.compile(r"^\((?P<owner>[^)]{1,40})\)\s*(?P<rest>.+)$")
+
+
+def _attendees(raw: Any) -> tuple[Attendee, ...]:
+    if not isinstance(raw, list):
+        return ()
+    people: list[Attendee] = []
+    for entry in raw:
+        if isinstance(entry, str) and entry.strip():
+            people.append(Attendee(name=entry.strip()))
+        elif isinstance(entry, dict):
+            name = (entry.get("name") or entry.get("display_name") or "").strip() or None
+            email = (entry.get("email") or "").strip() or None
+            if name or email:
+                people.append(Attendee(name=name, email=email))
+    return tuple(people)
+
+
+def extract_action_items(body: str) -> tuple[str, ...]:
+    """Pull the bullets under a Next Steps heading, and nothing else.
+
+    Deliberately narrow. Reading action items out of the whole summary would
+    sweep up decisions and observations as though they were commitments, which
+    is how a meeting note turns into tasks nobody agreed to.
+    """
+    if not body:
+        return ()
+    lines = body.splitlines()
+    items: list[str] = []
+    collecting = False
+    for line in lines:
+        if _NEXT_STEPS.match(line.strip()):
+            collecting = True
+            continue
+        if collecting and _HEADING.match(line.strip()):
+            break
+        if not collecting:
+            continue
+        match = _BULLET.match(line)
+        if match:
+            items.append(match.group("text"))
+    return tuple(items)
+
+
+def derive_title(body: str, *, fallback: str) -> str:
+    """A usable title when the provider supplies none.
+
+    The first sentence of a Wispr summary is a one-line description of the
+    meeting, which is exactly what a title wants to be. Trimmed to something
+    filename-shaped.
+    """
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or _HEADING.match(stripped):
+            continue
+        sentence = re.split(r"(?<=[.!?])\s", stripped)[0].strip(" .")
+        if not sentence:
+            continue
+        if len(sentence) <= 80:
+            return sentence
+        # Trim on a word boundary: a title cut mid-word reads as corruption.
+        return sentence[:80].rsplit(" ", 1)[0].rstrip(" ,;:-")
+    return fallback
+
+
+def to_record(payload: dict[str, Any]) -> MeetingRecord:
+    """Map one Wispr meeting (list item or detail) onto the internal record."""
+    if not isinstance(payload, dict) or not payload.get("id"):
+        raise ValueError("A Wispr meeting payload needs an id")
+
+    start = parse_timestamp(payload.get("start"))
+    if start is None:
+        raise ValueError(f"Wispr meeting {payload['id']} has no usable start time")
+
+    # Detail calls put the notes in `summary`; list items carry a truncated
+    # `content_excerpt`. `content` has been empty on every capture seen.
+    body = (payload.get("summary") or payload.get("content") or payload.get("content_excerpt") or "").strip()
+
+    provider_title = (payload.get("title") or "").strip()
+    title = provider_title or derive_title(body, fallback=f"Meeting {start.astimezone():%H:%M}")
+
+    return MeetingRecord(
+        source=SOURCE,
+        source_id=str(payload["id"]),
+        start=start,
+        end=parse_timestamp(payload.get("end")),
+        title=title,
+        body=body,
+        attendees=_attendees(payload.get("attendees")),
+        action_items=extract_action_items(body),
+        has_transcript=bool(payload.get("has_transcript")),
+        finalized=bool(payload.get("finalized", True)),
+        modified_at=parse_timestamp(payload.get("modified_at")),
+        extra={"title_was_derived": not provider_title},
+    )

--- a/core/meeting_sources/wispr_adapter.py
+++ b/core/meeting_sources/wispr_adapter.py
@@ -29,7 +29,7 @@ SOURCE = "wispr"
 _NEXT_STEPS = re.compile(r"^#{1,6}\s*next steps\s*$", re.IGNORECASE)
 _HEADING = re.compile(r"^#{1,6}\s+")
 _BULLET = re.compile(r"^\s*[-*]\s+(?P<text>.+?)\s*$")
-# "- (Ken) Add Pipedrive deal id..." — the parenthesised owner is a speaker
+# "- (Speaker 1) Send the revised figures": the parenthesised owner is a speaker
 # label, which for this source may be "Speaker 1" and is not a resolved person.
 _LEADING_OWNER = re.compile(r"^\((?P<owner>[^)]{1,40})\)\s*(?P<rest>.+)$")
 

--- a/core/tests/test_calendar_lookup.py
+++ b/core/tests/test_calendar_lookup.py
@@ -1,0 +1,150 @@
+"""Reading the calendar must fail loudly enough to be distinguishable from silence.
+
+Every failure path here returns None, and the whole point is that callers can
+tell "the calendar could not be read" apart from "the meeting had no
+attendees". If any of these ever returns an empty list instead, a machine
+without calendar access will start reporting confident, false statements about
+who was in a room.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from core.meeting_sources import calendar_lookup
+
+
+def _profile(tmp_path, payload: str):
+    system = tmp_path / "System"
+    system.mkdir(parents=True, exist_ok=True)
+    (system / "user-profile.yaml").write_text(payload, encoding="utf-8")
+
+
+def _helper(tmp_path):
+    helper = tmp_path / calendar_lookup.HELPER
+    helper.parent.mkdir(parents=True, exist_ok=True)
+    helper.write_text("# stub\n", encoding="utf-8")
+    return helper
+
+
+def test_the_configured_work_calendar_wins(tmp_path):
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\nwork_email: fixture-a@invalid.test\n")
+
+    assert calendar_lookup.default_calendar_name(tmp_path) == "Team Diary"
+
+
+def test_work_email_is_the_next_choice(tmp_path):
+    _profile(tmp_path, "work_email: fixture-person@invalid.test\n")
+
+    assert calendar_lookup.default_calendar_name(tmp_path) == "fixture-person@invalid.test"
+
+
+def test_a_name_and_domain_are_the_last_resort(tmp_path):
+    _profile(tmp_path, "name: Fixture-Person\nemail_domain: invalid.test\n")
+
+    assert calendar_lookup.default_calendar_name(tmp_path) == "fixture-person@invalid.test"
+
+
+def test_an_unconfigured_profile_yields_nothing_rather_than_a_guess(tmp_path):
+    """The calendar server falls back to a "Work" calendar; this must not.
+
+    Querying a calendar the user does not have returns an empty result, and an
+    empty result here is indistinguishable from a meeting nobody attended.
+    """
+    _profile(tmp_path, "name: Fixture-Person\n")
+
+    assert calendar_lookup.default_calendar_name(tmp_path) is None
+
+
+def test_an_unreadable_profile_is_not_a_calendar_fault(tmp_path):
+    _profile(tmp_path, "this: [is: not: valid: yaml\n")
+
+    assert calendar_lookup.default_calendar_name(tmp_path) is None
+
+
+def test_a_missing_helper_returns_unavailable_not_empty(tmp_path):
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None
+
+
+def test_no_configured_calendar_returns_unavailable(tmp_path):
+    _helper(tmp_path)
+    _profile(tmp_path, "name: Fixture-Person\n")
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None
+
+
+def _run(monkeypatch, *, returncode=0, stdout="", stderr=""):
+    def fake(*_args, **_kwargs):
+        return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+    monkeypatch.setattr(calendar_lookup.subprocess, "run", fake)
+
+
+def test_events_are_returned_on_success(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    events = [{"start": "2026-08-14T09:00:00+01:00", "title": "Review", "attendees": []}]
+    _run(monkeypatch, stdout=json.dumps(events))
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) == events
+
+
+def test_an_events_key_is_unwrapped(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    _run(monkeypatch, stdout=json.dumps({"events": [{"start": "x"}]}))
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) == [
+        {"start": "x"}
+    ]
+
+
+def test_a_failing_helper_returns_unavailable(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    _run(monkeypatch, returncode=1, stderr="calendar access denied")
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None
+
+
+def test_output_that_is_not_json_returns_unavailable(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    _run(monkeypatch, stdout="not json at all")
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None
+
+
+def test_a_timeout_returns_unavailable(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+
+    def boom(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="calendar", timeout=30)
+
+    monkeypatch.setattr(calendar_lookup.subprocess, "run", boom)
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None
+
+
+def test_non_mapping_entries_are_discarded(tmp_path, monkeypatch):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    _run(monkeypatch, stdout=json.dumps([{"start": "ok"}, "junk", 7]))
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) == [
+        {"start": "ok"}
+    ]
+
+
+@pytest.mark.parametrize("payload", ["null", '"a string"', "42"])
+def test_a_payload_that_is_not_a_list_returns_unavailable(tmp_path, monkeypatch, payload):
+    _helper(tmp_path)
+    _profile(tmp_path, "calendar:\n  work_calendar: Team Diary\n")
+    _run(monkeypatch, stdout=payload)
+
+    assert calendar_lookup.events_around(tmp_path, start_offset_days=-1, end_offset_days=1) is None

--- a/core/tests/test_meeting_attribution.py
+++ b/core/tests/test_meeting_attribution.py
@@ -1,0 +1,118 @@
+"""An unattributed capture must become attributed only where the calendar proves it.
+
+The failure this prevents has already happened once in practice: a note claimed
+a calendar match at 300 seconds when the real delta was 346, and the attendance
+it asserted was invented. The boundary is therefore tested exactly.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from core.meeting_sources import attribution, wispr_adapter
+from core.meeting_sources.landing_zone import write
+
+START = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def _capture(**overrides):
+    payload = {
+        "id": "cap-1",
+        "title": "",
+        "summary": "Weekly review.\n\n### Next Steps\n- (Speaker 1) Chase the credit\n",
+        "start": START.isoformat().replace("+00:00", "Z"),
+        "finalized": True,
+        "attendees": [],
+    }
+    payload.update(overrides)
+    return wispr_adapter.to_record(payload)
+
+
+def _event(offset_seconds=0, *, title="Commercial Review", attendees=None):
+    return {
+        "start": (START + timedelta(seconds=offset_seconds)).isoformat(),
+        "title": title,
+        "attendees": attendees if attendees is not None else [
+            {"name": "Ada Reeve", "email": "fixture-ken@invalid.test"},
+            {"name": "Bea Nolan", "email": "fixture-emily@invalid.test"},
+        ],
+    }
+
+
+def test_a_matching_event_resolves_attendance_and_the_real_title():
+    resolved = attribution.resolve(_capture(), [_event()])
+
+    assert resolved.attribution_is_reliable is True
+    assert {person.email for person in resolved.attendees} == {
+        "fixture-ken@invalid.test",
+        "fixture-emily@invalid.test",
+    }
+    assert resolved.title == "Commercial Review"
+    assert resolved.extra["title_from_calendar"] is True
+
+
+def test_the_five_minute_boundary_is_exact():
+    """300 seconds matches, 301 does not. This is the case that bit before."""
+    assert attribution.resolve(_capture(), [_event(300)]).attribution_is_reliable is True
+
+    beyond = attribution.resolve(_capture(), [_event(301)])
+    assert beyond.attribution_is_reliable is False
+    assert beyond.extra["attribution_match"] == "unmatched"
+
+
+def test_no_calendar_events_leaves_the_capture_honestly_unattributed():
+    resolved = attribution.resolve(_capture(), [])
+
+    assert resolved.attribution_is_reliable is False
+    assert resolved.extra["attribution_match"] == "unmatched"
+    assert resolved.extra["attribution_reason"]
+
+
+def test_an_ambiguous_match_does_not_pick_one():
+    """Two equally close events with nothing to separate them must not be guessed."""
+    resolved = attribution.resolve(
+        _capture(),
+        [_event(0, title="Review A", attendees=[{"email": "fixture-a@invalid.test"}]),
+         _event(0, title="Review B", attendees=[{"email": "fixture-b@invalid.test"}])],
+    )
+
+    assert resolved.attribution_is_reliable is False
+    assert resolved.extra["attribution_match"] == "ambiguous"
+
+
+def test_a_matched_event_with_no_attendees_is_still_unresolved():
+    """The match is real; the attendance is not thereby known."""
+    resolved = attribution.resolve(_capture(), [_event(attendees=[])])
+
+    assert resolved.attribution_is_reliable is False
+    assert resolved.extra["attribution_reason"] == "matched_event_has_no_attendees"
+
+
+def test_a_capture_that_already_knows_its_attendees_is_left_alone():
+    already = _capture(attendees=[{"name": "Sarah", "email": "fixture-sarah@invalid.test"}])
+
+    resolved = attribution.resolve(already, [_event()])
+
+    assert resolved is already, "no calendar lookup is needed or wanted"
+
+
+def test_a_derived_title_is_not_offered_to_the_matcher_as_corroboration():
+    """The matcher tie-breaks on title. A title we invented is not evidence."""
+    capture = attribution.record_as_capture(_capture())
+    assert capture["title"] == ""
+
+
+def test_the_note_reports_resolved_attendance_and_drops_the_warning(tmp_path):
+    resolved = attribution.resolve(_capture(), [_event()])
+    text = write(tmp_path, resolved).read_text()
+
+    assert "attribution_resolved: true" in text
+    assert "Attendance unresolved" not in text
+    assert "fixture-ken@invalid.test" in text
+
+
+def test_the_note_keeps_the_warning_when_the_calendar_could_not_confirm(tmp_path):
+    resolved = attribution.resolve(_capture(), [])
+    text = write(tmp_path, resolved).read_text()
+
+    assert "attribution_resolved: false" in text
+    assert "Attendance unresolved" in text

--- a/core/tests/test_meeting_attribution.py
+++ b/core/tests/test_meeting_attribution.py
@@ -32,7 +32,7 @@ def _event(offset_seconds=0, *, title="Commercial Review", attendees=None):
         "start": (START + timedelta(seconds=offset_seconds)).isoformat(),
         "title": title,
         "attendees": attendees if attendees is not None else [
-            {"name": "Ada Reeve", "email": "fixture-ken@invalid.test"},
+            {"name": "Ada Reeve", "email": "fixture-owner@invalid.test"},
             {"name": "Bea Nolan", "email": "fixture-emily@invalid.test"},
         ],
     }
@@ -43,7 +43,7 @@ def test_a_matching_event_resolves_attendance_and_the_real_title():
 
     assert resolved.attribution_is_reliable is True
     assert {person.email for person in resolved.attendees} == {
-        "fixture-ken@invalid.test",
+        "fixture-owner@invalid.test",
         "fixture-emily@invalid.test",
     }
     assert resolved.title == "Commercial Review"
@@ -107,7 +107,7 @@ def test_the_note_reports_resolved_attendance_and_drops_the_warning(tmp_path):
 
     assert "attribution_resolved: true" in text
     assert "Attendance unresolved" not in text
-    assert "fixture-ken@invalid.test" in text
+    assert "fixture-owner@invalid.test" in text
 
 
 def test_the_note_keeps_the_warning_when_the_calendar_could_not_confirm(tmp_path):

--- a/core/tests/test_meeting_record_contract.py
+++ b/core/tests/test_meeting_record_contract.py
@@ -1,0 +1,209 @@
+"""The record has to fit two unlike providers, or it is not a contract.
+
+Granola and Wispr disagree about almost everything at the edges: titles,
+attendees, how action items are written, whether attribution can be trusted.
+If the record only fits one of them it is a shape drawn around that one, and
+provider three forks the code again. These tests are the contract itself.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.meeting_sources import granola_adapter, landing_zone, wispr_adapter
+from core.meeting_sources.record import MeetingRecord
+
+GRANOLA_DETAIL = {
+    "id": "gran-1",
+    "title": "Quarterly review",
+    "created_at": "2026-08-14T09:00:00Z",
+    "updated_at": "2026-08-14T10:30:00Z",
+    "web_url": "https://notes.granola.ai/gran-1",
+    "summary_markdown": (
+        "## Discussion\n"
+        "- Renewal is on track\n\n"
+        "## Actions\n"
+        "- [ ] Send the revised SOW\n"
+        "- [x] Book the follow-up\n"
+    ),
+    "attendees": [
+        {"name": "Cara Vance", "email": "fixture-sarah@invalid.test"},
+        {"email": "fixture-ken@invalid.test"},
+    ],
+    "transcript": [{"text": "hello"}, {"text": "goodbye"}],
+}
+
+WISPR_DETAIL = {
+    "id": "wis-1",
+    "title": "",
+    "summary": "Weekly review of pipeline.\n\n### Next Steps\n- (Speaker 1) Chase the credit\n",
+    "start": "2026-08-14T12:00:00Z",
+    "end": "2026-08-14T12:45:00Z",
+    "finalized": True,
+    "has_transcript": True,
+    "attendees": [],
+}
+
+
+def test_both_providers_produce_the_same_type():
+    assert isinstance(granola_adapter.to_record(GRANOLA_DETAIL), MeetingRecord)
+    assert isinstance(wispr_adapter.to_record(WISPR_DETAIL), MeetingRecord)
+
+
+def test_the_record_carries_each_provider_own_identity():
+    granola = granola_adapter.to_record(GRANOLA_DETAIL)
+    wispr = wispr_adapter.to_record(WISPR_DETAIL)
+
+    assert (granola.source, granola.source_id) == ("granola", "gran-1")
+    assert (wispr.source, wispr.source_id) == ("wispr", "wis-1")
+
+
+def test_attribution_reliability_differs_and_the_record_says_which():
+    """This is the difference that matters most downstream.
+
+    Granola knows who was there, so a name in its notes is a person. Wispr does
+    not, so a name in its summary is a guess. Collapsing the two is how an
+    invented commitment reaches a person page.
+    """
+    assert granola_adapter.to_record(GRANOLA_DETAIL).attribution_is_reliable is True
+    assert wispr_adapter.to_record(WISPR_DETAIL).attribution_is_reliable is False
+
+
+def test_action_items_survive_two_completely_different_notations():
+    granola = granola_adapter.to_record(GRANOLA_DETAIL)
+    wispr = wispr_adapter.to_record(WISPR_DETAIL)
+
+    assert granola.action_items == ("Send the revised SOW",)
+    assert wispr.action_items == ("(Speaker 1) Chase the credit",)
+
+
+def test_a_completed_checkbox_is_not_imported_as_an_open_task():
+    """Handing back finished work as a new task is worse than missing it."""
+    items = granola_adapter.extract_action_items(GRANOLA_DETAIL["summary_markdown"])
+    assert all("follow-up" not in item for item in items)
+
+
+def test_a_provider_title_is_kept_and_a_missing_one_is_flagged():
+    assert granola_adapter.to_record(GRANOLA_DETAIL).extra["title_was_derived"] is False
+    assert wispr_adapter.to_record(WISPR_DETAIL).extra["title_was_derived"] is True
+
+
+def test_both_land_in_the_same_folder_with_the_same_frontmatter_grammar(tmp_path):
+    """Downstream must not be able to tell which source a note came from."""
+    granola_path = landing_zone.write(tmp_path, granola_adapter.to_record(GRANOLA_DETAIL))
+    wispr_path = landing_zone.write(tmp_path, wispr_adapter.to_record(WISPR_DETAIL))
+
+    assert granola_path.parent == wispr_path.parent
+    granola_text, wispr_text = granola_path.read_text(), wispr_path.read_text()
+
+    assert "\nsource: granola\n" in granola_text and "\ngranola_id: gran-1\n" in granola_text
+    assert "\nsource: wispr\n" in wispr_text and "\nwispr_id: wis-1\n" in wispr_text
+    for text in (granola_text, wispr_text):
+        assert "type: meeting" in text
+        assert "ai_analyzed: false" in text
+
+
+def test_only_the_unreliable_source_carries_the_attribution_warning(tmp_path):
+    granola_text = landing_zone.write(tmp_path, granola_adapter.to_record(GRANOLA_DETAIL)).read_text()
+    wispr_text = landing_zone.write(tmp_path, wispr_adapter.to_record(WISPR_DETAIL)).read_text()
+
+    assert "Attendance unresolved" not in granola_text
+    assert "Attendance unresolved" in wispr_text
+
+
+def test_granola_attendees_reach_the_note_for_person_routing(tmp_path):
+    text = landing_zone.write(tmp_path, granola_adapter.to_record(GRANOLA_DETAIL)).read_text()
+
+    assert "fixture-sarah@invalid.test" in text
+    assert "fixture-ken@invalid.test" in text
+
+
+def test_dedup_is_per_source_so_two_providers_never_collide(tmp_path):
+    granola = granola_adapter.to_record(GRANOLA_DETAIL)
+    wispr = wispr_adapter.to_record(WISPR_DETAIL)
+    landing_zone.write(tmp_path, granola)
+    landing_zone.write(tmp_path, wispr)
+
+    assert landing_zone.existing_source_ids(tmp_path, "granola") == {"gran-1"}
+    assert landing_zone.existing_source_ids(tmp_path, "wispr") == {"wis-1"}
+
+
+def test_a_payload_without_a_usable_time_is_refused_by_both():
+    with pytest.raises(ValueError):
+        granola_adapter.to_record({**GRANOLA_DETAIL, "created_at": None})
+    with pytest.raises(ValueError):
+        wispr_adapter.to_record({**WISPR_DETAIL, "start": None})
+
+
+# --- The generic layer must stay generic ------------------------------------
+#
+# Attribution, the landing zone and the record are Dex-level machinery. They
+# happen to have been built while wiring one provider, which is exactly the
+# circumstance in which a provider name leaks into shared code and the next
+# source has to fork it.
+
+
+def test_attribution_resolves_a_granola_capture_by_the_same_route(tmp_path):
+    """The attendee matcher is wired at the note level, not to one connector.
+
+    Granola usually supplies attendees, but it does not always: a note taken
+    from a meeting with no calendar entry arrives bare, exactly like a Wispr
+    capture. It must resolve through the same path, with no Granola-specific
+    handling anywhere.
+    """
+    from core.meeting_sources import attribution
+
+    bare = granola_adapter.to_record({**GRANOLA_DETAIL, "attendees": []})
+    assert bare.attribution_is_reliable is False
+
+    resolved = attribution.resolve(
+        bare,
+        [
+            {
+                "start": "2026-08-14T09:00:00+00:00",
+                "title": "Quarterly review",
+                "attendees": [{"name": "Cara Vance", "email": "fixture-sarah@invalid.test"}],
+            }
+        ],
+    )
+
+    assert resolved.source == "granola"
+    assert resolved.attribution_is_reliable is True
+    assert [person.email for person in resolved.attendees] == ["fixture-sarah@invalid.test"]
+
+
+def test_the_generic_modules_name_no_provider():
+    """A guard against the obvious future regression.
+
+    If a provider name appears in the record, the attribution join, the landing
+    zone or the calendar lookup, the next source has to fork that file instead
+    of adding an adapter, which is the whole failure this design avoids.
+    """
+    import pathlib
+
+    package = pathlib.Path(__file__).resolve().parents[1] / "meeting_sources"
+    for module in ("record.py", "attribution.py", "landing_zone.py", "calendar_lookup.py"):
+        text = (package / module).read_text(encoding="utf-8").lower()
+        for provider in ("wispr", "granola", "otter", "fathom", "zoom"):
+            assert provider not in text, f"{module} names {provider}; it must stay provider-neutral"
+
+
+def test_the_landing_zone_writes_any_source_without_being_taught_it(tmp_path):
+    """A source it has never heard of must land correctly on the same rules."""
+    from datetime import datetime, timezone
+
+    from core.meeting_sources.record import MeetingRecord
+
+    invented = MeetingRecord(
+        source="fathom",
+        source_id="fth-9",
+        start=datetime(2026, 8, 14, 15, 0, tzinfo=timezone.utc),
+        title="Pipeline review",
+        body="Notes.",
+    )
+
+    path = landing_zone.write(tmp_path, invented)
+    text = path.read_text()
+
+    assert "\nsource: fathom\n" in text
+    assert "\nfathom_id: fth-9\n" in text
+    assert landing_zone.existing_source_ids(tmp_path, "fathom") == {"fth-9"}

--- a/core/tests/test_meeting_record_contract.py
+++ b/core/tests/test_meeting_record_contract.py
@@ -27,7 +27,7 @@ GRANOLA_DETAIL = {
     ),
     "attendees": [
         {"name": "Cara Vance", "email": "fixture-sarah@invalid.test"},
-        {"email": "fixture-ken@invalid.test"},
+        {"email": "fixture-owner@invalid.test"},
     ],
     "transcript": [{"text": "hello"}, {"text": "goodbye"}],
 }
@@ -114,7 +114,7 @@ def test_granola_attendees_reach_the_note_for_person_routing(tmp_path):
     text = landing_zone.write(tmp_path, granola_adapter.to_record(GRANOLA_DETAIL)).read_text()
 
     assert "fixture-sarah@invalid.test" in text
-    assert "fixture-ken@invalid.test" in text
+    assert "fixture-owner@invalid.test" in text
 
 
 def test_dedup_is_per_source_so_two_providers_never_collide(tmp_path):

--- a/docs/meeting-sources.md
+++ b/docs/meeting-sources.md
@@ -1,0 +1,104 @@
+# Meeting sources
+
+A meeting source is a choice, not a fork in the code. Adding one should mean
+writing an adapter, never editing `/process-meetings`, onboarding, or the flows.
+
+This is the contract that makes that true.
+
+## The shape
+
+```
+provider payload  ->  adapter  ->  MeetingRecord  ->  landing zone  ->  existing detector
+```
+
+Only the adapter knows which provider it came from. Everything to the right of
+it is provider-neutral, and a test fails the build if a provider name appears in
+`record.py`, `attribution.py`, `landing_zone.py` or `calendar_lookup.py`.
+
+## The record
+
+`core/meeting_sources/record.py`. Two decisions in it carry the weight.
+
+**Absence is representable.** `title` and `attendees` are routinely empty from
+real providers: a recorder that titles and attributes from a calendar it cannot
+read returns neither. A record that forced them would push adapters into
+inventing values, and an invented attendee becomes an invented commitment two
+steps later. Empty means unknown, and callers must treat it that way. That is
+what `attribution_is_reliable` is for.
+
+**Provenance is mandatory.** `source` and `source_id` are what dedup and
+person-page touch tracking run on. They are written to the note as two separate
+frontmatter keys, `source: <name>` and `<name>_id: <id>`. Folding the id into
+the source line makes the note look new on every sweep.
+
+## Writing an adapter
+
+One function: provider payload in, `MeetingRecord` out. Look at
+`granola_adapter.py` and `wispr_adapter.py` together, because they disagree at
+almost every edge and that is the point:
+
+| | Granola | Wispr |
+|---|---|---|
+| Title | Supplied | None; derived from the body and flagged |
+| Attendees | With emails | None |
+| Action items | Curated checkboxes | Prose under a "Next Steps" heading |
+
+Two rules learned from those two:
+
+- **Take action items from where the provider actually puts them, and nowhere
+  else.** Reading the whole summary sweeps up decisions and observations as
+  though they were commitments, which is how a meeting note produces tasks
+  nobody agreed to.
+- **Do not import work already marked done.** Handing someone back something
+  they have finished is worse than missing it.
+
+## Attendance
+
+`attribution.resolve(record, calendar_events)` uses the matcher Dex already
+ships, `match_capture_to_calendar`: nearest start within five minutes,
+tie-broken on title and participant overlap.
+
+A capture that matches gains real attendees and the calendar's title. One that
+does not keeps its warning and records why, because "no entry within the window"
+and "the calendar could not be read" call for different responses.
+
+Three refusals, each of which would otherwise state something false about who
+was in a room:
+
+- A derived title is never offered to the matcher as corroboration. It
+  tie-breaks on title, and a title we invented is not evidence.
+- Matching an event that lists nobody leaves attendance unresolved. The match is
+  real; the attendance is not thereby known.
+- A calendar that cannot be read is never reported as a meeting with no
+  attendees. `calendar_lookup` returns `None` for every failure, and callers
+  must distinguish that from an empty list.
+
+**Trap:** the matcher parses timestamps and rejects any that does not declare an
+offset. Passing a `datetime` rather than an ISO string makes every capture come
+back `unmatched / capture_timestamp_missing_timezone`, which is
+indistinguishable from a genuinely absent calendar entry. Attribution then
+silently never works while appearing to.
+
+## Acquisition, and who holds the credential
+
+Fetching is per-provider by nature, but one property of it is worth deciding
+deliberately: **who holds the credential.**
+
+- **Dex-held** (an API key, or OAuth through the connection manager): the source
+  can be swept on a schedule and works whichever MCP client the vault is opened
+  in.
+- **Host-held** (a credential inside an MCP client's connector store): the
+  source can only be read while a human is signed in to that client, and moving
+  the vault to another client breaks it silently.
+
+Prefer Dex-held. A provider exposing a standards-compliant remote MCP server can
+be Dex-held even when the obvious route is a host connector.
+
+However it is fetched, write into the landing zone (`core.paths.MEETINGS_DIR`)
+and stop. The existing detector picks the note up unchanged.
+
+## Honest failure
+
+A sweep that cannot reach its provider must say so. Reporting "no new meetings"
+when the real answer is "the recorder was unreachable" turns an outage into a
+quiet week, and nobody investigates a quiet week.


### PR DESCRIPTION
Second of three. This is the half you called the risky one in #75: define the internal record, and move a provider onto it.

Independent of #560 (that one is credentials, this one is notes). #561 builds on this.

## The record

Two decisions carry the weight.

**Absence is representable.** Titles and attendees are routinely empty from real providers, because a recorder that titles and attributes from a calendar it cannot read returns neither. A record that forced them would push adapters into inventing values, and an invented attendee becomes an invented commitment two steps later. Empty means unknown and callers must treat it that way.

**Provenance is mandatory.** `source` and `source_id` are what dedup and person-page touch tracking run on, so a record without them is reprocessed as new on every sweep.

## Two adapters, on purpose

A contract fitted to one provider is a shape drawn around that provider, and provider three then forks the same conditional again, which is @m13v's point on #75 and the reason for the shape you asked for.

Granola and Wispr disagree at nearly every edge:

| | Granola | Wispr |
|---|---|---|
| Title | Supplied | None, derived and flagged |
| Attendees | With emails | None |
| Action items | Curated checkboxes | Prose under a heading |

Both produce the same record, and 14 contract tests assert nothing downstream can tell them apart, including that the landing zone correctly writes a source it has never been taught. **Granola's behaviour is unchanged**; only its output shape is now shared. Completed checkboxes are deliberately not imported, since handing someone back work they have finished is worse than missing it.

## Attendance

Resolved through `match_capture_to_calendar`, which Dex already ships. A capture that matches gains real attendees and the real title; one that does not keeps an explicit warning and records **why**, because no entry within the window and a calendar that could not be read call for different responses from a user.

Three refusals are tested, each of which would otherwise produce a confident false statement about who was in a room:

- A derived title is never offered to the matcher as corroboration. It tie-breaks on title, and a title we invented is not evidence.
- Matching an event that lists nobody leaves attendance unresolved. The match is real; the attendance is not thereby known.
- A calendar that cannot be read is never reported as a meeting with no attendees.

**One trap worth recording for anyone else calling that matcher:** it parses timestamps and rejects any that does not declare an offset, so passing a `datetime` rather than an ISO string makes every capture come back `unmatched / capture_timestamp_missing_timezone`. That is indistinguishable from a genuinely absent calendar entry, so attribution silently never works while appearing to. Only the positive-path test catches it.

## Neutrality

Notes land in `00-Inbox/Meetings/` so the existing detector picks them up unchanged, per the landing-zone contract. A guard fails the build if the record, the attribution join, the landing zone or the calendar lookup ever names a provider. It caught a docstring on its first run: harmless prose, but a rule with an exception in it stops being enforced.

**Verification.** 23 tests here; 199 across the full stack. Ruff clean. Attendance resolution verified on live data: of four real captures, two matched real calendar entries and were written with their actual attendees and calendar titles, two were written honestly unresolved.