### PR TITLE
Read weekly priorities written with a comma, not just an em dash

### DIFF
--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2521,6 +2521,8 @@ def parse_weekly_priorities(filepath: Path) -> List[Dict[str, Any]]:
         # Or task-style: - [ ] **Priority Title** ^week-2026-W05-p1
         
         priority_match = re.match(r'(\d+)\.\s+(.+?)\s+—\s+\*\*(.+?)\*\*(?:\s+\^(week-\d{4}-W\d{2}-p\d+))?', line)
+        if not priority_match:
+            priority_match = re.match(r'(\d+)\.\s+\*\*(.+?)\*\*,\s+\*\*(.+?)\*\*(?:\s+\^(week-\d{4}-W\d{2}-p\d+))?', line)
         if priority_match:
             priority_num = int(priority_match.group(1))
             title = priority_match.group(2).strip()

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -209,6 +209,26 @@ def test_valid_weekly_priority_link_round_trips_into_week_progress(task_vault):
     assert linked["tasks_done"] == 0
 
 
+def test_comma_form_priority_is_visible_in_week_tools(task_vault):
+    priority_id = "week-2026-W36-p1"
+    task_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        f"1. **Finish customer evidence**, **Test Pillar** ^{priority_id}\n",
+        encoding="utf-8",
+    )
+
+    priorities = _call_tool(
+        "get_week_priorities",
+        {"week_date": "2026-08-31"},
+    )
+    progress = _call_tool("get_week_progress")
+
+    assert priorities["count"] == 1
+    assert [item["priority_id"] for item in priorities["priorities"]] == [priority_id]
+    assert progress["summary"]["total"] == 1
+    assert [item["priority_id"] for item in progress["priorities"]] == [priority_id]
+
+
 def test_invalid_weekly_priority_lists_available_ids_without_writing(task_vault):
     available_id = "week-2026-W28-p1"
     task_vault["priorities"].write_text(


### PR DESCRIPTION
## Why

Weekly progress could report **zero** existing priorities when the Week Priorities file used the comma form `1. **Title**, **Pillar** ^week-…` instead of the em-dash form the reader already understood. Both public Work tools (`get_week_priorities` and `get_week_progress`) went silent.

This is unreleased Core reliability. No reporter contact.

## What changed

- `parse_weekly_priorities` also accepts the comma + double-bold form.
- The canonical em-dash writer is unchanged.
- One public-boundary regression covers both tools.

## Proof

- The new test fails on the old parser (`count == 0`) and passes with this change.
- `pytest core/tests/test_work_server_roundtrip.py`: 35 passed after rebase onto current main.

## Out of scope

No release, no install, no message to the person who reported it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing change with a regression test; no auth, data migration, or write-path changes.
> 
> **Overview**
> **Weekly priorities** written as `1. **Title**, **Pillar** ^week-…` were ignored by `parse_weekly_priorities`, so `get_week_priorities` and `get_week_progress` could show **zero** priorities even when the file had entries.
> 
> The parser now falls back to a second regex for that comma + double-bold line shape after the existing em-dash pattern. Canonical write paths and the em-dash reader path are unchanged.
> 
> A roundtrip test seeds that comma form in `Week Priorities` and asserts both MCP tools return the priority ID and counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bb928e82ded0440737fc9b97c5f1d4ef12cd94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->