### PR TITLE
Fix calendar attendee email resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ along than it was.
   named by ID in Success criteria.** Progress stayed “not started” unless that
   task also had a separate weekly-priority backlink. Only exact task IDs count;
   close names are still ignored.
+* **Calendar no longer attaches a meeting attendee to the wrong person just
+  because another person page mentioned that email in its notes.** Dex now
+  matches attendee emails only against recorded person email fields. The
+  correct structured-email page still resolves.
 
 Public Latest remains 1.97.6 until the next numbered release.
 

--- a/core/mcp/calendar_server.py
+++ b/core/mcp/calendar_server.py
@@ -44,6 +44,7 @@ from mcp.server.models import InitializationOptions
 _repo_root = str(Path(__file__).parent.parent.parent)
 if _repo_root not in sys.path:
     sys.path.append(_repo_root)
+from core.entity_engine.contract import parse_entity_page
 from core.paths import PEOPLE_DIR
 from core.paths import VAULT_ROOT as VAULT_PATH
 from core.utils.feature_status import feature_status
@@ -298,6 +299,7 @@ def normalize_name_for_filename(name: str) -> str:
 
 def find_person_page(name: str, email: str) -> Optional[Path]:
     """Find an existing person page by name or email."""
+    normalized_email = email.strip().casefold()
     # Try multiple name variations
     name_variations = [
         normalize_name_for_filename(name),
@@ -326,12 +328,15 @@ def find_person_page(name: str, email: str) -> Optional[Path]:
                         if name_parts[0] in file_stem_lower and name_parts[-1] in file_stem_lower:
                             return file
                 
-                # Check by email in file content
+                # Check only structured person fields, not incidental prose mentions.
                 try:
-                    content = file.read_text()
-                    if email.lower() in content.lower():
+                    person_emails = parse_entity_page(file).get("emails", [])
+                    if normalized_email and normalized_email in {
+                        str(person_email).strip().casefold()
+                        for person_email in person_emails
+                    }:
                         return file
-                except:
+                except (OSError, UnicodeError):
                     pass
     return None
 

--- a/core/tests/test_calendar_server.py
+++ b/core/tests/test_calendar_server.py
@@ -322,3 +322,60 @@ def test_calendar_read_empty_results_remain_healthy(
     assert "user_message" not in payload
     assert "warning" not in payload
     assert payload[empty_field] == ([] if empty_field == "events" else None)
+
+
+def test_attendee_resolution_ignores_email_mentions_outside_person_fields(
+    monkeypatch,
+    tmp_path,
+):
+    vault = tmp_path / "vault"
+    people = vault / "05-Areas" / "People"
+    incidental = people / "Internal" / "Incidental_Contact.md"
+    actual = people / "External" / "Actual_Attendee.md"
+    incidental.parent.mkdir(parents=True)
+    actual.parent.mkdir(parents=True)
+    incidental.write_text(
+        "---\nname: Incidental Contact\nemails: [incidental@example.com]\n---\n"
+        "Meeting note: follow up with actual.attendee@example.com next week.\n"
+    )
+    actual.write_text(
+        "---\nname: Actual Attendee\nemails: [actual.attendee@example.com]\n---\n"
+    )
+    events = [
+        {
+            "title": "Customer call",
+            "attendees": [
+                {
+                    "name": "Calendar Display Name",
+                    "email": "actual.attendee@example.com",
+                    "status": "accepted",
+                }
+            ],
+        }
+    ]
+    monkeypatch.setattr(calendar_server, "VAULT_PATH", vault)
+    monkeypatch.setattr(calendar_server, "PEOPLE_DIR", people)
+    monkeypatch.setattr(
+        calendar_server,
+        "run_shell_script",
+        lambda *args: (True, json.dumps(events)),
+    )
+
+    payload = _decode_tool_result(
+        asyncio.run(
+            calendar_server._handle_call_tool_inner(
+                "calendar_get_events_with_attendees",
+                {
+                    "calendar_name": "Work",
+                    "start_date": "2026-09-04",
+                    "end_date": "2026-09-05",
+                },
+            )
+        )
+    )
+
+    attendee = payload["events"][0]["attendees"][0]
+    assert attendee["has_person_page"] is True
+    assert attendee["person_page"] == (
+        "05-Areas/People/External/Actual_Attendee.md"
+    )

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -3,7 +3,9 @@
 The subprocess timeouts in this module are hang-guards, not performance
 assertions: under pytest-xdist the release builds here run while other workers
 keep every core busy, so the guards carry several multiples of headroom over
-the serial runtime. Tightening them re-introduces load flakes.
+the serial runtime. Tightening them re-introduces load flakes. Vault-bundle
+hang-guards start a new process group and kill it on timeout so a descendant
+such as npm cannot hold captured pipes after bash is gone.
 """
 
 from __future__ import annotations
@@ -14,9 +16,11 @@ import io
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tarfile
+import time
 from pathlib import Path
 from types import ModuleType
 
@@ -118,6 +122,130 @@ RELEASE_BUILD_ABSENT = (
     "System/integrations/slack.yaml",
 )
 
+_VAULT_BUNDLE_TIMEOUT_SECONDS = 240
+_PROCESS_GROUP_DRAIN_SECONDS = 5
+
+
+def _kill_process_group(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            # macOS CI can deny killpg with EPERM while the child is still
+            # ours to kill. Fall back to the process handle so a timeout
+            # stays a timeout instead of hanging on captured pipes.
+            pass
+    try:
+        process.kill()
+    except ProcessLookupError:
+        return
+
+
+def _run_captured_timed(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    timeout: int = _VAULT_BUNDLE_TIMEOUT_SECONDS,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run a hang-guarded command; kill the whole process group on timeout.
+
+    ``subprocess.run(..., capture_output=True, timeout=...)`` SIGKILLs only
+    the parent. ``communicate()`` can then wait forever while a descendant
+    still holds the captured stdout/stderr pipes, so the hang-guard never
+    flushes. A new session plus ``killpg`` lets those pipes drain.
+    """
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        start_new_session=(os.name == "posix"),
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        _kill_process_group(process)
+        try:
+            stdout, stderr = process.communicate(timeout=_PROCESS_GROUP_DRAIN_SECONDS)
+        except subprocess.TimeoutExpired as drain_exc:
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
+            stdout = drain_exc.stdout
+            stderr = drain_exc.stderr
+        raise subprocess.TimeoutExpired(
+            cmd=command,
+            timeout=timeout,
+            output=stdout,
+            stderr=stderr,
+        ) from exc
+    completed = subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+    if check:
+        completed.check_returncode()
+    return completed
+
+
+def _run_vault_bundle(
+    clone: Path,
+    output: Path,
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+    timeout: int = _VAULT_BUNDLE_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    merged = dict(env) if env is not None else os.environ.copy()
+    merged["DEX_VAULT_BUNDLE_PHASE_TIMING"] = "1"
+    try:
+        return _run_captured_timed(
+            ["bash", "scripts/build-vault-bundle.sh", str(output)],
+            cwd=clone,
+            env=merged,
+            timeout=timeout,
+            check=check,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise AssertionError(
+            "build-vault-bundle timed out after "
+            f"{timeout}s; last phases:\n"
+            f"stdout:\n{exc.stdout}\nstderr:\n{exc.stderr}"
+        ) from exc
+
+
+def test_captured_timeout_kills_pipe_holding_descendant(tmp_path: Path) -> None:
+    """A grandchild holding captured pipes must not stall the hang-guard."""
+
+    script = tmp_path / "hold-pipes.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        "python3 -c "
+        "'import sys, time; sys.stderr.write(\"child-start\\n\"); "
+        "sys.stderr.flush(); time.sleep(30)' &\n"
+        "wait\n",
+        encoding="utf-8",
+    )
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        _run_captured_timed(["bash", str(script)], cwd=tmp_path, timeout=1)
+    elapsed = time.monotonic() - started
+    assert elapsed < 8, elapsed
+    assert "child-start" in (caught.value.stderr or "")
+
 
 def _load_tau_checker() -> ModuleType:
     path = REPO_ROOT / "scripts/check-tau-removal.py"
@@ -126,6 +254,7 @@ def _load_tau_checker() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
 
 def _archive_members() -> set[str]:
     """Return paths from the archive users receive from the current checkout."""
@@ -807,14 +936,7 @@ def test_raw_vault_bundle_has_package_profile_manifest_agreement(tmp_path: Path)
         json.dumps({"profile": "legacy-v1", "release_version": "0.0.1", "schema_version": 1}, indent=2) + "\n"
     )
     output = tmp_path / "bundle-output"
-    subprocess.run(
-        ["bash", "scripts/build-vault-bundle.sh", str(output)],
-        cwd=clone,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=240,
-    )
+    _run_vault_bundle(clone, output, check=True)
     archive_path = next(output.glob("dex-vault-bundle-v*.tar.gz"))
     with tarfile.open(archive_path, "r:gz") as archive:
         package = json.load(archive.extractfile("./package.json"))
@@ -855,23 +977,7 @@ def test_raw_vault_bundle_publishes_standalone_verified_bridge(tmp_path: Path) -
     clone = _clone_repo(tmp_path, "raw-vault-bundle-bridge-asset")
     _commit_release_inputs_if_changed(clone)
     output = tmp_path / "bridge-asset-output"
-    env = os.environ.copy()
-    env["DEX_VAULT_BUNDLE_PHASE_TIMING"] = "1"
-    try:
-        subprocess.run(
-            ["bash", "scripts/build-vault-bundle.sh", str(output)],
-            cwd=clone,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=240,
-            env=env,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise AssertionError(
-            "build-vault-bundle timed out after 240s; last phases:\n"
-            f"stdout:\n{exc.stdout}\nstderr:\n{exc.stderr}"
-        ) from exc
+    _run_vault_bundle(clone, output, check=True)
 
     version = json.loads((clone / "package.json").read_text(encoding="utf-8"))["version"]
     bridge = output / f"dex-update-bridge-v{version}.py"
@@ -914,13 +1020,8 @@ def test_raw_vault_bundle_rejects_dirty_protocol_inputs_not_in_source_commit(
     environment = os.environ.copy()
     environment["PATH"] = f"{spy_dir}{os.pathsep}{environment['PATH']}"
 
-    result = subprocess.run(
-        ["bash", "scripts/build-vault-bundle.sh", str(tmp_path / "blocked-bundle")],
-        cwd=clone,
-        capture_output=True,
-        text=True,
-        timeout=240,
-        env=environment,
+    result = _run_vault_bundle(
+        clone, tmp_path / "blocked-bundle", env=environment
     )
 
     assert result.returncode == 1
@@ -1785,14 +1886,7 @@ def test_vault_bundle_tree_manifest_and_archive_contain_no_tau(tmp_path: Path) -
     output_dir = tmp_path / "bundle-output"
     environment = os.environ.copy()
     environment["npm_config_offline"] = "true"
-    build_result = subprocess.run(
-        ["bash", "scripts/build-vault-bundle.sh", str(output_dir)],
-        cwd=clone,
-        capture_output=True,
-        text=True,
-        timeout=240,
-        env=environment,
-    )
+    build_result = _run_vault_bundle(clone, output_dir, env=environment)
     assert build_result.returncode == 0, build_result.stdout + build_result.stderr
 
     archive_path = next(output_dir.glob("dex-vault-bundle-v*.tar.gz"))
@@ -2223,14 +2317,7 @@ def test_vault_build_rejects_tau_before_build_package_or_archive_commands(
     environment["PATH"] = f"{spy_dir}{os.pathsep}{environment['PATH']}"
     output_dir = tmp_path / "blocked-output"
 
-    result = subprocess.run(
-        ["bash", "scripts/build-vault-bundle.sh", str(output_dir)],
-        cwd=clone,
-        capture_output=True,
-        text=True,
-        timeout=240,
-        env=environment,
-    )
+    result = _run_vault_bundle(clone, output_dir, env=environment)
     assert result.returncode == 1
     assert "Tau Mirror npx loader" in result.stdout
     assert not sentinel.exists()

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -211,6 +211,15 @@ def _run_vault_bundle(
 ) -> subprocess.CompletedProcess[str]:
     merged = dict(env) if env is not None else os.environ.copy()
     merged["DEX_VAULT_BUNDLE_PHASE_TIMING"] = "1"
+    # Covering Mac CI hung for 240s in the staged
+    # `npm ci --omit=dev --ignore-scripts` after one deprecation warning,
+    # never reaching after-npm-ci. The job already ran npm ci for this
+    # checkout, so the cache is warm. Stay offline and skip audit/fund
+    # so a miss fails fast instead of waiting on the registry under xdist.
+    merged.setdefault("npm_config_offline", "true")
+    merged.setdefault("npm_config_audit", "false")
+    merged.setdefault("npm_config_fund", "false")
+    merged.setdefault("npm_config_progress", "false")
     try:
         return _run_captured_timed(
             ["bash", "scripts/build-vault-bundle.sh", str(output)],

--- a/core/tests/test_distribution_artifacts.py
+++ b/core/tests/test_distribution_artifacts.py
@@ -855,14 +855,23 @@ def test_raw_vault_bundle_publishes_standalone_verified_bridge(tmp_path: Path) -
     clone = _clone_repo(tmp_path, "raw-vault-bundle-bridge-asset")
     _commit_release_inputs_if_changed(clone)
     output = tmp_path / "bridge-asset-output"
-    subprocess.run(
-        ["bash", "scripts/build-vault-bundle.sh", str(output)],
-        cwd=clone,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=240,
-    )
+    env = os.environ.copy()
+    env["DEX_VAULT_BUNDLE_PHASE_TIMING"] = "1"
+    try:
+        subprocess.run(
+            ["bash", "scripts/build-vault-bundle.sh", str(output)],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=240,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise AssertionError(
+            "build-vault-bundle timed out after 240s; last phases:\n"
+            f"stdout:\n{exc.stdout}\nstderr:\n{exc.stderr}"
+        ) from exc
 
     version = json.loads((clone / "package.json").read_text(encoding="utf-8"))["version"]
     bridge = output / f"dex-update-bridge-v{version}.py"

--- a/scripts/build-vault-bundle.sh
+++ b/scripts/build-vault-bundle.sh
@@ -6,6 +6,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OUTPUT_DIR="${1:-$REPO_ROOT/dist}"
+
+_phase() {
+  if [ "${DEX_VAULT_BUNDLE_PHASE_TIMING:-}" = "1" ]; then
+    printf 'vault-bundle phase %s at %s\n' "$1" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
+  fi
+}
+_phase start
 DISTIGNORE="$REPO_ROOT/.distignore"
 PRODUCT_AGENTS_TEMPLATE="$REPO_ROOT/core/harnesses/templates/product-AGENTS.md"
 
@@ -25,7 +32,9 @@ if [ "$PRODUCT_AGENTS_TEMPLATE_SIZE" -eq 0 ] || [ "$PRODUCT_AGENTS_TEMPLATE_SIZE
 fi
 
 # Reject unsafe source inputs before staging or running npm.
+_phase before-tau-source-check
 python3 "$REPO_ROOT/scripts/check-tau-removal.py" --source-root "$REPO_ROOT"
+_phase after-tau-source-check
 
 VERSION="$(node -p "require('$REPO_ROOT/package.json').version")"
 mkdir -p "$OUTPUT_DIR"
@@ -62,6 +71,7 @@ if ! git diff --quiet "$SOURCE_COMMIT" -- "${PROTOCOL_SOURCE_PATHS[@]}"; then
 fi
 
 # The bundle must carry the protocol for these exact committed source artifacts.
+_phase before-protocol-generate
 python3 "$REPO_ROOT/scripts/generate-update-journey-protocol.py" \
   --output "$JOURNEY_PROTOCOL_CHECK"
 if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/core/update/journey-protocol-v1.json"; then
@@ -69,6 +79,7 @@ if ! cmp -s "$JOURNEY_PROTOCOL_CHECK" "$REPO_ROOT/core/update/journey-protocol-v
   echo "Run python3 scripts/generate-update-journey-protocol.py and commit the result." >&2
   exit 1
 fi
+_phase after-protocol-check
 
 # Match build-release.sh's .distignore removals without copying ignored local
 # files such as .env. Include untracked, non-ignored files so the script is
@@ -80,7 +91,9 @@ done | LC_ALL=C sort -u > "$ALL_FILES"
 sh "$REPO_ROOT/scripts/resolve-distignore-files.sh" \
   "$DISTIGNORE" "$ALL_FILES" "$EXCLUDED_FILES" "$INCLUDED_FILES"
 
+_phase before-rsync-staging
 rsync -a --files-from="$INCLUDED_FILES" ./ "$STAGING_DIR/"
+_phase after-rsync-staging
 
 # The contributor AGENTS.md is intentionally excluded by .distignore. Install
 # the product bootstrap from the canonical template before building the
@@ -145,12 +158,15 @@ python3 "$REPO_ROOT/scripts/check-catalog-coverage.py" --release-root "$STAGING_
 
 # The staged tree is the release input. Check it before npm can execute or
 # access a registry.
+_phase before-tau-tree-check
 python3 "$REPO_ROOT/scripts/check-tau-removal.py" --tree "$STAGING_DIR"
 
+_phase before-npm-ci
 (
   cd "$STAGING_DIR"
   npm ci --omit=dev --ignore-scripts
 )
+_phase after-npm-ci
 # npm creates command shims as symlinks. Dex does not execute dependency CLIs
 # from the vault bundle, so remove them rather than weakening the no-symlink
 # distribution contract.
@@ -165,6 +181,7 @@ rm -f "$TARBALL" "$CHECKSUM" "$BRIDGE_ASSET" "$BRIDGE_CHECKSUM"
   # belt-and-braces for any stray on-disk macOS metadata, matching the manifest.
   COPYFILE_DISABLE=1 tar --exclude='._*' --exclude='.DS_Store' -czf "$TARBALL" .
 )
+_phase after-tarball
 python3 "$REPO_ROOT/scripts/check-tau-removal.py" --archive "$TARBALL"
 (
   cd "$OUTPUT_DIR"
@@ -189,3 +206,4 @@ echo "Built $TARBALL"
 echo "Checksum $CHECKSUM"
 echo "Bridge $BRIDGE_ASSET"
 echo "Bridge checksum $BRIDGE_CHECKSUM"
+_phase done


### PR DESCRIPTION
## Summary
- Calendar could attach a meeting attendee to the **wrong person** when another person page merely mentioned that email in its notes.
- Front Desk independently replayed the public-boundary regression onto current main `5c55d39a`: it failed first (`Internal/Incidental_Contact.md`), then passed after matching attendee emails only against Dex’s structured person email fields.
- The correct structured-email page still resolves. Changelog is under Unreleased (next public version is 1.97.7). Package remains 1.97.6.

## Test Plan
- [x] `test_attendee_resolution_ignores_email_mentions_outside_person_fields` failed on current main, then passed
- [x] 25 Calendar server tests passed; 86 Calendar/entity/meeting-context tests passed
- [x] Ruff passed
- [ ] Covering CI including test-results / touched-file coverage

Do not contact the reporter. Do not cut a public Dex release from this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Calendar person resolution behavior changes for edge cases (fewer false positives); vault-bundle test harness changes affect CI reliability, not production bundle output logic beyond optional phase logging.
> 
> **Overview**
> **Calendar attendee linking** no longer treats a bare email mention in person-page body text as a match. `find_person_page` now compares the attendee address only against emails from `parse_entity_page` (frontmatter/structured fields), with case-normalized comparison and narrower read-error handling. A regression test covers the case where one page’s notes mention another person’s address.
> 
> **Vault-bundle distribution tests** replace plain `subprocess.run(..., timeout=...)` with `_run_captured_timed` / `_run_vault_bundle`: new process groups are killed on timeout so npm or other descendants cannot leave captured pipes hanging under xdist. Tests default npm to offline/audit-off for faster failure on cache miss; timeouts surface `DEX_VAULT_BUNDLE_PHASE_TIMING` output from `build-vault-bundle.sh`.
> 
> **CHANGELOG** records the calendar fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae979d8968199ce2bd8498ecf5531369ec0a6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->