### PR TITLE
Tell people to close Mail sessions before refreshing search

### DIFF
--- a/.claude/skills/apple-mail-setup/SKILL.md
+++ b/.claude/skills/apple-mail-setup/SKILL.md
@@ -104,6 +104,10 @@ reading nothing."
 
 ### 5. Build the index
 
+If any Dex, Claude, or Cursor session is using Mail search, quit those first. A live
+Mail server holds the search-index lock for its whole life, so the command below fails
+while those sessions are open.
+
 Have the user run, in the terminal they just granted access to:
 
 ```
@@ -162,7 +166,8 @@ Then tell them the two maintenance facts that matter:
 
 **Search returns empty but `status` says an index exists:**
 Run `/dex-doctor`. A file can exist while its schema is broken, it contains zero messages,
-or its recorded sync is stale. Rebuild with `apple-mail-mcp rebuild --verbose` if instructed.
+or its recorded sync is stale. If Doctor asks you to rebuild, quit every Dex, Claude, or Cursor session that is using Mail search first, then run `apple-mail-mcp rebuild --verbose`.
+A live Mail server holds the search-index lock for its whole life.
 
 **The index is in a custom location:**
 Dex follows `APPLE_MAIL_INDEX_PATH` from the registered MCP server first, then `[index] path`
@@ -176,6 +181,7 @@ the permission at launch.
 Run `apple-mail-mcp status`, then `/dex-doctor`. A recent last-sync time is not enough —
 if Doctor says the serving process cannot read `~/Library/Mail`, grant Full Disk Access
 to Dex / Claude / Cursor (not only Terminal), quit and reopen that app, then rebuild.
+If Doctor asks you to refresh or rebuild the index, quit every Dex, Claude, or Cursor session that is using Mail search first — a live Mail server holds the search-index lock for its whole life, so the refresh command fails while those sessions stay open.
 
 **Search returns subject-looking hits labelled as body matches:**
 On 0.4.3, body search with no usable index falls through to a live Mail query of

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -4193,8 +4193,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/apple-mail-setup/SKILL.md",
-        "sha256": "655d4cc71d12d8a5b942df4ff1015e821803e7f66f2266c4c81fcc509b7938f5",
-        "byte_size": 9363
+        "sha256": "8978a2e927a3b2414505b10cd05e4410a23551fafc638cd2c0972ea1b09974aa",
+        "byte_size": 9980
       },
       "value": "Set up and verify Apple Mail search on macOS, including the search index that silently returns nothing when it was never built.",
       "jobs_served": [

--- a/core/tests/test_apple_mail_health.py
+++ b/core/tests/test_apple_mail_health.py
@@ -328,6 +328,16 @@ def test_apple_mail_setup_action_names_serving_process_full_disk_access():
     assert "does not need this permission" not in action
 
 
+def test_apple_mail_setup_action_closes_live_sessions_before_refresh():
+    index_action = apple_mail_health.setup_action("index")
+    rebuild_action = apple_mail_health.setup_action("rebuild")
+
+    for action in (index_action, rebuild_action):
+        assert "Quit every Dex, Claude, or Cursor session that is using Mail search" in action
+        assert "holds the search-index lock" in action
+        assert "apple-mail-mcp" in action
+
+
 def test_apple_mail_search_uses_custom_path_and_real_sqlite_state(monkeypatch, context):
     _register_apple_mail_user_scope(context)
     custom_index = context.home / "private-mail" / "search.sqlite"

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -610,3 +610,12 @@ def test_apple_mail_setup_names_serving_process_full_disk_access() -> None:
     assert "~/Library/Mail" in setup
     assert "Do **not** grant it to Dex, Claude, or the ordinary MCP server process." not in setup
     assert "fresh-looking index can still be frozen" in setup or "write a fresh" in setup
+
+
+def test_apple_mail_setup_closes_live_sessions_before_index_refresh() -> None:
+    setup = _read(".claude/skills/apple-mail-setup/SKILL.md")
+
+    assert "Quit every Dex, Claude, or Cursor session that is using Mail search" in setup or (
+        "quit every Dex, Claude, or Cursor session that is using Mail search" in setup
+    )
+    assert "holds the search-index lock" in setup

--- a/core/utils/apple_mail_health.py
+++ b/core/utils/apple_mail_health.py
@@ -54,7 +54,9 @@ def setup_action(command: str) -> str:
     """Return the exact index command plus the Full Disk Access prerequisite."""
     operation = "rebuilding" if command == "rebuild" else "building"
     return (
-        f"Run `umask 077; apple-mail-mcp {command} --verbose` from a terminal app "
+        "Quit every Dex, Claude, or Cursor session that is using Mail search "
+        "(a live Mail server holds the search-index lock for its whole life), then "
+        f"run `umask 077; apple-mail-mcp {command} --verbose` from a terminal app "
         "granted Full Disk Access: System Settings > Privacy & Security > "
         "Full Disk Access. Quit and reopen that terminal before "
         f"{operation}. The app that launches the Mail server (Dex, Claude, or Cursor) "


### PR DESCRIPTION
## What this is
Apple Mail search can go stale during normal multi-session use. The community server elects one lifetime index writer; a live session therefore blocks `apple-mail-mcp index` / `rebuild`. Dex still told people to run that blocked command.

## Why it matters
Doctor and setup were giving a recovery that cannot succeed while Mail search is in use.

## The change
Keep the upstream per-session model. Doctor recovery and Apple Mail setup now say to quit every Dex, Claude, or Cursor session using Mail search before refresh. This does not add a Dex-owned shared Mail service.

## Proof
- Isolated two-server reproduction: refresh exited 1 after 31.8s with the upstream writer-lock error.
- New tests failed on current main, then passed: 76 Apple Mail health + instruction-honesty tests green; Ruff clean.

## Not in this PR
No shared local Mail daemon, no release, no reporter contact. Receipt `dex-feedback-investigation-a7339b4b86bca123`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing documentation and Doctor fix strings only; no auth, data handling, or Mail server architecture changes.
> 
> **Overview**
> **Apple Mail index/rebuild guidance now accounts for the upstream search-index lock** held for the lifetime of any live Mail MCP server.
> 
> `setup_action()` in `apple_mail_health.py` prepends Doctor recovery text with instructions to quit every Dex, Claude, or Cursor session using Mail search before running `apple-mail-mcp index` or `rebuild`, and explains that a live server blocks those commands. The **apple-mail-setup** skill mirrors the same steps in the build section and troubleshooting (rebuild / refresh paths). Tests lock in the new copy for both the health helper and `SKILL.md`, and the lens catalog entry for `apple-mail-setup` is re-hashed for the doc change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78c6f30f6ac333e81dea342d523fb5107eae157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->