### PR TITLE
Fix nightly configs self-check when optional capabilities are enabled

### DIFF
--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -650,6 +650,27 @@ def test_json_without_ledger_writes_nothing(tmp_path: Path, capsys) -> None:
     assert not (vault / "System" / ".dex" / "smoke-history.jsonl").exists()
 
 
+def test_configs_journey_validates_enabled_capability_in_isolated_runner(tmp_path: Path) -> None:
+    vault = _write_valid_vault(tmp_path)
+    profile = vault / "System" / "user-profile.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8")
+        + "capabilities:\n  career:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=REPO_ROOT,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    assert run.harness_failed is False
+    assert run.exit_code == 0
+    assert run.report["journeys"][0]["verdict"] == "OK"
+    assert run.report["journeys"][0]["detail"] == "parsed and validated 3 configuration files"
+
+
 def test_head_runner_generation_stays_coherent_when_release_is_older(tmp_path: Path) -> None:
     vault = _write_valid_vault(tmp_path)
     repo = _release_repo(

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -90,6 +90,9 @@ MCP_ONCE_CONSENT_DETAIL = "valid fresh single-use consent token is required"
 MCP_ONCE_TOKEN_PREFIX = "dex-mcp-once-consent-"
 MCP_ONCE_TOKEN_MAX_AGE_SECONDS = 120.0
 TRUSTED_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
+RUNNER_EXTERNAL_RELATIVES = frozenset(
+    {Path("packages/dex-contracts/dist/portable-vault.contract.json")}
+)
 RUNNER_FALLBACK_RELATIVES = (
     Path("core/__init__.py"),
     Path("core/paths.py"),
@@ -100,6 +103,7 @@ RUNNER_FALLBACK_RELATIVES = (
     Path("core/utils/trust_registry.py"),
     Path("core/utils/update_verifier.py"),
     Path("core/utils/validators.py"),
+    *RUNNER_EXTERNAL_RELATIVES,
 )
 CONTENT_VERIFIED_SENSITIVE_DEPENDENCIES = frozenset(
     {
@@ -977,7 +981,10 @@ def _materialize_runner(destination: Path) -> Path:
         if (
             relative.is_absolute()
             or not relative.parts
-            or relative.parts[0] != "core"
+            or (
+                relative.parts[0] != "core"
+                and relative not in RUNNER_EXTERNAL_RELATIVES
+            )
             or any(part in {"", ".", ".."} for part in relative.parts)
         ):
             raise JourneySafetySkip(f"tracked runner path is unsafe: {relative}")
@@ -2046,7 +2053,17 @@ def _missing_release_ref_reason(channel: str, *, server: bool = False) -> str:
 
 
 def _git_tree_paths(repo_root: Path, treeish: str) -> set[str] | None:
-    command = _git_command(repo_root, "ls-tree", "-r", "-z", "--name-only", treeish, "--", "core")
+    command = _git_command(
+        repo_root,
+        "ls-tree",
+        "-r",
+        "-z",
+        "--name-only",
+        treeish,
+        "--",
+        "core",
+        *(relative.as_posix() for relative in RUNNER_EXTERNAL_RELATIVES),
+    )
     if command is None:
         return None
     result = subprocess.run(


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-0747a102357fa4a8`
- Mission Control: `bug-report-nightly-smoke-check-core-utils-smoke-py-run-by-t-0747a10235`

## What Changed
- The nightly `configs` self-check copied `core/` into an isolated runner but omitted the shipped capability contract at `packages/dex-contracts/dist/portable-vault.contract.json`.
- Profiles with an optional capability enabled then failed before Dex was tested (`configs=UNKNOWN`, exit 2).
- Admit that one tracked, regular, non-symlink file through the existing no-follow, byte-verified snapshot route. No other package files are admitted.

## Test Plan
- Unit/integration tests added or updated: `test_configs_journey_validates_enabled_capability_in_isolated_runner`
- Negative/error-path tests added or updated: the new test was observed red against the parent `smoke.py` (harness_failed, missing contract) and green after the fix
- Commands run locally after rebase onto current main:
  - focused regression: pass
  - 11 nearby smoke tests: pass
  - Ruff on the two changed files: pass
  - compileall + `git diff --check`: pass

## Quality Gates
- [x] Regression test added for this bug fix
- [x] Failure mode validated (optional capability enabled; isolated runner missing the contract)
- [x] No docs impact — runner snapshot behaviour only
- [ ] CI lint + tests expected to cover `core/tests/test_smoke.py` via the sharded `tests` job

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this PR; overnight configs check returns to UNKNOWN on capability-enabled profiles

## Docs Impact
- If none, reason: no user-facing command or contract change; one extra tracked file is copied into the existing isolated runner snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows an internal smoke snapshot allowlist by one tracked JSON file; no user-facing API or auth changes.
> 
> **Overview**
> Fixes the nightly **`configs`** smoke journey failing with **UNKNOWN** when a vault enables an optional capability (e.g. `career`), because the isolated runner only copied **`core/`** and left out the shipped contract at **`packages/dex-contracts/dist/portable-vault.contract.json`**.
> 
> The runner snapshot now treats that path as a single **allowlisted external** file: it is included in **`RUNNER_FALLBACK_RELATIVES`**, listed in **`git ls-tree`** alongside **`core`**, and admitted through **`_materialize_runner`**’s existing no-follow, byte-verified copy path—no broader **`packages/`** exposure.
> 
> Adds **`test_configs_journey_validates_enabled_capability_in_isolated_runner`** to assert **`configs`** returns **OK** with career enabled in the isolated runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d733bae806591eef3d1c04ce6ca37a0a1adae026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->