### PR TITLE
Fix weekly priorities losing their quarterly-goal link

### DIFF
--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2524,13 +2524,17 @@ def parse_weekly_priorities(filepath: Path) -> List[Dict[str, Any]]:
             pillar = priority_match.group(3).strip()
             priority_id = priority_match.group(4) if priority_match.group(4) else None
             
-            # Look for linked goal in following lines
+            # Look for a linked goal in this priority's metadata bullets.
             linked_goal_id = None
-            j = i + 1
-            if j < len(lines) and 'Quarterly goal:' in lines[j]:
-                goal_match = re.search(r'\[(Q\d+-\d{4}-goal-\d+)\]', lines[j])
+            for metadata_line in lines[i + 1:]:
+                if not re.match(r'^\s+-\s+', metadata_line):
+                    break
+                if 'Quarterly goal:' not in metadata_line:
+                    continue
+                goal_match = re.search(r'\[(Q\d+-\d{4}-goal-\d+)\]', metadata_line)
                 if goal_match:
                     linked_goal_id = goal_match.group(1)
+                break
             
             # Check completion (look for checkmark or completion note)
             completed = False  # For now, will enhance later

--- a/core/tests/test_work_server_weekly_priority_creation.py
+++ b/core/tests/test_work_server_weekly_priority_creation.py
@@ -34,6 +34,11 @@ def _call_create_priority(**overrides) -> dict:
     return json.loads(result[0].text)
 
 
+def _call_get_priorities() -> dict:
+    result = asyncio.run(work_server.handle_call_tool("get_week_priorities", {}))
+    return json.loads(result[0].text)
+
+
 @pytest.fixture
 def priority_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     path = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
@@ -106,6 +111,27 @@ def test_create_weekly_priority_writes_explicit_goal_link_without_mangling_headi
     )
     assert content.count(TOP_3) == 1
     assert content.count("## 📊 Review") == 1
+
+
+def test_created_weekly_priority_reads_back_its_goal_after_success_criteria(
+    priority_file: Path,
+):
+    priority_file.write_text(
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        "## 📊 Review\n",
+        encoding="utf-8",
+    )
+
+    created = _call_create_priority(
+        success_criteria="Playbook is shared with Sales",
+        quarterly_goal_id="Q3-2026-goal-2",
+    )
+    listed = _call_get_priorities()
+
+    assert created["linked_goal"] == "Q3-2026-goal-2"
+    assert listed["priorities"][0]["linked_goal_id"] == "Q3-2026-goal-2"
+    assert listed["alignment_summary"]["priorities_linked_to_goals"] == 1
 
 
 @pytest.mark.parametrize("existing_count", [1, 2])


### PR DESCRIPTION
## What this is
Creating a weekly priority with both success criteria and a quarterly goal writes the goal correctly, but reading the week only inspected the first metadata bullet. That made a connected priority look orphaned.

## Why it matters
Weekly planning is a repeat-use surface. A written quarterly-goal link that disappears on read is data loss, not a display glitch.

## The change
`parse_weekly_priorities` now scans only that priority’s own indented metadata bullets and stops before the next item.

## Proof
- Current main reproduced the loss: `test_created_weekly_priority_reads_back_its_goal_after_success_criteria` failed (`linked_goal_id` was `None`).
- After this change that test passes.
- `core/tests/test_work_server*.py`: 89 passed.
- Ruff and Python compile passed locally.

## Not in this PR
No release, deploy, or reporter contact. Feedback receipt `dex-feedback-investigation-45b3173f66834f47`. Card `bug-report-week-plan-create-weekly-priority-get-week-priori-45b3173f66`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser change in weekly priority read path with a targeted regression test; no auth, persistence, or API contract changes beyond fixing incorrect parsed fields.
> 
> **Overview**
> Fixes **data loss** when `get_week_priorities` parses priorities that include both success criteria and a quarterly goal. Creation already wrote both bullets, but **`parse_weekly_priorities` only checked the line immediately after the priority title**, so a goal on a later metadata bullet was dropped and alignment looked wrong.
> 
> Parsing now **walks that priority’s indented `-` metadata bullets** (stopping at the next non-bullet line) and picks up `Quarterly goal: […]` wherever it appears among those bullets.
> 
> Adds **`test_created_weekly_priority_reads_back_its_goal_after_success_criteria`**, which creates a priority with success criteria plus a goal and asserts read-back `linked_goal_id` and `alignment_summary.priorities_linked_to_goals`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455afa4280cf32038378e5b25547bb76d93f5003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->