### PR TITLE
Tell VS Code and Cursor users to grant Calendar in System Settings

### DIFF
--- a/.claude/skills/calendar-setup/SKILL.md
+++ b/.claude/skills/calendar-setup/SKILL.md
@@ -5,7 +5,7 @@ description: "Grant Python calendar access for ~30x faster calendar queries. Use
 
 # Calendar Setup - Enable Fast Queries
 
-**Purpose:** Grant Python calendar access for 30x faster calendar queries (30s → <1s)
+**Purpose:** Grant calendar access for 30x faster calendar queries (30s → <1s)
 
 **When to run:**
 - After initial Dex installation
@@ -19,17 +19,14 @@ description: "Grant Python calendar access for ~30x faster calendar queries. Use
 1. **Check current permission status:**
    - Run the permission checker: `python3 core/mcp/scripts/check_calendar_permission.py`
    - Show the user what status was returned
+   - Do not promise that a Mac permission dialog will appear. When Dex runs inside VS Code or Cursor, that dialog often never shows.
 
 2. **If Already Authorized:**
    - Great! Calendar queries are already optimized.
    - No action needed.
 
-3. **If NotDetermined (permission not yet requested):**
-   - The script will show a macOS permission dialog
-   - Guide user: "Click 'OK' when the dialog appears to grant Python access to Calendar"
-   - Run the script again to verify
-
-4. **If Denied (previously rejected):**
+3. **If NotDetermined or Denied:**
+   - VS Code and Cursor are first-class Calendar surfaces. Send the person to System Settings for the app Dex is running in. Do not send them to a standalone terminal as the only path. Do not tell them to wait for a popup. Do not tell them that granting Terminal, Python, or python3 is enough.
    - Show clear instructions:
      ```
      To enable fast calendar queries:
@@ -37,27 +34,30 @@ description: "Grant Python calendar access for ~30x faster calendar queries. Use
      1. Open System Settings (Command+Space, type "System Settings")
      2. Click "Privacy & Security" in the sidebar
      3. Click "Calendars"
-     4. Find "Python" or "python3" in the list
-     5. Enable the checkbox
-     6. Run `/calendar-setup` again to verify
+     4. Find the app Dex is running in — VS Code or Cursor — and turn it on
+     5. Click that app and set access to Full (not "Add Only")
+     6. Quit the editor and open it again
+     7. Run /calendar-setup again to verify
      ```
+   - A Terminal grant does not transfer to the editor. Reinstalling Dex does not fix a missing editor grant.
 
-5. **If Restricted:**
+4. **If Restricted:**
    - Explain: "Calendar access is blocked by system policies (parental controls or enterprise MDM)"
    - Calendar queries will use AppleScript (slower but functional)
    - No user action possible
 
-6. **After Success:**
+5. **After Success:**
    - Confirm: "✅ Calendar access granted! Queries are now 30x faster."
    - Explain: "Calendar queries now use native EventKit instead of AppleScript"
-   - No need to run this again - permission is persistent
+   - No need to run this again - permission is persistent for that app
 
 ---
 
 ## Technical Notes
 
 - **EventKit vs AppleScript:** EventKit uses database queries (fast), AppleScript loads all events then filters (slow)
-- **Permission is persistent:** Once granted, Python keeps access until explicitly revoked
+- **Permission is per app:** macOS grants Calendar access to the app that is asking. When Dex runs inside VS Code or Cursor, grant that editor. A Terminal grant does not carry over.
+- **Permission is persistent:** Once granted to the editor, access lasts until it is revoked
 - **Privacy:** All calendar data stays local - Dex never sends calendar data anywhere
 - **Fallback:** If EventKit isn't available, Dex falls back to AppleScript (works but slower)
 
@@ -69,10 +69,13 @@ description: "Grant Python calendar access for ~30x faster calendar queries. Use
 - Run: `pip3 install pyobjc-framework-EventKit`
 - This should have been installed during Dex setup
 
-**Permission dialog doesn't appear:**
-- System Settings might already show "Denied" from a previous attempt
-- Follow the manual steps above to toggle permission on
+**No permission popup / access still denied:**
+- Do not wait for a dialog, and do not switch to Terminal as the only fix
+- Open System Settings → Privacy & Security → Calendars
+- Turn on VS Code or Cursor (the app Dex is running in) and set Full access
+- A grant already given to Terminal, Python, or python3 does not transfer
+- Reinstalling Dex does not fix this
 
 **Still seeing slow queries after granting access:**
-- Restart your coding harness (Cursor/Claude Code/Pi) to reload MCP server
+- Restart the app Dex is running in (VS Code or Cursor) to reload the calendar connection
 - Verify permission: `python3 core/mcp/scripts/check_calendar_permission.py`

--- a/06-Resources/Dex_System/Calendar_Setup.md
+++ b/06-Resources/Dex_System/Calendar_Setup.md
@@ -10,7 +10,7 @@ If `/google-workspace-setup` already set your calendar source to Google, skip th
 
 ## How it works in one sentence
 
-Dex reads your calendar from the **Calendar app** that came with your Mac. So you add your Google account to that app once, let Cursor use it, and Dex sees your meetings.
+Dex reads your calendar from the **Calendar app** that came with your Mac. So you add your Google account to that app once, let the app Dex is running in use it, and Dex sees your meetings.
 
 ---
 
@@ -28,16 +28,16 @@ Dex doesn't talk to Google directly. It uses the built-in **Calendar** app on yo
 
 Your Google events will now appear in the Calendar app. Once they're here, Dex can see them too.
 
-### Step 2: Let Cursor use your calendar
+### Step 2: Let the app Dex is running in use your calendar
 
-macOS only lets apps see your calendar if you allow it.
+macOS only lets an app see your calendar if you allow **that** app. VS Code and Cursor are first-class Calendar surfaces — grant Calendar for the app you are in.
 
 1. Open **System Settings** (or **System Preferences** on older macOS).
 2. Go to **Privacy & Security** → **Calendars**.
-3. Find **Cursor** in the list and turn it **On**.
-4. Click **Cursor** and set access to **Full** (not "Add Only") so Dex can read your events.
+3. Find **VS Code** or **Cursor** — whichever app Dex is running in — and turn it **On**.
+4. Click that app and set access to **Full** (not "Add Only") so Dex can read your events.
 
-The first time Cursor tries to read your calendar, macOS may show a popup: **"Cursor would like to access your calendars"**. Click **Allow**.
+Do not wait for a Mac permission popup. It often never appears when Dex runs inside VS Code or Cursor. A grant given to Terminal does **not** transfer to the editor. Reinstalling Dex does **not** fix a missing grant.
 
 **Done.** Run `/daily-plan` or ask "what's on my calendar today?" — your Google meetings (including recurring ones) should show on the right days.
 
@@ -47,22 +47,27 @@ The first time Cursor tries to read your calendar, macOS may show a popup: **"Cu
 
 | What you see | What to do |
 |--------------|------------|
-| **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **Cursor** on, then click **Cursor** and set access to **Full** (not "Add Only"). Quit Cursor and open it again. |
-| **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart Cursor. |
+| **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **VS Code** or **Cursor** on (the app Dex is running in), then click that app and set access to **Full** (not "Add Only"). Quit the editor and open it again. Do not switch to Terminal as the only fix, and do not reinstall Dex. |
+| **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart the editor. |
 | **Calendar is empty or very slow** | Same as above: both setup steps, and if you didn't run the installer, run the `pip3 install` line above. |
 
 ---
 
-## Known limitation: the VS Code extension can't use Apple Reminders
+## If Dex is running inside VS Code or Cursor
 
-macOS grants calendar and reminders access **per app** — it looks at which app is asking. When Dex runs through the **Claude Code extension inside VS Code** (rather than from a normal terminal window), macOS never shows the permission popup to that process at all, and access granted to Terminal does **not** carry over. The result: Apple Reminders features (phone capture via a "Dex Inbox" list, "Dex Today" sync) are simply unavailable in that setup — not misconfigured, unavailable. Reinstalling or redoing the setup steps will not change this.
+macOS grants calendar access **per app** — it looks at which app is asking. When Dex runs inside **VS Code** or **Cursor**, that editor is the app that needs Calendar access.
 
-What to do instead:
+What to do:
 
-- **Run Dex from a standalone terminal window** (Terminal.app, or another terminal app launched on its own). The permission popup appears there, and access works after you click Allow.
-- **Or keep using the VS Code extension without Reminders features.** Dex skips them silently when access is unavailable — daily planning and reviews work normally without them.
+1. Open **System Settings** → **Privacy & Security** → **Calendars**.
+2. Turn on **VS Code** or **Cursor** — the app you are in — and set access to **Full**.
+3. Quit that app and open it again, then ask Dex to check your calendar.
 
-This was verified directly (August 2026): the same check succeeds from Terminal.app, and fails from both VS Code's built-in terminal and the extension's own process — even after access was granted in Terminal.app first.
+A grant given to Terminal does **not** carry over to the editor. Reinstalling Dex or redoing setup will not change that. Do not treat a standalone terminal as the only path, and do not wait for a permission popup — it often never appears from inside the editor.
+
+Apple Reminders is a separate toggle in the same **Privacy & Security** list. Grant it for the same editor app if you use those features. If Reminders tools still fail after that, Dex skips them — that is not a Calendar failure, and reinstalling will not fix it.
+
+This was verified directly (August 2026): the same calendar check can succeed from Terminal.app and fail from both VS Code's built-in terminal and the editor's own process after access was granted in Terminal.app first. That is why the editor grant in System Settings is the path.
 
 ---
 
@@ -75,6 +80,6 @@ If you have several calendars and want Dex to focus on one (e.g. your work calen
 ## Summary
 
 1. **Add Google to the Calendar app** — Calendar → Add Account → Google → sign in.
-2. **Allow Cursor to access Calendars** — System Settings → Privacy & Security → Calendars → Cursor On, then click Cursor and choose **Full** access (not "Add Only").
+2. **Allow the app Dex is running in to access Calendars** — System Settings → Privacy & Security → Calendars → turn on VS Code or Cursor, then choose **Full** access (not "Add Only").
 
 After that, your Google Calendar meetings show up in Dex on the right days, including recurring events.

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -4318,8 +4318,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/calendar-setup/SKILL.md",
-        "sha256": "ae0331bf55f3d011de82e650c94777736bc63a01a71c35d6114e3011af24a9e5",
-        "byte_size": 2857
+        "sha256": "869f40739647c2a4cdb249010907278bb19767965e374bbe8d394d7af6828378",
+        "byte_size": 3671
       },
       "value": "Grant Python calendar access for ~30x faster calendar queries.",
       "jobs_served": [

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -619,3 +619,31 @@ def test_apple_mail_setup_closes_live_sessions_before_index_refresh() -> None:
         "quit every Dex, Claude, or Cursor session that is using Mail search" in setup
     )
     assert "holds the search-index lock" in setup
+
+
+def test_calendar_setup_treats_editor_as_first_class_surface() -> None:
+    paths = (
+        ".claude/skills/calendar-setup/SKILL.md",
+        "docs/Dex_System/Calendar_Setup.md",
+        "06-Resources/Dex_System/Calendar_Setup.md",
+    )
+    for relative in paths:
+        text = _read(relative)
+        lower = text.lower()
+        assert "System Settings" in text, relative
+        assert "Privacy & Security" in text, relative
+        assert "Calendars" in text, relative
+        assert "VS Code" in text, relative
+        assert "Cursor" in text, relative
+        assert "does not transfer" in lower or "does not carry over" in lower, relative
+        assert "reinstall" in lower, relative
+        assert "Claude Code" not in text, relative
+        assert "The script will show a macOS permission dialog" not in text, relative
+        assert "Click 'OK' when the dialog appears" not in text, relative
+        assert "Run Dex from a standalone terminal window" not in text, relative
+        assert 'Find "Python" or "python3" in the list' not in text, relative
+
+    skill = _read(".claude/skills/calendar-setup/SKILL.md")
+    assert "first-class Calendar surfaces" in skill
+    assert "Do not promise that a Mac permission dialog will appear" in skill
+    assert "Do not send them to a standalone terminal as the only path" in skill

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -629,7 +629,7 @@ def test_calendar_setup_treats_editor_as_first_class_surface() -> None:
     )
     for relative in paths:
         text = _read(relative)
-        lower = text.lower()
+        lower = text.lower().replace("**", "")
         assert "System Settings" in text, relative
         assert "Privacy & Security" in text, relative
         assert "Calendars" in text, relative

--- a/docs/Dex_System/Calendar_Setup.md
+++ b/docs/Dex_System/Calendar_Setup.md
@@ -10,7 +10,7 @@ If `/google-workspace-setup` already set your calendar source to Google, skip th
 
 ## How it works in one sentence
 
-Dex reads your calendar from the **Calendar app** that came with your Mac. So you add your Google account to that app once, let Cursor use it, and Dex sees your meetings.
+Dex reads your calendar from the **Calendar app** that came with your Mac. So you add your Google account to that app once, let the app Dex is running in use it, and Dex sees your meetings.
 
 ---
 
@@ -28,16 +28,16 @@ Dex doesn't talk to Google directly. It uses the built-in **Calendar** app on yo
 
 Your Google events will now appear in the Calendar app. Once they're here, Dex can see them too.
 
-### Step 2: Let Cursor use your calendar
+### Step 2: Let the app Dex is running in use your calendar
 
-macOS only lets apps see your calendar if you allow it.
+macOS only lets an app see your calendar if you allow **that** app. VS Code and Cursor are first-class Calendar surfaces — grant Calendar for the app you are in.
 
 1. Open **System Settings** (or **System Preferences** on older macOS).
 2. Go to **Privacy & Security** → **Calendars**.
-3. Find **Cursor** in the list and turn it **On**.
-4. Click **Cursor** and set access to **Full** (not "Add Only") so Dex can read your events.
+3. Find **VS Code** or **Cursor** — whichever app Dex is running in — and turn it **On**.
+4. Click that app and set access to **Full** (not "Add Only") so Dex can read your events.
 
-The first time Cursor tries to read your calendar, macOS may show a popup: **"Cursor would like to access your calendars"**. Click **Allow**.
+Do not wait for a Mac permission popup. It often never appears when Dex runs inside VS Code or Cursor. A grant given to Terminal does **not** transfer to the editor. Reinstalling Dex does **not** fix a missing grant.
 
 **Done.** Run `/daily-plan` or ask "what's on my calendar today?" — your Google meetings (including recurring ones) should show on the right days.
 
@@ -47,22 +47,27 @@ The first time Cursor tries to read your calendar, macOS may show a popup: **"Cu
 
 | What you see | What to do |
 |--------------|------------|
-| **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **Cursor** on, then click **Cursor** and set access to **Full** (not "Add Only"). Quit Cursor and open it again. |
-| **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart Cursor. |
+| **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **VS Code** or **Cursor** on (the app Dex is running in), then click that app and set access to **Full** (not "Add Only"). Quit the editor and open it again. Do not switch to Terminal as the only fix, and do not reinstall Dex. |
+| **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart the editor. |
 | **Calendar is empty or very slow** | Same as above: both setup steps, and if you didn't run the installer, run the `pip3 install` line above. |
 
 ---
 
-## Known limitation: the VS Code extension can't use Apple Reminders
+## If Dex is running inside VS Code or Cursor
 
-macOS grants calendar and reminders access **per app** — it looks at which app is asking. When Dex runs through the **Claude Code extension inside VS Code** (rather than from a normal terminal window), macOS never shows the permission popup to that process at all, and access granted to Terminal does **not** carry over. The result: Apple Reminders features (phone capture via a "Dex Inbox" list, "Dex Today" sync) are simply unavailable in that setup — not misconfigured, unavailable. Reinstalling or redoing the setup steps will not change this.
+macOS grants calendar access **per app** — it looks at which app is asking. When Dex runs inside **VS Code** or **Cursor**, that editor is the app that needs Calendar access.
 
-What to do instead:
+What to do:
 
-- **Run Dex from a standalone terminal window** (Terminal.app, or another terminal app launched on its own). The permission popup appears there, and access works after you click Allow.
-- **Or keep using the VS Code extension without Reminders features.** Dex skips them silently when access is unavailable — daily planning and reviews work normally without them.
+1. Open **System Settings** → **Privacy & Security** → **Calendars**.
+2. Turn on **VS Code** or **Cursor** — the app you are in — and set access to **Full**.
+3. Quit that app and open it again, then ask Dex to check your calendar.
 
-This was verified directly (August 2026): the same check succeeds from Terminal.app, and fails from both VS Code's built-in terminal and the extension's own process — even after access was granted in Terminal.app first.
+A grant given to Terminal does **not** carry over to the editor. Reinstalling Dex or redoing setup will not change that. Do not treat a standalone terminal as the only path, and do not wait for a permission popup — it often never appears from inside the editor.
+
+Apple Reminders is a separate toggle in the same **Privacy & Security** list. Grant it for the same editor app if you use those features. If Reminders tools still fail after that, Dex skips them — that is not a Calendar failure, and reinstalling will not fix it.
+
+This was verified directly (August 2026): the same calendar check can succeed from Terminal.app and fail from both VS Code's built-in terminal and the editor's own process after access was granted in Terminal.app first. That is why the editor grant in System Settings is the path.
 
 ---
 
@@ -75,6 +80,6 @@ If you have several calendars and want Dex to focus on one (e.g. your work calen
 ## Summary
 
 1. **Add Google to the Calendar app** — Calendar → Add Account → Google → sign in.
-2. **Allow Cursor to access Calendars** — System Settings → Privacy & Security → Calendars → Cursor On, then click Cursor and choose **Full** access (not "Add Only").
+2. **Allow the app Dex is running in to access Calendars** — System Settings → Privacy & Security → Calendars → turn on VS Code or Cursor, then choose **Full** access (not "Add Only").
 
 After that, your Google Calendar meetings show up in Dex on the right days, including recurring events.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Private ticket: [davekilleen/dex-feedback#15](https://github.com/davekilleen/dex-feedback/issues/15) (DEX-134, Michelle Wright).

## Linked Issue
- Linear issue: `DEX-134`

## What Changed
When Dex runs inside VS Code or Cursor, Calendar access has to be granted for **that app** in **System Settings → Privacy & Security → Calendars**.

The old copy still sent people to a standalone terminal as the main fix, and `/calendar-setup` still promised a Mac permission popup and told people to turn on Python. A Terminal grant does not transfer. Reinstalling does not fix it. The popup often never appears from inside the editor.

This PR rewrites that customer-facing and agent-facing copy only:

- VS Code and Cursor are first-class Calendar surfaces
- System Settings is the path
- Terminal is not the only path
- No manufactured permission popup
- Vendor product names removed from the copy this change touches

No `package.json` bump. No release.

## Test Plan
- Unit/integration tests added or updated: `test_calendar_setup_treats_editor_as_first_class_surface` in `core/tests/test_instruction_honesty.py`
- Negative/error-path tests added or updated: the new test rejects the old popup, Terminal-only, and Python-list instructions
- Commands run locally:
  - `pytest core/tests/test_instruction_honesty.py::test_calendar_setup_treats_editor_as_first_class_surface` — passed
  - `pytest core/tests/test_docs_bridge.py` — passed
  - `pytest core/tests/test_dex_lens_catalog_generation.py::test_real_registry_source_pins_match_the_shipped_skills` — passed
  - `pytest core/tests/test_architecture_inventory.py` — passed

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [ ] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [ ] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): low
- Rollback plan: revert this PR. Copy and a Lens catalogue pin only; no runtime behavior change.

## Docs Impact
- Files updated:
  - `.claude/skills/calendar-setup/SKILL.md`
  - `docs/Dex_System/Calendar_Setup.md`
  - `06-Resources/Dex_System/Calendar_Setup.md` (byte-identical vault copy)
  - `core/lens-catalog/registry.json` (skill hash/size pin)
  - `core/tests/test_instruction_honesty.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b469e21c-0fff-41d9-835f-8e2092b9d150?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b469e21c-0fff-41d9-835f-8e2092b9d150&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

