### PR TITLE
Ask the unpublished connector box what was decided lately — unreleased

### DIFF
--- a/core/context/decision_record.py
+++ b/core/context/decision_record.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Read-only lookup of a vault's own decision records.
 
-The packed connector box asks this module what was decided about a topic and
-returns the choice plus the file it came from. It never writes, never invents a
-decision, and never reads meetings or other notes as a substitute.
+The packed connector box asks this module what was decided about a topic, or
+what was decided lately with no topic, and returns the choice plus the file it
+came from. It never writes, never invents a decision, and never reads meetings
+or other notes as a substitute.
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ STOPWORDS = {
     "with",
 }
 SKIP_NAMES = {"readme.md"}
+LATELY_WORDS = frozenset({"lately", "recent", "recently"})
 MAX_MATCHES = 8
 
 
@@ -198,11 +200,17 @@ def _first_sentence(body: str) -> str:
     return ""
 
 
-def _normalize_topic(topic: Any) -> str:
-    if not isinstance(topic, str):
+def _normalize_topic(topic: Any) -> str | None:
+    if topic is None:
         return ""
+    if not isinstance(topic, str):
+        return None
     cleaned = TOPIC_WRAPPER.sub("", topic.strip())
     return cleaned.strip(" ?.")
+
+
+def _is_lately(query: str) -> bool:
+    return not query or query.lower() in LATELY_WORDS
 
 
 def _tokens(text: str) -> list[str]:
@@ -225,12 +233,15 @@ def _empty(topic: str) -> dict[str, Any]:
     return {"found": False, "topic": topic, "matches": []}
 
 
-def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]:
-    """Return matching decision-record entries for a topic, never raising."""
+def ask_what_was_decided(vault: str | Path | None, topic: Any = None) -> dict[str, Any]:
+    """Return matching or recent decision-record entries, never raising."""
     query = _normalize_topic(topic)
+    if query is None:
+        return _empty("")
+    lately = _is_lately(query)
     empty = _empty(query)
     root = _coerce_root(vault)
-    if root is None or not query:
+    if root is None:
         return empty
     matches: list[dict[str, str]] = []
     for path in _decision_files(root):
@@ -239,7 +250,7 @@ def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]
             continue
         relative = _relative_file(root, path)
         for entry in _entries(content, fallback_title=path.stem.replace("_", " ")):
-            if not _matches_topic(entry, query):
+            if not lately and not _matches_topic(entry, query):
                 continue
             matches.append(
                 {
@@ -258,7 +269,11 @@ def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Ask a Dex folder what was decided")
     parser.add_argument("--vault", required=True, help="Dex folder root")
-    parser.add_argument("--topic", required=True, help="Topic to look up")
+    parser.add_argument(
+        "--topic",
+        default="",
+        help="Topic to look up; omit to ask what was decided lately",
+    )
     parser.add_argument("--format", choices=("json", "text"), default="text")
     args = parser.parse_args(argv)
     payload = ask_what_was_decided(args.vault, args.topic)

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CARD = REPO_ROOT / "docs" / "founder-cards" / "connector-box.md"
 LAB_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/486"
 ASK_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/515"
+LATELY_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/537"
 PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
 LEAVE_SENTENCE = "delete the packed file and build folder"
 MODEL_OR_VENDOR = re.compile(
@@ -25,19 +26,29 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     card = CARD.read_text(encoding="utf-8")
     assert LAB_ISSUE in card
     assert ASK_ISSUE in card
+    assert LATELY_ISSUE in card
     assert PACK_COMMAND in card
     assert "SHA-256 sidecar" in card
     assert "io.github.davekilleen/dex" in card
     assert "one_line_after_publish" in card
     assert "decision record" in card
     assert "what was decided" in card
+    assert "no topic" in card
+    assert "lately" in card
     assert LEAVE_SENTENCE in card
     assert "Nobody has walked this card" in card
     assert "Do not publish" in card
     assert "Decision ask answered from a decision record" in card
+    assert "Lately ask answered with no topic" in card
     headings = [line for line in card.splitlines() if line.startswith("### Step ")]
-    assert headings == ["### Step 1", "### Step 2", "### Step 3", "### Step 4"]
-    assert card.count("- [ ] I saw that.") == 4
+    assert headings == [
+        "### Step 1",
+        "### Step 2",
+        "### Step 3",
+        "### Step 4",
+        "### Step 5",
+    ]
+    assert card.count("- [ ] I saw that.") == 5
 
 
 def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:

--- a/core/tests/test_decision_record.py
+++ b/core/tests/test_decision_record.py
@@ -77,5 +77,47 @@ def test_ask_skips_symlinks_and_paths_outside_the_folder(tmp_path: Path) -> None
     payload = ask_what_was_decided(vault, "Secret")
     assert payload["found"] is False
     assert ask_what_was_decided(None, "Secret")["found"] is False
-    assert ask_what_was_decided(vault, "")["found"] is False
     assert ask_what_was_decided(vault, object())["found"] is False
+
+
+def test_ask_without_a_topic_returns_what_was_decided_lately(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_decision_log(
+        vault,
+        title="Keep pricing annual-only",
+        decision="Sell only annual plans.",
+        date="2026-04-12",
+    )
+    folder = vault / "06-Resources" / "Decisions"
+    (folder / "Hiring.md").write_text(
+        "## 2026-05-20 — Pause hiring\n\n**Decision:** No new roles until June.\n",
+        encoding="utf-8",
+    )
+    payload = ask_what_was_decided(vault, None)
+    assert payload["found"] is True
+    assert payload["topic"] == ""
+    assert [row["decision"] for row in payload["matches"]] == [
+        "No new roles until June.",
+        "Sell only annual plans.",
+    ]
+    assert payload["matches"][0]["file"] == "06-Resources/Decisions/Hiring.md"
+    lately = ask_what_was_decided(vault, "what was decided lately")
+    assert lately["found"] is True
+    assert lately["matches"][0]["decision"] == "No new roles until June."
+    empty = ask_what_was_decided(vault, "")
+    assert empty["found"] is True
+    assert empty["matches"][0]["file"] == "06-Resources/Decisions/Hiring.md"
+
+
+def test_lately_does_not_invent_or_use_meeting_notes(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    (meetings / "2026-04-12 - Pricing.md").write_text(
+        "## Notes\n\nWe decided to give pricing away for free.\n",
+        encoding="utf-8",
+    )
+    payload = ask_what_was_decided(vault, None)
+    assert payload["found"] is False
+    assert payload["matches"] == []

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -474,10 +474,19 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
                     "arguments": {"vault_path": str(vault), "topic": "pricing"},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_was_decided",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
         ],
         cwd=vault,
     )
-    assert len(responses) == 6
+    assert len(responses) == 7
     names = {tool["name"] for tool in responses[1]["result"]["tools"]}
     assert names == {
         "dex_harness_profiles",
@@ -486,6 +495,13 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "ask_what_was_decided",
         "check_safety_gate",
     }
+    ask_tool = next(
+        tool
+        for tool in responses[1]["result"]["tools"]
+        if tool["name"] == "ask_what_was_decided"
+    )
+    required = (ask_tool.get("inputSchema") or {}).get("required") or []
+    assert "topic" not in required
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
     person = responses[3]["result"]["structuredContent"]
     assert person["found"] is True
@@ -496,6 +512,10 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
     assert ask["found"] is True
     assert ask["matches"][0]["decision"] == "Sell only annual plans."
     assert ask["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
+    lately = responses[6]["result"]["structuredContent"]
+    assert lately["found"] is True
+    assert lately["topic"] == ""
+    assert lately["matches"][0]["decision"] == "Sell only annual plans."
 
 
 def test_plugin_hooks_inject_session_context_and_block_destructive_work(tmp_path: Path) -> None:

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -185,16 +185,36 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
                     "arguments": {"vault_path": str(vault), "topic": "pricing"},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_was_decided",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
         ],
         vault=vault,
     )
-    assert {tool["name"] for tool in responses[1]["result"]["tools"]} == READ_ONLY_TOOLS
+    tools = responses[1]["result"]["tools"]
+    assert {tool["name"] for tool in tools} == READ_ONLY_TOOLS
+    ask_tool = next(tool for tool in tools if tool["name"] == "ask_what_was_decided")
+    required = (ask_tool.get("inputSchema") or {}).get("required") or []
+    assert "topic" not in required
+    assert "lately" in ask_tool["description"]
+    assert "no topic" in ask_tool["description"]
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
     assert responses[3]["result"]["structuredContent"]["refused"] is True
     ask = responses[4]["result"]["structuredContent"]
     assert ask["found"] is True
     assert ask["matches"][0]["decision"] == "Sell only annual plans."
     assert ask["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
+    lately = responses[5]["result"]["structuredContent"]
+    assert lately["found"] is True
+    assert lately["topic"] == ""
+    assert lately["matches"][0]["decision"] == "Sell only annual plans."
+    assert lately["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
 
 
 def test_live_npm_publish_is_refused(tmp_path: Path) -> None:

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -35,7 +35,8 @@ has already passed that evidence gate.
 `packages/dex-agent-plugin/` contains one generated package with:
 
 - the portable Dex skill catalogue;
-- read-only `boot_today`, `get_person_context`, `ask_what_was_decided`,
+- read-only `boot_today`, `get_person_context`, `ask_what_was_decided`
+  (a topic, or lately with no topic),
   `check_safety_gate`, and `dex_harness_profiles` MCP tools;
 - byte-identical vendored copies of the canonical context and safety modules;
 - SessionStart context and PreToolUse safety hooks for hosts that can genuinely

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -6,6 +6,7 @@ This is a local pack check. It is not a catalogue install.
 **Lab issues (leave open):**
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/486
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/515
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/537
 
 ## Steps
 
@@ -53,11 +54,21 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 
 **If this fails, send back this exact sentence:** `connector-box step 4 failed: the packed box did not answer from a decision record.`
 
+### Step 5
+
+1. Before anything is published, ask the packed box what was decided lately. Do not give it a topic.
+
+**What you should see:** The recent choices from your own decision record, each with the file that record lives in.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 5 failed: the packed box did not answer what was decided lately.`
+
 ## After the last checkbox
 
 If every box is checked, send this exact sentence:
 
-`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Not a catalogue install.`
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Not a catalogue install.`
 
 If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
 

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -24,7 +24,8 @@ Plugins v1 root contract and also includes native manifests for:
 - Other Agent Plugins v1 clients through `plugin.json` and `mcp.json`.
 
 The MCP bridge exposes `boot_today`, `get_person_context`,
-`ask_what_was_decided`, `check_safety_gate`, and `dex_harness_profiles`. It is
+`ask_what_was_decided` (a topic, or lately with no topic),
+`check_safety_gate`, and `dex_harness_profiles`. It is
 dependency-free, relocatable, read-only, and uses the same vendored source
 modules as dex-core.
 The safety MCP tool is advisory unless the host calls it before acting; the

--- a/packages/dex-agent-plugin/runtime/core/context/decision_record.py
+++ b/packages/dex-agent-plugin/runtime/core/context/decision_record.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Read-only lookup of a vault's own decision records.
 
-The packed connector box asks this module what was decided about a topic and
-returns the choice plus the file it came from. It never writes, never invents a
-decision, and never reads meetings or other notes as a substitute.
+The packed connector box asks this module what was decided about a topic, or
+what was decided lately with no topic, and returns the choice plus the file it
+came from. It never writes, never invents a decision, and never reads meetings
+or other notes as a substitute.
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ STOPWORDS = {
     "with",
 }
 SKIP_NAMES = {"readme.md"}
+LATELY_WORDS = frozenset({"lately", "recent", "recently"})
 MAX_MATCHES = 8
 
 
@@ -198,11 +200,17 @@ def _first_sentence(body: str) -> str:
     return ""
 
 
-def _normalize_topic(topic: Any) -> str:
-    if not isinstance(topic, str):
+def _normalize_topic(topic: Any) -> str | None:
+    if topic is None:
         return ""
+    if not isinstance(topic, str):
+        return None
     cleaned = TOPIC_WRAPPER.sub("", topic.strip())
     return cleaned.strip(" ?.")
+
+
+def _is_lately(query: str) -> bool:
+    return not query or query.lower() in LATELY_WORDS
 
 
 def _tokens(text: str) -> list[str]:
@@ -225,12 +233,15 @@ def _empty(topic: str) -> dict[str, Any]:
     return {"found": False, "topic": topic, "matches": []}
 
 
-def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]:
-    """Return matching decision-record entries for a topic, never raising."""
+def ask_what_was_decided(vault: str | Path | None, topic: Any = None) -> dict[str, Any]:
+    """Return matching or recent decision-record entries, never raising."""
     query = _normalize_topic(topic)
+    if query is None:
+        return _empty("")
+    lately = _is_lately(query)
     empty = _empty(query)
     root = _coerce_root(vault)
-    if root is None or not query:
+    if root is None:
         return empty
     matches: list[dict[str, str]] = []
     for path in _decision_files(root):
@@ -239,7 +250,7 @@ def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]
             continue
         relative = _relative_file(root, path)
         for entry in _entries(content, fallback_title=path.stem.replace("_", " ")):
-            if not _matches_topic(entry, query):
+            if not lately and not _matches_topic(entry, query):
                 continue
             matches.append(
                 {
@@ -258,7 +269,11 @@ def ask_what_was_decided(vault: str | Path | None, topic: Any) -> dict[str, Any]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Ask a Dex folder what was decided")
     parser.add_argument("--vault", required=True, help="Dex folder root")
-    parser.add_argument("--topic", required=True, help="Topic to look up")
+    parser.add_argument(
+        "--topic",
+        default="",
+        help="Topic to look up; omit to ask what was decided lately",
+    )
     parser.add_argument("--format", choices=("json", "text"), default="text")
     args = parser.parse_args(argv)
     payload = ask_what_was_decided(args.vault, args.topic)

--- a/packages/dex-agent-plugin/server.py
+++ b/packages/dex-agent-plugin/server.py
@@ -94,13 +94,13 @@ def _tools() -> list[dict[str, Any]]:
         {
             "name": "ask_what_was_decided",
             "description": (
-                "Answer what was decided about a topic from this Dex folder's "
-                "own decision record, including the file it came from."
+                "Answer what was decided about a topic, or what was decided "
+                "lately with no topic, from this Dex folder's own decision "
+                "record, including the file it came from."
             ),
             "inputSchema": {
                 "type": "object",
                 "properties": {**vault, "topic": {"type": "string"}},
-                "required": ["topic"],
             },
         },
         {

--- a/packages/dex-claude-desktop/manifest.json
+++ b/packages/dex-claude-desktop/manifest.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "ask_what_was_decided",
-      "description": "Answer what was decided from this Dex folder's own decision record."
+      "description": "Answer what was decided about a topic, or lately with no topic, from this Dex folder's own decision record."
     },
     {
       "name": "check_safety_gate",

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -8,8 +8,8 @@ unreleased.
 ## What a person can do now
 
 Pack the box locally. Then, before anything is published, ask it what was
-decided about a topic. It answers from that Dex folder's own decision record
-and names the file it came from.
+decided about a topic, or what was decided lately with no topic. It answers
+from that Dex folder's own decision record and names the file it came from.
 
 ## What a person can do after a public catalogue publish
 
@@ -27,8 +27,8 @@ DEX_VAULT_PATH="/path/to/your/Dex" npx -y dex-mcp
 
 Point `DEX_VAULT_PATH` at the Dex folder on that computer. The server can read
 today's context, look up a person, list host support, refuse a destructive
-command, and answer what was decided about a topic from that folder's own
-decision record. It cannot write the vault.
+command, and answer what was decided about a topic or what was decided lately
+with no topic from that folder's own decision record. It cannot write the vault.
 
 ## What is true now
 

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -168,7 +168,10 @@ def _claude_desktop_manifest() -> dict:
             {"name": "get_person_context", "description": "Read context about a person."},
             {
                 "name": "ask_what_was_decided",
-                "description": "Answer what was decided from this Dex folder's own decision record.",
+                "description": (
+                    "Answer what was decided about a topic, or lately with no "
+                    "topic, from this Dex folder's own decision record."
+                ),
             },
             {"name": "check_safety_gate", "description": "Check a proposed command or path."},
         ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 537](https://github.com/davekilleen/dex-product-gtm-lab/issues/537) open. Assign: davekilleen.

Branched from draft PR 666 head `4e3d053e028582b0364a31006d7afe7ec7161acd`. Do not merge 666. Do not merge 620. Ignore leftover 619. Do not merge lab PR 532. Do not invent the Work folder grant.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 537: https://github.com/davekilleen/dex-product-gtm-lab/issues/537 (reference only — do not close)

## What a person can do
Pack the connector box locally, then before anything is published, ask it what was decided lately with no topic. It answers recent choices from that Dex folder's own decision record and names each file.

## What Changed
- Packed box `ask_what_was_decided` now answers lately when no topic is given
- Topic asks still come only from the person's own decision records, with the source file
- Founder card step 5 walks the lately ask
- Live-publish refusal guard is untouched
- Lot 0 packed the 666 box first: topic was still required, empty/lately asks returned nothing, so this lot continued
- No catalogue install step. Nobody has walked the card

## Test Plan
- Local lot 0 + lately ask: 32 passed (`test_decision_record`, founder card, unpublished lookup, pack/sidecar/refusal, packed-box topic and no-topic round trip)
- Lot 0 on the 666 head before this change: pack printed `Validated. Still unreleased. Did not publish.`, SHA-256 sidecar present, `ask_what_was_decided` required a topic, no-topic/empty/lately calls returned no matches, so lately with no topic did not already exist
- Live-publish refusal guard: source unchanged and `test_live_npm_publish_is_refused` green
- Negative/error-path: missing folder, meeting notes are not used as a substitute, non-string topic is ignored, symlinks skipped
- Founder-content gate: pass
- Not run here: Gemini/Desktop bundle builder (`mcpb` missing on this runner; pre-existing, not this lot)

This runner could not read the private lab spec (`davekilleen/dex-product-gtm-lab` issue 537 or lab PR 532). The work follows the written person-can-do: the connector box tells what was decided lately with no topic.

## Quality Gates
- [x] Isolated branch from 666 head `4e3d053e`
- [x] Lately with no topic did not already exist on the packed 666 box (lot 0 continued)
- [x] Live-publish refusal guard source is unchanged
- [x] Local lot-0 + lately + unpublished tests passed on this runner
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (read-only lately ask on an unpublished box; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `packages/dex-mcp/README.md` and portable plugin copy only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7afcaca-ebef-420c-bbec-9cca3a2bfff6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7afcaca-ebef-420c-bbec-9cca3a2bfff6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

