### PR TITLE
fix: establish Reminders access before EventKit use

### DIFF
--- a/core/mcp/scripts/reminders_eventkit.py
+++ b/core/mcp/scripts/reminders_eventkit.py
@@ -16,16 +16,60 @@ Usage:
 
 import json
 import sys
+import threading
 import time
 from datetime import datetime
 
 import EventKit
 from Foundation import NSDate, NSRunLoop
 
+REMINDERS_ACCESS_DENIED = (
+    "Reminders access denied. Enable it in System Settings → "
+    "Privacy & Security → Reminders, then try again."
+)
+
+
+def request_reminders_access(store, completion):
+    """Request full Reminders access with the current macOS API when available."""
+    if hasattr(store, "requestFullAccessToRemindersWithCompletion_"):
+        store.requestFullAccessToRemindersWithCompletion_(completion)
+    else:
+        store.requestAccessToEntityType_completion_(
+            EventKit.EKEntityTypeReminder, completion
+        )
+
+
+def ensure_reminders_access(store):
+    """Return whether the store has full Reminders access, requesting it once if new."""
+    status = EventKit.EKEventStore.authorizationStatusForEntityType_(
+        EventKit.EKEntityTypeReminder
+    )
+    full_access = getattr(EventKit, "EKAuthorizationStatusFullAccess", 3)
+    if status == full_access:
+        return True
+
+    not_determined = getattr(EventKit, "EKAuthorizationStatusNotDetermined", 0)
+    if status != not_determined:
+        return False
+
+    done = threading.Event()
+    result = [False]
+
+    def completion(granted, error):
+        result[0] = bool(granted)
+        done.set()
+
+    request_reminders_access(store, completion)
+    done.wait(timeout=60)
+    return result[0]
+
 
 def get_store():
     """Get an authorized EKEventStore for Reminders."""
     store = EventKit.EKEventStore.alloc().init()
+    if not ensure_reminders_access(store):
+        print(json.dumps({"error": REMINDERS_ACCESS_DENIED}))
+        sys.exit(1)
     return store
 
 

--- a/core/tests/test_reminders_eventkit_script.py
+++ b/core/tests/test_reminders_eventkit_script.py
@@ -102,3 +102,68 @@ def test_list_lists_requests_fresh_reminders_access_before_reading(monkeypatch, 
 
     assert json.loads(capsys.readouterr().out) == []
     assert store.requests == ["requestFullAccessToRemindersWithCompletion_"]
+
+
+class _LegacyStore:
+    """Pre-macOS-14 store: the modern full-access API does not exist here."""
+
+    def __init__(self):
+        self.granted = False
+        self.requests = []
+
+    def requestAccessToEntityType_completion_(self, entity_type, completion):
+        self.requests.append("requestAccessToEntityType_completion_")
+        self.granted = True
+        completion(True, None)
+
+    def calendarsForEntityType_(self, entity_type):
+        if not self.granted:
+            raise AssertionError("Reminders were read before access was granted")
+        return []
+
+
+def test_older_macos_falls_back_to_the_legacy_access_request(monkeypatch, capsys):
+    store = _LegacyStore()
+    _UndeterminedEventStore.store = store
+    monkeypatch.setattr(
+        reminders_eventkit,
+        "EventKit",
+        SimpleNamespace(EKEntityTypeReminder=1, EKEventStore=_UndeterminedEventStore),
+    )
+
+    reminders_eventkit.list_lists()
+
+    assert json.loads(capsys.readouterr().out) == []
+    assert store.requests == ["requestAccessToEntityType_completion_"]
+
+
+GUARDED_COMMANDS = (
+    ("list_lists", ()),
+    ("list_items", ("Dex Today",)),
+    ("list_completed_items", ("Dex Today",)),
+    ("complete_item", ("reminder-id",)),
+    ("create_item", ("Dex Today", "Title")),
+    ("find_and_complete", ("Dex Today", "query")),
+    ("clear_completed", ("Dex Today",)),
+    ("ensure_lists", ()),
+)
+
+
+@pytest.mark.parametrize("command,args", GUARDED_COMMANDS)
+def test_every_reminders_command_refuses_before_reading_when_access_is_denied(
+    monkeypatch, capsys, command, args
+):
+    """No public command may touch EventKit data without established access."""
+    monkeypatch.setattr(
+        reminders_eventkit,
+        "EventKit",
+        SimpleNamespace(EKEntityTypeReminder=1, EKEventStore=_DeniedEventStore),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        getattr(reminders_eventkit, command)(*args)
+
+    assert exc.value.code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "error": reminders_eventkit.REMINDERS_ACCESS_DENIED
+    }

--- a/core/tests/test_reminders_eventkit_script.py
+++ b/core/tests/test_reminders_eventkit_script.py
@@ -1,0 +1,104 @@
+"""Coverage for the Reminders EventKit command boundary."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.modules.setdefault("EventKit", SimpleNamespace())
+sys.modules.setdefault(
+    "Foundation",
+    SimpleNamespace(NSDate=SimpleNamespace(), NSRunLoop=SimpleNamespace()),
+)
+
+from core.mcp.scripts import reminders_eventkit
+
+
+class _DeniedStore:
+    def calendarsForEntityType_(self, entity_type):
+        return []
+
+    def defaultCalendarForNewReminders(self):
+        return None
+
+
+class _DeniedEventStore:
+    @classmethod
+    def authorizationStatusForEntityType_(cls, entity_type):
+        return 2
+
+    @classmethod
+    def alloc(cls):
+        return cls()
+
+    def init(self):
+        return _DeniedStore()
+
+
+class _UndeterminedStore:
+    def __init__(self):
+        self.granted = False
+        self.requests = []
+
+    def requestFullAccessToRemindersWithCompletion_(self, completion):
+        self.requests.append("requestFullAccessToRemindersWithCompletion_")
+        self.granted = True
+        completion(True, None)
+
+    def calendarsForEntityType_(self, entity_type):
+        if not self.granted:
+            raise AssertionError("Reminders were read before access was granted")
+        return []
+
+
+class _UndeterminedEventStore:
+    store = _UndeterminedStore()
+
+    @classmethod
+    def authorizationStatusForEntityType_(cls, entity_type):
+        return 0
+
+    @classmethod
+    def alloc(cls):
+        return cls()
+
+    def init(self):
+        return self.store
+
+
+def test_ensure_lists_reports_how_to_grant_denied_reminders_access(monkeypatch, capsys):
+    monkeypatch.setattr(
+        reminders_eventkit,
+        "EventKit",
+        SimpleNamespace(EKEntityTypeReminder=1, EKEventStore=_DeniedEventStore),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        reminders_eventkit.ensure_lists()
+
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "error": (
+            "Reminders access denied. Enable it in System Settings → "
+            "Privacy & Security → Reminders, then try again."
+        )
+    }
+
+
+def test_list_lists_requests_fresh_reminders_access_before_reading(monkeypatch, capsys):
+    store = _UndeterminedStore()
+    _UndeterminedEventStore.store = store
+    monkeypatch.setattr(
+        reminders_eventkit,
+        "EventKit",
+        SimpleNamespace(EKEntityTypeReminder=1, EKEventStore=_UndeterminedEventStore),
+    )
+
+    reminders_eventkit.list_lists()
+
+    assert json.loads(capsys.readouterr().out) == []
+    assert store.requests == ["requestFullAccessToRemindersWithCompletion_"]


### PR DESCRIPTION
## What was broken

A user on v1.97.6 hit a raw `NoneType` traceback from Reminders. `reminders_eventkit.py`'s `get_store()` created an `EKEventStore` and handed it straight to callers — it never checked or requested macOS Reminders permission. Without a TCC grant EventKit returns empty/`None` objects instead of erroring, so the first attribute access blew up with a Python traceback the user could do nothing with.

The Calendar half of the same file pair already fixed this in #377 (including the macOS 14+ detail that the legacy `requestAccessToEntityType_completion_` reports denied immediately without ever showing the prompt). Reminders was never given the same treatment.

## The fix

One shared guard at the single seam every command already funnels through — `get_store()`. All eight public commands (`list_lists`, `list_items`, `list_completed`, `complete`, `create`, `find_and_complete`, `clear_completed`, `ensure_lists`) call it as their first statement, so nothing can read EventKit data before access is established.

- **Fresh installs** request full access via `requestFullAccessToRemindersWithCompletion_` on macOS 14+, falling back to `requestAccessToEntityType_completion_` on older systems.
- **Denied or restricted** prints actionable JSON — "Enable it in System Settings → Privacy & Security → Reminders" — and exits 1. `calendar_server.py`'s `run_shell_script` already falls back to stdout on a non-zero exit (#377), so the MCP surfaces the instruction rather than "Exit code: 1".
- No behaviour change once access is granted.

## Review notes

Reviewed independently and replayed onto current `main` (origin had moved 250 commits since the original commit; the replay was clean, source unchanged).

The original commit proved the guard for only two commands and left the older-macOS fallback path untested even though the fix depends on it. This PR adds:

- a parametrised test asserting **every one of the eight commands** refuses with the System Settings instruction before touching EventKit data;
- a legacy-store test that fails if the pre-macOS-14 request path is dropped.

All three gates were proven to fail on a deliberate break and pass restored:

| Deliberate break | Result |
|---|---|
| Remove the guard from `get_store()` | 11 failed |
| Drop the older-macOS fallback branch | 1 failed (the legacy test) |
| Treat denied status as authorized | 9 failed |
| Restored | 11 passed |

## Not proven here

The tests stub `EventKit`, so they prove the control flow, not real TCC behaviour. No CI runner can exercise a real macOS permission prompt. The macOS-hosted `tests` shard job covers the changed files; a real end-to-end grant/deny on a Mac with Reminders data remains unverified.

Scope is deliberately limited to Reminders. The separate Calendar "Add Events Only" work is not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS Reminders CLI guard and tests; no auth, data migration, or behavior change when permission is already granted.
> 
> **Overview**
> **Reminders MCP commands no longer touch EventKit until macOS Reminders permission is handled**, mirroring the Calendar EventKit fix.
> 
> `get_store()` now runs an access gate: if authorization is already full, behavior is unchanged; if status is *not determined*, it requests access (macOS 14+ via `requestFullAccessToRemindersWithCompletion_`, older macOS via `requestAccessToEntityType_completion_`) and waits on a completion callback; if access is denied or restricted, it prints JSON with a **System Settings → Privacy & Security → Reminders** message and exits with code 1 instead of surfacing a `NoneType` traceback.
> 
> A new test module stubs EventKit to assert denied access returns that error for all eight command entry points, that undetermined status triggers the modern request before any reads, and that stores without the macOS 14 API use the legacy request path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58872839f7821783a5ebe42571c777aad718ada7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->