### PR TITLE
fix: make the first vault-ignore repair safe for older Dex updates

### DIFF
--- a/.github/workflows/historic-fleet-darwin.yml
+++ b/.github/workflows/historic-fleet-darwin.yml
@@ -20,6 +20,7 @@ on:
       - scripts/build-release.sh
       - scripts/build-vault-bundle.sh
       - scripts/check-release-catalog-tag-identity.py
+      - scripts/compose-vault-gitignore.py
       - scripts/dex_update_bridge.py
       - scripts/release_fleet.py
       - scripts/release_fleet_acceptance.py

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -98,6 +98,7 @@ RELEASE_BUILD_INPUTS = (
     "scripts/check-catalog-coverage.py",
     "scripts/check-release-catalog-tag-identity.py",
     "scripts/check-tau-removal.py",
+    "scripts/compose-vault-gitignore.py",
     "scripts/dex_update_bridge.py",
     "scripts/generate-manifest.sh",
     "scripts/generate-release-catalog.py",
@@ -279,6 +280,61 @@ def _build_release_in_clone(
         text=True,
     )
     return clone, set(result.stdout.splitlines())
+
+
+def test_first_release_with_vault_gitignore_repair_tracks_para_files(
+    tmp_path: Path,
+) -> None:
+    """The release bytes must be vault-safe before an older updater writes them.
+
+    A release cannot rely on a composer introduced by that same release: the
+    already-running updater plans and writes the release before its replacement
+    module is installed.  Exercise the built release artifact directly, which
+    is therefore the earliest seam shared by every historic updater.
+    """
+    clone, members = _build_release_in_clone(
+        tmp_path,
+        name="release-vault-gitignore",
+    )
+    assert ".gitignore" in members
+    release_gitignore = subprocess.run(
+        ["git", "show", "release:.gitignore"],
+        cwd=clone,
+        check=True,
+        capture_output=True,
+    ).stdout
+
+    vault = tmp_path / "vault-gitignore"
+    vault.mkdir()
+    (vault / ".gitignore").write_bytes(release_gitignore)
+    user_paths = (
+        "00-Inbox/capture.md",
+        "04-Projects/active.md",
+        "07-Archives/finished.md",
+    )
+    for relative in (*user_paths, ".env", "README.md"):
+        target = vault / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "init", "--quiet"], cwd=vault, check=True)
+
+    user_check = subprocess.run(
+        ["git", "check-ignore", "-v", "--", *user_paths],
+        cwd=vault,
+        capture_output=True,
+        text=True,
+    )
+    assert user_check.returncode == 1, user_check.stdout
+    assert user_check.stdout == ""
+
+    protected_check = subprocess.run(
+        ["git", "check-ignore", "--", ".env", "README.md"],
+        cwd=vault,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert set(protected_check.stdout.splitlines()) == {".env", "README.md"}
 
 
 def _run_tau_check(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -745,6 +801,7 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
         package = json.load(archive.extractfile("./package.json"))
         profile = json.load(archive.extractfile("./System/.release-evidence-profile.json"))
         manifest = archive.extractfile("./System/.installed-files.manifest").read().decode().splitlines()
+        gitignore = archive.extractfile("./.gitignore").read().decode()
         shipped = {
             member.name.removeprefix("./")
             for member in archive.getmembers()
@@ -753,6 +810,9 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
     }
     assert package["version"] == profile["release_version"]
     assert profile["profile"] == "legacy-v1"
+    assert "\n!/04-Projects/\n" in gitignore
+    assert "\n.env\n" in gitignore
+    assert "\n/README.md\n" in gitignore
     for script_name in (
         "test:hooks",
         "test:scripts",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -76,8 +76,9 @@ CATALOG_GENERATOR=$(mktemp)
 CATALOG_COVERAGE_CHECKER=$(mktemp)
 CATALOG_IDENTITY_CHECKER=$(mktemp)
 JOURNEY_PROTOCOL_CHECK=$(mktemp)
+GITIGNORE_COMPOSER=$(mktemp)
 MATCHES_FILE=$(mktemp)
-trap 'rm -f "$DISTIGNORE" "$TAU_CHECKER" "$CATALOG_GENERATOR" "$CATALOG_COVERAGE_CHECKER" "$CATALOG_IDENTITY_CHECKER" "$JOURNEY_PROTOCOL_CHECK" "$MATCHES_FILE"' EXIT
+trap 'rm -f "$DISTIGNORE" "$TAU_CHECKER" "$CATALOG_GENERATOR" "$CATALOG_COVERAGE_CHECKER" "$CATALOG_IDENTITY_CHECKER" "$JOURNEY_PROTOCOL_CHECK" "$GITIGNORE_COMPOSER" "$MATCHES_FILE"' EXIT
 if ! git show "$SOURCE_BRANCH:.distignore" > "$DISTIGNORE"; then
     echo "Error: .distignore not found in selected source '$SOURCE_BRANCH'." >&2
     exit 1
@@ -124,6 +125,7 @@ SOURCE_SHA=$(git rev-parse "$SOURCE_BRANCH")
 git show "$SOURCE_SHA:scripts/generate-release-catalog.py" > "$CATALOG_GENERATOR"
 git show "$SOURCE_SHA:scripts/check-catalog-coverage.py" > "$CATALOG_COVERAGE_CHECKER"
 git show "$SOURCE_SHA:scripts/check-release-catalog-tag-identity.py" > "$CATALOG_IDENTITY_CHECKER"
+git show "$SOURCE_SHA:scripts/compose-vault-gitignore.py" > "$GITIGNORE_COMPOSER"
 SOURCE_PACKAGE_SIZE=$(git cat-file -s "$SOURCE_SHA:package.json" 2>/dev/null || true)
 if ! [[ "$SOURCE_PACKAGE_SIZE" =~ ^[0-9]+$ ]] || [ "$SOURCE_PACKAGE_SIZE" -gt 1048576 ]; then
     echo "Error: selected source package.json is missing or exceeds 1 MiB." >&2
@@ -242,6 +244,14 @@ python3 "$CATALOG_COVERAGE_CHECKER" --release-root "$REPO_ROOT"
 git add -- "$MANIFEST" "$CATALOG" "$BRIDGE_RELEASE" \
     packages/dex-contracts/dist/release-catalog-v1.schema.json \
     packages/dex-contracts/dist/release-catalog-v2.schema.json
+
+# A release must carry vault-safe ignore bytes before an already-running old
+# updater plans it. A composer introduced by this same release arrives one
+# write too late, so make the immutable release artifact safe at build time.
+# Run after every other staging operation because these vault-side rules
+# deliberately ignore release-owned paths such as core/ and packages/.
+python3 "$GITIGNORE_COMPOSER" .gitignore
+git add -- .gitignore
 
 if git diff --cached --quiet; then
     echo "Nothing to remove — release branch matches main."

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -71,6 +71,10 @@ sh "$REPO_ROOT/scripts/resolve-distignore-files.sh" \
 
 rsync -a --files-from="$INCLUDED_FILES" ./ "$STAGING_DIR/"
 
+# Match the release branch exactly: historic updaters can write these bytes
+# before the replacement updater module has been installed.
+python3 "$REPO_ROOT/scripts/compose-vault-gitignore.py" "$STAGING_DIR/.gitignore"
+
 # Keep package metadata identical to the release branch transformation.
 node - "$STAGING_DIR/package.json" <<'NODE'
 const fs = require('node:fs');

--- a/scripts/compose-vault-gitignore.py
+++ b/scripts/compose-vault-gitignore.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Make a release's .gitignore safe before any historic updater can write it."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd()))
+
+from core.update.apply_update import _compose_gitignore
+
+
+def compose_file(path: Path) -> None:
+    target = path.resolve()
+    if path.is_symlink() or not target.is_file():
+        raise RuntimeError(f"release .gitignore is not a regular file: {path}")
+    current = target.read_bytes()
+    composed = _compose_gitignore(current, target.parent)
+    if composed == current:
+        return
+
+    mode = target.stat().st_mode & 0o777
+    temporary = target.parent / f".{target.name}.compose-{os.getpid()}"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        written = 0
+        while written < len(composed):
+            count = os.write(descriptor, composed[written:])
+            if count <= 0:
+                raise OSError("release .gitignore write made no progress")
+            written += count
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.replace(temporary, target)
+        directory = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    compose_file(args.path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Plain English

Updating Dex into the first release that repairs `.gitignore` could still leave the user's personal folders hidden from Git. The running old updater wrote the release's ignore file *before* the new repair code was installed, so the repair arrived one write too late.

This change makes both release artifacts carry the vault-safe ignore file at build time, so an older updater cannot write the broken version. Public Dex stays **v1.96.6**. This PR does not cut a new download. The reporter is not being contacted.

## Evidence

- Uncomposed current `.gitignore` still ignores `04-Projects/` (and other vault folders). After composition those folders are not ignored; `.env` stays ignored.
- `test_first_release_with_vault_gitignore_repair_tracks_para_files` passed against a real `build-release.sh` artifact.
- `test_raw_vault_bundle_has_package_profile_manifest_agreement` passed, including the bundle `.gitignore` assertions.
- Composer unit tests in `test_apply_update.py` re-run on this rebased commit.
- Rebased onto current `main` (`26fa8945`). Conflicts in the historic-fleet path list and `build-release.sh` temp-file cleanup were resolved by keeping both the catalog-identity checker and the new composer.

## Do not

- Do not cut a Dex release from this PR
- Do not contact the reporter
- Do not treat merge as live for existing installs until a later release

Card: `bug-report-dex-update-eb229d20bf` (feedback receipt `dex-feedback-investigation-eb229d20bfc4fee2`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 70d49f3afa49012585099fc3668a614c1f87678f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->