### PR TITLE
Dex Everywhere lot: family PreToolUse refusal — unreleased

### DIFF
--- a/core/harnesses/adapters/copilot-cli.json
+++ b/core/harnesses/adapters/copilot-cli.json
@@ -3,10 +3,10 @@
   "harness_id": "copilot-cli",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. Hooks are not bundled; safety stays an explicit MCP check. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
+    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "install_command": "copilot plugin install ./packages/dex-agent-plugin",

--- a/core/harnesses/adapters/vscode.json
+++ b/core/harnesses/adapters/vscode.json
@@ -3,10 +3,10 @@
   "harness_id": "vscode",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. Hooks are not part of this path. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
+    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "settings_off_by_default": ["chat.plugins.enabled"],

--- a/core/harnesses/profiles/copilot-cli.json
+++ b/core/harnesses/profiles/copilot-cli.json
@@ -29,9 +29,9 @@
     },
     {
       "id": "hooks",
-      "mode": "unavailable",
-      "notes": "Copilot's native hook schema differs from the Claude and Codex files in this package, so no Copilot hook is claimed.",
-      "status": "not-verified",
+      "mode": "guided",
+      "notes": "The shipped package includes the family PreToolUse refusal hook file. A person still has to install the local plugin. Fixture-proved; not a recorded live walk.",
+      "status": "native",
       "tier": 3
     },
     {
@@ -76,13 +76,15 @@
   },
   "display_name": "GitHub Copilot CLI",
   "evidence": [
-    "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference"
+    "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference",
+    "https://docs.github.com/en/copilot/reference/hooks-reference",
+    "https://code.visualstudio.com/docs/agent-customization/agent-plugins"
   ],
   "id": "copilot-cli",
   "limitations": [
     "A person still has to install the reviewed local plugin with `copilot plugin install ./packages/dex-agent-plugin` and start the CLI from the Dex folder. Detection tests and CI do not prove that journey.",
     "Ubuntu Cloud is not a person opening this terminal. No recorded live session exists.",
-    "Hooks are not included in this release; shared safety remains an explicit MCP check rather than automatic enforcement."
+    "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
   ],
   "modes": [
     "tier-0-vault",
@@ -90,7 +92,7 @@
     "tier-2-skills"
   ],
   "name": "GitHub Copilot CLI",
-  "summary": "Open Plugin Spec package for Copilot CLI with skills and MCP. A person still has to install the reviewed local plugin and start the CLI from the Dex folder. Hooks are not claimed.",
+  "summary": "Open Plugin Spec package for Copilot CLI with skills, MCP, and the family PreToolUse refusal file. A person still has to install the reviewed local plugin and start the CLI from the Dex folder.",
   "support_level": "supported",
   "vendor": "GitHub"
 }

--- a/core/harnesses/profiles/kiro.json
+++ b/core/harnesses/profiles/kiro.json
@@ -30,7 +30,7 @@
     {
       "id": "hooks",
       "mode": "unavailable",
-      "notes": "This path does not add a Kiro hooks step. Safety stays an explicit MCP check.",
+      "notes": "Kiro's first-party hooks are workspace files under .kiro/hooks with a different schema. Powers do not load the family plugin hook file. Safety stays an explicit MCP check.",
       "status": "not-verified",
       "tier": 3
     },
@@ -78,6 +78,7 @@
   "evidence": [
     "https://kiro.dev/docs/powers/",
     "https://kiro.dev/docs/powers/installation/",
+    "https://kiro.dev/docs/hooks/",
     "https://agent-plugins.org/specification"
   ],
   "id": "kiro",
@@ -93,7 +94,7 @@
     "tier-2-skills"
   ],
   "name": "Kiro",
-  "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Hooks are not claimed.",
+  "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Family plugin hooks are not claimed.",
   "support_level": "supported",
   "vendor": "Amazon"
 }

--- a/core/harnesses/profiles/vscode.json
+++ b/core/harnesses/profiles/vscode.json
@@ -29,9 +29,9 @@
     },
     {
       "id": "hooks",
-      "mode": "unavailable",
-      "notes": "This path does not add a VS Code hooks step. Safety stays an explicit MCP check.",
-      "status": "not-verified",
+      "mode": "guided",
+      "notes": "The shipped package includes the family PreToolUse refusal hook file. Plugin settings stay off until a person turns them on. Fixture-proved; not a recorded live walk.",
+      "status": "native",
       "tier": 3
     },
     {
@@ -77,6 +77,7 @@
   "display_name": "Visual Studio Code",
   "evidence": [
     "https://code.visualstudio.com/docs/agent-customization/agent-plugins",
+    "https://code.visualstudio.com/docs/agent-customization/hooks",
     "https://agent-plugins.org/specification"
   ],
   "id": "vscode",
@@ -84,7 +85,7 @@
     "VS Code plugin settings stay off by default. A person still has to turn on chat.plugins.enabled, point chat.pluginLocations at ./packages/dex-agent-plugin, and reload. Detection tests and CI do not prove that journey.",
     "If auto-detect is empty or names Cursor or Kiro, confirm VS Code in /setup.",
     "Ubuntu Cloud is not a person opening VS Code. No recorded live session exists.",
-    "Hooks are not included in this path; shared safety remains an explicit MCP check."
+    "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
   ],
   "modes": [
     "tier-0-vault",
@@ -92,7 +93,7 @@
     "tier-2-skills"
   ],
   "name": "Visual Studio Code",
-  "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. Hooks are not claimed.",
+  "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. The family PreToolUse refusal file is included.",
   "support_level": "supported",
   "vendor": "Microsoft"
 }

--- a/core/harnesses/registry.json
+++ b/core/harnesses/registry.json
@@ -184,14 +184,14 @@
       "name": "GitHub Copilot CLI",
       "display_name": "GitHub Copilot CLI",
       "vendor": "GitHub",
-      "summary": "Open Plugin Spec package for Copilot CLI with skills and MCP. A person still has to install the reviewed local plugin and start the CLI from the Dex folder. Hooks are not claimed.",
+      "summary": "Open Plugin Spec package for Copilot CLI with skills, MCP, and the family PreToolUse refusal file. A person still has to install the reviewed local plugin and start the CLI from the Dex folder.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/copilot-cli.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The current working directory is the vault after the person starts the CLI from the Dex folder."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "The Open Plugin Spec package includes a relocatable stdio MCP server in mcp.json."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Copilot CLI loads skills from the installed plugin."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "Copilot's native hook schema differs from the Claude and Codex files in this package, so no Copilot hook is claimed."},
+        {"id": "hooks", "status": "native", "tier": 3, "mode": "guided", "notes": "The shipped package includes the family PreToolUse refusal hook file. A person still has to install the local plugin. Fixture-proved; not a recorded live walk."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "Available lifecycle events depend on the installed Copilot CLI version."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "CLI interaction is host-native."},
@@ -202,9 +202,13 @@
       "limitations": [
         "A person still has to install the reviewed local plugin with `copilot plugin install ./packages/dex-agent-plugin` and start the CLI from the Dex folder. Detection tests and CI do not prove that journey.",
         "Ubuntu Cloud is not a person opening this terminal. No recorded live session exists.",
-        "Hooks are not included in this release; shared safety remains an explicit MCP check rather than automatic enforcement."
+        "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
       ],
-      "evidence": ["https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference"]
+      "evidence": [
+        "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference",
+        "https://docs.github.com/en/copilot/reference/hooks-reference",
+        "https://code.visualstudio.com/docs/agent-customization/agent-plugins"
+      ]
     },
     {
       "id": "cowork",
@@ -280,14 +284,14 @@
       "name": "Kiro",
       "display_name": "Kiro",
       "vendor": "Amazon",
-      "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Hooks are not claimed.",
+      "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Family plugin hooks are not claimed.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/kiro.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The open Dex folder is the vault after the person starts Kiro there."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "Kiro loads mcp.json from the imported power and manages those servers with the power."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Skills come from the shipped package skills/ folder."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "This path does not add a Kiro hooks step. Safety stays an explicit MCP check."},
+        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "Kiro's first-party hooks are workspace files under .kiro/hooks with a different schema. Powers do not load the family plugin hook file. Safety stays an explicit MCP check."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "The power loads when the person names Dex or another listed keyword."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Kiro chat is host-native."},
@@ -301,7 +305,12 @@
         "Ubuntu Cloud is not a person opening Kiro. No recorded live session exists.",
         "Hooks are not included in this path; shared safety remains an explicit MCP check."
       ],
-      "evidence": ["https://kiro.dev/docs/powers/", "https://kiro.dev/docs/powers/installation/", "https://agent-plugins.org/specification"]
+      "evidence": [
+        "https://kiro.dev/docs/powers/",
+        "https://kiro.dev/docs/powers/installation/",
+        "https://kiro.dev/docs/hooks/",
+        "https://agent-plugins.org/specification"
+      ]
     },
     {
       "id": "pi",
@@ -360,14 +369,14 @@
       "name": "Visual Studio Code",
       "display_name": "Visual Studio Code",
       "vendor": "Microsoft",
-      "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. Hooks are not claimed.",
+      "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. The family PreToolUse refusal file is included.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/vscode.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The open Dex folder is the vault after the person starts VS Code there."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "VS Code reads mcp.json from the local plugin after the plugin is enabled."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Skills come from the shipped package skills/ folder."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "This path does not add a VS Code hooks step. Safety stays an explicit MCP check."},
+        {"id": "hooks", "status": "native", "tier": 3, "mode": "guided", "notes": "The shipped package includes the family PreToolUse refusal hook file. Plugin settings stay off until a person turns them on. Fixture-proved; not a recorded live walk."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "Plugin load depends on the person turning on chat.plugins.enabled and pointing chat.pluginLocations at the shipped package."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "VS Code chat is host-native."},
@@ -379,9 +388,13 @@
         "VS Code plugin settings stay off by default. A person still has to turn on chat.plugins.enabled, point chat.pluginLocations at ./packages/dex-agent-plugin, and reload. Detection tests and CI do not prove that journey.",
         "If auto-detect is empty or names Cursor or Kiro, confirm VS Code in /setup.",
         "Ubuntu Cloud is not a person opening VS Code. No recorded live session exists.",
-        "Hooks are not included in this path; shared safety remains an explicit MCP check."
+        "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
       ],
-      "evidence": ["https://code.visualstudio.com/docs/agent-customization/agent-plugins", "https://agent-plugins.org/specification"]
+      "evidence": [
+        "https://code.visualstudio.com/docs/agent-customization/agent-plugins",
+        "https://code.visualstudio.com/docs/agent-customization/hooks",
+        "https://agent-plugins.org/specification"
+      ]
     }
   ]
 }

--- a/core/tests/test_copilot_cli_host.py
+++ b/core/tests/test_copilot_cli_host.py
@@ -68,7 +68,12 @@ def test_copilot_cli_plugin_uses_the_open_package_layout() -> None:
     mcp = json.loads((PLUGIN_ROOT / "mcp.json").read_text(encoding="utf-8"))
     claude_mcp = json.loads((PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
 
-    assert adapter["native_paths"] == ["plugin.json", "skills/", "mcp.json"]
+    assert adapter["native_paths"] == [
+        "plugin.json",
+        "skills/",
+        "mcp.json",
+        "com.github.copilot/hooks/hooks.json",
+    ]
     assert adapter["status"] == "native-local"
     assert manifest["$schema"] == adapter["example"]["open_plugin_schema"]
     assert manifest["name"] == "dex-agent-plugin"
@@ -102,7 +107,8 @@ def test_copilot_cli_install_contract_names_local_plugin_and_folder() -> None:
     assert "dex folder" in guide
     assert "ubuntu cloud" in guide
     assert "not a live install" in guide
-    assert "hooks are not bundled" in guide
+    assert "family" in guide
+    assert "pretooluse" in guide
 
 
 def test_developer_guide_names_the_copilot_cli_terminal_steps() -> None:
@@ -146,8 +152,8 @@ def test_doctor_names_copilot_person_and_hook_limits_without_calling_it_chatgpt_
     assert result.structured_detail["selected"] == ["copilot-cli"]
     assert result.structured_detail["limitations"] == {"copilot-cli": limitations}
     rows = {row["id"]: row for row in get_profile("copilot-cli").capability_rows()}
-    assert rows["hooks"]["status"] == "not-verified"
-    assert rows["hooks"]["mode"] == "unavailable"
+    assert rows["hooks"]["status"] == "native"
+    assert rows["hooks"]["mode"] == "guided"
     assert get_profile("copilot-cli").adapter["status"] == "native-local"
 
 
@@ -247,7 +253,7 @@ def test_copilot_mcp_json_can_read_a_vault_without_opening_the_cli(tmp_path: Pat
     assert server["command"] == "node"
     assert "copilot" not in args
     assert "no recorded live session" in limitations
-    assert "hooks are not included" in limitations
+    assert "fixture-proved" in limitations
     assert get_profile("copilot-cli").capability_rows()
     rows = {row["id"]: row for row in get_profile("copilot-cli").capability_rows()}
-    assert rows["hooks"]["mode"] == "unavailable"
+    assert rows["hooks"]["mode"] == "guided"

--- a/core/tests/test_harness_golden_journeys.py
+++ b/core/tests/test_harness_golden_journeys.py
@@ -101,8 +101,8 @@ def test_each_harness_has_one_real_surface_and_one_explicit_boundary() -> None:
 
     copilot = _rows("copilot-cli")
     assert copilot["agent-plugins"]["status"] == "native"
-    assert copilot["hooks"]["status"] == "not-verified"
-    assert copilot["hooks"]["mode"] == "unavailable"
+    assert copilot["hooks"]["status"] == "native"
+    assert copilot["hooks"]["mode"] == "guided"
     copilot_limits = " ".join(get_profile("copilot-cli").limitations).lower()
     assert "person" in copilot_limits
     assert "copilot plugin install" in copilot_limits
@@ -138,7 +138,8 @@ def test_each_harness_has_one_real_surface_and_one_explicit_boundary() -> None:
 
     vscode = _rows("vscode")
     assert vscode["agent-plugins"]["status"] == "native"
-    assert vscode["hooks"]["mode"] == "unavailable"
+    assert vscode["hooks"]["status"] == "native"
+    assert vscode["hooks"]["mode"] == "guided"
     vscode_limits = " ".join(get_profile("vscode").limitations).lower()
     assert "off by default" in vscode_limits
     assert "chat.plugins.enabled" in vscode_limits

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -512,6 +512,61 @@ def test_plugin_hooks_inject_session_context_and_block_destructive_work(tmp_path
     assert json.loads(blocked.stdout)["decision"] == "block"
 
 
+def test_family_pretooluse_file_refuses_a_destructive_command(tmp_path: Path) -> None:
+    family_hooks = json.loads(
+        (PLUGIN_ROOT / "com.github.copilot" / "hooks" / "hooks.json").read_text()
+    )
+    command = family_hooks["hooks"]["PreToolUse"][0]["command"]
+
+    assert family_hooks["version"] == 1
+    assert family_hooks["hooks"]["PreToolUse"][0]["cwd"] == "${PLUGIN_ROOT}"
+    assert "--protocol copilot" in command
+    assert "${PLUGIN_ROOT}/bin/dex-python.mjs" in command
+
+    vault = tmp_path / "vault"
+    (vault / "System").mkdir(parents=True)
+    (vault / "System" / "pillars.yaml").write_text(
+        "pillars:\n  - id: customer\n    name: Customer\n    description: Listen\n",
+        encoding="utf-8",
+    )
+    snake = subprocess.run(
+        ["node", str(PLUGIN_ROOT / "bin" / "dex-python.mjs"), "hook", "--protocol", "copilot"],
+        input=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "cwd": str(vault),
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+    )
+    snake_denial = json.loads(snake.stdout)
+    camel = subprocess.run(
+        ["node", str(PLUGIN_ROOT / "bin" / "dex-python.mjs"), "hook", "--protocol", "copilot"],
+        input=json.dumps(
+            {
+                "hookEventName": "preToolUse",
+                "cwd": str(vault),
+                "toolName": "runTerminalCommand",
+                "toolArgs": {"command": "rm -rf /"},
+            }
+        ),
+        text=True,
+        capture_output=True,
+    )
+    camel_denial = json.loads(camel.stdout)
+
+    assert snake.returncode == 2
+    assert snake_denial["permissionDecision"] == "deny"
+    assert snake_denial["permissionDecisionReason"]
+    assert snake_denial["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert camel.returncode == 2
+    assert camel_denial["permissionDecision"] == "deny"
+    assert camel_denial["permissionDecisionReason"]
+
+
 def test_plugin_generator_check_is_clean() -> None:
     generator = _load_generator()
     assert generator.check_plugin(REPO_ROOT) == 0

--- a/core/tests/test_harness_registry.py
+++ b/core/tests/test_harness_registry.py
@@ -138,8 +138,8 @@ def test_profiles_are_json_serializable_and_have_honest_modes() -> None:
     bb = {row["id"]: row for row in get_profile("bb").capability_rows()}
     assert bb["agent-plugins"]["status"] == "native"
     copilot = {row["id"]: row for row in get_profile("copilot-cli").capability_rows()}
-    assert copilot["hooks"]["status"] == "not-verified"
-    assert copilot["hooks"]["mode"] == "unavailable"
+    assert copilot["hooks"]["status"] == "native"
+    assert copilot["hooks"]["mode"] == "guided"
 
     cursor = {row["id"]: row for row in get_profile("cursor").capability_rows()}
     assert cursor["agent-plugins"]["status"] == "native"

--- a/core/tests/test_vscode_kiro_host.py
+++ b/core/tests/test_vscode_kiro_host.py
@@ -95,8 +95,15 @@ def test_vscode_install_contract_names_off_by_default_settings_and_setup_picker(
     assert "./packages/dex-agent-plugin" in guide
     assert "/setup" in example["setup_picker"]
     assert "ubuntu cloud" in guide
-    assert "hooks are not part of this path" in guide
+    assert "family" in guide
+    assert "pretooluse" in guide
     assert "chatgpt" not in guide
+    assert adapter["native_paths"] == [
+        "plugin.json",
+        "skills/",
+        "mcp.json",
+        "com.github.copilot/hooks/hooks.json",
+    ]
     for relative in adapter["native_paths"]:
         assert (PLUGIN_ROOT / relative).exists()
 
@@ -158,13 +165,13 @@ def test_doctor_names_vscode_settings_and_setup_picker_without_calling_it_chatgp
     assert "/setup" in joined
     assert "person" in joined
     assert "ubuntu cloud" in joined
-    assert "hooks are not included" in joined
+    assert "fixture-proved" in joined
     assert "chatgpt" not in joined
     assert result.structured_detail["selected"] == ["vscode"]
     assert result.structured_detail["limitations"] == {"vscode": limitations}
     rows = {row["id"]: row for row in get_profile("vscode").capability_rows()}
-    assert rows["hooks"]["status"] == "not-verified"
-    assert rows["hooks"]["mode"] == "unavailable"
+    assert rows["hooks"]["status"] == "native"
+    assert rows["hooks"]["mode"] == "guided"
     assert get_profile("vscode").adapter["status"] == "native-local"
 
 

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -75,9 +75,9 @@ and the final publication step succeeds.
 | Claude Code | Run `claude plugin validate packages/dex-agent-plugin`, then test with `claude --plugin-dir ./packages/dex-agent-plugin` before creating a private marketplace entry. | The shared package maps two lifecycle guarantees; Claude's complete mature Dex hook suite remains the reference. |
 | Claude Desktop | Select `build/portable-artifacts/dex-claude-desktop.mcpb` in **Settings > Extensions > Advanced settings > Install Extension**, then select the Dex vault during configuration. | The officially validated desktop bundle exposes local read-only MCP tools. Chat does not run hooks, and Python 3.11+ remains required. |
 | Claude Cowork | Upload/install the reviewed Claude plugin package and grant the full Dex folder. | Cowork external connectors require a public internet endpoint, so the local stdio MCP server is not claimed. |
-| GitHub Copilot CLI | From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the working directory. | Skills and MCP use the open package. Hooks are not bundled. A person must do this in a real terminal; Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
+| GitHub Copilot CLI | From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the working directory. | Skills, MCP, and the family PreToolUse refusal file use the open package. A person must do this in a real terminal; Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
 | Cursor | Copy or link `packages/dex-agent-plugin` to `~/.cursor/plugins/local/dex`, reload Cursor, and approve the native hooks. | Local sessions get context and safety hooks. Cursor cloud agents do not run `sessionStart`, so that lifecycle guarantee is local-only. |
-| Visual Studio Code | Open the Dex folder. Turn on `chat.plugins.enabled` (it stays off by default), add `chat.pluginLocations` so `./packages/dex-agent-plugin` is true, and reload. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in `/setup`. | Skills and MCP use the shipped package. Hooks are not part of this path. A person must do this in real VS Code; Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
+| Visual Studio Code | Open the Dex folder. Turn on `chat.plugins.enabled` (it stays off by default), add `chat.pluginLocations` so `./packages/dex-agent-plugin` is true, and reload. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in `/setup`. | Skills, MCP, and the family PreToolUse refusal file use the shipped package. A person must do this in real VS Code; Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
 | Kiro | Open the Dex folder. In the Powers panel choose Add Custom Power, then Import power from a folder, and select `packages/dex-agent-plugin`. Name Dex in chat so Kiro wakes the power. If Dex guessed VS Code, Cursor, or nothing, confirm Kiro in `/setup`. | Skills and MCP use the shipped package. Kiro wakes Dex when named because the package already lists `dex` in its keywords. Hooks are not part of this path. Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
 | Gemini CLI | Run `gemini extensions install build/portable-artifacts/dex-gemini-extension`, approve its hooks, and restart Gemini CLI in the full Dex folder. | Gemini's fixed hook file uses a different schema, so Dex builds a separate complete artifact from the same canonical sources. |
 | Agent Plugins v1 client | Install the folder using root `plugin.json` and `mcp.json`. | The open specification standardizes skills and MCP, not every host lifecycle. |
@@ -92,9 +92,10 @@ After installation, verify these outcomes in a fresh task:
 2. `boot_today` reads the selected vault without writing anything.
 3. `get_person_context` returns a known person or a clean `found: false` result.
 4. `check_safety_gate` refuses a synthetic `rm -rf /` proposal.
-5. In a verified Codex, Claude, Cursor, or Gemini hook package, session start
-   injects current Dex context and the host's pre-tool event blocks that
-   synthetic destructive proposal before execution.
+5. In a verified Codex, Claude, Cursor, Gemini, or family-hook package, session
+   start injects current Dex context where that host supports it, and the
+   host's pre-tool event blocks that synthetic destructive proposal before
+   execution.
 6. Doctor reports the confirmed harness receipt and does not call a guided or
    unavailable feature automatic.
 
@@ -125,5 +126,7 @@ First-party references used for this build:
   and [Gemini hooks](https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/reference.md)
 - [Agent Plugins v1 specification](https://agent-plugins.org/specification)
 - [VS Code agent plugins](https://code.visualstudio.com/docs/agent-customization/agent-plugins)
-- [Kiro powers](https://kiro.dev/docs/powers/) and [installing a local power](https://kiro.dev/docs/powers/installation/)
+  and [VS Code agent hooks](https://code.visualstudio.com/docs/agent-customization/hooks)
+- [Kiro powers](https://kiro.dev/docs/powers/), [installing a local power](https://kiro.dev/docs/powers/installation/),
+  and [Kiro hooks](https://kiro.dev/docs/hooks/)
 - [Pi documentation](https://pi.dev/docs/latest) and [BB](https://getbb.app/)

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -12,9 +12,9 @@ Plugins v1 root contract and also includes native manifests for:
 - GitHub Copilot CLI through its Open Plugin Spec support. A person installs
   the reviewed local package with `copilot plugin install
   ./packages/dex-agent-plugin`, confirms it in `copilot plugin list`, and
-  starts the CLI from the Dex folder. Skills and MCP are native; hooks are
-  not claimed. That terminal journey has not been recorded yet. Ubuntu Cloud
-  is not a person opening this CLI.
+  starts the CLI from the Dex folder. Skills, MCP, and the family PreToolUse
+  refusal file are in the package. That terminal journey has not been recorded
+  yet. Ubuntu Cloud is not a person opening this CLI.
 - Cursor through its native manifest and local `sessionStart`/`preToolUse`
   hooks. Cursor cloud agents do not run `sessionStart`.
 - Gemini CLI through a separately built extension with Gemini's fixed hook
@@ -24,8 +24,8 @@ Plugins v1 root contract and also includes native manifests for:
 - Other Agent Plugins v1 clients through `plugin.json` and `mcp.json`.
 - Visual Studio Code after a person turns on `chat.plugins.enabled` (off by
   default) and points `chat.pluginLocations` at this folder. If Dex guessed
-  Cursor, Kiro, or nothing, confirm VS Code in `/setup`. Hooks are not claimed.
-  Ubuntu Cloud is not a person opening VS Code.
+  Cursor, Kiro, or nothing, confirm VS Code in `/setup`. The family PreToolUse
+  refusal file is included. Ubuntu Cloud is not a person opening VS Code.
 - Kiro after a person imports this folder as a custom power and names Dex so
   the power wakes. If Dex guessed VS Code, Cursor, or nothing, confirm Kiro in
   `/setup`. Hooks are not claimed. Ubuntu Cloud is not a person opening Kiro.
@@ -34,7 +34,8 @@ The MCP bridge exposes `boot_today`, `get_person_context`,
 `check_safety_gate`, and `dex_harness_profiles`. It is dependency-free,
 relocatable, read-only, and uses the same vendored source modules as dex-core.
 The safety MCP tool is advisory unless the host calls it before acting; the
-native Codex/Claude `PreToolUse` hook can actively refuse known-dangerous work.
+native Codex/Claude `PreToolUse` hook and the family PreToolUse refusal file
+can actively refuse known-dangerous work where those hosts load them.
 
 ## Release platforms
 

--- a/packages/dex-agent-plugin/ai.heydex.dex/adapters/copilot-cli.json
+++ b/packages/dex-agent-plugin/ai.heydex.dex/adapters/copilot-cli.json
@@ -3,10 +3,10 @@
   "harness_id": "copilot-cli",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. Hooks are not bundled; safety stays an explicit MCP check. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
+    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "install_command": "copilot plugin install ./packages/dex-agent-plugin",

--- a/packages/dex-agent-plugin/ai.heydex.dex/adapters/vscode.json
+++ b/packages/dex-agent-plugin/ai.heydex.dex/adapters/vscode.json
@@ -3,10 +3,10 @@
   "harness_id": "vscode",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. Hooks are not part of this path. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
+    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "settings_off_by_default": ["chat.plugins.enabled"],

--- a/packages/dex-agent-plugin/com.github.copilot/hooks/hooks.json
+++ b/packages/dex-agent-plugin/com.github.copilot/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "node \"${PLUGIN_ROOT}/bin/dex-python.mjs\" hook --protocol copilot",
+        "bash": "node \"${PLUGIN_ROOT}/bin/dex-python.mjs\" hook --protocol copilot",
+        "powershell": "node \"${PLUGIN_ROOT}/bin/dex-python.mjs\" hook --protocol copilot",
+        "cwd": "${PLUGIN_ROOT}",
+        "timeoutSec": 15
+      }
+    ]
+  }
+}

--- a/packages/dex-agent-plugin/hook.py
+++ b/packages/dex-agent-plugin/hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared Dex lifecycle adapter for Codex and Claude plugin hosts."""
+"""Shared Dex lifecycle adapter for plugin hosts."""
 
 from __future__ import annotations
 
@@ -72,7 +72,40 @@ def _session_start(payload: dict[str, Any], protocol: str) -> int:
     return 0
 
 
+def _family_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Map the code-assistant family's documented PreToolUse shapes onto the shared gate."""
+    normalized = dict(payload)
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        mapped = dict(tool_input)
+    else:
+        tool_args = payload.get("toolArgs") or payload.get("tool_args")
+        if isinstance(tool_args, dict):
+            mapped = dict(tool_args)
+        elif isinstance(tool_args, str) and tool_args.strip():
+            mapped = {"command": tool_args}
+        else:
+            mapped = {}
+    if "file_path" not in mapped and isinstance(mapped.get("filePath"), str):
+        mapped["file_path"] = mapped["filePath"]
+    if not mapped.get("command"):
+        for key in ("command", "cmd"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                mapped["command"] = value
+                break
+    normalized["tool_input"] = mapped
+    tool_name = payload.get("tool_name")
+    if not (isinstance(tool_name, str) and tool_name.strip()):
+        family_name = payload.get("toolName")
+        if isinstance(family_name, str) and family_name.strip():
+            normalized["tool_name"] = family_name
+    return normalized
+
+
 def _pre_tool_use(payload: dict[str, Any], protocol: str) -> int:
+    if protocol == "copilot":
+        payload = _family_payload(payload)
     decision = evaluate_hook_payload(payload, vault=_vault(payload))
     if decision.refused:
         if protocol == "cursor":
@@ -87,6 +120,18 @@ def _pre_tool_use(payload: dict[str, Any], protocol: str) -> int:
             output = {"decision": "deny", "reason": decision.reason}
             sys.stdout.write(json.dumps(output, ensure_ascii=False) + "\n")
             return 0
+        if protocol == "copilot":
+            output = {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": decision.reason,
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": decision.reason,
+                },
+            }
+            sys.stdout.write(json.dumps(output, ensure_ascii=False) + "\n")
+            return decision.hook_exit
         # This compact contract is understood by Claude plugins and remains a
         # documented compatibility shape in Codex's hook runner.
         sys.stdout.write(decision.as_hook_json() + "\n")
@@ -112,7 +157,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "--protocol",
-        choices=("claude", "codex", "cursor", "gemini"),
+        choices=("claude", "codex", "cursor", "gemini", "copilot"),
         default="claude",
     )
     args, _ = parser.parse_known_args(argv)

--- a/packages/dex-agent-plugin/metadata/harnesses/adapters/copilot-cli.json
+++ b/packages/dex-agent-plugin/metadata/harnesses/adapters/copilot-cli.json
@@ -3,10 +3,10 @@
   "harness_id": "copilot-cli",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. Hooks are not bundled; safety stays an explicit MCP check. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
+    "install_guide": "From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex appears in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the current working directory. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening this terminal. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "install_command": "copilot plugin install ./packages/dex-agent-plugin",

--- a/packages/dex-agent-plugin/metadata/harnesses/adapters/vscode.json
+++ b/packages/dex-agent-plugin/metadata/harnesses/adapters/vscode.json
@@ -3,10 +3,10 @@
   "harness_id": "vscode",
   "status": "native-local",
   "kind": "open-plugin-spec",
-  "native_paths": ["plugin.json", "skills/", "mcp.json"],
+  "native_paths": ["plugin.json", "skills/", "mcp.json", "com.github.copilot/hooks/hooks.json"],
   "example": {
     "manifest": "packages/dex-agent-plugin/plugin.json",
-    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. Hooks are not part of this path. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
+    "install_guide": "Open the Dex folder in VS Code. Agent plugins stay off until you turn them on: set chat.plugins.enabled to true, then add chat.pluginLocations so ./packages/dex-agent-plugin is true. Reload VS Code. Confirm Dex skills and the bundled MCP tools appear. If Dex guessed Cursor, Kiro, or nothing, confirm VS Code in /setup. The family PreToolUse refusal file is in the shipped package. Ubuntu Cloud is not a person opening VS Code. A detection test or green CI is not a live install.",
     "portable_surface": ["skills/", "mcp.json"],
     "local_package": "./packages/dex-agent-plugin",
     "settings_off_by_default": ["chat.plugins.enabled"],

--- a/packages/dex-agent-plugin/metadata/harnesses/registry.json
+++ b/packages/dex-agent-plugin/metadata/harnesses/registry.json
@@ -184,14 +184,14 @@
       "name": "GitHub Copilot CLI",
       "display_name": "GitHub Copilot CLI",
       "vendor": "GitHub",
-      "summary": "Open Plugin Spec package for Copilot CLI with skills and MCP. A person still has to install the reviewed local plugin and start the CLI from the Dex folder. Hooks are not claimed.",
+      "summary": "Open Plugin Spec package for Copilot CLI with skills, MCP, and the family PreToolUse refusal file. A person still has to install the reviewed local plugin and start the CLI from the Dex folder.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/copilot-cli.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The current working directory is the vault after the person starts the CLI from the Dex folder."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "The Open Plugin Spec package includes a relocatable stdio MCP server in mcp.json."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Copilot CLI loads skills from the installed plugin."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "Copilot's native hook schema differs from the Claude and Codex files in this package, so no Copilot hook is claimed."},
+        {"id": "hooks", "status": "native", "tier": 3, "mode": "guided", "notes": "The shipped package includes the family PreToolUse refusal hook file. A person still has to install the local plugin. Fixture-proved; not a recorded live walk."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "Available lifecycle events depend on the installed Copilot CLI version."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "CLI interaction is host-native."},
@@ -202,9 +202,13 @@
       "limitations": [
         "A person still has to install the reviewed local plugin with `copilot plugin install ./packages/dex-agent-plugin` and start the CLI from the Dex folder. Detection tests and CI do not prove that journey.",
         "Ubuntu Cloud is not a person opening this terminal. No recorded live session exists.",
-        "Hooks are not included in this release; shared safety remains an explicit MCP check rather than automatic enforcement."
+        "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
       ],
-      "evidence": ["https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference"]
+      "evidence": [
+        "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference",
+        "https://docs.github.com/en/copilot/reference/hooks-reference",
+        "https://code.visualstudio.com/docs/agent-customization/agent-plugins"
+      ]
     },
     {
       "id": "cowork",
@@ -280,14 +284,14 @@
       "name": "Kiro",
       "display_name": "Kiro",
       "vendor": "Amazon",
-      "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Hooks are not claimed.",
+      "summary": "Kiro can load the same local Agent Plugins package as a custom power. It wakes Dex when you name it. A person still has to import the reviewed folder. Family plugin hooks are not claimed.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/kiro.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The open Dex folder is the vault after the person starts Kiro there."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "Kiro loads mcp.json from the imported power and manages those servers with the power."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Skills come from the shipped package skills/ folder."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "This path does not add a Kiro hooks step. Safety stays an explicit MCP check."},
+        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "Kiro's first-party hooks are workspace files under .kiro/hooks with a different schema. Powers do not load the family plugin hook file. Safety stays an explicit MCP check."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "The power loads when the person names Dex or another listed keyword."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Kiro chat is host-native."},
@@ -301,7 +305,12 @@
         "Ubuntu Cloud is not a person opening Kiro. No recorded live session exists.",
         "Hooks are not included in this path; shared safety remains an explicit MCP check."
       ],
-      "evidence": ["https://kiro.dev/docs/powers/", "https://kiro.dev/docs/powers/installation/", "https://agent-plugins.org/specification"]
+      "evidence": [
+        "https://kiro.dev/docs/powers/",
+        "https://kiro.dev/docs/powers/installation/",
+        "https://kiro.dev/docs/hooks/",
+        "https://agent-plugins.org/specification"
+      ]
     },
     {
       "id": "pi",
@@ -360,14 +369,14 @@
       "name": "Visual Studio Code",
       "display_name": "Visual Studio Code",
       "vendor": "Microsoft",
-      "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. Hooks are not claimed.",
+      "summary": "VS Code can load the same local Agent Plugins package after a person turns on plugin settings that stay off by default. The family PreToolUse refusal file is included.",
       "adapter": {"kind": "open-plugin-spec", "status": "native-local", "manifest": "plugin.json", "install_guide": "core/harnesses/adapters/vscode.json"},
       "support_level": "supported",
       "capabilities": [
         {"id": "vault", "status": "native", "tier": 0, "mode": "on_demand", "notes": "The open Dex folder is the vault after the person starts VS Code there."},
         {"id": "mcp", "status": "native", "tier": 1, "mode": "on_demand", "notes": "VS Code reads mcp.json from the local plugin after the plugin is enabled."},
         {"id": "agent-skills", "status": "native", "tier": 2, "mode": "on_demand", "notes": "Skills come from the shipped package skills/ folder."},
-        {"id": "hooks", "status": "not-verified", "tier": 3, "mode": "unavailable", "notes": "This path does not add a VS Code hooks step. Safety stays an explicit MCP check."},
+        {"id": "hooks", "status": "native", "tier": 3, "mode": "guided", "notes": "The shipped package includes the family PreToolUse refusal hook file. Plugin settings stay off until a person turns them on. Fixture-proved; not a recorded live walk."},
         {"id": "session-lifecycle", "status": "partial", "tier": 3, "mode": "guided", "notes": "Plugin load depends on the person turning on chat.plugins.enabled and pointing chat.pluginLocations at the shipped package."},
         {"id": "background-jobs", "status": "none", "tier": 1, "mode": "unavailable", "notes": "No Dex scheduler contract is assumed."},
         {"id": "interactive-prompts", "status": "native", "tier": 2, "mode": "on_demand", "notes": "VS Code chat is host-native."},
@@ -379,9 +388,13 @@
         "VS Code plugin settings stay off by default. A person still has to turn on chat.plugins.enabled, point chat.pluginLocations at ./packages/dex-agent-plugin, and reload. Detection tests and CI do not prove that journey.",
         "If auto-detect is empty or names Cursor or Kiro, confirm VS Code in /setup.",
         "Ubuntu Cloud is not a person opening VS Code. No recorded live session exists.",
-        "Hooks are not included in this path; shared safety remains an explicit MCP check."
+        "The family PreToolUse refusal hook is fixture-proved in this package. That is not a live walk."
       ],
-      "evidence": ["https://code.visualstudio.com/docs/agent-customization/agent-plugins", "https://agent-plugins.org/specification"]
+      "evidence": [
+        "https://code.visualstudio.com/docs/agent-customization/agent-plugins",
+        "https://code.visualstudio.com/docs/agent-customization/hooks",
+        "https://agent-plugins.org/specification"
+      ]
     }
   ]
 }

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -230,6 +230,19 @@ def _codex_hooks_json() -> dict:
     }
 
 
+def _family_hooks_json() -> dict:
+    command = 'node "${PLUGIN_ROOT}/bin/dex-python.mjs" hook --protocol copilot'
+    entry = {
+        "type": "command",
+        "command": command,
+        "bash": command,
+        "powershell": command,
+        "cwd": "${PLUGIN_ROOT}",
+        "timeoutSec": 15,
+    }
+    return {"version": 1, "hooks": {"PreToolUse": [entry]}}
+
+
 def _cursor_hooks_json() -> dict:
     command = "node ./bin/dex-python.mjs hook --protocol cursor"
     return {
@@ -326,6 +339,9 @@ def expected_plugin_files(repo_root: Path = REPO_ROOT) -> dict[Path, bytes]:
         Path("packages/dex-agent-plugin/hooks/hooks.json"): _json_bytes(_hooks_json()),
         Path("packages/dex-agent-plugin/hooks/codex.json"): _json_bytes(_codex_hooks_json()),
         Path("packages/dex-agent-plugin/hooks/cursor.json"): _json_bytes(_cursor_hooks_json()),
+        Path("packages/dex-agent-plugin/com.github.copilot/hooks/hooks.json"): _json_bytes(
+            _family_hooks_json()
+        ),
         Path("packages/dex-gemini-extension/gemini-extension.json"): _json_bytes(_gemini_extension_json()),
         Path("packages/dex-gemini-extension/hooks/hooks.json"): _json_bytes(_gemini_hooks_json()),
         Path("packages/dex-claude-desktop/manifest.json"): _json_bytes(_claude_desktop_manifest()),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Hidden until green.

References lab [463](https://github.com/davekilleen/dex-product-gtm-lab/issues/463). Do not close 463. Do not continue leftover PR 619. Do not start 462. This runner does not invent the ChatGPT Work folder grant.

## What this pull request is
Lot 0 of the Everywhere hooks lane, started from the 648 head.

**Contract: confirmed for the code-assistant family, refused for Kiro.**

First-party docs for the family plugin format place the hook file at `com.github.copilot/hooks/hooks.json` and let PreToolUse deny a tool call. That file is now in the shipped package and calls the already-proven shared refusal gate. VS Code and Copilot CLI profiles are promoted from unavailable (guided, fixture-proved). Kiro stays unavailable: its first-party hooks live under `.kiro/hooks/` with a different schema, and powers do not load this family file.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Opening VS Code or the CLI on a real machine to watch a live refusal is still yours.

## Fixture result
A fixture sends a destructive command (`rm -rf /`) through the family PreToolUse protocol. The gate refuses it (`permissionDecision: deny`, exit 2). Ubuntu Cloud is not a person opening those hosts. Detection tests and green CI are not a live install.

## Honest limits
- Kiro is not claimed. That is the honest reading of its first-party hooks docs.
- The live walk stays Dave's.
- The ChatGPT Work vault-folder grant is still not invented.
- 462 (uninstall line) is not started here.

## Stay here
Stay on this draft. Do not resume PR 619. Do not merge or publish.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f54c19-2615-4261-a545-0b09997e40e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f54c19-2615-4261-a545-0b09997e40e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

