### PR TITLE
Fix external task sync when a task has a real date value

### DIFF
--- a/core/integrations/task_sync.py
+++ b/core/integrations/task_sync.py
@@ -32,6 +32,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _json_default(value: object) -> str:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(
+        f"Object of type {value.__class__.__name__} is not JSON serializable"
+    )
+
+
 def _new_service_state(last_sync: str | None = None) -> dict[str, Any]:
     return {
         "last_sync": last_sync or _now_iso(),
@@ -208,7 +216,7 @@ def _run_adapter(
     runner = ADAPTERS_DIR / "run.cjs"
     result = subprocess.run(
         [_find_node(), str(runner), service, operation],
-        input=json.dumps({"config": config, "args": args}),
+        input=json.dumps({"config": config, "args": args}, default=_json_default),
         capture_output=True,
         text=True,
         timeout=30,

--- a/core/tests/test_task_sync.py
+++ b/core/tests/test_task_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -241,6 +242,36 @@ def test_push_create_records_opaque_mapping(sync_vault, monkeypatch):
     assert state["todoist"]["map"] == {
         "task-20260712-001": "opaque:todoist:9007199254740999"
     }
+
+
+def test_date_typed_canonical_task_reaches_adapter_as_iso_string(
+    sync_vault, monkeypatch
+):
+    _enable(sync_vault, "todoist")
+    _write_tasks(
+        sync_vault["tasks"],
+        "- [ ] Prepare customer follow-up ^task-20260827-001",
+    )
+    task_sync._write_state(
+        _state(todoist=_service_state("2026-08-26T08:00:00+00:00"))
+    )
+    canonical_task = work_server.parse_tasks_file(sync_vault["tasks"])[0]
+    canonical_task["due"] = date(2026, 8, 28)
+    monkeypatch.setattr(task_sync, "_canonical_tasks", lambda: [canonical_task])
+    calls = _install_fake_runner(
+        monkeypatch,
+        {
+            ("todoist", "create"): "external-date-task",
+            ("todoist", "get_changes"): [],
+        },
+    )
+
+    result = task_sync.sync_external_tasks(services=["todoist"])
+
+    assert result["todoist"]["errors"] == []
+    assert result["todoist"]["pushed_creates"] == 1
+    assert calls[0]["operation"] == "create"
+    assert calls[0]["request"]["args"]["due"] == "2026-08-28"
 
 
 def test_push_skips_tasks_older_than_service_baseline(sync_vault, monkeypatch):


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-a0ccb13c2c47e59e`
- Mission Control: `bug-report-task-sync-sync-external-tasks-a0ccb13c2c`

## What Changed
- External task sync stopped before reaching Todoist (or another configured service) when a canonical task carried a real Python `date` value.
- Convert only `date` and `datetime` values to ISO strings at the shared Python-to-Node JSON boundary. Unsupported objects still fail loudly.

## Test Plan
- Unit/integration tests added or updated: `test_date_typed_canonical_task_reaches_adapter_as_iso_string`
- Negative/error-path tests added or updated: the new test was observed red against the parent (`Object of type date is not JSON serializable`, zero creates) and green after the fix (`due` reaches the adapter as `2026-08-28`)
- Commands run locally after rebase onto current main:
  - focused regression: pass
  - `core/tests/test_task_sync.py`: 38 passed
  - Ruff on the two changed files: pass
  - compileall + `git diff --check`: pass

## Quality Gates
- [x] Regression test added for this bug fix
- [x] Failure mode validated (date-typed canonical due field)
- [x] No docs impact
- [ ] CI lint + tests expected to cover `core/tests/test_task_sync.py` via the sharded `tests` job

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this PR; date-typed canonical fields again abort the configured sync before the adapter

## Docs Impact
- If none, reason: adapter JSON encoding only; no user-facing command change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow encoding change at the adapter subprocess boundary with a targeted regression test; no auth or persistence behavior changes.
> 
> **Overview**
> External task sync could abort before calling Todoist (or other adapters) when a canonical task included a Python **`date`** or **`datetime`** on fields such as **`due`**, because **`json.dumps`** on the Python→Node adapter stdin was not JSON-serializable.
> 
> This adds **`_json_default`** and wires it into **`_run_adapter`** so only **`date`**/**`datetime`** values become ISO strings at that boundary; other non-JSON types still raise **`TypeError`**.
> 
> A regression test asserts a **`date`-typed **`due`** reaches the create adapter payload as **`"2026-08-28"`** and sync completes without errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ffcba09bca06f45516719786c904e011692207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->