### PR TITLE
Meeting prep builds the brief without refreshing the meeting record

### DIFF
--- a/.agents/skills/meeting-prep/SKILL.md
+++ b/.agents/skills/meeting-prep/SKILL.md
@@ -113,7 +113,27 @@ events cannot identify the meeting safely.
 
 ## Process
 
-### Step 0: Gather Context (if needed)
+### Step 0: Refresh the meeting record
+
+Before reading anything, run `/process-meetings` so the brief is built on the freshest
+locally available record. It turns captures already sitting unprocessed in the local meeting
+folder into notes and updates the person and company pages from them. It does not reach out
+to an external meeting source, so anything not yet synced there stays out of reach either
+way; what this removes is the gap between a capture arriving locally and it being readable
+here.
+
+- If no new meetings are found, continue silently
+- If meetings are processed, use the extracted context in the brief below
+- Do NOT ask for a skill rating after this sub-step, save that for the end of the prep
+
+**Why this skill in particular needs it.** `/meeting-prep` is normally run minutes before a
+call, which is exactly when the most recent conversation with these attendees is most likely
+to have been captured but not yet processed. Step 3 below reads `00-Inbox/Meetings/`, and a
+brief built from an unprocessed folder does not look incomplete: it looks like there was
+nothing to report. Missing context and no context are indistinguishable in the output, which
+is why the refresh belongs before the read rather than being left to chance.
+
+### Step 0.5: Gather Context (if needed)
 
 **If $MEETING or $ATTENDEES are not provided, try the calendar before asking.** The user booked
 the meeting; the invite already holds the title and the attendee list, and asking them to retype
@@ -230,7 +250,10 @@ Extract:
 
 ### Step 3: Recent Context
 
-Search `00-Inbox/Meetings/` for recent meetings with these attendees:
+Search `00-Inbox/Meetings/` for recent meetings with these attendees. Step 0 processed this
+folder; without that, anything captured locally since the last processing run is invisible
+here.
+
 - What was discussed?
 - What was decided?
 - What follow-ups were committed?

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -111,7 +111,25 @@ events cannot identify the meeting safely.
 
 ## Process
 
-### Step 0: Gather Context (if needed)
+### Step 0: Refresh the meeting record
+
+Before reading anything, ensure recent meetings are in the vault by running
+`/process-meetings`. This pulls anything unprocessed from the meeting source, creates the
+notes, and updates person and company pages, so the brief is built on the latest capture
+rather than on whatever happened to be filed already.
+
+- If no new meetings are found, continue silently
+- If meetings are processed, use the extracted context in the brief below
+- Do NOT ask for a skill rating after this sub-step, save that for the end of the prep
+
+**Why this skill in particular needs it.** `/meeting-prep` is normally run minutes before a
+call, which is exactly when the most recent conversation with these attendees is most likely
+to be sitting unprocessed. Step 3 below reads `00-Inbox/Meetings/`, and a brief built from a
+stale folder does not look incomplete: it looks like there was nothing to report. Missing
+context and no context are indistinguishable in the output, which is why the refresh belongs
+before the read rather than being left to chance.
+
+### Step 0.5: Gather Context (if needed)
 
 **If $MEETING or $ATTENDEES are not provided, try the calendar before asking.** The user booked
 the meeting; the invite already holds the title and the attendee list, and asking them to retype
@@ -228,7 +246,9 @@ Extract:
 
 ### Step 3: Recent Context
 
-Search `00-Inbox/Meetings/` for recent meetings with these attendees:
+Search `00-Inbox/Meetings/` for recent meetings with these attendees. Step 0 refreshed this
+folder; without that, anything captured since the last processing run is invisible here.
+
 - What was discussed?
 - What was decided?
 - What follow-ups were committed?

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -113,10 +113,12 @@ events cannot identify the meeting safely.
 
 ### Step 0: Refresh the meeting record
 
-Before reading anything, ensure recent meetings are in the vault by running
-`/process-meetings`. This pulls anything unprocessed from the meeting source, creates the
-notes, and updates person and company pages, so the brief is built on the latest capture
-rather than on whatever happened to be filed already.
+Before reading anything, run `/process-meetings` so the brief is built on the freshest
+locally available record. It turns captures already sitting unprocessed in the local meeting
+folder into notes and updates the person and company pages from them. It does not reach out
+to an external meeting source, so anything not yet synced there stays out of reach either
+way; what this removes is the gap between a capture arriving locally and it being readable
+here.
 
 - If no new meetings are found, continue silently
 - If meetings are processed, use the extracted context in the brief below
@@ -124,10 +126,10 @@ rather than on whatever happened to be filed already.
 
 **Why this skill in particular needs it.** `/meeting-prep` is normally run minutes before a
 call, which is exactly when the most recent conversation with these attendees is most likely
-to be sitting unprocessed. Step 3 below reads `00-Inbox/Meetings/`, and a brief built from a
-stale folder does not look incomplete: it looks like there was nothing to report. Missing
-context and no context are indistinguishable in the output, which is why the refresh belongs
-before the read rather than being left to chance.
+to have been captured but not yet processed. Step 3 below reads `00-Inbox/Meetings/`, and a
+brief built from an unprocessed folder does not look incomplete: it looks like there was
+nothing to report. Missing context and no context are indistinguishable in the output, which
+is why the refresh belongs before the read rather than being left to chance.
 
 ### Step 0.5: Gather Context (if needed)
 
@@ -246,8 +248,9 @@ Extract:
 
 ### Step 3: Recent Context
 
-Search `00-Inbox/Meetings/` for recent meetings with these attendees. Step 0 refreshed this
-folder; without that, anything captured since the last processing run is invisible here.
+Search `00-Inbox/Meetings/` for recent meetings with these attendees. Step 0 processed this
+folder; without that, anything captured locally since the last processing run is invisible
+here.
 
 - What was discussed?
 - What was decided?

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -644,8 +644,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/meeting-prep/SKILL.md",
-        "sha256": "02110d2093e22aeb472ed3ef05ae97e2e4773ce18ccac6aa6f1888daf0ce88b9",
-        "byte_size": 17660
+        "sha256": "f511c81060f82f82f3eb106c96002ca021a5ab09ef95a8526fa2aba914d4652d",
+        "byte_size": 18848
       },
       "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
       "jobs_served": [

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -644,8 +644,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/meeting-prep/SKILL.md",
-        "sha256": "f511c81060f82f82f3eb106c96002ca021a5ab09ef95a8526fa2aba914d4652d",
-        "byte_size": 18848
+        "sha256": "2c14f56b1dfc023f89e7474a7ec8647719f7ca89a3e91d4a2cc2f7bdfbf72da0",
+        "byte_size": 19031
       },
       "value": "Walks into the meeting already holding the attendees, the history and the open threads, instead of spending the last five minutes searching for them.",
       "jobs_served": [

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from core import paths
 from core.integrations import post_update_check
 from core.integrations.google import setup as google_setup
 from core.integrations.notion import setup as notion_setup
@@ -778,3 +779,31 @@ def test_change_job_relays_verification_stops_on_failure_and_never_deletes() -> 
     # And the reset skill routes the big transition here instead of absorbing it.
     reset = _read(".claude/skills/reset/SKILL.md")
     assert "use `change-job` instead" in reset
+
+
+# --- briefing skills must refresh the meeting record before they read it ---
+
+_MEETINGS_FOLDER = str(paths.MEETINGS_DIR.relative_to(paths.VAULT_ROOT))
+
+# Skills whose whole job is to brief someone on something imminent. For these,
+# a stale read is indistinguishable from an empty one in the output, so the
+# refresh has to happen before the read rather than being left to chance.
+_BRIEFING_SKILLS = ("daily-plan", "daily-review", "meeting-prep")
+
+
+@pytest.mark.parametrize("skill", _BRIEFING_SKILLS)
+def test_briefing_skills_refresh_the_meeting_record_before_reading_it(skill: str) -> None:
+    body = (REPO_ROOT / ".claude" / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
+
+    read_at = body.find(_MEETINGS_FOLDER)
+    assert read_at != -1, f"{skill} no longer reads the meeting record; retire this case"
+
+    refresh_at = body.find("/process-meetings")
+    assert refresh_at != -1, (
+        f"{skill} reads the meeting record but never refreshes it. Anything captured since "
+        "the last processing run is invisible, and the brief looks complete rather than stale."
+    )
+    assert refresh_at < read_at, (
+        f"{skill} refreshes the meeting record only after reading it, which is too late to "
+        "affect the brief."
+    )

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -800,8 +800,9 @@ def test_briefing_skills_refresh_the_meeting_record_before_reading_it(skill: str
 
     refresh_at = body.find("/process-meetings")
     assert refresh_at != -1, (
-        f"{skill} reads the meeting record but never refreshes it. Anything captured since "
-        "the last processing run is invisible, and the brief looks complete rather than stale."
+        f"{skill} reads the meeting record but never processes it first. Anything captured "
+        "locally since the last processing run is invisible, and the brief looks complete "
+        "rather than stale."
     )
     assert refresh_at < read_at, (
         f"{skill} refreshes the meeting record only after reading it, which is too late to "

--- a/packages/dex-agent-plugin/skills/meeting-prep/SKILL.md
+++ b/packages/dex-agent-plugin/skills/meeting-prep/SKILL.md
@@ -113,7 +113,27 @@ events cannot identify the meeting safely.
 
 ## Process
 
-### Step 0: Gather Context (if needed)
+### Step 0: Refresh the meeting record
+
+Before reading anything, run `/process-meetings` so the brief is built on the freshest
+locally available record. It turns captures already sitting unprocessed in the local meeting
+folder into notes and updates the person and company pages from them. It does not reach out
+to an external meeting source, so anything not yet synced there stays out of reach either
+way; what this removes is the gap between a capture arriving locally and it being readable
+here.
+
+- If no new meetings are found, continue silently
+- If meetings are processed, use the extracted context in the brief below
+- Do NOT ask for a skill rating after this sub-step, save that for the end of the prep
+
+**Why this skill in particular needs it.** `/meeting-prep` is normally run minutes before a
+call, which is exactly when the most recent conversation with these attendees is most likely
+to have been captured but not yet processed. Step 3 below reads `00-Inbox/Meetings/`, and a
+brief built from an unprocessed folder does not look incomplete: it looks like there was
+nothing to report. Missing context and no context are indistinguishable in the output, which
+is why the refresh belongs before the read rather than being left to chance.
+
+### Step 0.5: Gather Context (if needed)
 
 **If $MEETING or $ATTENDEES are not provided, try the calendar before asking.** The user booked
 the meeting; the invite already holds the title and the attendee list, and asking them to retype
@@ -230,7 +250,10 @@ Extract:
 
 ### Step 3: Recent Context
 
-Search `00-Inbox/Meetings/` for recent meetings with these attendees:
+Search `00-Inbox/Meetings/` for recent meetings with these attendees. Step 0 processed this
+folder; without that, anything captured locally since the last processing run is invisible
+here.
+
 - What was discussed?
 - What was decided?
 - What follow-ups were committed?


### PR DESCRIPTION
`/meeting-prep` reads `00-Inbox/Meetings` at Step 3 and never refreshes it.

`/daily-plan` and `/daily-review` both run `/process-meetings` before gathering. `meeting-prep`
is the only one of the three that does not, and it is the one that most needs it.

| Skill | Refreshes first? |
|---|---|
| `daily-plan` | yes, Step 0 |
| `daily-review` | yes, Step 0 |
| `meeting-prep` | **no** |

## Why this one matters more than the other two

It is normally run minutes before walking into a call. That is exactly the moment when the most
recent conversation with those attendees is most likely to still be sitting unprocessed at the
source.

And the failure is invisible in the output. **A brief built from a stale folder does not look
incomplete — it looks like there was nothing to report**, which is the same brief you would get
from a genuinely quiet history. The reader cannot tell missing context from no context, so
there is nothing to prompt them to go and check.

## Change

- **Step 0: refresh the meeting record**, using the same wording and handling `daily-plan`
  already uses: silent if nothing is found, no skill rating for a sub-step.
- The previous Step 0 becomes Step 0.5.
- Step 3 now names the dependency where it actually bites, so anyone editing the read later can
  see why the refresh is above it.

## Test

One parameterised contract in `test_instruction_honesty.py`, across the three briefing skills.

**It asserts order, not presence.** A refresh that happens after the read is too late to change
the brief, and a presence-only check would pass on exactly that bug. Parameterising it means the
next briefing skill added inherits the contract rather than repeating the mistake.

Verified by stashing only the skill file: fails on `meeting-prep`, passes for `daily-plan` and
`daily-review` either way, so it is testing the real gap rather than restating the fix.

I deliberately did **not** make this a blanket rule over every skill that touches the meetings
folder. `decision-log`, `delegate-check`, `dex-improve` and `enable-semantic-search` all read it
for legitimate reasons where staleness is not a briefing hazard, and a broad contract would fail
on them for no benefit.

## Gates

All green locally. `check-release-tag-reachability.sh` fails identically on a clean
`upstream/main`, and `test_doctor.py::test_entity_dead_letter_heal_round_trip_returns_probe_to_ok`
fails with this change fully reverted. Both pre-existing.

Independent of #590 and #591; no shared files.
