### PR TITLE
Ask the unpublished connector box who is in today's plan — unreleased

### DIFF
--- a/core/context/__init__.py
+++ b/core/context/__init__.py
@@ -3,6 +3,7 @@
 from .decision_record import ask_what_was_decided
 from .person_context import (
     ask_what_is_still_open_with_people,
+    ask_who_is_in_todays_plan,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -13,6 +14,7 @@ from .session_boot import build_session_boot, format_session_boot_text
 __all__ = [
     "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
+    "ask_who_is_in_todays_plan",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/core/context/person_context.py
+++ b/core/context/person_context.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import sys
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +20,7 @@ try:
 except (ImportError, ModuleNotFoundError):  # standalone plugin has no full entity engine
     _canonical_parse_entity_page = None
 
-from core.paths import PEOPLE_DIR, resolve_for_vault
+from core.paths import DAILY_PLANS_DIR, PEOPLE_DIR, resolve_for_vault
 
 PEOPLE_SUBDIRS = ("Internal", "External", "CPO_Network")
 SKIP_EXTS = {
@@ -32,7 +33,9 @@ FILE_REF = re.compile(
 )
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
 NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
+NONE_TODAY_PEOPLE_SENTENCE = "Nobody is named in today's plan."
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
+WIKI_LINK = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
 PERSON_FIELD = re.compile(
     r"^(?:\|\s*(?:\*\*)?)?(name|role|company|last[_ ]interaction)"
     r"(?:\*\*)?\s*(?:\||:)\s*(.*?)(?:\s*\|)?$",
@@ -211,6 +214,153 @@ def ask_what_is_still_open_with_people(vault: str | Path | None) -> dict[str, An
     return {"found": True, "matches": matches, "sentence": ""}
 
 
+def _recorded(value: Any) -> str:
+    """Return a stored field as text, or empty. Never invent a placeholder."""
+    if value is None:
+        return ""
+    text = value.strip() if isinstance(value, str) else str(value).strip()
+    if not text or text.lower() in {"null", "none", "~"}:
+        return ""
+    return text
+
+
+def _today_plan_file(root: Path, today: date | None = None) -> Path | None:
+    try:
+        stamp = (today or date.today()).strftime("%Y-%m-%d")
+    except (AttributeError, OverflowError, ValueError):
+        stamp = date.today().strftime("%Y-%m-%d")
+    path = resolve_for_vault(root, DAILY_PLANS_DIR) / f"{stamp}.md"
+    try:
+        if path.is_symlink() or not path.is_file() or not _inside(root, path):
+            return None
+    except OSError:
+        return None
+    return path
+
+
+def _wiki_lookup_keys(raw: str) -> list[str]:
+    target = raw.strip()
+    stem = Path(target.replace("\\", "/")).name
+    if stem.lower().endswith(".md"):
+        stem = stem[:-3]
+    folded = stem.lower()
+    spaced = stem.replace("_", " ").lower()
+    keys = [folded]
+    if spaced != folded:
+        keys.append(spaced)
+    return keys
+
+
+def _unique_index_paths(index: dict[str, Path]) -> list[Path]:
+    seen: set[str] = set()
+    paths: list[Path] = []
+    for path in index.values():
+        try:
+            ident = str(path.resolve())
+        except OSError:
+            ident = str(path)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        paths.append(path)
+    return paths
+
+
+def _people_named_in_plan(content: str, index: dict[str, Path]) -> list[Path]:
+    """Person pages named in the plan, first mention first. Never guessed."""
+    content_lower = content.lower()
+    hits: list[tuple[int, Path]] = []
+    for match in WIKI_LINK.finditer(content):
+        for key in _wiki_lookup_keys(match.group(1)):
+            if key in index:
+                hits.append((match.start(), index[key]))
+                break
+    for match in FILE_REF.finditer(content):
+        key = match.group(1).lower()
+        if key in index:
+            hits.append((match.start(), index[key]))
+    for path in _unique_index_paths(index):
+        needle = path.stem.replace("_", " ").lower()
+        if " " not in needle:
+            continue
+        pos = content_lower.find(needle)
+        if pos >= 0:
+            hits.append((pos, path))
+    hits.sort(key=lambda item: item[0])
+    ordered: list[Path] = []
+    seen: set[str] = set()
+    for _offset, path in hits:
+        try:
+            ident = str(path.resolve())
+        except OSError:
+            ident = str(path)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        ordered.append(path)
+    return ordered
+
+
+def _today_people_row(root: Path, path: Path) -> dict[str, Any]:
+    parsed = _parse_person_page(path)
+    page = _relative_file(root, path)
+    if not parsed:
+        return {
+            "person": path.stem.replace("_", " "),
+            "role": "",
+            "company": "",
+            "last_interaction": "",
+            "open_items": [],
+            "page": page,
+        }
+    raw_items = parsed.get("open_items")
+    open_items: list[str] = []
+    if isinstance(raw_items, list):
+        for item in raw_items:
+            text = str(item).strip()
+            if text:
+                open_items.append(text)
+    return {
+        "person": _recorded(parsed.get("name")) or path.stem.replace("_", " "),
+        "role": _recorded(parsed.get("role")),
+        "company": _recorded(parsed.get("company")),
+        "last_interaction": _recorded(parsed.get("last_interaction")),
+        "open_items": open_items,
+        "page": page,
+    }
+
+
+def ask_who_is_in_todays_plan(
+    vault: str | Path | None,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """Return each named person in today's plan, never raising.
+
+    Each row carries recorded role, company, last interaction, every open
+    item, and the person page, in plan order. Missing fields stay empty.
+    Meeting notes and the task list are not a substitute. The function
+    never writes and never reaches the network.
+    """
+    empty = {"found": False, "matches": [], "sentence": NONE_TODAY_PEOPLE_SENTENCE}
+    root = _coerce_root(vault)
+    if root is None:
+        return empty
+    plan = _today_plan_file(root, today)
+    if plan is None:
+        return empty
+    try:
+        content = plan.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return empty
+    index = _index_person_pages(root)
+    if not index:
+        return empty
+    matches = [_today_people_row(root, path) for path in _people_named_in_plan(content, index)]
+    if not matches:
+        return empty
+    return {"found": True, "matches": matches, "sentence": ""}
+
+
 def get_person_context(vault: str | Path | None, name: Any) -> dict[str, Any]:
     """Return the context payload for one person, never raising on bad input."""
     root = _coerce_root(vault)
@@ -352,18 +502,45 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="List unchecked to-dos from person pages",
     )
+    parser.add_argument(
+        "--todays-plan",
+        action="store_true",
+        help="List people named in today's plan",
+    )
     parser.add_argument("--format", choices=("json", "hook-json", "text"), default="json")
     args = parser.parse_args(argv)
-    if args.still_open:
+    if args.todays_plan:
+        payload = ask_who_is_in_todays_plan(args.vault)
+    elif args.still_open:
         payload = ask_what_is_still_open_with_people(args.vault)
     elif args.from_file:
         payload = inject_person_context_for_file(args.vault, args.from_file)
     elif args.name is not None:
         payload = get_person_context(args.vault, args.name)
     else:
-        parser.error("pass --name, --from-file, or --still-open")
+        parser.error("pass --name, --from-file, --still-open, or --todays-plan")
         return 2
     if args.format == "text":
+        if args.todays_plan:
+            matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
+            if not matches:
+                sys.stdout.write(str(payload.get("sentence") or NONE_TODAY_PEOPLE_SENTENCE) + "\n")
+                return 0
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                sys.stdout.write(f"{match.get('person') or ''}\n")
+                sys.stdout.write(f"Role: {match.get('role') or ''}\n")
+                sys.stdout.write(f"Company: {match.get('company') or ''}\n")
+                sys.stdout.write(f"Last interaction: {match.get('last_interaction') or ''}\n")
+                items = match.get("open_items")
+                if isinstance(items, list) and items:
+                    for item in items:
+                        sys.stdout.write(f"Open item: {item}\n")
+                else:
+                    sys.stdout.write("Open item: \n")
+                sys.stdout.write(f"Page: {match.get('page') or ''}\n")
+            return 0
         if args.still_open:
             matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
             if not matches:

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -11,6 +11,7 @@ LAB_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/486"
 ASK_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/515"
 LATELY_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/537"
 OPEN_ITEMS_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/559"
+TODAY_PEOPLE_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/571"
 PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
 LEAVE_SENTENCE = "delete the packed file and build folder"
 MODEL_OR_VENDOR = re.compile(
@@ -29,6 +30,7 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert ASK_ISSUE in card
     assert LATELY_ISSUE in card
     assert OPEN_ITEMS_ISSUE in card
+    assert TODAY_PEOPLE_ISSUE in card
     assert PACK_COMMAND in card
     assert "SHA-256 sidecar" in card
     assert "io.github.davekilleen/dex" in card
@@ -39,12 +41,16 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert "lately" in card
     assert "still open with people" in card
     assert "person pages" in card
+    assert "who is in today's plan" in card
+    assert "plan order" in card
+    assert "never guessed" in card
     assert LEAVE_SENTENCE in card
     assert "Nobody has walked this card" in card
     assert "Do not publish" in card
     assert "Decision ask answered from a decision record" in card
     assert "Lately ask answered with no topic" in card
     assert "Open items with people listed from person pages" in card
+    assert "People in today's plan listed from the plan and person pages" in card
     headings = [line for line in card.splitlines() if line.startswith("### Step ")]
     assert headings == [
         "### Step 1",
@@ -53,8 +59,9 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
         "### Step 4",
         "### Step 5",
         "### Step 6",
+        "### Step 7",
     ]
-    assert card.count("- [ ] I saw that.") == 6
+    assert card.count("- [ ] I saw that.") == 7
 
 
 def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:

--- a/core/tests/test_copilot_cli_host.py
+++ b/core/tests/test_copilot_cli_host.py
@@ -242,6 +242,7 @@ def test_copilot_mcp_json_can_read_a_vault_without_opening_the_cli(tmp_path: Pat
         "get_person_context",
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
+        "ask_who_is_in_todays_plan",
         "check_safety_gate",
     }
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+from datetime import date
 from pathlib import Path
 
 import jsonschema
@@ -306,6 +307,7 @@ def test_artifact_builder_produces_installable_gemini_and_mcpb_bundles(
         "get_person_context",
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
+        "ask_who_is_in_todays_plan",
         "check_safety_gate",
     }
     desktop = tmp_path / "dex-claude-desktop"
@@ -431,6 +433,12 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n---\n- [ ] Send the operating memo\n",
         encoding="utf-8",
     )
+    plans = vault / "00-Inbox" / "Daily_Plans"
+    plans.mkdir(parents=True)
+    (plans / f"{date.today().strftime('%Y-%m-%d')}.md").write_text(
+        "# Daily Plan\n\n**Attendees:** Ada Lovelace\n",
+        encoding="utf-8",
+    )
     decisions = vault / "06-Resources" / "Decisions"
     decisions.mkdir(parents=True)
     (decisions / "Decision_Log.md").write_text(
@@ -493,10 +501,19 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
                     "arguments": {"vault_path": str(vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_who_is_in_todays_plan",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
         ],
         cwd=vault,
     )
-    assert len(responses) == 8
+    assert len(responses) == 9
     names = {tool["name"] for tool in responses[1]["result"]["tools"]}
     assert names == {
         "dex_harness_profiles",
@@ -504,6 +521,7 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "get_person_context",
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
+        "ask_who_is_in_todays_plan",
         "check_safety_gate",
     }
     ask_tool = next(
@@ -532,6 +550,12 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
     assert open_with_people["matches"][0]["item"] == "Send the operating memo"
     assert open_with_people["matches"][0]["person"] == "Ada Lovelace"
     assert open_with_people["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
+    today_people = responses[8]["result"]["structuredContent"]
+    assert today_people["found"] is True
+    assert today_people["matches"][0]["person"] == "Ada Lovelace"
+    assert today_people["matches"][0]["page"] == (
         "05-Areas/People/Internal/Ada_Lovelace.md"
     )
 

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tarfile
+from datetime import date
 from pathlib import Path
 
 import jsonschema
@@ -24,6 +25,7 @@ READ_ONLY_TOOLS = {
     "get_person_context",
     "ask_what_was_decided",
     "ask_what_is_still_open_with_people",
+    "ask_who_is_in_todays_plan",
     "check_safety_gate",
 }
 
@@ -147,7 +149,14 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     person_dir = vault / "05-Areas" / "People" / "Internal"
     person_dir.mkdir(parents=True)
     (person_dir / "Ada_Lovelace.md").write_text(
-        "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n---\n- [ ] Send the operating memo\n",
+        "---\nname: Ada Lovelace\nrole: Founder\ncompany: Analytical Engines\n"
+        "last_interaction: 2026-04-12\n---\n- [ ] Send the operating memo\n",
+        encoding="utf-8",
+    )
+    plans = vault / "00-Inbox" / "Daily_Plans"
+    plans.mkdir(parents=True)
+    (plans / f"{date.today().strftime('%Y-%m-%d')}.md").write_text(
+        "# Daily Plan\n\n**Attendees:** Ada Lovelace\n",
         encoding="utf-8",
     )
     decisions = vault / "06-Resources" / "Decisions"
@@ -215,6 +224,24 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
                     "arguments": {"vault_path": str(empty_vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_who_is_in_todays_plan",
+                    "arguments": {"vault_path": str(vault)},
+                },
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_who_is_in_todays_plan",
+                    "arguments": {"vault_path": str(empty_vault)},
+                },
+            },
         ],
         vault=vault,
     )
@@ -230,6 +257,11 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     )
     assert "person" in open_tool["description"].lower()
     assert "page" in open_tool["description"].lower()
+    today_tool = next(tool for tool in tools if tool["name"] == "ask_who_is_in_todays_plan")
+    assert "today" in today_tool["description"].lower()
+    assert "plan order" in today_tool["description"]
+    required_today = (today_tool.get("inputSchema") or {}).get("required") or []
+    assert "name" not in required_today
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"
     assert responses[3]["result"]["structuredContent"]["refused"] is True
     ask = responses[4]["result"]["structuredContent"]
@@ -253,6 +285,20 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     assert none_open["found"] is False
     assert none_open["matches"] == []
     assert none_open["sentence"] == "No unchecked to-dos on person pages."
+    today_people = responses[8]["result"]["structuredContent"]
+    assert today_people["found"] is True
+    assert today_people["matches"][0]["person"] == "Ada Lovelace"
+    assert today_people["matches"][0]["role"] == "Founder"
+    assert today_people["matches"][0]["company"] == "Analytical Engines"
+    assert today_people["matches"][0]["last_interaction"] == "2026-04-12"
+    assert today_people["matches"][0]["open_items"] == ["Send the operating memo"]
+    assert today_people["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
+    none_today = responses[9]["result"]["structuredContent"]
+    assert none_today["found"] is False
+    assert none_today["matches"] == []
+    assert none_today["sentence"] == "Nobody is named in today's plan."
 
 
 def test_live_npm_publish_is_refused(tmp_path: Path) -> None:

--- a/core/tests/test_today_plan_people.py
+++ b/core/tests/test_today_plan_people.py
@@ -1,0 +1,218 @@
+"""Read-only today's-plan people list for the unpublished connector box."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from core.context.person_context import (
+    NONE_TODAY_PEOPLE_SENTENCE,
+    ask_who_is_in_todays_plan,
+)
+
+TODAY = date(2026, 8, 30)
+
+
+def _write_person(
+    vault: Path,
+    *,
+    filename: str,
+    name: str,
+    body: str = "",
+    role: str | None = "Partner",
+    company: str | None = "Example",
+    last_interaction: str | None = "2026-04-12",
+    subdir: str = "Internal",
+) -> Path:
+    folder = vault / "05-Areas" / "People" / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / filename
+    lines = [f"name: {name}"]
+    if role is not None:
+        lines.append(f"role: {role}")
+    if company is not None:
+        lines.append(f"company: {company}")
+    if last_interaction is not None:
+        lines.append(f"last_interaction: {last_interaction}")
+    front = "---\n" + "\n".join(lines) + "\n---\n"
+    path.write_text(f"{front}\n{body}\n", encoding="utf-8")
+    return path
+
+
+def _write_plan(vault: Path, body: str, day: date = TODAY) -> Path:
+    folder = vault / "00-Inbox" / "Daily_Plans"
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / f"{day.strftime('%Y-%m-%d')}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_list_names_each_person_in_plan_order_with_recorded_fields(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        role="Founder",
+        company="Analytical Engines",
+        last_interaction="2026-04-12",
+        body="- [ ] Send the operating memo\n- [x] Done already\n",
+    )
+    _write_person(
+        vault,
+        filename="Charles_Babbage.md",
+        name="Charles Babbage",
+        role="Engineer",
+        company="Difference Co",
+        last_interaction="2026-04-01",
+        body="- [ ] Review the engine notes\n- [ ] File the drawings\n",
+        subdir="External",
+    )
+    _write_plan(
+        vault,
+        "# Daily Plan\n\n**Attendees:** Charles Babbage, Ada Lovelace\n",
+    )
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    assert payload["found"] is True
+    assert payload["sentence"] == ""
+    assert payload["matches"] == [
+        {
+            "person": "Charles Babbage",
+            "role": "Engineer",
+            "company": "Difference Co",
+            "last_interaction": "2026-04-01",
+            "open_items": ["Review the engine notes", "File the drawings"],
+            "page": "05-Areas/People/External/Charles_Babbage.md",
+        },
+        {
+            "person": "Ada Lovelace",
+            "role": "Founder",
+            "company": "Analytical Engines",
+            "last_interaction": "2026-04-12",
+            "open_items": ["Send the operating memo"],
+            "page": "05-Areas/People/Internal/Ada_Lovelace.md",
+        },
+    ]
+
+
+def test_missing_fields_stay_empty_and_are_never_guessed(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        role=None,
+        company=None,
+        last_interaction=None,
+        body="- [x] Already sent the memo\n",
+    )
+    _write_plan(vault, "# Daily Plan\n\nPrep with [[Ada Lovelace]] before noon.\n")
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    row = payload["matches"][0]
+    assert payload["found"] is True
+    assert row["person"] == "Ada Lovelace"
+    assert row["role"] == ""
+    assert row["company"] == ""
+    assert row["last_interaction"] == ""
+    assert row["open_items"] == []
+    assert row["page"] == "05-Areas/People/Internal/Ada_Lovelace.md"
+    blob = str(payload)
+    assert "Unknown" not in blob
+    assert "No role" not in blob
+
+
+def test_honest_sentence_when_nobody_is_named(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n",
+    )
+    _write_plan(vault, "# Daily Plan\n\nFocus on the operating memo.\n")
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NONE_TODAY_PEOPLE_SENTENCE
+    assert payload["sentence"] == "Nobody is named in today's plan."
+
+
+def test_list_does_not_use_meetings_tasks_or_yesterday(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n",
+    )
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    (meetings / "2026-08-30 - Pricing.md").write_text(
+        "**Attendees:** Ada Lovelace\n",
+        encoding="utf-8",
+    )
+    tasks = vault / "03-Tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "Tasks.md").write_text(
+        "- [ ] Follow up with Ada Lovelace\n",
+        encoding="utf-8",
+    )
+    _write_plan(
+        vault,
+        "# Daily Plan\n\n**Attendees:** Ada Lovelace\n",
+        day=date(2026, 8, 29),
+    )
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NONE_TODAY_PEOPLE_SENTENCE
+
+
+def test_list_skips_symlinks_and_does_not_write(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    outside_person = tmp_path / "outside-person.md"
+    outside_person.write_text(
+        "---\nname: Secret Person\nrole: Hidden\n---\n",
+        encoding="utf-8",
+    )
+    folder = vault / "05-Areas" / "People" / "Internal"
+    folder.mkdir(parents=True)
+    (folder / "Secret_Person.md").symlink_to(outside_person)
+    page = _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n",
+    )
+    outside_plan = tmp_path / "outside-plan.md"
+    outside_plan.write_text("**Attendees:** Ada Lovelace\n", encoding="utf-8")
+    plans = vault / "00-Inbox" / "Daily_Plans"
+    plans.mkdir(parents=True)
+    (plans / f"{TODAY.strftime('%Y-%m-%d')}.md").symlink_to(outside_plan)
+    before = page.read_text(encoding="utf-8")
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    assert payload["found"] is False
+    assert payload["sentence"] == NONE_TODAY_PEOPLE_SENTENCE
+    (plans / f"{TODAY.strftime('%Y-%m-%d')}.md").unlink()
+    real_plan = _write_plan(vault, "**Attendees:** Ada Lovelace, Secret Person\n")
+    payload = ask_who_is_in_todays_plan(vault, today=TODAY)
+    assert payload["found"] is True
+    assert [row["person"] for row in payload["matches"]] == ["Ada Lovelace"]
+    assert ask_who_is_in_todays_plan(None)["found"] is False
+    assert ask_who_is_in_todays_plan(None)["sentence"] == NONE_TODAY_PEOPLE_SENTENCE
+    assert page.read_text(encoding="utf-8") == before
+    assert real_plan.read_text(encoding="utf-8").startswith("**Attendees:**")
+    assert outside_person.read_text(encoding="utf-8").startswith("---\nname: Secret Person")
+
+
+def test_today_people_lookup_stays_local() -> None:
+    source = (
+        Path(__file__).resolve().parents[2] / "core" / "context" / "person_context.py"
+    ).read_text(encoding="utf-8")
+    for needle in ("urllib", "requests", "http.client", "socket"):
+        assert needle not in source

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -38,6 +38,7 @@ has already passed that evidence gate.
 - read-only `boot_today`, `get_person_context`, `ask_what_was_decided`
   (a topic, or lately with no topic),
   `ask_what_is_still_open_with_people`,
+  `ask_who_is_in_todays_plan`,
   `check_safety_gate`, and `dex_harness_profiles` MCP tools;
 - byte-identical vendored copies of the canonical context and safety modules;
 - SessionStart context and PreToolUse safety hooks for hosts that can genuinely

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -8,6 +8,7 @@ This is a local pack check. It is not a catalogue install.
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/515
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/537
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/559
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/571
 
 ## Steps
 
@@ -75,11 +76,21 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 
 **If this fails, send back this exact sentence:** `connector-box step 6 failed: the packed box did not list what is still open with people.`
 
+### Step 7
+
+1. Before anything is published, ask the packed box who is in today's plan.
+
+**What you should see:** Each named person's recorded role, company, last interaction, and every open item, each naming the person page, in plan order. Missing fields empty, never guessed.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 7 failed: the packed box did not list who is in today's plan.`
+
 ## After the last checkbox
 
 If every box is checked, send this exact sentence:
 
-`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Open items with people listed from person pages. Not a catalogue install.`
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Open items with people listed from person pages. People in today's plan listed from the plan and person pages. Not a catalogue install.`
 
 If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
 

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -26,6 +26,7 @@ Plugins v1 root contract and also includes native manifests for:
 The MCP bridge exposes `boot_today`, `get_person_context`,
 `ask_what_was_decided` (a topic, or lately with no topic),
 `ask_what_is_still_open_with_people`,
+`ask_who_is_in_todays_plan`,
 `check_safety_gate`, and `dex_harness_profiles`. It is
 dependency-free, relocatable, read-only, and uses the same vendored source
 modules as dex-core.

--- a/packages/dex-agent-plugin/runtime/core/context/__init__.py
+++ b/packages/dex-agent-plugin/runtime/core/context/__init__.py
@@ -3,6 +3,7 @@
 from .decision_record import ask_what_was_decided
 from .person_context import (
     ask_what_is_still_open_with_people,
+    ask_who_is_in_todays_plan,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -13,6 +14,7 @@ from .session_boot import build_session_boot, format_session_boot_text
 __all__ = [
     "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
+    "ask_who_is_in_todays_plan",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/packages/dex-agent-plugin/runtime/core/context/person_context.py
+++ b/packages/dex-agent-plugin/runtime/core/context/person_context.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import sys
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +20,7 @@ try:
 except (ImportError, ModuleNotFoundError):  # standalone plugin has no full entity engine
     _canonical_parse_entity_page = None
 
-from core.paths import PEOPLE_DIR, resolve_for_vault
+from core.paths import DAILY_PLANS_DIR, PEOPLE_DIR, resolve_for_vault
 
 PEOPLE_SUBDIRS = ("Internal", "External", "CPO_Network")
 SKIP_EXTS = {
@@ -32,7 +33,9 @@ FILE_REF = re.compile(
 )
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
 NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
+NONE_TODAY_PEOPLE_SENTENCE = "Nobody is named in today's plan."
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
+WIKI_LINK = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
 PERSON_FIELD = re.compile(
     r"^(?:\|\s*(?:\*\*)?)?(name|role|company|last[_ ]interaction)"
     r"(?:\*\*)?\s*(?:\||:)\s*(.*?)(?:\s*\|)?$",
@@ -211,6 +214,153 @@ def ask_what_is_still_open_with_people(vault: str | Path | None) -> dict[str, An
     return {"found": True, "matches": matches, "sentence": ""}
 
 
+def _recorded(value: Any) -> str:
+    """Return a stored field as text, or empty. Never invent a placeholder."""
+    if value is None:
+        return ""
+    text = value.strip() if isinstance(value, str) else str(value).strip()
+    if not text or text.lower() in {"null", "none", "~"}:
+        return ""
+    return text
+
+
+def _today_plan_file(root: Path, today: date | None = None) -> Path | None:
+    try:
+        stamp = (today or date.today()).strftime("%Y-%m-%d")
+    except (AttributeError, OverflowError, ValueError):
+        stamp = date.today().strftime("%Y-%m-%d")
+    path = resolve_for_vault(root, DAILY_PLANS_DIR) / f"{stamp}.md"
+    try:
+        if path.is_symlink() or not path.is_file() or not _inside(root, path):
+            return None
+    except OSError:
+        return None
+    return path
+
+
+def _wiki_lookup_keys(raw: str) -> list[str]:
+    target = raw.strip()
+    stem = Path(target.replace("\\", "/")).name
+    if stem.lower().endswith(".md"):
+        stem = stem[:-3]
+    folded = stem.lower()
+    spaced = stem.replace("_", " ").lower()
+    keys = [folded]
+    if spaced != folded:
+        keys.append(spaced)
+    return keys
+
+
+def _unique_index_paths(index: dict[str, Path]) -> list[Path]:
+    seen: set[str] = set()
+    paths: list[Path] = []
+    for path in index.values():
+        try:
+            ident = str(path.resolve())
+        except OSError:
+            ident = str(path)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        paths.append(path)
+    return paths
+
+
+def _people_named_in_plan(content: str, index: dict[str, Path]) -> list[Path]:
+    """Person pages named in the plan, first mention first. Never guessed."""
+    content_lower = content.lower()
+    hits: list[tuple[int, Path]] = []
+    for match in WIKI_LINK.finditer(content):
+        for key in _wiki_lookup_keys(match.group(1)):
+            if key in index:
+                hits.append((match.start(), index[key]))
+                break
+    for match in FILE_REF.finditer(content):
+        key = match.group(1).lower()
+        if key in index:
+            hits.append((match.start(), index[key]))
+    for path in _unique_index_paths(index):
+        needle = path.stem.replace("_", " ").lower()
+        if " " not in needle:
+            continue
+        pos = content_lower.find(needle)
+        if pos >= 0:
+            hits.append((pos, path))
+    hits.sort(key=lambda item: item[0])
+    ordered: list[Path] = []
+    seen: set[str] = set()
+    for _offset, path in hits:
+        try:
+            ident = str(path.resolve())
+        except OSError:
+            ident = str(path)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        ordered.append(path)
+    return ordered
+
+
+def _today_people_row(root: Path, path: Path) -> dict[str, Any]:
+    parsed = _parse_person_page(path)
+    page = _relative_file(root, path)
+    if not parsed:
+        return {
+            "person": path.stem.replace("_", " "),
+            "role": "",
+            "company": "",
+            "last_interaction": "",
+            "open_items": [],
+            "page": page,
+        }
+    raw_items = parsed.get("open_items")
+    open_items: list[str] = []
+    if isinstance(raw_items, list):
+        for item in raw_items:
+            text = str(item).strip()
+            if text:
+                open_items.append(text)
+    return {
+        "person": _recorded(parsed.get("name")) or path.stem.replace("_", " "),
+        "role": _recorded(parsed.get("role")),
+        "company": _recorded(parsed.get("company")),
+        "last_interaction": _recorded(parsed.get("last_interaction")),
+        "open_items": open_items,
+        "page": page,
+    }
+
+
+def ask_who_is_in_todays_plan(
+    vault: str | Path | None,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """Return each named person in today's plan, never raising.
+
+    Each row carries recorded role, company, last interaction, every open
+    item, and the person page, in plan order. Missing fields stay empty.
+    Meeting notes and the task list are not a substitute. The function
+    never writes and never reaches the network.
+    """
+    empty = {"found": False, "matches": [], "sentence": NONE_TODAY_PEOPLE_SENTENCE}
+    root = _coerce_root(vault)
+    if root is None:
+        return empty
+    plan = _today_plan_file(root, today)
+    if plan is None:
+        return empty
+    try:
+        content = plan.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return empty
+    index = _index_person_pages(root)
+    if not index:
+        return empty
+    matches = [_today_people_row(root, path) for path in _people_named_in_plan(content, index)]
+    if not matches:
+        return empty
+    return {"found": True, "matches": matches, "sentence": ""}
+
+
 def get_person_context(vault: str | Path | None, name: Any) -> dict[str, Any]:
     """Return the context payload for one person, never raising on bad input."""
     root = _coerce_root(vault)
@@ -352,18 +502,45 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="List unchecked to-dos from person pages",
     )
+    parser.add_argument(
+        "--todays-plan",
+        action="store_true",
+        help="List people named in today's plan",
+    )
     parser.add_argument("--format", choices=("json", "hook-json", "text"), default="json")
     args = parser.parse_args(argv)
-    if args.still_open:
+    if args.todays_plan:
+        payload = ask_who_is_in_todays_plan(args.vault)
+    elif args.still_open:
         payload = ask_what_is_still_open_with_people(args.vault)
     elif args.from_file:
         payload = inject_person_context_for_file(args.vault, args.from_file)
     elif args.name is not None:
         payload = get_person_context(args.vault, args.name)
     else:
-        parser.error("pass --name, --from-file, or --still-open")
+        parser.error("pass --name, --from-file, --still-open, or --todays-plan")
         return 2
     if args.format == "text":
+        if args.todays_plan:
+            matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
+            if not matches:
+                sys.stdout.write(str(payload.get("sentence") or NONE_TODAY_PEOPLE_SENTENCE) + "\n")
+                return 0
+            for match in matches:
+                if not isinstance(match, dict):
+                    continue
+                sys.stdout.write(f"{match.get('person') or ''}\n")
+                sys.stdout.write(f"Role: {match.get('role') or ''}\n")
+                sys.stdout.write(f"Company: {match.get('company') or ''}\n")
+                sys.stdout.write(f"Last interaction: {match.get('last_interaction') or ''}\n")
+                items = match.get("open_items")
+                if isinstance(items, list) and items:
+                    for item in items:
+                        sys.stdout.write(f"Open item: {item}\n")
+                else:
+                    sys.stdout.write("Open item: \n")
+                sys.stdout.write(f"Page: {match.get('page') or ''}\n")
+            return 0
         if args.still_open:
             matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
             if not matches:

--- a/packages/dex-agent-plugin/server.py
+++ b/packages/dex-agent-plugin/server.py
@@ -20,6 +20,7 @@ if str(RUNTIME) not in sys.path:
 from core.context.decision_record import ask_what_was_decided  # noqa: E402
 from core.context.person_context import (  # noqa: E402
     ask_what_is_still_open_with_people,
+    ask_who_is_in_todays_plan,
     get_person_context,
 )
 from core.context.session_boot import build_session_boot  # noqa: E402
@@ -115,6 +116,16 @@ def _tools() -> list[dict[str, Any]]:
             "inputSchema": {"type": "object", "properties": vault},
         },
         {
+            "name": "ask_who_is_in_todays_plan",
+            "description": (
+                "Answer who is in today's plan: each named person's recorded "
+                "role, company, last interaction, and every open item, each "
+                "row naming the person page, in plan order. Missing field "
+                "empty, never guessed."
+            ),
+            "inputSchema": {"type": "object", "properties": vault},
+        },
+        {
             "name": "check_safety_gate",
             "description": "Check a proposed command or path before a harness executes it.",
             "inputSchema": {
@@ -169,6 +180,11 @@ def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
             return _tool_result(
                 request_id,
                 ask_what_is_still_open_with_people(_vault(arguments)),
+            )
+        if name == "ask_who_is_in_todays_plan":
+            return _tool_result(
+                request_id,
+                ask_who_is_in_todays_plan(_vault(arguments)),
             )
         if name == "check_safety_gate":
             decision = evaluate_safety_gate(

--- a/packages/dex-claude-desktop/manifest.json
+++ b/packages/dex-claude-desktop/manifest.json
@@ -57,6 +57,10 @@
       "description": "List every unchecked to-do from person pages, each naming the person and the page. Honest sentence if none."
     },
     {
+      "name": "ask_who_is_in_todays_plan",
+      "description": "Answer who is in today's plan: each named person's recorded role, company, last interaction, and every open item, each row naming the person page, in plan order. Missing field empty, never guessed."
+    },
+    {
       "name": "check_safety_gate",
       "description": "Check a proposed command or path."
     }

--- a/packages/dex-mcp/README.md
+++ b/packages/dex-mcp/README.md
@@ -12,7 +12,9 @@ decided about a topic, or what was decided lately with no topic. It answers
 from that Dex folder's own decision record and names the file it came from.
 Ask it what is still open with people: it lists every unchecked to-do from
 person pages, each naming the person and the page, or an honest sentence if
-none.
+none. Ask it who is in today's plan: it answers with each named person's
+recorded role, company, last interaction, and every open item, each row
+naming the person page, in plan order. Missing fields stay empty.
 
 ## What a person can do after a public catalogue publish
 
@@ -31,8 +33,9 @@ DEX_VAULT_PATH="/path/to/your/Dex" npx -y dex-mcp
 Point `DEX_VAULT_PATH` at the Dex folder on that computer. The server can read
 today's context, look up a person, list host support, refuse a destructive
 command, answer what was decided about a topic or what was decided lately
-with no topic from that folder's own decision record, and list what is still
-open with people from person pages. It cannot write the vault.
+with no topic from that folder's own decision record, list what is still
+open with people from person pages, and say who is in today's plan from the
+plan and person pages. It cannot write the vault.
 
 ## What is true now
 

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -180,6 +180,15 @@ def _claude_desktop_manifest() -> dict:
                     "the person and the page. Honest sentence if none."
                 ),
             },
+            {
+                "name": "ask_who_is_in_todays_plan",
+                "description": (
+                    "Answer who is in today's plan: each named person's "
+                    "recorded role, company, last interaction, and every "
+                    "open item, each row naming the person page, in plan "
+                    "order. Missing field empty, never guessed."
+                ),
+            },
             {"name": "check_safety_gate", "description": "Check a proposed command or path."},
         ],
         "compatibility": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 571](https://github.com/davekilleen/dex-product-gtm-lab/issues/571) open. Assign: davekilleen.

Branched from draft PR 674 head `1f5cf26086611f6ef3808430bf07e102427131ad`. Do not merge 674. Do not merge 672. Do not merge 673. Do not merge 669. Do not merge 670. Do not merge 671. Do not merge 619/620. Do not merge lab 569. Not 505. Not Solo. Not Mobile. Do not invent the Work folder grant. `granted=true` is never set.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 571: https://github.com/davekilleen/dex-product-gtm-lab/issues/571 (reference only — do not close)

## What a person can do
Pack the connector box locally, then before anything is published, ask it who is in today's plan. It answers with each named person's recorded role, company, last interaction, and every open item, each row naming the person page, in plan order. Missing fields stay empty, never guessed.

## What Changed
- Packed box `ask_who_is_in_todays_plan` lists each named person from today's plan
- Each row carries recorded role, company, last interaction, every open item, and the person page
- Rows stay in plan order
- Missing fields are empty. Placeholders such as "Unknown" or "No role" are not used
- Meeting notes, the task list, and yesterday's plan are not used as a substitute
- Founder card step 7 walks the today's-plan people ask
- Live-publish refusal guard is untouched
- Lot 0 packed the 674 box first: tools/list had no today's-plan people ask, `get_person_context` still required a name, so this list did not already exist and this lot continued
- No catalogue install step. Nobody has walked the card

## Test Plan
- Local lot 0 on the 674 head before this change: pack printed `Validated. Still unreleased. Did not publish.`, SHA-256 sidecar present, `ask_who_is_in_todays_plan` was absent, `get_person_context` required a name, so the today's-plan people list did not already exist
- Local lot 0 + today's-plan people ask: 35 passed (`test_today_plan_people`, founder card, open items, pack/sidecar/refusal, packed-box list and empty-sentence round trip, plugin MCP round trip)
- Live-publish refusal guard: source unchanged vs `1f5cf260` and `test_live_npm_publish_is_refused` green
- Negative/error-path: missing plan, meeting notes, Tasks.md, and yesterday ignored; completed boxes ignored; symlinks skipped; missing fields empty; no write
- Founder-card walk and refusal-guard presence: pass
- PII and founder-content gates: pass
- Not run here: Gemini/Desktop bundle builder (`mcpb` missing on this runner; pre-existing, not this lot)

This runner could not read the private lab spec (`davekilleen/dex-product-gtm-lab` issue 571). The work follows the written person-can-do: the unpublished connector box answers who is in today's plan. This runner could not set the GitHub assignee from this token. The body still asks for davekilleen.

## Quality Gates
- [x] Isolated branch from 674 head `1f5cf260`
- [x] Today's-plan people list did not already exist on that packed head (lot 0 continued)
- [x] Live-publish refusal guard source is unchanged
- [x] Local lot-0 + today's-plan + unpublished tests passed on this runner
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (read-only list on an unpublished box; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `packages/dex-mcp/README.md` and portable plugin copy only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fdbcb02-7030-4630-ba9a-b12a83db05c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fdbcb02-7030-4630-ba9a-b12a83db05c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

