### PR TITLE
Stop meeting sync attaching vendor meetings to opted-out People notes

### DIFF
--- a/.scripts/lib/entity-identity.cjs
+++ b/.scripts/lib/entity-identity.cjs
@@ -86,7 +86,7 @@ function resolveEntityPath(vaultRoot, identity) {
     } catch (_) {
       continue;
     }
-    if (entity.quarantined || entity.type !== identity.kind) continue;
+    if (entity.quarantined || entity.exclude_from_matching || entity.type !== identity.kind) continue;
     if (identity.kind === 'person' && wantedEmails.size > 0) {
       const pageEmails = normalizedEmails(entity.emails);
       if ([...wantedEmails].some(email => pageEmails.has(email))) {

--- a/.scripts/lib/entity-pages.cjs
+++ b/.scripts/lib/entity-pages.cjs
@@ -31,7 +31,8 @@ function emptyResult() {
     type: null, name: null, role: null, company: null, company_page: null,
     emails: [], aliases: [], location: null, last_interaction: null,
     domains: [], website: null, status: null, touches: [], last_touched: null,
-    quarantined: false, source_formats: [],
+    quarantined: false, exclude_from_matching: false, declared_non_entity: false,
+    source_formats: [],
   };
 }
 
@@ -240,6 +241,7 @@ function legacyFields(body) {
 
 function inferType(filePath, values) {
   if (values.type === 'person' || values.type === 'company') return values.type;
+  if (values.declared_non_entity) return null;
   const parts = filePath.split(path.sep).map(part => part.toLowerCase());
   if (parts.includes('people')) return 'person';
   if (parts.includes('companies')) return 'company';
@@ -255,6 +257,15 @@ function parseEntityPage(filePath) {
   const legacy = legacyFields(split.body);
   const result = emptyResult();
   result.quarantined = split.quarantined;
+  if (split.frontmatter && !split.quarantined) {
+    result.exclude_from_matching = split.frontmatter.exclude_from_matching === true;
+    if (Object.hasOwn(split.frontmatter, 'type')) {
+      const declared = normaliseScalar(split.frontmatter.type);
+      result.declared_non_entity = Boolean(
+        declared && declared !== 'person' && declared !== 'company',
+      );
+    }
+  }
   if (split.had) result.source_formats.push('frontmatter');
   result.source_formats.push(...legacy.formats);
   for (const key of CANONICAL_FIELDS) {
@@ -485,6 +496,12 @@ function mergeFrontmatterText(
   effectiveCurrent.relationships = normaliseRelationships(
     split.frontmatter?.relationships,
   ) || [];
+  if (split.frontmatter && Object.hasOwn(split.frontmatter, 'type')) {
+    const declared = normaliseScalar(split.frontmatter.type);
+    effectiveCurrent.declared_non_entity = Boolean(
+      declared && declared !== 'person' && declared !== 'company',
+    );
+  }
   effectiveCurrent.type = inferType(filePath, effectiveCurrent);
   if (effectiveCurrent.type && !effectiveCurrent.name) {
     const heading = /^#\s+(.+?)\s*$/m.exec(split.body);

--- a/.scripts/lib/tests/entity-identity.test.cjs
+++ b/.scripts/lib/tests/entity-identity.test.cjs
@@ -138,6 +138,46 @@ test('an unmatched company domain never falls back to a namesake', (t) => {
   }), null);
 });
 
+function writeMarkedNote(vault, relativeSegments, frontmatter) {
+  const filePath = path.join(vault, '05-Areas', 'People', ...relativeSegments);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---\n${frontmatter}---\n# Alex Smith\n\nPersonal reminder, not a CRM person.\n`,
+  );
+  return filePath;
+}
+
+test('exclude_from_matching blocks unique-name fallback', (t) => {
+  const vault = makeVault(t);
+  writeMarkedNote(
+    vault,
+    ['Personal', 'Alex_Smith.md'],
+    'exclude_from_matching: true\n',
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'Alex Smith',
+    emails: [],
+  }), null);
+});
+
+test('an explicit non-person type is not inferred from the People path', (t) => {
+  const vault = makeVault(t);
+  writeMarkedNote(
+    vault,
+    ['Personal', 'Alex_Smith.md'],
+    'type: note\n',
+  );
+
+  assert.equal(resolveEntityPath(vault, {
+    kind: 'person',
+    name: 'Alex Smith',
+    emails: [],
+  }), null);
+});
+
 test('two live namesakes cannot be resolved by name alone', (t) => {
   const vault = makeVault(t);
   writePerson(

--- a/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
+++ b/.scripts/meeting-intel/__tests__/entity-creation.test.cjs
@@ -332,6 +332,42 @@ test('auto mode creates a canonical company page from two observed contacts', ()
   assert.match(lines.join('\n'), /Created company page:/);
 }));
 
+test('meeting sync does not attach an email-less attendee to a never-match People note', () => withVault(vault => {
+  const notePath = path.join(vault, '05-Areas', 'People', 'Personal', 'Alex_Smith.md');
+  fs.mkdirSync(path.dirname(notePath), { recursive: true });
+  const original = [
+    '---',
+    'exclude_from_matching: true',
+    'type: note',
+    '---',
+    '# Alex Smith',
+    '',
+    'Personal reminder, not a CRM person.',
+    '',
+  ].join('\n');
+  fs.writeFileSync(notePath, original);
+
+  const result = processEntityCreation([
+    {
+      id: 'vendor-review',
+      title: 'Vendor review',
+      createdAt: '2026-08-28T10:00:00Z',
+      transcript: '',
+      filteredAttendees: [{ name: 'Alex Smith', location: 'external' }],
+    },
+    {
+      id: 'vendor-review-2',
+      title: 'Vendor review follow-up',
+      createdAt: '2026-08-28T11:00:00Z',
+      transcript: '',
+      filteredAttendees: [{ name: 'Alex Smith', location: 'external' }],
+    },
+  ], { entity_creation: { mode: 'auto' } });
+
+  assert.deepEqual(result.created, []);
+  assert.equal(fs.readFileSync(notePath, 'utf8'), original);
+}));
+
 test('batch sync logs idempotent person and company touches without fabricating no-email attendees', () => withVault(vault => {
   const attendees = [
     { name: 'Jane Doe', email: 'jane@example.com', location: 'external' },

--- a/core/entity_engine/contract.py
+++ b/core/entity_engine/contract.py
@@ -122,6 +122,8 @@ def _empty_result() -> dict[str, Any]:
         "touches": [],
         "last_touched": None,
         "quarantined": False,
+        "exclude_from_matching": False,
+        "declared_non_entity": False,
         "source_formats": [],
     }
 
@@ -386,6 +388,8 @@ def _split_frontmatter(
 def _infer_type(path: Path, values: dict[str, Any]) -> str | None:
     if values.get("type") in {"person", "company"}:
         return values["type"]
+    if values.get("declared_non_entity"):
+        return None
     try:
         path.resolve().relative_to(PEOPLE_DIR.resolve())
         return "person"
@@ -414,6 +418,13 @@ def parse_entity_page(path: str | Path) -> dict[str, Any]:
     pipe, inline, legacy_formats = _legacy_fields(body)
     result = _empty_result()
     result["quarantined"] = quarantined
+    if frontmatter is not None and not quarantined:
+        result["exclude_from_matching"] = frontmatter.get("exclude_from_matching") is True
+        if "type" in frontmatter:
+            declared = _normalise_scalar(frontmatter.get("type"))
+            result["declared_non_entity"] = bool(
+                declared and declared not in {"person", "company"}
+            )
     if had_frontmatter:
         result["source_formats"].append("frontmatter")
     result["source_formats"].extend(legacy_formats)
@@ -554,6 +565,11 @@ def merge_frontmatter_text(
         )
         or []
     )
+    if parsed is not None and "type" in parsed:
+        declared = _normalise_scalar(parsed.get("type"))
+        effective_current["declared_non_entity"] = bool(
+            declared and declared not in {"person", "company"}
+        )
     effective_current["type"] = _infer_type(page_path, effective_current)
     if effective_current["type"] and not effective_current["name"]:
         heading = re.search(r"^#\s+(.+?)\s*$", body, re.MULTILINE)

--- a/core/tests/fixtures/entity_pages/01-frontmatter-only.expected.json
+++ b/core/tests/fixtures/entity_pages/01-frontmatter-only.expected.json
@@ -1,1 +1,26 @@
-{"type":"person","name":"Alice Smith","role":"VP Product","company":"Acme","company_page":"Acme_Corp","emails":["alice@example.com"],"aliases":["Al"],"location":"external","last_interaction":"2026-07-01","domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["frontmatter"]}
+{
+  "type": "person",
+  "name": "Alice Smith",
+  "role": "VP Product",
+  "company": "Acme",
+  "company_page": "Acme_Corp",
+  "emails": [
+    "alice@example.com"
+  ],
+  "aliases": [
+    "Al"
+  ],
+  "location": "external",
+  "last_interaction": "2026-07-01",
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/02-pipe-table.expected.json
+++ b/core/tests/fixtures/entity_pages/02-pipe-table.expected.json
@@ -1,1 +1,25 @@
-{"type":"person","name":"Bob Jones","role":"Engineer","company":"Beta Ltd","company_page":"Beta_Ltd","emails":["bob@beta.test"],"aliases":[],"location":null,"last_interaction":"2026-06-30","domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["pipe_table","inline_bold"]}
+{
+  "type": "person",
+  "name": "Bob Jones",
+  "role": "Engineer",
+  "company": "Beta Ltd",
+  "company_page": "Beta_Ltd",
+  "emails": [
+    "bob@beta.test"
+  ],
+  "aliases": [],
+  "location": null,
+  "last_interaction": "2026-06-30",
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "pipe_table",
+    "inline_bold"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/03-inline-bold.expected.json
+++ b/core/tests/fixtures/entity_pages/03-inline-bold.expected.json
@@ -1,1 +1,24 @@
-{"type":"person","name":"Carol Ng","role":"Founder","company":"Gamma","company_page":null,"emails":["carol@gamma.io"],"aliases":[],"location":"external","last_interaction":"2026-05-04","domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["inline_bold"]}
+{
+  "type": "person",
+  "name": "Carol Ng",
+  "role": "Founder",
+  "company": "Gamma",
+  "company_page": null,
+  "emails": [
+    "carol@gamma.io"
+  ],
+  "aliases": [],
+  "location": "external",
+  "last_interaction": "2026-05-04",
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "inline_bold"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/04-overview-table.expected.json
+++ b/core/tests/fixtures/entity_pages/04-overview-table.expected.json
@@ -1,1 +1,24 @@
-{"type":"person","name":"Dana Ray","role":null,"company":"Delta","company_page":null,"emails":["dana@delta.dev"],"aliases":[],"location":null,"last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["pipe_table"]}
+{
+  "type": "person",
+  "name": "Dana Ray",
+  "role": null,
+  "company": "Delta",
+  "company_page": null,
+  "emails": [
+    "dana@delta.dev"
+  ],
+  "aliases": [],
+  "location": null,
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "pipe_table"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/05-mixed-conflict.expected.json
+++ b/core/tests/fixtures/entity_pages/05-mixed-conflict.expected.json
@@ -1,1 +1,24 @@
-{"type":"person","name":"Eve Frontmatter","role":"Designer","company":"Canonical Co","company_page":null,"emails":[],"aliases":[],"location":"internal","last_interaction":"2026-07-02","domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["frontmatter","pipe_table","inline_bold"]}
+{
+  "type": "person",
+  "name": "Eve Frontmatter",
+  "role": "Designer",
+  "company": "Canonical Co",
+  "company_page": null,
+  "emails": [],
+  "aliases": [],
+  "location": "internal",
+  "last_interaction": "2026-07-02",
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter",
+    "pipe_table",
+    "inline_bold"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/06-unicode-name.expected.json
+++ b/core/tests/fixtures/entity_pages/06-unicode-name.expected.json
@@ -1,1 +1,26 @@
-{"type":"person","name":"José García","role":"Diseñador","company":null,"company_page":null,"emails":["jose@ejemplo.es"],"aliases":["Pepe"],"location":"external","last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["frontmatter"]}
+{
+  "type": "person",
+  "name": "Jos\u00e9 Garc\u00eda",
+  "role": "Dise\u00f1ador",
+  "company": null,
+  "company_page": null,
+  "emails": [
+    "jose@ejemplo.es"
+  ],
+  "aliases": [
+    "Pepe"
+  ],
+  "location": "external",
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/07-readme-non-entity.expected.json
+++ b/core/tests/fixtures/entity_pages/07-readme-non-entity.expected.json
@@ -1,1 +1,20 @@
-{"type":null,"name":null,"role":null,"company":null,"company_page":null,"emails":[],"aliases":[],"location":null,"last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":[]}
+{
+  "type": null,
+  "name": null,
+  "role": null,
+  "company": null,
+  "company_page": null,
+  "emails": [],
+  "aliases": [],
+  "location": null,
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": []
+}

--- a/core/tests/fixtures/entity_pages/08-malformed-yaml.expected.json
+++ b/core/tests/fixtures/entity_pages/08-malformed-yaml.expected.json
@@ -1,1 +1,25 @@
-{"type":"person","name":"Quarantined Person","role":null,"company":"Recovery Corp","company_page":null,"emails":["recover@example.com"],"aliases":[],"location":null,"last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":true,"source_formats":["frontmatter","inline_bold"]}
+{
+  "type": "person",
+  "name": "Quarantined Person",
+  "role": null,
+  "company": "Recovery Corp",
+  "company_page": null,
+  "emails": [
+    "recover@example.com"
+  ],
+  "aliases": [],
+  "location": null,
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": true,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter",
+    "inline_bold"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/09-crlf.expected.json
+++ b/core/tests/fixtures/entity_pages/09-crlf.expected.json
@@ -1,1 +1,24 @@
-{"type":"company","name":"CRLF Corp","role":null,"company":null,"company_page":null,"emails":[],"aliases":[],"location":null,"last_interaction":null,"domains":["crlf.example"],"website":"https://crlf.example","status":"Active","touches":[],"last_touched":null,"quarantined":false,"source_formats":["frontmatter"]}
+{
+  "type": "company",
+  "name": "CRLF Corp",
+  "role": null,
+  "company": null,
+  "company_page": null,
+  "emails": [],
+  "aliases": [],
+  "location": null,
+  "last_interaction": null,
+  "domains": [
+    "crlf.example"
+  ],
+  "website": "https://crlf.example",
+  "status": "Active",
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/10-utf8-bom.expected.json
+++ b/core/tests/fixtures/entity_pages/10-utf8-bom.expected.json
@@ -1,1 +1,24 @@
-{"type":"person","name":"BOM Person","role":null,"company":null,"company_page":null,"emails":["bom@example.com"],"aliases":[],"location":"unknown","last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":["frontmatter"]}
+{
+  "type": "person",
+  "name": "BOM Person",
+  "role": null,
+  "company": null,
+  "company_page": null,
+  "emails": [
+    "bom@example.com"
+  ],
+  "aliases": [],
+  "location": "unknown",
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": [
+    "frontmatter"
+  ]
+}

--- a/core/tests/fixtures/entity_pages/11-empty.expected.json
+++ b/core/tests/fixtures/entity_pages/11-empty.expected.json
@@ -1,1 +1,20 @@
-{"type":null,"name":null,"role":null,"company":null,"company_page":null,"emails":[],"aliases":[],"location":null,"last_interaction":null,"domains":[],"website":null,"status":null,"touches":[],"last_touched":null,"quarantined":false,"source_formats":[]}
+{
+  "type": null,
+  "name": null,
+  "role": null,
+  "company": null,
+  "company_page": null,
+  "emails": [],
+  "aliases": [],
+  "location": null,
+  "last_interaction": null,
+  "domains": [],
+  "website": null,
+  "status": null,
+  "touches": [],
+  "last_touched": null,
+  "quarantined": false,
+  "exclude_from_matching": false,
+  "declared_non_entity": false,
+  "source_formats": []
+}


### PR DESCRIPTION
## What this is
Meeting sync could treat any uniquely named note under People as a person. An email-less attendee with the same name could therefore add a vendor meeting to a personal note. `type: note` and `exclude_from_matching: true` were ignored.

## Why it matters
Repeatable meeting sync must not corrupt notes that are not person records.

## The change
Front Desk recorded the backwards-compatible contract: honor an explicit page-level never-match. Dex now skips pages with `exclude_from_matching: true`, and does not infer person-hood from the People path when `type` is explicitly something other than person/company. Unique-name matching for unmarked person pages is unchanged.

## Proof
- New identity tests failed on current main, then passed.
- Meeting-sync test: a Personal/Alex_Smith.md note with both markers is not mutated by an email-less Alex Smith attendee.
- Existing unique-name and namesake tests still pass (176 local script tests plus the DEX_PYTHON-gated suite in CI).

## Not in this PR
No change to default unique-name matching, no release, no reporter contact. Receipt `dex-feedback-investigation-492137738c249e22`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who meeting sync and identity resolution can bind to, which affects touch logging on People notes; behavior is narrowly scoped to explicit opt-out markers and non-entity types.
> 
> **Overview**
> Meeting sync could treat a uniquely named note under **People** as a person and attach vendor meetings when an email-less attendee shared the same name. This PR implements the documented **never-match** contract so those personal notes stay untouched.
> 
> **Parsing** (Node `entity-pages` and Python `contract`) now surfaces `exclude_from_matching` and `declared_non_entity` from frontmatter. **`inferType`** no longer treats a file as a person/company from folder path when frontmatter declares a non-entity `type` (e.g. `type: note`). **`resolveEntityPath`** skips quarantined pages, pages with `exclude_from_matching: true`, and pages whose inferred type does not match the lookup.
> 
> Default unique-name matching for ordinary person pages is unchanged. Tests cover identity resolution and an end-to-end case where auto meeting sync does not create or mutate a marked **Alex_Smith** personal note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc731e7ac88cdd09c0397487db54a82f6c46044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->