### PR TITLE
Dex Everywhere lot: uninstall lines for written hosts — unreleased

### DIFF
--- a/core/tests/test_harness_golden_journeys.py
+++ b/core/tests/test_harness_golden_journeys.py
@@ -237,3 +237,48 @@ def test_developer_preview_guide_names_every_supported_profile_and_stop_line() -
     assert "Exact-commit native evidence belongs to the draft pull request" in guide
     assert "| macOS | Release-ready |" not in guide
     assert "| Windows | Release-ready |" not in guide
+
+
+_JOURNEY_TABLE_HEADER = "| Harness | Local package journey | Honest boundary |"
+_LEAVE_TABLE_HEADER = "| Harness | How to leave |"
+
+
+def _markdown_table_rows(guide: str, header: str) -> list[tuple[str, ...]]:
+    lines = guide.splitlines()
+    try:
+        start = next(index for index, line in enumerate(lines) if line.strip() == header)
+    except StopIteration as exc:
+        raise AssertionError(f"missing table header: {header}") from exc
+
+    rows: list[tuple[str, ...]] = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            break
+        cells = tuple(cell.strip() for cell in stripped.strip("|").split("|"))
+        if cells and all(cell and set(cell) <= set("-:") for cell in cells):
+            continue
+        rows.append(cells)
+    return rows
+
+
+def test_each_written_host_has_one_uninstall_line_that_names_residue() -> None:
+    """A new host row in the install table must ship with one How to leave line."""
+    guide = (REPO_ROOT / "docs" / "HARNESS-PORTABILITY.md").read_text(encoding="utf-8")
+    journey_rows = _markdown_table_rows(guide, _JOURNEY_TABLE_HEADER)
+    leave_rows = _markdown_table_rows(guide, _LEAVE_TABLE_HEADER)
+
+    assert journey_rows, "local installation journeys table is empty"
+    journey_hosts = [row[0] for row in journey_rows]
+    leave_hosts = [row[0] for row in leave_rows]
+    assert leave_hosts == journey_hosts, (
+        "every written host row needs one matching How to leave row; "
+        f"install={journey_hosts!r} leave={leave_hosts!r}"
+    )
+    for host, row in zip(leave_hosts, leave_rows, strict=True):
+        assert len(row) >= 2, f"{host} How to leave row has no uninstall cell"
+        leave = row[1]
+        assert leave, f"{host} is missing an uninstall line"
+        assert "leftover" in leave.lower(), (
+            f"{host} must name residue honestly (include leftover): {leave!r}"
+        )

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -82,6 +82,22 @@ and the final publication step succeeds.
 | Pi | Use the native `dex-pi/extensions/dex` package from the pinned [`dex-pi` commit `5bf33ad7b23a06a890b25445cb1b4f4077b2ac19`](https://github.com/davekilleen/dex-pi/tree/5bf33ad7b23a06a890b25445cb1b4f4077b2ac19) and open the full Dex folder. | Pi has no built-in MCP client; its extension supplies native tools and lifecycle events instead. Core verifies the pinned manifest and source-level lifecycle markers when the checkout is available; live installation remains a release-candidate check. |
 | BB | Install the separately built `bb-plugin-dex` package from a reviewed local path and select the vault in settings. | Version one is macOS-only and read-only: status, capabilities, brief, CLI, and panel; no jobs, writes, provider bridge, or marketplace release. BB's Windows route uses WSL2 and stays in the deferred Linux lane. |
 
+Each written host above has one uninstall line. Residue is named even when the host has no clean first-party command. Dex does not ship an uninstaller.
+
+| Harness | How to leave |
+| --- | --- |
+| Codex CLI / desktop | Run `codex plugin remove dex@dex-unreleased`, then `codex plugin marketplace remove dex-unreleased`. Leftover: hook trust in `~/.codex/config.toml`. |
+| ChatGPT Work desktop | Uninstall Dex in the Plugins tab, delete `~/.codex/plugins/dex`, and remove the Dex listing from `~/.agents/plugins/marketplace.json`. Leftover: the vault-folder grant — a person must revoke it; this runner will not invent that grant. The cache at `~/.codex/plugins/cache/dex-unreleased/dex/local/` is not Work proof. |
+| Claude Code | Stop using `claude --plugin-dir ./packages/dex-agent-plugin`; that flag is a test invocation, not an install. If you later installed from a marketplace, run `claude plugin uninstall` with the same plugin@marketplace name you installed. Leftover: plugin cache and hook trust. |
+| Claude Desktop | Uninstall the Dex extension in Settings > Extensions. Leftover: the Dex vault path in that extension's configuration. |
+| Claude Cowork | Uninstall Dex in Customize → Plugins. Leftover: the Dex folder grant. |
+| GitHub Copilot CLI | Run `copilot plugin uninstall dex-agent-plugin`. Leftover: a direct-install copy under `~/.copilot/installed-plugins/_direct/`. |
+| Cursor | Delete or unlink `~/.cursor/plugins/local/dex` and reload Cursor. Leftover: hook approval. |
+| Gemini CLI | Run `gemini extensions uninstall dex`. Leftover: hook approval in Gemini CLI settings. |
+| Agent Plugins v1 client | Stop pointing the client at the Dex plugin folder. Leftover: none that Dex owns; Dex does not claim a cache here. |
+| Pi | Run `pi remove` on the same native `dex-pi/extensions/dex` source you installed (`pi uninstall` is the alias). Leftover: extension registration in Pi settings until a new session. |
+| BB | Run `bb plugin remove` for the local `bb-plugin-dex` package. Leftover: the vault setting; local source files stay on disk. |
+
 ## Acceptance journey
 
 After installation, verify these outcomes in a fresh task:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased.

## What this pull request is
A person now has one written uninstall line for every local Dex install path already in the portability table. Residue is named honestly. A test fails if a new host row is added without a matching How to leave line.

This is a new draft from `77242824` (lot 0 re-verifies). It does not continue PR 659 or leftover PR 619. Lab ticket: https://github.com/davekilleen/dex-product-gtm-lab/issues/462 — leave 462 open.

This runner could not read the private lab spec (`davekilleen/dex-product-gtm-lab` draft 462). The lines use first-party uninstall commands for the hosts already written. No uninstaller. No new host. No catalogue step. No invented ChatGPT Work folder grant.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not close lab 462. Revoking a ChatGPT Work vault-folder grant is still yours.

## What a person can do now
For each written host in `docs/HARNESS-PORTABILITY.md`, follow that host's **How to leave** line. Leftovers are named on the same line (hook trust, folder grant, cache, vault setting). Dex does not remove those leftovers for you.

## Honest limits
- Docs and one test only. No uninstall binary, no Doctor probe, no registry change.
- VS Code and Kiro are not in this table at this start commit. They are not added here.
- The ChatGPT Work vault-folder grant is still a person leftover. This runner will not invent that grant.
- Ubuntu Cloud is not a person uninstalling on a real machine.

## Stay here
Stay on this draft. Do not resume PR 659 or leftover PR 619. Do not merge or publish. Leave lab 462 open.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63f54c19-2615-4261-a545-0b09997e40e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63f54c19-2615-4261-a545-0b09997e40e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

