### PR TITLE
Fix Windows Work MCP reads of weekly planning files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## Unreleased — next public version is 1.97.8
+
+On Windows, Dex could refuse to read a perfectly valid weekly planning file
+because the notes emoji is not ASCII. Week progress, task lists, summaries,
+scheduling, and new tasks all failed instead of returning results.
+
+**What this fixes for you:**
+
+* **Work planning tools on Windows now read your weekly file as UTF-8.** A
+  notes emoji in that file no longer blocks week progress, task lists,
+  summaries, scheduling suggestions, or creating a task.
+
+Public Latest remains 1.97.7 until the next numbered release.
+
 ## [1.97.7] — Changing jobs keeps everything, and tasks get a home under each goal (2026-09-03)
 
 The last goal in your quarterly plan could pick up checkboxes that belonged to

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2741,7 +2741,7 @@ def parse_weekly_priorities(filepath: Path) -> List[Dict[str, Any]]:
     if not filepath.exists():
         return []
     
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     priorities = []
     
     lines = content.split('\n')
@@ -2792,7 +2792,7 @@ def _task_ids_named_in_priority_success_criteria(priority_id: str) -> set[str]:
     if not priorities_file.exists():
         return set()
 
-    lines = priorities_file.read_text().split('\n')
+    lines = priorities_file.read_text(encoding="utf-8").split('\n')
     priority_index = next(
         (
             index
@@ -2833,7 +2833,7 @@ def find_linked_tasks(priority_id: str) -> List[Dict[str, Any]]:
     if not tasks_file.exists():
         return []
     
-    content = tasks_file.read_text()
+    content = tasks_file.read_text(encoding="utf-8")
     lines = content.split('\n')
     
     referenced_task_ids = _task_ids_named_in_priority_success_criteria(priority_id)
@@ -3005,7 +3005,7 @@ def parse_tasks_file(filepath: Path) -> List[Dict[str, Any]]:
     if not filepath.exists():
         return tasks
     
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     lines = content.split('\n')
     
     current_section = None

--- a/core/tests/test_work_server_roundtrip.py
+++ b/core/tests/test_work_server_roundtrip.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from datetime import date, datetime
 from pathlib import Path
@@ -207,6 +208,42 @@ def test_valid_weekly_priority_link_round_trips_into_week_progress(task_vault):
     linked = next(item for item in progress["priorities"] if item["priority_id"] == priority_id)
     assert linked["tasks_total"] == 1
     assert linked["tasks_done"] == 0
+
+
+def test_week_progress_reads_utf8_priority_with_windows_default(
+    task_vault, monkeypatch
+):
+    task_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        "1. Ship customer launch — **Test Pillar** ^week-2026-W36-p1\n\n"
+        "## 📝 Notes\n",
+        encoding="utf-8",
+    )
+    original_open = io.open
+
+    def windows_default_open(
+        file,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+        closefd=True,
+        opener=None,
+    ):
+        if "b" not in mode and encoding in (None, "locale"):
+            encoding = "cp1252"
+        return original_open(
+            file, mode, buffering, encoding, errors, newline, closefd, opener
+        )
+
+    monkeypatch.setattr(io, "open", windows_default_open)
+
+    progress = _call_tool("get_week_progress")
+
+    assert [priority["title"] for priority in progress["priorities"]] == [
+        "Ship customer launch"
+    ]
 
 
 def test_public_week_progress_counts_completed_task_named_in_success_criteria(


### PR DESCRIPTION
## Why

On Windows, Dex work tools could fail while reading a valid weekly planning file because the notes emoji is not ASCII. Python used the OS default decoder (cp1252), so week progress, task lists, summaries, scheduling, and new tasks all crashed instead of returning results.

## What

Shared weekly-file and task-file readers now decode UTF-8 explicitly, including the success-criteria reader added after 1.97.6.

Proven red on current main (`UnicodeDecodeError` byte `0x9d`), then green. 40 related round-trip tests pass. The five named public tools succeed under a simulated Windows default.

Unreleased changelog for a future 1.97.8. `package.json` remains 1.97.7. Not a public release.

## Test plan

- [x] `test_week_progress_reads_utf8_priority_with_windows_default` failed on current main, then passed
- [x] `core/tests/test_work_server_roundtrip.py` 40 passed
- [ ] Covering Dex CI tests (1)(2)(3) + test-results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow encoding fix for markdown reads plus a regression test; behavior on UTF-8 vaults is unchanged on Unix and should improve on Windows.
> 
> **Overview**
> **Fixes Work MCP tools failing on Windows** when weekly planning files contain non-ASCII text (e.g. a 📝 notes heading). Those reads no longer rely on the system default encoding (cp1252).
> 
> **`parse_weekly_priorities`**, success-criteria lookup, **linked-task** scanning, and **`parse_tasks_file`** now call **`read_text(encoding="utf-8")`** so week progress, task lists, summaries, scheduling, and task creation can parse valid UTF-8 vault files.
> 
> Adds a regression test that simulates Windows default **`open`** encoding and asserts **`get_week_progress`** still parses priorities. **CHANGELOG** documents the fix under unreleased **1.97.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb224fdc9b7e41a991c0b4746459760e9e8c0a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->