### PR TITLE
Stop treating a broken first-setup split as already finished

### DIFF
--- a/core/migrations/v1-to-v2-brain-vault-split.cjs
+++ b/core/migrations/v1-to-v2-brain-vault-split.cjs
@@ -2338,12 +2338,28 @@ function journalAfterPhase(root, state, phase) {
   writeJournal(root, state);
 }
 
+function assertCompletedTopology(root, state) {
+  if (state?.status !== 'complete') return false;
+  const decision = topologyDecision(inspectTopology(root));
+  if (decision !== 'post-split') {
+    throw new Error(`Migration journal says complete, but the live topology is ${decision}. Dex stopped without changing files because the vault Git folder is not safely usable.`);
+  }
+  const vaultGit = path.join(root, '.git');
+  const head = gitDir(root, vaultGit, ['rev-parse', '--verify', 'HEAD^{commit}'], {
+    allowFailure: true,
+  });
+  if (head.status !== 0) {
+    throw new Error('Migration journal says complete, but the vault Git branch is not usable. Dex stopped without changing files and preserved every Git folder for recovery.');
+  }
+  return true;
+}
+
 function runPhases(root, mode, options = {}) {
   let state = readJournal(root);
   if (mode === 'resume' && !state) {
     throw new Error('There is no saved migration to resume. Run --dry-run first, then --auto when you are ready.');
   }
-  if (state?.status === 'complete' && topologyDecision(inspectTopology(root)) === 'post-split') {
+  if (assertCompletedTopology(root, state)) {
     console.log('The brain and vault split is already complete. Nothing changed.');
     return 0;
   }
@@ -2421,8 +2437,10 @@ function runPhases(root, mode, options = {}) {
 function statusMigration(root) {
   const state = readJournal(root);
   const topology = inspectTopology(root);
+  assertCompletedTopology(root, state);
+  const decision = topologyDecision(topology);
   console.log(`Migration status: ${state?.status || 'not started'}.`);
-  console.log(`Topology: ${topologyDecision(topology)}.`);
+  console.log(`Topology: ${decision}.`);
   if (state?.nextPhase !== undefined && state.nextPhase <= 9) {
     console.log(`Next phase: P${state.nextPhase}.`);
   }

--- a/core/tests/brain-vault-migrator-integration.test.cjs
+++ b/core/tests/brain-vault-migrator-integration.test.cjs
@@ -109,6 +109,7 @@ function snapshotKnownUserFiles(root) {
     '05-Areas/People/External/Ada_Lovelace.md',
     '.claude/skills-custom/foo/SKILL.md',
     '.mcp.json',
+    'System/user-profile.yaml',
     'System/integrations/config.yaml',
     'System/integrations/slack.yaml',
     'System/user-profile.yaml',
@@ -396,6 +397,69 @@ test('real migration preserves user bytes and creates two isolated histories', (
   migrate(vault, '--restore');
   assert.deepEqual(snapshotFiles(vault), secondCycleSnapshot);
   assert.match(fs.readFileSync(path.join(vault, '.gitignore'), 'utf8'), /changed after the first restore/);
+});
+
+test('status refuses a completed journal when the live vault Git folder is missing', () => {
+  const vault = makeFixture();
+  migrate(vault, '--auto');
+  fs.renameSync(path.join(vault, '.git'), path.join(vault, '.git 2'));
+
+  const result = migrate(vault, '--status', { expectedStatus: 1 });
+
+  assert.match(
+    result.stdout + result.stderr,
+    /journal says complete.*live topology is restore-archive/i,
+  );
+  assert.doesNotMatch(result.stdout, /Migration status: complete/);
+  assert.equal(fs.existsSync(path.join(vault, '.git')), false);
+  assert.equal(fs.existsSync(path.join(vault, '.dex', 'pre-split-archive.git')), true);
+  assert.equal(fs.existsSync(path.join(vault, '.git 2')), true);
+});
+
+test('status refuses a completed journal when the vault branch was moved into a collision folder', () => {
+  const vault = makeFixture();
+  migrate(vault, '--auto');
+  const branch = git(vault, 'symbolic-ref', 'HEAD');
+  const branchPath = path.join(vault, '.git', ...branch.split('/'));
+  const collisionPath = path.join(
+    vault,
+    '.git',
+    'refs',
+    'heads 2',
+    path.basename(branchPath),
+  );
+  fs.mkdirSync(path.dirname(collisionPath), { recursive: true });
+  fs.renameSync(branchPath, collisionPath);
+
+  const result = migrate(vault, '--status', { expectedStatus: 1 });
+
+  assert.match(
+    result.stdout + result.stderr,
+    /journal says complete.*vault Git branch is not usable/i,
+  );
+  assert.equal(fs.existsSync(branchPath), false);
+  assert.equal(fs.existsSync(collisionPath), true);
+  assert.equal(fs.existsSync(path.join(vault, '.dex', 'pre-split-archive.git')), true);
+});
+
+test('resume preserves every Git folder when a completed journal has an invalid live topology', () => {
+  const vault = makeFixture();
+  migrate(vault, '--auto');
+  fs.renameSync(path.join(vault, '.git'), path.join(vault, '.git 2'));
+  const statePath = path.join(vault, 'System', '.dex', 'migration-v2-state.json');
+  const stateBefore = fs.readFileSync(statePath);
+
+  const result = migrate(vault, '--resume', { expectedStatus: 1 });
+
+  assert.match(
+    result.stdout + result.stderr,
+    /journal says complete.*live topology is restore-archive/i,
+  );
+  assert.equal(fs.existsSync(path.join(vault, '.git')), false);
+  assert.equal(fs.existsSync(path.join(vault, '.dex', 'pre-split-archive.git')), true);
+  assert.equal(fs.existsSync(path.join(vault, '.dex', 'brain.git')), true);
+  assert.equal(fs.existsSync(path.join(vault, '.git 2')), true);
+  assert.deepEqual(fs.readFileSync(statePath), stateBefore);
 });
 
 test('every journaled phase can stop, resume, and restore byte-exactly', { timeout: 240_000 }, () => {


### PR DESCRIPTION
## Why

After a first-setup brain/vault split, Dex could trust a saved “complete” label even when the vault Git folder was missing or its branch had been moved into a Finder-style ` 2` collision folder. Resume could then consume the only undo archive.

This is unreleased Core reliability. No reporter contact.

## What changed

- Before treating a split as complete, Dex now checks the live folder shape and that the vault Git branch still has a real HEAD.
- If that check fails, status and resume stop without moving any Git folders.
- Three public-boundary regressions cover missing `.git`, a `refs/heads 2` collision, and resume leaving every recovery folder untouched.

## Proof

- The three new tests fail on the old migrator and pass after this change, including after rebase onto current main.
- Unit file: 24/24.

## Out of scope

No public Dex release. No message to the person who reported it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-setup migration recovery paths where mistaken “already complete” could destroy undo archives; scope is the unreleased v2 split migrator with regression tests.
> 
> **Overview**
> The brain/vault migrator no longer treats a journaled **complete** status as proof the split finished safely. **`assertCompletedTopology`** now requires the on-disk layout to be **`post-split`** and the vault **`.git`** to resolve a real **HEAD** before **`--auto`** exits early or **`--status`** prints success.
> 
> When the journal and reality disagree—missing **`.git`**, Finder-style **`refs/heads 2`** collisions, or **`restore-archive`** topology—**`--status`** and **`--resume`** **fail without renaming or consuming** recovery folders (**`pre-split-archive.git`**, **`brain.git`**). Integration tests cover those three failure shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19e577bc380970b9d5a4183f4491cbffd8e2ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->