### PR TITLE
release: v1.96.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.96.8] — 🧰 Dex still knows who you are after an update, and Mail search checkup stops a false alarm (2026-08-21)
+
+After the first setup, an update could greet you like a stranger. Your name, role, company size, working style, and focus areas snapped back to “Not yet configured,” even though the settings file from setup still had the real values. Nothing warned you. Separately, Mail search checkup could say the search index was broken when the index was actually current, because the checkup process itself could not read Mail.
+
+**What this fixes for you:**
+
+* **Your profile stays after an update.** Dex rereads the settings you already filled in and puts your name, role, company size, working style, and focus areas back into the main instructions. It no longer pretends you never finished setup.
+* **A brand-new folder still starts blank.** Until you finish the first setup, those lines stay empty. Dex does not invent a profile.
+* **The notes you added for yourself still survive.** The personal-instructions block is unchanged.
+* **Mail search checkup no longer calls a current index broken.** If the index is up to date and only the checkup helper cannot see Mail, Dex says it does not know, instead of telling you Mail search is broken.
+
+Amit Godbole caught the profile wipe by reading the update preview. Chris Jackson found the Mail false alarm. v1.96.7 never shipped a Mac file; this is the first download with these fixes.
+
 ## [1.96.7] — 🧰 Dex still knows who you are after an update, and Mail search checkup stops a false alarm (2026-08-20)
 
 After the first setup, an update could greet you like a stranger. Your name, role, company size, working style, and focus areas snapped back to “Not yet configured,” even though the settings file from setup still had the real values. Nothing warned you. Separately, Mail search checkup could say the search index was broken when the index was actually current, because the checkup process itself could not read Mail.

--- a/System/.local-only-preservation-transition.json
+++ b/System/.local-only-preservation-transition.json
@@ -2,5 +2,5 @@
   "schema_version": 2,
   "baseline_version": 3,
   "phase": "untrack-v3",
-  "release_version": "1.96.7"
+  "release_version": "1.96.8"
 }

--- a/System/.release-evidence-profile.json
+++ b/System/.release-evidence-profile.json
@@ -1,5 +1,5 @@
 {
   "profile": "legacy-v1",
-  "release_version": "1.96.7",
+  "release_version": "1.96.8",
   "schema_version": 1
 }

--- a/core/lifecycle/catalog/bridge-release.json
+++ b/core/lifecycle/catalog/bridge-release.json
@@ -1,1 +1,1 @@
-{"bridge_contract_version":1,"release_version":"1.96.7","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}
+{"bridge_contract_version":1,"release_version":"1.96.8","transaction_journal":{"current_schema":2,"incompatible_action":"rollback-only","minimum_resumable_schema":1,"previous_schema":1}}

--- a/docs/UPDATE-RESCUE.md
+++ b/docs/UPDATE-RESCUE.md
@@ -146,23 +146,23 @@ identity. A newer source commit, a mutable branch, or a similarly named tag is
 not equivalent, and an older bridge must refuse rather than silently
 substituting a newer release.
 
-Download the versioned bridge and its checksum from the public v1.96.7 release,
+Download the versioned bridge and its checksum from the public v1.96.8 release,
 verify the bytes, then run that exact artifact. Run this block from the vault
 root. It keeps the downloaded files in a temporary folder outside the vault.
 
 ```bash
 BRIDGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dex-update-bridge.XXXXXX")"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.7/dex-update-bridge-v1.96.7.py" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.8/dex-update-bridge-v1.96.8.py" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.8.py"
 curl -fL \
-  "https://github.com/davekilleen/Dex/releases/download/v1.96.7/dex-update-bridge-v1.96.7.py.sha256" \
-  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py.sha256"
+  "https://github.com/davekilleen/Dex/releases/download/v1.96.8/dex-update-bridge-v1.96.8.py.sha256" \
+  -o "$BRIDGE_DIR/dex-update-bridge-v1.96.8.py.sha256"
 (
   cd "$BRIDGE_DIR"
-  shasum -a 256 -c "dex-update-bridge-v1.96.7.py.sha256"
+  shasum -a 256 -c "dex-update-bridge-v1.96.8.py.sha256"
 )
-python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.7.py" --vault "$PWD"
+python3 "$BRIDGE_DIR/dex-update-bridge-v1.96.8.py" --vault "$PWD"
 ```
 
 It shows up to three independent previews and requires `APPLY` for each: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.7",
+  "version": "1.96.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dex-pkm",
-      "version": "1.96.7",
+      "version": "1.96.8",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/generative-ai": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dex-pkm",
-  "version": "1.96.7",
+  "version": "1.96.8",
   "description": "Dex - Personal Knowledge Management System",
   "private": true,
   "scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Public Dex cut for **v1.96.8**. Dave already approved publishing to production.
- Do not retag or republish v1.96.7. Leave the empty 1.96.7 GitHub draft unpublished.

## What Changed
- Single commit `release: v1.96.8` (`84f96c2d2ca5c7c0f1be2120ed2fb54af2ae259a`) on top of origin/main `8f9d6d31` (PR 578 yaml import fix).
- `package.json` / `package-lock.json` bumped to 1.96.8.
- CHANGELOG latest heading is the approved 1.96.8 copy. The existing 1.96.7 section is unchanged.
- UPDATE-RESCUE, evidence profile, preservation transition, bridge-release, and installed-files manifest stamped by `scripts/release.sh patch`.
- This is the first public download that includes Amit’s profile fix, Chris’s Mail checkup fix, and the yaml import fix. v1.96.7 never shipped a Mac file.

## Why a PR instead of a direct push
`git push origin HEAD:main` was rejected: main requires 2 of 2 status checks. Per the official cut, this PR is the single `release: v1.96.8` commit with the filled CHANGELOG. **No tag was pushed.** Do not tag this branch. Do not create a GitHub Release by hand. Do not run `release_publish.py publish`.

## After merge (required for `build-release`)
1. Confirm origin/main HEAD’s tree is this release tree (`package.json` is 1.96.8).
2. Create annotated tag `v1.96.8` on that exact origin/main HEAD and push it immediately:
   `git push origin refs/tags/v1.96.8`
3. CI `build-release` waits ~60s for that tag and refuses if the tag tree ≠ HEAD tree.

## Test Plan
- Unit/integration tests added or updated: none — this is the official `release.sh` stamp plus the approved CHANGELOG fill.
- Negative/error-path tests added or updated: none needed.
- Commands run locally:
  - Confirmed origin/main was `8f9d6d31` with package.json 1.96.7 and CHANGELOG latest heading 1.96.7.
  - `bash scripts/release.sh patch`
  - Replaced the empty `## [1.96.8] — (date)` heading with the approved copy, amended into the same `release: v1.96.8` commit.
  - Direct `HEAD:main` push rejected by branch protection; local `v1.96.8` tag deleted so this branch is not tagged.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed. Official release stamp only; no behavior change beyond version/CHANGELOG/rescue/manifest files.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases. Did not retag 1.96.7. Did not touch the 1.96.7 draft. Did not tag this branch.
- [x] I updated docs or confirmed no docs impact. CHANGELOG and UPDATE-RESCUE stamped with the release.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): medium — this is the production version stamp. Merging without then tagging origin/main will fail `build-release`.
- Rollback plan: do not merge if another commit lands on main first; rebase this single commit onto current origin/main and restamp only if needed. If merged by mistake before tagging, tag the exact main HEAD tree as `v1.96.8` or cut a later patch. Never retag v1.96.7.

## Docs Impact
- Files updated: `CHANGELOG.md`, `docs/UPDATE-RESCUE.md`, plus the generated release stamps listed above.
- If none, reason: n/a

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-408ab7c2-a7a3-4fa1-8624-cbb45a362e7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-408ab7c2-a7a3-4fa1-8624-cbb45a362e7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

