### PR TITLE
Stop claiming learning review is active for Documents vaults

### DIFF
--- a/.scripts/install-learning-automation.sh
+++ b/.scripts/install-learning-automation.sh
@@ -79,6 +79,13 @@ VAULT_ROOT="$(dirname "$SCRIPT_DIR")"
 echo "Vault path: $VAULT_ROOT"
 echo ""
 
+LEARNING_REVIEW_SUPPORTED=true
+case "$VAULT_ROOT" in
+  "$HOME/Documents"|"$HOME/Documents/"*)
+    LEARNING_REVIEW_SUPPORTED=false
+    ;;
+esac
+
 # Never point machine-wide background jobs at a temporary checkout. A git
 # worktree marks .git as a file; a real clone or plain vault does not.
 if [[ -f "$VAULT_ROOT/.git" || "$VAULT_ROOT" == */worktrees/* ]]; then
@@ -100,8 +107,17 @@ if [[ -n "$NODE_PATH" ]]; then
 else
   echo -e "${RED}✗${NC} Node.js not found; skipping changelog checker installation" >&2
 fi
-sed "s|{{VAULT_PATH}}|$VAULT_ROOT|g" "$SCRIPT_DIR/$LEARNING_PLIST" > "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
-echo -e "${GREEN}✓${NC} Installed learning review plist to $LAUNCH_AGENTS_DIR (with your vault path)"
+if [[ "$LEARNING_REVIEW_SUPPORTED" == true ]]; then
+  sed "s|{{VAULT_PATH}}|$VAULT_ROOT|g" "$SCRIPT_DIR/$LEARNING_PLIST" > "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
+  echo -e "${GREEN}✓${NC} Installed learning review plist to $LAUNCH_AGENTS_DIR (with your vault path)"
+else
+  if launchctl list | grep -q "com.dex.learning-review"; then
+    launchctl unload "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST" 2>/dev/null || true
+  fi
+  rm -f "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
+  echo -e "${YELLOW}!${NC} Learning Review: Not installed — macOS privacy blocks background shell jobs from reading vaults inside Documents."
+  echo "  Move your Dex vault outside Documents, then run this installer again."
+fi
 
 # Load changelog checker
 if [[ -n "$NODE_PATH" ]]; then
@@ -112,12 +128,14 @@ if [[ -n "$NODE_PATH" ]]; then
   echo -e "${GREEN}✓${NC} Loaded changelog checker (runs every 6 hours)"
 fi
 
-# Load learning review
-if launchctl list | grep -q "com.dex.learning-review"; then
-  launchctl unload "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
+# Load learning review when macOS can give it access to the vault
+if [[ "$LEARNING_REVIEW_SUPPORTED" == true ]]; then
+  if launchctl list | grep -q "com.dex.learning-review"; then
+    launchctl unload "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
+  fi
+  launchctl load "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
+  echo -e "${GREEN}✓${NC} Loaded learning review (runs daily at 5pm)"
 fi
-launchctl load "$LAUNCH_AGENTS_DIR/$LEARNING_PLIST"
-echo -e "${GREEN}✓${NC} Loaded learning review (runs daily at 5pm)"
 
 echo ""
 echo -e "${GREEN}Installation complete!${NC}"
@@ -128,7 +146,11 @@ if [[ -n "$NODE_PATH" ]]; then
 else
   echo "  • Changelog Checker: Not installed (Node.js not found)"
 fi
-echo "  • Learning Review: Prompts for learning review daily at 5pm"
+if [[ "$LEARNING_REVIEW_SUPPORTED" == true ]]; then
+  echo "  • Learning Review: Prompts for learning review daily at 5pm"
+else
+  echo "  • Learning Review: Not installed (vault is inside Documents)"
+fi
 echo ""
 echo "Logs will be written to:"
 echo "  • .scripts/logs/changelog-checker.log"

--- a/core/tests/test_learning_automation.py
+++ b/core/tests/test_learning_automation.py
@@ -1,0 +1,83 @@
+"""Behavior tests for the background learning LaunchAgent installer."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / ".scripts" / "install-learning-automation.sh"
+CHANGELOG_PLIST = REPO_ROOT / ".scripts" / "com.dex.changelog-checker.plist"
+LEARNING_PLIST = REPO_ROOT / ".scripts" / "com.dex.learning-review.plist"
+
+
+def test_documents_vault_does_not_claim_blocked_learning_review_is_active(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    scripts = home / "Documents" / "Dex" / ".scripts"
+    scripts.mkdir(parents=True)
+    for source in (INSTALLER, CHANGELOG_PLIST, LEARNING_PLIST):
+        shutil.copy2(source, scripts / source.name)
+
+    agents = home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    installed_learning_plist = agents / LEARNING_PLIST.name
+    installed_learning_plist.write_text("previous broken job", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "launchctl-calls"
+    launchctl = bin_dir / "launchctl"
+    launchctl.write_text(
+        "#!/bin/bash\n"
+        "case \"${1:-}\" in\n"
+        "  list) printf '%s\\n' '- 126 com.dex.learning-review' ;;\n"
+        "  load|unload) printf '%s %s\\n' \"$1\" \"$2\" >> \"$LAUNCHCTL_CALLS\" ;;\n"
+        "  *) exit 2 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    launchctl.chmod(0o755)
+    node = bin_dir / "node"
+    node.write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+    node.chmod(0o755)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "LAUNCHCTL_CALLS": str(calls),
+    }
+
+    result = subprocess.run(
+        ["bash", str(scripts / INSTALLER.name)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    launchctl_calls = calls.read_text(encoding="utf-8") if calls.exists() else ""
+
+    assert {
+        "returncode": result.returncode,
+        "learning_plist_exists": installed_learning_plist.exists(),
+        "learning_load_requested": any(
+            line.startswith("load ") and line.endswith(LEARNING_PLIST.name)
+            for line in launchctl_calls.splitlines()
+        ),
+        "changelog_load_requested": any(
+            line.startswith("load ") and line.endswith(CHANGELOG_PLIST.name)
+            for line in launchctl_calls.splitlines()
+        ),
+        "explains_privacy_block": "macOS privacy blocks background shell jobs" in result.stdout,
+        "reports_not_installed": "Learning Review: Not installed" in result.stdout,
+    } == {
+        "returncode": 0,
+        "learning_plist_exists": False,
+        "learning_load_requested": False,
+        "changelog_load_requested": True,
+        "explains_privacy_block": True,
+        "reports_not_installed": True,
+    }


### PR DESCRIPTION
## What this is
Dex's learning installer can say the daily learning review is active even when the vault lives in macOS Documents. macOS privacy then blocks that background shell job immediately (exit 126), so the review never runs.

## Why it matters
A silent permanent failure breaks the learning promise: Dex reports a healthy setup while it cannot review captured learnings on a schedule.

## The change
Independently replayed on current main (not the stale investigation commit). If the vault is in Documents, keep the working changelog job, unload and remove the blocked learning-review job, and say that moving the vault outside Documents enables it.

## Proof
- Focused test failed first on current main: installer exit 0, changelog still loaded, learning-review plist kept, load requested, no privacy explanation.
- Same test passed after the Documents guard.
- Original reproduction no longer claims the review is active.
- Non-Documents vaults still install and load the learning-review job.
- Related learning/launch-agent tests 17/17; Ruff; `bash -n` on the installer.

## Not in this PR
No release, no reporter contact. Receipt `dex-feedback-investigation-0dd57646ebbb9b97`. Card `bug-report-background-learning-automation-scripts-install-l-0dd57646eb`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer behavior change for a known-broken path only; changelog automation unchanged and covered by a focused regression test.
> 
> **Overview**
> **Fixes false “learning review is active” reporting** when the Dex vault lives under macOS `Documents`, where privacy rules block the background shell job (often exit 126) even after install.
> 
> `install-learning-automation.sh` now sets **`LEARNING_REVIEW_SUPPORTED`** from the vault path. For `$HOME/Documents` and subfolders it **does not** install or `launchctl load` the learning-review agent, **unloads and removes** any existing plist, and prints a clear privacy warning plus guidance to move the vault. The changelog checker still installs and loads when Node is available.
> 
> The install summary no longer lists Learning Review as active for Documents vaults; it says it was not installed for that reason.
> 
> Adds **`test_learning_automation.py`** to assert Documents installs: success exit, changelog load, no learning plist/load, and the new messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f57504dac10d2794397560596b674687c1af07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->