### PR TITLE
Ask the unpublished connector box who is named in one note — unreleased

### DIFF
--- a/core/context/__init__.py
+++ b/core/context/__init__.py
@@ -4,6 +4,7 @@ from .decision_record import ask_what_was_decided
 from .person_context import (
     ask_what_is_still_open_with_people,
     ask_who_is_in_todays_plan,
+    ask_who_is_named_in_note,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -15,6 +16,7 @@ __all__ = [
     "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
     "ask_who_is_in_todays_plan",
+    "ask_who_is_named_in_note",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/core/context/person_context.py
+++ b/core/context/person_context.py
@@ -34,6 +34,12 @@ FILE_REF = re.compile(
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
 NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
 NONE_TODAY_PEOPLE_SENTENCE = "Nobody is named in today's plan."
+NONE_NOTE_PEOPLE_SENTENCE = "That note does not name anyone from your person pages."
+NOTE_MISSING_SENTENCE = "There is no note at that path in your Dex folder."
+NOTE_REFUSED_SENTENCE = (
+    "That path is not a note this box will read. "
+    "It reads only notes inside your own Dex folder."
+)
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
 WIKI_LINK = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
 PERSON_FIELD = re.compile(
@@ -358,6 +364,89 @@ def ask_who_is_in_todays_plan(
     matches = [_today_people_row(root, path) for path in _people_named_in_plan(content, index)]
     if not matches:
         return empty
+    return {"found": True, "matches": matches, "sentence": ""}
+
+
+def _empty_who_in_note(sentence: str) -> dict[str, Any]:
+    return {"found": False, "matches": [], "sentence": sentence}
+
+
+def _note_path_read_fence(
+    root: Path, note_path: str | Path | None
+) -> tuple[str | None, Path | None]:
+    """Reuse find_people_in_file read fences. Never follow a symlink."""
+    if note_path is None:
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        raw_path = str(note_path)
+        target = Path(note_path)
+    except (TypeError, ValueError, OSError):
+        return NOTE_REFUSED_SENTENCE, None
+    normalised_raw_path = raw_path.replace("\\", "/")
+    if (
+        not raw_path.strip()
+        or normalised_raw_path == "People"
+        or normalised_raw_path.startswith("People/")
+        or "/People/" in normalised_raw_path
+    ):
+        return NOTE_REFUSED_SENTENCE, None
+    if target.suffix.lower() in SKIP_EXTS:
+        return NOTE_REFUSED_SENTENCE, None
+    resolved = target if target.is_absolute() else root / target
+    try:
+        if resolved.is_symlink():
+            return NOTE_REFUSED_SENTENCE, None
+    except OSError:
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        resolved = resolved.resolve()
+    except OSError:
+        return NOTE_MISSING_SENTENCE, None
+    if not _inside(root, resolved):
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        if not resolved.is_file():
+            return NOTE_MISSING_SENTENCE, None
+    except OSError:
+        return NOTE_MISSING_SENTENCE, None
+    return None, resolved
+
+
+def ask_who_is_named_in_note(
+    vault: str | Path | None,
+    note_path: str | Path | None,
+) -> dict[str, Any]:
+    """Return each named person in one note, never raising.
+
+    Each row carries recorded role, company, last interaction, every open
+    item, and the person page, in the note's own order of first mention.
+    Missing fields stay empty. The function never writes and never
+    reaches the network. Paths outside the vault, person-tree recursion,
+    binary files, and symlinks are refused. A missing file gets an honest
+    sentence. A note that names nobody gets an honest sentence.
+    """
+    nobody = _empty_who_in_note(NONE_NOTE_PEOPLE_SENTENCE)
+    root = _coerce_root(vault)
+    if root is None:
+        return nobody
+    fence, path = _note_path_read_fence(root, note_path)
+    if fence is not None:
+        return _empty_who_in_note(fence)
+    if path is None:
+        return _empty_who_in_note(NOTE_REFUSED_SENTENCE)
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return _empty_who_in_note(NOTE_REFUSED_SENTENCE)
+    index = _index_person_pages(root)
+    if not index:
+        return nobody
+    matches = [
+        _today_people_row(root, person_path)
+        for person_path in _people_named_in_plan(content, index)
+    ]
+    if not matches:
+        return nobody
     return {"found": True, "matches": matches, "sentence": ""}
 
 

--- a/core/tests/test_connector_box_founder_card.py
+++ b/core/tests/test_connector_box_founder_card.py
@@ -12,6 +12,7 @@ ASK_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/515"
 LATELY_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/537"
 OPEN_ITEMS_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/559"
 TODAY_PEOPLE_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/571"
+WHO_IN_NOTE_ISSUE = "https://github.com/davekilleen/dex-product-gtm-lab/issues/594"
 PACK_COMMAND = "python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-artifact"
 LEAVE_SENTENCE = "delete the packed file and build folder"
 MODEL_OR_VENDOR = re.compile(
@@ -31,6 +32,7 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert LATELY_ISSUE in card
     assert OPEN_ITEMS_ISSUE in card
     assert TODAY_PEOPLE_ISSUE in card
+    assert WHO_IN_NOTE_ISSUE in card
     assert PACK_COMMAND in card
     assert "SHA-256 sidecar" in card
     assert "io.github.davekilleen/dex" in card
@@ -44,6 +46,9 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
     assert "who is in today's plan" in card
     assert "plan order" in card
     assert "never guessed" in card
+    assert "who is named in one of your own notes" in card
+    assert "connector-box step 8 failed: the packed box did not answer who is named in a note." in card
+    assert "Who is named in a note listed from that note and person pages" in card
     assert LEAVE_SENTENCE in card
     assert "Nobody has walked this card" in card
     assert "Do not publish" in card
@@ -60,8 +65,11 @@ def test_founder_card_walks_pack_checksum_and_future_name() -> None:
         "### Step 5",
         "### Step 6",
         "### Step 7",
+        "### Step 8",
     ]
-    assert card.count("- [ ] I saw that.") == 7
+    assert card.count("- [ ] I saw that.") == 8
+    leave = card.split("## Leave", 1)[1].split("## Status", 1)[0]
+    assert leave.strip() == "When you are finished, delete the packed file and build folder."
 
 
 def test_founder_card_has_no_catalogue_install_or_publish_step() -> None:

--- a/core/tests/test_copilot_cli_host.py
+++ b/core/tests/test_copilot_cli_host.py
@@ -243,6 +243,7 @@ def test_copilot_mcp_json_can_read_a_vault_without_opening_the_cli(tmp_path: Pat
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
         "ask_who_is_in_todays_plan",
+        "ask_who_is_named_in_note",
         "check_safety_gate",
     }
     assert responses[2]["result"]["structuredContent"]["pillars"][0]["name"] == "Focus"

--- a/core/tests/test_harness_plugin.py
+++ b/core/tests/test_harness_plugin.py
@@ -308,6 +308,7 @@ def test_artifact_builder_produces_installable_gemini_and_mcpb_bundles(
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
         "ask_who_is_in_todays_plan",
+        "ask_who_is_named_in_note",
         "check_safety_gate",
     }
     desktop = tmp_path / "dex-claude-desktop"
@@ -439,6 +440,13 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "# Daily Plan\n\n**Attendees:** Ada Lovelace\n",
         encoding="utf-8",
     )
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    note = meetings / "2026-08-30 - Engine review.md"
+    note.write_text(
+        "# Engine review\n\nWalked [[Ada Lovelace]] through the memo.\n",
+        encoding="utf-8",
+    )
     decisions = vault / "06-Resources" / "Decisions"
     decisions.mkdir(parents=True)
     (decisions / "Decision_Log.md").write_text(
@@ -510,10 +518,22 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
                     "arguments": {"vault_path": str(vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_who_is_named_in_note",
+                    "arguments": {
+                        "vault_path": str(vault),
+                        "note_path": "00-Inbox/Meetings/2026-08-30 - Engine review.md",
+                    },
+                },
+            },
         ],
         cwd=vault,
     )
-    assert len(responses) == 9
+    assert len(responses) == 10
     names = {tool["name"] for tool in responses[1]["result"]["tools"]}
     assert names == {
         "dex_harness_profiles",
@@ -522,6 +542,7 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
         "ask_what_was_decided",
         "ask_what_is_still_open_with_people",
         "ask_who_is_in_todays_plan",
+        "ask_who_is_named_in_note",
         "check_safety_gate",
     }
     ask_tool = next(
@@ -558,6 +579,22 @@ def test_plugin_mcp_lists_and_calls_shared_read_only_tools(tmp_path: Path) -> No
     assert today_people["matches"][0]["page"] == (
         "05-Areas/People/Internal/Ada_Lovelace.md"
     )
+    who_in_note = responses[9]["result"]["structuredContent"]
+    assert who_in_note["found"] is True
+    assert who_in_note["matches"][0]["person"] == "Ada Lovelace"
+    assert who_in_note["matches"][0]["role"] == "Founder"
+    assert who_in_note["matches"][0]["company"] == "Analytical Engines"
+    assert who_in_note["matches"][0]["open_items"] == ["Send the operating memo"]
+    assert who_in_note["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
+    note_tool = next(
+        tool
+        for tool in responses[1]["result"]["tools"]
+        if tool["name"] == "ask_who_is_named_in_note"
+    )
+    required_note = (note_tool.get("inputSchema") or {}).get("required") or []
+    assert "note_path" in required_note
 
 
 def test_plugin_hooks_inject_session_context_and_block_destructive_work(tmp_path: Path) -> None:

--- a/core/tests/test_mcp_registry_artifact.py
+++ b/core/tests/test_mcp_registry_artifact.py
@@ -26,6 +26,7 @@ READ_ONLY_TOOLS = {
     "ask_what_was_decided",
     "ask_what_is_still_open_with_people",
     "ask_who_is_in_todays_plan",
+    "ask_who_is_named_in_note",
     "check_safety_gate",
 }
 
@@ -159,6 +160,12 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
         "# Daily Plan\n\n**Attendees:** Ada Lovelace\n",
         encoding="utf-8",
     )
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    (meetings / "2026-08-30 - Engine review.md").write_text(
+        "# Engine review\n\nWalked [[Ada Lovelace]] through the memo.\n",
+        encoding="utf-8",
+    )
     decisions = vault / "06-Resources" / "Decisions"
     decisions.mkdir(parents=True)
     (decisions / "Decision_Log.md").write_text(
@@ -242,6 +249,18 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
                     "arguments": {"vault_path": str(empty_vault)},
                 },
             },
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "ask_who_is_named_in_note",
+                    "arguments": {
+                        "vault_path": str(vault),
+                        "note_path": "00-Inbox/Meetings/2026-08-30 - Engine review.md",
+                    },
+                },
+            },
         ],
         vault=vault,
     )
@@ -299,6 +318,21 @@ def test_packed_server_still_reads_a_vault_and_refuses_destruction(tmp_path: Pat
     assert none_today["found"] is False
     assert none_today["matches"] == []
     assert none_today["sentence"] == "Nobody is named in today's plan."
+    note_tool = next(tool for tool in tools if tool["name"] == "ask_who_is_named_in_note")
+    assert "note" in note_tool["description"].lower()
+    assert "own order" in note_tool["description"]
+    required_note = (note_tool.get("inputSchema") or {}).get("required") or []
+    assert "note_path" in required_note
+    who_in_note = responses[10]["result"]["structuredContent"]
+    assert who_in_note["found"] is True
+    assert who_in_note["matches"][0]["person"] == "Ada Lovelace"
+    assert who_in_note["matches"][0]["role"] == "Founder"
+    assert who_in_note["matches"][0]["company"] == "Analytical Engines"
+    assert who_in_note["matches"][0]["last_interaction"] == "2026-04-12"
+    assert who_in_note["matches"][0]["open_items"] == ["Send the operating memo"]
+    assert who_in_note["matches"][0]["page"] == (
+        "05-Areas/People/Internal/Ada_Lovelace.md"
+    )
 
 
 def test_live_npm_publish_is_refused(tmp_path: Path) -> None:

--- a/core/tests/test_who_in_note.py
+++ b/core/tests/test_who_in_note.py
@@ -1,0 +1,234 @@
+"""Read-only who-is-named-in-a-note list for the unpublished connector box."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.context.person_context import (
+    NONE_NOTE_PEOPLE_SENTENCE,
+    NOTE_MISSING_SENTENCE,
+    NOTE_REFUSED_SENTENCE,
+    ask_who_is_named_in_note,
+)
+
+
+def _write_person(
+    vault: Path,
+    *,
+    filename: str,
+    name: str,
+    body: str = "",
+    role: str | None = "Partner",
+    company: str | None = "Example",
+    last_interaction: str | None = "2026-04-12",
+    subdir: str = "Internal",
+) -> Path:
+    folder = vault / "05-Areas" / "People" / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / filename
+    lines = [f"name: {name}"]
+    if role is not None:
+        lines.append(f"role: {role}")
+    if company is not None:
+        lines.append(f"company: {company}")
+    if last_interaction is not None:
+        lines.append(f"last_interaction: {last_interaction}")
+    front = "---\n" + "\n".join(lines) + "\n---\n"
+    path.write_text(f"{front}\n{body}\n", encoding="utf-8")
+    return path
+
+
+def _write_note(vault: Path, relative: str, body: str) -> Path:
+    path = vault / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_list_names_each_person_in_note_order_with_recorded_fields(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        role="Founder",
+        company="Analytical Engines",
+        last_interaction="2026-04-12",
+        body="- [ ] Send the operating memo\n- [x] Done already\n",
+    )
+    _write_person(
+        vault,
+        filename="Charles_Babbage.md",
+        name="Charles Babbage",
+        role="Engineer",
+        company="Difference Co",
+        last_interaction="2026-04-01",
+        body="- [ ] Review the engine notes\n- [ ] File the drawings\n",
+        subdir="External",
+    )
+    _write_person(
+        vault,
+        filename="Grace_Hopper.md",
+        name="Grace Hopper",
+        role="Rear Admiral",
+        company="Navy",
+        last_interaction="2026-03-20",
+        body="- [ ] Compile the compiler notes\n",
+        subdir="External",
+    )
+    _write_person(
+        vault,
+        filename="Michael_Faraday.md",
+        name="Michael Faraday",
+        role="Scientist",
+        company="Royal Institution",
+        last_interaction="2026-02-01",
+        body="- [ ] Unused person must not appear\n",
+    )
+    _write_person(
+        vault,
+        filename="Maya.md",
+        name="Maya",
+        role="Operator",
+        company="Solo",
+        last_interaction="2026-01-01",
+        body="- [ ] Single-word prose must not match\n",
+    )
+    note = _write_note(
+        vault,
+        "00-Inbox/Meetings/2026-08-30 - Engine review.md",
+        "# Engine review\n\n"
+        "Walked [[Ada Lovelace]] through the memo.\n"
+        "See also People/External/Charles_Babbage.md for the drawings.\n"
+        "Grace Hopper will review the compiler notes.\n"
+        "Maya asked a question in prose only.\n",
+    )
+    payload = ask_who_is_named_in_note(vault, note)
+    assert payload["found"] is True
+    assert payload["sentence"] == ""
+    assert payload["matches"] == [
+        {
+            "person": "Ada Lovelace",
+            "role": "Founder",
+            "company": "Analytical Engines",
+            "last_interaction": "2026-04-12",
+            "open_items": ["Send the operating memo"],
+            "page": "05-Areas/People/Internal/Ada_Lovelace.md",
+        },
+        {
+            "person": "Charles Babbage",
+            "role": "Engineer",
+            "company": "Difference Co",
+            "last_interaction": "2026-04-01",
+            "open_items": ["Review the engine notes", "File the drawings"],
+            "page": "05-Areas/People/External/Charles_Babbage.md",
+        },
+        {
+            "person": "Grace Hopper",
+            "role": "Rear Admiral",
+            "company": "Navy",
+            "last_interaction": "2026-03-20",
+            "open_items": ["Compile the compiler notes"],
+            "page": "05-Areas/People/External/Grace_Hopper.md",
+        },
+    ]
+    named = [row["person"] for row in payload["matches"]]
+    assert "Michael Faraday" not in named
+    assert "Maya" not in named
+
+
+def test_path_outside_vault_is_refused_and_never_read(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(vault, filename="Ada_Lovelace.md", name="Ada Lovelace")
+    secret = "OUTSIDE-NOTE-SECRET-SHOULD-NEVER-BE-READ"
+    outside = tmp_path / "outside.md"
+    outside.write_text(f"# Secret\n\n[[Ada Lovelace]] {secret}\n", encoding="utf-8")
+    payload = ask_who_is_named_in_note(vault, outside)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NOTE_REFUSED_SENTENCE
+    assert secret not in str(payload)
+    assert outside.read_text(encoding="utf-8").startswith("# Secret")
+
+
+def test_person_tree_path_is_refused(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    page = _write_person(
+        vault,
+        filename="Ada_Lovelace.md",
+        name="Ada Lovelace",
+        body="- [ ] Send the operating memo\n",
+    )
+    payload = ask_who_is_named_in_note(vault, "05-Areas/People/Internal/Ada_Lovelace.md")
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NOTE_REFUSED_SENTENCE
+    assert page.read_text(encoding="utf-8").startswith("---")
+
+
+def test_missing_file_gets_no_note_sentence(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(vault, filename="Ada_Lovelace.md", name="Ada Lovelace")
+    payload = ask_who_is_named_in_note(
+        vault, "00-Inbox/Meetings/2026-08-30 - Missing.md"
+    )
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NOTE_MISSING_SENTENCE
+
+
+def test_binary_extension_is_refused(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(vault, filename="Ada_Lovelace.md", name="Ada Lovelace")
+    binary = vault / "00-Inbox" / "Meetings" / "photo.png"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"\x89PNG\r\n\x1a\nnot-a-note")
+    payload = ask_who_is_named_in_note(vault, "00-Inbox/Meetings/photo.png")
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NOTE_REFUSED_SENTENCE
+
+
+def test_stripped_names_get_nobody_named_sentence_exactly_once(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(vault, filename="Ada_Lovelace.md", name="Ada Lovelace")
+    note = _write_note(
+        vault,
+        "04-Projects/Engine.md",
+        "# Engine\n\nPrep with [[Ada Lovelace]] before noon.\n",
+    )
+    named = ask_who_is_named_in_note(vault, note)
+    assert named["found"] is True
+    note.write_text("# Engine\n\nFocus on the operating memo.\n", encoding="utf-8")
+    payload = ask_who_is_named_in_note(vault, note)
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NONE_NOTE_PEOPLE_SENTENCE
+    assert payload["sentence"] == "That note does not name anyone from your person pages."
+    assert str(payload).count(NONE_NOTE_PEOPLE_SENTENCE) == 1
+
+
+def test_symlinked_note_is_refused_and_never_followed(tmp_path: Path) -> None:
+    vault = tmp_path / "Dex"
+    vault.mkdir()
+    _write_person(vault, filename="Ada_Lovelace.md", name="Ada Lovelace")
+    secret = "SYMLINK-TARGET-SECRET-SHOULD-NEVER-BE-READ"
+    target = tmp_path / "outside-note.md"
+    target.write_text(f"# Linked\n\n[[Ada Lovelace]] {secret}\n", encoding="utf-8")
+    meetings = vault / "00-Inbox" / "Meetings"
+    meetings.mkdir(parents=True)
+    link = meetings / "linked.md"
+    link.symlink_to(target)
+    payload = ask_who_is_named_in_note(vault, "00-Inbox/Meetings/linked.md")
+    assert payload["found"] is False
+    assert payload["matches"] == []
+    assert payload["sentence"] == NOTE_REFUSED_SENTENCE
+    assert secret not in str(payload)
+    assert target.read_text(encoding="utf-8").startswith("# Linked")
+    assert link.is_symlink()

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -39,6 +39,7 @@ has already passed that evidence gate.
   (a topic, or lately with no topic),
   `ask_what_is_still_open_with_people`,
   `ask_who_is_in_todays_plan`,
+  `ask_who_is_named_in_note`,
   `check_safety_gate`, and `dex_harness_profiles` MCP tools;
 - byte-identical vendored copies of the canonical context and safety modules;
 - SessionStart context and PreToolUse safety hooks for hosts that can genuinely

--- a/docs/founder-cards/connector-box.md
+++ b/docs/founder-cards/connector-box.md
@@ -9,6 +9,7 @@ This is a local pack check. It is not a catalogue install.
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/537
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/559
 - https://github.com/davekilleen/dex-product-gtm-lab/issues/571
+- https://github.com/davekilleen/dex-product-gtm-lab/issues/594
 
 ## Steps
 
@@ -86,11 +87,21 @@ python3 scripts/build-mcp-registry-artifact.py --output-dir build/mcp-registry-a
 
 **If this fails, send back this exact sentence:** `connector-box step 7 failed: the packed box did not list who is in today's plan.`
 
+### Step 8
+
+1. Before anything is published, ask the packed box who is named in one of your own notes, by its path inside the folder.
+
+**What you should see:** Each named person's recorded role, company, last interaction, and every open item, each naming the person page, in the note's own order. Missing fields empty, never guessed. A note that names nobody gets one honest sentence.
+
+- [ ] I saw that.
+
+**If this fails, send back this exact sentence:** `connector-box step 8 failed: the packed box did not answer who is named in a note.`
+
 ## After the last checkbox
 
 If every box is checked, send this exact sentence:
 
-`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Open items with people listed from person pages. People in today's plan listed from the plan and person pages. Not a catalogue install.`
+`connector-box pack matched. SHA-256 sidecar present. Future catalogue name is io.github.davekilleen/dex. Decision ask answered from a decision record. Lately ask answered with no topic. Open items with people listed from person pages. People in today's plan listed from the plan and person pages. Who is named in a note listed from that note and person pages. Not a catalogue install.`
 
 If any box is unchecked, send only the failure sentence from that step. Do not continue past a failed step. Do not publish. Do not sign. Do not store a secret. Do not invite anyone.
 

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -27,6 +27,7 @@ The MCP bridge exposes `boot_today`, `get_person_context`,
 `ask_what_was_decided` (a topic, or lately with no topic),
 `ask_what_is_still_open_with_people`,
 `ask_who_is_in_todays_plan`,
+`ask_who_is_named_in_note`,
 `check_safety_gate`, and `dex_harness_profiles`. It is
 dependency-free, relocatable, read-only, and uses the same vendored source
 modules as dex-core.

--- a/packages/dex-agent-plugin/runtime/core/context/__init__.py
+++ b/packages/dex-agent-plugin/runtime/core/context/__init__.py
@@ -4,6 +4,7 @@ from .decision_record import ask_what_was_decided
 from .person_context import (
     ask_what_is_still_open_with_people,
     ask_who_is_in_todays_plan,
+    ask_who_is_named_in_note,
     find_people_in_file,
     format_person_context_block,
     get_person_context,
@@ -15,6 +16,7 @@ __all__ = [
     "ask_what_is_still_open_with_people",
     "ask_what_was_decided",
     "ask_who_is_in_todays_plan",
+    "ask_who_is_named_in_note",
     "build_session_boot",
     "find_people_in_file",
     "format_person_context_block",

--- a/packages/dex-agent-plugin/runtime/core/context/person_context.py
+++ b/packages/dex-agent-plugin/runtime/core/context/person_context.py
@@ -34,6 +34,12 @@ FILE_REF = re.compile(
 OPEN_ITEM = re.compile(r"^- \[ \] (.+)$", re.MULTILINE)
 NONE_OPEN_SENTENCE = "No unchecked to-dos on person pages."
 NONE_TODAY_PEOPLE_SENTENCE = "Nobody is named in today's plan."
+NONE_NOTE_PEOPLE_SENTENCE = "That note does not name anyone from your person pages."
+NOTE_MISSING_SENTENCE = "There is no note at that path in your Dex folder."
+NOTE_REFUSED_SENTENCE = (
+    "That path is not a note this box will read. "
+    "It reads only notes inside your own Dex folder."
+)
 MEETING_HINTS = ("meeting", "attendee", "call with", "met with")
 WIKI_LINK = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
 PERSON_FIELD = re.compile(
@@ -358,6 +364,89 @@ def ask_who_is_in_todays_plan(
     matches = [_today_people_row(root, path) for path in _people_named_in_plan(content, index)]
     if not matches:
         return empty
+    return {"found": True, "matches": matches, "sentence": ""}
+
+
+def _empty_who_in_note(sentence: str) -> dict[str, Any]:
+    return {"found": False, "matches": [], "sentence": sentence}
+
+
+def _note_path_read_fence(
+    root: Path, note_path: str | Path | None
+) -> tuple[str | None, Path | None]:
+    """Reuse find_people_in_file read fences. Never follow a symlink."""
+    if note_path is None:
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        raw_path = str(note_path)
+        target = Path(note_path)
+    except (TypeError, ValueError, OSError):
+        return NOTE_REFUSED_SENTENCE, None
+    normalised_raw_path = raw_path.replace("\\", "/")
+    if (
+        not raw_path.strip()
+        or normalised_raw_path == "People"
+        or normalised_raw_path.startswith("People/")
+        or "/People/" in normalised_raw_path
+    ):
+        return NOTE_REFUSED_SENTENCE, None
+    if target.suffix.lower() in SKIP_EXTS:
+        return NOTE_REFUSED_SENTENCE, None
+    resolved = target if target.is_absolute() else root / target
+    try:
+        if resolved.is_symlink():
+            return NOTE_REFUSED_SENTENCE, None
+    except OSError:
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        resolved = resolved.resolve()
+    except OSError:
+        return NOTE_MISSING_SENTENCE, None
+    if not _inside(root, resolved):
+        return NOTE_REFUSED_SENTENCE, None
+    try:
+        if not resolved.is_file():
+            return NOTE_MISSING_SENTENCE, None
+    except OSError:
+        return NOTE_MISSING_SENTENCE, None
+    return None, resolved
+
+
+def ask_who_is_named_in_note(
+    vault: str | Path | None,
+    note_path: str | Path | None,
+) -> dict[str, Any]:
+    """Return each named person in one note, never raising.
+
+    Each row carries recorded role, company, last interaction, every open
+    item, and the person page, in the note's own order of first mention.
+    Missing fields stay empty. The function never writes and never
+    reaches the network. Paths outside the vault, person-tree recursion,
+    binary files, and symlinks are refused. A missing file gets an honest
+    sentence. A note that names nobody gets an honest sentence.
+    """
+    nobody = _empty_who_in_note(NONE_NOTE_PEOPLE_SENTENCE)
+    root = _coerce_root(vault)
+    if root is None:
+        return nobody
+    fence, path = _note_path_read_fence(root, note_path)
+    if fence is not None:
+        return _empty_who_in_note(fence)
+    if path is None:
+        return _empty_who_in_note(NOTE_REFUSED_SENTENCE)
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return _empty_who_in_note(NOTE_REFUSED_SENTENCE)
+    index = _index_person_pages(root)
+    if not index:
+        return nobody
+    matches = [
+        _today_people_row(root, person_path)
+        for person_path in _people_named_in_plan(content, index)
+    ]
+    if not matches:
+        return nobody
     return {"found": True, "matches": matches, "sentence": ""}
 
 

--- a/packages/dex-agent-plugin/server.py
+++ b/packages/dex-agent-plugin/server.py
@@ -21,6 +21,7 @@ from core.context.decision_record import ask_what_was_decided  # noqa: E402
 from core.context.person_context import (  # noqa: E402
     ask_what_is_still_open_with_people,
     ask_who_is_in_todays_plan,
+    ask_who_is_named_in_note,
     get_person_context,
 )
 from core.context.session_boot import build_session_boot  # noqa: E402
@@ -126,6 +127,27 @@ def _tools() -> list[dict[str, Any]]:
             "inputSchema": {"type": "object", "properties": vault},
         },
         {
+            "name": "ask_who_is_named_in_note",
+            "description": (
+                "Answer who is named in one note inside this Dex folder: "
+                "each named person's recorded role, company, last "
+                "interaction, and every open item, each row naming the "
+                "person page, in the note's own order. Missing fields stay "
+                "empty, never guessed. Refuses paths outside the folder."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    **vault,
+                    "note_path": {
+                        "type": "string",
+                        "description": "A path inside the Dex folder",
+                    },
+                },
+                "required": ["note_path"],
+            },
+        },
+        {
             "name": "check_safety_gate",
             "description": "Check a proposed command or path before a harness executes it.",
             "inputSchema": {
@@ -185,6 +207,13 @@ def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
             return _tool_result(
                 request_id,
                 ask_who_is_in_todays_plan(_vault(arguments)),
+            )
+        if name == "ask_who_is_named_in_note":
+            return _tool_result(
+                request_id,
+                ask_who_is_named_in_note(
+                    _vault(arguments), arguments.get("note_path")
+                ),
             )
         if name == "check_safety_gate":
             decision = evaluate_safety_gate(

--- a/packages/dex-claude-desktop/manifest.json
+++ b/packages/dex-claude-desktop/manifest.json
@@ -61,6 +61,10 @@
       "description": "Answer who is in today's plan: each named person's recorded role, company, last interaction, and every open item, each row naming the person page, in plan order. Missing field empty, never guessed."
     },
     {
+      "name": "ask_who_is_named_in_note",
+      "description": "Answer who is named in one note inside this Dex folder: each named person's recorded role, company, last interaction, and every open item, each row naming the person page, in the note's own order. Missing fields stay empty, never guessed. Refuses paths outside the folder."
+    },
+    {
       "name": "check_safety_gate",
       "description": "Check a proposed command or path."
     }

--- a/scripts/generate-portable-plugin.py
+++ b/scripts/generate-portable-plugin.py
@@ -189,6 +189,17 @@ def _claude_desktop_manifest() -> dict:
                     "order. Missing field empty, never guessed."
                 ),
             },
+            {
+                "name": "ask_who_is_named_in_note",
+                "description": (
+                    "Answer who is named in one note inside this Dex folder: "
+                    "each named person's recorded role, company, last "
+                    "interaction, and every open item, each row naming the "
+                    "person page, in the note's own order. Missing fields "
+                    "stay empty, never guessed. Refuses paths outside the "
+                    "folder."
+                ),
+            },
             {"name": "check_safety_gate", "description": "Check a proposed command or path."},
         ],
         "compatibility": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do not merge, publish, deploy, marketplace, or install for users. Programme stays unreleased. Leave [lab 594](https://github.com/davekilleen/dex-product-gtm-lab/issues/594) open. Assign: davekilleen.

Branched from draft PR 676 head `7184afe94eabce9699417c4c8dcf74a7be5e304a`. Do not merge 677. Do not merge 676. Do not merge 675. Do not merge 672. Do not merge 673. Do not merge 674. Do not merge 669. Do not merge 670. Do not merge 671. Do not merge 619/620. Lab PRs 589 and 569 stay spec-only unmerged. Not Solo. Not Mobile. Do not invent the Work folder grant. `granted=true` is never set.

## What I need from you
Nothing now. Leave this draft open. Do not merge. Do not publish. Do not sign, store, or invite anyone from this factory.

## Linked Issue
- Lab issue 594: https://github.com/davekilleen/dex-product-gtm-lab/issues/594 (reference only — do not close)

## What a person can do
Maya's terminal agent is reading with her through the unpublished connector box. She asks who is named in one of her own notes — a meeting note, a project page — giving the note's path inside her own Dex folder. The box answers with each named person's recorded role, company, last interaction, and every open item, each row naming the person page, in the note's own order of first mention. A note that names nobody gets one honest sentence. A path outside her Dex folder, a path that is not there, or a binary file gets a plain refusal sentence — the box never reads outside her own folder. Nothing is edited, nothing goes online, nothing is guessed.

## What Changed
- Engine `ask_who_is_named_in_note(vault, note_path)` reuses the existing read fences, matches with `_people_named_in_plan`, and shapes rows with `_today_people_row`
- Packed box eighth tool `ask_who_is_named_in_note` takes `vault_path` plus required `note_path`
- Each row carries recorded role, company, last interaction, every open item, and the person page, in the note's own order
- Missing fields stay empty, never guessed
- Honest sentences: nobody named, no note at that path, path refused
- Founder card step 8 walks the who-is-named-in-a-note ask
- Leave section unchanged: delete the packed file and build folder
- Live-publish refusal guard is untouched
- Lot 0 on `origin/main` `534f574a` and the open drafts: no box tool takes a note path; this person-can-do was not already landed
- Handler shape on 676 head is still `_tools()` plus `_handle` dispatch; the new tool follows it
- No catalogue install step. Nobody has walked the card

## Test Plan
- Named engine: `core/tests/test_who_in_note.py` — 7 passed (note-order rows, unnamed person absent, single-word prose skipped, outside/person-tree/binary/symlink refused, missing file, nobody-named sentence once)
- Server stdio: `test_plugin_mcp_lists_and_calls_shared_read_only_tools` — 8 tools listed, new tool called end-to-end
- Byte-identical runtime: `test_vendored_runtime_is_byte_identical_to_shared_core` passed
- Generator: `scripts/verify-portable-plugin-runtime.py` passed; `test_plugin_generator_check_is_clean` passed
- Packed journey: `test_packed_server_still_reads_a_vault_and_refuses_destruction` passed
- Live-publish refusal: `test_live_npm_publish_is_refused` passed
- Card: `test_connector_box_founder_card.py` — step 8 present with exact failure sentence; leave section unchanged
- Named set on this runner: 16 passed, 0 failed
- Sibling today's-plan engine and remaining packed-artifact tests: 12 passed
- Not run here / pre-existing: Gemini/Desktop bundle builder (`mcpb` missing on this runner); `test_copilot_cli_host` collection needs the `mcp` package (pre-existing)

This runner could not set the GitHub assignee from this token. The body still asks for davekilleen.

## Quality Gates
- [x] Isolated branch from 676 head `7184afe9`
- [x] Who-is-named-in-a-note ask did not already exist on main or the open drafts (lot 0 continued)
- [x] Live-publish refusal guard source is unchanged
- [x] Named tests passed on this runner
- [ ] Nobody has walked the card

## Risk & Rollback
- Risk level: low (read-only list on an unpublished box; refusal guard unchanged)
- Rollback plan: leave this draft unmerged

## Docs Impact
- `docs/founder-cards/connector-box.md` (kept out of the user distribution surface)
- `docs/HARNESS-PORTABILITY.md` and portable plugin README tool list only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52a14d4f-9766-4ce7-8f9a-0c7ee7f7a0b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52a14d4f-9766-4ce7-8f9a-0c7ee7f7a0b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

