### PR TITLE
Tell users a certificate failure is not an internet outage

### DIFF
--- a/.claude/skills/feedback/scripts/feedback_client.py
+++ b/.claude/skills/feedback/scripts/feedback_client.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import os
 import re
+import ssl
 import stat
 import sys
 import time
@@ -85,6 +86,10 @@ class AuthError(FeedbackError):
 
 
 class NetworkError(FeedbackError):
+    exit_code = 3
+
+
+class CertificateError(FeedbackError):
     exit_code = 3
 
 
@@ -219,10 +224,28 @@ def _request_json(
             status = response.status
     except urllib.error.HTTPError as error:
         raise _http_error_to_feedback_error(error)
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except urllib.error.URLError as error:
+        if isinstance(error.reason, ssl.SSLCertVerificationError):
+            raise CertificateError(
+                f"Could not verify the secure certificate from {get_api_base_url(api_base)}. "
+                "This can happen when a corporate network inspects encrypted traffic; "
+                "your internet connection may still be working. Ask your IT team to check "
+                "the network's certificate setup, then try again."
+            ) from error
         raise NetworkError(
             f"Could not reach {get_api_base_url(api_base)}. Check your internet connection and try again."
-        )
+        ) from error
+    except ssl.SSLCertVerificationError as error:
+        raise CertificateError(
+            f"Could not verify the secure certificate from {get_api_base_url(api_base)}. "
+            "This can happen when a corporate network inspects encrypted traffic; "
+            "your internet connection may still be working. Ask your IT team to check "
+            "the network's certificate setup, then try again."
+        ) from error
+    except (TimeoutError, OSError) as error:
+        raise NetworkError(
+            f"Could not reach {get_api_base_url(api_base)}. Check your internet connection and try again."
+        ) from error
 
     return _decode_json_response(status, response_body)
 
@@ -660,6 +683,9 @@ def main(argv: "list[str] | None" = None) -> int:
         return args.func(args)
     except AuthError as error:
         print(f"CONNECTION NEEDED: {error.user_message}")
+        return error.exit_code
+    except CertificateError as error:
+        print(f"CERTIFICATE ERROR: {error.user_message}")
         return error.exit_code
     except NetworkError as error:
         print(f"NETWORK ERROR: {error.user_message}")

--- a/core/tests/test_feedback_client_script.py
+++ b/core/tests/test_feedback_client_script.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import ssl
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -270,3 +272,27 @@ def test_link_with_blank_code_does_not_reuse_the_connection_needed_exit_code(cap
     out = capsys.readouterr().out
     assert "sign-in code is required" in out
     assert "CONNECTION NEEDED" not in out
+
+
+def test_link_reports_wrapped_certificate_failure_as_a_trust_problem(monkeypatch, capsys):
+    client = _load_script()
+    certificate_error = ssl.SSLCertVerificationError(
+        1,
+        "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+        "CA cert does not include key usage extension",
+    )
+
+    def reject_certificate(*args, **kwargs):
+        raise urllib.error.URLError(certificate_error)
+
+    monkeypatch.setattr(client.urllib.request, "urlopen", reject_certificate)
+
+    code = client.main(
+        ["link", "--code", "ABC123", "--api-base", "https://feedback.example"]
+    )
+
+    assert code == 3
+    output = capsys.readouterr().out
+    assert output.startswith("CERTIFICATE ERROR: ")
+    assert "corporate network" in output
+    assert "internet connection may still be working" in output


### PR DESCRIPTION
## Linked Issue
- Feedback receipt: `dex-feedback-investigation-501a491d09075006`
- Mission Control: `bug-report-feedback-claude-skills-feedback-scripts-feedback-501a491d09`

## What Changed
- Dex feedback treated a certificate-trust failure as a generic network outage.
- Distinguish `SSLCertVerificationError`, keep certificate checking fully enforced, and explain that corporate network inspection can cause it.

## Test Plan
- Added `test_link_reports_wrapped_certificate_failure_as_a_trust_problem`
- Observed red (`NETWORK ERROR`) then green (`CERTIFICATE ERROR` plus corporate-network guidance)
- After rebase: 16 feedback-client tests passed; Ruff passed

## Risk & Rollback
- Risk level: low
- Rollback: revert this PR

## Docs Impact
- None: error classification and user-facing recovery text only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error handling only; SSL verification is unchanged and no auth or data paths are modified.
> 
> **Overview**
> The feedback CLI no longer tells users to “check your internet” when TLS certificate verification fails. **`SSLCertVerificationError`** (including when wrapped in **`URLError`**) now raises a dedicated **`CertificateError`** with a **`CERTIFICATE ERROR:`** prefix and copy that points to corporate TLS inspection and IT certificate setup while noting connectivity may still be fine.
> 
> Certificate verification stays strict—only classification and user-facing recovery text change. A test mocks a wrapped cert failure on **`link`** and asserts exit code 3 and the new messaging instead of **`NETWORK ERROR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed6d756288171c1a9a4fc64a64755ac2fe0461f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->