### PR TITLE
Fix Mac release build: compose gitignore without PyYAML

### DIFF
--- a/core/tests/test_apply_update.py
+++ b/core/tests/test_apply_update.py
@@ -2073,6 +2073,56 @@ def test_composed_gitignore_refuses_non_utf8_release_bytes() -> None:
         apply_update._compose_gitignore(b"\xff\xfe", Path("/unused"))
 
 
+_NO_PYYAML_COMPOSE_GITIGNORE_PROGRAM = r"""
+import sys
+from pathlib import Path
+
+class _BlockYaml:
+    def find_spec(self, name, path=None, target=None):
+        if name == "yaml" or name.startswith("yaml."):
+            raise ImportError("No module named 'yaml' (blocked to reproduce bare python3)")
+        return None
+
+sys.meta_path.insert(0, _BlockYaml())
+
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    pass
+else:
+    raise SystemExit("yaml was importable; the no-pyyaml precondition is not met")
+
+from core.update.apply_update import _compose_gitignore
+
+composed = _compose_gitignore(b"# rules\n", Path("/unused"))
+if not composed.startswith(b"# rules\n"):
+    raise SystemExit("compose-gitignore returned unexpected bytes")
+print("ok")
+"""
+
+
+def test_compose_gitignore_import_does_not_require_pyyaml() -> None:
+    """Mac release builds compose .gitignore with a python3 that has no PyYAML.
+
+    User Profile composition needs yaml. Gitignore composition does not, and
+    scripts/compose-vault-gitignore.py imports _compose_gitignore from this
+    module. A top-level yaml import breaks that job.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(REPO_ROOT), env.get("PYTHONPATH", "")])
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", _NO_PYYAML_COMPOSE_GITIGNORE_PROGRAM],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
 def test_vault_section_assumes_direct_child_exceptions_only() -> None:
     """Guard the contract shape the generator relies on.
 

--- a/core/update/apply_update.py
+++ b/core/update/apply_update.py
@@ -21,8 +21,6 @@ from pathlib import Path
 from time import monotonic as _monotonic
 from typing import Any, Callable
 
-import yaml
-
 from core import portable_contract
 from core.transaction.engine import PlanEntry, Transaction
 from core.utils import release_channel
@@ -155,6 +153,8 @@ def _read_user_profile(vault_root: Path) -> dict[str, Any] | None:
         text = raw.decode("utf-8")
     except UnicodeDecodeError as error:
         raise CompositionError("System/user-profile.yaml is not UTF-8") from error
+    import yaml  # lazy: gitignore composition must import this module without PyYAML
+
     try:
         parsed = yaml.safe_load(text)
     except yaml.YAMLError as error:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Public cut v1.96.7 (`805a8c6`, tag `v1.96.7`) — CI `build-release` on https://github.com/davekilleen/Dex/actions/runs/32425748398 failed while composing the vault gitignore:
  ```
  from core.update.apply_update import _compose_gitignore
  ModuleNotFoundError: No module named 'yaml'
  ```
- No Linear ticket. Do not cut a release from this PR. CEO will cut v1.96.8 after this lands.

## What Changed
- PR 576 added a top-level `import yaml` to `core/update/apply_update.py` for User Profile composition after update.
- The macos `build-release` job runs `npm ci` then `scripts/build-release.sh`. It does not install PyYAML. Gitignore composition does not need yaml.
- This PR lazy-imports `yaml` only inside `_read_user_profile()`, so `scripts/compose-vault-gitignore.py` can import `_compose_gitignore` on a bare python3.
- User Profile-after-update behavior from PR 576 is unchanged.

## Test Plan
- Unit/integration tests added or updated:
  - `test_compose_gitignore_import_does_not_require_pyyaml` blocks `yaml` at import time, then imports `_compose_gitignore` and runs it.
- Negative/error-path tests added or updated:
  - Existing User Profile composition tests in `core/tests/test_apply_update.py` still cover populated, unconfigured, invalid, symlink, and directory profile cases.
- Commands run locally:
  - `python3 -m pytest core/tests/test_apply_update.py -m "not fuzz"` — 81 passed
  - Direct no-yaml import of `_compose_gitignore` succeeded

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass. Quality already passed on this PR.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert this PR. The Mac `build-release` job will fail again on gitignore composition until PyYAML is present or the import is lazy.

## Docs Impact
- Files updated: none
- If none, reason: no user-facing behavior change. Quality + tests already passed on v1.96.7; only the Mac asset build died. Hidden empty GitHub draft for v1.96.7 is left alone.

## Out of scope (deliberate)
- No CHANGELOG / package.json / UPDATE-RESCUE / manifest / tag edits
- No PyYAML install added to the Mac release job
- No release cut, no retag, no Dex.dmg touch
- Do not publish or delete the hidden v1.96.7 draft

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-720dba13-6283-492b-a482-787e96d1e71c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-720dba13-6283-492b-a482-787e96d1e71c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

