### PR TITLE
Resolve task companies by exact filename when display name differs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ along than it was.
   Promotions and other folders could make the plan say hundreds when only a few
   messages were in Primary or Inbox. The headline now counts that attention
   inbox, and omits the number if the source cannot scope it reliably.
+* **Creating a task no longer refuses a company Dex already has, just because
+  the page filename is the short name and the display name is longer.** A
+  filename-only match is enough. Close-but-not-exact names still get a list of
+  suggestions instead of a guess.
 
 Public Latest remains 1.97.6 until the next numbered release.
 

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -1456,6 +1456,14 @@ def resolve_account_link(account: str) -> Dict[str, Any]:
             if given_folded == (company.get('name') or '').casefold()
         ]
         how = 'name'
+        if not matches:
+            given_filename = Path(given).stem.replace('_', ' ').casefold()
+            matches = [
+                company for company in companies
+                if given_filename
+                == Path(company.get('path') or '').stem.replace('_', ' ').casefold()
+            ]
+            how = 'filename'
 
     candidate_paths = sorted({
         company['path'] for company in matches

--- a/core/tests/test_work_server_entity_links.py
+++ b/core/tests/test_work_server_entity_links.py
@@ -440,6 +440,34 @@ def test_create_task_resolves_account_by_domain(entity_vault):
     assert resolved_path in entity_vault["tasks"].read_text(encoding="utf-8")
 
 
+def test_create_task_resolves_account_by_exact_filename_when_display_name_differs(
+    entity_vault,
+):
+    company = _write_company(
+        entity_vault,
+        "ACME_INC.md",
+        "Acme Incorporated",
+    )
+    resolved_path = _vault_relative(company, entity_vault["root"])
+
+    created = _call_tool(
+        "create_task",
+        {
+            "title": "Prepare the Acme account review",
+            "pillar": "pillar_1",
+            "account": "ACME INC",
+        },
+    )
+
+    assert created["success"] is True
+    assert created["links"]["account"] == {
+        "given": "ACME INC",
+        "resolved_path": resolved_path,
+        "how": "filename",
+    }
+    assert created["task"]["account"] == resolved_path
+
+
 def test_create_task_strong_goal_inference_uses_title_and_context(entity_vault):
     goal_id = "Q3-2026-goal-1"
     _write_goals(


### PR DESCRIPTION
## What this is
Creating a task could refuse a company Dex already had, when the page filename matched the short account name but the display name was longer.

## What changed
- Account resolution now accepts an exact filename match after the display-name match misses.
- Close-but-not-exact names still return suggestions instead of guessing.
- A contract test locks the filename-only case.

## Proof
On current `main` (`7bc43b56`) the new test failed first (`success` was false). After the filename fallback it passed. 93 Work MCP tests passed. Changelog notes this under Unreleased / next public version 1.97.7. Package version stays 1.97.6.

## Not in this PR
No public Dex release. The person who reported it was not contacted.

Independent Front Desk replay of unpushed investigation commit `27138a4b` onto current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Work MCP account linking with a new fallback path and test coverage; no auth, data migration, or broad API surface impact.
> 
> **Overview**
> **Task creation** no longer fails when the user supplies an account string that matches an existing company page **filename** but not its longer **display name**.
> 
> Account resolution in `work_server.py` still tries domain and exact display-name matches first; if name matching finds nothing, it now compares normalized page stems (`Path` stem, underscores as spaces, case-insensitive) and records resolution as `how: 'filename'`. Ambiguity and close-match suggestion behavior for non-exact names is unchanged.
> 
> CHANGELOG Unreleased documents the fix; a Work MCP test covers the `ACME INC` → `ACME_INC.md` / “Acme Incorporated” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d847ef970d430f0a5dff3045370906aa2dbe2fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->