### PR TITLE
Stop quarterly goals absorbing later checklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.97.7] — Quarterly goals stop swallowing later checklists (unreleased)
+
+The last goal in your quarterly plan could pick up checkboxes that belonged to
+the next section — carried work, a divider, a later heading. Dex then treated
+that unrelated list as milestones for the goal, so progress looked further
+along than it was.
+
+**What this fixes for you:**
+
+* **A new heading or a divider ends the goal.** Checkboxes below that line stay
+  out of the goal's milestones. Real milestones above the line are unchanged.
+
+This is on the main codebase and is not in the public Latest yet.
+
 ## [1.97.6] — Dex stops saying things are running when they are not (2026-08-29)
 
 Dex told you a few things were switched on when they were not. Usage tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.97.7] — Quarterly goals stop swallowing later checklists (unreleased)
+## Unreleased — next public version is 1.97.7
 
 The last goal in your quarterly plan could pick up checkboxes that belonged to
 the next section — carried work, a divider, a later heading. Dex then treated
@@ -19,7 +19,7 @@ along than it was.
 * **A new heading or a divider ends the goal.** Checkboxes below that line stay
   out of the goal's milestones. Real milestones above the line are unchanged.
 
-This is on the main codebase and is not in the public Latest yet.
+Public Latest remains 1.97.6 until the next numbered release.
 
 ## [1.97.6] — Dex stops saying things are running when they are not (2026-08-29)
 

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2236,7 +2236,9 @@ def parse_quarterly_goals(filepath: Path) -> List[Dict[str, Any]]:
             impact_level = None
             
             j = i + 1
-            while j < len(lines) and not lines[j].startswith('###'):
+            while j < len(lines) and not re.match(
+                r'^(?:##\s|###\s|---\s*$)', lines[j]
+            ):
                 if '**What success looks like:**' in lines[j]:
                     # Read next non-empty line
                     k = j + 1

--- a/core/tests/test_work_server_quarterly_goals.py
+++ b/core/tests/test_work_server_quarterly_goals.py
@@ -1,0 +1,49 @@
+"""Behavioral coverage for quarterly-goal reads through the Work MCP."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+
+def _get_quarterly_goals() -> dict:
+    result = asyncio.run(work_server.handle_call_tool("get_quarterly_goals", {}))
+    return json.loads(result[0].text)
+
+
+@pytest.mark.parametrize("boundary", ["## Carried From Last Quarter", "---"])
+def test_get_quarterly_goals_excludes_checklists_after_goal_section(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+) -> None:
+    goals_file = tmp_path / "01-Quarter_Goals/Quarter_Goals.md"
+    goals_file.parent.mkdir(parents=True)
+    goals_file.write_text(
+        "# Q4 2026 Goals\n\n"
+        "### 1. Make planning trustworthy — **Product** ^Q4-2026-goal-1\n\n"
+        "**Key milestones:**\n"
+        "- [x] This milestone belongs to the goal\n\n"
+        f"{boundary}\n\n"
+        "- [ ] This is unrelated carried work\n",
+        encoding="utf-8",
+    )
+    profile = tmp_path / "System/user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    profile.write_text(
+        "capabilities:\n  quarter_goals:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals_file)
+    monkeypatch.setattr(work_server, "USER_PROFILE_FILE", profile)
+
+    payload = _get_quarterly_goals()
+
+    assert payload["goals"][0]["milestones"] == [
+        {"title": "This milestone belongs to the goal", "completed": True}
+    ]


### PR DESCRIPTION
## What this is
A quarterly-goals file with a later heading or divider after the last goal made Dex treat that later checklist as milestones for the goal.

## What changed
- `parse_quarterly_goals` stops at `##`, `###`, or a horizontal divider.
- A public Work MCP regression covers both boundary forms.
- Changelog notes this for unreleased 1.97.7. Package version stays 1.97.6.

## Proof
On current `main` (`1a675a91`) the new test failed for both an H2 section and a divider (the later checkbox leaked in). After the one-line stop, both cases pass. Related Work MCP roundtrip tests: 37 passed.

## Not in this PR
No public Dex release. The person who reported it was not contacted.

Independent Front Desk replay of unpushed investigation commit `96cefb41` onto current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown parsing change with a targeted regression test; no auth, data migration, or API contract changes.
> 
> **Overview**
> **Quarterly goal parsing** no longer treats checkboxes under a later `##` heading, the next `###` goal, or a `---` divider as milestones for the preceding goal—so progress and milestone lists match what’s actually in that goal section.
> 
> The Work MCP `parse_quarterly_goals` loop now stops on those boundaries instead of only on `###`. A new regression test exercises both an H2 section and a horizontal rule via `get_quarterly_goals`. The changelog documents the fix for unreleased **1.97.7** (package version unchanged at 1.97.6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10bd0468c7577485edbca866a8a22bdc1dcdc3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->