### PR TITLE
Name the week-review Tasks.md clear-down as a parent follow-up

### DIFF
--- a/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/week-review/AGENT_INSTRUCTIONS.md
@@ -3,9 +3,11 @@
 You are gathering context for a weekly review synthesis. Collect data from all
 available sources, analyse patterns, and write a complete weekly synthesis
 file. You gather evidence; the interactive review (assessments, goal updates,
-career evidence capture, next week's priorities) happens in the main
-conversation from your findings. Be direct and concise: concrete numbers, not
-vague percentages. Skip any section gracefully if a tool fails.
+career evidence capture, next week's priorities, and clearing completed
+tasks from `03-Tasks/Tasks.md`) happens in the main conversation from your
+findings. Do not delete or edit `03-Tasks/Tasks.md` yourself. Be direct and
+concise: concrete numbers, not vague percentages. Skip any section
+gracefully if a tool fails.
 
 **Week ending:** {{TARGET_DATE}} ({{DAY_NAME}}, {{MONTH}} {{DD}}, {{YYYY}})
 **Week start (first working day):** {{WEEK_START_DATE}}
@@ -37,6 +39,9 @@ Read `03-Tasks/Tasks.md` and scan for completion timestamps in the week
 ({{WEEK_START_DATE}} to {{TARGET_DATE}}):
 - Tasks completed, tasks added mid-week, tasks carried over
 - Completion rate
+
+Read only. Do not delete completed tasks or otherwise edit this file. The
+parent clears completed tasks after the user confirms.
 
 ### 1.3 Quarterly Goals Progress (if enabled)
 
@@ -214,7 +219,14 @@ Summary:
 - Projects that moved this week: [list, or none]
 - Journal themes: [brief, or "not enabled"]
 - Skills declining or below 3.0: [list, or "all stable"]
-- Sections needing interactive input: Career Evidence, Next Week confirmation
+- Sections needing interactive input: Career Evidence, Next Week confirmation, clear completed tasks from 03-Tasks/Tasks.md
+
+Clear completed tasks (parent only, after confirm):
+- Name this as a required follow-up. Do not delete or edit `03-Tasks/Tasks.md` yourself.
+- Parent removes whole task blocks (checkbox line through the next
+  non-indented boundary), never a per-line sweep of `[x]` lines.
+- Parent tells the user how many completed tasks will be cleared and
+  confirms before deleting.
 
 [Any warnings or issues encountered]
 ```

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -55,9 +55,10 @@ never substitute for it.
 
 **Stays inline:** the whole interactive review, priority-by-priority assessment,
 pattern discussion, goal updates, career evidence capture, next week's priority
-confirmation, the Dex Inbox check (Step 0.5), and the `/identity-snapshot` run
-that follows the synthesis. The subagent gathers evidence; it does not make
-judgements.
+confirmation, the Dex Inbox check (Step 0.5), clearing completed tasks from
+`03-Tasks/Tasks.md` after confirm (the delegated summary names this step), and
+the `/identity-snapshot` run that follows the synthesis. The subagent gathers
+evidence; it does not make judgements.
 
 ## Purpose
 
@@ -522,6 +523,9 @@ Add a section to the review:
 ---
 
 ## Follow-up Actions
+
+The delegated gatherer's structured summary names the Tasks.md clear-down
+as required interactive input. Do not skip it after a delegated run.
 
 After synthesis:
 1. Update Tasks.md with new priorities

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -564,8 +564,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-review/SKILL.md",
-        "sha256": "7c8d1a8cab205c8f6d30ac4f3c0b4cc46a2b59c5ff5b832edd81c88ae715f78c",
-        "byte_size": 19136
+        "sha256": "79e9ee08d47e060e1ab10a37aa39764ce3249557b074b01a96ee1eac4410a820",
+        "byte_size": 19385
       },
       "value": "Reviews the week in concrete finished work and the patterns behind it, and deliberately refuses to invent a completion percentage that would make a bad week look measured.",
       "jobs_served": [

--- a/core/tests/test_week_review_clear_completed_tasks_instruction_contract.py
+++ b/core/tests/test_week_review_clear_completed_tasks_instruction_contract.py
@@ -1,0 +1,75 @@
+"""Week-review must name the Tasks.md clear-down as a parent follow-up.
+
+The parent skill already tells Dex to remove whole completed task blocks
+after confirming the count. These tests keep that instruction on both
+halves of the skill, and keep the delegated gatherer from deleting
+``03-Tasks/Tasks.md`` itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEEK_REVIEW_SKILL = REPO_ROOT / ".claude/skills/week-review/SKILL.md"
+WEEK_REVIEW_AGENT = REPO_ROOT / ".claude/skills/week-review/AGENT_INSTRUCTIONS.md"
+WEEK_REVIEW_FILES = (
+    WEEK_REVIEW_SKILL,
+    WEEK_REVIEW_AGENT,
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("path", WEEK_REVIEW_FILES, ids=lambda path: path.name)
+def test_week_review_names_whole_block_clear_down_and_confirm(path: Path) -> None:
+    text = _read(path)
+    lowered = text.lower()
+
+    assert "03-Tasks/Tasks.md" in text
+    assert "whole task blocks" in lowered
+    assert "confirm" in lowered
+    assert "per-line" in lowered
+    assert "[x]" in text
+
+
+def test_week_review_agent_names_clear_down_as_parent_interactive_input() -> None:
+    text = _read(WEEK_REVIEW_AGENT)
+    final_output = text.split("## Final Output", 1)[1]
+
+    assert "Sections needing interactive input" in final_output
+    assert "clear completed tasks from 03-Tasks/Tasks.md" in final_output
+    assert "parent only" in final_output.lower()
+    assert "after confirm" in final_output.lower()
+
+
+def test_week_review_agent_does_not_instruct_subagent_to_delete_tasks_md() -> None:
+    text = _read(WEEK_REVIEW_AGENT)
+    lowered = text.lower()
+
+    assert "do not delete or edit `03-tasks/tasks.md`" in lowered
+    assert "read only" in lowered
+    assert "parent clears completed tasks" in lowered or "parent only" in lowered
+
+    write_verbs = (
+        "write `03-tasks/tasks.md`",
+        "edit `03-tasks/tasks.md` to remove",
+        "clear completed tasks out of `03-tasks/tasks.md`",
+        "delete completed tasks from `03-tasks/tasks.md`",
+    )
+    for phrase in write_verbs:
+        assert phrase not in lowered
+
+
+def test_week_review_skill_says_delegated_summary_names_the_clear_down() -> None:
+    text = _read(WEEK_REVIEW_SKILL)
+
+    assert "delegated summary names this step" in text.lower() or (
+        "delegated gatherer's structured summary names the Tasks.md clear-down"
+        in text
+    )
+    assert "Do not skip it after a delegated run" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Chassis

Already on `main` — this PR does not rebuild it:

- `.claude/skills/week-review/SKILL.md` Follow-up Actions already tell the **parent** skill to remove whole completed task **blocks** from `03-Tasks/Tasks.md` (checkbox line through the next non-indented boundary), confirm the count first, and never strip lone `[x]` lines.
- There is no work-management tool that deletes completed tasks. This PR does not add one.

The bug is a notice/instruction miss: the delegated gatherer (`AGENT_INSTRUCTIONS.md`) listed only Career Evidence and Next Week confirmation as interactive input, so a delegated `/week-review` silently skipped the clear-down the parent skill promised.

## Linked Issue
- Linear: `DEX-136`
- Private ticket: davekilleen/dex-feedback#13 (Michelle Wright: week-review said it would clear completed `[x]` tasks from `03-Tasks/Tasks.md`, but the file stays dirty)

## What Changed
- Named the Tasks.md clear-down as required interactive input in the gatherer's Final Output, with whole-block remove, confirm-count-first, and never per-line `[x]` deletes.
- Kept the gatherer from deleting or editing `03-Tasks/Tasks.md` itself — the parent does that after confirm.
- Added a short pointer in the parent skill that the delegated summary names this step, including in the "Stays inline" list so it is not easy to miss.
- Added `test_week_review_clear_completed_tasks_instruction_contract.py` so both files keep the whole-block + confirm language and the gatherer cannot be told to delete Tasks.md itself.
- Refreshed the week-review source pin in `core/lens-catalog/registry.json` so the skill-file hash matches the edited bytes. That is the only catalog change.

## Test Plan
- Unit/integration tests added or updated: `core/tests/test_week_review_clear_completed_tasks_instruction_contract.py`
- Negative/error-path tests added or updated: gatherer must not contain write/delete instructions for Tasks.md
- Commands run locally:
  - `python3 -m pytest core/tests/test_week_review_clear_completed_tasks_instruction_contract.py core/tests/test_skill_delegated_gathering.py core/tests/test_daily_plan_inbox_path_contract.py core/tests/test_calendar_provider_routing_instruction_contract.py core/tests/test_calendar_skill_degradation_instruction_contract.py core/tests/test_instruction_honesty.py -q` — 89 passed
  - After the pin refresh: Lens catalog generation / pin tests passed locally
- CI: all 13 checks passed on `81b1c9bc`

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low
- Rollback plan: revert this PR. No data-path or tool change.

## Docs Impact
- Files updated: `.claude/skills/week-review/SKILL.md`, `.claude/skills/week-review/AGENT_INSTRUCTIONS.md`, `core/lens-catalog/registry.json` (source pin only)
- Instruction-only. No changelog version heading (per ship constraints).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a09fd59c-fad4-4d5b-98e6-033cb552fd01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a09fd59c-fad4-4d5b-98e6-033cb552fd01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

