### PR TITLE
Record every session end, and say when the transcript could not be found

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,51 +1,94 @@
 #!/bin/bash
 # Claude Code SessionEnd Hook
-# Logs session end timestamp for tracking
-# For Dex personal knowledge system
+# Records that a session ended, so the day's learning file is never silently empty.
 #
-# ⚠️ IMPORTANT: This only works in Claude Code desktop/CLI
-# - Requires graceful shutdown (via `exit` command or proper quit)
-# - Does NOT work in Cursor (closing window terminates process immediately)
-# - For Cursor: Use /daily-review command manually before closing
+# ⚠️ Requires graceful shutdown (via `exit` or a proper quit). Closing a Cursor
+# window terminates the process immediately and no SessionEnd hook runs at all.
 #
-# NOTE: This hook only logs timestamps. Actual learning extraction happens
-# via /daily-review command, which intelligently scans for patterns and improvements.
+# NOTE: this hook records the session boundary. Learning EXTRACTION happens in
+# /daily-review, which scans the transcript for patterns worth keeping.
+#
+# Two faults this file used to have, both silent:
+#
+#   1. It read the transcript path from "$1", and settings.json passes
+#      "$transcript_path" -- a shell variable nothing in the hook environment
+#      ever sets, so it expanded to empty on every real invocation. Hooks are
+#      given their payload as JSON on stdin (see soft-promise-detector.py).
+#      Stdin is now the primary source, with argv kept as a fallback because
+#      the test harness invokes the hook directly.
+#
+#   2. It gated the whole session record on having a transcript path. The
+#      valuable part -- that a session ended, and when -- does not depend on
+#      that optional detail. Gating the essential on the optional meant a
+#      missing path produced a file containing nothing but its own header,
+#      which reads as "nothing happened" rather than "this did not work".
+#
+# Observed before the fix: two consecutive days whose learning files contained
+# only the header, while the autocommit hook faithfully committed them and every
+# mechanism reported success.
 
-CLAUDE_DIR="$CLAUDE_PROJECT_DIR"
+CLAUDE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 SESSION_LEARNINGS_DIR="$CLAUDE_DIR/System/Session_Learnings"
-TRANSCRIPT_PATH="$1"  # Passed as argument by Claude Code
 
-# Ensure session learnings directory exists
-mkdir -p "$SESSION_LEARNINGS_DIR"
+# Payload arrives as JSON on stdin. Read it only when stdin is not a terminal,
+# so direct invocation from a shell cannot hang waiting for input.
+PAYLOAD=""
+if [ ! -t 0 ]; then
+    PAYLOAD="$(cat 2>/dev/null || true)"
+fi
 
-# Get today's date for the learning file
+TRANSCRIPT_PATH=""
+if [ -n "$PAYLOAD" ]; then
+    # Deliberately not a JSON parser: bash has none, and adding an interpreter
+    # start to a shutdown path to read one string is not worth it.
+    if [[ "$PAYLOAD" =~ \"transcript_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+        TRANSCRIPT_PATH="${BASH_REMATCH[1]}"
+    fi
+fi
+# Fallback for direct invocation (the hook harness passes it as an argument).
+[ -z "$TRANSCRIPT_PATH" ] && TRANSCRIPT_PATH="${1:-}"
+
+mkdir -p "$SESSION_LEARNINGS_DIR" 2>/dev/null || exit 0
+
 TODAY=$(date +%Y-%m-%d)
 LEARNING_FILE="$SESSION_LEARNINGS_DIR/$TODAY.md"
 
-# Create or append to today's learning file
 if [[ ! -f "$LEARNING_FILE" ]]; then
-    cat > "$LEARNING_FILE" <<EOF
+    cat > "$LEARNING_FILE" <<HEADER
 # Session Learnings - $TODAY
 
 Automatically captured from Claude Code sessions.
 
 ---
 
-EOF
+HEADER
 fi
 
-# Log session end time with transcript reference
-# Actual learning extraction happens via /daily-review command
-if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
-    echo "## $(date +%H:%M) - Session completed" >> "$LEARNING_FILE"
-    echo "" >> "$LEARNING_FILE"
-    echo "**Session ended**" >> "$LEARNING_FILE"
-    echo "**Transcript:** \`$TRANSCRIPT_PATH\`" >> "$LEARNING_FILE"
-    echo "" >> "$LEARNING_FILE"
-    echo "_Note: Run /daily-review to extract learnings from this session._" >> "$LEARNING_FILE"
-    echo "" >> "$LEARNING_FILE"
-    echo "---" >> "$LEARNING_FILE"
-    echo "" >> "$LEARNING_FILE"
-fi
+# The session record is written unconditionally. Whether the transcript could be
+# located is reported as part of it, because a learning file that cannot say
+# "the transcript was not available" is indistinguishable from a quiet day.
+{
+    echo "## $(date +%H:%M) - Session completed"
+    echo ""
+    echo "**Session ended**"
+    if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
+        echo "**Transcript:** \`$TRANSCRIPT_PATH\`"
+        echo ""
+        echo "_Note: Run /daily-review to extract learnings from this session._"
+    elif [[ -n "$TRANSCRIPT_PATH" ]]; then
+        echo "**Transcript:** recorded as \`$TRANSCRIPT_PATH\`, but no file exists there."
+        echo ""
+        echo "_Learnings cannot be extracted automatically. If this session mattered,"
+        echo "capture them by hand before the detail is gone._"
+    else
+        echo "**Transcript:** not supplied to this hook."
+        echo ""
+        echo "_Learnings cannot be extracted automatically. If this session mattered,"
+        echo "capture them by hand before the detail is gone._"
+    fi
+    echo ""
+    echo "---"
+    echo ""
+} >> "$LEARNING_FILE"
 
 exit 0

--- a/.claude/hooks/tests/session-end-record.test.cjs
+++ b/.claude/hooks/tests/session-end-record.test.cjs
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOK_PATH = path.resolve(__dirname, '..', 'session-end.sh');
+
+function sandbox(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-session-end-'));
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return vault;
+}
+
+function run(vault, { stdin = '', args = [] } = {}) {
+  return spawnSync('/bin/bash', [HOOK_PATH, ...args], {
+    encoding: 'utf8',
+    input: stdin,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: vault },
+  });
+}
+
+function learningFile(vault) {
+  const today = new Date().toISOString().slice(0, 10);
+  return fs.readFileSync(
+    path.join(vault, 'System', 'Session_Learnings', `${today}.md`),
+    'utf8',
+  );
+}
+
+test('reads the transcript path from the JSON payload on stdin', (t) => {
+  const vault = sandbox(t);
+  const transcript = path.join(vault, 'transcript.jsonl');
+  fs.writeFileSync(transcript, '{}\n');
+
+  const result = run(vault, { stdin: JSON.stringify({ transcript_path: transcript }) });
+
+  assert.equal(result.status, 0);
+  const text = learningFile(vault);
+  assert.match(text, new RegExp(`Transcript:.*${transcript.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'u'));
+  assert.match(text, /Run \/daily-review/u);
+});
+
+test('records the session even when no transcript is supplied', (t) => {
+  const vault = sandbox(t);
+
+  // This is the real-world case: settings.json passed "$transcript_path", a
+  // shell variable nothing sets, so the hook received nothing on every run.
+  const result = run(vault, { stdin: '{}' });
+
+  assert.equal(result.status, 0);
+  const text = learningFile(vault);
+  assert.match(text, /Session completed/u, 'the session boundary must be recorded regardless');
+  assert.match(text, /not supplied to this hook/u, 'and the gap must be stated, not hidden');
+});
+
+test('says so when the transcript path points at nothing', (t) => {
+  const vault = sandbox(t);
+
+  run(vault, { stdin: JSON.stringify({ transcript_path: '/nonexistent/x.jsonl' }) });
+
+  const text = learningFile(vault);
+  assert.match(text, /no file exists there/u);
+  assert.doesNotMatch(text, /Run \/daily-review/u, 'must not promise extraction it cannot do');
+});
+
+test('still accepts an argv transcript, for direct invocation', (t) => {
+  const vault = sandbox(t);
+  const transcript = path.join(vault, 'transcript.jsonl');
+  fs.writeFileSync(transcript, '{}\n');
+
+  run(vault, { args: [transcript] });
+
+  assert.match(learningFile(vault), /Run \/daily-review/u);
+});
+
+test('a day file is never left containing only its header', (t) => {
+  const vault = sandbox(t);
+
+  run(vault, { stdin: '{}' });
+
+  const text = learningFile(vault);
+  const afterHeader = text.split('---')[1] || '';
+  assert.notEqual(
+    afterHeader.trim(),
+    '',
+    'an empty day file is indistinguishable from a day where nothing was captured',
+  );
+});
+
+test('appends rather than replacing when a session already ended today', (t) => {
+  const vault = sandbox(t);
+
+  run(vault, { stdin: '{}' });
+  run(vault, { stdin: '{}' });
+
+  const occurrences = learningFile(vault).match(/Session completed/gu) || [];
+  assert.equal(occurrences.length, 2);
+});


### PR DESCRIPTION
First half of #564. Independent of #566 and touches no shared file.

## The symptom

Two consecutive days on this vault where `System/Session_Learnings/YYYY-MM-DD.md` contained only its header:

```
# Session Learnings - 2026-08-18

Automatically captured from Claude Code sessions.

---
```

Byte-identical for the following day. Meanwhile `vault-autocommit` fired on both days and committed those files faithfully. Every mechanism reported success and nothing was captured.

## The cause, which is more specific than "a branch didn't fire"

`session-end.sh` reads the transcript path from `$1`. `settings.json` invokes it as:

```
"$CLAUDE_PROJECT_DIR"/.claude/hooks/session-end.sh "$transcript_path"
```

`$transcript_path` is a shell variable that nothing in the hook environment sets, so it expands to empty on **every** real invocation. Hooks are given their payload as JSON on stdin — `soft-promise-detector.py` already does `json.load(sys.stdin)`. So the hook was written against an input contract that does not exist, and the harness test passed because it invokes the hook directly with an argument.

The second fault compounds it: the entire session record was gated on that path. But the valuable part — a session ended, at this time — does not depend on the transcript. **Gating the essential on the optional** turned a broken input contract into a file that reads as a quiet day.

## What changes

- **Stdin JSON is the primary source**, argv retained as fallback so direct invocation and the existing harness test still work.
- **The session record is written unconditionally.** Whether the transcript was located is reported as part of it, in three distinguishable states: found, named but absent, or never supplied.
- **It stops promising extraction it cannot deliver.** The old text emitted "Run /daily-review to extract learnings from this session" in every case, including those where no transcript exists.

## Deliberately not included

`settings.json` is untouched. The `"$transcript_path"` argument is now redundant rather than harmful, and removing it is a separate tidy-up that would collide with other in-flight work on that file.

The second half of #564 — capturing corrections mid-session rather than depending on an end-of-day manual step — is a separate change and will be a separate PR.

## Verification

Six new tests: stdin payload, no transcript supplied, path present but file absent, argv fallback, the day file never left header-only, and repeat sessions appending rather than replacing.

All twelve `quality` gates pass locally. Hook harness 158 → 164 passing, failures unchanged at 34 (pre-existing on clean `main` in this environment). The existing `session end runs directly and records its transcript` test still passes.