### PR TITLE
fix(update): keep a missing YAML reader from looking like a broken channel

### DIFF
--- a/core/tests/test_lifecycle_service_contract.py
+++ b/core/tests/test_lifecycle_service_contract.py
@@ -8,6 +8,7 @@ import json
 import plistlib
 import re
 import shutil
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -509,6 +510,28 @@ def test_release_delivery_is_non_mutating_and_exposed_only_through_the_lifecycle
         {"vault_root": str(vault)},
         response,
     )
+
+
+def test_release_delivery_reports_missing_channel_reader_dependency(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    profile = vault / "System" / "user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("updates:\n  channel: stable\n", encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    response = service.deliver_latest_release(vault)
+
+    assert response == {
+        "api_version": service.api_version,
+        "status": "not-delivered",
+        "evidence": {
+            "status": "UNKNOWN",
+            "reason": "missing-dependency",
+        },
+    }
 
 
 def test_legacy_release_delivery_operation_is_a_non_mutating_bridge(tmp_path: Path) -> None:

--- a/core/utils/update_verifier.py
+++ b/core/utils/update_verifier.py
@@ -1094,6 +1094,8 @@ class UpdateVerifier:
         self._budget = ExecutionBudget.start(self.wall_clock_seconds)
         self.git.use_budget(self._budget)
         try:
+            if channel == "missing-dependency":
+                return {"status": STATUS_UNKNOWN, "reason": "missing-dependency"}
             if channel not in _VALID_CHANNELS:
                 return {"status": STATUS_UNKNOWN, "reason": "channel-invalid"}
             if channel != "stable":


### PR DESCRIPTION
## Plain English

Dex Update can tell someone their release channel is broken when the real problem is a missing local YAML reader (PyYAML). The profile can correctly say stable. The updater still called that a bad channel, which sends the person looking in the wrong place.

This two-line change keeps the existing `missing-dependency` reason instead of collapsing it into `channel-invalid`. Public Dex stays **v1.96.6**. This PR does not cut a new download. The reporter is not being contacted.

## Evidence

- Deliberate break: without the two-line guard, `deliver_latest_release` returns `channel-invalid` for a valid stable profile when `yaml` is missing.
- With the guard: the same public lifecycle-service call returns `missing-dependency`.
- Cherry-picked cleanly onto current main after PR 572 (`68899f8d`).
- 31 related channel/lifecycle tests passed; Ruff and compilation passed.

## Do not

- Do not cut a Dex release from this PR
- Do not contact the reporter
- Do not treat merge as live for existing installs until a later release

Card: `bug-report-dex-update-22c934f7c7` (feedback receipt `dex-feedback-investigation-22c934f7c711a3e9`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 125efbfe53129988f2948a57e9e012038420450a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->