### PR TITLE
docs: record GitHub vs /feedback reporting split

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -8,6 +8,13 @@ description: Report a Dex bug to the Dex team with zero homework — Dex investi
 Turn "something in Dex is broken" into a high-quality report on the Dex team's desk,
 with the user doing nothing but approving. Contract: `docs/feedback-loop-contract.md`.
 
+`/feedback` is for something that only showed up on this machine (a broken index,
+a Doctor lie, a missing file). Dex investigates locally; the user approves what
+leaves. Product defects, design, and anything another contributor should see
+belong on GitHub issues — that is the public record. A proposed change is a
+GitHub PR: issues argue, PRs show the bytes. If this reporting channel is down,
+GitHub is the backstop.
+
 ## Cardinal rules (read every time)
 
 1. **The conversation is never a source.** A report may contain ONLY the allowed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,18 @@ Anything that makes Dex better for someone else:
 
 ---
 
+## Issues, Pull Requests, and `/feedback`
+
+Short split, so nobody has to guess:
+
+- **GitHub issues** — product defects, design, and anything another contributor should see. This is the public record.
+- **GitHub PRs** — a proposed change. Issues argue; PRs show the bytes.
+- **`/feedback`** — something that only showed up on your machine (a broken index, a Doctor lie, a missing file). Dex investigates locally, you approve what leaves.
+
+If the reporting channel is down, GitHub is the backstop.
+
+---
+
 ## How to Share Your Changes
 
 ### The simple version (recommended)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- https://github.com/davekilleen/Dex/issues/563

## What Changed
- Added Dave's reporting-channel split to `CONTRIBUTING.md` so contributors do not have to ask: GitHub issues are the public record for product defects and design; GitHub PRs are proposed changes; `/feedback` is for something that only showed up on your machine.
- Mentioned GitHub in the `/feedback` skill (it had no GitHub mention before), including GitHub as the backstop if the reporting channel is down.

This is Dave's split from #563, not a new policy.

## Test Plan
- Unit/integration tests added or updated: none (docs only)
- Negative/error-path tests added or updated: none
- Commands run locally: read back the two files against Dave's comment on #563

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [ ] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert the commit; the two files return to their previous text.

## Docs Impact
- Files updated: `CONTRIBUTING.md`, `.claude/skills/feedback/SKILL.md`
- If none, reason: n/a

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1712b9e-0469-4e48-b1f1-6427c61f3d0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1712b9e-0469-4e48-b1f1-6427c61f3d0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

