### PR TITLE
Fix Doctor deep scan on manual and ZIP Dex installs

### DIFF
--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -378,6 +378,51 @@ def test_report_schema_exit_zero_and_no_live_write(tmp_path: Path) -> None:
     assert _tree_hash(vault) == before
 
 
+def test_manual_install_configs_snapshot_keeps_capability_validator_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import yaml
+
+    vault = _write_valid_vault(tmp_path)
+    (vault / "System" / "user-profile.yaml").write_text(
+        "name: Smoke User\n"
+        "capabilities:\n"
+        "  career:\n"
+        "    enabled: false\n"
+        "analytics:\n"
+        "  enabled: false\n",
+        encoding="utf-8",
+    )
+    for relative in (*smoke.RUNNER_FALLBACK_RELATIVES, Path("core/capabilities.py")):
+        destination = vault / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative, destination)
+
+    yaml_site_packages = Path(yaml.__file__).resolve().parent.parent
+    monkeypatch.setattr(
+        smoke.sysconfig,
+        "get_paths",
+        lambda: {
+            "purelib": str(yaml_site_packages),
+            "platlib": str(yaml_site_packages),
+        },
+    )
+    monkeypatch.setattr(smoke, "RUNNER_ROOT", vault)
+
+    run = smoke.run_smoke(
+        vault_root=vault,
+        repo_root=vault,
+        journey_definitions=(_definition("configs"),),
+    )
+
+    journey = run.report["journeys"][0]
+    assert {"verdict": journey["verdict"], "detail": journey["detail"]} == {
+        "verdict": "OK",
+        "detail": "parsed and validated 3 configuration files",
+    }
+
+
 def test_fresh_release_without_onboarding_or_python_packages_has_clean_verdicts(
     monkeypatch,
     tmp_path: Path,

--- a/core/utils/smoke.py
+++ b/core/utils/smoke.py
@@ -96,6 +96,7 @@ RUNNER_EXTERNAL_RELATIVES = frozenset(
 RUNNER_FALLBACK_RELATIVES = (
     Path("core/__init__.py"),
     Path("core/paths.py"),
+    Path("core/portable_contract.py"),
     Path("core/utils/__init__.py"),
     Path("core/utils/dex_logger.py"),
     Path("core/utils/release_channel.py"),

--- a/core/utils/validators.py
+++ b/core/utils/validators.py
@@ -72,9 +72,9 @@ def validate_user_profile_config(config: object) -> list[str]:
             errors.append("feedback.review_mode must be always-review or auto-send")
     capabilities = config.get("capabilities")
     if isinstance(capabilities, Mapping):
-        from core.capabilities import room_ids
+        from core.portable_contract import CAPABILITIES
 
-        declared = set(room_ids())
+        declared = set(CAPABILITIES)
         for room, state in capabilities.items():
             if room not in declared:
                 errors.append(f"capabilities contains unknown room {room!r}")


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-e9eb27e9b802caa4`
- Mission Control: `bug-report-dex-doctor-deep-scan-smoke-journeys-check-e9eb27e9b8`

## What Changed
- Manual and ZIP-style Dex installs have no Git metadata, so Doctor's isolated smoke snapshot omitted the capability registry. The validator then imported `core.capabilities`, which is not in that snapshot, and reported `No module named 'core.capabilities'` even when Python was healthy.
- Read room ids from the lightweight `core.portable_contract.CAPABILITIES` source of truth, and include `core/portable_contract.py` in the no-Git fallback snapshot. No capability-provisioning engine is imported.

## Test Plan
- Unit/integration tests added or updated: `test_manual_install_configs_snapshot_keeps_capability_validator_dependency`
- Negative/error-path tests added or updated: the new test was observed red against the parent (`configs UNKNOWN`, `No module named 'core.capabilities'`) and green after the fix
- Commands run locally after rebase onto current main (includes the already-merged overnight-contract snapshot):
  - focused regression: pass
  - existing `test_configs_journey_validates_enabled_capability_in_isolated_runner`: pass
  - 3 nearby smoke tests: pass
  - Ruff on the three changed files: pass
  - compileall + `git diff --check`: pass

## Quality Gates
- [x] Regression test added for this bug fix
- [x] Failure mode validated (manual/ZIP install, no Git, isolated runner)
- [x] No docs impact
- [ ] CI lint + tests expected to cover `core/tests/test_smoke.py` via the sharded `tests` job

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this PR; ZIP/manual Doctor deep scans again misdiagnose a missing Dex module

## Docs Impact
- If none, reason: isolated runner snapshot and validator import only; no user-facing command change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to validator imports and smoke snapshot file list; behavior is the same for capability room names, with a targeted regression test.
> 
> **Overview**
> Fixes **Doctor deep scan** false failures on manual and ZIP installs where Git is absent and the isolated smoke runner uses a file-copy fallback instead of `git ls-tree`.
> 
> **Capability validation** in `validate_user_profile_config` now reads allowed room ids from `core.portable_contract.CAPABILITIES` instead of importing `core.capabilities`, which was not bundled in the no-Git snapshot and triggered `No module named 'core.capabilities'`.
> 
> The smoke runner **fallback snapshot** includes `core/portable_contract.py` via `RUNNER_FALLBACK_RELATIVES`. A regression test simulates a manual install (vault as repo root, fallback files only) and asserts the **configs** journey returns OK when `user-profile.yaml` includes capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4462ccdc986777f02cb177bc25118ba212951941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->