### PR TITLE
Keep Doctor progress without shared probe timeouts

### DIFF
--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,7 +1,6 @@
 """Contract tests for the /dex-doctor collector."""
 
 import hashlib
-import inspect
 import json
 import os
 import plistlib
@@ -1576,131 +1575,54 @@ def test_main_heal_flag_invokes_t1_and_still_returns_json(monkeypatch, context, 
     assert calls == [context]
 
 
-def test_heal_speaks_on_stderr_before_and_during_checks(monkeypatch, context, capsys):
-    """Visible life starts before the first check; progress is the two shipped sentences."""
-    monkeypatch.setattr(doctor, "_apply_t1_heals", lambda _context: ({}, []))
-    seen_before_first = []
+def test_main_heal_reports_progress_before_repairs_and_checks(
+    monkeypatch, context, capsys
+):
+    """A stuck step must not leave the person staring at an empty terminal."""
+    observed_stderr = []
+
+    def heal(_context):
+        observed_stderr.append(capsys.readouterr().err)
+        return {}, []
 
     def first_probe(_context):
-        seen_before_first.append(capsys.readouterr().err)
+        observed_stderr.append(capsys.readouterr().err)
+        return doctor.ProbeResult("OK", "Stub probe completed.")
+
+    _stub_probes(monkeypatch)
+    monkeypatch.setattr(doctor, "_apply_t1_heals", heal)
+    monkeypatch.setattr(doctor, "_probe_vault_structure", first_probe)
+
+    assert doctor.main(["--heal"], context=context) == 0
+    captured = capsys.readouterr()
+
+    assert observed_stderr == [
+        f"{doctor.HEAL_PROGRESS}\n",
+        f"{doctor.CHECK_PROGRESS}\n",
+    ]
+    assert captured.err == ""
+    assert json.loads(captured.out)["mode"] == "quick"
+
+
+def test_collect_runs_probes_in_process_without_shared_timeout_threads(
+    monkeypatch, context, capsys
+):
+    """Checks must not be abandoned in daemon threads after a shared deadline."""
+    caller = threading.get_ident()
+    seen: list[int] = []
+
+    def first_probe(_context):
+        seen.append(threading.get_ident())
         return doctor.ProbeResult("OK", "Stub probe completed.")
 
     _stub_probes(monkeypatch)
     monkeypatch.setattr(doctor, "_probe_vault_structure", first_probe)
 
-    exit_code = doctor.main(["--heal"], context=context)
-    captured = capsys.readouterr()
-    report = json.loads(captured.out)
+    report = doctor.collect(context=context)
 
-    assert exit_code == 0
-    assert seen_before_first[0].splitlines() == [
-        doctor.HEAL_PROGRESS,
-        doctor.CHECK_PROGRESS,
-    ]
-    assert captured.err == ""
-    assert doctor.HEAL_PROGRESS not in captured.out
-    assert doctor.CHECK_PROGRESS not in captured.out
-    assert report["mode"] == "quick"
-
-
-def test_stuck_check_times_out_and_later_checks_still_run(monkeypatch, context):
-    """A stuck probe is time-boxed so later probes still run. Heals are not this path."""
-    monkeypatch.setattr(doctor, "CHECK_TIMEOUT_SECONDS", 0.2)
-    monkeypatch.setattr(doctor, "_apply_t1_heals", lambda _context: ({}, []))
-    spoken: list[str] = []
-    real_progress = doctor._progress
-    monkeypatch.setattr(
-        doctor,
-        "_progress",
-        lambda message: spoken.append(message) or real_progress(message),
-    )
-    order: list[str] = []
-
-    def hang(_context):
-        order.append("hang")
-        time.sleep(30)
-        order.append("hang-finished")
-        return doctor.ProbeResult("OK", "should not count")
-
-    def later(_context):
-        order.append("later")
-        return doctor.ProbeResult("OFF", "Later check ran.")
-
-    _stub_probes(monkeypatch)
-    monkeypatch.setattr(doctor, "_probe_vault_structure", hang)
-    monkeypatch.setattr(doctor, "_probe_vault_configs", later)
-
-    started = time.monotonic()
-    report = doctor.collect(heal=True, context=context)
-    elapsed = time.monotonic() - started
-
-    assert elapsed < 5
-    assert order == ["hang", "later"]
-    assert _check(report, "vault.structure")["verdict"] == "UNKNOWN"
-    assert "timed out" in _check(report, "vault.structure")["detail"]
-    assert _check(report, "vault.configs")["verdict"] == "OFF"
-    assert _check(report, "doctor.self")["verdict"] == "BROKEN"
-    assert {"id": "vault.structure", "error": "timed out"} in report["instruments"]["failed"]
-    assert spoken == [doctor.HEAL_PROGRESS, doctor.CHECK_PROGRESS]
-
-
-def test_t1_heal_path_does_not_wrap_mutations_in_run_bounded():
-    """Heals must not go through `_run_bounded`. That helper abandons a daemon worker."""
-    assert "_run_bounded" not in inspect.getsource(doctor._t1_stage)
-    assert "_run_bounded" not in inspect.getsource(doctor._apply_t1_heals)
-
-
-def test_heals_are_not_abandoned_in_a_daemon_thread(monkeypatch, context):
-    """A heal that outlasts the probe bound must finish on the collector thread.
-
-    Wrapping heals in `_run_bounded` would start a daemon worker, time out, and
-    leave the mutation running after later heals and probes begin.
-    """
-    monkeypatch.setattr(doctor, "CHECK_TIMEOUT_SECONDS", 0.2)
-    bounded_calls: list[float] = []
-    real_bounded = doctor._run_bounded
-
-    def spy_bounded(operation, timeout_seconds):
-        bounded_calls.append(timeout_seconds)
-        return real_bounded(operation, timeout_seconds)
-
-    monkeypatch.setattr(doctor, "_run_bounded", spy_bounded)
-    for name in doctor.PARA_PATH_NAMES:
-        context.core_path(name).mkdir(parents=True, exist_ok=True)
-    (context.vault_root / "core" / "paths.json").write_text("{}\n")
-    caller = threading.get_ident()
-    seen: list[tuple[str, int]] = []
-
-    def slow_executables(_context):
-        seen.append(("exec", threading.get_ident()))
-        time.sleep(0.45)
-        return []
-
-    def env_finding(_context):
-        seen.append(("env", threading.get_ident()))
-        return None
-
-    monkeypatch.setattr(doctor, "_paths_export_for", lambda _context: {})
-    monkeypatch.setattr(doctor, "_repo_shipped_executables", slow_executables)
-    monkeypatch.setattr(doctor, "_env_permission_finding", env_finding)
-    monkeypatch.setattr(doctor, "_acknowledge_resolved_preflight_errors", lambda _context: 0)
-    monkeypatch.setattr(doctor, "_heal_claude_composition", lambda _context: None)
-    monkeypatch.setattr(
-        doctor,
-        "_probe_capability_rooms",
-        lambda _context: doctor.ProbeResult("OK", "rooms"),
-    )
-
-    started = time.monotonic()
-    actions, errors = doctor._apply_t1_heals(context)
-    elapsed = time.monotonic() - started
-
-    assert bounded_calls == []
-    assert elapsed >= 0.4
-    assert [name for name, _ident in seen] == ["exec", "env"]
-    assert all(ident == caller for _name, ident in seen)
-    assert errors == []
-    assert actions == {}
+    assert seen == [caller]
+    assert _check(report, "vault.structure")["verdict"] == "OK"
+    assert capsys.readouterr().err == ""
 
 
 def test_heal_failure_stays_in_thread_and_later_heals_still_run(monkeypatch, context):
@@ -1735,42 +1657,6 @@ def test_heal_failure_stays_in_thread_and_later_heals_still_run(monkeypatch, con
     assert all(ident == caller for _name, ident in seen)
     assert errors == ["Executable-mode heal failed: exec boom"]
     assert actions == {}
-
-
-def test_stuck_deep_assessment_does_not_mute_later_deep_checks(monkeypatch, context):
-    monkeypatch.setattr(doctor, "CHECK_TIMEOUT_SECONDS", 0.2)
-    spoken: list[str] = []
-    real_progress = doctor._progress
-    monkeypatch.setattr(
-        doctor,
-        "_progress",
-        lambda message: spoken.append(message) or real_progress(message),
-    )
-    _stub_probes(monkeypatch)
-
-    def hang(_context):
-        time.sleep(30)
-        return doctor.ProbeResult("OK", "should not count")
-
-    def later(_context):
-        return doctor.ProbeResult(
-            "OK",
-            "migration status ran",
-            structured_detail={"capsules": [], "truncated": False, "pending": False},
-        )
-
-    monkeypatch.setattr(doctor, "_probe_customization_assessment", hang)
-    monkeypatch.setattr(doctor, "_probe_customization_migration_status", later)
-
-    report = doctor.collect(deep=True, context=context)
-
-    assert _check(report, "customizations.assessment")["verdict"] == "UNKNOWN"
-    assert "timed out" in _check(report, "customizations.assessment")["detail"]
-    assert _check(report, "customizations.migration-status")["verdict"] == "OK"
-    assert "customization_assessment" not in report
-    assert report["customization_migration_status"]["pending"] is False
-    assert _check(report, "doctor.self")["verdict"] == "BROKEN"
-    assert spoken == [doctor.CHECK_PROGRESS]
 
 
 def test_doctor_skill_keeps_collector_stderr_visible():

--- a/core/utils/doctor.py
+++ b/core/utils/doctor.py
@@ -17,7 +17,6 @@ import stat
 import subprocess
 import sys
 import tempfile
-import threading
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
@@ -50,10 +49,6 @@ from core.utils import (
 VERDICTS = frozenset({"OK", "OFF", "BROKEN", "UNKNOWN"})
 DOCTOR_GIT_CANDIDATES = (Path("/usr/bin/git"), Path("/bin/git"))
 QMD_STATUS_TIMEOUT_SECONDS = 10
-# In-process hang bound for probes only. Individual subprocess probes already
-# use 10–35s timeouts; those do not bound a probe that never returns. Heals
-# stay in-process and must finish or fail in-thread.
-CHECK_TIMEOUT_SECONDS = 30
 
 # The nightly ledger is written once a night, so two days tolerates a single
 # missed run before the ledger is treated as stopped rather than merely quiet.
@@ -686,30 +681,6 @@ def _progress(message: str) -> None:
     print(message, file=sys.stderr, flush=True)
 
 
-def _run_bounded(operation, timeout_seconds: float):
-    """Run a probe in a daemon thread; raise TimeoutError if it exceeds the bound.
-
-    Heals are not wrapped here. The worker is not killed: a stuck probe may
-    keep running in the background so one hang cannot mute later probes.
-    """
-    outcome: dict[str, Any] = {}
-
-    def runner() -> None:
-        try:
-            outcome["value"] = operation()
-        except Exception as error:
-            outcome["error"] = error
-
-    worker = threading.Thread(target=runner, daemon=True)
-    worker.start()
-    worker.join(timeout_seconds)
-    if worker.is_alive():
-        raise TimeoutError("timed out")
-    if "error" in outcome:
-        raise outcome["error"]
-    return outcome.get("value")
-
-
 def _one_line(value: object) -> str:
     return " ".join(str(value).split()) or value.__class__.__name__
 
@@ -1113,6 +1084,7 @@ def collect(
     *,
     deep: bool = False,
     heal: bool = False,
+    progress: bool = False,
     context: DoctorContext | None = None,
 ) -> dict[str, Any]:
     """Run the selected registry and return its JSON-serializable report."""
@@ -1123,7 +1095,8 @@ def collect(
 
     t1_actions: dict[str, list[str]] = {}
     if heal:
-        _progress(HEAL_PROGRESS)
+        if progress:
+            _progress(HEAL_PROGRESS)
         try:
             t1_actions, t1_errors = _apply_t1_heals(context)
             if t1_errors:
@@ -1131,7 +1104,8 @@ def collect(
         except Exception as error:
             failed.append({"id": "doctor.self", "error": _one_line(error)})
 
-    _progress(CHECK_PROGRESS)
+    if progress:
+        _progress(CHECK_PROGRESS)
     # One classification pass over ~/Library/LaunchAgents is shared by
     # jobs.loaded and jobs.fresh instead of re-parsing every plist twice.
     _begin_launch_agent_scan_scope(context)
@@ -1139,12 +1113,8 @@ def collect(
         for definition in definitions:
             if definition.id == "doctor.self":
                 continue
-            probe = globals()[definition.probe]
             try:
-                result = _run_bounded(
-                    lambda current=probe: current(context),
-                    CHECK_TIMEOUT_SECONDS,
-                )
+                result = globals()[definition.probe](context)
             except Exception as error:
                 error_text = _actionable_probe_error(error)
                 failed.append({"id": definition.id, "error": error_text})
@@ -5883,7 +5853,12 @@ def main(argv: list[str] | None = None, *, context: DoctorContext | None = None)
             credential_report = run_credential_workflow(root, action, journal_id=journal_id)
             print(json.dumps(credential_report, indent=2))
             return 2 if credential_report.get("migration_state") == "refused" and action != "status" else 0
-        report = collect(deep=args.deep, heal=args.heal, context=context)
+        report = collect(
+            deep=args.deep,
+            heal=args.heal,
+            progress=True,
+            context=context,
+        )
         output = json.dumps(report, indent=2)
     except Exception as error:
         print(f"dex-doctor could not produce JSON: {_one_line(error)}", file=sys.stderr)

--- a/docs/dex-doctor-spec.md
+++ b/docs/dex-doctor-spec.md
@@ -143,8 +143,7 @@ stub all external probes.
 - JSON contract shape (keys, verdict enum) — this is the skill's API
 - freshness thresholds honored only when job installed
 - `--heal` prints `Apply safe Tier-1 repairs before checking.` on stderr immediately, then `Checking this Dex install (read-only)...` before the read-only pass; JSON stays on stdout at the end
-- a probe that exceeds the per-check bound is `UNKNOWN` with `instruments.failed` populated, `doctor.self` `BROKEN`, and later probes still run
-- Tier-1 heals run in-process (not in a daemon thread). A heal failure is reported in-thread and later heals still run. Tests fail if a heal is abandoned in a daemon thread.
+- probes and Tier-1 heals run in-process; Doctor does not abandon work in daemon threads after a shared deadline
 
 ## Non-goals (v1)
 


### PR DESCRIPTION
## What changed

- remove the global 30-second probe deadline and daemon-thread wrapper merged in #603
- keep the two immediate Doctor progress messages on stderr
- keep JSON on stdout and keep programmatic collect() calls silent by default
- add a focused safeguard proving probes run in-process

## Why

The shared deadline can cut off legitimate healthy checks. A timed-out daemon worker is not cancelled, so it can keep running and race later Doctor work against process-global state.

The reporter-specific underlying stall is still machine-dependent. This PR preserves the separately reviewed safe outcome: Doctor visibly says which stage it reached without changing probe timing or execution order.

## Verification

- red before the correction: the new safeguard observed the first probe running on a different thread
- Doctor suite: 223 passed
- Ruff, Python compilation, and diff hygiene pass
- forced-stall CLI replay prints both progress lines before external timeout while stdout remains empty
- two independent exact-head reviews passed with no findings

## Delivery boundary

This corrects the unsafe execution behavior from #603. It does not merge, release, deploy, or contact the reporter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes per-probe time-boxing that could cut off slow but healthy checks; hangs now block the whole run until subprocess-level timeouts or external kill, which is intentional but changes operational behavior for stuck probes.
> 
> **Overview**
> Reverts the **global 30s probe deadline** and **`_run_bounded` daemon-thread wrapper** so checks run **synchronously on the collector thread**. A timed-out worker was never cancelled and could keep racing later heals and probes against shared state.
> 
> **CLI behavior is preserved:** `main()` passes **`progress=True`** into `collect()`, so `--heal` still prints the two stderr stage lines before repairs and before the read-only pass; JSON remains on stdout. **`collect()` defaults `progress=False`**, so programmatic callers stay quiet.
> 
> Tests drop timeout/stuck-probe scenarios tied to the old wrapper and add a safeguard that the first probe runs on the **same thread** as the collector. The dex-doctor spec is updated to require in-process probes and Tier-1 heals with no shared-deadline daemon abandonment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c712619089270e9486c30f5edc421259a966b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->