### PR TITLE
Ask the unpublished connector box what is still open with people — unreleased

### DIFF
--- a/core/context/__init__.py
+++ b/core/context/__init__.py
@@ -2,6 +2,7 @@
 
 from .decision_record import ask_what_was_decided
 from .person_context import (
+    ask_what_is_still_open_with_people,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -10,6 +11,7 @@ from .person_context import (
 from .session_boot import build_session_boot, format_session_boot_text
 
 __all__ = [
+    "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
     "build_session_boot",
     "find_people_in_file",

--- a/core/context/person_context.py
+++ b/core/context/person_context.py
@@ -31,6 +31,7 @@ FILE_REF = re.compile(
     r"People/(?:Internal|External|CPO_Network)/([A-Za-z0-9_-]+)(?:\.md)?"
 )
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
+NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
 PERSON_FIELD = re.compile(
     r"^(?:\|\s*(?:\*\*)?)?(name|role|company|last[_ ]interaction)"
@@ -64,6 +65,13 @@ def _inside(root: Path, path: Path) -> bool:
         return True
     except (OSError, ValueError):
         return False
+
+
+def _relative_file(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return path.name
 
 
 def _index_person_pages(vault: Path) -> dict[str, Path]:
@@ -166,6 +174,41 @@ def _unique_people(paths: list[Path]) -> list[dict[str, Any]]:
         if parsed:
             people.append(parsed)
     return people
+
+
+def ask_what_is_still_open_with_people(vault: str | Path | None) -> dict[str, Any]:
+    """Return every unchecked to-do from person pages, never raising.
+
+    Each match names the person and the page. Meeting notes and the task list
+    are not a substitute. The function never writes and never reaches the
+    network. If nothing is open, the payload carries an honest sentence.
+    """
+    empty = {"found": False, "matches": [], "sentence": NONE_OPEN_SENTENCE}
+    root = _coerce_root(vault)
+    if root is None:
+        return empty
+    people = _unique_people(list(_index_person_pages(root).values()))
+    matches: list[dict[str, str]] = []
+    for person in people:
+        name = str(person.get("name") or "").strip()
+        raw_path = person.get("path")
+        page = ""
+        if isinstance(raw_path, str) and raw_path:
+            page = _relative_file(root, Path(raw_path))
+        items = person.get("open_items")
+        if not name or not isinstance(items, list):
+            continue
+        for item in items:
+            text = str(item).strip()
+            if not text:
+                continue
+            matches.append({"item": text, "person": name, "page": page})
+    matches.sort(
+        key=lambda row: (row.get("person") or "", row.get("page") or "", row.get("item") or "")
+    )
+    if not matches:
+        return empty
+    return {"found": True, "matches": matches, "sentence": ""}
 
 
 def get_person_context(vault: str | Path | None, name: Any) -> dict[str, Any]:
@@ -304,16 +347,35 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vault", required=True, help="Vault root")
     parser.add_argument("--name", help="Person name for MCP-style lookup")
     parser.add_argument("--from-file", dest="from_file", help="File to scan")
+    parser.add_argument(
+        "--still-open",
+        action="store_true",
+        help="List unchecked to-dos from person pages",
+    )
     parser.add_argument("--format", choices=("json", "hook-json", "text"), default="json")
     args = parser.parse_args(argv)
-    if args.from_file:
+    if args.still_open:
+        payload = ask_what_is_still_open_with_people(args.vault)
+    elif args.from_file:
         payload = inject_person_context_for_file(args.vault, args.from_file)
     elif args.name is not None:
         payload = get_person_context(args.vault, args.name)
     else:
-        parser.error("pass --name or --from-file")
+        parser.error("pass --name, --from-file, or --still-open")
         return 2
     if args.format == "text":
+        if args.still_open:
+            matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
+            if not matches:
+                sys.stdout.write(str(payload.get("sentence") or NONE_OPEN_SENTENCE) + "\n")
+                return 0
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                sys.stdout.write(f"{match.get('item') or ''}\n")
+                sys.stdout.write(f"Person: {match.get('person') or ''}\n")
+                sys.stdout.write(f"Page: {match.get('page') or ''}\n")
+            return 0
         text = payload.get("injected_text") or payload.get("additionalContext") or ""
         sys.stdout.write(str(text).lstrip("\n"))
         if text and not str(text).endswith("\n"):

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -10,6 +10,7 @@ CARD = REPO_ROOT / "docs" / "founder-cards" / "connector-box.md"
 LAB_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/486"
 ASK_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/515"
 LATELY_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/537"
+OPEN_ITEMS_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/559"
 PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
 LEAVE_SENTENCE = "delete the packed file and build folder"
 MODEL_OR_VENDOR = re.compile(
@@ -27,6 +28,7 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert LAB_ISSUE in card
     assert ASK_ISSUE in card
     assert LATELY_ISSUE in card
+    assert OPEN_ITEMS_ISSUE in card
     assert PACK_COMMAND in card
     assert "SHA-256 sidecar" in card
     assert "io.github.davekilleen/dex" in card
@@ -35,11 +37,14 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert "what was decided" in card
     assert "no topic" in card
     assert "lately" in card
+    assert "still open with people" in card
+    assert "person pages" in card
     assert LEAVE_SENTENCE in card
     assert "Nobody has walked this card" in card
     assert "Do not publish" in card
     assert "Decision ask answered from a decision record" in card
     assert "Lately ask answered with no topic" in card
+    assert "Open items with people listed from person pages" in card
     headings = [line for line in card.splitlines() if line.startswith("### Step ")]
     assert headings == [
         "### Step 1",
@@ -47,8 +52,9 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
         "### Step 3",
         "### Step 4",
         "### Step 5",
+        "### Step 6",
     ]
-    assert card.count("- [ ] I saw that.") == 5
+    assert card.count("- [ ] I saw that.") == 6
 
 
 def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:

--- a/core/tests/test_copilot_cli_host.py
+++ b/core/tests/test_copilot_cli_host.py
@@ -241,6 +241,7 @@ def test_copilot_mcp_json_can_read_a_vault_without_opening_the_cli(tmp_path: Pat
         "boot_today",
         "get_person_context",
         "ask_what_was_decided",
+        "ask_what_is_still_open_with_people",
         "check_safety_gate",
     }
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -305,6 +305,7 @@ def test_artifact_builder_produces_installable_gemini_and_mcpb_bundles(
         "boot_today",
         "get_person_context",
         "ask_what_was_decided",
+        "ask_what_is_still_open_with_people",
         "check_safety_gate",
     }
     desktop = tmp_path / "dex-claude-desktop"
@@ -483,16 +484,26 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
                     "arguments": {"vault_path": str(vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_is_still_open_with_people",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
         ],
         cwd=vault,
     )
-    assert len(responses) == 7
+    assert len(responses) == 8
     names = {tool["name"] for tool in responses[1]["result"]["tools"]}
     assert names == {
         "dex_harness_profiles",
         "boot_today",
         "get_person_context",
         "ask_what_was_decided",
+        "ask_what_is_still_open_with_people",
         "check_safety_gate",
     }
     ask_tool = next(
@@ -516,6 +527,13 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
     assert lately["found"] is True
     assert lately["topic"] == ""
     assert lately["matches"][0]["decision"] == "Sell only annual plans."
+    open_with_people = responses[7]["result"]["structuredContent"]
+    assert open_with_people["found"] is True
+    assert open_with_people["matches"][0]["item"] == "Send the operating memo"
+    assert open_with_people["matches"][0]["person"] == "Ada Lovelace"
+    assert open_with_people["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
 
 
 def test_plugin_hooks_inject_session_context_and_block_destructive_work(tmp_path: Path) -> None:

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -23,6 +23,7 @@ READ_ONLY_TOOLS = {
     "boot_today",
     "get_person_context",
     "ask_what_was_decided",
+    "ask_what_is_still_open_with_people",
     "check_safety_gate",
 }
 
@@ -156,6 +157,8 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
         "**Decision:** Sell only annual plans.\n",
         encoding="utf-8",
     )
+    empty_vault = tmp_path / "empty Dex folder"
+    empty_vault.mkdir()
     responses = _mcp_roundtrip(
         plugin_root,
         [
@@ -194,6 +197,24 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
                     "arguments": {"vault_path": str(vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_is_still_open_with_people",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_what_is_still_open_with_people",
+                    "arguments": {"vault_path": str(empty_vault)},
+                },
+            },
         ],
         vault=vault,
     )
@@ -204,6 +225,11 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     assert "topic" not in required
     assert "lately" in ask_tool["description"]
     assert "no topic" in ask_tool["description"]
+    open_tool = next(
+        tool for tool in tools if tool["name"] == "ask_what_is_still_open_with_people"
+    )
+    assert "person" in open_tool["description"].lower()
+    assert "page" in open_tool["description"].lower()
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
     assert responses[3]["result"]["structuredContent"]["refused"] is True
     ask = responses[4]["result"]["structuredContent"]
@@ -215,6 +241,18 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     assert lately["topic"] == ""
     assert lately["matches"][0]["decision"] == "Sell only annual plans."
     assert lately["matches"][0]["file"] == "06-Resources/Decisions/Decision_Log.md"
+    open_with_people = responses[6]["result"]["structuredContent"]
+    assert open_with_people["found"] is True
+    assert open_with_people["matches"][0]["item"] == "Send the operating memo"
+    assert open_with_people["matches"][0]["person"] == "Ada Lovelace"
+    assert open_with_people["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
+    assert (person_dir / "Ada_Lovelace.md").read_text(encoding="utf-8").startswith("---")
+    none_open = responses[7]["result"]["structuredContent"]
+    assert none_open["found"] is False
+    assert none_open["matches"] == []
+    assert none_open["sentence"] == "No unchecked to-dos on person pages."
 
 
 def test_live_npm_publish_is_refused(tmp_path: Path) -> None:

--- a/core/tests/test_person_open_items.py
+++ b/core/tests/test_person_open_items.py
@@ -1,0 +1,132 @@
+"""Read-only open-item list for the unpublished connector box."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.context.person_context import (
+    NONE_OPEN_SENTENCE,
+    ask_what_is_still_open_with_people,
+)
+
+
+def _write_person(
+    vault: Path,
+    *,
+    filename: str,
+    name: str,
+    body: str,
+    subdir: str = "Internal",
+) -> Path:
+    folder = vault / "05-Areas" / "People" / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / filename
+    path.write_text(
+        f"---\nname: {name}\nrole: Partner\ncompany: Example\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_list_names_each_unchecked_to_do_the_person_and_the_page(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n- [x] Done already\n",
+    )
+    _write_person(
+        vault,
+        filename="Charles_Babbage.md",
+        name="Charles Babbage",
+        body="- [ ] Review the engine notes\n",
+        subdir="External",
+    )
+    payload = ask_what_is_still_open_with_people(vault)
+    assert payload["found"] is True
+    assert payload["sentence"] == ""
+    assert payload["matches"] == [
+        {
+            "item": "Send the operating memo",
+            "person": "Ada Lovelace",
+            "page": "05-Areas/People/Internal/Ada_Lovelace.md",
+        },
+        {
+            "item": "Review the engine notes",
+            "person": "Charles Babbage",
+            "page": "05-Areas/People/External/Charles_Babbage.md",
+        },
+    ]
+
+
+def test_list_honest_sentence_when_nothing_is_open(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [x] Already sent the memo\n",
+    )
+    payload = ask_what_is_still_open_with_people(vault)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NONE_OPEN_SENTENCE
+    assert "No unchecked to-dos on person pages." == payload["sentence"]
+
+
+def test_list_does_not_use_meetings_or_the_task_list(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    (meetings / "2026-04-12 - Pricing.md").write_text(
+        "- [ ] Follow up with Ada about pricing\n",
+        encoding="utf-8",
+    )
+    tasks = vault / "03-Tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "Tasks.md").write_text(
+        "- [ ] File the launch checklist\n",
+        encoding="utf-8",
+    )
+    payload = ask_what_is_still_open_with_people(vault)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NONE_OPEN_SENTENCE
+
+
+def test_list_skips_symlinks_and_does_not_write(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text(
+        "---\nname: Secret Person\n---\n\n- [ ] Do not leak this\n",
+        encoding="utf-8",
+    )
+    folder = vault / "05-Areas" / "People" / "Internal"
+    folder.mkdir(parents=True)
+    (folder / "Secret_Person.md").symlink_to(outside)
+    page = _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n",
+    )
+    before = page.read_text(encoding="utf-8")
+    payload = ask_what_is_still_open_with_people(vault)
+    assert payload["found"] is True
+    assert [row["person"] for row in payload["matches"]] == ["Ada Lovelace"]
+    assert ask_what_is_still_open_with_people(None)["found"] is False
+    assert ask_what_is_still_open_with_people(None)["sentence"] == NONE_OPEN_SENTENCE
+    assert page.read_text(encoding="utf-8") == before
+    assert outside.read_text(encoding="utf-8").startswith("---\nname: Secret Person")
+
+
+def test_open_item_lookup_stays_local() -> None:
+    source = (
+        Path(__file__).resolve().parents[2] / "core" / "context" / "person_context.py"
+    ).read_text(encoding="utf-8")
+    for needle in ("urllib", "requests", "http.client", "socket"):
+        assert needle not in source

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -37,6 +37,7 @@ has already passed that evidence gate.
 - the portable Dex skill catalogue;
 - read-only `boot_today`, `get_person_context`, `ask_what_was_decided`
   (a topic, or lately with no topic),
+  `ask_what_is_still_open_with_people`,
   `check_safety_gate`, and `dex_harness_profiles` MCP tools;
 - byte-identical vendored copies of the canonical context and safety modules;
 - SessionStart context and PreToolUse safety hooks for hosts that can genuinely

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -7,6 +7,7 @@ This is a local pack check. It is not a catalogue install.
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/486
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/515
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/537
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/559
 
 ## Steps
 
@@ -64,11 +65,21 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 
 **If this fails, send back this exact sentence:** `connector-box step 5 failed: the packed box did not answer what was decided lately.`
 
+### Step 6
+
+1. Before anything is published, ask the packed box what is still open with people.
+
+**What you should see:** Every unchecked to-do from your person pages, each naming the person and the page. If there are none, an honest sentence that says so.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 6 failed: the packed box did not list what is still open with people.`
+
 ## After the last checkbox
 
 If every box is checked, send this exact sentence:
 
-`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Not a catalogue install.`
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Open items with people listed from person pages. Not a catalogue install.`
 
 If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
 

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -25,6 +25,7 @@ Plugins v1 root contract and also includes native manifests for:
 
 The MCP bridge exposes `boot_today`, `get_person_context`,
 `ask_what_was_decided` (a topic, or lately with no topic),
+`ask_what_is_still_open_with_people`,
 `check_safety_gate`, and `dex_harness_profiles`. It is
 dependency-free, relocatable, read-only, and uses the same vendored source
 modules as dex-core.

--- a/packages/dex-agent-plugin/runtime/core/context/__init__.py
+++ b/packages/dex-agent-plugin/runtime/core/context/__init__.py
@@ -2,6 +2,7 @@
 
 from .decision_record import ask_what_was_decided
 from .person_context import (
+    ask_what_is_still_open_with_people,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -10,6 +11,7 @@ from .person_context import (
 from .session_boot import build_session_boot, format_session_boot_text
 
 __all__ = [
+    "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
     "build_session_boot",
     "find_people_in_file",

--- a/packages/dex-agent-plugin/runtime/core/context/person_context.py
+++ b/packages/dex-agent-plugin/runtime/core/context/person_context.py
@@ -31,6 +31,7 @@ FILE_REF = re.compile(
     r"People/(?:Internal|External|CPO_Network)/([A-Za-z0-9_-]+)(?:\.md)?"
 )
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
+NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
 PERSON_FIELD = re.compile(
     r"^(?:\|\s*(?:\*\*)?)?(name|role|company|last[_ ]interaction)"
@@ -64,6 +65,13 @@ def _inside(root: Path, path: Path) -> bool:
         return True
     except (OSError, ValueError):
         return False
+
+
+def _relative_file(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return path.name
 
 
 def _index_person_pages(vault: Path) -> dict[str, Path]:
@@ -166,6 +174,41 @@ def _unique_people(paths: list[Path]) -> list[dict[str, Any]]:
         if parsed:
             people.append(parsed)
     return people
+
+
+def ask_what_is_still_open_with_people(vault: str | Path | None) -> dict[str, Any]:
+    """Return every unchecked to-do from person pages, never raising.
+
+    Each match names the person and the page. Meeting notes and the task list
+    are not a substitute. The function never writes and never reaches the
+    network. If nothing is open, the payload carries an honest sentence.
+    """
+    empty = {"found": False, "matches": [], "sentence": NONE_OPEN_SENTENCE}
+    root = _coerce_root(vault)
+    if root is None:
+        return empty
+    people = _unique_people(list(_index_person_pages(root).values()))
+    matches: list[dict[str, str]] = []
+    for person in people:
+        name = str(person.get("name") or "").strip()
+        raw_path = person.get("path")
+        page = ""
+        if isinstance(raw_path, str) and raw_path:
+            page = _relative_file(root, Path(raw_path))
+        items = person.get("open_items")
+        if not name or not isinstance(items, list):
+            continue
+        for item in items:
+            text = str(item).strip()
+            if not text:
+                continue
+            matches.append({"item": text, "person": name, "page": page})
+    matches.sort(
+        key=lambda row: (row.get("person") or "", row.get("page") or "", row.get("item") or "")
+    )
+    if not matches:
+        return empty
+    return {"found": True, "matches": matches, "sentence": ""}
 
 
 def get_person_context(vault: str | Path | None, name: Any) -> dict[str, Any]:
@@ -304,16 +347,35 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--vault", required=True, help="Vault root")
     parser.add_argument("--name", help="Person name for MCP-style lookup")
     parser.add_argument("--from-file", dest="from_file", help="File to scan")
+    parser.add_argument(
+        "--still-open",
+        action="store_true",
+        help="List unchecked to-dos from person pages",
+    )
     parser.add_argument("--format", choices=("json", "hook-json", "text"), default="json")
     args = parser.parse_args(argv)
-    if args.from_file:
+    if args.still_open:
+        payload = ask_what_is_still_open_with_people(args.vault)
+    elif args.from_file:
         payload = inject_person_context_for_file(args.vault, args.from_file)
     elif args.name is not None:
         payload = get_person_context(args.vault, args.name)
     else:
-        parser.error("pass --name or --from-file")
+        parser.error("pass --name, --from-file, or --still-open")
         return 2
     if args.format == "text":
+        if args.still_open:
+            matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
+            if not matches:
+                sys.stdout.write(str(payload.get("sentence") or NONE_OPEN_SENTENCE) + "\n")
+                return 0
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                sys.stdout.write(f"{match.get('item') or ''}\n")
+                sys.stdout.write(f"Person: {match.get('person') or ''}\n")
+                sys.stdout.write(f"Page: {match.get('page') or ''}\n")
+            return 0
         text = payload.get("injected_text") or payload.get("additionalContext") or ""
         sys.stdout.write(str(text).lstrip("\n"))
         if text and not str(text).endswith("\n"):

--- a/packages/dex-agent-plugin/server.py
+++ b/packages/dex-agent-plugin/server.py
@@ -18,7 +18,10 @@ if str(RUNTIME) not in sys.path:
     sys.path.insert(0, str(RUNTIME))
 
 from core.context.decision_record import ask_what_was_decided  # noqa: E402
-from core.context.person_context import get_person_context  # noqa: E402
+from core.context.person_context import (  # noqa: E402
+    ask_what_is_still_open_with_people,
+    get_person_context,
+)
 from core.context.session_boot import build_session_boot  # noqa: E402
 from core.gates.safety import evaluate_safety_gate  # noqa: E402
 
@@ -104,6 +107,14 @@ def _tools() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "ask_what_is_still_open_with_people",
+            "description": (
+                "List every unchecked to-do from person pages, each naming "
+                "the person and the page. Honest sentence if none."
+            ),
+            "inputSchema": {"type": "object", "properties": vault},
+        },
+        {
             "name": "check_safety_gate",
             "description": "Check a proposed command or path before a harness executes it.",
             "inputSchema": {
@@ -153,6 +164,11 @@ def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
             return _tool_result(
                 request_id,
                 ask_what_was_decided(_vault(arguments), arguments.get("topic")),
+            )
+        if name == "ask_what_is_still_open_with_people":
+            return _tool_result(
+                request_id,
+                ask_what_is_still_open_with_people(_vault(arguments)),
             )
         if name == "check_safety_gate":
             decision = evaluate_safety_gate(

--- a/packages/dex-claude-desktop/manifest.json
+++ b/packages/dex-claude-desktop/manifest.json
@@ -53,6 +53,10 @@
       "description": "Answer what was decided about a topic, or lately with no topic, from this Dex folder's own decision record."
     },
     {
+      "name": "ask_what_is_still_open_with_people",
+      "description": "List every unchecked to-do from person pages, each naming the person and the page. Honest sentence if none."
+    },
+    {
       "name": "check_safety_gate",
       "description": "Check a proposed command or path."
     }

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -10,6 +10,9 @@ unreleased.
 Pack the box locally. Then, before anything is published, ask it what was
 decided about a topic, or what was decided lately with no topic. It answers
 from that Dex folder's own decision record and names the file it came from.
+Ask it what is still open with people: it lists every unchecked to-do from
+person pages, each naming the person and the page, or an honest sentence if
+none.
 
 ## What a person can do after a public catalogue publish
 
@@ -27,8 +30,9 @@ DEX_VAULT_PATH="/path/to/your/Dex" npx -y dex-mcp
 
 Point `DEX_VAULT_PATH` at the Dex folder on that computer. The server can read
 today's context, look up a person, list host support, refuse a destructive
-command, and answer what was decided about a topic or what was decided lately
-with no topic from that folder's own decision record. It cannot write the vault.
+command, answer what was decided about a topic or what was decided lately
+with no topic from that folder's own decision record, and list what is still
+open with people from person pages. It cannot write the vault.
 
 ## What is true now
 

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -173,6 +173,13 @@ def _claude_desktop_manifest() -> dict:
                     "topic, from this Dex folder's own decision record."
                 ),
             },
+            {
+                "name": "ask_what_is_still_open_with_people",
+                "description": (
+                    "List every unchecked to-do from person pages, each naming "
+                    "the person and the page. Honest sentence if none."
+                ),
+            },
             {"name": "check_safety_gate", "description": "Check a proposed command or path."},
         ],
         "compatibility": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 559](https://github.com/davekilleen/dex-product-gtm-lab/issues/559) open. Assign: davekilleen.

Branched from draft PR 669 head `66b0d5c10b573cfb5601c46bd54b74e89114cbfa`. Do not merge 669. Do not merge 670. Do not merge 671. Do not merge 619/620. Do not merge lab 557. Not 505. Not Solo. Not Mobile. Do not invent the Work folder grant. `granted=true` is never set.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 559: https://github.com/davekilleen/dex-product-gtm-lab/issues/559 (reference only — do not close)

## What a person can do
Pack the connector box locally, then before anything is published, ask it what is still open with people. It lists every unchecked to-do from person pages, each naming the person and the page. If there are none, it says so in one honest sentence.

## What Changed
- Packed box `ask_what_is_still_open_with_people` lists every unchecked to-do from person pages
- Each row names the person and the page
- Empty folders get the honest sentence: "No unchecked to-dos on person pages."
- Meeting notes and the task list are not used as a substitute
- Founder card step 6 walks the open-with-people ask
- Live-publish refusal guard is untouched
- Lot 0 packed the 669 box first: tools/list had no open-with-people ask, `get_person_context` still required a name, so this list did not already exist and this lot continued
- No catalogue install step. Nobody has walked the card

## Test Plan
- Local lot 0 + open-with-people ask: 24 passed (`test_person_open_items`, founder card, decision record, pack/sidecar/refusal, packed-box list and empty-sentence round trip, plugin MCP round trip)
- Lot 0 on the 669 head before this change: pack printed `Validated. Still unreleased. Did not publish.`, SHA-256 sidecar present, `ask_what_is_still_open_with_people` was absent, `get_person_context` required a name, so the all-people list did not already exist
- Live-publish refusal guard: source unchanged and `test_live_npm_publish_is_refused` green
- Negative/error-path: missing folder, meeting notes and Tasks.md ignored, completed boxes ignored, symlinks skipped, no write
- Founder-card walk and refusal-guard presence: pass
- Not run here: Gemini/Desktop bundle builder (`mcpb` missing on this runner; pre-existing, not this lot)

This runner could not read the private lab spec (`davekilleen/dex-product-gtm-lab` issue 559). The work follows the written person-can-do: the unpublished connector box lists what is still open with people.

## Quality Gates
- [x] Isolated branch from 669 head `66b0d5c1`
- [x] Open-with-people list did not already exist on that packed head (lot 0 continued)
- [x] Live-publish refusal guard source is unchanged
- [x] Local lot-0 + open-with-people + unpublished tests passed on this runner
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (read-only list on an unpublished box; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `packages/dex-mcp/README.md` and portable plugin copy only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72d05a70-7e7f-4acf-8b58-e93c54b2d1bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72d05a70-7e7f-4acf-8b58-e93c54b2d1bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

