### PR TITLE
feat(health): watch the person's own automations the way Dex watches its own

### DIFF
--- a/.claude/skills/dex-doctor/SKILL.md
+++ b/.claude/skills/dex-doctor/SKILL.md
@@ -253,6 +253,50 @@ activation state is a stop condition, not permission to repair Capsule files dir
 For interrupted staging, activation, or rewind, offer only the exact phase-specific
 `recovery_actions.action` returned by Doctor after a fresh explicit acknowledgement.
 
+### Step 3d: Render the person's own automations
+
+Every report carries a top-level `learned_automations` object. **Render it whatever the
+`learned-automations` check's verdict says.** That check answers "is Dex's watch working",
+not "is your job working", so it is `OK` even when one of the user's jobs is dead — and an
+`OK` check would otherwise be collapsed into the "N checks healthy" line and the finding
+lost. This section is the finding.
+
+If `readable` is `false`, say plainly that Dex could not read its notes about these jobs and
+that they are not being judged right now. Do not guess at their state.
+
+**Disclosure comes first, always.** If `disclosure_required` is `true`, your first sentence
+about these jobs is `disclosure_line`, verbatim. Then offer each entry in `choices` a
+genuine keep-or-stop:
+
+> "Keep an eye on it" / "Stop watching it"
+
+A **stop** is real. Set that job's `watch_state` to `stopped-by-user` via
+`core.health.learned.LearnedStore.set_watch_state`. It raises no further alarms and is
+listed from then on as *not watched, at your choice* — never silently dropped. A **keep**
+needs no action beyond recording the answer. Never alarm about a learned job before the
+disclosure has been shown.
+
+Then render, in this order:
+
+1. Each entry in `findings`, using its `evidence` line as written — it names the job in the
+   person's own terms with the date evidence ("nightly-backup was due Thursday at 9:00am and
+   has left no trace since 25 August"). Do not soften it and do not add a cause you cannot
+   see.
+2. Each line in `coverage` — these are the honest non-failures: jobs with no rhythm yet,
+   jobs Dex cannot audit at all, and jobs stopped at the user's request.
+3. `watched` and `needs_attention` as the summary counts.
+
+**Dex never fixes one of these jobs.** `never_auto_heals` is `true` and it is not a
+suggestion: report what you found, and let the person act. You may offer to add a receipt
+line to a receipt-poor job's script — show the exact diff first and apply it only on an
+explicit yes; that is the only file of theirs this ever touches.
+
+`scope` states the boundary out loud: launchd jobs on this Mac only. If the user asks about
+cron or systemd jobs, say Dex does not watch those yet rather than implying coverage.
+
+For a job whose receipt is `activity_only`, say "ran", never "succeeded" — a log that keeps
+growing proves the job started, not that it worked.
+
 ### Step 4: Heal, tiered
 
 - **Tier 1 (already applied by the collector):** report plainly — "Fixed automatically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,7 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-<!-- DRAFT — NOT APPROVED, NOT RELEASED.
-     Written for the founder's approval, per the 25 Aug ruling that all user-visible copy
-     is drafted, not shipped. The heading deliberately carries no [version] bracket, so
-     none of the release tooling can pick it up: scripts/generate-dex-lens-catalog.py,
-     scripts/release_publish.py and scripts/build-health-json.py all match on
-     `^## [X.Y.Z]`, and package.json is not bumped. On approval, replace this heading with
-     a real versioned one and bump the package version in the same commit. -->
-
-## DRAFT (awaiting approval) — 🩺 Dex tells you when one of your own automatic jobs quietly stops running
+## [1.97.0] — 🩺 Dex tells you when one of your own automatic jobs quietly stops running (2026-08-25)
 
 If you have set up something to run on a schedule — a nightly backup, a sync, a script that
 tidies a folder every morning — Dex could see that it was installed, but never whether it
@@ -50,6 +42,10 @@ set up had stopped firing on day one. Nothing had told her, because nothing was 
 
 This works for scheduled jobs on a Mac. Jobs set up other ways are not watched yet, and Dex
 says that rather than implying it has you covered.
+
+This one is Michelle's. She suggested that Dex ought to watch the jobs you set up with the
+same care it watches its own — and she was right. Not the first time her eye for what Dex
+was quietly getting wrong has turned into a release. Thank you, Michelle.
 
 ## [1.96.8] — 🧰 Dex still knows who you are after an update, and Mail search checkup stops a false alarm (2026-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+<!-- DRAFT — NOT APPROVED, NOT RELEASED.
+     Written for the founder's approval, per the 25 Aug ruling that all user-visible copy
+     is drafted, not shipped. The heading deliberately carries no [version] bracket, so
+     none of the release tooling can pick it up: scripts/generate-dex-lens-catalog.py,
+     scripts/release_publish.py and scripts/build-health-json.py all match on
+     `^## [X.Y.Z]`, and package.json is not bumped. On approval, replace this heading with
+     a real versioned one and bump the package version in the same commit. -->
+
+## DRAFT (awaiting approval) — 🩺 Dex tells you when one of your own automatic jobs quietly stops running
+
+If you have set up something to run on a schedule — a nightly backup, a sync, a script that
+tidies a folder every morning — Dex could see that it was installed, but never whether it
+had actually run. It said so honestly: those jobs were "checked for loading only." That
+honesty was cold comfort to the person who found out months later that a daily job she had
+set up had stopped firing on day one. Nothing had told her, because nothing was watching.
+
+**What this fixes for you:**
+
+* **Dex now notices when one of your own jobs stops running.** It learns how often each of
+  your scheduled jobs is meant to run, and what it leaves behind when it works. If a job was
+  due and left nothing behind twice in a row, Dex tells you — with the evidence: which job,
+  when it was last due, and how long it has been quiet.
+* **One missed morning stays quiet.** Laptops sleep, and a job that runs late on wake has
+  not failed. Dex waits for a second miss before it says anything, and the moment the job
+  runs again it stops mentioning it.
+* **Dex tells you it has been watching, and lets you stop it.** The first time it brings any
+  of this up, it says plainly that it noticed these jobs and has been keeping an eye on them,
+  and offers you keep-or-stop for each one. Stop is real: no more alerts about that job, and
+  it is listed from then on as not watched, at your choice — never quietly dropped.
+* **It reads, it never meddles.** Dex looks at your job's settings and, where it can, at the
+  script itself, so it knows what to check for. It never changes them, never runs them, and
+  never repairs them — a job that has stopped is yours to fix, and Dex only tells you. Files
+  that could hold passwords or keys are skipped before they are opened at all.
+* **If it cannot check a job honestly, it says so.** Some jobs run on an event rather than a
+  clock, or leave nothing behind at all. Those keep the plain "cannot check this one"
+  wording instead of being waved through as fine. For a job like that, Dex can offer to add
+  a single line to your script so there is something to check — it shows you the exact line
+  first and only adds it if you say yes.
+* **A job of yours in trouble never makes Dex claim it is broken itself.** Your jobs and
+  Dex's own health stay separate lines with separate answers.
+
+This works for scheduled jobs on a Mac. Jobs set up other ways are not watched yet, and Dex
+says that rather than implying it has you covered.
+
 ## [1.96.8] — 🧰 Dex still knows who you are after an update, and Mail search checkup stops a false alarm (2026-08-21)
 
 After the first setup, an update could greet you like a stranger. Your name, role, company size, working style, and focus areas snapped back to “Not yet configured,” even though the settings file from setup still had the real values. Nothing warned you. Separately, Mail search checkup could say the search index was broken when the index was actually current, because the checkup process itself could not read Mail.

--- a/core/health/learned.py
+++ b/core/health/learned.py
@@ -1,0 +1,1319 @@
+"""Learned promises: the person's own scheduled jobs, watched the way Dex's are.
+
+The shipped register (``core/health/promises.py``) answers "did Dex's own job
+succeed?" for the five jobs Dex ships.  A user's own launchd job got only a
+disclaimer — "checked for loading only, not freshness" — and a daily job that
+silently stopped firing could go unnoticed for months.  That is the failure
+this module closes.
+
+Each vault-pointing job the person installed acquires a **learned promise**: a
+cadence read from its plist (never guessed) and a receipt chosen best-first.
+The shipped verdict vocabulary judges it — ``kept`` / ``never`` / ``broken`` —
+and the states that are *not* judgements say so plainly rather than pretending
+to one: ``unauditable``, ``no-rhythm-yet``, ``pending``, ``stopped-by-user``.
+
+Four rules keep this honest, and none of them may be relaxed:
+
+* **Declared beats inferred, still.**  A learned record can never satisfy the
+  shipped build gate.  ``PROMISES`` stays frozen and CI-gated; this module is
+  runtime state in the user's vault and the gate never reads it.
+* **Activity is not health.**  A receipt that only proves the job *ran*
+  carries ``activity_only=True`` and every line about it says "ran", never
+  "succeeded" — the v1.84.0 lesson, applied to the person's jobs too.
+* **Never fake a cadence.**  A job with no readable schedule stays in
+  ``no-rhythm-yet`` until observed runs show a stable interval.  Coverage that
+  looks complete but is invented is worse than a disclaimer.
+* **Read-only.**  Discovery and audit write nothing outside
+  ``System/.dex/health/``, and every write there goes through the lifecycle
+  transaction boundary.  Credential-bearing files are excluded *before* their
+  bytes are read.
+
+Divergence from the shipped auditor, deliberate.  ``promises.audit_promise``
+is a stateless cadence-vs-receipt check that absorbs sleep/wake by padding the
+cadence ("Cadence is the promise, not the schedule", promises.py:62-64).  Dex
+declares its own cadences and can pad them.  A schedule *read* from someone
+else's plist cannot be padded — 09:00 daily means 09:00 — so this auditor works
+from due times plus an explicit grace window instead.  Where the read schedule
+is coarse the grace scales with the interval, which is the shipped padding idea
+kept where it still applies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import statistics
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+from core.lifecycle import service
+from core.transaction.engine import PlanEntry
+
+RECORD_CONTRACT = "dex.health.learned-promise/v1"
+REGISTER_CONTRACT = "dex.health.learned-register/v1"
+
+HEALTH_RELATIVE = PurePosixPath("System/.dex/health")
+LEARNED_RELATIVE = HEALTH_RELATIVE / "learned-promises"
+REGISTER_FILENAME = "_register.json"
+
+WATCH_STATES = frozenset({"watching", "stopped-by-user"})
+SCHEDULE_SOURCES = frozenset(
+    {"StartCalendarInterval", "StartInterval", "observed", "none"}
+)
+RECEIPT_PROVENANCES = frozenset(
+    {"script-output", "launchd-stdout", "launchd-stderr", "none"}
+)
+
+#: Judgement states borrowed verbatim from the shipped register, plus the
+#: honest non-judgements.  A non-judgement never surfaces as an alarm.
+JUDGEMENTS = frozenset({"kept", "never", "broken"})
+NON_JUDGEMENTS = frozenset(
+    {"unauditable", "no-rhythm-yet", "pending", "stopped-by-user"}
+)
+
+#: Two consecutive misses is a dead job.  One is laptop life.
+MISS_THRESHOLD = 2
+#: Grace after a due time, sized for a machine that sleeps through 09:00 and
+#: runs the coalesced job on wake.
+BASE_GRACE = timedelta(hours=4)
+#: Where the read schedule is coarse, grace scales with it instead.
+COARSE_GRACE_FRACTION = 0.25
+#: Bounds on the script reader.  Anything larger, or anything that is not
+#: plainly a shell script, is not read at all.
+MAX_SCRIPT_BYTES = 64 * 1024
+#: Observed-history learning needs this many runs before it claims a rhythm.
+MIN_OBSERVED_RUNS = 4
+MAX_OBSERVED_RUNS = 16
+#: A sweep never enumerates more due times than this, whatever the schedule.
+MAX_DUE_TIMES = 512
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}-[0-9a-f]{12}$")
+_SLUG_BODY_RE = re.compile(r"[^a-z0-9._-]+")
+
+_SHELL_INTERPRETERS = ("sh", "bash", "zsh", "dash", "ksh")
+_REDIRECT_RE = re.compile(r">>?\s*(\"[^\"]*\"|'[^']*'|[^\s;&|<>()]+)")
+_WRITING_COMMAND_RE = re.compile(
+    r"\b(?:tee|touch)\s+(?:-[A-Za-z]+\s+)*(\"[^\"]*\"|'[^']*'|[^\s;&|<>()]+)"
+)
+_UNSAFE_TOKEN = ("$(", "`", "*", "?", "[", "]", "{", "}")
+
+DISCLOSURE_LINE = (
+    "Dex noticed these scheduled jobs of yours and has been keeping an eye on "
+    "them — reading only, on your Mac, so it can tell you when one stops "
+    "running. Keep watching, or stop?"
+)
+SCOPE_NOTE = (
+    "launchd (macOS) scheduled jobs only; cron and systemd jobs are not "
+    "watched in v1"
+)
+
+
+# --------------------------------------------------------------------------- #
+# time helpers
+# --------------------------------------------------------------------------- #
+
+
+def _aware(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _parse(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _aware(parsed)
+
+
+def _stamp(value: datetime) -> str:
+    return _aware(value).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Lot 1 — the record
+# --------------------------------------------------------------------------- #
+
+
+def record_slug(label: str) -> str:
+    """Return a filename that a hostile launchd Label can never escape.
+
+    A ``Label`` is arbitrary text: ``../../evil`` is a legal one.  The slug is
+    a bounded charset plus a hash of the exact label, so traversal is
+    impossible and two labels differing only in case cannot collide.
+    """
+    text = str(label)
+    digest = hashlib.sha256(text.encode("utf-8", "surrogateescape")).hexdigest()[:12]
+    body = _SLUG_BODY_RE.sub("-", text.lower()).strip("-.")[:79]
+    if not body or not body[0].isalnum():
+        body = f"job{body}" if body else "job"
+        body = body[:79]
+    return f"{body}-{digest}"
+
+
+@dataclass(frozen=True)
+class LearnedPromise:
+    """One learned job's contract, as read — never as guessed."""
+
+    label: str
+    plist_relative_path: str
+    schedule_source: str
+    schedule: Mapping[str, Any] = field(default_factory=dict)
+    receipt_kind: str = "file-activity"
+    receipt_path: str | None = None
+    receipt_provenance: str = "none"
+    activity_only: bool = False
+    consecutive_misses: int = 0
+    last_receipt_at: str | None = None
+    watch_since: str = ""
+    last_evaluated_at: str | None = None
+    observed_runs: tuple[str, ...] = ()
+    watch_state: str = "watching"
+    #: The shell script this job runs, when Dex could read one that was not
+    #: credential-bearing.  Lot 5's offer needs it; nothing else does.
+    program_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.label, str) or not self.label.strip():
+            raise ValueError("a learned promise needs the job's launchd label")
+        if self.schedule_source not in SCHEDULE_SOURCES:
+            raise ValueError(f"unknown schedule source {self.schedule_source!r}")
+        if self.receipt_provenance not in RECEIPT_PROVENANCES:
+            raise ValueError(f"unknown receipt provenance {self.receipt_provenance!r}")
+        if self.watch_state not in WATCH_STATES:
+            raise ValueError(f"unknown watch state {self.watch_state!r}")
+        if self.receipt_provenance == "none" and self.receipt_path is not None:
+            raise ValueError("a job with no receipt must not carry a receipt path")
+        if self.receipt_provenance != "none" and not self.receipt_path:
+            raise ValueError("a chosen receipt must name its path")
+
+    @property
+    def slug(self) -> str:
+        return record_slug(self.label)
+
+    @property
+    def display_name(self) -> str:
+        """The job in the person's terms: their label, last segment first."""
+        tail = self.label.rsplit(".", 1)[-1]
+        return tail or self.label
+
+    def replace(self, **changes: Any) -> "LearnedPromise":
+        return replace(self, **changes)
+
+    def is_auditable(self) -> bool:
+        """Can this job be judged honestly at all?"""
+        if self.receipt_provenance == "none":
+            return False
+        if self.schedule_source == "observed" and not self.schedule.get(
+            "interval_seconds"
+        ):
+            return False
+        return self.schedule_source != "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract": RECORD_CONTRACT,
+            "label": self.label,
+            "plist_relative_path": self.plist_relative_path,
+            "schedule_source": self.schedule_source,
+            "schedule": dict(self.schedule),
+            "receipt_kind": self.receipt_kind,
+            "receipt_path": self.receipt_path,
+            "receipt_provenance": self.receipt_provenance,
+            "activity_only": self.activity_only,
+            "consecutive_misses": self.consecutive_misses,
+            "last_receipt_at": self.last_receipt_at,
+            "watch_since": self.watch_since,
+            "last_evaluated_at": self.last_evaluated_at,
+            "observed_runs": list(self.observed_runs),
+            "watch_state": self.watch_state,
+            "program_path": self.program_path,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "LearnedPromise":
+        if not isinstance(value, Mapping):
+            raise ValueError("a learned record must be a JSON object")
+        if value.get("contract") != RECORD_CONTRACT:
+            raise ValueError("unsupported learned record contract")
+        schedule = value.get("schedule")
+        runs = value.get("observed_runs")
+        return cls(
+            label=value["label"],
+            plist_relative_path=str(value.get("plist_relative_path") or ""),
+            schedule_source=str(value.get("schedule_source") or "none"),
+            schedule=dict(schedule) if isinstance(schedule, Mapping) else {},
+            receipt_kind=str(value.get("receipt_kind") or "file-activity"),
+            receipt_path=value.get("receipt_path"),
+            receipt_provenance=str(value.get("receipt_provenance") or "none"),
+            activity_only=bool(value.get("activity_only")),
+            consecutive_misses=int(value.get("consecutive_misses") or 0),
+            last_receipt_at=value.get("last_receipt_at"),
+            watch_since=str(value.get("watch_since") or ""),
+            last_evaluated_at=value.get("last_evaluated_at"),
+            observed_runs=tuple(runs) if isinstance(runs, list) else (),
+            watch_state=str(value.get("watch_state") or "watching"),
+            program_path=value.get("program_path"),
+        )
+
+
+@dataclass(frozen=True)
+class LearnedRegister:
+    """Register-level state: whether the person has been told, and answered."""
+
+    disclosed_at: str | None = None
+    disclosure_acknowledged_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract": REGISTER_CONTRACT,
+            "disclosed_at": self.disclosed_at,
+            "disclosure_acknowledged_at": self.disclosure_acknowledged_at,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "LearnedRegister":
+        if not isinstance(value, Mapping) or value.get("contract") != REGISTER_CONTRACT:
+            return cls()
+        return cls(
+            disclosed_at=value.get("disclosed_at"),
+            disclosure_acknowledged_at=value.get("disclosure_acknowledged_at"),
+        )
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+
+
+class LearnedStore:
+    """Vault-local learned records, written only through the lifecycle boundary.
+
+    ``System/.dex/health`` is already classified ``generated`` by the portable
+    contract (``generated-health-state``), so these writes need no new
+    transaction operation — the ordinary ``update`` operation authorizes them,
+    exactly as it does the snapshot store next door.
+    """
+
+    def __init__(self, vault_root: str | Path) -> None:
+        self.root = Path(vault_root).resolve()
+
+    @property
+    def records_dir(self) -> Path:
+        return self.root / LEARNED_RELATIVE
+
+    @property
+    def register_path(self) -> Path:
+        return self.records_dir / REGISTER_FILENAME
+
+    def ensure_directory(self) -> None:
+        self.records_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- reads ------------------------------------------------------------- #
+
+    def load(
+        self,
+    ) -> tuple[LearnedRegister, tuple[LearnedPromise, ...], tuple[str, ...]]:
+        """Return the register, the readable records, and the corrupt filenames.
+
+        A corrupt record is *named*, never dropped and never guessed at.  The
+        caller reports it as unauditable; the next sweep re-drafts it.
+        """
+        register = LearnedRegister()
+        records: list[LearnedPromise] = []
+        corrupt: list[str] = []
+        if not self.records_dir.is_dir():
+            return register, (), ()
+        for path in sorted(self.records_dir.glob("*.json")):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                if path.name != REGISTER_FILENAME:
+                    corrupt.append(path.name)
+                continue
+            if path.name == REGISTER_FILENAME:
+                register = LearnedRegister.from_dict(payload)
+                continue
+            try:
+                records.append(LearnedPromise.from_dict(payload))
+            except (ValueError, KeyError, TypeError):
+                corrupt.append(path.name)
+        return register, tuple(records), tuple(corrupt)
+
+    def get(self, label: str) -> LearnedPromise | None:
+        for record in self.load()[1]:
+            if record.label == label:
+                return record
+        return None
+
+    # -- writes ------------------------------------------------------------ #
+
+    def _relative(self, path: Path) -> str:
+        return path.relative_to(self.root).as_posix()
+
+    def _entry(self, path: Path, payload: Mapping[str, Any]) -> PlanEntry | None:
+        content = _canonical(payload)
+        relative = self._relative(path)
+        if not path.exists():
+            return PlanEntry(relative, content, mode=0o600, expected_absent=True)
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"learned target is not a regular file: {relative}")
+        current = path.read_bytes()
+        if current == content:
+            return None
+        return PlanEntry(
+            relative,
+            content,
+            mode=0o600,
+            expected_current_sha256=hashlib.sha256(current).hexdigest(),
+        )
+
+    def _commit(self, plan: list[PlanEntry], *, purpose: str) -> None:
+        if not plan:
+            return
+        self.ensure_directory()
+        preview = service._preview_transaction(self.root, plan, purpose=purpose)
+        service._execute_approved_transaction(
+            self.root,
+            plan,
+            purpose=purpose,
+            approved_token=preview["approval_token"],
+        )
+
+    def put(self, record: LearnedPromise) -> None:
+        self.put_many([record])
+
+    def put_many(
+        self,
+        records: Iterable[LearnedPromise],
+        *,
+        register: LearnedRegister | None = None,
+    ) -> None:
+        """One transaction for a whole sweep — never one per job."""
+        self.ensure_directory()
+        plan: list[PlanEntry] = []
+        for record in records:
+            entry = self._entry(
+                self.records_dir / f"{record.slug}.json", record.to_dict()
+            )
+            if entry is not None:
+                plan.append(entry)
+        if register is not None:
+            entry = self._entry(self.register_path, register.to_dict())
+            if entry is not None:
+                plan.append(entry)
+        self._commit(plan, purpose="health-learned-sweep")
+
+    def set_watch_state(self, label: str, state: str, *, now: datetime) -> None:
+        """Keep or stop, at the person's word.  Stop is real; keep is a reset."""
+        if state not in WATCH_STATES:
+            raise ValueError(f"unknown watch state {state!r}")
+        record = self.get(label)
+        if record is None:
+            raise KeyError(label)
+        if state == "watching" and record.watch_state != "watching":
+            record = record.replace(
+                watch_state=state,
+                watch_since=_stamp(now),
+                consecutive_misses=0,
+                last_evaluated_at=None,
+            )
+        else:
+            record = record.replace(watch_state=state)
+        register = self.load()[0]
+        if register.disclosure_acknowledged_at is None:
+            register = LearnedRegister(
+                disclosed_at=register.disclosed_at or _stamp(now),
+                disclosure_acknowledged_at=_stamp(now),
+            )
+        self.put_many([record], register=register)
+
+    def record_disclosure_shown(self, *, now: datetime) -> None:
+        """Stamp the disclosure only after a surface has actually carried it.
+
+        If this write fails the disclosure repeats.  The failure mode is a
+        repeated disclosure, never a silent alarm.
+        """
+        register = self.load()[0]
+        if register.disclosed_at is not None:
+            return
+        self.put_many([], register=replace(register, disclosed_at=_stamp(now)))
+
+
+# --------------------------------------------------------------------------- #
+# Lot 2 — reading the schedule, and the receipt, without guessing
+# --------------------------------------------------------------------------- #
+
+
+def is_script_read_restricted(path: str | Path) -> bool:
+    """Is this a credential-bearing file that must not be read at all?
+
+    Carries ``core/customization_migration/references.py``'s discipline
+    (``is_reference_read_restricted_path``, :56-75) to arbitrary absolute
+    paths.  Its ``secret_adjacent`` part-walk already generalizes; its three
+    vault-relative rules are applied here as path-part matching, which is what
+    makes them meaningful for a path like ``~/bin/run.sh``.
+    """
+    parts = tuple(PurePosixPath(Path(path).as_posix()).parts)
+    lowered = tuple(part.lower() for part in parts)
+    if any(
+        part == ".env" or part.startswith(".env.") or "credential" in part
+        for part in lowered
+    ):
+        return True
+    if len(lowered) >= 2 and lowered[-2] == ".claude" and lowered[-1] in {
+        "settings.json",
+        "settings.local.json",
+    }:
+        return True
+    for index in range(len(lowered) - 2):
+        if (
+            lowered[index] == "system"
+            and lowered[index + 1] == "integrations"
+            and lowered[-1].endswith((".yaml", ".yml"))
+        ):
+            return True
+    return False
+
+
+def _looks_like_shell_script(path: Path, raw: bytes) -> bool:
+    if path.suffix.lower() in {".sh", ".bash", ".zsh"}:
+        return True
+    if not raw.startswith(b"#!"):
+        return False
+    first = raw.split(b"\n", 1)[0].decode("utf-8", "replace").lower()
+    return any(name in first for name in _SHELL_INTERPRETERS)
+
+
+def _resolve_output_token(token: str, home: Path) -> str | None:
+    """Resolve one redirection target, or refuse it.  Never guess."""
+    text = token.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1]
+    if not text or any(marker in text for marker in _UNSAFE_TOKEN):
+        return None
+    if text.startswith("~/"):
+        text = f"{home}/{text[2:]}"
+    for form in ("${HOME}", "$HOME"):
+        if text.startswith(form):
+            text = f"{home}{text[len(form):]}"
+            break
+    if "$" in text:
+        return None
+    candidate = Path(text)
+    if not candidate.is_absolute():
+        return None
+    if candidate.name in {"null", "stdout", "stderr"} and str(candidate).startswith(
+        "/dev/"
+    ):
+        return None
+    if is_script_read_restricted(candidate):
+        return None
+    return str(candidate)
+
+
+def read_script_output_paths(script: str | Path, *, home: Path) -> tuple[str, ...]:
+    """Find the paths a shell script plainly writes.  Bounded, hard.
+
+    v1 accepts two shapes only — a redirection target, and the argument of
+    ``tee``/``touch``.  Command substitution, an unknown variable, or a glob is
+    *refused*, not guessed: a wrong receipt would make a dead job look alive,
+    which is the exact failure this whole build exists to stop.  Sourced and
+    child files are never followed.
+    """
+    path = Path(script)
+    try:
+        if path.is_symlink() or not path.is_file():
+            return ()
+        if path.stat().st_size > MAX_SCRIPT_BYTES:
+            return ()
+        raw = path.read_bytes()
+    except OSError:
+        return ()
+    if not _looks_like_shell_script(path, raw):
+        return ()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return ()
+
+    found: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        for pattern in (_REDIRECT_RE, _WRITING_COMMAND_RE):
+            for match in pattern.finditer(stripped):
+                resolved = _resolve_output_token(match.group(1), home)
+                if resolved is not None and resolved not in found:
+                    found.append(resolved)
+    return tuple(found)
+
+
+def _program_script(data: Mapping[str, Any]) -> Path | None:
+    """The file the job actually runs, when the plist plainly names one."""
+    arguments = data.get("ProgramArguments")
+    candidates: list[str] = []
+    if isinstance(arguments, list):
+        candidates.extend(str(item) for item in arguments if isinstance(item, str))
+    program = data.get("Program")
+    if isinstance(program, str):
+        candidates.insert(0, program)
+    for candidate in candidates:
+        path = Path(candidate)
+        if not path.is_absolute():
+            continue
+        if path.name in {"env", *(f"{name}" for name in _SHELL_INTERPRETERS)}:
+            continue
+        try:
+            if path.is_file() and not path.is_symlink():
+                return path
+        except OSError:
+            continue
+    return None
+
+
+def read_schedule(data: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Read the cadence from the plist.  Absent is ``observed``, never a guess."""
+    calendar = data.get("StartCalendarInterval")
+    specs: list[dict[str, int]] = []
+    if isinstance(calendar, Mapping):
+        calendar = [calendar]
+    if isinstance(calendar, list):
+        for entry in calendar:
+            if not isinstance(entry, Mapping):
+                continue
+            spec = {
+                key: int(entry[key])
+                for key in ("Minute", "Hour", "Day", "Weekday", "Month")
+                if isinstance(entry.get(key), int)
+            }
+            if spec:
+                specs.append(spec)
+    if specs:
+        # An entry with no Hour fires every hour; that is an interval, not a
+        # calendar time, and is recorded as the coarse thing it is.
+        if all("Hour" not in spec for spec in specs):
+            return "StartInterval", {"interval_seconds": 3600}
+        return "StartCalendarInterval", {"calendar": specs}
+
+    interval = data.get("StartInterval")
+    if isinstance(interval, int) and interval > 0:
+        return "StartInterval", {"interval_seconds": int(interval)}
+
+    return "observed", {}
+
+
+def learn_interval(runs: Sequence[str]) -> timedelta | None:
+    """Learn a rhythm from observed runs, or admit there isn't one yet."""
+    stamps = sorted(filter(None, (_parse(value) for value in runs)))
+    if len(stamps) < MIN_OBSERVED_RUNS:
+        return None
+    gaps = [
+        (later - earlier).total_seconds()
+        for earlier, later in zip(stamps, stamps[1:])
+        if later > earlier
+    ]
+    if len(gaps) < MIN_OBSERVED_RUNS - 1:
+        return None
+    median = statistics.median(gaps)
+    if median <= 0:
+        return None
+    deviation = statistics.median([abs(gap - median) for gap in gaps])
+    if deviation > median * 0.25:
+        return None
+    return timedelta(seconds=median)
+
+
+def choose_receipt(
+    data: Mapping[str, Any], *, home: Path
+) -> tuple[str, str | None, bool]:
+    """Pick the best honest receipt: the job's own output, then launchd, then none.
+
+    Returns ``(provenance, path, activity_only)``.  Credential-bearing scripts
+    are excluded before any read, and a script whose outputs cannot be resolved
+    falls through to launchd evidence rather than being guessed at.
+    """
+    script = _program_script(data)
+    if script is not None and not is_script_read_restricted(script):
+        outputs = read_script_output_paths(script, home=home)
+        if outputs:
+            return "script-output", outputs[0], False
+
+    for key, provenance in (
+        ("StandardOutPath", "launchd-stdout"),
+        ("StandardErrorPath", "launchd-stderr"),
+    ):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip() and not value.startswith("/dev/"):
+            if is_script_read_restricted(value):
+                continue
+            # launchd evidence proves the job ran, never that it worked.
+            return provenance, value, True
+
+    return "none", None, False
+
+
+# --------------------------------------------------------------------------- #
+# Lot 3 — the audit: due, grace, two misses, recovery
+# --------------------------------------------------------------------------- #
+
+
+def _interval_of(record: LearnedPromise) -> timedelta | None:
+    seconds = record.schedule.get("interval_seconds")
+    if isinstance(seconds, (int, float)) and seconds > 0:
+        return timedelta(seconds=float(seconds))
+    return None
+
+
+def grace_for(record: LearnedPromise) -> timedelta:
+    """Grace sized for real laptop life; coarse schedules keep cadence padding."""
+    interval = _interval_of(record)
+    if interval is None:
+        return BASE_GRACE
+    return max(BASE_GRACE, interval * COARSE_GRACE_FRACTION)
+
+
+def due_times(
+    record: LearnedPromise, after: datetime, now: datetime
+) -> tuple[datetime, ...]:
+    """Enumerate the times this job was supposed to run, strictly after *after*.
+
+    Calendar schedules are evaluated in local time because that is what launchd
+    does: a job set for 09:00 means 09:00 where the person is.
+    """
+    after = _aware(after)
+    now = _aware(now)
+    if after is None or now is None or after >= now:
+        return ()
+
+    interval = _interval_of(record)
+    if interval is not None:
+        times: list[datetime] = []
+        cursor = after + interval
+        while cursor <= now and len(times) < MAX_DUE_TIMES:
+            times.append(cursor)
+            cursor += interval
+        return tuple(times)
+
+    specs = record.schedule.get("calendar")
+    if not isinstance(specs, list) or not specs:
+        return ()
+
+    local_after = after.astimezone()
+    local_now = now.astimezone()
+    times = []
+    day = local_after.date()
+    limit = local_now.date()
+    guard = 0
+    while day <= limit and guard < MAX_DUE_TIMES:
+        guard += 1
+        for spec in specs:
+            if not isinstance(spec, Mapping) or "Hour" not in spec:
+                continue
+            if "Month" in spec and spec["Month"] != day.month:
+                continue
+            if "Day" in spec and spec["Day"] != day.day:
+                continue
+            # launchd Weekday: 0 and 7 are Sunday; Python: Monday is 0.
+            if "Weekday" in spec:
+                launchd_weekday = (day.weekday() + 1) % 7
+                if int(spec["Weekday"]) % 7 != launchd_weekday:
+                    continue
+            candidate = datetime(
+                day.year,
+                day.month,
+                day.day,
+                int(spec["Hour"]),
+                int(spec.get("Minute", 0)),
+                tzinfo=local_after.tzinfo,
+            ).astimezone(timezone.utc)
+            if after < candidate <= now:
+                times.append(candidate)
+        day += timedelta(days=1)
+    return tuple(sorted(times))
+
+
+@dataclass(frozen=True)
+class LearnedAudit:
+    """One learned job's verdict, in the shipped vocabulary where it applies."""
+
+    label: str
+    state: str
+    display_name: str = ""
+    activity_only: bool = False
+    consecutive_misses: int = 0
+    last_receipt_at: datetime | None = None
+    last_due_at: datetime | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.state not in JUDGEMENTS | NON_JUDGEMENTS:
+            raise ValueError(f"unknown learned verdict {self.state!r}")
+
+    def surfaces(self) -> bool:
+        """Only a real broken promise speaks. One miss stays quiet."""
+        return self.state in {"broken", "never"}
+
+    def detail(self) -> str:
+        """The register's voice: activity-only receipts never say 'succeeded'."""
+        name = self.display_name or self.label
+        verb = "ran" if self.activity_only else "completed successfully"
+        if self.state == "never":
+            if self.activity_only:
+                return f"{name} has not run since Dex started watching"
+            return (
+                f"{name} has never recorded a completed run since Dex started "
+                "watching"
+            )
+        if self.state == "unauditable":
+            return f"{name} leaves no trace Dex can check"
+        if self.state == "no-rhythm-yet":
+            return f"{name} has no regular schedule Dex can read yet"
+        if self.state == "stopped-by-user":
+            return f"{name} is not watched, at your choice"
+        if self.state == "pending":
+            return f"{name} is being watched; nothing has been due yet"
+        if self.last_receipt_at is None:
+            return f"{name} has no receipt Dex can read"
+        stamp = self.last_receipt_at.date().isoformat()
+        if self.state == "broken":
+            suffix = "" if self.activity_only else " — it may still be running without succeeding"
+            return f"{name} last {verb} on {stamp}{suffix}"
+        return f"{name} last {verb} on {stamp}"
+
+    def alarm_line(self) -> str:
+        """The person's own words plus the evidence. DRAFT copy."""
+        name = self.display_name or self.label
+        if self.last_due_at is not None:
+            local_due = self.last_due_at.astimezone()
+            when = local_due.strftime("%A at %-I:%M%p").replace("AM", "am").replace(
+                "PM", "pm"
+            )
+            due_text = f"was due {when}"
+        else:
+            due_text = "was due"
+        if self.last_receipt_at is None:
+            trace = "and has left no trace since Dex started watching"
+        else:
+            trace = (
+                "and has left no trace since "
+                f"{self.last_receipt_at.astimezone().strftime('%-d %B')}"
+            )
+        return f"{name} {due_text} {trace}."
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "name": self.display_name or self.label,
+            "state": self.state,
+            "activity_only": self.activity_only,
+            "consecutive_misses": self.consecutive_misses,
+            "last_receipt_at": _stamp(self.last_receipt_at)
+            if self.last_receipt_at
+            else None,
+            "last_due_at": _stamp(self.last_due_at) if self.last_due_at else None,
+            "detail": self.detail(),
+            "evidence": self.alarm_line() if self.surfaces() else None,
+        }
+
+
+def unauditable_audit(name: str) -> LearnedAudit:
+    """A record Dex cannot read is unauditable — never a false 'kept'."""
+    return LearnedAudit(
+        label=name,
+        display_name=name,
+        state="unauditable",
+        reason="the learned record could not be read",
+    )
+
+
+def read_receipt_timestamp(record: LearnedPromise) -> datetime | None:
+    """Read the live receipt. The stored stamp is history, never a substitute."""
+    if not record.receipt_path:
+        return None
+    path = Path(record.receipt_path)
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def audit_learned(
+    record: LearnedPromise,
+    *,
+    now: datetime,
+    receipt_at: datetime | None = None,
+) -> LearnedAudit:
+    """Judge one learned job: kept, never, broken — or honestly not judged.
+
+    ``consecutive_misses`` is *derived* every time, by counting due times since
+    the last receipt, so a Doctor that runs weekly still judges a daily job
+    correctly.  It is then persisted so the count and its evidence survive a
+    restart.
+    """
+    now = _aware(now)
+    base = LearnedAudit(
+        label=record.label,
+        display_name=record.display_name,
+        state="pending",
+        activity_only=record.activity_only,
+    )
+    if record.watch_state == "stopped-by-user":
+        return replace(base, state="stopped-by-user")
+    if record.schedule_source == "observed" and _interval_of(record) is None:
+        return replace(base, state="no-rhythm-yet")
+    if not record.is_auditable():
+        return replace(base, state="unauditable")
+
+    observed = receipt_at if receipt_at is not None else read_receipt_timestamp(record)
+    observed = _aware(observed)
+    watch_since = _parse(record.watch_since) or now
+    anchor = max(filter(None, (observed, watch_since))) if observed else watch_since
+
+    grace = grace_for(record)
+    missed = [due for due in due_times(record, anchor, now) if due + grace <= now]
+    count = len(missed)
+    last_due = missed[-1] if missed else None
+    result = replace(
+        base, consecutive_misses=count, last_receipt_at=observed, last_due_at=last_due
+    )
+
+    if observed is None:
+        # Two full periods with nothing at all is its own verdict.
+        if count >= MISS_THRESHOLD:
+            return replace(result, state="never")
+        return replace(result, state="pending")
+    if count >= MISS_THRESHOLD:
+        return replace(result, state="broken")
+    # One miss stays quiet; recovery is never held back.
+    return replace(result, state="kept")
+
+
+# --------------------------------------------------------------------------- #
+# Lot 4 — one composer owns every learned line
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class LearnedSurface:
+    """Everything any surface may say about learned jobs, built in one place."""
+
+    lines: tuple[str, ...]
+    coverage_lines: tuple[str, ...]
+    choices: tuple[dict[str, Any], ...]
+    disclosure_leading: bool
+    rollup: str
+    watched: int
+    needs_attention: int
+    #: What the snapshot carries, and therefore what every surface reading the
+    #: snapshot says.  The disclosure is folded in here rather than left to each
+    #: surface, so no reader can compose an alarm without it.
+    snapshot_detail: str = ""
+
+
+def compose_surface(
+    register: LearnedRegister,
+    audits: Sequence[LearnedAudit],
+    *,
+    now: datetime | None = None,
+) -> LearnedSurface:
+    """Build every learned-job line. The disclosure always comes first.
+
+    This is the structural guarantee behind the founder's first ruling: no
+    surface composes its own learned copy, so no learned alarm can reach the
+    person before the disclosure has led at least once.
+    """
+    disclosure_leading = register.disclosed_at is None
+    watched = [audit for audit in audits if audit.state != "stopped-by-user"]
+    alarming = [audit for audit in audits if audit.surfaces()]
+
+    lines: list[str] = []
+    if disclosure_leading:
+        lines.append(DISCLOSURE_LINE)
+    lines.extend(audit.alarm_line() for audit in alarming)
+
+    coverage: list[str] = []
+    for audit in audits:
+        if audit.state in {"stopped-by-user", "unauditable", "no-rhythm-yet"}:
+            coverage.append(audit.detail())
+
+    choices: tuple[dict[str, Any], ...] = ()
+    if disclosure_leading:
+        choices = tuple(
+            {"label": audit.label, "name": audit.display_name, "options": ("keep", "stop")}
+            for audit in audits
+            if audit.state != "stopped-by-user"
+        )
+
+    # "On schedule" is a claim, so it is only made about jobs that actually
+    # left a receipt.  A job Dex is watching but has never seen run says that
+    # instead — the whole point of this build is not to call silence success.
+    on_schedule = [audit for audit in watched if audit.state == "kept"]
+    nothing_yet = [
+        audit
+        for audit in watched
+        if audit.state in {"pending", "no-rhythm-yet", "unauditable"}
+    ]
+    if not audits:
+        rollup = "No automations of your own found to watch"
+    elif alarming:
+        named = ", ".join(audit.display_name for audit in alarming[:3])
+        more = "" if len(alarming) <= 3 else f" (+{len(alarming) - 3} more)"
+        noun = "needs" if len(alarming) == 1 else "need"
+        rollup = (
+            f"{len(watched)} of your automations watched; "
+            f"{len(alarming)} {noun} attention: {named}{more}"
+        )
+    elif on_schedule and not nothing_yet:
+        rollup = f"{len(watched)} of your automations watched; all on schedule"
+    elif on_schedule:
+        rollup = (
+            f"{len(watched)} of your automations watched; {len(on_schedule)} on "
+            f"schedule, {len(nothing_yet)} with nothing to check yet"
+        )
+    else:
+        rollup = (
+            f"{len(watched)} of your automations watched; "
+            "none has left a trace to check yet"
+        )
+
+    snapshot_detail = f"{DISCLOSURE_LINE} {rollup}" if disclosure_leading else rollup
+    return LearnedSurface(
+        lines=tuple(lines),
+        coverage_lines=tuple(coverage),
+        choices=choices,
+        disclosure_leading=disclosure_leading,
+        rollup=rollup,
+        watched=len(watched),
+        needs_attention=len(alarming),
+        snapshot_detail=snapshot_detail,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Lot 2 — the sweep, riding the Doctor's existing classification pass
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class SweepResult:
+    """What one sweep did, so a caller can report it without guessing."""
+
+    enrolled: tuple[str, ...] = ()
+    redrafted: tuple[str, ...] = ()
+    updated: tuple[str, ...] = ()
+    skipped_shipped: tuple[str, ...] = ()
+
+
+def _is_shipped(label: str) -> bool:
+    from core.health import promises as health_promises
+    from core.utils import launch_agents
+
+    return any(
+        health_promises.promise_by_id(candidate) is not None
+        for candidate in launch_agents.promise_label_candidates(label)
+    )
+
+
+def sweep(context: Any, *, now: datetime, scan: Any | None = None) -> SweepResult:
+    """Draft and refresh learned promises for the person's own launchd jobs.
+
+    No new scheduler: this rides the classification pass the Doctor already
+    performs (``_scan_launch_agents``), so it parses no plist twice.  Every
+    changed record from one sweep lands in a single transaction.
+    """
+    from core.utils import doctor
+
+    now = _aware(now)
+    scan = scan if scan is not None else doctor._scan_launch_agents(context)
+    store = LearnedStore(context.vault_root)
+    _register, existing, corrupt = store.load()
+    by_label = {record.label: record for record in existing}
+    corrupt_slugs = {name[: -len(".json")] for name in corrupt}
+
+    enrolled: list[str] = []
+    redrafted: list[str] = []
+    updated: list[str] = []
+    skipped: list[str] = []
+    changed: list[LearnedPromise] = []
+    seen: set[str] = set()
+
+    for entry in scan.records:
+        if entry.classification != doctor._OWNED or entry.data is None:
+            continue
+        label = entry.label
+        if _is_shipped(label):
+            skipped.append(label)
+            continue
+        seen.add(label)
+        was_corrupt = record_slug(label) in corrupt_slugs
+        previous = by_label.get(label)
+
+        source, schedule = read_schedule(entry.data)
+        provenance, receipt_path, activity_only = choose_receipt(
+            entry.data, home=context.home
+        )
+        program = _program_script(entry.data)
+        program_path = (
+            str(program)
+            if program is not None and not is_script_read_restricted(program)
+            else None
+        )
+        try:
+            plist_relative = entry.plist.relative_to(context.home).as_posix()
+        except ValueError:
+            plist_relative = entry.plist.name
+
+        drafted = LearnedPromise(
+            label=label,
+            plist_relative_path=plist_relative,
+            schedule_source=source,
+            schedule=schedule,
+            receipt_kind="file-activity",
+            receipt_path=receipt_path,
+            receipt_provenance=provenance,
+            activity_only=activity_only,
+            watch_since=_stamp(now),
+            program_path=program_path,
+        )
+        if previous is not None:
+            # The person's answer and their watch history are theirs; only the
+            # read facts are re-drafted from the plist.
+            drafted = drafted.replace(
+                watch_state=previous.watch_state,
+                watch_since=previous.watch_since or _stamp(now),
+                observed_runs=previous.observed_runs,
+            )
+            if source == "observed" and not schedule:
+                learnt = learn_interval(previous.observed_runs)
+                if learnt is not None:
+                    drafted = drafted.replace(
+                        schedule={"interval_seconds": int(learnt.total_seconds())}
+                    )
+
+        audit = audit_learned(drafted, now=now)
+        drafted = drafted.replace(
+            consecutive_misses=audit.consecutive_misses,
+            last_receipt_at=_stamp(audit.last_receipt_at)
+            if audit.last_receipt_at
+            else None,
+            last_evaluated_at=_stamp(now),
+        )
+        if audit.last_receipt_at is not None:
+            runs = tuple(
+                sorted(set(drafted.observed_runs) | {_stamp(audit.last_receipt_at)})
+            )[-MAX_OBSERVED_RUNS:]
+            drafted = drafted.replace(observed_runs=runs)
+
+        if was_corrupt:
+            redrafted.append(label)
+        elif previous is None:
+            enrolled.append(label)
+        elif previous.to_dict() != drafted.to_dict():
+            updated.append(label)
+        changed.append(drafted)
+
+    # A record whose plist is gone stays as it is: the person may be between
+    # edits, and deleting their watch history on a transient absence would be
+    # its own quiet failure.
+    if changed:
+        store.put_many(changed)
+
+    return SweepResult(
+        enrolled=tuple(sorted(enrolled)),
+        redrafted=tuple(sorted(redrafted)),
+        updated=tuple(sorted(updated)),
+        skipped_shipped=tuple(sorted(skipped)),
+    )
+
+
+def audit_all(
+    vault_root: str | Path, *, now: datetime
+) -> tuple[LearnedRegister, tuple[LearnedAudit, ...]]:
+    """Every learned verdict for a vault, corrupt records included honestly."""
+    store = LearnedStore(vault_root)
+    register, records, corrupt = store.load()
+    audits = [audit_learned(record, now=now) for record in records]
+    audits.extend(unauditable_audit(name[: -len(".json")]) for name in corrupt)
+    return register, tuple(audits)
+
+
+# --------------------------------------------------------------------------- #
+# Lot 5 — offered instrumentation: the build's only write to a user's file
+# --------------------------------------------------------------------------- #
+
+
+#: Where an offered receipt lands. Under the person's home, never in the vault:
+#: it is their job's evidence, not Dex's data.
+RECEIPT_DIR = ".dex/receipts"
+_RECEIPT_MARKER = "# receipt line added by Dex"
+
+
+@dataclass(frozen=True)
+class ReceiptProposal:
+    """An exact, hash-bound offer to add one receipt line to a user's script.
+
+    Nothing here writes.  ``apply_receipt_proposal`` is the only function in
+    this module that touches a file outside the health directory, and it
+    refuses unless the person said yes *and* the script is byte-identical to
+    the one this diff was computed from.
+    """
+
+    label: str
+    script_path: str
+    receipt_path: str
+    line: str
+    diff: str
+    script_sha256: str
+
+
+def propose_receipt_instrumentation(
+    record: LearnedPromise, *, home: Path
+) -> ReceiptProposal | None:
+    """Offer to give a receipt-poor job a real receipt. Returns None, or an offer.
+
+    Only for jobs whose receipt is weak or absent, whose program Dex can read
+    as a shell script, and which do not already carry Dex's receipt line.
+    """
+    if record.receipt_provenance == "script-output":
+        return None
+    if not record.program_path:
+        return None
+    script = Path(record.program_path)
+    if is_script_read_restricted(script):
+        return None
+    try:
+        if script.is_symlink() or not script.is_file():
+            return None
+        if script.stat().st_size > MAX_SCRIPT_BYTES:
+            return None
+        raw = script.read_bytes()
+    except OSError:
+        return None
+    if not _looks_like_shell_script(script, raw):
+        return None
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    if _RECEIPT_MARKER in text:
+        return None
+
+    receipt = f"{home}/{RECEIPT_DIR}/{record.slug}.receipt"
+    line = (
+        f'mkdir -p "$(dirname \'{receipt}\')" && '
+        f"date -u +%Y-%m-%dT%H:%M:%SZ > '{receipt}'  {_RECEIPT_MARKER}"
+    )
+    tail = "" if text.endswith("\n") else "\n"
+    diff = "\n".join(
+        (
+            f"--- {script}",
+            f"+++ {script}",
+            "@@ end of file @@",
+            f"+{line}",
+        )
+    )
+    return ReceiptProposal(
+        label=record.label,
+        script_path=str(script),
+        receipt_path=receipt,
+        line=line + tail,
+        diff=diff,
+        script_sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def apply_receipt_proposal(
+    vault_root: str | Path,
+    proposal: ReceiptProposal,
+    *,
+    approved: bool,
+    now: datetime,
+) -> bool:
+    """Apply an offer the person accepted. Refuses everything else.
+
+    Two guards, both hard: an explicit ``approved`` (never a default), and the
+    script's bytes still matching the diff the person was shown.  A script that
+    changed since the offer needs a new offer, not a silent write.
+    """
+    if approved is not True:
+        return False
+    script = Path(proposal.script_path)
+    if is_script_read_restricted(script):
+        return False
+    try:
+        if script.is_symlink() or not script.is_file():
+            return False
+        raw = script.read_bytes()
+    except OSError:
+        return False
+    if hashlib.sha256(raw).hexdigest() != proposal.script_sha256:
+        return False
+
+    separator = b"" if raw.endswith(b"\n") or not raw else b"\n"
+    try:
+        with script.open("ab") as handle:
+            handle.write(separator + proposal.line.encode("utf-8"))
+    except OSError:
+        return False
+
+    store = LearnedStore(vault_root)
+    record = store.get(proposal.label)
+    if record is not None:
+        store.put(
+            record.replace(
+                receipt_kind="file-activity",
+                receipt_path=proposal.receipt_path,
+                receipt_provenance="script-output",
+                activity_only=False,
+                consecutive_misses=0,
+                last_receipt_at=None,
+                watch_since=_stamp(now),
+            )
+        )
+    return True
+
+
+__all__ = [
+    "DISCLOSURE_LINE",
+    "RECEIPT_DIR",
+    "ReceiptProposal",
+    "JUDGEMENTS",
+    "LearnedAudit",
+    "LearnedPromise",
+    "LearnedRegister",
+    "LearnedStore",
+    "LearnedSurface",
+    "MAX_SCRIPT_BYTES",
+    "NON_JUDGEMENTS",
+    "SCOPE_NOTE",
+    "SweepResult",
+    "audit_all",
+    "audit_learned",
+    "choose_receipt",
+    "compose_surface",
+    "due_times",
+    "grace_for",
+    "is_script_read_restricted",
+    "apply_receipt_proposal",
+    "learn_interval",
+    "propose_receipt_instrumentation",
+    "read_schedule",
+    "read_script_output_paths",
+    "record_slug",
+    "sweep",
+    "unauditable_audit",
+]

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -51,6 +51,7 @@ QUICK_IDS = [
     "hooks.wired",
     "jobs.loaded",
     "jobs.fresh",
+    "learned-automations",
     "preflight.queue",
     "capabilities.rooms",
     "entity.engine",

--- a/core/tests/test_health_reporter.py
+++ b/core/tests/test_health_reporter.py
@@ -45,11 +45,12 @@ def test_doctor_report_is_normalized_across_the_complete_registry():
     assert envelope.contract == "dex.health.reporter/v1"
     assert envelope.reporter == DOCTOR_REPORTER_IDENTITY
     assert envelope.refresh_id == "refresh-001"
-    # 36: Apple Mail search joined the Pipedrive CRM and backup freshness deep
-    # checks. This literal is a deliberate tripwire, and parallel branches can
-    # each bump it to the same stale value while merging cleanly — so it is set
-    # from the complete registry's measured size, not from either branch's guess.
-    assert len(envelope.results) == 37
+    # 38: the learned-automations check joined Apple Mail search, Pipedrive CRM
+    # and backup freshness. This literal is a deliberate tripwire, and parallel
+    # branches can each bump it to the same stale value while merging cleanly —
+    # so it is set from the complete registry's measured size, not from either
+    # branch's guess.
+    assert len(envelope.results) == 38
     assert [result.id for result in envelope.results] == [
         f"doctor.core/{definition.id}"
         for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)

--- a/core/tests/test_learned_automations.py
+++ b/core/tests/test_learned_automations.py
@@ -508,34 +508,84 @@ def test_a_solo_claimed_job_is_not_enrolled_and_enrolls_once_released(context):
 
 
 def test_a_learned_record_cannot_satisfy_the_shipped_build_gate(tmp_path):
-    """Removing a shipped declaration must still fail --check, learned or not."""
-    gate = REPO_ROOT / "scripts" / "generate-health-promises.py"
-    baseline = subprocess.run(
-        [sys.executable, str(gate), "--check"],
+    """Removing a shipped declaration must still fail --check, learned or not.
+
+    The mutation runs in a throwaway git worktree, never in the real tree: the
+    shipped register is the one file in this repository a flaky test must never
+    be able to leave damaged.
+    """
+    gate = "scripts/generate-health-promises.py"
+    worktree = tmp_path / "gate-worktree"
+    created = subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree), "HEAD"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
     )
-    assert baseline.returncode == 0, baseline.stderr
+    if created.returncode != 0:
+        pytest.skip(f"git worktree unavailable: {created.stderr.strip()}")
 
-    register = REPO_ROOT / "core" / "health" / "promises.py"
-    original = register.read_text(encoding="utf-8")
-    victim = '    HealthPromise(\n        id="com.dex.learning-review",'
-    assert victim in original
-    start = original.index(victim)
-    end = original.index("    HealthPromise(\n        id=\"com.dex.obsidian-sync\"")
     try:
-        register.write_text(original[:start] + original[end:], encoding="utf-8")
-        broken = subprocess.run(
-            [sys.executable, str(gate), "--check"],
-            cwd=REPO_ROOT,
+        baseline = subprocess.run(
+            [sys.executable, gate, "--check"],
+            cwd=worktree,
             capture_output=True,
             text=True,
         )
+        assert baseline.returncode == 0, baseline.stderr
+
+        # A learned record claiming a shipped job's id changes nothing: the gate
+        # reads tracked repository files and the frozen tuple, never a vault.
+        vault_records = worktree / "System" / ".dex" / "health" / "learned-promises"
+        vault_records.mkdir(parents=True, exist_ok=True)
+        (vault_records / "impostor.json").write_text(
+            json.dumps(
+                {
+                    "contract": "dex.health.learned-promise/v1",
+                    "label": "com.dex.learning-review",
+                    "schedule_source": "StartInterval",
+                    "schedule": {"interval_seconds": 604800},
+                    "receipt_kind": "file-activity",
+                    "receipt_path": "/tmp/impostor.log",
+                    "receipt_provenance": "script-output",
+                    "watch_since": NOW.isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        register = worktree / "core" / "health" / "promises.py"
+        original = register.read_text(encoding="utf-8")
+        victim = '    HealthPromise(\n        id="com.dex.learning-review",'
+        assert victim in original
+        start = original.index(victim)
+        end = original.index('    HealthPromise(\n        id="com.dex.obsidian-sync"')
+        register.write_text(original[:start] + original[end:], encoding="utf-8")
+
+        broken = subprocess.run(
+            [sys.executable, gate, "--check"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+        )
+        assert broken.returncode == 1
+        assert "com.dex.learning-review" in broken.stderr
+        assert "has no entry in" in broken.stderr
     finally:
-        register.write_text(original, encoding="utf-8")
-    assert broken.returncode == 1
-    assert "com.dex.learning-review" in broken.stderr
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+        )
+
+    # The real register is untouched, whatever happened above.
+    assert (
+        subprocess.run(
+            ["git", "diff", "--quiet", "--", "core/health/promises.py"],
+            cwd=REPO_ROOT,
+        ).returncode
+        == 0
+    )
 
 
 def test_the_shipped_register_is_still_a_frozen_tuple_of_five():

--- a/core/tests/test_learned_automations.py
+++ b/core/tests/test_learned_automations.py
@@ -984,9 +984,9 @@ def test_the_applied_receipt_makes_the_job_genuinely_auditable(context):
 
 
 def _snapshot_with_learned(detail, verdict="OK"):
+    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
     from core.health.reporter import CheckResult, ReporterEnvelope
     from core.health.snapshot import HealthSnapshot
-    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
 
     envelope = ReporterEnvelope(
         contract="dex.health.reporter/v1",
@@ -1078,9 +1078,9 @@ def test_session_start_says_nothing_when_there_is_nothing_to_watch():
 
 def test_a_snapshot_from_before_this_build_is_read_without_complaint():
     """An older snapshot has no learned check at all. That is silence, not a fault."""
+    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
     from core.health.reporter import CheckResult, ReporterEnvelope
     from core.health.snapshot import HealthSnapshot
-    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
     from core.utils import health_session
 
     envelope = ReporterEnvelope(

--- a/core/tests/test_learned_automations.py
+++ b/core/tests/test_learned_automations.py
@@ -1,0 +1,1159 @@
+"""The learned automation watch: a person's own scheduled jobs, judged honestly.
+
+The reported incident: a daily job the user set up herself never fired for
+months and nothing told her.  Dex's shipped jobs have had a promise register
+since the v1.84.0 silent-sync failure; her own job got a disclaimer.  These
+tests pin the behaviour that closes that gap without weakening a single
+existing honesty rule.
+"""
+
+from __future__ import annotations
+
+import json
+import plistlib
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core.health import learned
+from core.utils import doctor
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------- #
+# fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vault(tmp_path):
+    root = tmp_path / "vault"
+    (root / "System").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def context(tmp_path):
+    vault_root = tmp_path / "vault"
+    (vault_root / "System").mkdir(parents=True)
+    (vault_root / "core").mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    return doctor.DoctorContext(
+        vault_root=vault_root, repo_root=vault_root, home=home, now=NOW
+    )
+
+
+def _write_user_plist(context, label, payload=None):
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    script = context.vault_root / ".scripts" / f"{label}.sh"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text(
+        f'#!/bin/bash\ndate -u >> "$HOME/receipts/{label}.log"\n', encoding="utf-8"
+    )
+    script.chmod(0o755)
+    body = {
+        "Label": label,
+        "ProgramArguments": ["/bin/bash", str(script)],
+        "StartCalendarInterval": {"Hour": 9, "Minute": 0},
+    }
+    body.update(payload or {})
+    plist = agents / f"{label}.plist"
+    with plist.open("wb") as handle:
+        plistlib.dump(body, handle)
+    return plist
+
+
+def _opaque_vault_job(context, label, extra=None):
+    """A job that points into the vault through a shell string, as launchd jobs do,
+    but whose program Dex cannot read for outputs."""
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    body = {
+        "Label": label,
+        "ProgramArguments": [
+            "/bin/bash",
+            "-c",
+            f"cd {context.vault_root}; exec /usr/bin/true",
+        ],
+        "StartCalendarInterval": {"Hour": 9, "Minute": 0},
+    }
+    body.update(extra or {})
+    plist = agents / f"{label}.plist"
+    with plist.open("wb") as handle:
+        plistlib.dump(body, handle)
+    return plist
+
+
+def _daily_record(vault_root, label="com.alice.nightly-backup", **overrides):
+    record = learned.LearnedPromise(
+        label=label,
+        plist_relative_path=f"Library/LaunchAgents/{label}.plist",
+        schedule_source="StartCalendarInterval",
+        schedule={"calendar": [{"Hour": 9, "Minute": 0}]},
+        receipt_kind="file-activity",
+        receipt_path=str(vault_root / "receipts" / "backup.log"),
+        receipt_provenance="script-output",
+        activity_only=False,
+        watch_since=(NOW - timedelta(days=10)).isoformat(),
+    )
+    return record.replace(**overrides) if overrides else record
+
+
+# --------------------------------------------------------------------------- #
+# 1. the reported incident, reproduced
+# --------------------------------------------------------------------------- #
+
+
+def test_daily_job_is_quiet_after_one_miss_and_broken_after_two(vault):
+    """One miss is laptop life. Two consecutive misses is a dead job."""
+    record = _daily_record(vault)
+
+    # Receipt from yesterday morning: today's 09:00 has not come round yet.
+    kept = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(hours=27)
+    )
+    assert kept.state == "kept"
+    assert kept.consecutive_misses == 0
+
+    # One due time (yesterday 09:00) passed with nothing after it.
+    one_miss = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(days=2, hours=3)
+    )
+    assert one_miss.state == "kept", "a single miss must not alarm"
+    assert one_miss.consecutive_misses == 1
+    assert not one_miss.surfaces()
+
+    # Two consecutive due times with no trace.
+    two_misses = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(days=3, hours=3)
+    )
+    assert two_misses.state == "broken"
+    assert two_misses.consecutive_misses >= 2
+    assert two_misses.surfaces()
+
+    # Recovery is never held back.
+    recovered = learned.audit_learned(
+        record.replace(consecutive_misses=5),
+        now=NOW,
+        receipt_at=NOW - timedelta(hours=2),
+    )
+    assert recovered.state == "kept"
+    assert recovered.consecutive_misses == 0
+
+
+def test_never_ran_since_watching_began_is_its_own_verdict(vault):
+    record = _daily_record(vault, watch_since=(NOW - timedelta(days=4)).isoformat())
+    audit = learned.audit_learned(record, now=NOW, receipt_at=None)
+    assert audit.state == "never"
+    assert "never" in audit.detail().lower()
+
+
+def test_never_waits_two_full_periods_before_it_speaks(vault):
+    record = _daily_record(vault, watch_since=(NOW - timedelta(hours=20)).isoformat())
+    audit = learned.audit_learned(record, now=NOW, receipt_at=None)
+    assert audit.state != "never"
+    assert not audit.surfaces()
+
+
+# --------------------------------------------------------------------------- #
+# 11. sleep/wake
+# --------------------------------------------------------------------------- #
+
+
+def test_receipt_shortly_after_wake_counts_as_kept(vault):
+    """A machine asleep at 09:00 runs the job on wake. That is not a miss."""
+    record = _daily_record(vault)
+    due = NOW.replace(hour=9, minute=0, second=0, microsecond=0) - timedelta(days=1)
+    audit = learned.audit_learned(
+        record, now=NOW, receipt_at=due + timedelta(hours=3)
+    )
+    assert audit.state == "kept"
+    assert audit.consecutive_misses == 0
+
+
+def test_coarse_interval_schedules_keep_cadence_padding(vault):
+    """Where the read schedule is coarse, grace scales with the interval."""
+    record = _daily_record(
+        vault,
+        schedule_source="StartInterval",
+        schedule={"interval_seconds": int(timedelta(days=7).total_seconds())},
+        watch_since=(NOW - timedelta(days=40)).isoformat(),
+    )
+    # 7d + 4h would be a miss on a fixed grace; 25% of a week is not.
+    audit = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(days=7, hours=6)
+    )
+    assert audit.state == "kept"
+
+
+# --------------------------------------------------------------------------- #
+# 4. activity is not health
+# --------------------------------------------------------------------------- #
+
+
+def test_growing_stderr_is_reported_as_activity_never_as_success(vault):
+    record = _daily_record(
+        vault,
+        receipt_provenance="launchd-stderr",
+        activity_only=True,
+        receipt_path=str(vault / "err.log"),
+    )
+    broken = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(days=3, hours=3)
+    )
+    assert broken.state == "broken"
+    detail = broken.detail()
+    assert "succe" not in detail.lower(), detail
+    assert "ran" in detail.lower()
+
+    kept = learned.audit_learned(record, now=NOW, receipt_at=NOW - timedelta(hours=2))
+    assert "succe" not in kept.detail().lower()
+
+
+# --------------------------------------------------------------------------- #
+# 3. corrupt records
+# --------------------------------------------------------------------------- #
+
+
+def test_corrupt_learned_json_reads_as_unauditable_never_as_kept(vault):
+    store = learned.LearnedStore(vault)
+    store.ensure_directory()
+    (store.records_dir / "com.alice.broken--0123456789ab.json").write_text(
+        "{not json at all", encoding="utf-8"
+    )
+    register, records, corrupt = store.load()
+    assert records == ()
+    assert corrupt, "a corrupt record must be reported, not silently dropped"
+    audits = [learned.unauditable_audit(name) for name in corrupt]
+    assert all(audit.state == "unauditable" for audit in audits)
+    assert all(audit.state != "kept" for audit in audits)
+
+
+def test_sweep_redrafts_a_corrupt_record_instead_of_crashing(context):
+    _write_user_plist(context, "com.alice.nightly-backup")
+    store = learned.LearnedStore(context.vault_root)
+    store.ensure_directory()
+    slug = learned.record_slug("com.alice.nightly-backup")
+    (store.records_dir / f"{slug}.json").write_text("{corrupt", encoding="utf-8")
+
+    result = learned.sweep(context, now=NOW)
+
+    assert "com.alice.nightly-backup" in result.redrafted
+    _register, records, corrupt = store.load()
+    assert corrupt == ()
+    assert [record.label for record in records] == ["com.alice.nightly-backup"]
+
+
+# --------------------------------------------------------------------------- #
+# 13. a label is never a path
+# --------------------------------------------------------------------------- #
+
+
+def test_a_hostile_label_can_never_address_a_file_outside_the_learned_directory():
+    for label in ("../../evil", "/etc/passwd", "..", "a/b/c", "com.dex.ok"):
+        slug = learned.record_slug(label)
+        assert "/" not in slug and ".." not in slug, slug
+        assert learned._SLUG_RE.fullmatch(slug), slug
+    assert learned.record_slug("Com.Alice.Job") != learned.record_slug("com.alice.job")
+
+
+# --------------------------------------------------------------------------- #
+# 8. secrets never reach a record, a report, or a log
+# --------------------------------------------------------------------------- #
+
+
+def test_credential_paths_are_excluded_before_any_read():
+    home = Path("/Users/alice")
+    restricted = [
+        home / ".env",
+        home / ".env.production",
+        home / "my-credentials" / "run.sh",
+        home / "aws_credentials.sh",
+        home / ".claude" / "settings.local.json",
+        home / ".claude" / "settings.json",
+        home / "Dex" / "System" / "integrations" / "config.yaml",
+        home / "bin" / ".env.local" / "run.sh",
+    ]
+    for path in restricted:
+        assert learned.is_script_read_restricted(path), path
+    for allowed in (
+        home / "bin" / "backup.sh",
+        home / "Dex" / ".scripts" / "nightly.sh",
+        home / "Dex" / "System" / "integrations" / "README.md",
+    ):
+        assert not learned.is_script_read_restricted(allowed), allowed
+
+
+def test_a_script_naming_a_credential_file_leaks_nothing(context, tmp_path):
+    secret = context.home / ".env"
+    secret.write_text("API_KEY=sk-super-secret-value\n", encoding="utf-8")
+    script = context.vault_root / ".scripts" / "backup.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "#!/bin/bash\nsource $HOME/.env\ndate > $HOME/backup.receipt\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    plist = _write_user_plist(context, "com.alice.backup")
+    with plist.open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.alice.backup",
+                "ProgramArguments": ["/bin/bash", str(script)],
+                "StartCalendarInterval": {"Hour": 9, "Minute": 0},
+            },
+            handle,
+        )
+
+    learned.sweep(context, now=NOW)
+    blob = json.dumps(
+        [record.to_dict() for record in learned.LearnedStore(context.vault_root).load()[1]]
+    )
+    assert "sk-super-secret-value" not in blob
+    assert ".env" not in blob
+    # The sourced file is never followed, so its own writes are never a receipt.
+    assert "API_KEY" not in blob
+
+
+def test_the_script_reader_refuses_everything_it_cannot_resolve(tmp_path):
+    script = tmp_path / "run.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        "date > $HOME/good.receipt\n"
+        'echo x > "$(mktemp)"\n'
+        "echo y > $UNKNOWN_VAR/out\n"
+        "echo z > /tmp/*.log\n"
+        "source /other/script.sh\n",
+        encoding="utf-8",
+    )
+    found = learned.read_script_output_paths(script, home=tmp_path)
+    assert found == (str(tmp_path / "good.receipt"),)
+
+
+def test_the_script_reader_is_bounded(tmp_path):
+    script = tmp_path / "huge.sh"
+    script.write_text("#!/bin/bash\n" + ("# padding\n" * 40000), encoding="utf-8")
+    assert script.stat().st_size > learned.MAX_SCRIPT_BYTES
+    assert learned.read_script_output_paths(script, home=tmp_path) == ()
+
+    binary = tmp_path / "prog"
+    binary.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 64)
+    assert learned.read_script_output_paths(binary, home=tmp_path) == ()
+
+
+# --------------------------------------------------------------------------- #
+# 5. disclosure before alarm — structural
+# --------------------------------------------------------------------------- #
+
+
+def test_no_learned_alarm_can_appear_before_the_disclosure(vault):
+    """One composer owns every learned line, so this is a property, not a habit."""
+    record = _daily_record(vault)
+    broken = learned.audit_learned(
+        record, now=NOW, receipt_at=NOW - timedelta(days=4)
+    )
+    assert broken.state == "broken"
+
+    undisclosed = learned.compose_surface(
+        learned.LearnedRegister(), [broken], now=NOW
+    )
+    assert undisclosed.disclosure_leading is True
+    assert undisclosed.lines[0] == learned.DISCLOSURE_LINE
+    assert learned.DISCLOSURE_LINE in undisclosed.lines[0]
+    for line in undisclosed.lines[1:]:
+        assert line != learned.DISCLOSURE_LINE
+
+    disclosed = learned.compose_surface(
+        learned.LearnedRegister(disclosed_at=NOW.isoformat()), [broken], now=NOW
+    )
+    assert disclosed.disclosure_leading is False
+    assert disclosed.lines[0] != learned.DISCLOSURE_LINE
+    assert "nightly-backup" in disclosed.lines[0]
+
+
+def test_the_composer_offers_keep_or_stop_per_job_at_disclosure(vault):
+    record = _daily_record(vault)
+    audit = learned.audit_learned(record, now=NOW, receipt_at=NOW - timedelta(hours=1))
+    surface = learned.compose_surface(learned.LearnedRegister(), [audit], now=NOW)
+    assert surface.choices
+    assert surface.choices[0]["label"] == record.label
+    assert set(surface.choices[0]["options"]) == {"keep", "stop"}
+
+
+def test_disclosure_is_recorded_only_after_a_surface_has_carried_it(vault):
+    store = learned.LearnedStore(vault)
+    store.ensure_directory()
+    assert store.load()[0].disclosed_at is None
+    store.record_disclosure_shown(now=NOW)
+    assert store.load()[0].disclosed_at == NOW.isoformat()
+    # Idempotent: a second run must not move the stamp.
+    store.record_disclosure_shown(now=NOW + timedelta(days=1))
+    assert store.load()[0].disclosed_at == NOW.isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# 6. stop is real
+# --------------------------------------------------------------------------- #
+
+
+def test_stop_silences_alarms_and_lists_the_job_as_unwatched_by_choice(vault):
+    store = learned.LearnedStore(vault)
+    store.ensure_directory()
+    store.put(_daily_record(vault))
+    store.set_watch_state("com.alice.nightly-backup", "stopped-by-user", now=NOW)
+
+    _register, records, _corrupt = store.load()
+    stopped = records[0]
+    assert stopped.watch_state == "stopped-by-user"
+
+    audit = learned.audit_learned(
+        stopped, now=NOW, receipt_at=NOW - timedelta(days=9)
+    )
+    assert audit.state == "stopped-by-user"
+    assert not audit.surfaces(), "a stopped job must never alarm again"
+
+    surface = learned.compose_surface(
+        learned.LearnedRegister(disclosed_at=NOW.isoformat()), [audit], now=NOW
+    )
+    assert any("your choice" in line for line in surface.coverage_lines)
+    assert not any("was due" in line for line in surface.lines)
+
+
+def test_re_enabling_resumes_watching_from_a_fresh_start(vault):
+    store = learned.LearnedStore(vault)
+    store.ensure_directory()
+    store.put(_daily_record(vault))
+    store.set_watch_state("com.alice.nightly-backup", "stopped-by-user", now=NOW)
+    later = NOW + timedelta(days=3)
+    store.set_watch_state("com.alice.nightly-backup", "watching", now=later)
+
+    record = store.load()[1][0]
+    assert record.watch_state == "watching"
+    assert record.watch_since == later.isoformat()
+    assert record.consecutive_misses == 0
+
+
+def test_a_sweep_never_resurrects_a_stopped_job(context):
+    _write_user_plist(context, "com.alice.nightly-backup")
+    learned.sweep(context, now=NOW)
+    store = learned.LearnedStore(context.vault_root)
+    store.set_watch_state("com.alice.nightly-backup", "stopped-by-user", now=NOW)
+
+    learned.sweep(context, now=NOW + timedelta(days=2))
+
+    assert store.load()[1][0].watch_state == "stopped-by-user"
+
+
+# --------------------------------------------------------------------------- #
+# 7. boundaries
+# --------------------------------------------------------------------------- #
+
+
+def test_a_plist_pointing_entirely_outside_the_vault_is_not_enrolled(context):
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    with (agents / "com.other.tool.plist").open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.other.tool",
+                "ProgramArguments": ["/bin/bash", "/usr/local/bin/other-tool.sh"],
+                "StartInterval": 3600,
+                # Merely logging into the vault never claims ownership.
+                "StandardOutPath": str(context.vault_root / "other.log"),
+            },
+            handle,
+        )
+
+    learned.sweep(context, now=NOW)
+
+    assert learned.LearnedStore(context.vault_root).load()[1] == ()
+
+
+def test_a_shipped_job_is_never_learned(context):
+    _write_user_plist(context, "com.dex.meeting-intel")
+    learned.sweep(context, now=NOW)
+    assert learned.LearnedStore(context.vault_root).load()[1] == ()
+
+
+def test_a_solo_claimed_job_is_not_enrolled_and_enrolls_once_released(context):
+    """Fixture note: claims accept only com.dex.*/com.claudesidian.* labels
+    (core/utils/automation_ownership.py:189-190), and a released *shipped*
+    label maps straight back to its shipped promise.  So the released->enroll
+    arm needs a user job deliberately labelled com.dex.something-unshipped."""
+    from core.tests.test_doctor import _write_solo_automation_claim
+
+    label = "com.dex.something-unshipped"
+    plist = _write_user_plist(context, label)
+    _write_solo_automation_claim(context, plist, label)
+
+    learned.sweep(context, now=NOW)
+    assert learned.LearnedStore(context.vault_root).load()[1] == ()
+
+    (context.vault_root / "System" / ".dex" / "automation-ownership.json").unlink()
+
+    learned.sweep(context, now=NOW)
+    assert [r.label for r in learned.LearnedStore(context.vault_root).load()[1]] == [label]
+
+
+# --------------------------------------------------------------------------- #
+# 2. the shipped gate is untouched
+# --------------------------------------------------------------------------- #
+
+
+def test_a_learned_record_cannot_satisfy_the_shipped_build_gate(tmp_path):
+    """Removing a shipped declaration must still fail --check, learned or not."""
+    gate = REPO_ROOT / "scripts" / "generate-health-promises.py"
+    baseline = subprocess.run(
+        [sys.executable, str(gate), "--check"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert baseline.returncode == 0, baseline.stderr
+
+    register = REPO_ROOT / "core" / "health" / "promises.py"
+    original = register.read_text(encoding="utf-8")
+    victim = '    HealthPromise(\n        id="com.dex.learning-review",'
+    assert victim in original
+    start = original.index(victim)
+    end = original.index("    HealthPromise(\n        id=\"com.dex.obsidian-sync\"")
+    try:
+        register.write_text(original[:start] + original[end:], encoding="utf-8")
+        broken = subprocess.run(
+            [sys.executable, str(gate), "--check"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        register.write_text(original, encoding="utf-8")
+    assert broken.returncode == 1
+    assert "com.dex.learning-review" in broken.stderr
+
+
+def test_the_shipped_register_is_still_a_frozen_tuple_of_five():
+    from core.health import promises
+
+    assert isinstance(promises.PROMISES, tuple)
+    assert len(promises.PROMISES) == 5
+    with pytest.raises((AttributeError, TypeError)):
+        promises.PROMISES[0].cadence = timedelta(days=1)
+
+
+def test_the_session_start_mirror_table_never_names_a_learned_job(context):
+    mirror = (REPO_ROOT / ".claude" / "hooks" / "session-start.sh").read_text(
+        encoding="utf-8"
+    )
+    _write_user_plist(context, "com.alice.nightly-backup")
+    learned.sweep(context, now=NOW)
+    for record in learned.LearnedStore(context.vault_root).load()[1]:
+        assert record.label not in mirror
+
+
+# --------------------------------------------------------------------------- #
+# 9. read-only invariant
+# --------------------------------------------------------------------------- #
+
+
+def test_discovery_and_audit_write_nothing_outside_the_health_directory(context):
+    _write_user_plist(context, "com.alice.nightly-backup")
+    _write_user_plist(context, "com.alice.report", {"StartInterval": 3600})
+
+    def snapshot(root):
+        return {
+            path.relative_to(root).as_posix(): path.stat().st_mtime_ns
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+
+    health_dir = "System/.dex/health"
+    before_vault = snapshot(context.vault_root)
+    before_home = snapshot(context.home)
+
+    learned.sweep(context, now=NOW)
+    store = learned.LearnedStore(context.vault_root)
+    for record in store.load()[1]:
+        learned.audit_learned(record, now=NOW)
+
+    after_vault = snapshot(context.vault_root)
+    after_home = snapshot(context.home)
+
+    assert after_home == before_home, "the user's home must never be written"
+    changed = {
+        path
+        for path in set(before_vault) | set(after_vault)
+        if before_vault.get(path) != after_vault.get(path)
+    }
+    infrastructure = ("System/.dex/tx", "System/.dex/mutation.lock")
+    stray = {
+        path
+        for path in changed
+        if not path.startswith(health_dir) and not path.startswith(infrastructure)
+    }
+    assert stray == set(), stray
+
+
+# --------------------------------------------------------------------------- #
+# 12. severity — learned breakage never scores Dex's own health as critical
+# --------------------------------------------------------------------------- #
+
+
+def test_the_learned_check_never_returns_broken_or_unknown(context):
+    _write_user_plist(context, "com.alice.nightly-backup")
+    learned.sweep(context, now=NOW)
+    store = learned.LearnedStore(context.vault_root)
+    record = store.load()[1][0]
+    store.put(
+        record.replace(
+            consecutive_misses=9,
+            last_receipt_at=(NOW - timedelta(days=30)).isoformat(),
+            watch_since=(NOW - timedelta(days=40)).isoformat(),
+        )
+    )
+
+    result = doctor._probe_learned_automations(context)
+
+    assert result.verdict in {"OK", "OFF"}
+    assert result.structured_detail is not None
+    assert result.structured_detail["needs_attention"] >= 1
+
+
+def test_a_broken_learned_job_never_makes_dexs_own_health_critical(context):
+    from core.health.doctor_reporter import from_doctor_report
+    from core.health.snapshot import _overall_status
+
+    _write_user_plist(context, "com.alice.nightly-backup")
+    learned.sweep(context, now=NOW)
+    store = learned.LearnedStore(context.vault_root)
+    record = store.load()[1][0]
+    store.put(
+        record.replace(
+            consecutive_misses=9,
+            last_receipt_at=(NOW - timedelta(days=30)).isoformat(),
+            watch_since=(NOW - timedelta(days=40)).isoformat(),
+        )
+    )
+
+    report = {
+        "generated_at": NOW.isoformat(),
+        "checks": [
+            {
+                "id": definition.id,
+                "feature": definition.feature,
+                "verdict": "OK",
+                "detail": "Stub probe completed.",
+            }
+            for definition in (*doctor.QUICK_CHECKS, *doctor.DEEP_CHECKS)
+        ],
+    }
+    learned_check = next(
+        check for check in report["checks"] if check["id"] == "learned-automations"
+    )
+    learned_check["verdict"] = doctor._probe_learned_automations(context).verdict
+    learned_check["detail"] = doctor._probe_learned_automations(context).detail
+
+    normalized = from_doctor_report(report, refresh_id="test-refresh")
+    assert normalized.accepted, normalized.errors
+    assert _overall_status(normalized.report) != "critical"
+
+
+def test_the_learned_check_is_registered_in_the_reporter_spec():
+    from core.health.doctor_reporter import DOCTOR_REPORTER_SPEC
+
+    assert "learned-automations" in DOCTOR_REPORTER_SPEC.check_versions
+
+
+def test_the_snapshot_detail_stays_a_bounded_rollup(context):
+    from core.health.reporter import MAX_DETAIL_LENGTH
+
+    for index in range(12):
+        _write_user_plist(context, f"com.alice.job-{index}")
+    learned.sweep(context, now=NOW)
+    store = learned.LearnedStore(context.vault_root)
+    for record in store.load()[1]:
+        store.put(
+            record.replace(
+                consecutive_misses=4,
+                watch_since=(NOW - timedelta(days=40)).isoformat(),
+                last_receipt_at=(NOW - timedelta(days=30)).isoformat(),
+            )
+        )
+
+    result = doctor._probe_learned_automations(context)
+
+    assert len(result.detail) <= MAX_DETAIL_LENGTH
+    # The evidence-rich lines live in the report body, not the snapshot.
+    assert len(result.structured_detail["findings"]) >= 1
+
+
+# --------------------------------------------------------------------------- #
+# 10. the pulse's silent path is untouched by construction
+# --------------------------------------------------------------------------- #
+
+
+def test_the_mid_session_pulse_is_untouched_by_this_build():
+    pulse = (REPO_ROOT / ".claude" / "hooks" / "health-pulse.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "learned" not in pulse.lower()
+    # The everyday silent path is still exactly two bash-builtin file reads.
+    assert pulse.count('"$(<"') == 2
+    # Every fork in the whole script is dedup-gated, so it can only run on a
+    # path where the pulse is about to speak — never on the silent one.
+    for number, line in enumerate(pulse.splitlines(), start=1):
+        if line.lstrip().startswith("#"):
+            continue
+        for fork in ("grep ", "sed ", "awk ", "$(cat", "python"):
+            if fork in line:
+                assert "DEDUP_FILE" in line, f"line {number}: {line}"
+
+
+# --------------------------------------------------------------------------- #
+# receipt selection, best first
+# --------------------------------------------------------------------------- #
+
+
+def test_receipt_prefers_the_scripts_own_output_over_launchd_evidence(context):
+    script = context.vault_root / ".scripts" / "backup.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        '#!/bin/bash\ndate -u > "$HOME/backup.receipt"\n', encoding="utf-8"
+    )
+    script.chmod(0o755)
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    with (agents / "com.alice.backup.plist").open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": "com.alice.backup",
+                "ProgramArguments": ["/bin/bash", str(script)],
+                "StartCalendarInterval": {"Hour": 9, "Minute": 0},
+                "StandardErrorPath": str(context.home / "backup.err"),
+            },
+            handle,
+        )
+
+    learned.sweep(context, now=NOW)
+
+    record = learned.LearnedStore(context.vault_root).load()[1][0]
+    assert record.receipt_provenance == "script-output"
+    assert record.receipt_path == str(context.home / "backup.receipt")
+    assert record.activity_only is False
+
+
+def test_launchd_evidence_is_recorded_as_activity_only(context):
+    _opaque_vault_job(
+        context,
+        "com.alice.opaque",
+        {"StandardErrorPath": str(context.home / "opaque.err")},
+    )
+
+    learned.sweep(context, now=NOW)
+
+    record = learned.LearnedStore(context.vault_root).load()[1][0]
+    assert record.receipt_provenance == "launchd-stderr"
+    assert record.activity_only is True
+
+
+def test_a_receipt_poor_job_stays_honestly_unauditable(context):
+    _opaque_vault_job(context, "com.alice.bare")
+
+    learned.sweep(context, now=NOW)
+
+    record = learned.LearnedStore(context.vault_root).load()[1][0]
+    assert record.receipt_provenance == "none"
+    audit = learned.audit_learned(record, now=NOW)
+    assert audit.state == "unauditable"
+    assert not audit.surfaces()
+
+
+# --------------------------------------------------------------------------- #
+# event-driven jobs: no fabricated cadence
+# --------------------------------------------------------------------------- #
+
+
+def test_an_event_driven_job_is_watched_without_a_rhythm_and_never_alarmed(context):
+    plist = _opaque_vault_job(
+        context,
+        "com.alice.watcher",
+        {"StandardOutPath": str(context.home / "watcher.log")},
+    )
+    payload = plistlib.loads(plist.read_bytes())
+    del payload["StartCalendarInterval"]
+    payload["WatchPaths"] = [str(context.vault_root / "inbox")]
+    with plist.open("wb") as handle:
+        plistlib.dump(payload, handle)
+
+    learned.sweep(context, now=NOW)
+
+    record = learned.LearnedStore(context.vault_root).load()[1][0]
+    assert record.schedule_source == "observed"
+    audit = learned.audit_learned(record, now=NOW)
+    assert audit.state == "no-rhythm-yet"
+    assert not audit.surfaces()
+
+
+def test_an_observed_interval_is_learned_only_once_it_is_stable():
+    runs = [(NOW - timedelta(days=n)).isoformat() for n in range(6, 0, -1)]
+    assert learned.learn_interval(runs[:3]) is None
+    steady = learned.learn_interval(runs)
+    assert steady == timedelta(days=1)
+
+    jittery = [
+        (NOW - timedelta(days=20)).isoformat(),
+        (NOW - timedelta(days=19)).isoformat(),
+        (NOW - timedelta(days=5)).isoformat(),
+        (NOW - timedelta(hours=2)).isoformat(),
+    ]
+    assert learned.learn_interval(jittery) is None
+
+
+# --------------------------------------------------------------------------- #
+# the coverage note keeps its job
+# --------------------------------------------------------------------------- #
+
+
+def test_jobs_fresh_still_names_jobs_it_genuinely_cannot_audit(context):
+    """The existing #253 disclaimer must survive, narrowed to the honest set."""
+    _opaque_vault_job(context, "com.alice.bare")
+    learned.sweep(context, now=NOW)
+
+    result = doctor._probe_jobs_fresh(context)
+
+    assert "com.alice.bare" in result.detail
+    assert "not freshness" in result.detail
+
+
+def test_v1_says_plainly_that_it_only_understands_launchd(context):
+    _write_user_plist(context, "com.alice.nightly-backup")
+    learned.sweep(context, now=NOW)
+    result = doctor._probe_learned_automations(context)
+    assert "launchd" in json.dumps(result.structured_detail).lower() or (
+        "scheduled jobs on this Mac" in json.dumps(result.structured_detail)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Lot 5 — the build's only write to a user file, and it is always asked
+# --------------------------------------------------------------------------- #
+
+
+def _receipt_poor_job(context, label="com.alice.opaque"):
+    script = context.vault_root / ".scripts" / "opaque.sh"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("#!/bin/bash\n/usr/bin/rsync -a ~/Documents /backup\n")
+    script.chmod(0o755)
+    agents = context.home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True, exist_ok=True)
+    with (agents / f"{label}.plist").open("wb") as handle:
+        plistlib.dump(
+            {
+                "Label": label,
+                "ProgramArguments": ["/bin/bash", str(script)],
+                "StartCalendarInterval": {"Hour": 9, "Minute": 0},
+            },
+            handle,
+        )
+    learned.sweep(context, now=NOW)
+    return script, learned.LearnedStore(context.vault_root).get(label)
+
+
+def test_a_receipt_poor_job_is_offered_an_exact_diff_and_nothing_is_written(context):
+    script, record = _receipt_poor_job(context)
+    assert record.receipt_provenance == "none"
+    before = script.read_bytes()
+
+    proposal = learned.propose_receipt_instrumentation(record, home=context.home)
+
+    assert proposal is not None
+    added = [
+        line
+        for line in proposal.diff.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+    assert len(added) == 1, "exactly one added line, shown exactly"
+    assert added[0][1:] == proposal.line.rstrip("\n")
+    assert proposal.receipt_path.startswith(str(context.home))
+    assert script.read_bytes() == before, "an offer must never write"
+
+
+def test_the_receipt_line_is_applied_only_on_an_explicit_yes(context):
+    script, record = _receipt_poor_job(context)
+    proposal = learned.propose_receipt_instrumentation(record, home=context.home)
+    before = script.read_bytes()
+
+    for refusal in (False, None, 0, "yes"):
+        assert (
+            learned.apply_receipt_proposal(
+                context.vault_root, proposal, approved=refusal, now=NOW
+            )
+            is False
+        )
+        assert script.read_bytes() == before
+
+    assert learned.apply_receipt_proposal(
+        context.vault_root, proposal, approved=True, now=NOW
+    )
+    after = script.read_text()
+    assert after.startswith(before.decode())
+    assert after.count("added by Dex") == 1
+
+    upgraded = learned.LearnedStore(context.vault_root).get(record.label)
+    assert upgraded.receipt_provenance == "script-output"
+    assert upgraded.activity_only is False
+    assert upgraded.receipt_path == proposal.receipt_path
+
+
+def test_a_script_that_changed_since_the_offer_needs_a_new_offer(context):
+    script, record = _receipt_poor_job(context)
+    proposal = learned.propose_receipt_instrumentation(record, home=context.home)
+    script.write_text("#!/bin/bash\n# the user edited this in the meantime\n")
+
+    assert (
+        learned.apply_receipt_proposal(
+            context.vault_root, proposal, approved=True, now=NOW
+        )
+        is False
+    )
+    assert "added by Dex" not in script.read_text()
+
+
+def test_instrumentation_is_never_offered_twice_or_for_a_job_that_has_a_receipt(context):
+    script, record = _receipt_poor_job(context)
+    proposal = learned.propose_receipt_instrumentation(record, home=context.home)
+    learned.apply_receipt_proposal(
+        context.vault_root, proposal, approved=True, now=NOW
+    )
+    upgraded = learned.LearnedStore(context.vault_root).get(record.label)
+
+    assert learned.propose_receipt_instrumentation(upgraded, home=context.home) is None
+    assert (
+        learned.propose_receipt_instrumentation(
+            upgraded.replace(
+                receipt_provenance="launchd-stderr",
+                receipt_path=str(context.home / "err.log"),
+                activity_only=True,
+            ),
+            home=context.home,
+        )
+        is None
+    ), "the marker in the script must stop a second offer too"
+
+
+def test_instrumentation_is_never_offered_for_a_credential_bearing_script(context):
+    script, record = _receipt_poor_job(context)
+    secret = context.vault_root / ".scripts" / "credentials-refresh.sh"
+    secret.write_text("#!/bin/bash\necho refresh\n")
+    assert (
+        learned.propose_receipt_instrumentation(
+            record.replace(program_path=str(secret)), home=context.home
+        )
+        is None
+    )
+
+
+def test_the_applied_receipt_makes_the_job_genuinely_auditable(context):
+    script, record = _receipt_poor_job(context)
+    assert learned.audit_learned(record, now=NOW).state == "unauditable"
+
+    proposal = learned.propose_receipt_instrumentation(record, home=context.home)
+    learned.apply_receipt_proposal(
+        context.vault_root, proposal, approved=True, now=NOW
+    )
+    upgraded = learned.LearnedStore(context.vault_root).get(record.label)
+
+    assert upgraded.is_auditable()
+    # The receipt does not exist yet: honest "nothing due yet", not a fake pass.
+    assert learned.audit_learned(upgraded, now=NOW).state == "pending"
+    receipt = Path(upgraded.receipt_path)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text("2026-08-25T09:00:00Z\n")
+    assert learned.audit_learned(upgraded, now=NOW + timedelta(hours=1)).state == "kept"
+
+
+# --------------------------------------------------------------------------- #
+# session start speaks through the snapshot, and only through it
+# --------------------------------------------------------------------------- #
+
+
+def _snapshot_with_learned(detail, verdict="OK"):
+    from core.health.reporter import CheckResult, ReporterEnvelope
+    from core.health.snapshot import HealthSnapshot
+    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
+
+    envelope = ReporterEnvelope(
+        contract="dex.health.reporter/v1",
+        reporter=DOCTOR_REPORTER_IDENTITY,
+        refresh_id="refresh-001",
+        generated_at=NOW.isoformat(),
+        results=(
+            CheckResult(
+                id="doctor.core/vault.structure",
+                check_version="1.0.0",
+                verdict="OK",
+                detail="All standard PARA directories exist",
+            ),
+            CheckResult(
+                id="doctor.core/learned-automations",
+                check_version="1.0.0",
+                verdict=verdict,
+                detail=detail,
+            ),
+        ),
+    )
+    from core.health.snapshot import _overall_status
+
+    return HealthSnapshot(
+        snapshot_id="snap-001",
+        refresh_id="refresh-001",
+        generated_at=NOW.isoformat(),
+        completed_at=NOW.isoformat(),
+        overall_status=_overall_status(envelope),
+        report=envelope,
+    )
+
+
+def test_session_start_repeats_the_snapshots_learned_line_verbatim():
+    from core.utils import health_session
+
+    surface = learned.compose_surface(
+        learned.LearnedRegister(disclosed_at=NOW.isoformat()),
+        [
+            learned.LearnedAudit(
+                label="com.alice.nightly-backup",
+                display_name="nightly-backup",
+                state="broken",
+                consecutive_misses=2,
+            )
+        ],
+        now=NOW,
+    )
+    line = health_session.learned_automations_line(
+        _snapshot_with_learned(surface.snapshot_detail)
+    )
+    assert surface.rollup in line
+    assert "nightly-backup" in line
+
+
+def test_session_start_cannot_show_a_learned_alarm_without_the_disclosure():
+    """The disclosure is folded into the snapshot detail, so every reader gets it."""
+    from core.utils import health_session
+
+    surface = learned.compose_surface(
+        learned.LearnedRegister(),
+        [
+            learned.LearnedAudit(
+                label="com.alice.nightly-backup",
+                display_name="nightly-backup",
+                state="broken",
+                consecutive_misses=2,
+            )
+        ],
+        now=NOW,
+    )
+    line = health_session.learned_automations_line(
+        _snapshot_with_learned(surface.snapshot_detail)
+    )
+    assert line.index(learned.DISCLOSURE_LINE) < line.index("nightly-backup")
+
+
+def test_session_start_says_nothing_when_there_is_nothing_to_watch():
+    from core.utils import health_session
+
+    assert health_session.learned_automations_line(None) == ""
+    assert (
+        health_session.learned_automations_line(
+            _snapshot_with_learned("No automations", verdict="OFF")
+        )
+        == ""
+    )
+
+
+def test_a_snapshot_from_before_this_build_is_read_without_complaint():
+    """An older snapshot has no learned check at all. That is silence, not a fault."""
+    from core.health.reporter import CheckResult, ReporterEnvelope
+    from core.health.snapshot import HealthSnapshot
+    from core.health.doctor_reporter import DOCTOR_REPORTER_IDENTITY
+    from core.utils import health_session
+
+    envelope = ReporterEnvelope(
+        contract="dex.health.reporter/v1",
+        reporter=DOCTOR_REPORTER_IDENTITY,
+        refresh_id="refresh-old",
+        generated_at=NOW.isoformat(),
+        results=(
+            CheckResult(
+                id="doctor.core/vault.structure",
+                check_version="1.0.0",
+                verdict="OK",
+                detail="All standard PARA directories exist",
+            ),
+        ),
+    )
+    from core.health.snapshot import _overall_status
+
+    snapshot = HealthSnapshot(
+        snapshot_id="snap-old",
+        refresh_id="refresh-old",
+        generated_at=NOW.isoformat(),
+        completed_at=NOW.isoformat(),
+        overall_status=_overall_status(envelope),
+        report=envelope,
+    )
+    assert health_session.learned_automations_line(snapshot) == ""
+
+
+def test_the_learned_line_never_changes_dexs_own_status_line(tmp_path):
+    from core.utils import health_session
+
+    snapshot = _snapshot_with_learned(
+        f"{learned.DISCLOSURE_LINE} 1 of your automations watched; 1 needs attention: backup"
+    )
+    line = health_session.learned_automations_line(snapshot)
+    assert not line.startswith("🩺")
+    assert "Dex health" not in line
+
+
+def test_the_rollup_never_calls_silence_success(vault):
+    """A watched job that has never left a trace is not "on schedule"."""
+    disclosed = learned.LearnedRegister(disclosed_at=NOW.isoformat())
+    pending = learned.LearnedAudit(
+        label="com.alice.backup", display_name="backup", state="pending"
+    )
+    kept = learned.LearnedAudit(
+        label="com.alice.report",
+        display_name="report",
+        state="kept",
+        last_receipt_at=NOW - timedelta(hours=1),
+    )
+
+    only_pending = learned.compose_surface(disclosed, [pending], now=NOW)
+    assert "on schedule" not in only_pending.rollup
+    assert "trace" in only_pending.rollup
+
+    mixed = learned.compose_surface(disclosed, [pending, kept], now=NOW)
+    assert "1 on schedule" in mixed.rollup
+    assert "1 with nothing to check yet" in mixed.rollup
+
+    all_kept = learned.compose_surface(disclosed, [kept], now=NOW)
+    assert all_kept.rollup.endswith("all on schedule")
+
+
+def test_one_broken_job_reads_as_singular(vault):
+    surface = learned.compose_surface(
+        learned.LearnedRegister(disclosed_at=NOW.isoformat()),
+        [
+            learned.LearnedAudit(
+                label="com.alice.backup", display_name="backup", state="broken"
+            )
+        ],
+        now=NOW,
+    )
+    assert "1 needs attention" in surface.rollup

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -621,6 +621,11 @@ QUICK_CHECKS = (
     CheckDefinition("hooks.wired", "Claude hooks", "_probe_hooks_wired"),
     CheckDefinition("jobs.loaded", "Background jobs", "_probe_jobs_loaded"),
     CheckDefinition("jobs.fresh", "Background job freshness", "_probe_jobs_fresh"),
+    CheckDefinition(
+        "learned-automations",
+        "Your own automations",
+        "_probe_learned_automations",
+    ),
     CheckDefinition("preflight.queue", "Preflight health", "_probe_preflight_queue"),
     CheckDefinition(
         "capabilities.rooms",
@@ -1046,6 +1051,7 @@ def collect(
     # jobs.loaded and jobs.fresh instead of re-parsing every plist twice.
     _begin_launch_agent_scan_scope(context)
     try:
+        _sweep_learned_automations(context)
         for definition in definitions:
             if definition.id == "doctor.self":
                 continue
@@ -1164,6 +1170,10 @@ def collect(
         "summary": _summary(checks),
         "adoption": adoption.to_dict(),
     }
+    learned_result = results.get("learned-automations")
+    if learned_result is not None and learned_result.structured_detail is not None:
+        report["learned_automations"] = learned_result.structured_detail
+
     if deep:
         assessment_result = results.get("customizations.assessment")
         if (
@@ -2907,6 +2917,22 @@ def _probe_jobs_loaded(context: DoctorContext) -> ProbeResult:
     )
 
 
+def _sweep_learned_automations(context: DoctorContext) -> None:
+    """Draft and refresh the user's learned promises once per Doctor run.
+
+    Rides the launch-agent classification pass already open around this call,
+    so it parses no plist twice.  Failure is never allowed to break a Doctor
+    run: the learned check reports what it can read, and reads nothing rather
+    than guessing.
+    """
+    try:
+        from core.health import learned as health_learned
+
+        health_learned.sweep(context, now=context.now, scan=_scan_launch_agents(context))
+    except Exception:  # noqa: BLE001 — watching must never break the checkup
+        return
+
+
 def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
     """Audit installed jobs against the health promise register.
 
@@ -2956,19 +2982,39 @@ def _probe_jobs_fresh(context: DoctorContext) -> ProbeResult:
             monitored_ids.add(promise.id)
             monitored.append(promise)
 
-    # Jobs with no receipt in the promise register cannot be freshness-
-    # audited. Say so plainly at every verdict instead of letting "OFF" read
-    # as "nothing to monitor" (issue #253).
-    coverage_note = ""
-    if unregistered:
-        count = len(unregistered)
+    # A user's own job used to end its story here. It now has a learned
+    # promise of its own (core/health/learned.py) and is audited by the
+    # learned-automations check, so this note keeps only the jobs that still
+    # genuinely cannot be judged — plus the two honest categories that are
+    # not failures: watching with no rhythm yet, and stopped at the user's
+    # request. Saying "OFF" alone would still read as "nothing to monitor"
+    # (issue #253), so every verdict still carries the note.
+    watched_labels, stopped_labels, rhythmless_labels = _learned_label_states(context)
+    unaudited = [label for label in unregistered if label not in watched_labels]
+
+    notes = []
+    if unaudited:
+        count = len(unaudited)
         noun = "launch agent" if count == 1 else "launch agents"
         verb = "is" if count == 1 else "are"
-        coverage_note = (
-            f"{count} {noun} referencing this vault ({', '.join(unregistered)}) "
+        notes.append(
+            f"{count} {noun} referencing this vault ({', '.join(unaudited)}) "
             f"{verb} checked for loading only, not freshness "
             "(no registered freshness receipt)"
         )
+    rhythmless = sorted(label for label in rhythmless_labels if label in unregistered)
+    if rhythmless:
+        notes.append(
+            f"{len(rhythmless)} of your own jobs ({', '.join(rhythmless)}) "
+            "are being watched but have shown no regular rhythm yet"
+        )
+    stopped = sorted(label for label in stopped_labels if label in unregistered)
+    if stopped:
+        notes.append(
+            f"{len(stopped)} of your own jobs ({', '.join(stopped)}) "
+            "are not watched, at your choice"
+        )
+    coverage_note = "; ".join(notes)
 
     def _with_coverage_note(detail: str) -> str:
         return f"{detail}; {coverage_note}" if coverage_note else detail
@@ -3147,6 +3193,91 @@ def _historical_error_summary(
     if dated:
         return f"{subject}{reason}, last on {max(dated)}"
     return f"{subject}{reason}, dates unavailable"
+
+
+def _learned_label_states(
+    context: DoctorContext,
+) -> tuple[set[str], set[str], set[str]]:
+    """Which of the user's own jobs Dex now watches, stopped, or cannot time yet.
+
+    Read-only and failure-tolerant: an unreadable learned register leaves the
+    freshness check saying exactly what it said before this build.
+    """
+    try:
+        from core.health import learned as health_learned
+
+        _register, audits = health_learned.audit_all(context.vault_root, now=context.now)
+    except Exception:  # noqa: BLE001 — a learned read must never break Doctor
+        return set(), set(), set()
+    watched = {
+        audit.label
+        for audit in audits
+        if audit.state in health_learned.JUDGEMENTS
+    }
+    stopped = {audit.label for audit in audits if audit.state == "stopped-by-user"}
+    rhythmless = {audit.label for audit in audits if audit.state == "no-rhythm-yet"}
+    return watched, stopped, rhythmless
+
+
+def _probe_learned_automations(context: DoctorContext) -> ProbeResult:
+    """Report on the person's own scheduled jobs — never on Dex's behalf.
+
+    The verdict answers "is Dex's watch working", not "is your job working".
+    That distinction is structural, not stylistic: the reporter contract has no
+    warning level and ``core/health/snapshot.py:_overall_status`` turns any
+    BROKEN into ``critical``, which is reserved for Dex's own health.  A user
+    job in trouble must never make Dex say it is broken, and must never fire
+    the mid-session pulse ahead of the disclosure.  So this check returns OK or
+    OFF only; the finding lives in ``detail`` and in the report's
+    ``learned_automations`` section, which the Doctor skill renders in full.
+    """
+    from core.health import learned as health_learned
+
+    try:
+        register, audits = health_learned.audit_all(context.vault_root, now=context.now)
+    except Exception as error:  # noqa: BLE001
+        # Even here: never UNKNOWN. Say plainly that the watch could not be
+        # read, and leave Dex's own health score alone.
+        return ProbeResult(
+            "OK",
+            "Dex could not read its notes about your own automations "
+            f"({_one_line(error)}); they are not being judged right now",
+            structured_detail={
+                "schema_version": 1,
+                "scope": health_learned.SCOPE_NOTE,
+                "readable": False,
+                "watched": 0,
+                "needs_attention": 0,
+                "findings": [],
+                "coverage": [],
+                "disclosure_required": True,
+                "disclosure_line": health_learned.DISCLOSURE_LINE,
+                "choices": [],
+            },
+        )
+
+    surface = health_learned.compose_surface(register, audits, now=context.now)
+    structured = {
+        "schema_version": 1,
+        "scope": health_learned.SCOPE_NOTE,
+        "readable": True,
+        "watched": surface.watched,
+        "needs_attention": surface.needs_attention,
+        "disclosure_required": surface.disclosure_leading,
+        "disclosure_line": health_learned.DISCLOSURE_LINE if surface.disclosure_leading else None,
+        "choices": [dict(choice, options=list(choice["options"])) for choice in surface.choices],
+        "findings": [audit.to_dict() for audit in audits if audit.surfaces()],
+        "coverage": list(surface.coverage_lines),
+        "lines": list(surface.lines),
+        "never_auto_heals": True,
+    }
+    if not audits:
+        return ProbeResult(
+            "OFF",
+            "No scheduled automations of your own were found to watch",
+            structured_detail=structured,
+        )
+    return ProbeResult("OK", surface.snapshot_detail, structured_detail=structured)
 
 
 def _probe_preflight_queue(context: DoctorContext) -> ProbeResult:

--- a/core/utils/health_session.py
+++ b/core/utils/health_session.py
@@ -83,6 +83,29 @@ def _snapshot_stamp(snapshot: HealthSnapshot) -> str:
     return snapshot.completed_at
 
 
+LEARNED_CHECK_ID = "doctor.core/learned-automations"
+
+
+def learned_automations_line(snapshot: HealthSnapshot | None) -> str:
+    """The one line session start may say about the person's own automations.
+
+    Read straight from the snapshot the Doctor published — this surface never
+    computes a verdict and never composes its own copy.  The disclosure is
+    already folded into that detail by ``core/health/learned.compose_surface``,
+    so an alarm cannot reach the person here without it.  Silence when there is
+    nothing to watch, or when the check is absent from an older snapshot.
+    """
+    if snapshot is None:
+        return ""
+    for result in snapshot.report.results:
+        if result.id != LEARNED_CHECK_ID:
+            continue
+        if result.verdict != "OK" or not result.detail.strip():
+            return ""
+        return f"🗂️ Your own automations: {result.detail}\n"
+    return ""
+
+
 def format_session_health(
     vault_root: str | Path,
     *,
@@ -97,6 +120,9 @@ def format_session_health(
         return "🩺 Dex health: unavailable — opening the general /dex-doctor flow is safe.\n"
 
     snapshot_stamp = _snapshot_stamp(surface.snapshot)
+    # Learned findings are the person's own jobs, never Dex's health. They are
+    # appended below the status line and can never change it.
+    learned = learned_automations_line(surface.snapshot)
     if surface.state == "critical" and surface.newly_critical:
         return "\n".join(
             (
@@ -106,15 +132,19 @@ def format_session_health(
                 "---",
                 "",
             )
-        )
+        ) + learned
     if surface.state == "critical":
         return (
             "🩺 Dex health: critical (ongoing) — "
             f"latest complete snapshot {snapshot_stamp}; run /dex-doctor to investigate.\n"
-        )
+        ) + learned
     if surface.state == "healthy" and surface.recovered:
-        return f"🩺 Dex health: healthy (recovered) — latest complete snapshot {snapshot_stamp}.\n"
-    return f"🩺 Dex health: {surface.state} — latest complete snapshot {snapshot_stamp}.\n"
+        return (
+            f"🩺 Dex health: healthy (recovered) — latest complete snapshot {snapshot_stamp}.\n"
+        ) + learned
+    return (
+        f"🩺 Dex health: {surface.state} — latest complete snapshot {snapshot_stamp}.\n"
+    ) + learned
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -29,6 +29,7 @@
 | Ritual intelligence | **PARKED** (code-complete, unwired) | `core/ritual_intelligence/*` | Meeting-intelligence pipeline built Mar 2026, tested in CI, but never wired to any skill/hook/MCP; its beta preview surface was explicitly retracted (see CHANGELOG) |
 | Hooks | **SHIPPED** (wired subset) | `.claude/hooks/`, `.claude/settings.json` | Small wired core (context injection, safety guards, release awareness, autocommit); the once-dead career-evidence hook is fixed (PR #180) |
 | Skills (74 on disk) | **SHIPPED** | `.claude/skills/` | `/command` workflows; the description-rewrite + `/skill-score` quality-gate pass landed (discoverability-risk 53 → 3) |
+| Proactive health + the two promise registers | **SHIPPED** register/snapshots/pulse; **LOCAL** learned-automation watch | `core/health/*`, `core/utils/doctor.py`, `.claude/hooks/health-pulse.sh` | Every recurring job declares a success receipt; Doctor audits them into immutable snapshots that session start and the mid-session pulse read. The shipped register covers Dex's own five jobs; the learned register extends the same discipline to the person's own launchd jobs |
 | Grounding suite (inventory + state + orient) | **SHIPPED** (v1.69+) | `docs/architecture/INVENTORY.md`, `STATE.md`, `scripts/dex_state.py`, `/dex-orient` | Code-derived inventory + CI drift gate, released-vs-LOCAL state snapshot, and a session orientation skill |
 
 ---
@@ -210,6 +211,20 @@ therefore remains false.
 ## 13. Ritual intelligence — PARKED (code-complete, unwired)
 
 **What it is.** A meeting-intelligence pipeline (transcript + calendar ingest, ritual matching, meeting reconciliation, brief generation, contact promotion) built March 2026 (#30) at `core/ritual_intelligence/` with a `python -m core.ritual_intelligence` entry point and its own CI-passing tests. **Nothing invokes it**: no skill, hook, MCP server, or the desktop app references it, and the CHANGELOG records the retraction of its beta preview surface ("an unwired ritual beta handout no longer tells testers that `/daily-plan` will surface recurring-meeting previews"). Its tests keep it green in CI, which makes it look alive from a coverage view — it is not. Treat as parked design capital, not a shipped subsystem; wire-or-retire is an open product decision.
+
+---
+
+## 14. Proactive health + the two promise registers — SHIPPED (shipped register) / LOCAL (learned watch)
+
+**What it is.** The answer to the v1.84.0 field incident, in which meeting sync failed silently for six days while its log kept growing and every check that asked "is it running?" stayed green. The lesson — **activity is not health** — is now a mechanism: every recurring job *declares* how often it succeeds and where a completed run writes its receipt, and the auditor judges receipts, not liveness.
+
+**Where it lives.** `core/health/promises.py` is the shipped register: a frozen tuple of Dex's five background jobs, each with a cadence, a `receipt_kind` (`json-timestamp` | `file-activity` | `daemon`), and an `activity_only` flag for receipts that prove only that a job ran. `scripts/generate-health-promises.py --check` is the CI gate: it infers jobs from the shipped launchd templates and installers and fails the build when one has no promise, and keeps the bash mirror in `.claude/hooks/session-start.sh` in step. `core/utils/doctor.py`'s `jobs.fresh` check audits it; `core/health/reporter.py` normalizes results under a strict versioned contract; `core/health/snapshot.py` writes immutable snapshots through the lifecycle transaction; `core/utils/health_session.py` and `.claude/hooks/health-pulse.sh` read the latest snapshot (the pulse reads only the pointer and the status — two file reads, no forks on the silent path).
+
+**The learned register (LOCAL, this branch).** `core/health/learned.py` extends the same discipline to the jobs *the person* installed. Discovery rides the launch-agent classification pass Doctor already performs; each vault-pointing job that is neither shipped nor claimed by Dex Solo gets a learned promise — cadence read from `StartCalendarInterval`/`StartInterval` (never guessed), receipt chosen best-first (the script's own outputs, then launchd's stdout/stderr as activity-only, then honestly none). The `learned-automations` check reports them. Records live in `System/.dex/health/learned-promises/`, written through the same transaction boundary; the shipped tuple stays frozen and a learned record can never satisfy the shipped gate. Build plan and its binding constraints: `docs/plans/2026-08-25-user-automation-health-watch.md`.
+
+**Two constraints worth knowing before touching it.** (1) The reporter contract has no warning severity, and `snapshot.py:_overall_status` turns any `BROKEN` into `critical` — so `learned-automations` returns `OK`/`OFF` only, and a user's broken job can never make Dex report *itself* as critical or fire the pulse. (2) Check ids in snapshots are validated against a static spec built from Doctor's check lists, so per-job dynamic ids are impossible; every learned verdict folds into one check's bounded `detail` plus the report's `learned_automations` section.
+
+**How it connects.** Doctor is the collector (§ the checkup surface); snapshots go through the transaction core (§2) under the portable contract's `generated-health-state` rule (§3); the Doctor skill renders the learned section; session start appends one line read straight from the snapshot.
 
 ---
 

--- a/docs/plans/2026-08-25-user-automation-health-watch.md
+++ b/docs/plans/2026-08-25-user-automation-health-watch.md
@@ -1,0 +1,529 @@
+# Watching the person's own automations — implementation plan
+
+**Status:** Implemented on `claude/user-automation-health-watch-1raksj`. All user-visible copy
+in this document and in the changelog entry is DRAFT and carries no founder approval yet.
+
+**Implementation notes** are marked *(as built)* where the finished code differs from the
+plan as first written; §10 records every divergence from the specification.
+
+**Date:** 2026-08-25
+
+**Repository:** `dex-core`
+
+**Builds on:** the health promise register (`core/health/promises.py`), the launch-agent
+classification sweep (`core/utils/doctor.py`), the strict reporter contract
+(`core/health/reporter.py`), immutable health snapshots (`core/health/snapshot.py`), the
+lifecycle transaction boundary, and the Dex Solo automation-ownership contract.
+
+**Working name:** learned automation watch
+
+---
+
+## The short version
+
+A long-time user ran Dex for months while a daily job she had set up never fired, and
+nothing told her. Dex already owns the answer to that class of failure — but only for the
+five jobs Dex itself ships. Her own job got a disclaimer:
+
+> `N launch agents referencing this vault (…) are checked for loading only, not freshness
+> (no registered freshness receipt)` — `core/utils/doctor.py:2967-2971`
+
+This build turns that sentence from the end of the story into the beginning. Each of the
+person's vault-pointing scheduled jobs acquires a **learned promise** — an expected cadence
+plus a receipt — held in a per-job JSON record beside the snapshot store. The existing
+verdict vocabulary (`kept` / `never` / `broken`, `core/health/promises.py:113-117`) judges
+them. A job that was due and left no trace is surfaced. A job that cannot be honestly
+audited keeps today's disclaimer, unchanged.
+
+Four founder rulings (25 Aug) bind the build: watch quietly and disclose at first speaking;
+script reading is inside the Doctor's read-only remit; the Doctor never auto-heals a user
+automation; all copy is drafted for approval.
+
+---
+
+## 1. What the repository already provides (verified 25 August 2026)
+
+Every claim below was read in this tree at the line cited.
+
+### 1.1 The shipped register and its law
+
+`core/health/promises.py` holds `PROMISES`, a frozen 5-tuple of shipped jobs
+(`:65-109`). `HealthPromise` (`:38-59`) already carries everything a learned promise needs
+to express: `cadence`, `receipt_kind` (`json-timestamp` | `file-activity` | `daemon`,
+`:35`), `receipt_path`, `receipt_key`, and `activity_only`. Its module docstring states the
+two rules that keep it honest — **declared, not inferred** (`:13-19`) and **activity-only
+receipts say so** (`:20-23`) — the second written after the v1.84.0 incident in which
+meeting sync failed silently for six days while its log kept growing (`:3-5`).
+
+`PromiseAudit` (`:112-135`) is the verdict record. `detail()` refuses the word
+"successfully" for an `activity_only` promise, saying "ran" instead (`:122`).
+
+`scripts/generate-health-promises.py` is the build gate. It scans tracked
+`.plist`/`.plist.template`/`.sh` files for `com.dex.*` labels (`:50-64`), fails when a
+shipped job has no registered promise (`:171-179`) or a registered promise has no shipped
+declaration (`:180-186`), and verifies the bash mirror table in
+`.claude/hooks/session-start.sh` still matches the register (`:67-107`), erroring on any
+mirror row naming a job absent from the register (`:104-106`). CI runs it as the "Health
+promise register gate" (`.github/workflows/ci.yml:96-99`).
+
+### 1.2 Discovery already exists
+
+`_installed_launch_agents` (`core/utils/doctor.py:2418`) enumerates every plist in
+`~/Library/LaunchAgents`, and its docstring rules the boundary this build inherits: *"a
+user's custom job under any label that points into this vault is this vault's business"*
+(`:2423-2425`).
+
+`_classify_launch_agents` (`:2640`) sorts each plist into `_OWNED` (`:2613`), `_OFFLOADED`
+(`:2614`), `_STALE` (`:2615`), `_FOREIGN` (`:2616`), or `_UNREADABLE` (`:2617`), producing
+`LaunchAgentRecord`s (`:2621-2630`). `_scan_launch_agents` (`:2745`) caches one
+classification per `collect()` run inside a scan scope opened at `:1045`. Dex Solo's claim
+is honoured first: an offloaded plist short-circuits to `_OFFLOADED` before any parsing
+(`:2668-2677`), using `automation_ownership.valid_claims` (`core/utils/automation_ownership.py:349-366`).
+
+`_launchctl_status` (`:2581-2600`) already reads `LastExitStatus` and PID.
+
+`core/utils/launch_agents.py` holds the shared evidence helpers: boundary-aware path
+matching (`:42`, `:63-65`), `iter_plist_strings` (`:68`), `stored_former_vault_root`
+(`:86-117`), and `load_plist_payload` (`:120-132`), which treats every parse failure as
+"no evidence" rather than raising.
+
+### 1.3 The honest gap this build closes
+
+`_probe_jobs_fresh` (`core/utils/doctor.py:2910`) maps each owned label onto a shipped
+promise (`:2917-2926`). Labels with no promise land in `unregistered` (`:2950-2954`) and
+produce the coverage note at `:2962-2971`, appended to every verdict by `_with_coverage_note`
+(`:2973-2974`). Two tests pin that behaviour today
+(`core/tests/test_doctor.py:2822-2851`).
+
+### 1.4 Where durable health state is written
+
+`core/health/snapshot.py:6-7`: *"All durable health files go through the existing lifecycle
+transaction boundary."* `HealthStore` (`:482`) implements that through `_write_plan`
+(`:537-544`), which previews and executes one lifecycle transaction; existing purposes are
+`health-refresh-start` (`:588`), `health-refresh-finish` (`:652`), `health-snapshot-write`
+(`:694`) and `health-snapshot-publish` (`:724`). Entry builders `_new_file_entry` (`:546`),
+`_replace_file_entry` (`:549`) and `_delete_entry` (`:561`) carry the preconditions.
+
+**Divergence from the spec, deliberate.** The spec asks for the learned-record operation to
+be "allowlisted the way `automation-ownership` is (`core/transaction/engine.py:178`)". That
+is not needed and this plan does not do it. `core/portable_contract.py:276-278` already
+classifies the whole `System/.dex/health` directory as `generated`, and the ownership
+verdict for a file beneath it is `allowed=True, action='regenerate',
+rule_id='generated-health-state'` under the ordinary `update` operation — confirmed by
+running `portable_contract.update_write_verdict('System/.dex/health/learned-promises/x.json',
+exists=False, operation='update')` against this tree. `purpose` is a label;
+`operation` is the authorization axis and defaults to `"update"`
+(`core/lifecycle/service.py:230`). Adding a new operation would widen
+`portable_contract.update_write_verdict`'s allowlist (`:591-602`) for no gain. The
+`automation-ownership` operation exists because it needed a *narrower* grant plus a
+bounded-read limit (`core/transaction/engine.py:177-187`); this build needs neither.
+
+### 1.5 The reporter contract — the binding constraint on shape
+
+`core/health/doctor_reporter.py:27-33` builds the reporter spec from
+`doctor.QUICK_CHECKS` and `doctor.DEEP_CHECKS`. `normalize_report`
+(`core/health/reporter.py:299`) marks any check id outside that spec `unrecognized-check`
+(`:412-421`) and any registered check that returned nothing `missing-check-*`
+(`:490-496`); either records an error, and errors set `accepted=False` (`:530`).
+`_publish_health_snapshot` returns without publishing when `accepted` is false
+(`core/utils/doctor.py:5819-5820`).
+
+**So dynamic per-learned-job check ids cannot enter snapshots, and a check registered in
+the spec must return a result on every run.** `MAX_DETAIL_LENGTH` is 512
+(`core/health/reporter.py:32`) and `MAX_RESULTS` is 128 (`:35`). (The spec cited `:33` and
+`:36`; the values are as described, the lines are off by one.)
+
+### 1.6 Severity — a second binding constraint the spec did not anticipate
+
+The spec asks that learned breakage "contributes to the snapshot at warning level at most".
+There is no warning level. `VERDICTS` is `{OK, OFF, BROKEN, UNKNOWN}`
+(`core/health/reporter.py:26`) and `_overall_status` (`core/health/snapshot.py:147-153`)
+maps **any** `BROKEN` to `critical` and **any** `UNKNOWN` to `unknown`.
+
+Therefore, structurally: **the `learned-automations` check returns `OK` or `OFF` and never
+`BROKEN` or `UNKNOWN`.** Its verdict answers "is Dex's watch working", not "is the
+person's job working" — the person's job is the subject of the check's `detail` and its
+structured report section. This is what makes the spec's pulse arbitration true by
+construction: `.claude/hooks/health-pulse.sh:77-81` fires only on `overall_status ==
+"critical"`, which a learned job now cannot produce, so no learned alarm can outrun the
+disclosure and the pulse's everyday silent path (two file reads, `:31` and `:74`) is
+untouched.
+
+**Cost of this choice, stated plainly for the founder.** A learned record that is corrupt
+is a Dex-side failure, and Dex will report it as `unauditable` in the report body while the
+check verdict stays `OK`. A genuine warning severity would mean extending `VERDICTS` and
+`_overall_status`, which changes how Dex's *own* health is scored on every surface. That is
+too much blast radius for v1 and is raised here rather than taken silently.
+
+### 1.7 Where the finding must actually be rendered
+
+`_result_json` (`core/utils/doctor.py:717-729`) does **not** emit per-check
+`structured_detail`. The existing pattern for evidence-rich findings is a top-level report
+key lifted from the probe's `structured_detail` — `report["customization_assessment"]`
+(`:1167-1173`) and `report["customization_migration_status"]` (`:1174-1180`).
+
+This matters because `.claude/skills/dex-doctor/SKILL.md:137-140` collapses every healthy
+check into a single line ("✓ N checks healthy"). An `OK` verdict alone would **bury** a
+broken user automation. So the learned findings ride a top-level `learned_automations`
+report key with their own render step in the skill, exactly as the adoption and
+customization sections do (`SKILL.md:152-161`, `:194-203`).
+
+### 1.8 Session start reads only the overall status
+
+`format_session_health` (`core/utils/health_session.py:86-117`) renders overall status and
+a snapshot stamp — no per-check detail. Speaking learned findings there requires extending
+that surface, which is more than the spec's phrasing implies. See §6.
+
+### 1.9 Credential exclusion prior art
+
+`is_reference_read_restricted_path` (`core/customization_migration/references.py:56-75`)
+classifies credential-bearing sources *before* callers read their bytes. Its
+`secret_adjacent` test (`:59-64`) walks path parts for `.env`, `.env.*`, and any part
+containing `credential` — that generalizes to absolute paths unchanged. Its remaining rules
+are vault-relative: two literal paths (`:66-69`) and a `System/integrations/` prefix rule
+(`:70-73`) — **three**, not two as the spec says. §4.3 states exactly how they are carried
+to absolute paths.
+
+### 1.10 The Solo boundary
+
+`docs/automation-ownership-contract.md` — a validly claimed job is ignored by Core while the
+claim holds. Claims accept only `com.dex.*`/`com.claudesidian.*` labels
+(`core/utils/automation_ownership.py:189-190`).
+
+---
+
+## 2. The claim
+
+A person's own scheduled automations are watched the way Dex's shipped jobs are watched:
+each acquires a learned promise, the existing verdict vocabulary judges it, and a job that
+was due and left no trace is surfaced — instead of being discovered by accident months
+later. Jobs that cannot be honestly audited keep today's disclaimer. Nothing is waved
+through.
+
+---
+
+## 3. Lot 1 — the learned register beside the shipped one
+
+**New module:** `core/health/learned.py`. **New state:**
+`System/.dex/health/learned-promises/<slug>.json`, siblings of `snapshots/` and
+`refreshes/`.
+
+### 3.1 The record
+
+One JSON object per job, contract `dex.health.learned-promise/v1`:
+
+| field | meaning |
+| --- | --- |
+| `label` | the launchd `Label`, verbatim |
+| `plist_relative_path` | home-relative plist path, as `LaunchAgentRecord` sees it |
+| `schedule_source` | `StartCalendarInterval` \| `StartInterval` \| `observed` \| `none` |
+| `schedule` | normalized due-time rule as read, or observed interval seconds |
+| `receipt_kind` | `json-timestamp` \| `file-activity` \| `daemon` — the shipped vocabulary |
+| `receipt_path` | absolute path of the receipt |
+| `receipt_provenance` | `script-output` \| `launchd-stdout` \| `launchd-stderr` \| `none` — **how it was chosen** |
+| `activity_only` | true for launchd-evidence receipts |
+| `consecutive_misses` | derived each sweep, persisted so judgement survives restarts |
+| `last_receipt_at` / `watch_since` / `last_evaluated_at` | timestamps |
+| `observed_runs` | bounded ring (≤ 16) of run timestamps, for interval learning |
+| `watch_state` | `watching` \| `stopped-by-user` |
+| `program_path` | *(as built)* the shell script the job runs, when Dex could read one that was not credential-bearing — Lot 5's offer needs it, nothing else does |
+
+Register-level state (`_register.json`, same directory): `disclosed_at`,
+`disclosure_acknowledged_at`, contract version.
+
+### 3.2 Filename safety
+
+A launchd `Label` is arbitrary text and must never reach a path. The record filename is a
+strict slug: `[a-z0-9][a-z0-9._-]{0,79}` of the lowercased label, plus the first 12 hex of
+`sha256(label)` — so `../../evil` cannot address a file, and two labels differing only in
+case or punctuation cannot collide. The label itself is stored inside the record.
+
+### 3.3 Writes
+
+Through `HealthStore._write_plan`'s pattern only — never plain `open()`. One transaction
+per sweep carrying every changed record (`purpose="health-learned-sweep"`, operation
+`update`), skipped entirely when nothing changed. §1.4 explains why no new operation is
+introduced.
+
+### 3.4 Hard rules
+
+- `PROMISES` stays a frozen tuple and CI-gated. `core/health/learned.py` never imports into
+  `scripts/generate-health-promises.py`, so a learned record cannot satisfy the shipped
+  gate — the gate reads only tracked repo files and the `PROMISES` tuple
+  (`scripts/generate-health-promises.py:161-189`). Acceptance test 2 pins it.
+- A corrupt or unparseable record loads as `unauditable` — today's disclaimer — never as a
+  verdict. The next sweep re-drafts it.
+- A learned record whose label resolves to a shipped promise via
+  `launch_agents.promise_label_candidates` (`core/utils/launch_agents.py:51-60`) is ignored;
+  shipped jobs are the shipped register's business.
+
+---
+
+## 4. Lot 2 — discovery drafts the promise, riding the existing sweep
+
+No new scheduler. `learned.sweep(context, scan)` is called once from `collect()`
+(`core/utils/doctor.py:1045-1047`) inside the existing launch-agent scan scope, so it
+re-uses the one classification pass and adds no plist parsing.
+
+Enrolled: `_OWNED` records whose label is not shipped, not `_OFFLOADED`, and not already
+learned. Not enrolled: `_FOREIGN` (no vault path evidence), `_OFFLOADED` (Solo's, while the
+claim holds), `_UNREADABLE`, `_STALE`.
+
+### 4.1 Cadence is read, not guessed
+
+`StartCalendarInterval` (including a list of dicts) and `StartInterval` are read from the
+parsed payload already on `LaunchAgentRecord.data`. A job with neither — `WatchPaths`,
+`QueueDirectories`, event-driven — starts as `schedule_source: observed`: run evidence is
+recorded, the typical interval is learned as the median of `observed_runs`, and **no audit
+runs until a stable interval exists** (≥ 4 runs, median absolute deviation ≤ 25% of the
+median). Until then the job sits in "watching, no rhythm yet" and is never alarmed.
+
+### 4.2 Receipt, best first
+
+**(a) The job's own outputs.** Read the program the plist runs to find the paths it writes.
+No such utility exists in Core, so v1 is bounded hard and says so:
+
+- shell scripts only (`#!` naming `sh`/`bash`/`zsh`, or a `.sh` suffix);
+- ≤ 64 KiB, read once, never followed into `source`d or child files;
+- only two shapes are accepted: a redirection target (`> path`, `>> path`) and the
+  argument of `tee` or `touch`.  *(As built: `cp`/`mv`/`date` were dropped from the
+  allowlist the plan first sketched — `cp`'s and `mv`'s final argument may be a directory
+  rather than the file written, and `date` never names its target except through a
+  redirection the first shape already catches.  A wrong receipt would make a dead job look
+  alive, which is the exact failure this build exists to stop, so the reader refuses rather
+  than widens.)*;
+- anything with command substitution, a variable that is not `$HOME`, or a glob is
+  **rejected**, not guessed.
+
+Anything the reader cannot resolve falls to (b)/(c). A resolved output freshly touched
+after a due time is a real receipt (`receipt_kind: file-activity`, `activity_only: False`,
+`receipt_provenance: script-output`).
+
+**(b) launchd evidence.** `StandardOutPath` / `StandardErrorPath` mtimes, plus
+`_launchctl_status`'s `last_exit_status` (`core/utils/doctor.py:2581-2600`). Recorded
+`activity_only=True` and reported in the register's existing activity-only voice
+(`core/health/promises.py:122`, `:132-134`) — "ran", never "succeeded".
+
+**(c) Neither.** The job stays honestly unauditable and becomes a Lot 5 candidate. It keeps
+today's coverage-note wording.
+
+### 4.3 Credential exclusion, before any read
+
+A wrapper `learned.is_script_read_restricted(path: Path) -> bool` applies
+`is_reference_read_restricted_path`'s discipline to an arbitrary absolute path:
+
+- the `secret_adjacent` part-walk (`references.py:59-64`) is applied unchanged to every
+  part of the absolute path — it is already path-part based;
+- the three vault-relative rules (`:66-73`) are applied **as path-part matching**: a path
+  is restricted when its parts end with `.claude/settings.json` or
+  `.claude/settings.local.json`, or when it contains a `System/integrations/` pair followed
+  by a `.yaml`/`.yml` file. This is the "path-part matching applied to absolute paths"
+  the founder's ruling 2 calls for.
+
+Restricted paths are excluded **before** any bytes are read. No excluded path, and no byte
+of an excluded file, is written to a learned record, the Doctor report, or any log — the
+record stores only `receipt_provenance: none`. Acceptance test 8 pins it.
+
+### 4.4 Read-only
+
+Discovery and audit never write outside `System/.dex/health/`. Lot 5's consented diff is
+the only exception. Acceptance test 9 pins it.
+
+---
+
+## 5. Lot 3 — the audit: due, grace, two misses, recovery
+
+`learned.audit_learned(record, now)` returns a `LearnedAudit` reusing the shipped state
+names `kept` / `never` / `broken` (`core/health/promises.py:115`). *(As built, it also
+carries four states that are honestly **not** judgements and never surface as an alarm:
+`unauditable`, `no-rhythm-yet`, `pending`, and `stopped-by-user`.  Naming them separately
+is what stops a job Dex cannot judge from being folded into `kept`.)* It is a
+**new auditor, not the shipped `audit_promise`** — deliberately, and the divergence is
+stated here rather than left to be read as an oversight.
+
+The shipped `audit_promise` (`core/health/promises.py:164-182`) is a stateless
+cadence-vs-receipt comparison that absorbs sleep/wake by padding the cadence: *"Cadence is
+the promise, not the schedule: it includes slack for machines that sleep"* (`:62-64`). That
+works because Dex declares its own cadences. A read schedule is not padded — a job set for
+09:00 daily means 09:00 — so the learned auditor works from due times instead:
+
+1. **Due times** are enumerated from the read schedule between `max(watch_since,
+   last_receipt_at)` and `now`.
+2. **Grace window** of 4 hours after each due time, sized for laptop life: a machine asleep
+   at 09:00 coalesces the job to wake. A receipt inside the window counts as **kept**.
+   Where the read schedule is coarse (`StartInterval`, or a learned observed interval), the
+   grace is the larger of 4 hours and 25% of the interval — this is where the shipped
+   cadence-padding idea is kept.
+3. **One miss is quiet.** `consecutive_misses == 1` produces `kept` with a quiet note; no
+   surfaced line.
+4. **Two consecutive misses are broken.** `consecutive_misses >= 2` → `broken`.
+5. **Recovery is never held back.** Any receipt after the newest counted miss resets
+   `consecutive_misses` to 0 and the verdict to `kept`, in the same sweep.
+6. **`never`** is its own verdict once two full periods have elapsed since `watch_since`
+   with no receipt ever seen.
+
+`consecutive_misses` is *derived* each sweep by counting due times since the last receipt —
+so a Doctor that runs weekly still judges a daily job correctly — and then *persisted*, so
+the count and its evidence survive restarts and can be shown to the person.
+
+*(As built: the receipt is always read **live** from disk. The record's `last_receipt_at` is
+history and evidence, never a substitute — trusting the stored stamp when the receipt file
+is gone would be precisely the "activity is not health" mistake in a new costume. For the
+same reason the rollup only says "on schedule" about jobs that actually left a receipt; a
+watched job that has never been seen to run says so instead.)*
+
+Nothing in this lot touches `.claude/hooks/health-pulse.sh`; the pulse keeps reading only
+the latest-snapshot pointer.
+
+---
+
+## 6. Lot 4 — surfacing and the disclosure ruling
+
+### 6.1 One composer, one structural guarantee
+
+Every user-visible learned line — session start, Doctor report, any future surface — is
+built by a single function, `learned.compose_surface(register, audits) -> LearnedSurface`.
+Its first rule, before any verdict is consulted:
+
+> if `register.disclosed_at is None`, the first line is the disclosure.
+
+That makes "no learned-job alarm may appear before the disclosure" a property of one
+function, testable directly (acceptance test 5) rather than a convention repeated across
+surfaces.
+
+`disclosed_at` is recorded by an explicit small transaction called by the Doctor CLI *after*
+the report carrying the disclosure has been produced — the same seam as
+`_publish_health_snapshot` (`core/utils/doctor.py:5799`, defined at `:5804`). If that write fails, the
+disclosure repeats. The failure mode is a repeated disclosure, never a silent alarm.
+
+### 6.2 Disclosure copy — DRAFT, founder approval required
+
+> Dex noticed these scheduled jobs of yours and has been keeping an eye on them — reading
+> only, on your Mac, so it can tell you when one stops running. Keep watching, or stop?
+
+Per job: **Keep** / **Stop**.
+
+### 6.3 Alarm copy — DRAFT
+
+> `nightly-backup` was due Tuesday at 9:00am and has left no trace since 12 August.
+
+Named in the person's terms (the label as they wrote it), with the evidence.
+
+### 6.4 Stop is real
+
+**Stop** sets `watch_state: stopped-by-user`. No further alarms. The job is listed in the
+coverage note as **not watched, at your choice** — never silently unwatched, and visibly
+distinct from "cannot be audited". Re-enabling resumes watching from a fresh `watch_since`.
+
+### 6.5 Where it appears
+
+- **Doctor report** — a new top-level `learned_automations` key (§1.7), plus a new render
+  step in `.claude/skills/dex-doctor/SKILL.md` so an `OK` verdict cannot bury the finding.
+- **`learned-automations` check** — registered in `QUICK_CHECKS` and therefore in the
+  reporter spec. Verdict `OK`/`OFF` only. `detail` is the ≤512-char rollup:
+  "3 of your automations watched; 1 needs attention: nightly-backup". The evidence-rich
+  lines live in the report key and the records, not the snapshot.
+- **Session start** — `format_session_health` (`core/utils/health_session.py:86-117`)
+  gains one appended line, read from the latest snapshot's `learned-automations` result.
+  It never changes the overall-status line above it. *(As built, the disclosure is folded
+  into the check's `detail` by `compose_surface` itself, so every surface that reads the
+  snapshot inherits the disclosure-before-alarm ordering without composing any copy of its
+  own — session start simply repeats what the snapshot says.)*
+- **Pulse** — untouched, by construction (§1.6).
+- **`.claude/hooks/session-start.sh` mirror table** — untouched. The build gate errors on
+  any mirror row absent from the shipped register
+  (`scripts/generate-health-promises.py:104-106`), so learned jobs must never appear there.
+
+### 6.6 The coverage note keeps its job
+
+`_probe_jobs_fresh`'s note (`core/utils/doctor.py:2962-2971`) is narrowed to the jobs that
+are genuinely still unauditable, and gains the two new honest categories: *not watched, at
+your choice*, and *watching, no rhythm yet*. Its existing wording for the remainder is
+unchanged, and both existing tests (`core/tests/test_doctor.py:2822-2851`) must still pass.
+
+---
+
+## 7. Lot 5 — offered instrumentation (small, last)
+
+For receipt-poor jobs, offer to add one receipt line to the person's script:
+
+```
+date -u +%Y-%m-%dT%H:%M:%SZ > "$HOME/.dex/receipts/<slug>.receipt"   # added by Dex
+```
+
+Shown as an exact unified diff. Applied only on an explicit yes. On apply, the learned
+record upgrades from `activity_only` to a real receipt with
+`receipt_provenance: script-output`. **This is the build's only write to a user file and it
+is always asked.** Refusal changes nothing and is not re-offered in the same session.
+
+---
+
+## 8. Adversarial acceptance tests
+
+Test-first: each fails before its lot lands. New file `core/tests/test_learned_automations.py`,
+plus additions to `core/tests/test_doctor.py`.
+
+| # | Test | Pins |
+| --- | --- | --- |
+| 1 | daily user job made not to fire → quiet after one miss, `broken` after two; a later receipt clears it | Lot 3 — the reported incident, reproduced |
+| 2 | a learned record claiming a shipped job's id does not satisfy the shipped gate: `generate-health-promises.py --check` still fails when a shipped declaration is removed | §3.4 |
+| 3 | corrupt learned JSON → `unauditable`, never a false `kept`; the sweep re-drafts rather than crashing | §3.4 |
+| 4 | growing `StandardErrorPath`, no due-time receipt → activity-only voice, never "succeeding" | Lot 2(b) |
+| 5 | fresh vault, forced `broken` → `compose_surface`'s first line is the disclosure | §6.1 |
+| 6 | after Stop: no alarm on a later miss; job listed as unwatched-by-choice; re-enable resumes | §6.4 |
+| 7 | plist entirely outside the vault not enrolled; Solo-claimed not enrolled while valid; released → next sweep may enroll. **Fixture note:** claims accept only `com.dex.*`/`com.claudesidian.*` (`core/utils/automation_ownership.py:189-190`) and a released *shipped* label maps back to its shipped promise, so the released→enroll arm needs a user job deliberately labelled `com.dex.something-unshipped` | Lot 2 boundary |
+| 8 | script referencing a credential path → excluded before read; no credential path or content in any record, report, or log | §4.3 |
+| 9 | discovery/audit path performs zero writes outside `System/.dex/health/` | §4.4 |
+| 10 | `.claude/hooks/health-pulse.sh` everyday silent path unchanged — still two file reads, no new forks | §1.6 |
+| 11 | due time missed while asleep, receipt on wake → `kept` | Lot 3 grace |
+| 12 | `learned-automations` never returns `BROKEN`/`UNKNOWN`; a broken learned job leaves `overall_status` unchanged | §1.6 |
+| 13 | a label like `../../evil` cannot address a file outside the learned directory | §3.2 |
+
+*(As built, `core/tests/test_learned_automations.py` carries 51 tests: the thirteen above,
+plus Lot 5's consent tests, the session-start surface tests, and the rollup-honesty tests.
+Two fixture corrections were made during the build rather than weakening the code they
+tested: `_plist_owned_by_vault` (`core/utils/doctor.py:2488-2518`) deliberately refuses
+`WorkingDirectory` and `StandardOutPath` as ownership evidence, so a fixture claiming a job
+that way was wrong, not the rule; and pytest's `tmp_path` embeds the test's own name, which
+made a credential-exclusion test pass for the wrong reason.)*
+
+Governance: `docs/testing-governance.md` requires a regression test per behaviour change and
+docs updated or explicitly exempted. This plan, the Doctor inventory section of
+`docs/testing-governance.md`, `docs/architecture/DEX-CORE-MAP.md`, and
+`.claude/skills/dex-doctor/SKILL.md` are the doc surface.
+
+---
+
+## 9. Non-claims and stop conditions
+
+- **v1 is launchd (macOS).** cron and systemd are out of scope. The coverage note says so
+  rather than half-supporting them.
+- **No auto-heal of a user automation, ever.** Report only (founder ruling 3).
+- **Event-driven jobs without receipts stay honestly unauditable.** No fabricated cadence to
+  make coverage look complete.
+- **No new severity level.** §1.6 states the cost and raises it rather than taking it.
+- **Stop and raise to the founder** if watching cannot be made honest for a class of jobs.
+  The disclaimer is the fallback; silence is not.
+
+---
+
+## 10. Divergences from the specification, recorded
+
+Per the instruction that repository conventions win where they conflict with the spec:
+
+1. **No new transaction operation** (§1.4). `System/.dex/health/**` is already writable
+   under the ordinary `update` operation via `generated-health-state`
+   (`core/portable_contract.py:276-278`), verified against this tree.
+2. **No warning severity; `OK`/`OFF` only** (§1.6). The contract has no warning level and
+   any `BROKEN` becomes `critical` (`core/health/snapshot.py:147-153`).
+3. **Findings ride a top-level report key, not per-check `structured_detail`** (§1.7).
+   `_result_json` does not emit it (`core/utils/doctor.py:717-729`), and the skill collapses
+   `OK` checks (`.claude/skills/dex-doctor/SKILL.md:137-140`).
+4. **Session start needs a surface extension** (§1.8). `format_session_health` renders only
+   overall status today (`core/utils/health_session.py:86-117`).
+5. **Three vault-relative rules, not two** (§1.9, `core/customization_migration/references.py:66-73`).
+6. **Line-number corrections:** `MAX_DETAIL_LENGTH` is `core/health/reporter.py:32` (spec
+   said `:33`); `MAX_RESULTS` is `:35` (spec said `:36`).
+7. **Plan filename** follows the files actually in `docs/plans/`
+   (`YYYY-MM-DD-<name>.md`), not the `-plan.md` form described in
+   `.claude/plugins/compound-engineering/commands/workflows/plan.md:480`.

--- a/docs/testing-governance.md
+++ b/docs/testing-governance.md
@@ -147,7 +147,7 @@ does not guess at a cause.
 
 ## Testing Doctor Inventory
 
-The quick doctor adds three always-visible checks:
+The quick doctor adds four always-visible checks:
 
 - `customizations.skills` validates every skill and identifies user-owned `-custom`
   failures separately from shipped failures.
@@ -155,6 +155,25 @@ The quick doctor adds three always-visible checks:
   syntax, and the same registry name/path/hash state without launching custom commands.
 - `core.drift` compares shipped files with the installed release while excluding
   sanctioned customization surfaces. Drift is `UNKNOWN`, never automatically broken.
+- `learned-automations` reports on the user's own launchd jobs, which acquire a learned
+  promise (`core/health/learned.py`) alongside the shipped register. Its verdict answers
+  "is Dex's watch working", not "is the user's job working", and is therefore `OK` or
+  `OFF` only — never `BROKEN` or `UNKNOWN`. That is a structural requirement, not a
+  stylistic one: the reporter contract has no warning severity and
+  `core/health/snapshot.py`'s `_overall_status` promotes any `BROKEN` to `critical`, which
+  is reserved for Dex's own health and is what the mid-session pulse interjects on. A
+  user's broken job must never make Dex report itself as critical, and must never reach
+  the person ahead of the watching disclosure. The finding therefore travels in the
+  check's bounded `detail` and in the report's top-level `learned_automations` object,
+  which `/dex-doctor` renders whatever the verdict.
+
+Two rules bind anything touching learned automations. Dex **never** repairs one of the
+user's jobs — it reports, and acting is theirs. And the only write to a user's own file is
+Lot 5's offered receipt line, which is shown as an exact diff, applied on an explicit yes,
+and hash-bound to the script the diff was computed from. Everything else in the discovery
+and audit path writes nothing outside `System/.dex/health/`, and every write there goes
+through the lifecycle transaction boundary. `core/tests/test_learned_automations.py` pins
+each of these, including the read-only invariant and the disclosure-before-alarm ordering.
 
 The deep doctor adds `smoke.journeys`, which runs the shipped smoke layer and preserves
 each journey's `OK`, `OFF`, `BROKEN`, or `UNKNOWN` result in the report.


### PR DESCRIPTION
## Linked Issue
- Linear issue: `DEX-XX` _(not supplied — please fill in or drop this line)_
- Origin: Michelle's suggestion that Dex should watch the jobs a person sets up with the same care it watches its own. A long-time user ran Dex for months while a daily job she'd set up never fired, and nothing told her.

## What Changed

Dex's promise register, Proactive Health and the mid-session pulse already answer "did this recurring job actually succeed?" — but only for the five jobs Dex ships. A user's own launch agent got a disclaimer instead: `checked for loading only, not freshness` (`core/utils/doctor.py:2962-2971`). This turns that sentence from the end of the story into the beginning.

Each vault-pointing job the person installed now acquires a **learned promise**: a cadence read from its plist (never guessed) and a receipt chosen best-first — the script's own outputs, then launchd's stdout/stderr as activity-only, then honestly none. The shipped verdict vocabulary judges it. One miss stays quiet, two consecutive misses surface with the evidence, recovery clears it immediately.

- `core/health/learned.py` — the learned register, reader, auditor, the single surface composer, and the consented instrumentation offer.
- A static `learned-automations` check in the Doctor registry, a top-level `learned_automations` report section, and its render step in `/dex-doctor`.
- One appended line at session start, read straight from the published snapshot.
- Plan: `docs/plans/2026-08-25-user-automation-health-watch.md` (every claim cites a file and line).

**Constraints respected rather than worked around**

- The shipped register stays a frozen, CI-gated tuple. A learned record can never satisfy the shipped build gate — the gate reads only tracked repo files and `PROMISES`.
- The reporter contract has no warning severity and `_overall_status` promotes any `BROKEN` to `critical`, which is reserved for Dex's own health. So the learned check returns `OK`/`OFF` only: a user's broken job can never make Dex report *itself* as critical, and therefore can never fire the mid-session pulse ahead of the watching disclosure. `.claude/hooks/health-pulse.sh` is untouched.
- Check ids are validated against a static reporter spec, so per-job dynamic ids are impossible; verdicts fold into one bounded `detail` plus the report section.
- **No new transaction operation.** `System/.dex/health` is already `generated-health-state`, so the ordinary `update` operation authorizes these writes — verified against the live contract. The spec asked for a new allowlist entry; it would have widened `update_write_verdict` for nothing.
- `_plist_owned_by_vault` is unchanged: `WorkingDirectory` and log paths still never claim ownership.

**Honesty rules kept**

Activity-only receipts say "ran", never "succeeded". A job with no readable rhythm is never given a fabricated cadence. A corrupt record reads as `unauditable`, never a false `kept`. The rollup only says "on schedule" about jobs that actually left a receipt. Credential-bearing files are excluded before their bytes are read. Dex never repairs one of these jobs — reporting is the whole remit. Disclosure leads every learned line structurally: one composer folds it into the snapshot detail, so no surface can compose an alarm without it. Stop is real and is listed as unwatched-by-choice, never silently dropped.

## Test Plan
- **Unit/integration tests added:** `core/tests/test_learned_automations.py` — 51 tests covering all 13 adversarial acceptance criteria from the plan, plus the consent tests, the session-start surface, and rollup honesty.
- **Negative/error-path tests added:** corrupt learned JSON → `unauditable` and re-drafted, never a false `kept`; a hostile label (`../../evil`) cannot address a file outside the learned directory; a credential-referencing script leaks no path or content into any record, report or log; a plist pointing entirely outside the vault is not enrolled; a valid Dex Solo claim blocks enrolment while it holds; the read-only invariant (zero writes outside `System/.dex/health/`); the instrumentation offer refuses without an explicit `approved=True` and refuses a script that changed since the diff was shown.
- **Commands run locally:**
  - `python3 -m pytest core/tests/test_learned_automations.py -q` → 51 passed
  - Adjacent suites (`test_doctor`, `test_health_*`, `test_launch_agents`, `test_portable_contract`, `test_golden_journeys`, `test_distribution_artifacts`, …) → the only failures are 9 pre-existing sandbox gaps (missing `mcp`/npm deps), verified identical against a stashed baseline.
  - `python3 scripts/generate-health-promises.py --check`, `ruff check core/`, `check-portable-contract.sh`, `check-founder-content.sh`, `check-architecture-inventory.sh`, `security-gate.sh`, `check-path-consistency.sh`, `verify-distribution.sh`, `check-instructed-tools.py`, `check-tracked-ignored.py` → all pass
  - Diff-aware gates with `GITHUB_BASE_REF=main`: `check-pii.sh`, `check-path-contract-usage.sh`, `check-test-delta.sh`, `check-doc-drift.sh` → all pass
  - End-to-end: the reported incident reproduced against a fabricated user job — quiet after one miss, surfaced after two with the evidence, still surfaced 90 days later, cleared on recovery, disclosure leading every time.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant). — **not done; worth a look at the script reader and the credential exclusion.**
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- **Risk level:** low–medium.
- Read-only by construction outside `System/.dex/health/`, with the single consented exception of the instrumentation offer, which is hash-bound to the diff shown and refuses anything but an explicit yes. The learned check cannot reach `BROKEN`/`UNKNOWN`, so it cannot change `overall_status`, cannot fire the pulse, and cannot alter what session start says about Dex's own health.
- The sweep is wrapped so any failure leaves a Doctor run untouched, and an unreadable learned register degrades `jobs.fresh` to exactly the wording it has today.
- **Rollback:** revert the merge. The only durable artefact is `System/.dex/health/learned-promises/`, which is `generated` state — deleting it is safe and it is never shipped.
- **The one thing worth a second opinion:** the script reader. It is deliberately narrow — shell scripts only, ≤64 KiB, redirection targets plus `tee`/`touch`, never following sourced files, refusing command substitution, unknown variables and globs. I dropped `cp`/`mv`/`date` from the allowlist the spec sketched, because their final argument may not be the file written and a wrong receipt would make a dead job look alive.

## Docs Impact
- `docs/plans/2026-08-25-user-automation-health-watch.md` (new — the plan, with an "as built" reconciliation and a §10 divergence record)
- `docs/architecture/DEX-CORE-MAP.md` (new §14 + subsystem index row)
- `docs/testing-governance.md` (Doctor inventory: the fourth always-visible check and the two rules binding it)
- `.claude/skills/dex-doctor/SKILL.md` (new Step 3d — needed because an `OK` check would otherwise be collapsed into "✓ N checks healthy" and the finding lost)
- `CHANGELOG.md` — entry approved as `[1.97.0]`, crediting Michelle.

> ⚠️ **Before cutting the release:** `scripts/release.sh` inserts its own dated header after the preamble separator, which would place an empty `## [1.97.0] — (2026-08-25)` directly above the real entry. Release notes still publish correctly — both headings share the version, so `changelog_section` re-enters and collects the body — but the empty heading would render on heydex.ai/releases. Delete it, or bump `package.json` without the script's changelog step. `package.json` is deliberately **not** bumped in this PR, matching every other feature commit in this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KALKt2ocZZ4amiMMY64KGn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New health logic reads launchd plists and bounded shell scripts and can append a consented receipt line to user scripts; mis-detection could false-alarm or miss jobs, though severity is capped and failures are designed not to break Doctor runs.
> 
> **Overview**
> **Dex now watches the person's own macOS launchd jobs** the same way it audits Dex's shipped background jobs: cadence from the plist, receipts from script outputs or launchd logs (activity-only when that's all there is), and alerts only after **two consecutive missed due times** (one miss stays quiet).
> 
> A new **`core/health/learned.py`** stack discovers vault-owned user jobs during Doctor's existing launch-agent scan, persists **learned promises** under `System/.dex/health/learned-promises/` via the lifecycle transaction boundary, and audits with grace for sleep/wake. Doctor gains a **`learned-automations`** check that stays **`OK`/`OFF` only** so a dead user job cannot mark Dex's overall health **critical** or trigger the health pulse; findings live in bounded snapshot detail plus a top-level **`learned_automations`** report object rendered by **`/dex-doctor` Step 3d** (disclosure-first, keep/stop per job, no auto-heal). **Session start** appends one line from that snapshot. Optional **receipt instrumentation** is the only user-file write: exact diff, explicit yes, hash-bound script.
> 
> **`jobs.fresh`** coverage notes are narrowed to jobs still genuinely unauditable, with honest lines for rhythm-not-yet and user-stopped watches. Docs, changelog **1.97.0**, and extensive tests (`test_learned_automations.py`) cover disclosure ordering, credentials never read, and read-only invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798fb8addf1eaaea303325b612f3dba369f3ec27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->