### PR TITLE
Read Anthropic's official Claude Code changelog

### DIFF
--- a/.scripts/check-anthropic-changelog.cjs
+++ b/.scripts/check-anthropic-changelog.cjs
@@ -53,11 +53,9 @@ const MIN_CHECK_INTERVAL_HOURS = 24;
 const MAX_REDIRECTS = 5;
 const DEFAULT_TIMEOUT_MS = 15000;
 
-// Changelog sources (try in order). Keep these product URLs as shipped;
-// fetch follows redirects instead of replacing them.
+// Anthropic's platform release notes direct Claude Code users to this changelog.
 const CHANGELOG_SOURCES = [
-  'https://docs.anthropic.com/en/release-notes/changelog',
-  'https://www.anthropic.com/changelog'
+  'https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md'
 ];
 
 function resolveChangelogSources(env = process.env) {
@@ -284,7 +282,7 @@ async function detectChanges(state, env = process.env) {
 
   // Simple heuristic: look for version numbers or date patterns
   // This is intentionally simple - full analysis happens in /dex-whats-new
-  const versionMatches = changelogContent.match(/version\s+(\d+\.\d+\.\d+)/gi) || [];
+  const versionMatches = changelogContent.match(/(?:version\s+|^##\s+v?)(\d+\.\d+\.\d+)/gim) || [];
   const dateMatches = changelogContent.match(/202[0-9]-[0-1][0-9]-[0-3][0-9]/g) || [];
 
   let latestVersion = null;

--- a/.scripts/lib/tests/check-anthropic-changelog.test.cjs
+++ b/.scripts/lib/tests/check-anthropic-changelog.test.cjs
@@ -70,8 +70,11 @@ function runCli(vault, { args = [], sources = '', timeoutMs = 4000, extraEnv = {
   });
 }
 
-test('shipped sources stay the two existing product URLs; no extra https hosts', () => {
-  assert.equal(CHANGELOG_SOURCES.length, 2);
+const OFFICIAL_CHANGELOG =
+  'https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md';
+
+test('shipped source is Anthropic official Claude Code changelog; no extra https hosts', () => {
+  assert.deepEqual(CHANGELOG_SOURCES, [OFFICIAL_CHANGELOG]);
   const sourceText = fs.readFileSync(scriptPath, 'utf8');
   const httpsUrls = [...sourceText.matchAll(/https:\/\/[^\s'"]+/g)].map((match) => match[0]);
   assert.deepEqual(httpsUrls, CHANGELOG_SOURCES);
@@ -270,6 +273,24 @@ test('imported main returns 0 after a successful redirected check and writes the
   assert.equal(code, 0);
   const state = JSON.parse(fs.readFileSync(path.join(vault, 'System', 'claude-code-state.json'), 'utf8'));
   assert.equal(state.last_version_seen, '2.0.0');
+  assert.ok(fs.existsSync(path.join(vault, 'System', 'changelog-updates-pending.md')));
+});
+
+test('detects Markdown version headings used by the official Claude Code changelog', async (t) => {
+  const vault = makeVault(t);
+  writeState(vault, { last_check: '2020-01-01', last_version_seen: '1.0.0', features_seen: [] });
+  const { origin } = await listen(t, (_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('# Changelog\n\n## 2.1.251\n\n- Added a capability\n');
+  });
+
+  const code = await main({
+    args: ['--force'],
+    env: envFor(vault, `${origin}/CHANGELOG.md`),
+  });
+  assert.equal(code, 0);
+  const state = JSON.parse(fs.readFileSync(path.join(vault, 'System', 'claude-code-state.json'), 'utf8'));
+  assert.equal(state.last_version_seen, '2.1.251');
   assert.ok(fs.existsSync(path.join(vault, 'System', 'changelog-updates-pending.md')));
 });
 


### PR DESCRIPTION
## What this is
Dex's background Claude update checker still requested two Anthropic product addresses. Live probes from this machine show both 404 (one after a 301). The official Claude Code changelog is on GitHub and uses Markdown headings such as \`## 2.1.251\`, which the checker could not parse.

## Why it matters
The scheduled job that is supposed to notice new Claude capabilities was silently unable to fetch or recognize updates.

## The change
Independently replayed on current main (not the stale investigation commit). Current main already returns a real failure when every fetch dies and already follows redirects/timeouts; those stay. This change replaces the two dead addresses with Anthropic's official Claude Code changelog and recognizes its version headings. Existing \`version 1.2.3\` prose still matches.

## Proof
- Independent HTTP probes: docs changelog 301 then 404; anthropic.com/changelog 404; official GitHub changelog 200 starting \`## 2.1.251\`.
- New heading-parser test failed first on current main (\`last_version_seen\` stayed \`1.0.0\`, log said \`Latest version: none found\`).
- After the source and parser change: 17/17 changelog script tests passed.
- Live \`--force --dry-run\` fetched the official changelog and detected version 2.1.251.

## Not in this PR
No release, no reporter contact. Receipt \`dex-feedback-investigation-d4349d57fd3789c4\`. Card \`bug-report-scripts-check-anthropic-changelog-cjs-background-d4349d57fd\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to a background changelog fetch script and its tests; no auth, data, or user-facing runtime paths.
> 
> **Overview**
> Fixes Dex’s background Claude update checker, which was failing because the two default Anthropic product changelog URLs no longer return usable content.
> 
> **Default source** is now the official Claude Code `CHANGELOG.md` on GitHub (`raw.githubusercontent.com/.../CHANGELOG.md`). `DEX_CHANGELOG_SOURCES` override behavior is unchanged.
> 
> **Version detection** still recognizes `version 1.2.3` prose and also parses Markdown release headings like `## 2.1.251`, so fetched changelog text can drive `last_version_seen` and pending alerts again.
> 
> Tests assert the single shipped URL and add coverage for heading-style versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f87d055ccf30e6bbc9ee6f62f05e4db2fc5f6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->