### PR TITLE
Ask the unpublished MCP connector box what was decided — unreleased

### DIFF
--- a/core/context/__init__.py
+++ b/core/context/__init__.py
@@ -1,5 +1,6 @@
 """Harness-neutral context payloads used by MCP and Claude wrappers."""
 
+from .decision_record import ask_what_was_decided
 from .person_context import (
     find_people_in_file,
     format_person_context_block,
@@ -9,6 +10,7 @@ from .person_context import (
 from .session_boot import build_session_boot, format_session_boot_text
 
 __all__ = [
+    "ask_what_was_decided",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/core/context/decision_record.py
+++ b/core/context/decision_record.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Read-only lookup of a vault's own decision records.
+
+The packed connector box asks this module what was decided about a topic and
+returns the choice plus the file it came from. It never writes, never invents a
+decision, and never reads meetings or other notes as a substitute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.paths import PROJECTS_DIR, RESOURCES_DIR, resolve_for_vault
+
+HEADING = re.compile(r"^##\s+(.+?)\s*$")
+DATED_HEADING = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})\s+[—–-]\s+(?P<title>.+)$"
+)
+DECISION_LINE = re.compile(
+    r"^\*\*Decision:\*\*\s*(.+?)\s*$",
+    re.IGNORECASE,
+)
+TOPIC_WRAPPER = re.compile(
+    r"^(?:what(?:\s+was)?\s+)?(?:was\s+)?decided(?:\s+about)?\s+",
+    re.IGNORECASE,
+)
+TOKEN = re.compile(r"[a-z0-9]{3,}")
+STOPWORDS = {
+    "about",
+    "and",
+    "decided",
+    "decision",
+    "for",
+    "from",
+    "the",
+    "this",
+    "that",
+    "was",
+    "what",
+    "with",
+}
+SKIP_NAMES = {"readme.md"}
+MAX_MATCHES = 8
+
+
+def _coerce_root(vault: str | Path | None) -> Path | None:
+    if vault is None:
+        return None
+    try:
+        root = Path(vault).expanduser()
+    except (TypeError, ValueError, OSError):
+        return None
+    try:
+        if not root.is_dir():
+            return None
+        return root.resolve()
+    except OSError:
+        return None
+
+
+def _inside(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _real_file(root: Path, path: Path) -> Path | None:
+    try:
+        if path.is_symlink() or not path.is_file() or not _inside(root, path):
+            return None
+        return path
+    except OSError:
+        return None
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def _relative_file(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return path.name
+
+
+def _decisions_dir(vault: Path) -> Path:
+    return resolve_for_vault(vault, RESOURCES_DIR) / "Decisions"
+
+
+def _projects_dir(vault: Path) -> Path:
+    return resolve_for_vault(vault, PROJECTS_DIR)
+
+
+def _decision_files(vault: Path) -> list[Path]:
+    files: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path) -> None:
+        real = _real_file(vault, path)
+        if real is None or real.name.lower() in SKIP_NAMES:
+            return
+        try:
+            key = str(real.resolve())
+        except OSError:
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        files.append(real)
+
+    decisions_dir = _decisions_dir(vault)
+    try:
+        if decisions_dir.is_dir() and not decisions_dir.is_symlink() and _inside(
+            vault, decisions_dir
+        ):
+            for path in sorted(decisions_dir.rglob("*.md")):
+                _add(path)
+    except OSError:
+        pass
+
+    projects_dir = _projects_dir(vault)
+    try:
+        if projects_dir.is_dir() and not projects_dir.is_symlink() and _inside(
+            vault, projects_dir
+        ):
+            for path in sorted(projects_dir.rglob("Decisions.md")):
+                _add(path)
+    except OSError:
+        pass
+    return files
+
+
+def _entries(content: str, *, fallback_title: str) -> list[dict[str, str]]:
+    lines = content.splitlines()
+    starts: list[int] = [
+        index for index, line in enumerate(lines) if HEADING.match(line)
+    ]
+    if not starts:
+        body = content.strip()
+        if not body:
+            return []
+        return [
+            {
+                "title": fallback_title,
+                "date": "",
+                "decision": _first_decision(body) or _first_sentence(body),
+                "body": body,
+            }
+        ]
+    entries: list[dict[str, str]] = []
+    for index, start in enumerate(starts):
+        end = starts[index + 1] if index + 1 < len(starts) else len(lines)
+        heading = HEADING.match(lines[start])
+        raw_heading = heading.group(1).strip() if heading else fallback_title
+        dated = DATED_HEADING.match(raw_heading)
+        title = dated.group("title").strip() if dated else raw_heading
+        date = dated.group("date") if dated else ""
+        body = "\n".join(lines[start:end]).strip()
+        entries.append(
+            {
+                "title": title,
+                "date": date,
+                "decision": _first_decision(body) or title,
+                "body": body,
+            }
+        )
+    return entries
+
+
+def _first_decision(body: str) -> str:
+    for line in body.splitlines():
+        match = DECISION_LINE.match(line.strip())
+        if match:
+            return match.group(1).strip()
+    return ""
+
+
+def _first_sentence(body: str) -> str:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def _normalize_topic(topic: Any) -> str:
+    if not isinstance(topic, str):
+        return ""
+    cleaned = TOPIC_WRAPPER.sub("", topic.strip())
+    return cleaned.strip(" ?.")
+
+
+def _tokens(text: str) -> list[str]:
+    return [token for token in TOKEN.findall(text.lower()) if token not in STOPWORDS]
+
+
+def _matches_topic(entry: dict[str, str], topic: str) -> bool:
+    haystack = f"{entry.get('title', '')}\n{entry.get('decision', '')}\n{entry.get('body', '')}"
+    folded = haystack.lower()
+    needle = topic.lower()
+    if needle and needle in folded:
+        return True
+    tokens = _tokens(topic)
+    if not tokens:
+        return False
+    return all(token in folded for token in tokens)
+
+
+def _empty(topic: str) -> dict[str, Any]:
+    return {"found": False, "topic": topic, "matches": []}
+
+
+def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]:
+    """Return matching decision-record entries for a topic, never raising."""
+    query = _normalize_topic(topic)
+    empty = _empty(query)
+    root = _coerce_root(vault)
+    if root is None or not query:
+        return empty
+    matches: list[dict[str, str]] = []
+    for path in _decision_files(root):
+        content = _read_text(path)
+        if not content:
+            continue
+        relative = _relative_file(root, path)
+        for entry in _entries(content, fallback_title=path.stem.replace("_", " ")):
+            if not _matches_topic(entry, query):
+                continue
+            matches.append(
+                {
+                    "title": entry["title"],
+                    "date": entry["date"],
+                    "decision": entry["decision"],
+                    "file": relative,
+                }
+            )
+    matches.sort(key=lambda row: (row.get("date") or "", row.get("title") or ""), reverse=True)
+    empty["found"] = bool(matches)
+    empty["matches"] = matches[:MAX_MATCHES]
+    return empty
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Ask a Dex folder what was decided")
+    parser.add_argument("--vault", required=True, help="Dex folder root")
+    parser.add_argument("--topic", required=True, help="Topic to look up")
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    args = parser.parse_args(argv)
+    payload = ask_what_was_decided(args.vault, args.topic)
+    if args.format == "json":
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+    if not payload["found"]:
+        sys.stdout.write("No matching decision record.\n")
+        return 0
+    for match in payload["matches"]:
+        decision = str(match.get("decision") or "").strip()
+        source = str(match.get("file") or "").strip()
+        sys.stdout.write(f"{decision}\n")
+        sys.stdout.write(f"File: {source}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -8,6 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CARD = REPO_ROOT / "docs" / "founder-cards" / "connector-box.md"
 LAB_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/486"
+ASK_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/515"
 PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
 LEAVE_SENTENCE = "delete the packed file and build folder"
 MODEL_OR_VENDOR = re.compile(
@@ -23,17 +24,20 @@ CATALOGUE_INSTALL = re.compile(
 def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     card = CARD.read_text(encoding="utf-8")
     assert LAB_ISSUE in card
+    assert ASK_ISSUE in card
     assert PACK_COMMAND in card
     assert "SHA-256 sidecar" in card
     assert "io.github.davekilleen/dex" in card
     assert "one_line_after_publish" in card
+    assert "decision record" in card
+    assert "what was decided" in card
     assert LEAVE_SENTENCE in card
     assert "Nobody has walked this card" in card
     assert "Do not publish" in card
-    assert "It is not a catalogue install" in card
+    assert "Decision ask answered from a decision record" in card
     headings = [line for line in card.splitlines() if line.startswith("### Step ")]
-    assert headings == ["### Step 1", "### Step 2", "### Step 3"]
-    assert card.count("- [ ] I saw that.") == 3
+    assert headings == ["### Step 1", "### Step 2", "### Step 3", "### Step 4"]
+    assert card.count("- [ ] I saw that.") == 4
 
 
 def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:

--- a/core/tests/test_copilot_cli_host.py
+++ b/core/tests/test_copilot_cli_host.py
@@ -240,6 +240,7 @@ def test_copilot_mcp_json_can_read_a_vault_without_opening_the_cli(tmp_path: Pat
         "dex_harness_profiles",
         "boot_today",
         "get_person_context",
+        "ask_what_was_decided",
         "check_safety_gate",
     }
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"

--- a/core/tests/test_decision_record.py
+++ b/core/tests/test_decision_record.py
@@ -1,0 +1,81 @@
+"""Read-only decision-record lookup for the unpublished connector box."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.context.decision_record import ask_what_was_decided
+
+
+def _write_decision_log(vault: Path, *, title: str, decision: str, date: str = "2026-04-12") -> Path:
+    folder = vault / "06-Resources" / "Decisions"
+    folder.mkdir(parents=True)
+    path = folder / "Decision_Log.md"
+    path.write_text(
+        f"## {date} — {title}\n\n"
+        f"**Decision:** {decision}\n\n"
+        "**Context:** The choice had to be written down.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ask_returns_the_decision_and_the_file(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_decision_log(
+        vault,
+        title="Keep pricing annual-only",
+        decision="Sell only annual plans.",
+    )
+    payload = ask_what_was_decided(vault, "what was decided about pricing")
+    assert payload["found"] is True
+    assert payload["matches"][0]["decision"] == "Sell only annual plans."
+    assert payload["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
+    assert payload["matches"][0]["title"] == "Keep pricing annual-only"
+
+
+def test_ask_reads_a_project_decision_record(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    project = vault / "04-Projects" / "Checkout"
+    project.mkdir(parents=True)
+    (project / "Decisions.md").write_text(
+        "## 2026-05-01 — Pause guest checkout\n\n"
+        "**Decision:** Guest checkout stays off until fraud review finishes.\n",
+        encoding="utf-8",
+    )
+    payload = ask_what_was_decided(vault, "guest checkout")
+    assert payload["found"] is True
+    assert payload["matches"][0]["file"] == "04-Projects/Checkout/Decisions.md"
+    assert "Guest checkout stays off" in payload["matches"][0]["decision"]
+
+
+def test_ask_does_not_invent_or_use_meeting_notes(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    (meetings / "2026-04-12 - Pricing.md").write_text(
+        "## Notes\n\nWe decided to give pricing away for free.\n",
+        encoding="utf-8",
+    )
+    payload = ask_what_was_decided(vault, "pricing")
+    assert payload["found"] is False
+    assert payload["matches"] == []
+
+
+def test_ask_skips_symlinks_and_paths_outside_the_folder(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text(
+        "## 2026-01-01 — Secret\n\n**Decision:** Do not leak this.\n",
+        encoding="utf-8",
+    )
+    folder = vault / "06-Resources" / "Decisions"
+    folder.mkdir(parents=True)
+    (folder / "Decision_Log.md").symlink_to(outside)
+    payload = ask_what_was_decided(vault, "Secret")
+    assert payload["found"] is False
+    assert ask_what_was_decided(None, "Secret")["found"] is False
+    assert ask_what_was_decided(vault, "")["found"] is False
+    assert ask_what_was_decided(vault, object())["found"] is False

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -304,6 +304,7 @@ def test_artifact_builder_produces_installable_gemini_and_mcpb_bundles(
         "dex_harness_profiles",
         "boot_today",
         "get_person_context",
+        "ask_what_was_decided",
         "check_safety_gate",
     }
     desktop = tmp_path / "dex-claude-desktop"
@@ -389,6 +390,7 @@ def test_vendored_runtime_is_byte_identical_to_shared_core() -> None:
         "core/path_safety.py",
         "core/context/__init__.py",
         "core/context/person_context.py",
+        "core/context/decision_record.py",
         "core/context/session_boot.py",
         "core/gates/__init__.py",
         "core/gates/safety.py",
@@ -428,6 +430,13 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n---\n- [ ] Send the operating memo\n",
         encoding="utf-8",
     )
+    decisions = vault / "06-Resources" / "Decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "Decision_Log.md").write_text(
+        "## 2026-04-12 — Keep pricing annual-only\n\n"
+        "**Decision:** Sell only annual plans.\n",
+        encoding="utf-8",
+    )
     responses = _mcp_roundtrip(
         [
             {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
@@ -456,15 +465,25 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
                     "arguments": {"vault_path": str(vault), "command": "rm -rf /"},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_was_decided",
+                    "arguments": {"vault_path": str(vault), "topic": "pricing"},
+                },
+            },
         ],
         cwd=vault,
     )
-    assert len(responses) == 5
+    assert len(responses) == 6
     names = {tool["name"] for tool in responses[1]["result"]["tools"]}
     assert names == {
         "dex_harness_profiles",
         "boot_today",
         "get_person_context",
+        "ask_what_was_decided",
         "check_safety_gate",
     }
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
@@ -473,6 +492,10 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
     assert person["matches"][0]["company"] == "Analytical Engines"
     safety = responses[4]["result"]["structuredContent"]
     assert safety["refused"] is True
+    ask = responses[5]["result"]["structuredContent"]
+    assert ask["found"] is True
+    assert ask["matches"][0]["decision"] == "Sell only annual plans."
+    assert ask["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
 
 
 def test_plugin_hooks_inject_session_context_and_block_destructive_work(tmp_path: Path) -> None:

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -22,6 +22,7 @@ READ_ONLY_TOOLS = {
     "dex_harness_profiles",
     "boot_today",
     "get_person_context",
+    "ask_what_was_decided",
     "check_safety_gate",
 }
 
@@ -120,6 +121,7 @@ def test_builder_packs_checksums_validates_and_stays_unreleased(tmp_path: Path) 
     assert "package/server.py" in names
     assert "package/bin/dex-python.mjs" in names
     assert "package/runtime/core/gates/safety.py" in names
+    assert "package/runtime/core/context/decision_record.py" in names
     assert package["private"] is True
     assert package["mcpName"] == "io.github.davekilleen/dex"
     assert server_py == (PLUGIN_ROOT / "server.py").read_bytes()
@@ -147,6 +149,13 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
         "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n---\n- [ ] Send the operating memo\n",
         encoding="utf-8",
     )
+    decisions = vault / "06-Resources" / "Decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "Decision_Log.md").write_text(
+        "## 2026-04-12 — Keep pricing annual-only\n\n"
+        "**Decision:** Sell only annual plans.\n",
+        encoding="utf-8",
+    )
     responses = _mcp_roundtrip(
         plugin_root,
         [
@@ -167,12 +176,25 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
                     "arguments": {"vault_path": str(vault), "command": "rm -rf /"},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_was_decided",
+                    "arguments": {"vault_path": str(vault), "topic": "pricing"},
+                },
+            },
         ],
         vault=vault,
     )
     assert {tool["name"] for tool in responses[1]["result"]["tools"]} == READ_ONLY_TOOLS
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
     assert responses[3]["result"]["structuredContent"]["refused"] is True
+    ask = responses[4]["result"]["structuredContent"]
+    assert ask["found"] is True
+    assert ask["matches"][0]["decision"] == "Sell only annual plans."
+    assert ask["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
 
 
 def test_live_npm_publish_is_refused(tmp_path: Path) -> None:

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -35,8 +35,8 @@ has already passed that evidence gate.
 `packages/dex-agent-plugin/` contains one generated package with:
 
 - the portable Dex skill catalogue;
-- read-only `boot_today`, `get_person_context`, `check_safety_gate`, and
-  `dex_harness_profiles` MCP tools;
+- read-only `boot_today`, `get_person_context`, `ask_what_was_decided`,
+  `check_safety_gate`, and `dex_harness_profiles` MCP tools;
 - byte-identical vendored copies of the canonical context and safety modules;
 - SessionStart context and PreToolUse safety hooks for hosts that can genuinely
   run them;

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -3,7 +3,9 @@
 Unreleased. Nobody has walked this card. Do not publish. Do not merge.
 This is a local pack check. It is not a catalogue install.
 
-**Lab issue (leave open):** https://github.com/davekilleen/dex-product-gtm-lab/issues/486
+**Lab issues (leave open):**
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/486
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/515
 
 ## Steps
 
@@ -41,11 +43,21 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 
 **If this fails, send back this exact sentence:** `connector-box step 3 failed: the future catalogue name was missing.`
 
+### Step 4
+
+1. Before anything is published, ask the packed box what was decided about a topic that is already written in your own decision record.
+
+**What you should see:** The choice in one sentence, and the file that decision record lives in.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 4 failed: the packed box did not answer from a decision record.`
+
 ## After the last checkbox
 
 If every box is checked, send this exact sentence:
 
-`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Not a catalogue install.`
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Not a catalogue install.`
 
 If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
 

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -24,8 +24,9 @@ Plugins v1 root contract and also includes native manifests for:
 - Other Agent Plugins v1 clients through `plugin.json` and `mcp.json`.
 
 The MCP bridge exposes `boot_today`, `get_person_context`,
-`check_safety_gate`, and `dex_harness_profiles`. It is dependency-free,
-relocatable, read-only, and uses the same vendored source modules as dex-core.
+`ask_what_was_decided`, `check_safety_gate`, and `dex_harness_profiles`. It is
+dependency-free, relocatable, read-only, and uses the same vendored source
+modules as dex-core.
 The safety MCP tool is advisory unless the host calls it before acting; the
 native Codex/Claude `PreToolUse` hook can actively refuse known-dangerous work.
 

--- a/packages/dex-agent-plugin/runtime/core/context/__init__.py
+++ b/packages/dex-agent-plugin/runtime/core/context/__init__.py
@@ -1,5 +1,6 @@
 """Harness-neutral context payloads used by MCP and Claude wrappers."""
 
+from .decision_record import ask_what_was_decided
 from .person_context import (
     find_people_in_file,
     format_person_context_block,
@@ -9,6 +10,7 @@ from .person_context import (
 from .session_boot import build_session_boot, format_session_boot_text
 
 __all__ = [
+    "ask_what_was_decided",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/packages/dex-agent-plugin/runtime/core/context/decision_record.py
+++ b/packages/dex-agent-plugin/runtime/core/context/decision_record.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Read-only lookup of a vault's own decision records.
+
+The packed connector box asks this module what was decided about a topic and
+returns the choice plus the file it came from. It never writes, never invents a
+decision, and never reads meetings or other notes as a substitute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.paths import PROJECTS_DIR, RESOURCES_DIR, resolve_for_vault
+
+HEADING = re.compile(r"^##\s+(.+?)\s*$")
+DATED_HEADING = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})\s+[—–-]\s+(?P<title>.+)$"
+)
+DECISION_LINE = re.compile(
+    r"^\*\*Decision:\*\*\s*(.+?)\s*$",
+    re.IGNORECASE,
+)
+TOPIC_WRAPPER = re.compile(
+    r"^(?:what(?:\s+was)?\s+)?(?:was\s+)?decided(?:\s+about)?\s+",
+    re.IGNORECASE,
+)
+TOKEN = re.compile(r"[a-z0-9]{3,}")
+STOPWORDS = {
+    "about",
+    "and",
+    "decided",
+    "decision",
+    "for",
+    "from",
+    "the",
+    "this",
+    "that",
+    "was",
+    "what",
+    "with",
+}
+SKIP_NAMES = {"readme.md"}
+MAX_MATCHES = 8
+
+
+def _coerce_root(vault: str | Path | None) -> Path | None:
+    if vault is None:
+        return None
+    try:
+        root = Path(vault).expanduser()
+    except (TypeError, ValueError, OSError):
+        return None
+    try:
+        if not root.is_dir():
+            return None
+        return root.resolve()
+    except OSError:
+        return None
+
+
+def _inside(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _real_file(root: Path, path: Path) -> Path | None:
+    try:
+        if path.is_symlink() or not path.is_file() or not _inside(root, path):
+            return None
+        return path
+    except OSError:
+        return None
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def _relative_file(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return path.name
+
+
+def _decisions_dir(vault: Path) -> Path:
+    return resolve_for_vault(vault, RESOURCES_DIR) / "Decisions"
+
+
+def _projects_dir(vault: Path) -> Path:
+    return resolve_for_vault(vault, PROJECTS_DIR)
+
+
+def _decision_files(vault: Path) -> list[Path]:
+    files: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path) -> None:
+        real = _real_file(vault, path)
+        if real is None or real.name.lower() in SKIP_NAMES:
+            return
+        try:
+            key = str(real.resolve())
+        except OSError:
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        files.append(real)
+
+    decisions_dir = _decisions_dir(vault)
+    try:
+        if decisions_dir.is_dir() and not decisions_dir.is_symlink() and _inside(
+            vault, decisions_dir
+        ):
+            for path in sorted(decisions_dir.rglob("*.md")):
+                _add(path)
+    except OSError:
+        pass
+
+    projects_dir = _projects_dir(vault)
+    try:
+        if projects_dir.is_dir() and not projects_dir.is_symlink() and _inside(
+            vault, projects_dir
+        ):
+            for path in sorted(projects_dir.rglob("Decisions.md")):
+                _add(path)
+    except OSError:
+        pass
+    return files
+
+
+def _entries(content: str, *, fallback_title: str) -> list[dict[str, str]]:
+    lines = content.splitlines()
+    starts: list[int] = [
+        index for index, line in enumerate(lines) if HEADING.match(line)
+    ]
+    if not starts:
+        body = content.strip()
+        if not body:
+            return []
+        return [
+            {
+                "title": fallback_title,
+                "date": "",
+                "decision": _first_decision(body) or _first_sentence(body),
+                "body": body,
+            }
+        ]
+    entries: list[dict[str, str]] = []
+    for index, start in enumerate(starts):
+        end = starts[index + 1] if index + 1 < len(starts) else len(lines)
+        heading = HEADING.match(lines[start])
+        raw_heading = heading.group(1).strip() if heading else fallback_title
+        dated = DATED_HEADING.match(raw_heading)
+        title = dated.group("title").strip() if dated else raw_heading
+        date = dated.group("date") if dated else ""
+        body = "\n".join(lines[start:end]).strip()
+        entries.append(
+            {
+                "title": title,
+                "date": date,
+                "decision": _first_decision(body) or title,
+                "body": body,
+            }
+        )
+    return entries
+
+
+def _first_decision(body: str) -> str:
+    for line in body.splitlines():
+        match = DECISION_LINE.match(line.strip())
+        if match:
+            return match.group(1).strip()
+    return ""
+
+
+def _first_sentence(body: str) -> str:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def _normalize_topic(topic: Any) -> str:
+    if not isinstance(topic, str):
+        return ""
+    cleaned = TOPIC_WRAPPER.sub("", topic.strip())
+    return cleaned.strip(" ?.")
+
+
+def _tokens(text: str) -> list[str]:
+    return [token for token in TOKEN.findall(text.lower()) if token not in STOPWORDS]
+
+
+def _matches_topic(entry: dict[str, str], topic: str) -> bool:
+    haystack = f"{entry.get('title', '')}\n{entry.get('decision', '')}\n{entry.get('body', '')}"
+    folded = haystack.lower()
+    needle = topic.lower()
+    if needle and needle in folded:
+        return True
+    tokens = _tokens(topic)
+    if not tokens:
+        return False
+    return all(token in folded for token in tokens)
+
+
+def _empty(topic: str) -> dict[str, Any]:
+    return {"found": False, "topic": topic, "matches": []}
+
+
+def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]:
+    """Return matching decision-record entries for a topic, never raising."""
+    query = _normalize_topic(topic)
+    empty = _empty(query)
+    root = _coerce_root(vault)
+    if root is None or not query:
+        return empty
+    matches: list[dict[str, str]] = []
+    for path in _decision_files(root):
+        content = _read_text(path)
+        if not content:
+            continue
+        relative = _relative_file(root, path)
+        for entry in _entries(content, fallback_title=path.stem.replace("_", " ")):
+            if not _matches_topic(entry, query):
+                continue
+            matches.append(
+                {
+                    "title": entry["title"],
+                    "date": entry["date"],
+                    "decision": entry["decision"],
+                    "file": relative,
+                }
+            )
+    matches.sort(key=lambda row: (row.get("date") or "", row.get("title") or ""), reverse=True)
+    empty["found"] = bool(matches)
+    empty["matches"] = matches[:MAX_MATCHES]
+    return empty
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Ask a Dex folder what was decided")
+    parser.add_argument("--vault", required=True, help="Dex folder root")
+    parser.add_argument("--topic", required=True, help="Topic to look up")
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    args = parser.parse_args(argv)
+    payload = ask_what_was_decided(args.vault, args.topic)
+    if args.format == "json":
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+    if not payload["found"]:
+        sys.stdout.write("No matching decision record.\n")
+        return 0
+    for match in payload["matches"]:
+        decision = str(match.get("decision") or "").strip()
+        source = str(match.get("file") or "").strip()
+        sys.stdout.write(f"{decision}\n")
+        sys.stdout.write(f"File: {source}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/dex-agent-plugin/server.py
+++ b/packages/dex-agent-plugin/server.py
@@ -17,6 +17,7 @@ RUNTIME = ROOT / "runtime"
 if str(RUNTIME) not in sys.path:
     sys.path.insert(0, str(RUNTIME))
 
+from core.context.decision_record import ask_what_was_decided  # noqa: E402
 from core.context.person_context import get_person_context  # noqa: E402
 from core.context.session_boot import build_session_boot  # noqa: E402
 from core.gates.safety import evaluate_safety_gate  # noqa: E402
@@ -91,6 +92,18 @@ def _tools() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "ask_what_was_decided",
+            "description": (
+                "Answer what was decided about a topic from this Dex folder's "
+                "own decision record, including the file it came from."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {**vault, "topic": {"type": "string"}},
+                "required": ["topic"],
+            },
+        },
+        {
             "name": "check_safety_gate",
             "description": "Check a proposed command or path before a harness executes it.",
             "inputSchema": {
@@ -135,6 +148,11 @@ def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
             return _tool_result(
                 request_id,
                 get_person_context(_vault(arguments), arguments.get("name")),
+            )
+        if name == "ask_what_was_decided":
+            return _tool_result(
+                request_id,
+                ask_what_was_decided(_vault(arguments), arguments.get("topic")),
             )
         if name == "check_safety_gate":
             decision = evaluate_safety_gate(

--- a/packages/dex-claude-desktop/README.md
+++ b/packages/dex-claude-desktop/README.md
@@ -1,7 +1,7 @@
 # Dex for Claude Desktop
 
 This source directory becomes the unreleased `dex-claude-desktop.mcpb` local
-extension. It exposes four read-only Dex MCP tools and asks the user to select
+extension. It exposes the read-only Dex MCP tools and asks the user to select
 their Dex folder during installation. Claude Desktop chat does not run lifecycle
 hooks, so this artifact makes no hook or automatic-safety claim.
 

--- a/packages/dex-claude-desktop/manifest.json
+++ b/packages/dex-claude-desktop/manifest.json
@@ -49,6 +49,10 @@
       "description": "Read context about a person."
     },
     {
+      "name": "ask_what_was_decided",
+      "description": "Answer what was decided from this Dex folder's own decision record."
+    },
+    {
       "name": "check_safety_gate",
       "description": "Check a proposed command or path."
     }

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -5,6 +5,12 @@ read-only tools. After a public catalogue publish, a person can point any MCP
 app at one line. Until then, the package stays local, checksummed, and
 unreleased.
 
+## What a person can do now
+
+Pack the box locally. Then, before anything is published, ask it what was
+decided about a topic. It answers from that Dex folder's own decision record
+and names the file it came from.
+
 ## What a person can do after a public catalogue publish
 
 Add this one line in an MCP app that can install from the official catalogue:
@@ -20,8 +26,9 @@ DEX_VAULT_PATH="/path/to/your/Dex" npx -y dex-mcp
 ```
 
 Point `DEX_VAULT_PATH` at the Dex folder on that computer. The server can read
-today's context, look up a person, list host support, and refuse a destructive
-command. It cannot write the vault.
+today's context, look up a person, list host support, refuse a destructive
+command, and answer what was decided about a topic from that folder's own
+decision record. It cannot write the vault.
 
 ## What is true now
 

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -28,6 +28,7 @@ RUNTIME_SOURCES = (
     Path("core/path_safety.py"),
     Path("core/context/__init__.py"),
     Path("core/context/person_context.py"),
+    Path("core/context/decision_record.py"),
     Path("core/context/session_boot.py"),
     Path("core/gates/__init__.py"),
     Path("core/gates/safety.py"),
@@ -165,6 +166,10 @@ def _claude_desktop_manifest() -> dict:
             {"name": "dex_harness_profiles", "description": "List Dex harness support."},
             {"name": "boot_today", "description": "Read today's Dex context."},
             {"name": "get_person_context", "description": "Read context about a person."},
+            {
+                "name": "ask_what_was_decided",
+                "description": "Answer what was decided from this Dex folder's own decision record.",
+            },
             {"name": "check_safety_gate", "description": "Check a proposed command or path."},
         ],
         "compatibility": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 515](https://github.com/davekilleen/dex-product-gtm-lab/issues/515) open. Assign: davekilleen.

Branched from draft PR 662 head `44d98d1a1042c8eef5a50e005ce7d71985c941f0`. Do not merge 662. Do not merge 620. Ignore leftover 619. Do not merge lab PR 512. Do not invent the Work folder grant.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 515: https://github.com/davekilleen/dex-product-gtm-lab/issues/515 (reference only — do not close)

## What a person can do
Pack the connector box locally, then before anything is published, ask it what was decided about a topic. It answers from that Dex folder's own decision record and names the file it came from.

## What Changed
- Packed box now has a read-only `ask_what_was_decided` tool
- Answers come only from the person's own decision records, with the source file
- Founder card step 4 walks that ask
- Live-publish refusal guard is untouched
- Lot 0 first packed the 662 box: the ask was not already there, so this lot continued
- No catalogue install step. Nobody has walked the card

## Test Plan
- Local lot 0 + ask: 18 passed (`test_decision_record`, founder card, unpublished lookup, pack/sidecar/refusal, packed-box ask round trip)
- Lot 0 on the 662 head before this change: pack printed `Validated. Still unreleased. Did not publish.`, SHA-256 sidecar present, tools were only the four older ones, so the ask did not already exist
- Live-publish refusal guard: source unchanged and `test_live_npm_publish_is_refused` green
- Negative/error-path: empty topic, missing folder, meeting notes are not used as a substitute, symlinks skipped
- Founder-content gate: pass
- Not run here: Gemini/Desktop bundle builder (`mcpb` missing on this runner; pre-existing, not this lot)

## Quality Gates
- [x] Isolated branch from 662 head `44d98d1a`
- [x] Ask did not already exist on the packed 662 box (lot 0 continued)
- [x] Live-publish refusal guard source is unchanged
- [x] Local lot-0 + ask + unpublished tests passed on this runner
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (read-only ask on an unpublished box; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `packages/dex-mcp/README.md` and portable plugin copy only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff8baab6-d7d9-46b1-abe3-a113e581e82b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff8baab6-d7d9-46b1-abe3-a113e581e82b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

