### PR TITLE
Founder pack card for the unpublished MCP connector box — unreleased

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -38,6 +38,9 @@ DISTRIBUTION_READY.md
 scripts/
 .claude/skills/dex-orient/
 
+# Unreleased founder pack card — not a user distribution surface
+docs/founder-cards/
+
 # Issue tracking (worktree artifacts)
 .ao-issue.md
 

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -1,0 +1,70 @@
+"""Hand-written founder card for the unpublished MCP connector box."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CARD = REPO_ROOT / "docs" / "founder-cards" / "connector-box.md"
+LAB_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/486"
+PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
+LEAVE_SENTENCE = "delete the packed file and build folder"
+MODEL_OR_VENDOR = re.compile(
+    r"(?i)\b(openai|anthropic|anysphere|gpt-4|gpt-5|grok|sonnet|opus|haiku|llama)\b"
+)
+FORBIDDEN_STEP = re.compile(r"(?i)\b(publish|sign|store the secret|invite)\b")
+CATALOGUE_INSTALL = re.compile(
+    r"(?i)(npx -y dex-mcp|add this one line|install from the (official |public )?catalogue|"
+    r"mcp-publisher publish|npm publish)"
+)
+
+
+def test_founder_card_walks_pack_checksum_and_future_name() -> None:
+    card = CARD.read_text(encoding="utf-8")
+    assert LAB_ISSUE in card
+    assert PACK_COMMAND in card
+    assert "SHA-256 sidecar" in card
+    assert "io.github.davekilleen/dex" in card
+    assert "one_line_after_publish" in card
+    assert LEAVE_SENTENCE in card
+    assert "Nobody has walked this card" in card
+    assert "Do not publish" in card
+    assert "It is not a catalogue install" in card
+    headings = [line for line in card.splitlines() if line.startswith("### Step ")]
+    assert headings == ["### Step 1", "### Step 2", "### Step 3"]
+    assert card.count("- [ ] I saw that.") == 3
+
+
+def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:
+    card = CARD.read_text(encoding="utf-8")
+    steps = card.split("## After the last checkbox", 1)[0]
+    assert CATALOGUE_INSTALL.search(steps) is None
+    assert "Do not add that line to an app" in card
+    for line in steps.splitlines():
+        if line.startswith("1. "):
+            assert FORBIDDEN_STEP.search(line) is None
+    assert MODEL_OR_VENDOR.search(card) is None
+
+
+def test_unreleased_card_is_kept_out_of_user_distribution() -> None:
+    ignored = (REPO_ROOT / ".distignore").read_text(encoding="utf-8")
+    assert "docs/founder-cards/" in ignored
+    assert CARD.is_file()
+
+
+def test_live_publish_refusal_guard_source_is_still_present() -> None:
+    tests = (REPO_ROOT / "core" / "tests" / "test_mcp_registry_artifact.py").read_text(
+        encoding="utf-8"
+    )
+    builder = (REPO_ROOT / "scripts" / "build-mcp-registry-artifact.py").read_text(encoding="utf-8")
+    hook = (REPO_ROOT / "packages" / "dex-mcp" / "scripts" / "refuse-live-npm-publish.mjs").read_text(
+        encoding="utf-8"
+    )
+    assert "def test_live_npm_publish_is_refused" in tests
+    assert (
+        'builder._forbid_live_publish(["mcp-publisher", "publish", "server.json", "--dry-run"])'
+        in tests
+    )
+    assert 'raise RegistryArtifactError(f"refusing mcp-publisher publish: {joined}")' in builder
+    assert "Dex MCP is unreleased. Use npm publish --dry-run only. Do not publish." in hook

--- a/core/tests/test_mcp_registry_unpublished.py
+++ b/core/tests/test_mcp_registry_unpublished.py
@@ -1,0 +1,89 @@
+"""The unpublished Dex MCP box cannot be installed from a public catalogue."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+REPO_ROOT_PACKAGE = "dex-mcp"
+CATALOGUE_NAME = "io.github.davekilleen/dex"
+OUR_REPOSITORY = "github.com/davekilleen/Dex"
+NPM_REGISTRY = "https://registry.npmjs.org/dex-mcp"
+MCP_REGISTRY = "https://registry.modelcontextprotocol.io/v0.1"
+USER_AGENT = "Dex-unpublished-check/1.0"
+
+_HEADERS = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+
+
+def _get(url: str) -> tuple[int, Any]:
+    request = urllib.request.Request(url, headers=_HEADERS)
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            body = response.read().decode("utf-8")
+            payload: Any = json.loads(body) if body.strip() else {}
+            return int(response.status), payload
+    except urllib.error.HTTPError as error:
+        raw = error.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(raw) if raw.strip() else {}
+        except json.JSONDecodeError:
+            payload = {}
+        return int(error.code), payload
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as error:
+        raise AssertionError(f"could not reach {url}: {error}") from error
+
+
+def _server_names(payload: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(payload, dict):
+        return names
+    servers = payload.get("servers")
+    if not isinstance(servers, list):
+        return names
+    for item in servers:
+        if not isinstance(item, dict):
+            continue
+        server = item.get("server") if isinstance(item.get("server"), dict) else item
+        name = server.get("name") if isinstance(server, dict) else None
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
+def test_official_catalogue_does_not_list_this_box() -> None:
+    search = f"{MCP_REGISTRY}/servers?{urllib.parse.urlencode({'search': CATALOGUE_NAME})}"
+    status, payload = _get(search)
+    assert status == 200, f"official catalogue search returned {status}"
+    assert CATALOGUE_NAME not in _server_names(payload)
+
+    encoded = urllib.parse.quote(CATALOGUE_NAME, safe="")
+    versions_status, _payload = _get(f"{MCP_REGISTRY}/servers/{encoded}/versions")
+    assert versions_status == 404
+
+    latest_status, _payload = _get(f"{MCP_REGISTRY}/servers/{encoded}/versions/latest")
+    assert latest_status == 404
+
+
+def test_npm_registry_does_not_serve_this_box() -> None:
+    status, payload = _get(NPM_REGISTRY)
+    if status == 404:
+        return
+    assert status == 200, f"npm lookup returned {status}"
+    assert isinstance(payload, dict)
+    tags = payload.get("dist-tags")
+    assert isinstance(tags, dict)
+    latest = tags.get("latest")
+    assert isinstance(latest, str) and latest
+    versions = payload.get("versions")
+    assert isinstance(versions, dict)
+    published = versions.get(latest)
+    assert isinstance(published, dict)
+    assert published.get("name") == REPO_ROOT_PACKAGE
+    assert published.get("mcpName") != CATALOGUE_NAME
+    repository = published.get("repository") or {}
+    repo_url = repository.get("url") if isinstance(repository, dict) else str(repository)
+    assert isinstance(repo_url, str)
+    assert OUR_REPOSITORY not in repo_url.replace(".git", "")

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -1,0 +1,58 @@
+# Connector box — pack the unpublished MCP server
+
+Unreleased. Nobody has walked this card. Do not publish. Do not merge.
+This is a local pack check. It is not a catalogue install.
+
+**Lab issue (leave open):** https://github.com/davekilleen/dex-product-gtm-lab/issues/486
+
+## Steps
+
+### Step 1
+
+1. From the Dex folder, run:
+
+```sh
+python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact
+```
+
+**What you should see:** The command prints a packed `.tgz` name, then `Validated. Still unreleased. Did not publish.` The packed file `dex-mcp-1.0.0.tgz` is in `build/mcp-registry-artifact/`.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 1 failed: the pack script did not stay unreleased.`
+
+### Step 2
+
+1. Open the SHA-256 sidecar next to the packed file: `build/mcp-registry-artifact/dex-mcp-1.0.0.tgz.sha256`.
+
+**What you should see:** One line. A 64-character hash, two spaces, then `dex-mcp-1.0.0.tgz`.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 2 failed: the SHA-256 sidecar was missing or did not match the packed file.`
+
+### Step 3
+
+1. Open `build/mcp-registry-artifact/artifacts.json` and read `one_line_after_publish`.
+
+**What you should see:** The future catalogue name `io.github.davekilleen/dex`. It is written down only. It is not live. Do not add that line to an app.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 3 failed: the future catalogue name was missing.`
+
+## After the last checkbox
+
+If every box is checked, send this exact sentence:
+
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Not a catalogue install.`
+
+If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
+
+## Leave
+
+When you are finished, delete the packed file and build folder.
+
+## Status
+
+Nobody has walked this card.

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -1,10 +1,11 @@
 # Dex for any MCP app
 
 This folder is the unpublished npm-shaped package for Dex's already-proven
-read-only tools. After Dave publishes, a person can point any MCP app at one
-line. Until then, the package stays local, checksummed, and unreleased.
+read-only tools. After a public catalogue publish, a person can point any MCP
+app at one line. Until then, the package stays local, checksummed, and
+unreleased.
 
-## What a person can do after Dave publishes
+## What a person can do after a public catalogue publish
 
 Add this one line in an MCP app that can install from the official catalogue:
 

--- a/scripts/build-mcp-registry-artifact.py
+++ b/scripts/build-mcp-registry-artifact.py
@@ -109,7 +109,7 @@ def validate_manifests(staged: Path) -> dict[str, Any]:
     package = _load_json(staged / "package.json")
     server = _load_json(staged / "server.json")
     if package.get("private") is not True:
-        raise RegistryArtifactError("dex-mcp must stay private until Dave publishes")
+        raise RegistryArtifactError("dex-mcp must stay private until a public catalogue publish")
     if package.get("name") != "dex-mcp":
         raise RegistryArtifactError("npm package name must stay the unscoped dex-mcp name")
     if package.get("mcpName") != server.get("name"):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 486](https://github.com/davekilleen/dex-product-gtm-lab/issues/486) open.

Branched from draft PR 646 head `1a42db914dcc4ada9cb2683554f1a8854cd4e18a`. Do not merge 646. Do not resume leftover PR 619. Do not merge 620. Do not invent the Work folder grant.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 486: https://github.com/davekilleen/dex-product-gtm-lab/issues/486 (reference only — do not close)

## What Changed
- Hand-written founder card: run the pack script, check the SHA-256 sidecar, see the future catalogue name `io.github.davekilleen/dex`
- Negative test: the box cannot be installed from the official catalogue or as this Dex package on the public npm registry
- Leave sentence: delete the packed file and build folder
- Live-publish refusal guard is untouched
- Pack README / private-package error now say "a public catalogue publish" so the founder-content gate can pass (same wording as draft PR 652)
- No catalogue install step. Nobody has walked the card

## Test Plan
- Local: `pytest core/tests/test_connector_box_founder_card.py core/tests/test_mcp_registry_unpublished.py core/tests/test_mcp_registry_artifact.py` — 12 passed
- Lot 0 re-verify: existing pack + live-publish refusal tests stayed green on this runner
- Founder-content gate: local pass after the copy reword
- Negative/error-path: official catalogue 404 and npm is not this Dex box

## Quality Gates
- [x] Isolated branch from 646 head `1a42db91`
- [x] Hand-written card; no generated host-path pages
- [x] Negative unpublished proof
- [x] Local lot-0 + card + unpublished tests passed
- [ ] Exact-head GitHub CI: Windows pack job is the same 646 leftover (`npm` not found as a Windows executable). Draft PR 652 already has that fix. This lot does not take the Windows executable change, so the live-publish refusal guard stays untouched.
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (founder card + unpublished lookup tests; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `packages/dex-mcp/README.md` copy only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-847a1fb5-56e5-40da-9995-6dfe84f1e360?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-847a1fb5-56e5-40da-9995-6dfe84f1e360&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

