### PR TITLE
Keep meeting analysis when Anthropic returns thinking first

### DIFF
--- a/.scripts/lib/llm-client.cjs
+++ b/.scripts/lib/llm-client.cjs
@@ -42,7 +42,8 @@ async function generateWithAnthropic(prompt, options = {}) {
     ]
   });
   
-  return message.content[0].text;
+  const textBlock = message.content.find(block => block.type === 'text');
+  return textBlock ? textBlock.text : '';
 }
 
 // ============================================================================

--- a/.scripts/lib/tests/llm-client.test.cjs
+++ b/.scripts/lib/tests/llm-client.test.cjs
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const CLIENT_PATH = require.resolve('../llm-client.cjs');
+
+test('Anthropic returns the text block when thinking comes first', async () => {
+  const originalLoad = Module._load;
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  class Anthropic {
+    constructor() {
+      this.messages = {
+        create: async () => ({
+          content: [
+            { type: 'thinking', thinking: 'private reasoning' },
+            { type: 'text', text: 'meeting analysis' },
+          ],
+        }),
+      };
+    }
+  }
+
+  Module._load = function loadWithAnthropicFixture(request, parent, isMain) {
+    if (request === '@anthropic-ai/sdk') return Anthropic;
+    if (request === 'dotenv') return { config() {} };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  process.env.ANTHROPIC_API_KEY = 'local-test-key';
+  delete require.cache[CLIENT_PATH];
+
+  try {
+    const { generateContent } = require(CLIENT_PATH);
+
+    const result = await generateContent('analyse this meeting', {
+      provider: 'anthropic',
+    });
+
+    assert.equal(result, 'meeting analysis');
+  } finally {
+    Module._load = originalLoad;
+    delete require.cache[CLIENT_PATH];
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+  }
+});


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-688083f526fbd157`
- Mission Control: `bug-report-meeting-intel-llm-client-scripts-lib-llm-client--688083f526`

## What Changed
- The Anthropic meeting-intel client always read `content[0].text`, so a leading thinking block made valid analysis empty.
- Read the first `text` block instead.

## Test Plan
- Added `.scripts/lib/tests/llm-client.test.cjs`
- Observed red (`undefined`) then green (`meeting analysis`)
- After rebase: the new Node test passed

## Risk & Rollback
- Risk level: low
- Rollback: revert this PR

## Docs Impact
- None: Anthropic response parsing only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Anthropic response parsing in a shared script helper, with a regression test and no auth or data-model impact.
> 
> **Overview**
> Fixes **meeting intel** (and other `.scripts` flows using `generateContent`) returning blank output when Anthropic puts a **`thinking`** block before the **`text`** block in `message.content`.
> 
> **`generateWithAnthropic`** no longer assumes `content[0]` is text; it selects the first block with `type === 'text'` and returns that text, or `''` if none exists.
> 
> Adds a Node test that mocks a thinking-first response and asserts the client still returns **`meeting analysis`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81e11f4078a4751ee3ecf2085ebcfdcc0193823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->