### PR TITLE
The nightly checkup cannot find node, so no .cjs hook has been checked

### DIFF
--- a/.scripts/com.dex.smoke-nightly.plist.template
+++ b/.scripts/com.dex.smoke-nightly.plist.template
@@ -11,6 +11,14 @@
     </array>
     <key>WorkingDirectory</key>
     <string>__VAULT_PATH__</string>
+    <!-- launchd supplies a minimal PATH. Both Homebrew prefixes are listed so a
+         scheduled run can find node for the hook syntax checks, matching the
+         other shipped Dex Launch Agents. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin</string>
+    </dict>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/.scripts/nightly-smoke.sh
+++ b/.scripts/nightly-smoke.sh
@@ -19,6 +19,28 @@ else
     PYTHON="python3"
 fi
 
+# Make node discoverable, the same way PYTHON is resolved above.
+#
+# smoke.py syntax-checks Dex's .cjs hooks with node, and finds node by looking
+# on the inherited PATH. launchd hands a scheduled job a minimal PATH that does
+# not include either Homebrew prefix, so on a normal Mac node is invisible here
+# even though it works in every terminal. The hooks journey then reports
+# UNKNOWN rather than BROKEN, so nightly hook checking can be dead for months
+# without anything looking wrong.
+#
+# Appending is deliberate: anything already on PATH keeps priority, and the
+# validated-tool checks in core/utils/release_channel.py still decide what is
+# safe to use. This only widens where node may be found, never what is trusted.
+if ! command -v node >/dev/null 2>&1; then
+    for NODE_DIR in /opt/homebrew/bin /usr/local/bin; do
+        if [ -x "$NODE_DIR/node" ]; then
+            PATH="$PATH:$NODE_DIR"
+            export PATH
+            break
+        fi
+    done
+fi
+
 cd "$VAULT_PATH"
 set +e
 VAULT_PATH="$VAULT_PATH" "$PYTHON" core/utils/smoke.py --json --ledger

--- a/core/tests/test_smoke_automation.py
+++ b/core/tests/test_smoke_automation.py
@@ -181,6 +181,15 @@ def test_the_worker_widens_path_for_node_when_the_environment_hides_it(tmp_path:
     node.write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
     node.chmod(0o755)
 
+    # PATH must hide node for the fallback to be exercised at all, and
+    # "/usr/bin:/bin" does not hide it everywhere: some hosts ship
+    # /usr/bin/node, where the guard resolves node immediately and this test
+    # silently asserts nothing. An empty directory hides it on every host.
+    # The block below uses only bash builtins, and bash is invoked by absolute
+    # path, so an otherwise-unusable PATH costs it nothing.
+    empty = tmp_path / "empty-path"
+    empty.mkdir()
+
     # Reproduce the worker's discovery block against a PATH with no node on it,
     # pointing it at the fake prefix instead of the real one.
     lines = WORKER.read_text(encoding="utf-8").splitlines()
@@ -190,7 +199,7 @@ def test_the_worker_widens_path_for_node_when_the_environment_hides_it(tmp_path:
     block = "\n".join(lines[start:end + 1]).replace("/opt/homebrew/bin", str(fake_prefix))
 
     result = subprocess.run(
-        ["/bin/bash", "-c", f'PATH="/usr/bin:/bin"\n{block}\ncommand -v node'],
+        ["/bin/bash", "-c", f'PATH="{empty}"\n{block}\ncommand -v node'],
         capture_output=True,
         text=True,
         check=False,

--- a/core/tests/test_smoke_automation.py
+++ b/core/tests/test_smoke_automation.py
@@ -148,3 +148,64 @@ def test_nightly_worker_records_broken_verdict_without_success_heartbeat(tmp_pat
     assert (vault / "telemetry-called").exists()
     assert not (vault / ".scripts" / "logs" / "smoke-nightly.log").exists()
     assert not (vault / "System" / ".dex" / "session-health-success.json").exists()
+
+
+def test_rendered_plist_gives_the_job_a_path_that_can_reach_node(tmp_path: Path) -> None:
+    """launchd supplies a minimal PATH, so the job has to bring its own.
+
+    Without this, smoke.py cannot find node, every .cjs hook syntax check
+    reports UNKNOWN, and nightly hook checking is dead without looking broken.
+    """
+    rendered = TEMPLATE.read_text(encoding="utf-8").replace("__VAULT_PATH__", str(tmp_path))
+    plist = plistlib.loads(rendered.encode("utf-8"))
+
+    path = plist["EnvironmentVariables"]["PATH"].split(":")
+
+    # Both Homebrew prefixes: Apple Silicon and Intel.
+    assert "/opt/homebrew/bin" in path
+    assert "/usr/local/bin" in path
+    # The system locations the other shipped agents also carry.
+    assert "/usr/bin" in path
+
+
+def test_the_worker_widens_path_for_node_when_the_environment_hides_it(tmp_path: Path) -> None:
+    """The worker must repair a minimal PATH itself, not rely on the plist.
+
+    An install that already exists keeps its installed plist across updates,
+    so a template-only fix would never reach it. The worker script does get
+    updated, which is why the fallback lives here too.
+    """
+    fake_prefix = tmp_path / "opt" / "homebrew" / "bin"
+    fake_prefix.mkdir(parents=True)
+    node = fake_prefix / "node"
+    node.write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+    node.chmod(0o755)
+
+    # Reproduce the worker's discovery block against a PATH with no node on it,
+    # pointing it at the fake prefix instead of the real one.
+    lines = WORKER.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("if ! command -v node"))
+    # The block ends at the next unindented "fi", not the inner one.
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "fi")
+    block = "\n".join(lines[start:end + 1]).replace("/opt/homebrew/bin", str(fake_prefix))
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", f'PATH="/usr/bin:/bin"\n{block}\ncommand -v node'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(node)
+
+
+def test_the_worker_leaves_an_already_working_path_alone() -> None:
+    """Anything already on PATH keeps priority; this only widens the search."""
+    snippet = WORKER.read_text(encoding="utf-8")
+    start = snippet.index("if ! command -v node")
+
+    # The guard is a negative check, so a PATH that already resolves node is
+    # never touched.
+    assert snippet[start:].startswith("if ! command -v node >/dev/null 2>&1; then")
+    assert 'PATH="$PATH:$NODE_DIR"' in snippet, "must append, never prepend or replace"


### PR DESCRIPTION
`smoke.py` syntax-checks Dex's `.cjs` hooks with node, and finds node by looking on the
inherited PATH. launchd hands a scheduled job a minimal PATH containing neither Homebrew
prefix, so on a normal Mac **node is invisible to the nightly run even though it works in
every terminal**.

The failure is quiet by construction. The hooks journey returns `UNKNOWN`, not `BROKEN`, so it
reads as "could not check this" rather than "hook checking has not run for months". On the
vault I found this on, every `.cjs` hook had gone unverified since early August and nothing
ever said so.

Demonstrated directly against `sanitized_path_with_tools`, which is what populates
`DEX_SMOKE_NODE`:

```
launchd default PATH (/usr/bin:/bin:/usr/sbin:/sbin) : node found = False
with a Homebrew prefix appended                      : node found = True
```

When node is not found, `DEX_SMOKE_NODE` is never set, and `_node_from_clean_environment()`
reads only that variable — so every `.cjs` check returns `node is unavailable for --check`.

## Why the shipped files disagree with each other

`.scripts/com.dex.smoke-nightly.plist.template` carries **no `EnvironmentVariables` block at
all**. The other two shipped Launch Agents both set a PATH:

| Agent | PATH |
|---|---|
| `com.dex.changelog-checker.plist` | `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` |
| `com.dex.learning-review.plist` | `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` |
| `com.dex.smoke-nightly.plist.template` | *(none)* |

Those two also predate Apple Silicon: they list `/usr/local/bin` but not `/opt/homebrew/bin`,
so they would miss a Homebrew tool on any current Mac. I have not touched them here to keep
this reviewable, but they are the same bug waiting to be reported.

## Two changes, because one alone does not reach everybody

**The template** now sets a PATH including both Homebrew prefixes, so new installs are correct.

**`nightly-smoke.sh` widens PATH itself** when node is not already reachable. This is the part
that fixes installs that *already exist*: an update refreshes scripts but never rewrites an
installed plist, so a template-only fix would leave every current user broken.

The worker resolves node the same defensive way it already resolves `python` a few lines above,
which felt like the right local idiom.

## On the security posture

I looked at this carefully because `release_channel.py` is deliberately strict, and I did not
want to weaken it.

The worker **appends** to PATH rather than prepending, so anything already there keeps
priority, and the guard is a negative check so a working PATH is never touched. `_validated_tool()`
still decides what is safe to execute — it rejects symlinked parents, world-writable
directories, anything inside the vault, and anything in a temp location. **This widens where
node may be looked for; it does not widen what is trusted.**

I deliberately did *not* take the other available route — having
`_node_from_clean_environment()` fall back to `shutil.which()` — for two reasons. It would
bypass `_validated_tool()` entirely, and it would not work anyway: the PATH it searches is the
same minimal one that caused the problem.

## Tests

Three, in `core/tests/test_smoke_automation.py`, and **each one fails on the unpatched tree**:

- the rendered plist gives the job a PATH containing both Homebrew prefixes
- the worker's discovery block finds a node placed outside PATH (driven against a fake prefix
  in `tmp_path`, so it does not depend on the machine running it)
- the worker appends rather than replacing, and skips entirely when node already resolves

Verified by stashing only the two fixed files and re-running: 3 failed, 5 passed.

## Gates

All green locally. `check-release-tag-reachability.sh` fails identically on a clean
`upstream/main` checkout, and `test_doctor.py::test_entity_dead_letter_heal_round_trip_returns_probe_to_ok`
also fails with this change fully reverted — both pre-existing, neither from here.

Independent of #590; they touch no common files.
