### PR TITLE
Pack Dex's read-only MCP server for one-line install — still unpublished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,12 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Build and validate installable harness artifacts
         run: python scripts/build-portable-harness-artifacts.py --output-dir build/portable-artifacts
+      - name: Pack the unpublished MCP catalogue artifact
+        run: python scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact
+      - name: Verify the packed MCP server still answers
+        env:
+          DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: python scripts/verify-portable-plugin-runtime.py --plugin-root build/mcp-registry-artifact/dex-mcp --skip-hooks
       - name: Verify portable plugin runtime and release boundary
         env:
           DEX_PYTHON: ${{ steps.setup-python.outputs.python-path }}

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -522,6 +522,8 @@ def test_ci_runs_the_runtime_verifier_on_macos_and_windows() -> None:
     assert "macos-latest" in job
     assert "windows-latest" in job
     assert "build-portable-harness-artifacts.py" in job
+    assert "build-mcp-registry-artifact.py" in job
+    assert "--plugin-root build/mcp-registry-artifact/dex-mcp --skip-hooks" in job
     assert "verify-portable-plugin-runtime.py --require-release-ready" in job
     assert "--plugin-root build/portable-artifacts/dex-gemini-extension" in job
     assert "--plugin-root build/portable-artifacts/dex-claude-desktop --skip-hooks" in job

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -1,0 +1,237 @@
+"""The proven read-only Dex MCP server packs as an unpublished npm artifact."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_SOURCE = REPO_ROOT / "packages" / "dex-mcp"
+PLUGIN_ROOT = REPO_ROOT / "packages" / "dex-agent-plugin"
+BUILDER = REPO_ROOT / "scripts" / "build-mcp-registry-artifact.py"
+SAFE_PUBLISHER = REPO_ROOT / "scripts" / "run-mcp-publisher-safe.py"
+READ_ONLY_TOOLS = {
+    "dex_harness_profiles",
+    "boot_today",
+    "get_person_context",
+    "check_safety_gate",
+}
+
+
+def _load_builder():
+    spec = importlib.util.spec_from_file_location("build_mcp_registry_artifact", BUILDER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _mcp_roundtrip(plugin_root: Path, messages: list[dict], *, vault: Path) -> list[dict]:
+    payload = "".join(json.dumps(message) + "\n" for message in messages)
+    completed = subprocess.run(
+        ["node", str(plugin_root / "bin" / "dex-python.mjs"), "mcp"],
+        input=payload,
+        text=True,
+        capture_output=True,
+        cwd=vault,
+        env={**os.environ, "PYTHONNOUSERSITE": "1", "DEX_VAULT_PATH": str(vault)},
+        check=True,
+    )
+    return [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+
+
+def test_source_package_is_npm_shaped_and_unpublished() -> None:
+    package = json.loads((PACKAGE_SOURCE / "package.json").read_text(encoding="utf-8"))
+    server = json.loads((PACKAGE_SOURCE / "server.json").read_text(encoding="utf-8"))
+    readme = (PACKAGE_SOURCE / "README.md").read_text(encoding="utf-8")
+
+    assert package["name"] == "dex-mcp"
+    assert package["private"] is True
+    assert package["mcpName"] == "io.github.davekilleen/dex"
+    assert package["bin"]["dex-mcp"] == "./bin/dex-python.mjs"
+    assert "prepublishOnly" in package["scripts"]
+    assert server["name"] == package["mcpName"]
+    assert server["packages"][0]["identifier"] == "dex-mcp"
+    assert server["packages"][0]["registryType"] == "npm"
+    assert server["packages"][0]["transport"]["type"] == "stdio"
+    assert "io.github.davekilleen/dex" in readme
+    assert "npx -y dex-mcp" in readme
+    assert "will not publish" in readme
+    assert "@heydex" not in json.dumps(package)
+    assert "npm adduser" not in readme
+
+
+def test_builder_packs_checksums_validates_and_stays_unreleased(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [sys.executable, str(BUILDER), "--output-dir", str(tmp_path)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "Still unreleased" in completed.stdout
+    assert "Did not publish" in completed.stdout
+
+    tarball = tmp_path / "dex-mcp-1.0.0.tgz"
+    checksum = tmp_path / "dex-mcp-1.0.0.tgz.sha256"
+    index = json.loads((tmp_path / "artifacts.json").read_text(encoding="utf-8"))
+    staged = tmp_path / "dex-mcp"
+    assert tarball.is_file()
+    assert checksum.is_file()
+    assert index["release_status"] == "unreleased"
+    assert index["published"] is False
+    assert index["one_line_after_publish"] == "io.github.davekilleen/dex"
+    assert index["validation"]["npm_publish"] == "dry-run"
+    assert index["artifacts"][0]["sha256"] == _sha256(tarball)
+    assert checksum.read_text(encoding="utf-8").startswith(index["artifacts"][0]["sha256"])
+
+    schema = _load_builder()._official_schema()
+    if schema is not None:
+        jsonschema.validate(
+            json.loads((staged / "server.json").read_text(encoding="utf-8")),
+            schema,
+        )
+
+    with tarfile.open(tarball, "r:gz") as archive:
+        names = set(archive.getnames())
+        package_file = archive.extractfile("package/package.json")
+        server_file = archive.extractfile("package/server.py")
+        assert package_file is not None
+        assert server_file is not None
+        package = json.loads(package_file.read())
+        server_py = server_file.read()
+    assert "package/server.py" in names
+    assert "package/bin/dex-python.mjs" in names
+    assert "package/runtime/core/gates/safety.py" in names
+    assert package["private"] is True
+    assert package["mcpName"] == "io.github.davekilleen/dex"
+    assert server_py == (PLUGIN_ROOT / "server.py").read_bytes()
+    assert not any(name.startswith("package/skills/") for name in names)
+
+
+def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Path) -> None:
+    subprocess.run(
+        [sys.executable, str(BUILDER), "--output-dir", str(tmp_path / "artifacts")],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    plugin_root = tmp_path / "artifacts" / "dex-mcp"
+    vault = tmp_path / "Dex folder"
+    (vault / "System").mkdir(parents=True)
+    (vault / "System" / "pillars.yaml").write_text(
+        'pillars:\n  - id: focus\n    name: "Focus"\n    description: "Do the important work"\n',
+        encoding="utf-8",
+    )
+    person_dir = vault / "05-Areas" / "People" / "Internal"
+    person_dir.mkdir(parents=True)
+    (person_dir / "Ada_Lovelace.md").write_text(
+        "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n---\n- [ ] Send the operating memo\n",
+        encoding="utf-8",
+    )
+    responses = _mcp_roundtrip(
+        plugin_root,
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "boot_today", "arguments": {"vault_path": str(vault)}},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "check_safety_gate",
+                    "arguments": {"vault_path": str(vault), "command": "rm -rf /"},
+                },
+            },
+        ],
+        vault=vault,
+    )
+    assert {tool["name"] for tool in responses[1]["result"]["tools"]} == READ_ONLY_TOOLS
+    assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
+    assert responses[3]["result"]["structuredContent"]["refused"] is True
+
+
+def test_live_npm_publish_is_refused(tmp_path: Path) -> None:
+    builder = _load_builder()
+    staged = builder.stage_package(tmp_path)
+    try:
+        builder._forbid_live_publish(["npm", "publish"])
+    except builder.RegistryArtifactError as error:
+        assert "refusing live npm publish" in str(error)
+    else:
+        raise AssertionError("live npm publish must be refused")
+    try:
+        builder._forbid_live_publish(["mcp-publisher", "publish", "server.json"])
+    except builder.RegistryArtifactError as error:
+        assert "refusing live mcp-publisher publish" in str(error)
+    else:
+        raise AssertionError("live mcp-publisher publish must be refused")
+
+    blocked = subprocess.run(
+        ["npm", "publish"],
+        cwd=staged,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert blocked.returncode != 0
+    assert "unreleased" in blocked.stderr.lower() or "dry-run" in blocked.stderr.lower()
+
+
+def test_safe_publisher_wrapper_forces_dry_run(tmp_path: Path) -> None:
+    fake = tmp_path / "mcp-publisher"
+    fake.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$0.args\"\n",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SAFE_PUBLISHER),
+            "publish",
+            str(PACKAGE_SOURCE / "server.json"),
+            "--mcp-publisher",
+            str(fake),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    recorded = Path(str(fake) + ".args").read_text(encoding="utf-8")
+    assert "--dry-run" in recorded
+    assert completed.returncode == 0
+
+
+def test_builder_rejects_a_released_channel(tmp_path: Path) -> None:
+    builder = _load_builder()
+    try:
+        builder.build(tmp_path, release_status="stable")
+    except builder.RegistryArtifactError as error:
+        assert "unreleased" in str(error)
+    else:
+        raise AssertionError("a released channel must be rejected")

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -72,7 +72,8 @@ def test_source_package_is_npm_shaped_and_unpublished() -> None:
     assert server["packages"][0]["transport"]["type"] == "stdio"
     assert "io.github.davekilleen/dex" in readme
     assert "npx -y dex-mcp" in readme
-    assert "will not publish" in readme
+    assert "will not create an npm account" in readme
+    assert "not publish" in readme
     assert "@heydex" not in json.dumps(package)
     assert "npm adduser" not in readme
 
@@ -186,9 +187,15 @@ def test_live_npm_publish_is_refused(tmp_path: Path) -> None:
     try:
         builder._forbid_live_publish(["mcp-publisher", "publish", "server.json"])
     except builder.RegistryArtifactError as error:
-        assert "refusing live mcp-publisher publish" in str(error)
+        assert "refusing mcp-publisher publish" in str(error)
     else:
-        raise AssertionError("live mcp-publisher publish must be refused")
+        raise AssertionError("mcp-publisher publish must be refused")
+    try:
+        builder._forbid_live_publish(["mcp-publisher", "publish", "server.json", "--dry-run"])
+    except builder.RegistryArtifactError as error:
+        assert "refusing mcp-publisher publish" in str(error)
+    else:
+        raise AssertionError("mcp-publisher publish is refused even with --dry-run")
 
     blocked = subprocess.run(
         ["npm", "publish"],
@@ -201,14 +208,14 @@ def test_live_npm_publish_is_refused(tmp_path: Path) -> None:
     assert "unreleased" in blocked.stderr.lower() or "dry-run" in blocked.stderr.lower()
 
 
-def test_safe_publisher_wrapper_forces_dry_run(tmp_path: Path) -> None:
+def test_safe_publisher_wrapper_only_validates(tmp_path: Path) -> None:
     fake = tmp_path / "mcp-publisher"
     fake.write_text(
         "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$0.args\"\n",
         encoding="utf-8",
     )
     fake.chmod(0o755)
-    completed = subprocess.run(
+    refused = subprocess.run(
         [
             sys.executable,
             str(SAFE_PUBLISHER),
@@ -220,10 +227,28 @@ def test_safe_publisher_wrapper_forces_dry_run(tmp_path: Path) -> None:
         cwd=REPO_ROOT,
         text=True,
         capture_output=True,
+        check=False,
+    )
+    assert refused.returncode != 0
+    assert not Path(str(fake) + ".args").exists()
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SAFE_PUBLISHER),
+            "validate",
+            str(PACKAGE_SOURCE / "server.json"),
+            "--mcp-publisher",
+            str(fake),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
         check=True,
     )
     recorded = Path(str(fake) + ".args").read_text(encoding="utf-8")
-    assert "--dry-run" in recorded
+    assert recorded.startswith("validate ")
+    assert "publish" not in recorded
     assert completed.returncode == 0
 
 

--- a/core/tests/test_release_workflows_draft_first.py
+++ b/core/tests/test_release_workflows_draft_first.py
@@ -195,6 +195,10 @@ def test_both_release_lanes_build_and_attach_portable_harness_assets() -> None:
             for match in re.finditer(r'--extra-asset "([^"]+)"', publish)
         }
         assert expected_assets <= attached
+        assert not any("dex-mcp" in asset for asset in attached)
+        assert "build-mcp-registry-artifact.py" not in build
+        assert "npm publish" not in publish
+        assert "mcp-publisher publish" not in publish
 
 
 def test_the_publishing_step_still_runs_only_after_all_release_gates() -> None:

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -62,7 +62,13 @@ python3 scripts/build-portable-harness-artifacts.py --output-dir build/portable-
 The builder validates and packs `dex-claude-desktop.mcpb`, builds the complete
 `dex-gemini-extension/` install directory and deterministic archive, and writes
 `artifacts.json` with unreleased status, sizes, and SHA-256 checksums. It does
-not publish, install, or release anything. The stable and beta release jobs run
+not publish, install, or release anything. A separate command packs the same
+read-only MCP server as an npm-shaped `.tgz` for the official catalogue, still
+without publishing:
+
+```sh
+python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact
+``` The stable and beta release jobs run
 the same builder with the matching channel recorded in `artifacts.json`, then
 attach both archives and the index through Dex's draft-first, byte-verified
 publication path. No attachment is public until the release itself is approved
@@ -79,6 +85,7 @@ and the final publication step succeeds.
 | Cursor | Copy or link `packages/dex-agent-plugin` to `~/.cursor/plugins/local/dex`, reload Cursor, and approve the native hooks. | Local sessions get context and safety hooks. Cursor cloud agents do not run `sessionStart`, so that lifecycle guarantee is local-only. |
 | Gemini CLI | Run `gemini extensions install build/portable-artifacts/dex-gemini-extension`, approve its hooks, and restart Gemini CLI in the full Dex folder. | Gemini's fixed hook file uses a different schema, so Dex builds a separate complete artifact from the same canonical sources. |
 | Agent Plugins v1 client | Install the folder using root `plugin.json` and `mcp.json`. | The open specification standardizes skills and MCP, not every host lifecycle. |
+| Official MCP catalogue | After Dave publishes, add one line in any MCP app: `io.github.davekilleen/dex`. Until then, pack locally with `python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact`. | The already-proven read-only server is packed as an npm-shaped `.tgz`, checksummed, and validated with dry-run only. It is not on npm and not in the public catalogue. This runner will not create an npm account or publish. |
 | Pi | Use the native `dex-pi/extensions/dex` package from the pinned [`dex-pi` commit `5bf33ad7b23a06a890b25445cb1b4f4077b2ac19`](https://github.com/davekilleen/dex-pi/tree/5bf33ad7b23a06a890b25445cb1b4f4077b2ac19) and open the full Dex folder. | Pi has no built-in MCP client; its extension supplies native tools and lifecycle events instead. Core verifies the pinned manifest and source-level lifecycle markers when the checkout is available; live installation remains a release-candidate check. |
 | BB | Install the separately built `bb-plugin-dex` package from a reviewed local path and select the vault in settings. | Version one is macOS-only and read-only: status, capabilities, brief, CLI, and panel; no jobs, writes, provider bridge, or marketplace release. BB's Windows route uses WSL2 and stays in the deferred Linux lane. |
 

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -1,0 +1,39 @@
+# Dex for any MCP app
+
+This folder is the unpublished npm-shaped package for Dex's already-proven
+read-only tools. After Dave publishes, a person can point any MCP app at one
+line. Until then, the package stays local, checksummed, and unreleased.
+
+## What a person can do after Dave publishes
+
+Add this one line in an MCP app that can install from the official catalogue:
+
+```text
+io.github.davekilleen/dex
+```
+
+Or start the same server from a terminal:
+
+```sh
+DEX_VAULT_PATH="/path/to/your/Dex" npx -y dex-mcp
+```
+
+Point `DEX_VAULT_PATH` at the Dex folder on that computer. The server can read
+today's context, look up a person, list host support, and refuse a destructive
+command. It cannot write the vault.
+
+## What is true now
+
+This package is packed and checked on the review branch. It is not on npm. It is
+not in the public catalogue. This runner will not create an npm account, will
+not publish, and will not invent the ChatGPT Work folder grant.
+
+To pack and check locally without publishing:
+
+```sh
+python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact
+```
+
+The builder writes a `.tgz`, a SHA-256 sidecar, and an `unreleased` index. It
+only runs `npm publish --dry-run` and `mcp-publisher` with `--dry-run` or
+`validate`.

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -35,5 +35,5 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 ```
 
 The builder writes a `.tgz`, a SHA-256 sidecar, and an `unreleased` index. It
-only runs `npm publish --dry-run` and `mcp-publisher` with `--dry-run` or
-`validate`.
+only runs `npm publish --dry-run` and `mcp-publisher validate`. It never
+publishes.

--- a/packages/dex-mcp/package.json
+++ b/packages/dex-mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "dex-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Read-only Dex context and safety tools for any local MCP app.",
+  "mcpName": "io.github.davekilleen/dex",
+  "type": "module",
+  "bin": {
+    "dex-mcp": "./bin/dex-python.mjs"
+  },
+  "files": [
+    "bin",
+    "metadata",
+    "runtime",
+    "scripts/refuse-live-npm-publish.mjs",
+    "server.py",
+    "server.json",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/davekilleen/Dex.git",
+    "directory": "packages/dex-mcp"
+  },
+  "homepage": "https://heydex.ai",
+  "scripts": {
+    "prepublishOnly": "node ./scripts/refuse-live-npm-publish.mjs"
+  }
+}

--- a/packages/dex-mcp/scripts/refuse-live-npm-publish.mjs
+++ b/packages/dex-mcp/scripts/refuse-live-npm-publish.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const dryRun = process.env.npm_config_dry_run === "true";
+if (!dryRun) {
+  process.stderr.write(
+    "Dex MCP is unreleased. Use npm publish --dry-run only. Do not publish.\n",
+  );
+  process.exit(1);
+}

--- a/packages/dex-mcp/server.json
+++ b/packages/dex-mcp/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.davekilleen/dex",
+  "title": "Dex",
+  "description": "Read-only Dex context and safety tools for any local MCP app.",
+  "version": "1.0.0",
+  "websiteUrl": "https://heydex.ai",
+  "repository": {
+    "url": "https://github.com/davekilleen/Dex",
+    "source": "github",
+    "subfolder": "packages/dex-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "dex-mcp",
+      "version": "1.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DEX_VAULT_PATH",
+          "description": "Path to the Dex folder on this computer.",
+          "isRequired": true,
+          "format": "filepath"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/build-mcp-registry-artifact.py
+++ b/scripts/build-mcp-registry-artifact.py
@@ -83,8 +83,7 @@ def _forbid_live_publish(command: list[str]) -> None:
     if "npm" in command and "publish" in command and "--dry-run" not in command:
         raise RegistryArtifactError(f"refusing live npm publish: {joined}")
     if "mcp-publisher" in Path(command[0]).name and "publish" in command:
-        if "--dry-run" not in command:
-            raise RegistryArtifactError(f"refusing live mcp-publisher publish: {joined}")
+        raise RegistryArtifactError(f"refusing mcp-publisher publish: {joined}")
 
 
 def stage_package(output_dir: Path) -> Path:
@@ -166,10 +165,7 @@ def validate_with_mcp_publisher(staged: Path) -> str:
         return "skipped: mcp-publisher is not installed"
     validate = [publisher, "validate", str(staged / "server.json")]
     _run(validate, cwd=staged)
-    publish = [publisher, "publish", str(staged / "server.json"), "--dry-run"]
-    _forbid_live_publish(publish)
-    _run(publish, cwd=staged)
-    return "validated and publish --dry-run"
+    return "validate"
 
 
 def write_checksum(tarball: Path) -> Path:

--- a/scripts/build-mcp-registry-artifact.py
+++ b/scripts/build-mcp-registry-artifact.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Pack the proven read-only Dex MCP server as an unpublished npm-shaped artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "packages" / "dex-agent-plugin"
+PACKAGE_SOURCE = REPO_ROOT / "packages" / "dex-mcp"
+OFFICIAL_SCHEMA_URL = (
+    "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+)
+SHARED_DIRECTORIES = ("bin", "metadata", "runtime")
+SHARED_FILES = ("server.py",)
+PACKAGE_FILES = ("package.json", "server.json", "README.md")
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - CI installs jsonschema with the test extra
+    jsonschema = None
+
+
+class RegistryArtifactError(RuntimeError):
+    """A packing or validation step failed without publishing."""
+
+
+def _remove_existing(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _copy_tree(source: Path, target: Path) -> None:
+    shutil.copytree(
+        source,
+        target,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise RegistryArtifactError(f"{path} must contain a JSON object")
+    return parsed
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RegistryArtifactError(
+            f"{' '.join(command)} failed:\n{completed.stdout}\n{completed.stderr}"
+        )
+    return completed
+
+
+def _forbid_live_publish(command: list[str]) -> None:
+    joined = " ".join(command)
+    if "npm" in command and "publish" in command and "--dry-run" not in command:
+        raise RegistryArtifactError(f"refusing live npm publish: {joined}")
+    if "mcp-publisher" in Path(command[0]).name and "publish" in command:
+        if "--dry-run" not in command:
+            raise RegistryArtifactError(f"refusing live mcp-publisher publish: {joined}")
+
+
+def stage_package(output_dir: Path) -> Path:
+    staged = output_dir / "dex-mcp"
+    _remove_existing(staged)
+    staged.mkdir(parents=True)
+    for name in SHARED_DIRECTORIES:
+        _copy_tree(PLUGIN_ROOT / name, staged / name)
+    for name in SHARED_FILES:
+        shutil.copy2(PLUGIN_ROOT / name, staged / name)
+    for name in PACKAGE_FILES:
+        shutil.copy2(PACKAGE_SOURCE / name, staged / name)
+    scripts = staged / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        PACKAGE_SOURCE / "scripts" / "refuse-live-npm-publish.mjs",
+        scripts / "refuse-live-npm-publish.mjs",
+    )
+    return staged
+
+
+def validate_manifests(staged: Path) -> dict[str, Any]:
+    package = _load_json(staged / "package.json")
+    server = _load_json(staged / "server.json")
+    if package.get("private") is not True:
+        raise RegistryArtifactError("dex-mcp must stay private until Dave publishes")
+    if package.get("name") != "dex-mcp":
+        raise RegistryArtifactError("npm package name must stay the unscoped dex-mcp name")
+    if package.get("mcpName") != server.get("name"):
+        raise RegistryArtifactError("package.json mcpName must match server.json name")
+    if server.get("name") != "io.github.davekilleen/dex":
+        raise RegistryArtifactError("registry name must stay io.github.davekilleen/dex")
+    packages = server.get("packages")
+    if not isinstance(packages, list) or not packages:
+        raise RegistryArtifactError("server.json must declare the npm package")
+    npm_package = packages[0]
+    if npm_package.get("registryType") != "npm" or npm_package.get("identifier") != "dex-mcp":
+        raise RegistryArtifactError("server.json must point at the unpublished dex-mcp npm package")
+    if jsonschema is not None:
+        schema = _official_schema()
+        if schema is not None:
+            jsonschema.validate(server, schema)
+    return {"package": package, "server": server}
+
+
+def _official_schema() -> dict[str, Any] | None:
+    try:
+        with urllib.request.urlopen(OFFICIAL_SCHEMA_URL, timeout=20) as response:
+            parsed = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def pack_npm(staged: Path, output_dir: Path) -> Path:
+    completed = _run(["npm", "pack", "--pack-destination", str(output_dir)], cwd=staged)
+    names = [line.strip() for line in completed.stdout.splitlines() if line.strip().endswith(".tgz")]
+    if not names:
+        raise RegistryArtifactError("npm pack did not write a .tgz")
+    tarball = output_dir / names[-1]
+    if not tarball.is_file():
+        raise RegistryArtifactError(f"npm pack reported {tarball.name} but the file is missing")
+    return tarball
+
+
+def dry_run_npm_publish(staged: Path) -> str:
+    command = ["npm", "publish", "--dry-run"]
+    _forbid_live_publish(command)
+    completed = _run(command, cwd=staged)
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    if "dex-mcp" not in combined:
+        raise RegistryArtifactError("npm publish --dry-run did not mention dex-mcp")
+    return combined
+
+
+def validate_with_mcp_publisher(staged: Path) -> str:
+    publisher = shutil.which("mcp-publisher")
+    if not publisher:
+        return "skipped: mcp-publisher is not installed"
+    validate = [publisher, "validate", str(staged / "server.json")]
+    _run(validate, cwd=staged)
+    publish = [publisher, "publish", str(staged / "server.json"), "--dry-run"]
+    _forbid_live_publish(publish)
+    _run(publish, cwd=staged)
+    return "validated and publish --dry-run"
+
+
+def write_checksum(tarball: Path) -> Path:
+    sidecar = Path(f"{tarball}.sha256")
+    sidecar.write_text(f"{_sha256(tarball)}  {tarball.name}\n", encoding="utf-8")
+    return sidecar
+
+
+def write_index(
+    output_dir: Path,
+    tarball: Path,
+    *,
+    release_status: str,
+    validation: dict[str, Any],
+) -> Path:
+    index = output_dir / "artifacts.json"
+    payload = {
+        "schema_version": "1.0.0",
+        "release_status": release_status,
+        "published": False,
+        "one_line_after_publish": "io.github.davekilleen/dex",
+        "artifacts": [
+            {
+                "name": tarball.name,
+                "sha256": _sha256(tarball),
+                "bytes": tarball.stat().st_size,
+            }
+        ],
+        "validation": validation,
+    }
+    index.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return index
+
+
+def build(output_dir: Path, *, release_status: str = "unreleased") -> Path:
+    if release_status != "unreleased":
+        raise RegistryArtifactError("the MCP registry artifact must stay unreleased")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    staged = stage_package(output_dir)
+    manifests = validate_manifests(staged)
+    tarball = pack_npm(staged, output_dir)
+    npm_dry_run = dry_run_npm_publish(staged)
+    publisher_status = validate_with_mcp_publisher(staged)
+    checksum = write_checksum(tarball)
+    validation = {
+        "official_schema": manifests["server"]["$schema"],
+        "npm_pack": tarball.name,
+        "npm_publish": "dry-run",
+        "mcp_publisher": publisher_status,
+        "checksum": checksum.name,
+    }
+    write_index(output_dir, tarball, release_status=release_status, validation=validation)
+    if "dry-run" not in npm_dry_run.lower() and "dry run" not in npm_dry_run.lower():
+        raise RegistryArtifactError("npm publish --dry-run did not report a dry run")
+    return tarball
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    tarball = build(args.output_dir.expanduser().resolve())
+    print(f"Packed {tarball.name}: {_sha256(tarball)}")
+    print("Validated. Still unreleased. Did not publish.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-mcp-publisher-safe.py
+++ b/scripts/run-mcp-publisher-safe.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run mcp-publisher only in validate or publish --dry-run mode."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ALLOWED_COMMANDS = frozenset({"validate", "publish"})
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=sorted(ALLOWED_COMMANDS))
+    parser.add_argument("server_json", nargs="?", default="server.json")
+    parser.add_argument(
+        "--mcp-publisher",
+        default=shutil.which("mcp-publisher"),
+        help="Path to mcp-publisher. Defaults to PATH.",
+    )
+    args = parser.parse_args(argv)
+
+    publisher = args.mcp_publisher
+    if not publisher:
+        print("mcp-publisher is not installed; skipped official CLI validation.")
+        return 0
+
+    server_json = Path(args.server_json).expanduser()
+    command = [publisher, args.command, str(server_json)]
+    if args.command == "publish":
+        command.append("--dry-run")
+
+    completed = subprocess.run(command, check=False)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-mcp-publisher-safe.py
+++ b/scripts/run-mcp-publisher-safe.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-"""Run mcp-publisher only in validate or publish --dry-run mode."""
+"""Run mcp-publisher validate only. Never publish."""
 
 from __future__ import annotations
 
 import argparse
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
-
-ALLOWED_COMMANDS = frozenset({"validate", "publish"})
+ALLOWED_COMMANDS = frozenset({"validate"})
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,10 +28,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     server_json = Path(args.server_json).expanduser()
-    command = [publisher, args.command, str(server_json)]
-    if args.command == "publish":
-        command.append("--dry-run")
-
+    command = [publisher, "validate", str(server_json)]
     completed = subprocess.run(command, check=False)
     return completed.returncode
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased.

## What this pull request is
Dex's already-proven read-only tools are now packed as an npm-shaped package. After Dave publishes, a person can point any MCP app at one line. This draft only packs, checksums, and dry-run validates. Nothing went live.

Branched from `cursor/dex-everywhere-codex-first-c346` (Dex draft PR 620). Do not push to 619 or 620.

## What a person can do now
- Pack the unpublished package locally: `python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact`
- Get a `.tgz`, a SHA-256 sidecar, and an `unreleased` index
- Confirm the same four read-only tools still answer, and a destructive command is still refused
- See the future one-liner written down: `io.github.davekilleen/dex`

## What a person cannot do yet
- Install Dex from npm or the public MCP catalogue — it is not published
- Point an MCP app at that one line in real life — only after Dave publishes
- Use this runner to create an npm account or publish

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish.

The lab spec at `davekilleen/dex-product-gtm-lab` draft PR 398 was not readable from this runner (the GitHub token can only see `davekilleen/Dex`). This implements the official MCP catalogue contract plus the done line you gave: packed, checksummed, validated, still unreleased.

This runner did not invent an npm account or the ChatGPT Work folder grant. Live `npm publish` is refused unless `--dry-run` is set. `mcp-publisher publish` is refused even with a fake dry-run, because the official CLI has no real dry-run. Only `mcp-publisher validate` is allowed.

Local proof on this head: the packed file validated against the official catalogue schema, `npm publish --dry-run` succeeded, and `mcp-publisher validate` said the catalogue file is valid. Still unpublished.

## Stay here
Stay on this draft. Do not resume PR 619 or 620. Do not publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94e8275-275e-4b74-98e4-e3d2719f0ce9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94e8275-275e-4b74-98e4-e3d2719f0ce9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

