### PR TITLE
Pending-learnings nudge sees the real backlog, not only last week's pending

### DIFF
--- a/.claude/reference/mcp-servers.md
+++ b/.claude/reference/mcp-servers.md
@@ -372,12 +372,12 @@ node .scripts/check-anthropic-changelog.cjs --dry-run  # Preview mode
 **Purpose:** Remind user to review accumulated session learnings
 
 **How it works:**
-1. Scans `System/Session_Learnings/` for files from past 7 days
-2. Counts learnings with `**Status:** pending`
-3. If 5+ pending learnings:
+1. Scans every `System/Session_Learnings/` file (not only the past 7 days)
+2. Counts learnings whose `**Status:**` is still open: `pending`, `captured`, `noted`, `partially fixed`, or `in-progress` (hyphen/space and capitalization variants included). Closed labels such as `implemented` and `won't-fix` are ignored.
+3. If 5+ open learnings:
    - Writes reminder to `System/learning-review-pending.md`
    - Session start hook displays count and suggests `/dex-whats-new --learnings`
-4. If <5 pending, removes any existing reminder file
+4. If <5 open, removes any existing reminder file
 
 **Manual testing:**
 ```bash

--- a/.scripts/learning-review-prompt.sh
+++ b/.scripts/learning-review-prompt.sh
@@ -13,6 +13,13 @@ PROMPT_FILE="$VAULT_ROOT/System/learning-review-pending.md"
 LOG_DIR="$VAULT_ROOT/.scripts/logs"
 LOG_FILE="$LOG_DIR/learning-review.log"
 
+# Open backlog statuses: the original "pending" plus the labels used in
+# real vaults (captured, noted, partially fixed, in-progress). Closed
+# statuses (implemented, won't-fix, and similar) stay out of the count.
+# Match is case-insensitive; hyphen/space variants of the multi-word
+# labels are accepted. The rest of the Status line must be that label.
+BACKLOG_STATUS_REGEX='^\*\*Status:\*\*[[:space:]]*(pending|captured|noted|partially[[:space:]]+fixed|partially-fixed|in-progress|in[[:space:]]+progress)[[:space:]]*$'
+
 # Create log directory if needed
 mkdir -p "$LOG_DIR"
 
@@ -29,35 +36,29 @@ if [[ ! -d "$SESSION_LEARNINGS_DIR" ]]; then
   exit 0
 fi
 
-# Count pending learnings (files from last 7 days with "pending" status)
 PENDING_COUNT=0
-WEEK_AGO=$(date -v-7d +%Y-%m-%d)
 
-log "Scanning for learnings since $WEEK_AGO"
+log "Scanning session learnings for open backlog statuses"
 
-# Find learning files from the past week
+# Count open-backlog learnings in every dated file, including older ones.
 for file in "$SESSION_LEARNINGS_DIR"/*.md; do
   if [[ ! -f "$file" ]]; then
     continue
   fi
-  
+
   # Extract date from filename (YYYY-MM-DD.md)
   filename=$(basename "$file" .md)
-  
+
   # Skip README
   if [[ "$filename" == "README" ]]; then
     continue
   fi
-  
-  # Check if file is from the past week
-  if [[ "$filename" > "$WEEK_AGO" ]] || [[ "$filename" == "$WEEK_AGO" ]]; then
-    # Count "pending" learnings in this file
-    pending=$(grep -c "^\*\*Status:\*\* pending" "$file" 2>/dev/null || echo "0")
-    # Strip any whitespace and ensure it's a number
-    pending=$(echo "$pending" | tr -d '[:space:]')
-    pending=${pending:-0}
-    PENDING_COUNT=$((PENDING_COUNT + pending))
-  fi
+
+  pending=$(grep -ciE "$BACKLOG_STATUS_REGEX" "$file" 2>/dev/null || true)
+  # Strip any whitespace and ensure it's a number
+  pending=$(echo "$pending" | tr -d '[:space:]')
+  pending=${pending:-0}
+  PENDING_COUNT=$((PENDING_COUNT + pending))
 done
 
 log "Found $PENDING_COUNT pending learnings"
@@ -65,11 +66,11 @@ log "Found $PENDING_COUNT pending learnings"
 # If 5+ pending learnings, create prompt file
 if [[ $PENDING_COUNT -ge 5 ]]; then
   log "Creating learning review prompt (threshold met: $PENDING_COUNT >= 5)"
-  
+
   cat > "$PROMPT_FILE" <<EOF
 # 📚 Pending Learnings Review
 
-**Count:** $PENDING_COUNT pending learnings from the past week
+**Count:** $PENDING_COUNT pending learnings
 **Detected:** $(date -u +"%Y-%m-%d %H:%M UTC")
 
 ---
@@ -93,7 +94,7 @@ EOF
   log "Prompt file created at $PROMPT_FILE"
 else
   log "Threshold not met ($PENDING_COUNT < 5), no prompt needed"
-  
+
   # Remove any existing prompt file
   if [[ -f "$PROMPT_FILE" ]]; then
     rm "$PROMPT_FILE"

--- a/System/Session_Learnings/README.md
+++ b/System/Session_Learnings/README.md
@@ -17,7 +17,7 @@ Each learning includes:
 - **What happened** — Specific situation
 - **Why it matters** — Impact on system/workflow
 - **Suggested fix** — Specific action with file paths
-- **Status** — pending, implemented, or won't-fix
+- **Status** — pending, captured, noted, partially fixed, or in-progress until implemented or won't-fix
 
 ## Naming Convention
 

--- a/core/tests/test_learning_review_prompt.py
+++ b/core/tests/test_learning_review_prompt.py
@@ -1,0 +1,253 @@
+"""Pending-learnings nudge counts the real open backlog, not only last week's pending.
+
+The daily prompt must see captured / noted / partially fixed / in-progress
+(and pending) in Session_Learnings files of any age. Closed statuses stay out.
+The reminder file keeps the existing Count line and /dex-whats-new next step.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_SOURCE = REPO_ROOT / ".scripts" / "learning-review-prompt.sh"
+SESSION_START = REPO_ROOT / ".claude" / "hooks" / "session-start.sh"
+
+# Same extraction session-start.sh uses on learning-review-pending.md.
+SESSION_START_COUNT = re.compile(r"^\*\*Count:\*\* ([0-9]*)", re.MULTILINE)
+
+
+def _vault_with_script(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    scripts = vault / ".scripts"
+    scripts.mkdir(parents=True)
+    dest = scripts / "learning-review-prompt.sh"
+    shutil.copyfile(SCRIPT_SOURCE, dest)
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR)
+    return vault
+
+
+def _write_learnings(vault: Path, filename: str, statuses: list[str]) -> None:
+    learnings = vault / "System" / "Session_Learnings"
+    learnings.mkdir(parents=True, exist_ok=True)
+    blocks = []
+    for index, status in enumerate(statuses, start=1):
+        blocks.append(
+            "\n".join(
+                [
+                    f"## [12:{index:02d}] - Fixture learning {index}",
+                    "",
+                    f"**What happened:** Fixture situation {index}",
+                    f"**Why it matters:** Fixture impact {index}",
+                    f"**Suggested fix:** Fixture fix {index}",
+                    f"**Status:** {status}",
+                    "",
+                ]
+            )
+        )
+    (learnings / filename).write_text("\n---\n".join(blocks), encoding="utf-8")
+
+
+def _run_prompt(vault: Path) -> subprocess.CompletedProcess[str]:
+    script = vault / ".scripts" / "learning-review-prompt.sh"
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=vault,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _prompt_path(vault: Path) -> Path:
+    return vault / "System" / "learning-review-pending.md"
+
+
+def _count_from_prompt(prompt: str) -> str:
+    match = SESSION_START_COUNT.search(prompt)
+    assert match is not None, prompt
+    return match.group(1)
+
+
+def test_shell_script_parses() -> None:
+    subprocess.run(["bash", "-n", str(SCRIPT_SOURCE)], check=True)
+
+
+def test_session_start_still_reads_count_from_the_existing_line() -> None:
+    text = SESSION_START.read_text(encoding="utf-8")
+    assert 'grep "^\\*\\*Count:\\*\\*" "$LEARNING_PENDING"' in text
+    assert "Pending Learnings Review" in text
+    assert "/dex-whats-new --learnings" in text
+
+
+def test_named_backlog_statuses_and_older_files_meet_threshold(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(vault, "2025-01-15.md", ["captured"])
+    _write_learnings(vault, "2025-06-02.md", ["noted"])
+    _write_learnings(vault, "2024-11-30.md", ["partially fixed"])
+    _write_learnings(vault, "2025-12-01.md", ["in-progress"])
+    _write_learnings(vault, "2026-08-20.md", ["pending"])
+
+    _run_prompt(vault)
+
+    prompt = _prompt_path(vault).read_text(encoding="utf-8")
+    assert _count_from_prompt(prompt) == "5"
+    assert "**Count:** 5 pending learnings" in prompt
+    assert "/dex-whats-new --learnings" in prompt
+    assert "from the past week" not in prompt
+
+
+def test_old_captured_with_four_recent_pending_is_no_longer_invisible(
+    tmp_path: Path,
+) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(vault, "2026-08-21.md", ["pending", "pending"])
+    _write_learnings(vault, "2026-08-22.md", ["pending", "pending"])
+    _write_learnings(vault, "2025-03-01.md", ["captured"])
+
+    _run_prompt(vault)
+
+    prompt = _prompt_path(vault).read_text(encoding="utf-8")
+    assert _count_from_prompt(prompt) == "5"
+
+
+def test_closed_statuses_never_count_even_when_many_and_old(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(
+        vault,
+        "2024-01-01.md",
+        ["implemented", "won't-fix", "done", "resolved", "archived", "complete"],
+    )
+    _write_learnings(vault, "2026-08-26.md", ["pending"] * 4)
+
+    _run_prompt(vault)
+
+    assert not _prompt_path(vault).exists()
+
+
+def test_four_open_stays_quiet(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(vault, "2025-01-01.md", ["captured", "noted"])
+    _write_learnings(vault, "2026-08-01.md", ["partially fixed", "in-progress"])
+
+    _run_prompt(vault)
+
+    assert not _prompt_path(vault).exists()
+
+
+def test_readme_status_lines_are_skipped(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(vault, "README.md", ["pending"] * 5)
+    _write_learnings(vault, "2026-08-20.md", ["pending"] * 4)
+
+    _run_prompt(vault)
+
+    assert not _prompt_path(vault).exists()
+
+
+def test_body_text_pending_without_status_line_does_not_count(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    learnings = vault / "System" / "Session_Learnings"
+    learnings.mkdir(parents=True)
+    (learnings / "2026-08-20.md").write_text(
+        "\n".join(
+            [
+                "## [12:01] - Fixture learning",
+                "",
+                "**What happened:** The word pending appears in the body.",
+                "**Why it matters:** False positives would inflate the nudge.",
+                "**Suggested fix:** Keep counting Status lines only.",
+                "**Status:** implemented",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_learnings(vault, "2026-08-21.md", ["pending"] * 4)
+
+    _run_prompt(vault)
+
+    assert not _prompt_path(vault).exists()
+
+
+def test_hyphen_and_space_variants_and_case_fold(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    _write_learnings(vault, "2025-02-01.md", ["Pending"])
+    _write_learnings(vault, "2025-02-02.md", ["CAPTURED"])
+    _write_learnings(vault, "2025-02-03.md", ["partially-fixed"])
+    _write_learnings(vault, "2025-02-04.md", ["in progress"])
+    _write_learnings(vault, "2025-02-05.md", ["  noted  "])
+
+    _run_prompt(vault)
+
+    prompt = _prompt_path(vault).read_text(encoding="utf-8")
+    assert _count_from_prompt(prompt) == "5"
+
+
+def test_missing_learnings_dir_exits_quietly(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    result = _run_prompt(vault)
+    assert result.returncode == 0
+    assert not _prompt_path(vault).exists()
+
+
+def test_existing_prompt_is_removed_when_backlog_drops(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    prompt = _prompt_path(vault)
+    prompt.parent.mkdir(parents=True)
+    prompt.write_text("stale prompt\n", encoding="utf-8")
+    _write_learnings(vault, "2026-08-20.md", ["pending"] * 2)
+
+    _run_prompt(vault)
+
+    assert not prompt.exists()
+
+
+def test_crlf_and_eof_without_newline_still_count(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    learnings = vault / "System" / "Session_Learnings"
+    learnings.mkdir(parents=True)
+    crlf = "\r\n".join(
+        [
+            "## [12:01] - Fixture learning",
+            "",
+            "**Status:** captured",
+            "",
+            "## [12:02] - Fixture learning two",
+            "",
+            "**Status:** noted",
+            "",
+        ]
+    )
+    (learnings / "2025-04-01.md").write_bytes(crlf.encode("utf-8"))
+    (learnings / "2025-04-02.md").write_text(
+        "## [12:03] - Fixture learning three\n**Status:** pending",
+        encoding="utf-8",
+    )
+    (learnings / "2025-04-03.md").write_text(
+        "**Status:** in-progress\n**Status:** partially fixed\n",
+        encoding="utf-8",
+    )
+
+    _run_prompt(vault)
+
+    prompt = _prompt_path(vault).read_text(encoding="utf-8")
+    assert _count_from_prompt(prompt) == "5"
+
+
+def test_indented_status_line_is_not_a_learning(tmp_path: Path) -> None:
+    vault = _vault_with_script(tmp_path)
+    learnings = vault / "System" / "Session_Learnings"
+    learnings.mkdir(parents=True)
+    (learnings / "2026-08-20.md").write_text(
+        "  **Status:** pending\n" * 5,
+        encoding="utf-8",
+    )
+
+    _run_prompt(vault)
+
+    assert not _prompt_path(vault).exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does the chassis already do here?

Verified on current `main` (`05eaf507`). A plan without this section is not a plan.

- `.scripts/learning-review-prompt.sh` — daily 5pm Launch Agent (also session-start, once per day). It counted only lines matching `**Status:** pending` in `System/Session_Learnings/*.md` whose filename date was in the last 7 days (`date -v-7d`, Mac-only). Threshold 5. Then it wrote `System/learning-review-pending.md`, or removed that file when the count was under 5.
- Session start — if that file exists, it greps `**Count:** N` and prints the existing banner: `Pending Learnings Review (N)` / `Session learnings ready for review` / `Run: /dex-whats-new --learnings`. Untouched here.
- Canonical write path (`CLAUDE.md` / `/daily-review`) still records `**Status:** pending`. The seed README listed pending / implemented / won't-fix. Real vaults also use captured, noted, partially fixed, and in-progress. Those labels, and anything older than 7 days, were invisible to the nudge.
- `core/mcp/dex_improvements_server.py` `parse_session_learnings()` still filters `status == pending` only. That is backlog synthesis, not this nudge. Untouched here.
- No existing tests covered the prompt script.

This PR does not stamp a new release; 1.97.3 already shipped on `main`.

Private ticket ref (do not ping, do not close): davekilleen/dex-feedback#21 (DEX-121 / GS-INBOX-B2). No public Dex issue invented.

## Linked Issue
- Linear issue: `DEX-121` (private feedback #21)

## What Changed
- The pending-learnings nudge now counts every dated Session_Learnings file, not only the last 7 days.
- Open backlog labels counted: pending, captured, noted, partially fixed, in-progress (hyphen/space and capitalization variants). Closed labels such as implemented and won't-fix stay out.
- Reminder voice is unchanged: same heading, same `/dex-whats-new --learnings` next step, still called pending learnings. The Count line dropped only the now-false "from the past week" clause so session-start still parses `**Count:** N`.
- Threshold remains 5. README and the technical how-it-works note now list the open labels the nudge actually sees.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_learning_review_prompt.py`
- Negative/error-path tests added or updated: four open stays quiet; closed statuses never count; README ignored; body-text "pending" ignored; indented Status lines ignored; missing folder exits quietly; stale prompt removed under threshold; CRLF and EOF-without-newline still count; session-start still reads the Count line
- Commands run locally: `python3 -m pytest core/tests/test_learning_review_prompt.py -q` (13 passed); `ruff check` on the new test file

## Adversarial review
- Literal `pending` in 7 days was the chassis. Older captured/noted/partially fixed/in-progress now count; that was the miss.
- Closed labels cannot inflate the nudge.
- README and non-Status "pending" text cannot trip the threshold.
- Session-start banner copy was not rewritten. No new tester sentences. No status breakdown in the reminder.
- Remaining strictness kept from chassis: Status must be a start-of-line `**Status:**` label; annotated values like `pending (waiting)` still do not count; subfolders are not scanned.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this branch. The nudge returns to last-7-days `pending` only.

## Docs Impact
- Files updated: `.claude/reference/mcp-servers.md`, `System/Session_Learnings/README.md`
- No changelog / no package version bump (this is not a release).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce4def48-21c1-4a43-bc7c-9a58a1c7c3bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce4def48-21c1-4a43-bc7c-9a58a1c7c3bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

