### PR TITLE
Stage the v1.97.12 release notes ahead of the release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+This release also carries everything listed under v1.97.11 below: that
+version's build never reached the downloads page (its release run stopped
+before publishing), so updating from v1.97.10 brings both sets of changes
+at once.
+
+**What this fixes for you:**
+
+* **Dex Lens can now see the whole of Dex, area by area.** The published
+  capability catalogue now carries Dex's fourteen capability families —
+  meeting follow-through, proactive health and recovery, backup confidence,
+  durable work memory and the rest — signed alongside the capabilities
+  themselves. A Dex Lens checkup can tell you which of those areas your own
+  system covers, where the gaps are, and how far your install sits behind
+  the current release, instead of judging one capability at a time.
+* **Weekly planning no longer trips on a goal without an ID.** A quarterly
+  goal written by hand, without the ID Dex normally adds, could stop weekly
+  planning with an error. Planning now works around it, tells you which goal
+  needs an ID and exactly where to put it, and never mistakes "can't read
+  the links" for "no activity".
+* **A weekly priority that names its quarterly goal now counts toward it.**
+* **Planning next quarter early no longer hides this quarter's goals.** If
+  you record next quarter in your profile and write its goals ahead of time,
+  asking for your quarterly goals answers for the quarter you are planning —
+  and never replaces the goals you can see today with an empty page.
+
+Also in this release: every change to Dex itself now gets an automatic
+Claude review before it ships, replacing the previous review bot.
+
 ## [1.97.11] — The files Dex ships can finally prove themselves, and a guided repair when they can't (2026-09-07)
 
 A long-time beta tester's checkup flagged 1,807 files as ones Dex "couldn't


### PR DESCRIPTION
## Linked Issue
- Linear issue: none — release preparation for v1.97.12

## What Changed
- CHANGELOG.md: the v1.97.12 release notes, placed directly after the preamble separator with no version header. `scripts/release.sh` inserts the new `## [1.97.12] — (date)` header at exactly that position, so when the founder runs the release cut these notes land under the header **inside the release commit itself** — which the release-tree gate requires (a post-tag content commit would fail "Refuse to label a different tree as this version")
- Notes cover everything on main since the v1.97.11 build (which never published: version bumped without its tag — this release supersedes it and says so): the fourteen signed capability families in the Lens catalogue (#707), weekly planning surviving goals without IDs (#704), weekly priorities that name their goal counting toward it (#709), declared-quarter goal planning (#706, unlisted in the 1.97.11 notes), and the automatic Claude review on every PR (#708)

## Test Plan
- Unit/integration tests added or updated: none — changelog text only
- Negative/error-path tests added or updated: n/a
- Commands run locally: verified the notes sit immediately after the `---` separator so the release script's header-insertion lands on top of them

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [ ] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk level (low/medium/high): low — documentation only; the unusual header-less placement is deliberate and explained above, and resolves itself the moment the release cut runs
- Rollback plan: revert the commit

## Docs Impact
- Files updated: CHANGELOG.md
- If none, reason: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MsxdAWqeVULH8JEih85qB

---
_Generated by [Claude Code](https://claude.ai/code/session_014MsxdAWqeVULH8JEih85qB)_