### PR TITLE
Only shorten a name to a first-name link when the note names the person

### DIFF
--- a/.claude/hooks/tests/auto-link-people.test.cjs
+++ b/.claude/hooks/tests/auto-link-people.test.cjs
@@ -151,6 +151,17 @@ test('does not link an ambiguous standalone first name', () => {
   assert.equal(autoLinkContent('Sarah raised the risk.', registry), 'Sarah raised the risk.');
 });
 
+test('does not link a unique bare first name without document evidence', () => {
+  const { autoLinkContent } = loadScript();
+  const registry = makeRegistry({
+    fullNames: ['Emma Brown'],
+    firstNames: [['Emma', 'Emma Brown']],
+    targets: [['Emma Brown', 'Emma_Brown']],
+  });
+
+  assert.equal(autoLinkContent('Decision owned by Emma).', registry), 'Decision owned by Emma).');
+});
+
 test('poisons a known first name when an unknown full name uses it', () => {
   const { autoLinkContent } = loadScript();
   const registry = makeRegistry({
@@ -216,8 +227,8 @@ test('applies the complete stoplist case-sensitively', () => {
     firstNames: [['mark', 'mark Person']],
   });
   assert.equal(
-    autoLinkContent('mark spoke.', lowercaseRegistry),
-    '[[mark Person|mark]] spoke.',
+    autoLinkContent('---\nattendee: mark Person\n---\nmark spoke.', lowercaseRegistry),
+    '---\nattendee: mark Person\n---\n[[mark Person|mark]] spoke.',
   );
 });
 
@@ -333,10 +344,12 @@ test('does not match names inside longer words or compound identifiers', () => {
     fullNames: ['Sarah Chen'],
     firstNames: [['Sarah', 'Sarah Chen']],
   });
+  const frontmatter = '---\nattendee: Sarah Chen\n---\n';
+  const prose = 'preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane Sarah';
 
   assert.equal(
-    autoLinkContent('preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane Sarah', registry),
-    'preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane [[Sarah Chen|Sarah]]',
+    autoLinkContent(frontmatter + prose, registry),
+    frontmatter + 'preSarah Sarahish Sarah2 _Sarah Sarah-Jane 𐐀Sarah Sarah–Jane [[Sarah Chen|Sarah]]',
   );
 });
 

--- a/.scripts/auto-link-people.cjs
+++ b/.scripts/auto-link-people.cjs
@@ -456,6 +456,17 @@ function boundaryIsSafe(text, start, length) {
     && (!next || !WORD_CONTINUATION.test(next));
 }
 
+function containsName(text, name) {
+  let fromIndex = 0;
+  while (fromIndex < text.length) {
+    const start = text.indexOf(name, fromIndex);
+    if (start === -1) return false;
+    if (boundaryIsSafe(text, start, name.length)) return true;
+    fromIndex = start + Math.max(1, name.length);
+  }
+  return false;
+}
+
 function findPoisonedFirstNames(text, registry, protectedRanges) {
   const poisoned = new Set();
   const pattern = /[\p{Lu}][\p{L}\p{M}'’\p{Pd}]*/gu;
@@ -517,6 +528,10 @@ function autoLinkContent(text, registry = buildRegistry()) {
       || firstName === ownerFirstName
       || STOPLIST.has(firstName)
       || poisoned.has(firstName)
+      // A unique name in the vault is not proof that this note means the
+      // same person. Require the full name somewhere in this document (the
+      // meeting attendee metadata counts) before shortening it to a first-name link.
+      || !containsName(text, fullName)
     ) {
       continue;
     }


### PR DESCRIPTION
## What was wrong

If a vault had exactly one person page for a given first name, auto-linking treated
that uniqueness as proof of identity. The bare word `Emma` in `Decision owned by Emma).`
became a confident `[[Emma_Brown|Emma]]` link — even when the note meant a different
Emma, or no Emma on file at all. A wrong person link then propagates a false assertion
into every later note that reads it.

Reported through feedback; reproduced 3/3 at the shipped CLI boundary.

## The fix

An ordinary first name is only shortened to a link when the person's **full name
appears somewhere in the same document**. Meeting attendee metadata counts as that
evidence. Explicit aliases and full-name mentions are unchanged.

Two files: `.scripts/auto-link-people.cjs` (a `containsName` helper plus one guard
clause) and its test file.

## Evidence

Replayed independently onto exact live main `0a764eb9` (HEAD == merge-base == live main).

**Fail-first, at the shipped CLI boundary on unmodified main:**
```
$ node .scripts/auto-link-people.cjs "<vault>/00-Inbox/Meetings/2026-09-07 - Sync.md"
added 1 person link
  [[Emma_Brown|Emma]]
Decision owned by [[Emma_Brown|Emma]]).
```

**Fail-first, unit:** with only the new regression added and no product change,
`not ok 7 - does not link a unique bare first name without document evidence`
(20 pass / 1 fail).

**Gate proves it can fail:** with the guard deliberately deleted, the same test goes
red again (20 pass / 1 fail); restoring it returns 21/21.

**Behaviour after the fix, at the CLI boundary:**
| Case | Result |
|---|---|
| Bare `Emma`, no evidence | no changes (was the bug) |
| `Emma Brown joined. ... Emma).` | both link |
| `attendees: - Emma Brown` in frontmatter | first name links |

**Suites:** hooks 235/235, scripts+meeting-intel 190/190 (`DEX_PYTHON=/usr/bin/python3`).
**Static gates:** syntax, PII, founder-content, path-contract, path-consistency,
architecture-inventory, doc-drift — all pass.

## Notes

No changelog or version bump. Two existing tests (case-sensitive stoplist, word-boundary)
asserted linking without a full name in-document; they were given the evidence the new
contract requires, keeping their original subject intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)