### PR TITLE
Stop Obsidian setup rewriting Dex files in a fresh vault

### DIFF
--- a/core/obsidian/migrate_to_wikilinks.py
+++ b/core/obsidian/migrate_to_wikilinks.py
@@ -11,6 +11,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.portable_contract import ContractViolation, resolve
+
 try:
     from tqdm import tqdm
     HAS_TQDM = True
@@ -19,17 +25,37 @@ except ImportError:
 
 BASE_DIR = Path(os.environ.get('VAULT_PATH', Path.cwd()))
 
+
+def _entity_files(directory: Path):
+    """Yield real entity pages, never the shipped folder placeholder."""
+    if not directory.exists():
+        return
+    for entity_file in directory.rglob('*.md'):
+        if entity_file.name.casefold() != 'readme.md':
+            yield entity_file
+
+
+def _is_migratable_markdown(path: Path) -> bool:
+    """Only user-owned or seeded vault content may be rewritten."""
+    if path.is_symlink():
+        return False
+    try:
+        relative = path.relative_to(BASE_DIR).as_posix()
+        resolution = resolve(relative)
+    except (ContractViolation, ValueError):
+        return False
+    return not resolution.denied and resolution.ownership in {'seed', 'vault'}
+
 # Build indices for smart conversion
 def build_person_index() -> dict:
     """Build index of all person filenames"""
     people_dir = BASE_DIR / '05-Areas' / 'People'
     index = {}
     
-    if people_dir.exists():
-        for person_file in people_dir.rglob('*.md'):
-            name = person_file.stem  # e.g., John_Doe
-            rel_path = person_file.relative_to(BASE_DIR)
-            index[name] = str(rel_path)
+    for person_file in _entity_files(people_dir):
+        name = person_file.stem  # e.g., John_Doe
+        rel_path = person_file.relative_to(BASE_DIR)
+        index[name] = str(rel_path)
     
     return index
 
@@ -38,11 +64,10 @@ def build_project_index() -> dict:
     projects_dir = BASE_DIR / '04-Projects'
     index = {}
     
-    if projects_dir.exists():
-        for proj_file in projects_dir.rglob('*.md'):
-            name = proj_file.stem
-            rel_path = proj_file.relative_to(BASE_DIR)
-            index[name] = str(rel_path)
+    for proj_file in _entity_files(projects_dir):
+        name = proj_file.stem
+        rel_path = proj_file.relative_to(BASE_DIR)
+        index[name] = str(rel_path)
     
     return index
 
@@ -51,11 +76,10 @@ def build_company_index() -> dict:
     companies_dir = BASE_DIR / '05-Areas' / 'Companies'
     index = {}
     
-    if companies_dir.exists():
-        for comp_file in companies_dir.rglob('*.md'):
-            name = comp_file.stem
-            rel_path = comp_file.relative_to(BASE_DIR)
-            index[name] = str(rel_path)
+    for comp_file in _entity_files(companies_dir):
+        name = comp_file.stem
+        rel_path = comp_file.relative_to(BASE_DIR)
+        index[name] = str(rel_path)
     
     return index
 
@@ -64,13 +88,19 @@ def convert_references_in_file(content: str, person_idx: dict,
     """Convert plain text references to wiki links. Returns (new_content, num_changes)"""
     changes = 0
     
-    # Skip code blocks
-    code_blocks = []
-    def save_code_block(match):
-        code_blocks.append(match.group(0))
-        return f"__CODE_BLOCK_{len(code_blocks)-1}__"
+    # Skip fenced blocks and inline code spans.
+    code_spans = []
+    def save_code_span(match):
+        code_spans.append(match.group(0))
+        return f"__CODE_SPAN_{len(code_spans)-1}__"
     
-    content = re.sub(r'```.*?```', save_code_block, content, flags=re.DOTALL)
+    content = re.sub(r'```.*?```', save_code_span, content, flags=re.DOTALL)
+    content = re.sub(
+        r'(?P<ticks>`+).*?(?P=ticks)',
+        save_code_span,
+        content,
+        flags=re.DOTALL,
+    )
     
     # Convert person references (Firstname_Lastname pattern)
     for person_name, person_path in person_idx.items():
@@ -104,9 +134,9 @@ def convert_references_in_file(content: str, person_idx: dict,
         content = re.sub(pattern, r'[[^\1]]', content)
         changes += matches
     
-    # Restore code blocks
-    for i, block in enumerate(code_blocks):
-        content = content.replace(f"__CODE_BLOCK_{i}__", block)
+    # Restore code blocks and inline spans.
+    for i, span in enumerate(code_spans):
+        content = content.replace(f"__CODE_SPAN_{i}__", span)
     
     return content, changes
 
@@ -121,7 +151,48 @@ def estimate_migration(files: List[Path]) -> str:
         minutes = int(est_seconds / 60)
         return f"~{minutes} minute{'s' if minutes > 1 else ''}"
 
-def migrate_vault(dry_run: bool = False):
+
+def create_git_backup() -> tuple[str, bool]:
+    """Capture the exact pre-migration state and return its commit plus creation flag."""
+    add = subprocess.run(
+        ['git', 'add', '-A'],
+        cwd=BASE_DIR,
+        capture_output=True,
+        text=True,
+    )
+    if add.returncode != 0:
+        raise RuntimeError(add.stderr.strip() or 'git could not stage the vault')
+
+    staged = subprocess.run(
+        ['git', 'diff', '--cached', '--quiet', '--'],
+        cwd=BASE_DIR,
+    )
+    if staged.returncode not in (0, 1):
+        raise RuntimeError('git could not verify the staged backup state')
+
+    created = staged.returncode == 1
+    if created:
+        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+        commit = subprocess.run(
+            ['git', 'commit', '-m', f'Backup before Obsidian migration - {timestamp}'],
+            cwd=BASE_DIR,
+            capture_output=True,
+            text=True,
+        )
+        if commit.returncode != 0:
+            raise RuntimeError(commit.stderr.strip() or commit.stdout.strip() or 'git could not create the backup commit')
+
+    baseline = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=BASE_DIR,
+        capture_output=True,
+        text=True,
+    )
+    if baseline.returncode != 0:
+        raise RuntimeError(baseline.stderr.strip() or 'git could not identify the backup commit')
+    return baseline.stdout.strip(), created
+
+def migrate_vault(dry_run: bool = False) -> int:
     """Main migration function"""
     print("Dex Obsidian Migration\n" + "="*50)
     
@@ -136,7 +207,10 @@ def migrate_vault(dry_run: bool = False):
     
     # Find all markdown files
     print("\nScanning vault...")
-    md_files = list(BASE_DIR.rglob('*.md'))
+    md_files = [
+        path for path in BASE_DIR.rglob('*.md')
+        if _is_migratable_markdown(path)
+    ]
     print(f"  Found {len(md_files)} markdown files")
     print(f"  Estimated time: {estimate_migration(md_files)}")
     
@@ -146,11 +220,18 @@ def migrate_vault(dry_run: bool = False):
     input("\nPress Enter to continue...")
     
     # Create backup via git
+    backup_ref = None
     if not dry_run:
         print("\nCreating backup...")
-        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
-        subprocess.run(['git', 'add', '-A'], cwd=BASE_DIR)
-        subprocess.run(['git', 'commit', '-m', f'Backup before Obsidian migration - {timestamp}'], cwd=BASE_DIR)
+        try:
+            backup_ref, backup_created = create_git_backup()
+        except RuntimeError as error:
+            print(f"Backup failed; no files were changed: {error}")
+            return 1
+        if backup_created:
+            print(f"  Backup commit created: {backup_ref}")
+        else:
+            print(f"  No new commit needed; the vault was already captured at {backup_ref}")
     
     # Process files
     print("\nConverting files...")
@@ -182,7 +263,11 @@ def migrate_vault(dry_run: bool = False):
     print(f"  Total conversions: {total_changes}")
     
     if not dry_run:
-        print("\nBackup saved. To revert: git reset --hard HEAD~1")
+        print(f"\nBackup baseline: {backup_ref}")
+        print(
+            "To revert these changes without rewriting history: "
+            f"git restore --source={backup_ref} --worktree -- ."
+        )
         
         # macOS notification
         subprocess.run([
@@ -196,6 +281,8 @@ def migrate_vault(dry_run: bool = False):
     else:
         print("\n[DRY RUN] No files were modified. Run without --dry-run to apply changes.")
 
+    return 0
+
 if __name__ == '__main__':
     dry_run = '--dry-run' in sys.argv
-    migrate_vault(dry_run=dry_run)
+    raise SystemExit(migrate_vault(dry_run=dry_run))

--- a/core/tests/test_obsidian_wikilink_migration.py
+++ b/core/tests/test_obsidian_wikilink_migration.py
@@ -18,7 +18,7 @@ def _write(path: Path, content: str) -> None:
 
 def _git(vault: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", "-c", "user.name=Dex Test", "-c", "user.email=test@example.invalid", *args],
+        ["git", "-c", "user.name=Dex Test", "-c", "user.email=test@example.com", *args],
         cwd=vault,
         check=True,
         capture_output=True,

--- a/core/tests/test_obsidian_wikilink_migration.py
+++ b/core/tests/test_obsidian_wikilink_migration.py
@@ -1,0 +1,85 @@
+"""Command-level coverage for the Obsidian wiki-link migration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_SCRIPT = REPO_ROOT / "core/obsidian/migrate_to_wikilinks.py"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _git(vault: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-c", "user.name=Dex Test", "-c", "user.email=test@example.invalid", *args],
+        cwd=vault,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_fresh_vault_migration_only_rewrites_user_content(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    product_files = {
+        "CLAUDE.md": "Read `.claude/skills/README.md`, README, and ^task-20260128-010.\n",
+        ".claude/skills/README.md": "This README is product documentation.\n",
+        "docs/Dex_Technical_Guide.md": "Example: `^task-20260128-011`.\n",
+    }
+    placeholders = (
+        "04-Projects/README.md",
+        "05-Areas/People/README.md",
+        "05-Areas/Companies/README.md",
+    )
+    for relative, content in product_files.items():
+        _write(vault / relative, content)
+    for relative in placeholders:
+        _write(vault / relative, "Placeholder README only.\n")
+    tasks = vault / "03-Tasks/Tasks.md"
+    _write(
+        tasks,
+        "Keep README plain and `^task-20260128-001` literal.\n"
+        "Convert the real anchor ^task-20260128-002.\n",
+    )
+
+    tools = tmp_path / "bin"
+    for name in ("osascript", "afplay"):
+        executable = tools / name
+        _write(executable, "#!/bin/sh\nexit 0\n")
+        executable.chmod(0o755)
+
+    _git(vault, "init", "-q")
+    _git(vault, "add", "-A")
+    _git(vault, "commit", "-q", "-m", "pristine fresh vault")
+    head_before = _git(vault, "rev-parse", "HEAD").stdout.strip()
+
+    result = subprocess.run(
+        [sys.executable, str(MIGRATION_SCRIPT)],
+        cwd=vault,
+        env={**os.environ, "PATH": f"{tools}:{os.environ['PATH']}", "VAULT_PATH": str(vault)},
+        input="\n",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Found 0 people" in result.stdout
+    assert "Found 0 projects" in result.stdout
+    assert "Found 0 companies" in result.stdout
+    assert "git reset --hard HEAD~1" not in result.stdout
+    assert head_before in result.stdout
+    assert _git(vault, "rev-parse", "HEAD").stdout.strip() == head_before
+    for relative, content in product_files.items():
+        assert (vault / relative).read_text(encoding="utf-8") == content
+    assert tasks.read_text(encoding="utf-8") == (
+        "Keep README plain and `^task-20260128-001` literal.\n"
+        "Convert the real anchor [[^task-20260128-002]].\n"
+    )


### PR DESCRIPTION
## Plain English

Obsidian wiki-link setup on a brand-new vault could treat placeholder README pages as people, projects, and companies, then rewrite Dex product docs and inline code examples. Setup looked successful. The vault was not.

It also printed `git reset --hard HEAD~1` even when no backup commit existed, which can undo the wrong history.

## Fix

- Index real entity pages only, never placeholder README files
- Rewrite only user-owned or seeded vault content (existing ownership contract)
- Leave fenced and inline code alone
- Record the exact pre-migration Git commit and tell people to restore that commit, not to rewrite history

Cherry-picked onto current Dex `main` (includes the already-merged Obsidian LaunchAgent fix) from verified local commit `96615d65`. Independent re-run: focused regression pass, 104 migration/task/ownership tests pass, Ruff and compile clean. No reporter contact. No Dex cut.

## Tests

- `core/tests/test_obsidian_wikilink_migration.py` — fresh vault: 0 false entities, product files unchanged, inline code preserved, real task converted, no `HEAD~1` advice

Mission Control: `bug-report-dex-obsidian-setup-core-obsidian-migrate-to-wiki-c399237bc0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a vault-wide rewrite tool and git backup/restore path. Safer than before, but still mutates markdown and git state if the ownership filter or backup logic is wrong.
> 
> **Overview**
> Stops Obsidian wiki-link setup from treating placeholder READMEs as people/projects/companies and rewriting Dex product docs on a fresh vault.
> 
> Entity indexes skip `README.md`. Rewrites are limited to non-denied `seed`/`vault` paths via `resolve`. Fenced and inline code are left alone so examples like `` `^task-...` `` stay literal.
> 
> Git backup now records the exact pre-migration `HEAD` (only committing if there is something to stage) and tells users to `git restore --source=<ref>` instead of `git reset --hard HEAD~1`. Backup failure aborts before any file changes.
> 
> Adds a command-level test that a pristine vault keeps product files, converts only real task anchors, and does not rewrite history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ea9d07560e11bbda0b987f97fa882a34989a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->