### PR TITLE
Fix weekly progress for referenced tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ along than it was.
 * **Blocked tasks no longer stay behind after Dex says their status changed.**
   The task tool now recognizes the blocked marker in the main list and other
   copies, can mark a task blocked, and completes every matching copy together.
+* **Weekly progress no longer ignores a completed task the priority already
+  named by ID in Success criteria.** Progress stayed “not started” unless that
+  task also had a separate weekly-priority backlink. Only exact task IDs count;
+  close names are still ignored.
 
 Public Latest remains 1.97.6 until the next numbered release.
 

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2590,6 +2590,47 @@ def parse_weekly_priorities(filepath: Path) -> List[Dict[str, Any]]:
     
     return priorities
 
+def _task_ids_named_in_priority_success_criteria(priority_id: str) -> set[str]:
+    """Return exact task IDs named in one priority's success criteria."""
+    priorities_file = get_week_priorities_file()
+    if not priorities_file.exists():
+        return set()
+
+    lines = priorities_file.read_text().split('\n')
+    priority_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if extract_priority_id(line) == priority_id
+        ),
+        None,
+    )
+    if priority_index is None:
+        return set()
+
+    priority_indent = _indent_width(lines[priority_index])
+    referenced_task_ids = set()
+    task_id_pattern = r'(?<![A-Za-z0-9_-])(task-\d{8}-\d{3,})(?![A-Za-z0-9_-])'
+
+    for line in lines[priority_index + 1:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _indent_width(line) <= priority_indent:
+            break
+
+        success_criteria = re.match(
+            r'^-\s*Success criteria\s*:\s*(.+)$',
+            stripped,
+            re.IGNORECASE,
+        )
+        if success_criteria:
+            referenced_task_ids.update(
+                re.findall(task_id_pattern, success_criteria.group(1))
+            )
+
+    return referenced_task_ids
+
 def find_linked_tasks(priority_id: str) -> List[Dict[str, Any]]:
     """Find all tasks linked to a weekly priority"""
     tasks_file = get_tasks_file()
@@ -2599,20 +2640,25 @@ def find_linked_tasks(priority_id: str) -> List[Dict[str, Any]]:
     content = tasks_file.read_text()
     lines = content.split('\n')
     
+    referenced_task_ids = _task_ids_named_in_priority_success_criteria(priority_id)
     linked_tasks = []
     for i, line in enumerate(lines):
         if not (line.strip().startswith('- [ ]') or line.strip().startswith('- [x]')):
             continue
 
+        task_id = extract_task_id(line)
         linked_text = '\n'.join([line, *_task_child_lines(lines, i)])
         priority_pattern = (
             rf'(?<![A-Za-z0-9_-]){re.escape(priority_id)}(?![A-Za-z0-9_-])'
         )
-        if not re.search(priority_pattern, linked_text):
+        if (
+            not re.search(priority_pattern, linked_text)
+            and task_id not in referenced_task_ids
+        ):
             continue
 
         linked_tasks.append({
-            'task_id': extract_task_id(line),
+            'task_id': task_id,
             'title': _task_title_from_line(line).split('|', 1)[0].strip(),
             'completed': '- [x]' in line,
             'line_number': i + 1

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -209,6 +209,41 @@ def test_valid_weekly_priority_link_round_trips_into_week_progress(task_vault):
     assert linked["tasks_done"] == 0
 
 
+def test_public_week_progress_counts_completed_task_named_in_success_criteria(
+    task_vault,
+):
+    priority_id = "week-2026-W28-p3"
+    task_id = "task-20260711-062"
+    task_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        f"3. Restore customer confidence — **Test Pillar** ^{priority_id}\n"
+        f"   - Success criteria: Complete {task_id} and share the result\n",
+        encoding="utf-8",
+    )
+    task_vault["tasks"].write_text(
+        "# Tasks\n\n## Done\n"
+        f"- [x] Share customer recovery result ^{task_id} ✅ 2026-07-11 16:30\n"
+        "   - Pillar: Test Pillar | Priority: P1\n",
+        encoding="utf-8",
+    )
+
+    progress = _call_tool("get_week_progress")
+    priority = next(
+        item for item in progress["priorities"]
+        if item["priority_id"] == priority_id
+    )
+
+    assert priority == {
+        "priority_id": priority_id,
+        "title": "Restore customer confidence",
+        "pillar": "Test Pillar",
+        "status": "complete",
+        "tasks_done": 1,
+        "tasks_total": 1,
+        "warning": None,
+    }
+
+
 def test_comma_form_priority_is_visible_in_week_tools(task_vault):
     priority_id = "week-2026-W36-p1"
     task_vault["priorities"].write_text(


### PR DESCRIPTION
## Summary
- Weekly progress could stay **not started** after a completed task when the priority named that task’s exact ID in Success criteria but the task had no separate weekly-priority backlink.
- Front Desk independently replayed the public-boundary regression onto current main `0c1d16de`: it failed first (`tasks_total: 0`, `status: not_started`), then passed after a read-only exact-ID fallback in the canonical Success criteria child line.
- No fuzzy matching. No vault writes. Changelog is under Unreleased (next public version is 1.97.7). Package remains 1.97.6.

## Test Plan
- [x] `test_public_week_progress_counts_completed_task_named_in_success_criteria` failed on current main, then passed
- [x] 39 roundtrip tests passed; 97 Work MCP tests passed
- [x] Ruff and Python compilation passed
- [ ] Covering CI including test-results / touched-file coverage

Do not contact the reporter. Do not cut a public Dex release from this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only parsing extension to task–priority linking for progress reporting, covered by a targeted regression test.
> 
> **Overview**
> **Weekly progress** now treats a task as linked to a priority when its exact `task-…` ID appears in that priority’s **Success criteria** line, not only when the task body backlinks the weekly priority ID.
> 
> `find_linked_tasks` gains a read-only helper that scans the priority block for success-criteria text and collects exact task IDs (no fuzzy name matching). Linked-task totals and completion status for `get_week_progress` therefore reflect criteria-referenced work even without a separate priority backlink on the task.
> 
> Changelog **Unreleased** notes the fix; a roundtrip test locks in a completed task counted via success criteria only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd806bd0f9cb83c94f2a487ce73613047adf476f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->