### PR TITLE
Dex Everywhere lot: fleet leftover on e8b24265 — unreleased

### DIFF
--- a/core/tests/test_dex_everywhere_vscode_kiro_fleet_record.py
+++ b/core/tests/test_dex_everywhere_vscode_kiro_fleet_record.py
@@ -1,0 +1,62 @@
+"""The e8b24265 record names green Dex CI and the named reason fleet did not run."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = REPO_ROOT / "docs" / "plans" / "2026-08-27-dex-everywhere-codex-evidence.md"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "historic-fleet-darwin.yml"
+
+DEX_CI_RUN = "https://github.com/davekilleen/Dex/actions/runs/33257169650"
+SUCCESSOR_FLEET_CANARY_RUN = "https://github.com/davekilleen/Dex/actions/runs/33247935319"
+RECORDED_SHA = "e8b24265"
+FULL_SHA = "e8b24265919f78ceaaa7c4d1914b09225a6340e4"
+SUCCESSOR_SHA = "77242824"
+
+FLEET_WATCHED_PATHS = {
+    ".github/workflows/historic-fleet-darwin.yml",
+    "package.json",
+    "core/update/journey-protocol-v1.json",
+    "scripts/build-release.sh",
+    "scripts/build-vault-bundle.sh",
+    "scripts/check-release-catalog-tag-identity.py",
+    "scripts/compose-vault-gitignore.py",
+    "scripts/dex_update_bridge.py",
+    "scripts/release_fleet.py",
+    "scripts/release_fleet_acceptance.py",
+    "scripts/release_fleet_executor.py",
+    "scripts/run-historic-fleet-darwin.sh",
+}
+
+
+def test_evidence_names_e8b24265_dex_ci_and_the_path_filter_reason_fleet_did_not_run() -> None:
+    text = EVIDENCE.read_text(encoding="utf-8")
+    lowered = text.lower()
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = workflow.get("on", workflow.get(True))
+    watched = set(triggers["pull_request"]["paths"])
+
+    assert watched == FLEET_WATCHED_PATHS
+    assert DEX_CI_RUN in text
+    assert SUCCESSOR_FLEET_CANARY_RUN in text
+    assert RECORDED_SHA in text
+    assert FULL_SHA in text
+    assert SUCCESSOR_SHA in text
+    assert "green" in lowered
+    assert "success" in lowered
+    assert "did not run" in lowered
+    assert "watched release/fleet files" in lowered
+    assert "do not bump a watched path" in lowered
+    assert "not a person-can-open win" in lowered
+    assert "no person opened a host" in lowered
+    assert "not itself the freeze" in lowered
+    assert "that is not this head" in lowered
+    assert "green fleet is not a person opening visual studio code or kiro" in lowered
+    assert "do not add hooks" in lowered
+    assert "do not invent a new host" in lowered
+    assert "opening visual studio code or kiro on a real machine stays dave's" in lowered
+    assert "someone opened a host" not in lowered
+    assert "opened a live install" not in lowered
+    assert "pending" not in lowered
+    assert "in_progress" not in lowered

--- a/docs/plans/2026-08-27-dex-everywhere-codex-evidence.md
+++ b/docs/plans/2026-08-27-dex-everywhere-codex-evidence.md
@@ -5,6 +5,20 @@
 **Live successor:** draft PR 620, branch `cursor/dex-everywhere-codex-first-c346`. Do not push to leftover PR 619 / `cursor/dex-everywhere-phase-1a-c346`.  
 **Sequence:** Copilot CLI is written and not opened. Codex, Cowork, Pi, and BB stay green. ChatGPT Work vault-folder grant is the only leftover that still needs Dave on a real desktop. Do not invent that grant. Programme stays unreleased.
 
+## Fleet leftover on VS Code/Kiro freeze SHA `e8b24265`
+
+Host-path HEAD recorded here: `e8b24265919f78ceaaa7c4d1914b09225a6340e4` on draft PR 650 / `cursor/everywhere-vscode-kiro-freeze-c346`. This lot targets the successor (`cursor/dex-everywhere-codex-first-c346`, draft PR 620). Do not merge 620. Leftover PR 619 / `cursor/dex-everywhere-phase-1a-c346` is dead. Do not add hooks. Do not invent a new host.
+
+Dex CI is green on that exact SHA:
+
+- Dex CI: https://github.com/davekilleen/Dex/actions/runs/33257169650 — **GREEN** / success
+
+The twelve-journey Mac fleet canary did not run on that exact SHA. GitHub only starts `historic-fleet-darwin-pr-canary` when a pull request changes one of the watched release/fleet files (`.github/workflows/historic-fleet-darwin.yml`, root `package.json`, `core/update/journey-protocol-v1.json`, `scripts/build-release.sh`, `scripts/build-vault-bundle.sh`, `scripts/check-release-catalog-tag-identity.py`, `scripts/compose-vault-gitignore.py`, `scripts/dex_update_bridge.py`, `scripts/release_fleet.py`, `scripts/release_fleet_acceptance.py`, `scripts/release_fleet_executor.py`, `scripts/run-historic-fleet-darwin.sh`). PR 650 did not change those files. Formal `historic-fleet-darwin` stays skipped on pull requests. Successor `77242824` already has that canary green at https://github.com/davekilleen/Dex/actions/runs/33247935319. That is not this head.
+
+This lot commit is a later head and is not itself the freeze. Do not bump a watched path to invent fleet proof on `e8b24265`. Green fleet is not a person opening Visual Studio Code or Kiro.
+
+Green Dex CI is not a person-can-open win. No person opened a host. Opening Visual Studio Code or Kiro on a real machine stays Dave's. Do not add hooks. Do not invent a new host.
+
 ## What “Codex done” means
 
 Dex works in **Codex CLI and Codex desktop**. The Codex editor add-on does not load this plugin; that limit is recorded in the Codex host profile and is intentional.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge 620. This lot targets the successor (`cursor/dex-everywhere-codex-first-c346`, draft PR 620). Leftover PR 619 / `cursor/dex-everywhere-phase-1a-c346` is dead. Do not merge this lot to main. Do not merge 650.

Records VS Code/Kiro freeze head `e8b24265919f78ceaaa7c4d1914b09225a6340e4` (draft PR 650) only.

- Dex CI GREEN: https://github.com/davekilleen/Dex/actions/runs/33257169650
- Fleet canary did not run on that exact SHA. Named reason: GitHub only starts `historic-fleet-darwin-pr-canary` when a pull request changes one of the watched release/fleet files. PR 650 did not change those files. Formal `historic-fleet-darwin` stays skipped on pull requests.
- Successor `77242824` already has that canary green: https://github.com/davekilleen/Dex/actions/runs/33247935319. That is not this head.

Do not add hooks. Do not invent a new host. Do not bump a watched path to invent fleet proof on `e8b24265`. Green fleet is not a person opening Visual Studio Code or Kiro. This record commit is a later head and is not itself the freeze. Opening Visual Studio Code or Kiro on a real machine stays Dave's.

> AGENT GENERATED: by Cursor Grok 4.6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c48b042-02d1-48ed-a51e-e5de6ed4c346?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c48b042-02d1-48ed-a51e-e5de6ed4c346&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

