### PR TITLE
Starter for the learning routing step from #503: parse, cluster, propose, record

### DIFF
--- a/core/tests/test_learning_routing.py
+++ b/core/tests/test_learning_routing.py
@@ -1,0 +1,195 @@
+"""Captured learnings are worth nothing until something routes them.
+
+These cover the mechanical half only: parsing, clustering, the trigger, and
+recording an outcome. Applying an edit stays in the skill, because it must be
+shown and confirmed first.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from core.utils import learning_routing as routing
+
+TODAY = date(2026, 8, 19)
+
+
+def _day_file(vault: Path, day: str, body: str) -> Path:
+    folder = vault / routing.LEARNINGS_RELATIVE
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / f"{day}.md"
+    path.write_text(f"# Session Learnings - {day}\n\n---\n\n{body}", encoding="utf-8")
+    return path
+
+
+ENTRY = """## 09:15 - Correction
+
+**What was said:**
+
+> stop over inferring from timesheet codes
+
+**Why it matters:** it invents facts about the day.
+**Status:** pending
+
+---
+
+## 11:40 - Correction
+
+**What was said:**
+
+> the daily-plan skill skipped step 5.8 entirely
+
+**Why it matters:** an unrun step looks identical to an empty one.
+**Status:** pending
+
+---
+"""
+
+
+def test_entries_are_parsed_with_their_location(tmp_path):
+    path = _day_file(tmp_path, "2026-08-18", ENTRY)
+
+    entries = routing.parse_file(path)
+
+    assert len(entries) == 2
+    assert entries[0].time == "09:15"
+    assert "timesheet codes" in entries[0].body
+    assert entries[0].day == date(2026, 8, 18)
+    assert all(e.is_pending for e in entries)
+
+
+def test_a_file_that_is_not_a_day_is_ignored(tmp_path):
+    folder = tmp_path / routing.LEARNINGS_RELATIVE
+    folder.mkdir(parents=True)
+    readme = folder / "README.md"
+    readme.write_text("## 09:00 - not a learning\n**Status:** pending\n", encoding="utf-8")
+
+    assert routing.parse_file(readme) == []
+
+
+def test_a_malformed_file_yields_nothing_rather_than_raising(tmp_path):
+    path = _day_file(tmp_path, "2026-08-18", "no entries here at all\n")
+
+    assert routing.parse_file(path) == []
+
+
+def test_already_routed_entries_are_not_pending(tmp_path):
+    _day_file(
+        tmp_path,
+        "2026-08-18",
+        "## 09:15 - Done one\n\n**Status:** implemented (2026-08-18 — CLAUDE-custom.md)\n\n---\n",
+    )
+
+    entries = routing.read_all(tmp_path)
+
+    assert len(entries) == 1
+    assert routing.pending(entries) == []
+
+
+def test_clusters_group_by_destination_not_by_wording(tmp_path):
+    _day_file(tmp_path, "2026-08-18", ENTRY)
+
+    clusters = routing.cluster(routing.read_all(tmp_path))
+    kinds = {c.kind for c in clusters}
+
+    assert "behavioural" in kinds
+    assert "skill-defect" in kinds
+    for c in clusters:
+        assert c.destination, "every cluster must name where it goes"
+
+
+def test_a_cluster_of_several_entries_becomes_one_edit(tmp_path):
+    """Josh's point: eight related entries are one rule, not eight edits."""
+    many = "".join(
+        f"## 0{n}:00 - Correction\n\n> stop assuming, always verify first\n\n**Status:** pending\n\n---\n\n"
+        for n in range(1, 5)
+    )
+    _day_file(tmp_path, "2026-08-18", many)
+
+    clusters = routing.cluster(routing.read_all(tmp_path))
+
+    assert len(clusters) == 1
+    assert len(clusters[0].entries) == 4
+
+
+def test_the_trigger_fires_on_volume(tmp_path):
+    body = "".join(
+        f"## 09:{n:02d} - Correction\n\n> stop doing that\n\n**Status:** pending\n\n---\n\n"
+        for n in range(12)
+    )
+    _day_file(tmp_path, "2026-08-19", body)
+
+    due, reason = routing.should_review(routing.read_all(tmp_path), today=TODAY)
+
+    assert due is True
+    assert "pending" in reason
+
+
+def test_the_trigger_fires_on_age_even_for_a_single_entry(tmp_path):
+    """A count-only trigger never fires on a slow, steady leak."""
+    old = (TODAY - timedelta(days=30)).isoformat()
+    _day_file(tmp_path, old, "## 09:00 - Correction\n\n> stop that\n\n**Status:** pending\n\n---\n")
+
+    due, reason = routing.should_review(routing.read_all(tmp_path), today=TODAY)
+
+    assert due is True
+    assert "days old" in reason
+
+
+def test_the_trigger_stays_quiet_on_a_small_recent_backlog(tmp_path):
+    """A hook that fires into a healthy vault is noise."""
+    _day_file(tmp_path, "2026-08-19", "## 09:00 - Correction\n\n> stop that\n\n**Status:** pending\n\n---\n")
+
+    due, _ = routing.should_review(routing.read_all(tmp_path), today=TODAY)
+
+    assert due is False
+
+
+def test_the_trigger_is_silent_on_an_empty_vault(tmp_path):
+    due, reason = routing.should_review(routing.read_all(tmp_path), today=TODAY)
+
+    assert due is False
+    assert reason == "nothing pending"
+
+
+def test_recording_an_outcome_says_where_it_went(tmp_path):
+    path = _day_file(tmp_path, "2026-08-18", ENTRY)
+    entry = routing.parse_file(path)[0]
+
+    assert routing.set_status(entry, routing.IMPLEMENTED, "CLAUDE-custom.md", today=TODAY) is True
+
+    text = path.read_text(encoding="utf-8")
+    assert "**Status:** implemented (2026-08-19 — CLAUDE-custom.md)" in text
+    # A falling count must mean something was installed, not that it aged out.
+    assert routing.pending(routing.parse_file(path)) != routing.parse_file(path)
+
+
+def test_dropping_an_entry_records_why(tmp_path):
+    path = _day_file(tmp_path, "2026-08-18", ENTRY)
+    entry = routing.parse_file(path)[0]
+
+    routing.set_status(entry, routing.DROPPED, "already covered by an existing rule", today=TODAY)
+
+    assert "dropped (2026-08-19 — already covered" in path.read_text(encoding="utf-8")
+
+
+def test_two_entries_in_one_file_never_have_their_statuses_crossed(tmp_path):
+    path = _day_file(tmp_path, "2026-08-18", ENTRY)
+    second = routing.parse_file(path)[1]
+
+    routing.set_status(second, routing.IMPLEMENTED, "process-meetings SKILL.md", today=TODAY)
+
+    reparsed = routing.parse_file(path)
+    assert reparsed[0].is_pending, "the first entry must be untouched"
+    assert reparsed[1].status == routing.IMPLEMENTED
+
+
+def test_an_invented_status_is_refused(tmp_path):
+    """Without a third state, stale entries either linger or get quietly deleted."""
+    path = _day_file(tmp_path, "2026-08-18", ENTRY)
+    entry = routing.parse_file(path)[0]
+
+    with pytest.raises(ValueError):
+        routing.set_status(entry, "done", "somewhere")

--- a/core/utils/learning_routing.py
+++ b/core/utils/learning_routing.py
@@ -1,0 +1,256 @@
+"""Read captured learnings, cluster them, and propose where each should go.
+
+Written as a starting point for the routing step described in #503 by
+@joshm-simril, against the shape @davekilleen specified there. The routing table
+below is Josh's, not mine.
+
+**What this module deliberately does not do: apply anything.** The requirement
+that Dex never silently rewrites its own instructions means the edit must be
+shown and confirmed before it lands, and confirmation belongs in the skill that
+can hold a conversation. Everything here is analysis and bookkeeping: parse the
+entries, group the ones that share a cause, propose a destination, and record
+the outcome once a human has decided.
+
+The split matters. Clustering and destination-proposal are mechanical and
+testable; deciding whether a proposed edit is right is judgement. Mixing them
+would put an unreviewable decision inside a function that looks like a helper.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+
+LEARNINGS_RELATIVE = Path("System") / "Session_Learnings"
+
+PENDING = "pending"
+IMPLEMENTED = "implemented"
+DROPPED = "dropped"
+
+_HEADING = re.compile(r"^##\s+\[?(?P<time>\d{1,2}:\d{2})\]?\s*[-–]\s*(?P<title>.+?)\s*$")
+_STATUS = re.compile(r"^\*\*Status:\*\*\s*(?P<status>\w+)", re.IGNORECASE)
+_DAY_FILE = re.compile(r"^(?P<day>\d{4}-\d{2}-\d{2})\.md$")
+
+# Josh's routing table from #503, kept as data so it can be edited without
+# touching code -- which was one of his own open questions.
+DESTINATIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "behavioural",
+        ("stop ", "don't", "do not", "always", "never", "you keep", "instead of",
+         "prefer", "correction", "over-infer", "assume", "check first", "verify"),
+    ),
+    (
+        "skill-defect",
+        ("skill", "/daily-plan", "/daily-review", "/week-plan", "/week-review",
+         "/process-meetings", "/meeting-prep", "step ", "the flow"),
+    ),
+    (
+        "environment-fact",
+        ("mcp", "hook", "launchd", "permission", "index", "timezone", "macos",
+         "path", "environment", "tenant"),
+    ),
+    (
+        "code-defect",
+        ("traceback", "exit code", "returns", "crash", "exception", "silently",
+         "regex", "parser", "null", "none"),
+    ),
+)
+
+DESTINATION_TARGETS = {
+    "behavioural": "CLAUDE-custom.md user-extensions block, and/or a memory file with its index line",
+    "skill-defect": "that skill's SKILL.md, as a real numbered step rather than prose",
+    "environment-fact": "the matching file in .claude/reference/",
+    "code-defect": "fix directly if small and safe, otherwise capture as a backlog idea",
+    "unclassified": "needs a human read; no destination proposed",
+}
+
+
+@dataclass
+class Entry:
+    """One captured learning, with enough location to rewrite its status."""
+
+    day: date
+    time: str
+    title: str
+    body: str
+    status: str
+    source_file: Path
+    line_number: int
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status.lower() == PENDING
+
+    def age_days(self, today: date | None = None) -> int:
+        return ((today or date.today()) - self.day).days
+
+    @property
+    def text(self) -> str:
+        return f"{self.title}\n{self.body}"
+
+
+@dataclass
+class Cluster:
+    """Entries that appear to share a cause, and where they should go.
+
+    Clusters are the point. Josh's observation was that eight related entries
+    about silent failure became one rule, not eight edits, and that the value
+    is in the grouping rather than the volume.
+    """
+
+    kind: str
+    entries: list[Entry] = field(default_factory=list)
+
+    @property
+    def destination(self) -> str:
+        return DESTINATION_TARGETS[self.kind]
+
+    @property
+    def oldest_days(self) -> int:
+        return max((e.age_days() for e in self.entries), default=0)
+
+
+def _classify(text: str) -> str:
+    lowered = text.lower()
+    best, score = "unclassified", 0
+    for kind, needles in DESTINATIONS:
+        hits = sum(1 for n in needles if n in lowered)
+        if hits > score:
+            best, score = kind, hits
+    return best
+
+
+def parse_file(path: Path) -> list[Entry]:
+    """Entries in one day file. A malformed file yields nothing, never raises."""
+    match = _DAY_FILE.match(path.name)
+    if not match:
+        return []
+    try:
+        day = datetime.strptime(match.group("day"), "%Y-%m-%d").date()
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, ValueError, UnicodeDecodeError):
+        return []
+
+    entries: list[Entry] = []
+    current: dict | None = None
+    body: list[str] = []
+
+    def flush() -> None:
+        if current is None:
+            return
+        entries.append(
+            Entry(
+                day=day,
+                time=current["time"],
+                title=current["title"],
+                body="\n".join(body).strip(),
+                status=current["status"],
+                source_file=path,
+                line_number=current["line"],
+            )
+        )
+
+    for index, line in enumerate(lines, start=1):
+        heading = _HEADING.match(line)
+        if heading:
+            flush()
+            body = []
+            current = {
+                "time": heading.group("time"),
+                "title": heading.group("title"),
+                "status": PENDING,
+                "line": index,
+            }
+            continue
+        if current is None:
+            continue
+        status = _STATUS.match(line.strip())
+        if status:
+            current["status"] = status.group("status").lower()
+            continue
+        body.append(line)
+    flush()
+    return entries
+
+
+def read_all(vault_root: Path) -> list[Entry]:
+    folder = vault_root / LEARNINGS_RELATIVE
+    if not folder.is_dir():
+        return []
+    entries: list[Entry] = []
+    for path in sorted(folder.glob("*.md")):
+        entries.extend(parse_file(path))
+    return entries
+
+
+def pending(entries: list[Entry]) -> list[Entry]:
+    return [e for e in entries if e.is_pending]
+
+
+def cluster(entries: list[Entry]) -> list[Cluster]:
+    """Group pending entries by proposed destination, oldest cluster first.
+
+    Grouping is by destination rather than by topic similarity on purpose: two
+    entries that belong in the same file are worth reviewing together even when
+    they read differently, and one that belongs somewhere else is not made
+    easier to handle by sitting next to them.
+    """
+    buckets: dict[str, Cluster] = {}
+    for entry in pending(entries):
+        kind = _classify(entry.text)
+        buckets.setdefault(kind, Cluster(kind=kind)).entries.append(entry)
+    return sorted(buckets.values(), key=lambda c: c.oldest_days, reverse=True)
+
+
+def should_review(
+    entries: list[Entry], *, min_count: int = 10, max_age_days: int = 14, today: date | None = None
+) -> tuple[bool, str]:
+    """Whether a review is due, and the reason to show the user.
+
+    Volume or age, per @davekilleen's spec. Age matters independently because a
+    single correction left for a fortnight is a worse signal than ten from this
+    morning, and a count-only trigger never fires on a slow, steady leak.
+    """
+    outstanding = pending(entries)
+    if not outstanding:
+        return False, "nothing pending"
+    oldest = max(e.age_days(today) for e in outstanding)
+    if len(outstanding) >= min_count:
+        return True, f"{len(outstanding)} learnings pending"
+    if oldest >= max_age_days:
+        return True, f"oldest pending learning is {oldest} days old"
+    return False, f"{len(outstanding)} pending, oldest {oldest} days"
+
+
+def set_status(entry: Entry, status: str, detail: str, *, today: date | None = None) -> bool:
+    """Record an outcome against one entry, in place. Returns whether it changed.
+
+    Only ever called after a human has confirmed the edit. The status line
+    carries where it went or why it was dropped, so a falling count means
+    something was installed rather than something aged out of view.
+    """
+    if status not in (IMPLEMENTED, DROPPED):
+        raise ValueError(f"status must be {IMPLEMENTED!r} or {DROPPED!r}, not {status!r}")
+    stamp = (today or date.today()).isoformat()
+    replacement = f"**Status:** {status} ({stamp} — {detail})"
+
+    try:
+        lines = entry.source_file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+
+    # Search forward from the heading for this entry's own status line, so two
+    # entries in one file can never have their statuses crossed.
+    for index in range(entry.line_number, len(lines)):
+        if _HEADING.match(lines[index]):
+            break
+        if _STATUS.match(lines[index].strip()):
+            lines[index] = replacement
+            try:
+                entry.source_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            except OSError:
+                return False
+            entry.status = status
+            return True
+    return False


### PR DESCRIPTION
**Draft, and offered rather than claimed.** @joshm-simril diagnosed this on #503 and said they'd propose a PR; this is a starting point in case it's useful, not an attempt to take it over. Take it, fork it, or bin it — no feelings either way.

I'm raising it because we hit the same wall from the other side. My capture work (#564, #567, #568) writes corrections into `Session_Learnings/` — and without the routing step they land in a directory that `session-start.sh` never reads. It injects `Mistake_Patterns.md` and `Working_Preferences.md`, so captured entries never reach the next session. Capture without routing is exactly the archive Josh described.

## Built to the spec on #503

@davekilleen asked for: trigger on age or volume, cluster related items, show the exact destination and edit, apply only after confirmation, and mark each item implemented with date and destination or dropped with a reason.

This covers the mechanical half of that:

| Piece | Behaviour |
|---|---|
| **Parse** | Entries from `Session_Learnings`, with enough location to rewrite one status without disturbing its neighbours |
| **Cluster** | By proposed destination rather than wording — two entries belonging in the same file are worth reviewing together even when they read differently |
| **Trigger** | Volume **or** age |
| **Record** | `implemented (date — destination)` or `dropped (date — reason)`; an invented third status is refused |

Josh's routing table is kept **as data, not code**, so it can be edited without touching this module — that was one of his open questions.

## What it deliberately does not do

**It applies nothing.** Dex must never silently rewrite its own instructions, so the edit has to be shown and confirmed before it lands, and confirmation belongs in the skill that can hold a conversation.

That split is the design, not a shortcut: clustering and destination-proposal are mechanical and testable, while deciding whether a proposed edit is *right* is judgement. Mixing them would bury an unreviewable decision inside something that looks like a helper.

## On the open questions from #503

- **Threshold — volume or age?** Both, independently. A single correction left for a fortnight is a worse signal than ten from this morning, and a count-only trigger never fires on a slow, steady leak.
- **`dropped` as a third state?** Kept, and I'd argue for it: without it, stale entries either linger forever or get quietly deleted, and a falling count stops meaning anything.
- **Where should the routing table live?** As data here, for the reason above.
- **One hook or two?** Not addressed — that's a wiring decision and belongs with whoever takes this forward.

## Verification

14 tests, including that two entries in one file can never have their statuses crossed, that a non-day file is ignored, and that the trigger stays quiet on a healthy vault. All twelve `quality` gates pass.