### PR TITLE
Routine analytics receipts evict the snapshots a user would actually rewind

### DIFF
--- a/core/tests/test_transaction_core.py
+++ b/core/tests/test_transaction_core.py
@@ -1371,3 +1371,53 @@ def test_commit_prunes_to_last_three_snapshots(tmp_path: Path) -> None:
     tx_root = vault / "System/.dex/tx"
     remaining = [p for p in tx_root.iterdir() if p.is_dir()]
     assert len(remaining) == 3
+
+
+def _committed_tx_operations(vault: Path) -> list[str | None]:
+    """The BEGIN operation of every surviving committed transaction, oldest first."""
+    operations: list[str | None] = []
+    for candidate in sorted((vault / "System" / ".dex" / "tx").iterdir()):
+        if not candidate.is_dir():
+            continue
+        entries = Journal(candidate / "journal.jsonl").read()
+        if not any(entry.event == "COMMITTED" for entry in entries):
+            continue
+        begin = next((entry for entry in entries if entry.event == "BEGIN"), None)
+        operations.append(begin.payload.get("operation") if begin else None)
+    return operations
+
+
+def test_bookkeeping_transactions_do_not_evict_rewindable_snapshots(tmp_path: Path) -> None:
+    """Retention is per class, so routine receipts cannot cost a user their undo.
+
+    ``analytics-receipt`` is written on every session start. Sharing one
+    keep-last-3 budget meant three ordinary session opens evicted an adoption
+    snapshot, after which ``rewind_adoption`` refuses with "no longer available
+    under keep-last-3 retention" through no action of the user's.
+    """
+    vault = _vault(tmp_path)
+    for index in range(3):
+        Transaction.begin(
+            vault,
+            [PlanEntry("System/.installed-files.manifest", f"manifest {index}\n".encode())],
+        ).run()
+    assert _committed_tx_operations(vault).count("update") == 3
+
+    receipt = portable_contract.ANALYTICS_ATTEMPT_RECEIPT_RELATIVE
+    for index in range(6):
+        Transaction.begin(
+            vault,
+            [PlanEntry(receipt, f"{{\"n\": {index}}}\n".encode())],
+            operation="analytics-receipt",
+            max_read_bytes_by_relative={
+                receipt: portable_contract.ANALYTICS_ATTEMPT_RECEIPT_TRANSACTION_MAX_BYTES
+            },
+        ).run()
+
+    surviving = _committed_tx_operations(vault)
+    assert surviving.count("update") == 3, (
+        "routine bookkeeping evicted a rewindable snapshot: " f"{surviving}"
+    )
+    assert surviving.count("analytics-receipt") == 3, (
+        "bookkeeping should keep its own newest three, not grow without bound: " f"{surviving}"
+    )

--- a/core/transaction/engine.py
+++ b/core/transaction/engine.py
@@ -46,6 +46,13 @@ from core.transaction.snapshot import Snapshot
 TX_ROOT_RELATIVE = Path("System") / ".dex" / "tx"
 
 
+# Operations that only append their own small receipt. They are committed and
+# byte-verified like any other transaction, but there is nothing in them a user
+# would ask to undo, so they must not consume the retention budget that adoption
+# and release snapshots depend on. See ``Transaction._prune_committed``.
+BOOKKEEPING_OPERATIONS = frozenset({"analytics-receipt", "automation-ownership"})
+
+
 class TransactionError(RuntimeError):
     """The transaction could not proceed safely."""
 
@@ -570,20 +577,41 @@ class Transaction:
         """Retention (owner decision, lean): keep the newest ``keep`` COMMITTED
         transactions' snapshots for undo; delete older COMMITTED ones. Only
         transactions that verifiably reached COMMITTED are ever pruned —
-        anything unreadable or unfinished is left for resume()."""
+        anything unreadable or unfinished is left for resume().
+
+        ``keep`` is applied per class. Bookkeeping operations append a receipt
+        line and have nothing a user would ever ask to rewind, but they are
+        frequent: ``analytics-receipt`` alone fires on every session start. When
+        they shared one budget with the operations that matter, three ordinary
+        session opens were enough to evict an adoption snapshot, and
+        ``rewind_adoption`` would then refuse with "no longer available under
+        keep-last-3 retention" through no action of the user's. Counting the two
+        classes separately keeps the documented promise -- rewind available
+        while the snapshot is among the newest three -- true against the
+        operations that promise is about.
+        """
         tx_root = self.vault_root / TX_ROOT_RELATIVE
-        committed: list[Path] = []
+        rewindable: list[Path] = []
+        bookkeeping: list[Path] = []
         for candidate in sorted(tx_root.iterdir()):
             if not candidate.is_dir():
                 continue
             try:
-                events = {entry.event for entry in Journal(candidate / "journal.jsonl").read()}
+                entries = Journal(candidate / "journal.jsonl").read()
             except JournalCorruptError:
                 continue
-            if "COMMITTED" in events:
-                committed.append(candidate)
-        for stale in committed[:-keep] if keep else committed:
-            shutil.rmtree(stale, ignore_errors=True)
+            if not any(entry.event == "COMMITTED" for entry in entries):
+                continue
+            operation = None
+            for entry in entries:
+                if entry.event == "BEGIN":
+                    operation = entry.payload.get("operation")
+                    break
+            bucket = bookkeeping if operation in BOOKKEEPING_OPERATIONS else rewindable
+            bucket.append(candidate)
+        for group in (rewindable, bookkeeping):
+            for stale in group[:-keep] if keep else group:
+                shutil.rmtree(stale, ignore_errors=True)
 
     # -- recovery / undo -------------------------------------------------------
 


### PR DESCRIPTION
## What this fixes for you

If an update or a change to your setup goes wrong, Dex offers to put it back. That offer currently expires far sooner than anyone intends — often within minutes of ordinary use, without you doing anything at all.

- **Your undo lasts as long as it says it does.** Dex keeps the last three snapshots. The catch is that routine record-keeping was counted in those three, and Dex writes one of those records every time you open a session.
- **Nothing changes about how much disk this uses.** Record-keeping snapshots are still kept, just counted separately.

## What I measured

An update committed its snapshot at 00:38 and reported it present, rewind available. By 09:33 the directory held three transactions, **all `analytics-receipt`**, written between 09:30 and 09:33 that morning. The update's snapshot was gone. Nothing happened in between except opening Dex.

`analytics-receipt` is written for `session_started`, `task_created`, `task_completed` and `idea_implemented`. Recent counts on this vault:

| Date | Receipts |
|---|---|
| 14 Aug | 3 |
| **17 Aug** | **30** |
| 18 Aug | 4 |
| 19 Aug | 13 |
| 20 Aug | 4 |

Three is the whole budget.

## Why it reads as correct behaviour

`rewind_adoption` refuses with:

> the adoption snapshot is no longer available under keep-last-3 retention; this adoption can no longer be rewound

which sounds like a policy working as designed rather than telemetry having spent the budget.

`/dex-update` states the caveat honestly — *"rewind remains available while its snapshot is retained among the newest three"* — but a reader hears three meaningful operations, not three session opens. And the only retention signal `read_lifecycle_state` exposes is `warning_threshold_bytes: 2147483648` against **52 KB** of actual usage, so the size warning can never fire while the thing that actually removes the snapshot is invisible.

## The change

`_prune_committed` applies `keep` per class. `BOOKKEEPING_OPERATIONS` (`analytics-receipt`, `automation-ownership`) append their own small receipt and hold nothing a user would ask to undo. They keep their own newest three and can no longer evict an adoption or release snapshot.

The `keep=3` policy itself is untouched, and so is the disk footprint.

## Verification

- New test builds three `update` transactions then six `analytics-receipt` ones and asserts all three rewindable snapshots survive.
- **Negative control**: reverting only `engine.py` and keeping the test fails with `routine bookkeeping evicted a rewindable snapshot: ['analytics-receipt', 'analytics-receipt', 'analytics-receipt']` — the reported failure exactly.
- `test_transaction_core.py`, `test_adoption_transaction.py`, `test_provision_transaction.py`: **103 passed**.
- `ruff check` clean.

## Related

There is a larger question next door that I have written up as #585 rather than a PR, since the fix is a design decision: a release update writes no adoption receipt at all, so `/dex-rollback` has nothing to rewind after an update regardless of retention. This PR is worth having either way — it fixes the paths that *are* rewindable today.