### PR TITLE
Align Google Workspace setup name and honor session connectors

### DIFF
--- a/.claude/skills/google-workspace-setup/SKILL.md
+++ b/.claude/skills/google-workspace-setup/SKILL.md
@@ -61,7 +61,7 @@ Do not treat `System/integrations/config.yaml` as the only connectedness signal.
 1. **Session connectors already available.** Inspect the tools already present in this session for Gmail, Google Calendar, and Google Drive.
    - A **Calendar-only** or **Drive-only** connector is not a full Google Workspace connection. Do not skip setup in those cases — this skill's job includes email, and those connectors do not provide Gmail.
    - If a **Gmail** session connector is available, try a test query (search a recent email) **without** requiring Dex config to be enabled first. If Gmail responds, treat email as already connected: do not add a second MCP server, and skip to **Step 5** (Configure Labels). Note missing Calendar or Drive tools, but do not install a duplicate Gmail server when Gmail already works.
-2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a test query via `google-workspace-mcp`. If healthy and responding, skip to **Step 5**.
+2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a **Gmail** test query via `google-workspace-mcp` (search a recent email). Calendar or Drive responding is not enough to skip. If Gmail responds, skip to **Step 5**. If Gmail fails, continue to Step 2 even when Calendar looks healthy — do not bypass re-auth.
 3. If Gmail is not healthy on either path, continue to Step 2.
 
 ### Step 2: Explain What We're Setting Up

--- a/.claude/skills/google-workspace-setup/SKILL.md
+++ b/.claude/skills/google-workspace-setup/SKILL.md
@@ -56,11 +56,13 @@ Dex reads your email **on demand** -- nothing is stored permanently. Emails are 
 
 ### Step 1: Check if Already Connected
 
-Do not treat `System/integrations/config.yaml` as the only connectedness signal. Google Workspace may already be usable through **session connectors** — Gmail, Google Calendar, or Google Drive tools already available in this session — even when that file does not say `google-workspace.enabled: true`.
+Do not treat `System/integrations/config.yaml` as the only connectedness signal. Google Workspace email may already be usable through a **Gmail session connector** already available in this session, even when that file does not say `google-workspace.enabled: true`.
 
-1. **Session connectors already available.** Inspect the tools already present in this session for Gmail, Google Calendar, and Google Drive. If any of those connectors are available, try a test query (search a recent email, or list today's calendar events) **without** requiring Dex config to be enabled first. If they respond, treat Google Workspace as already connected: do not add a second MCP server, and skip to **Step 5** (Configure Labels).
+1. **Session connectors already available.** Inspect the tools already present in this session for Gmail, Google Calendar, and Google Drive.
+   - A **Calendar-only** or **Drive-only** connector is not a full Google Workspace connection. Do not skip setup in those cases — this skill's job includes email, and those connectors do not provide Gmail.
+   - If a **Gmail** session connector is available, try a test query (search a recent email) **without** requiring Dex config to be enabled first. If Gmail responds, treat email as already connected: do not add a second MCP server, and skip to **Step 5** (Configure Labels). Note missing Calendar or Drive tools, but do not install a duplicate Gmail server when Gmail already works.
 2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a test query via `google-workspace-mcp`. If healthy and responding, skip to **Step 5**.
-3. If neither path is healthy and responding, continue to Step 2.
+3. If Gmail is not healthy on either path, continue to Step 2.
 
 ### Step 2: Explain What We're Setting Up
 
@@ -88,7 +90,7 @@ Wait for confirmation.
 
 ### Step 3: Add the Google Workspace MCP Server
 
-If Step 1 already found a healthy session connector, skip this step — do not register a second Google Workspace server.
+If Step 1 already found a healthy **Gmail** session connector, skip this step — do not register a second Gmail/Workspace server. A healthy Calendar or Drive connector alone is not a reason to skip.
 
 Check the user's MCP configuration. If `google-workspace-mcp` is not listed:
 
@@ -280,7 +282,7 @@ Google OAuth tokens typically last 1 hour, but refresh tokens are longer-lived. 
 
 ### "Google Workspace MCP not found"
 
-First check whether session connectors for Gmail, Google Calendar, or Google Drive are already available in this session. If they are healthy, Dex can use those and does not need a second server. If they are not, re-run `/google-workspace-setup` and it will detect and add `google-workspace-mcp`.
+First check whether a **Gmail** session connector is already available in this session. If Gmail is healthy, Dex can use it and does not need a second server. A Calendar-only or Drive-only connector is not enough — continue and add `google-workspace-mcp` so email works. If Gmail is missing or unhealthy, re-run `/google-workspace-setup` and it will detect and add `google-workspace-mcp`.
 
 ### Permission Errors
 
@@ -312,7 +314,7 @@ Some organizations restrict OAuth access for third-party apps:
 
 If the user runs `/google-workspace-setup` when already configured:
 
-1. Check current status via a test query — including session connectors already available in this session, not only `System/integrations/config.yaml`
+1. Check current status via a test query — including a Gmail session connector already available in this session, not only `System/integrations/config.yaml`. Calendar-only or Drive-only is not enough to treat Gmail as connected.
 2. Show current config from `System/integrations/config.yaml` if present
 3. Offer options:
    - Update watched labels

--- a/.claude/skills/google-workspace-setup/SKILL.md
+++ b/.claude/skills/google-workspace-setup/SKILL.md
@@ -178,10 +178,10 @@ Save their preference. Map choice 1 to `draft_and_send: true`, choice 2 to `draf
 
 ### Step 6: Test the Connection
 
-Run a quick test to confirm everything works:
+Run a quick test to confirm everything works. **Email is the connectedness bar.** Calendar is extra.
 
-1. Search for a recent email (e.g., from the last 24 hours)
-2. Verify calendar access (list today's events)
+1. **Email (required).** Search for a recent email (e.g., from the last 24 hours). If this fails, troubleshoot before proceeding — do not write `google-workspace.enabled: true` until Gmail responds.
+2. **Calendar (optional).** If a Calendar connector is available, list today's events. If Calendar is missing — including a Gmail-only session connector — note it and continue. Do not block saving config on a missing calendar.
 
 Show a brief summary:
 
@@ -189,11 +189,10 @@ Show a brief summary:
 **Quick test results:**
 - Email search: Working (found [N] recent emails)
 - Calendar: Working (found [N] events today)
-
-Everything looks good!
+  # or: Not available in this session — email still counts as connected
 ```
 
-If either fails, troubleshoot before proceeding.
+If email works, proceed to Step 7 even when Calendar is missing. Only email failure blocks saving configuration.
 
 ### Step 7: Save Configuration
 

--- a/.claude/skills/google-workspace-setup/SKILL.md
+++ b/.claude/skills/google-workspace-setup/SKILL.md
@@ -56,10 +56,11 @@ Dex reads your email **on demand** -- nothing is stored permanently. Emails are 
 
 ### Step 1: Check if Already Connected
 
-1. Check `System/integrations/config.yaml` for `google-workspace.enabled: true`
-2. If enabled, try a test query via Google Workspace MCP (e.g., search for a recent email)
-3. If healthy and responding, skip to **Step 5** (Configure Labels)
-4. If the tool is not available or errors, continue to Step 2
+Do not treat `System/integrations/config.yaml` as the only connectedness signal. Google Workspace may already be usable through **session connectors** — Gmail, Google Calendar, or Google Drive tools already available in this session — even when that file does not say `google-workspace.enabled: true`.
+
+1. **Session connectors already available.** Inspect the tools already present in this session for Gmail, Google Calendar, and Google Drive. If any of those connectors are available, try a test query (search a recent email, or list today's calendar events) **without** requiring Dex config to be enabled first. If they respond, treat Google Workspace as already connected: do not add a second MCP server, and skip to **Step 5** (Configure Labels).
+2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a test query via `google-workspace-mcp`. If healthy and responding, skip to **Step 5**.
+3. If neither path is healthy and responding, continue to Step 2.
 
 ### Step 2: Explain What We're Setting Up
 
@@ -87,6 +88,8 @@ Wait for confirmation.
 
 ### Step 3: Add the Google Workspace MCP Server
 
+If Step 1 already found a healthy session connector, skip this step — do not register a second Google Workspace server.
+
 Check the user's MCP configuration. If `google-workspace-mcp` is not listed:
 
 1. Explain what we're adding:
@@ -94,7 +97,7 @@ Check the user's MCP configuration. If `google-workspace-mcp` is not listed:
 ```
 I need to add the Google Workspace connector to your Dex configuration.
 
-This is an open-source bridge (github.com/taylorwilsdon/google_workspace_mcp)
+This is an open-source bridge (`google-workspace-mcp`)
 that connects to Google's APIs via OAuth. Your credentials stay on your machine.
 ```
 
@@ -109,6 +112,8 @@ that connects to Google's APIs via OAuth. Your credentials stay on your machine.
   }
 }
 ```
+
+The config key, the `npx` package, and the name in the explanation must all be `google-workspace-mcp`. Do not substitute a different repository or package name.
 
 3. Tell the user the MCP server needs to restart for changes to take effect.
 
@@ -275,7 +280,7 @@ Google OAuth tokens typically last 1 hour, but refresh tokens are longer-lived. 
 
 ### "Google Workspace MCP not found"
 
-The server might not be in your configuration. Re-run `/google-workspace-setup` and it will detect and fix this.
+First check whether session connectors for Gmail, Google Calendar, or Google Drive are already available in this session. If they are healthy, Dex can use those and does not need a second server. If they are not, re-run `/google-workspace-setup` and it will detect and add `google-workspace-mcp`.
 
 ### Permission Errors
 
@@ -307,8 +312,8 @@ Some organizations restrict OAuth access for third-party apps:
 
 If the user runs `/google-workspace-setup` when already configured:
 
-1. Check current status via a test query
-2. Show current config from `System/integrations/config.yaml`
+1. Check current status via a test query — including session connectors already available in this session, not only `System/integrations/config.yaml`
+2. Show current config from `System/integrations/config.yaml` if present
 3. Offer options:
    - Update watched labels
    - Change write preferences (auto-draft vs ask each time)

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -5560,8 +5560,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/google-workspace-setup/SKILL.md",
-        "sha256": "fc328db7f6cf4a4de9ab9af2a2e47096670b8689f46558da398d543ada0b1919",
-        "byte_size": 11291
+        "sha256": "d47310a4b3688dc856c3e6dce432469d31b2a67f8b919f482a96e1f014fbf28c",
+        "byte_size": 11784
       },
       "value": "Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep.",
       "jobs_served": [

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -5560,8 +5560,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/google-workspace-setup/SKILL.md",
-        "sha256": "f3b4b5b8bbd378e42870a0567ccddc8ccdf2d37c5470a87b9db01cf8e2e18f6d",
-        "byte_size": 12277
+        "sha256": "65a6a4a6b58f943ea6eea9ce04d778fc5885b2cc6f239fd155176aeee44e9ea1",
+        "byte_size": 12450
       },
       "value": "Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep.",
       "jobs_served": [

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -5560,8 +5560,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/google-workspace-setup/SKILL.md",
-        "sha256": "1315f76bfa9f738cf23b4ecd5de575350c2b4f231539a39177de54cf2bf7f7a8",
-        "byte_size": 10002
+        "sha256": "fc328db7f6cf4a4de9ab9af2a2e47096670b8689f46558da398d543ada0b1919",
+        "byte_size": 11291
       },
       "value": "Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep.",
       "jobs_served": [

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -5560,8 +5560,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/google-workspace-setup/SKILL.md",
-        "sha256": "d47310a4b3688dc856c3e6dce432469d31b2a67f8b919f482a96e1f014fbf28c",
-        "byte_size": 11784
+        "sha256": "f3b4b5b8bbd378e42870a0567ccddc8ccdf2d37c5470a87b9db01cf8e2e18f6d",
+        "byte_size": 12277
       },
       "value": "Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep.",
       "jobs_served": [

--- a/core/tests/test_google_workspace_setup_instruction_contract.py
+++ b/core/tests/test_google_workspace_setup_instruction_contract.py
@@ -99,6 +99,22 @@ def test_step1_checks_session_connectors_without_waiting_on_dex_config() -> None
     assert enabled_lines[0].lstrip().startswith("2."), enabled_lines[0]
 
 
+def test_dex_config_skip_requires_gmail_not_any_workspace_query() -> None:
+    """A Calendar-healthy, Gmail-broken Dex config must not skip to label setup."""
+
+    step1 = _step1(_body())
+    dex_config = next(
+        line
+        for line in step1.splitlines()
+        if line.lstrip().startswith("2.") and "Dex config" in line
+    )
+    lowered = dex_config.lower()
+    assert "gmail" in lowered
+    assert "calendar or drive responding is not enough" in lowered
+    assert "if gmail fails" in lowered
+    assert "if healthy and responding" not in lowered
+
+
 def test_step3_does_not_add_a_second_server_when_gmail_session_connector_is_healthy() -> None:
     step3 = _step3(_body())
     lowered = step3.lower()

--- a/core/tests/test_google_workspace_setup_instruction_contract.py
+++ b/core/tests/test_google_workspace_setup_instruction_contract.py
@@ -75,6 +75,10 @@ def test_step1_checks_session_connectors_without_waiting_on_dex_config() -> None
     assert "google calendar" in lowered
     assert "google drive" in lowered
     assert "without" in lowered and "enabled first" in lowered
+    assert "if any of those connectors" not in lowered
+    assert "calendar-only" in lowered
+    assert "drive-only" in lowered
+    assert "do not skip setup" in lowered
 
     # The intro may name config.yaml to say it is *not* the only signal.
     # Connectedness order is the numbered list: session connectors first.
@@ -91,9 +95,30 @@ def test_step1_checks_session_connectors_without_waiting_on_dex_config() -> None
     assert enabled_lines[0].lstrip().startswith("2."), enabled_lines[0]
 
 
-def test_step3_does_not_add_a_second_server_when_session_connectors_are_healthy() -> None:
+def test_step3_does_not_add_a_second_server_when_gmail_session_connector_is_healthy() -> None:
     step3 = _step3(_body())
     lowered = step3.lower()
+    assert "gmail" in lowered
     assert "session connector" in lowered
     assert "skip this step" in lowered
     assert "second" in lowered
+    assert "alone is not a reason to skip" in lowered
+
+
+def test_calendar_or_drive_alone_does_not_skip_gmail_setup() -> None:
+    """Partial session connectors must not be treated as a full Workspace connection."""
+
+    body = _body()
+    step1 = _step1(body)
+    step3 = _step3(body)
+    troubleshooting = _section(
+        body,
+        '### "Google Workspace MCP not found"',
+        "### Permission Errors",
+    )
+    for section in (step1, step3, troubleshooting):
+        lowered = section.lower()
+        assert "gmail" in lowered
+        assert "calendar-only" in lowered or "calendar or drive" in lowered
+        assert "not" in lowered
+        assert "skip" in lowered or "not enough" in lowered

--- a/core/tests/test_google_workspace_setup_instruction_contract.py
+++ b/core/tests/test_google_workspace_setup_instruction_contract.py
@@ -1,0 +1,99 @@
+"""Instruction contract for Google Workspace setup identity and connectedness.
+
+This is an instruction-contract test. It reads the shipped setup skill; it does
+not start an MCP server, run OAuth, or claim a live Google account is connected.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL = REPO_ROOT / ".claude/skills/google-workspace-setup/SKILL.md"
+INSTALL_IDENTITY = "google-workspace-mcp"
+UNDERSCORE_PACKAGE = "google_workspace_mcp"
+
+
+def _body() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _section(body: str, start: str, end: str) -> str:
+    assert start in body, f"missing heading {start!r}"
+    rest = body.split(start, 1)[1]
+    assert end in rest, f"missing closing heading {end!r} after {start!r}"
+    return rest.split(end, 1)[0]
+
+
+def _step1(body: str) -> str:
+    return _section(body, "### Step 1: Check if Already Connected", "### Step 2:")
+
+
+def _step3(body: str) -> str:
+    return _section(body, "### Step 3: Add the Google Workspace MCP Server", "### Step 4:")
+
+
+def test_step3_prose_and_config_name_the_same_install_identity() -> None:
+    """The explanation and the config block must name one package, not two."""
+
+    step3 = _step3(_body())
+    assert f"`{INSTALL_IDENTITY}`" in step3, "Step 3 prose must name the install identity"
+    assert UNDERSCORE_PACKAGE not in step3, "Step 3 must not name a different underscore package"
+
+    match = re.search(r"```json\n(\{.*?\})\n```", step3, re.S)
+    assert match, "Step 3 is missing its MCP config JSON block"
+    config = json.loads(match.group(1))
+    assert list(config) == [INSTALL_IDENTITY], config
+    entry = config[INSTALL_IDENTITY]
+    assert entry["command"] == "npx", entry
+    assert entry["args"] == ["-y", INSTALL_IDENTITY], entry["args"]
+
+
+def test_skill_never_names_the_underscore_package_as_the_install_target() -> None:
+    body = _body()
+    assert UNDERSCORE_PACKAGE not in body
+    assert INSTALL_IDENTITY in body
+    frontmatter = body.split("---", 2)[1]
+    assert f"mcp_server: {INSTALL_IDENTITY}" in frontmatter
+
+
+def test_step1_checks_session_connectors_without_waiting_on_dex_config() -> None:
+    """Session connectors already in this session must be checked first.
+
+    Gating the only test query on `google-workspace.enabled: true` skips
+    already-available session connectors and can add a second server.
+    """
+
+    step1 = _step1(_body())
+    lowered = step1.lower()
+    assert "session connector" in lowered, "Step 1 must name session connectors"
+    assert "already available" in lowered
+    assert "this session" in lowered
+    assert "gmail" in lowered
+    assert "google calendar" in lowered
+    assert "google drive" in lowered
+    assert "without" in lowered and "enabled first" in lowered
+
+    # The intro may name config.yaml to say it is *not* the only signal.
+    # Connectedness order is the numbered list: session connectors first.
+    numbered = re.findall(r"^\d+\.\s+\*\*([^*]+)\*\*", step1, re.M)
+    assert numbered, "Step 1 must use a numbered connectedness list"
+    assert numbered[0].lower().startswith("session connector"), numbered
+    assert any(item.lower().startswith("dex config") for item in numbered[1:]), numbered
+    enabled_lines = [
+        line
+        for line in step1.splitlines()
+        if "google-workspace.enabled: true" in line and line.lstrip()[:1].isdigit()
+    ]
+    assert len(enabled_lines) == 1, enabled_lines
+    assert enabled_lines[0].lstrip().startswith("2."), enabled_lines[0]
+
+
+def test_step3_does_not_add_a_second_server_when_session_connectors_are_healthy() -> None:
+    step3 = _step3(_body())
+    lowered = step3.lower()
+    assert "session connector" in lowered
+    assert "skip this step" in lowered
+    assert "second" in lowered

--- a/core/tests/test_google_workspace_setup_instruction_contract.py
+++ b/core/tests/test_google_workspace_setup_instruction_contract.py
@@ -35,6 +35,10 @@ def _step3(body: str) -> str:
     return _section(body, "### Step 3: Add the Google Workspace MCP Server", "### Step 4:")
 
 
+def _step6(body: str) -> str:
+    return _section(body, "### Step 6: Test the Connection", "### Step 7:")
+
+
 def test_step3_prose_and_config_name_the_same_install_identity() -> None:
     """The explanation and the config block must name one package, not two."""
 
@@ -122,3 +126,17 @@ def test_calendar_or_drive_alone_does_not_skip_gmail_setup() -> None:
         assert "calendar-only" in lowered or "calendar or drive" in lowered
         assert "not" in lowered
         assert "skip" in lowered or "not enough" in lowered
+
+
+def test_gmail_only_connection_test_still_saves_config() -> None:
+    """Missing calendar must not block writing google-workspace.enabled after Gmail works."""
+
+    step6 = _step6(_body())
+    lowered = step6.lower()
+    assert "email is the connectedness bar" in lowered
+    assert "required" in lowered
+    assert "optional" in lowered
+    assert "do not block saving config" in lowered
+    assert "gmail-only" in lowered
+    assert "only email failure blocks saving configuration" in lowered
+    assert "if either fails" not in lowered


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linked Issue
- Linear issue: `DEX-108` (GS-INBOX-B2)
- No public Dex issue. Do not invent one.

## What does the chassis already do here?

Verified on current `main` after fetch: released **v1.97.3**, then later main at `cf1571f8`. This branch is rebased onto that tip. Both original bugs were in the shipped skill. No code was changed until this inventory was written.

**The setup flow is prompt-driven.** There is no Python/Node executor for `/google-workspace-setup`. The chassis *is* the skill plus a few neighboring contracts:

- `.claude/skills/google-workspace-setup/SKILL.md` — the live setup skill. Frontmatter already names `mcp_server: google-workspace-mcp`. Step 3's JSON already installs `npx -y google-workspace-mcp`. Step 4 already runs `npx google-workspace-mcp`. Step 7 already persists `mcp_server: google-workspace-mcp`. Step 1 only read `System/integrations/config.yaml` for `google-workspace.enabled: true` and gated the only test query on that flag, so already-available session connectors were never inspected. Step 3 prose named a different underscore package than the config block. Step 6 originally required both email and calendar before saving config.
- `.claude/skills/daily-plan/SKILL.md` — email source table already names `google-workspace-mcp` as the Gmail query server. Section 5.8 already treats a registered `apple-mail-mcp` server as connected in addition to Dex config.
- `.claude/skills/week-review/SKILL.md` — section 5.5 uses the same config.yaml + registered-server pattern for email stats.
- `.claude/skills/ms-teams-setup/SKILL.md` — Step 1 already probes the live Teams MCP first, without requiring Dex config to be enabled.
- `.claude/skills/zoom-setup/SKILL.md` — Step 2 already checks whether Granola MCP tools are available in the session, not only config.yaml.
- `core/integrations/detect.py` — older onboarding helper. Left alone.
- `core/integrations/google/setup.py` — older `/integrate-mcp` helper. Left alone.
- `core/lens-catalog/registry.json` + `scripts/generate-dex-lens-catalog.py` — every SKILL.md edit must refresh the declared `sha256` / `byte_size` pin.

**What this PR changes:** only the Google Workspace setup skill, the Lens pin for that file, and an instruction-contract test. It does not add a new MCP, change `detect.py`, or bump a release. `package.json` and changelog identity are untouched.

## What Changed
- Rebased onto current `origin/main` so branch protection can merge.
- Step 3 prose, JSON key, and `npx` package now all name `google-workspace-mcp`.
- Step 1 checks session connectors **before** Dex config. Skip adding a second server only when a **Gmail** session connector is healthy. Calendar-only or Drive-only does not skip email setup.
- Step 6: email is the connectedness bar. Missing calendar does not block writing `google-workspace.enabled: true`.
- Lens catalogue pin refreshed. Instruction-contract tests lock the above.

## Test Plan
- `python3 -m pytest core/tests/test_google_workspace_setup_instruction_contract.py core/tests/test_dex_lens_catalog_generation.py::test_real_registry_source_pins_match_the_shipped_skills -q`

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this PR.

## Docs Impact
- Files updated: `.claude/skills/google-workspace-setup/SKILL.md`, `core/lens-catalog/registry.json`
- No `CHANGELOG.md` or `package.json` bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-501c7aba-a0f7-4b4c-ad87-a55460a76af8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-501c7aba-a0f7-4b4c-ad87-a55460a76af8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

