### PR TITLE
Fix Obsidian sync setup reporting success while the Mac daemon crash-loops

### DIFF
--- a/core/obsidian/install_sync_daemon.sh
+++ b/core/obsidian/install_sync_daemon.sh
@@ -4,7 +4,9 @@
 set -e  # Exit on error
 
 VAULT_PATH="${VAULT_PATH:-$(pwd)}"
-PLIST_PATH="$HOME/Library/LaunchAgents/com.dex.obsidian-sync.plist"
+LABEL="com.dex.obsidian-sync"
+PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL.plist"
+PINNED_PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin"
 
 # Never point machine-wide background jobs at a temporary checkout. A git
 # worktree marks .git as a file; a real clone or plain vault does not.
@@ -26,10 +28,19 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
     exit 1
 fi
 
-# Check if watchdog is installed
-if ! python3 -c "import watchdog" 2>/dev/null; then
+# launchd does not inherit the user's shell PATH. Pin the same supported
+# interpreter for dependency setup and the background job.
+PYTHON_BIN="$(command -v python3 || true)"
+if [[ -z "$PYTHON_BIN" ]] || ! "$PYTHON_BIN" -c "import sys; raise SystemExit(sys.version_info < (3, 10))" 2>/dev/null; then
+    echo "Error: Obsidian sync requires Python 3.10 or newer."
+    echo "Install a current Python, then run this installer again."
+    exit 1
+fi
+
+# Check if watchdog is installed for the exact interpreter launchd will run.
+if ! "$PYTHON_BIN" -c "import watchdog" 2>/dev/null; then
     echo "Installing watchdog package..."
-    pip3 install watchdog
+    "$PYTHON_BIN" -m pip install watchdog
 fi
 
 echo "Installing Dex Obsidian Sync Daemon..."
@@ -44,16 +55,18 @@ cat > "$PLIST_PATH" <<EOF
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.dex.obsidian-sync</string>
+    <string>$LABEL</string>
     <key>ProgramArguments</key>
     <array>
-        <string>python3</string>
+        <string>$PYTHON_BIN</string>
         <string>$VAULT_PATH/core/obsidian/sync_daemon.py</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
         <key>VAULT_PATH</key>
         <string>$VAULT_PATH</string>
+        <key>PATH</key>
+        <string>$PINNED_PATH</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
@@ -68,7 +81,7 @@ cat > "$PLIST_PATH" <<EOF
 EOF
 
 # Unload existing agent if running
-if launchctl list | grep -q "com.dex.obsidian-sync"; then
+if launchctl list | grep -q "$LABEL"; then
     echo "Stopping existing daemon..."
     launchctl unload "$PLIST_PATH" 2>/dev/null || true
 fi
@@ -77,9 +90,11 @@ fi
 echo "Starting daemon..."
 launchctl load "$PLIST_PATH"
 
-# Wait a moment and check if it started
+# Wait a moment and check whether it stayed running. A crash-looping launchd
+# job still appears in `launchctl list`, but its last exit status is non-zero.
 sleep 2
-if launchctl list | grep -q "com.dex.obsidian-sync"; then
+DAEMON_STATUS="$(launchctl list | awk -v label="$LABEL" '$3 == label { print $2; exit }')"
+if [[ "$DAEMON_STATUS" == "0" ]]; then
     echo ""
     echo "✅ Sync daemon installed and started successfully!"
     echo ""
@@ -95,7 +110,11 @@ if launchctl list | grep -q "com.dex.obsidian-sync"; then
     echo "The daemon will automatically start on login."
 else
     echo ""
-    echo "⚠️  Daemon may not have started successfully."
+    if [[ -n "$DAEMON_STATUS" ]]; then
+        echo "⚠️  Daemon exited with exit status $DAEMON_STATUS."
+    else
+        echo "⚠️  Daemon may not have started successfully."
+    fi
     echo "Check the error log: $VAULT_PATH/System/obsidian-sync-error.log"
     exit 1
 fi

--- a/core/tests/test_obsidian_sync_installer.py
+++ b/core/tests/test_obsidian_sync_installer.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "core" / "obsidian" / "install_sync_daemon.sh"
+LABEL = "com.dex.obsidian-sync"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _run_installer(
+    tmp_path: Path,
+    *,
+    launch_status: int = 0,
+    supported_python: bool = True,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    fake_bin = tmp_path / "bin"
+    calls = tmp_path / "calls.log"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    (vault / "System").mkdir(parents=True)
+    fake_bin.mkdir()
+
+    version_exit = 0 if supported_python else 1
+    python = fake_bin / "python3"
+    _write_executable(
+        python,
+        f"""#!/bin/bash
+printf 'python3:%s\\n' "$*" >> "$CALL_LOG"
+if [[ "$*" == *"sys.version_info"* ]]; then exit {version_exit}; fi
+if [[ "$1" == "-c" && "$2" == "import watchdog" ]]; then exit 1; fi
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" && "$4" == "watchdog" ]]; then exit 0; fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "pip3",
+        """#!/bin/bash
+printf 'pip3:%s\n' "$*" >> "$CALL_LOG"
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "launchctl",
+        f"""#!/bin/bash
+printf 'launchctl:%s\\n' "$*" >> "$CALL_LOG"
+case "$1" in
+  list) printf '%s\\n' $'-\\t{launch_status}\\t{LABEL}' ;;
+  load|unload) exit 0 ;;
+  *) exit 2 ;;
+esac
+""",
+    )
+    _write_executable(fake_bin / "sleep", "#!/bin/bash\nexit 0\n")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CALL_LOG": str(calls),
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "VAULT_PATH": str(vault),
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'OSTYPE=darwin; source "$1"',
+            "obsidian-installer-test",
+            str(INSTALLER),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    plist = home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+    return result, plist, calls
+
+
+def test_installer_pins_and_reuses_one_supported_python(tmp_path: Path) -> None:
+    result, plist, calls = _run_installer(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    with plist.open("rb") as handle:
+        payload = plistlib.load(handle)
+    selected_python = str(tmp_path / "bin" / "python3")
+    assert payload["ProgramArguments"][0] == selected_python
+    assert "PATH" in payload["EnvironmentVariables"]
+    assert "python3:-m pip install watchdog" in calls.read_text()
+    assert "pip3:" not in calls.read_text()
+
+
+def test_installer_rejects_python_older_than_runtime_requires(tmp_path: Path) -> None:
+    result, plist, _calls = _run_installer(tmp_path, supported_python=False)
+
+    assert result.returncode == 1
+    assert "Python 3.10 or newer" in result.stdout
+    assert not plist.exists()
+
+
+def test_installer_does_not_report_success_for_crash_loop(tmp_path: Path) -> None:
+    result, _plist, _calls = _run_installer(tmp_path, launch_status=1)
+
+    assert result.returncode == 1
+    assert "installed and started successfully" not in result.stdout
+    assert "exit status 1" in result.stdout


### PR DESCRIPTION
## Plain English

Obsidian setup step 6 could say the Mac background sync installed successfully while the installed job immediately exited and launchd kept restarting it. Setup looked done; the feature was not running.

Cause: the installer wrote bare `python3` into the LaunchAgent. launchd does not use the user's shell PATH, so Apple Python 3.9 could be selected, crash, and still count as "started" because the installer only checked that the job label existed.

## Fix

- Pin one verified Python 3.10+ interpreter for watchdog install and the LaunchAgent
- Refuse older Python
- Treat a non-zero launchd last-exit status as failure, not success

Cherry-picked onto current `main` (`v1.96.8`) from verified local commit `930e801`. Independent re-run here: 3 new installer tests, 9 sync-daemon tests, and 36 Doctor job/plist tests passed; `bash -n` clean. No reporter contact. No Dex cut in this PR.

## Tests

- `core/tests/test_obsidian_sync_installer.py` — bare-python pin, Python 3.9 rejected, crash-loop is not success
- Existing `test_sync_daemon.py` and Doctor job/plist coverage

Mission Control: `bug-report-dex-obsidian-setup-step-6-core-obsidian-install--3a2eb47000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS LaunchAgent install for a background daemon (interpreter, PATH, pip). Scope is small and installer-only, but a bad pin could leave sync not running.
> 
> **Overview**
> Stops Obsidian Mac setup from reporting success when the background sync job immediately crash-loops.
> 
> The installer now resolves a **Python 3.10+** interpreter, installs `watchdog` with that same binary, and writes the absolute path plus a pinned `PATH` into the LaunchAgent plist instead of bare `python3`. Older Python is rejected before the plist is written.
> 
> Success is based on launchd’s last exit status being `0`, not merely that the job label exists. New installer tests cover interpreter pinning, Python 3.9 rejection, and crash-loop failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d954f8328a5cda19f45d8adab9f12508ec7e88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->