### PR TITLE
Large vault notes are saved, not treated as secrets

### DIFF
--- a/.claude/hooks/tests/vault-autocommit.test.cjs
+++ b/.claude/hooks/tests/vault-autocommit.test.cjs
@@ -16,6 +16,9 @@ const CONTRACT_PATH = path.join(
   'dist',
   'portable-vault.contract.json',
 );
+// Files only slightly over 1 MiB can still exit 0 with ENOBUFS on some
+// runtimes. 2 MiB is the size that actually gets SIGTERM + truncated stdout.
+const OVER_DEFAULT_SPAWN_BUFFER = (2 * 1024 * 1024) + 16;
 
 function git(root, ...args) {
   // -c safe.bareRepository=all: these tests create their own throwaway bare
@@ -105,7 +108,10 @@ test('enabled hook holds back contract-denied paths and staged content secrets',
   const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
 
   assert.equal(result.feature_status, 'ok');
-  assert.match(result.user_message, /held back|protected/i);
+  assert.equal(
+    result.user_message,
+    'Dex saved eligible changes locally and held back 1 protected file. It did not run a push.',
+  );
   assert.equal(git(root, 'show', 'HEAD:04-Projects/safe.md'), 'safe note');
   for (const relative of ['04-Projects/session.md', '.env']) {
     assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
@@ -125,7 +131,10 @@ test('enabled hook scans NUL-containing buffers for secret content', (t) => {
   const result = hook.run({ root, now: new Date('2026-07-13T10:00:00Z') });
 
   assert.equal(result.feature_status, 'ok');
-  assert.match(result.user_message, /held back|protected/i);
+  assert.equal(
+    result.user_message,
+    'Dex saved eligible changes locally and held back 1 protected file. It did not run a push.',
+  );
   assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', '04-Projects/binary-note.bin'), '');
   assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
 });
@@ -249,6 +258,154 @@ test('the ignored-path sweep is scoped to vault regions and never widens to priv
     assert.equal(git(root, 'ls-tree', '-r', '--name-only', 'HEAD', '--', relative), '', relative);
   }
   assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
+test('the spawn buffer is raised past the 1 MiB child-process default', () => {
+  const hook = require(HOOK_PATH);
+  assert.ok(hook.GIT_SPAWN_MAX_BUFFER > 1024 * 1024);
+});
+
+test('enabled hook commits a vault note larger than the default spawn buffer and does not call it protected', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  const large = Buffer.concat([
+    Buffer.alloc(OVER_DEFAULT_SPAWN_BUFFER, 0x61),
+    Buffer.from('\nmeeting note\n'),
+  ]);
+  fs.writeFileSync(path.join(root, '04-Projects', 'large-note.md'), large);
+  fs.writeFileSync(path.join(root, '04-Projects', 'small.md'), 'small note\n');
+
+  const result = hook.run({ root, now: new Date('2026-08-27T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(result.success, true);
+  assert.equal(
+    result.user_message,
+    'Dex saved this session to local vault history. It did not run a push.',
+  );
+  assert.doesNotMatch(result.user_message, /protected|held back/i);
+  assert.equal(git(root, 'show', 'HEAD:04-Projects/small.md'), 'small note');
+  assert.equal(
+    git(root, 'cat-file', '-s', 'HEAD:04-Projects/large-note.md'),
+    String(large.length),
+  );
+});
+
+test('enabled hook still holds back secret content past the default spawn buffer', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  const largeClean = Buffer.concat([
+    Buffer.alloc(OVER_DEFAULT_SPAWN_BUFFER, 0x62),
+    Buffer.from('\nclean note\n'),
+  ]);
+  const largeSecret = Buffer.concat([
+    Buffer.alloc(OVER_DEFAULT_SPAWN_BUFFER, 0x63),
+    Buffer.from('{"access_token":"scanner-positive-fixture-value"}\n'),
+  ]);
+  fs.writeFileSync(path.join(root, '04-Projects', 'large-clean.md'), largeClean);
+  fs.writeFileSync(path.join(root, '04-Projects', 'large-secret.md'), largeSecret);
+
+  const result = hook.run({ root, now: new Date('2026-08-27T10:00:00Z') });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(
+    result.user_message,
+    'Dex saved eligible changes locally and held back 1 protected file. It did not run a push.',
+  );
+  assert.equal(
+    git(root, 'cat-file', '-s', 'HEAD:04-Projects/large-clean.md'),
+    String(largeClean.length),
+  );
+  assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', '04-Projects/large-secret.md'), '');
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
+test('enabled hook says it could not read an oversized blob instead of calling it protected', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  git(root, 'add', '--', 'System/user-profile.yaml');
+  git(root, '-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '--quiet', '-m', 'seed');
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'too-large.md'), `${'note text\n'.repeat(20)}`);
+
+  const result = hook.run({
+    root,
+    now: new Date('2026-08-27T10:00:00Z'),
+    gitShowMaxBuffer: 64,
+  });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(
+    result.user_message,
+    'Dex could not read 1 file; there were no other changes to save.',
+  );
+  assert.doesNotMatch(result.user_message, /protected|held back|secret/i);
+  assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', '04-Projects/too-large.md'), '');
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+  assert.equal(
+    fs.readFileSync(path.join(root, '04-Projects', 'too-large.md'), 'utf8').startsWith('note text'),
+    true,
+  );
+});
+
+test('enabled hook names protected files and unread files separately', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(path.join(root, '04-Projects', 'ok.md'), 'ok\n');
+  fs.writeFileSync(
+    path.join(root, '04-Projects', 'session.md'),
+    '{"access_token":"scanner-positive-fixture-value"}\n',
+  );
+  fs.writeFileSync(path.join(root, '04-Projects', 'too-large.md'), `${'unread note\n'.repeat(20)}`);
+
+  const result = hook.run({
+    root,
+    now: new Date('2026-08-27T10:00:00Z'),
+    gitShowMaxBuffer: 64,
+  });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(
+    result.user_message,
+    'Dex saved eligible changes locally, held back 1 protected file, and could not read 1 file. It did not run a push.',
+  );
+  assert.equal(git(root, 'show', 'HEAD:04-Projects/ok.md'), 'ok');
+  for (const relative of ['04-Projects/session.md', '04-Projects/too-large.md']) {
+    assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
+  }
+  assert.equal(git(root, 'diff', '--cached', '--name-only'), '');
+});
+
+test('enabled hook keeps protected and unread copy distinct when nothing else saved', (t) => {
+  const hook = require(HOOK_PATH);
+  const root = fixture(t, true);
+  git(root, 'add', '--', 'System/user-profile.yaml');
+  git(root, '-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '--quiet', '-m', 'seed');
+  fs.mkdirSync(path.join(root, '04-Projects'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '04-Projects', 'session.md'),
+    '{"access_token":"scanner-positive-fixture-value"}\n',
+  );
+  fs.writeFileSync(path.join(root, '04-Projects', 'too-large.md'), `${'unread note\n'.repeat(20)}`);
+
+  const result = hook.run({
+    root,
+    now: new Date('2026-08-27T10:00:00Z'),
+    gitShowMaxBuffer: 64,
+  });
+
+  assert.equal(result.feature_status, 'ok');
+  assert.equal(
+    result.user_message,
+    'Dex held back 1 protected file and could not read 1 file; there were no other changes to save.',
+  );
+  assert.doesNotMatch(result.user_message, /secret/i);
+  for (const relative of ['04-Projects/session.md', '04-Projects/too-large.md']) {
+    assert.equal(git(root, 'ls-tree', '--name-only', 'HEAD', '--', relative), '', relative);
+  }
 });
 
 test('settings wires the opt-in hook after session-end and the shipped profile defaults off', () => {

--- a/.claude/hooks/vault-autocommit.cjs
+++ b/.claude/hooks/vault-autocommit.cjs
@@ -11,6 +11,10 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const FEATURE = 'Vault auto-commit';
+// spawnSync defaults to 1 MiB. A vault note larger than that used to fail
+// `git show` and get counted with protected files. Raise the cap, and keep
+// unread/too-large distinct from a secret hold.
+const GIT_SPAWN_MAX_BUFFER = 64 * 1024 * 1024;
 const CONTRACT_RELATIVE = path.join(
   'packages',
   'dex-contracts',
@@ -218,6 +222,7 @@ function git(root, args, options = {}) {
     ...args,
   ], {
     encoding: options.encoding === undefined ? 'utf8' : options.encoding,
+    maxBuffer: options.maxBuffer || GIT_SPAWN_MAX_BUFFER,
     env: {
       PATH: `${path.dirname(executable)}:/usr/bin:/bin`,
       HOME: fs.existsSync('/var/empty') ? '/var/empty' : os.tmpdir(),
@@ -280,21 +285,69 @@ function candidateWorktreePaths(root, contract) {
   return [...new Set(paths)].sort();
 }
 
-function stagedRejectedPaths(root, contract) {
+function blobMaxBuffer(options = {}) {
+  const requested = options.gitShowMaxBuffer;
+  if (Number.isSafeInteger(requested) && requested > 0) return requested;
+  return GIT_SPAWN_MAX_BUFFER;
+}
+
+function stagedBlobKind(root, relative, maxBuffer) {
+  const sizeResult = git(root, ['cat-file', '-s', `:${relative}`]);
+  if (sizeResult.status !== 0) return 'unread';
+  const size = Number.parseInt(String(sizeResult.stdout).trim(), 10);
+  if (!Number.isSafeInteger(size) || size < 0 || size > maxBuffer) return 'unread';
+  const blob = git(root, ['show', `:${relative}`], { encoding: null, maxBuffer });
+  if (blob.error || blob.status !== 0) return 'unread';
+  if (containsSecretContent(blob.stdout)) return 'protected';
+  return 'ok';
+}
+
+function stagedRejectedPaths(root, contract, maxBuffer) {
   const staged = nulPaths(
     git(root, ['diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'], { encoding: null }),
   );
   if (staged === null) return null;
-  const rejected = [];
+  const protectedPaths = [];
+  const unreadPaths = [];
   for (const relative of staged) {
     if (!eligiblePath(contract, relative)) {
-      rejected.push(relative);
+      protectedPaths.push(relative);
       continue;
     }
-    const blob = git(root, ['show', `:${relative}`], { encoding: null });
-    if (blob.status !== 0 || containsSecretContent(blob.stdout)) rejected.push(relative);
+    const kind = stagedBlobKind(root, relative, maxBuffer);
+    if (kind === 'protected') protectedPaths.push(relative);
+    else if (kind === 'unread') unreadPaths.push(relative);
   }
-  return rejected;
+  return { protectedPaths, unreadPaths };
+}
+
+function counted(noun, count) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function snapshotMessage(committed, protectedCount, unreadCount) {
+  const held = protectedCount > 0
+    ? `held back ${counted('protected file', protectedCount)}`
+    : '';
+  const unread = unreadCount > 0
+    ? `could not read ${counted('file', unreadCount)}`
+    : '';
+  if (!committed && protectedCount === 0 && unreadCount === 0) {
+    return 'Your vault was already saved; there were no new changes to commit.';
+  }
+  if (committed && protectedCount === 0 && unreadCount === 0) {
+    return 'Dex saved this session to local vault history. It did not run a push.';
+  }
+  if (!committed) {
+    if (protectedCount > 0 && unreadCount > 0) {
+      return `Dex ${held} and ${unread}; there were no other changes to save.`;
+    }
+    return `Dex ${held || unread}; there were no other changes to save.`;
+  }
+  if (protectedCount > 0 && unreadCount > 0) {
+    return `Dex saved eligible changes locally, ${held}, and ${unread}. It did not run a push.`;
+  }
+  return `Dex saved eligible changes locally and ${held || unread}. It did not run a push.`;
 }
 
 function unstagePaths(root, paths) {
@@ -358,18 +411,19 @@ function run(options = {}) {
     if (eligible.length > 0 && git(root, ['add', '-A', '-f', '--', ...eligible]).status !== 0) {
       return status('broken', 'Vault auto-commit could not prepare the local snapshot. Files are unchanged.');
     }
-    const rejected = stagedRejectedPaths(root, contract);
-    if (rejected === null || !unstagePaths(root, rejected)) {
-      return status('broken', 'Vault auto-commit found protected files but could not unstage them safely.');
+    const verdicts = stagedRejectedPaths(root, contract, blobMaxBuffer(options));
+    if (verdicts === null) {
+      return status('broken', 'Vault auto-commit could not inspect staged files. Files are unchanged.');
     }
+    const heldBack = [...verdicts.protectedPaths, ...verdicts.unreadPaths];
+    if (!unstagePaths(root, heldBack)) {
+      return status('broken', 'Vault auto-commit could not unstage files safely. Files are unchanged.');
+    }
+    const protectedCount = verdicts.protectedPaths.length;
+    const unreadCount = verdicts.unreadPaths.length;
     const staged = git(root, ['diff', '--cached', '--quiet']);
     if (staged.status === 0) {
-      return status(
-        'ok',
-        rejected.length > 0
-          ? `Dex held back ${rejected.length} protected ${rejected.length === 1 ? 'file' : 'files'}; there were no other changes to save.`
-          : 'Your vault was already saved; there were no new changes to commit.',
-      );
+      return status('ok', snapshotMessage(false, protectedCount, unreadCount));
     }
     if (staged.status !== 1) {
       return status('unknown', 'Vault auto-commit could not determine whether a snapshot was needed.');
@@ -379,12 +433,7 @@ function run(options = {}) {
     if (committed.status !== 0) {
       return status('broken', 'Vault auto-commit could not create the local snapshot. Files remain in the vault.');
     }
-    return status(
-      'ok',
-      rejected.length > 0
-        ? `Dex saved eligible changes locally and held back ${rejected.length} protected ${rejected.length === 1 ? 'file' : 'files'}. It did not run a push.`
-        : 'Dex saved this session to local vault history. It did not run a push.',
-    );
+    return status('ok', snapshotMessage(true, protectedCount, unreadCount));
   } catch {
     return status('unknown', 'Vault auto-commit could not check this session, so it left the vault alone.');
   } finally {
@@ -392,7 +441,7 @@ function run(options = {}) {
   }
 }
 
-module.exports = { classify, parseVaultAutoCommit, run };
+module.exports = { classify, parseVaultAutoCommit, run, GIT_SPAWN_MAX_BUFFER };
 
 if (require.main === module) {
   run();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does the chassis already do here?

Verified on current `main` (`05eaf507`). A plan without this section is not a plan.

- `.claude/hooks/vault-autocommit.cjs` `git()` — `spawnSync` with no `maxBuffer`, so the child-process default of 1 MiB applies.
- `.claude/hooks/vault-autocommit.cjs` `stagedRejectedPaths()` — `git show :path` of the staged blob; `blob.status !== 0` **or** secret-shaped content both went into the same rejected list.
- User copy already in that hook: `Dex held back N protected file(s)` / `Dex saved eligible changes locally and held back N protected file(s). It did not run a push.` That is the existing tester privacy voice. A read failure used it too, so a large note read as a secret hold.
- `.claude/settings.json` SessionEnd already runs this hook. It still never pushes.
- `core/migrations/v1-to-v2-brain-vault-split.cjs` already sets `DEFAULT_SPAWN_MAX_BUFFER` to 1 GiB, and its secret scan **skips** files over 1 MiB rather than labelling them secret (`scanForSecrets`).
- `.scripts/lib/entity-engine-client.cjs` already raises `maxBuffer` past 1 MiB for large child output.
- This PR does not stamp a new release; 1.97.3 already shipped on `main`.

Private ticket refs (do not ping, do not close): davekilleen/dex-feedback#32 (DEX-110 / GS-INBOX-B2). No public Dex issue invented.

## Linked Issue
- Linear issue: `DEX-110` (private feedback #32)

## What Changed
- `git()` now passes a 64 MiB spawn buffer, so ordinary large notes can be read and scanned.
- Staged blobs that still cannot be read (over the cap, or `git show` failed) are unstaged as **unread**, not as protected.
- Existing protected copy is unchanged for contract-denied paths and secret-shaped content.
- Unread copy uses the hook's existing "could not read" voice. Mixed runs name both counts separately.
- Unread files stay out of the snapshot (fail closed). They are not committed unscanned.

## Test Plan
- Unit/integration tests added or updated: `.claude/hooks/tests/vault-autocommit.test.cjs`
- Negative/error-path tests added or updated:
  - 2 MiB clean note is committed and the message does not say protected/held back
  - 2 MiB note with secret-shaped content at the end is still held back as protected; a 2 MiB clean sibling is saved
  - Injected tiny read cap: unread copy, not protected, file left on disk unstaged
  - Mixed protected + unread + eligible; mixed protected + unread with nothing else saved
  - Existing secret/denied copy locked to the current tester sentences
- Commands run locally: `node --test .claude/hooks/tests/vault-autocommit.test.cjs` (15/15), `scripts/check-pii.sh`, `scripts/check-founder-content.sh`

## Adversarial review
- On this runtime, 1 MiB + 16 bytes can still exit 0 with `ENOBUFS` and a complete stdout. 2 MiB is the size that is SIGTERM'd and truncated. Regression fixtures use 2 MiB.
- `blob.error` is treated as unread even when status is 0, so a truncated read is never secret-scanned and never committed.
- Did not stream blobs through a temp file. That would write secret-shaped content into `/tmp`.
- Did not invent new privacy/secret vocabulary for the unread path. "could not read" already lives in this hook. Protected sentences are byte-locked in tests.
- `gitShowMaxBuffer` is a test-only `run()` option, not an environment knob.
- Files over 64 MiB still fail closed as unread. That is a remaining ceiling, not a secret hold.
- Unstage-failure copy no longer claims "protected files" when the held-back set may only be unread.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this branch. Large notes go back to the 1 MiB spawn cap and the false protected copy.

## Docs Impact
- Files updated: none
- If none, reason: no changelog; no new tester privacy sentences; the false secret-hold copy is the thing being removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b99a9626-cf8b-4ede-80ee-6720c9c48967?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b99a9626-cf8b-4ede-80ee-6720c9c48967&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

