### PR TITLE
Explain macOS 'Add Events Only' calendar access instead of a generic denial

### DIFF
--- a/06-Resources/Dex_System/Calendar_Setup.md
+++ b/06-Resources/Dex_System/Calendar_Setup.md
@@ -48,6 +48,7 @@ Do not wait for a Mac permission popup. It often never appears when Dex runs ins
 | What you see | What to do |
 |--------------|------------|
 | **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **VS Code** or **Cursor** on (the app Dex is running in), then click that app and set access to **Full** (not "Add Only"). Quit the editor and open it again. Do not switch to Terminal as the only fix, and do not reinstall Dex. |
+| **"Calendar access is set to Add Events Only"** | macOS is letting Dex add events but not read them. Go to **System Settings** → **Privacy & Security** → **Calendars**, click the app Dex is running in (**VS Code**, **Cursor**, or **Terminal**) and change it from "Add Events Only" to **Full Access**. Quit that app and open it again. Asking Dex again without changing the setting will not help. |
 | **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart the editor. |
 | **Calendar is empty or very slow** | Same as above: both setup steps, and if you didn't run the installer, run the `pip3 install` line above. |
 

--- a/core/mcp/scripts/calendar_eventkit.py
+++ b/core/mcp/scripts/calendar_eventkit.py
@@ -27,6 +27,11 @@ CALENDAR_ACCESS_DENIED = (
     "Calendar access denied. Enable in System Settings → Privacy & Security → Calendars. "
     f"See {CALENDAR_SETUP_DOC.relative_to(VAULT_ROOT)} for full setup."
 )
+CALENDAR_ACCESS_WRITE_ONLY = (
+    "Calendar access is set to Add Events Only. Dex needs Full Access to read events. "
+    "In System Settings → Privacy & Security → Calendars, change the app running Dex to Full Access. "
+    f"See {CALENDAR_SETUP_DOC.relative_to(VAULT_ROOT)} for full setup."
+)
 
 
 def request_calendar_access(store, completion):
@@ -46,11 +51,14 @@ def request_calendar_access(store, completion):
 def ensure_calendar_access(store):
     """Request calendar access if needed; wait for user to grant. Required to see all calendars (e.g. Google)."""
     status = EventKit.EKEventStore.authorizationStatusForEntityType_(EventKit.EKEntityTypeEvent)
-    # 3 = Authorized, 2 = Denied, 0 = NotDetermined, 1 = Restricted
+    # 3 = FullAccess, 2 = Denied, 0 = NotDetermined, 1 = Restricted, 4 = WriteOnly
     if status == 3:
         return True
     if status == 2:
         return False
+    if status == getattr(EventKit, "EKAuthorizationStatusWriteOnly", 4):
+        print(json.dumps({"error": CALENDAR_ACCESS_WRITE_ONLY}))
+        sys.exit(1)
     # NotDetermined or Restricted: request access
     done = threading.Event()
     result = [None]

--- a/core/tests/test_calendar_eventkit_script.py
+++ b/core/tests/test_calendar_eventkit_script.py
@@ -6,6 +6,8 @@ import json
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 sys.modules.setdefault("EventKit", SimpleNamespace())
 
 from core.mcp.scripts import calendar_eventkit
@@ -141,6 +143,17 @@ class _LegacyStore:
         completion(True, None)
 
 
+class _WriteOnlyStore:
+    """Store whose host app has macOS Add Events Only access."""
+
+    def __init__(self):
+        self.calls = []
+
+    def requestFullAccessToEventsWithCompletion_(self, completion):
+        self.calls.append("requestFullAccessToEventsWithCompletion_")
+        completion(False, None)
+
+
 def test_request_calendar_access_prefers_modern_full_access_api(monkeypatch):
     """On macOS 14+ the legacy request API reports denied without prompting,
     so fresh grants were impossible (#377) — the modern API must win."""
@@ -163,6 +176,28 @@ def test_request_calendar_access_falls_back_to_legacy_api(monkeypatch):
 
     assert store.calls == ["requestAccessToEntityType_completion_"]
     assert granted == [True]
+
+
+def test_list_calendars_explains_write_only_access(monkeypatch, capsys):
+    store = _WriteOnlyStore()
+    event_store = SimpleNamespace(
+        alloc=lambda: SimpleNamespace(init=lambda: store),
+        authorizationStatusForEntityType_=lambda _: 4,
+    )
+    monkeypatch.setattr(
+        calendar_eventkit,
+        "EventKit",
+        SimpleNamespace(EKEntityTypeEvent=0, EKEventStore=event_store),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        calendar_eventkit.list_calendars()
+
+    assert exc_info.value.code == 1
+    message = json.loads(capsys.readouterr().out)["error"]
+    assert "Add Events Only" in message
+    assert "Full Access" in message
+    assert store.calls == []
 
 
 def test_get_events_prints_json(monkeypatch, capsys):

--- a/docs/Dex_System/Calendar_Setup.md
+++ b/docs/Dex_System/Calendar_Setup.md
@@ -48,6 +48,7 @@ Do not wait for a Mac permission popup. It often never appears when Dex runs ins
 | What you see | What to do |
 |--------------|------------|
 | **"Calendar access denied"** | Go to **System Settings** → **Privacy & Security** → **Calendars**, turn **VS Code** or **Cursor** on (the app Dex is running in), then click that app and set access to **Full** (not "Add Only"). Quit the editor and open it again. Do not switch to Terminal as the only fix, and do not reinstall Dex. |
+| **"Calendar access is set to Add Events Only"** | macOS is letting Dex add events but not read them. Go to **System Settings** → **Privacy & Security** → **Calendars**, click the app Dex is running in (**VS Code**, **Cursor**, or **Terminal**) and change it from "Add Events Only" to **Full Access**. Quit that app and open it again. Asking Dex again without changing the setting will not help. |
 | **No meetings or wrong dates for recurring events** | Make sure you did both steps above. If you installed Dex without running the installer (e.g. you installed Python packages yourself), open Terminal and run: `pip3 install --user pyobjc-framework-EventKit`, then restart the editor. |
 | **Calendar is empty or very slow** | Same as above: both setup steps, and if you didn't run the installer, run the `pip3 install` line above. |
 


### PR DESCRIPTION
## What was wrong

macOS 14+ has a third calendar permission state: **Add Events Only** (`EKAuthorizationStatusWriteOnly`, status `4`). Dex's EventKit script only knew about FullAccess (3), Denied (2), NotDetermined (0) and Restricted (1), so status 4 fell into the "undecided — go ask" branch.

Two user-visible consequences:

1. Dex issued `requestFullAccessToEventsWithCompletion_` again. macOS only prompts once per app per entity type, so no dialog appeared — the call returned denied immediately after the script had waited on it.
2. The user was then shown `Calendar access denied`, which is wrong. Access was granted; it was granted at the wrong level. The message gave them nothing to act on.

Dex's own Doctor already classified status 4 correctly (`core/utils/doctor.py`, `write_only` → BROKEN with a Full Access heal). The MCP script was the surface that had not caught up.

## What changes

`ensure_calendar_access` now recognises write-only and exits with precise guidance:

> Calendar access is set to Add Events Only. Dex needs Full Access to read events. In System Settings → Privacy & Security → Calendars, change the app running Dex to Full Access.

It makes **no** redundant access request. All four permission gates — `list_calendars`, `get_events_data` (serving both `events` and `attendees`), `search_events`, `get_next_event` — route through this helper, so every CLI command gets the accurate message.

The Calendar setup guide gains a troubleshooting row matching the exact new wording, so a user who searches the doc for what Dex printed finds it.

## Evidence

`core/tests/test_calendar_eventkit_script.py::test_list_calendars_explains_write_only_access` asserts the message names both "Add Events Only" and "Full Access", exits 1, and that the store received zero request calls.

Proven to have teeth: with the write-only branch deleted, the test fails with the old text — `assert 'Add Events Only' in 'Calendar access denied. ...'`. Restored, 20 calendar/eventkit tests pass (script + doctor).

## Scope

No changelog entry: in this repo CHANGELOG.md is written by the release lane, not by feature PRs. No release tag — v1.97.6 shipped today and this is a merge-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, user-facing error-path change in the EventKit script and docs; no auth or data-model changes, with regression coverage for the new branch.
> 
> **Overview**
> **EventKit access handling** now treats macOS **Add Events Only** (`EKAuthorizationStatusWriteOnly`, status 4) as its own case instead of falling through to a redundant full-access request and a misleading **Calendar access denied** message.
> 
> When write-only is detected, `ensure_calendar_access` **exits immediately** with JSON error text that names **Add Events Only**, asks for **Full Access** in System Settings, and links to the setup doc—**without** calling `requestFullAccessToEventsWithCompletion_`. Every calendar CLI path that already uses this helper (`list`, events/attendees, search, next) gets the new behavior.
> 
> **Docs** add a troubleshooting table row in `Calendar_Setup.md` (resources + docs copies) that matches the new error wording.
> 
> **Tests** add `test_list_calendars_explains_write_only_access`, asserting exit code 1, the message content, and that no access-request APIs run on the mock store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046e73ea66cd95e7f46452b3de2961b8ee7853b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

