### PR TITLE
Answer for the quarter you are planning, without hiding today's goals

### DIFF
--- a/System/user-profile-template.yaml
+++ b/System/user-profile-template.yaml
@@ -167,8 +167,14 @@ quarterly_planning:
   # Common: 1 (calendar year), 2 (some fiscal years), 4 (many fiscal years)
   q1_start_month: 1
   
-  # Current quarter — derived at runtime from q1_start_month.
-  # Ship empty so no frozen quarter is distributed; the system fills this in.
+  # The quarter you are planning. Leave empty to follow today's date.
+  # Set it to the quarter you are actively planning — for example "Q4 2026"
+  # while you get a head start on next quarter — and your quarterly goals
+  # lookup answers for that quarter instead. It is only followed when the
+  # quarter has not already ended, starts no more than one quarter from now,
+  # and you have goals written for it, so it can never blank out the goals you
+  # can see today. Pacing and velocity always follow today's real quarter.
+  # Ship empty so no frozen quarter is distributed.
   current_quarter: ""
   
   # Current quarter dates — derived at runtime; ship empty (see above).

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2334,6 +2334,89 @@ def extract_goal_id(text: str) -> Optional[str]:
     match = re.search(r'\^(Q\d+-\d{4}-goal-\d+)', text)
     return match.group(1) if match else None
 
+def _fiscal_quarter_window(day: date, q1_start_month: int) -> tuple:
+    """First and last day of the fiscal quarter containing `day`.
+
+    Worked out from the fiscal start month by counting whole months, so it does
+    not depend on get_quarter_info's own start-year arithmetic.
+    """
+    import calendar
+    index = day.year * 12 + (day.month - 1)
+    start_index = index - ((index - (q1_start_month - 1)) % 3)
+    start = date(start_index // 12, start_index % 12 + 1, 1)
+    end_index = start_index + 2
+    end_year, end_month = end_index // 12, end_index % 12 + 1
+    end = date(end_year, end_month, calendar.monthrange(end_year, end_month)[1])
+    return start, end
+
+
+def _fiscal_quarter_label(day: date, q1_start_month: int) -> str:
+    """The quarter name get_quarter_info gives to the quarter containing `day`.
+
+    Kept identical to that function on purpose: goals are matched against these
+    strings, so a different naming rule here would simply fail to match.
+    """
+    return f"Q{((day.month - q1_start_month) % 12) // 3 + 1} {day.year}"
+
+
+def _declared_planning_quarter(today: date) -> Optional[str]:
+    """The quarter the user says they are planning, when it is safe to use.
+
+    Someone preparing the next quarter early records that choice in their
+    profile. It is returned only when it names the quarter running now or the
+    one starting immediately after, so vaults still carrying the Q1 2026 value
+    seeded into early installs — a value nothing ever rewrites — can never be
+    stranded in a quarter that is long gone.
+
+    Deliberately independent of get_quarter_info: that function answers "which
+    quarter is it now", which velocity and weekly pacing depend on. Pointing it
+    at a quarter that has not started yet produces negative elapsed weeks and a
+    "behind pace" verdict for a quarter nobody has begun.
+    """
+    if not (USER_PROFILE_FILE.exists() and yaml):
+        return None
+    try:
+        data = yaml.safe_load(USER_PROFILE_FILE.read_text())
+    except Exception as e:
+        logger.error(f"Error reading quarterly_planning: {e}")
+        return None
+
+    configured = data.get('quarterly_planning') if isinstance(data, dict) else None
+    if not isinstance(configured, dict):
+        return None
+
+    # An absent or blank key parses as None, whose str() is the word "None" —
+    # treat every empty shape as "not chosen" rather than as a bad value.
+    raw = str(configured.get('current_quarter') or '').strip()
+    if not re.fullmatch(r'Q[1-4]\s+\d{4}', raw):
+        if raw:
+            # Say so rather than falling back silently: a near miss like
+            # "q4 2026" or "Q4-2026" is otherwise indistinguishable from the
+            # bug where the chosen quarter was ignored altogether.
+            logger.warning(
+                "Ignoring quarterly_planning.current_quarter %r: expected the "
+                "form 'Q4 2026'. Using today's quarter instead.",
+                raw,
+            )
+        return None
+    declared = re.sub(r'\s+', ' ', raw)
+
+    q1_start_month = configured.get('q1_start_month', 1)
+    if not isinstance(q1_start_month, int) or not 1 <= q1_start_month <= 12:
+        q1_start_month = 1
+
+    # Name the quarter running now and the one starting the day after it ends,
+    # then accept the declaration only if it is one of those two. Comparing
+    # names rather than reconstructing dates from the name removes the guesswork
+    # about which calendar year a quarter that straddles new year belongs to.
+    _, live_end = _fiscal_quarter_window(today, q1_start_month)
+    allowed = {
+        _fiscal_quarter_label(today, q1_start_month),
+        _fiscal_quarter_label(live_end + timedelta(days=1), q1_start_month),
+    }
+    return declared if declared in allowed else None
+
+
 def parse_quarterly_goals(filepath: Path) -> List[Dict[str, Any]]:
     """Parse quarterly goals from 01-Quarter_Goals/Quarter_Goals.md"""
     if not filepath.exists():
@@ -6131,15 +6214,22 @@ async def _handle_call_tool_inner(
         quarter = arguments.get('quarter') if arguments else None
         include_completed = arguments.get('include_completed', True) if arguments else True
         
-        # Determine quarter if not provided
-        if not quarter:
-            quarter_info = get_quarter_info()
-            quarter = quarter_info['quarter']
-        
         # Read goals
         goals_file = QUARTER_GOALS_FILE
         
         goals = parse_quarterly_goals(goals_file)
+        
+        # Determine quarter if not provided
+        if not quarter:
+            quarter = get_quarter_info()['quarter']
+            # Someone planning the next quarter early said so in their profile.
+            # Answer for that quarter, but only once it actually has goals —
+            # otherwise honoring it would replace the goals they can see today
+            # with an empty list, which is the very complaint this addresses.
+            declared = _declared_planning_quarter(_tz_today())
+            if declared and declared != quarter:
+                if any(goal.get('quarter') == declared for goal in goals):
+                    quarter = declared
         
         # Filter by quarter and completion
         filtered_goals = []

--- a/core/tests/test_work_server_quarter_resolution.py
+++ b/core/tests/test_work_server_quarter_resolution.py
@@ -1,0 +1,415 @@
+"""Regression coverage for which quarter the Work MCP answers goals for.
+
+Someone preparing the next quarter early records that choice in their profile.
+These tests hold the public `get_quarterly_goals` boundary to that choice, while
+guaranteeing it can never take away goals the user can already see, and that the
+Q1 2026 value seeded into early vaults can never strand anyone in an expired
+quarter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from core.mcp import work_server
+
+TODAY = date(2026, 9, 7)  # inside Q3 2026 for a January fiscal year
+
+
+def _call_quarterly_goals(arguments: dict | None = None) -> dict:
+    result = asyncio.run(
+        work_server.handle_call_tool("get_quarterly_goals", arguments or {})
+    )
+    return json.loads(result[0].text)
+
+
+def _vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    current_quarter: str | None,
+    goals_quarter: str,
+    q1_start_month: int = 1,
+    quarter_start: str | None = None,
+    quarter_end: str | None = None,
+) -> None:
+    profile = tmp_path / "System/user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    lines = [
+        "capabilities:",
+        "  quarter_goals:",
+        "    enabled: true",
+        "quarterly_planning:",
+        f"  q1_start_month: {q1_start_month}",
+    ]
+    if current_quarter is not None:
+        lines.append(f"  current_quarter: {current_quarter}")
+    if quarter_start is not None:
+        lines.append(f"  quarter_start_date: {quarter_start}")
+    if quarter_end is not None:
+        lines.append(f"  quarter_end_date: {quarter_end}")
+    profile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    goals = tmp_path / "01-Quarter_Goals/Quarter_Goals.md"
+    goals.parent.mkdir(parents=True)
+    goals.write_text(
+        f"---\nquarter: {goals_quarter}\n---\n"
+        f"### 1. Prepare {goals_quarter} — **Growth** "
+        f"^{goals_quarter.replace(' ', '-')}-goal-1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(work_server, "USER_PROFILE_FILE", profile)
+    monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals)
+    monkeypatch.setattr(
+        work_server, "get_week_priorities_file", lambda: tmp_path / "missing.md"
+    )
+    monkeypatch.setattr(work_server, "_tz_today", lambda: TODAY)
+
+
+# --- the reported bug -------------------------------------------------------
+
+
+def test_goals_written_for_the_declared_next_quarter_are_returned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The original report: next quarter chosen, goals written, nothing shown."""
+    _vault(
+        tmp_path,
+        monkeypatch,
+        current_quarter="Q4 2026",
+        goals_quarter="Q4 2026",
+        quarter_start="2026-10-01",
+        quarter_end="2026-12-31",
+    )
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q4 2026"
+    assert result["count"] == 1
+    assert result["goals"][0]["title"] == "Prepare Q4 2026"
+
+
+def test_declared_quarter_is_honored_when_its_cached_dates_are_blank(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shipped profile shape leaves the cached dates empty."""
+    _vault(
+        tmp_path, monkeypatch, current_quarter="Q4 2026", goals_quarter="Q4 2026"
+    )
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q4 2026"
+    assert result["count"] == 1
+
+
+# --- the fix must never take goals away -------------------------------------
+
+
+def test_declaring_next_quarter_never_hides_the_goals_you_already_have(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Choosing next quarter before writing its goals must not blank the page.
+
+    This is the shape that matters most: the goals file is still this quarter's,
+    and answering for the declared quarter would replace one visible goal with an
+    empty list — the very complaint being fixed.
+    """
+    _vault(
+        tmp_path, monkeypatch, current_quarter="Q4 2026", goals_quarter="Q3 2026"
+    )
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q3 2026"
+    assert result["count"] == 1
+    assert result["goals"][0]["title"] == "Prepare Q3 2026"
+
+
+# --- expired and out-of-range declarations ----------------------------------
+
+
+def test_the_old_seeded_q1_2026_value_is_ignored_even_with_matching_goals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Early vaults were seeded with Q1 2026 and nothing ever rewrites it."""
+    _vault(
+        tmp_path,
+        monkeypatch,
+        current_quarter="Q1 2026",
+        goals_quarter="Q1 2026",
+        quarter_start="2026-01-01",
+        quarter_end="2026-03-31",
+    )
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q3 2026"
+    assert result["count"] == 0
+
+
+def test_a_quarter_beyond_the_next_one_is_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _vault(
+        tmp_path, monkeypatch, current_quarter="Q2 2027", goals_quarter="Q2 2027"
+    )
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q3 2026"
+
+
+@pytest.mark.parametrize(
+    "value", ["next quarter", "q4 2026", "Q4-2026", "2026 Q4", "Q5 2026", ""]
+)
+def test_an_unreadable_declared_quarter_is_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    _vault(tmp_path, monkeypatch, current_quarter=value, goals_quarter="Q3 2026")
+
+    result = _call_quarterly_goals()
+
+    assert result["quarter"] == "Q3 2026"
+    assert result["count"] == 1
+
+
+def test_an_explicit_quarter_argument_still_wins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _vault(
+        tmp_path, monkeypatch, current_quarter="Q4 2026", goals_quarter="Q4 2026"
+    )
+
+    result = _call_quarterly_goals({"quarter": "Q3 2026"})
+
+    assert result["quarter"] == "Q3 2026"
+    assert result["count"] == 0
+
+
+# --- pacing and "which quarter is it now" must not move ---------------------
+
+
+def test_a_declared_quarter_never_moves_what_quarter_it_is_now(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_quarter_info drives velocity and weekly pacing.
+
+    Pointing it at a quarter that has not started yet yields negative elapsed
+    weeks and a "behind pace" verdict for a quarter nobody has begun, so the
+    declared quarter must not reach it.
+    """
+    _vault(
+        tmp_path, monkeypatch, current_quarter="Q4 2026", goals_quarter="Q4 2026"
+    )
+
+    info = work_server.get_quarter_info()
+
+    assert info["quarter"] == "Q3 2026"
+    assert info["start_date"] == date(2026, 7, 1)
+    assert info["end_date"] == date(2026, 9, 30)
+    assert info["weeks_remaining"] >= 0
+
+
+# --- the safety window itself -----------------------------------------------
+
+
+@pytest.mark.parametrize("q1_start_month", list(range(1, 13)))
+def test_an_expired_declaration_is_rejected_for_every_fiscal_year_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    q1_start_month: int,
+) -> None:
+    """A quarter labelled two years ago has ended under any fiscal calendar."""
+    _vault(
+        tmp_path,
+        monkeypatch,
+        current_quarter="Q1 2024",
+        goals_quarter="Q1 2024",
+        q1_start_month=q1_start_month,
+    )
+
+    assert work_server._declared_planning_quarter(TODAY) is None
+
+
+@pytest.mark.parametrize("q1_start_month", list(range(1, 13)))
+def test_a_far_future_declaration_is_rejected_for_every_fiscal_year_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    q1_start_month: int,
+) -> None:
+    """Nothing more than one quarter ahead may be honored, whatever the calendar."""
+    _vault(
+        tmp_path,
+        monkeypatch,
+        current_quarter="Q1 2029",
+        goals_quarter="Q1 2029",
+        q1_start_month=q1_start_month,
+    )
+
+    assert work_server._declared_planning_quarter(TODAY) is None
+
+
+def _quarter_windows_by_stepping(q1_start_month: int) -> list:
+    """Every fiscal quarter from 2023 to 2029, built by walking months forward.
+
+    Deliberately a different construction from the implementation's month-index
+    arithmetic, so this is an independent oracle rather than a restatement.
+    """
+    import calendar as _calendar
+
+    windows = []
+    year, month = 2023, q1_start_month
+    while year < 2030:
+        start = date(year, month, 1)
+        end_month, end_year = month, year
+        for _ in range(2):
+            end_month += 1
+            if end_month > 12:
+                end_month, end_year = 1, end_year + 1
+        end = date(
+            end_year, end_month, _calendar.monthrange(end_year, end_month)[1]
+        )
+        windows.append((start, end))
+        month += 3
+        if month > 12:
+            month -= 12
+            year += 1
+    return windows
+
+
+@pytest.mark.parametrize("q1_start_month", list(range(1, 13)))
+def test_an_accepted_declaration_is_always_the_live_or_next_quarter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    q1_start_month: int,
+) -> None:
+    """Sweeps every day of 2026, including the quarter-end days.
+
+    An earlier version of this guard allowed anything starting within 92 days,
+    which let a quarter *two* ahead through on the last day of a quarter. The
+    oracle here is built by stepping months forward, independently of the
+    implementation, so it can catch that class of bug.
+    """
+    profile = tmp_path / "System/user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    monkeypatch.setattr(work_server, "USER_PROFILE_FILE", profile)
+
+    windows = _quarter_windows_by_stepping(q1_start_month)
+    accepted_days = 0
+
+    # Every quarter boundary in 2026 and the days either side of it, plus a
+    # mid-month sample: the boundaries are where an off-by-one shows up.
+    probe_days = set()
+    for start, end in windows:
+        for anchor in (start, end):
+            for delta in (-1, 0, 1):
+                candidate = anchor + timedelta(days=delta)
+                if candidate.year == 2026:
+                    probe_days.add(candidate)
+    for month in range(1, 13):
+        probe_days.add(date(2026, month, 15))
+
+    for day in sorted(probe_days):
+        live = next(i for i, (s, e) in enumerate(windows) if s <= day <= e)
+        allowed_windows = {windows[live], windows[live + 1]}
+
+        for label_year in (2025, 2026, 2027):
+            for num in (1, 2, 3, 4):
+                profile.write_text(
+                    "quarterly_planning:\n"
+                    f"  q1_start_month: {q1_start_month}\n"
+                    f"  current_quarter: Q{num} {label_year}\n",
+                    encoding="utf-8",
+                )
+                got = work_server._declared_planning_quarter(day)
+                if got is None:
+                    continue
+                accepted_days += 1
+                # Whatever was accepted must name one of exactly two windows.
+                matching = [
+                    w
+                    for w in allowed_windows
+                    if work_server._fiscal_quarter_label(w[0], q1_start_month) == got
+                    or work_server._fiscal_quarter_label(w[1], q1_start_month) == got
+                ]
+                assert matching, (
+                    f"honored {got!r} on {day} for q1_start_month="
+                    f"{q1_start_month}, but that is neither the live quarter "
+                    f"{windows[live]} nor the next one {windows[live + 1]}"
+                )
+
+    assert accepted_days > 0, "the sweep never accepted anything — it proves nothing"
+
+
+def test_the_day_a_quarter_ends_does_not_admit_the_quarter_after_next(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact days an earlier 92-day bound got wrong."""
+    profile = tmp_path / "System/user-profile.yaml"
+    profile.parent.mkdir(parents=True)
+    monkeypatch.setattr(work_server, "USER_PROFILE_FILE", profile)
+
+    for today, two_ahead, next_one in [
+        (date(2026, 3, 31), "Q3 2026", "Q2 2026"),
+        (date(2026, 12, 31), "Q2 2027", "Q1 2027"),
+    ]:
+        profile.write_text(
+            "quarterly_planning:\n  q1_start_month: 1\n"
+            f"  current_quarter: {two_ahead}\n",
+            encoding="utf-8",
+        )
+        assert work_server._declared_planning_quarter(today) is None
+
+        profile.write_text(
+            "quarterly_planning:\n  q1_start_month: 1\n"
+            f"  current_quarter: {next_one}\n",
+            encoding="utf-8",
+        )
+        assert work_server._declared_planning_quarter(today) == next_one
+
+
+def test_a_near_miss_quarter_string_is_reported_not_swallowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """"q4 2026" must not look identical to the bug of ignoring the choice."""
+    _vault(tmp_path, monkeypatch, current_quarter="q4 2026", goals_quarter="Q3 2026")
+
+    with caplog.at_level("WARNING", logger=work_server.logger.name):
+        assert work_server._declared_planning_quarter(TODAY) is None
+
+    assert any("q4 2026" in record.getMessage() for record in caplog.records), (
+        caplog.text
+    )
+
+
+def test_an_empty_declaration_is_silent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shipped default is empty; it must not warn on every call."""
+    _vault(tmp_path, monkeypatch, current_quarter="", goals_quarter="Q3 2026")
+
+    with caplog.at_level("WARNING", logger=work_server.logger.name):
+        assert work_server._declared_planning_quarter(TODAY) is None
+
+    assert not caplog.records, caplog.text


### PR DESCRIPTION
## What was broken

Someone preparing the next quarter early sets that quarter in their profile, writes their goals for it, then asks Dex for their quarterly goals — and gets an empty list. `get_quarterly_goals` never read `quarterly_planning.current_quarter` and always filtered by the quarter derived from today's date.

Reproduced at the public boundary on unmodified `main` (`9fa8754d`): a Q4 2026 profile plus one Q4 goal returns `quarter: "Q3 2026"`, `count: 0`.

## The fix

`get_quarterly_goals` resolves the declared quarter through a new `_declared_planning_quarter` helper, which returns it **only** when all three hold:

1. the quarter has not already ended,
2. it starts no more than one quarter from now, and
3. the goals file actually holds goals for it.

Each constraint has a test that fails when that constraint is removed.

## Why it is shaped this way — three traps, found by review and each now covered

The obvious implementation (make `get_quarter_info` itself honor the declaration) was written first and **rejected after independent review caught it regressing real behaviour**. All three problems are reproduced and guarded:

* **It could take goals away.** With a goals file still written for `Q3 2026` and a profile declaring `Q4 2026`, the obvious version returns `count: 0` where `main` returns the user's Q3 goal — replacing visible goals with an empty list, which is the very complaint being fixed. Condition 3 makes that impossible. `test_declaring_next_quarter_never_hides_the_goals_you_already_have` passes on `main`, fails on the rejected version, and passes here.
* **It corrupted pacing.** `get_quarter_info` answers "which quarter is it now" and drives velocity and weekly planning. Pointing it at a quarter that has not started produced `weeks_elapsed: -3` and a "behind pace — need acceleration" verdict for a quarter nobody had begun. This change does not touch `get_quarter_info` at all; a test asserts it still returns today's quarter when a declaration is present.
* **Its safety window was built on broken math, and then was off by one.** Bounding the declared window with the date-derived `quarter_end` inherits a pre-existing defect where that window is a year adrift for non-January fiscal years. A second review pass then found that the replacement — "starts within 92 days" — admitted the quarter *two* ahead on the last day of a quarter (`2026-03-31` honoring `Q3 2026`; `2026-12-31` honoring `Q2 2027`). Both are gone: quarter windows are counted in whole months here, and the declaration is matched against the **names of the live and next quarters** rather than against a distance. All four review reproductions are now rejected.

## Also fixed

* `System/user-profile-template.yaml` described `current_quarter` as a runtime-derived cache "the system fills in" — nothing writes it, and it is now a user-facing choice. The comment now says what it does and what bounds it.
* A near-miss value such as `q4 2026` or `Q4-2026` now logs a warning naming the expected form, instead of falling back silently in a way indistinguishable from the original bug.
* An absent key parses as `None`, whose `str()` is the word `"None"` — every empty shape is treated as "not chosen" rather than as a bad value. (Caught by the test added for the point above, which would otherwise have warned for every ordinary user.)

## Evidence

- **Fail-first:** both reported-bug tests fail on pristine `9fa8754d`.
- **Regression guard:** `never_hides_the_goals_you_already_have` passes on `main` and here, and fails on the rejected implementation — it is a real guard, not a restatement of the fix.
- **Four deliberate breaks:** disabling the declaration lookup fails exactly the 2 reported-bug tests; dropping the has-goals guard fails exactly the never-hides test; accepting any declaration fails 39 window tests; removing the near-miss warning fails its test. Restoring each returns to 52 passed.
- **The window test is an independent oracle, and is proven to bite.** The first version of this test re-derived the implementation's own predicate and held by construction. It was replaced with quarter windows built by stepping months forward, swept across every quarter boundary of 2026 for all twelve fiscal start months. Re-introducing the old 92-day bound fails it for **all 12** fiscal calendars plus an explicit boundary-day test; the tautological version passed that same bound.
- **Suite:** `core/tests -k "work_server or quarter or mcp"` gives 25 failed / 415 passed; pristine `9fa8754d` gives an **identical** 25-failure set with 363 passed. Pre-existing and environment-related; this adds 52 passes and breaks nothing.
- **Gates run locally on this exact head:** distribution, diff-aware test gate, PII, doc drift, path-contract, architecture inventory, portable contract, founder content, security gate, health promises, instructed tools, tracked-ignored, `ruff check core/`, compilation — all pass. (The two release-tag gates only fail locally because this worktree names its remote `upstream`; both passed in CI on the prior head and nothing here touches tags.)

## Changelog

Deliberately **not** included. The distribution gate requires `package.json` to match the changelog's top version, so adding an entry forces a version bump — and an untagged bump blocks every later `build-release` run on main. This delivery is no-release, so the user-facing wording is parked on the Mission Control card for the release lane. (Sibling PR #704 carries none either.)

## Scope

`get_quarterly_goals` and one new helper. Sibling PR #704 touches lines ~2933 and ~6836+ of the same file; no overlap, either can land first.

## Known limit of this fix (filed separately)

Every goal's quarter comes from the goals file's single frontmatter label, which is written once at file creation and never revisited — so goals *created* for a new quarter are still recorded under the old one, and this fix is reachable today only for a file already labelled for the declared quarter (which is the reported reproduction). Pre-existing, not caused by this PR, and a wider change than this card: filed as `bug-new-quarter-goals-inherit-the-old-quarters-file-label-b7e2d1a4c3`.

## Separate pre-existing defect (filed, not fixed here)

`main`'s date-derived quarter window does not contain today for **11 of 12** fiscal start months — every value except January. With `q1_start_month: 10` and today 2026-09-07 it returns `Q4 2026` dated `2025-07-01 → 2025-09-30`. Present on pristine `9fa8754d` and untouched by this PR; filed as card `bug-quarter-dates-wrong-year-for-oct-dec-fiscal-years-a1f4c73b90` rather than mixed in. This is why the safety window above avoids depending on it.

Mission Control: `bug-report-work-mcp-quarterly-goals-get-quarter-info-get-qu-d236bc5e24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


_Two independent review passes were run on this branch; every finding from both is either fixed above or filed as its own card. Note that the repo's Cursor review bots reported `neutral` because they could not run (account usage limit), which is no-signal, not an approval — logged for Dave separately._
