### PR TITLE
Stop unused Google setting from blocking Todoist sync

### DIFF
--- a/core/integrations/task_sync.py
+++ b/core/integrations/task_sync.py
@@ -137,9 +137,9 @@ def _enabled_services(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
     legacy = config.get("enabled")
     if isinstance(legacy, dict):
         for name, value in legacy.items():
-            if value is True:
-                settings = config.get(name)
-                enabled[str(name)] = settings if isinstance(settings, dict) else {}
+            settings = config.get(name)
+            if value is True and isinstance(settings, dict):
+                enabled[str(name)] = settings
 
     for name, settings in config.items():
         if name == "enabled" or not isinstance(settings, dict):

--- a/core/tests/test_task_sync.py
+++ b/core/tests/test_task_sync.py
@@ -213,6 +213,28 @@ def test_first_service_run_creates_baseline_without_adapter_calls(sync_vault, mo
     assert not sync_vault["inbound"].exists()
 
 
+def test_unscoped_sync_ignores_global_flags_without_task_service_settings(
+    sync_vault, monkeypatch
+):
+    _enable(sync_vault, "todoist")
+    sync_vault["config"].write_text(
+        "enabled:\n  google: true\n"
+        + sync_vault["config"].read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("first run must not call an adapter")
+
+    monkeypatch.setattr(task_sync, "_run_adapter", fail_if_called)
+
+    result = task_sync.sync_external_tasks()
+
+    assert set(result) == {"todoist"}
+    assert result["todoist"]["first_run"] is True
+    assert result["todoist"]["errors"] == []
+
+
 def test_push_create_records_opaque_mapping(sync_vault, monkeypatch):
     _enable(sync_vault, "todoist")
     _write_tasks(


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-03b6b571a2b14840`
- Mission Control: `bug-report-task-sync-sync-external-tasks-03b6b571a2`

## What Changed
- An all-services task sync treated a broad Google feature switch as a Google Tasks provider, then failed because Dex has no Google Tasks adapter. Todoist itself was healthy.
- Ignore a legacy `enabled.<name>: true` flag unless that service also has a settings object.

## Test Plan
- Added `test_unscoped_sync_ignores_global_flags_without_task_service_settings`
- Observed red (result included `google`) then green (only `todoist`)
- After rebase onto current main: `core/tests/test_task_sync.py` 39 passed; Ruff passed

## Risk & Rollback
- Risk level: low
- Rollback: revert this PR

## Docs Impact
- None: service-selection filter only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows legacy config interpretation for service selection only; real task providers still need dict settings and explicit `enabled: true` as before.
> 
> **Overview**
> **Fixes unscoped task sync treating unrelated global feature flags (e.g. `enabled.google: true`) as enabled task providers**, which could pull in services with no adapter/settings and break otherwise healthy syncs like Todoist.
> 
> In `_enabled_services`, legacy `enabled.<name>: true` entries now count only when `config` also has a **dict** settings block for that name—no more defaulting to `{}` for flag-only names.
> 
> Adds regression test `test_unscoped_sync_ignores_global_flags_without_task_service_settings`: with `enabled.google: true` plus a real Todoist block, `sync_external_tasks()` returns only Todoist with no adapter calls and no errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a78bc97607bd925401a8dece94dda89ac5164fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->