### PR TITLE
Count daily-plan email from Primary or Inbox, not every unread

### DIFF
--- a/.agents/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/.agents/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -139,7 +139,10 @@ server as connected. Before querying any connected email source, run
 
 If the source is connected and healthy:
 
-- Get unread count and priority emails
+- Use an attention-inbox count for the headline, never a provider-wide unread total.
+  For Google Workspace, count `is:unread category:primary`; use monitored labels
+  separately to find priority messages. For Apple Mail, count unread messages in Inbox
+  mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 - Flag emails needing reply (received more than 48 hours ago, from key contacts
   in `05-Areas/People/`)
 - Surface threads involving the target date's meeting attendees

--- a/.agents/skills/daily-plan/SKILL.md
+++ b/.agents/skills/daily-plan/SKILL.md
@@ -348,13 +348,16 @@ source, run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable o
 `mail.apple-search` check reports `OK` / `feature_status: ok`.
 
 If connected and healthy:
-1. Get unread count and priority emails from monitored labels
+1. Use an attention-inbox count for the headline, never a provider-wide unread total.
+   For Google Workspace, count `is:unread category:primary`; use monitored labels
+   separately to find priority messages. For Apple Mail, count unread messages in Inbox
+   mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 2. Flag emails needing reply (> 48h since received, from key contacts in `05-Areas/People/`)
 3. Surface email threads with today's meeting attendees
 
 Include in plan:
 
-> "Email: [X] unread, [Y] need replies. [Z] threads with today's meeting attendees."
+> "Email: [X] unread in Primary/Inbox, [Y] need replies. [Z] threads with today's meeting attendees."
 
 For Apple Mail, never interpret an empty search as "no matching mail" unless that health check
 is OK. If a connected source is broken or could not be checked, **do not silently skip**:

--- a/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/.claude/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -139,7 +139,10 @@ server as connected. Before querying any connected email source, run
 
 If the source is connected and healthy:
 
-- Get unread count and priority emails
+- Use an attention-inbox count for the headline, never a provider-wide unread total.
+  For Google Workspace, count `is:unread category:primary`; use monitored labels
+  separately to find priority messages. For Apple Mail, count unread messages in Inbox
+  mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 - Flag emails needing reply (received more than 48 hours ago, from key contacts
   in `05-Areas/People/`)
 - Surface threads involving the target date's meeting attendees

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -355,13 +355,16 @@ source, run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable o
 `mail.apple-search` check reports `OK` / `feature_status: ok`.
 
 If connected and healthy:
-1. Get unread count and priority emails from monitored labels
+1. Use an attention-inbox count for the headline, never a provider-wide unread total.
+   For Google Workspace, count `is:unread category:primary`; use monitored labels
+   separately to find priority messages. For Apple Mail, count unread messages in Inbox
+   mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 2. Flag emails needing reply (> 48h since received, from key contacts in `05-Areas/People/`)
 3. Surface email threads with today's meeting attendees
 
 Include in plan:
 
-> "Email: [X] unread, [Y] need replies. [Z] threads with today's meeting attendees."
+> "Email: [X] unread in Primary/Inbox, [Y] need replies. [Z] threads with today's meeting attendees."
 
 For Apple Mail, never interpret an empty search as "no matching mail" unless that health check
 is OK. If a connected source is broken or could not be checked, **do not silently skip**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ along than it was.
 
 * **A new heading or a divider ends the goal.** Checkboxes below that line stay
   out of the goal's milestones. Real milestones above the line are unchanged.
+* **The daily plan no longer treats every unread email as the headline backlog.**
+  Promotions and other folders could make the plan say hundreds when only a few
+  messages were in Primary or Inbox. The headline now counts that attention
+  inbox, and omits the number if the source cannot scope it reliably.
 
 Public Latest remains 1.97.6 until the next numbered release.
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -52,8 +52,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/daily-plan/SKILL.md",
-        "sha256": "4f4bfce7329ba488d74fd5ca4c0366e607602e5fca2f2bb6a356ff47ef7a6c64",
-        "byte_size": 33273
+        "sha256": "5768ed132995aee9ffef08fe7a3c497d4d7922b8468961c3cba6e9457ddd33a4",
+        "byte_size": 33572
       },
       "value": "Helps a person choose a small, realistic focus list before the day scatters across meetings, tasks and loose commitments.",
       "jobs_served": [

--- a/core/tests/test_daily_plan_email_intelligence.py
+++ b/core/tests/test_daily_plan_email_intelligence.py
@@ -1,0 +1,25 @@
+"""Keep daily-plan email headlines scoped to mail that may need attention."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DAILY_PLAN = ROOT / ".claude" / "skills" / "daily-plan"
+EMAIL_INSTRUCTION_PATHS = (
+    DAILY_PLAN / "SKILL.md",
+    DAILY_PLAN / "AGENT_INSTRUCTIONS.md",
+)
+
+
+def test_daily_plan_headline_unread_count_uses_the_attention_inbox() -> None:
+    for path in EMAIL_INSTRUCTION_PATHS:
+        text = path.read_text(encoding="utf-8")
+        contract = " ".join(text.split())
+        assert "never a provider-wide unread total" in contract, path
+        assert "`is:unread category:primary`" in contract, path
+        assert "unread messages in Inbox mailboxes" in contract, path
+        assert "omit the headline unread count" in contract, path
+
+    skill = (DAILY_PLAN / "SKILL.md").read_text(encoding="utf-8")
+    assert '"Email: [X] unread in Primary/Inbox' in skill

--- a/packages/dex-agent-plugin/skills/daily-plan/AGENT_INSTRUCTIONS.md
+++ b/packages/dex-agent-plugin/skills/daily-plan/AGENT_INSTRUCTIONS.md
@@ -139,7 +139,10 @@ server as connected. Before querying any connected email source, run
 
 If the source is connected and healthy:
 
-- Get unread count and priority emails
+- Use an attention-inbox count for the headline, never a provider-wide unread total.
+  For Google Workspace, count `is:unread category:primary`; use monitored labels
+  separately to find priority messages. For Apple Mail, count unread messages in Inbox
+  mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 - Flag emails needing reply (received more than 48 hours ago, from key contacts
   in `05-Areas/People/`)
 - Surface threads involving the target date's meeting attendees

--- a/packages/dex-agent-plugin/skills/daily-plan/SKILL.md
+++ b/packages/dex-agent-plugin/skills/daily-plan/SKILL.md
@@ -348,13 +348,16 @@ source, run `python3 core/utils/doctor.py --deep`; Apple Mail search is usable o
 `mail.apple-search` check reports `OK` / `feature_status: ok`.
 
 If connected and healthy:
-1. Get unread count and priority emails from monitored labels
+1. Use an attention-inbox count for the headline, never a provider-wide unread total.
+   For Google Workspace, count `is:unread category:primary`; use monitored labels
+   separately to find priority messages. For Apple Mail, count unread messages in Inbox
+   mailboxes. If the source cannot scope this reliably, omit the headline unread count.
 2. Flag emails needing reply (> 48h since received, from key contacts in `05-Areas/People/`)
 3. Surface email threads with today's meeting attendees
 
 Include in plan:
 
-> "Email: [X] unread, [Y] need replies. [Z] threads with today's meeting attendees."
+> "Email: [X] unread in Primary/Inbox, [Y] need replies. [Z] threads with today's meeting attendees."
 
 For Apple Mail, never interpret an empty search as "no matching mail" unless that health check
 is OK. If a connected source is broken or could not be checked, **do not silently skip**:


### PR DESCRIPTION
## What this is
The daily plan could treat every unread email as the headline backlog, including promotions, so the number could look like hundreds when only a few messages were in Primary or Inbox.

## What changed
- Both daily-plan gathering prompts now count Google Primary and Apple Mail Inbox for the headline.
- If the source cannot scope that reliably, the headline number is omitted.
- A contract test locks the wording in both instruction files.

## Proof
On current `main` (`1e73611`) the new test failed first. After the instruction change it passed. Changelog notes this under Unreleased / next public version 1.97.7. Package version stays 1.97.6.

## Not in this PR
No public Dex release. The person who reported it was not contacted.

Independent Front Desk replay of unpushed investigation commit `709b1e24` onto current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-contract changes only; no email MCP or counting logic in application code.
> 
> **Overview**
> **Daily-plan email intelligence** no longer tells agents to use provider-wide unread totals for the plan headline. Instructions in `SKILL.md` and `AGENT_INSTRUCTIONS.md` (mirrored under `.claude`, `.agents`, and `packages/dex-agent-plugin`) now require an **attention-inbox** count: Gmail via `` `is:unread category:primary` `` with monitored labels used only for priority surfacing, Apple Mail via unread in Inbox mailboxes, and **no headline number** when the source cannot scope that reliably.
> 
> The sample plan line changes to **"Email: [X] unread in Primary/Inbox, …"** so the summary matches the new rule. **Unreleased changelog** documents the user-visible fix, **`core/lens-catalog/registry.json`** picks up the updated `daily-plan` skill hash, and **`core/tests/test_daily_plan_email_intelligence.py`** locks the contract on the `.claude` copies of both instruction files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b469ff08e5e6e61d30e2162538964c63ed37b6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->