### PR TITLE
fix: changelog-checker always exits so the background job cannot hang

### DIFF
--- a/.scripts/check-anthropic-changelog.cjs
+++ b/.scripts/check-anthropic-changelog.cjs
@@ -2,90 +2,136 @@
 
 /**
  * Check Anthropic Changelog - Background self-learning automation
- * 
+ *
  * Monitors Anthropic's changelog for new Claude Code features and capabilities.
  * Writes alert file when updates detected, prompting user to run /dex-whats-new.
- * 
+ *
  * Designed to run automatically via macOS Launch Agent every 6 hours.
  * No Cursor or Claude required - fully autonomous change detection.
- * 
+ *
  * Usage:
  *   node .scripts/check-anthropic-changelog.cjs           # Check for updates
  *   node .scripts/check-anthropic-changelog.cjs --force   # Force check even if recently checked
  *   node .scripts/check-anthropic-changelog.cjs --dry-run # Show what would be detected
  */
 
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
 const https = require('https');
 
 // ============================================================================
 // CONFIGURATION
 // ============================================================================
 
-const VAULT_ROOT = path.resolve(__dirname, '..');
-const STATE_FILE = path.join(VAULT_ROOT, 'System', 'claude-code-state.json');
-const PENDING_FILE = path.join(VAULT_ROOT, 'System', 'changelog-updates-pending.md');
-const LOG_DIR = path.join(VAULT_ROOT, '.scripts', 'logs');
-const LOG_FILE = path.join(LOG_DIR, 'changelog-checker.log');
+function vaultRoot(env = process.env) {
+  return env.DEX_VAULT_ROOT
+    ? path.resolve(env.DEX_VAULT_ROOT)
+    : path.resolve(__dirname, '..');
+}
+
+function stateFile(env = process.env) {
+  return path.join(vaultRoot(env), 'System', 'claude-code-state.json');
+}
+
+function pendingFile(env = process.env) {
+  return path.join(vaultRoot(env), 'System', 'changelog-updates-pending.md');
+}
+
+function logDir(env = process.env) {
+  return path.join(vaultRoot(env), '.scripts', 'logs');
+}
+
+function logFile(env = process.env) {
+  return path.join(logDir(env), 'changelog-checker.log');
+}
 
 // Check at most once every 24 hours (unless --force)
 const MIN_CHECK_INTERVAL_HOURS = 24;
+const MAX_REDIRECTS = 5;
+const DEFAULT_TIMEOUT_MS = 15000;
 
-// Anthropic changelog sources (try in order)
+// Changelog sources (try in order). Keep these product URLs as shipped;
+// fetch follows redirects instead of replacing them.
 const CHANGELOG_SOURCES = [
   'https://docs.anthropic.com/en/release-notes/changelog',
   'https://www.anthropic.com/changelog'
 ];
 
+function resolveChangelogSources(env = process.env) {
+  if (env.DEX_CHANGELOG_SOURCES === undefined) {
+    return CHANGELOG_SOURCES.slice();
+  }
+  return String(env.DEX_CHANGELOG_SOURCES)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function requestTimeoutMs(env = process.env) {
+  const raw = env.DEX_CHANGELOG_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
 // ============================================================================
 // LOGGING
 // ============================================================================
 
-function log(message, level = 'INFO') {
+function log(message, level = 'INFO', env = process.env) {
   const timestamp = new Date().toISOString();
   const logMessage = `[${timestamp}] [${level}] ${message}`;
   console.log(logMessage);
-  
-  // Write to log file
-  if (!fs.existsSync(LOG_DIR)) {
-    fs.mkdirSync(LOG_DIR, { recursive: true });
+
+  const directory = logDir(env);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
   }
-  fs.appendFileSync(LOG_FILE, logMessage + '\n');
+  fs.appendFileSync(logFile(env), logMessage + '\n');
 }
 
 // ============================================================================
 // STATE MANAGEMENT
 // ============================================================================
 
-function loadState() {
+function loadState(env = process.env) {
   const defaults = {
     last_check: null,
     last_version_seen: null,
     features_seen: []
   };
-  
-  if (!fs.existsSync(STATE_FILE)) {
-    log('State file not found, creating new one');
-    saveState(defaults);
+  const file = stateFile(env);
+
+  if (!fs.existsSync(file)) {
+    log('State file not found, creating new one', 'INFO', env);
+    saveState(defaults, env);
     return defaults;
   }
-  
+
   try {
-    const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+    const state = JSON.parse(fs.readFileSync(file, 'utf-8'));
     return { ...defaults, ...state };
   } catch (e) {
-    log(`Error reading state file: ${e.message}`, 'ERROR');
+    log(`Error reading state file: ${e.message}`, 'ERROR', env);
     return defaults;
   }
 }
 
-function saveState(state) {
+function saveState(state, env = process.env) {
   try {
-    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
-    log('State file updated');
+    const file = stateFile(env);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(state, null, 2));
+    log('State file updated', 'INFO', env);
   } catch (e) {
-    log(`Error writing state file: ${e.message}`, 'ERROR');
+    log(`Error writing state file: ${e.message}`, 'ERROR', env);
   }
 }
 
@@ -93,75 +139,154 @@ function saveState(state) {
 // CHANGE DETECTION
 // ============================================================================
 
-function shouldCheck(state, force) {
+function shouldCheck(state, force, env = process.env) {
   if (force) {
-    log('Force flag set, checking regardless of last check time');
+    log('Force flag set, checking regardless of last check time', 'INFO', env);
     return true;
   }
-  
+
   if (!state.last_check) {
-    log('No previous check found, running first check');
+    log('No previous check found, running first check', 'INFO', env);
     return true;
   }
-  
+
   const lastCheck = new Date(state.last_check);
   const now = new Date();
   const hoursSinceLastCheck = (now - lastCheck) / (1000 * 60 * 60);
-  
+
   if (hoursSinceLastCheck < MIN_CHECK_INTERVAL_HOURS) {
-    log(`Last check was ${hoursSinceLastCheck.toFixed(1)} hours ago, skipping (minimum interval: ${MIN_CHECK_INTERVAL_HOURS}h)`);
+    log(
+      `Last check was ${hoursSinceLastCheck.toFixed(1)} hours ago, skipping (minimum interval: ${MIN_CHECK_INTERVAL_HOURS}h)`,
+      'INFO',
+      env,
+    );
     return false;
   }
-  
-  log(`Last check was ${hoursSinceLastCheck.toFixed(1)} hours ago, running check`);
+
+  log(`Last check was ${hoursSinceLastCheck.toFixed(1)} hours ago, running check`, 'INFO', env);
   return true;
 }
 
-function fetchChangelog(url) {
-  return new Promise((resolve, reject) => {
-    https.get(url, (res) => {
-      if (res.statusCode !== 200) {
-        reject(new Error(`HTTP ${res.statusCode}`));
-        return;
-      }
-      
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => resolve(data));
-    }).on('error', reject);
+function clientForUrl(urlObject) {
+  if (urlObject.protocol === 'https:') return https;
+  if (urlObject.protocol === 'http:') return http;
+  return null;
+}
+
+function drainResponse(res) {
+  return new Promise((resolve) => {
+    res.on('end', resolve);
+    res.on('error', resolve);
+    res.resume();
   });
 }
 
-async function detectChanges(state) {
-  log('Fetching Anthropic changelog...');
-  
+function fetchChangelog(url, options = {}) {
+  const remaining = options.remaining ?? MAX_REDIRECTS;
+  const timeoutMs = options.timeoutMs ?? requestTimeoutMs(options.env || process.env);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (err, value) => {
+      if (settled) return;
+      settled = true;
+      if (err) reject(err);
+      else resolve(value);
+    };
+
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch (e) {
+      finish(new Error(`Invalid URL: ${e.message}`));
+      return;
+    }
+
+    const client = clientForUrl(parsed);
+    if (!client) {
+      finish(new Error(`Unsupported protocol: ${parsed.protocol}`));
+      return;
+    }
+
+    let handedOff = false;
+    const req = client.get(parsed, { agent: false }, (res) => {
+      const status = res.statusCode || 0;
+      if (status >= 300 && status < 400 && res.headers.location) {
+        const location = res.headers.location;
+        drainResponse(res).then(() => {
+          if (settled) return;
+          handedOff = true;
+          req.setTimeout(0);
+          if (remaining <= 0) {
+            finish(new Error('Too many redirects'));
+            return;
+          }
+          let nextUrl;
+          try {
+            nextUrl = new URL(location, url).toString();
+          } catch (e) {
+            finish(new Error(`Invalid redirect: ${e.message}`));
+            return;
+          }
+          return fetchChangelog(nextUrl, { ...options, remaining: remaining - 1 });
+        }).then((body) => {
+          if (body !== undefined) finish(null, body);
+        }).catch((err) => finish(err));
+        return;
+      }
+
+      if (status !== 200) {
+        drainResponse(res).then(() => {
+          if (!settled) finish(new Error(`HTTP ${status}`));
+        });
+        return;
+      }
+
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => finish(null, Buffer.concat(chunks).toString('utf8')));
+      res.on('error', (err) => finish(err));
+    });
+
+    req.setTimeout(timeoutMs, () => {
+      if (settled || handedOff) return;
+      req.destroy(new Error('Request timed out'));
+      finish(new Error('Request timed out'));
+    });
+    req.on('error', (err) => {
+      if (!handedOff) finish(err);
+    });
+  });
+}
+
+async function detectChanges(state, env = process.env) {
+  log('Fetching Anthropic changelog...', 'INFO', env);
+
   let changelogContent = null;
   let successUrl = null;
-  
-  // Try each source URL
-  for (const url of CHANGELOG_SOURCES) {
+  const sources = resolveChangelogSources(env);
+
+  for (const url of sources) {
     try {
-      log(`Trying ${url}...`);
-      changelogContent = await fetchChangelog(url);
+      log(`Trying ${url}...`, 'INFO', env);
+      changelogContent = await fetchChangelog(url, { env, timeoutMs: requestTimeoutMs(env) });
       successUrl = url;
-      log(`Successfully fetched from ${url}`);
+      log(`Successfully fetched from ${url}`, 'INFO', env);
       break;
     } catch (e) {
-      log(`Failed to fetch from ${url}: ${e.message}`, 'WARN');
+      log(`Failed to fetch from ${url}: ${e.message}`, 'WARN', env);
     }
   }
-  
+
   if (!changelogContent) {
-    log('Could not fetch changelog from any source', 'ERROR');
+    log('Could not fetch changelog from any source', 'ERROR', env);
     return null;
   }
-  
+
   // Simple heuristic: look for version numbers or date patterns
   // This is intentionally simple - full analysis happens in /dex-whats-new
   const versionMatches = changelogContent.match(/version\s+(\d+\.\d+\.\d+)/gi) || [];
   const dateMatches = changelogContent.match(/202[0-9]-[0-1][0-9]-[0-3][0-9]/g) || [];
-  
-  // Extract latest version if found
+
   let latestVersion = null;
   if (versionMatches.length > 0) {
     const versions = versionMatches.map(v => v.match(/(\d+\.\d+\.\d+)/)[1]);
@@ -174,18 +299,16 @@ async function detectChanges(state) {
       return 0;
     })[0];
   }
-  
-  // Extract latest date if found
+
   let latestDate = null;
   if (dateMatches.length > 0) {
     latestDate = dateMatches.sort().reverse()[0];
   }
-  
-  // Determine if there are changes
-  const hasChanges = 
+
+  const hasChanges =
     (latestVersion && latestVersion !== state.last_version_seen) ||
     (latestDate && (!state.last_check || latestDate > state.last_check));
-  
+
   return {
     hasChanges,
     latestVersion,
@@ -198,7 +321,7 @@ async function detectChanges(state) {
 // ALERT MANAGEMENT
 // ============================================================================
 
-function createPendingAlert(changes) {
+function createPendingAlert(changes, env = process.env) {
   const content = `# 🆕 Claude Code Updates Detected
 
 **Detected:** ${new Date().toISOString()}
@@ -222,14 +345,15 @@ This file will be deleted once you run the command.
 *Auto-generated by .scripts/check-anthropic-changelog.cjs*
 `;
 
-  fs.writeFileSync(PENDING_FILE, content);
-  log(`Created pending alert file: ${PENDING_FILE}`);
+  fs.writeFileSync(pendingFile(env), content);
+  log(`Created pending alert file: ${pendingFile(env)}`, 'INFO', env);
 }
 
-function removePendingAlert() {
-  if (fs.existsSync(PENDING_FILE)) {
-    fs.unlinkSync(PENDING_FILE);
-    log('Removed pending alert file');
+function removePendingAlert(env = process.env) {
+  const file = pendingFile(env);
+  if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+    log('Removed pending alert file', 'INFO', env);
   }
 }
 
@@ -237,88 +361,100 @@ function removePendingAlert() {
 // MAIN
 // ============================================================================
 
-async function main() {
-  const args = process.argv.slice(2);
+async function main(options = {}) {
+  const env = options.env || process.env;
+  const args = options.args || process.argv.slice(2);
   const force = args.includes('--force');
   const dryRun = args.includes('--dry-run');
-  
+  const file = stateFile(env);
+
   // Fast path: check last check timestamp without loading full state
-  if (!force && fs.existsSync(STATE_FILE)) {
+  if (!force && fs.existsSync(file)) {
     try {
-      const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+      const state = JSON.parse(fs.readFileSync(file, 'utf-8'));
       if (state.last_check) {
         const lastCheck = new Date(state.last_check);
         const hoursSince = (new Date() - lastCheck) / (1000 * 60 * 60);
         if (hoursSince < MIN_CHECK_INTERVAL_HOURS) {
-          // Exit silently - this is the common case during session start
-          process.exit(0);
+          return 0;
         }
       }
     } catch (e) {
       // Fall through to normal logging if state file is corrupted
     }
   }
-  
-  log('=== Anthropic Changelog Check Started ===');
-  
+
+  log('=== Anthropic Changelog Check Started ===', 'INFO', env);
+
   if (dryRun) {
-    log('DRY RUN MODE - No files will be modified');
+    log('DRY RUN MODE - No files will be modified', 'INFO', env);
   }
-  
-  // Load current state
-  const state = loadState();
-  log(`Current state: last_check=${state.last_check}, last_version=${state.last_version_seen}`);
-  
-  // Check if we should run
-  if (!shouldCheck(state, force)) {
-    log('=== Check skipped (too soon) ===');
-    return;
+
+  const state = loadState(env);
+  log(`Current state: last_check=${state.last_check}, last_version=${state.last_version_seen}`, 'INFO', env);
+
+  if (!shouldCheck(state, force, env)) {
+    log('=== Check skipped (too soon) ===', 'INFO', env);
+    return 0;
   }
-  
-  // Detect changes
-  const changes = await detectChanges(state);
-  
+
+  const changes = await detectChanges(state, env);
+
   if (!changes) {
-    log('=== Check failed (could not fetch changelog) ===', 'ERROR');
-    return;
+    log('=== Check failed (could not fetch changelog) ===', 'ERROR', env);
+    return 1;
   }
-  
-  log(`Changes detected: ${changes.hasChanges}`);
-  log(`Latest version: ${changes.latestVersion || 'none found'}`);
-  log(`Latest date: ${changes.latestDate || 'none found'}`);
-  
+
+  log(`Changes detected: ${changes.hasChanges}`, 'INFO', env);
+  log(`Latest version: ${changes.latestVersion || 'none found'}`, 'INFO', env);
+  log(`Latest date: ${changes.latestDate || 'none found'}`, 'INFO', env);
+
   if (dryRun) {
-    log('DRY RUN - Would have updated state and created alert if changes detected');
-    log('=== Dry Run Complete ===');
-    return;
+    log('DRY RUN - Would have updated state and created alert if changes detected', 'INFO', env);
+    log('=== Dry Run Complete ===', 'INFO', env);
+    return 0;
   }
-  
-  // Update state
+
   const newState = {
     ...state,
     last_check: new Date().toISOString().split('T')[0], // YYYY-MM-DD
     last_version_seen: changes.latestVersion || state.last_version_seen,
     features_seen: state.features_seen // Preserved, updated by /dex-whats-new
   };
-  
-  saveState(newState);
-  
-  // Create alert if changes detected
+
+  saveState(newState, env);
+
   if (changes.hasChanges) {
-    log('NEW CHANGES DETECTED - Creating alert file');
-    createPendingAlert(changes);
+    log('NEW CHANGES DETECTED - Creating alert file', 'INFO', env);
+    createPendingAlert(changes, env);
   } else {
-    log('No new changes detected');
-    // Remove any existing alert (user may have already reviewed)
-    removePendingAlert();
+    log('No new changes detected', 'INFO', env);
+    removePendingAlert(env);
   }
-  
-  log('=== Check Complete ===');
+
+  log('=== Check Complete ===', 'INFO', env);
+  return 0;
 }
 
-// Run
-main().catch(err => {
-  log(`Fatal error: ${err.message}`, 'ERROR');
-  console.error(err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(typeof code === 'number' ? code : 1))
+    .catch((err) => {
+      try {
+        log(`Fatal error: ${err.message}`, 'ERROR');
+      } catch (_) {
+        console.error(`Fatal error: ${err.message}`);
+      }
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  CHANGELOG_SOURCES,
+  MAX_REDIRECTS,
+  fetchChangelog,
+  main,
+  resolveChangelogSources,
+  requestTimeoutMs,
+};

--- a/.scripts/lib/tests/check-anthropic-changelog.test.cjs
+++ b/.scripts/lib/tests/check-anthropic-changelog.test.cjs
@@ -1,0 +1,278 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const scriptPath = path.join(repoRoot, '.scripts', 'check-anthropic-changelog.cjs');
+
+const {
+  CHANGELOG_SOURCES,
+  MAX_REDIRECTS,
+  fetchChangelog,
+  main,
+} = require(scriptPath);
+
+function makeVault(t) {
+  const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'dex-changelog-checker-'));
+  fs.mkdirSync(path.join(vault, 'System'), { recursive: true });
+  fs.mkdirSync(path.join(vault, '.scripts', 'logs'), { recursive: true });
+  t.after(() => fs.rmSync(vault, { recursive: true, force: true }));
+  return vault;
+}
+
+function writeState(vault, state) {
+  fs.writeFileSync(
+    path.join(vault, 'System', 'claude-code-state.json'),
+    JSON.stringify(state, null, 2),
+  );
+}
+
+function listen(t, handler) {
+  const server = http.createServer(handler);
+  t.after(() => server.close());
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ origin: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function envFor(vault, originPath, extra = {}) {
+  return {
+    ...process.env,
+    DEX_VAULT_ROOT: vault,
+    DEX_CHANGELOG_TIMEOUT_MS: '2000',
+    DEX_CHANGELOG_SOURCES: originPath,
+    ...extra,
+  };
+}
+
+function runCli(vault, { args = [], sources = '', timeoutMs = 4000, extraEnv = {} } = {}) {
+  return childProcess.spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DEX_VAULT_ROOT: vault,
+      DEX_CHANGELOG_TIMEOUT_MS: '200',
+      DEX_CHANGELOG_SOURCES: sources,
+      ...extraEnv,
+    },
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+  });
+}
+
+test('shipped sources stay the two existing product URLs; no extra https hosts', () => {
+  assert.equal(CHANGELOG_SOURCES.length, 2);
+  const sourceText = fs.readFileSync(scriptPath, 'utf8');
+  const httpsUrls = [...sourceText.matchAll(/https:\/\/[^\s'"]+/g)].map((match) => match[0]);
+  assert.deepEqual(httpsUrls, CHANGELOG_SOURCES);
+});
+
+test('product filename stays as shipped', () => {
+  assert.equal(path.basename(scriptPath), 'check-anthropic-changelog.cjs');
+  assert.ok(fs.existsSync(scriptPath));
+});
+
+test('CLI wrapper exits with the returned code on every path', () => {
+  const source = fs.readFileSync(scriptPath, 'utf8');
+  assert.match(source, /if \(require\.main === module\)/);
+  assert.match(source, /process\.exit\(typeof code === 'number' \? code : 1\)/);
+  assert.match(source, /process\.exit\(1\)/);
+});
+
+test('fetch follows a relative redirect and returns the final body', async (t) => {
+  const { origin } = await listen(t, (req, res) => {
+    if (req.url === '/from') {
+      res.writeHead(302, { Location: '/to' });
+      res.end('moved');
+      return;
+    }
+    if (req.url === '/to') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('version 1.2.3 2026-08-27');
+      return;
+    }
+    res.writeHead(404);
+    res.end('missing');
+  });
+
+  const body = await fetchChangelog(`${origin}/from`);
+  assert.match(body, /version 1\.2\.3/);
+});
+
+test('fetch follows an absolute redirect across ports', async (t) => {
+  const destination = await listen(t, (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('arrived-at-destination');
+  });
+  const start = await listen(t, (req, res) => {
+    res.writeHead(301, { Location: `${destination.origin}/final` });
+    res.end();
+  });
+
+  const body = await fetchChangelog(`${start.origin}/start`);
+  assert.equal(body, 'arrived-at-destination');
+});
+
+test('fetch rejects after draining a redirect loop instead of hanging', async (t) => {
+  const { origin } = await listen(t, (req, res) => {
+    res.writeHead(302, { Location: req.url === '/a' ? '/b' : '/a' });
+    res.end('loop');
+  });
+
+  await assert.rejects(
+    () => fetchChangelog(`${origin}/a`, { timeoutMs: 2000 }),
+    /Too many redirects/,
+  );
+});
+
+test('fetch times out when the connected server never responds', async (t) => {
+  const { origin } = await listen(t, () => {
+    // Intentionally never respond.
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => fetchChangelog(`${origin}/slow`, { timeoutMs: 150 }),
+    /timed out/i,
+  );
+  assert.ok(Date.now() - started < 1500);
+});
+
+test('fetch times out when a redirect body never ends', async (t) => {
+  const { origin } = await listen(t, (req, res) => {
+    res.writeHead(302, { Location: '/to' });
+    res.write('partial');
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => fetchChangelog(`${origin}/from`, { timeoutMs: 150 }),
+    /timed out/i,
+  );
+  assert.ok(Date.now() - started < 1500);
+});
+
+test('fetch times out when a non-200 body never ends', async (t) => {
+  const { origin } = await listen(t, (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.write('partial');
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => fetchChangelog(`${origin}/missing`, { timeoutMs: 150 }),
+    /timed out/i,
+  );
+  assert.ok(Date.now() - started < 1500);
+});
+
+test('process exits 0 on skip without fetching', (t) => {
+  const vault = makeVault(t);
+  writeState(vault, {
+    last_check: new Date().toISOString().slice(0, 10),
+    last_version_seen: null,
+    features_seen: [],
+  });
+
+  const result = runCli(vault, { sources: 'http://127.0.0.1:1/unused' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.error, undefined);
+  assert.equal(result.stdout, '');
+});
+
+test('process exits 1 on fetch failure with no sources, without hanging', (t) => {
+  const vault = makeVault(t);
+  const started = Date.now();
+  const result = runCli(vault, { args: ['--force'], sources: '' });
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.equal(result.error, undefined);
+  assert.ok(Date.now() - started < 2000);
+  assert.match(result.stdout, /could not fetch changelog/i);
+});
+
+test('process exits 1 on unreachable source timeout instead of hanging', (t) => {
+  const vault = makeVault(t);
+  const started = Date.now();
+  const result = runCli(vault, {
+    args: ['--force'],
+    sources: 'http://127.0.0.1:1/slow',
+    extraEnv: { DEX_CHANGELOG_TIMEOUT_MS: '150' },
+  });
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.equal(result.error, undefined);
+  assert.ok(Date.now() - started < 2000);
+  assert.match(result.stdout, /timed out|could not fetch changelog|ECONNREFUSED/i);
+});
+
+test('imported main returns 0 on dry-run after a redirected fetch', async (t) => {
+  const vault = makeVault(t);
+  const { origin } = await listen(t, (req, res) => {
+    if (req.url === '/old') {
+      res.writeHead(302, { Location: '/new' });
+      res.end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('version 9.9.9 2026-08-01');
+  });
+
+  const code = await main({
+    args: ['--force', '--dry-run'],
+    env: envFor(vault, `${origin}/old`),
+  });
+  assert.equal(code, 0);
+  const state = JSON.parse(fs.readFileSync(path.join(vault, 'System', 'claude-code-state.json'), 'utf8'));
+  assert.equal(state.last_version_seen, null);
+  assert.equal(fs.existsSync(path.join(vault, 'System', 'changelog-updates-pending.md')), false);
+});
+
+test('imported main returns 1 after draining a non-200 body', async (t) => {
+  const vault = makeVault(t);
+  const { origin } = await listen(t, (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('x'.repeat(2048));
+  });
+
+  const code = await main({
+    args: ['--force'],
+    env: envFor(vault, `${origin}/missing`),
+  });
+  assert.equal(code, 1);
+});
+
+test('imported main returns 0 after a successful redirected check and writes the alert', async (t) => {
+  const vault = makeVault(t);
+  writeState(vault, { last_check: '2020-01-01', last_version_seen: '1.0.0', features_seen: [] });
+  const { origin } = await listen(t, (req, res) => {
+    if (req.url === '/legacy') {
+      res.writeHead(301, { Location: '/current' });
+      res.end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('version 2.0.0 2026-08-27');
+  });
+
+  const code = await main({
+    args: ['--force'],
+    env: envFor(vault, `${origin}/legacy`),
+  });
+  assert.equal(code, 0);
+  const state = JSON.parse(fs.readFileSync(path.join(vault, 'System', 'claude-code-state.json'), 'utf8'));
+  assert.equal(state.last_version_seen, '2.0.0');
+  assert.ok(fs.existsSync(path.join(vault, 'System', 'changelog-updates-pending.md')));
+});
+
+test('redirect hop cap is a small finite number', () => {
+  assert.equal(MAX_REDIRECTS, 5);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Private ticket: davekilleen/dex-feedback#27 (DEX-115 / GS-INBOX-B2). Do not close that issue. Do not ping the reporter.

## What does the chassis already do here?

Verified against current `origin/main` at `05eaf507` (public v1.97.3 plus later merged work).

Already on current `main`:

- `.scripts/check-anthropic-changelog.cjs` is the shipped job. Filename stays. LaunchAgent `.scripts/com.dex.changelog-checker.plist` runs it every 6 hours (`StartInterval` 21600), with no `KeepAlive` and no `TimeOut`.
- `CHANGELOG_SOURCES` is already exactly two URLs: `https://docs.anthropic.com/en/release-notes/changelog` and `https://www.anthropic.com/changelog`. Reproduced live: the first returns **301** (unfollowed); the second returns **404**. Following the 301 still lands on **404**. Both sources are dead for a 200 body.
- `fetchChangelog` used `https.get` and rejected any non-200 **without reading or destroying the response**. Node keeps that TLS socket open.
- `main()` called `process.exit(0)` only on the fast-path skip (recent `last_check`). Fetch failure, the second skip, dry-run, and success all `return`ed with no exit.
- The catch path already `process.exit(1)`.
- Reproduced on current main: reject `HTTP 301`, `main` returns, event loop still alive 3s later with a `TLSSocket` handle. That is the LaunchAgent hang.
- Doctor already treats this job as **activity-only** on `.scripts/logs/changelog-checker.log` (7-day cadence). Left as-is.
- Product filenames `claude-code-state.json`, `changelog-updates-pending.md`, and `changelog-checker.log` already exist. Left as-is.

Still broken on current `main` (this PR):

- A 301/404 fetch left the socket open and never exited, so launchd kept the job running.
- Redirects were not followed.
- There was no request timeout.

## What Changed

- Follow HTTP(S) redirects (relative and absolute), cap at 5 hops, drain non-200 bodies, `agent: false` so keep-alive cannot hold the process.
- 15s request timeout (overridable in tests). The timer stays armed until the body ends, so a 302/404 that never finishes the body cannot hang.
- `main()` returns `0` on skip / dry-run / success and `1` on fetch failure. The CLI wrapper always `process.exit`s that code (or `1` if a number is missing).
- The two shipped source URLs are unchanged. No new vendor-named URLs. No changelog/version bump.

## Test Plan

- Unit/integration tests added: `.scripts/lib/tests/check-anthropic-changelog.test.cjs` (picked up by `npm run test:scripts`)
- Covers: relative + absolute redirects, redirect-loop cap, timeout on no headers / unfinished 302 body / unfinished 404 body, CLI exit 0 on skip, CLI exit 1 on fetch failure and unreachable source, imported `main()` 0 on dry-run and success, imported `main()` 1 on 404, shipped URL freeze
- Commands run locally: `node --test .scripts/lib/tests/check-anthropic-changelog.test.cjs` → **16 passed**

## Ralph Wiggum Loop

- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

Adversarial review: REQUEST CHANGES on a remaining hang if a 302/404 body never ended after the timer was cleared. Fixed: timer stays armed until drain completes; new tests cover unfinished redirect and non-200 bodies. Remaining nits left on purpose: no host allowlist for redirects (following is the ticket), CLI success/dry-run spawn tests skipped in this sandbox because parent-child localhost sockets are blocked here (in-process `main()` covers those return codes; CI macOS can still run the CLI skip/fail spawn tests).

## Quality Gates

- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback

- Risk level: low
- Rollback plan: revert this branch. The job goes back to hanging on a 301. Plist, source URLs, and product filenames are untouched.

## Docs Impact

- Files updated: `.scripts/check-anthropic-changelog.cjs`, `.scripts/lib/tests/check-anthropic-changelog.test.cjs`
- No CHANGELOG entry (matches GS-INBOX-B1 / PR 616; this is not a release).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ca8339b-c353-428a-9e9c-adaff40ce83f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ca8339b-c353-428a-9e9c-adaff40ce83f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

