### PR TITLE
release: v1.96.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.7] — 🧰 Dex still knows who you are after an update, and Mail search checkup stops a false alarm (2026-08-20)
+
+After the first setup, an update could greet you like a stranger. Your name, role, company size, working style, and focus areas snapped back to “Not yet configured,” even though the settings file from setup still had the real values. Nothing warned you. Separately, Mail search checkup could say the search index was broken when the index was actually current, because the checkup process itself could not read Mail.
+
+**What this fixes for you:**
+
+* **Your profile stays after an update.** Dex rereads the settings you already filled in and puts your name, role, company size, working style, and focus areas back into the main instructions. It no longer pretends you never finished setup.
+* **A brand-new folder still starts blank.** Until you finish the first setup, those lines stay empty. Dex does not invent a profile.
+* **The notes you added for yourself still survive.** The personal-instructions block is unchanged.
+* **Mail search checkup no longer calls a current index broken.** If the index is up to date and only the checkup helper cannot see Mail, Dex says it does not know, instead of telling you Mail search is broken.
+
+Amit Godbole caught the profile wipe by reading the update preview. Chris Jackson found the Mail false alarm.
+
 ## [1.96.6] — 🧰 Your promotion score uses real evidence, and Mail search checkup tells the truth (2026-08-17)
 
 The promotion score could look confident while using made-up points. Skills were always 15. Growth was always 5. Evidence sitting in the Evidence folder — the place career setup itself uses — counted as nothing. Separately, Mail search checkup could look healthy when it could not actually see Mail, or when the search index was missing, empty, or unreadable. And if you record meetings with Wispr, Dex already understood those notes, but settings still refused the word Wispr.

--- a/System/.installed-files.manifest
+++ b/System/.installed-files.manifest
@@ -14,6 +14,7 @@
 .claude/hooks/adapters/todoist.cjs
 .claude/hooks/adapters/trello.cjs
 .claude/hooks/career-evidence-capture.cjs
+.claude/hooks/claude-composition-refresh.sh
 .claude/hooks/company-context-injector.cjs
 .claude/hooks/connection-health-checker.cjs
 .claude/hooks/daily-plan-quick-ref.cjs
@@ -1045,6 +1046,7 @@ core/tests/test_capabilities.py
 core/tests/test_career_promotion_readiness.py
 core/tests/test_ci_concurrency_never_cancels_main.py
 core/tests/test_ci_shard_durations.py
+core/tests/test_claude_composition.py
 core/tests/test_commitments_skill.py
 core/tests/test_company_domains.py
 core/tests/test_company_index.py
@@ -1230,6 +1232,7 @@ core/update/journey_protocol.py
 core/utils/__init__.py
 core/utils/apple_mail_health.py
 core/utils/automation_ownership.py
+core/utils/claude_composition.py
 core/utils/company_domains.py
 core/utils/credential_migration_exceptions.json
 core/utils/credential_remediation.py
@@ -1374,6 +1377,7 @@ scripts/check-tau-removal.py
 scripts/check-test-delta.sh
 scripts/check-tracked-ignored.py
 scripts/check_release_assets.py
+scripts/compose-vault-gitignore.py
 scripts/configure-branch-protection.sh
 scripts/connections-consumer-smoke.mjs
 scripts/connections-contract-validation.mjs

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.6"
+  "release_version": "1.96.7"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.6",
+  "release_version": "1.96.7",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.6","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.7","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.6 release,
+Download the versioned bridge and its checksum from the public v1.96.7 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.6/dex-update-bridge-v1.96.6.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.7/dex-update-bridge-v1.96.7.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.6/dex-update-bridge-v1.96.6.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.7/dex-update-bridge-v1.96.7.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.6.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.7.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.6.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.6",
+  "version": "1.96.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.6",
+      "version": "1.96.7",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.6",
+  "version": "1.96.7",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cut complete

Public Dex is stamped as **v1.96.7** on `main`. The download job is still building the public files.

- Merge: `805a8c6212fa5728c526f90e0c0987fd01557dfa` (`release: v1.96.7`)
- Annotated tag `v1.96.7` names that same commit and the same tree (`37870846ec6f9ed45dd0a5496f05ff137c64efd9`)
- `package.json` on `origin/main` is `1.96.7`
- CHANGELOG has the filled 1.96.7 notes (not an empty heading)
- Main CI is running: https://github.com/davekilleen/Dex/actions/runs/32425748398
- `build-release` starts after quality + tests on that run. Do not create a GitHub Release by hand.
- Public download is not live yet. Latest published release is still v1.96.6. Expect 20–40 minutes on macos-latest.

## What testers get

- After an update, Dex rereads the setup profile (name, role, company size, working style, focus areas) instead of greeting you as a stranger. Fixes #574 (merged via #576).
- Mail search checkup no longer calls a current index broken when only the checkup helper cannot read Mail. Fixes #446 (merged via #575).

Amit Godbole caught the profile wipe. Chris Jackson found the Mail false alarm.

Do not comment on those issues from this PR. The public download is not ready yet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43a5bcbd-683f-4874-898c-da9e6e85eb9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43a5bcbd-683f-4874-898c-da9e6e85eb9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

