### PR TITLE
Count a weekly priority that names its quarterly goal

### DIFF
--- a/.agents/skills/week-plan/SKILL.md
+++ b/.agents/skills/week-plan/SKILL.md
@@ -288,6 +288,10 @@ Check `System/Dex_Backlog.md` for high-priority improvement ideas worth tackling
 
 Archive old file to `07-Archives/Plans/YYYY-Wxx.md`.
 
+Use the exact `goal_id` returned by the planning tools in each linked
+`Quarterly goal` bullet. For work that advances no quarterly goal, write
+`Operational` instead of inventing or paraphrasing an ID.
+
 Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 ```markdown
@@ -328,19 +332,19 @@ Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 1. **[Priority 1]** — **[Pillar]** ^week-YYYY-WXX-p1
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 2. **[Priority 2]** — **[Pillar]** ^week-YYYY-WXX-p2
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 3. **[Priority 3]** — **[Pillar]** ^week-YYYY-WXX-p3
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X] or Operational
+   - Quarterly goal: [Qx-YYYY-goal-N] or Operational
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
 

--- a/.claude/skills/week-plan/SKILL.md
+++ b/.claude/skills/week-plan/SKILL.md
@@ -286,6 +286,10 @@ Check `System/Dex_Backlog.md` for high-priority improvement ideas worth tackling
 
 Archive old file to `07-Archives/Plans/YYYY-Wxx.md`.
 
+Use the exact `goal_id` returned by the planning tools in each linked
+`Quarterly goal` bullet. For work that advances no quarterly goal, write
+`Operational` instead of inventing or paraphrasing an ID.
+
 Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 ```markdown
@@ -326,19 +330,19 @@ Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 1. **[Priority 1]** — **[Pillar]** ^week-YYYY-WXX-p1
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 2. **[Priority 2]** — **[Pillar]** ^week-YYYY-WXX-p2
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 3. **[Priority 3]** — **[Pillar]** ^week-YYYY-WXX-p3
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X] or Operational
+   - Quarterly goal: [Qx-YYYY-goal-N] or Operational
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
 

--- a/core/lens-catalog/registry.json
+++ b/core/lens-catalog/registry.json
@@ -122,8 +122,8 @@
       "source": {
         "kind": "active-skill",
         "path": ".claude/skills/week-plan/SKILL.md",
-        "sha256": "4869440e3bc53319412f365de76359f4f169e786353b83d2f27dada882e32cdb",
-        "byte_size": 16297
+        "sha256": "9f98cdfcacfea8d79d1ed437e21b173fdae37329dce1fbcaf377c17f470e3e23",
+        "byte_size": 16511
       },
       "value": "Turns goals, capacity and open work into a weekly focus plan, so repeated work starts from priorities rather than a blank chat.",
       "jobs_served": [

--- a/core/mcp/work_server.py
+++ b/core/mcp/work_server.py
@@ -2601,6 +2601,12 @@ def get_goal_by_id(goal_id: str) -> Optional[Dict[str, Any]]:
 
 def find_linked_priorities(goal_id: str) -> List[Dict[str, Any]]:
     """Find all weekly priorities linked to a goal"""
+    # A goal with no ID cannot own a link. Without this guard the reference
+    # pattern below would collapse to a bare word boundary and match every
+    # priority line, inventing links that were never written.
+    if not goal_id:
+        return []
+
     priorities_file = get_week_priorities_file()
     if not priorities_file.exists():
         return []
@@ -2608,30 +2614,49 @@ def find_linked_priorities(goal_id: str) -> List[Dict[str, Any]]:
     content = priorities_file.read_text()
     lines = content.split('\n')
     
+    goal_reference = re.compile(
+        rf'(?<![A-Za-z0-9_-]){re.escape(goal_id)}(?![A-Za-z0-9_-])'
+    )
     linked_priorities = []
     for i, line in enumerate(lines):
-        # Look for lines that mention the goal_id
-        if goal_id in line:
-            # Check if this is a priority line
-            if '**' in line and ('- [ ]' in line or '- [x]' in line or line.strip().startswith('1.') or line.strip().startswith('2.') or line.strip().startswith('3.')):
-                completed = '- [x]' in line
-                
-                # Extract priority ID
-                priority_id = extract_priority_id(line)
-                
-                # Extract title
-                title_match = re.search(r'(?:\d+\.\s+)?(.+?)\s+—', line)
-                if not title_match:
-                    title_match = re.search(r'\*\*(.+?)\*\*', line)
-                title = title_match.group(1).strip() if title_match else line.strip()
-                
-                linked_priorities.append({
-                    'priority_id': priority_id,
-                    'title': title,
-                    'completed': completed,
-                    'line_number': i + 1
-                })
-    
+        stripped = line.strip()
+        is_priority_line = '**' in line and (
+            '- [ ]' in line
+            or '- [x]' in line
+            or bool(re.match(r'\d+\.\s+', stripped))
+        )
+        if not is_priority_line:
+            continue
+
+        linked = bool(goal_reference.search(line))
+        if not linked:
+            for metadata_line in lines[i + 1:]:
+                if not re.match(r'^\s+-\s+', metadata_line):
+                    break
+                if 'Quarterly goal:' in metadata_line and goal_reference.search(metadata_line):
+                    linked = True
+                    break
+        if not linked:
+            continue
+
+        completed = '- [x]' in line
+
+        # Extract priority ID
+        priority_id = extract_priority_id(line)
+
+        # Extract title
+        title_match = re.search(r'(?:\d+\.\s+)?(.+?)\s+—', line)
+        if not title_match:
+            title_match = re.search(r'\*\*(.+?)\*\*', line)
+        title = title_match.group(1).strip() if title_match else stripped
+
+        linked_priorities.append({
+            'priority_id': priority_id,
+            'title': title,
+            'completed': completed,
+            'line_number': i + 1
+        })
+
     return linked_priorities
 
 def calculate_goal_progress(goal_id: str) -> Dict[str, Any]:

--- a/core/tests/test_instruction_honesty.py
+++ b/core/tests/test_instruction_honesty.py
@@ -486,6 +486,14 @@ def test_week_skills_read_the_users_working_week_for_timing() -> None:
     assert "Friday/end of week" not in week_review
 
 
+def test_week_plan_writes_machine_readable_quarterly_goal_links() -> None:
+    week_plan = _read(".claude/skills/week-plan/SKILL.md")
+
+    assert "Use the exact `goal_id` returned by the planning tools" in week_plan
+    assert week_plan.count("- Quarterly goal: [Qx-YYYY-goal-N]") == 3
+    assert "[Q1 Goal #X]" not in week_plan
+
+
 def test_onboarding_runs_the_first_week_reveal_before_tool_discovery() -> None:
     flow = _read(".claude/flows/onboarding.md")
     finale = flow.split("## Step 9:", 1)[1].split("## Step 10:", 1)[0]

--- a/core/tests/test_work_server_weekly_planning_context.py
+++ b/core/tests/test_work_server_weekly_planning_context.py
@@ -163,6 +163,15 @@ def test_anchored_goals_keep_their_linked_priorities(planning_vault):
     assert anchored["has_activity"] is True
 
 
+def test_a_goal_with_no_id_is_credited_with_no_priorities(planning_vault):
+    """An ID-less goal owns nothing, so it must never absorb every priority."""
+    _write_priorities(planning_vault["priorities"])
+
+    assert work_server.find_linked_priorities("") == []
+    assert work_server.find_linked_priorities(None) == []
+    assert len(work_server.find_linked_priorities(ANCHORED_ID)) == 1
+
+
 def test_goal_without_id_is_never_offered_as_a_priority_link(planning_vault):
     """Suggesting a link that create_weekly_priority would refuse helps nobody."""
     _write_goals(planning_vault["goals"], with_anchored=False)

--- a/core/tests/test_work_server_weekly_priority_creation.py
+++ b/core/tests/test_work_server_weekly_priority_creation.py
@@ -39,12 +39,24 @@ def _call_get_priorities() -> dict:
     return json.loads(result[0].text)
 
 
+def _call_get_goal_status(goal_id: str) -> dict:
+    result = asyncio.run(
+        work_server.handle_call_tool("get_goal_status", {"goal_id": goal_id})
+    )
+    return json.loads(result[0].text)
+
+
 @pytest.fixture
 def priority_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     path = tmp_path / "02-Week_Priorities" / "Week_Priorities.md"
     path.parent.mkdir(parents=True)
     goals = tmp_path / "01-Quarter_Goals" / "Quarter_Goals.md"
+    tasks = tmp_path / "03-Tasks" / "Tasks.md"
+    tasks.parent.mkdir(parents=True)
+    tasks.write_text("# Tasks\n", encoding="utf-8")
 
+    monkeypatch.setattr(work_server, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(work_server, "get_tasks_file", lambda: tasks)
     monkeypatch.setattr(work_server, "get_week_priorities_file", lambda: path)
     monkeypatch.setattr(work_server, "QUARTER_GOALS_FILE", goals)
     monkeypatch.setattr(work_server, "PILLARS", PILLARS)
@@ -132,6 +144,47 @@ def test_created_weekly_priority_reads_back_its_goal_after_success_criteria(
     assert created["linked_goal"] == "Q3-2026-goal-2"
     assert listed["priorities"][0]["linked_goal_id"] == "Q3-2026-goal-2"
     assert listed["alignment_summary"]["priorities_linked_to_goals"] == 1
+
+
+@pytest.mark.parametrize("existing_count", [0, 3])
+def test_created_goal_link_is_visible_to_goal_status_for_any_priority_number(
+    priority_file: Path,
+    existing_count: int,
+):
+    goal_id = "Q3-2026-goal-2"
+    goals_file = priority_file.parents[1] / "01-Quarter_Goals" / "Quarter_Goals.md"
+    goals_file.parent.mkdir(parents=True, exist_ok=True)
+    goals_file.write_text(
+        "# Quarter Goals\n\n"
+        f"### 1. Publish renewal proof — **Customer Growth** ^{goal_id}\n",
+        encoding="utf-8",
+    )
+    existing = "".join(
+        f"{number}. Existing priority {number} — **Customer Growth** "
+        f"^week-2026-W29-p{number}\n"
+        for number in range(1, existing_count + 1)
+    )
+    priority_file.write_text(
+        "# Week Priorities\n\n"
+        f"{TOP_3}\n\n"
+        f"{existing}\n"
+        "## 📊 Review\n",
+        encoding="utf-8",
+    )
+
+    created = _call_create_priority(quarterly_goal_id=goal_id)
+    listed = _call_get_priorities()
+    status = _call_get_goal_status(goal_id)
+
+    created_priority = next(
+        priority
+        for priority in listed["priorities"]
+        if priority["priority_id"] == created["priority_id"]
+    )
+    assert created_priority["linked_goal_id"] == goal_id
+    assert status["linked_priorities_count"] == 1
+    assert status["progress_method"] == "automatic"
+    assert status["stalled"] is False
 
 
 @pytest.mark.parametrize("existing_count", [1, 2])

--- a/packages/dex-agent-plugin/skills/week-plan/SKILL.md
+++ b/packages/dex-agent-plugin/skills/week-plan/SKILL.md
@@ -288,6 +288,10 @@ Check `System/Dex_Backlog.md` for high-priority improvement ideas worth tackling
 
 Archive old file to `07-Archives/Plans/YYYY-Wxx.md`.
 
+Use the exact `goal_id` returned by the planning tools in each linked
+`Quarterly goal` bullet. For work that advances no quarterly goal, write
+`Operational` instead of inventing or paraphrasing an ID.
+
 Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 ```markdown
@@ -328,19 +332,19 @@ Create updated `02-Week_Priorities/Week_Priorities.md`:
 
 1. **[Priority 1]** — **[Pillar]** ^week-YYYY-WXX-p1
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 2. **[Priority 2]** — **[Pillar]** ^week-YYYY-WXX-p2
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X]
+   - Quarterly goal: [Qx-YYYY-goal-N]
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
    
 3. **[Priority 3]** — **[Pillar]** ^week-YYYY-WXX-p3
    - Success criteria: [What done looks like]
-   - Quarterly goal: [Q1 Goal #X] or Operational
+   - Quarterly goal: [Qx-YYYY-goal-N] or Operational
    - **Scheduled:** [Day/time block]
    - Effort: [deep_work / medium / quick]
 


### PR DESCRIPTION
## What was broken

Dex could create a weekly priority linked to a quarterly goal, list it back showing the link — and then report that same goal as having **zero linked priorities** and mark it **stalled**.

Reported through `/feedback`. Reproduced through the public work-MCP boundary on live main `b352c373` before touching product code.

## Cause

`find_linked_priorities` only recognised a goal link written **inline on the priority's own title line**, and only for priorities whose line started `1.`, `2.` or `3.`.

Dex's own writer (`create_weekly_priority`) and `/week-plan` both put the link on a `- Quarterly goal: [ID]` metadata bullet *underneath* the priority, at whatever number that priority has. `parse_weekly_priorities` already reads that bullet — which is why `get_week_priorities` showed the link correctly while `get_goal_status` saw nothing.

So the link Dex had just written was invisible to the code that counts links, even for priority 1.

## The change

- **`core/mcp/work_server.py`** — `find_linked_priorities` now reads the `Quarterly goal:` metadata bullet under every numbered priority, using the same walk `parse_weekly_priorities` uses. Legacy inline links still work.
- **Empty/absent goal ID short-circuits to no links.** Without it, `re.escape("")` inside the lookaround pattern collapses to a bare word boundary and matches every priority line — an ID-less goal would claim the whole file. This is the exact class of false link #704 just closed.
- **`/week-plan` SKILL.md** (canonical + both generated harness copies) now writes the exact `goal_id`, or `Operational`, instead of the decorative placeholder `[Q1 Goal #X]`.
- **`core/lens-catalog/registry.json`** re-pinned for the edited skill.

## Deliberate scope boundary

- A goal that genuinely has no linked priority still reports a **measured zero**.
- Old human-readable placeholder text is **not** guessed at. The evidence contains no affected week-file bytes, and mapping a placeholder to a specific goal could credit work to the wrong one. The fix prevents new placeholders and reads both canonical and legacy links correctly.

## Evidence

Fail-first, independently replayed on this branch's base (live main `b352c373`), not taken on report:

| Check | Result |
|---|---|
| Regression on unmodified main | **2 failed** — `linked_priorities_count == 0` for both the 1st and 4th priority |
| Same regression after the fix | 8 passed |
| Mutation: remove the metadata walk | 1st- and 4th-priority tests fail; restored, green |
| Mutation: remove the empty-ID guard | ID-less goal claims all 2 priorities in the file; restored, green |
| Covering tests (`weekly_priority_creation` + `weekly_planning_context`) | 38 passed |
| Lens catalogue generation + instruction honesty | 107 passed |
| Ruff `core/` | clean |
| `compileall core/mcp/work_server.py` | clean |
| Diff-aware test gate, doc drift, architecture inventory, path consistency | pass |

No release, no version bump, no changelog entry — nothing here ships until a release is cut deliberately.

Card: `bug-report-work-mcp-weekly-priority-to-quarterly-goal-linki-ef864496c1`
