### PR TITLE
The configs smoke journey can never pass on a vault that uses capability rooms

### DIFF
--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -1981,3 +1981,96 @@ def test_every_runtime_core_path_survives_git_archive() -> None:
         exported = {member.name for member in archive.getmembers() if member.isfile()}
 
     assert sorted(runtime - exported) == []
+
+
+def test_capability_room_ids_returns_none_when_registry_module_is_absent(monkeypatch) -> None:
+    """An unreachable registry is "could not check", never "no rooms exist"."""
+    import builtins
+
+    from core.utils import validators
+
+    real_import = builtins.__import__
+
+    def refuse(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "core" and fromlist and "capabilities" in fromlist:
+            raise ImportError("cannot import name 'capabilities' from 'core'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", refuse)
+    assert validators.capability_room_ids() is None
+
+
+def test_capability_room_ids_returns_none_when_registry_file_is_unreadable(monkeypatch) -> None:
+    """The core-only runner has the module but not the contract it reads."""
+    from core import capabilities
+    from core.utils import validators
+
+    def unreadable() -> set[str]:
+        raise capabilities.CapabilityError("Could not read capability registry: nowhere")
+
+    monkeypatch.setattr(capabilities, "room_ids", unreadable)
+    assert validators.capability_room_ids() is None
+
+
+def test_user_profile_capabilities_are_shape_checked_without_the_registry(monkeypatch) -> None:
+    """A missing registry must not make a healthy configuration look invalid."""
+    from core.utils import validators
+
+    monkeypatch.setattr(validators, "capability_room_ids", lambda: None)
+    config = {
+        "name": "Someone",
+        "email_domain": "example.com",
+        "capabilities": {"anything": {"enabled": True}},
+    }
+    assert validators.validate_user_profile_config(config) == []
+
+    bad_shape = {
+        "name": "Someone",
+        "email_domain": "example.com",
+        "capabilities": {"anything": {"enabled": "yes"}},
+    }
+    assert validators.validate_user_profile_config(bad_shape) == [
+        "capabilities.anything.enabled must be true or false"
+    ]
+
+
+def test_unknown_room_is_still_reported_when_the_registry_is_reachable(monkeypatch) -> None:
+    """The cross-check must keep working wherever the registry can be read."""
+    from core.utils import validators
+
+    monkeypatch.setattr(validators, "capability_room_ids", lambda: {"sales"})
+    config = {
+        "name": "Someone",
+        "email_domain": "example.com",
+        "capabilities": {"not_a_room": {"enabled": True}},
+    }
+    assert validators.validate_user_profile_config(config) == [
+        "capabilities contains unknown room 'not_a_room'"
+    ]
+
+
+def test_configs_journey_passes_and_names_the_skipped_cross_check(tmp_path, monkeypatch) -> None:
+    """Without the registry the journey stays OK and says what it did not check.
+
+    Regression for the configs journey reporting UNKNOWN on every run: the
+    registry is outside the core-only runner, so it can never be read there, and
+    an UNKNOWN verdict stopped the health snapshot completing indefinitely.
+    """
+    from core.utils import validators
+
+    vault = _write_valid_vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8") + "\ncapabilities:\n  anything:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(validators, "capability_room_ids", lambda: None)
+    result = smoke._journey_configs(vault, None)
+    assert result["verdict"] == "OK"
+    assert "were not cross-checked" in result["detail"]
+
+    monkeypatch.setattr(validators, "capability_room_ids", lambda: {"anything"})
+    checked = smoke._journey_configs(vault, None)
+    assert checked["verdict"] == "OK"
+    assert "were not cross-checked" not in checked["detail"]

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -1878,6 +1878,21 @@ def _journey_configs(vault: Path, _release_root: Path) -> dict[str, str]:
 
     if errors:
         return {"verdict": "BROKEN", "detail": "; ".join(errors)}
+    # Name what was not checked. The capability registry lives outside ``core``
+    # and this runner is materialised core-only by design, so the room-name
+    # cross-check cannot run here. That is a bounded gap in an otherwise valid
+    # pass, not a failure: reporting BROKEN would call a healthy configuration
+    # invalid, and reporting UNKNOWN would stop the health snapshot completing
+    # on every vault that uses capability rooms.
+    if validators.capability_room_ids() is None:
+        return {
+            "verdict": "OK",
+            "detail": (
+                f"parsed and validated {checked} configuration files; "
+                "capability room names were not cross-checked because the registry "
+                "is outside the core-only smoke runner"
+            ),
+        }
     return {"verdict": "OK", "detail": f"parsed and validated {checked} configuration files"}
 
 

--- a/core/utils/validators.py
+++ b/core/utils/validators.py
@@ -72,17 +72,16 @@ def validate_user_profile_config(config: object) -> list[str]:
             errors.append("feedback.review_mode must be always-review or auto-send")
     capabilities = config.get("capabilities")
     if isinstance(capabilities, Mapping):
-        from core.capabilities import room_ids
-
-        declared = set(room_ids())
         for room, state in capabilities.items():
-            if room not in declared:
-                errors.append(f"capabilities contains unknown room {room!r}")
-                continue
             if not isinstance(state, Mapping):
                 errors.append(f"capabilities.{room} must be an object")
             elif not isinstance(state.get("enabled"), bool):
                 errors.append(f"capabilities.{room}.enabled must be true or false")
+        declared = capability_room_ids()
+        if declared is not None:
+            for room in capabilities:
+                if room not in declared:
+                    errors.append(f"capabilities contains unknown room {room!r}")
     return errors
 
 
@@ -237,3 +236,29 @@ def validate_mcp_config(config: object) -> list[str]:
 
     errors.extend(_placeholder_errors(parsed))
     return errors
+
+
+def capability_room_ids() -> set[str] | None:
+    """Known capability room ids, or ``None`` when the registry is unreachable.
+
+    ``None`` is "could not check", never "no rooms exist". The registry lives in
+    ``packages/dex-contracts/``, outside ``core``, and the smoke runner is
+    materialised core-only by design, so inside a journey subprocess this is
+    legitimately unreachable however complete the runner is. Callers must treat
+    ``None`` as an unchecked condition and say so, rather than reporting the
+    user's configuration as invalid.
+    """
+    try:
+        from core import capabilities as capability_registry
+
+        return set(capability_registry.room_ids())
+    except ImportError:
+        # ImportError, not ModuleNotFoundError: when ``core`` imports but the
+        # submodule is absent -- the smoke runner's fallback tree -- Python
+        # raises the parent class.
+        return None
+    except ValueError:
+        # CapabilityError subclasses ValueError. Catching the base deliberately:
+        # naming CapabilityError here would raise NameError on the import-failed
+        # path, where the class was never bound.
+        return None


### PR DESCRIPTION
## What this fixes for you

If you have capability rooms switched on, Dex's nightly self-checkup has been failing one of its six checks every single night, and quietly refusing to publish a health result because of it.

- **Your health status starts working again.** The checkup could never finish, so the last complete snapshot on my vault was eight days old while every session start told me health was "critical". The scheduled job was running fine and exiting cleanly the whole time.
- **Dex stops blaming itself for something it cannot do here.** The old message read "Dex's own code could not be loaded. This is a Dex checkup fault", which sounds like a broken install. Nothing was broken.
- **Your configuration is not called invalid.** One check that cannot run in this context no longer costs you the whole file's validation.

## The cause

`validate_user_profile_config` cross-checks capability room names against the registry in `packages/dex-contracts/`. That is outside `core`, and the smoke runner is materialised **core-only by design** — `_materialize_runner` refuses any path whose first part is not `core`, and `_git_tree_paths` scopes its listing to `-- core`. So inside a journey subprocess the registry is unreachable no matter how complete the runner is.

It surfaces two ways, one cause:

| Where | What happens |
|---|---|
| `core` absent from the vault Git tree (every vault, since the composed `.gitignore` ignores `/core/*`) | runner falls back to `RUNNER_FALLBACK_RELATIVES`, which has no `core/capabilities.py`; the lazy import raises `ModuleNotFoundError` |
| `core` tracked | module present, contract file still absent; `room_ids()` raises `CapabilityError` |

I verified both by rebuilding the nine-file fallback tree and a full 390-file `core` tree and running the validator in each.

## The fix

Separate "could not check" from "invalid".

`capability_room_ids()` returns `None` when the registry is unreachable. Shape checks run regardless. The journey passes and names the one cross-check it could not perform.

Reporting `BROKEN` would call a healthy configuration invalid. Staying `UNKNOWN` keeps the health snapshot from ever completing. Neither is right for a bounded gap in an otherwise valid pass.

The cross-check itself is unchanged wherever the registry can be read.

## Verification

- 5 new tests: registry-absent, registry-unreadable, shape-checks-without-registry, unknown-room-still-caught, and the journey verdict both ways.
- `core/tests/test_smoke.py`: 69 passed. `test_hanging_preparation_is_killed_within_the_journey_budget` fails, and **fails identically on clean `upstream/main`** — pre-existing, not from this change.
- End to end on a real vault, `configs` goes from `UNKNOWN` to `OK: parsed and validated 4 configuration files; capability room names were not cross-checked because the registry is outside the core-only smoke runner`.
- `ruff check` clean on all three touched files.

## Noted in passing, not fixed here

`RUNNER_FALLBACK_RELATIVES` has drifted from its own import graph. Walking the transitive `core` imports of its nine members finds four missing: `core/capabilities.py`, `core/lens_catalog_sources.py`, `core/utils/local_git.py`, `core/utils/mcp_handshake.py`.

I deliberately did **not** complete that list here. Adding `core/capabilities.py` alone converts a caught `ModuleNotFoundError` into an uncaught `CapabilityError`, which is worse. Happy to send the list plus an import-closure test as a separate PR if you want it.