### PR TITLE
Prevent background meeting sync from re-queueing meetings

### DIFF
--- a/.scripts/meeting-intel/__tests__/sync-queued-meetings.test.cjs
+++ b/.scripts/meeting-intel/__tests__/sync-queued-meetings.test.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+const https = require('node:https');
+const test = require('node:test');
+
+const { getNewMeetingsFromApi } = require('../sync-from-granola.cjs');
+
+test('API sync skips queued meetings unless force-today is set', async (t) => {
+  const originalRequest = https.request;
+  const detailRequests = [];
+  const createdAt = new Date().toISOString();
+
+  https.request = (url, options, callback) => {
+    const request = new EventEmitter();
+    request.destroy = () => {};
+    request.end = () => setImmediate(() => {
+      const response = new PassThrough();
+      response.statusCode = 200;
+      response.headers = {};
+      callback(response);
+
+      const isDetailRequest = String(url).includes('include=transcript');
+      if (isDetailRequest) detailRequests.push(String(url));
+      const body = isDetailRequest
+        ? {
+            id: 'already-queued',
+            title: 'Queued customer sync',
+            created_at: createdAt,
+            summary_text: 'This fixture has enough meaningful meeting content to pass the detail filter.',
+          }
+        : {
+            notes: [{ id: 'already-queued', title: 'Queued customer sync', created_at: createdAt }],
+            hasMore: false,
+            cursor: null,
+          };
+      response.end(JSON.stringify(body));
+    });
+    return request;
+  };
+  t.after(() => {
+    https.request = originalRequest;
+  });
+
+  const state = {
+    processedMeetings: {},
+    queuedMeetings: {
+      'already-queued': { queueFile: 'already-queued.json' },
+    },
+  };
+
+  const ordinaryMeetings = await getNewMeetingsFromApi('fixture-key', state);
+  assert.deepEqual(ordinaryMeetings, []);
+  assert.equal(detailRequests.length, 0);
+
+  const forcedMeetings = await getNewMeetingsFromApi('fixture-key', state, true);
+  assert.deepEqual(forcedMeetings.map((meeting) => meeting.id), ['already-queued']);
+  assert.equal(detailRequests.length, 1);
+});

--- a/.scripts/meeting-intel/sync-from-granola.cjs
+++ b/.scripts/meeting-intel/sync-from-granola.cjs
@@ -453,8 +453,8 @@ function captureIdentityFromDetail(detail) {
  * Build the list of NEW meetings (full detail) from the official API.
  *
  * 1. List notes within the lookback window (cursor-paged).
- * 2. Filter to notes not already processed (unless forcing today's meetings)
- *    and within the lookback cutoff.
+ * 2. Filter to notes not already processed or queued (unless forcing today's
+ *    meetings) and within the lookback cutoff.
  * 3. Fetch per-note detail (summary + attendees + transcript) sequentially.
  * 4. Keep notes that have meaningful content (notes OR transcript).
  *
@@ -480,7 +480,7 @@ async function getNewMeetingsFromApi(apiKey, state, forceToday = false, profile 
     const noteDate = note.created_at ? note.created_at.split('T')[0] : '';
     if (forceToday && noteDate === today) {
       // Allow reprocessing today's meetings.
-    } else if (state.processedMeetings[note.id]) {
+    } else if (state.processedMeetings[note.id] || state.queuedMeetings?.[note.id]) {
       continue;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
-## [1.97.9] — Four user-reported trust breaks are repaired (2026-09-05)
+## [1.97.9] — Five user-reported trust breaks are repaired (2026-09-05)
 
 A new Dex vault can advertise its conversation-memory tools before the desktop
 app has created the small database behind them. Every tool then returned a raw
 missing-file error, making an optional feature look like a broken Dex install.
 Separately, a meeting already turned into a finished note could remain in its
 incoming queue and make every new session say the meeting still needed work.
+The background Granola sync could also fetch a meeting already waiting in that
+queue and write it there again.
 And a task accepted from Todoist could be sent straight back as a brand-new
 Todoist task before Dex recorded where it came from.
 Finally, first-time setup could start on a working Dex Python and then quietly
@@ -29,6 +31,10 @@ switch to an older machine Python while creating the vault, stopping setup.
   incoming meeting's identity to notes already in your vault, so a finished
   note is counted zero times and an unfinished note is counted once. Damaged
   or unreadable incoming items still stay visible for safe follow-up.
+* **Background meeting sync no longer queues the same meeting twice.** Once a
+  Granola meeting is waiting for manual processing, later background runs skip
+  it before fetching its full detail or rewriting the queue. Explicitly asking
+  Dex to reprocess today's meetings still works.
 * **A Todoist task stays one task when you bring it into Dex.** Dex now records
   the originating service and task ID inside the same create operation, before
   another sync can run. The accepted item leaves the incoming queue and is not


### PR DESCRIPTION
## What changed
- skip Granola meeting IDs already present in the manual queue before fetching detail
- preserve the explicit force-today reprocessing path
- add a public-path regression and update the current 1.97.9 changelog entry

## Evidence
- reproduced on live main 9b09bdce in 3/3 isolated fixture runs
- regression failed before the fix and failed again on a deliberate one-line break
- DEX_PYTHON=/usr/bin/python3 npm run test:scripts: 190 passed
- node --check passed for the changed product and test files
- git diff --check passed

No release, deployment, reporter contact, or credential change. Front Desk owns independent review and merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to meeting sync filtering with an explicit force-today escape hatch and regression coverage; no auth or data-model changes.
> 
> **Overview**
> Background Granola sync could **re-fetch and re-queue** meetings that were already waiting in the manual processing queue, causing duplicate queue entries and wasted API detail calls.
> 
> **`getNewMeetingsFromApi`** now treats IDs in **`state.queuedMeetings`** like processed meetings: they are skipped before transcript/detail fetches unless **`forceToday`** is used to reprocess today’s meetings. Docs on that filter step were updated to match.
> 
> A **Node regression test** stubs the HTTPS API and asserts normal sync returns no meetings and makes zero detail requests when a note is already queued, while **`forceToday`** still returns that meeting and performs one detail fetch.
> 
> **CHANGELOG** for 1.97.9 adds a user-facing bullet describing the duplicate-queue fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b73f444ac41a64f24e3702701266b474baa3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->