### PR TITLE
Teach Google Workspace setup the connector it actually installs

### DIFF
--- a/.claude/skills/google-workspace-setup/SKILL.md
+++ b/.claude/skills/google-workspace-setup/SKILL.md
@@ -41,7 +41,9 @@ Once connected, Dex can:
 
 ## Privacy
 
-Dex reads your email **on demand** -- nothing is stored permanently. Emails are fetched, summarized, and discarded after the session. Only YOUR account is accessible (scoped to your OAuth login). The OAuth token stays local on your machine and is gitignored.
+Dex reads your email **on demand** -- nothing is stored permanently. Emails are fetched, summarized, and discarded after the session. Only accounts you explicitly connect are accessible. OAuth credentials stay local in `~/.google-mcp/credentials.json`, and account tokens stay local under `~/.google-mcp/tokens/`; never paste either into chat or commit them to Git.
+
+**Permission truth:** this connector requests a fixed set of nine OAuth scopes covering Docs, Drive, Sheets, Gmail, Calendar, Slides, and Forms. Changing selections on Google's consent screen does not narrow the permissions the connector requests. Its `--read-only` server mode blocks write tools after authorization, but does not reduce the underlying OAuth grant. Explain this before setup and let the user stop if that access is broader than they want.
 
 ## When to Run
 
@@ -60,8 +62,8 @@ Do not treat `System/integrations/config.yaml` as the only connectedness signal.
 
 1. **Session connectors already available.** Inspect the tools already present in this session for Gmail, Google Calendar, and Google Drive.
    - A **Calendar-only** or **Drive-only** connector is not a full Google Workspace connection. Do not skip setup in those cases — this skill's job includes email, and those connectors do not provide Gmail.
-   - If a **Gmail** session connector is available, try a test query (search a recent email) **without** requiring Dex config to be enabled first. If Gmail responds, treat email as already connected: do not add a second MCP server, and skip to **Step 5** (Configure Labels). Note missing Calendar or Drive tools, but do not install a duplicate Gmail server when Gmail already works.
-2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a **Gmail** test query via `google-workspace-mcp` (search a recent email). Calendar or Drive responding is not enough to skip. If Gmail responds, skip to **Step 5**. If Gmail fails, continue to Step 2 even when Calendar looks healthy — do not bypass re-auth.
+   - If a **Gmail** session connector is available, try a test query (search a recent email) **without** requiring Dex config to be enabled first. If Gmail responds, treat email as already connected: do not add a second MCP server, and skip to **Step 6** (Configure Labels). Note missing Calendar or Drive tools, but do not install a duplicate Gmail server when Gmail already works.
+2. **Dex config.** Check `System/integrations/config.yaml` for `google-workspace.enabled: true`. If enabled, try a **Gmail** test query via `google-workspace-mcp` (search a recent email). Calendar or Drive responding is not enough to skip. If Gmail responds, skip to **Step 6**. If Gmail fails, continue to Step 2 even when Calendar looks healthy — do not bypass re-auth.
 3. If Gmail is not healthy on either path, continue to Step 2.
 
 ### Step 2: Explain What We're Setting Up
@@ -76,19 +78,49 @@ You'll authorize Dex once, and it remembers your login locally.
 
 **What you'll need:**
 - A Google account (Gmail, Workspace, or personal)
-- About 3 minutes for the OAuth flow
+- Node.js 20 or newer
+- Access to create an OAuth client in Google Cloud
+- About 15-20 minutes for the one-time Google Cloud and OAuth setup
 
 **What Dex will be able to do:**
 - Read your emails (search, unread, threads)
 - Read Google Calendar, Docs, and Sheets
 - Send emails and create events (always with your confirmation first)
 
+**Important permission detail:**
+The connector requests a fixed set of nine OAuth scopes across Docs, Drive, Sheets,
+Gmail, Calendar, Slides, and Forms. Choosing fewer items on Google's consent screen
+does not narrow the permissions the connector requests. If that is broader than you
+want, stop here rather than authorizing it.
+
 **Ready to go?**
 ```
 
 Wait for confirmation.
 
-### Step 3: Add the Google Workspace MCP Server
+### Step 3: Create the Google Cloud App
+
+The installed connector is the npm package `google-workspace-mcp`, maintained at
+`github.com/pm990320/google-workspace-mcp`. Keep every setup and troubleshooting
+instruction aligned to that package and its CLI.
+
+Walk the user through the following browser steps. This is the substantial part of setup:
+
+1. **Create or select a Google Cloud project.**
+2. **Enable the required Google APIs:** Google Docs, Drive, Sheets, Gmail, Calendar,
+   Slides, and Forms.
+3. **Configure the OAuth consent screen.** Use the audience appropriate to the user's
+   account or organization. If the app is in testing mode, continue to the next step.
+4. **Add the Google account as a test user** when the consent screen is in testing mode.
+5. Create a **Desktop app** OAuth client. Download its JSON credentials file.
+6. Put that file at `~/.google-mcp/credentials.json`. Create `~/.google-mcp/` first if
+   needed and restrict the file to the current user. Ask for the downloaded file's local
+   path; never ask the user to paste its contents into chat.
+
+Confirm that the credentials file exists before continuing, but never print or read its
+secret values into the conversation.
+
+### Step 4: Add the Google Workspace MCP Server
 
 If Step 1 already found a healthy **Gmail** session connector, skip this step — do not register a second Gmail/Workspace server. A healthy Calendar or Drive connector alone is not a reason to skip.
 
@@ -99,7 +131,7 @@ Check the user's MCP configuration. If `google-workspace-mcp` is not listed:
 ```
 I need to add the Google Workspace connector to your Dex configuration.
 
-This is an open-source bridge (`google-workspace-mcp`)
+This is an open-source bridge (github.com/pm990320/google-workspace-mcp)
 that connects to Google's APIs via OAuth. Your credentials stay on your machine.
 ```
 
@@ -109,7 +141,7 @@ that connects to Google's APIs via OAuth. Your credentials stay on your machine.
 {
   "google-workspace-mcp": {
     "command": "npx",
-    "args": ["-y", "google-workspace-mcp"],
+    "args": ["-y", "google-workspace-mcp", "serve"],
     "env": {}
   }
 }
@@ -119,12 +151,15 @@ The config key, the `npx` package, and the name in the explanation must all be `
 
 3. Tell the user the MCP server needs to restart for changes to take effect.
 
-### Step 4: Authenticate via OAuth
+### Step 5: Authenticate via OAuth
 
-1. Run `npx google-workspace-mcp` -- this starts the OAuth flow
-2. A browser window opens for Google sign-in
-3. The user authorizes the requested scopes (Gmail read/send, Calendar, Docs)
-4. The token is saved locally to `System/.gmail-oauth-token.json`
+1. Run `npx -y google-workspace-mcp setup` to verify the local credentials file.
+2. Run `npx -y google-workspace-mcp accounts add main` to start the OAuth flow.
+3. A browser window opens for Google sign-in. If it does not, use the authorization URL
+   printed by the connector.
+4. The user reviews and authorizes the connector's fixed permission set.
+5. The account token is saved locally under `~/.google-mcp/tokens/`.
+6. Run `npx -y google-workspace-mcp status` and require a ready result before continuing.
 
 **If OAuth succeeds:**
 ```
@@ -142,9 +177,10 @@ The OAuth flow didn't complete. A few things to check:
 Want to retry?
 ```
 
-Retry up to 2 times, then offer to skip and come back later.
+Retry up to 2 times, then offer to skip and come back later. Do not mark the integration
+enabled unless the status command and the live tool checks both succeed.
 
-### Step 5: Configure Labels and Write Preferences
+### Step 6: Configure Labels and Write Preferences
 
 Once connected, ask:
 
@@ -176,7 +212,7 @@ Would you prefer:
 
 Save their preference. Map choice 1 to `draft_and_send: true`, choice 2 to `draft_and_send: false`.
 
-### Step 6: Test the Connection
+### Step 7: Test the Connection
 
 Run a quick test to confirm everything works. **Email is the connectedness bar.** Calendar is extra.
 
@@ -192,9 +228,9 @@ Show a brief summary:
   # or: Not available in this session — email still counts as connected
 ```
 
-If email works, proceed to Step 7 even when Calendar is missing. Only email failure blocks saving configuration.
+If email works, proceed to Step 8 even when Calendar is missing. Only email failure blocks saving configuration.
 
-### Step 7: Save Configuration
+### Step 8: Save Configuration
 
 Write to `System/integrations/config.yaml` -- update the google-workspace section:
 
@@ -235,7 +271,7 @@ calendar:
 
 Keep any existing `work_calendar` value. Do not invent new privacy or consent language; this only records which calendar daily planning should read.
 
-### Step 8: Confirm with Capability Cascade
+### Step 9: Confirm with Capability Cascade
 
 ```
 **Google Workspace is connected!**
@@ -294,9 +330,10 @@ During `/daily-plan`, Dex checks for stale email threads:
 
 Google OAuth tokens typically last 1 hour, but refresh tokens are longer-lived. If you see auth errors:
 
-1. Run `/google-workspace-setup` to trigger a token refresh
-2. If the refresh token is also expired, you'll need to re-authorize through the browser
-3. This is rare -- usually happens after 6+ months or if you revoked access in Google settings
+1. Run `npx -y google-workspace-mcp status` to identify the affected account.
+2. If re-authorization is required, remove and re-add that named account through the
+   connector's account commands, then complete the browser flow again.
+3. Re-run the live email and calendar checks before marking the setup healthy.
 
 ### "Google Workspace MCP not found"
 
@@ -306,9 +343,12 @@ First check whether a **Gmail** session connector is already available in this s
 
 If certain features don't work (e.g., can't send emails):
 
-1. The OAuth scopes might be incomplete
-2. Run `/google-workspace-setup` to re-authorize with full scopes
-3. Make sure you approved ALL permissions in the Google consent screen
+1. Run `npx -y google-workspace-mcp accounts test-permissions main` (replace `main` if
+   the user chose another account name).
+2. Confirm that all seven required Google APIs are enabled in the selected Cloud project.
+3. Confirm that the account is an allowed test user when the consent screen is in testing.
+4. Do not tell the user to narrow or expand individual scopes: this connector requests a
+   fixed set, so the remedy is to fix the project/API/test-user setup or stop using it.
 
 ### Rate Limiting
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -5560,8 +5560,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/google-workspace-setup/SKILL.md",
-        "sha256": "53d0dd2fe08b6440fc2ed6013bcf821ec231cbeb3c4fff0413a47357454fae6b",
-        "byte_size": 13368
+        "sha256": "e95e0d399ee2347d867b90a4e45d0d269a3ddba2b1edb9bc1d3c40ec8866fab3",
+        "byte_size": 16331
       },
       "value": "Connect Google Workspace (Gmail, Calendar, Docs) for email-aware planning and meeting prep.",
       "jobs_served": [

--- a/core/tests/test_google_workspace_setup_instruction_contract.py
+++ b/core/tests/test_google_workspace_setup_instruction_contract.py
@@ -32,11 +32,11 @@ def _step1(body: str) -> str:
 
 
 def _step3(body: str) -> str:
-    return _section(body, "### Step 3: Add the Google Workspace MCP Server", "### Step 4:")
+    return _section(body, "### Step 4: Add the Google Workspace MCP Server", "### Step 5:")
 
 
 def _step6(body: str) -> str:
-    return _section(body, "### Step 6: Test the Connection", "### Step 7:")
+    return _section(body, "### Step 7: Test the Connection", "### Step 8:")
 
 
 def test_step3_prose_and_config_name_the_same_install_identity() -> None:
@@ -52,7 +52,7 @@ def test_step3_prose_and_config_name_the_same_install_identity() -> None:
     assert list(config) == [INSTALL_IDENTITY], config
     entry = config[INSTALL_IDENTITY]
     assert entry["command"] == "npx", entry
-    assert entry["args"] == ["-y", INSTALL_IDENTITY], entry["args"]
+    assert entry["args"] == ["-y", INSTALL_IDENTITY, "serve"], entry["args"]
 
 
 def test_skill_never_names_the_underscore_package_as_the_install_target() -> None:

--- a/core/tests/test_google_workspace_setup_truth.py
+++ b/core/tests/test_google_workspace_setup_truth.py
@@ -1,0 +1,34 @@
+"""Keep the shipped Google Workspace setup journey aligned with its MCP package."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL = REPO_ROOT / ".claude" / "skills" / "google-workspace-setup" / "SKILL.md"
+
+
+def test_google_workspace_setup_matches_the_connector_it_installs() -> None:
+    instructions = SKILL.read_text(encoding="utf-8")
+
+    assert "pm990320/google-workspace-mcp" in instructions
+    assert "taylorwilsdon/google_workspace_mcp" not in instructions
+    assert "15-20 minutes" in instructions
+
+    for required_step in (
+        "Create or select a Google Cloud project",
+        "Enable the required Google APIs",
+        "Configure the OAuth consent screen",
+        "Add the Google account as a test user",
+        "Create a **Desktop app** OAuth client",
+        "`~/.google-mcp/credentials.json`",
+    ):
+        assert required_step in instructions
+
+    assert '["-y", "google-workspace-mcp", "serve"]' in instructions
+    assert "`npx -y google-workspace-mcp accounts add main`" in instructions
+    assert "`~/.google-mcp/tokens/`" in instructions
+    assert "fixed set of nine OAuth scopes" in instructions
+    assert "does not narrow the permissions the connector requests" in instructions
+
+    assert "About 3 minutes" not in instructions
+    assert "Run `npx google-workspace-mcp` -- this starts the OAuth flow" not in instructions
+    assert "`System/.gmail-oauth-token.json`" not in instructions


### PR DESCRIPTION
## What this is
Dex's Google Workspace setup guide still skipped the real Google Cloud registration, taught a command that cannot complete the installed package's setup, and did not disclose the connector's fixed nine-permission grant.

## Why it matters
Someone can follow the guide correctly and still fail to connect Gmail, Calendar, and Docs. That is the moment Dex is supposed to become useful.

## The change
Independently replayed on current main (not the stale investigation commit). The later Gmail-session and calendar-source rules stay. The guide now names `pm990320/google-workspace-mcp`, walks the Cloud/API/consent/test-user/Desktop-client/credentials journey, uses `accounts add` and `serve`, stores credentials under `~/.google-mcp`, and explains the nine-scope grant before authorization.

## Proof
- Focused public-instruction test failed first on current main (missing package owner, Cloud journey, serve/accounts-add, and scope disclosure).
- Same test passed after the guide change.
- Existing Google Workspace identity/connectedness and calendar-provider instruction contracts passed (12/12).
- Lens pin recomputed to the new skill bytes. Architecture inventory unchanged. Instructed-tool gate passed (125 files).
- Published npm package `google-workspace-mcp@2.3.6` was inspected, not executed: nine scopes, `serve`, `accounts add`, `~/.google-mcp/credentials.json` and `tokens/`.

## Not in this PR
No release, no reporter contact, no execution of the third-party package. Receipt `dex-feedback-investigation-81284c0ede6d1205`. Card `bug-report-google-workspace-setup-81284c0ede`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no runtime integration or OAuth code paths change.
> 
> **Overview**
> **Rewrites the `/google-workspace-setup` skill** so instructions match the installed `pm990320/google-workspace-mcp` package instead of a shortened OAuth-only path that could not succeed.
> 
> The guide now includes a **Google Cloud one-time setup** (project, seven APIs, consent screen, test user, Desktop OAuth client, `~/.google-mcp/credentials.json`), documents **nine fixed OAuth scopes** and that consent-screen checkboxes do not narrow the grant, and uses **`npx … serve`**, **`setup` / `accounts add` / `status`**, with tokens under **`~/.google-mcp/tokens/`**. Privacy, prerequisites (Node 20+, ~15–20 minutes), and troubleshooting are updated accordingly; enabling the integration is gated on **status plus live Gmail checks**.
> 
> **Tests and catalog:** existing instruction-contract tests pick up renumbered steps and the `serve` arg; a new **`test_google_workspace_setup_truth.py`** locks package repo, Cloud steps, CLI strings, and forbids stale copy (`System/.gmail-oauth-token.json`, “3 minutes”). Lens registry **SHA/size** for the skill is refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ecb4b25d808cd16b11bf85c30a306cc6de1c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->