### PR TITLE
B5: package pinned collaboration Core artifact

### DIFF
--- a/.github/workflows/b5-core-collaboration-artifact.yml
+++ b/.github/workflows/b5-core-collaboration-artifact.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: Dex
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Check out pinned Buzz runtime source

--- a/.github/workflows/b5-core-collaboration-artifact.yml
+++ b/.github/workflows/b5-core-collaboration-artifact.yml
@@ -52,10 +52,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Set up pinned Rust toolchain
-        shell: bash
-        run: rustup toolchain install 1.95.0 --profile minimal
-
       - name: Check source contract
         shell: bash
         env:
@@ -72,17 +68,19 @@ jobs:
           DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: |
           output="$RUNNER_TEMP/dex-core-collaboration"
-          cargo_bin="$(rustup which cargo --toolchain 1.95.0)"
-          "$DEX_PYTHON" packages/dex-collaboration-cli/build_artifact.py \
+          build_json="$("$DEX_PYTHON" packages/dex-collaboration-cli/build_artifact.py \
             --buzz-source "$GITHUB_WORKSPACE/_buzz" \
-            --cargo "$cargo_bin" \
             --jobs 6 \
-            --output "$output"
-          artifact_dir="$(find "$output" -mindepth 1 -maxdepth 1 -type d \
-            -name 'dex-core-collaboration-cli-*' -print -quit)"
-          test -n "$artifact_dir"
+            --output "$output")"
+          printf '%s\n' "$build_json"
+          artifact_dir="$("$DEX_PYTHON" -c \
+            'import json,sys; print(json.loads(sys.argv[1])["artifact_dir"])' \
+            "$build_json")"
+          archive="$("$DEX_PYTHON" -c \
+            'import json,sys; print(json.loads(sys.argv[1])["archive"])' \
+            "$build_json")"
           printf 'artifact_dir=%s\n' "$artifact_dir" >> "$GITHUB_OUTPUT"
-          printf 'archive=%s.tar.gz\n' "$artifact_dir" >> "$GITHUB_OUTPUT"
+          printf 'archive=%s\n' "$archive" >> "$GITHUB_OUTPUT"
 
       - name: Verify extracted artifact and archive
         shell: bash

--- a/.github/workflows/b5-core-collaboration-artifact.yml
+++ b/.github/workflows/b5-core-collaboration-artifact.yml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
         env:
           DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+          DEX_TEST_BUZZ_LAUNCHER_SOURCE: ${{ github.workspace }}/_buzz
         run: |
           "$DEX_PYTHON" packages/dex-collaboration-cli/tests/test_artifact_contract.py
           /bin/bash -n packages/dex-collaboration-cli/src/core

--- a/.github/workflows/b5-core-collaboration-artifact.yml
+++ b/.github/workflows/b5-core-collaboration-artifact.yml
@@ -1,0 +1,105 @@
+name: B5 Core collaboration artifact
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - packages/dex-collaboration-cli/**
+      - .github/workflows/b5-core-collaboration-artifact.yml
+  push:
+    branches:
+      - main
+    paths:
+      - packages/dex-collaboration-cli/**
+      - .github/workflows/b5-core-collaboration-artifact.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: b5-core-collaboration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-verify:
+    name: ${{ matrix.os }} native artifact
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+
+    steps:
+      - name: Check out Dex Core
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check out pinned Buzz runtime source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: block/buzz
+          ref: b2ac66cde81df7ce1afc50016e1571cb6e8b7779
+          path: _buzz
+          persist-credentials: false
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up pinned Rust toolchain
+        shell: bash
+        run: rustup toolchain install 1.95.0 --profile minimal
+
+      - name: Check source contract
+        shell: bash
+        env:
+          DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          "$DEX_PYTHON" packages/dex-collaboration-cli/tests/test_artifact_contract.py
+          /bin/bash -n packages/dex-collaboration-cli/src/core
+          "$DEX_PYTHON" -m py_compile packages/dex-collaboration-cli/*.py
+
+      - name: Build pinned native artifact
+        id: build
+        shell: bash
+        env:
+          DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          output="$RUNNER_TEMP/dex-core-collaboration"
+          cargo_bin="$(rustup which cargo --toolchain 1.95.0)"
+          "$DEX_PYTHON" packages/dex-collaboration-cli/build_artifact.py \
+            --buzz-source "$GITHUB_WORKSPACE/_buzz" \
+            --cargo "$cargo_bin" \
+            --jobs 6 \
+            --output "$output"
+          artifact_dir="$(find "$output" -mindepth 1 -maxdepth 1 -type d \
+            -name 'dex-core-collaboration-cli-*' -print -quit)"
+          test -n "$artifact_dir"
+          printf 'artifact_dir=%s\n' "$artifact_dir" >> "$GITHUB_OUTPUT"
+          printf 'archive=%s.tar.gz\n' "$artifact_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Verify extracted artifact and archive
+        shell: bash
+        env:
+          DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+          ARTIFACT_DIR: ${{ steps.build.outputs.artifact_dir }}
+          ARCHIVE: ${{ steps.build.outputs.archive }}
+        run: |
+          env PATH= "$DEX_PYTHON" packages/dex-collaboration-cli/verify_artifact.py "$ARTIFACT_DIR"
+          env PATH= "$DEX_PYTHON" packages/dex-collaboration-cli/verify_artifact.py "$ARCHIVE"
+
+      - name: Upload CI-only native artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dex-core-collaboration-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            ${{ steps.build.outputs.archive }}
+            ${{ steps.build.outputs.archive }}.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/b5-core-collaboration-artifact.yml
+++ b/.github/workflows/b5-core-collaboration-artifact.yml
@@ -25,6 +25,9 @@ jobs:
     name: ${{ matrix.os }} native artifact
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: Dex
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +39,7 @@ jobs:
       - name: Check out Dex Core
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          path: Dex
           persist-credentials: false
 
       - name: Check out pinned Buzz runtime source
@@ -43,7 +47,7 @@ jobs:
         with:
           repository: block/buzz
           ref: b2ac66cde81df7ce1afc50016e1571cb6e8b7779
-          path: _buzz
+          path: Buzz
           persist-credentials: false
 
       - name: Set up Python
@@ -56,7 +60,7 @@ jobs:
         shell: bash
         env:
           DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-          DEX_TEST_BUZZ_LAUNCHER_SOURCE: ${{ github.workspace }}/_buzz
+          DEX_TEST_BUZZ_LAUNCHER_SOURCE: ${{ github.workspace }}/Buzz
         run: |
           "$DEX_PYTHON" packages/dex-collaboration-cli/tests/test_artifact_contract.py
           /bin/bash -n packages/dex-collaboration-cli/src/core
@@ -70,7 +74,7 @@ jobs:
         run: |
           output="$RUNNER_TEMP/dex-core-collaboration"
           build_json="$("$DEX_PYTHON" packages/dex-collaboration-cli/build_artifact.py \
-            --buzz-source "$GITHUB_WORKSPACE/_buzz" \
+            --buzz-source "$GITHUB_WORKSPACE/Buzz" \
             --jobs 6 \
             --output "$output")"
           printf '%s\n' "$build_json"

--- a/packages/dex-collaboration-cli/README.md
+++ b/packages/dex-collaboration-cli/README.md
@@ -71,7 +71,8 @@ than overstating its evidence.
 
 Use a clean Buzz checkout at the exact revision. The builder invokes that
 checkout's tracked Hermit launchers for Rust 1.95.0, strips inherited
-Rust/Cargo/Hermit overrides, and always builds into a new empty target:
+Rust/Cargo/Hermit overrides, gives Hermit a new builder-owned HOME, cache,
+state and executable path, and always builds into a new empty target:
 
 ```bash
 python3 packages/dex-collaboration-cli/build_artifact.py \

--- a/packages/dex-collaboration-cli/README.md
+++ b/packages/dex-collaboration-cli/README.md
@@ -15,6 +15,11 @@ artifact only: it is not wired into Dex's installer, release workflow, or an
 existing packaged app. That integration and packaged-app proof remain B5.4
 work.
 
+The native dependency closure is recorded per executable and restricted to
+the operating system baseline (`/usr/lib` and system frameworks on macOS;
+glibc/loader libraries on Linux). The verifier recomputes that closure on each
+fresh CI host and rejects custom search paths or non-baseline libraries.
+
 ## Frozen boundary
 
 `contract.json` pins the collaboration runtime to
@@ -53,15 +58,20 @@ identities are never overwritten. Standard output is JSON-only; failures are
 JSON on standard error, and native error details are scrubbed of the active
 private key.
 
-Buzz uses NIP-29 semantics: the selected creator identity signs the create
+Buzz uses NIP-29 semantics: the selected creator identity authorizes the create
 request, while canonical channel metadata returned by the relay is
-relay-signed. The behavioral proof verifies the creator selection, the room
-flags, and a post/timeline round-trip signed by that same identity without
-misreporting the relay metadata signer as the creator.
+relay-signed. The package boundary test proves that `stream` and `open` are
+sent, and the behavioral proof verifies the returned room name/description and
+the creator's pubkey on kind-9 timeline events. The pinned CLI does not expose
+the raw canonical room tags or event signatures through these commands, so the
+proof reports those two independent cryptographic checks as `false` rather
+than overstating its evidence.
 
 ## Build and verify
 
-Use a Buzz checkout at the exact revision and Rust 1.95.0:
+Use a clean Buzz checkout at the exact revision. The builder invokes that
+checkout's tracked Hermit launchers for Rust 1.95.0, strips inherited
+Rust/Cargo/Hermit overrides, and always builds into a new empty target:
 
 ```bash
 python3 packages/dex-collaboration-cli/build_artifact.py \
@@ -88,8 +98,8 @@ python3 packages/dex-collaboration-cli/prove_real_runtime.py \
 
 The proof creates a uniquely named disposable room on that relay. It uses
 fresh temporary homes and an empty caller `PATH`, checks identity persistence
-and overwrite refusal, selected creator identity and room flags, signed kind-9
-post/timeline semantics, newest-tail limiting, JSON failures for invalid and
+and overwrite refusal, selected creator identity and requested room flags,
+kind-9 author post/timeline semantics, newest-tail limiting, JSON failures for invalid and
 unknown inputs, relay failure handling, and private-key non-disclosure.
 
 ## CI

--- a/packages/dex-collaboration-cli/README.md
+++ b/packages/dex-collaboration-cli/README.md
@@ -54,7 +54,10 @@ service.
 Identity private keys remain in
 `$DEX_STUDIO_HOME/keys/agents/<id>/key.json` (or
 `$HOME/.dex-studio/...`) with `0700` directories and `0600` files. Existing
-identities are never overwritten. Standard output is JSON-only; failures are
+identities are never overwritten. Selected identity IDs use the same canonical
+lowercase slug grammar as generated IDs; dot, slash, and traversal paths are
+rejected before key lookup. Pre-existing symlinks in the studio, keys, or
+agents custody root fail closed. Standard output is JSON-only; failures are
 JSON on standard error, and native error details are scrubbed of the active
 private key.
 
@@ -69,10 +72,18 @@ than overstating its evidence.
 
 ## Build and verify
 
-Use a clean Buzz checkout at the exact revision. The builder invokes that
-checkout's tracked Hermit launchers for Rust 1.95.0, strips inherited
+Use clean Dex and Buzz checkouts at their exact revisions. The builder invokes
+Buzz's tracked Hermit launchers for Rust 1.95.0, strips inherited
 Rust/Cargo/Hermit overrides, gives Hermit a new builder-owned HOME, cache,
-state and executable path, and always builds into a new empty target:
+state and executable path, and always builds into a new empty target. All
+private build state lives in a temporary sibling outside the requested output
+and is removed on success or failure. A successful output contains only the
+artifact directory, archive, and archive checksum sidecar; rerunning against
+that non-empty output is refused.
+
+The manifest records the clean Dex revision and the SHA-256 identity of
+`contract.json`. The verifier binds those fields to the exact Buzz repository,
+Buzz revision, and package source contract. Build and verify with:
 
 ```bash
 python3 packages/dex-collaboration-cli/build_artifact.py \

--- a/packages/dex-collaboration-cli/README.md
+++ b/packages/dex-collaboration-cli/README.md
@@ -1,0 +1,99 @@
+# Dex Core collaboration CLI artifact
+
+This package owns the narrow B5 Core-artifact seam for Dex's Solo beta. It
+builds a platform-labelled, installable archive containing a `core` executable
+and the real native Buzz clients needed for:
+
+- `core identity create --name NAME`
+- `core rooms list [--as ID] --json`
+- `core rooms create --name NAME [--description TEXT] [--as ID]`
+- `core post --as ID --room UUID --text TEXT`
+- `core timeline --room UUID [--as ID] [--limit N] --json`
+
+The artifact is implemented and verifiable in this package. It is a CI
+artifact only: it is not wired into Dex's installer, release workflow, or an
+existing packaged app. That integration and packaged-app proof remain B5.4
+work.
+
+## Frozen boundary
+
+`contract.json` pins the collaboration runtime to
+`block/buzz@b2ac66cde81df7ce1afc50016e1571cb6e8b7779`. The builder compiles
+`buzz-cli` and `buzz-admin` from that exact checkout with the locked dependency
+graph. It rejects a dirty source tree and does not accept caller-provided
+runtime binaries.
+
+The artifact contains:
+
+```text
+dex-core-collaboration-cli-<platform>-<architecture>/
+├── bin/core
+├── libexec/buzz
+├── libexec/buzz-admin
+├── LICENSES/Buzz-LICENSE
+├── manifest.json
+└── SHA256SUMS
+```
+
+Supported labels are `linux` or `darwin` and `x86_64` or `arm64`. The verifier
+checks the native executable headers against those labels, exact payload and
+modes, every manifest/checksum entry, the pinned source revision, and that
+`bin/core --artifact-info` runs with fresh homes and an empty caller `PATH`.
+The `.tar.gz.sha256` sidecar is verified before the archive is safely extracted
+and checked again.
+
+`BUZZ_RELAY_URL` is the explicit service boundary and defaults to
+`ws://127.0.0.1:34000`. The packaged artifact does not provide or start that
+service.
+
+Identity private keys remain in
+`$DEX_STUDIO_HOME/keys/agents/<id>/key.json` (or
+`$HOME/.dex-studio/...`) with `0700` directories and `0600` files. Existing
+identities are never overwritten. Standard output is JSON-only; failures are
+JSON on standard error, and native error details are scrubbed of the active
+private key.
+
+Buzz uses NIP-29 semantics: the selected creator identity signs the create
+request, while canonical channel metadata returned by the relay is
+relay-signed. The behavioral proof verifies the creator selection, the room
+flags, and a post/timeline round-trip signed by that same identity without
+misreporting the relay metadata signer as the creator.
+
+## Build and verify
+
+Use a Buzz checkout at the exact revision and Rust 1.95.0:
+
+```bash
+python3 packages/dex-collaboration-cli/build_artifact.py \
+  --buzz-source /path/to/buzz \
+  --output /tmp/dex-core-artifacts
+
+python3 packages/dex-collaboration-cli/verify_artifact.py \
+  /tmp/dex-core-artifacts/dex-core-collaboration-cli-linux-x86_64
+
+python3 packages/dex-collaboration-cli/verify_artifact.py \
+  /tmp/dex-core-artifacts/dex-core-collaboration-cli-linux-x86_64.tar.gz
+```
+
+The builder defaults to six Cargo jobs and refuses values above nine so it
+cannot silently consume every core on shared build hosts.
+
+With a development relay available, run the real behavioral proof against an
+already verified extracted artifact:
+
+```bash
+python3 packages/dex-collaboration-cli/prove_real_runtime.py \
+  /tmp/dex-core-artifacts/dex-core-collaboration-cli-linux-x86_64
+```
+
+The proof creates a uniquely named disposable room on that relay. It uses
+fresh temporary homes and an empty caller `PATH`, checks identity persistence
+and overwrite refusal, selected creator identity and room flags, signed kind-9
+post/timeline semantics, newest-tail limiting, JSON failures for invalid and
+unknown inputs, relay failure handling, and private-key non-disclosure.
+
+## CI
+
+`.github/workflows/b5-core-collaboration-artifact.yml` builds and verifies
+native Linux and macOS archives, then uploads them as short-lived workflow
+artifacts. It has no release trigger and publishes no GitHub Release assets.

--- a/packages/dex-collaboration-cli/artifact_support.py
+++ b/packages/dex-collaboration-cli/artifact_support.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import hashlib
 import os
 import platform
+import re
 import stat
 import struct
+import subprocess
 import sys
 from pathlib import Path
 
@@ -89,6 +91,67 @@ def native_identity(path: Path) -> tuple[str, str, str]:
         return "mach-o", "darwin", arch
 
     raise ArtifactError(f"runtime is not a supported native executable: {path}")
+
+
+def native_dependencies(path: Path, platform_label: str) -> list[str]:
+    if platform_label == "linux":
+        result = subprocess.run(
+            ["/usr/bin/readelf", "-d", path],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise ArtifactError(f"ELF dependency closure could not be read: {path.name}")
+        if "(RPATH)" in result.stdout or "(RUNPATH)" in result.stdout:
+            raise ArtifactError(f"native runtime has a non-baseline search path: {path.name}")
+        dependencies = re.findall(r"\(NEEDED\).*Shared library: \[([^]]+)\]", result.stdout)
+    elif platform_label == "darwin":
+        result = subprocess.run(
+            ["/usr/bin/otool", "-L", path],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise ArtifactError(f"Mach-O dependency closure could not be read: {path.name}")
+        dependencies = [
+            line.strip().split(" (", 1)[0]
+            for line in result.stdout.splitlines()[1:]
+            if line.strip()
+        ]
+    else:
+        raise ArtifactError(f"unsupported dependency platform: {platform_label}")
+    require_baseline_dependencies(platform_label, dependencies)
+    return sorted(set(dependencies))
+
+
+def require_baseline_dependencies(platform_label: str, dependencies: list[str]) -> None:
+    if not dependencies:
+        raise ArtifactError("native runtime dependency closure is empty")
+    if platform_label == "linux":
+        allowed = {
+            "libc.so.6",
+            "libdl.so.2",
+            "libgcc_s.so.1",
+            "libm.so.6",
+            "libpthread.so.0",
+            "libresolv.so.2",
+            "librt.so.1",
+            "libutil.so.1",
+            "ld-linux-x86-64.so.2",
+            "ld-linux-aarch64.so.1",
+        }
+        rejected = [dependency for dependency in dependencies if dependency not in allowed]
+    elif platform_label == "darwin":
+        rejected = [
+            dependency
+            for dependency in dependencies
+            if not dependency.startswith("/usr/lib/")
+            and not dependency.startswith("/System/Library/Frameworks/")
+        ]
+    else:
+        raise ArtifactError(f"unsupported dependency platform: {platform_label}")
+    if rejected:
+        raise ArtifactError(f"native runtime has non-baseline dependencies: {', '.join(rejected)}")
 
 
 def canonical_json_bytes(document: object) -> bytes:

--- a/packages/dex-collaboration-cli/artifact_support.py
+++ b/packages/dex-collaboration-cli/artifact_support.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import stat
+import struct
+import sys
+from pathlib import Path
+
+
+class ArtifactError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def host_platform() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    raise ArtifactError(f"unsupported build platform: {sys.platform}")
+
+
+def normalize_arch(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"x86_64", "amd64"}:
+        return "x86_64"
+    if normalized in {"arm64", "aarch64"}:
+        return "arm64"
+    raise ArtifactError(f"unsupported architecture: {value}")
+
+
+def host_arch() -> str:
+    return normalize_arch(platform.machine())
+
+
+def executable_mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def require_regular_executable(path: Path, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise ArtifactError(f"{label} is missing: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ArtifactError(f"{label} must be a regular file")
+    if metadata.st_mode & 0o111 == 0:
+        raise ArtifactError(f"{label} is not executable")
+
+
+def native_identity(path: Path) -> tuple[str, str, str]:
+    data = path.read_bytes()[:4096]
+    if data.startswith(b"\x7fELF"):
+        if len(data) < 20:
+            raise ArtifactError(f"native executable header is truncated: {path}")
+        byte_order = "<" if data[5] == 1 else ">" if data[5] == 2 else ""
+        if not byte_order:
+            raise ArtifactError(f"native executable byte order is invalid: {path}")
+        machine = struct.unpack(f"{byte_order}H", data[18:20])[0]
+        arch = {62: "x86_64", 183: "arm64"}.get(machine)
+        if not arch:
+            raise ArtifactError(f"unsupported ELF architecture {machine}: {path}")
+        return "elf", "linux", arch
+
+    magic = data[:4]
+    macho_orders = {
+        b"\xcf\xfa\xed\xfe": "<",
+        b"\xfe\xed\xfa\xcf": ">",
+        b"\xce\xfa\xed\xfe": "<",
+        b"\xfe\xed\xfa\xce": ">",
+    }
+    byte_order = macho_orders.get(magic)
+    if byte_order:
+        if len(data) < 8:
+            raise ArtifactError(f"native executable header is truncated: {path}")
+        cpu_type = struct.unpack(f"{byte_order}I", data[4:8])[0]
+        arch = {0x01000007: "x86_64", 0x0100000C: "arm64"}.get(cpu_type)
+        if not arch:
+            raise ArtifactError(f"unsupported Mach-O architecture {cpu_type}: {path}")
+        return "mach-o", "darwin", arch
+
+    raise ArtifactError(f"runtime is not a supported native executable: {path}")
+
+
+def canonical_json_bytes(document: object) -> bytes:
+    import json
+
+    return (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def require_mode(path: Path, expected: int) -> None:
+    actual = executable_mode(path)
+    if actual != expected:
+        raise ArtifactError(f"{path.name} mode is {actual:04o}, expected {expected:04o}")
+
+
+def safe_relative_files(root: Path) -> list[Path]:
+    result: list[Path] = []
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        for name in directory_names:
+            candidate = directory_path / name
+            if candidate.is_symlink():
+                raise ArtifactError(f"artifact contains a symlink: {candidate.relative_to(root)}")
+        for name in file_names:
+            candidate = directory_path / name
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise ArtifactError(f"artifact contains a non-regular file: {candidate.relative_to(root)}")
+            result.append(candidate.relative_to(root))
+    return sorted(result, key=lambda item: item.as_posix())

--- a/packages/dex-collaboration-cli/build_artifact.py
+++ b/packages/dex-collaboration-cli/build_artifact.py
@@ -130,12 +130,6 @@ def _sanitized_build_environment(
 ) -> dict[str, str]:
     inherited = os.environ if source_environment is None else source_environment
     allowed = (
-        "HOME",
-        "USER",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-        "XDG_CACHE_HOME",
         "HTTP_PROXY",
         "HTTPS_PROXY",
         "NO_PROXY",
@@ -147,9 +141,23 @@ def _sanitized_build_environment(
     )
     environment = {key: inherited[key] for key in allowed if inherited.get(key)}
     trusted_bin = f"{source / 'bin'}:" if source is not None else ""
+    build_root = target_dir.parent
+    hermit_home = build_root / ".hermit-home"
+    hermit_state = build_root / ".hermit-state"
+    hermit_executable = hermit_state / "pkg" / "hermit@stable" / "hermit"
+    xdg_cache = build_root / ".xdg-cache"
+    temporary = build_root / ".tmp"
+    for directory in (hermit_home, hermit_state, xdg_cache, temporary):
+        directory.mkdir(parents=True, exist_ok=True)
+        directory.chmod(0o700)
     environment.update(
         {
             "PATH": f"{trusted_bin}/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": str(hermit_home),
+            "XDG_CACHE_HOME": str(xdg_cache),
+            "TMPDIR": str(temporary),
+            "HERMIT_STATE_DIR": str(hermit_state),
+            "HERMIT_EXE": str(hermit_executable),
             "CARGO_TARGET_DIR": str(target_dir),
             "CARGO_TERM_COLOR": "never",
         }
@@ -302,6 +310,7 @@ def build(args: argparse.Namespace) -> dict[str, str]:
             "buzz_revision": expected_revision,
             "buzz_tree_clean": True,
             "cargo_target_fresh": True,
+            "hermit_state_isolated": True,
             "dex_revision": _git_head(dex_root),
             "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
             "toolchain": toolchain,

--- a/packages/dex-collaboration-cli/build_artifact.py
+++ b/packages/dex-collaboration-cli/build_artifact.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 import gzip
 import json
+import os
+import re
 import shutil
 import subprocess
 import sys
@@ -15,6 +17,7 @@ from artifact_support import (
     canonical_json_bytes,
     host_arch,
     host_platform,
+    native_dependencies,
     native_identity,
     require_regular_executable,
     sha256_file,
@@ -25,6 +28,30 @@ PACKAGE_ROOT = Path(__file__).resolve().parent
 
 class BuildError(ArtifactError):
     pass
+
+
+def _bounded_cargo_diagnostic(stderr: str, source: Path, target: Path) -> str:
+    sanitized = stderr.replace(str(source.resolve()), "<buzz-source>")
+    sanitized = sanitized.replace(str(target.resolve()), "<cargo-target>")
+    user_home = str(Path.home())
+    if user_home:
+        sanitized = sanitized.replace(user_home, "<user-home>")
+    sanitized = re.sub(
+        r"(?i)\b([a-z0-9_]*(?:token|secret|password|private[_-]?key)[a-z0-9_]*)\s*[=:]\s*\S+",
+        lambda match: f"{match.group(1)}=[redacted]",
+        sanitized,
+    )
+    lines = sanitized.splitlines()
+    first_error = next(
+        (index for index, line in enumerate(lines) if re.match(r"^\s*(error(?:\[[^]]+\])?:|Caused by:)", line)),
+        max(0, len(lines) - 12),
+    )
+    start = max(0, first_error - 2)
+    selected = lines[start : start + 24]
+    diagnostic = "\n".join(selected).strip()
+    if len(diagnostic) > 4096:
+        diagnostic = diagnostic[:4083] + "\n[truncated]"
+    return diagnostic or "Cargo failed without diagnostic output"
 
 
 def _git_head(source: Path) -> str:
@@ -75,17 +102,67 @@ def _source_epoch(repo: Path) -> int:
     return int(result.stdout.strip())
 
 
-def _build_pinned_runtime(args: argparse.Namespace) -> tuple[Path, Path]:
-    cargo = args.cargo
-    if cargo is None:
-        source_cargo = args.buzz_source / "bin" / "cargo"
-        cargo = source_cargo if source_cargo.is_file() else Path("cargo")
-    environment = None
-    target_dir = args.cargo_target_dir
-    if target_dir is not None:
-        import os
+def _toolchain_identity(source: Path, environment: dict[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name in ("cargo", "rustc"):
+        executable = source / "bin" / name
+        completed = subprocess.run(
+            [executable, "--version", "--verbose"],
+            cwd=source,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise BuildError(f"pinned Buzz {name} launcher failed")
+        first_line = completed.stdout.splitlines()[0] if completed.stdout else ""
+        if not first_line.startswith(f"{name} 1.95.0 "):
+            raise BuildError(f"pinned Buzz {name} is not version 1.95.0")
+        result[name] = first_line
+    return result
 
-        environment = {**os.environ, "CARGO_TARGET_DIR": str(target_dir)}
+
+def _sanitized_build_environment(
+    target_dir: Path,
+    *,
+    source_environment: dict[str, str] | None = None,
+    source: Path | None = None,
+) -> dict[str, str]:
+    inherited = os.environ if source_environment is None else source_environment
+    allowed = (
+        "HOME",
+        "USER",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "XDG_CACHE_HOME",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+    )
+    environment = {key: inherited[key] for key in allowed if inherited.get(key)}
+    trusted_bin = f"{source / 'bin'}:" if source is not None else ""
+    environment.update(
+        {
+            "PATH": f"{trusted_bin}/usr/bin:/bin:/usr/sbin:/sbin",
+            "CARGO_TARGET_DIR": str(target_dir),
+            "CARGO_TERM_COLOR": "never",
+        }
+    )
+    return environment
+
+
+def _build_pinned_runtime(args: argparse.Namespace) -> tuple[Path, Path, dict[str, str]]:
+    cargo = args.buzz_source / "bin" / "cargo"
+    target_dir = args.output / ".cargo-target"
+    target_dir.mkdir()
+    environment = _sanitized_build_environment(target_dir, source=args.buzz_source)
+    toolchain = _toolchain_identity(args.buzz_source, environment)
     result = subprocess.run(
         [
             str(cargo),
@@ -105,13 +182,11 @@ def _build_pinned_runtime(args: argparse.Namespace) -> tuple[Path, Path]:
         text=True,
     )
     if result.returncode != 0:
-        detail = (result.stderr or result.stdout).strip().splitlines()
-        final_line = detail[-1] if detail else "unknown Cargo failure"
-        raise BuildError(f"pinned Buzz release build failed: {final_line}")
-    target_root = target_dir if target_dir is not None else args.buzz_source / "target"
-    buzz = target_root / "release" / "buzz"
-    buzz_admin = target_root / "release" / "buzz-admin"
-    return buzz, buzz_admin
+        detail = _bounded_cargo_diagnostic(result.stderr or result.stdout, args.buzz_source, target_dir)
+        raise BuildError(f"pinned Buzz release build failed:\n{detail}")
+    buzz = target_dir / "release" / "buzz"
+    buzz_admin = target_dir / "release" / "buzz-admin"
+    return buzz, buzz_admin, toolchain
 
 
 def _write_deterministic_archive(artifact_dir: Path, archive: Path, epoch: int) -> None:
@@ -137,6 +212,8 @@ def _write_deterministic_archive(artifact_dir: Path, archive: Path, epoch: int) 
 
 
 def build(args: argparse.Namespace) -> dict[str, str]:
+    if args.output.exists() and any(args.output.iterdir()):
+        raise BuildError("artifact output directory must be empty")
     contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
     expected_revision = contract["buzz_revision"]
     actual_revision = _git_head(args.buzz_source)
@@ -147,7 +224,8 @@ def build(args: argparse.Namespace) -> dict[str, str]:
         )
     _require_clean_source(args.buzz_source)
 
-    buzz_bin, buzz_admin_bin = _build_pinned_runtime(args)
+    args.output.mkdir(parents=True, exist_ok=True)
+    buzz_bin, buzz_admin_bin, toolchain = _build_pinned_runtime(args)
     for path, label in (
         (buzz_bin, "Buzz client"),
         (buzz_admin_bin, "Buzz admin client"),
@@ -169,8 +247,8 @@ def build(args: argparse.Namespace) -> dict[str, str]:
                 f"{name} targets {runtime_platform}/{runtime_arch}, expected "
                 f"{platform_label}/{architecture}"
             )
+        native_dependencies(path, platform_label)
 
-    args.output.mkdir(parents=True, exist_ok=True)
     artifact_name = f"{contract['artifact_id']}-{platform_label}-{architecture}"
     artifact_dir = args.output / artifact_name
     if artifact_dir.exists():
@@ -198,7 +276,13 @@ def build(args: argparse.Namespace) -> dict[str, str]:
         if relative.startswith("libexec/"):
             runtime_name = Path(relative).name
             binary_format, _, binary_arch = runtime_identities[runtime_name]
-            entry.update({"format": binary_format, "architecture": binary_arch})
+            entry.update(
+                {
+                    "format": binary_format,
+                    "architecture": binary_arch,
+                    "dependencies": native_dependencies(destination, platform_label),
+                }
+            )
         elif relative == "bin/core":
             entry["format"] = "bash"
         else:
@@ -217,8 +301,10 @@ def build(args: argparse.Namespace) -> dict[str, str]:
             "buzz_repository": contract["buzz_repository"],
             "buzz_revision": expected_revision,
             "buzz_tree_clean": True,
+            "cargo_target_fresh": True,
             "dex_revision": _git_head(dex_root),
             "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
+            "toolchain": toolchain,
         },
         "files": sorted(files, key=lambda entry: str(entry["path"])),
     }
@@ -253,8 +339,6 @@ def build(args: argparse.Namespace) -> dict[str, str]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--buzz-source", type=Path, required=True)
-    parser.add_argument("--cargo", type=Path)
-    parser.add_argument("--cargo-target-dir", type=Path)
     parser.add_argument("--jobs", type=int, default=6)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)

--- a/packages/dex-collaboration-cli/build_artifact.py
+++ b/packages/dex-collaboration-cli/build_artifact.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+from artifact_support import (
+    ArtifactError,
+    canonical_json_bytes,
+    host_arch,
+    host_platform,
+    native_identity,
+    require_regular_executable,
+    sha256_file,
+)
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+
+
+class BuildError(ArtifactError):
+    pass
+
+
+def _git_head(source: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BuildError("Buzz source is not a readable Git checkout")
+    return result.stdout.strip()
+
+
+def _require_clean_source(source: Path) -> None:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BuildError("Buzz source cleanliness could not be verified")
+    if result.stdout:
+        raise BuildError("Buzz source checkout is dirty; runtime provenance is not exact")
+
+
+def _copy_payload(source: Path, destination: Path, mode: int) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    destination.chmod(mode)
+
+
+def _source_epoch(repo: Path) -> int:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", "-s", "--format=%ct", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip().isdigit():
+        raise BuildError("Dex source timestamp could not be read")
+    return int(result.stdout.strip())
+
+
+def _build_pinned_runtime(args: argparse.Namespace) -> tuple[Path, Path]:
+    cargo = args.cargo
+    if cargo is None:
+        source_cargo = args.buzz_source / "bin" / "cargo"
+        cargo = source_cargo if source_cargo.is_file() else Path("cargo")
+    environment = None
+    target_dir = args.cargo_target_dir
+    if target_dir is not None:
+        import os
+
+        environment = {**os.environ, "CARGO_TARGET_DIR": str(target_dir)}
+    result = subprocess.run(
+        [
+            str(cargo),
+            "build",
+            "--locked",
+            "--release",
+            "--jobs",
+            str(args.jobs),
+            "--package",
+            "buzz-cli",
+            "--package",
+            "buzz-admin",
+        ],
+        cwd=args.buzz_source,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        final_line = detail[-1] if detail else "unknown Cargo failure"
+        raise BuildError(f"pinned Buzz release build failed: {final_line}")
+    target_root = target_dir if target_dir is not None else args.buzz_source / "target"
+    buzz = target_root / "release" / "buzz"
+    buzz_admin = target_root / "release" / "buzz-admin"
+    return buzz, buzz_admin
+
+
+def _write_deterministic_archive(artifact_dir: Path, archive: Path, epoch: int) -> None:
+    with archive.open("wb") as raw:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=epoch) as compressed:
+            with tarfile.open(fileobj=compressed, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+                for path in sorted(artifact_dir.rglob("*"), key=lambda item: item.as_posix()):
+                    if not path.is_file():
+                        continue
+                    relative = path.relative_to(artifact_dir.parent)
+                    data = path.read_bytes()
+                    info = tarfile.TarInfo(relative.as_posix())
+                    info.size = len(data)
+                    info.mode = path.stat().st_mode & 0o777
+                    info.mtime = epoch
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = "root"
+                    info.gname = "root"
+                    import io
+
+                    tar.addfile(info, io.BytesIO(data))
+
+
+def build(args: argparse.Namespace) -> dict[str, str]:
+    contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
+    expected_revision = contract["buzz_revision"]
+    actual_revision = _git_head(args.buzz_source)
+    if actual_revision != expected_revision:
+        raise BuildError(
+            "runtime is not proven at the pinned Buzz revision "
+            f"{expected_revision} (found {actual_revision or 'none'})"
+        )
+    _require_clean_source(args.buzz_source)
+
+    buzz_bin, buzz_admin_bin = _build_pinned_runtime(args)
+    for path, label in (
+        (buzz_bin, "Buzz client"),
+        (buzz_admin_bin, "Buzz admin client"),
+        (PACKAGE_ROOT / "src" / "core", "Core executable"),
+    ):
+        require_regular_executable(path, label)
+    buzz_license = args.buzz_source / "LICENSE"
+    if not buzz_license.is_file() or buzz_license.is_symlink():
+        raise BuildError("pinned Buzz LICENSE is missing")
+
+    platform_label = host_platform()
+    architecture = host_arch()
+    runtime_identities: dict[str, tuple[str, str, str]] = {}
+    for name, path in (("buzz", buzz_bin), ("buzz-admin", buzz_admin_bin)):
+        runtime_identities[name] = native_identity(path)
+        _, runtime_platform, runtime_arch = runtime_identities[name]
+        if (runtime_platform, runtime_arch) != (platform_label, architecture):
+            raise BuildError(
+                f"{name} targets {runtime_platform}/{runtime_arch}, expected "
+                f"{platform_label}/{architecture}"
+            )
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    artifact_name = f"{contract['artifact_id']}-{platform_label}-{architecture}"
+    artifact_dir = args.output / artifact_name
+    if artifact_dir.exists():
+        raise BuildError(f"artifact output already exists: {artifact_dir}")
+    artifact_dir.mkdir()
+
+    payload = (
+        (PACKAGE_ROOT / "src" / "core", artifact_dir / "bin" / "core", 0o755),
+        (buzz_bin, artifact_dir / "libexec" / "buzz", 0o755),
+        (buzz_admin_bin, artifact_dir / "libexec" / "buzz-admin", 0o755),
+        (buzz_license, artifact_dir / "LICENSES" / "Buzz-LICENSE", 0o644),
+    )
+    for source, destination, mode in payload:
+        _copy_payload(source, destination, mode)
+
+    dex_root = PACKAGE_ROOT.parents[1]
+    files = []
+    for _, destination, mode in payload:
+        relative = destination.relative_to(artifact_dir).as_posix()
+        entry: dict[str, object] = {
+            "path": relative,
+            "mode": f"{mode:04o}",
+            "sha256": sha256_file(destination),
+        }
+        if relative.startswith("libexec/"):
+            runtime_name = Path(relative).name
+            binary_format, _, binary_arch = runtime_identities[runtime_name]
+            entry.update({"format": binary_format, "architecture": binary_arch})
+        elif relative == "bin/core":
+            entry["format"] = "bash"
+        else:
+            entry["format"] = "text"
+        files.append(entry)
+
+    manifest = {
+        "schema": "dex-collaboration-cli-artifact/1",
+        "artifact_id": contract["artifact_id"],
+        "artifact_name": artifact_name,
+        "platform": platform_label,
+        "architecture": architecture,
+        "commands": contract["commands"],
+        "relay": contract["service_boundary"],
+        "sources": {
+            "buzz_repository": contract["buzz_repository"],
+            "buzz_revision": expected_revision,
+            "buzz_tree_clean": True,
+            "dex_revision": _git_head(dex_root),
+            "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
+        },
+        "files": sorted(files, key=lambda entry: str(entry["path"])),
+    }
+    manifest_path = artifact_dir / "manifest.json"
+    manifest_path.write_bytes(canonical_json_bytes(manifest))
+    manifest_path.chmod(0o644)
+
+    checksum_paths = [destination.relative_to(artifact_dir) for _, destination, _ in payload]
+    checksum_paths.append(Path("manifest.json"))
+    sums = "".join(
+        f"{sha256_file(artifact_dir / relative)}  {relative.as_posix()}\n"
+        for relative in sorted(checksum_paths, key=lambda item: item.as_posix())
+    )
+    sums_path = artifact_dir / "SHA256SUMS"
+    sums_path.write_text(sums, encoding="utf-8")
+    sums_path.chmod(0o644)
+
+    archive = args.output / f"{artifact_name}.tar.gz"
+    _write_deterministic_archive(artifact_dir, archive, _source_epoch(dex_root))
+    archive_checksum = sha256_file(archive)
+    checksum_file = Path(f"{archive}.sha256")
+    checksum_file.write_text(f"{archive_checksum}  {archive.name}\n", encoding="utf-8")
+    return {
+        "artifact_dir": str(artifact_dir.resolve()),
+        "archive": str(archive.resolve()),
+        "archive_sha256": archive_checksum,
+        "platform": platform_label,
+        "architecture": architecture,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--buzz-source", type=Path, required=True)
+    parser.add_argument("--cargo", type=Path)
+    parser.add_argument("--cargo-target-dir", type=Path)
+    parser.add_argument("--jobs", type=int, default=6)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.jobs < 1 or args.jobs > 9:
+            raise BuildError("--jobs must be between 1 and 9")
+        result = build(args)
+        print(json.dumps(result, separators=(",", ":")))
+        return 0
+    except (ArtifactError, KeyError, OSError, json.JSONDecodeError) as error:
+        print(json.dumps({"error": str(error)}, separators=(",", ":")), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/dex-collaboration-cli/build_artifact.py
+++ b/packages/dex-collaboration-cli/build_artifact.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 from pathlib import Path
 
 from artifact_support import (
@@ -80,9 +81,11 @@ def _require_clean_source(source: Path) -> None:
         text=True,
     )
     if result.returncode != 0:
-        raise BuildError("Buzz source cleanliness could not be verified")
+        label = "Dex" if source.resolve() == PACKAGE_ROOT.parents[1].resolve() else "Buzz"
+        raise BuildError(f"{label} source cleanliness could not be verified")
     if result.stdout:
-        raise BuildError("Buzz source checkout is dirty; runtime provenance is not exact")
+        label = "Dex" if source.resolve() == PACKAGE_ROOT.parents[1].resolve() else "Buzz"
+        raise BuildError(f"{label} source checkout is dirty; artifact provenance is not exact")
 
 
 def _copy_payload(source: Path, destination: Path, mode: int) -> None:
@@ -165,9 +168,12 @@ def _sanitized_build_environment(
     return environment
 
 
-def _build_pinned_runtime(args: argparse.Namespace) -> tuple[Path, Path, dict[str, str]]:
+def _build_pinned_runtime(
+    args: argparse.Namespace,
+    build_root: Path,
+) -> tuple[Path, Path, dict[str, str]]:
     cargo = args.buzz_source / "bin" / "cargo"
-    target_dir = args.output / ".cargo-target"
+    target_dir = build_root / ".cargo-target"
     target_dir.mkdir()
     environment = _sanitized_build_environment(target_dir, source=args.buzz_source)
     toolchain = _toolchain_identity(args.buzz_source, environment)
@@ -231,111 +237,126 @@ def build(args: argparse.Namespace) -> dict[str, str]:
             f"{expected_revision} (found {actual_revision or 'none'})"
         )
     _require_clean_source(args.buzz_source)
-
-    args.output.mkdir(parents=True, exist_ok=True)
-    buzz_bin, buzz_admin_bin, toolchain = _build_pinned_runtime(args)
-    for path, label in (
-        (buzz_bin, "Buzz client"),
-        (buzz_admin_bin, "Buzz admin client"),
-        (PACKAGE_ROOT / "src" / "core", "Core executable"),
-    ):
-        require_regular_executable(path, label)
-    buzz_license = args.buzz_source / "LICENSE"
-    if not buzz_license.is_file() or buzz_license.is_symlink():
-        raise BuildError("pinned Buzz LICENSE is missing")
-
-    platform_label = host_platform()
-    architecture = host_arch()
-    runtime_identities: dict[str, tuple[str, str, str]] = {}
-    for name, path in (("buzz", buzz_bin), ("buzz-admin", buzz_admin_bin)):
-        runtime_identities[name] = native_identity(path)
-        _, runtime_platform, runtime_arch = runtime_identities[name]
-        if (runtime_platform, runtime_arch) != (platform_label, architecture):
-            raise BuildError(
-                f"{name} targets {runtime_platform}/{runtime_arch}, expected "
-                f"{platform_label}/{architecture}"
-            )
-        native_dependencies(path, platform_label)
-
-    artifact_name = f"{contract['artifact_id']}-{platform_label}-{architecture}"
-    artifact_dir = args.output / artifact_name
-    if artifact_dir.exists():
-        raise BuildError(f"artifact output already exists: {artifact_dir}")
-    artifact_dir.mkdir()
-
-    payload = (
-        (PACKAGE_ROOT / "src" / "core", artifact_dir / "bin" / "core", 0o755),
-        (buzz_bin, artifact_dir / "libexec" / "buzz", 0o755),
-        (buzz_admin_bin, artifact_dir / "libexec" / "buzz-admin", 0o755),
-        (buzz_license, artifact_dir / "LICENSES" / "Buzz-LICENSE", 0o644),
-    )
-    for source, destination, mode in payload:
-        _copy_payload(source, destination, mode)
-
     dex_root = PACKAGE_ROOT.parents[1]
-    files = []
-    for _, destination, mode in payload:
-        relative = destination.relative_to(artifact_dir).as_posix()
-        entry: dict[str, object] = {
-            "path": relative,
-            "mode": f"{mode:04o}",
-            "sha256": sha256_file(destination),
+    _require_clean_source(dex_root)
+    dex_revision = _git_head(dex_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix=".dex-core-build-",
+        dir=args.output.parent,
+    ) as temporary:
+        build_root = Path(temporary)
+        deliverables = build_root / "deliverables"
+        deliverables.mkdir()
+        buzz_bin, buzz_admin_bin, toolchain = _build_pinned_runtime(args, build_root)
+        for path, label in (
+            (buzz_bin, "Buzz client"),
+            (buzz_admin_bin, "Buzz admin client"),
+            (PACKAGE_ROOT / "src" / "core", "Core executable"),
+        ):
+            require_regular_executable(path, label)
+        buzz_license = args.buzz_source / "LICENSE"
+        if not buzz_license.is_file() or buzz_license.is_symlink():
+            raise BuildError("pinned Buzz LICENSE is missing")
+
+        platform_label = host_platform()
+        architecture = host_arch()
+        runtime_identities: dict[str, tuple[str, str, str]] = {}
+        for name, path in (("buzz", buzz_bin), ("buzz-admin", buzz_admin_bin)):
+            runtime_identities[name] = native_identity(path)
+            _, runtime_platform, runtime_arch = runtime_identities[name]
+            if (runtime_platform, runtime_arch) != (platform_label, architecture):
+                raise BuildError(
+                    f"{name} targets {runtime_platform}/{runtime_arch}, expected "
+                    f"{platform_label}/{architecture}"
+                )
+            native_dependencies(path, platform_label)
+
+        artifact_name = f"{contract['artifact_id']}-{platform_label}-{architecture}"
+        artifact_dir = deliverables / artifact_name
+        artifact_dir.mkdir()
+
+        payload = (
+            (PACKAGE_ROOT / "src" / "core", artifact_dir / "bin" / "core", 0o755),
+            (buzz_bin, artifact_dir / "libexec" / "buzz", 0o755),
+            (buzz_admin_bin, artifact_dir / "libexec" / "buzz-admin", 0o755),
+            (buzz_license, artifact_dir / "LICENSES" / "Buzz-LICENSE", 0o644),
+        )
+        for source, destination, mode in payload:
+            _copy_payload(source, destination, mode)
+
+        files = []
+        for _, destination, mode in payload:
+            relative = destination.relative_to(artifact_dir).as_posix()
+            entry: dict[str, object] = {
+                "path": relative,
+                "mode": f"{mode:04o}",
+                "sha256": sha256_file(destination),
+            }
+            if relative.startswith("libexec/"):
+                runtime_name = Path(relative).name
+                binary_format, _, binary_arch = runtime_identities[runtime_name]
+                entry.update(
+                    {
+                        "format": binary_format,
+                        "architecture": binary_arch,
+                        "dependencies": native_dependencies(destination, platform_label),
+                    }
+                )
+            elif relative == "bin/core":
+                entry["format"] = "bash"
+            else:
+                entry["format"] = "text"
+            files.append(entry)
+
+        manifest = {
+            "schema": "dex-collaboration-cli-artifact/1",
+            "artifact_id": contract["artifact_id"],
+            "artifact_name": artifact_name,
+            "platform": platform_label,
+            "architecture": architecture,
+            "commands": contract["commands"],
+            "relay": contract["service_boundary"],
+            "sources": {
+                "buzz_repository": contract["buzz_repository"],
+                "buzz_revision": expected_revision,
+                "buzz_tree_clean": True,
+                "cargo_target_fresh": True,
+                "hermit_state_isolated": True,
+                "dex_revision": dex_revision,
+                "dex_tree_clean": True,
+                "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
+                "toolchain": toolchain,
+            },
+            "files": sorted(files, key=lambda entry: str(entry["path"])),
         }
-        if relative.startswith("libexec/"):
-            runtime_name = Path(relative).name
-            binary_format, _, binary_arch = runtime_identities[runtime_name]
-            entry.update(
-                {
-                    "format": binary_format,
-                    "architecture": binary_arch,
-                    "dependencies": native_dependencies(destination, platform_label),
-                }
-            )
-        elif relative == "bin/core":
-            entry["format"] = "bash"
-        else:
-            entry["format"] = "text"
-        files.append(entry)
+        manifest_path = artifact_dir / "manifest.json"
+        manifest_path.write_bytes(canonical_json_bytes(manifest))
+        manifest_path.chmod(0o644)
 
-    manifest = {
-        "schema": "dex-collaboration-cli-artifact/1",
-        "artifact_id": contract["artifact_id"],
-        "artifact_name": artifact_name,
-        "platform": platform_label,
-        "architecture": architecture,
-        "commands": contract["commands"],
-        "relay": contract["service_boundary"],
-        "sources": {
-            "buzz_repository": contract["buzz_repository"],
-            "buzz_revision": expected_revision,
-            "buzz_tree_clean": True,
-            "cargo_target_fresh": True,
-            "hermit_state_isolated": True,
-            "dex_revision": _git_head(dex_root),
-            "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
-            "toolchain": toolchain,
-        },
-        "files": sorted(files, key=lambda entry: str(entry["path"])),
-    }
-    manifest_path = artifact_dir / "manifest.json"
-    manifest_path.write_bytes(canonical_json_bytes(manifest))
-    manifest_path.chmod(0o644)
+        checksum_paths = [destination.relative_to(artifact_dir) for _, destination, _ in payload]
+        checksum_paths.append(Path("manifest.json"))
+        sums = "".join(
+            f"{sha256_file(artifact_dir / relative)}  {relative.as_posix()}\n"
+            for relative in sorted(checksum_paths, key=lambda item: item.as_posix())
+        )
+        sums_path = artifact_dir / "SHA256SUMS"
+        sums_path.write_text(sums, encoding="utf-8")
+        sums_path.chmod(0o644)
 
-    checksum_paths = [destination.relative_to(artifact_dir) for _, destination, _ in payload]
-    checksum_paths.append(Path("manifest.json"))
-    sums = "".join(
-        f"{sha256_file(artifact_dir / relative)}  {relative.as_posix()}\n"
-        for relative in sorted(checksum_paths, key=lambda item: item.as_posix())
-    )
-    sums_path = artifact_dir / "SHA256SUMS"
-    sums_path.write_text(sums, encoding="utf-8")
-    sums_path.chmod(0o644)
+        archive = deliverables / f"{artifact_name}.tar.gz"
+        _write_deterministic_archive(artifact_dir, archive, _source_epoch(dex_root))
+        archive_checksum = sha256_file(archive)
+        checksum_file = Path(f"{archive}.sha256")
+        checksum_file.write_text(f"{archive_checksum}  {archive.name}\n", encoding="utf-8")
 
+        if args.output.exists():
+            args.output.rmdir()
+        deliverables.replace(args.output)
+
+    artifact_dir = args.output / artifact_name
     archive = args.output / f"{artifact_name}.tar.gz"
-    _write_deterministic_archive(artifact_dir, archive, _source_epoch(dex_root))
-    archive_checksum = sha256_file(archive)
-    checksum_file = Path(f"{archive}.sha256")
-    checksum_file.write_text(f"{archive_checksum}  {archive.name}\n", encoding="utf-8")
     return {
         "artifact_dir": str(artifact_dir.resolve()),
         "archive": str(archive.resolve()),
@@ -353,6 +374,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        args.buzz_source = args.buzz_source.resolve()
+        args.output = args.output.resolve()
         if args.jobs < 1 or args.jobs > 9:
             raise BuildError("--jobs must be between 1 and 9")
         result = build(args)

--- a/packages/dex-collaboration-cli/contract.json
+++ b/packages/dex-collaboration-cli/contract.json
@@ -1,0 +1,23 @@
+{
+  "schema": "dex-collaboration-cli-source/1",
+  "artifact_id": "dex-core-collaboration-cli",
+  "buzz_repository": "https://github.com/block/buzz.git",
+  "buzz_revision": "b2ac66cde81df7ce1afc50016e1571cb6e8b7779",
+  "commands": [
+    "identity create",
+    "rooms list",
+    "rooms create",
+    "post",
+    "timeline"
+  ],
+  "runtime_entries": [
+    "bin/core",
+    "libexec/buzz",
+    "libexec/buzz-admin"
+  ],
+  "service_boundary": {
+    "environment": "BUZZ_RELAY_URL",
+    "default": "ws://127.0.0.1:34000",
+    "provided_by": "the packaged Dex collaboration service"
+  }
+}

--- a/packages/dex-collaboration-cli/prove_real_runtime.py
+++ b/packages/dex-collaboration-cli/prove_real_runtime.py
@@ -178,7 +178,7 @@ def prove(artifact: Path, relay: str) -> dict[str, object]:
             or room_detail.get("name") != room_name
             or room_detail.get("description") != description
         ):
-            raise ProofError("room flags were not preserved by the relay")
+            raise ProofError("room name or description was not preserved by the relay")
         relay_metadata_pubkey = str(room_detail.get("pubkey", ""))
 
         posted_ids: list[str] = []
@@ -225,7 +225,7 @@ def prove(artifact: Path, relay: str) -> dict[str, object]:
         if not isinstance(timeline, list) or [event.get("id") for event in timeline] != posted_ids[-2:]:
             raise ProofError("timeline did not return the newest two posts")
         if any(event.get("kind") != 9 or event.get("pubkey") != pubkey for event in timeline):
-            raise ProofError("timeline contains an unsigned or wrong-author post")
+            raise ProofError("timeline contains a wrong-kind or wrong-author post")
         created_times = [event.get("created_at") for event in timeline]
         if any(not isinstance(value, int) for value in created_times) or created_times != sorted(created_times):
             raise ProofError("timeline is not ascending with snake_case created_at values")
@@ -301,8 +301,16 @@ def prove(artifact: Path, relay: str) -> dict[str, object]:
                 "channel_id": room_id,
                 "selected_creator_identity_verified": True,
                 "relay_metadata_pubkey": relay_metadata_pubkey,
+                "requested_type": "stream",
+                "requested_visibility": "open",
+                "canonical_tags_independently_verified": False,
             },
-            "posts": {"signed_kind": 9, "count": len(posted_ids)},
+            "posts": {
+                "relay_returned_kind": 9,
+                "author_pubkey_matched": True,
+                "cryptographic_signature_independently_verified": False,
+                "count": len(posted_ids),
+            },
             "timeline": {"limit": 2, "newest_tail": True, "ascending": True},
             "negative_paths": ["invalid_limit", "unknown_identity", "unknown_room", "relay_failure"],
             "private_key_leaked": False,

--- a/packages/dex-collaboration-cli/prove_real_runtime.py
+++ b/packages/dex-collaboration-cli/prove_real_runtime.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class ProofError(RuntimeError):
+    pass
+
+
+def _decode_json(value: str, label: str) -> object:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ProofError(f"{label} did not return JSON") from error
+
+
+def _call(core: Path, environment: dict[str, str], *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [core, *arguments],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def _success(
+    transcripts: list[str],
+    core: Path,
+    environment: dict[str, str],
+    *arguments: str,
+) -> object:
+    result = _call(core, environment, *arguments)
+    transcripts.extend((result.stdout, result.stderr))
+    if result.returncode != 0 or result.stderr:
+        raise ProofError(f"core {' '.join(arguments)} failed")
+    return _decode_json(result.stdout, f"core {' '.join(arguments)}")
+
+
+def _failure(
+    transcripts: list[str],
+    core: Path,
+    environment: dict[str, str],
+    *arguments: str,
+) -> str:
+    result = _call(core, environment, *arguments)
+    transcripts.extend((result.stdout, result.stderr))
+    if result.returncode == 0 or result.stdout:
+        raise ProofError(f"core {' '.join(arguments)} unexpectedly succeeded")
+    error = _decode_json(result.stderr, f"core {' '.join(arguments)} error")
+    if not isinstance(error, dict) or not isinstance(error.get("error"), str):
+        raise ProofError(f"core {' '.join(arguments)} error contract is invalid")
+    return str(error["error"])
+
+
+def prove(artifact: Path, relay: str) -> dict[str, object]:
+    core = artifact / "bin" / "core"
+    buzz = artifact / "libexec" / "buzz"
+    manifest_path = artifact / "manifest.json"
+    if not core.is_file() or not buzz.is_file() or not manifest_path.is_file():
+        raise ProofError("verified artifact layout is required")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    transcripts: list[str] = []
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        studio_home = root / "studio"
+        environment = {
+            "PATH": "",
+            "HOME": str(root / "home"),
+            "DEX_STUDIO_HOME": str(studio_home),
+            "BUZZ_RELAY_URL": relay,
+        }
+        suffix = f"{datetime.now(UTC):%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
+        identity_name = f"B5 Evidence {suffix}"
+        identity = _success(
+            transcripts,
+            core,
+            environment,
+            "identity",
+            "create",
+            "--name",
+            identity_name,
+        )
+        if not isinstance(identity, dict):
+            raise ProofError("identity result is not an object")
+        identity_id = str(identity.get("id", ""))
+        pubkey = str(identity.get("pubkey", ""))
+        if not identity_id or len(pubkey) != 64:
+            raise ProofError("identity result is incomplete")
+        duplicate_error = _failure(
+            transcripts,
+            core,
+            environment,
+            "identity",
+            "create",
+            "--name",
+            identity_name,
+        )
+        if "already exists" not in duplicate_error:
+            raise ProofError("identity overwrite was not refused")
+
+        key_file = studio_home / "keys" / "agents" / identity_id / "key.json"
+        key_document = json.loads(key_file.read_text(encoding="utf-8"))
+        private_key = str(key_document.get("privkey", ""))
+        private_directories = (studio_home, studio_home / "keys", studio_home / "keys" / "agents", key_file.parent)
+        if (
+            len(private_key) != 64
+            or stat.S_IMODE(key_file.stat().st_mode) != 0o600
+            or any(stat.S_IMODE(path.stat().st_mode) != 0o700 for path in private_directories)
+        ):
+            raise ProofError("identity key custody contract is invalid")
+
+        room_name = f"B5 evidence {suffix}"
+        description = "Disposable local proof for Dex Core B5"
+        created = _success(
+            transcripts,
+            core,
+            environment,
+            "rooms",
+            "create",
+            "--name",
+            room_name,
+            "--description",
+            description,
+            "--as",
+            identity_id,
+        )
+        if not isinstance(created, dict) or not created.get("channel_id"):
+            raise ProofError("room creation result is incomplete")
+        room_id = str(created["channel_id"])
+
+        rooms = _success(
+            transcripts,
+            core,
+            environment,
+            "rooms",
+            "list",
+            "--as",
+            identity_id,
+            "--json",
+        )
+        if not isinstance(rooms, list) or not any(
+            room.get("channel_id") == room_id and room.get("name") == room_name
+            for room in rooms
+            if isinstance(room, dict)
+        ):
+            raise ProofError("created room is absent from rooms list")
+
+        # Buzz's NIP-29 canonical channel metadata is relay-signed. Its
+        # `pubkey` is therefore the relay authority, not a creator field. The
+        # selected creator identity is proven by the Core invocation above,
+        # the identity profile, and the signed message round-trip below.
+        room_result = subprocess.run(
+            [buzz, "channels", "get", "--channel", room_id],
+            env={**environment, "BUZZ_PRIVATE_KEY": private_key},
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        transcripts.extend((room_result.stdout, room_result.stderr))
+        room_detail = _decode_json(room_result.stdout, "packaged room detail lookup")
+        if (
+            room_result.returncode != 0
+            or not isinstance(room_detail, dict)
+            or room_detail.get("channel_id") != room_id
+            or room_detail.get("name") != room_name
+            or room_detail.get("description") != description
+        ):
+            raise ProofError("room flags were not preserved by the relay")
+        relay_metadata_pubkey = str(room_detail.get("pubkey", ""))
+
+        posted_ids: list[str] = []
+        for sequence in range(1, 4):
+            posted = _success(
+                transcripts,
+                core,
+                environment,
+                "post",
+                "--as",
+                identity_id,
+                "--room",
+                room_id,
+                "--text",
+                f"B5 proof message {sequence} ({suffix})",
+            )
+            if not isinstance(posted, dict) or not posted.get("event_id"):
+                raise ProofError("post result is incomplete")
+            posted_ids.append(str(posted["event_id"]))
+            if sequence < 3:
+                # Nostr timestamps have one-second precision. Distinct seconds
+                # make the newest-tail assertion deterministic rather than
+                # assigning an artificial order to simultaneous events.
+                time.sleep(1.05)
+
+        timeline: object = []
+        for _ in range(10):
+            timeline = _success(
+                transcripts,
+                core,
+                environment,
+                "timeline",
+                "--as",
+                identity_id,
+                "--room",
+                room_id,
+                "--limit",
+                "2",
+                "--json",
+            )
+            if isinstance(timeline, list) and [event.get("id") for event in timeline] == posted_ids[-2:]:
+                break
+            time.sleep(0.2)
+        if not isinstance(timeline, list) or [event.get("id") for event in timeline] != posted_ids[-2:]:
+            raise ProofError("timeline did not return the newest two posts")
+        if any(event.get("kind") != 9 or event.get("pubkey") != pubkey for event in timeline):
+            raise ProofError("timeline contains an unsigned or wrong-author post")
+        created_times = [event.get("created_at") for event in timeline]
+        if any(not isinstance(value, int) for value in created_times) or created_times != sorted(created_times):
+            raise ProofError("timeline is not ascending with snake_case created_at values")
+
+        invalid_limit = _failure(
+            transcripts,
+            core,
+            environment,
+            "timeline",
+            "--room",
+            room_id,
+            "--limit",
+            "0",
+        )
+        unknown_identity = _failure(
+            transcripts,
+            core,
+            environment,
+            "post",
+            "--as",
+            "missing-identity",
+            "--room",
+            room_id,
+            "--text",
+            "must fail",
+        )
+        unknown_room = _failure(
+            transcripts,
+            core,
+            environment,
+            "timeline",
+            "--as",
+            identity_id,
+            "--room",
+            str(uuid.uuid4()),
+            "--json",
+        )
+        relay_failure = _failure(
+            transcripts,
+            core,
+            {**environment, "BUZZ_RELAY_URL": "ws://127.0.0.1:1"},
+            "rooms",
+            "list",
+            "--as",
+            identity_id,
+            "--json",
+        )
+        required_errors = (
+            (invalid_limit, "1 to 200"),
+            (unknown_identity, "unknown identity"),
+            (unknown_room, "unknown room"),
+        )
+        for actual, expected in required_errors:
+            if expected not in actual:
+                raise ProofError(f"expected failure was not explicit: {expected}")
+        if not relay_failure:
+            raise ProofError("relay failure returned no detail")
+        if any(private_key in transcript for transcript in transcripts):
+            raise ProofError("private identity material leaked into command output")
+
+        return {
+            "schema": "dex-collaboration-cli-proof/1",
+            "status": "verified",
+            "artifact": str(artifact.resolve()),
+            "platform": manifest.get("platform"),
+            "architecture": manifest.get("architecture"),
+            "buzz_revision": manifest.get("sources", {}).get("buzz_revision"),
+            "relay": relay,
+            "fresh_home": True,
+            "empty_caller_path": True,
+            "identity": {"id": identity_id, "pubkey": pubkey, "overwrite_refused": True},
+            "room": {
+                "channel_id": room_id,
+                "selected_creator_identity_verified": True,
+                "relay_metadata_pubkey": relay_metadata_pubkey,
+            },
+            "posts": {"signed_kind": 9, "count": len(posted_ids)},
+            "timeline": {"limit": 2, "newest_tail": True, "ascending": True},
+            "negative_paths": ["invalid_limit", "unknown_identity", "unknown_room", "relay_failure"],
+            "private_key_leaked": False,
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--relay", default=os.environ.get("BUZZ_RELAY_URL", "ws://127.0.0.1:34000"))
+    args = parser.parse_args(argv)
+    try:
+        print(json.dumps(prove(args.artifact, args.relay), separators=(",", ":")))
+        return 0
+    except (ProofError, OSError, KeyError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        print(json.dumps({"error": str(error)}, separators=(",", ":")), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/dex-collaboration-cli/src/core
+++ b/packages/dex-collaboration-cli/src/core
@@ -1,0 +1,325 @@
+#!/bin/bash
+set -euo pipefail
+
+# Use only the operating-system baseline. The collaboration clients are resolved
+# from this artifact (or explicit test/development overrides), never caller PATH.
+PATH=/usr/bin:/bin
+export PATH
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+BUZZ="${DEX_BUZZ_BIN:-$SCRIPT_DIR/../libexec/buzz}"
+BUZZ_ADMIN="${DEX_BUZZ_ADMIN:-$SCRIPT_DIR/../libexec/buzz-admin}"
+STUDIO_HOME="${DEX_STUDIO_HOME:-${HOME:-}/.dex-studio}"
+KEYS_DIR="$STUDIO_HOME/keys/agents"
+export BUZZ_RELAY_URL="${BUZZ_RELAY_URL:-ws://127.0.0.1:34000}"
+
+json_escape() {
+  local input="${1:-}" output="" character code index
+  index=0
+  while [[ "$index" -lt "${#input}" ]]; do
+    character="${input:$index:1}"
+    case "$character" in
+      '"') output="$output\\\"" ;;
+      '\\') output="$output\\\\" ;;
+      $'\b') output="$output\\b" ;;
+      $'\f') output="$output\\f" ;;
+      $'\n') output="$output\\n" ;;
+      $'\r') output="$output\\r" ;;
+      $'\t') output="$output\\t" ;;
+      *)
+        LC_CTYPE=C printf -v code '%d' "'$character"
+        if [[ "$code" -lt 32 ]]; then
+          printf -v character '\\u%04x' "$code"
+        fi
+        output="$output$character"
+        ;;
+    esac
+    index=$((index + 1))
+  done
+  printf '%s' "$output"
+}
+
+die() {
+  printf '{"error":"%s"}\n' "$(json_escape "$1")" >&2
+  exit 1
+}
+
+require_runtime() {
+  [[ -x "$BUZZ" ]] || die "packaged Buzz client is missing or not executable"
+  [[ -x "$BUZZ_ADMIN" ]] || die "packaged Buzz admin client is missing or not executable"
+  [[ -n "${HOME:-}${DEX_STUDIO_HOME:-}" ]] || die "HOME or DEX_STUDIO_HOME is required"
+}
+
+slugify() {
+  LC_ALL=C printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+parse_key_line() {
+  local label="$1" payload="$2"
+  printf '%s\n' "$payload" | awk -v label="$label" '$1 " " $2 == label { print $3; exit }'
+}
+
+identity_create() {
+  local name="$1" forced_id="${2:-}" id pair pubkey privkey target_dir temp_dir created_at
+  id="$forced_id"
+  if [[ -z "$id" ]]; then
+    id="$(slugify "$name")"
+  fi
+  [[ -n "$id" ]] || die "identity name must contain a letter or number"
+  [[ "$id" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || die "identity id is invalid"
+
+  target_dir="$KEYS_DIR/$id"
+  [[ ! -e "$target_dir" ]] || die "identity already exists: $id"
+  mkdir -p -- "$KEYS_DIR"
+  chmod 0700 -- "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR"
+
+  if ! pair="$($BUZZ_ADMIN generate-key 2>&1)"; then
+    die "Buzz key generation failed"
+  fi
+  pubkey="$(parse_key_line "Public key:" "$pair")"
+  privkey="$(parse_key_line "Secret key:" "$pair")"
+  [[ "$pubkey" =~ ^[0-9a-fA-F]{64}$ && "$privkey" =~ ^[0-9a-fA-F]{64}$ ]] \
+    || die "Buzz key generation returned an invalid keypair"
+
+  temp_dir="$KEYS_DIR/.core-identity-$id-$$"
+  [[ ! -e "$temp_dir" ]] || die "temporary identity path already exists"
+  mkdir -- "$temp_dir"
+  chmod 0700 -- "$temp_dir"
+  created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  umask 077
+  printf '{"id":"%s","name":"%s","pubkey":"%s","privkey":"%s","created_at":"%s"}\n' \
+    "$(json_escape "$id")" "$(json_escape "$name")" "$pubkey" "$privkey" "$created_at" \
+    > "$temp_dir/key.json"
+  chmod 0600 -- "$temp_dir/key.json"
+
+  if ! BUZZ_PRIVATE_KEY="$privkey" "$BUZZ" users set-profile --name "$name" >/dev/null 2>&1; then
+    rm -f -- "$temp_dir/key.json"
+    rmdir -- "$temp_dir"
+    die "Buzz profile publication failed"
+  fi
+  mv -- "$temp_dir" "$target_dir"
+  printf '{"id":"%s","name":"%s","pubkey":"%s"}\n' \
+    "$(json_escape "$id")" "$(json_escape "$name")" "$pubkey"
+}
+
+ensure_studio_identity() {
+  if [[ ! -f "$KEYS_DIR/studio/key.json" ]]; then
+    identity_create "Studio Service" "studio" >/dev/null
+  fi
+}
+
+load_private_key() {
+  local identity_id="$1" key_file private_key
+  key_file="$KEYS_DIR/$identity_id/key.json"
+  [[ -f "$key_file" ]] || die "unknown identity: $identity_id"
+  private_key="$(
+    sed -n 's/.*"privkey"[[:space:]]*:[[:space:]]*"\([0-9a-fA-F]\{64\}\)".*/\1/p' \
+      "$key_file" | head -n 1
+  )"
+  [[ "$private_key" =~ ^[0-9a-fA-F]{64}$ ]] || die "identity key is invalid: $identity_id"
+  printf '%s' "$private_key"
+}
+
+run_buzz_json() {
+  local private_key="$1" operation="$2" output
+  shift 2
+  if ! output="$(BUZZ_PRIVATE_KEY="$private_key" "$BUZZ" "$@" 2>&1)"; then
+    output="${output//$private_key/[secret]}"
+    die "$operation failed${output:+: $output}"
+  fi
+  case "$output" in
+    \{* | \[*) printf '%s\n' "$output" ;;
+    *) die "$operation returned non-JSON output" ;;
+  esac
+}
+
+join_room_best_effort() {
+  local private_key="$1" room_id="$2"
+  BUZZ_PRIVATE_KEY="$private_key" "$BUZZ" channels join --channel "$room_id" \
+    >/dev/null 2>&1 || true
+}
+
+require_room() {
+  local private_key="$1" room_id="$2" operation="$3" output
+  if ! output="$(BUZZ_PRIVATE_KEY="$private_key" "$BUZZ" channels get --channel "$room_id" 2>&1)"; then
+    output="${output//$private_key/[secret]}"
+    die "$operation failed${output:+: $output}"
+  fi
+  case "$output" in
+    null) die "unknown room: $room_id" ;;
+    \{*) ;;
+    *) die "$operation returned non-JSON output" ;;
+  esac
+}
+
+if [[ "${1:-}" == "--artifact-info" && "$#" -eq 1 ]]; then
+  printf '%s\n' '{"schema":"dex-collaboration-cli/1","artifact_id":"dex-core-collaboration-cli","commands":["identity create","rooms list","rooms create","post","timeline"]}'
+  exit 0
+fi
+
+require_runtime
+
+command_name="${1:-}"
+if [[ "$command_name" == "identity" && "${2:-}" == "create" ]]; then
+  shift 2
+  name=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --name)
+        [[ "$#" -ge 2 ]] || die "--name requires a value"
+        name="$2"
+        shift 2
+        ;;
+      *) die "unknown identity create option: $1" ;;
+    esac
+  done
+  [[ -n "$name" ]] || die "--name is required"
+  identity_create "$name"
+  exit 0
+fi
+
+if [[ "$command_name" == "rooms" && "${2:-}" == "list" ]]; then
+  shift 2
+  owner="studio"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --as)
+        [[ "$#" -ge 2 ]] || die "--as requires a value"
+        owner="$2"
+        shift 2
+        ;;
+      --json) shift ;;
+      *) die "unknown rooms list option: $1" ;;
+    esac
+  done
+  if [[ "$owner" == "studio" ]]; then
+    ensure_studio_identity
+  fi
+  owner_key="$(load_private_key "$owner")"
+  run_buzz_json "$owner_key" "rooms list" channels list
+  exit 0
+fi
+
+if [[ "$command_name" == "rooms" && "${2:-}" == "create" ]]; then
+  shift 2
+  name=""
+  description=""
+  owner="studio"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --name)
+        [[ "$#" -ge 2 ]] || die "--name requires a value"
+        name="$2"
+        shift 2
+        ;;
+      --description)
+        [[ "$#" -ge 2 ]] || die "--description requires a value"
+        description="$2"
+        shift 2
+        ;;
+      --as)
+        [[ "$#" -ge 2 ]] || die "--as requires a value"
+        owner="$2"
+        shift 2
+        ;;
+      *) die "unknown rooms create option: $1" ;;
+    esac
+  done
+  [[ -n "$name" ]] || die "--name is required"
+  if [[ "$owner" == "studio" ]]; then
+    ensure_studio_identity
+  fi
+  owner_key="$(load_private_key "$owner")"
+  if [[ -n "$description" ]]; then
+    run_buzz_json "$owner_key" "rooms create" channels create \
+      --name "$name" --type stream --visibility open --description "$description"
+  else
+    run_buzz_json "$owner_key" "rooms create" channels create \
+      --name "$name" --type stream --visibility open
+  fi
+  exit 0
+fi
+
+if [[ "$command_name" == "post" ]]; then
+  shift
+  author=""
+  room=""
+  text=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --as)
+        [[ "$#" -ge 2 ]] || die "--as requires a value"
+        author="$2"
+        shift 2
+        ;;
+      --room)
+        [[ "$#" -ge 2 ]] || die "--room requires a value"
+        room="$2"
+        shift 2
+        ;;
+      --text)
+        [[ "$#" -ge 2 ]] || die "--text requires a value"
+        text="$2"
+        shift 2
+        ;;
+      *) die "unknown post option: $1" ;;
+    esac
+  done
+  [[ -n "$author" ]] || die "--as is required"
+  [[ -n "$room" ]] || die "--room is required"
+  [[ -n "$text" ]] || die "--text is required"
+  author_key="$(load_private_key "$author")"
+  require_room "$author_key" "$room" "post room lookup"
+  join_room_best_effort "$author_key" "$room"
+  run_buzz_json "$author_key" "post" messages send --channel "$room" --content "$text"
+  exit 0
+fi
+
+if [[ "$command_name" == "timeline" ]]; then
+  shift
+  room=""
+  limit=""
+  reader="studio"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --room)
+        [[ "$#" -ge 2 ]] || die "--room requires a value"
+        room="$2"
+        shift 2
+        ;;
+      --limit)
+        [[ "$#" -ge 2 ]] || die "--limit requires a value"
+        limit="$2"
+        shift 2
+        ;;
+      --as)
+        [[ "$#" -ge 2 ]] || die "--as requires a value"
+        reader="$2"
+        shift 2
+        ;;
+      --json) shift ;;
+      *) die "unknown timeline option: $1" ;;
+    esac
+  done
+  [[ -n "$room" ]] || die "--room is required"
+  if [[ -n "$limit" ]]; then
+    [[ "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 200 ]] \
+      || die "--limit must be an integer from 1 to 200"
+  fi
+  if [[ "$reader" == "studio" ]]; then
+    ensure_studio_identity
+  fi
+  reader_key="$(load_private_key "$reader")"
+  require_room "$reader_key" "$room" "timeline room lookup"
+  join_room_best_effort "$reader_key" "$room"
+  if [[ -n "$limit" ]]; then
+    run_buzz_json "$reader_key" "timeline" messages get --channel "$room" --limit "$limit"
+  else
+    run_buzz_json "$reader_key" "timeline" messages get --channel "$room"
+  fi
+  exit 0
+fi
+
+die "usage: core identity create|rooms list|rooms create|post|timeline"

--- a/packages/dex-collaboration-cli/src/core
+++ b/packages/dex-collaboration-cli/src/core
@@ -60,6 +60,34 @@ slugify() {
     | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
 }
 
+require_identity_id() {
+  local identity_id="$1"
+  [[ "$identity_id" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] \
+    || die "identity id is invalid"
+}
+
+ensure_custody_root() {
+  local directory parent
+  for directory in "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR"; do
+    [[ ! -L "$directory" ]] || die "unsafe identity custody"
+    if [[ -e "$directory" ]]; then
+      [[ -d "$directory" && -O "$directory" ]] || die "unsafe identity custody"
+    else
+      parent="${directory%/*}"
+      if [[ "$directory" != "$STUDIO_HOME" ]]; then
+        [[ -d "$parent" && ! -L "$parent" && -O "$parent" ]] \
+          || die "unsafe identity custody"
+      fi
+      mkdir "$directory" || die "unsafe identity custody"
+    fi
+    [[ -d "$directory" && ! -L "$directory" && -O "$directory" ]] \
+      || die "unsafe identity custody"
+    chmod 0700 "$directory" || die "unsafe identity custody"
+    [[ -d "$directory" && ! -L "$directory" && -O "$directory" ]] \
+      || die "unsafe identity custody"
+  done
+}
+
 parse_key_line() {
   local label="$1" payload="$2"
   printf '%s\n' "$payload" | awk -v label="$label" '$1 " " $2 == label { print $3; exit }'
@@ -67,17 +95,17 @@ parse_key_line() {
 
 identity_create() {
   local name="$1" forced_id="${2:-}" id pair pubkey privkey target_dir temp_dir created_at
+  local keys_root identity_root
   id="$forced_id"
   if [[ -z "$id" ]]; then
     id="$(slugify "$name")"
   fi
   [[ -n "$id" ]] || die "identity name must contain a letter or number"
-  [[ "$id" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || die "identity id is invalid"
+  require_identity_id "$id"
 
+  ensure_custody_root
   target_dir="$KEYS_DIR/$id"
-  [[ ! -e "$target_dir" ]] || die "identity already exists: $id"
-  mkdir -p "$KEYS_DIR"
-  chmod 0700 "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR"
+  [[ ! -e "$target_dir" && ! -L "$target_dir" ]] || die "identity already exists: $id"
 
   if ! pair="$($BUZZ_ADMIN generate-key 2>&1)"; then
     die "Buzz key generation failed"
@@ -88,7 +116,7 @@ identity_create() {
     || die "Buzz key generation returned an invalid keypair"
 
   temp_dir="$KEYS_DIR/.core-identity-$id-$$"
-  [[ ! -e "$temp_dir" ]] || die "temporary identity path already exists"
+  [[ ! -e "$temp_dir" && ! -L "$temp_dir" ]] || die "temporary identity path already exists"
   mkdir "$temp_dir"
   chmod 0700 "$temp_dir"
   created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
@@ -103,7 +131,17 @@ identity_create() {
     rmdir "$temp_dir"
     die "Buzz profile publication failed"
   fi
+  ensure_custody_root
+  [[ -d "$temp_dir" && ! -L "$temp_dir" && -O "$temp_dir" ]] \
+    || die "unsafe identity custody"
+  [[ ! -e "$target_dir" && ! -L "$target_dir" ]] || die "identity already exists: $id"
   mv "$temp_dir" "$target_dir"
+  keys_root="$(CDPATH= cd "$KEYS_DIR" && pwd -P)"
+  identity_root="$(CDPATH= cd "$target_dir" && pwd -P)"
+  case "$identity_root" in
+    "$keys_root"/*) ;;
+    *) die "unsafe identity custody" ;;
+  esac
   printf '{"id":"%s","name":"%s","pubkey":"%s"}\n' \
     "$(json_escape "$id")" "$(json_escape "$name")" "$pubkey"
 }
@@ -115,7 +153,8 @@ ensure_studio_identity() {
 }
 
 load_private_key() {
-  local identity_id="$1" key_file private_key directory mode
+  local identity_id="$1" key_file private_key directory mode keys_root identity_root
+  require_identity_id "$identity_id"
   key_file="$KEYS_DIR/$identity_id/key.json"
   [[ -e "$key_file" || -L "$key_file" ]] || die "unknown identity: $identity_id"
   for directory in "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR" "$KEYS_DIR/$identity_id"; do
@@ -130,6 +169,12 @@ load_private_key() {
     fi
     [[ "$mode" == "700" ]] || die "unsafe identity custody: $identity_id"
   done
+  keys_root="$(CDPATH= cd "$KEYS_DIR" && pwd -P)"
+  identity_root="$(CDPATH= cd "$KEYS_DIR/$identity_id" && pwd -P)"
+  case "$identity_root" in
+    "$keys_root"/*) ;;
+    *) die "unsafe identity custody: $identity_id" ;;
+  esac
   [[ -f "$key_file" && ! -L "$key_file" && -O "$key_file" ]] \
     || die "unsafe identity custody: $identity_id"
   if mode="$(stat -c '%a' "$key_file" 2>/dev/null)"; then

--- a/packages/dex-collaboration-cli/src/core
+++ b/packages/dex-collaboration-cli/src/core
@@ -2,14 +2,18 @@
 set -euo pipefail
 
 # Use only the operating-system baseline. The collaboration clients are resolved
-# from this artifact (or explicit test/development overrides), never caller PATH.
+# from this artifact, never caller PATH or caller-provided runtime overrides.
 PATH=/usr/bin:/bin
 export PATH
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-BUZZ="${DEX_BUZZ_BIN:-$SCRIPT_DIR/../libexec/buzz}"
-BUZZ_ADMIN="${DEX_BUZZ_ADMIN:-$SCRIPT_DIR/../libexec/buzz-admin}"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BUZZ="$SCRIPT_DIR/../libexec/buzz"
+BUZZ_ADMIN="$SCRIPT_DIR/../libexec/buzz-admin"
 STUDIO_HOME="${DEX_STUDIO_HOME:-${HOME:-}/.dex-studio}"
+case "$STUDIO_HOME" in
+  /*) ;;
+  *) STUDIO_HOME="$(pwd -P)/$STUDIO_HOME" ;;
+esac
 KEYS_DIR="$STUDIO_HOME/keys/agents"
 export BUZZ_RELAY_URL="${BUZZ_RELAY_URL:-ws://127.0.0.1:34000}"
 
@@ -72,8 +76,8 @@ identity_create() {
 
   target_dir="$KEYS_DIR/$id"
   [[ ! -e "$target_dir" ]] || die "identity already exists: $id"
-  mkdir -p -- "$KEYS_DIR"
-  chmod 0700 -- "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR"
+  mkdir -p "$KEYS_DIR"
+  chmod 0700 "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR"
 
   if ! pair="$($BUZZ_ADMIN generate-key 2>&1)"; then
     die "Buzz key generation failed"
@@ -85,21 +89,21 @@ identity_create() {
 
   temp_dir="$KEYS_DIR/.core-identity-$id-$$"
   [[ ! -e "$temp_dir" ]] || die "temporary identity path already exists"
-  mkdir -- "$temp_dir"
-  chmod 0700 -- "$temp_dir"
+  mkdir "$temp_dir"
+  chmod 0700 "$temp_dir"
   created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   umask 077
   printf '{"id":"%s","name":"%s","pubkey":"%s","privkey":"%s","created_at":"%s"}\n' \
     "$(json_escape "$id")" "$(json_escape "$name")" "$pubkey" "$privkey" "$created_at" \
     > "$temp_dir/key.json"
-  chmod 0600 -- "$temp_dir/key.json"
+  chmod 0600 "$temp_dir/key.json"
 
   if ! BUZZ_PRIVATE_KEY="$privkey" "$BUZZ" users set-profile --name "$name" >/dev/null 2>&1; then
-    rm -f -- "$temp_dir/key.json"
-    rmdir -- "$temp_dir"
+    rm -f "$temp_dir/key.json"
+    rmdir "$temp_dir"
     die "Buzz profile publication failed"
   fi
-  mv -- "$temp_dir" "$target_dir"
+  mv "$temp_dir" "$target_dir"
   printf '{"id":"%s","name":"%s","pubkey":"%s"}\n' \
     "$(json_escape "$id")" "$(json_escape "$name")" "$pubkey"
 }
@@ -111,9 +115,31 @@ ensure_studio_identity() {
 }
 
 load_private_key() {
-  local identity_id="$1" key_file private_key
+  local identity_id="$1" key_file private_key directory mode
   key_file="$KEYS_DIR/$identity_id/key.json"
-  [[ -f "$key_file" ]] || die "unknown identity: $identity_id"
+  [[ -e "$key_file" || -L "$key_file" ]] || die "unknown identity: $identity_id"
+  for directory in "$STUDIO_HOME" "$STUDIO_HOME/keys" "$KEYS_DIR" "$KEYS_DIR/$identity_id"; do
+    [[ -d "$directory" && ! -L "$directory" && -O "$directory" ]] \
+      || die "unsafe identity custody: $identity_id"
+    if mode="$(stat -c '%a' "$directory" 2>/dev/null)"; then
+      :
+    elif mode="$(stat -f '%Lp' "$directory" 2>/dev/null)"; then
+      :
+    else
+      die "unsafe identity custody: $identity_id"
+    fi
+    [[ "$mode" == "700" ]] || die "unsafe identity custody: $identity_id"
+  done
+  [[ -f "$key_file" && ! -L "$key_file" && -O "$key_file" ]] \
+    || die "unsafe identity custody: $identity_id"
+  if mode="$(stat -c '%a' "$key_file" 2>/dev/null)"; then
+    :
+  elif mode="$(stat -f '%Lp' "$key_file" 2>/dev/null)"; then
+    :
+  else
+    die "unsafe identity custody: $identity_id"
+  fi
+  [[ "$mode" == "600" ]] || die "unsafe identity custody: $identity_id"
   private_key="$(
     sed -n 's/.*"privkey"[[:space:]]*:[[:space:]]*"\([0-9a-fA-F]\{64\}\)".*/\1/p' \
       "$key_file" | head -n 1

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -626,12 +626,27 @@ class SourceContractTests(unittest.TestCase):
                         os.chdir(previous)
                 self.assertEqual(result, 0)
                 arguments = build.call_args.args[0]
-                self.assertEqual(arguments.buzz_source, root / "relative-buzz")
-                self.assertEqual(arguments.output, root / "relative-output")
+                canonical_root = root.resolve()
+                self.assertEqual(arguments.buzz_source, canonical_root / "relative-buzz")
+                self.assertEqual(arguments.output, canonical_root / "relative-output")
                 self.assertTrue(arguments.buzz_source.is_absolute())
                 self.assertTrue(arguments.output.is_absolute())
         finally:
             sys.path.pop(0)
+
+    def test_workflow_keeps_buzz_checkout_outside_the_dex_source_tree(self) -> None:
+        workflow = (
+            PACKAGE_ROOT.parents[1]
+            / ".github"
+            / "workflows"
+            / "b5-core-collaboration-artifact.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("working-directory: Dex", workflow)
+        self.assertIn("path: Dex", workflow)
+        self.assertIn("path: Buzz", workflow)
+        self.assertIn("${{ github.workspace }}/Buzz", workflow)
+        self.assertNotIn("path: _buzz", workflow)
 
     def test_failed_build_removes_private_state_outside_the_deliverable_output(self) -> None:
         sys.path.insert(0, str(PACKAGE_ROOT))

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -644,6 +644,7 @@ class SourceContractTests(unittest.TestCase):
 
         self.assertIn("working-directory: Dex", workflow)
         self.assertIn("path: Dex", workflow)
+        self.assertIn("ref: ${{ github.event.pull_request.head.sha || github.sha }}", workflow)
         self.assertIn("path: Buzz", workflow)
         self.assertIn("${{ github.workspace }}/Buzz", workflow)
         self.assertNotIn("path: _buzz", workflow)

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+CORE_SOURCE = PACKAGE_ROOT / "src" / "core"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _seed_identity(studio_home: Path, identity_id: str, private_key: str) -> None:
+    key_dir = studio_home / "keys" / "agents" / identity_id
+    key_dir.mkdir(parents=True)
+    key_dir.chmod(0o700)
+    key_file = key_dir / "key.json"
+    key_file.write_text(
+        json.dumps(
+            {
+                "id": identity_id,
+                "name": identity_id,
+                "pubkey": "a" * 64,
+                "privkey": private_key,
+            }
+        ),
+        encoding="utf-8",
+    )
+    key_file.chmod(0o600)
+
+
+class SourceContractTests(unittest.TestCase):
+    def test_source_contract_owns_the_b5_collaboration_commands(self) -> None:
+        contract_path = PACKAGE_ROOT / "contract.json"
+
+        self.assertTrue(
+            contract_path.is_file(),
+            "Dex Core has no package-owned B5 collaboration executable contract",
+        )
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        self.assertEqual(contract["schema"], "dex-collaboration-cli-source/1")
+        self.assertEqual(contract["artifact_id"], "dex-core-collaboration-cli")
+        self.assertEqual(
+            contract["commands"],
+            [
+                "identity create",
+                "rooms list",
+                "rooms create",
+                "post",
+                "timeline",
+            ],
+        )
+        self.assertEqual(
+            contract["buzz_revision"],
+            "b2ac66cde81df7ce1afc50016e1571cb6e8b7779",
+        )
+
+    def test_core_executable_reports_the_frozen_contract_without_a_relay(self) -> None:
+        source_path = CORE_SOURCE
+        self.assertTrue(source_path.is_file(), "the package owns no Core executable source")
+        self.assertTrue(source_path.stat().st_mode & 0o111, "Core source is not executable")
+        result = subprocess.run(
+            [source_path, "--artifact-info"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        info = json.loads(result.stdout)
+        self.assertEqual(info["schema"], "dex-collaboration-cli/1")
+        self.assertEqual(info["artifact_id"], "dex-core-collaboration-cli")
+        self.assertEqual(
+            info["commands"],
+            ["identity create", "rooms list", "rooms create", "post", "timeline"],
+        )
+
+    def test_identity_create_uses_the_bundled_admin_and_keeps_the_private_key_local(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            studio_home = root / "studio"
+            log_path = root / "buzz.log"
+            fake_admin = root / "buzz-admin"
+            fake_buzz = root / "buzz"
+            _write_executable(
+                fake_admin,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' 'Public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'\n"
+                "printf '%s\\n' 'Secret key: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'\n",
+            )
+            _write_executable(
+                fake_buzz,
+                "#!/usr/bin/env bash\n"
+                "printf '%s|%s\\n' \"$BUZZ_PRIVATE_KEY\" \"$*\" >> \"$DEX_TEST_LOG\"\n"
+                "printf '%s\\n' '{\"accepted\":true}'\n",
+            )
+            environment = {
+                **os.environ,
+                "DEX_STUDIO_HOME": str(studio_home),
+                "DEX_BUZZ_BIN": str(fake_buzz),
+                "DEX_BUZZ_ADMIN": str(fake_admin),
+                "DEX_TEST_LOG": str(log_path),
+            }
+            result = subprocess.run(
+                [CORE_SOURCE, "identity", "create", "--name", "Research Scout"],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            identity = json.loads(result.stdout)
+            self.assertEqual(
+                identity,
+                {
+                    "id": "research-scout",
+                    "name": "Research Scout",
+                    "pubkey": "a" * 64,
+                },
+            )
+            self.assertNotIn("b" * 64, result.stdout + result.stderr)
+            key_dir = studio_home / "keys" / "agents" / "research-scout"
+            key_file = key_dir / "key.json"
+            self.assertEqual(stat.S_IMODE(studio_home.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE((studio_home / "keys").stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE((studio_home / "keys" / "agents").stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(key_dir.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(key_file.stat().st_mode), 0o600)
+            self.assertEqual(json.loads(key_file.read_text(encoding="utf-8"))["privkey"], "b" * 64)
+            self.assertEqual(
+                log_path.read_text(encoding="utf-8").split("|", 1)[1].strip(),
+                "users set-profile --name Research Scout",
+            )
+
+            duplicate = subprocess.run(
+                [CORE_SOURCE, "identity", "create", "--name", "Research Scout"],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(duplicate.returncode, 0)
+            self.assertIn("identity already exists", json.loads(duplicate.stderr)["error"])
+
+    def test_room_commands_use_the_selected_owner_with_an_empty_caller_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            studio_home = root / "studio"
+            log_path = root / "buzz.log"
+            fake_admin = root / "buzz-admin"
+            fake_buzz = root / "buzz"
+            _seed_identity(studio_home, "studio", "c" * 64)
+            _seed_identity(studio_home, "room-owner", "d" * 64)
+            _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
+            _write_executable(
+                fake_buzz,
+                "#!/bin/bash\n"
+                "printf '%s|%s\\n' \"$BUZZ_PRIVATE_KEY\" \"$*\" >> \"$DEX_TEST_LOG\"\n"
+                "case \"$*\" in\n"
+                "  'channels list') printf '%s\\n' '[{\"channel_id\":\"room-1\",\"name\":\"Knowledge\",\"created_at\":1}]' ;;\n"
+                "  'channels create --name Knowledge --type stream --visibility open --description Shared facts') printf '%s\\n' '{\"accepted\":true,\"channel_id\":\"room-2\",\"event_id\":\"event-2\"}' ;;\n"
+                "  *) printf '%s\\n' 'unexpected invocation' >&2; exit 41 ;;\n"
+                "esac\n",
+            )
+            environment = {
+                **os.environ,
+                "PATH": "",
+                "DEX_STUDIO_HOME": str(studio_home),
+                "DEX_BUZZ_BIN": str(fake_buzz),
+                "DEX_BUZZ_ADMIN": str(fake_admin),
+                "DEX_TEST_LOG": str(log_path),
+            }
+            listed = subprocess.run(
+                [CORE_SOURCE, "rooms", "list", "--as", "studio", "--json"],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            created = subprocess.run(
+                [
+                    CORE_SOURCE,
+                    "rooms",
+                    "create",
+                    "--name",
+                    "Knowledge",
+                    "--description",
+                    "Shared facts",
+                    "--as",
+                    "room-owner",
+                ],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(listed.returncode, 0, listed.stdout + listed.stderr)
+            self.assertEqual(json.loads(listed.stdout)[0]["channel_id"], "room-1")
+            self.assertEqual(created.returncode, 0, created.stdout + created.stderr)
+            self.assertEqual(json.loads(created.stdout)["channel_id"], "room-2")
+            self.assertEqual(
+                log_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    f"{'c' * 64}|channels list",
+                    f"{'d' * 64}|channels create --name Knowledge --type stream --visibility open --description Shared facts",
+                ],
+            )
+
+    def test_post_and_timeline_preserve_signed_kind_nine_and_newest_tail_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            studio_home = root / "studio"
+            log_path = root / "buzz.log"
+            fake_admin = root / "buzz-admin"
+            fake_buzz = root / "buzz"
+            _seed_identity(studio_home, "studio", "c" * 64)
+            _seed_identity(studio_home, "research-scout", "d" * 64)
+            _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
+            _write_executable(
+                fake_buzz,
+                "#!/bin/bash\n"
+                "printf '%s|%s\\n' \"$BUZZ_PRIVATE_KEY\" \"$*\" >> \"$DEX_TEST_LOG\"\n"
+                "case \"$*\" in\n"
+                "  'channels get --channel room-1') printf '%s\\n' '{\"channel_id\":\"room-1\",\"name\":\"Knowledge\"}' ;;\n"
+                "  'channels join --channel room-1') printf '%s\\n' '{\"accepted\":true}' ;;\n"
+                "  'messages send --channel room-1 --content Finished the brief') printf '%s\\n' '{\"accepted\":true,\"event_id\":\"event-3\"}' ;;\n"
+                "  'messages get --channel room-1 --limit 2') printf '%s\\n' '[{\"id\":\"event-2\",\"pubkey\":\"author\",\"kind\":9,\"content\":\"older\",\"created_at\":20,\"tags\":[]},{\"id\":\"event-3\",\"pubkey\":\"author\",\"kind\":9,\"content\":\"Finished the brief\",\"created_at\":30,\"tags\":[]}]' ;;\n"
+                "  *) printf '%s\\n' 'unexpected invocation' >&2; exit 41 ;;\n"
+                "esac\n",
+            )
+            environment = {
+                **os.environ,
+                "PATH": "",
+                "DEX_STUDIO_HOME": str(studio_home),
+                "DEX_BUZZ_BIN": str(fake_buzz),
+                "DEX_BUZZ_ADMIN": str(fake_admin),
+                "DEX_TEST_LOG": str(log_path),
+            }
+            posted = subprocess.run(
+                [
+                    CORE_SOURCE,
+                    "post",
+                    "--as",
+                    "research-scout",
+                    "--room",
+                    "room-1",
+                    "--text",
+                    "Finished the brief",
+                ],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            timeline_result = subprocess.run(
+                [CORE_SOURCE, "timeline", "--room", "room-1", "--limit", "2", "--json"],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(posted.returncode, 0, posted.stdout + posted.stderr)
+            self.assertEqual(json.loads(posted.stdout)["event_id"], "event-3")
+            self.assertEqual(timeline_result.returncode, 0, timeline_result.stdout + timeline_result.stderr)
+            timeline = json.loads(timeline_result.stdout)
+            self.assertEqual([event["created_at"] for event in timeline], [20, 30])
+            self.assertEqual([event["kind"] for event in timeline], [9, 9])
+            self.assertEqual(timeline[-1]["content"], "Finished the brief")
+            calls = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertIn(f"{'d' * 64}|messages send --channel room-1 --content Finished the brief", calls)
+            self.assertIn(f"{'c' * 64}|messages get --channel room-1 --limit 2", calls)
+
+    def test_invalid_identity_room_limit_and_relay_failures_are_json_and_secret_free(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            studio_home = root / "studio"
+            fake_admin = root / "buzz-admin"
+            fake_buzz = root / "buzz"
+            private_key = "e" * 64
+            _seed_identity(studio_home, "studio", private_key)
+            _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
+            _write_executable(
+                fake_buzz,
+                "#!/bin/bash\n"
+                "case \"$*\" in\n"
+                "  'channels list') printf 'relay timed out for %s\\n' \"$BUZZ_PRIVATE_KEY\" >&2; exit 42 ;;\n"
+                "  'channels get --channel missing') printf '%s\\n' 'null' ;;\n"
+                "  *) exit 44 ;;\n"
+                "esac\n",
+            )
+            environment = {
+                **os.environ,
+                "PATH": "",
+                "DEX_STUDIO_HOME": str(studio_home),
+                "DEX_BUZZ_BIN": str(fake_buzz),
+                "DEX_BUZZ_ADMIN": str(fake_admin),
+            }
+            probes = [
+                subprocess.run(
+                    [CORE_SOURCE, "post", "--as", "missing", "--room", "room-1", "--text", "x"],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                ),
+                subprocess.run(
+                    [CORE_SOURCE, "timeline", "--room", "room-1", "--limit", "0"],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                ),
+                subprocess.run(
+                    [CORE_SOURCE, "timeline", "--room", "missing", "--json"],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                ),
+                subprocess.run(
+                    [CORE_SOURCE, "rooms", "list", "--json"],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                ),
+            ]
+
+            for result in probes:
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("error", json.loads(result.stderr))
+                self.assertNotIn(private_key, result.stderr)
+            self.assertIn("unknown identity", json.loads(probes[0].stderr)["error"])
+            self.assertIn("1 to 200", json.loads(probes[1].stderr)["error"])
+            self.assertIn("unknown room", json.loads(probes[2].stderr)["error"])
+            self.assertIn("relay timed out", json.loads(probes[3].stderr)["error"])
+
+    def test_archive_verification_rejects_a_sidecar_checksum_mismatch(self) -> None:
+        verifier = PACKAGE_ROOT / "verify_artifact.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "artifact.tar.gz"
+            archive.write_bytes(b"not the expected archive")
+            Path(f"{archive}.sha256").write_text(
+                f"{'0' * 64}  {archive.name}\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, verifier, archive],
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("archive SHA-256 mismatch", json.loads(result.stderr)["error"])
+
+    def test_builder_refuses_a_runtime_not_proven_at_the_pinned_buzz_revision(self) -> None:
+        builder = PACKAGE_ROOT / "build_artifact.py"
+        self.assertTrue(builder.is_file(), "the package owns no artifact builder")
+        with tempfile.TemporaryDirectory() as temporary:
+            result = subprocess.run(
+                [
+                    "python3",
+                    builder,
+                    "--buzz-source",
+                    PACKAGE_ROOT,
+                    "--output",
+                    temporary,
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        error = json.loads(result.stderr)
+        self.assertIn("pinned Buzz revision", error["error"])
+        self.assertEqual(result.stdout, "")
+
+    @unittest.skipUnless(
+        os.environ.get("DEX_TEST_BUZZ_SOURCE"),
+        "real pinned Buzz source was not supplied",
+    )
+    def test_real_runtime_builds_a_verified_platform_artifact(self) -> None:
+        builder = PACKAGE_ROOT / "build_artifact.py"
+        verifier = PACKAGE_ROOT / "verify_artifact.py"
+        self.assertTrue(verifier.is_file(), "the package owns no artifact verifier")
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            build_command = [
+                sys.executable,
+                builder,
+                "--buzz-source",
+                os.environ["DEX_TEST_BUZZ_SOURCE"],
+                "--output",
+                output,
+            ]
+            if os.environ.get("DEX_TEST_BUZZ_CARGO"):
+                build_command.extend(["--cargo", os.environ["DEX_TEST_BUZZ_CARGO"]])
+            if os.environ.get("DEX_TEST_BUZZ_TARGET_DIR"):
+                build_command.extend(
+                    ["--cargo-target-dir", os.environ["DEX_TEST_BUZZ_TARGET_DIR"]]
+                )
+            built = subprocess.run(
+                build_command,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(built.returncode, 0, built.stdout + built.stderr)
+            build_result = json.loads(built.stdout)
+            artifact_dir = Path(build_result["artifact_dir"])
+            archive = Path(build_result["archive"])
+            self.assertTrue((artifact_dir / "bin" / "core").is_file())
+            self.assertTrue((artifact_dir / "libexec" / "buzz").is_file())
+            self.assertTrue((artifact_dir / "libexec" / "buzz-admin").is_file())
+            self.assertTrue((artifact_dir / "manifest.json").is_file())
+            self.assertTrue((artifact_dir / "SHA256SUMS").is_file())
+            self.assertTrue(archive.is_file())
+            self.assertTrue(Path(f"{archive}.sha256").is_file())
+
+            verified = subprocess.run(
+                [sys.executable, verifier, artifact_dir],
+                env={**os.environ, "PATH": ""},
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(verified.returncode, 0, verified.stdout + verified.stderr)
+            report = json.loads(verified.stdout)
+            self.assertEqual(report["status"], "verified")
+            self.assertEqual(report["buzz_revision"], "b2ac66cde81df7ce1afc50016e1571cb6e8b7779")
+
+            archive_verified = subprocess.run(
+                [sys.executable, verifier, archive],
+                env={**os.environ, "PATH": ""},
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                archive_verified.returncode,
+                0,
+                archive_verified.stdout + archive_verified.stderr,
+            )
+            self.assertEqual(json.loads(archive_verified.stdout)["status"], "verified")
+            self.assertEqual(
+                json.loads(archive_verified.stdout)["artifact"],
+                str(archive.resolve()),
+            )
+
+            unexpected_directory = artifact_dir / "unexpected-empty-directory"
+            unexpected_directory.mkdir()
+            rejected = subprocess.run(
+                [sys.executable, verifier, artifact_dir],
+                capture_output=True,
+                text=True,
+            )
+            unexpected_directory.rmdir()
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn("unexpected directories", json.loads(rejected.stderr)["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -18,9 +19,22 @@ def _write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
+def _install_test_artifact(root: Path) -> tuple[Path, Path, Path]:
+    core = root / "bin" / "core"
+    buzz = root / "libexec" / "buzz"
+    buzz_admin = root / "libexec" / "buzz-admin"
+    core.parent.mkdir(parents=True)
+    buzz.parent.mkdir(parents=True)
+    shutil.copyfile(CORE_SOURCE, core)
+    core.chmod(0o755)
+    return core, buzz, buzz_admin
+
+
 def _seed_identity(studio_home: Path, identity_id: str, private_key: str) -> None:
     key_dir = studio_home / "keys" / "agents" / identity_id
     key_dir.mkdir(parents=True)
+    for directory in (studio_home, studio_home / "keys", studio_home / "keys" / "agents"):
+        directory.chmod(0o700)
     key_dir.chmod(0o700)
     key_file = key_dir / "key.json"
     key_file.write_text(
@@ -82,13 +96,23 @@ class SourceContractTests(unittest.TestCase):
             ["identity create", "rooms list", "rooms create", "post", "timeline"],
         )
 
+    def test_core_shell_is_bsd_portable_and_uses_only_bundled_runtime_paths(self) -> None:
+        source = CORE_SOURCE.read_text(encoding="utf-8")
+        for utility in ("chmod", "dirname", "mkdir", "mv", "rm", "rmdir"):
+            self.assertNotRegex(
+                source,
+                rf"(?m)^\s*{utility}\b[^\n]*\s--(?:\s|$)",
+                f"{utility} uses a non-POSIX option terminator",
+            )
+        self.assertNotIn("DEX_BUZZ_BIN", source)
+        self.assertNotIn("DEX_BUZZ_ADMIN", source)
+
     def test_identity_create_uses_the_bundled_admin_and_keeps_the_private_key_local(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             studio_home = root / "studio"
             log_path = root / "buzz.log"
-            fake_admin = root / "buzz-admin"
-            fake_buzz = root / "buzz"
+            core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
             _write_executable(
                 fake_admin,
                 "#!/usr/bin/env bash\n"
@@ -104,12 +128,10 @@ class SourceContractTests(unittest.TestCase):
             environment = {
                 **os.environ,
                 "DEX_STUDIO_HOME": str(studio_home),
-                "DEX_BUZZ_BIN": str(fake_buzz),
-                "DEX_BUZZ_ADMIN": str(fake_admin),
                 "DEX_TEST_LOG": str(log_path),
             }
             result = subprocess.run(
-                [CORE_SOURCE, "identity", "create", "--name", "Research Scout"],
+                [core, "identity", "create", "--name", "Research Scout"],
                 env=environment,
                 capture_output=True,
                 text=True,
@@ -140,7 +162,7 @@ class SourceContractTests(unittest.TestCase):
             )
 
             duplicate = subprocess.run(
-                [CORE_SOURCE, "identity", "create", "--name", "Research Scout"],
+                [core, "identity", "create", "--name", "Research Scout"],
                 env=environment,
                 capture_output=True,
                 text=True,
@@ -153,8 +175,7 @@ class SourceContractTests(unittest.TestCase):
             root = Path(temporary)
             studio_home = root / "studio"
             log_path = root / "buzz.log"
-            fake_admin = root / "buzz-admin"
-            fake_buzz = root / "buzz"
+            core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
             _seed_identity(studio_home, "studio", "c" * 64)
             _seed_identity(studio_home, "room-owner", "d" * 64)
             _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
@@ -172,19 +193,17 @@ class SourceContractTests(unittest.TestCase):
                 **os.environ,
                 "PATH": "",
                 "DEX_STUDIO_HOME": str(studio_home),
-                "DEX_BUZZ_BIN": str(fake_buzz),
-                "DEX_BUZZ_ADMIN": str(fake_admin),
                 "DEX_TEST_LOG": str(log_path),
             }
             listed = subprocess.run(
-                [CORE_SOURCE, "rooms", "list", "--as", "studio", "--json"],
+                [core, "rooms", "list", "--as", "studio", "--json"],
                 env=environment,
                 capture_output=True,
                 text=True,
             )
             created = subprocess.run(
                 [
-                    CORE_SOURCE,
+                    core,
                     "rooms",
                     "create",
                     "--name",
@@ -216,8 +235,7 @@ class SourceContractTests(unittest.TestCase):
             root = Path(temporary)
             studio_home = root / "studio"
             log_path = root / "buzz.log"
-            fake_admin = root / "buzz-admin"
-            fake_buzz = root / "buzz"
+            core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
             _seed_identity(studio_home, "studio", "c" * 64)
             _seed_identity(studio_home, "research-scout", "d" * 64)
             _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
@@ -237,13 +255,11 @@ class SourceContractTests(unittest.TestCase):
                 **os.environ,
                 "PATH": "",
                 "DEX_STUDIO_HOME": str(studio_home),
-                "DEX_BUZZ_BIN": str(fake_buzz),
-                "DEX_BUZZ_ADMIN": str(fake_admin),
                 "DEX_TEST_LOG": str(log_path),
             }
             posted = subprocess.run(
                 [
-                    CORE_SOURCE,
+                    core,
                     "post",
                     "--as",
                     "research-scout",
@@ -257,7 +273,7 @@ class SourceContractTests(unittest.TestCase):
                 text=True,
             )
             timeline_result = subprocess.run(
-                [CORE_SOURCE, "timeline", "--room", "room-1", "--limit", "2", "--json"],
+                [core, "timeline", "--room", "room-1", "--limit", "2", "--json"],
                 env=environment,
                 capture_output=True,
                 text=True,
@@ -278,8 +294,7 @@ class SourceContractTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             studio_home = root / "studio"
-            fake_admin = root / "buzz-admin"
-            fake_buzz = root / "buzz"
+            core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
             private_key = "e" * 64
             _seed_identity(studio_home, "studio", private_key)
             _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
@@ -296,30 +311,28 @@ class SourceContractTests(unittest.TestCase):
                 **os.environ,
                 "PATH": "",
                 "DEX_STUDIO_HOME": str(studio_home),
-                "DEX_BUZZ_BIN": str(fake_buzz),
-                "DEX_BUZZ_ADMIN": str(fake_admin),
             }
             probes = [
                 subprocess.run(
-                    [CORE_SOURCE, "post", "--as", "missing", "--room", "room-1", "--text", "x"],
+                    [core, "post", "--as", "missing", "--room", "room-1", "--text", "x"],
                     env=environment,
                     capture_output=True,
                     text=True,
                 ),
                 subprocess.run(
-                    [CORE_SOURCE, "timeline", "--room", "room-1", "--limit", "0"],
+                    [core, "timeline", "--room", "room-1", "--limit", "0"],
                     env=environment,
                     capture_output=True,
                     text=True,
                 ),
                 subprocess.run(
-                    [CORE_SOURCE, "timeline", "--room", "missing", "--json"],
+                    [core, "timeline", "--room", "missing", "--json"],
                     env=environment,
                     capture_output=True,
                     text=True,
                 ),
                 subprocess.run(
-                    [CORE_SOURCE, "rooms", "list", "--json"],
+                    [core, "rooms", "list", "--json"],
                     env=environment,
                     capture_output=True,
                     text=True,
@@ -335,6 +348,39 @@ class SourceContractTests(unittest.TestCase):
             self.assertIn("1 to 200", json.loads(probes[1].stderr)["error"])
             self.assertIn("unknown room", json.loads(probes[2].stderr)["error"])
             self.assertIn("relay timed out", json.loads(probes[3].stderr)["error"])
+
+    def test_existing_identity_custody_fails_closed_on_unsafe_modes_or_symlinks(self) -> None:
+        for unsafe_case in ("key-mode", "directory-mode", "key-symlink"):
+            with self.subTest(unsafe_case=unsafe_case), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                studio_home = root / "studio"
+                core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
+                _write_executable(fake_buzz, "#!/bin/bash\nexit 99\n")
+                _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
+                _seed_identity(studio_home, "unsafe", "f" * 64)
+                key_file = studio_home / "keys" / "agents" / "unsafe" / "key.json"
+                if unsafe_case == "key-mode":
+                    key_file.chmod(0o644)
+                elif unsafe_case == "directory-mode":
+                    key_file.parent.chmod(0o755)
+                else:
+                    original = key_file.with_name("original.json")
+                    key_file.rename(original)
+                    key_file.symlink_to(original)
+                result = subprocess.run(
+                    [core, "post", "--as", "unsafe", "--room", "room-1", "--text", "x"],
+                    env={
+                        **os.environ,
+                        "PATH": "",
+                        "DEX_STUDIO_HOME": str(studio_home),
+                    },
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("unsafe identity custody", json.loads(result.stderr)["error"])
+                self.assertNotIn("f" * 64, result.stderr)
 
     def test_archive_verification_rejects_a_sidecar_checksum_mismatch(self) -> None:
         verifier = PACKAGE_ROOT / "verify_artifact.py"
@@ -377,6 +423,101 @@ class SourceContractTests(unittest.TestCase):
         self.assertIn("pinned Buzz revision", error["error"])
         self.assertEqual(result.stdout, "")
 
+    def test_builder_has_no_caller_selected_cargo_or_target_and_redacts_diagnostics(self) -> None:
+        builder = PACKAGE_ROOT / "build_artifact.py"
+        help_result = subprocess.run(
+            [sys.executable, builder, "--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(help_result.returncode, 0)
+        self.assertNotIn("--cargo", help_result.stdout)
+        self.assertNotIn("--cargo-target-dir", help_result.stdout)
+
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import build_artifact
+
+            source = Path("/private/build/buzz")
+            target = Path("/private/build/target")
+            diagnostic = build_artifact._bounded_cargo_diagnostic(
+                "Compiling example\n"
+                f"error[E0001]: failed in {source}/crates/example/src/lib.rs\n"
+                f"  target: {target}/release/example\n"
+                "  BUZZ_PRIVATE_KEY=super-secret-value\n"
+                "warning: build failed, waiting for other jobs to finish...\n",
+                source,
+                target,
+            )
+        finally:
+            sys.path.pop(0)
+        self.assertIn("error[E0001]", diagnostic)
+        self.assertIn("<buzz-source>", diagnostic)
+        self.assertIn("<cargo-target>", diagnostic)
+        self.assertNotIn("/private/build", diagnostic)
+        self.assertNotIn("super-secret-value", diagnostic)
+        self.assertLessEqual(len(diagnostic), 4096)
+
+        poisoned = {
+            "RUSTC": "/tmp/fake-rustc",
+            "RUSTFLAGS": "--cfg injected",
+            "RUSTC_WRAPPER": "/tmp/fake-wrapper",
+            "CARGO_BUILD_RUSTC": "/tmp/fake-rustc",
+            "CARGO_TARGET_DIR": "/tmp/prebuilt",
+            "HERMIT_EXE": "/tmp/fake-hermit",
+        }
+        environment = build_artifact._sanitized_build_environment(
+            Path("/tmp/fresh-target"),
+            source_environment={**os.environ, **poisoned},
+        )
+        for key in poisoned:
+            if key == "CARGO_TARGET_DIR":
+                continue
+            self.assertNotIn(key, environment)
+        self.assertEqual(environment["CARGO_TARGET_DIR"], "/tmp/fresh-target")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            prebuilt_output = Path(temporary)
+            (prebuilt_output / ".cargo-target" / "release").mkdir(parents=True)
+            _write_executable(
+                prebuilt_output / ".cargo-target" / "release" / "buzz",
+                "#!/bin/bash\nexit 0\n",
+            )
+            rejected = subprocess.run(
+                [
+                    sys.executable,
+                    builder,
+                    "--buzz-source",
+                    PACKAGE_ROOT,
+                    "--output",
+                    prebuilt_output,
+                ],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("must be empty", json.loads(rejected.stderr)["error"])
+
+    def test_native_dependency_policy_rejects_non_baseline_libraries(self) -> None:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            from artifact_support import require_baseline_dependencies
+
+            require_baseline_dependencies(
+                "linux",
+                ["libc.so.6", "libm.so.6", "libgcc_s.so.1", "ld-linux-x86-64.so.2"],
+            )
+            with self.assertRaisesRegex(RuntimeError, "non-baseline"):
+                require_baseline_dependencies("linux", ["/tmp/libinjected.so"])
+            require_baseline_dependencies(
+                "darwin",
+                ["/usr/lib/libSystem.B.dylib", "/System/Library/Frameworks/Security.framework/Security"],
+            )
+            with self.assertRaisesRegex(RuntimeError, "non-baseline"):
+                require_baseline_dependencies("darwin", ["@rpath/libinjected.dylib"])
+        finally:
+            sys.path.pop(0)
+
     @unittest.skipUnless(
         os.environ.get("DEX_TEST_BUZZ_SOURCE"),
         "real pinned Buzz source was not supplied",
@@ -395,12 +536,6 @@ class SourceContractTests(unittest.TestCase):
                 "--output",
                 output,
             ]
-            if os.environ.get("DEX_TEST_BUZZ_CARGO"):
-                build_command.extend(["--cargo", os.environ["DEX_TEST_BUZZ_CARGO"]])
-            if os.environ.get("DEX_TEST_BUZZ_TARGET_DIR"):
-                build_command.extend(
-                    ["--cargo-target-dir", os.environ["DEX_TEST_BUZZ_TARGET_DIR"]]
-                )
             built = subprocess.run(
                 build_command,
                 capture_output=True,

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -9,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 CORE_SOURCE = PACKAGE_ROOT / "src" / "core"
@@ -382,6 +384,99 @@ class SourceContractTests(unittest.TestCase):
                 self.assertIn("unsafe identity custody", json.loads(result.stderr)["error"])
                 self.assertNotIn("f" * 64, result.stderr)
 
+    def test_every_selected_identity_rejects_dot_slash_and_traversal_ids(self) -> None:
+        probes = (
+            (".", ["rooms", "list", "--as", ".", "--json"]),
+            (
+                "nested/owner",
+                ["rooms", "create", "--name", "Knowledge", "--as", "nested/owner"],
+            ),
+            (
+                "../escaped",
+                ["post", "--as", "../escaped", "--room", "room-1", "--text", "x"],
+            ),
+            (
+                "../../escaped",
+                ["timeline", "--room", "room-1", "--as", "../../escaped", "--json"],
+            ),
+        )
+        for identity_id, arguments in probes:
+            with self.subTest(identity_id=identity_id), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                studio_home = root / "studio"
+                log_path = root / "buzz.log"
+                core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
+                _seed_identity(studio_home, identity_id, "f" * 64)
+                _write_executable(fake_admin, "#!/bin/bash\nexit 99\n")
+                _write_executable(
+                    fake_buzz,
+                    "#!/bin/bash\n"
+                    "printf '%s\\n' \"$*\" >> \"$DEX_TEST_LOG\"\n"
+                    "case \"$*\" in\n"
+                    "  'channels list') printf '%s\\n' '[]' ;;\n"
+                    "  'channels create --name Knowledge --type stream --visibility open') printf '%s\\n' '{\"channel_id\":\"room-2\"}' ;;\n"
+                    "  'channels get --channel room-1') printf '%s\\n' '{\"channel_id\":\"room-1\"}' ;;\n"
+                    "  'channels join --channel room-1') printf '%s\\n' '{\"accepted\":true}' ;;\n"
+                    "  'messages send --channel room-1 --content x') printf '%s\\n' '{\"event_id\":\"event-1\"}' ;;\n"
+                    "  'messages get --channel room-1') printf '%s\\n' '[]' ;;\n"
+                    "  *) exit 41 ;;\n"
+                    "esac\n",
+                )
+                result = subprocess.run(
+                    [core, *arguments],
+                    env={
+                        **os.environ,
+                        "PATH": "",
+                        "DEX_STUDIO_HOME": str(studio_home),
+                        "DEX_TEST_LOG": str(log_path),
+                    },
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("identity id is invalid", json.loads(result.stderr)["error"])
+                self.assertFalse(log_path.exists(), "invalid identity reached the Buzz runtime")
+
+    def test_identity_create_rejects_preexisting_symlinked_custody_parents(self) -> None:
+        for unsafe_parent in ("studio", "keys", "agents"):
+            with self.subTest(unsafe_parent=unsafe_parent), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                studio_home = root / "studio"
+                external = root / "external"
+                external.mkdir()
+                if unsafe_parent == "studio":
+                    studio_home.symlink_to(external, target_is_directory=True)
+                elif unsafe_parent == "keys":
+                    studio_home.mkdir()
+                    (studio_home / "keys").symlink_to(external, target_is_directory=True)
+                else:
+                    (studio_home / "keys").mkdir(parents=True)
+                    (studio_home / "keys" / "agents").symlink_to(
+                        external,
+                        target_is_directory=True,
+                    )
+                core, fake_buzz, fake_admin = _install_test_artifact(root / "artifact")
+                _write_executable(
+                    fake_admin,
+                    "#!/bin/bash\n"
+                    "printf '%s\\n' 'Public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'\n"
+                    "printf '%s\\n' 'Secret key: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'\n",
+                )
+                _write_executable(fake_buzz, "#!/bin/bash\nprintf '%s\\n' '{\"accepted\":true}'\n")
+                result = subprocess.run(
+                    [core, "identity", "create", "--name", "Research Scout"],
+                    env={**os.environ, "PATH": "", "DEX_STUDIO_HOME": str(studio_home)},
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("unsafe identity custody", json.loads(result.stderr)["error"])
+                self.assertEqual(list(external.rglob("key.json")), [])
+
     def test_archive_verification_rejects_a_sidecar_checksum_mismatch(self) -> None:
         verifier = PACKAGE_ROOT / "verify_artifact.py"
         with tempfile.TemporaryDirectory() as temporary:
@@ -510,6 +605,160 @@ class SourceContractTests(unittest.TestCase):
         self.assertNotEqual(rejected.returncode, 0)
         self.assertIn("must be empty", json.loads(rejected.stderr)["error"])
 
+    def test_builder_canonicalizes_relative_cli_paths_before_building(self) -> None:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import build_artifact
+
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                with (
+                    mock.patch.object(build_artifact, "build", return_value={"status": "ok"}) as build,
+                    mock.patch("builtins.print"),
+                ):
+                    previous = Path.cwd()
+                    try:
+                        os.chdir(root)
+                        result = build_artifact.main(
+                            ["--buzz-source", "relative-buzz", "--output", "relative-output"]
+                        )
+                    finally:
+                        os.chdir(previous)
+                self.assertEqual(result, 0)
+                arguments = build.call_args.args[0]
+                self.assertEqual(arguments.buzz_source, root / "relative-buzz")
+                self.assertEqual(arguments.output, root / "relative-output")
+                self.assertTrue(arguments.buzz_source.is_absolute())
+                self.assertTrue(arguments.output.is_absolute())
+        finally:
+            sys.path.pop(0)
+
+    def test_failed_build_removes_private_state_outside_the_deliverable_output(self) -> None:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import build_artifact
+
+            contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                source = root / "buzz"
+                source.mkdir()
+                output = root / "deliverables"
+                build_roots: list[Path] = []
+
+                def fail_runtime(arguments, build_root=None):
+                    private_root = Path(build_root) if build_root is not None else arguments.output
+                    build_roots.append(private_root)
+                    (private_root / ".hermit-state").mkdir(parents=True)
+                    raise build_artifact.BuildError("expected build failure")
+
+                arguments = type(
+                    "Arguments",
+                    (),
+                    {"buzz_source": source, "output": output, "jobs": 1},
+                )()
+                with (
+                    mock.patch.object(
+                        build_artifact,
+                        "_git_head",
+                        return_value=contract["buzz_revision"],
+                    ),
+                    mock.patch.object(build_artifact, "_require_clean_source"),
+                    mock.patch.object(
+                        build_artifact,
+                        "_build_pinned_runtime",
+                        side_effect=fail_runtime,
+                    ),
+                    self.assertRaisesRegex(build_artifact.BuildError, "expected build failure"),
+                ):
+                    build_artifact.build(arguments)
+
+                self.assertEqual(list(output.iterdir()) if output.exists() else [], [])
+                self.assertEqual(list(root.glob(".dex-core-build-*")), [])
+                self.assertEqual(len(build_roots), 1)
+                self.assertNotEqual(build_roots[0], output)
+        finally:
+            sys.path.pop(0)
+
+    def test_builder_requires_a_clean_dex_checkout_before_starting_runtime_build(self) -> None:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import build_artifact
+
+            contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
+            dex_root = PACKAGE_ROOT.parents[1]
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                source = root / "buzz"
+                source.mkdir()
+                output = root / "new-parent" / "output"
+                arguments = type(
+                    "Arguments",
+                    (),
+                    {"buzz_source": source, "output": output, "jobs": 1},
+                )()
+
+                def require_clean(checkout):
+                    if Path(checkout) == dex_root:
+                        self.assertFalse(output.parent.exists())
+                        raise build_artifact.BuildError(
+                            "Dex source checkout is dirty; artifact provenance is not exact"
+                        )
+
+                with (
+                    mock.patch.object(
+                        build_artifact,
+                        "_git_head",
+                        return_value=contract["buzz_revision"],
+                    ),
+                    mock.patch.object(
+                        build_artifact,
+                        "_require_clean_source",
+                        side_effect=require_clean,
+                    ),
+                    mock.patch.object(build_artifact, "_build_pinned_runtime") as runtime_build,
+                    self.assertRaisesRegex(build_artifact.BuildError, "Dex source checkout is dirty"),
+                ):
+                    build_artifact.build(arguments)
+                runtime_build.assert_not_called()
+                self.assertFalse(output.parent.exists())
+        finally:
+            sys.path.pop(0)
+
+    def test_verifier_binds_complete_provenance_to_the_source_contract(self) -> None:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import verify_artifact
+            from artifact_support import ArtifactError, sha256_file
+
+            contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
+            valid = {
+                "buzz_repository": contract["buzz_repository"],
+                "buzz_revision": contract["buzz_revision"],
+                "buzz_tree_clean": True,
+                "cargo_target_fresh": True,
+                "hermit_state_isolated": True,
+                "dex_revision": "a" * 40,
+                "dex_tree_clean": True,
+                "source_contract_sha256": sha256_file(PACKAGE_ROOT / "contract.json"),
+                "toolchain": {
+                    "cargo": "cargo 1.95.0 (test)",
+                    "rustc": "rustc 1.95.0 (test)",
+                },
+            }
+            verify_artifact._verify_source_identity(valid, contract)
+            invalid_values = {
+                "buzz_repository": "https://example.invalid/buzz.git",
+                "dex_revision": "not-a-revision",
+                "dex_tree_clean": False,
+                "source_contract_sha256": "0" * 64,
+            }
+            for field, value in invalid_values.items():
+                with self.subTest(field=field), self.assertRaises(ArtifactError):
+                    verify_artifact._verify_source_identity({**valid, field: value}, contract)
+        finally:
+            sys.path.pop(0)
+
     def test_native_dependency_policy_rejects_non_baseline_libraries(self) -> None:
         sys.path.insert(0, str(PACKAGE_ROOT))
         try:
@@ -632,6 +881,30 @@ class SourceContractTests(unittest.TestCase):
             self.assertTrue((artifact_dir / "SHA256SUMS").is_file())
             self.assertTrue(archive.is_file())
             self.assertTrue(Path(f"{archive}.sha256").is_file())
+            self.assertEqual(
+                {path.name for path in output.iterdir()},
+                {artifact_dir.name, archive.name, f"{archive.name}.sha256"},
+            )
+            manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
+            sources = manifest["sources"]
+            self.assertTrue(sources["dex_tree_clean"])
+            self.assertRegex(sources["dex_revision"], r"^[0-9a-f]{40}$")
+            self.assertEqual(
+                sources["source_contract_sha256"],
+                hashlib.sha256((PACKAGE_ROOT / "contract.json").read_bytes()).hexdigest(),
+            )
+            self.assertEqual(
+                sources["buzz_repository"],
+                "https://github.com/block/buzz.git",
+            )
+
+            rerun = subprocess.run(
+                build_command,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(rerun.returncode, 0)
+            self.assertIn("must be empty", json.loads(rerun.stderr)["error"])
 
             verified = subprocess.run(
                 [sys.executable, verifier, artifact_dir],

--- a/packages/dex-collaboration-cli/tests/test_artifact_contract.py
+++ b/packages/dex-collaboration-cli/tests/test_artifact_contract.py
@@ -465,16 +465,28 @@ class SourceContractTests(unittest.TestCase):
             "CARGO_BUILD_RUSTC": "/tmp/fake-rustc",
             "CARGO_TARGET_DIR": "/tmp/prebuilt",
             "HERMIT_EXE": "/tmp/fake-hermit",
+            "HERMIT_STATE_DIR": "/tmp/fake-hermit-state",
+            "HOME": "/tmp/fake-home",
+            "XDG_CACHE_HOME": "/tmp/fake-xdg",
         }
-        environment = build_artifact._sanitized_build_environment(
-            Path("/tmp/fresh-target"),
-            source_environment={**os.environ, **poisoned},
-        )
-        for key in poisoned:
-            if key == "CARGO_TARGET_DIR":
-                continue
-            self.assertNotIn(key, environment)
-        self.assertEqual(environment["CARGO_TARGET_DIR"], "/tmp/fresh-target")
+        with tempfile.TemporaryDirectory() as sanitized_temporary:
+            target = Path(sanitized_temporary) / "fresh-target"
+            environment = build_artifact._sanitized_build_environment(
+                target,
+                source_environment={**os.environ, **poisoned},
+            )
+            for key in ("RUSTC", "RUSTFLAGS", "RUSTC_WRAPPER", "CARGO_BUILD_RUSTC"):
+                self.assertNotIn(key, environment)
+            self.assertEqual(environment["CARGO_TARGET_DIR"], str(target))
+            self.assertEqual(environment["HOME"], str(target.parent / ".hermit-home"))
+            self.assertEqual(environment["XDG_CACHE_HOME"], str(target.parent / ".xdg-cache"))
+            self.assertEqual(environment["HERMIT_STATE_DIR"], str(target.parent / ".hermit-state"))
+            self.assertEqual(
+                environment["HERMIT_EXE"],
+                str(target.parent / ".hermit-state/pkg/hermit@stable/hermit"),
+            )
+            for key in ("HOME", "XDG_CACHE_HOME", "HERMIT_STATE_DIR", "HERMIT_EXE"):
+                self.assertNotEqual(environment[key], poisoned[key])
 
         with tempfile.TemporaryDirectory() as temporary:
             prebuilt_output = Path(temporary)
@@ -515,6 +527,74 @@ class SourceContractTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(RuntimeError, "non-baseline"):
                 require_baseline_dependencies("darwin", ["@rpath/libinjected.dylib"])
+        finally:
+            sys.path.pop(0)
+
+    @unittest.skipUnless(
+        os.environ.get("DEX_TEST_BUZZ_LAUNCHER_SOURCE"),
+        "real pinned Buzz launcher source was not supplied",
+    )
+    def test_build_environment_never_executes_caller_cached_hermit(self) -> None:
+        source = Path(os.environ["DEX_TEST_BUZZ_LAUNCHER_SOURCE"])
+        revision = subprocess.run(
+            ["git", "-C", source, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self.assertEqual(revision, "b2ac66cde81df7ce1afc50016e1571cb6e8b7779")
+
+        sys.path.insert(0, str(PACKAGE_ROOT))
+        try:
+            import build_artifact
+
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                caller_home = root / "caller-home"
+                caller_xdg = root / "caller-xdg"
+                target = root / "builder" / ".cargo-target"
+                poison_home_marker = root / "poison-home-ran"
+                poison_xdg_marker = root / "poison-xdg-ran"
+                controlled_marker = root / "controlled-ran"
+                fake_locations = (
+                    (caller_home / ".cache/hermit/pkg/hermit@stable/hermit", poison_home_marker),
+                    (caller_xdg / "hermit/pkg/hermit@stable/hermit", poison_xdg_marker),
+                    (
+                        target.parent / ".hermit-state/pkg/hermit@stable/hermit",
+                        controlled_marker,
+                    ),
+                )
+                for executable, marker in fake_locations:
+                    executable.parent.mkdir(parents=True)
+                    _write_executable(
+                        executable,
+                        "#!/bin/bash\n"
+                        f"/usr/bin/touch '{marker}'\n"
+                        "printf '%s\\n' 'cargo 1.95.0 (controlled-test)'\n",
+                    )
+                environment = build_artifact._sanitized_build_environment(
+                    target,
+                    source=source,
+                    source_environment={
+                        "HOME": str(caller_home),
+                        "XDG_CACHE_HOME": str(caller_xdg),
+                        "USER": "caller",
+                    },
+                )
+                result = subprocess.run(
+                    [source / "bin" / "cargo", "--version", "--verbose"],
+                    cwd=source,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertTrue(controlled_marker.is_file())
+                self.assertFalse(poison_home_marker.exists())
+                self.assertFalse(poison_xdg_marker.exists())
+                self.assertNotEqual(environment.get("HOME"), str(caller_home))
+                self.assertNotEqual(environment.get("XDG_CACHE_HOME"), str(caller_xdg))
         finally:
             sys.path.pop(0)
 

--- a/packages/dex-collaboration-cli/verify_artifact.py
+++ b/packages/dex-collaboration-cli/verify_artifact.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -23,6 +24,7 @@ from artifact_support import (
 )
 
 EXPECTED_COMMANDS = ["identity create", "rooms list", "rooms create", "post", "timeline"]
+PACKAGE_ROOT = Path(__file__).resolve().parent
 MAX_ARCHIVE_FILES = 64
 MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
 
@@ -47,6 +49,35 @@ def _read_sums(path: Path) -> dict[str, str]:
     return result
 
 
+def _verify_source_identity(sources: object, contract: dict[str, object]) -> None:
+    if not isinstance(sources, dict):
+        raise ArtifactError("artifact source provenance is missing")
+    if (
+        sources.get("buzz_repository") != contract.get("buzz_repository")
+        or sources.get("buzz_revision") != contract.get("buzz_revision")
+        or sources.get("buzz_tree_clean") is not True
+        or sources.get("cargo_target_fresh") is not True
+        or sources.get("hermit_state_isolated") is not True
+    ):
+        raise ArtifactError("pinned Buzz source identity is missing")
+    dex_revision = sources.get("dex_revision")
+    if (
+        not isinstance(dex_revision, str)
+        or re.fullmatch(r"[0-9a-f]{40}", dex_revision) is None
+        or sources.get("dex_tree_clean") is not True
+    ):
+        raise ArtifactError("clean Dex source identity is missing")
+    if sources.get("source_contract_sha256") != sha256_file(PACKAGE_ROOT / "contract.json"):
+        raise ArtifactError("artifact source contract identity is invalid")
+    toolchain = sources.get("toolchain")
+    if (
+        not isinstance(toolchain, dict)
+        or not str(toolchain.get("cargo", "")).startswith("cargo 1.95.0 ")
+        or not str(toolchain.get("rustc", "")).startswith("rustc 1.95.0 ")
+    ):
+        raise ArtifactError("pinned Rust toolchain identity is missing")
+
+
 def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, str]:
     if not root.is_dir() or root.is_symlink():
         raise ArtifactError("artifact must be an extracted regular directory")
@@ -57,21 +88,27 @@ def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, 
     if not sums_path.is_file() or sums_path.is_symlink():
         raise ArtifactError("SHA256SUMS is missing")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contract = json.loads((PACKAGE_ROOT / "contract.json").read_text(encoding="utf-8"))
     if manifest_path.read_bytes() != canonical_json_bytes(manifest):
         raise ArtifactError("manifest.json is not canonical")
     if manifest.get("schema") != "dex-collaboration-cli-artifact/1":
         raise ArtifactError("artifact manifest schema is unsupported")
-    if manifest.get("artifact_id") != "dex-core-collaboration-cli":
+    if manifest.get("artifact_id") != contract.get("artifact_id"):
         raise ArtifactError("artifact id is invalid")
     if manifest.get("platform") != expected_platform or manifest.get("architecture") != expected_arch:
         raise ArtifactError(
             f"artifact targets {manifest.get('platform')}/{manifest.get('architecture')}, "
             f"expected {expected_platform}/{expected_arch}"
         )
-    if manifest.get("commands") != EXPECTED_COMMANDS:
+    if manifest.get("commands") != contract.get("commands") or manifest.get("commands") != EXPECTED_COMMANDS:
         raise ArtifactError("artifact command contract is invalid")
     relay = manifest.get("relay")
-    if not isinstance(relay, dict) or relay.get("environment") != "BUZZ_RELAY_URL" or not relay.get("default"):
+    if (
+        not isinstance(relay, dict)
+        or relay != contract.get("service_boundary")
+        or relay.get("environment") != "BUZZ_RELAY_URL"
+        or not relay.get("default")
+    ):
         raise ArtifactError("artifact relay contract is invalid")
 
     entries = manifest.get("files")
@@ -154,21 +191,8 @@ def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, 
         raise ArtifactError("packaged Core executable contract does not match its manifest")
 
     sources = manifest.get("sources")
-    if (
-        not isinstance(sources, dict)
-        or sources.get("buzz_revision") != "b2ac66cde81df7ce1afc50016e1571cb6e8b7779"
-        or sources.get("buzz_tree_clean") is not True
-        or sources.get("cargo_target_fresh") is not True
-        or sources.get("hermit_state_isolated") is not True
-    ):
-        raise ArtifactError("pinned Buzz source identity is missing")
-    toolchain = sources.get("toolchain")
-    if (
-        not isinstance(toolchain, dict)
-        or not str(toolchain.get("cargo", "")).startswith("cargo 1.95.0 ")
-        or not str(toolchain.get("rustc", "")).startswith("rustc 1.95.0 ")
-    ):
-        raise ArtifactError("pinned Rust toolchain identity is missing")
+    _verify_source_identity(sources, contract)
+    assert isinstance(sources, dict)
     return {
         "status": "verified",
         "artifact": str(root.resolve()),

--- a/packages/dex-collaboration-cli/verify_artifact.py
+++ b/packages/dex-collaboration-cli/verify_artifact.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+from artifact_support import (
+    ArtifactError,
+    canonical_json_bytes,
+    host_arch,
+    host_platform,
+    native_identity,
+    require_mode,
+    safe_relative_files,
+    sha256_file,
+)
+
+EXPECTED_COMMANDS = ["identity create", "rooms list", "rooms create", "post", "timeline"]
+MAX_ARCHIVE_FILES = 64
+MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
+
+
+def _read_sums(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        raise ArtifactError("SHA256SUMS is empty")
+    for line in lines:
+        if len(line) < 67 or line[64:66] != "  ":
+            raise ArtifactError("SHA256SUMS is malformed")
+        checksum, relative = line[:64], line[66:]
+        if len(checksum) != 64 or any(character not in "0123456789abcdef" for character in checksum):
+            raise ArtifactError("SHA256SUMS contains an invalid checksum")
+        if not relative or relative.startswith("/") or ".." in Path(relative).parts or relative in result:
+            raise ArtifactError("SHA256SUMS contains an invalid path")
+        result[relative] = checksum
+    canonical = "".join(f"{result[key]}  {key}\n" for key in sorted(result))
+    if canonical != path.read_text(encoding="utf-8"):
+        raise ArtifactError("SHA256SUMS is not canonical")
+    return result
+
+
+def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, str]:
+    if not root.is_dir() or root.is_symlink():
+        raise ArtifactError("artifact must be an extracted regular directory")
+    manifest_path = root / "manifest.json"
+    sums_path = root / "SHA256SUMS"
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise ArtifactError("manifest.json is missing")
+    if not sums_path.is_file() or sums_path.is_symlink():
+        raise ArtifactError("SHA256SUMS is missing")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest_path.read_bytes() != canonical_json_bytes(manifest):
+        raise ArtifactError("manifest.json is not canonical")
+    if manifest.get("schema") != "dex-collaboration-cli-artifact/1":
+        raise ArtifactError("artifact manifest schema is unsupported")
+    if manifest.get("artifact_id") != "dex-core-collaboration-cli":
+        raise ArtifactError("artifact id is invalid")
+    if manifest.get("platform") != expected_platform or manifest.get("architecture") != expected_arch:
+        raise ArtifactError(
+            f"artifact targets {manifest.get('platform')}/{manifest.get('architecture')}, "
+            f"expected {expected_platform}/{expected_arch}"
+        )
+    if manifest.get("commands") != EXPECTED_COMMANDS:
+        raise ArtifactError("artifact command contract is invalid")
+    relay = manifest.get("relay")
+    if not isinstance(relay, dict) or relay.get("environment") != "BUZZ_RELAY_URL" or not relay.get("default"):
+        raise ArtifactError("artifact relay contract is invalid")
+
+    entries = manifest.get("files")
+    if not isinstance(entries, list):
+        raise ArtifactError("artifact file manifest is invalid")
+    entry_by_path: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            raise ArtifactError("artifact file entry is invalid")
+        relative = str(entry["path"])
+        if relative.startswith("/") or ".." in Path(relative).parts or relative in entry_by_path:
+            raise ArtifactError("artifact file entry path is invalid")
+        entry_by_path[relative] = entry
+    required_payload = {
+        "bin/core",
+        "libexec/buzz",
+        "libexec/buzz-admin",
+        "LICENSES/Buzz-LICENSE",
+    }
+    if set(entry_by_path) != required_payload:
+        raise ArtifactError("artifact payload set is incomplete or contains extras")
+
+    actual_files = {path.as_posix() for path in safe_relative_files(root)}
+    expected_files = required_payload | {"manifest.json", "SHA256SUMS"}
+    if actual_files != expected_files:
+        raise ArtifactError("artifact directory contains missing or unexpected files")
+    actual_directories = {
+        path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_dir()
+    }
+    if actual_directories != {"bin", "libexec", "LICENSES"}:
+        raise ArtifactError("artifact directory contains missing or unexpected directories")
+
+    sums = _read_sums(sums_path)
+    if set(sums) != required_payload | {"manifest.json"}:
+        raise ArtifactError("SHA256SUMS payload set is incomplete or contains extras")
+    for relative, expected_hash in sums.items():
+        if sha256_file(root / relative) != expected_hash:
+            raise ArtifactError(f"SHA-256 mismatch: {relative}")
+    for relative, entry in entry_by_path.items():
+        path = root / relative
+        expected_mode = int(str(entry.get("mode", "")), 8)
+        require_mode(path, expected_mode)
+        if entry.get("sha256") != sha256_file(path):
+            raise ArtifactError(f"manifest SHA-256 mismatch: {relative}")
+
+    core = root / "bin" / "core"
+    require_mode(core, 0o755)
+    for relative in ("libexec/buzz", "libexec/buzz-admin"):
+        runtime = root / relative
+        require_mode(runtime, 0o755)
+        binary_format, binary_platform, binary_arch = native_identity(runtime)
+        entry = entry_by_path[relative]
+        if (binary_platform, binary_arch) != (expected_platform, expected_arch):
+            raise ArtifactError(f"native runtime target mismatch: {relative}")
+        if entry.get("format") != binary_format or entry.get("architecture") != binary_arch:
+            raise ArtifactError(f"native runtime manifest mismatch: {relative}")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        environment = {
+            "PATH": "",
+            "HOME": str(Path(temporary) / "home"),
+            "DEX_STUDIO_HOME": str(Path(temporary) / "studio"),
+        }
+        result = subprocess.run(
+            [core, "--artifact-info"],
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+    if result.returncode != 0 or result.stderr:
+        raise ArtifactError("packaged Core executable is not runnable with an empty caller PATH")
+    try:
+        info = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ArtifactError("packaged Core executable did not emit JSON") from error
+    if info.get("schema") != "dex-collaboration-cli/1" or info.get("commands") != EXPECTED_COMMANDS:
+        raise ArtifactError("packaged Core executable contract does not match its manifest")
+
+    sources = manifest.get("sources")
+    if (
+        not isinstance(sources, dict)
+        or sources.get("buzz_revision") != "b2ac66cde81df7ce1afc50016e1571cb6e8b7779"
+        or sources.get("buzz_tree_clean") is not True
+    ):
+        raise ArtifactError("pinned Buzz source identity is missing")
+    return {
+        "status": "verified",
+        "artifact": str(root.resolve()),
+        "platform": expected_platform,
+        "architecture": expected_arch,
+        "buzz_revision": str(sources["buzz_revision"]),
+    }
+
+
+def _verify_archive_checksum(archive: Path) -> str:
+    if not archive.is_file() or archive.is_symlink():
+        raise ArtifactError("artifact archive must be a regular file")
+    sidecar = Path(f"{archive}.sha256")
+    if not sidecar.is_file() or sidecar.is_symlink():
+        raise ArtifactError("artifact archive SHA-256 sidecar is missing")
+    expected_line = sidecar.read_text(encoding="utf-8")
+    parts = expected_line.rstrip("\n").split("  ", 1)
+    if (
+        len(parts) != 2
+        or expected_line != f"{parts[0]}  {parts[1]}\n"
+        or len(parts[0]) != 64
+        or any(character not in "0123456789abcdef" for character in parts[0])
+        or parts[1] != archive.name
+    ):
+        raise ArtifactError("artifact archive SHA-256 sidecar is malformed")
+    actual = sha256_file(archive)
+    if actual != parts[0]:
+        raise ArtifactError("archive SHA-256 mismatch")
+    return actual
+
+
+def _extract_archive_safely(archive: Path, destination: Path) -> Path:
+    roots: set[str] = set()
+    members: set[str] = set()
+    extracted_bytes = 0
+    extracted_files = 0
+    with tarfile.open(archive, mode="r:gz") as bundle:
+        for member in bundle:
+            relative = PurePosixPath(member.name)
+            if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+                raise ArtifactError("artifact archive contains an unsafe path")
+            if member.name in members:
+                raise ArtifactError("artifact archive contains a duplicate path")
+            members.add(member.name)
+            roots.add(relative.parts[0])
+            if not member.isfile():
+                raise ArtifactError("artifact archive contains a non-regular entry")
+            extracted_files += 1
+            extracted_bytes += member.size
+            if extracted_files > MAX_ARCHIVE_FILES or extracted_bytes > MAX_ARCHIVE_BYTES:
+                raise ArtifactError("artifact archive exceeds the extraction limit")
+            target = destination.joinpath(*relative.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise ArtifactError("artifact archive entry could not be read")
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            target.chmod(member.mode & 0o777)
+    if len(roots) != 1:
+        raise ArtifactError("artifact archive must contain exactly one root directory")
+    root = destination / next(iter(roots))
+    if not root.is_dir():
+        raise ArtifactError("artifact archive root directory is missing")
+    return root
+
+
+def verify_input(path: Path, expected_platform: str, expected_arch: str) -> dict[str, str]:
+    if path.is_dir():
+        return verify(path, expected_platform, expected_arch)
+    archive_checksum = _verify_archive_checksum(path)
+    with tempfile.TemporaryDirectory() as temporary:
+        root = _extract_archive_safely(path, Path(temporary))
+        report = verify(root, expected_platform, expected_arch)
+    report.update(
+        {
+            "artifact": str(path.resolve()),
+            "artifact_kind": "archive",
+            "archive_sha256": archive_checksum,
+        }
+    )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--expect-platform", default=None)
+    parser.add_argument("--expect-arch", default=None)
+    args = parser.parse_args(argv)
+    try:
+        report = verify_input(
+            args.artifact,
+            args.expect_platform or host_platform(),
+            args.expect_arch or host_arch(),
+        )
+        print(json.dumps(report, separators=(",", ":")))
+        return 0
+    except (ArtifactError, KeyError, OSError, ValueError, json.JSONDecodeError, tarfile.TarError) as error:
+        print(json.dumps({"error": str(error)}, separators=(",", ":")), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/dex-collaboration-cli/verify_artifact.py
+++ b/packages/dex-collaboration-cli/verify_artifact.py
@@ -15,6 +15,7 @@ from artifact_support import (
     canonical_json_bytes,
     host_arch,
     host_platform,
+    native_dependencies,
     native_identity,
     require_mode,
     safe_relative_files,
@@ -127,6 +128,9 @@ def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, 
             raise ArtifactError(f"native runtime target mismatch: {relative}")
         if entry.get("format") != binary_format or entry.get("architecture") != binary_arch:
             raise ArtifactError(f"native runtime manifest mismatch: {relative}")
+        dependencies = native_dependencies(runtime, expected_platform)
+        if entry.get("dependencies") != dependencies:
+            raise ArtifactError(f"native runtime dependency manifest mismatch: {relative}")
 
     with tempfile.TemporaryDirectory() as temporary:
         environment = {
@@ -154,8 +158,16 @@ def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, 
         not isinstance(sources, dict)
         or sources.get("buzz_revision") != "b2ac66cde81df7ce1afc50016e1571cb6e8b7779"
         or sources.get("buzz_tree_clean") is not True
+        or sources.get("cargo_target_fresh") is not True
     ):
         raise ArtifactError("pinned Buzz source identity is missing")
+    toolchain = sources.get("toolchain")
+    if (
+        not isinstance(toolchain, dict)
+        or not str(toolchain.get("cargo", "")).startswith("cargo 1.95.0 ")
+        or not str(toolchain.get("rustc", "")).startswith("rustc 1.95.0 ")
+    ):
+        raise ArtifactError("pinned Rust toolchain identity is missing")
     return {
         "status": "verified",
         "artifact": str(root.resolve()),

--- a/packages/dex-collaboration-cli/verify_artifact.py
+++ b/packages/dex-collaboration-cli/verify_artifact.py
@@ -159,6 +159,7 @@ def verify(root: Path, expected_platform: str, expected_arch: str) -> dict[str, 
         or sources.get("buzz_revision") != "b2ac66cde81df7ce1afc50016e1571cb6e8b7779"
         or sources.get("buzz_tree_clean") is not True
         or sources.get("cargo_target_fresh") is not True
+        or sources.get("hermit_state_isolated") is not True
     ):
         raise ArtifactError("pinned Buzz source identity is missing")
     toolchain = sources.get("toolchain")


### PR DESCRIPTION
## Outcome

Hardens the package-owned B5 Core collaboration artifact and keeps the real native Buzz clients pinned to clean revision `b2ac66cde81df7ce1afc50016e1571cb6e8b7779`.

The narrow B5.3 command contract remains identity create, rooms list/create, post, and timeline. Selected identity IDs fail closed unless they match the canonical generated slug grammar; traversal inputs cannot escape the keys/agents custody root. Identity creation rejects pre-existing linked custody parents before creating, changing modes, or moving key material.

The builder requires clean Buzz and Dex checkouts, keeps build state outside the deliverable output, and publishes only the artifact directory, archive, and checksum sidecar. The verifier binds the clean Dex revision, exact Buzz repository/revision, and source-contract SHA-256.

Tracks davekilleen/dex-product-gtm-lab#345.

## Current exact-head evidence

- Exact head: `7b652f4fe0e86cc2bd43f8352a54e19c28f3e9d5`.
- Red-first contract coverage now requires the GitHub job to check out the exact pull-request head for PR events, falling back to `github.sha` for push/manual events. This prevents a synthetic merge snapshot from being packaged and recorded as the reviewed source revision.
- Dex and pinned Buzz check out as siblings, so the independent Buzz source does not dirty the Dex provenance tree.
- Relative paths are compared canonically, including macOS `/var` to `/private/var` resolution.
- Focused source contract suite is green locally: 21 tests discovered; 19 executed and two clean-Buzz-dependent tests skipped. Bash syntax, Python compilation, YAML parsing, and diff checks are green.

## Superseded evidence

- The earlier independent review at `d1a2947` passed its code scope, but its native CI later exposed the nested-checkout and macOS path defects.
- Review of `bd3ce36` confirmed those two repairs but found the workflow still built GitHub's synthetic pull-request merge commit: https://github.com/davekilleen/Dex/pull/599#issuecomment-5428280428
- The native artifacts produced by the superseded `bd3ce36` run are not acceptable evidence, even if that run completes.

## Pending gates

- Exact native Mac and Linux CI is PASS at `7b652f4fe0e86cc2bd43f8352a54e19c28f3e9d5`: https://github.com/davekilleen/Dex/actions/runs/32991806157. Both manifests record the exact reviewed Dex revision; Linux SHA-256 is `8267e5119a751194d577877a29b13e9bd8fb0810e03787866b8e0e1ae5f5d4ad`, macOS SHA-256 is `b4455d1ac5577b0b8732259a9e3a61138a3a06fc5f03bd1198e508ba5424d2ef`.
- Fresh independent exact-head review is PASS with zero P0-P2: https://github.com/davekilleen/Dex/pull/599#issuecomment-5428352233
- Solo PR #75 is review-green as a fail-closed packaging framework but intentionally accepts no real targets until these exact artifacts and their externally trusted digests exist.

## Evidence boundary

The pinned client normalizes room and timeline responses and does not expose raw canonical room tags or event signatures through these commands. The proof does not claim evidence the interface cannot provide.

## Explicit delivery boundary

This PR remains draft, unmerged, unreleased, uninstalled, and undeployed. Solo real-artifact integration, the missing packaged local collaboration service, B5.5 vendor parity, and real fresh-machine/Mac proofs remain incomplete.