### PR TITLE
fix: write and read daily plans in the inbox folder

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -40,7 +40,7 @@ These hooks are declared in skill frontmatter and exist only while that skill ru
 | Skill | Event | Matcher | Hook | Purpose |
 |---|---|---|---|---|
 | `/process-meetings` | `PostToolUse` | `Write` | `post-meeting-person-update.cjs` | Update recent interactions on existing person pages after a meeting note is written. |
-| `/daily-plan` | `Stop` | all | `daily-plan-quick-ref.cjs` | Generate `00-Inbox/Daily_Prep/YYYY-MM-DD-quickref.md` from the daily plan. |
+| `/daily-plan` | `Stop` | all | `daily-plan-quick-ref.cjs` | Generate `00-Inbox/Daily_Plans/YYYY-MM-DD-quickref.md` from the daily plan. |
 | `/career-coach` | `PostToolUse` | `Write` | `career-evidence-capture.cjs` | Detect possible career evidence and return a provenance-bearing, unconfirmed candidate; the hook never writes evidence. |
 
 `post-meeting-person-update.cjs` and `career-evidence-capture.cjs` are not global `PostToolUse` hooks.

--- a/.claude/hooks/daily-plan-quick-ref.cjs
+++ b/.claude/hooks/daily-plan-quick-ref.cjs
@@ -6,11 +6,17 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { loadPaths } = require('./paths.cjs');
 
-const vaultRoot = process.env.CLAUDE_PROJECT_DIR || path.resolve(__dirname, '../..');
+const paths = loadPaths();
+const planDir = paths.DAILY_PLANS_DIR;
+if (!planDir) {
+  process.exit(0);
+}
+
 const today = new Date().toISOString().split('T')[0];
-const planPath = path.join(vaultRoot, '00-Inbox/Daily_Prep', `${today}.md`);
-const quickRefPath = path.join(vaultRoot, '00-Inbox/Daily_Prep', `${today}-quickref.md`);
+const planPath = path.join(planDir, `${today}.md`);
+const quickRefPath = path.join(planDir, `${today}-quickref.md`);
 
 // Only run if today's plan exists
 if (!fs.existsSync(planPath)) {

--- a/.claude/hooks/tests/daily-plan-quick-ref.test.cjs
+++ b/.claude/hooks/tests/daily-plan-quick-ref.test.cjs
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadPaths } = require('../paths.cjs');
+
+const HOOK = path.resolve(__dirname, '../daily-plan-quick-ref.cjs');
+const SOURCE_PATHS = loadPaths();
+
+function remapVaultPath(vault, sourcePath) {
+  return path.join(vault, path.relative(SOURCE_PATHS.VAULT_ROOT, sourcePath));
+}
+
+function createVault(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-daily-plan-quickref-'));
+  const planDir = remapVaultPath(vault, SOURCE_PATHS.DAILY_PLANS_DIR);
+  fs.mkdirSync(planDir, { recursive: true });
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return { vault, planDir };
+}
+
+function runHook(vault) {
+  return spawnSync(process.execPath, [HOOK], {
+    cwd: vault,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: vault,
+      VAULT_PATH: vault,
+    },
+  });
+}
+
+test('quickref is written next to the inbox daily plan, not an archived copy', (t) => {
+  const { vault, planDir } = createVault(t);
+  const today = new Date().toISOString().split('T')[0];
+  fs.writeFileSync(
+    path.join(planDir, `${today}.md`),
+    ['# Daily Plan', '', '## Today\'s Focus', '- Ship the inbox path fix', ''].join('\n'),
+    'utf8',
+  );
+
+  const result = runHook(vault);
+
+  assert.equal(result.status, 0, result.stderr);
+  const quickref = path.join(planDir, `${today}-quickref.md`);
+  assert.equal(fs.existsSync(quickref), true);
+  const body = fs.readFileSync(quickref, 'utf8');
+  assert.match(body, /Ship the inbox path fix/);
+  assert.equal(fs.existsSync(path.join(vault, '00-Inbox', 'Daily_Prep', `${today}-quickref.md`)), false);
+  assert.equal(fs.existsSync(path.join(vault, '07-Archives', 'Plans', `${today}-quickref.md`)), false);
+});
+
+test('missing inbox daily plan is a silent no-op', (t) => {
+  const { vault } = createVault(t);
+  const result = runHook(vault);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+});

--- a/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -10,7 +10,7 @@ conversation.
 
 **Target date:** {{TARGET_DATE}} ({{DAY_NAME}}, {{MONTH}} {{DD}})
 
-**Write the draft plan to:** `07-Archives/Plans/{{TARGET_DATE}}.md`
+**Write the draft plan to:** `00-Inbox/Daily_Plans/{{TARGET_DATE}}.md`
 
 **Note:** PostToolUse hooks from the parent skill do not fire in this subagent
 context. Do not rely on hook-driven side effects for any write you make.
@@ -233,7 +233,7 @@ cooling entities or relationship suggestions from the feeds in 1.4.
 
 ## Phase 3: Write the Draft Plan
 
-Write the complete draft to `07-Archives/Plans/{{TARGET_DATE}}.md` using the
+Write the complete draft to `00-Inbox/Daily_Plans/{{TARGET_DATE}}.md` using the
 plan template from this skill's `SKILL.md` (Step 7: frontmatter, TL;DR, Week
 Progress, Today's Shape, Commitments Due, Today's Focus, Meetings with Context,
 Task Scheduling, Heads Up). Heads Up must include the previous-working-day
@@ -257,7 +257,7 @@ After writing the draft, return a structured summary to the conversation:
 ```
 AGENT COMPLETE
 
-Draft plan written: 07-Archives/Plans/{{TARGET_DATE}}.md
+Draft plan written: 00-Inbox/Daily_Plans/{{TARGET_DATE}}.md
 
 Summary:
 - Meetings today: [N], day type [stacked/moderate/open]

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -37,7 +37,7 @@ Agent tool, using the self-contained prompt in this skill's
    `{{DAY_NAME}}`, `{{MONTH}}`, `{{DD}}`).
 3. Call the Agent tool with `subagent_type: "general-purpose"`, that prompt, and
    a short description.
-4. Verify it wrote the draft plan to `07-Archives/Plans/YYYY-MM-DD.md`, then run
+4. Verify it wrote the draft plan to `00-Inbox/Daily_Plans/YYYY-MM-DD.md`, then run
    the remaining interactive steps from its findings and present the plan.
 5. **Close out every `<!-- NEEDS TASK -->` line in the draft.** The subagent
    never creates tasks, so a focus candidate with no existing task is written
@@ -583,7 +583,7 @@ Flag potential issues:
 item maps to a Tasks.md task — create the task first if needed). If the item is not a
 task at all, drop both the placeholder and the `- [ ]` checkbox for that line.
 
-Create `07-Archives/Plans/YYYY-MM-DD.md`:
+Create `00-Inbox/Daily_Plans/YYYY-MM-DD.md`:
 
 ```markdown
 ---

--- a/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-review/AGENT_INSTRUCTIONS.md
@@ -123,7 +123,7 @@ If not connected or unhealthy, skip silently.
 
 ## Step 3: Daily Plan Completion Tracking
 
-1. Read `07-Archives/Plans/{{TARGET_DATE}}.md` if it exists
+1. Read `00-Inbox/Daily_Plans/{{TARGET_DATE}}.md` if it exists
 2. Extract the planned focus items from "Today's Focus"
 3. For each, check `03-Tasks/Tasks.md` completion timestamps and the modified
    files for evidence; classify as Complete, In Progress (estimate %), or Not

--- a/.claude/skills/daily-review/SKILL.md
+++ b/.claude/skills/daily-review/SKILL.md
@@ -211,7 +211,7 @@ Use: reminders_clear_completed(list_name="Dex Today")
 
 ### 3.1 Find Today's Plan
 
-Look for `07-Archives/Plans/YYYY-MM-DD.md` (today's date).
+Look for `00-Inbox/Daily_Plans/YYYY-MM-DD.md` (today's date).
 
 ### 3.2 Extract Planned Focus
 

--- a/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
@@ -50,7 +50,7 @@ milestone, specific accomplishments that moved each goal.
 
 ### 1.4 Daily Completion Rate Trend
 
-Check `07-Archives/Plans/` for this week's daily plans and
+Check `00-Inbox/Daily_Plans/` for this week's daily plans and
 `07-Archives/Reviews/Daily_Review_YYYY-MM-DD.md` for each working day. Extract
 `plan_completion_rate` from review frontmatter where present. If only a plan
 exists for a day, count it as evidence of the planning ritual and note which

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -114,7 +114,7 @@ If items found:
 - `System/Session_Learnings/*.md` — Auto-captured session learnings
 
 ### 5. Daily Plans & Reviews
-- `07-Archives/Plans/YYYY-MM-DD.md` — This week's daily plans (primary record of planning ritual)
+- `00-Inbox/Daily_Plans/YYYY-MM-DD.md` — This week's daily plans (primary record of planning ritual)
 - `07-Archives/Reviews/Daily_Review_YYYY-MM-DD.md` — This week's reviews
 
 ### 6. Journals (If Enabled)
@@ -228,7 +228,7 @@ For each goal:
 
 ### 4. Daily Completion Rate Trend
 
-**First check `07-Archives/Plans/` for this week's daily plans.** Count how many days had a `/daily-plan` generated. If daily reviews also exist, cross-reference plan focus items against review completion. If only plans exist (no corresponding review), still count the plan as evidence of the planning ritual and note which focus items were checked off in the plan file itself.
+**First check `00-Inbox/Daily_Plans/` for this week's daily plans.** Count how many days had a `/daily-plan` generated. If daily reviews also exist, cross-reference plan focus items against review completion. If only plans exist (no corresponding review), still count the plan as evidence of the planning ritual and note which focus items were checked off in the plan file itself.
 Calculate completion trends:
 
 > "**Daily plan completion this week:**

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -641,7 +641,7 @@ Quarter Goals (01-Quarter_Goals/)
     ↓
 Week Priorities (02-Week_Priorities/)
     ↓
-Daily Plan (07-Archives/Plans/)
+Daily Plan (00-Inbox/Daily_Plans/)
     ↓
 Tasks (03-Tasks/)
 ```

--- a/06-Resources/Dex_System/Folder_Structure.md
+++ b/06-Resources/Dex_System/Folder_Structure.md
@@ -159,18 +159,19 @@ Archives = historical record, rarely consulted
 ```
 07-Archives/
 ├── Projects/        # Completed or cancelled projects
-├── Plans/           # Daily and weekly plans (auto-archived)
+├── Plans/           # Weekly plans (auto-archived)
 └── Reviews/         # Daily, weekly, and quarterly reviews (auto-archived)
 ```
 
 ### Auto-Archiving
 
 Plans and reviews automatically move here:
-- Daily plans → after `/daily-plan` runs
 - Daily reviews → after `/daily-review` runs
 - Weekly plans → after `/week-plan` runs
 - Weekly reviews → after `/week-review` runs
 - Quarterly reviews → after `/quarter-review` runs
+
+Daily plans stay in `00-Inbox/Daily_Plans/` so today's plan is with the rest of today's capture.
 
 ### Manual Archiving
 
@@ -193,6 +194,7 @@ Keep archives indefinitely—they're your historical record and learning source 
 00-Inbox/
 ├── Meetings/        # Meeting notes (auto-created by /process-meetings)
 │   └── YYYY-MM-DD/  # Meetings organized by date
+├── Daily_Plans/     # Today's plan from /daily-plan
 └── Ideas/           # Quick captures and random thoughts
 ```
 
@@ -253,8 +255,8 @@ If you enable quarterly and weekly planning, everything connects from pillars �
 3. **Week Priorities** (`02-Week_Priorities/Week_Priorities.md`)  
    Top 3 this week advancing quarterly goals (via `/week-plan`)
 
-4. **Daily Plan** (`07-Archives/Plans/`)  
-   Today's work supporting weekly priorities (auto-archived after `/daily-plan`)
+4. **Daily Plan** (`00-Inbox/Daily_Plans/`)  
+   Today's work supporting weekly priorities (created by `/daily-plan`)
 
 5. **Tasks** (`03-Tasks/Tasks.md`)  
    Backlog tagged with `#pillar [Q1-2] [Week-1]` connecting to goals

--- a/07-Archives/Plans/README.md
+++ b/07-Archives/Plans/README.md
@@ -1,26 +1,25 @@
 # Archived Plans
 
-Historical daily and weekly plans.
+Historical weekly plans.
 
 ## What Goes Here
 
-Plans automatically archive here:
-- **Daily plans** — Created by `/daily-plan`
-- **Weekly plans** — Created by `/week-plan`
+- **Weekly plans** — archived by `/week-plan` as `YYYY-Wxx.md`
+
+Daily plans live in `00-Inbox/Daily_Plans/`, not here. `/daily-plan` writes today's plan there; `/daily-review` and `/week-review` read it from there.
 
 ## Naming Convention
 
-- Daily: `YYYY-MM-DD.md`
 - Weekly: `YYYY-Wxx.md` (e.g., `2026-W04.md`)
 
 ## Purpose
 
-Archived plans help you:
+Archived weekly plans help you:
 - Review how you planned vs executed
-- Spot patterns in your daily workflow
+- Spot patterns in your weekly workflow
 - Reference past priorities and decisions
 - Track your planning evolution over time
-- Prepare for weekly/quarterly reviews
+- Prepare for quarterly reviews
 
 ## Retention
 
@@ -28,6 +27,6 @@ Keep indefinitely. Plans are lightweight and valuable for understanding your wor
 
 ## Integration
 
-- Weekly reviews reference recent daily plans
+- Weekly reviews reference recent daily plans in `00-Inbox/Daily_Plans/`
 - Quarterly reviews aggregate weekly plans
 - Work MCP's `get_pillar_summary` tool analyzes task distribution across strategic pillars

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -52,8 +52,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/daily-plan/SKILL.md",
-        "sha256": "639a0cfa35a5f126acfcd7325c8caebf26b45cea82d250a8b4b76a3201067a71",
-        "byte_size": 32926
+        "sha256": "579345c38cf39ff73fa5f178b9aac80b71e28f8a1e6648618b832ed78961a01d",
+        "byte_size": 32932
       },
       "value": "Helps a person choose a small, realistic focus list before the day scatters across meetings, tasks and loose commitments.",
       "jobs_served": [
@@ -483,8 +483,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/daily-review/SKILL.md",
-        "sha256": "df2e77a13ccd34cce7c9b34b1d92d99b1c09fbe93ebce60e486bbfa5b878ae8a",
-        "byte_size": 19256
+        "sha256": "bdaa24a66374f77568bcab0ba35c1e78dd163bc97bae53bc49cf7290c0854c0b",
+        "byte_size": 19259
       },
       "value": "Closes the day the morning plan opened: what actually got done against what was intended, what a meeting left behind, and what tomorrow starts with — so the loop finishes instead of drifting.",
       "jobs_served": [
@@ -564,8 +564,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-review/SKILL.md",
-        "sha256": "7972089ecf86d0ce8cc23281f490afabbd11ce8683856cf91479a856444ff905",
-        "byte_size": 19021
+        "sha256": "cc07404a8f174739e9e3028638f358f74f24c366b6c646edc4bf26fa8714dbea",
+        "byte_size": 19027
       },
       "value": "Reviews the week in concrete finished work and the patterns behind it, and deliberately refuses to invent a completion percentage that would make a bad week look measured.",
       "jobs_served": [

--- a/core/tests/test_daily_plan_inbox_path_contract.py
+++ b/core/tests/test_daily_plan_inbox_path_contract.py
@@ -1,0 +1,117 @@
+"""Daily plans belong in the inbox folder the chassis already names.
+
+The path contract, provision contract, and hook path table already set
+``DAILY_PLANS_DIR`` to ``00-Inbox/Daily_Plans``. These tests keep the daily-plan
+write path and the daily-review / week-review read paths on that folder, and
+leave weekly-plan archives in ``07-Archives/Plans/YYYY-Wxx.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from core import paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DAILY_PLANS_RELATIVE = "00-Inbox/Daily_Plans"
+ARCHIVED_PLANS_PREFIX = "07-Archives/Plans"
+ARCHIVED_DAILY_DATED = re.compile(
+    r"07-Archives/Plans/(?:YYYY-MM-DD|\{\{TARGET_DATE\}\})"
+)
+WEEKLY_ARCHIVE_NAME = "07-Archives/Plans/YYYY-Wxx.md"
+
+DAILY_PLAN_WRITE_FILES = (
+    REPO_ROOT / ".claude/skills/daily-plan/SKILL.md",
+    REPO_ROOT / ".claude/skills/daily-plan/AGENT_INSTRUCTIONS.md",
+)
+DAILY_PLAN_READ_FILES = (
+    REPO_ROOT / ".claude/skills/daily-review/SKILL.md",
+    REPO_ROOT / ".claude/skills/daily-review/AGENT_INSTRUCTIONS.md",
+    REPO_ROOT / ".claude/skills/week-review/SKILL.md",
+    REPO_ROOT / ".claude/skills/week-review/AGENT_INSTRUCTIONS.md",
+)
+FOLDER_GUIDES = (
+    REPO_ROOT / "docs/Dex_System/Folder_Structure.md",
+    REPO_ROOT / "06-Resources/Dex_System/Folder_Structure.md",
+    REPO_ROOT / "docs/Dex_System/Dex_Technical_Guide.md",
+    REPO_ROOT / "06-Resources/Dex_System/Dex_Technical_Guide.md",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_chassis_daily_plans_dir_is_inbox_daily_plans() -> None:
+    assert paths.DAILY_PLANS_DIR.name == "Daily_Plans"
+    assert paths.DAILY_PLANS_DIR.parent == paths.INBOX_DIR
+    assert paths.INBOX_DIR.name == "00-Inbox"
+
+    provision = json.loads((REPO_ROOT / "core/provision-contract.json").read_text())
+    assert provision["path_exports"]["DAILY_PLANS_DIR"] == DAILY_PLANS_RELATIVE
+
+    contract = json.loads(
+        (REPO_ROOT / "packages/dex-contracts/dist/paths.contract.json").read_text()
+    )
+    assert contract["vault_relative_paths"]["DAILY_PLANS_DIR"] == DAILY_PLANS_RELATIVE
+
+    hook_paths = _read(REPO_ROOT / ".claude/hooks/paths.cjs")
+    assert "DAILY_PLANS_DIR" in hook_paths
+    assert "Daily_Plans" in hook_paths
+
+
+@pytest.mark.parametrize("path", DAILY_PLAN_WRITE_FILES, ids=lambda path: path.name)
+def test_daily_plan_writes_to_inbox_daily_plans(path: Path) -> None:
+    text = _read(path)
+    assert f"{DAILY_PLANS_RELATIVE}/" in text
+    assert ARCHIVED_PLANS_PREFIX not in text
+    assert "Daily_Prep" not in text
+
+
+@pytest.mark.parametrize("path", DAILY_PLAN_READ_FILES, ids=lambda path: f"{path.parent.name}/{path.name}")
+def test_reviews_read_daily_plans_from_inbox(path: Path) -> None:
+    text = _read(path)
+    assert f"{DAILY_PLANS_RELATIVE}/" in text
+    assert ARCHIVED_PLANS_PREFIX not in text
+    assert ARCHIVED_DAILY_DATED.search(text) is None
+
+
+def test_week_plan_still_archives_weekly_files() -> None:
+    text = _read(REPO_ROOT / ".claude/skills/week-plan/SKILL.md")
+    assert WEEKLY_ARCHIVE_NAME in text
+    assert ARCHIVED_DAILY_DATED.search(text) is None
+
+
+def test_quickref_hook_reads_the_contract_daily_plans_dir() -> None:
+    text = _read(REPO_ROOT / ".claude/hooks/daily-plan-quick-ref.cjs")
+    assert "loadPaths" in text
+    assert "DAILY_PLANS_DIR" in text
+    assert "Daily_Prep" not in text
+    assert ARCHIVED_PLANS_PREFIX not in text
+    assert "00-Inbox" not in text
+
+
+@pytest.mark.parametrize("path", FOLDER_GUIDES, ids=lambda path: str(path.relative_to(REPO_ROOT)))
+def test_folder_guides_name_inbox_for_daily_plans(path: Path) -> None:
+    text = _read(path)
+    assert DAILY_PLANS_RELATIVE in text
+    assert ARCHIVED_DAILY_DATED.search(text) is None
+    assert "Daily Plan (`07-Archives/Plans/`)" not in text
+    assert "Daily Plan (07-Archives/Plans/)" not in text
+
+
+def test_archived_plans_readme_does_not_claim_daily_plan_creates_there() -> None:
+    text = _read(REPO_ROOT / "07-Archives/Plans/README.md")
+    assert DAILY_PLANS_RELATIVE in text
+    assert "Created by `/daily-plan`" not in text
+    assert ARCHIVED_DAILY_DATED.search(text) is None
+
+
+def test_archived_daily_dated_pattern_detects_the_old_write_path() -> None:
+    leaked = "Create `07-Archives/Plans/YYYY-MM-DD.md`:"
+    assert ARCHIVED_DAILY_DATED.search(leaked)
+    assert ARCHIVED_DAILY_DATED.search("Archive old file to `07-Archives/Plans/YYYY-Wxx.md`.") is None

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -641,7 +641,7 @@ Quarter Goals (01-Quarter_Goals/)
     ↓
 Week Priorities (02-Week_Priorities/)
     ↓
-Daily Plan (07-Archives/Plans/)
+Daily Plan (00-Inbox/Daily_Plans/)
     ↓
 Tasks (03-Tasks/)
 ```

--- a/docs/Dex_System/Folder_Structure.md
+++ b/docs/Dex_System/Folder_Structure.md
@@ -159,18 +159,19 @@ Archives = historical record, rarely consulted
 ```
 07-Archives/
 ├── Projects/        # Completed or cancelled projects
-├── Plans/           # Daily and weekly plans (auto-archived)
+├── Plans/           # Weekly plans (auto-archived)
 └── Reviews/         # Daily, weekly, and quarterly reviews (auto-archived)
 ```
 
 ### Auto-Archiving
 
 Plans and reviews automatically move here:
-- Daily plans → after `/daily-plan` runs
 - Daily reviews → after `/daily-review` runs
 - Weekly plans → after `/week-plan` runs
 - Weekly reviews → after `/week-review` runs
 - Quarterly reviews → after `/quarter-review` runs
+
+Daily plans stay in `00-Inbox/Daily_Plans/` so today's plan is with the rest of today's capture.
 
 ### Manual Archiving
 
@@ -193,6 +194,7 @@ Keep archives indefinitely—they're your historical record and learning source 
 00-Inbox/
 ├── Meetings/        # Meeting notes (auto-created by /process-meetings)
 │   └── YYYY-MM-DD/  # Meetings organized by date
+├── Daily_Plans/     # Today's plan from /daily-plan
 └── Ideas/           # Quick captures and random thoughts
 ```
 
@@ -253,8 +255,8 @@ If you enable quarterly and weekly planning, everything connects from pillars �
 3. **Week Priorities** (`02-Week_Priorities/Week_Priorities.md`)  
    Top 3 this week advancing quarterly goals (via `/week-plan`)
 
-4. **Daily Plan** (`07-Archives/Plans/`)  
-   Today's work supporting weekly priorities (auto-archived after `/daily-plan`)
+4. **Daily Plan** (`00-Inbox/Daily_Plans/`)  
+   Today's work supporting weekly priorities (created by `/daily-plan`)
 
 5. **Tasks** (`03-Tasks/Tasks.md`)  
    Backlog tagged with `#pillar [Q1-2] [Week-1]` connecting to goals


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Linear issue: `DEX-113` / `GS-INBOX-B2`
- Private ticket recorded locally as dex-feedback#29 (not pinged)

## What does the chassis already do here?

The vault path contract already names the daily-plan folder. This PR does not invent a new location.

- `core/paths.py`: `DAILY_PLANS_DIR = INBOX_DIR / 'Daily_Plans'`
- `core/provision-contract.json` and `packages/dex-contracts/dist/paths.contract.json`: `DAILY_PLANS_DIR` → `00-Inbox/Daily_Plans`
- `.claude/hooks/paths.cjs`: the same constant for hooks
- Seed already ships `00-Inbox/Daily_Plans/README.md`

The chassis does **not** write the dated plan file. Skills do. On current `main` those skills still pointed at `07-Archives/Plans/YYYY-MM-DD.md`, so morning planning filed today's plan next to archived weekly plans, and reviews looked in the wrong folder.

Weekly-plan archives (`07-Archives/Plans/YYYY-Wxx.md`) are a different file and are left alone.

## What Changed
- `/daily-plan` now writes `00-Inbox/Daily_Plans/YYYY-MM-DD.md` (skill + gathering prompt)
- `/daily-review` and `/week-review` read that same dated file
- The daily-plan Stop hook reads the contract folder instead of a third path (`Daily_Prep`)
- Folder guides and the archived-plans seed note now match the contract
- Lens catalogue pins refreshed for the three changed `SKILL.md` files
- Contract tests lock write/read paths and keep weekly archives on the old folder

Existing dated files already in `07-Archives/Plans/` are not moved. New writes go to the inbox folder.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_daily_plan_inbox_path_contract.py`, `.claude/hooks/tests/daily-plan-quick-ref.test.cjs`
- Negative/error-path tests added or updated: old dated archive path is detected; weekly `YYYY-Wxx.md` is not; missing inbox plan is a silent no-op for the hook
- Commands run locally:
  - `python3 -m pytest core/tests/test_daily_plan_inbox_path_contract.py core/tests/test_docs_bridge.py core/tests/test_dex_lens_catalog_generation.py::test_real_registry_source_pins_match_the_shipped_skills core/tests/test_skill_delegated_gathering.py core/tests/test_calendar_skill_degradation_instruction_contract.py core/tests/test_paths.py::TestDerivedPaths::test_daily_plans_dir_parent_is_inbox`
  - `node --test .claude/hooks/tests/daily-plan-quick-ref.test.cjs`
  - `python3 -m ruff check core/tests/test_daily_plan_inbox_path_contract.py`

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert this PR. Skills go back to writing and reading dated plans under `07-Archives/Plans/`. Files written to the inbox folder during the window stay there until moved by hand.

## Docs Impact
- Files updated: `docs/Dex_System/Folder_Structure.md`, `docs/Dex_System/Dex_Technical_Guide.md` (bridge copies under `06-Resources/Dex_System/` kept identical), `07-Archives/Plans/README.md`, `.claude/hooks/README.md`
- If none, reason: n/a

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43a3032d-804c-4dc7-8833-f218eda8820b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43a3032d-804c-4dc7-8833-f218eda8820b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

