### PR TITLE
Stop claiming usage analytics is active without a relay

### DIFF
--- a/.claude/flows/onboarding.md
+++ b/.claude/flows/onboarding.md
@@ -686,7 +686,7 @@ Want to connect Granola now with `/granola-setup`, then set up manual or automat
 
 **This is shown for ALL new users during onboarding.**
 
-Say: "One last thing: Dex collects anonymous feature usage data—things like 'ran /daily-plan' or 'created a task'—to help improve the product. No content, names, notes, or conversations are ever sent. You can opt out anytime by saying 'turn off Dex analytics'."
+Say: "One last thing: Dex can record anonymous feature-usage counts—things like 'ran /daily-plan' or 'created a task'—to help improve the product. New installs do not send that data yet because no usage relay is configured. No content, names, notes, or conversations are sent. You can keep it off by saying 'turn off Dex analytics'."
 
 Then:
 1. Update `System/usage_log.md`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,7 +478,7 @@ Person and company context hooks run automatically when reading files:
 
 ### Analytics (Opt-Out Model)
 
-Analytics is **on by default** for new installs. No prompting needed — users are informed during onboarding and can opt out anytime.
+Analytics is **not active** on new installs until a usage relay is configured. Consent may still be recorded as opted-in so it can turn on later; users can say "turn off Dex analytics" to keep it off. No prompting needed.
 
 **Do nothing unless the user explicitly asks to opt out or opt in.**
 

--- a/System/usage_log.md
+++ b/System/usage_log.md
@@ -108,7 +108,7 @@ Tracks anonymous feature usage tracking to help improve Dex.
 - **Last prompted:** (not applicable)
 
 **Values:**
-- `Consent decision: opted-in` → Analytics active (default for new installs)
+- `Consent decision: opted-in` → Consent recorded; analytics is still not active until a usage relay is configured
 - `Consent decision: opted-out` → User opted out (say "turn off Dex analytics" anytime)
 
 ---

--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -184,5 +184,5 @@ integrations:
 # Controls anonymous feature usage tracking to help the Dex maintainers improve Dex
 # Only Dex built-in features are tracked, never content or what you do with features
 analytics:
-  # Master switch - analytics on by default. Say "turn off Dex analytics" to opt out.
+  # Willingness to send usage analytics. Sending is not active until a usage relay is configured. Say "turn off Dex analytics" to keep it off.
   enabled: true

--- a/core/mcp/analytics_helper.py
+++ b/core/mcp/analytics_helper.py
@@ -213,11 +213,14 @@ def check_consent() -> str:
 
 def is_analytics_enabled() -> bool:
     """
-    Check if analytics is enabled.
-    
-    Only requires user consent (opted-in via usage_log.md).
+    Check if analytics is active and able to send.
+
+    Requires both recorded opt-in consent and a configured transport.
+    A shipped proxy with a blank relay address is not active.
     """
-    return check_consent() == 'opted-in'
+    if check_consent() != 'opted-in':
+        return False
+    return bool(get_analytics_transport().get('configured'))
 
 
 def load_user_profile() -> dict:

--- a/core/tests/test_analytics_attempt_receipts.py
+++ b/core/tests/test_analytics_attempt_receipts.py
@@ -367,6 +367,28 @@ def test_missing_collection_address_leaves_a_safe_not_sent_receipt(
     assert receipt[0]["reason"] == "no_analytics_endpoint"
 
 
+def test_shipped_blank_proxy_is_not_active_even_when_opted_in(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    vault = tmp_path / "vault"
+    system = vault / "System"
+    system.mkdir(parents=True)
+    (system / "usage_log.md").write_text(
+        "**Consent decision:** opted-in\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VAULT_PATH", str(vault))
+    monkeypatch.setenv("DEX_ANALYTICS_MODE", "proxy")
+    monkeypatch.setenv("DEX_ANALYTICS_ENDPOINT", "")
+    monkeypatch.delenv("PENDO_TRACK_SECRET", raising=False)
+
+    assert analytics_helper.is_analytics_enabled() is False
+    result = analytics_helper.fire_event("task_created")
+    assert result["fired"] is False
+    assert result["reason"] == "analytics_disabled"
+
+
 def test_http_rejection_receipt_hides_status_and_transport_details(
     tmp_path: Path,
     monkeypatch,

--- a/core/tests/test_analytics_event_wiring.py
+++ b/core/tests/test_analytics_event_wiring.py
@@ -298,6 +298,17 @@ def test_onboarding_never_treats_a_default_as_analytics_consent() -> None:
     assert "Consent decision: opted-in" in flow
     assert "enabled: true" in flow
     assert "analytics_consent_given" not in flow
+    assert "Dex collects anonymous feature usage data" not in flow
+    assert "no usage relay is configured" in flow
+
+
+def test_new_installs_do_not_claim_analytics_is_active() -> None:
+    claude = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    usage = (REPO_ROOT / "System/usage_log.md").read_text(encoding="utf-8")
+
+    assert "Analytics is **on by default**" not in claude
+    assert "Analytics active (default for new installs)" not in usage
+    assert "not active" in claude.lower() or "usage relay" in claude.lower()
 
 
 def test_no_tracked_source_declares_the_retired_consent_event() -> None:


### PR DESCRIPTION
## What this is
New Dex installs record analytics consent as opted-in and say usage tracking is on. The shipped proxy configuration has a blank relay address, so every opted-in event stays on the machine as a not-sent receipt.

## Why it matters
Q3 usage truth depends on honest delivery. Saying analytics is active while nothing can be sent produces no adoption evidence and weakens the consent promise.

## The change
Front Desk recorded the honesty path, not a new off-machine privacy relay (that would be new data leaving the machine). Analytics is active only when consent is opted-in **and** a transport is actually configured. Onboarding, CLAUDE.md, and the usage-log legend no longer claim new installs are collecting.

## Proof
- New test: shipped proxy + blank endpoint + opted-in is not active; `fire_event` returns `analytics_disabled`.
- Existing blank-endpoint receipt test still covers `no_analytics_endpoint` when enabled is forced.
- 47 analytics wiring/receipt tests passed locally.

## Not in this PR
No privacy relay, no Pendo key, no release, no reporter contact. Receipt `dex-feedback-investigation-3816383c9b11d791`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to analytics gating and documentation honesty; no new off-machine data paths or auth changes.
> 
> **Overview**
> **Analytics is only “on” when consent and a working send path both exist.** `is_analytics_enabled()` now returns true only for opted-in users **and** a configured transport (e.g. proxy mode with a non-blank `DEX_ANALYTICS_ENDPOINT`). Fresh installs with the default blank relay no longer count as collecting; `fire_event` short-circuits with `analytics_disabled` instead of implying delivery.
> 
> **User-facing copy matches that behavior.** Onboarding, `CLAUDE.md`, `System/usage_log.md`, and the profile template stop saying new installs are actively tracking; they explain that usage counts may be recorded locally but **nothing is sent until a usage relay is configured**, while opt-in can still be stored for later.
> 
> **Tests lock the contract.** A new receipt test covers opted-in + blank proxy endpoint → not enabled and `analytics_disabled` on fire; wiring tests assert docs dropped “on by default” / “analytics active” language and onboarding mentions the relay gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118c23cd22306f76496280d802d6adaeb2bbb67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->