### PR TITLE
fix(connections): stop the credential guard from flagging its own .gitignore

### DIFF
--- a/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
+++ b/core/integrations/connection-manager/connection-manager.phase5a-security.test.cjs
@@ -340,3 +340,48 @@ test('H6: credential writes fail closed when any credentials path is already git
     fs.rmSync(cleanVault, { recursive: true, force: true });
   }
 });
+
+test("H6b: the guard's own .gitignore and README may be tracked without blocking writes", () => {
+  const storePath = path.join(__dirname, 'token-store.cjs');
+  const command = `require(${JSON.stringify(storePath)}).saveApiKey('h6b-test',{apiKey:'FAKE-H6B-KEY'})`;
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-cm-h6b-'));
+  const credentials = path.join(vault, 'System', 'credentials');
+  try {
+    const init = spawnSync('git', ['init', '-q', vault], { encoding: 'utf8' });
+    assert.equal(init.status, 0, init.stderr);
+    fs.mkdirSync(credentials, { recursive: true });
+    // Exactly what ensureCredentialsGitignore() installs — committing these is the point:
+    // the '*' rule is what keeps every real credential out of Git.
+    fs.writeFileSync(path.join(credentials, '.gitignore'), '*\n!.gitignore\n!README.md\n');
+    fs.writeFileSync(path.join(credentials, 'README.md'), 'Credentials live here.\n');
+    const add = spawnSync(
+      'git',
+      ['-C', vault, 'add', '-f', 'System/credentials/.gitignore', 'System/credentials/README.md'],
+      { encoding: 'utf8' }
+    );
+    assert.equal(add.status, 0, add.stderr);
+
+    const result = spawnSync(process.execPath, ['-e', command], {
+      env: { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(path.join(credentials, 'tokens', 'h6b-test.json')), true);
+
+    // A genuine credential file alongside them must still fail closed.
+    fs.writeFileSync(path.join(credentials, 'oauth-apps.json'), '{"leaked":true}\n');
+    const addLeak = spawnSync('git', ['-C', vault, 'add', '-f', 'System/credentials/oauth-apps.json'], {
+      encoding: 'utf8',
+    });
+    assert.equal(addLeak.status, 0, addLeak.stderr);
+    const blocked = spawnSync(process.execPath, ['-e', command], {
+      env: { ...process.env, DEX_VAULT: vault, DEX_CM_NO_KEYCHAIN: '1' },
+      encoding: 'utf8',
+    });
+    assert.notEqual(blocked.status, 0);
+    assert.match(blocked.stderr, /oauth-apps\.json/);
+    assert.doesNotMatch(blocked.stderr, /\.gitignore|README\.md/);
+  } finally {
+    fs.rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/core/integrations/connection-manager/token-store.cjs
+++ b/core/integrations/connection-manager/token-store.cjs
@@ -98,6 +98,9 @@ function ensureCredentialsGitignore(dir) {
   }
 }
 
+// Files the credential guard installs on purpose; tracking these in Git is correct, not a leak.
+const GUARD_FILES = new Set(['.gitignore', 'README.md']);
+
 const _gitSafeCredentialDirs = new Set();
 
 function assertCredentialsNotTracked() {
@@ -123,17 +126,27 @@ function assertCredentialsNotTracked() {
   const relativeCredentialRoot = path.relative(repoRoot, credentialRoot).split(path.sep).join('/');
   let tracked;
   try {
-    tracked = execFileSync('git', ['-C', repoRoot, 'ls-files', '--', relativeCredentialRoot], {
+    // -z keeps unusual path characters verbatim; git would otherwise quote-escape them
+    // and the exact-path comparison below would silently stop matching.
+    tracked = execFileSync('git', ['-C', repoRoot, 'ls-files', '-z', '--', relativeCredentialRoot], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
+    });
   } catch (error) {
     throw new Error(`Cannot verify whether System/credentials is tracked by Git: ${error.message}`);
   }
-  if (tracked) {
+  // The guard files this module installs itself (.gitignore + README.md) are *meant* to be
+  // committed — the .gitignore is what keeps every real credential out of Git. Only genuine
+  // credential material counts as a tracking violation.
+  const allowed = new Set(Array.from(GUARD_FILES, (name) => `${relativeCredentialRoot}/${name}`));
+  const trackedOffenders = tracked
+    .split('\0')
+    .filter(Boolean)
+    .filter((entry) => !allowed.has(entry));
+  if (trackedOffenders.length) {
     throw new Error(
-      `Credential write refused because Git already tracks path(s) under System/credentials:\n${tracked}\n` +
-        `Remove them from Git's index without deleting local files, for example: git rm --cached -r -- ${relativeCredentialRoot}`
+      `Credential write refused because Git already tracks credential path(s) under System/credentials:\n${trackedOffenders.join('\n')}\n` +
+        `Remove them from Git's index without deleting local files, for example: git rm --cached -- ${trackedOffenders.join(' ')}`
     );
   }
   _gitSafeCredentialDirs.add(credentialRoot);

--- a/packages/dex-contracts/dist/connections-engine.manifest.json
+++ b/packages/dex-contracts/dist/connections-engine.manifest.json
@@ -11,8 +11,8 @@
         "connection-manager"
       ],
       "fileCount": 21,
-      "totalBytes": 239876,
-      "treeHash": "172e23653419cb5a45715ac84365906a449e96e2e8527ed98225bf58dadd94fd",
+      "totalBytes": 240701,
+      "treeHash": "1eee1feeb249ab16e28b30ffd1c267755d8e12431067a7209dc4ed247114f8a6",
       "files": [
         {
           "path": "auth-context.cjs",
@@ -116,8 +116,8 @@
         },
         {
           "path": "token-store.cjs",
-          "bytes": 47006,
-          "sha256": "30877cdcb1f7b16124974b88af7c170402eb07cc2cfd784e3b45a33af351764f"
+          "bytes": 47831,
+          "sha256": "12637af4a822b8fa5e315c9e42a8d92b232133b5b6ed23350f79ba0075de2c7e"
         }
       ]
     }


### PR DESCRIPTION
## The problem

Dex refuses to save any credential when Git tracks anything under `System/credentials`. That check is right in spirit, but it counted the guard's *own* files as violations.

`ensureCredentialsGitignore()` deliberately writes a `.gitignore` containing `*`, `!.gitignore`, `!README.md`. That file is the thing keeping every real credential out of Git, and it is meant to be committed alongside its README. The guard saw them in `git ls-files` and refused, so a **correctly protected vault could never save a credential at all**.

Worse, the error told the user to run `git rm --cached -r -- System/credentials`, which would delete the protection and leave the folder exposed on the next write.

Hit in practice while connecting a second Gmail account: `register-app` was blocked on a vault whose credentials directory had never leaked anything.

## The fix

- Exempt exactly `System/credentials/.gitignore` and `System/credentials/README.md`, matched by **exact path**, not basename.
- Switch `git ls-files` to `-z` so unusual path characters are not quote-escaped, which would otherwise break the exact-path comparison.
- The error now lists only real offenders and suggests removing only those, never the guard.

Genuine credential material still fails closed.

## Verification

- `H6b` added: guard files tracked -> write allowed; a tracked `oauth-apps.json` alongside them -> still blocked, message names `oauth-apps.json` and not the guard files.
- Existing `H6` (fail-closed on tracked credentials) still passes unchanged.
- Full connection-manager suite: **226/226 pass**.
- Confirmed the same scenario was blocked on the previous code and is allowed after.
- Engine manifest regenerated.

## Note for the reviewer

`main` currently has an unresolved merge in the working tree from another session, so this is not merged. Built on `v1.79.0` (402e47b5), ready once main is clean.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKgisBJt3QGF58oEzmhybJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e24c5029a9faa34ffff5295b0995bc9edf4078a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->