### PR TITLE
Fix calendar events landing a month late at month end

### DIFF
--- a/core/mcp/scripts/calendar_create_event.sh
+++ b/core/mcp/scripts/calendar_create_event.sh
@@ -20,8 +20,13 @@ osascript << EOF
 tell application "Calendar"
     set targetCal to calendar "$CALENDAR_NAME"
     
-    -- Build the date
+    -- Build the date.
+    -- Set the day to 1 first. AppleScript dates overflow rather than clamp, so
+    -- setting the month while the day is still today's can roll into the month
+    -- after the one asked for: on the 31st, setting month to September gives
+    -- 1 October, and the following "set day" then lands in October.
     set startDate to current date
+    set day of startDate to 1
     set year of startDate to $YEAR
     set month of startDate to $MONTH
     set day of startDate to $DAY

--- a/core/tests/test_calendar_create_event_month_end.py
+++ b/core/tests/test_calendar_create_event_month_end.py
@@ -1,0 +1,73 @@
+"""Regression: calendar events must not land a month late at month end.
+
+calendar_create_event.sh builds its start date by mutating `current date`.
+AppleScript dates overflow rather than clamp, so setting the month while the day
+is still today's can roll past the month asked for: on the 31st, setting the
+month to September gives 1 October, and the following `set day` lands in
+October. Asked for 2026-09-02 on 31 August, the event was created on 2 October,
+and the call still reported success.
+
+The fix is ordering: set the day to 1 before the year and month, so the later
+`set day` has a month that can hold it.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "core" / "mcp" / "scripts" / "calendar_create_event.sh"
+
+
+def test_day_is_reset_before_the_month_is_set():
+    """The ordering is the fix. Without the reset, a month-end run overflows."""
+    body = SCRIPT.read_text()
+    assert "set day of startDate to 1\n" in body, (
+        "the day is never reset to 1 before the month is set, so a run on the "
+        "29th to 31st will create the event in the month after the one asked for"
+    )
+    reset = body.index("set day of startDate to 1\n")
+    month = body.index("set month of startDate to")
+    day = body.index("set day of startDate to $DAY")
+    assert reset < month, (
+        "the day must be reset to 1 before the month is set, or a run on the "
+        "29th to 31st rolls into the month after the one requested"
+    )
+    assert month < day, "the real day must be set after the month"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="AppleScript is macOS only")
+def test_applescript_overflows_without_the_reset():
+    """Prove the mechanic the ordering defends against, so the guard above is
+    not mistaken for style."""
+    script = """
+    set d to current date
+    set day of d to 31
+    set year of d to 2026
+    set month of d to September
+    return month of d as string
+    """
+    out = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "October", (
+        "AppleScript no longer overflows when the day exceeds the target month; "
+        "if so, this guard can be relaxed"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="AppleScript is macOS only")
+def test_reset_prevents_the_overflow():
+    script = """
+    set d to current date
+    set day of d to 31
+    set day of d to 1
+    set year of d to 2026
+    set month of d to September
+    set day of d to 2
+    return (month of d as string) & " " & (day of d as string)
+    """
+    out = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "September 2"


### PR DESCRIPTION
## Linked Issue
- No Linear issue. Found while using Dex on 31 August 2026.

## What Changed

`core/mcp/scripts/calendar_create_event.sh` builds its start date by mutating `current date` in the order year, month, day. AppleScript dates overflow rather than clamp, so when today's day-of-month is larger than the target month has days, setting the month rolls into the month *after* the one requested, and the following `set day` lands there.

Asked for `2026-09-02` on 31 August, it created the event on **2 October**. It reported success, and the MCP echoed the requested date back in its result, so nothing surfaced the error.

The fix is one line: set the day to 1 before the year and month, so the later `set day` has a month that can hold it.

This is silent and date-dependent. It behaves for most of the month and quietly files events a month late on the 29th to 31st, which is also when someone is most likely to be scheduling into the following month.

## Test Plan
- Unit/integration tests added: `core/tests/test_calendar_create_event_month_end.py`, three tests. One asserts the ordering in the script, which is the actual regression guard and runs anywhere. Two prove the AppleScript overflow the ordering defends against, so the guard is not later mistaken for style; both are skipped off macOS following the pattern in `test_apple_mail_runtime_macos.py`.
- Negative path: verified the ordering guard fails against the current `main` version of the script, with a message explaining the consequence rather than a bare `substring not found`.
- Commands run locally: `pytest core/tests/test_calendar_create_event_month_end.py` (3 passed).
- End to end on 31 August 2026, the same request through both versions:

```
before   Created: ... at Friday, 2 October 2026 at 09:00:00
after    Created: ... at Wednesday, 2 September 2026 at 09:00:00
```

Test events were removed afterwards.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (not applicable; one line in one script).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests.
- [x] I added a regression test for this bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact (no user-facing docs describe this behaviour).
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level: low. One added line in a shell script, plus a new test file. The added line is a no-op on any date where the bug does not fire, because the day is overwritten two lines later.
- Rollback plan: revert the commit.

## Docs Impact
- Files updated: none.
- Reason: this restores the documented behaviour rather than changing it. The MCP already accepts `YYYY-MM-DD HH:MM` and claims to create the event then.

## One thing I did not change

The same script interpolates `$TITLE` and `$DESCRIPTION` into the AppleScript unescaped, so any double quote in either breaks the call with a syntax error. I hit that first, before the date bug. I have left it out to keep this PR to one thing, but it is worth a look and I am happy to send a second PR if useful.