### PR TITLE
Stop meeting prep from pinning a company mentioned only in notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,6 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.97.4] — 🏢 Meeting prep stops attaching the wrong company (2026-08-27)
-
-If another company's notes mentioned someone on your call, Dex could treat that
-company as the one you were meeting. That made meeting prep open the wrong page.
-
-**What this fixes for you:**
-
-* **The company on a meeting is the one that matches.** Dex uses the email
-  domain or the company name on the company page. A mention in someone else's
-  notes is no longer enough.
-* **Domains stored at the top of a company page are used.** Older pages that
-  list domains in a table still work.
-
----
-
 ## [1.97.3] — ↩️ After an update you can undo it, and Doctor talks while it heals (2026-08-27)
 
 An update could look finished while undo had nothing to go back to. New skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.97.4] — 🏢 Meeting prep stops attaching the wrong company (2026-08-27)
+
+If another company's notes mentioned someone on your call, Dex could treat that
+company as the one you were meeting. That made meeting prep open the wrong page.
+
+**What this fixes for you:**
+
+* **The company on a meeting is the one that matches.** Dex uses the email
+  domain or the company name on the company page. A mention in someone else's
+  notes is no longer enough.
+* **Domains stored at the top of a company page are used.** Older pages that
+  list domains in a table still work.
+
+---
+
 ## [1.97.3] — ↩️ After an update you can undo it, and Doctor talks while it heals (2026-08-27)
 
 An update could look finished while undo had nothing to go back to. New skills

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -167,7 +167,11 @@ from core.paths import (
     VAULT_ROOT as BASE_DIR,
 )
 from core.soft_promise import detect_soft_promises
-from core.utils.company_domains import registrable_domain
+from core.utils.company_domains import (
+    company_name_from_domain,
+    is_freemail,
+    registrable_domain,
+)
 from core.utils.entity_pages import parse_entity_page, render_person_page
 from core.utils.feature_status import feature_status
 
@@ -1133,23 +1137,17 @@ def find_people_at_company(company_name: str) -> List[Dict[str, Any]]:
     return people
 
 def get_company_domains(company_filepath: Path) -> List[str]:
-    """Extract domains from a company page"""
+    """Extract domains from a company page's structured fields.
+
+    Canonical pages store domains in frontmatter. Legacy pages keep them in a
+    Domains table row or an inline bold field. parse_entity_page already applies
+    that precedence; notes and other free text are not a domain source.
+    """
     if not company_filepath.exists():
         return []
-    
-    content = company_filepath.read_text()
-    domains = []
-    
-    for line in content.split('\n'):
-        if '**Domains**' in line and '|' in line:
-            parts = line.split('|')
-            if len(parts) >= 3:
-                domain_str = parts[2].strip()
-                # Parse comma-separated domains
-                domains = [d.strip() for d in domain_str.split(',') if d.strip()]
-                break
-    
-    return domains
+
+    entity = parse_entity_page(company_filepath)
+    return list(entity.get('domains') or [])
 
 # ============================================================================
 # PEOPLE DIRECTORY INDEX
@@ -3151,42 +3149,109 @@ def find_project_for_meeting(attendees: List[str], meeting_title: str) -> Option
     
     return best_match if best_score > 0 else None
 
+def _folded_company_text(value: str) -> str:
+    """Return a stable comparison key for a company or attendee name."""
+    return unicodedata.normalize(
+        'NFC',
+        re.sub(r'[\s_]+', ' ', value).strip(),
+    ).casefold()
+
+
+def _attendee_email_domain(attendee: str) -> Optional[str]:
+    """Return the host from an attendee email, if one is present."""
+    if '@' not in attendee:
+        return None
+    domain = attendee.rsplit('@', 1)[1]
+    domain = domain.strip().strip('>').split()[0].rstrip('.,;')
+    return domain or None
+
+
+def _company_match_record(
+    company_file: Path,
+    name: str,
+    domains: List[str],
+) -> Dict[str, Any]:
+    return {
+        'path': str(company_file.relative_to(BASE_DIR)),
+        'name': name,
+        'domains': domains,
+    }
+
+
 def find_company_for_attendees(attendees: List[str], domains: List[str] = None) -> Optional[Dict[str, Any]]:
-    """Find a company page based on attendees or email domains"""
+    """Find a company page from attendee email domains or structured names.
+
+    Pins only from structured company fields: frontmatter or legacy table/inline
+    domains, plus the page name. A mention in notes is not a match.
+    """
     if not COMPANIES_DIR.exists():
         return None
-    
-    search_terms = []
-    for attendee in attendees:
-        search_terms.append(attendee.lower())
-        # Extract potential company name from email
-        if '@' in attendee:
-            domain = attendee.split('@')[1].split('.')[0]
-            search_terms.append(domain)
-    
+
+    lookup_domains: List[str] = []
+    lookup_names: List[str] = []
+    for attendee in attendees or []:
+        email_domain = _attendee_email_domain(attendee)
+        if email_domain:
+            if is_freemail(email_domain):
+                continue
+            lookup_domains.append(email_domain)
+            derived = company_name_from_domain(email_domain)
+            if derived:
+                lookup_names.append(derived)
+        else:
+            stripped = attendee.strip()
+            if stripped:
+                lookup_names.append(stripped)
+
     if domains:
-        search_terms.extend([d.lower() for d in domains])
-    
+        lookup_domains.extend(
+            domain for domain in domains
+            if domain and not is_freemail(domain)
+        )
+
+    target_domains = {
+        registrable_domain(domain)
+        for domain in lookup_domains
+        if registrable_domain(domain)
+    }
+    target_names = {
+        _folded_company_text(name)
+        for name in lookup_names
+        if _folded_company_text(name)
+    }
+    if not target_domains and not target_names:
+        return None
+
+    name_match = None
     for company_file in COMPANIES_DIR.glob('*.md'):
         try:
-            content = company_file.read_text()
-            content_lower = content.lower()
-            company_name = company_file.stem.lower().replace('_', ' ')
-            
-            for term in search_terms:
-                if term in company_name or term in content_lower:
-                    # Extract company domains
-                    company_domains = get_company_domains(company_file)
-                    
-                    return {
-                        'path': str(company_file.relative_to(BASE_DIR)),
-                        'name': company_file.stem.replace('_', ' '),
-                        'domains': company_domains
-                    }
+            entity = parse_entity_page(company_file)
+            company_name = entity.get('name') or company_file.stem.replace('_', ' ')
+            company_domains = list(entity.get('domains') or [])
+            structured_domains = {
+                registrable_domain(domain)
+                for domain in company_domains
+                if registrable_domain(domain)
+            }
+            if target_domains & structured_domains:
+                return _company_match_record(
+                    company_file,
+                    company_name,
+                    company_domains,
+                )
+            if (
+                name_match is None
+                and _folded_company_text(company_name) in target_names
+            ):
+                name_match = _company_match_record(
+                    company_file,
+                    company_name,
+                    company_domains,
+                )
         except Exception:
             continue
-    
-    return None
+
+    return name_match
 
 def get_meeting_context_data(meeting_title: str = None, attendees: List[str] = None) -> Dict[str, Any]:
     """Get comprehensive context for a meeting based on attendees and title"""

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -1136,6 +1136,13 @@ def find_people_at_company(company_name: str) -> List[Dict[str, Any]]:
     
     return people
 
+def _structured_company_fields(company_filepath: Path) -> tuple[str, List[str]]:
+    """Return page name and domains from structured fields only."""
+    entity = parse_entity_page(company_filepath)
+    name = entity.get('name') or company_filepath.stem.replace('_', ' ')
+    return name, list(entity.get('domains') or [])
+
+
 def get_company_domains(company_filepath: Path) -> List[str]:
     """Extract domains from a company page's structured fields.
 
@@ -1146,8 +1153,7 @@ def get_company_domains(company_filepath: Path) -> List[str]:
     if not company_filepath.exists():
         return []
 
-    entity = parse_entity_page(company_filepath)
-    return list(entity.get('domains') or [])
+    return _structured_company_fields(company_filepath)[1]
 
 # ============================================================================
 # PEOPLE DIRECTORY INDEX
@@ -3225,9 +3231,7 @@ def find_company_for_attendees(attendees: List[str], domains: List[str] = None) 
     name_match = None
     for company_file in COMPANIES_DIR.glob('*.md'):
         try:
-            entity = parse_entity_page(company_file)
-            company_name = entity.get('name') or company_file.stem.replace('_', ' ')
-            company_domains = list(entity.get('domains') or [])
+            company_name, company_domains = _structured_company_fields(company_file)
             structured_domains = {
                 registrable_domain(domain)
                 for domain in company_domains

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3167,9 +3167,11 @@ def _attendee_email_domain(attendee: str) -> Optional[str]:
     """Return the host from an attendee email, if one is present."""
     if '@' not in attendee:
         return None
-    domain = attendee.rsplit('@', 1)[1]
-    domain = domain.strip().strip('>').split()[0].rstrip('.,;')
-    return domain or None
+    host = attendee.rsplit('@', 1)[1].strip().strip('>')
+    if not host:
+        return None
+    token = host.split(None, 1)[0].rstrip('.,;')
+    return token or None
 
 
 def _company_match_record(

--- a/core/tests/test_work_server_meeting_context.py
+++ b/core/tests/test_work_server_meeting_context.py
@@ -299,6 +299,21 @@ def test_find_company_for_attendees_can_pin_an_exact_structured_name(
     assert match["domains"] == ["northwind.example.org"]
 
 
+def test_find_company_for_attendees_skips_an_empty_email_host(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        render_company_page("Northwind", ["acme.com"]),
+        encoding="utf-8",
+    )
+
+    assert work_server.find_company_for_attendees(["broken@"]) is None
+    assert work_server.find_company_for_attendees(["Jane <jane@>"]) is None
+    result = _call_meeting_context("broken@")
+    assert result["related_company"] is None
+
+
 def test_find_company_for_attendees_skips_consumer_mail_domains(
     meeting_context_vault: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,

--- a/core/tests/test_work_server_meeting_context.py
+++ b/core/tests/test_work_server_meeting_context.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from core.mcp import work_server
+from core.utils.entity_pages import render_company_page
 
 
 def _call_meeting_context(attendee: str) -> dict:
@@ -49,6 +50,7 @@ def meeting_context_vault(
     return {
         "people": people_dir,
         "tasks": tasks_file,
+        "companies": companies_dir,
     }
 
 
@@ -146,3 +148,173 @@ def test_meeting_context_does_not_resolve_a_longer_person_page_name(
 
     assert result["attendee_details"] == []
     assert result["outstanding_tasks"] == []
+
+
+def test_get_company_domains_reads_frontmatter_not_notes(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        render_company_page("Northwind", ["acme.com"]),
+        encoding="utf-8",
+    )
+    company.write_text(
+        company.read_text(encoding="utf-8")
+        + "\nNotes mention partner.example.org and jane@acme.com.\n",
+        encoding="utf-8",
+    )
+
+    assert work_server.get_company_domains(company) == ["acme.com"]
+
+
+def test_get_company_domains_prefers_frontmatter_over_a_conflicting_table(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        "---\n"
+        "type: company\n"
+        "name: Northwind\n"
+        "domains: [\"acme.com\"]\n"
+        "---\n"
+        "# Northwind\n\n"
+        "| Field | Value |\n"
+        "|-------|-------|\n"
+        "| **Domains** | partner.example.org |\n",
+        encoding="utf-8",
+    )
+
+    assert work_server.get_company_domains(company) == ["acme.com"]
+
+
+def test_get_company_domains_still_reads_a_legacy_domains_table(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Legacy_Co.md"
+    company.write_text(
+        "# Legacy Co\n\n"
+        "| Field | Value |\n"
+        "|-------|-------|\n"
+        "| **Domains** | acme.com, acme.org |\n",
+        encoding="utf-8",
+    )
+
+    assert work_server.get_company_domains(company) == ["acme.com", "acme.org"]
+
+
+def test_meeting_context_does_not_pin_a_company_from_a_body_mention(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    distractor = meeting_context_vault["companies"] / "Aaa_Distractor.md"
+    distractor.write_text(
+        "# Distractor\n\n"
+        "Notes from a call with jane@acme.com about a shared vendor.\n",
+        encoding="utf-8",
+    )
+
+    result = _call_meeting_context("jane@acme.com")
+
+    assert result["related_company"] is None
+
+
+def test_meeting_context_pins_the_company_whose_frontmatter_domain_matches(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    distractor = meeting_context_vault["companies"] / "Aaa_Distractor.md"
+    distractor.write_text(
+        render_company_page("Distractor", ["partner.example.org"]),
+        encoding="utf-8",
+    )
+    distractor.write_text(
+        distractor.read_text(encoding="utf-8")
+        + "\nNotes mention jane@acme.com.\n",
+        encoding="utf-8",
+    )
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        render_company_page("Northwind", ["acme.com"]),
+        encoding="utf-8",
+    )
+
+    result = _call_meeting_context("Jane Doe <jane@acme.com>")
+
+    assert result["related_company"]["name"] == "Northwind"
+    assert result["related_company"]["domains"] == ["acme.com"]
+
+
+def test_find_company_for_attendees_matches_a_registrable_subdomain(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        render_company_page("Northwind", ["acme.co.uk"]),
+        encoding="utf-8",
+    )
+
+    match = work_server.find_company_for_attendees(
+        [],
+        domains=["mail.acme.co.uk"],
+    )
+
+    assert match["name"] == "Northwind"
+    assert match["domains"] == ["acme.co.uk"]
+
+
+def test_find_company_for_attendees_does_not_pin_from_a_name_substring(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Samsung.md"
+    company.write_text(
+        render_company_page("Samsung", ["samsung.example.org"]),
+        encoding="utf-8",
+    )
+
+    assert work_server.find_company_for_attendees(["Sam"]) is None
+
+
+def test_find_company_for_attendees_can_pin_an_exact_structured_name(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Northwind.md"
+    company.write_text(
+        render_company_page("Northwind", ["northwind.example.org"]),
+        encoding="utf-8",
+    )
+
+    match = work_server.find_company_for_attendees(["Northwind"])
+
+    assert match["name"] == "Northwind"
+    assert match["domains"] == ["northwind.example.org"]
+
+
+def test_find_company_for_attendees_skips_consumer_mail_domains(
+    meeting_context_vault: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    company = meeting_context_vault["companies"] / "Acme.md"
+    company.write_text(
+        render_company_page("Acme", ["acme.com"]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "is_freemail", lambda _domain: True)
+
+    assert work_server.find_company_for_attendees(["jane@acme.com"]) is None
+
+
+def test_find_company_for_attendees_prefers_a_domain_hit_over_an_earlier_name(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    named = meeting_context_vault["companies"] / "Aaa_Acme.md"
+    named.write_text(
+        render_company_page("Acme", ["partner.example.org"]),
+        encoding="utf-8",
+    )
+    domain_hit = meeting_context_vault["companies"] / "Northwind.md"
+    domain_hit.write_text(
+        render_company_page("Northwind", ["acme.com"]),
+        encoding="utf-8",
+    )
+
+    match = work_server.find_company_for_attendees(["jane@acme.com"])
+
+    assert match["name"] == "Northwind"

--- a/core/tests/test_work_server_meeting_context.py
+++ b/core/tests/test_work_server_meeting_context.py
@@ -202,6 +202,18 @@ def test_get_company_domains_still_reads_a_legacy_domains_table(
     assert work_server.get_company_domains(company) == ["acme.com", "acme.org"]
 
 
+def test_get_company_domains_reads_inline_bold_domains(
+    meeting_context_vault: dict[str, Path],
+) -> None:
+    company = meeting_context_vault["companies"] / "Inline_Co.md"
+    company.write_text(
+        "# Inline Co\n\n**Domains:** acme.com\n",
+        encoding="utf-8",
+    )
+
+    assert work_server.get_company_domains(company) == ["acme.com"]
+
+
 def test_meeting_context_does_not_pin_a_company_from_a_body_mention(
     meeting_context_vault: dict[str, Path],
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GS-INBOX-B2 / DEX-127

## What does the chassis already do here?

Company pages already have a single structured reader: `parse_entity_page`. It prefers frontmatter `domains`, then a legacy **Domains** table row, then an inline bold field. The company index and `find_company_by_domain` already match those domains with `registrable_domain`. Canonical pages rendered by `render_company_page` never write a **Domains** table at all.

Meeting context did not use that path.

- `get_company_domains` scanned for a markdown `| **Domains** |` line and ignored frontmatter.
- `find_company_for_attendees` walked company files in filesystem order and returned the first substring hit in the filename **or the page body**.
- `get_meeting_context` then pinned that hit as `related_company`.

So a note that mentioned an attendee (or an email fragment) could beat the company whose frontmatter actually listed that domain.

## What this PR changes

- `get_company_domains` reads structured fields through `parse_entity_page` (frontmatter first; table/inline still work).
- `find_company_for_attendees` pins from structured domains (registrable match) or an exact page name. Notes are not a pin source. Consumer-mail hosts are skipped. A domain hit beats an earlier name hit.
- Both helpers share one structured-field reader so they cannot drift.
- An attendee whose address ends at `@` is skipped instead of crashing meeting-company matching.

No new matcher. The leftover scanners now call the parser the rest of the chassis already uses.

Rebased onto current `main` (`cf1571f8`). Diff is `work_server.py` + meeting-context tests only. This is not a release; `package.json` and changelog identity are untouched.

## Adversarial review

- A body mention of the attendee no longer pins, even when that file sorts first.
- Frontmatter domains beat a conflicting table and beat notes.
- `Sam` does not pin `Samsung`; exact page name still can pin.
- `mail.acme.co.uk` matches structured `acme.co.uk` via the existing registrable helper.
- Derived names from email use `company_name_from_domain` (exact fold), not a body substring. A domain hit still wins over an earlier company with that derived name.
- Empty email hosts (`broken@`, `Jane <jane@>`) do not raise.
- Did not route meeting context through the SQLite company index. That index already uses this parser; reading the page keeps meeting prep on the source of truth.
- Person-page `company` is still unused here. That is a separate structured signal, not this bug.

## Test plan

- Frontmatter domains are returned; notes mentioning another host are ignored.
- Frontmatter wins over a conflicting **Domains** table.
- Legacy table-only and inline-bold pages still parse.
- Meeting context does not pin a company whose notes mention the attendee.
- Meeting context pins the later company whose frontmatter domain matches.
- Registrable subdomain match, exact name match, rejected name substring, skipped consumer-mail hosts, domain hit over earlier name, empty email host skipped.

Commands run locally: `python3 -m pytest core/tests/test_work_server_meeting_context.py -q` — 17 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765287bd-8873-4420-8012-8e177cb48d8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765287bd-8873-4420-8012-8e177cb48d8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

