### PR TITLE
fix: keep weekly planning working when a goal has no ID

### DIFF
--- a/.agents/skills/week-plan/SKILL.md
+++ b/.agents/skills/week-plan/SKILL.md
@@ -58,8 +58,11 @@ Check for `00-Inbox/Weekly_Synthesis_[last-monday].md`:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null — it has no ID to
+look up, and the call will tell you so rather than return a status.
 
 For each goal, get:
 - Current progress (concrete: "2 of 5 milestones complete")
@@ -67,7 +70,13 @@ For each goal, get:
 - Weeks since last activity
 - Stall warnings
 
-**Identify goals needing attention:**
+**Check `activity_known` before judging any goal.** When it is `false` — the
+goal was typed by hand with no ID, or recovered from a freeform list —
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never call such a goal orphaned or stalled on that basis.
+
+**Identify goals needing attention** (only among goals where `activity_known`
+is `true`):
 - Goals with no linked priorities (orphaned)
 - Goals with no activity in 2+ weeks (stalled)
 - Goals behind expected pace

--- a/.agents/skills/week-plan/SKILL.md
+++ b/.agents/skills/week-plan/SKILL.md
@@ -91,7 +91,11 @@ Get all open tasks and:
 Use: get_weekly_planning_context()
 ```
 
-Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming. Use them directly:
+Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming.
+
+**First, check `activity_known`.** When it is `false`, that goal has no usable ID — it was typed by hand, or recovered from a freeform list — so Dex cannot tell what links to it. `linked_priority_count`, `has_activity`, `open_task_count` and `next_up_tasks` are all `null` for that goal, meaning *not known*, never *none*. Do not read a `null` as zero, do not call it stalled or neglected, and do not call `get_goal_backlog` for it (a null ID falls back to every goal's backlog). Plan around it normally and pass on the `recommendations` line that says how to give it an ID.
+
+For every goal where `activity_known` is `true`, use the fields directly:
 
 - **Goal has `next_up_tasks`:** suggest those items by name — "Goal X's next-up items are A and B — they fit Wednesday's block."
 - **Stalled goal with open tasks but no groomed order:** call `get_goal_backlog(goal_id)` and pick candidates from the top of its ordering (priority, then oldest).

--- a/.agents/skills/week-review/SKILL.md
+++ b/.agents/skills/week-review/SKILL.md
@@ -209,8 +209,18 @@ Scan `03-Tasks/Tasks.md` for completion timestamps from this week:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null, or that is marked
+`provisional` — there is no ID to look up, and the call will say so rather than
+return a status.
+
+**Check `activity_known` before judging any goal.** When it is `false`,
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never report such a goal as stalled or as having no
+linked work; say its links cannot be read yet and pass on the recommendation
+about giving it an ID.
 
 For each goal:
 - Milestones completed this week

--- a/.claude/skills/week-plan/SKILL.md
+++ b/.claude/skills/week-plan/SKILL.md
@@ -56,8 +56,11 @@ Check for `00-Inbox/Weekly_Synthesis_[last-monday].md`:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null — it has no ID to
+look up, and the call will tell you so rather than return a status.
 
 For each goal, get:
 - Current progress (concrete: "2 of 5 milestones complete")
@@ -65,7 +68,13 @@ For each goal, get:
 - Weeks since last activity
 - Stall warnings
 
-**Identify goals needing attention:**
+**Check `activity_known` before judging any goal.** When it is `false` — the
+goal was typed by hand with no ID, or recovered from a freeform list —
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never call such a goal orphaned or stalled on that basis.
+
+**Identify goals needing attention** (only among goals where `activity_known`
+is `true`):
 - Goals with no linked priorities (orphaned)
 - Goals with no activity in 2+ weeks (stalled)
 - Goals behind expected pace

--- a/.claude/skills/week-plan/SKILL.md
+++ b/.claude/skills/week-plan/SKILL.md
@@ -89,7 +89,11 @@ Get all open tasks and:
 Use: get_weekly_planning_context()
 ```
 
-Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming. Use them directly:
+Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming.
+
+**First, check `activity_known`.** When it is `false`, that goal has no usable ID — it was typed by hand, or recovered from a freeform list — so Dex cannot tell what links to it. `linked_priority_count`, `has_activity`, `open_task_count` and `next_up_tasks` are all `null` for that goal, meaning *not known*, never *none*. Do not read a `null` as zero, do not call it stalled or neglected, and do not call `get_goal_backlog` for it (a null ID falls back to every goal's backlog). Plan around it normally and pass on the `recommendations` line that says how to give it an ID.
+
+For every goal where `activity_known` is `true`, use the fields directly:
 
 - **Goal has `next_up_tasks`:** suggest those items by name — "Goal X's next-up items are A and B — they fit Wednesday's block."
 - **Stalled goal with open tasks but no groomed order:** call `get_goal_backlog(goal_id)` and pick candidates from the top of its ordering (priority, then oldest).

--- a/.claude/skills/week-review/SKILL.md
+++ b/.claude/skills/week-review/SKILL.md
@@ -207,8 +207,18 @@ Scan `03-Tasks/Tasks.md` for completion timestamps from this week:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null, or that is marked
+`provisional` — there is no ID to look up, and the call will say so rather than
+return a status.
+
+**Check `activity_known` before judging any goal.** When it is `false`,
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never report such a goal as stalled or as having no
+linked work; say its links cannot be read yet and pass on the recommendation
+about giving it an ID.
 
 For each goal:
 - Milestones completed this week

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -122,8 +122,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-plan/SKILL.md",
-        "sha256": "02235fc9462e52666feb0c940d585124acdcbbd36229ec7072e6bd6613f16fb9",
-        "byte_size": 15133
+        "sha256": "4869440e3bc53319412f365de76359f4f169e786353b83d2f27dada882e32cdb",
+        "byte_size": 16297
       },
       "value": "Turns goals, capacity and open work into a weekly focus plan, so repeated work starts from priorities rather than a blank chat.",
       "jobs_served": [
@@ -564,8 +564,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-review/SKILL.md",
-        "sha256": "79e9ee08d47e060e1ab10a37aa39764ce3249557b074b01a96ee1eac4410a820",
-        "byte_size": 19385
+        "sha256": "04e09c80dcbb092e6d99f12088b8e5633a2b1c0b02c0c190aa6de46dc54e32ac",
+        "byte_size": 19905
       },
       "value": "Reviews the week in concrete finished work and the patterns behind it, and deliberately refuses to invent a completion percentage that would make a bad week look measured.",
       "jobs_served": [

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -6286,13 +6286,18 @@ async def _handle_call_tool_inner(
             if goal['quarter'] == quarter or not goal['quarter']:
                 if include_completed or goal['progress'] < 100:
                     # Enrich with linked priorities
+                    # A hand-written goal has no ID, and a provisional goal's
+                    # ID is generated and exists nowhere on disk. Neither one's
+                    # links can be read, so report unknown rather than zero.
+                    activity_known = bool(goal['goal_id']) and not goal.get('provisional')
                     linked_priorities = (
-                        find_linked_priorities(goal['goal_id'])
-                        if goal['goal_id'] and not goal.get('provisional')
-                        else []
+                        find_linked_priorities(goal['goal_id']) if activity_known else []
                     )
-                    goal['linked_priorities'] = linked_priorities
-                    goal['linked_priorities_count'] = len(linked_priorities)
+                    goal['activity_known'] = activity_known
+                    goal['linked_priorities'] = linked_priorities if activity_known else None
+                    goal['linked_priorities_count'] = (
+                        len(linked_priorities) if activity_known else None
+                    )
                     filtered_goals.append(goal)
         
         result = {
@@ -6316,7 +6321,20 @@ async def _handle_call_tool_inner(
 
     elif name == "get_goal_status":
         goal_id = arguments['goal_id']
-        
+
+        # get_goal_by_id(None) happily matches a hand-written goal, whose ID
+        # is also None, and every link lookup below then crashes on it.
+        if not goal_id:
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    "This goal has no ID, so Dex cannot tell what links to it. "
+                    "Add an ID like ^Qx-YYYY-goal-N straight after the bolded "
+                    "pillar in its heading in Quarter_Goals.md, or run "
+                    "migrate_quarterly_goals."
+                ),
+            }, indent=2))]
+
         goal = get_goal_by_id(goal_id)
         if not goal:
             return [types.TextContent(type="text", text=json.dumps({
@@ -6652,7 +6670,9 @@ async def _handle_call_tool_inner(
         
         # Check for stalled goals
         for goal in goals:
-            if goal.get('goal_id'):
+            # A provisional goal's ID is generated; it can neither be linked to
+            # nor be shown to lack links, so it is never "stalled".
+            if goal.get('goal_id') and not goal.get('provisional'):
                 linked_priorities = find_linked_priorities(goal['goal_id'])
                 if len(linked_priorities) == 0:
                     warnings.append({
@@ -6711,7 +6731,7 @@ async def _handle_call_tool_inner(
         goals_with_no_priorities = []
         
         for goal in goals:
-            if goal.get('goal_id'):
+            if goal.get('goal_id') and not goal.get('provisional'):
                 linked_priorities = find_linked_priorities(goal['goal_id'])
                 if len(linked_priorities) == 0:
                     goals_with_no_priorities.append(goal)
@@ -7074,8 +7094,9 @@ async def _handle_call_tool_inner(
             heading = "each heading" if count > 1 else "its heading"
             recommendations.append(
                 f"{subject} no ID, so Dex cannot tell which weekly priorities or "
-                f"tasks {belong}: {names}. Add an ID like ^Qx-YYYY-goal-N to the end "
-                f"of {heading} in Quarter_Goals.md, or run migrate_quarterly_goals "
+                f"tasks {belong}: {names}. Add an ID like ^Qx-YYYY-goal-N "
+                f"straight after the bolded pillar in {heading} in "
+                "Quarter_Goals.md, or run migrate_quarterly_goals "
                 f"to add {'them all at once' if count > 1 else 'it'}."
             )
         if provisional_goals:

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3016,6 +3016,20 @@ def infer_goal_link(priority_title: str, priority_pillar: str,
             })
             continue
 
+        # A goal with no ID cannot be linked to: create_weekly_priority
+        # rejects any goal that is absent from the available IDs. Surfacing it
+        # as a match would only promise a link that is refused a moment later.
+        if not goal_id:
+            candidates.append({
+                'goal_id': None,
+                'goal_title': goal_title,
+                'goal_pillar': goal_pillar,
+                'score': 0,
+                'confidence': 'none',
+                'reasons': ['goal_has_no_id'],
+            })
+            continue
+
         # --- Pillar match ---
         # Normalize pillar names: the goal stores display name like "deal_support",
         # the priority pillar may be the key or the display name
@@ -6926,7 +6940,13 @@ async def _handle_call_tool_inner(
         # Build goal health report
         goal_health = []
         for goal in goals:
-            linked_priorities = find_linked_priorities(goal.get('goal_id', ''))
+            # A hand-written goal heading carries no ^Qx-YYYY-goal-N anchor, so
+            # the parser yields goal_id None. Nothing can be linked to a goal
+            # with no ID, so report no links instead of crashing, and keep it
+            # out of every count that would otherwise claim work it cannot own.
+            goal_id = goal.get('goal_id')
+            activity_known = bool(goal_id)
+            linked_priorities = find_linked_priorities(goal_id) if activity_known else []
             completed_milestones = sum(1 for m in goal.get('milestones', []) if m.get('completed'))
             total_milestones = len(goal.get('milestones', []))
             next_milestone = None
@@ -6938,10 +6958,10 @@ async def _handle_call_tool_inner(
             goal_tasks = sorted(
                 (
                     task for task in open_backlog
-                    if task.get('goal') == goal.get('goal_id')
+                    if task.get('goal') == goal_id
                 ),
                 key=backlog_sort_key,
-            )
+            ) if activity_known else []
             next_up_tasks = [
                 {
                     'task_id': task.get('task_id'),
@@ -6954,7 +6974,7 @@ async def _handle_call_tool_inner(
             ][:3]
 
             goal_health.append({
-                'goal_id': goal.get('goal_id'),
+                'goal_id': goal_id,
                 'title': goal.get('title'),
                 'pillar': goal.get('pillar'),
                 'progress': goal.get('progress', 0),
@@ -6963,12 +6983,17 @@ async def _handle_call_tool_inner(
                 'next_milestone': next_milestone,
                 'linked_priority_count': len(linked_priorities),
                 'has_activity': len(linked_priorities) > 0,
+                'activity_known': activity_known,
                 'open_task_count': len(goal_tasks),
                 'next_up_tasks': next_up_tasks,
             })
 
-        # Identify neglected goals (0 linked priorities)
-        neglected_goals = [g for g in goal_health if not g['has_activity']]
+        # Identify neglected goals (0 linked priorities). A goal whose links
+        # cannot be read at all is unknown, not neglected.
+        neglected_goals = [
+            g for g in goal_health if g['activity_known'] and not g['has_activity']
+        ]
+        goals_missing_ids = [g for g in goal_health if not g['activity_known']]
 
         # Auto-match proposed priorities against goals if provided
         proposed = arguments.get('proposed_priorities', []) if arguments else []
@@ -6995,6 +7020,12 @@ async def _handle_call_tool_inner(
 
         # Build recommendations
         recommendations = []
+        for g in goals_missing_ids:
+            recommendations.append(
+                f"Goal \"{g['title']}\" has no ID, so Dex cannot tell which weekly "
+                "priorities or tasks belong to it. Add an ID like ^Qx-YYYY-goal-N to "
+                "the end of its heading in Quarter_Goals.md."
+            )
         if neglected_goals:
             names = ', '.join(f"Goal {g['goal_id']}: {g['title']}" for g in neglected_goals)
             recommendations.append(f"{len(neglected_goals)} goals have zero weekly activity: {names}")

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3019,9 +3019,9 @@ def infer_goal_link(priority_title: str, priority_pillar: str,
             })
             continue
 
-        # A goal with no ID cannot be linked to: create_weekly_priority
-        # rejects any goal that is absent from the available IDs. Surfacing it
-        # as a match would only promise a link that is refused a moment later.
+        # A goal with no ID cannot be linked to: create_task rejects any goal
+        # absent from the available IDs, and a None ID names nothing anywhere.
+        # Surfacing it as a match would only promise a link that cannot exist.
         if not goal_id:
             candidates.append({
                 'goal_id': None,
@@ -3292,9 +3292,32 @@ def migrate_quarterly_goals() -> Dict[str, Any]:
     # Parse existing goals
     existing_goals = parse_quarterly_goals(goals_file)
     goals_updated = 0
-    
-    # Find goals without IDs and add them
+    headings_needing_manual_fix = []
+
+    # A heading whose trailing anchor is not a canonical goal ID reads as
+    # ID-less to the parser, but must never be rewritten here: that anchor is
+    # the user's, and it may be load-bearing elsewhere in their vault. Name it
+    # instead, so the advice to run this tool has a route out.
     for i, line in enumerate(lines):
+        foreign_anchor = re.match(
+            r'(###\s+\d+\.\s+(.+?)\s+—\s+\*\*.*?\*\*)\s+(\^\S+)\s*$', line
+        )
+        if foreign_anchor and not re.fullmatch(
+            r'\^Q\d+-\d{4}-goal-\d+', foreign_anchor.group(3)
+        ):
+            headings_needing_manual_fix.append({
+                'line_number': i + 1,
+                'title': foreign_anchor.group(2).strip(),
+                'existing_anchor': foreign_anchor.group(3),
+                'reason': (
+                    'This heading ends with an anchor that is not a quarterly '
+                    'goal ID, so Dex cannot read it as one and will not '
+                    'overwrite your anchor. Replace it with ^Qn-YYYY-goal-N, '
+                    'or move your anchor elsewhere on the page.'
+                ),
+            })
+            continue
+
         # Match goal headers without IDs
         goal_match = re.match(r'(###\s+\d+\.\s+.+?\s+—\s+\*\*.*?\*\*)(?!\s+\^)', line)
         if goal_match:
@@ -3315,11 +3338,18 @@ def migrate_quarterly_goals() -> Dict[str, Any]:
     if goals_updated > 0:
         goals_file.write_text('\n'.join(lines))
     
-    return {
+    result = {
         'success': True,
         'goals_updated': goals_updated,
         'message': f"Added IDs to {goals_updated} quarterly goals"
     }
+    if headings_needing_manual_fix:
+        result['headings_needing_manual_fix'] = headings_needing_manual_fix
+        result['message'] += (
+            f"; {len(headings_needing_manual_fix)} heading(s) end with an anchor "
+            "that is not a goal ID and were left untouched"
+        )
+    return result
 
 def migrate_weekly_priorities() -> Dict[str, Any]:
     """Add IDs to existing weekly priorities that don't have them"""
@@ -6992,7 +7022,7 @@ async def _handle_call_tool_inner(
                 'activity_known': activity_known,
                 'provisional': provisional,
                 'open_task_count': len(goal_tasks) if activity_known else None,
-                'next_up_tasks': next_up_tasks,
+                'next_up_tasks': next_up_tasks if activity_known else None,
             })
 
         # Identify neglected goals (0 linked priorities). A goal whose links
@@ -7034,23 +7064,28 @@ async def _handle_call_tool_inner(
             names = ', '.join(f"\"{g['title']}\"" for g in goals_missing_ids)
             count = len(goals_missing_ids)
             subject = f"{count} goals have" if count > 1 else "1 goal has"
-            belong = "belong to them" if count > 1 else "belongs to it"
+            belong = "belong to them" if count > 1 else "belong to it"
             heading = "each heading" if count > 1 else "its heading"
             recommendations.append(
                 f"{subject} no ID, so Dex cannot tell which weekly priorities or "
                 f"tasks {belong}: {names}. Add an ID like ^Qx-YYYY-goal-N to the end "
                 f"of {heading} in Quarter_Goals.md, or run migrate_quarterly_goals "
-                "to add them all at once."
+                f"to add {'them all at once' if count > 1 else 'it'}."
             )
         if provisional_goals:
             names = ', '.join(f"\"{g['title']}\"" for g in provisional_goals)
             count = len(provisional_goals)
-            subject = f"{count} goals were" if count > 1 else "1 goal was"
+            many = count > 1
             recommendations.append(
-                f"{subject} recovered from a freeform list and are provisional: "
-                f"their IDs are generated, so nothing links to them automatically "
-                f"({names}). Structure them (e.g. via /quarter-plan) as "
-                "### N. Title — **Pillar** ^Qn-YYYY-goal-N to link real work."
+                f"{count} goals were" if many else "1 goal was"
+            )
+            recommendations[-1] += (
+                f" recovered from a freeform list and {'are' if many else 'is'} "
+                f"provisional: {'their IDs are' if many else 'its ID is'} generated, "
+                f"so nothing links to {'them' if many else 'it'} automatically "
+                f"({names}). Structure {'them' if many else 'it'} (e.g. via "
+                "/quarter-plan) as ### N. Title — **Pillar** ^Qn-YYYY-goal-N "
+                "to link real work."
             )
         if neglected_goals:
             names = ', '.join(f"Goal {g['goal_id']}: {g['title']}" for g in neglected_goals)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -6987,11 +6987,11 @@ async def _handle_call_tool_inner(
                 'milestones_completed': completed_milestones,
                 'milestones_total': total_milestones,
                 'next_milestone': next_milestone,
-                'linked_priority_count': len(linked_priorities),
-                'has_activity': len(linked_priorities) > 0,
+                'linked_priority_count': len(linked_priorities) if activity_known else None,
+                'has_activity': len(linked_priorities) > 0 if activity_known else None,
                 'activity_known': activity_known,
                 'provisional': provisional,
-                'open_task_count': len(goal_tasks),
+                'open_task_count': len(goal_tasks) if activity_known else None,
                 'next_up_tasks': next_up_tasks,
             })
 
@@ -7000,7 +7000,10 @@ async def _handle_call_tool_inner(
         neglected_goals = [
             g for g in goal_health if g['activity_known'] and not g['has_activity']
         ]
-        goals_missing_ids = [g for g in goal_health if not g['activity_known']]
+        goals_missing_ids = [
+            g for g in goal_health if not g['goal_id'] and not g['provisional']
+        ]
+        provisional_goals = [g for g in goal_health if g['provisional']]
 
         # Auto-match proposed priorities against goals if provided
         proposed = arguments.get('proposed_priorities', []) if arguments else []
@@ -7029,12 +7032,25 @@ async def _handle_call_tool_inner(
         recommendations = []
         if goals_missing_ids:
             names = ', '.join(f"\"{g['title']}\"" for g in goals_missing_ids)
-            plural = 's' if len(goals_missing_ids) > 1 else ''
+            count = len(goals_missing_ids)
+            subject = f"{count} goals have" if count > 1 else "1 goal has"
+            belong = "belong to them" if count > 1 else "belongs to it"
+            heading = "each heading" if count > 1 else "its heading"
             recommendations.append(
-                f"{len(goals_missing_ids)} goal{plural} have no ID, so Dex cannot tell "
-                f"which weekly priorities or tasks belong to them: {names}. Add an ID "
-                "like ^Qx-YYYY-goal-N to the end of each heading in Quarter_Goals.md, "
-                "or run migrate_quarterly_goals to add them all at once."
+                f"{subject} no ID, so Dex cannot tell which weekly priorities or "
+                f"tasks {belong}: {names}. Add an ID like ^Qx-YYYY-goal-N to the end "
+                f"of {heading} in Quarter_Goals.md, or run migrate_quarterly_goals "
+                "to add them all at once."
+            )
+        if provisional_goals:
+            names = ', '.join(f"\"{g['title']}\"" for g in provisional_goals)
+            count = len(provisional_goals)
+            subject = f"{count} goals were" if count > 1 else "1 goal was"
+            recommendations.append(
+                f"{subject} recovered from a freeform list and are provisional: "
+                f"their IDs are generated, so nothing links to them automatically "
+                f"({names}). Structure them (e.g. via /quarter-plan) as "
+                "### N. Title — **Pillar** ^Qn-YYYY-goal-N to link real work."
             )
         if neglected_goals:
             names = ', '.join(f"Goal {g['goal_id']}: {g['title']}" for g in neglected_goals)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3294,48 +3294,66 @@ def migrate_quarterly_goals() -> Dict[str, Any]:
     goals_updated = 0
     headings_needing_manual_fix = []
 
-    # A heading whose trailing anchor is not a canonical goal ID reads as
-    # ID-less to the parser, but must never be rewritten here: that anchor is
-    # the user's, and it may be load-bearing elsewhere in their vault. Name it
-    # instead, so the advice to run this tool has a route out.
+    # Decide on the whole heading line, not just its last token. A heading may
+    # already carry a valid goal ID somewhere other than straight after the
+    # pillar, and a user's own anchor may sit anywhere on the line. Neither may
+    # be rewritten here: adding a second ID would orphan every existing link,
+    # and overwriting a user's anchor destroys something that may be
+    # load-bearing elsewhere in their vault.
+    heading_re = re.compile(r'(###\s+\d+\.\s+(.+?)\s+—\s+\*\*.*?\*\*)(.*)$')
+    canonical_re = re.compile(r'\^Q\d+-\d{4}-goal-\d+')
+    any_anchor_re = re.compile(r'\^\S+')
+
     for i, line in enumerate(lines):
-        foreign_anchor = re.match(
-            r'(###\s+\d+\.\s+(.+?)\s+—\s+\*\*.*?\*\*)\s+(\^\S+)\s*$', line
-        )
-        if foreign_anchor and not re.fullmatch(
-            r'\^Q\d+-\d{4}-goal-\d+', foreign_anchor.group(3)
-        ):
+        heading = heading_re.match(line)
+        if not heading:
+            continue
+
+        goal_header, title, trailing = heading.group(1), heading.group(2).strip(), heading.group(3)
+
+        if canonical_re.search(line):
+            # Already has a goal ID. If it is not straight after the pillar the
+            # parser cannot read it, so name it rather than adding a second.
+            if not re.match(r'\s+\^Q\d+-\d{4}-goal-\d+', trailing):
+                headings_needing_manual_fix.append({
+                    'line_number': i + 1,
+                    'title': title,
+                    'existing_anchor': canonical_re.search(line).group(0),
+                    'reason': (
+                        'This heading has a goal ID, but not straight after the '
+                        'bolded pillar, which is the only place Dex reads it. '
+                        'Move it there. Dex will not add a second ID, because '
+                        'that would orphan everything already linked to this one.'
+                    ),
+                })
+            continue
+
+        foreign = any_anchor_re.search(trailing)
+        if foreign:
             headings_needing_manual_fix.append({
                 'line_number': i + 1,
-                'title': foreign_anchor.group(2).strip(),
-                'existing_anchor': foreign_anchor.group(3),
+                'title': title,
+                'existing_anchor': foreign.group(0),
                 'reason': (
-                    'This heading ends with an anchor that is not a quarterly '
-                    'goal ID, so Dex cannot read it as one and will not '
-                    'overwrite your anchor. Replace it with ^Qn-YYYY-goal-N, '
-                    'or move your anchor elsewhere on the page.'
+                    'This heading carries an anchor that is not a quarterly goal '
+                    'ID, so Dex cannot read it as one and will not overwrite your '
+                    'anchor. Replace it with ^Qn-YYYY-goal-N, or move your anchor '
+                    'elsewhere on the page.'
                 ),
             })
             continue
 
-        # Match goal headers without IDs
-        goal_match = re.match(r'(###\s+\d+\.\s+.+?\s+—\s+\*\*.*?\*\*)(?!\s+\^)', line)
-        if goal_match:
-            # This goal doesn't have an ID, add one. Anything the user wrote
-            # after the pillar is theirs and is carried through untouched.
-            goal_header = goal_match.group(1)
-            trailing = line[goal_match.end():]
-            
-            # Generate ID
-            quarter_match = re.search(r'quarter:\s+(.+)', content[:content.find(line)])
-            quarter = quarter_match.group(1) if quarter_match else get_quarter_info()['quarter']
-            
-            goal_id = generate_goal_id(quarter, existing_goals)
-            lines[i] = f"{goal_header} ^{goal_id}{trailing}"
-            
-            # Add this goal to existing_goals so next ID is incremented
-            existing_goals.append({'goal_id': goal_id})
-            goals_updated += 1
+        # No ID at all: add one straight after the pillar, where the parser
+        # looks, and carry anything the user wrote after it through untouched.
+        quarter_match = re.search(r'quarter:\s+(.+)', content[:content.find(line)])
+        quarter = quarter_match.group(1) if quarter_match else get_quarter_info()['quarter']
+
+        goal_id = generate_goal_id(quarter, existing_goals)
+        lines[i] = f"{goal_header} ^{goal_id}{trailing}"
+
+        # Add this goal to existing_goals so next ID is incremented
+        existing_goals.append({'goal_id': goal_id})
+        goals_updated += 1
     
     if goals_updated > 0:
         goals_file.write_text('\n'.join(lines))
@@ -6341,7 +6359,19 @@ async def _handle_call_tool_inner(
                 "success": False,
                 "error": f"Goal not found: {goal_id}"
             }, indent=2))]
-        
+
+        if goal.get('provisional'):
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    f"Goal '{goal['title']}' is provisional: it was recovered "
+                    "from a freeform list and its ID is generated, so it exists "
+                    "nowhere on disk and any match would be a collision. "
+                    "Structure it (e.g. via /quarter-plan) as "
+                    "### N. Title — **Pillar** ^Qn-YYYY-goal-N first."
+                ),
+            }, indent=2))]
+
         # Get linked priorities
         linked_priorities = find_linked_priorities(goal_id)
         
@@ -6768,6 +6798,19 @@ async def _handle_call_tool_inner(
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, cls=DateTimeEncoder))]
 
     elif name == "get_goal_backlog":
+        # An explicit null means the caller has a goal with no ID. Coercing that
+        # to 'all' hands back every other goal's backlog as if it were this
+        # goal's, which is worse than refusing.
+        if arguments and 'goal_id' in arguments and arguments['goal_id'] is None:
+            return [types.TextContent(type="text", text=json.dumps({
+                "success": False,
+                "error": (
+                    "That goal has no ID, so Dex cannot tell which tasks belong "
+                    "to it. Add an ID like ^Qx-YYYY-goal-N straight after the "
+                    "bolded pillar in its heading in Quarter_Goals.md, or run "
+                    "migrate_quarterly_goals. Pass 'all' if you meant every goal."
+                ),
+            }, indent=2))]
         requested_goal_id = str(arguments.get('goal_id') or 'all').strip() or 'all'
 
         goals = (

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2320,9 +2320,12 @@ def generate_goal_id(quarter: str, existing_goals: List[Dict]) -> str:
     max_num = 0
     prefix = f"{q_num}-{year}-goal-"
     for goal in existing_goals:
-        if 'goal_id' in goal and goal['goal_id'].startswith(prefix):
+        # A hand-written goal heading has no ID at all, and it is exactly the
+        # vault migrate_quarterly_goals exists to repair.
+        existing_id = goal.get('goal_id')
+        if existing_id and existing_id.startswith(prefix):
             try:
-                num = int(goal['goal_id'].split('-')[-1])
+                num = int(existing_id.split('-')[-1])
                 max_num = max(max_num, num)
             except (ValueError, IndexError):
                 continue
@@ -6945,7 +6948,10 @@ async def _handle_call_tool_inner(
             # with no ID, so report no links instead of crashing, and keep it
             # out of every count that would otherwise claim work it cannot own.
             goal_id = goal.get('goal_id')
-            activity_known = bool(goal_id)
+            # A provisional goal was recovered from freeform text; its ID
+            # exists nowhere on disk, so nothing can be linked to it either.
+            provisional = bool(goal.get('provisional'))
+            activity_known = bool(goal_id) and not provisional
             linked_priorities = find_linked_priorities(goal_id) if activity_known else []
             completed_milestones = sum(1 for m in goal.get('milestones', []) if m.get('completed'))
             total_milestones = len(goal.get('milestones', []))
@@ -6984,6 +6990,7 @@ async def _handle_call_tool_inner(
                 'linked_priority_count': len(linked_priorities),
                 'has_activity': len(linked_priorities) > 0,
                 'activity_known': activity_known,
+                'provisional': provisional,
                 'open_task_count': len(goal_tasks),
                 'next_up_tasks': next_up_tasks,
             })
@@ -7020,11 +7027,14 @@ async def _handle_call_tool_inner(
 
         # Build recommendations
         recommendations = []
-        for g in goals_missing_ids:
+        if goals_missing_ids:
+            names = ', '.join(f"\"{g['title']}\"" for g in goals_missing_ids)
+            plural = 's' if len(goals_missing_ids) > 1 else ''
             recommendations.append(
-                f"Goal \"{g['title']}\" has no ID, so Dex cannot tell which weekly "
-                "priorities or tasks belong to it. Add an ID like ^Qx-YYYY-goal-N to "
-                "the end of its heading in Quarter_Goals.md."
+                f"{len(goals_missing_ids)} goal{plural} have no ID, so Dex cannot tell "
+                f"which weekly priorities or tasks belong to them: {names}. Add an ID "
+                "like ^Qx-YYYY-goal-N to the end of each heading in Quarter_Goals.md, "
+                "or run migrate_quarterly_goals to add them all at once."
             )
         if neglected_goals:
             names = ', '.join(f"Goal {g['goal_id']}: {g['title']}" for g in neglected_goals)

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -3321,15 +3321,17 @@ def migrate_quarterly_goals() -> Dict[str, Any]:
         # Match goal headers without IDs
         goal_match = re.match(r'(###\s+\d+\.\s+.+?\s+—\s+\*\*.*?\*\*)(?!\s+\^)', line)
         if goal_match:
-            # This goal doesn't have an ID, add one
+            # This goal doesn't have an ID, add one. Anything the user wrote
+            # after the pillar is theirs and is carried through untouched.
             goal_header = goal_match.group(1)
+            trailing = line[goal_match.end():]
             
             # Generate ID
             quarter_match = re.search(r'quarter:\s+(.+)', content[:content.find(line)])
             quarter = quarter_match.group(1) if quarter_match else get_quarter_info()['quarter']
             
             goal_id = generate_goal_id(quarter, existing_goals)
-            lines[i] = f"{goal_header} ^{goal_id}"
+            lines[i] = f"{goal_header} ^{goal_id}{trailing}"
             
             # Add this goal to existing_goals so next ID is incremented
             existing_goals.append({'goal_id': goal_id})
@@ -6284,7 +6286,11 @@ async def _handle_call_tool_inner(
             if goal['quarter'] == quarter or not goal['quarter']:
                 if include_completed or goal['progress'] < 100:
                     # Enrich with linked priorities
-                    linked_priorities = find_linked_priorities(goal['goal_id']) if goal['goal_id'] else []
+                    linked_priorities = (
+                        find_linked_priorities(goal['goal_id'])
+                        if goal['goal_id'] and not goal.get('provisional')
+                        else []
+                    )
                     goal['linked_priorities'] = linked_priorities
                     goal['linked_priorities_count'] = len(linked_priorities)
                     filtered_goals.append(goal)

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -92,7 +92,8 @@ def test_goal_without_id_does_not_crash_weekly_planning_context(planning_vault):
     assert ANCHORLESS_TITLE in titles
     anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
     assert anchorless["goal_id"] is None
-    assert anchorless["linked_priority_count"] == 0
+    # Unknown, not zero: Dex never looked, because it could not.
+    assert anchorless["linked_priority_count"] is None
 
 
 def test_goal_without_id_is_not_reported_as_neglected(planning_vault):
@@ -142,7 +143,7 @@ def test_goal_without_id_does_not_absorb_unlinked_backlog_tasks(planning_vault):
     result = _call_tool("get_weekly_planning_context")
 
     anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
-    assert anchorless["open_task_count"] == 0
+    assert anchorless["open_task_count"] is None
     assert anchorless["next_up_tasks"] == []
     # The real link still lands on the goal that actually owns it.
     anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
@@ -266,3 +267,47 @@ def test_many_missing_ids_produce_one_recommendation(planning_vault):
     for n in range(1, 6):
         assert f"Hand written goal {n}" in id_recs[0]
     assert "Quarter_Goals.md" in id_recs[0]
+
+
+def test_provisional_goals_are_not_told_to_add_an_id(planning_vault):
+    """They have generated IDs; migration would report nothing to update."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n"
+        "- Grow the newsletter audience\n"
+        "- Reduce onboarding drop-off\n",
+        encoding="utf-8",
+    )
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    assert all("^Qx-YYYY-goal-N" not in r for r in result["recommendations"])
+    assert any("freeform" in r for r in result["recommendations"])
+
+
+def test_one_missing_id_reads_as_one(planning_vault):
+    """The single-goal case is the common one; it must not read as broken."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    rec = next(r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r)
+    assert "1 goal has no ID" in rec
+    assert "belongs to it" in rec
+    assert "goals have" not in rec
+
+
+def test_unknowable_activity_is_reported_as_unknown_not_as_zero(planning_vault):
+    """Reading has_activity alone must not resurrect the wrong answer."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["has_activity"] is None
+    assert anchorless["linked_priority_count"] is None
+    anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
+    assert anchored["has_activity"] is True
+    assert anchored["linked_priority_count"] == 1

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -1,0 +1,193 @@
+"""Weekly planning context must survive a hand-written goal with no hidden ID.
+
+A quarterly goal typed by hand has no `^Qx-YYYY-goal-N` anchor, so the parser
+yields `goal_id=None`. Weekly planning context has to keep working, must not
+claim priorities or backlog tasks that belong to nobody, and must say plainly
+which goal needs an ID.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+TEST_PILLARS = {
+    "pillar_1": {
+        "name": "Growth",
+        "description": "Neutral test work",
+        "keywords": ["growth"],
+    },
+}
+
+ANCHORLESS_TITLE = "Hand written goal without an anchor"
+ANCHORED_ID = "Q3-2026-goal-1"
+
+
+def _call_tool(name: str, arguments: dict | None = None) -> dict:
+    result = asyncio.run(work_server.handle_call_tool(name, arguments or {}))
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def planning_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    tasks_file = tmp_path / "03-Tasks" / "Tasks.md"
+    priorities_file = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
+    goals_file = tmp_path / "01-Quarter_Goals" / "Quarter_Goals.md"
+    for path in (tasks_file, priorities_file, goals_file):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    tasks_file.write_text("# Tasks\n\n## Next Week\n", encoding="utf-8")
+
+    monkeypatch.setattr(work_server, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: tasks_file)
+    monkeypatch.setattr(work_server, "get_week_priorities_file", lambda: priorities_file)
+    monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals_file)
+    monkeypatch.setattr(work_server, "PILLARS", TEST_PILLARS)
+    monkeypatch.setattr(work_server, "_fire_analytics_event", lambda *a, **k: None)
+    monkeypatch.setattr(work_server, "refresh_search_index", lambda: None)
+
+    return {"tasks": tasks_file, "priorities": priorities_file, "goals": goals_file}
+
+
+def _write_goals(goals_file: Path, *, with_anchored: bool = True) -> None:
+    anchored = (
+        f"### 1. Ship the launch — **Growth** ^{ANCHORED_ID}\n\n"
+        "**What success looks like:**\nLaunch is out.\n\n"
+        "- [ ] Draft the launch plan\n\n"
+        if with_anchored
+        else ""
+    )
+    goals_file.write_text(
+        "# Quarter Goals\n\n"
+        f"{anchored}"
+        f"### 2. {ANCHORLESS_TITLE} — **Growth**\n\n"
+        "**What success looks like:**\nSomething good happens.\n\n"
+        "- [ ] Write the first milestone\n",
+        encoding="utf-8",
+    )
+
+
+def _write_priorities(priorities_file: Path) -> None:
+    priorities_file.write_text(
+        "# Week Priorities\n\n"
+        f"1. **Ship the launch** — Growth (Goal: {ANCHORED_ID}) ^week-2026-W37-p1\n"
+        "2. **Unrelated operational work** — Growth ^week-2026-W37-p2\n",
+        encoding="utf-8",
+    )
+
+
+def test_goal_without_id_does_not_crash_weekly_planning_context(planning_vault):
+    """The reported failure: TypeError instead of usable planning context."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    titles = [goal["title"] for goal in result["goal_health"]]
+    assert ANCHORLESS_TITLE in titles
+    anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["goal_id"] is None
+    assert anchorless["linked_priority_count"] == 0
+
+
+def test_goal_without_id_is_not_reported_as_neglected(planning_vault):
+    """An unknowable link is not evidence of zero weekly activity."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["activity_known"] is False
+    # The anchored goal has a real linked priority, so nothing is neglected.
+    assert result["neglected_goals_count"] == 0
+    assert all("Goal None" not in rec for rec in result["recommendations"])
+    assert all(
+        s["from_goal"] is not None
+        for s in (result["suggested_priorities_from_goals"] or [])
+    )
+
+
+def test_goal_without_id_is_named_with_the_fix(planning_vault):
+    """The user is told which goal needs which anchor, and where to add it."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    text = " ".join(result["recommendations"])
+    assert ANCHORLESS_TITLE in text
+    assert "^Qx-YYYY-goal-N" in text
+    assert "Quarter_Goals.md" in text
+
+
+def test_goal_without_id_does_not_absorb_unlinked_backlog_tasks(planning_vault):
+    """Open tasks with no goal belong to no goal, not to the anchorless one."""
+    planning_vault["tasks"].write_text(
+        "# Tasks\n\n## Next Week\n"
+        "- [ ] Unlinked backlog work ^task-20260903-001\n"
+        "\t- Pillar: Growth | Priority: P1\n"
+        "- [ ] Linked backlog work ^task-20260903-002\n"
+        f"\t- Pillar: Growth | Priority: P1 | Goal: {ANCHORED_ID}\n",
+        encoding="utf-8",
+    )
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["open_task_count"] == 0
+    assert anchorless["next_up_tasks"] == []
+    # The real link still lands on the goal that actually owns it.
+    anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
+    assert anchored["open_task_count"] == 1
+
+
+def test_anchored_goals_keep_their_linked_priorities(planning_vault):
+    """The guard must not cost healthy goals their real linked context."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
+    assert anchored["linked_priority_count"] == 1
+    assert anchored["has_activity"] is True
+
+
+def test_goal_without_id_is_never_offered_as_a_priority_link(planning_vault):
+    """Suggesting a link that create_weekly_priority would refuse helps nobody."""
+    _write_goals(planning_vault["goals"], with_anchored=False)
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool(
+        "get_weekly_planning_context",
+        {"proposed_priorities": [{"title": ANCHORLESS_TITLE, "pillar": "Growth"}]},
+    )
+
+    matched = result["matched_priorities"][0]
+    # Even an exact title match against the ID-less goal yields no link.
+    assert matched["inferred_goal"] is None
+    assert matched["is_operational"] is True
+    assert matched["alternatives"] == []
+
+
+def test_anchored_goals_are_still_inferred_normally(planning_vault):
+    """The guard must not cost healthy goals their priority matching."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool(
+        "get_weekly_planning_context",
+        {"proposed_priorities": [{"title": "Ship the launch", "pillar": "Growth"}]},
+    )
+
+    matched = result["matched_priorities"][0]
+    assert matched["inferred_goal"]["goal_id"] == ANCHORED_ID
+    assert all(alt["goal_id"] is not None for alt in matched["alternatives"])

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -191,3 +191,78 @@ def test_anchored_goals_are_still_inferred_normally(planning_vault):
     matched = result["matched_priorities"][0]
     assert matched["inferred_goal"]["goal_id"] == ANCHORED_ID
     assert all(alt["goal_id"] is not None for alt in matched["alternatives"])
+
+
+def test_migration_can_add_the_missing_id_it_recommends(planning_vault):
+    """The one-call repair must survive the vault it exists to repair."""
+    _write_goals(planning_vault["goals"])
+
+    result = _call_tool("migrate_quarterly_goals")
+
+    assert result.get("success") is not False
+    text = planning_vault["goals"].read_text(encoding="utf-8")
+    heading = next(
+        line for line in text.split("\n") if ANCHORLESS_TITLE in line
+    )
+    assert "^Q" in heading and "-goal-" in heading
+    # The already-anchored goal keeps the ID it had.
+    assert f"^{ANCHORED_ID}" in text
+    # And the repaired goal is now readable by weekly planning.
+    after = _call_tool("get_weekly_planning_context")
+    assert all(g["activity_known"] for g in after["goal_health"])
+
+
+def test_creating_a_goal_works_alongside_an_anchorless_one(planning_vault):
+    """Adding a new goal must not trip over a hand-written neighbour."""
+    _write_goals(planning_vault["goals"])
+
+    result = _call_tool(
+        "create_quarterly_goal",
+        {
+            "title": "A brand new goal",
+            "pillar": "pillar_1",
+            "success_criteria": "The new goal is reachable.",
+        },
+    )
+
+    assert result.get("success") is not False
+    assert result["goal_id"].endswith("-goal-2")
+
+
+def test_provisional_goals_are_not_accused_of_zero_activity(planning_vault):
+    """A recovered goal's ID exists nowhere, so its links are unknowable."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n"
+        "- Grow the newsletter audience\n"
+        "- Reduce onboarding drop-off\n",
+        encoding="utf-8",
+    )
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    provisional = [g for g in result["goal_health"] if g.get("provisional")]
+    assert provisional, "expected recovered goals to be marked provisional"
+    assert all(not g["activity_known"] for g in provisional)
+    assert result["neglected_goals_count"] == 0
+    assert all("zero weekly activity" not in r for r in result["recommendations"])
+
+
+def test_many_missing_ids_produce_one_recommendation(planning_vault):
+    """Five copies of one sentence is not five pieces of advice."""
+    headings = "\n\n".join(
+        f"### {n}. Hand written goal {n} — **Growth**\n\n- [ ] A milestone"
+        for n in range(1, 6)
+    )
+    planning_vault["goals"].write_text(
+        f"# Quarter Goals\n\n{headings}\n", encoding="utf-8"
+    )
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    id_recs = [r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r]
+    assert len(id_recs) == 1
+    for n in range(1, 6):
+        assert f"Hand written goal {n}" in id_recs[0]
+    assert "Quarter_Goals.md" in id_recs[0]

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -144,7 +144,7 @@ def test_goal_without_id_does_not_absorb_unlinked_backlog_tasks(planning_vault):
 
     anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
     assert anchorless["open_task_count"] is None
-    assert anchorless["next_up_tasks"] == []
+    assert anchorless["next_up_tasks"] is None
     # The real link still lands on the goal that actually owns it.
     anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
     assert anchored["open_task_count"] == 1
@@ -294,8 +294,8 @@ def test_one_missing_id_reads_as_one(planning_vault):
 
     rec = next(r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r)
     assert "1 goal has no ID" in rec
-    assert "belongs to it" in rec
     assert "goals have" not in rec
+    assert "them all at once" not in rec
 
 
 def test_unknowable_activity_is_reported_as_unknown_not_as_zero(planning_vault):
@@ -311,3 +311,56 @@ def test_unknowable_activity_is_reported_as_unknown_not_as_zero(planning_vault):
     anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
     assert anchored["has_activity"] is True
     assert anchored["linked_priority_count"] == 1
+
+
+def test_migration_reports_headings_it_cannot_repair(planning_vault):
+    """A heading with a non-goal anchor is ID-less to the parser but skipped
+    by migration, so the advice would loop forever with no route out."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n"
+        "### 1. Goal with an unrelated anchor — **Growth** ^a1b2c3\n\n"
+        "- [ ] A milestone\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool("migrate_quarterly_goals")
+
+    assert result["goals_updated"] == 0
+    skipped = result.get("headings_needing_manual_fix") or []
+    assert any("Goal with an unrelated anchor" in s["title"] for s in skipped)
+    assert "^a1b2c3" in skipped[0]["existing_anchor"]
+    # The user's own anchor is never rewritten for them.
+    assert "^a1b2c3" in planning_vault["goals"].read_text(encoding="utf-8")
+
+
+def test_next_up_tasks_is_unknown_not_empty_when_links_are_unreadable(planning_vault):
+    """week-plan reads next_up_tasks directly; [] would read as 'nothing'."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_weekly_planning_context")
+
+    anchorless = next(g for g in result["goal_health"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["next_up_tasks"] is None
+    anchored = next(g for g in result["goal_health"] if g["goal_id"] == ANCHORED_ID)
+    assert anchored["next_up_tasks"] == []
+
+
+def test_single_goal_advice_reads_as_english(planning_vault):
+    """This text is user-facing; it has to read like a person wrote it."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+    result = _call_tool("get_weekly_planning_context")
+    rec = next(r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r)
+    assert "tasks belong to it" in rec
+    assert "belongs" not in rec
+
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n- Only one recovered goal\n", encoding="utf-8"
+    )
+    result = _call_tool("get_weekly_planning_context")
+    rec = next(r for r in result["recommendations"] if "freeform" in r)
+    assert "1 goal was recovered" in rec
+    assert "is provisional" in rec
+    assert "its ID is generated" in rec
+    assert "links to it automatically" in rec

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -407,5 +408,94 @@ def test_provisional_goals_claim_no_linked_priorities_anywhere(planning_vault):
 
     provisional = [g for g in result["goals"] if g.get("provisional")]
     assert provisional, "expected a recovered goal"
-    assert all(g["linked_priorities_count"] == 0 for g in provisional)
-    assert all(g["linked_priorities"] == [] for g in provisional)
+    # Unknown, not zero: a generated ID names nothing on disk.
+    assert all(g["linked_priorities_count"] is None for g in provisional)
+    assert all(g["linked_priorities"] is None for g in provisional)
+    assert all(g["activity_known"] is False for g in provisional)
+
+
+def test_goal_status_does_not_crash_on_a_goal_with_no_id(planning_vault):
+    """/week-plan calls get_goal_status per goal, so the reported crash still
+    reproduced one step before the handler this branch first fixed."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_goal_status", {"goal_id": None})
+
+    assert result["success"] is False
+    assert "no ID" in result["error"] or "not found" in result["error"].lower()
+
+
+def test_goal_status_still_works_for_a_real_goal(planning_vault):
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_goal_status", {"goal_id": ANCHORED_ID})
+
+    assert result["goal_id"] == ANCHORED_ID
+    assert result["linked_priorities_count"] == 1
+
+
+def test_quarterly_goals_marks_unreadable_links_as_unknown(planning_vault):
+    """/week-plan calls a goal with no linked priorities orphaned; it must not
+    do that to a goal whose links were never readable."""
+    _write_goals(planning_vault["goals"])
+    _write_priorities(planning_vault["priorities"])
+
+    result = _call_tool("get_quarterly_goals")
+
+    anchorless = next(g for g in result["goals"] if g["title"] == ANCHORLESS_TITLE)
+    assert anchorless["activity_known"] is False
+    assert anchorless["linked_priorities_count"] is None
+    anchored = next(g for g in result["goals"] if g["goal_id"] == ANCHORED_ID)
+    assert anchored["activity_known"] is True
+    assert anchored["linked_priorities_count"] == 1
+
+
+def test_work_summary_and_alignment_ignore_provisional_goals(planning_vault):
+    """A generated ID that collides with a real one must not inherit its work."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n- A recovered goal\n", encoding="utf-8"
+    )
+    # No goal references at all, so a provisional goal cannot be credited
+    # with someone else's priority and hide the false claim.
+    planning_vault["priorities"].write_text(
+        "# Week Priorities\n\n1. **Unrelated work** — Growth ^week-2026-W37-p1\n",
+        encoding="utf-8",
+    )
+
+    summary = _call_tool("get_work_summary")
+    stalled = [w for w in summary["warnings"] if w["type"] == "stalled_goal"]
+    assert stalled == []
+
+    alignment = _call_tool("check_goal_alignment")
+    assert alignment["goals_without_priorities"]["count"] == 0
+
+
+def test_migration_keeps_the_id_where_the_parser_can_read_it(planning_vault):
+    """The ID must sit directly after the pillar. Moving it after trailing
+    text makes the parser return None again - the original bug."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n### 1. Ship v2 — **Growth** (stretch)\n",
+        encoding="utf-8",
+    )
+
+    _call_tool("migrate_quarterly_goals")
+
+    heading = next(
+        line
+        for line in planning_vault["goals"].read_text(encoding="utf-8").split("\n")
+        if "Ship v2" in line
+    )
+    assert re.search(r"\*\*Growth\*\* \^Q\d+-\d{4}-goal-\d+ \(stretch\)", heading)
+    after = _call_tool("get_quarterly_goals")
+    assert all(g["goal_id"] for g in after["goals"])
+
+
+def test_missing_id_advice_says_where_the_id_goes(planning_vault):
+    """'the end of the heading' is wrong when the heading has trailing text."""
+    _write_goals(planning_vault["goals"])
+    result = _call_tool("get_weekly_planning_context")
+    rec = next(r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r)
+    assert "end of" not in rec
+    assert "pillar" in rec

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -364,3 +364,48 @@ def test_single_goal_advice_reads_as_english(planning_vault):
     assert "is provisional" in rec
     assert "its ID is generated" in rec
     assert "links to it automatically" in rec
+
+
+def test_migration_never_deletes_the_rest_of_a_heading(planning_vault):
+    """The PR tells every affected user to run this; it must not eat text."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n"
+        "### 1. Ship v2 — **Growth** (stretch, owner: Dana)\n\n"
+        "- [ ] A milestone\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool("migrate_quarterly_goals")
+
+    assert result["goals_updated"] == 1
+    heading = next(
+        line
+        for line in planning_vault["goals"].read_text(encoding="utf-8").split("\n")
+        if "Ship v2" in line
+    )
+    assert "(stretch, owner: Dana)" in heading
+    assert "^Q" in heading
+    # And the repaired heading still parses as a goal.
+    after = _call_tool("get_weekly_planning_context")
+    ship = next(g for g in after["goal_health"] if g["title"] == "Ship v2")
+    assert ship["goal_id"] is not None
+    assert ship["activity_known"] is True
+
+
+def test_provisional_goals_claim_no_linked_priorities_anywhere(planning_vault):
+    """A generated ID can collide with a stale reference in the week file."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n- A recovered goal\n", encoding="utf-8"
+    )
+    planning_vault["priorities"].write_text(
+        "# Week Priorities\n\n"
+        f"1. **Stale reference** — Growth (Goal: {ANCHORED_ID}) ^week-2026-W37-p1\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool("get_quarterly_goals")
+
+    provisional = [g for g in result["goals"] if g.get("provisional")]
+    assert provisional, "expected a recovered goal"
+    assert all(g["linked_priorities_count"] == 0 for g in provisional)
+    assert all(g["linked_priorities"] == [] for g in provisional)

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -499,3 +499,74 @@ def test_missing_id_advice_says_where_the_id_goes(planning_vault):
     rec = next(r for r in result["recommendations"] if "^Qx-YYYY-goal-N" in r)
     assert "end of" not in rec
     assert "pillar" in rec
+
+
+def test_migration_never_adds_a_second_id_to_a_heading(planning_vault):
+    """A heading whose valid ID sits after trailing text must be left alone;
+    adding a second ID orphans every existing link to the first."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n"
+        "### 1. Ship v2 — **Growth** (stretch) ^Q3-2026-goal-5\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool("migrate_quarterly_goals")
+
+    heading = next(
+        line
+        for line in planning_vault["goals"].read_text(encoding="utf-8").split("\n")
+        if "Ship v2" in line
+    )
+    assert heading.count("^Q") == 1
+    assert "^Q3-2026-goal-5" in heading
+    assert result["goals_updated"] == 0
+    entry = next(
+        h for h in result.get("headings_needing_manual_fix", [])
+        if "Ship v2" in h["title"]
+    )
+    # It already has a goal ID; the fix is to move it, not to replace it.
+    assert entry["existing_anchor"] == "^Q3-2026-goal-5"
+    assert "not straight after the bolded pillar" in entry["reason"]
+    assert "orphan" in entry["reason"]
+
+
+def test_migration_reports_a_foreign_anchor_anywhere_on_the_line(planning_vault):
+    """The anchor need not be the last token to strand the heading."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n### 1. Ship v2 — **Growth** ^a1b2c3 (stretch)\n",
+        encoding="utf-8",
+    )
+
+    result = _call_tool("migrate_quarterly_goals")
+
+    assert result["goals_updated"] == 0
+    skipped = result.get("headings_needing_manual_fix") or []
+    assert any("Ship v2" in h["title"] for h in skipped)
+    assert "^a1b2c3" in planning_vault["goals"].read_text(encoding="utf-8")
+
+
+def test_goal_status_refuses_a_provisional_goals_generated_id(planning_vault):
+    """Its ID exists nowhere on disk, so any match is a collision."""
+    planning_vault["goals"].write_text(
+        "# Quarter Goals\n\n- A recovered goal\n", encoding="utf-8"
+    )
+    _write_priorities(planning_vault["priorities"])
+
+    goals = _call_tool("get_quarterly_goals")["goals"]
+    generated_id = goals[0]["goal_id"]
+    assert generated_id, "expected a generated ID"
+
+    result = _call_tool("get_goal_status", {"goal_id": generated_id})
+
+    assert result["success"] is False
+    assert "provisional" in result["error"]
+
+
+def test_goal_backlog_refuses_a_null_goal_id(planning_vault):
+    """Coercing null to 'all' hands back every other goal's backlog."""
+    _write_goals(planning_vault["goals"])
+
+    result = _call_tool("get_goal_backlog", {"goal_id": None})
+
+    assert result["success"] is False
+    assert "no ID" in result["error"]

--- a/packages/dex-agent-plugin/skills/week-plan/SKILL.md
+++ b/packages/dex-agent-plugin/skills/week-plan/SKILL.md
@@ -58,8 +58,11 @@ Check for `00-Inbox/Weekly_Synthesis_[last-monday].md`:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null — it has no ID to
+look up, and the call will tell you so rather than return a status.
 
 For each goal, get:
 - Current progress (concrete: "2 of 5 milestones complete")
@@ -67,7 +70,13 @@ For each goal, get:
 - Weeks since last activity
 - Stall warnings
 
-**Identify goals needing attention:**
+**Check `activity_known` before judging any goal.** When it is `false` — the
+goal was typed by hand with no ID, or recovered from a freeform list —
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never call such a goal orphaned or stalled on that basis.
+
+**Identify goals needing attention** (only among goals where `activity_known`
+is `true`):
 - Goals with no linked priorities (orphaned)
 - Goals with no activity in 2+ weeks (stalled)
 - Goals behind expected pace

--- a/packages/dex-agent-plugin/skills/week-plan/SKILL.md
+++ b/packages/dex-agent-plugin/skills/week-plan/SKILL.md
@@ -91,7 +91,11 @@ Get all open tasks and:
 Use: get_weekly_planning_context()
 ```
 
-Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming. Use them directly:
+Each goal in the response's `goal_health` carries `open_task_count` and `next_up_tasks` — the top items the user already marked "take these first" during grooming.
+
+**First, check `activity_known`.** When it is `false`, that goal has no usable ID — it was typed by hand, or recovered from a freeform list — so Dex cannot tell what links to it. `linked_priority_count`, `has_activity`, `open_task_count` and `next_up_tasks` are all `null` for that goal, meaning *not known*, never *none*. Do not read a `null` as zero, do not call it stalled or neglected, and do not call `get_goal_backlog` for it (a null ID falls back to every goal's backlog). Plan around it normally and pass on the `recommendations` line that says how to give it an ID.
+
+For every goal where `activity_known` is `true`, use the fields directly:
 
 - **Goal has `next_up_tasks`:** suggest those items by name — "Goal X's next-up items are A and B — they fit Wednesday's block."
 - **Stalled goal with open tasks but no groomed order:** call `get_goal_backlog(goal_id)` and pick candidates from the top of its ordering (priority, then oldest).

--- a/packages/dex-agent-plugin/skills/week-review/SKILL.md
+++ b/packages/dex-agent-plugin/skills/week-review/SKILL.md
@@ -209,8 +209,18 @@ Scan `03-Tasks/Tasks.md` for completion timestamps from this week:
 
 ```
 Use: get_quarterly_goals()
-Use: get_goal_status(goal_id) for each goal
+Use: get_goal_status(goal_id) for each goal that has a goal_id
 ```
+
+Skip `get_goal_status` for any goal whose `goal_id` is null, or that is marked
+`provisional` — there is no ID to look up, and the call will say so rather than
+return a status.
+
+**Check `activity_known` before judging any goal.** When it is `false`,
+`linked_priorities` and `linked_priorities_count` are `null`, meaning *not
+known*, never *none*. Never report such a goal as stalled or as having no
+linked work; say its links cannot be read yet and pass on the recommendation
+about giving it an ID.
 
 For each goal:
 - Milestones completed this week


### PR DESCRIPTION
## What was broken

Weekly planning crashed outright if any quarterly goal heading was typed by hand.

A goal heading only gets a hidden ID (`^Q3-2026-goal-1`) when Dex writes it. Type one yourself and there's no ID, so the parser returns `goal_id=None`. `get_weekly_planning_context` passed that straight into `find_linked_priorities`, which does `if goal_id in line` — raising:

```
TypeError: 'in <string>' requires string as left operand, not NoneType
```

Reported via feedback (receipt held internally), and reproduced through the public MCP boundary before any product code was touched.

Underneath the crash sat one unmodelled idea: **a goal with no usable ID cannot own anything, and its links cannot be read at all.** Nothing in the codebase expressed that, so every tool that touched such a goal either crashed or quietly made something up. Six rounds of independent review traced it through the file; this PR closes every route found.

## What changed

**The crash, and what it was hiding**

- An ID-less goal yields no linked priorities instead of raising.
- It is no longer counted as having "zero weekly activity" — its links are *unknown*, not absent. New `activity_known` flag carries the distinction.
- It no longer absorbs the entire unlinked backlog: `task.get('goal')` is *also* `None` for tasks linked to nothing, so `task.get('goal') == goal.get('goal_id')` matched every orphan task.
- `linked_priority_count`, `has_activity`, `open_task_count` and `next_up_tasks` are `null` — *not known* — rather than `0`/`[]`, which read as "none".
- Goal matching no longer proposes an ID-less goal as a link target.

**Every other route to the same failure**

- `generate_goal_id` did `goal['goal_id'].startswith(...)` on a `None` ID, so `create_quarterly_goal` *and* `migrate_quarterly_goals` raised `AttributeError` on this same vault. Migration is the one-call repair the new advice points at — it was broken by the same root cause.
- `get_goal_status` still raised the **original `TypeError`**: `/week-plan` calls it per goal, `get_quarterly_goals` hands back `goal_id: null`, and `get_goal_by_id(None)` cheerfully matches the ID-less goal. The reported symptom survived until this was closed.
- `get_quarterly_goals` reported `linked_priorities_count: 0`, which `/week-plan` reads as "orphaned".
- `get_work_summary` and `check_goal_alignment` called provisional goals stalled, while a provisional goal's *generated* ID could collide with a real one and inherit its priorities.
- `get_goal_backlog` silently turned a null `goal_id` into `'all'` and returned every other goal's backlog as if it were this goal's.

**Making the repair actually work**

- `migrate_quarterly_goals` rebuilt each heading from a regex prefix, silently deleting anything the user wrote after the pillar (`— **Growth** (stretch, owner: Dana)`) and reporting success.
- It judged headings by their last token, so a valid ID sitting after trailing text got a **second, different ID** appended — orphaning every existing link.
- A user's own anchor (`^a1b2c3`) was only noticed when it happened to be last, leaving the heading unrepaired, unlisted, and the advice looping forever.
- It now decides on the whole line, never duplicates an ID, never overwrites a user's anchor, and reports what it deliberately left alone and why.

**The consumers**

`/week-plan` and `/week-review` were told to call `get_goal_status` for *every* goal and to treat "no linked priorities" as orphaned. With nullable fields they would have rendered unknown as zero — the exact error this PR removes one layer down. Both now check `activity_known` first, are told `null` means *not known*, and skip lookups for a null ID. All three mirrors of each skill regenerated, and the Lens catalog re-pinned to the new bytes.

## Verification

Fail-first throughout. On the current base (`e41ebec5`), **28 of 29** tests in the new file fail without this change — with the original `TypeError` and `AttributeError`.

1. Every one of the **22 guards** was removed deliberately, one at a time, and the covering test failed each time, then passed on restore. Two guards that did *not* fail on first attempt were treated as untested and the tests strengthened until they did. A guard that cannot be shown failing is not a guard.
2. `531 passed, 4 skipped` across 21 covering test files, on this exact head.
3. Ruff clean, `py_compile` clean, `git diff --check` clean.

**Rejected, with evidence:**

- Review proposed moving migration's inserted anchor *after* trailing text so Obsidian block links resolve. Verified against the parser regex that this returns `goal_id: None` again — it would reintroduce this very bug. Placement stays; a test now pins it with the reason.
- Review reported a missing `CHANGELOG.md` entry as mandated. Checked the last twelve merges on `main`: only release-branch merges touch `CHANGELOG.md`; every ordinary fix PR leaves it to `scripts/release.sh`. No release is requested here.

Rebased onto live `main` `e41ebec5` (past the `e19d5915` quarterly-goals merge). Verified no semantic overlap — that PR changes quarter *selection* above the filter loop this PR edits — and re-verified the fail-first result and all 531 tests on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
