### PR TITLE
Fix blocked task status round trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ along than it was.
   the page filename is the short name and the display name is longer.** A
   filename-only match is enough. Close-but-not-exact names still get a list of
   suggestions instead of a guess.
+* **Blocked tasks no longer stay behind after Dex says their status changed.**
+  The task tool now recognizes the blocked marker in the main list and other
+  copies, can mark a task blocked, and completes every matching copy together.
 
 Public Latest remains 1.97.6 until the next numbered release.
 

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -591,7 +591,7 @@ def _parse_task_metadata(child_lines: List[str], title: str) -> Dict[str, Any]:
 
 def _task_title_from_line(line: str) -> str:
     """Extract task text while accepting both completion timestamp layouts."""
-    title = re.sub(r'^\s*-\s*\[[x ]\]\s*', '', line, count=1)
+    title = re.sub(r'^\s*-\s*\[[ bBxX]\]\s*', '', line, count=1)
     title = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', title)
     title = re.sub(r'\s*\^task-\d{8}-\d{3,}\b', '', title)
     title = title.strip()
@@ -708,7 +708,9 @@ def find_task_by_id(task_id: str) -> List[Dict[str, Any]]:
             lines = content.split('\n')
 
             for i, line in enumerate(lines):
-                if anchored.search(line) and ('- [ ]' in line or '- [x]' in line):
+                if anchored.search(line) and re.match(
+                    r'^\s*-\s*\[[ bBxX]\]', line
+                ):
                     # Extract task title
                     title = _task_title_from_line(line).split('|', 1)[0].strip()
                     
@@ -717,7 +719,7 @@ def find_task_by_id(task_id: str) -> List[Dict[str, Any]]:
                         'line_number': i + 1,
                         'line_content': line,
                         'title': title,
-                        'completed': '- [x]' in line
+                        'completed': bool(re.match(r'^\s*-\s*\[[xX]\]', line))
                     })
         except Exception as e:
             logger.error(f"Error reading {md_file}: {e}")
@@ -763,8 +765,16 @@ def reusable_source_task_id(source: str, source_line: str) -> Optional[str]:
         return None
     return task_id
 
-def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, Any]:
+def update_task_status_everywhere(
+    task_id: str, completed: str | bool
+) -> Dict[str, Any]:
     """Update task status for all instances of a task ID across all files"""
+    status_code = (
+        ('d' if completed else 'n')
+        if isinstance(completed, bool)
+        else completed
+    )
+    completed = status_code == 'd'
     instances = find_task_by_id(task_id)
     
     if not instances:
@@ -788,7 +798,9 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
             
             # Update checkbox and normalize completion metadata around the anchor.
             if completed:
-                new_line = old_line.replace('- [ ]', '- [x]')
+                new_line = re.sub(
+                    r'^(\s*)-\s*\[[ bBxX]\]', r'\1- [x]', old_line, count=1
+                )
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
                 task_id_match = re.search(r'\^' + re.escape(task_id) + r'(?!\d)', new_line)
                 if task_id_match:
@@ -797,8 +809,16 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
                     ).rstrip()
                     new_line = f'{without_anchor} ✅ {completion_timestamp} ^{task_id}'
             else:
-                # Uncompleting: change checkbox and remove timestamp
-                new_line = old_line.replace('- [x]', '- [ ]')
+                # Non-completed statuses carry no completion timestamp. Blocked
+                # remains distinct; not-started and started retain the legacy
+                # open-checkbox representation.
+                target_checkbox = '- [b]' if status_code == 'b' else '- [ ]'
+                new_line = re.sub(
+                    r'^(\s*)-\s*\[[ bBxX]\]',
+                    lambda match: f'{match.group(1)}{target_checkbox}',
+                    old_line,
+                    count=1,
+                )
                 new_line = re.sub(r'\s*✅\s*\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}', '', new_line)
                 task_id_match = re.search(r'\^' + re.escape(task_id) + r'(?!\d)', new_line)
                 if task_id_match:
@@ -826,7 +846,11 @@ def update_task_status_everywhere(task_id: str, completed: bool) -> Dict[str, An
         'success': len(failed_files) == 0,
         'task_id': task_id,
         'title': instances[0]['title'] if instances else '',
-        'status': 'completed' if completed else 'not_completed',
+        'status': (
+            'completed'
+            if completed
+            else ('blocked' if status_code == 'b' else 'not_completed')
+        ),
         'completed_at': completion_timestamp if completed else None,
         'updated_files': updated_files,
         'instances_found': len(instances)
@@ -2739,9 +2763,11 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
             continue
         
         # Parse task lines
-        if line.strip().startswith('- [ ]') or line.strip().startswith('- [x]'):
+        checkbox_match = re.match(r'^-\s*\[([ bBxX])\]', line.strip())
+        if checkbox_match:
             task_counter += 1
-            completed = line.strip().startswith('- [x]')
+            checkbox_status = checkbox_match.group(1).lower()
+            completed = checkbox_status == 'x'
             
             # Extract task ID if present
             task_id = extract_task_id(line)
@@ -2757,7 +2783,7 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
                 continue
             
             # Determine status
-            status = 'd' if completed else 'n'
+            status = 'd' if completed else ('b' if checkbox_status == 'b' else 'n')
             
             metadata = _parse_task_metadata(_task_child_lines(lines, i), clean_title)
 
@@ -5105,7 +5131,7 @@ async def _handle_call_tool_inner(
         
         # If task_id provided, use it directly
         if task_id:
-            result = update_task_status_everywhere(task_id, completed)
+            result = update_task_status_everywhere(task_id, new_status)
             if not result['success']:
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
             
@@ -5157,7 +5183,7 @@ async def _handle_call_tool_inner(
             
             # If task has an ID, use the sync function
             if task.get('task_id'):
-                result = update_task_status_everywhere(task['task_id'], completed)
+                result = update_task_status_everywhere(task['task_id'], new_status)
 
                 if not result['success']:
                     return [types.TextContent(type="text", text=json.dumps(result, indent=2))]

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -662,6 +662,90 @@ def test_completion_normalizes_old_and_new_layouts_with_anchor_last(
     assert parsed["title"] == "Finish launch report"
 
 
+def test_status_tool_completes_blocked_canonical_task_and_open_copy(
+    task_vault, monkeypatch
+):
+    task_id = "task-20260711-049"
+    task_vault["tasks"].write_text(
+        f"# Tasks\n\n## Blocked\n- [b] Ship launch brief ^{task_id}\n",
+        encoding="utf-8",
+    )
+    archive_file = task_vault["root"] / "05-Areas" / "Projects" / "Launch.md"
+    archive_file.parent.mkdir(parents=True)
+    archive_file.write_text(
+        f"# Launch\n\n- [ ] Ship launch brief ^{task_id}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "_tz_now", lambda: datetime(2026, 7, 11, 21, 15))
+
+    result = _call_tool(
+        "update_task_status",
+        {"task_id": task_id, "status": "d"},
+    )
+
+    assert result["success"] is True
+    assert result["instances_found"] == 2
+    expected_line = (
+        "- [x] Ship launch brief ✅ 2026-07-11 21:15 "
+        f"^{task_id}"
+    )
+    assert task_vault["tasks"].read_text(encoding="utf-8").splitlines()[-1] == (
+        expected_line
+    )
+    assert archive_file.read_text(encoding="utf-8").splitlines()[-1] == expected_line
+
+
+def test_status_tool_marks_every_task_copy_blocked(task_vault):
+    task_id = "task-20260711-050"
+    task_vault["tasks"].write_text(
+        f"# Tasks\n\n## Next\n- [ ] Wait for customer evidence ^{task_id}\n",
+        encoding="utf-8",
+    )
+    project_file = task_vault["root"] / "04-Projects" / "Launch.md"
+    project_file.parent.mkdir(parents=True)
+    project_file.write_text(
+        f"# Launch\n\n- [ ] Wait for customer evidence ^{task_id}\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool(
+        "update_task_status",
+        {"task_id": task_id, "status": "b"},
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["instances_found"] == 2
+    expected_line = f"- [b] Wait for customer evidence ^{task_id}"
+    assert task_vault["tasks"].read_text(encoding="utf-8").splitlines()[-1] == (
+        expected_line
+    )
+    assert project_file.read_text(encoding="utf-8").splitlines()[-1] == expected_line
+
+
+def test_status_tool_finds_and_completes_blocked_task_by_title(
+    task_vault, monkeypatch
+):
+    task_id = "task-20260711-051"
+    task_vault["tasks"].write_text(
+        f"# Tasks\n\n## Blocked\n- [b] Publish launch brief ^{task_id}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(work_server, "_tz_now", lambda: datetime(2026, 7, 11, 21, 15))
+
+    result = _call_tool(
+        "update_task_status",
+        {"task_title": "Publish launch brief", "status": "d"},
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert task_vault["tasks"].read_text(encoding="utf-8").splitlines()[-1] == (
+        "- [x] Publish launch brief ✅ 2026-07-11 21:15 "
+        f"^{task_id}"
+    )
+
+
 @pytest.mark.parametrize(
     "task_line",
     [


### PR DESCRIPTION
## What this is
Changing a blocked task could say success while leaving the real task unchanged and only updating another copy.

## What changed
- The task tool now recognizes the blocked checkbox in the main list and other copies.
- It can mark a task blocked, and it completes every matching copy together.
- Three contract tests lock the false-success case, writing blocked to every copy, and finding a blocked task by title.

## Proof
On current `main` (`923874b2`) the three new tests failed first. After the marker repair they passed. 96 Work MCP tests passed. Changelog notes this under Unreleased / next public version 1.97.7. Package version stays 1.97.6.

## Not in this PR
No public Dex release. The person who reported it was not contacted.

Independent Front Desk replay of unpushed investigation commit `4045ae0e` onto current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared markdown mutation and task-sync paths used whenever status is updated by ID or title; behavior is well covered by new tests but touches core Work MCP file rewriting.
> 
> **Overview**
> **Blocked tasks now round-trip correctly** when Dex updates status via the Work MCP task tool. Previously, changing a blocked item could report success while leaving the canonical line on `- [b]` and only touching other copies.
> 
> Parsing and discovery now treat `- [b]` (along with open/done checkboxes) as a task line: title extraction, `find_task_by_id`, and vault parsing map the marker to status **`b`**. **`update_task_status_everywhere`** accepts the full status code (`d` / `b` / `n`, with bool still supported for done/not-done) and rewrites every anchored instance—completing blocked lines to `- [x]` with a timestamp, or setting **`- [b]`** when blocking—instead of only handling `- [ ]` / `- [x]`. The **`update_task_status`** handler passes **`new_status`** through so blocked updates are not collapsed to “not completed.”
> 
> Changelog notes the fix under Unreleased; three round-trip tests cover completing from blocked across files, blocking all copies, and resolving blocked tasks by title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3350462c8d4e3cb21d0b23e10d05295a7c349d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->