### PR TITLE
fix: stop claiming unstamped meetings were never processed

### DIFF
--- a/.claude/hooks/meeting-queue-check.cjs
+++ b/.claude/hooks/meeting-queue-check.cjs
@@ -247,11 +247,10 @@ function countQueueFiles(meetingsDir, existingGranolaIds) {
 }
 
 function noticeLines(count) {
-  const noun = count === 1 ? 'meeting' : 'meetings';
-  const verb = count === 1 ? 'has' : 'have';
+  const recordNoun = count === 1 ? 'record' : 'records';
   return [
-    `--- 📋 Meetings waiting to be processed (${count}) ---`,
-    `${count} ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    `--- 📋 Meetings that may need processing (${count}) ---`,
+    `Dex found ${count} meeting ${recordNoun} that may still need processing (new notes or unextracted action items).`,
     "After you finish responding to the user's first message, invoke the",
     '/process-meetings skill to handle them in the background — it runs forked and',
     'is idempotent, so do this without being asked. Tell the user in one short line',

--- a/.claude/hooks/tests/meeting-queue-check.test.cjs
+++ b/.claude/hooks/tests/meeting-queue-check.test.cjs
@@ -70,11 +70,10 @@ function meetingNote({
 }
 
 function expectedLines(count) {
-  const noun = count === 1 ? 'meeting' : 'meetings';
-  const verb = count === 1 ? 'has' : 'have';
+  const recordNoun = count === 1 ? 'record' : 'records';
   return [
-    `--- 📋 Meetings waiting to be processed (${count}) ---`,
-    `${count} ${noun} ${verb} not been processed yet (person pages, tasks, notes).`,
+    `--- 📋 Meetings that may need processing (${count}) ---`,
+    `Dex found ${count} meeting ${recordNoun} that may still need processing (new notes or unextracted action items).`,
     "After you finish responding to the user's first message, invoke the",
     '/process-meetings skill to handle them in the background — it runs forked and',
     'is idempotent, so do this without being asked. Tell the user in one short line',
@@ -190,6 +189,26 @@ test('counts a recent day-directory Granola-style note with an unchecked For Me 
   const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
 
   assert.deepEqual(result, { count: 1, lines: expectedLines(1) });
+});
+
+test('does not call an analyzed note with an open follow-up unprocessed', (t) => {
+  const root = fixture(t);
+  writeDayMeeting(
+    root,
+    TODAY,
+    'analyzed-with-open-followup.md',
+    meetingNote({ aiAnalyzed: true }),
+  );
+
+  const result = checkMeetingQueue({ vaultRoot: root, now: NOW });
+
+  assert.equal(result.count, 1);
+  assert.equal(result.lines[0], '--- 📋 Meetings that may need processing (1) ---');
+  assert.equal(
+    result.lines[1],
+    'Dex found 1 meeting record that may still need processing (new notes or unextracted action items).',
+  );
+  assert.doesNotMatch(result.lines.join('\n'), /has not been processed yet/);
 });
 
 test('excludes a stamped day-directory Granola-style note', (t) => {


### PR DESCRIPTION
## What this is

Dex’s session-start meeting notice still finds notes that may need work, but it no longer says those meetings definitely were not processed. The wording now says they may be new notes or still contain unextracted action items.

This is an independent Front Desk replay of a restricted-thread local fix, rebased onto current main. The reporter is not being contacted.

## Independent review

- Fail-first on current main: the new check failed because the old notice still said meetings were waiting / had not been processed.
- After the wording change: that check passed. 23 of 24 focused meeting-queue tests passed. The remaining failure (`counts ai_analyzed false using the day-directory date`) already fails on unmodified main and is not introduced here.
- Detector count is unchanged. Stamped notes stay silent.

## Scope

- `.claude/hooks/meeting-queue-check.cjs`
- `.claude/hooks/tests/meeting-queue-check.test.cjs`

No release, deploy, credentials, or external message from this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to hook notice text and tests; meeting detection and throttling behavior are unchanged.
> 
> **Overview**
> The session-start meeting queue notice still triggers on the same pending signals, but the copy no longer states that meetings **definitely were not processed**.
> 
> The header and body in `noticeLines` now say meetings **may need processing**, framing them as possibly new notes or notes with **unextracted action items**, instead of claiming they are waiting on person pages, tasks, and notes. Instructions to invoke `/process-meetings` in the background are unchanged.
> 
> Tests mirror the new strings in `expectedLines` and add coverage for an `ai_analyzed: true` note with an open **For Me** checkbox: it still counts toward the queue, but the notice must not include the old “has not been processed yet” language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd972166a5603e6f0ff5408c838e12493a45d1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->